### PR TITLE
[Android/iOS] Fix SwipeItem visibility change causing double command execution in Execute mode

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue7580.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue7580.cs
@@ -1,0 +1,106 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 7580, "Changing visibility on a SwipeItem causes multiple items to be executed", PlatformAffected.All)]
+public class Issue7580 : ContentPage
+{
+	public Issue7580()
+	{
+		var invokeCountLabel = new Label
+		{
+			Text = "InvokeCount: 0",
+			AutomationId = "InvokeCountLabel",
+			FontSize = 20
+		};
+
+		var statusLabel = new Label
+		{
+			Text = "Status: Ready",
+			AutomationId = "StatusLabel",
+			FontSize = 16
+		};
+
+		int invokeCount = 0;
+		bool isCompleted = true;
+
+		var setNotCompleted = new SwipeItem
+		{
+			Text = "Set not completed",
+			BackgroundColor = Colors.Red,
+			IsVisible = isCompleted,
+		};
+
+		var setCompleted = new SwipeItem
+		{
+			Text = "Set completed",
+			BackgroundColor = Colors.Green,
+			IsVisible = !isCompleted,
+		};
+
+		var toggleCommand = new Command(() =>
+		{
+			invokeCount++;
+			isCompleted = !isCompleted;
+
+			setNotCompleted.IsVisible = isCompleted;
+			setCompleted.IsVisible = !isCompleted;
+
+			invokeCountLabel.Text = $"InvokeCount: {invokeCount}";
+			statusLabel.Text = $"Status: IsCompleted={isCompleted}";
+
+			System.Diagnostics.Debug.WriteLine($"[Issue7580] Toggle invoked #{invokeCount}, IsCompleted={isCompleted}");
+		});
+
+		setNotCompleted.Command = toggleCommand;
+		setCompleted.Command = toggleCommand;
+
+		var swipeItems = new SwipeItems
+		{
+			Mode = SwipeMode.Execute
+		};
+		swipeItems.Add(setNotCompleted);
+		swipeItems.Add(setCompleted);
+
+		var swipeContent = new Grid
+		{
+			HeightRequest = 60,
+			BackgroundColor = Colors.LightGray,
+		};
+		swipeContent.Add(new Label
+		{
+			Text = "Swipe right to toggle",
+			AutomationId = "SwipeTarget",
+			HorizontalOptions = LayoutOptions.Center,
+			VerticalOptions = LayoutOptions.Center
+		});
+
+		var swipeView = new SwipeView
+		{
+			LeftItems = swipeItems,
+			Content = swipeContent,
+			Threshold = 250
+		};
+
+		Content = new VerticalStackLayout
+		{
+			Padding = 20,
+			Spacing = 10,
+			Children =
+			{
+				new Label
+				{
+					Text = "Issue 7580 - SwipeItem visibility toggle bug",
+					FontSize = 18,
+					FontAttributes = FontAttributes.Bold
+				},
+				new Label
+				{
+					Text = "Swipe right on the gray area. InvokeCount should be 1 after each swipe.",
+					FontSize = 14
+				},
+				invokeCountLabel,
+				statusLabel,
+				swipeView
+			}
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue7580.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue7580.cs
@@ -1,0 +1,40 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue7580 : _IssuesUITest
+{
+	public override string Issue => "Changing visibility on a SwipeItem causes multiple items to be executed";
+
+	public Issue7580(TestDevice device) : base(device)
+	{
+	}
+
+	[Test]
+	[Category(UITestCategories.SwipeView)]
+	public void SwipeItemVisibilityChangeShouldNotInvokeTwice()
+	{
+		App.WaitForElement("SwipeTarget");
+		App.WaitForElement("InvokeCountLabel");
+
+		var initialCount = App.FindElement("InvokeCountLabel").GetText();
+		Assert.That(initialCount, Is.EqualTo("InvokeCount: 0"));
+
+		var rect = App.WaitForElement("SwipeTarget").GetRect();
+		var centerY = rect.Y + rect.Height / 2;
+		var startX = rect.X + 20;
+		var endX = startX + 600;
+
+		App.DragCoordinates(startX, centerY, endX, centerY);
+
+		var afterFirstSwipe = App.FindElement("InvokeCountLabel").GetText();
+		Assert.That(afterFirstSwipe, Is.EqualTo("InvokeCount: 1"),
+			"SwipeItem command should be invoked exactly once per swipe");
+
+		var status = App.FindElement("StatusLabel").GetText();
+		Assert.That(status, Is.EqualTo("Status: IsCompleted=False"),
+			"IsCompleted should have toggled once from True to False");
+	}
+}

--- a/src/Core/src/Platform/Android/MauiSwipeView.cs
+++ b/src/Core/src/Platform/Android/MauiSwipeView.cs
@@ -985,10 +985,14 @@ namespace Microsoft.Maui.Platform
 
 				if (swipeItems.Mode == SwipeMode.Execute)
 				{
-					foreach (var swipeItem in swipeItems)
+					// Snapshot visible items before executing any commands.
+					// Executing a command may change visibility of other SwipeItems
+					// (e.g., toggling IsCompleted), which would cause the foreach
+					// to also execute newly-visible items. See #7580.
+					var visibleItems = swipeItems.Where(GetIsVisible).ToList();
+					foreach (var swipeItem in visibleItems)
 					{
-						if (GetIsVisible(swipeItem))
-							ExecuteSwipeItem(swipeItem);
+						ExecuteSwipeItem(swipeItem);
 					}
 
 					if (swipeItems.SwipeBehaviorOnInvoked != SwipeBehaviorOnInvoked.RemainOpen)

--- a/src/Core/src/Platform/Android/MauiSwipeView.cs
+++ b/src/Core/src/Platform/Android/MauiSwipeView.cs
@@ -985,15 +985,13 @@ namespace Microsoft.Maui.Platform
 
 				if (swipeItems.Mode == SwipeMode.Execute)
 				{
-					// Snapshot visible items before executing any commands.
-					// Executing a command may change visibility of other SwipeItems
-					// (e.g., toggling IsCompleted), which would cause the foreach
-					// to also execute newly-visible items. See #7580.
-					var visibleItems = swipeItems.Where(GetIsVisible).ToList();
-					foreach (var swipeItem in visibleItems)
-					{
-						ExecuteSwipeItem(swipeItem);
-					}
+					// Execute only the first visible item. In Execute mode, a swipe
+					// triggers a single action — matching WinUI behavior. Executing
+					// multiple items would cause side effects (e.g., visibility changes)
+					// that could trigger unintended additional executions. See #7580.
+					var itemToExecute = swipeItems.FirstOrDefault(GetIsVisible);
+					if (itemToExecute != null)
+						ExecuteSwipeItem(itemToExecute);
 
 					if (swipeItems.SwipeBehaviorOnInvoked != SwipeBehaviorOnInvoked.RemainOpen)
 						ResetSwipe();

--- a/src/Core/src/Platform/iOS/MauiSwipeView.cs
+++ b/src/Core/src/Platform/iOS/MauiSwipeView.cs
@@ -773,10 +773,14 @@ namespace Microsoft.Maui.Platform
 
 				if (swipeItems.Mode == SwipeMode.Execute)
 				{
-					foreach (var swipeItem in swipeItems)
+					// Snapshot visible items before executing any commands.
+					// Executing a command may change visibility of other SwipeItems
+					// (e.g., toggling IsCompleted), which would cause the foreach
+					// to also execute newly-visible items. See #7580.
+					var visibleItems = swipeItems.Where(GetIsVisible).ToList();
+					foreach (var swipeItem in visibleItems)
 					{
-						if (GetIsVisible(swipeItem))
-							MauiSwipeView.ExecuteSwipeItem(swipeItem);
+						MauiSwipeView.ExecuteSwipeItem(swipeItem);
 					}
 
 					if (swipeItems.SwipeBehaviorOnInvoked != SwipeBehaviorOnInvoked.RemainOpen)

--- a/src/Core/src/Platform/iOS/MauiSwipeView.cs
+++ b/src/Core/src/Platform/iOS/MauiSwipeView.cs
@@ -773,15 +773,13 @@ namespace Microsoft.Maui.Platform
 
 				if (swipeItems.Mode == SwipeMode.Execute)
 				{
-					// Snapshot visible items before executing any commands.
-					// Executing a command may change visibility of other SwipeItems
-					// (e.g., toggling IsCompleted), which would cause the foreach
-					// to also execute newly-visible items. See #7580.
-					var visibleItems = swipeItems.Where(GetIsVisible).ToList();
-					foreach (var swipeItem in visibleItems)
-					{
-						MauiSwipeView.ExecuteSwipeItem(swipeItem);
-					}
+					// Execute only the first visible item. In Execute mode, a swipe
+					// triggers a single action — matching WinUI behavior. Executing
+					// multiple items would cause side effects (e.g., visibility changes)
+					// that could trigger unintended additional executions. See #7580.
+					var itemToExecute = swipeItems.FirstOrDefault(GetIsVisible);
+					if (itemToExecute != null)
+						MauiSwipeView.ExecuteSwipeItem(itemToExecute);
 
 					if (swipeItems.SwipeBehaviorOnInvoked != SwipeBehaviorOnInvoked.RemainOpen)
 						ResetSwipe();


### PR DESCRIPTION
 <!-- Please let the below note in for people that find this PR -->
   > [!NOTE]
   > Are you waiting for the changes in this PR to be merged?
   > It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. 
  Thank you!
 
### Root Cause
In `SwipeView` Execute mode, when a swipe crosses the threshold, the framework iterates through all `SwipeItems` and executes the command for each visible item. The visibility check is performed dynamically during iteration. If the first item’s command changes the visibility of a sibling item (for example, toggling a boolean that controls which `SwipeItem` is shown), the newly visible item is also picked up and executed within the same loop. This leads to a double invocation, effectively cancelling the user’s intended action.
 
### Description of Change
Updated the Execute mode logic in `ValidateSwipeThreshold()` to execute only the first visible `SwipeItem` using `FirstOrDefault(GetIsVisible)`, instead of iterating through all items.

This change aligns Android and iOS with WinUI, where only one `SwipeItem` is allowed in Execute mode at the platform level. It also removes timing-related issues caused by UI updates during iteration and prevents potential multiple executions when additional `SwipeItems` are introduced in the future.
 
### Issues Fixed
Fixes #7580    
 
Tested the behaviour in the following platforms
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Screenshots - Android
| Before Issue Fix | After Issue Fix |
|------------------|-----------------|
| <video width="350" alt="withoutfix" src="https://github.com/user-attachments/assets/39fdad1f-cc24-4cca-9521-8c99e541c37b" /> | <video width="350" alt="withfix" src="https://github.com/user-attachments/assets/c6112298-4723-49e6-84fe-cea1e5e8fe0a" /> |

### Screenshots - iOS
| Before Issue Fix | After Issue Fix |
|------------------|-----------------|
| <video width="350" alt="withoutfix" src="https://github.com/user-attachments/assets/f935ffa7-3b6e-4e06-8562-dc234d373b16" /> | <video width="350" alt="withfix" src="https://github.com/user-attachments/assets/15711245-4d0d-4c16-9de8-edc7e442f5d9" /> |