### PR TITLE
Add delegate-based alert dialog extensibility convention (no public API changes)

### DIFF
--- a/src/Controls/src/Core/ActionSheetArguments.cs
+++ b/src/Controls/src/Core/ActionSheetArguments.cs
@@ -10,11 +10,11 @@ namespace Microsoft.Maui.Controls.Internals
 	/// <remarks>
 	/// Third-party platform backends may supply a custom action sheet implementation by registering
 	/// a keyed <see cref="System.Func{T1, T2, TResult}"/> of
-	/// <c>Func&lt;Microsoft.Maui.Controls.Page, ActionSheetArguments, System.Threading.Tasks.Task&gt;</c>
+	/// <c>Func&lt;Microsoft.Maui.Controls.Page, ActionSheetArguments, System.Threading.Tasks.Task&lt;string&gt;&gt;</c>
 	/// in the application's <see cref="System.IServiceProvider"/> with the service key
-	/// <c>Microsoft.Maui.Controls.DisplayActionSheet</c>. The delegate is expected to call
-	/// <see cref="SetResult(string)"/> when the user has made a choice. Unkeyed delegates are not
-	/// considered by this convention.
+	/// <c>Microsoft.Maui.Controls.DisplayActionSheet</c>. The delegate should return the selected
+	/// button text, or <see langword="null"/> when the action sheet is canceled or dismissed. Unkeyed
+	/// delegates are not considered by this convention.
 	/// <para>
 	/// Note: the keyed registration is reserved for MAUI action sheet handling. Do not reuse this
 	/// service key for unrelated services in the same service collection.

--- a/src/Controls/src/Core/ActionSheetArguments.cs
+++ b/src/Controls/src/Core/ActionSheetArguments.cs
@@ -9,15 +9,15 @@ namespace Microsoft.Maui.Controls.Internals
 	/// <summary>Arguments for an action sheet dialog.</summary>
 	/// <remarks>
 	/// Third-party platform backends may supply a custom action sheet implementation by registering
-	/// a <see cref="System.Func{T1, T2, TResult}"/> of
+	/// a keyed <see cref="System.Func{T1, T2, TResult}"/> of
 	/// <c>Func&lt;Microsoft.Maui.Controls.Page, ActionSheetArguments, System.Threading.Tasks.Task&gt;</c>
-	/// in the application's <see cref="System.IServiceProvider"/>. The delegate is expected to call
-	/// <see cref="SetResult(string)"/> when the user has made a choice.
+	/// in the application's <see cref="System.IServiceProvider"/> with the service key
+	/// <c>Microsoft.Maui.Controls.DisplayActionSheet</c>. The delegate is expected to call
+	/// <see cref="SetResult(string)"/> when the user has made a choice. Unkeyed delegates are not
+	/// considered by this convention.
 	/// <para>
-	/// Note: this convention uses an open <see cref="System.Func{T1, T2, TResult}"/> shape as the
-	/// service key. Only register this delegate type for MAUI action sheet handling; registering the
-	/// same closed generic for any other purpose in the same service collection will cause it to be
-	/// consumed as an action sheet handler.
+	/// Note: the keyed registration is reserved for MAUI action sheet handling. Do not reuse this
+	/// service key for unrelated services in the same service collection.
 	/// </para>
 	/// </remarks>
 	[EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Controls/src/Core/ActionSheetArguments.cs
+++ b/src/Controls/src/Core/ActionSheetArguments.cs
@@ -7,6 +7,13 @@ using System.Threading.Tasks;
 namespace Microsoft.Maui.Controls.Internals
 {
 	/// <summary>Arguments for an action sheet dialog.</summary>
+	/// <remarks>
+	/// Third-party platform backends may supply a custom action sheet implementation by registering
+	/// a <see cref="System.Func{T1, T2, TResult}"/> of
+	/// <c>Func&lt;Microsoft.Maui.Controls.Page, ActionSheetArguments, System.Threading.Tasks.Task&gt;</c>
+	/// in the application's <see cref="System.IServiceProvider"/>. The delegate is expected to call
+	/// <see cref="SetResult(string)"/> when the user has made a choice.
+	/// </remarks>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class ActionSheetArguments
 	{

--- a/src/Controls/src/Core/ActionSheetArguments.cs
+++ b/src/Controls/src/Core/ActionSheetArguments.cs
@@ -13,6 +13,12 @@ namespace Microsoft.Maui.Controls.Internals
 	/// <c>Func&lt;Microsoft.Maui.Controls.Page, ActionSheetArguments, System.Threading.Tasks.Task&gt;</c>
 	/// in the application's <see cref="System.IServiceProvider"/>. The delegate is expected to call
 	/// <see cref="SetResult(string)"/> when the user has made a choice.
+	/// <para>
+	/// Note: this convention uses an open <see cref="System.Func{T1, T2, TResult}"/> shape as the
+	/// service key. Only register this delegate type for MAUI action sheet handling; registering the
+	/// same closed generic for any other purpose in the same service collection will cause it to be
+	/// consumed as an action sheet handler.
+	/// </para>
 	/// </remarks>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class ActionSheetArguments

--- a/src/Controls/src/Core/AlertArguments.cs
+++ b/src/Controls/src/Core/AlertArguments.cs
@@ -10,11 +10,11 @@ namespace Microsoft.Maui.Controls.Internals
 	/// <para>
 	/// Third-party platform backends may supply a custom alert implementation by registering a
 	/// keyed <see cref="System.Func{T1, T2, TResult}"/> of
-	/// <c>Func&lt;Microsoft.Maui.Controls.Page, AlertArguments, System.Threading.Tasks.Task&gt;</c>
+	/// <c>Func&lt;Microsoft.Maui.Controls.Page, AlertArguments, System.Threading.Tasks.Task&lt;bool&gt;&gt;</c>
 	/// in the application's <see cref="System.IServiceProvider"/> with the service key
-	/// <c>Microsoft.Maui.Controls.DisplayAlert</c>. The delegate is expected to call
-	/// <see cref="SetResult(bool)"/> when the user has made a choice. Unkeyed delegates are not
-	/// considered by this convention.
+	/// <c>Microsoft.Maui.Controls.DisplayAlert</c>. The delegate should return <see langword="true"/>
+	/// when the user accepts the alert, or <see langword="false"/> when the user cancels or dismisses
+	/// it. Unkeyed delegates are not considered by this convention.
 	/// </para>
 	/// <para>
 	/// Note: the keyed registration is reserved for MAUI alert handling. Do not reuse this service

--- a/src/Controls/src/Core/AlertArguments.cs
+++ b/src/Controls/src/Core/AlertArguments.cs
@@ -9,16 +9,16 @@ namespace Microsoft.Maui.Controls.Internals
 	/// For internal use only. This API can be changed or removed without notice at any time.
 	/// <para>
 	/// Third-party platform backends may supply a custom alert implementation by registering a
-	/// <see cref="System.Func{T1, T2, TResult}"/> of
+	/// keyed <see cref="System.Func{T1, T2, TResult}"/> of
 	/// <c>Func&lt;Microsoft.Maui.Controls.Page, AlertArguments, System.Threading.Tasks.Task&gt;</c>
-	/// in the application's <see cref="System.IServiceProvider"/>. The delegate is expected to call
-	/// <see cref="SetResult(bool)"/> when the user has made a choice.
+	/// in the application's <see cref="System.IServiceProvider"/> with the service key
+	/// <c>Microsoft.Maui.Controls.DisplayAlert</c>. The delegate is expected to call
+	/// <see cref="SetResult(bool)"/> when the user has made a choice. Unkeyed delegates are not
+	/// considered by this convention.
 	/// </para>
 	/// <para>
-	/// Note: this convention uses an open <see cref="System.Func{T1, T2, TResult}"/> shape as the
-	/// service key. Only register this delegate type for MAUI alert handling; registering the same
-	/// closed generic for any other purpose in the same service collection will cause it to be
-	/// consumed as an alert handler.
+	/// Note: the keyed registration is reserved for MAUI alert handling. Do not reuse this service
+	/// key for unrelated services in the same service collection.
 	/// </para>
 	/// </remarks>
 	[EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Controls/src/Core/AlertArguments.cs
+++ b/src/Controls/src/Core/AlertArguments.cs
@@ -14,6 +14,12 @@ namespace Microsoft.Maui.Controls.Internals
 	/// in the application's <see cref="System.IServiceProvider"/>. The delegate is expected to call
 	/// <see cref="SetResult(bool)"/> when the user has made a choice.
 	/// </para>
+	/// <para>
+	/// Note: this convention uses an open <see cref="System.Func{T1, T2, TResult}"/> shape as the
+	/// service key. Only register this delegate type for MAUI alert handling; registering the same
+	/// closed generic for any other purpose in the same service collection will cause it to be
+	/// consumed as an alert handler.
+	/// </para>
 	/// </remarks>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class AlertArguments

--- a/src/Controls/src/Core/AlertArguments.cs
+++ b/src/Controls/src/Core/AlertArguments.cs
@@ -5,7 +5,16 @@ using System.Threading.Tasks;
 namespace Microsoft.Maui.Controls.Internals
 {
 	/// <summary>Contains configuration arguments for displaying platform-specific alert dialogs.</summary>
-	/// <remarks>For internal use only. This API can be changed or removed without notice at any time.</remarks>
+	/// <remarks>
+	/// For internal use only. This API can be changed or removed without notice at any time.
+	/// <para>
+	/// Third-party platform backends may supply a custom alert implementation by registering a
+	/// <see cref="System.Func{T1, T2, TResult}"/> of
+	/// <c>Func&lt;Microsoft.Maui.Controls.Page, AlertArguments, System.Threading.Tasks.Task&gt;</c>
+	/// in the application's <see cref="System.IServiceProvider"/>. The delegate is expected to call
+	/// <see cref="SetResult(bool)"/> when the user has made a choice.
+	/// </para>
+	/// </remarks>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class AlertArguments
 	{

--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Maui.Controls.Platform
 				return null;
 			}
 
-			return new DelegateAlertSubscription(alertHandler, actionSheetHandler, promptHandler, CreateSubscription(context));
+			return new DelegateAlertSubscription(alertHandler, actionSheetHandler, promptHandler, () => CreateSubscription(context));
 		}
 
 		public void Unsubscribe() =>

--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.cs
@@ -58,9 +58,9 @@ namespace Microsoft.Maui.Controls.Platform
 		}
 
 		// Looks for per-operation keyed dialog delegates registered in DI using ONLY already-public types:
-		//   Func<Page, AlertArguments, Task>
-		//   Func<Page, ActionSheetArguments, Task>
-		//   Func<Page, PromptArguments, Task>
+		//   Func<Page, AlertArguments, Task<bool>>
+		//   Func<Page, ActionSheetArguments, Task<string>>
+		//   Func<Page, PromptArguments, Task<string>>
 		// This lets third-party backends supply alert/dialog implementations without MAUI having to
 		// expose IAlertManagerSubscription publicly. Keyed registrations make the intent explicit and
 		// avoid consuming unrelated Func<> registrations. Any delegate that isn't registered falls
@@ -74,9 +74,9 @@ namespace Microsoft.Maui.Controls.Platform
 				return null;
 			}
 
-			var alertHandler = keyedServices.GetKeyedService<Func<Page, AlertArguments, Task>>(DisplayAlertServiceKey);
-			var actionSheetHandler = keyedServices.GetKeyedService<Func<Page, ActionSheetArguments, Task>>(DisplayActionSheetServiceKey);
-			var promptHandler = keyedServices.GetKeyedService<Func<Page, PromptArguments, Task>>(DisplayPromptServiceKey);
+			var alertHandler = keyedServices.GetKeyedService<Func<Page, AlertArguments, Task<bool>>>(DisplayAlertServiceKey);
+			var actionSheetHandler = keyedServices.GetKeyedService<Func<Page, ActionSheetArguments, Task<string>>>(DisplayActionSheetServiceKey);
+			var promptHandler = keyedServices.GetKeyedService<Func<Page, PromptArguments, Task<string>>>(DisplayPromptServiceKey);
 
 			if (alertHandler is null && actionSheetHandler is null && promptHandler is null)
 			{

--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Maui.Controls.Internals;
@@ -36,15 +37,40 @@ namespace Microsoft.Maui.Controls.Platform
 			}
 
 			_subscription =
-				// try use services
+				// try use services - an explicitly-registered subscription wins over everything else
 				context.Services.GetService<IAlertManagerSubscription>() ??
-				// fall back to the platform implementation and a "null implementation" on non-platforms
+				// then check for the delegate-based extensibility convention (see DelegateAlertSubscription)
+				TryCreateDelegateSubscription(context) ??
+				// finally fall back to the platform implementation (or a no-op on non-platforms)
 				CreateSubscription(context);
 
 			if (_subscription is null)
 			{
 				context.CreateLogger<AlertManager>()?.LogWarning("Warning - Unable to create alert manager subscription.");
 			}
+		}
+
+		// Looks for per-operation dialog delegates registered in DI using ONLY already-public types:
+		//   Func<Page, AlertArguments, Task>
+		//   Func<Page, ActionSheetArguments, Task>
+		//   Func<Page, PromptArguments, Task>
+		// This lets third-party backends supply alert/dialog implementations without MAUI having to
+		// expose IAlertManagerSubscription publicly. Any delegate that isn't registered falls through
+		// to the platform default (so backends can override only what they care about).
+		IAlertManagerSubscription? TryCreateDelegateSubscription(IMauiContext context)
+		{
+			var services = context.Services;
+
+			var alertHandler = services.GetService<Func<Page, AlertArguments, Task>>();
+			var actionSheetHandler = services.GetService<Func<Page, ActionSheetArguments, Task>>();
+			var promptHandler = services.GetService<Func<Page, PromptArguments, Task>>();
+
+			if (alertHandler is null && actionSheetHandler is null && promptHandler is null)
+			{
+				return null;
+			}
+
+			return new DelegateAlertSubscription(alertHandler, actionSheetHandler, promptHandler, CreateSubscription(context));
 		}
 
 		public void Unsubscribe() =>

--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.cs
@@ -8,6 +8,10 @@ namespace Microsoft.Maui.Controls.Platform
 {
 	internal partial class AlertManager : IAlertManager
 	{
+		internal const string DisplayAlertServiceKey = "Microsoft.Maui.Controls.DisplayAlert";
+		internal const string DisplayActionSheetServiceKey = "Microsoft.Maui.Controls.DisplayActionSheet";
+		internal const string DisplayPromptServiceKey = "Microsoft.Maui.Controls.DisplayPrompt";
+
 		readonly Window _window;
 
 		IAlertManagerSubscription? _subscription;
@@ -50,20 +54,26 @@ namespace Microsoft.Maui.Controls.Platform
 			}
 		}
 
-		// Looks for per-operation dialog delegates registered in DI using ONLY already-public types:
+		// Looks for per-operation keyed dialog delegates registered in DI using ONLY already-public types:
 		//   Func<Page, AlertArguments, Task>
 		//   Func<Page, ActionSheetArguments, Task>
 		//   Func<Page, PromptArguments, Task>
 		// This lets third-party backends supply alert/dialog implementations without MAUI having to
-		// expose IAlertManagerSubscription publicly. Any delegate that isn't registered falls through
-		// to the platform default (so backends can override only what they care about).
+		// expose IAlertManagerSubscription publicly. Keyed registrations make the intent explicit and
+		// avoid consuming unrelated Func<> registrations. Any delegate that isn't registered falls
+		// through to the platform default (so backends can override only what they care about).
 		IAlertManagerSubscription? TryCreateDelegateSubscription(IMauiContext context)
 		{
 			var services = context.Services;
 
-			var alertHandler = services.GetService<Func<Page, AlertArguments, Task>>();
-			var actionSheetHandler = services.GetService<Func<Page, ActionSheetArguments, Task>>();
-			var promptHandler = services.GetService<Func<Page, PromptArguments, Task>>();
+			if (services is not IKeyedServiceProvider keyedServices)
+			{
+				return null;
+			}
+
+			var alertHandler = keyedServices.GetKeyedService<Func<Page, AlertArguments, Task>>(DisplayAlertServiceKey);
+			var actionSheetHandler = keyedServices.GetKeyedService<Func<Page, ActionSheetArguments, Task>>(DisplayActionSheetServiceKey);
+			var promptHandler = keyedServices.GetKeyedService<Func<Page, PromptArguments, Task>>(DisplayPromptServiceKey);
 
 			if (alertHandler is null && actionSheetHandler is null && promptHandler is null)
 			{

--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Maui.Controls.Platform
 {
 	internal partial class AlertManager : IAlertManager
 	{
+		// These string values are documented in the XML remarks for AlertArguments,
+		// ActionSheetArguments, and PromptArguments. Third-party backends may depend
+		// on them as literal strings; do not change without breaking-change consideration.
 		internal const string DisplayAlertServiceKey = "Microsoft.Maui.Controls.DisplayAlert";
 		internal const string DisplayActionSheetServiceKey = "Microsoft.Maui.Controls.DisplayActionSheet";
 		internal const string DisplayPromptServiceKey = "Microsoft.Maui.Controls.DisplayPrompt";

--- a/src/Controls/src/Core/Platform/AlertManager/DelegateAlertSubscription.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/DelegateAlertSubscription.cs
@@ -14,9 +14,12 @@ namespace Microsoft.Maui.Controls.Platform
 	// This is the internal backing for the "delegate convention" extensibility seam. Consumers
 	// register any of the following in their MauiAppBuilder.Services (all types are already public):
 	//
-	//     services.AddSingleton<Func<Page, AlertArguments, Task>>(ShowAlertAsync);
-	//     services.AddSingleton<Func<Page, ActionSheetArguments, Task>>(ShowActionSheetAsync);
-	//     services.AddSingleton<Func<Page, PromptArguments, Task>>(ShowPromptAsync);
+	//     services.AddKeyedSingleton<Func<Page, AlertArguments, Task>>(
+	//         AlertManager.DisplayAlertServiceKey, ShowAlertAsync);
+	//     services.AddKeyedSingleton<Func<Page, ActionSheetArguments, Task>>(
+	//         AlertManager.DisplayActionSheetServiceKey, ShowActionSheetAsync);
+	//     services.AddKeyedSingleton<Func<Page, PromptArguments, Task>>(
+	//         AlertManager.DisplayPromptServiceKey, ShowPromptAsync);
 	//
 	// The delegate is expected to complete the argument's TaskCompletionSource via SetResult(...).
 	// If the delegate's returned Task faults or is cancelled, the exception / cancellation is

--- a/src/Controls/src/Core/Platform/AlertManager/DelegateAlertSubscription.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/DelegateAlertSubscription.cs
@@ -92,6 +92,11 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				task = invoker();
 			}
+			catch (OperationCanceledException ex)
+			{
+				completion.TrySetCanceled(ex.CancellationToken);
+				return;
+			}
 			catch (Exception ex)
 			{
 				completion.TrySetException(ex);
@@ -127,6 +132,16 @@ namespace Microsoft.Maui.Controls.Platform
 			}
 			else if (task.IsCanceled)
 			{
+				try
+				{
+					task.GetAwaiter().GetResult();
+				}
+				catch (OperationCanceledException ex)
+				{
+					completion.TrySetCanceled(ex.CancellationToken);
+					return;
+				}
+
 				completion.TrySetCanceled();
 			}
 			else

--- a/src/Controls/src/Core/Platform/AlertManager/DelegateAlertSubscription.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/DelegateAlertSubscription.cs
@@ -96,27 +96,32 @@ namespace Microsoft.Maui.Controls.Platform
 
 			if (task is null)
 			{
+				completion.TrySetException(new InvalidOperationException(
+					"Alert delegate returned a null Task. The delegate must return a non-null Task and call SetResult(...) on the provided arguments."));
 				return;
 			}
 
 			if (task.IsCompleted)
 			{
-				ForwardFaultOrCancellation(task, completion);
+				ForwardCompletion(task, completion);
 				return;
 			}
 
 			task.ContinueWith(
-				static (t, state) => ForwardFaultOrCancellation(t, (TaskCompletionSource<T>)state!),
+				static (t, state) => ForwardCompletion(t, (TaskCompletionSource<T>)state!),
 				completion,
 				CancellationToken.None,
 				TaskContinuationOptions.ExecuteSynchronously,
 				TaskScheduler.Default);
 		}
 
-		static void ForwardFaultOrCancellation<T>(Task task, TaskCompletionSource<T> completion)
+		static void ForwardCompletion<T>(Task task, TaskCompletionSource<T> completion)
 		{
 			// The delegate is responsible for calling SetResult(...) on successful completion.
-			// Only forward faults and cancellations so we don't overwrite the delegate's result.
+			// Forward faults and cancellations so the caller observes them. If the delegate's
+			// task completed successfully but never called SetResult, surface that as an
+			// InvalidOperationException instead of letting the caller hang forever.
+			// All paths use Try* so a delegate that did call SetResult is unaffected.
 			if (task.IsFaulted && task.Exception is not null)
 			{
 				completion.TrySetException(task.Exception.InnerExceptions);
@@ -124,6 +129,11 @@ namespace Microsoft.Maui.Controls.Platform
 			else if (task.IsCanceled)
 			{
 				completion.TrySetCanceled();
+			}
+			else if (!completion.Task.IsCompleted)
+			{
+				completion.TrySetException(new InvalidOperationException(
+					"Alert delegate completed without calling SetResult(...) on the provided arguments. The delegate must call SetResult before its returned Task completes."));
 			}
 		}
 	}

--- a/src/Controls/src/Core/Platform/AlertManager/DelegateAlertSubscription.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/DelegateAlertSubscription.cs
@@ -26,25 +26,26 @@ namespace Microsoft.Maui.Controls.Platform
 		readonly Func<Page, AlertArguments, Task>? _alertHandler;
 		readonly Func<Page, ActionSheetArguments, Task>? _actionSheetHandler;
 		readonly Func<Page, PromptArguments, Task>? _promptHandler;
-		readonly IAlertManagerSubscription _fallback;
+		readonly Lazy<IAlertManagerSubscription> _fallback;
 
 		public DelegateAlertSubscription(
 			Func<Page, AlertArguments, Task>? alertHandler,
 			Func<Page, ActionSheetArguments, Task>? actionSheetHandler,
 			Func<Page, PromptArguments, Task>? promptHandler,
-			IAlertManagerSubscription fallback)
+			Func<IAlertManagerSubscription> createFallback)
 		{
 			_alertHandler = alertHandler;
 			_actionSheetHandler = actionSheetHandler;
 			_promptHandler = promptHandler;
-			_fallback = fallback ?? throw new ArgumentNullException(nameof(fallback));
+			_fallback = new Lazy<IAlertManagerSubscription>(
+				createFallback ?? throw new ArgumentNullException(nameof(createFallback)));
 		}
 
 		public void OnAlertRequested(Page sender, AlertArguments arguments)
 		{
 			if (_alertHandler is null)
 			{
-				_fallback.OnAlertRequested(sender, arguments);
+				_fallback.Value.OnAlertRequested(sender, arguments);
 				return;
 			}
 
@@ -55,7 +56,7 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			if (_actionSheetHandler is null)
 			{
-				_fallback.OnActionSheetRequested(sender, arguments);
+				_fallback.Value.OnActionSheetRequested(sender, arguments);
 				return;
 			}
 
@@ -66,7 +67,7 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			if (_promptHandler is null)
 			{
-				_fallback.OnPromptRequested(sender, arguments);
+				_fallback.Value.OnPromptRequested(sender, arguments);
 				return;
 			}
 
@@ -78,7 +79,7 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			// OnPageBusy is obsolete and is not part of the delegate convention - always
 			// route to the platform fallback so busy-indicator behavior is unchanged.
-			_fallback.OnPageBusy(sender, enabled);
+			_fallback.Value.OnPageBusy(sender, enabled);
 		}
 
 		static void Invoke<T>(Func<Task> invoker, TaskCompletionSource<T> completion)
@@ -122,9 +123,9 @@ namespace Microsoft.Maui.Controls.Platform
 			// task completed successfully but never called SetResult, surface that as an
 			// InvalidOperationException instead of letting the caller hang forever.
 			// All paths use Try* so a delegate that did call SetResult is unaffected.
-			if (task.IsFaulted && task.Exception is not null)
+			if (task.IsFaulted)
 			{
-				completion.TrySetException(task.Exception.InnerExceptions);
+				completion.TrySetException(task.Exception!.InnerExceptions);
 			}
 			else if (task.IsCanceled)
 			{

--- a/src/Controls/src/Core/Platform/AlertManager/DelegateAlertSubscription.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/DelegateAlertSubscription.cs
@@ -14,27 +14,27 @@ namespace Microsoft.Maui.Controls.Platform
 	// This is the internal backing for the "delegate convention" extensibility seam. Consumers
 	// register any of the following in their MauiAppBuilder.Services (all types are already public):
 	//
-	//     services.AddKeyedSingleton<Func<Page, AlertArguments, Task>>(
+	//     services.AddKeyedSingleton<Func<Page, AlertArguments, Task<bool>>>(
 	//         AlertManager.DisplayAlertServiceKey, ShowAlertAsync);
-	//     services.AddKeyedSingleton<Func<Page, ActionSheetArguments, Task>>(
+	//     services.AddKeyedSingleton<Func<Page, ActionSheetArguments, Task<string>>>(
 	//         AlertManager.DisplayActionSheetServiceKey, ShowActionSheetAsync);
-	//     services.AddKeyedSingleton<Func<Page, PromptArguments, Task>>(
+	//     services.AddKeyedSingleton<Func<Page, PromptArguments, Task<string>>>(
 	//         AlertManager.DisplayPromptServiceKey, ShowPromptAsync);
 	//
-	// The delegate is expected to complete the argument's TaskCompletionSource via SetResult(...).
-	// If the delegate's returned Task faults or is cancelled, the exception / cancellation is
-	// forwarded to the TaskCompletionSource so that the calling DisplayXyzAsync() call observes it.
+	// The delegate returns the dialog result. This wrapper completes the argument's
+	// TaskCompletionSource so that the calling DisplayXyzAsync() call observes the result,
+	// exception, or cancellation.
 	internal sealed class DelegateAlertSubscription : IAlertManagerSubscription
 	{
-		readonly Func<Page, AlertArguments, Task>? _alertHandler;
-		readonly Func<Page, ActionSheetArguments, Task>? _actionSheetHandler;
-		readonly Func<Page, PromptArguments, Task>? _promptHandler;
+		readonly Func<Page, AlertArguments, Task<bool>>? _alertHandler;
+		readonly Func<Page, ActionSheetArguments, Task<string>>? _actionSheetHandler;
+		readonly Func<Page, PromptArguments, Task<string>>? _promptHandler;
 		readonly Lazy<IAlertManagerSubscription> _fallback;
 
 		public DelegateAlertSubscription(
-			Func<Page, AlertArguments, Task>? alertHandler,
-			Func<Page, ActionSheetArguments, Task>? actionSheetHandler,
-			Func<Page, PromptArguments, Task>? promptHandler,
+			Func<Page, AlertArguments, Task<bool>>? alertHandler,
+			Func<Page, ActionSheetArguments, Task<string>>? actionSheetHandler,
+			Func<Page, PromptArguments, Task<string>>? promptHandler,
 			Func<IAlertManagerSubscription> createFallback)
 		{
 			_alertHandler = alertHandler;
@@ -85,9 +85,9 @@ namespace Microsoft.Maui.Controls.Platform
 			_fallback.Value.OnPageBusy(sender, enabled);
 		}
 
-		static void Invoke<T>(Func<Task> invoker, TaskCompletionSource<T> completion)
+		static void Invoke<T>(Func<Task<T>> invoker, TaskCompletionSource<T> completion)
 		{
-			Task? task;
+			Task<T>? task;
 			try
 			{
 				task = invoker();
@@ -101,7 +101,7 @@ namespace Microsoft.Maui.Controls.Platform
 			if (task is null)
 			{
 				completion.TrySetException(new InvalidOperationException(
-					"Alert delegate returned a null Task. The delegate must return a non-null Task and call SetResult(...) on the provided arguments."));
+					"Dialog delegate returned a null Task. The delegate must return a non-null Task containing the dialog result."));
 				return;
 			}
 
@@ -119,13 +119,8 @@ namespace Microsoft.Maui.Controls.Platform
 				TaskScheduler.Default);
 		}
 
-		static void ForwardCompletion<T>(Task task, TaskCompletionSource<T> completion)
+		static void ForwardCompletion<T>(Task<T> task, TaskCompletionSource<T> completion)
 		{
-			// The delegate is responsible for calling SetResult(...) on successful completion.
-			// Forward faults and cancellations so the caller observes them. If the delegate's
-			// task completed successfully but never called SetResult, surface that as an
-			// InvalidOperationException instead of letting the caller hang forever.
-			// All paths use Try* so a delegate that did call SetResult is unaffected.
 			if (task.IsFaulted)
 			{
 				completion.TrySetException(task.Exception!.InnerExceptions);
@@ -134,10 +129,9 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				completion.TrySetCanceled();
 			}
-			else if (!completion.Task.IsCompleted)
+			else
 			{
-				completion.TrySetException(new InvalidOperationException(
-					"Alert delegate completed without calling SetResult(...) on the provided arguments. The delegate must call SetResult before its returned Task completes."));
+				completion.TrySetResult(task.Result);
 			}
 		}
 	}

--- a/src/Controls/src/Core/Platform/AlertManager/DelegateAlertSubscription.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/DelegateAlertSubscription.cs
@@ -1,0 +1,130 @@
+#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls.Internals;
+
+namespace Microsoft.Maui.Controls.Platform
+{
+	// An IAlertManagerSubscription implementation that dispatches alert, action sheet, and prompt
+	// requests to user-supplied delegates resolved from DI. If a delegate isn't supplied for a
+	// particular operation, the call falls through to the platform default subscription, so backends
+	// can override only the operations they care about.
+	//
+	// This is the internal backing for the "delegate convention" extensibility seam. Consumers
+	// register any of the following in their MauiAppBuilder.Services (all types are already public):
+	//
+	//     services.AddSingleton<Func<Page, AlertArguments, Task>>(ShowAlertAsync);
+	//     services.AddSingleton<Func<Page, ActionSheetArguments, Task>>(ShowActionSheetAsync);
+	//     services.AddSingleton<Func<Page, PromptArguments, Task>>(ShowPromptAsync);
+	//
+	// The delegate is expected to complete the argument's TaskCompletionSource via SetResult(...).
+	// If the delegate's returned Task faults or is cancelled, the exception / cancellation is
+	// forwarded to the TaskCompletionSource so that the calling DisplayXyzAsync() call observes it.
+	internal sealed class DelegateAlertSubscription : IAlertManagerSubscription
+	{
+		readonly Func<Page, AlertArguments, Task>? _alertHandler;
+		readonly Func<Page, ActionSheetArguments, Task>? _actionSheetHandler;
+		readonly Func<Page, PromptArguments, Task>? _promptHandler;
+		readonly IAlertManagerSubscription _fallback;
+
+		public DelegateAlertSubscription(
+			Func<Page, AlertArguments, Task>? alertHandler,
+			Func<Page, ActionSheetArguments, Task>? actionSheetHandler,
+			Func<Page, PromptArguments, Task>? promptHandler,
+			IAlertManagerSubscription fallback)
+		{
+			_alertHandler = alertHandler;
+			_actionSheetHandler = actionSheetHandler;
+			_promptHandler = promptHandler;
+			_fallback = fallback ?? throw new ArgumentNullException(nameof(fallback));
+		}
+
+		public void OnAlertRequested(Page sender, AlertArguments arguments)
+		{
+			if (_alertHandler is null)
+			{
+				_fallback.OnAlertRequested(sender, arguments);
+				return;
+			}
+
+			Invoke(() => _alertHandler(sender, arguments), arguments.Result);
+		}
+
+		public void OnActionSheetRequested(Page sender, ActionSheetArguments arguments)
+		{
+			if (_actionSheetHandler is null)
+			{
+				_fallback.OnActionSheetRequested(sender, arguments);
+				return;
+			}
+
+			Invoke(() => _actionSheetHandler(sender, arguments), arguments.Result);
+		}
+
+		public void OnPromptRequested(Page sender, PromptArguments arguments)
+		{
+			if (_promptHandler is null)
+			{
+				_fallback.OnPromptRequested(sender, arguments);
+				return;
+			}
+
+			Invoke(() => _promptHandler(sender, arguments), arguments.Result);
+		}
+
+		[Obsolete("This method is obsolete in .NET 10 and will be removed in .NET11.")]
+		public void OnPageBusy(Page sender, bool enabled)
+		{
+			// OnPageBusy is obsolete and is not part of the delegate convention - always
+			// route to the platform fallback so busy-indicator behavior is unchanged.
+			_fallback.OnPageBusy(sender, enabled);
+		}
+
+		static void Invoke<T>(Func<Task> invoker, TaskCompletionSource<T> completion)
+		{
+			Task? task;
+			try
+			{
+				task = invoker();
+			}
+			catch (Exception ex)
+			{
+				completion.TrySetException(ex);
+				return;
+			}
+
+			if (task is null)
+			{
+				return;
+			}
+
+			if (task.IsCompleted)
+			{
+				ForwardFaultOrCancellation(task, completion);
+				return;
+			}
+
+			task.ContinueWith(
+				static (t, state) => ForwardFaultOrCancellation(t, (TaskCompletionSource<T>)state!),
+				completion,
+				CancellationToken.None,
+				TaskContinuationOptions.ExecuteSynchronously,
+				TaskScheduler.Default);
+		}
+
+		static void ForwardFaultOrCancellation<T>(Task task, TaskCompletionSource<T> completion)
+		{
+			// The delegate is responsible for calling SetResult(...) on successful completion.
+			// Only forward faults and cancellations so we don't overwrite the delegate's result.
+			if (task.IsFaulted && task.Exception is not null)
+			{
+				completion.TrySetException(task.Exception.InnerExceptions);
+			}
+			else if (task.IsCanceled)
+			{
+				completion.TrySetCanceled();
+			}
+		}
+	}
+}

--- a/src/Controls/src/Core/PromptArguments.cs
+++ b/src/Controls/src/Core/PromptArguments.cs
@@ -7,15 +7,15 @@ namespace Microsoft.Maui.Controls.Internals
 	/// <summary>Arguments for a prompt dialog.</summary>
 	/// <remarks>
 	/// Third-party platform backends may supply a custom prompt implementation by registering a
-	/// <see cref="System.Func{T1, T2, TResult}"/> of
+	/// keyed <see cref="System.Func{T1, T2, TResult}"/> of
 	/// <c>Func&lt;Microsoft.Maui.Controls.Page, PromptArguments, System.Threading.Tasks.Task&gt;</c>
-	/// in the application's <see cref="System.IServiceProvider"/>. The delegate is expected to call
-	/// <see cref="SetResult(string)"/> when the user has submitted or cancelled the prompt.
+	/// in the application's <see cref="System.IServiceProvider"/> with the service key
+	/// <c>Microsoft.Maui.Controls.DisplayPrompt</c>. The delegate is expected to call
+	/// <see cref="SetResult(string)"/> when the user has submitted or cancelled the prompt. Unkeyed
+	/// delegates are not considered by this convention.
 	/// <para>
-	/// Note: this convention uses an open <see cref="System.Func{T1, T2, TResult}"/> shape as the
-	/// service key. Only register this delegate type for MAUI prompt handling; registering the same
-	/// closed generic for any other purpose in the same service collection will cause it to be
-	/// consumed as a prompt handler.
+	/// Note: the keyed registration is reserved for MAUI prompt handling. Do not reuse this service
+	/// key for unrelated services in the same service collection.
 	/// </para>
 	/// </remarks>
 	[EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Controls/src/Core/PromptArguments.cs
+++ b/src/Controls/src/Core/PromptArguments.cs
@@ -8,11 +8,11 @@ namespace Microsoft.Maui.Controls.Internals
 	/// <remarks>
 	/// Third-party platform backends may supply a custom prompt implementation by registering a
 	/// keyed <see cref="System.Func{T1, T2, TResult}"/> of
-	/// <c>Func&lt;Microsoft.Maui.Controls.Page, PromptArguments, System.Threading.Tasks.Task&gt;</c>
+	/// <c>Func&lt;Microsoft.Maui.Controls.Page, PromptArguments, System.Threading.Tasks.Task&lt;string&gt;&gt;</c>
 	/// in the application's <see cref="System.IServiceProvider"/> with the service key
-	/// <c>Microsoft.Maui.Controls.DisplayPrompt</c>. The delegate is expected to call
-	/// <see cref="SetResult(string)"/> when the user has submitted or cancelled the prompt. Unkeyed
-	/// delegates are not considered by this convention.
+	/// <c>Microsoft.Maui.Controls.DisplayPrompt</c>. The delegate should return the submitted text,
+	/// or <see langword="null"/> when the prompt is canceled or dismissed. Unkeyed delegates are not
+	/// considered by this convention.
 	/// <para>
 	/// Note: the keyed registration is reserved for MAUI prompt handling. Do not reuse this service
 	/// key for unrelated services in the same service collection.

--- a/src/Controls/src/Core/PromptArguments.cs
+++ b/src/Controls/src/Core/PromptArguments.cs
@@ -5,6 +5,13 @@ using System.Threading.Tasks;
 namespace Microsoft.Maui.Controls.Internals
 {
 	/// <summary>Arguments for a prompt dialog.</summary>
+	/// <remarks>
+	/// Third-party platform backends may supply a custom prompt implementation by registering a
+	/// <see cref="System.Func{T1, T2, TResult}"/> of
+	/// <c>Func&lt;Microsoft.Maui.Controls.Page, PromptArguments, System.Threading.Tasks.Task&gt;</c>
+	/// in the application's <see cref="System.IServiceProvider"/>. The delegate is expected to call
+	/// <see cref="SetResult(string)"/> when the user has submitted or cancelled the prompt.
+	/// </remarks>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class PromptArguments
 	{

--- a/src/Controls/src/Core/PromptArguments.cs
+++ b/src/Controls/src/Core/PromptArguments.cs
@@ -11,6 +11,12 @@ namespace Microsoft.Maui.Controls.Internals
 	/// <c>Func&lt;Microsoft.Maui.Controls.Page, PromptArguments, System.Threading.Tasks.Task&gt;</c>
 	/// in the application's <see cref="System.IServiceProvider"/>. The delegate is expected to call
 	/// <see cref="SetResult(string)"/> when the user has submitted or cancelled the prompt.
+	/// <para>
+	/// Note: this convention uses an open <see cref="System.Func{T1, T2, TResult}"/> shape as the
+	/// service key. Only register this delegate type for MAUI prompt handling; registering the same
+	/// closed generic for any other purpose in the same service collection will cause it to be
+	/// consumed as a prompt handler.
+	/// </para>
 	/// </remarks>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class PromptArguments

--- a/src/Controls/tests/Core.UnitTests/AlertManagerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/AlertManagerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Platform;
@@ -204,6 +205,100 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			continueTask.Wait();
 			sub.Received().OnActionSheetRequested(Arg.Is(page), Arg.Is(args));
 			Assert.True(completed);
+		}
+
+		[Fact]
+		public async Task DelegateFuncInterceptsDisplayAlert()
+		{
+			Func<Page, AlertArguments, Task> alertFunc = (page, args) =>
+			{
+				args.SetResult(true);
+				return Task.CompletedTask;
+			};
+
+			var window = CreateWindow(services =>
+			{
+				services.GetService(Arg.Is<Type>(x => x == typeof(Func<Page, AlertArguments, Task>))).Returns(alertFunc);
+			});
+			var page = new ContentPage { Handler = Substitute.For<IViewHandler>(), IsPlatformEnabled = true };
+			window.Page = page;
+
+			// No explicit IAlertManagerSubscription -> delegate convention kicks in.
+			Assert.NotNull(((AlertManager)window.AlertManager).Subscription);
+
+			var result = await page.DisplayAlertAsync("Title", "Message", "Accept", "Cancel");
+
+			Assert.True(result);
+		}
+
+		[Fact]
+		public async Task DelegateFuncFallsThroughForUnregisteredOperation()
+		{
+			// Register ONLY the alert delegate. Prompt requests should fall through to the platform
+			// default (which, in the test environment, is the Standard no-op AlertRequestHelper).
+			Func<Page, AlertArguments, Task> alertFunc = (page, args) =>
+			{
+				args.SetResult(true);
+				return Task.CompletedTask;
+			};
+
+			var window = CreateWindow(services =>
+			{
+				services.GetService(Arg.Is<Type>(x => x == typeof(Func<Page, AlertArguments, Task>))).Returns(alertFunc);
+			});
+			var page = new ContentPage { Handler = Substitute.For<IViewHandler>(), IsPlatformEnabled = true };
+			window.Page = page;
+
+			var alertResult = await page.DisplayAlertAsync("Title", "Message", "Accept", "Cancel");
+			Assert.True(alertResult);
+
+			// Prompt has no delegate registered; the test's Standard fallback is a no-op so the
+			// task should simply never complete. Verify that by racing it against a short delay.
+			var promptTask = page.DisplayPromptAsync("Title", "Message");
+			var winner = await Task.WhenAny(promptTask, Task.Delay(100));
+			Assert.NotSame(promptTask, winner);
+		}
+
+		[Fact]
+		public void ExplicitSubscriptionWinsOverDelegateFuncs()
+		{
+			Func<Page, AlertArguments, Task> alertFunc = (page, args) =>
+			{
+				args.SetResult(true);
+				return Task.CompletedTask;
+			};
+
+			var stub = Substitute.For<IAlertManagerSubscription>();
+			var window = CreateWindow(services =>
+			{
+				services.GetService(Arg.Is<Type>(x => x == typeof(IAlertManagerSubscription))).Returns(stub);
+				services.GetService(Arg.Is<Type>(x => x == typeof(Func<Page, AlertArguments, Task>))).Returns(alertFunc);
+			});
+			var page = new ContentPage { Handler = Substitute.For<IViewHandler>(), IsPlatformEnabled = true };
+			window.Page = page;
+
+			Assert.Same(stub, ((AlertManager)window.AlertManager).Subscription);
+
+			page.DisplayAlertAsync("Title", "Message", "Accept", "Cancel");
+
+			stub.Received().OnAlertRequested(Arg.Is(page), Arg.Any<AlertArguments>());
+		}
+
+		[Fact]
+		public async Task DelegateFuncExceptionPropagatesToCaller()
+		{
+			Func<Page, AlertArguments, Task> alertFunc = (page, args) => throw new InvalidOperationException("boom");
+
+			var window = CreateWindow(services =>
+			{
+				services.GetService(Arg.Is<Type>(x => x == typeof(Func<Page, AlertArguments, Task>))).Returns(alertFunc);
+			});
+			var page = new ContentPage { Handler = Substitute.For<IViewHandler>(), IsPlatformEnabled = true };
+			window.Page = page;
+
+			var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+				page.DisplayAlertAsync("Title", "Message", "Accept", "Cancel"));
+			Assert.Equal("boom", ex.Message);
 		}
 
 		[Fact]

--- a/src/Controls/tests/Core.UnitTests/AlertManagerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/AlertManagerTests.cs
@@ -219,11 +219,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[Fact]
 		public async Task DelegateFuncInterceptsDisplayAlert()
 		{
-			Func<Page, AlertArguments, Task> alertFunc = (page, args) =>
-			{
-				args.SetResult(true);
-				return Task.CompletedTask;
-			};
+			Func<Page, AlertArguments, Task<bool>> alertFunc = (page, args) => Task.FromResult(true);
 
 			var window = CreateWindow(services =>
 			{
@@ -244,16 +240,15 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public void UnkeyedDelegateFuncDoesNotUseDelegateConvention()
 		{
 			bool alertDelegateInvoked = false;
-			Func<Page, AlertArguments, Task> alertFunc = (page, args) =>
+			Func<Page, AlertArguments, Task<bool>> alertFunc = (page, args) =>
 			{
 				alertDelegateInvoked = true;
-				args.SetResult(true);
-				return Task.CompletedTask;
+				return Task.FromResult(true);
 			};
 
 			var window = CreateWindow(services =>
 			{
-				services.GetService(Arg.Is<Type>(x => x == typeof(Func<Page, AlertArguments, Task>))).Returns(alertFunc);
+				services.GetService(Arg.Is<Type>(x => x == typeof(Func<Page, AlertArguments, Task<bool>>))).Returns(alertFunc);
 			});
 			var page = new ContentPage { Handler = Substitute.For<IViewHandler>(), IsPlatformEnabled = true };
 			window.Page = page;
@@ -272,11 +267,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			// invoke the alert delegate. We assert that deterministically by tracking invocation
 			// of the alert delegate rather than racing a wall-clock timer against the prompt task.
 			bool alertDelegateInvoked = false;
-			Func<Page, AlertArguments, Task> alertFunc = (page, args) =>
+			Func<Page, AlertArguments, Task<bool>> alertFunc = (page, args) =>
 			{
 				alertDelegateInvoked = true;
-				args.SetResult(true);
-				return Task.CompletedTask;
+				return Task.FromResult(true);
 			};
 
 			var window = CreateWindow(services =>
@@ -303,11 +297,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[Fact]
 		public async Task DelegateFuncInterceptsDisplayActionSheet()
 		{
-			Func<Page, ActionSheetArguments, Task> actionSheetFunc = (page, args) =>
-			{
-				args.SetResult("Other 1");
-				return Task.CompletedTask;
-			};
+			Func<Page, ActionSheetArguments, Task<string>> actionSheetFunc = (page, args) => Task.FromResult("Other 1");
 
 			var window = CreateWindow(services =>
 			{
@@ -316,7 +306,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var page = new ContentPage { Handler = Substitute.For<IViewHandler>(), IsPlatformEnabled = true };
 			window.Page = page;
 
-			Assert.NotNull(window.AlertManager.Subscription);
+			Assert.NotNull(((AlertManager)window.AlertManager).Subscription);
 
 			var result = await page.DisplayActionSheet("Title", "Cancel", "Destruction", "Other 1", "Other 2");
 
@@ -326,11 +316,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[Fact]
 		public async Task DelegateFuncInterceptsDisplayPrompt()
 		{
-			Func<Page, PromptArguments, Task> promptFunc = (page, args) =>
-			{
-				args.SetResult("user input");
-				return Task.CompletedTask;
-			};
+			Func<Page, PromptArguments, Task<string>> promptFunc = (page, args) => Task.FromResult("user input");
 
 			var window = CreateWindow(services =>
 			{
@@ -339,7 +325,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var page = new ContentPage { Handler = Substitute.For<IViewHandler>(), IsPlatformEnabled = true };
 			window.Page = page;
 
-			Assert.NotNull(window.AlertManager.Subscription);
+			Assert.NotNull(((AlertManager)window.AlertManager).Subscription);
 
 			var result = await page.DisplayPromptAsync("Title", "Message");
 
@@ -349,11 +335,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[Fact]
 		public async Task ExplicitSubscriptionWinsOverDelegateFuncs()
 		{
-			Func<Page, AlertArguments, Task> alertFunc = (page, args) =>
-			{
-				args.SetResult(true);
-				return Task.CompletedTask;
-			};
+			Func<Page, AlertArguments, Task<bool>> alertFunc = (page, args) => Task.FromResult(true);
 
 			var stub = Substitute.For<IAlertManagerSubscription>();
 			var window = CreateWindow(services =>
@@ -379,7 +361,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[Fact]
 		public async Task DelegateFuncExceptionPropagatesToCaller()
 		{
-			Func<Page, AlertArguments, Task> alertFunc = (page, args) => throw new InvalidOperationException("boom");
+			Func<Page, AlertArguments, Task<bool>> alertFunc = (page, args) => throw new InvalidOperationException("boom");
 
 			var window = CreateWindow(services =>
 			{
@@ -399,7 +381,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			// Delegate returns a Task that faults asynchronously (after a yield), exercising the
 			// ContinueWith path in DelegateAlertSubscription.Invoke rather than the synchronous
 			// throw path covered by DelegateFuncExceptionPropagatesToCaller.
-			Func<Page, AlertArguments, Task> alertFunc = async (page, args) =>
+			Func<Page, AlertArguments, Task<bool>> alertFunc = async (page, args) =>
 			{
 				await Task.Yield();
 				throw new InvalidOperationException("async boom");
@@ -420,7 +402,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[Fact]
 		public async Task DelegateFuncCancellationPropagatesToCaller()
 		{
-			Func<Page, AlertArguments, Task> alertFunc = (page, args) => Task.FromCanceled(new CancellationToken(canceled: true));
+			Func<Page, AlertArguments, Task<bool>> alertFunc = (page, args) => Task.FromCanceled<bool>(new CancellationToken(canceled: true));
 
 			var window = CreateWindow(services =>
 			{
@@ -438,7 +420,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		{
 			// A delegate that returns null is a contract violation; the caller must observe it as
 			// an InvalidOperationException rather than hang forever waiting on the TCS.
-			Func<Page, AlertArguments, Task> alertFunc = (page, args) => null;
+			Func<Page, AlertArguments, Task<bool>> alertFunc = (page, args) => null;
 
 			var window = CreateWindow(services =>
 			{
@@ -453,12 +435,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
-		public async Task DelegateFuncCompletingWithoutSetResultFaultsTheCaller()
+		public async Task DelegateFuncReturningResultCompletesCallerWithoutSetResult()
 		{
-			// A delegate whose Task completes successfully without ever calling SetResult is also
-			// a contract violation; the caller must observe an InvalidOperationException rather
-			// than hang forever waiting on the TCS.
-			Func<Page, AlertArguments, Task> alertFunc = (page, args) => Task.CompletedTask;
+			Func<Page, AlertArguments, Task<bool>> alertFunc = (page, args) => Task.FromResult(false);
 
 			var window = CreateWindow(services =>
 			{
@@ -467,9 +446,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var page = new ContentPage { Handler = Substitute.For<IViewHandler>(), IsPlatformEnabled = true };
 			window.Page = page;
 
-			var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-				page.DisplayAlertAsync("Title", "Message", "Accept", "Cancel"));
-			Assert.Contains("SetResult", ex.Message, StringComparison.Ordinal);
+			var result = await page.DisplayAlertAsync("Title", "Message", "Accept", "Cancel");
+
+			Assert.False(result);
 		}
 
 		[Fact]

--- a/src/Controls/tests/Core.UnitTests/AlertManagerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/AlertManagerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Controls.Internals;
@@ -235,9 +236,13 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public async Task DelegateFuncFallsThroughForUnregisteredOperation()
 		{
 			// Register ONLY the alert delegate. Prompt requests should fall through to the platform
-			// default (which, in the test environment, is the Standard no-op AlertRequestHelper).
+			// default (the Standard no-op AlertRequestHelper in the test environment) and must NOT
+			// invoke the alert delegate. We assert that deterministically by tracking invocation
+			// of the alert delegate rather than racing a wall-clock timer against the prompt task.
+			bool alertDelegateInvoked = false;
 			Func<Page, AlertArguments, Task> alertFunc = (page, args) =>
 			{
+				alertDelegateInvoked = true;
 				args.SetResult(true);
 				return Task.CompletedTask;
 			};
@@ -249,14 +254,64 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var page = new ContentPage { Handler = Substitute.For<IViewHandler>(), IsPlatformEnabled = true };
 			window.Page = page;
 
+			// Sanity: the alert delegate IS invoked for alert requests.
 			var alertResult = await page.DisplayAlertAsync("Title", "Message", "Accept", "Cancel");
 			Assert.True(alertResult);
+			Assert.True(alertDelegateInvoked);
 
-			// Prompt has no delegate registered; the test's Standard fallback is a no-op so the
-			// task should simply never complete. Verify that by racing it against a short delay.
-			var promptTask = page.DisplayPromptAsync("Title", "Message");
-			var winner = await Task.WhenAny(promptTask, Task.Delay(100));
-			Assert.NotSame(promptTask, winner);
+			alertDelegateInvoked = false;
+
+			// Prompt has no delegate registered, so the alert delegate must NOT fire when a prompt
+			// is requested. The platform default no-op fallback is invoked instead, leaving the
+			// returned task pending forever (we don't await it).
+			_ = page.DisplayPromptAsync("Title", "Message");
+			Assert.False(alertDelegateInvoked);
+		}
+
+		[Fact]
+		public async Task DelegateFuncInterceptsDisplayActionSheet()
+		{
+			Func<Page, ActionSheetArguments, Task> actionSheetFunc = (page, args) =>
+			{
+				args.SetResult("Other 1");
+				return Task.CompletedTask;
+			};
+
+			var window = CreateWindow(services =>
+			{
+				services.GetService(Arg.Is<Type>(x => x == typeof(Func<Page, ActionSheetArguments, Task>))).Returns(actionSheetFunc);
+			});
+			var page = new ContentPage { Handler = Substitute.For<IViewHandler>(), IsPlatformEnabled = true };
+			window.Page = page;
+
+			Assert.NotNull(window.AlertManager.Subscription);
+
+			var result = await page.DisplayActionSheet("Title", "Cancel", "Destruction", "Other 1", "Other 2");
+
+			Assert.Equal("Other 1", result);
+		}
+
+		[Fact]
+		public async Task DelegateFuncInterceptsDisplayPrompt()
+		{
+			Func<Page, PromptArguments, Task> promptFunc = (page, args) =>
+			{
+				args.SetResult("user input");
+				return Task.CompletedTask;
+			};
+
+			var window = CreateWindow(services =>
+			{
+				services.GetService(Arg.Is<Type>(x => x == typeof(Func<Page, PromptArguments, Task>))).Returns(promptFunc);
+			});
+			var page = new ContentPage { Handler = Substitute.For<IViewHandler>(), IsPlatformEnabled = true };
+			window.Page = page;
+
+			Assert.NotNull(window.AlertManager.Subscription);
+
+			var result = await page.DisplayPromptAsync("Title", "Message");
+
+			Assert.Equal("user input", result);
 		}
 
 		[Fact]
@@ -299,6 +354,85 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
 				page.DisplayAlertAsync("Title", "Message", "Accept", "Cancel"));
 			Assert.Equal("boom", ex.Message);
+		}
+
+		[Fact]
+		public async Task DelegateFuncAsynchronousFaultPropagatesToCaller()
+		{
+			// Delegate returns a Task that faults asynchronously (after a yield), exercising the
+			// ContinueWith path in DelegateAlertSubscription.Invoke rather than the synchronous
+			// throw path covered by DelegateFuncExceptionPropagatesToCaller.
+			Func<Page, AlertArguments, Task> alertFunc = async (page, args) =>
+			{
+				await Task.Yield();
+				throw new InvalidOperationException("async boom");
+			};
+
+			var window = CreateWindow(services =>
+			{
+				services.GetService(Arg.Is<Type>(x => x == typeof(Func<Page, AlertArguments, Task>))).Returns(alertFunc);
+			});
+			var page = new ContentPage { Handler = Substitute.For<IViewHandler>(), IsPlatformEnabled = true };
+			window.Page = page;
+
+			var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+				page.DisplayAlertAsync("Title", "Message", "Accept", "Cancel"));
+			Assert.Equal("async boom", ex.Message);
+		}
+
+		[Fact]
+		public async Task DelegateFuncCancellationPropagatesToCaller()
+		{
+			Func<Page, AlertArguments, Task> alertFunc = (page, args) => Task.FromCanceled(new CancellationToken(canceled: true));
+
+			var window = CreateWindow(services =>
+			{
+				services.GetService(Arg.Is<Type>(x => x == typeof(Func<Page, AlertArguments, Task>))).Returns(alertFunc);
+			});
+			var page = new ContentPage { Handler = Substitute.For<IViewHandler>(), IsPlatformEnabled = true };
+			window.Page = page;
+
+			await Assert.ThrowsAsync<TaskCanceledException>(() =>
+				page.DisplayAlertAsync("Title", "Message", "Accept", "Cancel"));
+		}
+
+		[Fact]
+		public async Task DelegateFuncReturningNullTaskFaultsTheCaller()
+		{
+			// A delegate that returns null is a contract violation; the caller must observe it as
+			// an InvalidOperationException rather than hang forever waiting on the TCS.
+			Func<Page, AlertArguments, Task> alertFunc = (page, args) => null;
+
+			var window = CreateWindow(services =>
+			{
+				services.GetService(Arg.Is<Type>(x => x == typeof(Func<Page, AlertArguments, Task>))).Returns(alertFunc);
+			});
+			var page = new ContentPage { Handler = Substitute.For<IViewHandler>(), IsPlatformEnabled = true };
+			window.Page = page;
+
+			var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+				page.DisplayAlertAsync("Title", "Message", "Accept", "Cancel"));
+			Assert.Contains("null Task", ex.Message, StringComparison.Ordinal);
+		}
+
+		[Fact]
+		public async Task DelegateFuncCompletingWithoutSetResultFaultsTheCaller()
+		{
+			// A delegate whose Task completes successfully without ever calling SetResult is also
+			// a contract violation; the caller must observe an InvalidOperationException rather
+			// than hang forever waiting on the TCS.
+			Func<Page, AlertArguments, Task> alertFunc = (page, args) => Task.CompletedTask;
+
+			var window = CreateWindow(services =>
+			{
+				services.GetService(Arg.Is<Type>(x => x == typeof(Func<Page, AlertArguments, Task>))).Returns(alertFunc);
+			});
+			var page = new ContentPage { Handler = Substitute.For<IViewHandler>(), IsPlatformEnabled = true };
+			window.Page = page;
+
+			var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+				page.DisplayAlertAsync("Title", "Message", "Accept", "Cancel"));
+			Assert.Contains("SetResult", ex.Message, StringComparison.Ordinal);
 		}
 
 		[Fact]

--- a/src/Controls/tests/Core.UnitTests/AlertManagerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/AlertManagerTests.cs
@@ -315,7 +315,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
-		public void ExplicitSubscriptionWinsOverDelegateFuncs()
+		public async Task ExplicitSubscriptionWinsOverDelegateFuncs()
 		{
 			Func<Page, AlertArguments, Task> alertFunc = (page, args) =>
 			{
@@ -334,9 +334,14 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.Same(stub, ((AlertManager)window.AlertManager).Subscription);
 
-			page.DisplayAlertAsync("Title", "Message", "Accept", "Cancel");
+			AlertArguments args = null;
+			stub.When(x => x.OnAlertRequested(Arg.Any<Page>(), Arg.Any<AlertArguments>())).Do(x => args = x.Arg<AlertArguments>());
 
-			stub.Received().OnAlertRequested(Arg.Is(page), Arg.Any<AlertArguments>());
+			var resultTask = page.DisplayAlertAsync("Title", "Message", "Accept", "Cancel");
+
+			stub.Received().OnAlertRequested(Arg.Is(page), Arg.Is(args));
+			args.SetResult(true);
+			Assert.True(await resultTask);
 		}
 
 		[Fact]

--- a/src/Controls/tests/Core.UnitTests/AlertManagerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/AlertManagerTests.cs
@@ -402,7 +402,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[Fact]
 		public async Task DelegateFuncCancellationPropagatesToCaller()
 		{
-			Func<Page, AlertArguments, Task<bool>> alertFunc = (page, args) => Task.FromCanceled<bool>(new CancellationToken(canceled: true));
+			using var cancellationTokenSource = new CancellationTokenSource();
+			cancellationTokenSource.Cancel();
+			Func<Page, AlertArguments, Task<bool>> alertFunc = (page, args) => Task.FromCanceled<bool>(cancellationTokenSource.Token);
 
 			var window = CreateWindow(services =>
 			{
@@ -411,8 +413,31 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var page = new ContentPage { Handler = Substitute.For<IViewHandler>(), IsPlatformEnabled = true };
 			window.Page = page;
 
-			await Assert.ThrowsAsync<TaskCanceledException>(() =>
+			var ex = await Assert.ThrowsAsync<TaskCanceledException>(() =>
 				page.DisplayAlertAsync("Title", "Message", "Accept", "Cancel"));
+			Assert.Equal(cancellationTokenSource.Token, ex.CancellationToken);
+		}
+
+		[Fact]
+		public async Task DelegateFuncSynchronousCancellationCompletesCallerAsCanceled()
+		{
+			using var cancellationTokenSource = new CancellationTokenSource();
+			cancellationTokenSource.Cancel();
+			Func<Page, AlertArguments, Task<bool>> alertFunc = (page, args) => throw new OperationCanceledException(cancellationTokenSource.Token);
+
+			var window = CreateWindow(services =>
+			{
+				RegisterKeyedService(services, AlertManager.DisplayAlertServiceKey, alertFunc);
+			});
+			var page = new ContentPage { Handler = Substitute.For<IViewHandler>(), IsPlatformEnabled = true };
+			window.Page = page;
+
+			var resultTask = page.DisplayAlertAsync("Title", "Message", "Accept", "Cancel");
+
+			var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => resultTask);
+			Assert.True(resultTask.IsCanceled);
+			Assert.False(resultTask.IsFaulted);
+			Assert.Equal(cancellationTokenSource.Token, ex.CancellationToken);
 		}
 
 		[Fact]

--- a/src/Controls/tests/Core.UnitTests/AlertManagerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/AlertManagerTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 		private static Window CreateWindow(Action<IServiceProvider> builder = null)
 		{
-			var services = Substitute.For<IServiceProvider>();
+			var services = Substitute.For<IServiceProvider, IKeyedServiceProvider>();
 			builder?.Invoke(services);
 
 			var mauiContext = Substitute.For<IMauiContext>();
@@ -44,6 +44,14 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			window.Parent = app;
 
 			return window;
+		}
+
+		private static void RegisterKeyedService<TService>(IServiceProvider services, object serviceKey, TService service)
+			where TService : class
+		{
+			((IKeyedServiceProvider)services)
+				.GetKeyedService(Arg.Is<Type>(x => x == typeof(TService)), Arg.Is<object>(x => Equals(x, serviceKey)))
+				.Returns(service);
 		}
 
 		[Fact]
@@ -219,7 +227,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			var window = CreateWindow(services =>
 			{
-				services.GetService(Arg.Is<Type>(x => x == typeof(Func<Page, AlertArguments, Task>))).Returns(alertFunc);
+				RegisterKeyedService(services, AlertManager.DisplayAlertServiceKey, alertFunc);
 			});
 			var page = new ContentPage { Handler = Substitute.For<IViewHandler>(), IsPlatformEnabled = true };
 			window.Page = page;
@@ -230,6 +238,30 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var result = await page.DisplayAlertAsync("Title", "Message", "Accept", "Cancel");
 
 			Assert.True(result);
+		}
+
+		[Fact]
+		public void UnkeyedDelegateFuncDoesNotUseDelegateConvention()
+		{
+			bool alertDelegateInvoked = false;
+			Func<Page, AlertArguments, Task> alertFunc = (page, args) =>
+			{
+				alertDelegateInvoked = true;
+				args.SetResult(true);
+				return Task.CompletedTask;
+			};
+
+			var window = CreateWindow(services =>
+			{
+				services.GetService(Arg.Is<Type>(x => x == typeof(Func<Page, AlertArguments, Task>))).Returns(alertFunc);
+			});
+			var page = new ContentPage { Handler = Substitute.For<IViewHandler>(), IsPlatformEnabled = true };
+			window.Page = page;
+
+			var resultTask = page.DisplayAlertAsync("Title", "Message", "Accept", "Cancel");
+
+			Assert.False(alertDelegateInvoked);
+			Assert.False(resultTask.IsCompleted);
 		}
 
 		[Fact]
@@ -249,7 +281,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			var window = CreateWindow(services =>
 			{
-				services.GetService(Arg.Is<Type>(x => x == typeof(Func<Page, AlertArguments, Task>))).Returns(alertFunc);
+				RegisterKeyedService(services, AlertManager.DisplayAlertServiceKey, alertFunc);
 			});
 			var page = new ContentPage { Handler = Substitute.For<IViewHandler>(), IsPlatformEnabled = true };
 			window.Page = page;
@@ -279,7 +311,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			var window = CreateWindow(services =>
 			{
-				services.GetService(Arg.Is<Type>(x => x == typeof(Func<Page, ActionSheetArguments, Task>))).Returns(actionSheetFunc);
+				RegisterKeyedService(services, AlertManager.DisplayActionSheetServiceKey, actionSheetFunc);
 			});
 			var page = new ContentPage { Handler = Substitute.For<IViewHandler>(), IsPlatformEnabled = true };
 			window.Page = page;
@@ -302,7 +334,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			var window = CreateWindow(services =>
 			{
-				services.GetService(Arg.Is<Type>(x => x == typeof(Func<Page, PromptArguments, Task>))).Returns(promptFunc);
+				RegisterKeyedService(services, AlertManager.DisplayPromptServiceKey, promptFunc);
 			});
 			var page = new ContentPage { Handler = Substitute.For<IViewHandler>(), IsPlatformEnabled = true };
 			window.Page = page;
@@ -327,7 +359,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var window = CreateWindow(services =>
 			{
 				services.GetService(Arg.Is<Type>(x => x == typeof(IAlertManagerSubscription))).Returns(stub);
-				services.GetService(Arg.Is<Type>(x => x == typeof(Func<Page, AlertArguments, Task>))).Returns(alertFunc);
+				RegisterKeyedService(services, AlertManager.DisplayAlertServiceKey, alertFunc);
 			});
 			var page = new ContentPage { Handler = Substitute.For<IViewHandler>(), IsPlatformEnabled = true };
 			window.Page = page;
@@ -351,7 +383,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			var window = CreateWindow(services =>
 			{
-				services.GetService(Arg.Is<Type>(x => x == typeof(Func<Page, AlertArguments, Task>))).Returns(alertFunc);
+				RegisterKeyedService(services, AlertManager.DisplayAlertServiceKey, alertFunc);
 			});
 			var page = new ContentPage { Handler = Substitute.For<IViewHandler>(), IsPlatformEnabled = true };
 			window.Page = page;
@@ -375,7 +407,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			var window = CreateWindow(services =>
 			{
-				services.GetService(Arg.Is<Type>(x => x == typeof(Func<Page, AlertArguments, Task>))).Returns(alertFunc);
+				RegisterKeyedService(services, AlertManager.DisplayAlertServiceKey, alertFunc);
 			});
 			var page = new ContentPage { Handler = Substitute.For<IViewHandler>(), IsPlatformEnabled = true };
 			window.Page = page;
@@ -392,7 +424,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			var window = CreateWindow(services =>
 			{
-				services.GetService(Arg.Is<Type>(x => x == typeof(Func<Page, AlertArguments, Task>))).Returns(alertFunc);
+				RegisterKeyedService(services, AlertManager.DisplayAlertServiceKey, alertFunc);
 			});
 			var page = new ContentPage { Handler = Substitute.For<IViewHandler>(), IsPlatformEnabled = true };
 			window.Page = page;
@@ -410,7 +442,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			var window = CreateWindow(services =>
 			{
-				services.GetService(Arg.Is<Type>(x => x == typeof(Func<Page, AlertArguments, Task>))).Returns(alertFunc);
+				RegisterKeyedService(services, AlertManager.DisplayAlertServiceKey, alertFunc);
 			});
 			var page = new ContentPage { Handler = Substitute.For<IViewHandler>(), IsPlatformEnabled = true };
 			window.Page = page;
@@ -430,7 +462,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			var window = CreateWindow(services =>
 			{
-				services.GetService(Arg.Is<Type>(x => x == typeof(Func<Page, AlertArguments, Task>))).Returns(alertFunc);
+				RegisterKeyedService(services, AlertManager.DisplayAlertServiceKey, alertFunc);
 			});
 			var page = new ContentPage { Handler = Substitute.For<IViewHandler>(), IsPlatformEnabled = true };
 			window.Page = page;


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Enables third-party platform backends (for example Maui.Gtk) to provide their own `DisplayAlertAsync` / `DisplayActionSheetAsync` / `DisplayPromptAsync` implementations without MAUI exposing any new public API. This complements #33267: because that PR introduces a new public interface, it must wait for .NET 11. This PR solves the same problem using already-shipped public argument types, so it is shippable in .NET 10.

`AlertManager.Subscribe()` now keeps the existing explicit internal `IAlertManagerSubscription` path, then checks for keyed delegate registrations before falling back to the platform default. The delegate signatures use only existing public types:

```csharp
Func<Page, AlertArguments,       Task<bool>>
Func<Page, ActionSheetArguments, Task<string>>
Func<Page, PromptArguments,      Task<string>>
```

The registrations are keyed so MAUI does not accidentally consume unrelated `Func<>` services:

| Dialog | Service key |
|---|---|
| Alert | `Microsoft.Maui.Controls.DisplayAlert` |
| Action sheet | `Microsoft.Maui.Controls.DisplayActionSheet` |
| Prompt | `Microsoft.Maui.Controls.DisplayPrompt` |

Consumer usage:

```csharp
builder.Services.AddKeyedSingleton<Func<Page, AlertArguments, Task<bool>>>(
    "Microsoft.Maui.Controls.DisplayAlert",
    async (page, args) =>
    {
        return await MyGtkDialog.ShowAsync(args.Title, args.Message, args.Accept, args.Cancel);
    });
```

If any keyed delegate is registered, MAUI wraps it in a new internal `DelegateAlertSubscription`. Registered operations dispatch to their delegate; unregistered operations fall through to the platform default. The delegate returns the dialog result and MAUI completes the corresponding `AlertArguments`, `ActionSheetArguments`, or `PromptArguments` internally. If the delegate returns `null`, faults, or cancels, the caller observes that through the original `Display*Async` task instead of hanging silently.

Precedence order in `Subscribe()`:

1. Explicit `IAlertManagerSubscription` service (existing internal path, unchanged)
2. Keyed result-returning delegate convention (new)
3. Platform default subscription (existing fallback)

### Notes for reviewers

- Zero public API surface: no `PublicAPI.*.txt` changes. The new `DelegateAlertSubscription` class and key constants are internal; consumers use literal string keys documented on the existing argument types.
- Keyed registrations are intentional. Unkeyed `Func<>` services are ignored to avoid accidental collisions.
- The delegate returns the dialog result instead of calling `args.SetResult(...)`. This matches the built-in async platform pattern where MAUI completes the argument after awaiting the native dialog result.
- Per-operation fall-through is intentional. A backend can override just alerts and keep the platform action sheet/prompt, for example.
- `OnPageBusy` is excluded from the convention (obsolete in .NET 10, removed in .NET 11) and always routes to the fallback.
- When .NET 11 ships a proper public `IAlertManager`/`IAlertDialogProvider`, this delegate convention can stay as a lightweight alias or be deprecated. Either way, .NET 10 consumers are unblocked now.

### Tests

Unit coverage in `AlertManagerTests.cs` includes:

- Alert, action sheet, and prompt delegate dispatch
- Returned delegate results completing the original `Display*Async` caller
- Unregistered operation fall-through
- Unkeyed delegate services being ignored
- Explicit `IAlertManagerSubscription` precedence
- Synchronous and asynchronous delegate faults
- Delegate cancellation forwarding
- Null task contract violation

Focused `AlertManagerTests` pass locally: 21/21.

### Issues Fixed

Fixes #34104
