### PR TITLE
[Android] Fix WebViewBackgroundColorShouldBeApplied UI test regression on candidate branch

### DIFF
--- a/src/Core/src/Platform/Android/MauiHybridWebView.cs
+++ b/src/Core/src/Platform/Android/MauiHybridWebView.cs
@@ -33,13 +33,35 @@ namespace Microsoft.Maui.Platform
 		protected override void OnSizeChanged(int width, int height, int oldWidth, int oldHeight)
 		{
 			base.OnSizeChanged(width, height, oldWidth, oldHeight);
+			UpdateClipBounds(width, height);
+		}
 
+		protected override void OnAttachedToWindow()
+		{
+			base.OnAttachedToWindow();
+
+			// Re-evaluate ClipBounds when re-parented (e.g., wrapped in WrapperView for shadow)
+			UpdateClipBounds(Width, Height);
+		}
+
+		void UpdateClipBounds(int width, int height)
+		{
 			if (width > 0 && height > 0)
 			{
-				// Remove clip bounds once layout is complete and the view has its
-				// correct size. Setting null instead of exact bounds allows visual
-				// effects like shadows to render outside the view area.
-				ClipBounds = null;
+				if (Parent is WrapperView)
+				{
+					// Parent is WrapperView (shadow/border/clip applied).
+					// Remove ClipBounds to allow visual effects like shadows
+					// to render outside the view area.
+					ClipBounds = null;
+				}
+				else
+				{
+					// No WrapperView — apply exact bounds to prevent the WebView
+					// from briefly rendering at full screen size before layout.
+					_clipRect.Set(0, 0, width, height);
+					ClipBounds = _clipRect;
+				}
 			}
 			else
 			{

--- a/src/Core/src/Platform/Android/MauiWebView.cs
+++ b/src/Core/src/Platform/Android/MauiWebView.cs
@@ -26,13 +26,35 @@ namespace Microsoft.Maui.Platform
 		protected override void OnSizeChanged(int width, int height, int oldWidth, int oldHeight)
 		{
 			base.OnSizeChanged(width, height, oldWidth, oldHeight);
+			UpdateClipBounds(width, height);
+		}
 
+		protected override void OnAttachedToWindow()
+		{
+			base.OnAttachedToWindow();
+
+			// Re-evaluate ClipBounds when re-parented (e.g., wrapped in WrapperView for shadow)
+			UpdateClipBounds(Width, Height);
+		}
+
+		void UpdateClipBounds(int width, int height)
+		{
 			if (width > 0 && height > 0)
 			{
-				// Remove clip bounds once layout is complete and the view has its
-				// correct size. Setting null instead of exact bounds allows visual
-				// effects like shadows to render outside the view area.
-				ClipBounds = null;
+				if (Parent is WrapperView)
+				{
+					// Parent is WrapperView (shadow/border/clip applied).
+					// Remove ClipBounds to allow visual effects like shadows
+					// to render outside the view area.
+					ClipBounds = null;
+				}
+				else
+				{
+					// No WrapperView — apply exact bounds to prevent the WebView
+					// from briefly rendering at full screen size before layout.
+					_clipRect.Set(0, 0, width, height);
+					ClipBounds = _clipRect;
+				}
 			}
 			else
 			{

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -12,5 +12,7 @@ override Microsoft.Maui.Handlers.LabelHandler.GetDesiredSize(double widthConstra
 override Microsoft.Maui.Platform.ContentViewGroup.HasOverlappingRendering.get -> bool
 override Microsoft.Maui.Platform.LayoutViewGroup.HasOverlappingRendering.get -> bool
 override Microsoft.Maui.Platform.WrapperView.HasOverlappingRendering.get -> bool
+override Microsoft.Maui.Platform.MauiHybridWebView.OnAttachedToWindow() -> void
 override Microsoft.Maui.Platform.MauiHybridWebView.OnSizeChanged(int width, int height, int oldWidth, int oldHeight) -> void
+override Microsoft.Maui.Platform.MauiWebView.OnAttachedToWindow() -> void
 override Microsoft.Maui.Platform.MauiWebView.OnSizeChanged(int width, int height, int oldWidth, int oldHeight) -> void


### PR DESCRIPTION
 <!-- Please let the below note in for people that find this PR -->
   > [!NOTE]
   > Are you waiting for the changes in this PR to be merged?
   > It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. 
  Thank you!
 
### Root Cause
The previous regression fix (PR #35013) set `ClipBounds = null` unconditionally in `OnSizeChanged` to resolve shadow clipping. While effective for shadows, this reintroduced the original full-screen flash issue (#31475) on slower devices.

The underlying issue is that `ClipBounds = null` removes GPU-level rendering constraints. On slower devices, the hardware-accelerated WebView compositor renders a frame at full-screen size before Android layout bounds are enforced.

Debug analysis showed that when Shadow/Border/Clip is applied, MAUI wraps the WebView inside a `WrapperView`. In this scenario, the wrapper constrains rendering, making `ClipBounds = null` safe. Without decorations, the WebView is hosted directly under `LayoutViewGroup` (with `ClipChildren = false`), requiring explicit bounds to prevent the flash.
 
### Description of Change
Introduced a `UpdateClipBounds` method to dynamically determine the correct clipping strategy based on the parent:

* **Parent is WrapperView (decorations applied):** Sets `ClipBounds = null` to allow shadow and visual overflow
* **Parent is not WrapperView (no decorations):** Sets exact bounds to prevent full-screen flash on slower devices
* **Zero size:** Applies empty bounds to block rendering when the view is collapsed

Additionally, added an `OnAttachedToWindow` override to re-evaluate `ClipBounds` during runtime re-parenting (e.g., when shadow is toggled). This is required because re-parenting does not trigger `OnSizeChanged`.

This approach aligns with existing MAUI patterns (e.g., `ContentViewGroup` handling parent checks in similar lifecycle hooks).

### Issues Fixed
Fixes regression introduced by #35013 : 
`WebViewBackgroundColorShouldBeApplied`  on Candidate branch.
 
Tested the behaviour in the following platforms
- [x] Android
- [ ] Windows
- [ ] iOS
- [ ] Mac