### PR TITLE
[Windows] Fix WebView blank rendering when used with HybridWebView

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34558.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34558.cs
@@ -1,0 +1,44 @@
+namespace TestCases.HostApp.Issues;
+
+[Issue(IssueTracker.Github, 34558, "[Windows] WebView renders blank when HybridWebView and WebView coexist in same app", PlatformAffected.UWP)]
+public partial class Issue34558 : ContentPage
+{
+	public Issue34558()
+	{
+		var hybridStatusLabel = new Label
+		{
+			AutomationId = "HybridStatusLabel",
+			Text = "Test passes if WebView shows content below without any exception",
+		};
+
+		// HybridWebView — initializing this creates a separate CoreWebView2Environment (without fix)
+		// that conflicts with the regular WebView's default environment.
+		var hybridWebView = new HybridWebView
+		{
+			AutomationId = "HybridWebViewControl",
+			HybridRoot = "hybridroot",
+			HeightRequest = 120,
+			HorizontalOptions = LayoutOptions.Fill,
+		};
+
+		var webView = new WebView
+		{
+			AutomationId = "RegularWebView",
+			HeightRequest = 150,
+			HorizontalOptions = LayoutOptions.Fill,
+			Source = new HtmlWebViewSource { Html = "<html><body><h1>WebView should load here</h1><p>If you see this, the WebView is working.</p></body></html>" },
+		};
+
+		Content = new VerticalStackLayout
+		{
+			Spacing = 10,
+			Padding = new Thickness(16),
+			Children =
+			{
+				hybridStatusLabel,
+				hybridWebView,
+				webView,
+			}
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34558.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34558.cs
@@ -1,4 +1,4 @@
-namespace TestCases.HostApp.Issues;
+namespace Maui.Controls.Sample.Issues;
 
 [Issue(IssueTracker.Github, 34558, "[Windows] WebView renders blank when HybridWebView and WebView coexist in same app", PlatformAffected.UWP)]
 public partial class Issue34558 : ContentPage
@@ -29,7 +29,15 @@ public partial class Issue34558 : ContentPage
 			Source = new HtmlWebViewSource { Html = "<html><body><h1>WebView should load here</h1><p>If you see this, the WebView is working.</p></body></html>" },
 		};
 
-		Content = new VerticalStackLayout
+		// This label is added to the layout only after the WebView successfully navigates,
+		// so the UI test can wait for it to appear as proof the WebView rendered content.
+		var webViewNavigatedLabel = new Label
+		{
+			AutomationId = "WebViewNavigatedLabel",
+			Text = "WebView successfully navigated and rendered content!",
+		};
+
+		var layout = new VerticalStackLayout
 		{
 			Spacing = 10,
 			Padding = new Thickness(16),
@@ -40,5 +48,15 @@ public partial class Issue34558 : ContentPage
 				webView,
 			}
 		};
+
+		webView.Navigated += (s, e) =>
+		{
+			if (e.Result == WebNavigationResult.Success)
+			{
+				layout.Children.Add(webViewNavigatedLabel);
+			}
+		};
+
+		Content = layout;
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34558.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34558.cs
@@ -15,5 +15,13 @@ public class Issue34558 : _IssuesUITest
 	public void WebViewLoadsWhenCoexistingWithHybridWebView()
 	{
 		App.WaitForElement("HybridStatusLabel");
+		App.WaitForElement("RegularWebView");
+
+		var rect = App.WaitForElement("RegularWebView").GetRect();
+		Assert.That(rect.Height, Is.GreaterThan(0), "WebView should render with non-zero height");
+
+		// "WebViewNavigatedLabel" is only added to the layout after the WebView successfully
+		// navigates. Waiting for it confirms the WebView rendered content and was not blank.
+		App.WaitForElement("WebViewNavigatedLabel");
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34558.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34558.cs
@@ -1,0 +1,19 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue34558 : _IssuesUITest
+{
+	public Issue34558(TestDevice device) : base(device) { }
+
+	public override string Issue => "[Windows] WebView renders blank when HybridWebView and WebView coexist in same app";
+
+	[Test]
+	[Category(UITestCategories.WebView)]
+	public void WebViewLoadsWhenCoexistingWithHybridWebView()
+	{
+		App.WaitForElement("HybridStatusLabel");
+	}
+}

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Windows.cs
@@ -317,9 +317,9 @@ namespace Microsoft.Maui.Handlers
 					initializingArgs.BrowserExecutableFolder != null ||
 					initializingArgs.UserDataFolder != null ||
 					initializingArgs.EnvironmentOptions != null ||
-					initializingArgs.ScriptLocale != null ||
+					!string.IsNullOrEmpty(initializingArgs.ScriptLocale) ||
 					initializingArgs.IsInPrivateModeEnabled ||
-					initializingArgs.ProfileName != null;
+					!string.IsNullOrEmpty(initializingArgs.ProfileName);
 
 				if (hasCustomSettings)
 				{

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Windows.cs
@@ -307,17 +307,38 @@ namespace Microsoft.Maui.Handlers
 				var initializingArgs = new WebViewInitializationStartedEventArgs();
 				VirtualView?.WebViewInitializationStarted(initializingArgs);
 
-				var env = await CoreWebView2Environment.CreateWithOptionsAsync(
-					browserExecutableFolder: initializingArgs.BrowserExecutableFolder,
-					userDataFolder: initializingArgs.UserDataFolder,
-					options: initializingArgs.EnvironmentOptions);
+				// Only create a custom CoreWebView2Environment when the user has provided custom
+				// settings. Creating a separate environment with all-default settings conflicts with
+				// other WebView2 controls (e.g., regular WebView) in the same app that use the
+				// default environment, because WebView2 requires all controls sharing the same user
+				// data folder to use compatible environments. When no customizations are needed,
+				// use EnsureCoreWebView2Async() so this control joins the default shared environment.
+				bool hasCustomSettings =
+					initializingArgs.BrowserExecutableFolder != null ||
+					initializingArgs.UserDataFolder != null ||
+					initializingArgs.EnvironmentOptions != null ||
+					initializingArgs.ScriptLocale != null ||
+					initializingArgs.IsInPrivateModeEnabled ||
+					initializingArgs.ProfileName != null;
 
-				var options = env.CreateCoreWebView2ControllerOptions();
-				options.ScriptLocale = initializingArgs.ScriptLocale;
-				options.IsInPrivateModeEnabled = initializingArgs.IsInPrivateModeEnabled;
-				options.ProfileName = initializingArgs.ProfileName;
+				if (hasCustomSettings)
+				{
+					var env = await CoreWebView2Environment.CreateWithOptionsAsync(
+						browserExecutableFolder: initializingArgs.BrowserExecutableFolder,
+						userDataFolder: initializingArgs.UserDataFolder,
+						options: initializingArgs.EnvironmentOptions);
 
-				await webView.EnsureCoreWebView2Async(env, options);
+					var options = env.CreateCoreWebView2ControllerOptions();
+					options.ScriptLocale = initializingArgs.ScriptLocale;
+					options.IsInPrivateModeEnabled = initializingArgs.IsInPrivateModeEnabled;
+					options.ProfileName = initializingArgs.ProfileName;
+
+					await webView.EnsureCoreWebView2Async(env, options);
+				}
+				else
+				{
+					await webView.EnsureCoreWebView2Async();
+				}
 
 				webView.CoreWebView2.Settings.AreDevToolsEnabled = Handler?.DeveloperTools.Enabled ?? false;
 				webView.CoreWebView2.Settings.IsWebMessageEnabled = true;

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Windows.cs
@@ -314,12 +314,12 @@ namespace Microsoft.Maui.Handlers
 				// data folder to use compatible environments. When no customizations are needed,
 				// use EnsureCoreWebView2Async() so this control joins the default shared environment.
 				bool hasCustomSettings =
-					initializingArgs.BrowserExecutableFolder != null ||
-					initializingArgs.UserDataFolder != null ||
-					initializingArgs.EnvironmentOptions != null ||
-					initializingArgs.ScriptLocale != null ||
+					!string.IsNullOrEmpty(initializingArgs.BrowserExecutableFolder) ||
+					!string.IsNullOrEmpty(initializingArgs.UserDataFolder) ||
+					!string.IsNullOrEmpty(initializingArgs.EnvironmentOptions) ||
+					!string.IsNullOrEmpty(initializingArgs.ScriptLocale) ||
 					initializingArgs.IsInPrivateModeEnabled ||
-					initializingArgs.ProfileName != null;
+					!string.IsNullOrEmpty(initializingArgs.ProfileName);
 
 				if (hasCustomSettings)
 				{


### PR DESCRIPTION
<!-- Please keep the note below for people who find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment whether this change resolves your issue. Thank you!<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

This pull request addresses an issue where the `WebView` rendered blank when both a `HybridWebView` and a regular `WebView` coexisted in the same Windows (UWP) app. The main fix ensures that `HybridWebView` only creates a custom `CoreWebView2Environment` if custom settings are provided, allowing both controls to share the default environment and preventing conflicts. Additionally, new test cases have been added to verify the fix.
### Description of Change
**Bug fix for WebView and HybridWebView coexistence:**

* Updated `HybridWebViewHandler.Windows.cs` so that a custom `CoreWebView2Environment` is created only if the user provides custom settings; otherwise, the default shared environment is used. This prevents conflicts when both `HybridWebView` and `WebView` are present in the same app, resolving the blank rendering issue. [[1]](diffhunk://#diff-9adaedb7571e93283664d8e3db8d34930d748bbe1207eb004f53e25e08eaaaeaR310-R325) [[2]](diffhunk://#diff-9adaedb7571e93283664d8e3db8d34930d748bbe1207eb004f53e25e08eaaaeaR337-R341)

**Test coverage improvements:**

* Added a new UI test in `TestCases.Shared.Tests/Tests/Issues/Issue34558.cs` to verify that the regular `WebView` renders content successfully when coexisting with a `HybridWebView`.
* Introduced a new test case page in `TestCases.HostApp/Issues/Issue34558.cs` that sets up both controls and provides UI elements for automated verification.



<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #34558 
### Tested the behavior in the following platforms

- [x] Windows
- [ ] Android
- [ ] iOS
- [ ] Mac

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/4ba3435a-99af-4e7e-82be-6dbb588e07b6">  | <video src="https://github.com/user-attachments/assets/fb5b1e22-b317-4421-829c-0f9b15c84e77"> |
<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
