### PR TITLE
Fix MainThread throwing on custom platform backends

### DIFF
--- a/src/Core/src/Hosting/EssentialsMauiAppBuilderExtensions.cs
+++ b/src/Core/src/Hosting/EssentialsMauiAppBuilderExtensions.cs
@@ -83,6 +83,8 @@ namespace Microsoft.Maui.Hosting
 #endif
 			});
 
+			builder.Services.TryAddEnumerable(ServiceDescriptor.Transient<IMauiInitializeService, EssentialsInitializer>());
+
 			return builder;
 		}
 
@@ -92,6 +94,7 @@ namespace Microsoft.Maui.Hosting
 			{
 				builder.Services.AddSingleton<EssentialsRegistration>(new EssentialsRegistration(configureDelegate));
 			}
+
 			builder.Services.TryAddEnumerable(ServiceDescriptor.Transient<IMauiInitializeService, EssentialsInitializer>());
 
 			return builder;

--- a/src/Core/src/Hosting/EssentialsMauiAppBuilderExtensions.cs
+++ b/src/Core/src/Hosting/EssentialsMauiAppBuilderExtensions.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Dispatching;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.LifecycleEvents;
 #if ANDROID
@@ -135,6 +136,8 @@ namespace Microsoft.Maui.Hosting
 					}
 				}
 
+				BridgeMainThreadFromDispatcher(services);
+
 #if WINDOWS
 				ApplicationModel.Platform.MapServiceToken = _essentialsBuilder.MapServiceToken;
 #endif
@@ -150,6 +153,26 @@ namespace Microsoft.Maui.Hosting
 
 				if (_essentialsBuilder.TrackVersions)
 					VersionTracking.Track();
+			}
+
+			/// <summary>
+			/// Bridges the MAUI application dispatcher to MainThread so that
+			/// MainThread.BeginInvokeOnMainThread and MainThread.IsMainThread work
+			/// on custom platform backends / external TFMs where no native
+			/// MainThread implementation exists.
+			/// On supported platforms the Platform* methods take precedence and
+			/// the backing delegates are never consulted.
+			/// </summary>
+			static void BridgeMainThreadFromDispatcher(IServiceProvider services)
+			{
+				var dispatcherProvider = services.GetService<IDispatcherProvider>();
+				var dispatcher = dispatcherProvider?.GetForCurrentThread();
+				if (dispatcher is null)
+					return;
+
+				MainThread.SetCustomImplementation(
+					isMainThread: () => !dispatcher.IsDispatchRequired,
+					beginInvokeOnMainThread: action => dispatcher.Dispatch(action));
 			}
 
 			private static async void SetAppActions(IServiceProvider services, List<AppAction> appActions)

--- a/src/Core/src/Hosting/EssentialsMauiAppBuilderExtensions.cs
+++ b/src/Core/src/Hosting/EssentialsMauiAppBuilderExtensions.cs
@@ -83,7 +83,9 @@ namespace Microsoft.Maui.Hosting
 #endif
 			});
 
-			builder.Services.TryAddEnumerable(ServiceDescriptor.Transient<IMauiInitializeService, EssentialsInitializer>());
+#if !(ANDROID || __IOS__ || __MACCATALYST__ || WINDOWS || TIZEN)
+			builder.Services.TryAddEnumerable(ServiceDescriptor.Transient<IMauiInitializeService, MainThreadBridgeInitializer>());
+#endif
 
 			return builder;
 		}
@@ -118,6 +120,28 @@ namespace Microsoft.Maui.Hosting
 			}
 		}
 
+		/// <summary>
+		/// Lightweight initializer that bridges the MAUI application dispatcher to MainThread
+		/// so that MainThread.BeginInvokeOnMainThread and MainThread.IsMainThread work
+		/// on custom platform backends / external TFMs where no native
+		/// MainThread implementation exists.
+		/// </summary>
+#if !(ANDROID || __IOS__ || __MACCATALYST__ || WINDOWS || TIZEN)
+		class MainThreadBridgeInitializer : IMauiInitializeService
+		{
+			public void Initialize(IServiceProvider services)
+			{
+				var dispatcher = services.GetOptionalApplicationDispatcher();
+				if (dispatcher is null)
+					return;
+
+				MainThread.SetCustomImplementation(
+					isMainThread: () => !dispatcher.IsDispatchRequired,
+					beginInvokeOnMainThread: action => dispatcher.Dispatch(action));
+			}
+		}
+#endif
+
 		class EssentialsInitializer : IMauiInitializeService
 		{
 			private readonly IEnumerable<EssentialsRegistration> _essentialsRegistrations;
@@ -139,10 +163,6 @@ namespace Microsoft.Maui.Hosting
 					}
 				}
 
-#if !(ANDROID || __IOS__ || __MACCATALYST__ || WINDOWS || TIZEN)
-				BridgeMainThreadFromDispatcher(services);
-#endif
-
 #if WINDOWS
 				ApplicationModel.Platform.MapServiceToken = _essentialsBuilder.MapServiceToken;
 #endif
@@ -159,25 +179,6 @@ namespace Microsoft.Maui.Hosting
 				if (_essentialsBuilder.TrackVersions)
 					VersionTracking.Track();
 			}
-
-			/// <summary>
-			/// Bridges the MAUI application dispatcher to MainThread so that
-			/// MainThread.BeginInvokeOnMainThread and MainThread.IsMainThread work
-			/// on custom platform backends / external TFMs where no native
-			/// MainThread implementation exists.
-			/// </summary>
-#if !(ANDROID || __IOS__ || __MACCATALYST__ || WINDOWS || TIZEN)
-			static void BridgeMainThreadFromDispatcher(IServiceProvider services)
-			{
-				var dispatcher = services.GetOptionalApplicationDispatcher();
-				if (dispatcher is null)
-					return;
-
-				MainThread.SetCustomImplementation(
-					isMainThread: () => !dispatcher.IsDispatchRequired,
-					beginInvokeOnMainThread: action => dispatcher.Dispatch(action));
-			}
-#endif
 
 			private static async void SetAppActions(IServiceProvider services, List<AppAction> appActions)
 			{

--- a/src/Core/src/Hosting/EssentialsMauiAppBuilderExtensions.cs
+++ b/src/Core/src/Hosting/EssentialsMauiAppBuilderExtensions.cs
@@ -139,7 +139,9 @@ namespace Microsoft.Maui.Hosting
 					}
 				}
 
+#if !(ANDROID || __IOS__ || __MACCATALYST__ || WINDOWS || TIZEN)
 				BridgeMainThreadFromDispatcher(services);
+#endif
 
 #if WINDOWS
 				ApplicationModel.Platform.MapServiceToken = _essentialsBuilder.MapServiceToken;
@@ -163,13 +165,11 @@ namespace Microsoft.Maui.Hosting
 			/// MainThread.BeginInvokeOnMainThread and MainThread.IsMainThread work
 			/// on custom platform backends / external TFMs where no native
 			/// MainThread implementation exists.
-			/// On supported platforms the Platform* methods take precedence and
-			/// the backing delegates are never consulted.
 			/// </summary>
+#if !(ANDROID || __IOS__ || __MACCATALYST__ || WINDOWS || TIZEN)
 			static void BridgeMainThreadFromDispatcher(IServiceProvider services)
 			{
-				var dispatcherProvider = services.GetService<IDispatcherProvider>();
-				var dispatcher = dispatcherProvider?.GetForCurrentThread();
+				var dispatcher = services.GetOptionalApplicationDispatcher();
 				if (dispatcher is null)
 					return;
 
@@ -177,6 +177,7 @@ namespace Microsoft.Maui.Hosting
 					isMainThread: () => !dispatcher.IsDispatchRequired,
 					beginInvokeOnMainThread: action => dispatcher.Dispatch(action));
 			}
+#endif
 
 			private static async void SetAppActions(IServiceProvider services, List<AppAction> appActions)
 			{

--- a/src/Core/tests/UnitTests/Hosting/MainThreadBridgeTests.cs
+++ b/src/Core/tests/UnitTests/Hosting/MainThreadBridgeTests.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Dispatching;
 using Microsoft.Maui.Hosting;
@@ -176,13 +177,14 @@ namespace Microsoft.Maui.UnitTests.Hosting
 		}
 
 		[Fact]
-		public void MauiAppBuild_UsesCachedApplicationDispatcherForBridge()
+		public async Task InvokeOnMainThreadAsync_Action_WorksThroughBridge()
 		{
+			var dispatched = false;
 			var dispatcherStub = new DispatcherStub(
-				isInvokeRequired: () => false,
-				invokeOnMainThread: action => action());
+				isInvokeRequired: () => true,
+				invokeOnMainThread: action => { dispatched = true; action(); });
 
-			var dispatcherProvider = new SequencedDispatcherProvider(dispatcherStub, null);
+			var dispatcherProvider = new TestDispatcherProvider(dispatcherStub);
 			DispatcherProvider.SetCurrent(dispatcherProvider);
 
 			try
@@ -190,6 +192,34 @@ namespace Microsoft.Maui.UnitTests.Hosting
 				var builder = MauiApp.CreateBuilder();
 				using var app = builder.Build();
 
+				var actionExecuted = false;
+				await MainThread.InvokeOnMainThreadAsync(() => actionExecuted = true);
+
+				Assert.True(dispatched);
+				Assert.True(actionExecuted);
+			}
+			finally
+			{
+				DispatcherProvider.SetCurrent(null);
+			}
+		}
+
+		[Fact]
+		public void MauiAppBuild_BridgeUsesApplicationDispatcher()
+		{
+			var dispatcherStub = new DispatcherStub(
+				isInvokeRequired: () => false,
+				invokeOnMainThread: action => action());
+
+			var dispatcherProvider = new TestDispatcherProvider(dispatcherStub);
+			DispatcherProvider.SetCurrent(dispatcherProvider);
+
+			try
+			{
+				var builder = MauiApp.CreateBuilder();
+				using var app = builder.Build();
+
+				// Verify the bridge connected the dispatcher's IsDispatchRequired to MainThread.IsMainThread
 				Assert.True(MainThread.IsMainThread);
 			}
 			finally
@@ -208,26 +238,6 @@ namespace Microsoft.Maui.UnitTests.Hosting
 			}
 
 			public IDispatcher? GetForCurrentThread() => _dispatcher;
-		}
-
-		class SequencedDispatcherProvider : IDispatcherProvider
-		{
-			readonly IDispatcher?[] _dispatchers;
-			int _index;
-
-			public SequencedDispatcherProvider(params IDispatcher?[] dispatchers)
-			{
-				_dispatchers = dispatchers;
-			}
-
-			public IDispatcher? GetForCurrentThread()
-			{
-				var index = _index++;
-				if (index >= _dispatchers.Length)
-					index = _dispatchers.Length - 1;
-
-				return index >= 0 ? _dispatchers[index] : null;
-			}
 		}
 	}
 }

--- a/src/Core/tests/UnitTests/Hosting/MainThreadBridgeTests.cs
+++ b/src/Core/tests/UnitTests/Hosting/MainThreadBridgeTests.cs
@@ -135,7 +135,6 @@ namespace Microsoft.Maui.UnitTests.Hosting
 			try
 			{
 				var builder = MauiApp.CreateBuilder();
-				builder.ConfigureEssentials();
 				using var app = builder.Build();
 
 				// After MauiApp.Build(), the bridge should have connected MainThread
@@ -162,7 +161,6 @@ namespace Microsoft.Maui.UnitTests.Hosting
 			try
 			{
 				var builder = MauiApp.CreateBuilder();
-				builder.ConfigureEssentials();
 				using var app = builder.Build();
 
 				var actionExecuted = false;

--- a/src/Core/tests/UnitTests/Hosting/MainThreadBridgeTests.cs
+++ b/src/Core/tests/UnitTests/Hosting/MainThreadBridgeTests.cs
@@ -1,6 +1,6 @@
+#nullable enable
+
 using System;
-using System.Threading;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Dispatching;
 using Microsoft.Maui.Hosting;
@@ -63,7 +63,7 @@ namespace Microsoft.Maui.UnitTests.Hosting
 		public void WithCustomImpl_BeginInvoke_CallsBackingImpl()
 		{
 			var invoked = false;
-			Action capturedAction = null;
+			Action? capturedAction = null;
 
 			MainThread.SetCustomImplementation(
 				isMainThread: () => false,
@@ -73,7 +73,7 @@ namespace Microsoft.Maui.UnitTests.Hosting
 
 			// The custom impl captured the action; execute it
 			Assert.NotNull(capturedAction);
-			capturedAction();
+			capturedAction!();
 			Assert.True(invoked);
 		}
 
@@ -111,14 +111,14 @@ namespace Microsoft.Maui.UnitTests.Hosting
 		public void SetCustomImpl_NullIsMainThread_Throws()
 		{
 			Assert.Throws<ArgumentNullException>(
-				() => MainThread.SetCustomImplementation(null, _ => { }));
+				() => MainThread.SetCustomImplementation(null!, _ => { }));
 		}
 
 		[Fact]
 		public void SetCustomImpl_NullBeginInvoke_Throws()
 		{
 			Assert.Throws<ArgumentNullException>(
-				() => MainThread.SetCustomImplementation(() => true, null));
+				() => MainThread.SetCustomImplementation(() => true, null!));
 		}
 
 		[Fact]
@@ -175,6 +175,29 @@ namespace Microsoft.Maui.UnitTests.Hosting
 			}
 		}
 
+		[Fact]
+		public void MauiAppBuild_UsesCachedApplicationDispatcherForBridge()
+		{
+			var dispatcherStub = new DispatcherStub(
+				isInvokeRequired: () => false,
+				invokeOnMainThread: action => action());
+
+			var dispatcherProvider = new SequencedDispatcherProvider(dispatcherStub, null);
+			DispatcherProvider.SetCurrent(dispatcherProvider);
+
+			try
+			{
+				var builder = MauiApp.CreateBuilder();
+				using var app = builder.Build();
+
+				Assert.True(MainThread.IsMainThread);
+			}
+			finally
+			{
+				DispatcherProvider.SetCurrent(null);
+			}
+		}
+
 		class TestDispatcherProvider : IDispatcherProvider
 		{
 			readonly IDispatcher _dispatcher;
@@ -184,7 +207,27 @@ namespace Microsoft.Maui.UnitTests.Hosting
 				_dispatcher = dispatcher;
 			}
 
-			public IDispatcher GetForCurrentThread() => _dispatcher;
+			public IDispatcher? GetForCurrentThread() => _dispatcher;
+		}
+
+		class SequencedDispatcherProvider : IDispatcherProvider
+		{
+			readonly IDispatcher?[] _dispatchers;
+			int _index;
+
+			public SequencedDispatcherProvider(params IDispatcher?[] dispatchers)
+			{
+				_dispatchers = dispatchers;
+			}
+
+			public IDispatcher? GetForCurrentThread()
+			{
+				var index = _index++;
+				if (index >= _dispatchers.Length)
+					index = _dispatchers.Length - 1;
+
+				return index >= 0 ? _dispatchers[index] : null;
+			}
 		}
 	}
 }

--- a/src/Core/tests/UnitTests/Hosting/MainThreadBridgeTests.cs
+++ b/src/Core/tests/UnitTests/Hosting/MainThreadBridgeTests.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Dispatching;
+using Microsoft.Maui.Hosting;
+using Xunit;
+
+namespace Microsoft.Maui.UnitTests.Hosting
+{
+	[Category(TestCategory.Core, TestCategory.Hosting)]
+	public class MainThreadBridgeTests : IDisposable
+	{
+		public MainThreadBridgeTests()
+		{
+			// Ensure clean state before each test
+			MainThread.ClearCustomImplementation();
+		}
+
+		public void Dispose()
+		{
+			MainThread.ClearCustomImplementation();
+			DispatcherProvider.SetCurrent(null);
+		}
+
+		[Fact]
+		public void WithoutCustomImpl_IsMainThread_Throws()
+		{
+			// On netstandard with no backing implementation, IsMainThread should throw
+			Assert.Throws<NotImplementedInReferenceAssemblyException>(
+				() => _ = MainThread.IsMainThread);
+		}
+
+		[Fact]
+		public void WithoutCustomImpl_BeginInvoke_Throws()
+		{
+			// On netstandard with no backing implementation, BeginInvokeOnMainThread should throw
+			Assert.Throws<NotImplementedInReferenceAssemblyException>(
+				() => MainThread.BeginInvokeOnMainThread(() => { }));
+		}
+
+		[Fact]
+		public void WithCustomImpl_IsMainThread_UsesBackingImpl()
+		{
+			MainThread.SetCustomImplementation(
+				isMainThread: () => true,
+				beginInvokeOnMainThread: _ => { });
+
+			Assert.True(MainThread.IsMainThread);
+		}
+
+		[Fact]
+		public void WithCustomImpl_IsMainThread_ReturnsFalse()
+		{
+			MainThread.SetCustomImplementation(
+				isMainThread: () => false,
+				beginInvokeOnMainThread: _ => { });
+
+			Assert.False(MainThread.IsMainThread);
+		}
+
+		[Fact]
+		public void WithCustomImpl_BeginInvoke_CallsBackingImpl()
+		{
+			var invoked = false;
+			Action capturedAction = null;
+
+			MainThread.SetCustomImplementation(
+				isMainThread: () => false,
+				beginInvokeOnMainThread: action => capturedAction = action);
+
+			MainThread.BeginInvokeOnMainThread(() => invoked = true);
+
+			// The custom impl captured the action; execute it
+			Assert.NotNull(capturedAction);
+			capturedAction();
+			Assert.True(invoked);
+		}
+
+		[Fact]
+		public void BeginInvoke_WhenOnMainThread_InvokesDirectly()
+		{
+			var invoked = false;
+
+			MainThread.SetCustomImplementation(
+				isMainThread: () => true,
+				beginInvokeOnMainThread: _ => throw new InvalidOperationException("Should not be called"));
+
+			// When IsMainThread returns true, the shared code invokes the action directly
+			MainThread.BeginInvokeOnMainThread(() => invoked = true);
+
+			Assert.True(invoked);
+		}
+
+		[Fact]
+		public void ClearCustomImpl_RestoresThrowBehavior()
+		{
+			MainThread.SetCustomImplementation(
+				isMainThread: () => true,
+				beginInvokeOnMainThread: _ => { });
+
+			Assert.True(MainThread.IsMainThread);
+
+			MainThread.ClearCustomImplementation();
+
+			Assert.Throws<NotImplementedInReferenceAssemblyException>(
+				() => _ = MainThread.IsMainThread);
+		}
+
+		[Fact]
+		public void SetCustomImpl_NullIsMainThread_Throws()
+		{
+			Assert.Throws<ArgumentNullException>(
+				() => MainThread.SetCustomImplementation(null, _ => { }));
+		}
+
+		[Fact]
+		public void SetCustomImpl_NullBeginInvoke_Throws()
+		{
+			Assert.Throws<ArgumentNullException>(
+				() => MainThread.SetCustomImplementation(() => true, null));
+		}
+
+		[Fact]
+		public void MauiAppBuild_BridgesDispatcherToMainThread()
+		{
+			// Set up a dispatcher provider that returns a real dispatcher stub
+			var dispatcherStub = new DispatcherStub(
+				isInvokeRequired: () => false,
+				invokeOnMainThread: null);
+
+			var dispatcherProvider = new TestDispatcherProvider(dispatcherStub);
+			DispatcherProvider.SetCurrent(dispatcherProvider);
+
+			try
+			{
+				var builder = MauiApp.CreateBuilder();
+				builder.ConfigureEssentials();
+				using var app = builder.Build();
+
+				// After MauiApp.Build(), the bridge should have connected MainThread
+				// to the dispatcher. IsMainThread should return true (since IsDispatchRequired is false).
+				Assert.True(MainThread.IsMainThread);
+			}
+			finally
+			{
+				DispatcherProvider.SetCurrent(null);
+			}
+		}
+
+		[Fact]
+		public void MauiAppBuild_BeginInvoke_DispatchesToDispatcher()
+		{
+			var dispatched = false;
+			var dispatcherStub = new DispatcherStub(
+				isInvokeRequired: () => true,
+				invokeOnMainThread: action => { dispatched = true; action(); });
+
+			var dispatcherProvider = new TestDispatcherProvider(dispatcherStub);
+			DispatcherProvider.SetCurrent(dispatcherProvider);
+
+			try
+			{
+				var builder = MauiApp.CreateBuilder();
+				builder.ConfigureEssentials();
+				using var app = builder.Build();
+
+				var actionExecuted = false;
+				MainThread.BeginInvokeOnMainThread(() => actionExecuted = true);
+
+				Assert.True(dispatched);
+				Assert.True(actionExecuted);
+			}
+			finally
+			{
+				DispatcherProvider.SetCurrent(null);
+			}
+		}
+
+		class TestDispatcherProvider : IDispatcherProvider
+		{
+			readonly IDispatcher _dispatcher;
+
+			public TestDispatcherProvider(IDispatcher dispatcher)
+			{
+				_dispatcher = dispatcher;
+			}
+
+			public IDispatcher GetForCurrentThread() => _dispatcher;
+		}
+	}
+}

--- a/src/Essentials/src/AssemblyInfo/AssemblyInfo.shared.cs
+++ b/src/Essentials/src/AssemblyInfo/AssemblyInfo.shared.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 
+[assembly: InternalsVisibleTo("Microsoft.Maui")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Essentials.DeviceTests")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Essentials.UnitTests")]
 [assembly: InternalsVisibleTo("EssentialsTests")]
@@ -18,3 +19,4 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Microsoft.Maui.TestUtils")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.TestUtils.DeviceTests")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.TestUtils.DeviceTests.Runners")]
+[assembly: InternalsVisibleTo("Microsoft.Maui.UnitTests")]

--- a/src/Essentials/src/MainThread/MainThread.netstandard.cs
+++ b/src/Essentials/src/MainThread/MainThread.netstandard.cs
@@ -1,15 +1,25 @@
 using System;
+using System.Threading;
 
 namespace Microsoft.Maui.ApplicationModel
 {
 	public static partial class MainThread
 	{
-		static bool PlatformIsMainThread =>
-			s_mainThreadImplementation?.IsMainThread() ?? throw ExceptionUtils.NotSupportedOrImplementedException;
+		static bool PlatformIsMainThread
+		{
+			get
+			{
+				var implementation = Volatile.Read(ref s_mainThreadImplementation);
+				if (implementation is not null)
+					return implementation.IsMainThread();
+
+				throw ExceptionUtils.NotSupportedOrImplementedException;
+			}
+		}
 
 		static void PlatformBeginInvokeOnMainThread(Action action)
 		{
-			var implementation = s_mainThreadImplementation;
+			var implementation = Volatile.Read(ref s_mainThreadImplementation);
 			if (implementation is not null)
 				implementation.BeginInvokeOnMainThread(action);
 			else

--- a/src/Essentials/src/MainThread/MainThread.netstandard.cs
+++ b/src/Essentials/src/MainThread/MainThread.netstandard.cs
@@ -5,17 +5,15 @@ namespace Microsoft.Maui.ApplicationModel
 	public static partial class MainThread
 	{
 		static bool PlatformIsMainThread =>
-			s_isMainThreadImpl != null ? s_isMainThreadImpl.Invoke() : throw ExceptionUtils.NotSupportedOrImplementedException;
+			s_mainThreadImplementation?.IsMainThread() ?? throw ExceptionUtils.NotSupportedOrImplementedException;
 
 		static void PlatformBeginInvokeOnMainThread(Action action)
 		{
-			if (s_beginInvokeOnMainThreadImpl != null)
-			{
-				s_beginInvokeOnMainThreadImpl(action);
-				return;
-			}
-
-			throw ExceptionUtils.NotSupportedOrImplementedException;
+			var implementation = s_mainThreadImplementation;
+			if (implementation is not null)
+				implementation.BeginInvokeOnMainThread(action);
+			else
+				throw ExceptionUtils.NotSupportedOrImplementedException;
 		}
 	}
 }

--- a/src/Essentials/src/MainThread/MainThread.netstandard.cs
+++ b/src/Essentials/src/MainThread/MainThread.netstandard.cs
@@ -4,10 +4,18 @@ namespace Microsoft.Maui.ApplicationModel
 {
 	public static partial class MainThread
 	{
-		static void PlatformBeginInvokeOnMainThread(Action action) =>
-			throw ExceptionUtils.NotSupportedOrImplementedException;
-
 		static bool PlatformIsMainThread =>
+			s_isMainThreadImpl != null ? s_isMainThreadImpl.Invoke() : throw ExceptionUtils.NotSupportedOrImplementedException;
+
+		static void PlatformBeginInvokeOnMainThread(Action action)
+		{
+			if (s_beginInvokeOnMainThreadImpl != null)
+			{
+				s_beginInvokeOnMainThreadImpl(action);
+				return;
+			}
+
 			throw ExceptionUtils.NotSupportedOrImplementedException;
+		}
 	}
 }

--- a/src/Essentials/src/MainThread/MainThread.shared.cs
+++ b/src/Essentials/src/MainThread/MainThread.shared.cs
@@ -12,7 +12,15 @@ namespace Microsoft.Maui.ApplicationModel
 		// Internal backing for custom platform backends and dispatcher fallback.
 		// On supported platforms (Android, iOS, Windows), the Platform* methods are used directly.
 		// On netstandard/external TFMs, this provides the implementation as a single atomic state object.
-		static MainThreadImplementation s_mainThreadImplementation;
+		//
+		// Lifetime: This field is set once during MauiApp initialization and is expected to live
+		// for the duration of the application. It is NOT cleared on MauiApp.Dispose() because:
+		//   1. Custom backends typically have a single long-lived MauiApp instance.
+		//   2. Rebuilding calls SetCustomImplementation again, atomically replacing the old reference.
+		//   3. After disposal, callers should not invoke MainThread APIs; behavior is undefined.
+#nullable enable
+		static MainThreadImplementation? s_mainThreadImplementation;
+#nullable restore
 
 		sealed class MainThreadImplementation
 		{

--- a/src/Essentials/src/MainThread/MainThread.shared.cs
+++ b/src/Essentials/src/MainThread/MainThread.shared.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.ApplicationModel
 		// Internal backing for custom platform backends and dispatcher fallback.
 		// On supported platforms (Android, iOS, Windows), the Platform* methods are used directly.
 		// On netstandard/external TFMs, this provides the implementation as a single atomic state object.
-		static volatile MainThreadImplementation s_mainThreadImplementation;
+		static MainThreadImplementation s_mainThreadImplementation;
 
 		sealed class MainThreadImplementation
 		{
@@ -32,14 +32,14 @@ namespace Microsoft.Maui.ApplicationModel
 
 		internal static void SetCustomImplementation(Func<bool> isMainThread, Action<Action> beginInvokeOnMainThread)
 		{
-			s_mainThreadImplementation = new MainThreadImplementation(
+			Volatile.Write(ref s_mainThreadImplementation, new MainThreadImplementation(
 				isMainThread ?? throw new ArgumentNullException(nameof(isMainThread)),
-				beginInvokeOnMainThread ?? throw new ArgumentNullException(nameof(beginInvokeOnMainThread)));
+				beginInvokeOnMainThread ?? throw new ArgumentNullException(nameof(beginInvokeOnMainThread))));
 		}
 
 		internal static void ClearCustomImplementation()
 		{
-			s_mainThreadImplementation = null;
+			Volatile.Write(ref s_mainThreadImplementation, null);
 		}
 
 		/// <summary>

--- a/src/Essentials/src/MainThread/MainThread.shared.cs
+++ b/src/Essentials/src/MainThread/MainThread.shared.cs
@@ -9,6 +9,24 @@ namespace Microsoft.Maui.ApplicationModel
 	/// </summary>
 	public static partial class MainThread
 	{
+		// Internal backing for custom platform backends and dispatcher fallback.
+		// On supported platforms (Android, iOS, Windows), the Platform* methods are used directly.
+		// On netstandard/external TFMs, these delegates provide the implementation.
+		static Func<bool> s_isMainThreadImpl;
+		static Action<Action> s_beginInvokeOnMainThreadImpl;
+
+		internal static void SetCustomImplementation(Func<bool> isMainThread, Action<Action> beginInvokeOnMainThread)
+		{
+			s_isMainThreadImpl = isMainThread ?? throw new ArgumentNullException(nameof(isMainThread));
+			s_beginInvokeOnMainThreadImpl = beginInvokeOnMainThread ?? throw new ArgumentNullException(nameof(beginInvokeOnMainThread));
+		}
+
+		internal static void ClearCustomImplementation()
+		{
+			s_isMainThreadImpl = null;
+			s_beginInvokeOnMainThreadImpl = null;
+		}
+
 		/// <summary>
 		/// True if the current thread is the UI thread.
 		/// </summary>

--- a/src/Essentials/src/MainThread/MainThread.shared.cs
+++ b/src/Essentials/src/MainThread/MainThread.shared.cs
@@ -11,20 +11,35 @@ namespace Microsoft.Maui.ApplicationModel
 	{
 		// Internal backing for custom platform backends and dispatcher fallback.
 		// On supported platforms (Android, iOS, Windows), the Platform* methods are used directly.
-		// On netstandard/external TFMs, these delegates provide the implementation.
-		static Func<bool> s_isMainThreadImpl;
-		static Action<Action> s_beginInvokeOnMainThreadImpl;
+		// On netstandard/external TFMs, this provides the implementation as a single atomic state object.
+		static volatile MainThreadImplementation s_mainThreadImplementation;
+
+		sealed class MainThreadImplementation
+		{
+			readonly Func<bool> _isMainThread;
+			readonly Action<Action> _beginInvokeOnMainThread;
+
+			public MainThreadImplementation(Func<bool> isMainThread, Action<Action> beginInvokeOnMainThread)
+			{
+				_isMainThread = isMainThread;
+				_beginInvokeOnMainThread = beginInvokeOnMainThread;
+			}
+
+			public bool IsMainThread() => _isMainThread();
+
+			public void BeginInvokeOnMainThread(Action action) => _beginInvokeOnMainThread(action);
+		}
 
 		internal static void SetCustomImplementation(Func<bool> isMainThread, Action<Action> beginInvokeOnMainThread)
 		{
-			s_isMainThreadImpl = isMainThread ?? throw new ArgumentNullException(nameof(isMainThread));
-			s_beginInvokeOnMainThreadImpl = beginInvokeOnMainThread ?? throw new ArgumentNullException(nameof(beginInvokeOnMainThread));
+			s_mainThreadImplementation = new MainThreadImplementation(
+				isMainThread ?? throw new ArgumentNullException(nameof(isMainThread)),
+				beginInvokeOnMainThread ?? throw new ArgumentNullException(nameof(beginInvokeOnMainThread)));
 		}
 
 		internal static void ClearCustomImplementation()
 		{
-			s_isMainThreadImpl = null;
-			s_beginInvokeOnMainThreadImpl = null;
+			s_mainThreadImplementation = null;
 		}
 
 		/// <summary>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

`MainThread.BeginInvokeOnMainThread()` and `MainThread.InvokeOnMainThreadAsync()` throw `NotImplementedInReferenceAssemblyException` on custom platform backends (e.g. Linux/GTK) even though the MAUI Dispatcher works correctly. This PR bridges the MAUI application dispatcher to `MainThread` during Essentials initialization so that custom platform backends get working `MainThread` support automatically.

## Changes

- **`MainThread.shared.cs`**: Added internal backing delegates (`SetCustomImplementation`/`ClearCustomImplementation`) that allow a custom implementation to be injected
- **`MainThread.netstandard.cs`**: Modified `PlatformIsMainThread` and `PlatformBeginInvokeOnMainThread` to check backing delegates before throwing
- **`EssentialsMauiAppBuilderExtensions.cs`**: Added `BridgeMainThreadFromDispatcher()` that resolves the `IDispatcherProvider` during Essentials initialization and bridges it to `MainThread`
- **`AssemblyInfo.shared.cs`**: Added `InternalsVisibleTo` from Essentials to Core assembly
- **`MainThreadBridgeTests.cs`**: 11 focused regression tests covering direct injection, dispatcher bridge via `MauiApp.Build()`, argument validation, and cleanup

## Design

On supported platforms (Android, iOS, Windows, Tizen), the platform-specific `Platform*` partial methods are defined in their respective files and used directly — the backing delegates are never consulted. Only on netstandard/external TFMs do the backing delegates provide the implementation, falling back to the existing throw behavior when no implementation has been set.

The bridge is intentionally minimal: simple `Func<bool>` and `Action<Action>` delegates rather than a full `IMainThread` interface, keeping the change focused and avoiding new public API surface.

Fixes #34101