### PR TITLE
Support shared/custom Platforms folder mappings in SingleProject

### DIFF
--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.SingleProject.Before.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.SingleProject.Before.targets
@@ -29,12 +29,24 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <MauiPlatformSpecificFolder Include="$(AndroidProjectFolder)" TargetPlatformIdentifier="android" />
-    <MauiPlatformSpecificFolder Include="$(iOSProjectFolder)" TargetPlatformIdentifier="ios" />
-    <MauiPlatformSpecificFolder Include="$(MacCatalystProjectFolder)" TargetPlatformIdentifier="maccatalyst" />
-    <MauiPlatformSpecificFolder Include="$(WindowsProjectFolder)" TargetPlatformIdentifier="windows" />
-    <MauiPlatformSpecificFolder Include="$(TizenProjectFolder)" TargetPlatformIdentifier="tizen" />
+    <MauiPlatformSpecificFolder Include="$(AndroidProjectFolder)" TargetPlatformIdentifier="android" TargetPlatformIdentifiers="android" />
+    <MauiPlatformSpecificFolder Include="$(iOSProjectFolder)" TargetPlatformIdentifier="ios" TargetPlatformIdentifiers="ios" />
+    <MauiPlatformSpecificFolder Include="$(MacCatalystProjectFolder)" TargetPlatformIdentifier="maccatalyst" TargetPlatformIdentifiers="maccatalyst" />
+    <MauiPlatformSpecificFolder Include="$(WindowsProjectFolder)" TargetPlatformIdentifier="windows" TargetPlatformIdentifiers="windows" />
+    <MauiPlatformSpecificFolder Include="$(TizenProjectFolder)" TargetPlatformIdentifier="tizen" TargetPlatformIdentifiers="tizen" />
   </ItemGroup>
+
+  <Target Name="_MauiNormalizePlatformSpecificFolders"
+          BeforeTargets="_MauiCollectPlatformSpecificCompileItems;_MauiRemovePlatformCompileItems"
+          Condition=" '$(SingleProject)' == 'true' ">
+    <ItemGroup>
+      <MauiPlatformSpecificFolder
+          Update="@(MauiPlatformSpecificFolder)"
+          Condition=" '%(MauiPlatformSpecificFolder.TargetPlatformIdentifiers)' == '' and '%(MauiPlatformSpecificFolder.TargetPlatformIdentifier)' != '' ">
+        <TargetPlatformIdentifiers>%(MauiPlatformSpecificFolder.TargetPlatformIdentifier)</TargetPlatformIdentifiers>
+      </MauiPlatformSpecificFolder>
+    </ItemGroup>
+  </Target>
 
   <PropertyGroup Condition=" '$(SingleProject)' == 'true' and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'android' ">
     <AndroidManifest Condition=" Exists('$(AndroidProjectFolder)AndroidManifest.xml') ">$(AndroidProjectFolder)AndroidManifest.xml</AndroidManifest>

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.SingleProject.Before.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.SingleProject.Before.targets
@@ -54,8 +54,16 @@
     metadata. Instead, downstream consumers apply EnsureTrailingSlash() at the
     use site (see _MauiCollectPlatformSpecificCompileItems).
   -->
+  <!--
+    BeforeTargets is intentionally limited to _MauiRemovePlatformCompileItems
+    because _MauiCollectPlatformSpecificCompileItems already declares
+    DependsOnTargets="_MauiNormalizePlatformSpecificFolders" (single source of
+    truth for that ordering). The Remove target does not depend on Collect (so
+    Normalize-Before-Remove is the only way to guarantee Remove sees the
+    back-filled TargetPlatformIdentifiers metadata when Collect is short-circuited).
+  -->
   <Target Name="_MauiNormalizePlatformSpecificFolders"
-          BeforeTargets="_MauiCollectPlatformSpecificCompileItems;_MauiRemovePlatformCompileItems"
+          BeforeTargets="_MauiRemovePlatformCompileItems"
           Condition=" '$(SingleProject)' == 'true' ">
     <ItemGroup>
       <MauiPlatformSpecificFolder

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.SingleProject.Before.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.SingleProject.Before.targets
@@ -28,14 +28,32 @@
     <TizenProjectFolder>$([MSBuild]::EnsureTrailingSlash('$(TizenProjectFolder)'))</TizenProjectFolder>
   </PropertyGroup>
 
+  <!--
+    Built-in folder mappings declare only the legacy singular TargetPlatformIdentifier
+    metadata so that _MauiNormalizePlatformSpecificFolders is the single source of
+    truth for back-filling the plural TargetPlatformIdentifiers contract. Keeping
+    one source avoids drift between the two metadata fields and ensures the
+    normalization code path is exercised on every SingleProject build (so a
+    regression in the back-fill is caught immediately).
+  -->
   <ItemGroup>
-    <MauiPlatformSpecificFolder Include="$(AndroidProjectFolder)" TargetPlatformIdentifier="android" TargetPlatformIdentifiers="android" />
-    <MauiPlatformSpecificFolder Include="$(iOSProjectFolder)" TargetPlatformIdentifier="ios" TargetPlatformIdentifiers="ios" />
-    <MauiPlatformSpecificFolder Include="$(MacCatalystProjectFolder)" TargetPlatformIdentifier="maccatalyst" TargetPlatformIdentifiers="maccatalyst" />
-    <MauiPlatformSpecificFolder Include="$(WindowsProjectFolder)" TargetPlatformIdentifier="windows" TargetPlatformIdentifiers="windows" />
-    <MauiPlatformSpecificFolder Include="$(TizenProjectFolder)" TargetPlatformIdentifier="tizen" TargetPlatformIdentifiers="tizen" />
+    <MauiPlatformSpecificFolder Include="$(AndroidProjectFolder)" TargetPlatformIdentifier="android" />
+    <MauiPlatformSpecificFolder Include="$(iOSProjectFolder)" TargetPlatformIdentifier="ios" />
+    <MauiPlatformSpecificFolder Include="$(MacCatalystProjectFolder)" TargetPlatformIdentifier="maccatalyst" />
+    <MauiPlatformSpecificFolder Include="$(WindowsProjectFolder)" TargetPlatformIdentifier="windows" />
+    <MauiPlatformSpecificFolder Include="$(TizenProjectFolder)" TargetPlatformIdentifier="tizen" />
   </ItemGroup>
 
+  <!--
+    Normalize MauiPlatformSpecificFolder items so downstream targets and any
+    third-party extension can rely on a uniform shape:
+      - TargetPlatformIdentifiers is back-filled from the legacy singular
+        TargetPlatformIdentifier when only the singular is set.
+    Identity (folder path) is intentionally not rewritten here because MSBuild
+    item-Identity rewriting requires a remove/re-add dance that loses caller
+    metadata. Instead, downstream consumers apply EnsureTrailingSlash() at the
+    use site (see _MauiCollectPlatformSpecificCompileItems).
+  -->
   <Target Name="_MauiNormalizePlatformSpecificFolders"
           BeforeTargets="_MauiCollectPlatformSpecificCompileItems;_MauiRemovePlatformCompileItems"
           Condition=" '$(SingleProject)' == 'true' ">

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.SingleProject.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.SingleProject.targets
@@ -35,6 +35,17 @@
     </Compile>
   </ItemGroup>
 
+  <Target Name="_MauiCollectPlatformSpecificCompileItems"
+          DependsOnTargets="_MauiNormalizePlatformSpecificFolders"
+          BeforeTargets="_MauiRemovePlatformCompileItems"
+          Condition=" '$(SingleProject)' == 'true' and '@(MauiPlatformSpecificFolder)' != '' ">
+    <ItemGroup>
+      <_MauiPlatformSpecificCompileItems
+          Include="%(MauiPlatformSpecificFolder.Identity)**/*$(DefaultLanguageSourceExtension)"
+          Condition=" '%(MauiPlatformSpecificFolder.TargetPlatformIdentifiers)' == '' or ('$(TargetPlatformIdentifier)' != '' and $([System.String]::new(';%(MauiPlatformSpecificFolder.TargetPlatformIdentifiers);').ToLowerInvariant().Contains(';$(TargetPlatformIdentifier.ToLowerInvariant());')) )" />
+    </ItemGroup>
+  </Target>
+
   <!--
     Run before both _MauiInjectXamlCssAdditionalFiles and GenerateMSBuildEditorConfigFileShouldRun because
     if for some reason the _MauiInjectXamlCssAdditionalFiles target is not run, we still get in at the
@@ -46,10 +57,12 @@
 
   <!-- Removals -->
     <ItemGroup>
-      <!-- Remove everything that isn't part of this platform -->
-      <Compile
+      <!-- Remove everything that isn't part of this platform. -->
+      <_MauiPlatformCompileToRemove
           Condition=" '%(Compile.ExcludeFromCurrentConfiguration)' == 'true' "
-          Remove="$(PlatformsProjectFolder)**/*$(DefaultLanguageSourceExtension)" />
+          Include="$(PlatformsProjectFolder)**/*$(DefaultLanguageSourceExtension)"
+          Exclude="@(_MauiPlatformSpecificCompileItems)" />
+      <Compile Remove="@(_MauiPlatformCompileToRemove)" />
 
       <!-- Remove all Windows (WinUI) XAML Files from the Windows folder -->
       <_MauiXamlToRemove

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.SingleProject.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.SingleProject.targets
@@ -42,7 +42,7 @@
     <ItemGroup>
       <_MauiPlatformSpecificCompileItems
           Include="%(MauiPlatformSpecificFolder.Identity)**/*$(DefaultLanguageSourceExtension)"
-          Condition=" '%(MauiPlatformSpecificFolder.TargetPlatformIdentifiers)' == '' or ('$(TargetPlatformIdentifier)' != '' and $([System.String]::new(';%(MauiPlatformSpecificFolder.TargetPlatformIdentifiers);').ToLowerInvariant().Contains(';$(TargetPlatformIdentifier.ToLowerInvariant());')) )" />
+          Condition=" '%(MauiPlatformSpecificFolder.TargetPlatformIdentifiers)' == '' or ('$(TargetPlatformIdentifier)' != '' and $([System.String]::new(';%(MauiPlatformSpecificFolder.TargetPlatformIdentifiers);').Replace(' ', '').ToLowerInvariant().Contains(';$(TargetPlatformIdentifier.ToLowerInvariant());')) )" />
     </ItemGroup>
   </Target>
 

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.SingleProject.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.SingleProject.targets
@@ -35,14 +35,61 @@
     </Compile>
   </ItemGroup>
 
+  <!--
+    Build the per-platform allow-list of Compile items that should survive the
+    blanket Platforms/** removal performed by _MauiRemovePlatformCompileItems.
+
+    Identity normalization: EnsureTrailingSlash() guards against the
+    foot-gun where a user-supplied item like
+        <MauiPlatformSpecificFolder Include="Platforms\Apple" .../>
+    (no trailing separator) would expand to the glob "Platforms\Apple**/*.cs"
+    and silently match sibling folders such as "Platforms\AppleX\" or
+    "Platforms\AppleLegacy\".
+
+    TPI matching contract: TargetPlatformIdentifiers is a ';'-delimited list.
+    Comparison is case-insensitive and tolerates any whitespace (ASCII space,
+    tab, CR, LF) around each entry; the Regex.Replace(\s+, '') strip is
+    deliberate, not Replace(' ', ''), so values formatted across multiple lines
+    or copy-pasted with tabs continue to match.
+
+    Empty TargetPlatformIdentifiers means "always include" (condition-gated
+    folder). The '$(TargetPlatformIdentifier)' != '' guard prevents non-empty
+    lists from accidentally matching during non-platform (e.g. netstandard /
+    design-time) builds where $(TargetPlatformIdentifier) is empty.
+  -->
   <Target Name="_MauiCollectPlatformSpecificCompileItems"
           DependsOnTargets="_MauiNormalizePlatformSpecificFolders"
           BeforeTargets="_MauiRemovePlatformCompileItems"
           Condition=" '$(SingleProject)' == 'true' and '@(MauiPlatformSpecificFolder)' != '' ">
     <ItemGroup>
       <_MauiPlatformSpecificCompileItems
-          Include="%(MauiPlatformSpecificFolder.Identity)**/*$(DefaultLanguageSourceExtension)"
-          Condition=" '%(MauiPlatformSpecificFolder.TargetPlatformIdentifiers)' == '' or ('$(TargetPlatformIdentifier)' != '' and $([System.String]::new(';%(MauiPlatformSpecificFolder.TargetPlatformIdentifiers);').Replace(' ', '').ToLowerInvariant().Contains(';$(TargetPlatformIdentifier.ToLowerInvariant());')) )" />
+          Include="$([MSBuild]::EnsureTrailingSlash('%(MauiPlatformSpecificFolder.Identity)'))**/*$(DefaultLanguageSourceExtension)"
+          Condition=" '%(MauiPlatformSpecificFolder.TargetPlatformIdentifiers)' == '' or ('$(TargetPlatformIdentifier)' != '' and $([System.Text.RegularExpressions.Regex]::Replace(';%(MauiPlatformSpecificFolder.TargetPlatformIdentifiers);', '\s+', '').ToLowerInvariant().Contains(';$(TargetPlatformIdentifier.ToLowerInvariant());')) )" />
+    </ItemGroup>
+  </Target>
+
+  <!--
+    Flip ExcludeFromCurrentConfiguration back to false on the kept items so
+    Visual Studio's Solution Explorer / IntelliSense renders them as part of
+    the active configuration. The blanket <Compile Update> at the top of this
+    file unconditionally marks every $(PlatformsProjectFolder)/** file as
+    ExcludeFromCurrentConfiguration=true; the per-TPI flips at the top only
+    cover the built-in $(<TPI>ProjectFolder) paths. Without this target,
+    files in shared folders like Platforms/Apple/ compile correctly but
+    appear grayed-out in the IDE for both ios and maccatalyst targets.
+
+    This MUST run AFTER _MauiRemovePlatformCompileItems because that target
+    relies on cross-item-type batching of %(Compile.ExcludeFromCurrentConfiguration);
+    flipping kept items to false beforehand would remove them from the 'true'
+    batch and prevent the to-remove list from being computed correctly.
+  -->
+  <Target Name="_MauiUnflipKeptCompileItemMetadata"
+          AfterTargets="_MauiRemovePlatformCompileItems"
+          Condition=" '$(SingleProject)' == 'true' and '@(_MauiPlatformSpecificCompileItems)' != '' ">
+    <ItemGroup>
+      <Compile Update="@(_MauiPlatformSpecificCompileItems)">
+        <ExcludeFromCurrentConfiguration>false</ExcludeFromCurrentConfiguration>
+      </Compile>
     </ItemGroup>
   </Target>
 
@@ -57,7 +104,21 @@
 
   <!-- Removals -->
     <ItemGroup>
-      <!-- Remove everything that isn't part of this platform. -->
+      <!--
+        Remove every Compile item under $(PlatformsProjectFolder) that is not
+        part of the current build configuration AND has not been explicitly
+        kept by _MauiCollectPlatformSpecificCompileItems above.
+
+        The Condition references %(Compile.ExcludeFromCurrentConfiguration)
+        from inside an Include of a *different* item type — this is MSBuild
+        cross-item-type batching: the filesystem glob is evaluated once per
+        unique value of Compile.ExcludeFromCurrentConfiguration. In practice
+        the blanket <Compile Update> at the top of this file always marks
+        every $(PlatformsProjectFolder)/** file as ExcludeFromCurrentConfiguration=true,
+        so this batches into a single iteration; do NOT "simplify" away the
+        Condition without first re-verifying that contract still holds, or
+        files outside the active TPI may leak into the build.
+      -->
       <_MauiPlatformCompileToRemove
           Condition=" '%(Compile.ExcludeFromCurrentConfiguration)' == 'true' "
           Include="$(PlatformsProjectFolder)**/*$(DefaultLanguageSourceExtension)"

--- a/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
@@ -186,6 +186,13 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			return itemGroup;
 		}
 
+		void WriteFile(string name, string contents)
+		{
+			var filePath = IOPath.Combine(tempDirectory, name.Replace('\\', IOPath.DirectorySeparatorChar).Replace('/', IOPath.DirectorySeparatorChar));
+			Directory.CreateDirectory(IOPath.GetDirectoryName(filePath));
+			File.WriteAllText(filePath, contents);
+		}
+
 		string Build(string projectFile, string target = "Build", string verbosity = "normal", string additionalArgs = "", bool shouldSucceed = true)
 		{
 			var builder = new StringBuilder();
@@ -264,6 +271,46 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 		void AssertDoesNotExist(string path)
 		{
 			Assert.False(File.Exists(path), $"{path} should *not* exist!");
+		}
+
+		void AssertTypeExists(string assemblyPath, string fullTypeName)
+		{
+			using var assembly = AssemblyDefinition.ReadAssembly(assemblyPath);
+			Assert.Contains(assembly.MainModule.Types.Select(t => t.FullName), t => t == fullTypeName);
+		}
+
+		void AssertTypeDoesNotExist(string assemblyPath, string fullTypeName)
+		{
+			using var assembly = AssemblyDefinition.ReadAssembly(assemblyPath);
+			Assert.DoesNotContain(assembly.MainModule.Types.Select(t => t.FullName), t => t == fullTypeName);
+		}
+
+		void AddSingleProjectBeforeTargetsImport(XElement project)
+		{
+			var beforeTargetsPath = AssemblyInfoTests.GetFilePathFromRoot(IOPath.Combine("src", "Controls", "src", "Build.Tasks", "nuget", "buildTransitive", "netstandard2.0", "Microsoft.Maui.Controls.SingleProject.Before.targets"));
+			project.Add(NewElement("Import").WithAttribute("Project", beforeTargetsPath));
+		}
+
+		void AddSingleProjectTargetsImport(XElement project)
+		{
+			var targetsPath = AssemblyInfoTests.GetFilePathFromRoot(IOPath.Combine("src", "Controls", "src", "Build.Tasks", "nuget", "buildTransitive", "netstandard2.0", "Microsoft.Maui.Controls.SingleProject.targets"));
+			project.Add(NewElement("Import").WithAttribute("Project", targetsPath));
+		}
+
+		void AddMauiReferences(XElement project)
+		{
+			var itemGroup = NewElement("ItemGroup");
+			foreach (var assembly in references)
+			{
+				var reference = NewElement("Reference").WithAttribute("Include", assembly);
+				if (assembly.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+				{
+					reference.Add(NewElement("HintPath").WithValue(IOPath.Combine("..", "..", assembly)));
+				}
+				itemGroup.Add(reference);
+			}
+
+			project.Add(itemGroup);
 		}
 
 		[Fact]
@@ -562,6 +609,239 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			project.Save(projectFile);
 			var log = Build(projectFile, verbosity: "diagnostic");
 			Assert.False(log.Contains("Building target \"XamlC\"", StringComparison.Ordinal), "XamlC should be skipped if there are no .xaml files.");
+		}
+
+		[Theory]
+		[InlineData("ios", true)]
+		[InlineData("maccatalyst", true)]
+		[InlineData("android", false)]
+		public void SingleProject_SharedPlatformFolderMappingsAreRespected(string targetPlatformIdentifier, bool shouldIncludeAppleSharedFile)
+		{
+			SetUp();
+			var project = NewElement("Project").WithAttribute("Sdk", "Microsoft.NET.Sdk");
+			var propertyGroup = NewElement("PropertyGroup");
+			propertyGroup.Add(NewElement("TargetFramework").WithValue(GetTfm()));
+			propertyGroup.Add(NewElement("SingleProject").WithValue("true"));
+			project.Add(propertyGroup);
+			AddMauiReferences(project);
+			AddSingleProjectBeforeTargetsImport(project);
+
+			var customMappings = NewElement("ItemGroup");
+			customMappings.Add(NewElement("MauiPlatformSpecificFolder")
+				.WithAttribute("Include", "Platforms\\Apple\\")
+				.WithAttribute("TargetPlatformIdentifiers", "ios;maccatalyst"));
+			project.Add(customMappings);
+
+			WriteFile("Entry.cs", @"
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public static partial class CurrentPlatform
+{
+}
+
+public static class Entry
+{
+	public static string Value => CurrentPlatform.Name;
+}");
+
+			WriteFile("Platforms\\iOS\\CurrentPlatform.cs", @"
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public static partial class CurrentPlatform
+{
+	public static string Name => ""iOS"";
+}");
+
+			WriteFile("Platforms\\MacCatalyst\\CurrentPlatform.cs", @"
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public static partial class CurrentPlatform
+{
+	public static string Name => ""MacCatalyst"";
+}");
+
+			WriteFile("Platforms\\Android\\CurrentPlatform.cs", @"
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public static partial class CurrentPlatform
+{
+	public static string Name => ""Android"";
+}");
+
+			WriteFile("Platforms\\Apple\\AppleSharedMarker.cs", @"
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public static class AppleSharedMarker
+{
+	public static string Value => ""Apple"";
+}");
+
+			AddSingleProjectTargetsImport(project);
+
+			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
+			project.Save(projectFile);
+
+			Build(projectFile, additionalArgs: $"-p:TargetPlatformIdentifier={targetPlatformIdentifier}");
+
+			var testDll = IOPath.Combine(intermediateDirectory, "test.dll");
+			AssertExists(testDll, nonEmpty: true);
+
+			if (shouldIncludeAppleSharedFile)
+				AssertTypeExists(testDll, "Microsoft.Maui.Controls.Xaml.UnitTests.AppleSharedMarker");
+			else
+				AssertTypeDoesNotExist(testDll, "Microsoft.Maui.Controls.Xaml.UnitTests.AppleSharedMarker");
+		}
+
+		[Fact]
+		public void SingleProject_BuiltInPlatformFoldersCanBeExtended()
+		{
+			SetUp();
+			var project = NewElement("Project").WithAttribute("Sdk", "Microsoft.NET.Sdk");
+			var propertyGroup = NewElement("PropertyGroup");
+			propertyGroup.Add(NewElement("TargetFramework").WithValue(GetTfm()));
+			propertyGroup.Add(NewElement("SingleProject").WithValue("true"));
+			project.Add(propertyGroup);
+			AddMauiReferences(project);
+			AddSingleProjectBeforeTargetsImport(project);
+
+			var customMappings = NewElement("ItemGroup");
+			var update = NewElement("MauiPlatformSpecificFolder")
+				.WithAttribute("Update", "$(iOSProjectFolder)");
+			update.Add(NewElement("TargetPlatformIdentifiers").WithValue("ios;maccatalyst"));
+			customMappings.Add(update);
+			project.Add(customMappings);
+
+			WriteFile("Entry.cs", @"
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public static class Entry
+{
+	public static string Value => ExtendedIosMarker.Value;
+}");
+
+			WriteFile("Platforms\\iOS\\ExtendedIosMarker.cs", @"
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public static class ExtendedIosMarker
+{
+	public static string Value => ""SharedWithCatalyst"";
+}");
+
+			AddSingleProjectTargetsImport(project);
+
+			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
+			project.Save(projectFile);
+
+			Build(projectFile, additionalArgs: "-p:TargetPlatformIdentifier=maccatalyst");
+
+			var testDll = IOPath.Combine(intermediateDirectory, "test.dll");
+			AssertExists(testDll, nonEmpty: true);
+			AssertTypeExists(testDll, "Microsoft.Maui.Controls.Xaml.UnitTests.ExtendedIosMarker");
+		}
+
+		[Theory]
+		[InlineData("ios", true)]
+		[InlineData("maccatalyst", false)]
+		[InlineData("android", false)]
+		public void SingleProject_SingularPlatformFolderMetadataRemainsBackwardCompatible(string targetPlatformIdentifier, bool shouldIncludeLegacyFile)
+		{
+			SetUp();
+			var project = NewElement("Project").WithAttribute("Sdk", "Microsoft.NET.Sdk");
+			var propertyGroup = NewElement("PropertyGroup");
+			propertyGroup.Add(NewElement("TargetFramework").WithValue(GetTfm()));
+			propertyGroup.Add(NewElement("SingleProject").WithValue("true"));
+			project.Add(propertyGroup);
+			AddMauiReferences(project);
+			AddSingleProjectBeforeTargetsImport(project);
+
+			var customMappings = NewElement("ItemGroup");
+			customMappings.Add(NewElement("MauiPlatformSpecificFolder")
+				.WithAttribute("Include", "Platforms\\LegacyiOS\\")
+				.WithAttribute("TargetPlatformIdentifier", "ios"));
+			project.Add(customMappings);
+
+			WriteFile("Entry.cs", @"
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public static class Entry
+{
+	public static string Value => ""ok"";
+}");
+
+			WriteFile("Platforms\\LegacyiOS\\LegacyIosMarker.cs", @"
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public static class LegacyIosMarker
+{
+	public static string Value => ""LegacyiOS"";
+}");
+
+			AddSingleProjectTargetsImport(project);
+
+			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
+			project.Save(projectFile);
+
+			Build(projectFile, additionalArgs: $"-p:TargetPlatformIdentifier={targetPlatformIdentifier}");
+
+			var testDll = IOPath.Combine(intermediateDirectory, "test.dll");
+			AssertExists(testDll, nonEmpty: true);
+
+			if (shouldIncludeLegacyFile)
+				AssertTypeExists(testDll, "Microsoft.Maui.Controls.Xaml.UnitTests.LegacyIosMarker");
+			else
+				AssertTypeDoesNotExist(testDll, "Microsoft.Maui.Controls.Xaml.UnitTests.LegacyIosMarker");
+		}
+
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public void SingleProject_ConditionGatedPlatformFoldersCanParticipateWithoutATargetPlatformIdentifier(bool useLinuxFolder)
+		{
+			SetUp();
+			var project = NewElement("Project").WithAttribute("Sdk", "Microsoft.NET.Sdk");
+			var propertyGroup = NewElement("PropertyGroup");
+			propertyGroup.Add(NewElement("TargetFramework").WithValue(GetTfm()));
+			propertyGroup.Add(NewElement("SingleProject").WithValue("true"));
+			project.Add(propertyGroup);
+			AddMauiReferences(project);
+			AddSingleProjectBeforeTargetsImport(project);
+
+			var customMappings = NewElement("ItemGroup");
+			customMappings.Add(NewElement("MauiPlatformSpecificFolder")
+				.WithAttribute("Include", "Platforms\\Linux\\")
+				.WithAttribute("Condition", " '$(UseLinuxFolder)' == 'true' "));
+			project.Add(customMappings);
+
+			WriteFile("Entry.cs", @"
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public static class Entry
+{
+	public static string Value => ""ok"";
+}");
+
+			WriteFile("Platforms\\Linux\\LinuxMarker.cs", @"
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public static class LinuxMarker
+{
+	public static string Value => ""Linux"";
+}");
+
+			AddSingleProjectTargetsImport(project);
+
+			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
+			project.Save(projectFile);
+
+			Build(projectFile, additionalArgs: $"-p:UseLinuxFolder={useLinuxFolder.ToString().ToLowerInvariant()}");
+
+			var testDll = IOPath.Combine(intermediateDirectory, "test.dll");
+			AssertExists(testDll, nonEmpty: true);
+
+			if (useLinuxFolder)
+				AssertTypeExists(testDll, "Microsoft.Maui.Controls.Xaml.UnitTests.LinuxMarker");
+			else
+				AssertTypeDoesNotExist(testDll, "Microsoft.Maui.Controls.Xaml.UnitTests.LinuxMarker");
 		}
 
 		/// <summary>

--- a/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
@@ -612,10 +612,13 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 		}
 
 		[Theory]
-		[InlineData("ios", true)]
-		[InlineData("maccatalyst", true)]
-		[InlineData("android", false)]
-		public void SingleProject_SharedPlatformFolderMappingsAreRespected(string targetPlatformIdentifier, bool shouldIncludeAppleSharedFile)
+		[InlineData("ios", "ios;maccatalyst", true)]
+		[InlineData("maccatalyst", "ios;maccatalyst", true)]
+		[InlineData("android", "ios;maccatalyst", false)]
+		[InlineData("ios", "ios; maccatalyst", true)]
+		[InlineData("maccatalyst", "ios; maccatalyst", true)]
+		[InlineData("android", "ios; maccatalyst", false)]
+		public void SingleProject_SharedPlatformFolderMappingsAreRespected(string targetPlatformIdentifier, string targetPlatformIdentifiers, bool shouldIncludeAppleSharedFile)
 		{
 			SetUp();
 			var project = NewElement("Project").WithAttribute("Sdk", "Microsoft.NET.Sdk");
@@ -629,7 +632,7 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			var customMappings = NewElement("ItemGroup");
 			customMappings.Add(NewElement("MauiPlatformSpecificFolder")
 				.WithAttribute("Include", "Platforms\\Apple\\")
-				.WithAttribute("TargetPlatformIdentifiers", "ios;maccatalyst"));
+				.WithAttribute("TargetPlatformIdentifiers", targetPlatformIdentifiers));
 			project.Add(customMappings);
 
 			WriteFile("Entry.cs", @"

--- a/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
@@ -691,7 +691,7 @@ public static class AppleSharedMarker
 			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
 			project.Save(projectFile);
 
-			Build(projectFile, additionalArgs: $"-p:TargetPlatformIdentifier={targetPlatformIdentifier}");
+			Build(projectFile, additionalArgs: $"-p:TargetPlatformIdentifier={targetPlatformIdentifier} -p:MSBuildEnableWorkloadResolver=false");
 
 			var testDll = IOPath.Combine(intermediateDirectory, "test.dll");
 			AssertExists(testDll, nonEmpty: true);
@@ -754,7 +754,7 @@ public static class ExtendedIosMarker
 			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
 			project.Save(projectFile);
 
-			Build(projectFile, additionalArgs: "-p:TargetPlatformIdentifier=maccatalyst");
+			Build(projectFile, additionalArgs: "-p:TargetPlatformIdentifier=maccatalyst -p:MSBuildEnableWorkloadResolver=false");
 
 			var testDll = IOPath.Combine(intermediateDirectory, "test.dll");
 			AssertExists(testDll, nonEmpty: true);
@@ -818,7 +818,7 @@ public static class AppleXMarker
 			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
 			project.Save(projectFile);
 
-			Build(projectFile, additionalArgs: $"-p:TargetPlatformIdentifier={targetPlatformIdentifier}");
+			Build(projectFile, additionalArgs: $"-p:TargetPlatformIdentifier={targetPlatformIdentifier} -p:MSBuildEnableWorkloadResolver=false");
 
 			var testDll = IOPath.Combine(intermediateDirectory, "test.dll");
 			AssertExists(testDll, nonEmpty: true);
@@ -932,7 +932,7 @@ public static class LegacyIosMarker
 			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
 			project.Save(projectFile);
 
-			Build(projectFile, additionalArgs: $"-p:TargetPlatformIdentifier={targetPlatformIdentifier}");
+			Build(projectFile, additionalArgs: $"-p:TargetPlatformIdentifier={targetPlatformIdentifier} -p:MSBuildEnableWorkloadResolver=false");
 
 			var testDll = IOPath.Combine(intermediateDirectory, "test.dll");
 			AssertExists(testDll, nonEmpty: true);

--- a/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
@@ -295,6 +295,24 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 		{
 			var targetsPath = AssemblyInfoTests.GetFilePathFromRoot(IOPath.Combine("src", "Controls", "src", "Build.Tasks", "nuget", "buildTransitive", "netstandard2.0", "Microsoft.Maui.Controls.SingleProject.targets"));
 			project.Add(NewElement("Import").WithAttribute("Project", targetsPath));
+
+			// Assign the synthetic TargetPlatformIdentifier from a private test-only property
+			// inside a target rather than as a global 'dotnet build' property. Passing a platform
+			// TPI globally makes the SDK attempt workload resolution during evaluation for what is a
+			// plain net10.0 (non-platform) project, which fails on CI agents without that workload
+			// (NETSDK1208 / NETSDK1178) before the SingleProject targets under test ever run. Setting
+			// it here — after SDK evaluation but before the SingleProject compile-filtering targets —
+			// keeps the tests workload-neutral while still exercising the TPI-dependent logic (the
+			// allow-list built by _MauiCollectPlatformSpecificCompileItems determines which files are
+			// compiled, so it does not rely on the evaluation-time per-TPI Compile metadata flip).
+			var applyTpiTarget = NewElement("Target")
+				.WithAttribute("Name", "_ApplyTestTargetPlatformIdentifier")
+				.WithAttribute("BeforeTargets", "_MauiNormalizePlatformSpecificFolders;_MauiCollectPlatformSpecificCompileItems;_MauiRemovePlatformCompileItems")
+				.WithAttribute("Condition", " '$(_SingleProjectTestTargetPlatformIdentifier)' != '' ");
+			var tpiPropertyGroup = NewElement("PropertyGroup");
+			tpiPropertyGroup.Add(NewElement("TargetPlatformIdentifier").WithValue("$(_SingleProjectTestTargetPlatformIdentifier)"));
+			applyTpiTarget.Add(tpiPropertyGroup);
+			project.Add(applyTpiTarget);
 		}
 
 		void AddMauiReferences(XElement project)
@@ -691,7 +709,7 @@ public static class AppleSharedMarker
 			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
 			project.Save(projectFile);
 
-			Build(projectFile, additionalArgs: $"-p:TargetPlatformIdentifier={targetPlatformIdentifier} -p:MSBuildEnableWorkloadResolver=false");
+			Build(projectFile, additionalArgs: $"-p:_SingleProjectTestTargetPlatformIdentifier={targetPlatformIdentifier}");
 
 			var testDll = IOPath.Combine(intermediateDirectory, "test.dll");
 			AssertExists(testDll, nonEmpty: true);
@@ -754,7 +772,7 @@ public static class ExtendedIosMarker
 			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
 			project.Save(projectFile);
 
-			Build(projectFile, additionalArgs: "-p:TargetPlatformIdentifier=maccatalyst -p:MSBuildEnableWorkloadResolver=false");
+			Build(projectFile, additionalArgs: "-p:_SingleProjectTestTargetPlatformIdentifier=maccatalyst");
 
 			var testDll = IOPath.Combine(intermediateDirectory, "test.dll");
 			AssertExists(testDll, nonEmpty: true);
@@ -818,7 +836,7 @@ public static class AppleXMarker
 			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
 			project.Save(projectFile);
 
-			Build(projectFile, additionalArgs: $"-p:TargetPlatformIdentifier={targetPlatformIdentifier} -p:MSBuildEnableWorkloadResolver=false");
+			Build(projectFile, additionalArgs: $"-p:_SingleProjectTestTargetPlatformIdentifier={targetPlatformIdentifier}");
 
 			var testDll = IOPath.Combine(intermediateDirectory, "test.dll");
 			AssertExists(testDll, nonEmpty: true);
@@ -932,7 +950,7 @@ public static class LegacyIosMarker
 			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
 			project.Save(projectFile);
 
-			Build(projectFile, additionalArgs: $"-p:TargetPlatformIdentifier={targetPlatformIdentifier} -p:MSBuildEnableWorkloadResolver=false");
+			Build(projectFile, additionalArgs: $"-p:_SingleProjectTestTargetPlatformIdentifier={targetPlatformIdentifier}");
 
 			var testDll = IOPath.Combine(intermediateDirectory, "test.dll");
 			AssertExists(testDll, nonEmpty: true);

--- a/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
@@ -618,6 +618,13 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 		[InlineData("ios", "ios; maccatalyst", true)]
 		[InlineData("maccatalyst", "ios; maccatalyst", true)]
 		[InlineData("android", "ios; maccatalyst", false)]
+		// Tab and mixed whitespace in the list — see Regex.Replace(\s+, '') in
+		// _MauiCollectPlatformSpecificCompileItems. ASCII-space-only stripping
+		// (.Replace(' ', '')) would silently miss these and break shared folders.
+		[InlineData("ios", "ios;\tmaccatalyst", true)]
+		[InlineData("maccatalyst", "ios;\tmaccatalyst", true)]
+		[InlineData("ios", "ios; \t maccatalyst", true)]
+		[InlineData("maccatalyst", "ios; \t maccatalyst", true)]
 		public void SingleProject_SharedPlatformFolderMappingsAreRespected(string targetPlatformIdentifier, string targetPlatformIdentifiers, bool shouldIncludeAppleSharedFile)
 		{
 			SetUp();
@@ -707,12 +714,24 @@ public static class AppleSharedMarker
 			AddMauiReferences(project);
 			AddSingleProjectBeforeTargetsImport(project);
 
-			var customMappings = NewElement("ItemGroup");
+			// Real users author this as a Target rather than an inline ItemGroup.
+			// In a normal SDK-style csproj, the user's project body is evaluated
+			// before NuGet imports the SingleProject SDK targets, so an inline
+			// <MauiPlatformSpecificFolder Update="$(iOSProjectFolder)" .../> would
+			// silently no-op: $(iOSProjectFolder) is empty at evaluation time and
+			// the built-in items don't exist yet. Hooking _MauiNormalizePlatformSpecificFolders
+			// guarantees the Update runs after the SDK has populated both the
+			// built-in items and $(iOSProjectFolder).
+			var extendTarget = NewElement("Target")
+				.WithAttribute("Name", "MauiExtendIosToMacCatalyst")
+				.WithAttribute("BeforeTargets", "_MauiNormalizePlatformSpecificFolders");
+			var extendItemGroup = NewElement("ItemGroup");
 			var update = NewElement("MauiPlatformSpecificFolder")
 				.WithAttribute("Update", "$(iOSProjectFolder)");
 			update.Add(NewElement("TargetPlatformIdentifiers").WithValue("ios;maccatalyst"));
-			customMappings.Add(update);
-			project.Add(customMappings);
+			extendItemGroup.Add(update);
+			extendTarget.Add(extendItemGroup);
+			project.Add(extendTarget);
 
 			WriteFile("Entry.cs", @"
 namespace Microsoft.Maui.Controls.Xaml.UnitTests;
@@ -740,6 +759,133 @@ public static class ExtendedIosMarker
 			var testDll = IOPath.Combine(intermediateDirectory, "test.dll");
 			AssertExists(testDll, nonEmpty: true);
 			AssertTypeExists(testDll, "Microsoft.Maui.Controls.Xaml.UnitTests.ExtendedIosMarker");
+		}
+
+		// Regression test: a user-supplied folder declared without a trailing slash
+		// must NOT match sibling folders sharing a common prefix. Without
+		// EnsureTrailingSlash() in _MauiCollectPlatformSpecificCompileItems, the
+		// glob "Platforms\Apple**/*.cs" would silently include AppleX/AppleLegacy.
+		[Theory]
+		[InlineData("Platforms\\Apple")]
+		[InlineData("Platforms\\Apple\\")]
+		public void SingleProject_PlatformFolderWithoutTrailingSlashDoesNotMatchSiblingFolders(string includePath)
+		{
+			SetUp();
+			var project = NewElement("Project").WithAttribute("Sdk", "Microsoft.NET.Sdk");
+			var propertyGroup = NewElement("PropertyGroup");
+			propertyGroup.Add(NewElement("TargetFramework").WithValue(GetTfm()));
+			propertyGroup.Add(NewElement("SingleProject").WithValue("true"));
+			project.Add(propertyGroup);
+			AddMauiReferences(project);
+			AddSingleProjectBeforeTargetsImport(project);
+
+			var customMappings = NewElement("ItemGroup");
+			customMappings.Add(NewElement("MauiPlatformSpecificFolder")
+				.WithAttribute("Include", includePath)
+				.WithAttribute("TargetPlatformIdentifiers", "ios;maccatalyst"));
+			project.Add(customMappings);
+
+			WriteFile("Entry.cs", @"
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public static class Entry
+{
+	public static string Value => ""ok"";
+}");
+
+			WriteFile("Platforms\\Apple\\AppleSharedMarker.cs", @"
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public static class AppleSharedMarker
+{
+	public static string Value => ""Apple"";
+}");
+
+			// Sibling folder with a common prefix — must NOT be picked up by the
+			// "Apple" mapping regardless of trailing-slash authoring.
+			WriteFile("Platforms\\AppleX\\AppleXMarker.cs", @"
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public static class AppleXMarker
+{
+	public static string Value => ""AppleX"";
+}");
+
+			AddSingleProjectTargetsImport(project);
+
+			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
+			project.Save(projectFile);
+
+			Build(projectFile, additionalArgs: "-p:TargetPlatformIdentifier=ios");
+
+			var testDll = IOPath.Combine(intermediateDirectory, "test.dll");
+			AssertExists(testDll, nonEmpty: true);
+			AssertTypeExists(testDll, "Microsoft.Maui.Controls.Xaml.UnitTests.AppleSharedMarker");
+			AssertTypeDoesNotExist(testDll, "Microsoft.Maui.Controls.Xaml.UnitTests.AppleXMarker");
+		}
+
+		// Non-platform builds (TargetPlatformIdentifier empty, e.g. design-time
+		// or netstandard TFM) must keep removing platform folders that declare a
+		// non-empty TargetPlatformIdentifiers. Condition-gated folders with empty
+		// TargetPlatformIdentifiers must still participate when their condition
+		// evaluates to true — locks in the "empty TPI = always include" branch.
+		[Fact]
+		public void SingleProject_NonPlatformBuildExcludesPlatformSpecificFoldersButKeepsConditionGated()
+		{
+			SetUp();
+			var project = NewElement("Project").WithAttribute("Sdk", "Microsoft.NET.Sdk");
+			var propertyGroup = NewElement("PropertyGroup");
+			propertyGroup.Add(NewElement("TargetFramework").WithValue(GetTfm()));
+			propertyGroup.Add(NewElement("SingleProject").WithValue("true"));
+			project.Add(propertyGroup);
+			AddMauiReferences(project);
+			AddSingleProjectBeforeTargetsImport(project);
+
+			var customMappings = NewElement("ItemGroup");
+			customMappings.Add(NewElement("MauiPlatformSpecificFolder")
+				.WithAttribute("Include", "Platforms\\Apple\\")
+				.WithAttribute("TargetPlatformIdentifiers", "ios;maccatalyst"));
+			customMappings.Add(NewElement("MauiPlatformSpecificFolder")
+				.WithAttribute("Include", "Platforms\\Shared\\"));
+			project.Add(customMappings);
+
+			WriteFile("Entry.cs", @"
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public static class Entry
+{
+	public static string Value => ""ok"";
+}");
+
+			WriteFile("Platforms\\Apple\\AppleSharedMarker.cs", @"
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public static class AppleSharedMarker
+{
+	public static string Value => ""Apple"";
+}");
+
+			WriteFile("Platforms\\Shared\\SharedMarker.cs", @"
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public static class SharedMarker
+{
+	public static string Value => ""Shared"";
+}");
+
+			AddSingleProjectTargetsImport(project);
+
+			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
+			project.Save(projectFile);
+
+			// No -p:TargetPlatformIdentifier — simulates the non-platform TFM /
+			// design-time evaluation scenario.
+			Build(projectFile);
+
+			var testDll = IOPath.Combine(intermediateDirectory, "test.dll");
+			AssertExists(testDll, nonEmpty: true);
+			AssertTypeDoesNotExist(testDll, "Microsoft.Maui.Controls.Xaml.UnitTests.AppleSharedMarker");
+			AssertTypeExists(testDll, "Microsoft.Maui.Controls.Xaml.UnitTests.SharedMarker");
 		}
 
 		[Theory]

--- a/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
@@ -766,9 +766,11 @@ public static class ExtendedIosMarker
 		// EnsureTrailingSlash() in _MauiCollectPlatformSpecificCompileItems, the
 		// glob "Platforms\Apple**/*.cs" would silently include AppleX/AppleLegacy.
 		[Theory]
-		[InlineData("Platforms\\Apple")]
-		[InlineData("Platforms\\Apple\\")]
-		public void SingleProject_PlatformFolderWithoutTrailingSlashDoesNotMatchSiblingFolders(string includePath)
+		[InlineData("Platforms\\Apple", "ios")]
+		[InlineData("Platforms\\Apple\\", "ios")]
+		[InlineData("Platforms\\Apple", "maccatalyst")]
+		[InlineData("Platforms\\Apple\\", "maccatalyst")]
+		public void SingleProject_PlatformFolderWithoutTrailingSlashDoesNotMatchSiblingFolders(string includePath, string targetPlatformIdentifier)
 		{
 			SetUp();
 			var project = NewElement("Project").WithAttribute("Sdk", "Microsoft.NET.Sdk");
@@ -816,7 +818,7 @@ public static class AppleXMarker
 			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
 			project.Save(projectFile);
 
-			Build(projectFile, additionalArgs: "-p:TargetPlatformIdentifier=ios");
+			Build(projectFile, additionalArgs: $"-p:TargetPlatformIdentifier={targetPlatformIdentifier}");
 
 			var testDll = IOPath.Combine(intermediateDirectory, "test.dll");
 			AssertExists(testDll, nonEmpty: true);


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description of Change

This updates SingleProject compile filtering so `MauiPlatformSpecificFolder` can participate in the existing `Platforms/*` pipeline for shared and custom folder mappings.

Highlights:
- add plural `TargetPlatformIdentifiers` metadata while keeping the singular metadata path backward compatible
- preserve the existing `ExcludeFromCurrentConfiguration` / `_MauiRemovePlatformCompileItems` flow and its design-time behavior
- support shared folders such as `Platforms/Apple/` for `ios;maccatalyst`
- support extending built-in folder mappings and condition-gated non-TPI folders
- add focused MSBuild unit coverage for the new behavior and compatibility path

## Issues Fixed

Fixes #35042