### PR TITLE
Update branching instructions to be version-agnostic

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,7 +18,7 @@ When performing a code review on PRs that change functional code, run the pr-fin
 
 - **.NET SDK** - Version is **ALWAYS** defined in `global.json` at repository root
   - **main branch**: Latest stable .NET version
-  - **Feature branches**: Each `netN.0` branch targets the .NET N SDK. The highest `netN.0` branch is the current development branch for new features and API changes.
+  - **Feature branches**: Each `netN.0` branch targets the .NET N SDK. By convention, the highest `netN.0` branch is the current development branch for new features and API changes.
 - **Cake build system** for compilation and packaging (`dotnet cake`)
 - **MSBuild** with custom build tasks (must build `Microsoft.Maui.BuildTasks.slnf` first)
 - **Testing frameworks**:
@@ -139,7 +139,7 @@ When working with public API changes:
 
 ### Branching
 - `main` - For bug fixes without API changes
-- The highest `netN.0` branch - For new features and API changes. To find the current feature branch, run: `git for-each-ref --sort=-version:refname --count=1 --format='%(refname:lstrip=3)' refs/remotes/origin/net*.0`
+- The highest `netN.0` branch (by convention) - For new features and API changes. To find it, run `git fetch origin` then: `git for-each-ref --sort=-version:refname --count=1 --format='%(refname:lstrip=3)' refs/remotes/origin/net*.0`
 
 ### Git Workflow (Copilot CLI Rules)
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,8 +18,7 @@ When performing a code review on PRs that change functional code, run the pr-fin
 
 - **.NET SDK** - Version is **ALWAYS** defined in `global.json` at repository root
   - **main branch**: Latest stable .NET version
-  - **net10.0 branch**: .NET 10 SDK
-  - **Feature branches**: Each feature branch (e.g., `net11.0`, `net12.0`) correlates to its respective .NET version
+  - **Feature branches**: Each feature branch (e.g., `net11.0`, `net12.0`) correlates to its respective .NET version. The highest `netN.0` branch is the current development branch for new features and API changes.
 - **Cake build system** for compilation and packaging (`dotnet cake`)
 - **MSBuild** with custom build tasks (must build `Microsoft.Maui.BuildTasks.slnf` first)
 - **Testing frameworks**:
@@ -140,7 +139,7 @@ When working with public API changes:
 
 ### Branching
 - `main` - For bug fixes without API changes
-- `net10.0` - For new features and API changes
+- The highest `netN.0` branch (e.g., `net11.0`, `net12.0`) - For new features and API changes. To find the current feature branch, run: `git branch -r | grep -oE 'origin/net[0-9]+\.0$' | sort -t. -k1 -V | tail -1`
 
 ### Git Workflow (Copilot CLI Rules)
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,7 +18,7 @@ When performing a code review on PRs that change functional code, run the pr-fin
 
 - **.NET SDK** - Version is **ALWAYS** defined in `global.json` at repository root
   - **main branch**: Latest stable .NET version
-  - **Feature branches**: Each feature branch (e.g., `net11.0`, `net12.0`) correlates to its respective .NET version. The highest `netN.0` branch is the current development branch for new features and API changes.
+  - **Feature branches**: Each `netN.0` branch targets the .NET N SDK. The highest `netN.0` branch is the current development branch for new features and API changes.
 - **Cake build system** for compilation and packaging (`dotnet cake`)
 - **MSBuild** with custom build tasks (must build `Microsoft.Maui.BuildTasks.slnf` first)
 - **Testing frameworks**:
@@ -139,7 +139,7 @@ When working with public API changes:
 
 ### Branching
 - `main` - For bug fixes without API changes
-- The highest `netN.0` branch (e.g., `net11.0`, `net12.0`) - For new features and API changes. To find the current feature branch, run: `git branch -r | grep -oE 'origin/net[0-9]+\.0$' | sort -t. -k1 -V | tail -1`
+- The highest `netN.0` branch - For new features and API changes. To find the current feature branch, run: `git for-each-ref --sort=-version:refname --count=1 --format='%(refname:lstrip=3)' refs/remotes/origin/net*.0`
 
 ### Git Workflow (Copilot CLI Rules)
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

The branching instructions in `.github/copilot-instructions.md` hardcoded `net10.0` as the feature branch for new APIs. This becomes stale every time a new `netN.0` branch is created (e.g., `net11.0`, `net12.0`).

This PR replaces the hardcoded version with a dynamic convention: **the highest `netN.0` branch is the current feature branch for new features and API changes**. It also includes a discovery command so agents can programmatically find the right branch.

## Changes

- Removed hardcoded `net10.0 branch` line from Key Technologies section
- Updated Feature branches description to explain the "highest netN.0" convention
- Replaced hardcoded `net10.0` in Branching section with version-agnostic pattern and discovery command

## Why

This caused a real issue: during a multi-model code review of PR #34230, the reviewer incorrectly recommended targeting `net10.0` instead of `net11.0` because the instructions said `net10.0`. With this change, the instructions will remain correct as branches evolve.