### PR TITLE
[iOS] Fix stale bottom safe area after changing SafeAreaEdges with keyboard open

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28986_ContentPage.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28986_ContentPage.cs
@@ -130,5 +130,36 @@ public class Issue28986_ContentPage : _IssuesUITest
 			Assert.That(containerPositionWithoutSoftInput.Height, Is.EqualTo(containerPosition.Height), "ContentGrid height should return to original when Soft Input is dismissed with Container edges");
 		});
 	}
+
+	[Test]
+	[Category(UITestCategories.SafeAreaEdges)]
+	public void SafeAreaNoWhiteSpaceAfterKeyboardDismissAndEdgeToggle()
+	{
+		App.WaitForElement("ContentGrid");
+
+		App.Tap("GridResetAllButton");
+		var baselinePosition = App.WaitForElement("ContentGrid").GetRect();
+
+		App.Tap("SoftInputTestEntry");
+		App.RetryAssert(() =>
+		{
+			var withKeyboard = App.WaitForElement("ContentGrid").GetRect();
+			Assert.That(withKeyboard.Height, Is.LessThan(baselinePosition.Height),
+				"ContentGrid should shrink when keyboard is showing with SafeAreaEdges=All");
+		});
+
+		App.Tap("GridSetContainerButton");
+		App.DismissKeyboard();
+		App.Tap("GridResetAllButton");
+
+		App.RetryAssert(() =>
+		{
+			var finalPosition = App.WaitForElement("ContentGrid").GetRect();
+			Assert.That(finalPosition.Height, Is.EqualTo(baselinePosition.Height).Within(1),
+				"ContentGrid height should match baseline after toggling edges with keyboard dismiss — no white space (#34846)");
+			Assert.That(finalPosition.Y, Is.EqualTo(baselinePosition.Y).Within(1),
+				"ContentGrid Y should match baseline after toggling edges with keyboard dismiss");
+		});
+	}
 }
 #endif

--- a/src/Core/src/Platform/iOS/MauiView.cs
+++ b/src/Core/src/Platform/iOS/MauiView.cs
@@ -323,6 +323,16 @@ namespace Microsoft.Maui.Platform
 				NSNotificationCenter.DefaultCenter.RemoveObserver(hideObserver);
 				_keyboardWillHideObserver = null;
 			}
+
+			// Clear stale keyboard state so that re-subscribing later doesn't
+			// pick up a phantom keyboard frame from a previous session (#34846).
+			if (_isKeyboardShowing)
+			{
+				_isKeyboardShowing = false;
+				_keyboardFrame = CGRect.Empty;
+				_safeAreaInvalidated = true;
+				SetNeedsLayout();
+			}
 		}
 
 		void UpdateKeyboardSubscription()

--- a/src/Core/src/Platform/iOS/MauiView.cs
+++ b/src/Core/src/Platform/iOS/MauiView.cs
@@ -328,10 +328,7 @@ namespace Microsoft.Maui.Platform
 			// pick up a phantom keyboard frame from a previous session (#34846).
 			if (_isKeyboardShowing)
 			{
-				_isKeyboardShowing = false;
-				_keyboardFrame = CGRect.Empty;
-				_safeAreaInvalidated = true;
-				SetNeedsLayout();
+				ClearKeyboardState();
 			}
 		}
 
@@ -363,7 +360,9 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		void OnKeyboardWillHide(NSNotification notification)
+		void OnKeyboardWillHide(NSNotification notification) => ClearKeyboardState();
+
+		void ClearKeyboardState()
 		{
 			_safeAreaInvalidated = true;
 			_keyboardFrame = CGRect.Empty;


### PR DESCRIPTION
 <!-- Please let the below note in for people that find this PR -->
   > [!NOTE]
   > Are you waiting for the changes in this PR to be merged?
   > It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. 
  Thank you!
 
### Root Cause
When `SafeAreaEdges` changes from a mode that includes `SoftInput` (e.g., `All`) to one that does not (e.g., `Container`), the view unsubscribes from iOS keyboard notifications. However, the keyboard state (`_isKeyboardShowing`, `_keyboardFrame`) was not cleared. If the keyboard was open during unsubscription and later dismissed, the `OnKeyboardWillHide` event is never received. When switching back to a `SoftInput` mode, the view re-subscribes with stale state, applying incorrect bottom padding equal to the old keyboard height instead of the home indicator inset.
 
### Description of Change
Added state cleanup in `UnsubscribeFromKeyboardNotifications` in `MauiView.cs`. When unsubscribing, if the keyboard was previously visible, the method now clears the keyboard state, invalidates the safe area, and triggers a layout update. This prevents stale keyboard state from persisting across subscribe/unsubscribe cycles while preserving existing behavior in all other scenarios.

Also added a test in `Issue28986_ContentPage` that reproduces the exact sequence: switch to All, open keyboard, change to Container, dismiss keyboard, switch back to All, and verify the layout returns to baseline without phantom padding.
 
### Issues Fixed
Fixes #34846     
 
Tested the behaviour in the following platforms
- [x] Android
- [ ] Windows
- [x] iOS
- [x] Mac

### Screenshots
| Before Issue Fix | After Issue Fix |
|------------------|-----------------|
| <video width="350" alt="withoutfix" src="https://github.com/user-attachments/assets/48e5afe8-4b6c-4c5a-b223-91312bf212e3" /> | <video width="350" alt="withfix" src="https://github.com/user-attachments/assets/a7fa1af6-8927-4fed-a7f2-f8011bdbef8f" /> |