### PR TITLE
Add cross-OS Gradle cache fallback for Windows bootstrap

### DIFF
--- a/eng/pipelines/common/cache-gradle.yml
+++ b/eng/pipelines/common/cache-gradle.yml
@@ -38,4 +38,5 @@ steps:
     restoreKeys: |
       "gradle" | "v1" | "$(Agent.OS)" | ${{ parameters.checkoutDirectory }}/src/Core/AndroidNative/gradle/wrapper/gradle-wrapper.properties
       "gradle" | "v1" | "$(Agent.OS)"
+      "gradle" | "v1"
     path: $(GRADLE_USER_HOME)


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Problem

The official build on `release/10.0.1xx-sr6` ([build 2956987](https://dev.azure.com/dnceng/internal/_build/results?buildId=2956987)) still fails on Pack Windows with Gradle errors despite #35049. The root cause: **no Windows-specific Gradle cache entry exists for the `release/10.0.1xx-sr6` branch scope**.

The cache log shows:
```
Fingerprint: "gradle"|"v1"|"Windows_NT"|...
There is a cache miss.
```

Meanwhile Pack macOS succeeds because a macOS cache entry exists from `main` branch scope. Without a Windows cache, Gradle attempts to download from `repo.maven.apache.org`, which is blocked by [CFSClean network isolation](https://github.com/dotnet/maui/pull/34540):
```
error XAGRDL0000: Could not resolve net.java.dev.jna:jna-platform:5.6.0
  > Permission denied: getsockopt
```

## Fix

Add an OS-independent fallback restore key (`"gradle" | "v1"`) to `cache-gradle.yml`, allowing Windows to bootstrap from the macOS-populated cache when no Windows-specific entry exists.

## Why this is safe (addressing @jonathanpeppers's earlier concern from #35049)

The concern was that restoring a macOS Gradle cache on Windows could cause `aapt2` native binary crashes, since `aapt2` is published with OS-specific Maven classifiers (`aapt2-*-osx.jar` vs `aapt2-*-windows.jar`).

**This is not a risk because:**
- Gradle resolves `aapt2` by classifier — it will **never use** the macOS binary on Windows. It would attempt to download the Windows variant separately.
- If that download fails (due to CFSClean), it is **no worse** than the current situation (complete cache miss → same download failure).
- All other dependencies (`kotlin-stdlib`, `jna-platform`, `juniversalchardet`, `javax.annotation-api`, AndroidX, etc.) are **pure Java JARs** that are byte-identical across platforms.

**Net effect:** Cross-OS fallback gives Windows ~95% of cached deps (all Java JARs). The only gap is `aapt2-windows.jar`, which still needs Maven Central access. This is strictly better than the current complete cache miss.

Cross-checked with Claude Sonnet 4.6, GPT Codex 5.3, and Goldeneye — all agree Gradle self-heals on incompatible cache entries (cache miss → regenerate, not crash).

## Long-term fix

Request `repo.maven.apache.org` to be added to CFSClean allowlist. This cache fallback is a bridge until that happens.