### PR TITLE
[Android] BlazorWebView: Simplify Blazor startup scripts

### DIFF
--- a/src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs
+++ b/src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs
@@ -20,6 +20,56 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 
 		private static readonly Uri AppOriginUri = new(AppOrigin);
 
+		// Single startup script that:
+		//  - Is idempotent (guarded by window.__BlazorStarting) so duplicate OnPageFinished calls are safe.
+		//  - Sets up window.external.sendMessage/receiveMessage for the Blazor interop bridge.
+		//  - Listens for the native 'capturePort' message that delivers the native WebMessagePort.
+		//  - Calls Blazor.start() only after the native port is captured, ensuring window.external.sendMessage
+		//    has a live port before Blazor sends any messages.
+		//  - Sets window.__BlazorStarted after the Blazor.start() Promise resolves (used by test helpers as a readiness signal).
+		//  - Dispatches native→JS messages (arriving via PostWebMessage) directly to window.external.__callback.
+		//  - Validates message origin: only processes messages from the native PostWebMessage API
+		//    (event.source === null), skipping messages from subframes or other JS contexts.
+		private const string BlazorInitScript = """
+			(function () {
+				if (window.__BlazorStarting) { return 'false'; }
+				window.__BlazorStarting = true;
+
+				window.external = window.external || {};
+				window.external.sendMessage = function (message) {
+					if (window.__nativePort) {
+						window.__nativePort.postMessage(message);
+					}
+				};
+				window.external.receiveMessage = function (callback) {
+					window.external.__callback = callback;
+				};
+
+				window.addEventListener('message', function (event) {
+					// Only process messages from the native PostWebMessage API.
+					// Native messages have event.source === null; messages from subframes
+					// or other JS contexts have event.source set to the sending window.
+					if (event.source !== null) { return; }
+
+					if (event.data === 'capturePort') {
+						if (event.ports && event.ports[0] && !window.__nativePort) {
+							window.__nativePort = event.ports[0];
+							Promise.resolve(Blazor.start()).then(function () {
+								window.__BlazorStarted = true;
+							}, function (err) {
+								console.error('Blazor.start() failed:', err);
+								window.__BlazorStarting = false;
+							});
+						}
+					} else if (window.external.__callback) {
+						window.external.__callback(event.data);
+					}
+				}, false);
+
+				return 'true';
+			})();
+			""";
+
 		private readonly BlazorWebViewHandler? _webViewHandler;
 
 		public WebKitWebViewClient(BlazorWebViewHandler webViewHandler)
@@ -155,69 +205,16 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		{
 			_webViewHandler?.Logger.RunningBlazorStartupScripts();
 
-			// Confirm Blazor hasn't already initialized
-			view.EvaluateJavascript(@"
-				(function() { return typeof(window.__BlazorStarted); })();
-			", new JavaScriptValueCallback(blazorStarted =>
+			view.EvaluateJavascript(BlazorInitScript, new JavaScriptValueCallback(result =>
 			{
-				if (blazorStarted?.ToString() != "\"undefined\"")
+				// The init script returns 'true' if it performed first-time setup, or
+				// 'false' if it was a no-op (duplicate OnPageFinished). Only create the
+				// native MessageChannel when setup actually ran.
+				if (result?.ToString() == "\"true\"")
 				{
-					// Blazor has already started, we can just abort startup process
-					return;
+					_webViewHandler?.WebviewManager?.SetUpMessageChannel();
+					_webViewHandler?.Logger.BlazorStartupScriptsFinished();
 				}
-
-				// Set up JS ports
-				view.EvaluateJavascript(@"
-
-		const channel = new MessageChannel();
-		var nativeJsPortOne = channel.port1;
-		var nativeJsPortTwo = channel.port2;
-		window.addEventListener('message', function (event) {
-			if (event.data != 'capturePort') {
-				nativeJsPortOne.postMessage(event.data)
-			}
-			else if (event.data == 'capturePort') {
-				if (event.ports[0] != null) {
-					nativeJsPortTwo = event.ports[0]
-				}
-			}
-		}, false);
-
-		nativeJsPortOne.addEventListener('message', function (event) {
-		}, false);
-
-		nativeJsPortTwo.addEventListener('message', function (event) {
-			// data from native code to JS
-			if (window.external.__callback) {
-				window.external.__callback(event.data);
-			}
-		}, false);
-		nativeJsPortOne.start();
-		nativeJsPortTwo.start();
-
-		window.external.sendMessage = function (message) {
-			// data from JS to native code
-			nativeJsPortTwo.postMessage(message);
-		};
-
-		window.external.receiveMessage = function (callback) {
-			window.external.__callback = callback;
-		}
-				", new JavaScriptValueCallback(_ =>
-					{
-						// Set up Server ports
-						_webViewHandler?.WebviewManager?.SetUpMessageChannel();
-
-						// Start Blazor
-						view.EvaluateJavascript(@"
-							Blazor.start();
-							window.__BlazorStarted = true;
-						", new JavaScriptValueCallback(_ =>
-						{
-							// Done; no more action required
-							_webViewHandler?.Logger.BlazorStartupScriptsFinished();
-						}));
-					}));
 			}));
 		}
 

--- a/src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs
+++ b/src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs
@@ -28,7 +28,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		//    has a live port before Blazor sends any messages.
 		//  - Sets window.__BlazorStarted after the Blazor.start() Promise resolves (used by test helpers as a readiness signal).
 		//  - Dispatches native→JS messages (arriving via PostWebMessage) directly to window.external.__callback.
-		//  - Validates message origin for dispatch messages, skipping messages from subframes or other JS contexts.
+		//  - Validates message origin: only processes messages from the native PostWebMessage API
+		//    (event.source === null), skipping messages from subframes or other JS contexts.
 		private const string BlazorInitScript = """
 			(function () {
 				if (window.__BlazorStarting) { return 'false'; }
@@ -49,6 +50,11 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				}
 
 				window.__BlazorMessageHandler = function (event) {
+					// Only process messages from the native PostWebMessage API.
+					// Native messages have event.source === null; messages from subframes
+					// or other JS contexts have event.source set to the sending window.
+					if (event.source !== null) { return; }
+
 					if (event.data === 'capturePort') {
 						if (event.ports && event.ports[0] && !window.__nativePort) {
 							window.__nativePort = event.ports[0];
@@ -65,11 +71,6 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 						}
 						return;
 					}
-
-					// Only dispatch messages from the native PostWebMessage API.
-					// Native messages have event.source === null; messages from subframes
-					// or other JS contexts have event.source set to the sending window.
-					if (event.source !== null) { return; }
 
 					if (window.external.__callback) {
 						window.external.__callback(event.data);

--- a/src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs
+++ b/src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs
@@ -28,8 +28,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		//    has a live port before Blazor sends any messages.
 		//  - Sets window.__BlazorStarted after the Blazor.start() Promise resolves (used by test helpers as a readiness signal).
 		//  - Dispatches native→JS messages (arriving via PostWebMessage) directly to window.external.__callback.
-		//  - Validates message origin: only processes messages from the native PostWebMessage API
-		//    (event.source === null), skipping messages from subframes or other JS contexts.
+		//  - Validates message origin for dispatch messages, skipping messages from subframes or other JS contexts.
 		private const string BlazorInitScript = """
 			(function () {
 				if (window.__BlazorStarting) { return 'false'; }
@@ -45,26 +44,39 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 					window.external.__callback = callback;
 				};
 
-				window.addEventListener('message', function (event) {
-					// Only process messages from the native PostWebMessage API.
+				if (window.__BlazorMessageHandler) {
+					window.removeEventListener('message', window.__BlazorMessageHandler, false);
+				}
+
+				window.__BlazorMessageHandler = function (event) {
+					if (event.data === 'capturePort') {
+						if (event.ports && event.ports[0] && !window.__nativePort) {
+							window.__nativePort = event.ports[0];
+							Promise.resolve().then(function () {
+								return Blazor.start();
+							}).then(function () {
+								window.__BlazorStarted = true;
+							}, function (err) {
+								console.error('Blazor.start() failed:', err);
+								window.__nativePort = null;
+								window.__BlazorStarted = false;
+								window.__BlazorStarting = false;
+							});
+						}
+						return;
+					}
+
+					// Only dispatch messages from the native PostWebMessage API.
 					// Native messages have event.source === null; messages from subframes
 					// or other JS contexts have event.source set to the sending window.
 					if (event.source !== null) { return; }
 
-					if (event.data === 'capturePort') {
-						if (event.ports && event.ports[0] && !window.__nativePort) {
-							window.__nativePort = event.ports[0];
-							Promise.resolve(Blazor.start()).then(function () {
-								window.__BlazorStarted = true;
-							}, function (err) {
-								console.error('Blazor.start() failed:', err);
-								window.__BlazorStarting = false;
-							});
-						}
-					} else if (window.external.__callback) {
+					if (window.external.__callback) {
 						window.external.__callback(event.data);
 					}
-				}, false);
+				};
+
+				window.addEventListener('message', window.__BlazorMessageHandler, false);
 
 				return 'true';
 			})();
@@ -213,7 +225,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				if (result?.ToString() == "\"true\"")
 				{
 					_webViewHandler?.WebviewManager?.SetUpMessageChannel();
-					_webViewHandler?.Logger.BlazorStartupScriptsFinished();
+					_webViewHandler?.Logger.BlazorStartupScriptsSubmitted();
 				}
 			}));
 		}

--- a/src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs
+++ b/src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs
@@ -27,6 +27,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		//  - Calls Blazor.start() only after the native port is captured, ensuring window.external.sendMessage
 		//    has a live port before Blazor sends any messages.
 		//  - Sets window.__BlazorStarted after the Blazor.start() Promise resolves (used by test helpers as a readiness signal).
+		//  - Logs startup failures without discarding the captured native port because Blazor may already be attached.
 		//  - Dispatches native→JS messages (arriving via PostWebMessage) directly to window.external.__callback.
 		//  - Validates message origin: only processes messages from the native PostWebMessage API
 		//    (event.source === null), skipping messages from subframes or other JS contexts.
@@ -64,9 +65,6 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 								window.__BlazorStarted = true;
 							}, function (err) {
 								console.error('Blazor.start() failed:', err);
-								window.__nativePort = null;
-								window.__BlazorStarted = false;
-								window.__BlazorStarting = false;
 							});
 						}
 						return;

--- a/src/BlazorWebView/src/SharedSource/Log.cs
+++ b/src/BlazorWebView/src/SharedSource/Log.cs
@@ -56,6 +56,9 @@ internal static partial class Log
 	[LoggerMessage(EventId = 16, Level = LogLevel.Debug, Message = "Blazor startup scripts finished.")]
 	public static partial void BlazorStartupScriptsFinished(this ILogger logger);
 
+	[LoggerMessage(EventId = 40, Level = LogLevel.Debug, Message = "Blazor startup scripts submitted.")]
+	public static partial void BlazorStartupScriptsSubmitted(this ILogger logger);
+
 	[LoggerMessage(EventId = 17, Level = LogLevel.Debug, Message = "Creating WebKit WKWebView...")]
 	public static partial void CreatingWebKitWKWebView(this ILogger logger);
 

--- a/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.Startup.cs
+++ b/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.Startup.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components.WebView.Maui;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.MauiBlazorWebView.DeviceTests.Components;
+using Xunit;
+#if ANDROID
+using PlatformWebView = Android.Webkit.WebView;
+#elif IOS || MACCATALYST
+using PlatformWebView = WebKit.WKWebView;
+#elif WINDOWS
+using PlatformWebView = Microsoft.UI.Xaml.Controls.WebView2;
+#else
+using PlatformWebView = System.Object;
+#endif
+
+namespace Microsoft.Maui.MauiBlazorWebView.DeviceTests.Elements;
+
+public partial class BlazorWebViewTests
+{
+	async Task RunBlazorStartupTest(Func<PlatformWebView, Task> test)
+	{
+		EnsureHandlerCreated(additionalCreationActions: appBuilder =>
+		{
+			appBuilder.Services.AddMauiBlazorWebView();
+		});
+
+		var bwv = new BlazorWebViewWithCustomFiles
+		{
+			HostPage = "wwwroot/index.html",
+			CustomFiles = new Dictionary<string, string>
+			{
+				{ "index.html", TestStaticFilesContents.DefaultMauiIndexHtmlContent },
+			},
+		};
+		bwv.RootComponents.Add(new RootComponent { ComponentType = typeof(NoOpComponent), Selector = "#app", });
+
+		await InvokeOnMainThreadAsync(async () =>
+		{
+			var bwvHandler = CreateHandler<BlazorWebViewHandler>(bwv);
+			var platformWebView = bwvHandler.PlatformView;
+			await WebViewHelpers.WaitForWebViewReady(platformWebView);
+			await WebViewHelpers.WaitForControlDiv(platformWebView, controlValueToWaitFor: "Static");
+
+			await test(platformWebView);
+		});
+	}
+
+	[Fact]
+	public Task BlazorStartupSetsUpWindowExternal() => RunBlazorStartupTest(async platformWebView =>
+	{
+		// window.external should have sendMessage and receiveMessage functions on all platforms.
+		// Use .toString() to normalize boolean results across platforms (iOS returns "1" for true).
+		var hasSendMessage = await WebViewHelpers.ExecuteScriptAsync(platformWebView, "(typeof window.external.sendMessage === 'function').toString()");
+		var hasReceiveMessage = await WebViewHelpers.ExecuteScriptAsync(platformWebView, "(typeof window.external.receiveMessage === 'function').toString()");
+
+		Assert.True(hasSendMessage == "true" || hasSendMessage == "\"true\"", $"Expected sendMessage to be a function, got: {hasSendMessage}");
+		Assert.True(hasReceiveMessage == "true" || hasReceiveMessage == "\"true\"", $"Expected receiveMessage to be a function, got: {hasReceiveMessage}");
+	});
+
+#if ANDROID
+	[Fact]
+	public Task BlazorStartupSetsStartingAndStartedFlags() => RunBlazorStartupTest(async platformWebView =>
+	{
+		// After Blazor is fully started, both flags should be true
+		var startingValue = await WebViewHelpers.ExecuteScriptAsync(platformWebView, "window.__BlazorStarting === true");
+		var startedValue = await WebViewHelpers.ExecuteScriptAsync(platformWebView, "window.__BlazorStarted === true");
+
+		Assert.Equal("true", startingValue);
+		Assert.Equal("true", startedValue);
+	});
+
+	[Fact]
+	public Task BlazorStartupCapturesNativePort() => RunBlazorStartupTest(async platformWebView =>
+	{
+		// The native port should have been captured during startup
+		var hasNativePort = await WebViewHelpers.ExecuteScriptAsync(platformWebView, "window.__nativePort !== null && window.__nativePort !== undefined");
+
+		Assert.Equal("true", hasNativePort);
+	});
+
+	[Fact]
+	public Task BlazorStartupScriptIsIdempotent() => RunBlazorStartupTest(async platformWebView =>
+	{
+		// Store the original native port reference
+		await WebViewHelpers.ExecuteScriptAsync(platformWebView, "window.__originalNativePort = window.__nativePort");
+
+		// The __BlazorStarting guard should prevent re-initialization on duplicate OnPageFinished
+		var rerunResult = await WebViewHelpers.ExecuteScriptAsync(platformWebView,
+			"(function() { if (window.__BlazorStarting) { return 'blocked'; } return 'ran'; })()");
+
+		Assert.Equal("\"blocked\"", rerunResult);
+
+		// Verify the native port is still the same reference
+		var portUnchanged = await WebViewHelpers.ExecuteScriptAsync(platformWebView, "window.__nativePort === window.__originalNativePort");
+		Assert.Equal("true", portUnchanged);
+	});
+
+	[Fact]
+	public Task BlazorMessageDispatchOnlyProcessesNativeSourceMessages() => RunBlazorStartupTest(async platformWebView =>
+	{
+		// Verify the message listener is working by checking that the native bridge
+		// dispatched messages during startup (Blazor is running, which means
+		// null-source native messages were processed correctly).
+		var blazorRunning = await WebViewHelpers.ExecuteScriptAsync(platformWebView, "window.Blazor != null");
+		Assert.Equal("true", blazorRunning);
+
+		// Set up: a callback counter for native dispatch, and a separate test-only
+		// listener that gives us a positive signal when the message event fires.
+		await WebViewHelpers.ExecuteScriptAsync(platformWebView, @"
+			window.__nativeCallbackCount = 0;
+			window.__testMessageSeen = false;
+			window.external.receiveMessage(function(msg) { window.__nativeCallbackCount++; });
+			window.addEventListener('message', function(event) {
+				if (event.data === 'test-from-js') { window.__testMessageSeen = true; }
+			}, false);
+		");
+
+		// Send a message from JS using window.postMessage — these have event.source
+		// set to the current window (non-null), so they go through a different path
+		// than native PostWebMessage messages (which have null source).
+		await WebViewHelpers.ExecuteScriptAsync(platformWebView, "window.postMessage('test-from-js', '*')");
+
+		// Wait for positive confirmation that the message event was processed.
+		// Our test listener sets __testMessageSeen when it sees the message,
+		// which proves the event loop has processed it and the production
+		// listener also had its chance to run.
+		await WebViewHelpers.WaitForCondition(platformWebView, "window.__testMessageSeen === true");
+
+		// Now we can safely check: the callback count should still be zero because
+		// only native-sourced messages (null source) are dispatched to the callback.
+		var count = await WebViewHelpers.ExecuteScriptAsync(platformWebView, "window.__nativeCallbackCount");
+		Assert.Equal("0", count);
+	});
+#endif
+}

--- a/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.Startup.cs
+++ b/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.Startup.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.WebView.Maui;
 using Microsoft.Extensions.DependencyInjection;
@@ -20,6 +21,11 @@ namespace Microsoft.Maui.MauiBlazorWebView.DeviceTests.Elements;
 public partial class BlazorWebViewTests
 {
 	async Task RunBlazorStartupTest(Func<PlatformWebView, Task> test)
+	{
+		await RunBlazorStartupTest((_, platformWebView) => test(platformWebView));
+	}
+
+	async Task RunBlazorStartupTest(Func<BlazorWebViewHandler, PlatformWebView, Task> test)
 	{
 		EnsureHandlerCreated(additionalCreationActions: appBuilder =>
 		{
@@ -43,7 +49,7 @@ public partial class BlazorWebViewTests
 			await WebViewHelpers.WaitForWebViewReady(platformWebView);
 			await WebViewHelpers.WaitForControlDiv(platformWebView, controlValueToWaitFor: "Static");
 
-			await test(platformWebView);
+			await test(bwvHandler, platformWebView);
 		});
 	}
 
@@ -81,16 +87,19 @@ public partial class BlazorWebViewTests
 	});
 
 	[Fact]
-	public Task BlazorStartupScriptIsIdempotent() => RunBlazorStartupTest(async platformWebView =>
+	public Task BlazorStartupScriptIsIdempotent() => RunBlazorStartupTest(async (bwvHandler, platformWebView) =>
 	{
 		// Store the original native port reference
 		await WebViewHelpers.ExecuteScriptAsync(platformWebView, "window.__originalNativePort = window.__nativePort");
 
-		// The __BlazorStarting guard should prevent re-initialization on duplicate OnPageFinished
-		var rerunResult = await WebViewHelpers.ExecuteScriptAsync(platformWebView,
-			"(function() { if (window.__BlazorStarting) { return 'blocked'; } return 'ran'; })()");
+		var webViewClient = typeof(BlazorWebViewHandler)
+			.GetField("_webViewClient", BindingFlags.Instance | BindingFlags.NonPublic)!
+			.GetValue(bwvHandler) as global::Android.Webkit.WebViewClient;
 
-		Assert.Equal("\"blocked\"", rerunResult);
+		Assert.NotNull(webViewClient);
+
+		// Simulate a duplicate OnPageFinished callback so the production startup path runs again.
+		webViewClient.OnPageFinished(platformWebView, platformWebView.Url);
 
 		// Verify the native port is still the same reference
 		var portUnchanged = await WebViewHelpers.ExecuteScriptAsync(platformWebView, "window.__nativePort === window.__originalNativePort");

--- a/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.Startup.cs
+++ b/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.Startup.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.WebView.Maui;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Maui.MauiBlazorWebView.DeviceTests.Components;
 using Xunit;
 #if ANDROID
@@ -20,16 +22,39 @@ namespace Microsoft.Maui.MauiBlazorWebView.DeviceTests.Elements;
 
 public partial class BlazorWebViewTests
 {
-	async Task RunBlazorStartupTest(Func<PlatformWebView, Task> test)
+	Task RunBlazorStartupTest(
+		Func<PlatformWebView, Task> test,
+		TestLoggerProvider? testLoggerProvider = null,
+		Type? componentType = null,
+		string? indexHtml = null,
+		Func<PlatformWebView, Task>? waitForReady = null)
 	{
-		await RunBlazorStartupTest((_, platformWebView) => test(platformWebView));
+		return RunBlazorStartupTest(
+			(_, platformWebView) => test(platformWebView),
+			testLoggerProvider,
+			componentType,
+			indexHtml,
+			waitForReady);
 	}
 
-	async Task RunBlazorStartupTest(Func<BlazorWebViewHandler, PlatformWebView, Task> test)
+	async Task RunBlazorStartupTest(
+		Func<BlazorWebViewHandler, PlatformWebView, Task> test,
+		TestLoggerProvider? testLoggerProvider = null,
+		Type? componentType = null,
+		string? indexHtml = null,
+		Func<PlatformWebView, Task>? waitForReady = null)
 	{
 		EnsureHandlerCreated(additionalCreationActions: appBuilder =>
 		{
 			appBuilder.Services.AddMauiBlazorWebView();
+			if (testLoggerProvider is not null)
+			{
+				appBuilder.Services.AddLogging(logging =>
+				{
+					logging.AddFilter("Microsoft.AspNetCore.Components.WebView", LogLevel.Trace);
+					logging.AddProvider(testLoggerProvider);
+				});
+			}
 		});
 
 		var bwv = new BlazorWebViewWithCustomFiles
@@ -37,17 +62,24 @@ public partial class BlazorWebViewTests
 			HostPage = "wwwroot/index.html",
 			CustomFiles = new Dictionary<string, string>
 			{
-				{ "index.html", TestStaticFilesContents.DefaultMauiIndexHtmlContent },
+				{ "index.html", indexHtml ?? TestStaticFilesContents.DefaultMauiIndexHtmlContent },
 			},
 		};
-		bwv.RootComponents.Add(new RootComponent { ComponentType = typeof(NoOpComponent), Selector = "#app", });
+		bwv.RootComponents.Add(new RootComponent { ComponentType = componentType ?? typeof(NoOpComponent), Selector = "#app", });
 
 		await InvokeOnMainThreadAsync(async () =>
 		{
 			var bwvHandler = CreateHandler<BlazorWebViewHandler>(bwv);
 			var platformWebView = bwvHandler.PlatformView;
-			await WebViewHelpers.WaitForWebViewReady(platformWebView);
-			await WebViewHelpers.WaitForControlDiv(platformWebView, controlValueToWaitFor: "Static");
+			if (waitForReady is null)
+			{
+				await WebViewHelpers.WaitForWebViewReady(platformWebView);
+				await WebViewHelpers.WaitForControlDiv(platformWebView, controlValueToWaitFor: "Static");
+			}
+			else
+			{
+				await waitForReady(platformWebView);
+			}
 
 			await test(bwvHandler, platformWebView);
 		});
@@ -87,24 +119,81 @@ public partial class BlazorWebViewTests
 	});
 
 	[Fact]
-	public Task BlazorStartupScriptIsIdempotent() => RunBlazorStartupTest(async (bwvHandler, platformWebView) =>
+	public Task BlazorStartupScriptIsIdempotent()
 	{
-		// Store the original native port reference
-		await WebViewHelpers.ExecuteScriptAsync(platformWebView, "window.__originalNativePort = window.__nativePort");
+		var testLoggerProvider = new TestLoggerProvider();
+		return RunBlazorStartupTest(async (bwvHandler, platformWebView) =>
+		{
+			var setupEventsBefore = testLoggerProvider.GetEvents().Count(
+				logEvent => logEvent.EventId.Id == 40 && logEvent.EventId.Name == "BlazorStartupScriptsSubmitted");
+			Assert.Equal(1, setupEventsBefore);
 
-		var webViewClient = typeof(BlazorWebViewHandler)
-			.GetField("_webViewClient", BindingFlags.Instance | BindingFlags.NonPublic)!
-			.GetValue(bwvHandler) as global::Android.Webkit.WebViewClient;
+			// Store the original native port reference
+			await WebViewHelpers.ExecuteScriptAsync(platformWebView, "window.__originalNativePort = window.__nativePort");
 
-		Assert.NotNull(webViewClient);
+			var webViewClientField = typeof(BlazorWebViewHandler)
+				.GetField("_webViewClient", BindingFlags.Instance | BindingFlags.NonPublic);
+			Assert.NotNull(webViewClientField);
 
-		// Simulate a duplicate OnPageFinished callback so the production startup path runs again.
-		webViewClient.OnPageFinished(platformWebView, platformWebView.Url);
+			var webViewClient = webViewClientField.GetValue(bwvHandler) as global::Android.Webkit.WebViewClient;
+			Assert.NotNull(webViewClient);
 
-		// Verify the native port is still the same reference
-		var portUnchanged = await WebViewHelpers.ExecuteScriptAsync(platformWebView, "window.__nativePort === window.__originalNativePort");
-		Assert.Equal("true", portUnchanged);
-	});
+			// Simulate a duplicate OnPageFinished callback so the production startup path runs again.
+			webViewClient.OnPageFinished(platformWebView, platformWebView.Url);
+			await WebViewHelpers.ExecuteScriptAsync(platformWebView, "true");
+
+			// Verify the native port is still the same reference and no second channel setup was submitted.
+			var portUnchanged = await WebViewHelpers.ExecuteScriptAsync(platformWebView, "window.__nativePort === window.__originalNativePort");
+			Assert.Equal("true", portUnchanged);
+
+			var setupEventsAfter = testLoggerProvider.GetEvents().Count(
+				logEvent => logEvent.EventId.Id == 40 && logEvent.EventId.Name == "BlazorStartupScriptsSubmitted");
+			Assert.Equal(setupEventsBefore, setupEventsAfter);
+		}, testLoggerProvider);
+	}
+
+	[Fact]
+	public Task BlazorStartupRejectionPreservesLiveBridge()
+	{
+		var rejectingIndexHtml = TestStaticFilesContents.DefaultMauiIndexHtmlContent.Replace(
+			"</body>",
+			"""
+			    <script>
+			        (function () {
+			            const originalStart = Blazor.start.bind(Blazor);
+			            Blazor.start = function (options) {
+			                return originalStart(options).then(function (value) {
+			                    window.__wrappedBlazorStartRejected = true;
+			                    throw new Error('Deliberate post-start rejection');
+			                });
+			            };
+			        })();
+			    </script>
+			</body>
+			""",
+			StringComparison.Ordinal);
+
+		return RunBlazorStartupTest(
+			async platformWebView =>
+			{
+				var nativePortPresent = await WebViewHelpers.ExecuteScriptAsync(
+					platformWebView,
+					"window.__nativePort !== null && window.__nativePort !== undefined");
+				Assert.Equal("true", nativePortPresent);
+
+				await WebViewHelpers.ExecuteScriptAsync(
+					platformWebView,
+					"document.getElementById('incrementButton').click()");
+				await WebViewHelpers.WaitForControlDiv(platformWebView, controlValueToWaitFor: "1");
+			},
+			componentType: typeof(TestComponent1),
+			indexHtml: rejectingIndexHtml,
+			waitForReady: async platformWebView =>
+			{
+				await WebViewHelpers.WaitForCondition(platformWebView, "window.__wrappedBlazorStartRejected === true");
+				await WebViewHelpers.WaitForControlDiv(platformWebView, controlValueToWaitFor: "0");
+			});
+	}
 
 	[Fact]
 	public Task BlazorMessageDispatchOnlyProcessesNativeSourceMessages() => RunBlazorStartupTest(async platformWebView =>

--- a/src/BlazorWebView/tests/DeviceTests/WebViewHelpers.Shared.cs
+++ b/src/BlazorWebView/tests/DeviceTests/WebViewHelpers.Shared.cs
@@ -34,6 +34,26 @@ namespace Microsoft.Maui.MauiBlazorWebView.DeviceTests
 			throw await createExceptionWithTimeoutMS(MaxWaitTimes * WaitTimeInMS);
 		}
 
+		public static async Task WaitForCondition(PlatformWebView webView, string jsCondition)
+		{
+			await Retry(
+				async () =>
+				{
+					// Use .toString() to normalize booleans across platforms (iOS returns
+					// NSNumber "1" for true, Android returns "true", some platforms quote).
+					var result = await ExecuteScriptAsync(webView, $"({jsCondition}).toString()");
+					return
+						result == "true" ||
+						result == "\"true\"" ||
+						result == "1" ||
+						result == "\"1\"";
+				},
+				timeoutInMS =>
+				{
+					return Task.FromResult(new Exception($"Waited {timeoutInMS}ms but condition '{jsCondition}' never became true."));
+				});
+		}
+
 		/// <summary>
 		/// Executes an async JavaScript function body and waits for the result to be stored in controlDiv.
 		/// This method handles all the boilerplate for script injection and Promise avoidance.


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Refactors the Android `RunBlazorStartupScripts` method in `WebKitWebViewClient.cs` from a three-level nested `EvaluateJavascript` callback chain into one `BlazorInitScript` constant with one callback.

### What changed

**Before**: Three nested `EvaluateJavascript` calls with three `JavaScriptValueCallback` instances:
1. Check `window.__BlazorStarted`.
2. Inject JavaScript that creates a `MessageChannel`, sets up `window.external`, and configures port listeners.
3. After native `SetUpMessageChannel()` posts the port, inject `Blazor.start()` and set `__BlazorStarted`.

**After**: One `BlazorInitScript` constant and one `EvaluateJavascript` callback:
- Eliminates the JavaScript-side relay `MessageChannel`.
- Uses `window.__nativePort` for JavaScript-to-native messaging.
- Dispatches native-to-JavaScript messages from the window `message` event to `window.external.__callback`.
- Calls `Blazor.start()` from the `capturePort` handler so the native port is captured first.

### Startup flags

Introduces two flags:
- `window.__BlazorStarting` is set when the initialization script runs and guards duplicate `OnPageFinished` calls.
- `window.__BlazorStarted` is set after the `Blazor.start()` promise resolves and is used by `WaitForWebViewReady`.

### Message-source filtering

The message listener processes only events for which `event.source === null`; events from JavaScript contexts with a non-null source are skipped.

### Preserved behavior

- Native `WebMessageChannel` setup through `SetUpMessageChannel()`.
- Native-to-JavaScript `PostWebMessage` calls through `SendMessage()`.
- `BlazorWebMessageCallback` for JavaScript messages received on the native port.
- `autostart="false"` in templates; no template changes.

### New device tests

Adds `BlazorWebViewTests.Startup.cs` with six tests:

| Test | Scope | Verifies |
|---|---|---|
| `BlazorStartupSetsUpWindowExternal` | All platforms | `sendMessage` and `receiveMessage` are functions |
| `BlazorStartupSetsStartingAndStartedFlags` | Android | Both startup flags become `true` |
| `BlazorStartupCapturesNativePort` | Android | `window.__nativePort` is set after handoff |
| `BlazorStartupScriptIsIdempotent` | Android | Duplicate startup does not replace the port or submit another channel |
| `BlazorStartupRejectionPreservesLiveBridge` | Android | A post-start promise rejection does not destroy the active bridge |
| `BlazorMessageDispatchOnlyProcessesNativeSourceMessages` | Android | A same-window JavaScript message is not dispatched to the bridge callback |

Also adds `WebViewHelpers.WaitForCondition()`, which polls a JavaScript boolean expression through the existing retry infrastructure.

### Files changed

| File | Change |
|---|---|
| `src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs` | Refactors startup and bridge initialization |
| `src/BlazorWebView/src/SharedSource/Log.cs` | Adds the `BlazorStartupScriptsSubmitted` log event |
| `src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.Startup.cs` | Adds six startup tests |
| `src/BlazorWebView/tests/DeviceTests/WebViewHelpers.Shared.cs` | Adds `WaitForCondition` |

### Validation status

The trusted Android BlazorWebView Gate currently fails: 24 of 29 tests time out waiting for `window.Blazor` and `window.__BlazorStarted`. The implementation requires correction before merge; no passing test result is claimed.