### PR TITLE
Add Gradle cache to official pack pipeline

### DIFF
--- a/eng/pipelines/common/cache-gradle.yml
+++ b/eng/pipelines/common/cache-gradle.yml
@@ -38,5 +38,4 @@ steps:
     restoreKeys: |
       "gradle" | "v1" | "$(Agent.OS)" | ${{ parameters.checkoutDirectory }}/src/Core/AndroidNative/gradle/wrapper/gradle-wrapper.properties
       "gradle" | "v1" | "$(Agent.OS)"
-      "gradle" | "v1"
     path: $(GRADLE_USER_HOME)

--- a/eng/pipelines/common/cache-gradle.yml
+++ b/eng/pipelines/common/cache-gradle.yml
@@ -38,4 +38,5 @@ steps:
     restoreKeys: |
       "gradle" | "v1" | "$(Agent.OS)" | ${{ parameters.checkoutDirectory }}/src/Core/AndroidNative/gradle/wrapper/gradle-wrapper.properties
       "gradle" | "v1" | "$(Agent.OS)"
+      "gradle" | "v1"
     path: $(GRADLE_USER_HOME)

--- a/eng/pipelines/common/pack.yml
+++ b/eng/pipelines/common/pack.yml
@@ -85,6 +85,11 @@ steps:
     - ${{ each pair in step }}:
         ${{ pair.key }}: ${{ pair.value }}
 
+  # Cache Gradle downloads to avoid transient network failures during Android binding builds
+  - template: /eng/pipelines/common/cache-gradle.yml@self
+    parameters:
+      checkoutDirectory: ${{ parameters.checkoutDirectory }}
+
   - pwsh: ./build.ps1 --target=dotnet --configuration="${{ parameters.buildConfiguration }}" --verbosity=diagnostic --nugetsource="${{ parameters.nugetFolder }}"
     displayName: 'Install .NET'
     retryCountOnTaskFailure: 3


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Problem

The official build (`dotnet-maui`, definition 1095) for `release/10.0.1xx-sr6` has been failing with Gradle network errors on Windows:

```
Permission denied: getsockopt
Could not GET https://repo.maven.apache.org/maven2/...
gradlew.bat exited with code 1
```

Build [2954057](https://dev.azure.com/dnceng/internal/_build/results?buildId=2954057) failed even though it included the Gradle cache fix from PR #35016. The cache step was added to `provision.yml`, but the official Pack job uses `pack.yml` directly — which never calls `provision.yml`.

## Fix

Add the same `cache-gradle.yml` template call to `eng/pipelines/common/pack.yml` before the pack step, matching the pattern already used in `provision.yml`.

## Impact

This unblocks the 10.0.60 official build by ensuring the Gradle dependency cache is warm before the Pack step invokes Gradle on Windows agents with network isolation.