### PR TITLE
[net11.0][NativeAOT] Hook _PrepareTrimConfiguration to fix IL3050 on Android

### DIFF
--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -306,7 +306,7 @@
            Text="The %24(TargetFrameworkVersion) for $(ProjectName) ($(TargetFrameworkVersion)) is less than the minimum required %24(TargetFrameworkVersion) for Microsoft.Maui ($(MinTargetFrameworkVersionForMaui)). You need to increase the %24(TargetFrameworkVersion) for $(ProjectName)."   />
   </Target>
 
-  <Target Name="_MauiPrepareForILLink" BeforeTargets="PrepareForILLink;_GenerateRuntimeConfigurationFilesInputCache;XamlC">
+  <Target Name="_MauiPrepareForILLink" BeforeTargets="_PrepareTrimConfiguration;_GenerateRuntimeConfigurationFilesInputCache;XamlC">
     <PropertyGroup>
       <MauiEnableIVisualAssemblyScanning Condition="'$(MauiEnableIVisualAssemblyScanning)' == ''">false</MauiEnableIVisualAssemblyScanning>
     </PropertyGroup>


### PR DESCRIPTION
> [!NOTE]
> This PR was created with assistance from AI.

Port of #35071 to the `net11.0` branch.

## Summary

Add `_PrepareTrimConfiguration` to `_MauiPrepareForILLink`'s `BeforeTargets` so that `RuntimeHostConfigurationOption` items (like `IsHybridWebViewSupported`) are added before the runtime's internal target snapshots them into `_TrimmerFeatureSettings`.

## Problem

dotnet/runtime PR #124801 moved the `RuntimeHostConfigurationOption` → `_TrimmerFeatureSettings` conversion from `PrepareForILLink` into an earlier internal target (`_PrepareTrimConfiguration`). MAUI's `_MauiPrepareForILLink` hooks `BeforeTargets="PrepareForILLink"`, which now fires *after* the snapshot. As a result, ILC never receives `--feature` flags for MAUI's feature switches on Android NativeAOT, causing spurious IL3050 warnings for `HybridWebViewHandler`.

This is the branch (`net11.0`, SDK `11.0.100-preview.3.26203.107`) where the bug manifests — the .NET 11 SDK has `_PrepareTrimConfiguration`.

## Fix

Remove `PrepareForILLink` from `BeforeTargets` (redundant — it's a transitive dependent of `_PrepareTrimConfiguration`) and add `_PrepareTrimConfiguration` instead. This ensures MAUI's `RuntimeHostConfigurationOption` items are present when the snapshot runs.

**Temporary workaround** using the internal target name. The runtime fix (dotnet/runtime#127253) renames this to the public `PrepareTrimConfiguration`. Once that flows, update to `BeforeTargets="PrepareTrimConfiguration"`.

Workaround for dotnet/runtime#127017

cc @sbomer @simonrozsival