### PR TITLE
[core] Add keyed-DI screenshot extensibility for 3rd-party platform backends

### DIFF
--- a/src/Core/src/ScreenshotDispatch.cs
+++ b/src/Core/src/ScreenshotDispatch.cs
@@ -19,8 +19,8 @@ namespace Microsoft.Maui
 	/// the well-known keys defined on this type. The lambda receives the handler's
 	/// <see cref="IElementHandler.PlatformView"/> object and returns a task whose
 	/// result is the screenshot (or <see langword="null"/> if capture is not
-	/// supported for that view). The returned <see cref="Task{TResult}"/> itself
-	/// is expected to be non-null.
+	/// supported for that view). A hook that returns a <see langword="null"/>
+	/// task is treated as unsupported and produces a <see langword="null"/> result.
 	/// This contract intentionally uses only BCL types so it can ship without any
 	/// MAUI public API addition.
 	/// </remarks>
@@ -45,14 +45,12 @@ namespace Microsoft.Maui
 			if (handler!.MauiContext?.Services is not IKeyedServiceProvider keyedProvider)
 				return Task.FromResult<IScreenshotResult?>(null);
 
-			var capture = keyedProvider.GetKeyedService(
-				typeof(Func<object, Task<IScreenshotResult?>>),
-				serviceKey) as Func<object, Task<IScreenshotResult?>>;
+			var capture = keyedProvider.GetKeyedService<Func<object, Task<IScreenshotResult?>>>(serviceKey);
 
 			if (capture is null)
 				return Task.FromResult<IScreenshotResult?>(null);
 
-			return capture(platformView);
+			return capture(platformView) ?? Task.FromResult<IScreenshotResult?>(null);
 		}
 	}
 }

--- a/src/Core/src/ScreenshotDispatch.cs
+++ b/src/Core/src/ScreenshotDispatch.cs
@@ -14,10 +14,13 @@ namespace Microsoft.Maui
 	/// <remarks>
 	/// Third-party platform backends (e.g. macOS AppKit, Linux/GTK) register a
 	/// <see cref="Func{T, TResult}"/> of <see cref="object"/> to
-	/// <see cref="Task{TResult}"/> of <see cref="IScreenshotResult"/> under one of
+	/// <see cref="Task{TResult}"/> of nullable <see cref="IScreenshotResult"/>
+	/// (i.e. <c>Func&lt;object, Task&lt;IScreenshotResult?&gt;&gt;</c>) under one of
 	/// the well-known keys defined on this type. The lambda receives the handler's
-	/// <see cref="IElementHandler.PlatformView"/> object and returns a screenshot
-	/// result (or <see langword="null"/> if capture is not supported for that view).
+	/// <see cref="IElementHandler.PlatformView"/> object and returns a task whose
+	/// result is the screenshot (or <see langword="null"/> if capture is not
+	/// supported for that view). The returned <see cref="Task{TResult}"/> itself
+	/// is expected to be non-null.
 	/// This contract intentionally uses only BCL types so it can ship without any
 	/// MAUI public API addition.
 	/// </remarks>
@@ -49,7 +52,7 @@ namespace Microsoft.Maui
 			if (capture is null)
 				return Task.FromResult<IScreenshotResult?>(null);
 
-			return capture(platformView) ?? Task.FromResult<IScreenshotResult?>(null);
+			return capture(platformView);
 		}
 	}
 }

--- a/src/Core/src/ScreenshotDispatch.cs
+++ b/src/Core/src/ScreenshotDispatch.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.Media;
+
+namespace Microsoft.Maui
+{
+	/// <summary>
+	/// Internal helper that routes <see cref="ViewExtensions.CaptureAsync(IView)"/>
+	/// and <see cref="WindowExtensions.CaptureAsync(IWindow)"/> through a keyed DI
+	/// hook when MAUI is built for a non-built-in platform TFM and therefore has no
+	/// compile-time screenshot implementation.
+	/// </summary>
+	/// <remarks>
+	/// Third-party platform backends (e.g. macOS AppKit, Linux/GTK) register a
+	/// <see cref="Func{T, TResult}"/> of <see cref="object"/> to
+	/// <see cref="Task{TResult}"/> of <see cref="IScreenshotResult"/> under one of
+	/// the well-known keys defined on this type. The lambda receives the handler's
+	/// <see cref="IElementHandler.PlatformView"/> object and returns a screenshot
+	/// result (or <see langword="null"/> if capture is not supported for that view).
+	/// This contract intentionally uses only BCL types so it can ship without any
+	/// MAUI public API addition.
+	/// </remarks>
+	static class ScreenshotDispatch
+	{
+		/// <summary>
+		/// DI service key for the <see cref="IView"/> screenshot hook.
+		/// </summary>
+		public const string ViewCaptureKey = "Microsoft.Maui.ViewCapture";
+
+		/// <summary>
+		/// DI service key for the <see cref="IWindow"/> screenshot hook.
+		/// </summary>
+		public const string WindowCaptureKey = "Microsoft.Maui.WindowCapture";
+
+		public static Task<IScreenshotResult?> CaptureAsync(IElementHandler? handler, string serviceKey)
+		{
+			var platformView = handler?.PlatformView;
+			if (platformView is null)
+				return Task.FromResult<IScreenshotResult?>(null);
+
+			if (handler!.MauiContext?.Services is not IKeyedServiceProvider keyedProvider)
+				return Task.FromResult<IScreenshotResult?>(null);
+
+			var capture = keyedProvider.GetKeyedService(
+				typeof(Func<object, Task<IScreenshotResult?>>),
+				serviceKey) as Func<object, Task<IScreenshotResult?>>;
+
+			if (capture is null)
+				return Task.FromResult<IScreenshotResult?>(null);
+
+			return capture(platformView) ?? Task.FromResult<IScreenshotResult?>(null);
+		}
+	}
+}

--- a/src/Core/src/ViewExtensions.cs
+++ b/src/Core/src/ViewExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Maui.Graphics;
+using System;
 using System.Threading.Tasks;
 using Microsoft.Maui.Media;
 using System.Collections.Generic;
@@ -21,7 +22,6 @@ using ParentView = Tizen.NUI.BaseComponents.View;
 #else
 using PlatformView = System.Object;
 using ParentView = System.Object;
-using System;
 #endif
 
 namespace Microsoft.Maui
@@ -66,6 +66,26 @@ namespace Microsoft.Maui
 			}
 		}
 
+		/// <summary>
+		/// Captures a screenshot of the specified <paramref name="view"/>.
+		/// </summary>
+		/// <remarks>
+		/// On non-built-in platform TFMs (e.g. <c>net10.0-macos</c> AppKit backends,
+		/// <c>net10.0</c> Linux/GTK backends) where MAUI does not ship a screenshot
+		/// implementation, capture is routed through a keyed DI hook. Third-party
+		/// platform backends can opt in by registering a
+		/// <see cref="Func{T, TResult}"/> of <see cref="object"/> to
+		/// <c>Task&lt;IScreenshotResult?&gt;</c> under the service key
+		/// <c>"Microsoft.Maui.ViewCapture"</c>:
+		/// <code>
+		/// builder.Services.AddKeyedSingleton&lt;Func&lt;object, Task&lt;IScreenshotResult?&gt;&gt;&gt;(
+		///     "Microsoft.Maui.ViewCapture",
+		///     (_, _) =&gt; platformView =&gt; ((AppKit.NSView)platformView).CaptureAsync());
+		/// </code>
+		/// If no hook is registered (or the <see cref="IElementHandler.PlatformView"/>
+		/// is <see langword="null"/>), the returned task resolves to
+		/// <see langword="null"/>.
+		/// </remarks>
 		public static Task<IScreenshotResult?> CaptureAsync(this IView view)
 		{
 #if PLATFORM
@@ -77,7 +97,7 @@ namespace Microsoft.Maui
 
 			return CaptureAsync(platformView);
 #else
-			return Task.FromResult<IScreenshotResult?>(null);
+			return ScreenshotDispatch.CaptureAsync(view?.Handler, ScreenshotDispatch.ViewCaptureKey);
 #endif
 		}
 

--- a/src/Core/src/WindowExtensions.cs
+++ b/src/Core/src/WindowExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Maui.Media;
 #if __IOS__ || MACCATALYST
@@ -15,6 +16,26 @@ namespace Microsoft.Maui
 {
 	public static partial class WindowExtensions
 	{
+		/// <summary>
+		/// Captures a screenshot of the specified <paramref name="window"/>.
+		/// </summary>
+		/// <remarks>
+		/// On non-built-in platform TFMs (e.g. <c>net10.0-macos</c> AppKit backends,
+		/// <c>net10.0</c> Linux/GTK backends) where MAUI does not ship a screenshot
+		/// implementation, capture is routed through a keyed DI hook. Third-party
+		/// platform backends can opt in by registering a
+		/// <see cref="Func{T, TResult}"/> of <see cref="object"/> to
+		/// <c>Task&lt;IScreenshotResult?&gt;</c> under the service key
+		/// <c>"Microsoft.Maui.WindowCapture"</c>:
+		/// <code>
+		/// builder.Services.AddKeyedSingleton&lt;Func&lt;object, Task&lt;IScreenshotResult?&gt;&gt;&gt;(
+		///     "Microsoft.Maui.WindowCapture",
+		///     (_, _) =&gt; platformWindow =&gt; ((AppKit.NSWindow)platformWindow).CaptureAsync());
+		/// </code>
+		/// If no hook is registered (or the <see cref="IElementHandler.PlatformView"/>
+		/// is <see langword="null"/>), the returned task resolves to
+		/// <see langword="null"/>.
+		/// </remarks>
 		public static Task<IScreenshotResult?> CaptureAsync(this IWindow window)
 		{
 #if PLATFORM
@@ -26,7 +47,7 @@ namespace Microsoft.Maui
 
 			return CaptureAsync(platformView);
 #else
-			return Task.FromResult<IScreenshotResult?>(null);
+			return ScreenshotDispatch.CaptureAsync(window?.Handler, ScreenshotDispatch.WindowCaptureKey);
 #endif
 		}
 

--- a/src/Core/tests/UnitTests/Extensions/ScreenshotDispatchTests.cs
+++ b/src/Core/tests/UnitTests/Extensions/ScreenshotDispatchTests.cs
@@ -150,6 +150,20 @@ namespace Microsoft.Maui.UnitTests.Extensions
 		}
 
 		[Fact]
+		public async Task ViewCaptureAsync_HookReturnsNullTask_ReturnsNull()
+		{
+			var services = new ServiceCollection();
+			services.AddKeyedSingleton<Func<object, Task<IScreenshotResult?>>>(
+				"Microsoft.Maui.ViewCapture",
+				(_, _) => _ => null!);
+
+			var (view, _) = CreateViewWithHandler(services.BuildServiceProvider());
+
+			var result = await view.CaptureAsync();
+			Assert.Null(result);
+		}
+
+		[Fact]
 		public async Task WindowCaptureAsync_NullWindow_ReturnsNull()
 		{
 			IWindow? window = null;

--- a/src/Core/tests/UnitTests/Extensions/ScreenshotDispatchTests.cs
+++ b/src/Core/tests/UnitTests/Extensions/ScreenshotDispatchTests.cs
@@ -1,0 +1,219 @@
+#nullable enable
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.Media;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Maui.UnitTests.Extensions
+{
+	[System.ComponentModel.Category(TestCategory.Extensions)]
+	public class ScreenshotDispatchTests
+	{
+		// The test project targets $(_MauiDotNetTfm) = net10.0, so the #else
+		// branches of ViewExtensions.CaptureAsync / WindowExtensions.CaptureAsync
+		// are what gets compiled here. That's exactly the code path third-party
+		// platform backends hit, so these tests validate the real dispatch logic.
+
+		sealed class FakeScreenshotResult : IScreenshotResult
+		{
+			public int Width => 0;
+			public int Height => 0;
+			public Task<System.IO.Stream> OpenReadAsync(ScreenshotFormat format = ScreenshotFormat.Png, int quality = 100)
+				=> throw new NotImplementedException();
+			public Task CopyToAsync(System.IO.Stream destination, ScreenshotFormat format = ScreenshotFormat.Png, int quality = 100)
+				=> throw new NotImplementedException();
+		}
+
+		static (IView view, object platformView) CreateViewWithHandler(IServiceProvider services)
+		{
+			var platformView = new object();
+			var handler = Substitute.For<IViewHandler>();
+			handler.PlatformView.Returns(platformView);
+
+			var context = Substitute.For<IMauiContext>();
+			context.Services.Returns(services);
+			handler.MauiContext.Returns(context);
+
+			var view = Substitute.For<IView>();
+			view.Handler.Returns(handler);
+
+			return (view, platformView);
+		}
+
+		static (IWindow window, object platformView) CreateWindowWithHandler(IServiceProvider services)
+		{
+			var platformView = new object();
+			var handler = Substitute.For<IElementHandler>();
+			handler.PlatformView.Returns(platformView);
+
+			var context = Substitute.For<IMauiContext>();
+			context.Services.Returns(services);
+			handler.MauiContext.Returns(context);
+
+			var window = Substitute.For<IWindow>();
+			window.Handler.Returns(handler);
+
+			return (window, platformView);
+		}
+
+		[Fact]
+		public async Task ViewCaptureAsync_NullView_ReturnsNull()
+		{
+			IView? view = null;
+			var result = await view!.CaptureAsync();
+			Assert.Null(result);
+		}
+
+		[Fact]
+		public async Task ViewCaptureAsync_NoHandler_ReturnsNull()
+		{
+			var view = Substitute.For<IView>();
+			view.Handler.Returns((IViewHandler?)null);
+
+			var result = await view.CaptureAsync();
+			Assert.Null(result);
+		}
+
+		[Fact]
+		public async Task ViewCaptureAsync_NoPlatformView_ReturnsNull()
+		{
+			var handler = Substitute.For<IViewHandler>();
+			handler.PlatformView.Returns((object?)null);
+			var view = Substitute.For<IView>();
+			view.Handler.Returns(handler);
+
+			var result = await view.CaptureAsync();
+			Assert.Null(result);
+		}
+
+		[Fact]
+		public async Task ViewCaptureAsync_NoKeyedHookRegistered_ReturnsNull()
+		{
+			var services = new ServiceCollection().BuildServiceProvider();
+			var (view, _) = CreateViewWithHandler(services);
+
+			var result = await view.CaptureAsync();
+			Assert.Null(result);
+		}
+
+		[Fact]
+		public async Task ViewCaptureAsync_KeyedHookRegistered_IsInvokedWithPlatformView()
+		{
+			object? captured = null;
+			var expected = new FakeScreenshotResult();
+
+			var services = new ServiceCollection();
+			services.AddKeyedSingleton<Func<object, Task<IScreenshotResult?>>>(
+				"Microsoft.Maui.ViewCapture",
+				(_, _) => pv =>
+				{
+					captured = pv;
+					return Task.FromResult<IScreenshotResult?>(expected);
+				});
+
+			var (view, platformView) = CreateViewWithHandler(services.BuildServiceProvider());
+
+			var result = await view.CaptureAsync();
+
+			Assert.Same(platformView, captured);
+			Assert.Same(expected, result);
+		}
+
+		[Fact]
+		public async Task ViewCaptureAsync_HookRegisteredUnderWrongKey_ReturnsNull()
+		{
+			var services = new ServiceCollection();
+			services.AddKeyedSingleton<Func<object, Task<IScreenshotResult?>>>(
+				"Microsoft.Maui.WindowCapture", // wrong key for a view
+				(_, _) => _ => Task.FromResult<IScreenshotResult?>(new FakeScreenshotResult()));
+
+			var (view, _) = CreateViewWithHandler(services.BuildServiceProvider());
+
+			var result = await view.CaptureAsync();
+			Assert.Null(result);
+		}
+
+		[Fact]
+		public async Task ViewCaptureAsync_HookReturnsNullTask_ReturnsNull()
+		{
+			var services = new ServiceCollection();
+			services.AddKeyedSingleton<Func<object, Task<IScreenshotResult?>>>(
+				"Microsoft.Maui.ViewCapture",
+				(_, _) => _ => Task.FromResult<IScreenshotResult?>(null));
+
+			var (view, _) = CreateViewWithHandler(services.BuildServiceProvider());
+
+			var result = await view.CaptureAsync();
+			Assert.Null(result);
+		}
+
+		[Fact]
+		public async Task WindowCaptureAsync_NullWindow_ReturnsNull()
+		{
+			IWindow? window = null;
+			var result = await window!.CaptureAsync();
+			Assert.Null(result);
+		}
+
+		[Fact]
+		public async Task WindowCaptureAsync_KeyedHookRegistered_IsInvokedWithPlatformView()
+		{
+			object? captured = null;
+			var expected = new FakeScreenshotResult();
+
+			var services = new ServiceCollection();
+			services.AddKeyedSingleton<Func<object, Task<IScreenshotResult?>>>(
+				"Microsoft.Maui.WindowCapture",
+				(_, _) => pv =>
+				{
+					captured = pv;
+					return Task.FromResult<IScreenshotResult?>(expected);
+				});
+
+			var (window, platformView) = CreateWindowWithHandler(services.BuildServiceProvider());
+
+			var result = await window.CaptureAsync();
+
+			Assert.Same(platformView, captured);
+			Assert.Same(expected, result);
+		}
+
+		[Fact]
+		public async Task WindowCaptureAsync_HookRegisteredUnderWrongKey_ReturnsNull()
+		{
+			var services = new ServiceCollection();
+			services.AddKeyedSingleton<Func<object, Task<IScreenshotResult?>>>(
+				"Microsoft.Maui.ViewCapture", // wrong key for a window
+				(_, _) => _ => Task.FromResult<IScreenshotResult?>(new FakeScreenshotResult()));
+
+			var (window, _) = CreateWindowWithHandler(services.BuildServiceProvider());
+
+			var result = await window.CaptureAsync();
+			Assert.Null(result);
+		}
+
+		[Fact]
+		public async Task ViewAndWindowHooks_CoexistWithoutInterference()
+		{
+			var viewResult = new FakeScreenshotResult();
+			var windowResult = new FakeScreenshotResult();
+
+			var services = new ServiceCollection();
+			services.AddKeyedSingleton<Func<object, Task<IScreenshotResult?>>>(
+				"Microsoft.Maui.ViewCapture",
+				(_, _) => _ => Task.FromResult<IScreenshotResult?>(viewResult));
+			services.AddKeyedSingleton<Func<object, Task<IScreenshotResult?>>>(
+				"Microsoft.Maui.WindowCapture",
+				(_, _) => _ => Task.FromResult<IScreenshotResult?>(windowResult));
+			var provider = services.BuildServiceProvider();
+
+			var (view, _) = CreateViewWithHandler(provider);
+			var (window, _) = CreateWindowWithHandler(provider);
+
+			Assert.Same(viewResult, await view.CaptureAsync());
+			Assert.Same(windowResult, await window.CaptureAsync());
+		}
+	}
+}

--- a/src/Core/tests/UnitTests/Extensions/ScreenshotDispatchTests.cs
+++ b/src/Core/tests/UnitTests/Extensions/ScreenshotDispatchTests.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Maui.UnitTests.Extensions
 		}
 
 		[Fact]
-		public async Task ViewCaptureAsync_HookReturnsNullTask_ReturnsNull()
+		public async Task ViewCaptureAsync_HookReturnsNullResult_ReturnsNull()
 		{
 			var services = new ServiceCollection();
 			services.AddKeyedSingleton<Func<object, Task<IScreenshotResult?>>>(


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

Fixes #34266

## Problem

`ViewExtensions.CaptureAsync(IView)` and `WindowExtensions.CaptureAsync(IWindow)` are gated by `#if PLATFORM`. On any TFM that isn't one of MAUI's built-in platform targets (Android, iOS/MacCatalyst, Windows, Tizen) they return `null`. That blocks third-party platform backends — for example macOS AppKit or Linux/GTK — from plugging into `VisualDiagnostics.CaptureAsPngAsync(view)` or the public view-level capture API.

## Relationship to #34350

PR #34350 solves the same problem by adding a **new public `IViewScreenshot` interface**. Because that is a public API addition, it can only ship in .NET 11.

This PR takes a complementary approach with **zero public API additions**, so it can ship in **.NET 10**. The two PRs coexist: when #34350 lands, its `is IViewScreenshot` fast path runs *before* the keyed-DI fallback introduced here. Backends that register under .NET 10 via this mechanism continue to work unchanged in .NET 11.

## How it works

A new internal `ScreenshotDispatch` helper routes the non-`PLATFORM` `#else` branches of the two extension methods through a keyed DI lookup. The contract uses only BCL types:

```csharp
Func<object, Task<IScreenshotResult?>>  // key: "Microsoft.Maui.ViewCapture"
Func<object, Task<IScreenshotResult?>>  // key: "Microsoft.Maui.WindowCapture"
```

The lambda receives `handler.PlatformView` and returns an `IScreenshotResult?`. When no hook is registered (or `PlatformView` is `null`, or services aren't keyed) the call resolves to `null` — same as before.

### Backend registration

A third-party platform backend registers the hook once during builder configuration. For example, a hypothetical AppKit backend:

```csharp
builder.Services.AddKeyedSingleton<Func<object, Task<IScreenshotResult?>>>(
    "Microsoft.Maui.ViewCapture",
    (_, _) => platformView => ((AppKit.NSView)platformView).CaptureAsync());

builder.Services.AddKeyedSingleton<Func<object, Task<IScreenshotResult?>>>(
    "Microsoft.Maui.WindowCapture",
    (_, _) => platformView => ((AppKit.NSWindow)platformView).CaptureAsync());
```

## Why keyed DI (vs. reflection)

An earlier sketch considered convention-based reflection dispatch against `IScreenshot.CaptureAsync(TPlatformView)`. Keyed DI was chosen because it is strictly safer for trimming and AOT:

- **No reflection.** No `MethodInfo.Invoke`, no `Expression.Compile`, no `CreateDelegate`.
- **No `[DynamicDependency]` burden on the backend.** The typed capture method is reached via normal lambda-closure reachability.
- Microsoft.Extensions.DependencyInjection keyed services are already used elsewhere in MAUI Core (e.g. `KeyedWrappedServiceProvider`, `GetKeyedService<IDispatcher>`), so nothing new is taken on.

## Scope

- ✅ The `PLATFORM` code path (Android, iOS, MacCatalyst, Windows, Tizen) is **untouched** — zero behavior change on built-in platforms.
- ✅ Zero new public API surface. `ScreenshotDispatch` is `internal`; the key strings are documented in XML docs.
- ✅ Essentials (`IPlatformScreenshot`, `ScreenshotImplementation`) is **untouched**.

## Tests

11 new unit tests in `Core.UnitTests.Extensions.ScreenshotDispatchTests` (targets `net10.0`, i.e. the exact non-`PLATFORM` path exercised by this change):

- hook registered → invoked with `PlatformView`, result propagated
- hook not registered → `null`
- `PlatformView` null → `null`
- handler null / `IView` null → `null`
- hook registered under wrong key → `null`
- hook returns null task → `null` propagated
- view and window hooks coexist without interference

All pass locally.

## Files changed

- `src/Core/src/ScreenshotDispatch.cs` — new internal helper + key constants
- `src/Core/src/ViewExtensions.cs` — `#else` branch delegates to dispatcher; XML docs updated with registration example
- `src/Core/src/WindowExtensions.cs` — same treatment as `ViewExtensions`
- `src/Core/tests/UnitTests/Extensions/ScreenshotDispatchTests.cs` — 11 tests