### PR TITLE
Use Azure Artifacts Maven feed for CFSClean network isolation compliance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -102,6 +102,14 @@ When referencing or triggering CI pipelines, use these current pipeline names:
 
 **⚠️ Old pipeline names** (e.g., `MAUI-UITests-public`, `MAUI-public`) are **outdated** and should NOT be used. Always use the names above.
 
+### Gradle / Maven Dependency Failures (CFSClean)
+
+The official CI build uses CFSClean network isolation which blocks `repo.maven.apache.org`. All Gradle/Maven dependencies resolve through the `dotnet-public-maven` Azure Artifacts feed.
+
+**If CI fails with Gradle 401 errors** like `"No local versions of package"` or `"Please provide authentication to save package from upstream"`, it means a Maven package hasn't been ingested into the feed yet. **Fix:** run `./eng/ingest-maven-deps.sh` locally to pre-populate the feed. See `src/Core/AndroidNative/settings.gradle` for details.
+
+**Do NOT upgrade Gradle past 8.x** — the Android SDK's `net.android.init.gradle.kts` is incompatible with Gradle 9.x (`dotnet/android#10738`).
+
 ### Code Formatting
 
 Always format code before committing:

--- a/.github/instructions/android.instructions.md
+++ b/.github/instructions/android.instructions.md
@@ -126,30 +126,8 @@ protected override void DisconnectHandler(RecyclerView platformView)
 | Listener not working | Check lifecycle (register/unregister) |
 | Memory leak | Ensure Dispose() called on Java.Lang.Object |
 | Threading error | Use `platformView.Post()` for UI thread |
-| Gradle 401 / Maven dependency failure | Run `./eng/ingest-maven-deps.sh` (see below) |
+| Gradle 401 / Maven dependency failure | Run `./eng/ingest-maven-deps.sh` — see `copilot-instructions.md` |
 
 ## Gradle / Maven Dependency Failures
 
-### CFSClean Network Isolation
-
-The official CI build runs under CFSClean network isolation which blocks direct access to Maven Central (`repo.maven.apache.org`). All Gradle/Maven dependencies are resolved through the `dotnet-public-maven` Azure Artifacts feed instead.
-
-**Symptom:** Build fails with errors like:
-```
-error XAGRDL0000: Could not resolve com.android.tools.build:gradle:8.11.1
-  > Could not GET 'https://pkgs.dev.azure.com/.../maven/v1/...'
-  > Received status code 401: Unauthorized - No local versions of package
-```
-
-**Cause:** A new or updated Maven package hasn't been ingested into the `dotnet-public-maven` feed yet. The feed requires an authenticated first-time pull from upstream Maven Central.
-
-**Fix:** Run the ingestion script locally:
-```bash
-./eng/ingest-maven-deps.sh
-```
-
-This acquires an auth token, runs the Gradle build with `--refresh-dependencies`, and uses `curl` to force-ingest any packages that Gradle's credential provider can't reach.
-
-**When to run:** After adding or updating any dependency in `src/Core/AndroidNative/build.gradle` or `settings.gradle`.
-
-**Important:** Do NOT upgrade Gradle past 8.x — the Android SDK's `net.android.init.gradle.kts` is incompatible with Gradle 9.x (see `dotnet/android#10738`).
+CI uses CFSClean which blocks Maven Central. All deps go through the `dotnet-public-maven` Azure Artifacts feed. If a new package hasn't been ingested, CI fails with `XAGRDL0000` / 401. Run `./eng/ingest-maven-deps.sh` locally to fix. Do NOT upgrade Gradle past 8.x (`dotnet/android#10738`).

--- a/.github/instructions/android.instructions.md
+++ b/.github/instructions/android.instructions.md
@@ -4,6 +4,9 @@ applyTo:
   - "**/Android/**/*.cs"
   - "**/Platforms/Android/**/*.cs"
   - "**/Platform/Android/**/*.cs"
+  - "**/AndroidNative/**"
+  - "eng/init.gradle"
+  - "eng/ingest-maven-deps.sh"
 ---
 
 # Android Platform Development Guidelines
@@ -123,3 +126,30 @@ protected override void DisconnectHandler(RecyclerView platformView)
 | Listener not working | Check lifecycle (register/unregister) |
 | Memory leak | Ensure Dispose() called on Java.Lang.Object |
 | Threading error | Use `platformView.Post()` for UI thread |
+| Gradle 401 / Maven dependency failure | Run `./eng/ingest-maven-deps.sh` (see below) |
+
+## Gradle / Maven Dependency Failures
+
+### CFSClean Network Isolation
+
+The official CI build runs under CFSClean network isolation which blocks direct access to Maven Central (`repo.maven.apache.org`). All Gradle/Maven dependencies are resolved through the `dotnet-public-maven` Azure Artifacts feed instead.
+
+**Symptom:** Build fails with errors like:
+```
+error XAGRDL0000: Could not resolve com.android.tools.build:gradle:8.11.1
+  > Could not GET 'https://pkgs.dev.azure.com/.../maven/v1/...'
+  > Received status code 401: Unauthorized - No local versions of package
+```
+
+**Cause:** A new or updated Maven package hasn't been ingested into the `dotnet-public-maven` feed yet. The feed requires an authenticated first-time pull from upstream Maven Central.
+
+**Fix:** Run the ingestion script locally:
+```bash
+./eng/ingest-maven-deps.sh
+```
+
+This acquires an auth token, runs the Gradle build with `--refresh-dependencies`, and uses `curl` to force-ingest any packages that Gradle's credential provider can't reach.
+
+**When to run:** After adding or updating any dependency in `src/Core/AndroidNative/build.gradle` or `settings.gradle`.
+
+**Important:** Do NOT upgrade Gradle past 8.x — the Android SDK's `net.android.init.gradle.kts` is incompatible with Gradle 9.x (see `dotnet/android#10738`).

--- a/.github/skills/azdo-build-investigator/SKILL.md
+++ b/.github/skills/azdo-build-investigator/SKILL.md
@@ -66,6 +66,33 @@ If available, use the `mcp-binlog-tool` MCP server to analyze downloaded `.binlo
 | `error CS####` | `maui-pr` | C# compiler error — check file/line |
 | `error XA####` | `maui-pr` | Android build error |
 | `XamlC` | `maui-pr` | XAML compiler — usually missing type or bad binding |
+| `error XAGRDL0000` / `401` / `No local versions` | `maui-pr` or official build | Gradle/Maven feed issue — see below |
 | `XHarness timeout` | `maui-pr-devicetests` Helix logs | Test killed by infrastructure; may be transient |
 | `No test result files found` | `maui-pr-devicetests` Helix logs | Tests never ran or app crashed on launch |
 | UI test screenshot diff | `maui-pr-uitests` | Visual regression; check baseline images |
+
+### Gradle / Maven / CFSClean Failures
+
+The official build (`dotnet-maui`, def 1095, `dnceng/internal`) runs under CFSClean network isolation which blocks `repo.maven.apache.org`. All Gradle/Maven deps resolve through the `dotnet-public-maven` Azure Artifacts feed.
+
+**Error signatures:**
+```
+error XAGRDL0000: Could not resolve com.android.tools.build:gradle:8.11.1
+  > Received status code 401: Unauthorized - No local versions of package
+```
+```
+error XAGRDL0000: Could not GET '...pkgs.dev.azure.com/.../maven/v1/...'
+  > Unauthorized - Please provide authentication to save package from upstream
+```
+
+**Root cause:** A Maven package hasn't been ingested into the `dotnet-public-maven` feed yet. The credential provider plugin skips auth in CI (`TF_BUILD=True`), so new packages must be pre-ingested locally.
+
+**Fix:** Tell the user to run locally:
+```bash
+./eng/ingest-maven-deps.sh
+```
+
+**Do NOT:**
+- Suggest removing CFSClean from `ci-official.yml` — it's a security compliance requirement
+- Upgrade Gradle past 8.x — Android SDK's `net.android.init.gradle.kts` is incompatible with Gradle 9.x (`dotnet/android#10738`)
+- Add `mavenCentral()` or `google()` back to `settings.gradle` or `build.gradle` — use the Azure Artifacts feed

--- a/.github/skills/azdo-build-investigator/SKILL.md
+++ b/.github/skills/azdo-build-investigator/SKILL.md
@@ -73,8 +73,6 @@ If available, use the `mcp-binlog-tool` MCP server to analyze downloaded `.binlo
 
 ### Gradle / Maven / CFSClean Failures
 
-The official build (`dotnet-maui`, def 1095, `dnceng/internal`) runs under CFSClean network isolation which blocks `repo.maven.apache.org`. All Gradle/Maven deps resolve through the `dotnet-public-maven` Azure Artifacts feed.
-
 **Error signatures:**
 ```
 error XAGRDL0000: Could not resolve com.android.tools.build:gradle:8.11.1
@@ -85,14 +83,9 @@ error XAGRDL0000: Could not GET '...pkgs.dev.azure.com/.../maven/v1/...'
   > Unauthorized - Please provide authentication to save package from upstream
 ```
 
-**Root cause:** A Maven package hasn't been ingested into the `dotnet-public-maven` feed yet. The credential provider plugin skips auth in CI (`TF_BUILD=True`), so new packages must be pre-ingested locally.
-
-**Fix:** Tell the user to run locally:
-```bash
-./eng/ingest-maven-deps.sh
-```
+**Fix:** Tell the user to run `./eng/ingest-maven-deps.sh` locally to pre-ingest packages into the feed.
 
 **Do NOT:**
-- Suggest removing CFSClean from `ci-official.yml` — it's a security compliance requirement
-- Upgrade Gradle past 8.x — Android SDK's `net.android.init.gradle.kts` is incompatible with Gradle 9.x (`dotnet/android#10738`)
-- Add `mavenCentral()` or `google()` back to `settings.gradle` or `build.gradle` — use the Azure Artifacts feed
+- Remove CFSClean from `ci-official.yml` — security compliance requirement
+- Upgrade Gradle past 8.x — `dotnet/android#10738`
+- Add `mavenCentral()` or `google()` back — use the Azure Artifacts feed

--- a/eng/ingest-maven-deps.sh
+++ b/eng/ingest-maven-deps.sh
@@ -18,9 +18,11 @@
 #
 # HOW IT WORKS:
 #   1. Acquires an auth token via the .NET Azure Artifacts credential provider
-#   2. Runs the Gradle build with --refresh-dependencies to bypass local cache
+#   2. Pre-ingests platform-specific artifacts (e.g. aapt2) for all OS variants
+#      (macOS/Linux/Windows) since Gradle only resolves the local OS classifier
+#   3. Runs the Gradle build with --refresh-dependencies to bypass local cache
 #      and force actual downloads through the feed (which triggers ingestion)
-#   3. For packages that Gradle's credential provider can't reach (e.g. AGP's
+#   4. For packages that Gradle's credential provider can't reach (e.g. AGP's
 #      internal detachedConfiguration scopes), falls back to curl with Bearer
 #      token to force-ingest the specific package URLs
 #
@@ -65,9 +67,23 @@ if [ -z "$TOKEN" ]; then
 fi
 echo "Token acquired."
 
-# Step 2: Run Gradle build with refresh to ingest via credential provider
+# Step 2: Ingest platform-specific artifacts for all OS variants
+# Gradle only resolves the classifier for the current OS (e.g. aapt2-osx.jar on macOS).
+# CI builds on Windows/Linux need their variants pre-ingested too.
 echo ""
-echo "Step 1/2: Running Gradle build with --refresh-dependencies..."
+echo "Step 1/3: Ingesting cross-platform artifacts..."
+AAPT2_VERSION="8.11.1-12782657"
+for classifier in osx linux windows; do
+    for ext in jar pom; do
+        url="$FEED_URL/com/android/tools/build/aapt2/$AAPT2_VERSION/aapt2-$AAPT2_VERSION-$classifier.$ext"
+        code=$(curl -s -o /dev/null -w "%{http_code}" --oauth2-bearer "$TOKEN" "$url" 2>/dev/null)
+        echo "  aapt2-$AAPT2_VERSION-$classifier.$ext: $code"
+    done
+done
+
+# Step 3: Run Gradle build with refresh to ingest via credential provider
+echo ""
+echo "Step 2/3: Running Gradle build with --refresh-dependencies..."
 cd "$ANDROID_DIR"
 if ! ./gradlew build --no-daemon --refresh-dependencies \
     -Dazure.artifacts.credprovider.nonInteractive=true \
@@ -75,9 +91,9 @@ if ! ./gradlew build --no-daemon --refresh-dependencies \
     echo "WARNING: Initial Gradle build failed (expected if packages need ingestion). Continuing..."
 fi
 
-# Step 3: Loop — build, find missing packages, curl-ingest them
+# Step 4: Loop — build, find missing packages, curl-ingest them
 echo ""
-echo "Step 2/2: Ingesting any remaining packages via REST API..."
+echo "Step 3/3: Ingesting any remaining packages via REST API..."
 for i in $(seq 1 30); do
     result=$(./gradlew build --no-daemon \
         -Dazure.artifacts.credprovider.nonInteractive=true 2>&1 || true)

--- a/eng/ingest-maven-deps.sh
+++ b/eng/ingest-maven-deps.sh
@@ -69,16 +69,18 @@ echo "Token acquired."
 echo ""
 echo "Step 1/2: Running Gradle build with --refresh-dependencies..."
 cd "$ANDROID_DIR"
-./gradlew build --no-daemon --refresh-dependencies \
+if ! ./gradlew build --no-daemon --refresh-dependencies \
     -Dazure.artifacts.credprovider.nonInteractive=true \
-    -Dazure.artifacts.credprovider.isRetry=true 2>&1 | tail -3 || true
+    -Dazure.artifacts.credprovider.isRetry=true 2>&1 | tail -20; then
+    echo "WARNING: Initial Gradle build failed (expected if packages need ingestion). Continuing..."
+fi
 
 # Step 3: Loop — build, find missing packages, curl-ingest them
 echo ""
 echo "Step 2/2: Ingesting any remaining packages via REST API..."
 for i in $(seq 1 30); do
     result=$(./gradlew build --no-daemon \
-        -Dazure.artifacts.credprovider.nonInteractive=true 2>&1)
+        -Dazure.artifacts.credprovider.nonInteractive=true 2>&1 || true)
 
     if echo "$result" | grep -q "BUILD SUCCESSFUL"; then
         echo "All dependencies ingested successfully! ✅"
@@ -87,7 +89,7 @@ for i in $(seq 1 30); do
 
     # Extract failed URLs and curl them with auth
     urls=$(echo "$result" | grep "Could not GET\|Could not HEAD" \
-        | sed "s/.*'\(https:[^']*\)'.*/\1/" | sort -u | grep "pkgs.dev.azure.com")
+        | sed "s/.*'\(https:[^']*\)'.*/\1/" | sort -u | grep "pkgs.dev.azure.com" || true)
     count=$(echo "$urls" | grep -c "https" 2>/dev/null || echo "0")
 
     if [ "$count" = "0" ]; then
@@ -100,7 +102,7 @@ for i in $(seq 1 30); do
     echo "  Run $i: ingesting $count packages..."
     echo "$urls" | while read url; do
         [ -z "$url" ] && continue
-        code=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $TOKEN" "$url" 2>/dev/null)
+        code=$(curl -s -o /dev/null -w "%{http_code}" --oauth2-bearer "$TOKEN" "$url" 2>/dev/null)
         if [ "$code" = "200" ]; then
             echo "    ✅ $(basename "$url")"
         else

--- a/eng/ingest-maven-deps.sh
+++ b/eng/ingest-maven-deps.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# Ingest Maven/Gradle dependencies into the dotnet-public-maven Azure Artifacts feed.
+#
+# Run this locally after adding or updating Maven/Gradle dependencies in
+# src/Core/AndroidNative/ to ensure they are available in the feed for CI builds.
+#
+# Prerequisites:
+#   - JDK 17+
+#   - .NET Azure Artifacts credential provider installed
+#     (https://github.com/microsoft/artifacts-credprovider#installation)
+#
+# Usage:
+#   ./eng/ingest-maven-deps.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ANDROID_DIR="$REPO_ROOT/src/Core/AndroidNative"
+FEED_URL="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1"
+CRED_PROVIDER="$HOME/.nuget/plugins/netcore/CredentialProvider.Microsoft/CredentialProvider.Microsoft.dll"
+
+echo "=== Maven Dependency Ingestion for dotnet-public-maven ==="
+echo ""
+
+# Step 1: Get auth token
+echo "Acquiring auth token..."
+if [ ! -f "$CRED_PROVIDER" ]; then
+    echo "ERROR: Azure Artifacts credential provider not found at $CRED_PROVIDER"
+    echo "Install it from: https://github.com/microsoft/artifacts-credprovider#installation"
+    exit 1
+fi
+
+TOKEN=$(dotnet "$CRED_PROVIDER" -U "$FEED_URL" -F Json -N true -I true 2>/dev/null \
+    | python3 -c "import json,sys; print(json.load(sys.stdin).get('Password',''))" 2>/dev/null)
+
+if [ -z "$TOKEN" ]; then
+    echo "ERROR: Failed to acquire auth token. Make sure you're signed in to Azure DevOps."
+    exit 1
+fi
+echo "Token acquired."
+
+# Step 2: Run Gradle build with refresh to ingest via credential provider
+echo ""
+echo "Step 1/2: Running Gradle build with --refresh-dependencies..."
+cd "$ANDROID_DIR"
+./gradlew build --no-daemon --refresh-dependencies \
+    -Dazure.artifacts.credprovider.nonInteractive=true \
+    -Dazure.artifacts.credprovider.isRetry=true 2>&1 | tail -3 || true
+
+# Step 3: Loop — build, find missing packages, curl-ingest them
+echo ""
+echo "Step 2/2: Ingesting any remaining packages via REST API..."
+for i in $(seq 1 30); do
+    result=$(./gradlew build --no-daemon \
+        -Dazure.artifacts.credprovider.nonInteractive=true 2>&1)
+
+    if echo "$result" | grep -q "BUILD SUCCESSFUL"; then
+        echo "All dependencies ingested successfully! ✅"
+        exit 0
+    fi
+
+    # Extract failed URLs and curl them with auth
+    urls=$(echo "$result" | grep "Could not GET\|Could not HEAD" \
+        | sed "s/.*'\(https:[^']*\)'.*/\1/" | sort -u | grep "pkgs.dev.azure.com")
+    count=$(echo "$urls" | grep -c "https" 2>/dev/null || echo "0")
+
+    if [ "$count" = "0" ]; then
+        # No feed URLs failing — might be a different error
+        echo "Build failed but not due to feed issues. Check build output."
+        echo "$result" | grep -i "error" | grep -v "warning" | head -5
+        exit 1
+    fi
+
+    echo "  Run $i: ingesting $count packages..."
+    echo "$urls" | while read url; do
+        [ -z "$url" ] && continue
+        code=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $TOKEN" "$url" 2>/dev/null)
+        if [ "$code" = "200" ]; then
+            echo "    ✅ $(basename "$url")"
+        else
+            echo "    ❌ ($code) $(basename "$url")"
+        fi
+    done
+done
+
+echo "WARNING: Reached max iterations. Some packages may still need ingestion."
+exit 1

--- a/eng/ingest-maven-deps.sh
+++ b/eng/ingest-maven-deps.sh
@@ -1,8 +1,33 @@
 #!/bin/bash
 # Ingest Maven/Gradle dependencies into the dotnet-public-maven Azure Artifacts feed.
 #
-# Run this locally after adding or updating Maven/Gradle dependencies in
-# src/Core/AndroidNative/ to ensure they are available in the feed for CI builds.
+# WHY THIS IS NEEDED:
+#   CI builds run under CFSClean network isolation which blocks direct access to
+#   Maven Central (repo.maven.apache.org). All Maven dependencies are resolved
+#   through the dotnet-public-maven Azure Artifacts feed instead. However, this
+#   feed requires an authenticated request the FIRST time a package is pulled
+#   from upstream Maven Central — after that, anyone can read it anonymously.
+#
+#   The CI pipeline's credential provider plugin (com.microsoft.azure.artifacts.
+#   credprovider) skips authentication in Azure Pipelines (TF_BUILD=True), so
+#   new packages MUST be pre-ingested locally before CI can use them.
+#
+# WHEN TO RUN:
+#   After adding or updating any Maven/Gradle dependency in
+#   src/Core/AndroidNative/build.gradle or settings.gradle.
+#
+# HOW IT WORKS:
+#   1. Acquires an auth token via the .NET Azure Artifacts credential provider
+#   2. Runs the Gradle build with --refresh-dependencies to bypass local cache
+#      and force actual downloads through the feed (which triggers ingestion)
+#   3. For packages that Gradle's credential provider can't reach (e.g. AGP's
+#      internal detachedConfiguration scopes), falls back to curl with Bearer
+#      token to force-ingest the specific package URLs
+#
+# COMMON PITFALL:
+#   Running ./gradlew build without --refresh-dependencies may appear to succeed
+#   but actually resolves from ~/.gradle/caches/ (local cache from prior builds
+#   that used mavenCentral() directly). This does NOT ingest into the feed.
 #
 # Prerequisites:
 #   - JDK 17+

--- a/eng/init.gradle
+++ b/eng/init.gradle
@@ -1,0 +1,23 @@
+// Redirect Maven Central and Google Maven to Azure Artifacts feed
+// for CFSClean network isolation compliance.
+// See: https://aka.ms/1es/netiso/CFS
+allprojects {
+    repositories {
+        all { ArtifactRepository repo ->
+            if (repo instanceof MavenArtifactRepository &&
+                (repo.url.toString().contains(".maven.org") ||
+                    repo.url.toString().contains("maven.apache.org") ||
+                    repo.url.toString().contains("maven.google.com") ||
+                    repo.url.toString().contains("dl.google.com") ||
+                    repo.url.toString().contains("plugins.gradle.org"))) {
+                    def azureFeed = maven {
+                        url "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1"
+                        name "dotnet-public-maven"
+                    }
+                    project.logger.warn "Replacing repository ${repo.url} with Azure Artifacts feed ${azureFeed.url}."
+                    remove repo
+                    add azureFeed
+                }
+        }
+    }
+}

--- a/eng/init.gradle
+++ b/eng/init.gradle
@@ -3,20 +3,21 @@
 // See: https://aka.ms/1es/netiso/CFS
 allprojects {
     repositories {
+        def azureFeed = findByName("dotnet-public-maven") ?: maven {
+            url "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1"
+            name "dotnet-public-maven"
+        }
+
         all { ArtifactRepository repo ->
-            if (repo instanceof MavenArtifactRepository &&
+            if (repo != azureFeed &&
+                repo instanceof MavenArtifactRepository &&
                 (repo.url.toString().contains(".maven.org") ||
                     repo.url.toString().contains("maven.apache.org") ||
                     repo.url.toString().contains("maven.google.com") ||
                     repo.url.toString().contains("dl.google.com") ||
                     repo.url.toString().contains("plugins.gradle.org"))) {
-                    def azureFeed = maven {
-                        url "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1"
-                        name "dotnet-public-maven"
-                    }
                     project.logger.warn "Replacing repository ${repo.url} with Azure Artifacts feed ${azureFeed.url}."
                     remove repo
-                    add azureFeed
                 }
         }
     }

--- a/eng/pipelines/common/cache-gradle.yml
+++ b/eng/pipelines/common/cache-gradle.yml
@@ -42,11 +42,11 @@ steps:
 
 # Copy init.gradle AFTER cache restore so it is not overwritten by a stale cached copy
 - script: |
-    cp "${{ parameters.checkoutDirectory }}/eng/init.gradle" "$HOME/.gradle/init.gradle"
+    cp "${{ parameters.checkoutDirectory }}/eng/init.gradle" "$(GRADLE_USER_HOME)/init.gradle"
   displayName: install Gradle init script (Linux/macOS)
   condition: ne(variables['Agent.OS'], 'Windows_NT')
 
 - pwsh: |
-    Copy-Item "${{ parameters.checkoutDirectory }}/eng/init.gradle" (Join-Path $env:USERPROFILE ".gradle" "init.gradle")
+    Copy-Item "${{ parameters.checkoutDirectory }}/eng/init.gradle" (Join-Path "$(GRADLE_USER_HOME)" "init.gradle")
   displayName: install Gradle init script (Windows)
   condition: eq(variables['Agent.OS'], 'Windows_NT')

--- a/eng/pipelines/common/cache-gradle.yml
+++ b/eng/pipelines/common/cache-gradle.yml
@@ -16,7 +16,6 @@ steps:
 - script: |
     mkdir -p "$HOME/.gradle"
     echo "##vso[task.setvariable variable=GRADLE_USER_HOME]$HOME/.gradle"
-    cp "${{ parameters.checkoutDirectory }}/eng/init.gradle" "$HOME/.gradle/init.gradle"
   displayName: prepare Gradle cache variables (Linux/macOS)
   condition: ne(variables['Agent.OS'], 'Windows_NT')
 
@@ -24,7 +23,6 @@ steps:
     $gradleHome = Join-Path $env:USERPROFILE ".gradle"
     New-Item -ItemType Directory -Path $gradleHome -Force | Out-Null
     Write-Host "##vso[task.setvariable variable=GRADLE_USER_HOME]$gradleHome"
-    Copy-Item "${{ parameters.checkoutDirectory }}/eng/init.gradle" (Join-Path $gradleHome "init.gradle")
   displayName: prepare Gradle cache variables (Windows)
   condition: eq(variables['Agent.OS'], 'Windows_NT')
 
@@ -41,3 +39,14 @@ steps:
       "gradle" | "v1" | "$(Agent.OS)" | ${{ parameters.checkoutDirectory }}/src/Core/AndroidNative/gradle/wrapper/gradle-wrapper.properties
       "gradle" | "v1" | "$(Agent.OS)"
     path: $(GRADLE_USER_HOME)
+
+# Copy init.gradle AFTER cache restore so it is not overwritten by a stale cached copy
+- script: |
+    cp "${{ parameters.checkoutDirectory }}/eng/init.gradle" "$HOME/.gradle/init.gradle"
+  displayName: install Gradle init script (Linux/macOS)
+  condition: ne(variables['Agent.OS'], 'Windows_NT')
+
+- pwsh: |
+    Copy-Item "${{ parameters.checkoutDirectory }}/eng/init.gradle" (Join-Path $env:USERPROFILE ".gradle" "init.gradle")
+  displayName: install Gradle init script (Windows)
+  condition: eq(variables['Agent.OS'], 'Windows_NT')

--- a/eng/pipelines/common/cache-gradle.yml
+++ b/eng/pipelines/common/cache-gradle.yml
@@ -16,6 +16,7 @@ steps:
 - script: |
     mkdir -p "$HOME/.gradle"
     echo "##vso[task.setvariable variable=GRADLE_USER_HOME]$HOME/.gradle"
+    cp "${{ parameters.checkoutDirectory }}/eng/init.gradle" "$HOME/.gradle/init.gradle"
   displayName: prepare Gradle cache variables (Linux/macOS)
   condition: ne(variables['Agent.OS'], 'Windows_NT')
 
@@ -23,6 +24,7 @@ steps:
     $gradleHome = Join-Path $env:USERPROFILE ".gradle"
     New-Item -ItemType Directory -Path $gradleHome -Force | Out-Null
     Write-Host "##vso[task.setvariable variable=GRADLE_USER_HOME]$gradleHome"
+    Copy-Item "${{ parameters.checkoutDirectory }}/eng/init.gradle" (Join-Path $gradleHome "init.gradle")
   displayName: prepare Gradle cache variables (Windows)
   condition: eq(variables['Agent.OS'], 'Windows_NT')
 

--- a/src/Core/AndroidNative/build.gradle
+++ b/src/Core/AndroidNative/build.gradle
@@ -1,5 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
+    repositories {
+        maven {
+            url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
+        }
+    }
     dependencies {
         classpath "com.android.tools.build:gradle:8.11.1"
     }

--- a/src/Core/AndroidNative/build.gradle
+++ b/src/Core/AndroidNative/build.gradle
@@ -1,9 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
     dependencies {
         classpath "com.android.tools.build:gradle:8.11.1"
     }

--- a/src/Core/AndroidNative/build.gradle
+++ b/src/Core/AndroidNative/build.gradle
@@ -3,6 +3,7 @@ buildscript {
     repositories {
         maven {
             url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
+            name = 'dotnet-public-maven'
         }
     }
     dependencies {

--- a/src/Core/AndroidNative/gradle/wrapper/gradle-wrapper.properties
+++ b/src/Core/AndroidNative/gradle/wrapper/gradle-wrapper.properties
@@ -1,3 +1,9 @@
+# DO NOT upgrade Gradle beyond 8.x without verifying that the Microsoft.Android.Sdk
+# version used by this branch supports it. The Android SDK generates a
+# net.android.init.gradle.kts script that has a Kotlin type mismatch (String? vs Any)
+# incompatible with Gradle 9.x's stricter type checking. The fix is merged upstream
+# (dotnet/android#10738) but must ship in the Android SDK version referenced by this
+# branch before Gradle can be upgraded.
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip

--- a/src/Core/AndroidNative/gradle/wrapper/gradle-wrapper.properties
+++ b/src/Core/AndroidNative/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/Core/AndroidNative/gradle/wrapper/gradle-wrapper.properties
+++ b/src/Core/AndroidNative/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/Core/AndroidNative/settings.gradle
+++ b/src/Core/AndroidNative/settings.gradle
@@ -7,7 +7,7 @@ pluginManagement {
 }
 
 dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositoriesMode.set(RepositoriesMode.PREFER_PROJECT)
     repositories {
         maven {
             url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'

--- a/src/Core/AndroidNative/settings.gradle
+++ b/src/Core/AndroidNative/settings.gradle
@@ -1,9 +1,18 @@
 pluginManagement {
     repositories {
         maven {
+            url = 'https://pkgs.dev.azure.com/artifacts-public/PublicTools/_packaging/AzureArtifacts/maven/v1'
+            name = 'AzureArtifacts'
+        }
+        maven {
             url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
+            name = 'dotnet-public-maven'
         }
     }
+}
+
+plugins {
+    id 'com.microsoft.azure.artifacts.credprovider' version '1.1.1'
 }
 
 dependencyResolutionManagement {
@@ -11,6 +20,7 @@ dependencyResolutionManagement {
     repositories {
         maven {
             url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
+            name = 'dotnet-public-maven'
         }
     }
 }

--- a/src/Core/AndroidNative/settings.gradle
+++ b/src/Core/AndroidNative/settings.gradle
@@ -1,16 +1,17 @@
 pluginManagement {
     repositories {
-        google()
-        mavenCentral()
-        gradlePluginPortal()
+        maven {
+            url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
+        }
     }
 }
 
 dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.PREFER_PROJECT)
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
-        google()
-        mavenCentral()
+        maven {
+            url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
+        }
     }
 }
 

--- a/src/Core/AndroidNative/settings.gradle
+++ b/src/Core/AndroidNative/settings.gradle
@@ -1,3 +1,11 @@
+// All Maven dependencies are resolved through the dnceng Azure Artifacts feed
+// (dotnet-public-maven) for CFSClean network isolation compliance. The feed
+// proxies Maven Central, Google Maven, and Gradle Plugin Portal.
+//
+// When adding or updating dependencies, run eng/ingest-maven-deps.sh locally
+// to ensure new packages are ingested into the feed before CI can use them.
+// See: https://aka.ms/1es/netiso/CFS
+
 pluginManagement {
     repositories {
         maven {

--- a/src/Core/AndroidNative/settings.gradle
+++ b/src/Core/AndroidNative/settings.gradle
@@ -2,8 +2,13 @@
 // (dotnet-public-maven) for CFSClean network isolation compliance. The feed
 // proxies Maven Central, Google Maven, and Gradle Plugin Portal.
 //
-// When adding or updating dependencies, run eng/ingest-maven-deps.sh locally
-// to ensure new packages are ingested into the feed before CI can use them.
+// IMPORTANT: New packages must be ingested into the feed before CI can use them.
+// The CI credential provider plugin skips auth in Azure Pipelines, so packages
+// that aren't already in the feed will fail with 401. After adding or updating
+// dependencies, run:
+//
+//   ./eng/ingest-maven-deps.sh
+//
 // See: https://aka.ms/1es/netiso/CFS
 
 pluginManagement {


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Problem

The official build pipeline (`dotnet-maui`, def 1095) fails because [CFSClean network isolation](https://github.com/dotnet/maui/pull/34540) blocks direct access to `repo.maven.apache.org`. This breaks two separate Gradle invocations:

1. **`src/Core/AndroidNative` build** — our own Gradle project
2. **`Microsoft.Android.Sdk.Bindings.Gradle.targets`** — Android SDK binding generator in `Core.csproj`

Per [1ES CFS guidance](https://aka.ms/1es/netiso/CFS), the fix is to route all Maven dependency resolution through an Azure Artifacts feed with upstream sources.

## Fix

### Gradle configuration changes
- **`settings.gradle`** — Replace `mavenCentral()`, `google()`, `gradlePluginPortal()` with the `dotnet-public-maven` Azure Artifacts feed. Add the [Azure Artifacts Gradle credential provider](https://pkgs.dev.azure.com/artifacts-public/PublicTools/_packaging/AzureArtifacts/maven/v1) plugin (v1.1.1) for local authentication.
- **`build.gradle`** — Point `buildscript.repositories` to the same feed for AGP classpath resolution.
- **`eng/init.gradle`** — Global Gradle init script that redirects any remaining Maven Central/Google Maven references (e.g. from `Microsoft.Android.Sdk.Bindings.Gradle.targets`) to the feed. Installed into `GRADLE_USER_HOME` by the pipeline.

### Pipeline changes
- **`cache-gradle.yml`** — Copy `init.gradle` into `GRADLE_USER_HOME` **after** cache restore to prevent stale cached copies. Uses `$(GRADLE_USER_HOME)` variable for the destination path.

### Why the ingestion script (`eng/ingest-maven-deps.sh`) is needed

The `dotnet-public-maven` feed proxies Maven Central, but new packages require an **authenticated first-time pull** to be saved. The Gradle credential provider plugin has two limitations that prevent `dotnet build` from self-ingesting:

1. **Skips entirely in CI** — when `TF_BUILD=True` (Azure Pipelines), the plugin is a no-op
2. **Doesn't cover all Gradle scopes** — the plugin injects auth into `pluginManagement.repositories` and `project.repositories`, but NOT `buildscript.repositories` or AGP's internal `detachedConfiguration` scopes. This means `dotnet build` locally cannot ingest new packages through the Android SDK binding targets even with correct credentials.

We verified this by adding an un-ingested package (`io.coil-kt:coil:2.7.0`) — `dotnet build` fails with 401 despite the credential provider authenticating successfully.

**Upstream issue:** [microsoft/artifacts-credprovider#671](https://github.com/microsoft/artifacts-credprovider/issues/671)

The script works around these gaps by:
1. Acquiring an auth token via the .NET credential provider (MSAL)
2. Pre-ingesting platform-specific artifacts (aapt2) for all OS variants (macOS/Linux/Windows)
3. Running Gradle with `--refresh-dependencies` to bypass local cache
4. Falling back to `curl` with Bearer token for unreachable scopes

**Run `./eng/ingest-maven-deps.sh` after adding or updating any Maven/Gradle dependency.**

### Documentation updates
- `settings.gradle` — explains the feed setup and when to run the script
- `gradle-wrapper.properties` — warning not to upgrade Gradle past 8.x (`dotnet/android#10738`)
- `copilot-instructions.md` — always-on guidance for Gradle 401 failures
- `azdo-build-investigator/SKILL.md` — error signatures and DO NOTs for CI investigation
- `android.instructions.md` — quick reference for Android developers

## Verified

- ✅ Internal official build [2961149](https://dev.azure.com/dnceng/internal/_build/results?buildId=2961149) passed — Pack macOS + Pack Windows both green
- ✅ Same pattern used by dotnet/aspnetcore ([PR #64962](https://github.com/dotnet/aspnetcore/pull/64962))
- ✅ Feed is public — no auth needed to read already-ingested packages, external contributors can build without credentials
- ✅ Locally verified: `dotnet build` works for already-ingested packages, fails for new ones (confirming script is needed)