### PR TITLE
Improve XEXPR diagnostics for interpolated strings and lambda method groups

### DIFF
--- a/src/Controls/src/SourceGen/AnalyzerReleases.Unshipped.md
+++ b/src/Controls/src/SourceGen/AnalyzerReleases.Unshipped.md
@@ -32,3 +32,4 @@ MAUIX2012 | XamlParsing | Error | CSharpExpressionsRequirePreviewFeatures
 MAUIX2013 | XamlParsing | Error | AsyncLambdaNotSupported
 MAUIX2015 | XamlParsing | Error | XCodeNotChildOfRoot
 MAUIX2016 | XamlParsing | Error | XCodeRequiresXClass
+MAUIX2017 | XamlParsing | Error | LambdaMethodGroupReference

--- a/src/Controls/src/SourceGen/AnalyzerReleases.Unshipped.md
+++ b/src/Controls/src/SourceGen/AnalyzerReleases.Unshipped.md
@@ -30,3 +30,6 @@ MAUIX2010 | XamlParsing | Info | ExpressionNotSettable
 MAUIX2011 | XamlParsing | Warning | AmbiguousMemberWithStaticType
 MAUIX2012 | XamlParsing | Error | CSharpExpressionsRequirePreviewFeatures
 MAUIX2013 | XamlParsing | Error | AsyncLambdaNotSupported
+MAUIX2015 | XamlParsing | Error | XCodeNotChildOfRoot
+MAUIX2016 | XamlParsing | Error | XCodeRequiresXClass
+MAUIX2017 | XamlParsing | Error | LambdaMethodGroupReference

--- a/src/Controls/src/SourceGen/CSharpExpressionHelpers.cs
+++ b/src/Controls/src/SourceGen/CSharpExpressionHelpers.cs
@@ -889,4 +889,94 @@ static class CSharpExpressionHelpers
 		// Use same extraction as expressions
 		return GetExpressionCode(value);
 	}
+
+	/// <summary>
+	/// Extracts identifiers from interpolated string holes.
+	/// E.g., for <c>$"Hello, {Name1}!"</c> returns ["Name1"].
+	/// For <c>$"Hello, {User.Name}!"</c> returns ["User"].
+	/// Only returns root identifiers (first segment before any dot).
+	/// </summary>
+	public static List<string> ExtractInterpolatedStringIdentifiers(string expressionCode)
+	{
+		var identifiers = new List<string>();
+
+		// Try parsing as a C# expression to extract interpolation holes
+		var tree = CSharpSyntaxTree.ParseText(expressionCode, new CSharpParseOptions(kind: SourceCodeKind.Script));
+		var root = tree.GetRoot();
+
+		foreach (var interpolation in root.DescendantNodes().OfType<InterpolationSyntax>())
+		{
+			// Get the expression inside the interpolation hole
+			var expr = interpolation.Expression;
+			if (expr == null)
+				continue;
+
+			// Extract the root identifier from the interpolation expression
+			string rootIdentifier;
+			if (expr is IdentifierNameSyntax idName)
+			{
+				rootIdentifier = idName.Identifier.Text;
+			}
+			else if (expr is MemberAccessExpressionSyntax memberAccess)
+			{
+				// Walk to the leftmost identifier
+				var current = memberAccess.Expression;
+				while (current is MemberAccessExpressionSyntax nested)
+					current = nested.Expression;
+				if (current is IdentifierNameSyntax leftId)
+					rootIdentifier = leftId.Identifier.Text;
+				else
+					continue;
+			}
+			else
+			{
+				continue;
+			}
+
+			if (!string.IsNullOrEmpty(rootIdentifier) && !identifiers.Contains(rootIdentifier))
+				identifiers.Add(rootIdentifier);
+		}
+
+		return identifiers;
+	}
+
+	/// <summary>
+	/// Checks if a lambda expression body is a method group reference (member access without invocation).
+	/// E.g., <c>(s, e) => this.OnClicked</c> is a method group (missing parentheses).
+	/// Returns the method group expression and the lambda parameters if detected, null otherwise.
+	/// </summary>
+	public static (string methodGroup, string lambdaParams)? DetectLambdaMethodGroupReference(string expressionCode)
+	{
+		// Parse the expression as C#
+		var tree = CSharpSyntaxTree.ParseText(expressionCode, new CSharpParseOptions(kind: SourceCodeKind.Script));
+		var root = tree.GetRoot();
+
+		// Find lambda expressions
+		var lambda = root.DescendantNodes().OfType<ParenthesizedLambdaExpressionSyntax>().FirstOrDefault();
+		if (lambda == null)
+			return null;
+
+		// Get the lambda body - should be an expression (not a block)
+		var body = lambda.ExpressionBody;
+		if (body == null)
+			return null;
+
+		// Check if the body is a member access (this.Method or just Method) without invocation
+		if (body is MemberAccessExpressionSyntax memberAccess)
+		{
+			// Check that the parent is NOT an InvocationExpression
+			// (If it were "this.Method()", the body would be InvocationExpressionSyntax, not MemberAccessExpressionSyntax)
+			var parameters = string.Join(", ", lambda.ParameterList.Parameters.Select(p => p.Identifier.Text));
+			return (memberAccess.ToString(), parameters);
+		}
+
+		// Also check for bare identifier (e.g., (s, e) => OnClicked)
+		if (body is IdentifierNameSyntax identifier)
+		{
+			var parameters = string.Join(", ", lambda.ParameterList.Parameters.Select(p => p.Identifier.Text));
+			return (identifier.Identifier.Text, parameters);
+		}
+
+		return null;
+	}
 }

--- a/src/Controls/src/SourceGen/CSharpExpressionHelpers.cs
+++ b/src/Controls/src/SourceGen/CSharpExpressionHelpers.cs
@@ -16,6 +16,18 @@ namespace Microsoft.Maui.Controls.SourceGen;
 /// <param name="Code">The C# expression code to emit (already has single quotes transformed to double quotes).</param>
 internal sealed record Expression(string Code);
 
+internal readonly struct InterpolatedStringIdentifier
+{
+	public string Identifier { get; }
+	public string TypeReferenceCandidate { get; }
+
+	public InterpolatedStringIdentifier(string identifier, string? typeReferenceCandidate = null)
+	{
+		Identifier = identifier;
+		TypeReferenceCandidate = typeReferenceCandidate ?? identifier;
+	}
+}
+
 /// <summary>
 /// Helper methods for detecting and transforming C# expressions embedded in XAML.
 /// </summary>
@@ -897,8 +909,15 @@ static class CSharpExpressionHelpers
 	/// Only returns root identifiers (first segment before any dot).
 	/// </summary>
 	public static List<string> ExtractInterpolatedStringIdentifiers(string expressionCode)
+		=> ExtractInterpolatedStringIdentifierReferences(expressionCode)
+			.Select(reference => reference.Identifier)
+			.Distinct()
+			.ToList();
+
+	public static List<InterpolatedStringIdentifier> ExtractInterpolatedStringIdentifierReferences(string expressionCode)
 	{
-		var identifiers = new List<string>();
+		var identifiers = new List<InterpolatedStringIdentifier>();
+		var seen = new HashSet<string>(StringComparer.Ordinal);
 
 		// Try parsing as a C# expression to extract interpolation holes
 		var tree = CSharpSyntaxTree.ParseText(expressionCode, new CSharpParseOptions(kind: SourceCodeKind.Script));
@@ -911,33 +930,148 @@ static class CSharpExpressionHelpers
 			if (expr == null)
 				continue;
 
-			// Extract the root identifier from the interpolation expression
-			string rootIdentifier;
-			if (expr is IdentifierNameSyntax idName)
-			{
-				rootIdentifier = idName.Identifier.Text;
-			}
-			else if (expr is MemberAccessExpressionSyntax memberAccess)
-			{
-				// Walk to the leftmost identifier
-				var current = memberAccess.Expression;
-				while (current is MemberAccessExpressionSyntax nested)
-					current = nested.Expression;
-				if (current is IdentifierNameSyntax leftId)
-					rootIdentifier = leftId.Identifier.Text;
-				else
-					continue;
-			}
-			else
-			{
-				continue;
-			}
-
-			if (!string.IsNullOrEmpty(rootIdentifier) && !identifiers.Contains(rootIdentifier))
-				identifiers.Add(rootIdentifier);
+			ExtractInterpolatedExpressionIdentifiers(expr, identifiers, seen);
 		}
 
 		return identifiers;
+	}
+
+	static void ExtractInterpolatedExpressionIdentifiers(ExpressionSyntax expression, List<InterpolatedStringIdentifier> identifiers, HashSet<string> seen)
+	{
+		switch (expression)
+		{
+			case IdentifierNameSyntax idName:
+				AddInterpolatedIdentifier(idName.Identifier.Text, idName.Identifier.Text, identifiers, seen);
+				break;
+			case MemberAccessExpressionSyntax memberAccess:
+				AddMemberAccessRoot(memberAccess, identifiers, seen);
+				break;
+			case InvocationExpressionSyntax invocation:
+				AddInvocationIdentifiers(invocation, identifiers, seen);
+				break;
+			case BinaryExpressionSyntax binary:
+				ExtractInterpolatedExpressionIdentifiers(binary.Left, identifiers, seen);
+				ExtractInterpolatedExpressionIdentifiers(binary.Right, identifiers, seen);
+				break;
+			case ConditionalExpressionSyntax conditional:
+				ExtractInterpolatedExpressionIdentifiers(conditional.Condition, identifiers, seen);
+				ExtractInterpolatedExpressionIdentifiers(conditional.WhenTrue, identifiers, seen);
+				ExtractInterpolatedExpressionIdentifiers(conditional.WhenFalse, identifiers, seen);
+				break;
+			case ParenthesizedExpressionSyntax parenthesized:
+				ExtractInterpolatedExpressionIdentifiers(parenthesized.Expression, identifiers, seen);
+				break;
+			case PrefixUnaryExpressionSyntax prefixUnary:
+				ExtractInterpolatedExpressionIdentifiers(prefixUnary.Operand, identifiers, seen);
+				break;
+			case PostfixUnaryExpressionSyntax postfixUnary:
+				ExtractInterpolatedExpressionIdentifiers(postfixUnary.Operand, identifiers, seen);
+				break;
+			case ConditionalAccessExpressionSyntax conditionalAccess:
+				ExtractInterpolatedExpressionIdentifiers(conditionalAccess.Expression, identifiers, seen);
+				ExtractConditionalAccessIdentifiers(conditionalAccess.WhenNotNull, identifiers, seen);
+				break;
+			case ElementAccessExpressionSyntax elementAccess:
+				ExtractInterpolatedExpressionIdentifiers(elementAccess.Expression, identifiers, seen);
+				foreach (var argument in elementAccess.ArgumentList.Arguments)
+					ExtractInterpolatedExpressionIdentifiers(argument.Expression, identifiers, seen);
+				break;
+			case CastExpressionSyntax cast:
+				ExtractInterpolatedExpressionIdentifiers(cast.Expression, identifiers, seen);
+				break;
+			case AwaitExpressionSyntax awaitExpression:
+				ExtractInterpolatedExpressionIdentifiers(awaitExpression.Expression, identifiers, seen);
+				break;
+		}
+	}
+
+	static void AddInvocationIdentifiers(InvocationExpressionSyntax invocation, List<InterpolatedStringIdentifier> identifiers, HashSet<string> seen)
+	{
+		switch (invocation.Expression)
+		{
+			case IdentifierNameSyntax identifier when IsNameOfInvocation(identifier):
+				return;
+			case IdentifierNameSyntax identifier:
+				AddInterpolatedIdentifier(identifier.Identifier.Text, identifier.Identifier.Text, identifiers, seen);
+				break;
+			case MemberAccessExpressionSyntax memberAccess:
+				if (!AddMemberAccessRoot(memberAccess, identifiers, seen))
+					ExtractInterpolatedExpressionIdentifiers(memberAccess.Expression, identifiers, seen);
+				break;
+			default:
+				ExtractInterpolatedExpressionIdentifiers(invocation.Expression, identifiers, seen);
+				break;
+		}
+
+		foreach (var argument in invocation.ArgumentList.Arguments)
+			ExtractInterpolatedExpressionIdentifiers(argument.Expression, identifiers, seen);
+	}
+
+	static bool IsNameOfInvocation(IdentifierNameSyntax identifier)
+		=> string.Equals(identifier.Identifier.Text, "nameof", StringComparison.Ordinal);
+
+	static void ExtractConditionalAccessIdentifiers(ExpressionSyntax expression, List<InterpolatedStringIdentifier> identifiers, HashSet<string> seen)
+	{
+		switch (expression)
+		{
+			case InvocationExpressionSyntax invocation:
+				foreach (var argument in invocation.ArgumentList.Arguments)
+					ExtractInterpolatedExpressionIdentifiers(argument.Expression, identifiers, seen);
+				break;
+			case MemberAccessExpressionSyntax memberAccess:
+				if (!AddMemberAccessRoot(memberAccess, identifiers, seen))
+					ExtractInterpolatedExpressionIdentifiers(memberAccess.Expression, identifiers, seen);
+				break;
+			default:
+				ExtractInterpolatedExpressionIdentifiers(expression, identifiers, seen);
+				break;
+		}
+	}
+
+	static bool AddMemberAccessRoot(MemberAccessExpressionSyntax memberAccess, List<InterpolatedStringIdentifier> identifiers, HashSet<string> seen)
+	{
+		if (!TryGetMemberAccessParts(memberAccess, out var parts) || parts.Count == 0)
+			return false;
+
+		var rootIdentifier = parts[0];
+		var typeReferenceCandidate = parts.Count > 1
+			? string.Join(".", parts.Take(parts.Count - 1))
+			: rootIdentifier;
+		AddInterpolatedIdentifier(rootIdentifier, typeReferenceCandidate, identifiers, seen);
+		return true;
+	}
+
+	static bool TryGetMemberAccessParts(ExpressionSyntax expression, out List<string> parts)
+	{
+		parts = new List<string>();
+		return TryAppendMemberAccessParts(expression, parts);
+	}
+
+	static bool TryAppendMemberAccessParts(ExpressionSyntax expression, List<string> parts)
+	{
+		switch (expression)
+		{
+			case IdentifierNameSyntax identifier:
+				parts.Add(identifier.Identifier.Text);
+				return true;
+			case MemberAccessExpressionSyntax memberAccess:
+				if (!TryAppendMemberAccessParts(memberAccess.Expression, parts))
+					return false;
+				parts.Add(memberAccess.Name.Identifier.Text);
+				return true;
+			default:
+				return false;
+		}
+	}
+
+	static void AddInterpolatedIdentifier(string identifier, string typeReferenceCandidate, List<InterpolatedStringIdentifier> identifiers, HashSet<string> seen)
+	{
+		if (string.IsNullOrEmpty(identifier))
+			return;
+
+		var key = $"{identifier}|{typeReferenceCandidate}";
+		if (seen.Add(key))
+			identifiers.Add(new InterpolatedStringIdentifier(identifier, typeReferenceCandidate));
 	}
 
 	/// <summary>
@@ -945,7 +1079,7 @@ static class CSharpExpressionHelpers
 	/// E.g., <c>(s, e) => this.OnClicked</c> is a method group (missing parentheses).
 	/// Returns the method group expression and the lambda parameters if detected, null otherwise.
 	/// </summary>
-	public static (string methodGroup, string lambdaParams)? DetectLambdaMethodGroupReference(string expressionCode)
+	public static (string methodGroup, string suggestion)? DetectLambdaMethodGroupReference(string expressionCode)
 	{
 		// Parse the expression as C#
 		var tree = CSharpSyntaxTree.ParseText(expressionCode, new CSharpParseOptions(kind: SourceCodeKind.Script));
@@ -966,17 +1100,26 @@ static class CSharpExpressionHelpers
 		{
 			// Check that the parent is NOT an InvocationExpression
 			// (If it were "this.Method()", the body would be InvocationExpressionSyntax, not MemberAccessExpressionSyntax)
-			var parameters = string.Join(", ", lambda.ParameterList.Parameters.Select(p => p.Identifier.Text));
-			return (memberAccess.ToString(), parameters);
+			var methodGroup = memberAccess.ToString();
+			return (methodGroup, CreateLambdaMethodGroupSuggestion(methodGroup, lambda.ParameterList.Parameters));
 		}
 
 		// Also check for bare identifier (e.g., (s, e) => OnClicked)
 		if (body is IdentifierNameSyntax identifier)
 		{
-			var parameters = string.Join(", ", lambda.ParameterList.Parameters.Select(p => p.Identifier.Text));
-			return (identifier.Identifier.Text, parameters);
+			var methodGroup = identifier.Identifier.Text;
+			return (methodGroup, CreateLambdaMethodGroupSuggestion(methodGroup, lambda.ParameterList.Parameters));
 		}
 
 		return null;
+	}
+
+	static string CreateLambdaMethodGroupSuggestion(string methodGroup, SeparatedSyntaxList<ParameterSyntax> parameters)
+	{
+		var parameterNames = parameters.Select(p => p.Identifier.Text).ToList();
+		if (parameterNames.Any(name => string.IsNullOrEmpty(name) || name == "_"))
+			return string.Empty;
+
+		return $" Did you mean '{methodGroup}({string.Join(", ", parameterNames)})'?";
 	}
 }

--- a/src/Controls/src/SourceGen/Descriptors.cs
+++ b/src/Controls/src/SourceGen/Descriptors.cs
@@ -317,6 +317,14 @@ namespace Microsoft.Maui.Controls.SourceGen
 			defaultSeverity: DiagnosticSeverity.Error,
 			isEnabledByDefault: true);
 
+		public static DiagnosticDescriptor LambdaMethodGroupReference = new DiagnosticDescriptor(
+			id: "MAUIX2017",
+			title: "Lambda body is a method group reference",
+			messageFormat: "Lambda body '{0}' is a method group reference, not a method invocation. Did you mean '{0}({1})'?",
+			category: "XamlParsing",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true);
+
 		// x:Code diagnostics
 		public static DiagnosticDescriptor XCodeNotChildOfRoot = new DiagnosticDescriptor(
 			id: "MAUIX2015",

--- a/src/Controls/src/SourceGen/Descriptors.cs
+++ b/src/Controls/src/SourceGen/Descriptors.cs
@@ -317,6 +317,31 @@ namespace Microsoft.Maui.Controls.SourceGen
 			defaultSeverity: DiagnosticSeverity.Error,
 			isEnabledByDefault: true);
 
+		public static DiagnosticDescriptor LambdaMethodGroupReference = new DiagnosticDescriptor(
+			id: "MAUIX2017",
+			title: "Lambda body is a method group reference",
+			messageFormat: "Lambda body '{0}' is a method group reference, not a method invocation. Did you mean '{0}({1})'?",
+			category: "XamlParsing",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true);
+
+		// x:Code diagnostics
+		public static DiagnosticDescriptor XCodeNotChildOfRoot = new DiagnosticDescriptor(
+			id: "MAUIX2015",
+			title: "x:Code must be an immediate child of the root element",
+			messageFormat: "x:Code must be an immediate child of the root element.",
+			category: "XamlParsing",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true);
+
+		public static DiagnosticDescriptor XCodeRequiresXClass = new DiagnosticDescriptor(
+			id: "MAUIX2016",
+			title: "x:Code requires x:Class on the root element",
+			messageFormat: "x:Code requires x:Class to be specified on the root element.",
+			category: "XamlParsing",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true);
+
 		public static DiagnosticDescriptor MissingEventHandler = new DiagnosticDescriptor(
 			id: "MAUIX2014",
 			title: new LocalizableResourceString(nameof(MauiGResources.MissingEventHandlerTitle), MauiGResources.ResourceManager, typeof(MauiGResources)),

--- a/src/Controls/src/SourceGen/Descriptors.cs
+++ b/src/Controls/src/SourceGen/Descriptors.cs
@@ -320,7 +320,7 @@ namespace Microsoft.Maui.Controls.SourceGen
 		public static DiagnosticDescriptor LambdaMethodGroupReference = new DiagnosticDescriptor(
 			id: "MAUIX2017",
 			title: "Lambda body is a method group reference",
-			messageFormat: "Lambda body '{0}' is a method group reference, not a method invocation. Did you mean '{0}({1})'?",
+			messageFormat: "Lambda body '{0}' is a method group reference, not a method invocation.{1}",
 			category: "XamlParsing",
 			defaultSeverity: DiagnosticSeverity.Error,
 			isEnabledByDefault: true);
@@ -409,4 +409,3 @@ namespace Microsoft.Maui.Controls.SourceGen
 
 	}
 }
-

--- a/src/Controls/src/SourceGen/ExpressionAnalyzer.cs
+++ b/src/Controls/src/SourceGen/ExpressionAnalyzer.cs
@@ -257,7 +257,7 @@ internal static class ExpressionAnalyzer
 	/// <param name="dataType">Optional DataType symbol to filter handlers (only include members on this type)</param>
 	/// <param name="rootType">Optional root type (page/view) to identify local members that need capturing</param>
 	/// <returns>Analysis result with handlers, captures, and transformed expression</returns>
-	public static ExpressionAnalysisResult Analyze(string expression, string sourceParameterName = "__source", ITypeSymbol? dataType = null, ITypeSymbol? rootType = null)
+	public static ExpressionAnalysisResult Analyze(string expression, string sourceParameterName = "__source", ITypeSymbol? dataType = null, ITypeSymbol? rootType = null, Compilation? compilation = null)
 	{
 		var captures = new List<LocalCapture>();
 		var transformedExpression = expression;
@@ -332,11 +332,12 @@ internal static class ExpressionAnalyzer
 		// Also exclude handlers whose parent is a capture variable (__capture_*) - those are local, not bindings
 		if (dataType != null)
 		{
-			handlers = handlers.Where(h => 
-				h.PropertyName == "." || 
+			handlers = handlers.Where(h =>
+				!IsStaticTypeHandler(h, sourceParameterName, dataType, rootType, compilation) &&
+				(h.PropertyName == "." ||
 				(h.ParentExpression != sourceParameterName &&  // Keep nested handlers...
 				 !h.ParentExpression.Contains("__capture_")) ||  // ...unless parent is a capture variable
-				HasProperty(dataType, h.PropertyName)  // Top-level must exist on DataType
+				HasProperty(dataType, h.PropertyName))  // Top-level must exist on DataType
 			).ToList();
 		}
 
@@ -351,6 +352,46 @@ internal static class ExpressionAnalyzer
 		var isSettable = captures.Count == 0 && IsSimplePropertyChain(expression);
 
 		return new ExpressionAnalysisResult(handlers, captures, transformedExpression, isSettable);
+	}
+
+	private static bool IsStaticTypeHandler(BindingHandler handler, string sourceParameterName, ITypeSymbol dataType, ITypeSymbol? rootType, Compilation? compilation)
+	{
+		if (compilation == null)
+			return false;
+
+		var chain = GetHandlerChain(handler, sourceParameterName);
+		if (chain.Count == 0)
+			return false;
+
+		var rootIdentifier = chain[0];
+		if (HasProperty(dataType, rootIdentifier))
+			return false;
+
+		for (var i = chain.Count; i >= 1; i--)
+		{
+			if (MemberResolver.ResolvesToType(compilation, string.Join(".", chain.Take(i)), MemberResolver.GetContainingNamespace(rootType)))
+				return true;
+		}
+
+		return false;
+	}
+
+	private static List<string> GetHandlerChain(BindingHandler handler, string sourceParameterName)
+	{
+		var chain = new List<string>();
+		if (handler.ParentExpression == sourceParameterName)
+		{
+			chain.Add(handler.PropertyName);
+			return chain;
+		}
+
+		var sourcePrefix = sourceParameterName + ".";
+		if (!handler.ParentExpression.StartsWith(sourcePrefix, StringComparison.Ordinal))
+			return chain;
+
+		chain.AddRange(handler.ParentExpression.Substring(sourcePrefix.Length).Split('.'));
+		chain.Add(handler.PropertyName);
+		return chain;
 	}
 
 	/// <summary>

--- a/src/Controls/src/SourceGen/MemberResolver.cs
+++ b/src/Controls/src/SourceGen/MemberResolver.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Microsoft.Maui.Controls.SourceGen;
 
@@ -117,7 +119,7 @@ internal static class MemberResolver
 		// Check if root identifier also resolves to a type in the compilation
 		var conflictsWithStatic = (onThis || onDataType) && 
 			compilation != null && 
-			ResolvesToType(compilation, rootIdentifier);
+			ResolvesToType(compilation, rootIdentifier, GetContainingNamespace(thisType));
 
 		MemberLocation location;
 		if (onThis && onDataType)
@@ -135,18 +137,42 @@ internal static class MemberResolver
 	/// <summary>
 	/// Checks if an identifier resolves to a type in the compilation (including via global usings).
 	/// </summary>
-	private static bool ResolvesToType(Compilation compilation, string identifier)
+	public static bool StartsWithTypeReference(Compilation compilation, string expression, string? containingNamespace = null)
 	{
+		foreach (var typeName in GetPossibleTypeNames(expression))
+		{
+			if (ResolvesToType(compilation, typeName, containingNamespace))
+				return true;
+		}
+
+		return false;
+	}
+
+	public static bool ResolvesToType(Compilation compilation, string typeName, string? containingNamespace = null)
+	{
+		var normalizedTypeName = NormalizeTypeName(typeName);
+		if (string.IsNullOrEmpty(normalizedTypeName))
+			return false;
+
+		if (compilation.GetTypeByMetadataName(normalizedTypeName) != null)
+			return true;
+
+		if (!string.IsNullOrEmpty(containingNamespace) &&
+			compilation.GetTypeByMetadataName($"{containingNamespace}.{normalizedTypeName}") != null)
+		{
+			return true;
+		}
+
 		// Collect all global using namespaces from the compilation's syntax trees
 		var globalNamespaces = new HashSet<string>();
 		
 		foreach (var tree in compilation.SyntaxTrees)
 		{
 			var root = tree.GetRoot();
-			foreach (var usingDirective in root.DescendantNodes().OfType<Microsoft.CodeAnalysis.CSharp.Syntax.UsingDirectiveSyntax>())
+			foreach (var usingDirective in root.DescendantNodes().OfType<UsingDirectiveSyntax>())
 			{
 				// Check for global usings (global using System;)
-				if (usingDirective.GlobalKeyword.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.GlobalKeyword))
+				if (usingDirective.GlobalKeyword.IsKind(SyntaxKind.GlobalKeyword))
 				{
 					var namespaceName = usingDirective.Name?.ToString();
 					if (!string.IsNullOrEmpty(namespaceName))
@@ -158,18 +184,99 @@ internal static class MemberResolver
 		// Check if the identifier resolves to a type in any of the global namespaces
 		foreach (var ns in globalNamespaces)
 		{
-			var fullName = $"{ns}.{identifier}";
+			var fullName = $"{ns}.{normalizedTypeName}";
 			var type = compilation.GetTypeByMetadataName(fullName);
 			if (type != null)
 				return true;
 		}
 		
 		// Also check in the global namespace itself
-		var globalType = compilation.GetTypeByMetadataName(identifier);
+		var globalType = compilation.GetTypeByMetadataName(normalizedTypeName);
 		if (globalType != null)
 			return true;
 		
 		return false;
+	}
+
+	public static string? GetContainingNamespace(ITypeSymbol? typeSymbol)
+		=> GetNamespaceName(typeSymbol?.ContainingNamespace);
+
+	private static string? GetNamespaceName(INamespaceSymbol? namespaceSymbol)
+	{
+		if (namespaceSymbol == null || namespaceSymbol.IsGlobalNamespace)
+			return null;
+
+		var names = new Stack<string>();
+		var current = namespaceSymbol;
+		while (current != null && !current.IsGlobalNamespace)
+		{
+			names.Push(current.Name);
+			current = current.ContainingNamespace;
+		}
+
+		return string.Join(".", names);
+	}
+
+	private static string NormalizeTypeName(string typeName)
+	{
+		var normalized = typeName.Trim();
+		const string GlobalAlias = "global::";
+		if (normalized.StartsWith(GlobalAlias, StringComparison.Ordinal))
+			normalized = normalized.Substring(GlobalAlias.Length);
+		return normalized;
+	}
+
+	private static IEnumerable<string> GetPossibleTypeNames(string expression)
+	{
+		var leadingMemberAccess = ReadLeadingMemberAccess(expression);
+		if (string.IsNullOrEmpty(leadingMemberAccess))
+			yield break;
+
+		var normalized = NormalizeTypeName(leadingMemberAccess);
+		var parts = normalized.Split('.');
+		for (var i = parts.Length; i >= 1; i--)
+			yield return string.Join(".", parts.Take(i));
+	}
+
+	private static string ReadLeadingMemberAccess(string expression)
+	{
+		if (string.IsNullOrWhiteSpace(expression))
+			return string.Empty;
+
+		var trimmed = expression.TrimStart();
+		var start = 0;
+		var position = 0;
+		const string GlobalAlias = "global::";
+		if (trimmed.StartsWith(GlobalAlias, StringComparison.Ordinal))
+			position = GlobalAlias.Length;
+
+		if (!TryReadIdentifier(trimmed, ref position))
+			return string.Empty;
+
+		while (position < trimmed.Length && trimmed[position] == '.')
+		{
+			var beforeDot = position;
+			position++;
+			if (!TryReadIdentifier(trimmed, ref position))
+			{
+				position = beforeDot;
+				break;
+			}
+		}
+
+		return trimmed.Substring(start, position - start);
+	}
+
+	private static bool TryReadIdentifier(string text, ref int position)
+	{
+		if (position >= text.Length || (!char.IsLetter(text[position]) && text[position] != '_'))
+			return false;
+
+		position++;
+		while (position < text.Length && (char.IsLetterOrDigit(text[position]) || text[position] == '_'))
+			position++;
+
+		return true;
 	}
 
 	/// <summary>
@@ -230,17 +337,20 @@ internal static class MemberResolver
 	}
 
 	/// <summary>
-	/// Checks if a type has a member (property or field) with the given name.
+	/// Checks if a type has a member with the given name.
 	/// </summary>
-	private static bool HasMember(ITypeSymbol type, string memberName)
+	public static bool HasMember(ITypeSymbol? type, string memberName, bool includeMethods = false)
 	{
+		if (type == null)
+			return false;
+
 		// Check this type and all base types
 		var currentType = type;
 		while (currentType != null)
 		{
 			foreach (var member in currentType.GetMembers(memberName))
 			{
-				if (member is IPropertySymbol || member is IFieldSymbol)
+				if (member is IPropertySymbol || member is IFieldSymbol || (includeMethods && member is IMethodSymbol))
 					return true;
 			}
 			currentType = currentType.BaseType;

--- a/src/Controls/src/SourceGen/SetPropertyHelpers.cs
+++ b/src/Controls/src/SourceGen/SetPropertyHelpers.cs
@@ -231,6 +231,16 @@ static class SetPropertyHelpers
 		// Handle lambda expressions
 		if (vn.Value is Expression expression)
 		{
+			// Check for method group reference in lambda body (missing parentheses)
+			var methodGroupRef = CSharpExpressionHelpers.DetectLambdaMethodGroupReference(expression.Code);
+			if (methodGroupRef != null)
+			{
+				var (methodGroup, lambdaParams) = methodGroupRef.Value;
+				var location = LocationCreate(context.ProjectItem.RelativePath!, (IXmlLineInfo)valueNode, expression.Code);
+				context.ReportDiagnostic(Diagnostic.Create(Descriptors.LambdaMethodGroupReference, location, methodGroup, lambdaParams));
+				return;
+			}
+
 			if (treeOrder && icWriter != null && inflatorVar != null)
 			{
 				writer = icWriter;
@@ -703,6 +713,22 @@ static class SetPropertyHelpers
 			var neitherLocation = LocationCreate(context.ProjectItem.RelativePath!, (IXmlLineInfo)valueNode, expression.Code);
 			context.ReportDiagnostic(Diagnostic.Create(Descriptors.MemberNotFound, neitherLocation, resolution.RootIdentifier, context.RootType?.Name ?? "this", dataTypeSymbol.Name));
 			return true; // Handled (with error)
+		}
+
+		// Validate identifiers inside interpolated string holes
+		if (expression.Code.StartsWith("$\"", StringComparison.Ordinal) || expression.Code.StartsWith("$@\"", StringComparison.Ordinal))
+		{
+			var interpolatedIds = CSharpExpressionHelpers.ExtractInterpolatedStringIdentifiers(expression.Code);
+			foreach (var id in interpolatedIds)
+			{
+				var idResolution = MemberResolver.Resolve(id, context.RootType, dataTypeSymbol, context.Compilation);
+				if (idResolution.Location == MemberLocation.Neither)
+				{
+					var idLocation = LocationCreate(context.ProjectItem.RelativePath!, (IXmlLineInfo)valueNode, expression.Code);
+					context.ReportDiagnostic(Diagnostic.Create(Descriptors.MemberNotFound, idLocation, id, context.RootType?.Name ?? "this", dataTypeSymbol.Name));
+					return true; // Handled (with error)
+				}
+			}
 		}
 
 		// If we have binding handlers, this needs a TypedBinding

--- a/src/Controls/src/SourceGen/SetPropertyHelpers.cs
+++ b/src/Controls/src/SourceGen/SetPropertyHelpers.cs
@@ -235,9 +235,9 @@ static class SetPropertyHelpers
 			var methodGroupRef = CSharpExpressionHelpers.DetectLambdaMethodGroupReference(expression.Code);
 			if (methodGroupRef != null)
 			{
-				var (methodGroup, lambdaParams) = methodGroupRef.Value;
+				var (methodGroup, suggestion) = methodGroupRef.Value;
 				var location = LocationCreate(context.ProjectItem.RelativePath!, (IXmlLineInfo)valueNode, expression.Code);
-				context.ReportDiagnostic(Diagnostic.Create(Descriptors.LambdaMethodGroupReference, location, methodGroup, lambdaParams));
+				context.ReportDiagnostic(Diagnostic.Create(Descriptors.LambdaMethodGroupReference, location, methodGroup, suggestion));
 				return;
 			}
 
@@ -683,7 +683,7 @@ static class SetPropertyHelpers
 		}
 
 		// Analyze the expression for mixed local+binding scenarios
-		var analysis = ExpressionAnalyzer.Analyze(expression.Code, "__source", dataTypeSymbol, context.RootType);
+		var analysis = ExpressionAnalyzer.Analyze(expression.Code, "__source", dataTypeSymbol, context.RootType, context.Compilation);
 
 		// Check for ambiguity first - resolve the expression
 		var resolution = MemberResolver.Resolve(expression.Code, context.RootType, dataTypeSymbol, context.Compilation);
@@ -708,7 +708,8 @@ static class SetPropertyHelpers
 		// Handle not-found case for simple identifiers
 		if (resolution.Location == MemberLocation.Neither &&
 			!string.IsNullOrEmpty(resolution.RootIdentifier) &&
-			MemberResolver.IsSimpleIdentifier(expression.Code))
+			MemberResolver.IsSimpleIdentifier(expression.Code) &&
+			!MemberResolver.StartsWithTypeReference(context.Compilation, expression.Code, MemberResolver.GetContainingNamespace(context.RootType)))
 		{
 			var neitherLocation = LocationCreate(context.ProjectItem.RelativePath!, (IXmlLineInfo)valueNode, expression.Code);
 			context.ReportDiagnostic(Diagnostic.Create(Descriptors.MemberNotFound, neitherLocation, resolution.RootIdentifier, context.RootType?.Name ?? "this", dataTypeSymbol.Name));
@@ -718,11 +719,15 @@ static class SetPropertyHelpers
 		// Validate identifiers inside interpolated string holes
 		if (expression.Code.StartsWith("$\"", StringComparison.Ordinal) || expression.Code.StartsWith("$@\"", StringComparison.Ordinal))
 		{
-			var interpolatedIds = CSharpExpressionHelpers.ExtractInterpolatedStringIdentifiers(expression.Code);
-			foreach (var id in interpolatedIds)
+			var interpolatedIds = CSharpExpressionHelpers.ExtractInterpolatedStringIdentifierReferences(expression.Code);
+			foreach (var idReference in interpolatedIds)
 			{
+				var id = idReference.Identifier;
 				var idResolution = MemberResolver.Resolve(id, context.RootType, dataTypeSymbol, context.Compilation);
-				if (idResolution.Location == MemberLocation.Neither)
+				if (idResolution.Location == MemberLocation.Neither &&
+					!MemberResolver.HasMember(context.RootType, id, includeMethods: true) &&
+					!MemberResolver.HasMember(dataTypeSymbol, id, includeMethods: true) &&
+					!MemberResolver.ResolvesToType(context.Compilation, idReference.TypeReferenceCandidate, MemberResolver.GetContainingNamespace(context.RootType)))
 				{
 					var idLocation = LocationCreate(context.ProjectItem.RelativePath!, (IXmlLineInfo)valueNode, expression.Code);
 					context.ReportDiagnostic(Diagnostic.Create(Descriptors.MemberNotFound, idLocation, id, context.RootType?.Name ?? "this", dataTypeSymbol.Name));
@@ -776,7 +781,7 @@ static class SetPropertyHelpers
 			expression, context.Compilation, dataTypeSymbol, context.RootType);
 
 		// Analyze expression for mixed local+binding scenarios
-		var analysis = ExpressionAnalyzer.Analyze(transformedExpression, "__source", dataTypeSymbol, context.RootType);
+		var analysis = ExpressionAnalyzer.Analyze(transformedExpression, "__source", dataTypeSymbol, context.RootType, context.Compilation);
 		var handlers = analysis.Handlers;
 
 		// Resolve the expression's result type for TProperty.

--- a/src/Controls/tests/SourceGen.UnitTests/CSharpExpressionDiagnosticsTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/CSharpExpressionDiagnosticsTests.cs
@@ -809,4 +809,90 @@ public partial class OperatorAliasPage : ContentPage
 		Assert.Contains(" <= ", output, StringComparison.Ordinal);
 		Assert.Contains(" >= ", output, StringComparison.Ordinal);
 	}
+
+	[Fact]
+	public void InterpolatedString_NonExistentMember_ShouldReportDiagnostic()
+	{
+		// When an interpolated string references a member that doesn't exist,
+		// the source generator should report MAUIX2009 instead of letting it
+		// fall through to a C# compilation error.
+		var xaml =
+"""
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:TestApp"
+             x:Class="TestApp.InterpolatedNotFoundPage"
+             x:DataType="local:InterpolatedNotFoundViewModel">
+    <Label Text="{$'Hello, {Name1}!'}" />
+</ContentPage>
+""";
+
+		var codeBehind =
+"""
+using System.ComponentModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace TestApp;
+
+public class InterpolatedNotFoundViewModel : INotifyPropertyChanged
+{
+	public string Name { get; set; } = "World";
+	public event PropertyChangedEventHandler? PropertyChanged;
+}
+
+[XamlProcessing(XamlInflator.SourceGen)]
+public partial class InterpolatedNotFoundPage : ContentPage
+{
+	public InterpolatedNotFoundPage() => InitializeComponent();
+}
+""";
+
+		var (result, _) = RunGenerator(xaml, codeBehind, assertNoCompilationErrors: false);
+
+		// Currently: Name1 doesn't exist on either the page or the ViewModel.
+		// The source gen emits $"Hello, {__source.Name1}!" which fails at C# compilation.
+		// Ideally, MAUIX2009 should be reported at source generation time.
+		Assert.Contains(result.Diagnostics, d => d.Id == "MAUIX2009");
+	}
+
+	[Fact]
+	public void LambdaEventHandler_MethodGroupWithoutInvocation_ShouldReportDiagnostic()
+	{
+		// When a lambda event handler references a method without calling it (missing parentheses),
+		// the source generator should detect this and report a diagnostic instead of
+		// letting it fall through to a C# compilation error.
+		var xaml =
+"""
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="TestApp.MethodGroupLambdaPage">
+    <Button Clicked="{(s, e) => this.OnCounterClicked}" />
+</ContentPage>
+""";
+
+		var codeBehind =
+"""
+using System;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace TestApp;
+
+[XamlProcessing(XamlInflator.SourceGen)]
+public partial class MethodGroupLambdaPage : ContentPage
+{
+	public int ClickCount { get; set; }
+	public void OnCounterClicked(object? sender, EventArgs e) => ClickCount++;
+	public MethodGroupLambdaPage() => InitializeComponent();
+}
+""";
+
+		var (result, _) = RunGenerator(xaml, codeBehind, assertNoCompilationErrors: false);
+
+		// The source gen should detect the method group reference and emit MAUIX2017.
+		Assert.Contains(result.Diagnostics, d => d.Id == "MAUIX2017");
+	}
 }

--- a/src/Controls/tests/SourceGen.UnitTests/CSharpExpressionDiagnosticsTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/CSharpExpressionDiagnosticsTests.cs
@@ -702,7 +702,7 @@ public partial class StringMethodPage : ContentPage
 
 		// Should compile without errors
 		Assert.DoesNotContain(result.Diagnostics, d => d.Severity == DiagnosticSeverity.Error);
-		
+
 		// Generated code should have "x" (string literal), not 'x' (char literal)
 		Assert.Contains("\"x\"", output, StringComparison.Ordinal);
 	}
@@ -748,7 +748,7 @@ public partial class CharMethodPage : ContentPage
 
 		// Should have no source generator diagnostics (errors)
 		Assert.DoesNotContain(result.Diagnostics, d => d.Severity == DiagnosticSeverity.Error);
-		
+
 		// Generated code should have 'x' (char literal)
 		Assert.Contains("'x'", output, StringComparison.Ordinal);
 	}
@@ -797,10 +797,10 @@ public partial class OperatorAliasPage : ContentPage
 """;
 
 		var (result, output) = RunGenerator(xaml, codeBehind, assertNoCompilationErrors: false);
-		
+
 		// Should have no source generator diagnostics (errors)
 		Assert.DoesNotContain(result.Diagnostics, d => d.Severity == DiagnosticSeverity.Error);
-		
+
 		// Generated code should have C# operators instead of aliases
 		Assert.Contains("&&", output, StringComparison.Ordinal);
 		Assert.Contains("||", output, StringComparison.Ordinal);
@@ -858,6 +858,143 @@ public partial class InterpolatedNotFoundPage : ContentPage
 	}
 
 	[Fact]
+	public void InterpolatedString_StaticTypeReferences_ShouldNotReportMemberNotFound()
+	{
+		var xaml =
+"""
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:TestApp"
+             x:Class="TestApp.StaticTypeInterpolationPage"
+             x:DataType="local:StaticTypeInterpolationViewModel">
+    <VerticalStackLayout>
+        <Label Text="{$'{DateTime.Now}'}" />
+        <Label Text="{$'{Math.Max(X, Y)}'}" />
+        <Label Text="{$'{System.DateTime.Now}'}" />
+        <Label Text="{$'{LocalStatic.Format(X)}'}" />
+    </VerticalStackLayout>
+</ContentPage>
+""";
+
+		var codeBehind =
+"""
+global using System;
+using System.ComponentModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace TestApp;
+
+public class StaticTypeInterpolationViewModel : INotifyPropertyChanged
+{
+	public int X { get; set; } = 3;
+	public int Y { get; set; } = 5;
+	public event PropertyChangedEventHandler? PropertyChanged;
+}
+
+public static class LocalStatic
+{
+	public static string Format(int value) => value.ToString();
+}
+
+[XamlProcessing(XamlInflator.SourceGen)]
+public partial class StaticTypeInterpolationPage : ContentPage
+{
+	public StaticTypeInterpolationPage() => InitializeComponent();
+}
+""";
+
+		var (result, _) = RunGenerator(xaml, codeBehind);
+
+		Assert.DoesNotContain(result.Diagnostics, d => d.Id == "MAUIX2009");
+	}
+
+	[Fact]
+	public void InterpolatedString_BinaryAndConditionalHoles_ShouldNotReportMemberNotFound()
+	{
+		var xaml =
+"""
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:TestApp"
+             x:Class="TestApp.InterpolatedComplexHolesPage"
+             x:DataType="local:InterpolatedComplexHolesViewModel">
+    <Label Text="{$'{X + Y} {(UseX ? X : Y)}'}" />
+</ContentPage>
+""";
+
+		var codeBehind =
+"""
+using System.ComponentModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace TestApp;
+
+public class InterpolatedComplexHolesViewModel : INotifyPropertyChanged
+{
+	public int X { get; set; } = 3;
+	public int Y { get; set; } = 5;
+	public bool UseX { get; set; } = true;
+	public event PropertyChangedEventHandler? PropertyChanged;
+}
+
+[XamlProcessing(XamlInflator.SourceGen)]
+public partial class InterpolatedComplexHolesPage : ContentPage
+{
+	public InterpolatedComplexHolesPage() => InitializeComponent();
+}
+""";
+
+		var (result, _) = RunGenerator(xaml, codeBehind);
+
+		Assert.DoesNotContain(result.Diagnostics, d => d.Id == "MAUIX2009");
+	}
+
+	[Fact]
+	public void InterpolatedString_BinaryHoleWithMissingMember_ShouldReportDiagnostic()
+	{
+		var xaml =
+"""
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:TestApp"
+             x:Class="TestApp.InterpolatedBinaryMissingPage"
+             x:DataType="local:InterpolatedBinaryMissingViewModel">
+    <Label Text="{$'{X + MissingValue}'}" />
+</ContentPage>
+""";
+
+		var codeBehind =
+"""
+using System.ComponentModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace TestApp;
+
+public class InterpolatedBinaryMissingViewModel : INotifyPropertyChanged
+{
+	public int X { get; set; } = 3;
+	public event PropertyChangedEventHandler? PropertyChanged;
+}
+
+[XamlProcessing(XamlInflator.SourceGen)]
+public partial class InterpolatedBinaryMissingPage : ContentPage
+{
+	public InterpolatedBinaryMissingPage() => InitializeComponent();
+}
+""";
+
+		var (result, _) = RunGenerator(xaml, codeBehind, assertNoCompilationErrors: false);
+
+		Assert.Contains(result.Diagnostics, d => d.Id == "MAUIX2009");
+	}
+
+	[Fact]
 	public void LambdaEventHandler_MethodGroupWithoutInvocation_ShouldReportDiagnostic()
 	{
 		// When a lambda event handler references a method without calling it (missing parentheses),
@@ -894,5 +1031,45 @@ public partial class MethodGroupLambdaPage : ContentPage
 
 		// The source gen should detect the method group reference and emit MAUIX2017.
 		Assert.Contains(result.Diagnostics, d => d.Id == "MAUIX2017");
+		var diagnostic = result.Diagnostics.First(d => d.Id == "MAUIX2017");
+		Assert.Contains("Did you mean 'this.OnCounterClicked(s, e)'", diagnostic.GetMessage(), StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void LambdaEventHandler_MethodGroupWithDiscardParameters_ShouldOmitSuggestion()
+	{
+		var xaml =
+"""
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="TestApp.DiscardMethodGroupLambdaPage">
+    <Button Clicked="{(_, _) => this.OnCounterClicked}" />
+</ContentPage>
+""";
+
+		var codeBehind =
+"""
+using System;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace TestApp;
+
+[XamlProcessing(XamlInflator.SourceGen)]
+public partial class DiscardMethodGroupLambdaPage : ContentPage
+{
+	public int ClickCount { get; set; }
+	public void OnCounterClicked(object? sender, EventArgs e) => ClickCount++;
+	public DiscardMethodGroupLambdaPage() => InitializeComponent();
+}
+""";
+
+		var (result, _) = RunGenerator(xaml, codeBehind, assertNoCompilationErrors: false);
+
+		Assert.Contains(result.Diagnostics, d => d.Id == "MAUIX2017");
+		var diagnostic = result.Diagnostics.First(d => d.Id == "MAUIX2017");
+		Assert.DoesNotContain("Did you mean", diagnostic.GetMessage(), StringComparison.Ordinal);
+		Assert.DoesNotContain("(_, _)", diagnostic.GetMessage(), StringComparison.Ordinal);
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Two XAML C# expression (XEXPR) scenarios currently produce **C# compilation errors** instead of **source generator diagnostics**, making errors harder to understand and fix. This PR catches both at source generation time with clear messages.

### Issue 1: Interpolated string with nonexistent member

```xml
<Label Text="{$'Hello, {Name1}!'}" />
```

When `Name1` doesn't exist on the page or ViewModel, the source gen previously emitted `$"Hello, {__source.Name1}!"` verbatim, resulting in a cryptic C# compilation error. Now **MAUIX2009** is reported: _"'Name1' not found on 'MyPage' or 'MyViewModel'."_

**Root cause**: The existing MAUIX2009 check only ran for "simple identifiers" (`IsSimpleIdentifier` returns false for interpolated strings due to `$`, `{`, `}` chars). The fix extracts identifiers from interpolation holes using Roslyn and validates each against `MemberResolver`.

### Issue 2: Lambda with method group instead of invocation

```xml
<Button Clicked="{(s, e) => this.OnCounterClicked}" />
```

Missing `()` caused the source gen to emit `button.Clicked += (s, e) => this.OnCounterClicked;` — invalid C# (method group can't be expression body of void-returning lambda). Now **MAUIX2017** is reported: _"Lambda body 'this.OnCounterClicked' is a method group reference, not a method invocation. Did you mean 'this.OnCounterClicked(s, e)'?"_

**Root cause**: `ConnectEvent()` emitted lambda expressions with zero validation. The fix parses the lambda body with Roslyn to detect `MemberAccessExpression` without invocation.

## Changes

| File | Change |
|------|--------|
| `CSharpExpressionHelpers.cs` | New `ExtractInterpolatedStringIdentifiers()` and `DetectLambdaMethodGroupReference()` helpers |
| `SetPropertyHelpers.cs` | Interpolated string member validation in `TryHandleExpressionBinding()`; method group check in `ConnectEvent()` |
| `Descriptors.cs` | New `MAUIX2017` diagnostic descriptor |
| `AnalyzerReleases.Unshipped.md` | Register MAUIX2017 |
| `CSharpExpressionDiagnosticsTests.cs` | 2 new tests (204/204 pass) |
