### PR TITLE
Fix Shadow does not honour Styles

### DIFF
--- a/src/Controls/src/Core/Shadow.cs
+++ b/src/Controls/src/Core/Shadow.cs
@@ -19,6 +19,13 @@ namespace Microsoft.Maui.Controls
 
 		Paint IShadow.Paint => Brush;
 
+		internal readonly MergedStyle _mergedStyle;
+
+		public Shadow()
+		{
+			_mergedStyle = new MergedStyle(GetType(), this);
+		}
+
 		public float Radius
 		{
 			get { return (float)GetValue(RadiusProperty); }

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -2236,13 +2236,9 @@ namespace Microsoft.Maui.Controls
 			if (shadow is not null)
 			{
 				shadow.Parent = this;
-				SetInheritedBindingContext(shadow, BindingContext);
 				_shadowChanged ??= (sender, e) => OnPropertyChanged(nameof(Shadow));
 				_shadowProxy ??= new();
 				_shadowProxy.Subscribe(shadow, _shadowChanged);
-
-				OnParentResourcesChanged(this.GetMergedResources());
-				((IElementDefinition)this).AddResourcesChangedListener(shadow.OnParentResourcesChanged);
 			}
 		}
 
@@ -2252,8 +2248,6 @@ namespace Microsoft.Maui.Controls
 
 			if (shadow is not null)
 			{
-				((IElementDefinition)this).RemoveResourcesChangedListener(shadow.OnParentResourcesChanged);
-
 				SetInheritedBindingContext(shadow, null);
 				_shadowProxy?.Unsubscribe();
 

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -2235,6 +2235,7 @@ namespace Microsoft.Maui.Controls
 
 			if (shadow is not null)
 			{
+				shadow.Parent = this;
 				SetInheritedBindingContext(shadow, BindingContext);
 				_shadowChanged ??= (sender, e) => OnPropertyChanged(nameof(Shadow));
 				_shadowProxy ??= new();
@@ -2255,6 +2256,9 @@ namespace Microsoft.Maui.Controls
 
 				SetInheritedBindingContext(shadow, null);
 				_shadowProxy?.Unsubscribe();
+
+				if (shadow.Parent == this)
+					shadow.Parent = null;
 			}
 		}
 

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -2258,7 +2258,9 @@ namespace Microsoft.Maui.Controls
 				_shadowProxy?.Unsubscribe();
 
 				if (shadow.Parent == this)
+				{
 					shadow.Parent = null;
+				}
 			}
 		}
 

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui19560.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui19560.xaml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			 x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui19560">
+	<ContentPage.Resources>
+		<ResourceDictionary>
+			<Style TargetType="Shadow">
+				<Setter Property="Radius" Value="15" />
+				<Setter Property="Opacity" Value="0.5" />
+				<Setter Property="Brush" Value="Red" />
+				<Setter Property="Offset" Value="10,10" />
+			</Style>
+		</ResourceDictionary>
+	</ContentPage.Resources>
+	<Label BackgroundColor="White"
+		TextColor="Black"
+		x:Name="label"
+		Text="Standalone label with a shadow - shadow should be red if it's picking up styles.">
+		<Label.Shadow>
+			<Shadow />
+		</Label.Shadow>
+	</Label>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui19560.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui19560.xaml.cs
@@ -1,0 +1,28 @@
+using Microsoft.Maui.Graphics;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui19560 : ContentPage
+{
+	public Maui19560()
+	{
+		InitializeComponent();
+	}
+
+	[Collection("Xaml Inflation")]
+	public class Tests
+	{
+		[Theory]
+		[XamlInflatorData]
+		internal void StylesAreAppliedToShadow(XamlInflator inflator)
+		{
+			var page = new Maui19560(inflator);
+			Assert.Equal(Colors.Red, ((SolidColorBrush)page.label.Shadow.Brush).Color);
+			Assert.Equal(0.5f, page.label.Shadow.Opacity);
+			Assert.Equal(15f, page.label.Shadow.Radius);
+			Assert.Equal(10, page.label.Shadow.Offset.X);
+			Assert.Equal(10, page.label.Shadow.Offset.Y);
+		}
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details:

If I use a Shadow, and update the appropriate Style in Styles.xaml, the shadow does not apply the properties set in the style.
       
### Root Cause:

Shadow inherits directly from Element and had no constructor. MAUI's implicit style system works by calling 
  MergedStyle.RegisterImplicitStyles() during an element's construction — this registers a SetDynamicResource(prop, type.FullName) listener that watches for <Style TargetType="Shadow"> entries in any ResourceDictionary up the visual tree. Since Shadow never initialized a MergedStyle, that listener was never registered. As a result, any implicit style targeting Shadow was silently ignored — the resources existed and were correctly propagated by the parent VisualElement, but Shadow had no mechanism to receive and apply them.

### Description of Change:

An internal readonly MergedStyle _mergedStyle field and a public Shadow() constructor that initializes it with new MergedStyle(GetType(), this). Once constructed, MergedStyle automatically registers the dynamic resource
listener for the Shadow type, and implicit styles start resolving correctly. This is the exact same pattern used by Span, which faces the identical problem as another non-visual Element subclass that needs style resolution.

**Tested the behavior in the following platforms: **

- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Reference:

N/A

### Issues Fixed:

Fixes  #19560         

### Screenshots
| Before  | After  |
|---------|--------|
| <img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/0b9bea52-3ac9-445a-8b76-f8189da3fa66" /> | <img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/edef89a1-a8ea-4e77-ac0d-6ecf6bee683c" /> |

