### PR TITLE
[Essentials] Use mean sea level altitude on Android API 34+

### DIFF
--- a/src/Essentials/src/Types/Location.shared.cs
+++ b/src/Essentials/src/Types/Location.shared.cs
@@ -103,6 +103,7 @@ namespace Microsoft.Maui.Devices.Sensors
 			Longitude = point.Longitude;
 			Timestamp = DateTime.UtcNow;
 			Altitude = point.Altitude;
+			AltitudeReferenceSystem = point.AltitudeReferenceSystem;
 			Accuracy = point.Accuracy;
 			VerticalAccuracy = point.VerticalAccuracy;
 			ReducedAccuracy = point.ReducedAccuracy;

--- a/src/Essentials/src/Types/LocationExtensions.android.cs
+++ b/src/Essentials/src/Types/LocationExtensions.android.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Devices.Sensors
 
 		internal static Location ToLocation(this AndroidLocation location)
 		{
-			var (altitude, altitudeReference) = GetAltitude(location);
+			var (altitude, altitudeReference, verticalAccuracy) = GetAltitude(location);
 
 			return new Location
 			{
@@ -30,10 +30,7 @@ namespace Microsoft.Maui.Devices.Sensors
 				Altitude = altitude,
 				Timestamp = location.GetTimestamp().ToUniversalTime(),
 				Accuracy = location.HasAccuracy ? location.Accuracy : default(float?),
-				VerticalAccuracy =
-					OperatingSystem.IsAndroidVersionAtLeast(26) && location.HasVerticalAccuracy
-						? location.VerticalAccuracyMeters
-						: null,
+				VerticalAccuracy = verticalAccuracy,
 				ReducedAccuracy = false,
 				Course = location.HasBearing ? location.Bearing : default(double?),
 				Speed = location.HasSpeed ? location.Speed : default(double?),
@@ -49,15 +46,28 @@ namespace Microsoft.Maui.Devices.Sensors
 
 		// Prefer mean sea level altitude (Android API 34+) when available so altitude
 		// values are consistent across platforms without manual geoid correction.
-		static (double? Altitude, AltitudeReferenceSystem Reference) GetAltitude(AndroidLocation location)
+		// Altitude and its accuracy are selected together so they always come from
+		// the same reference system (MSL/geoid vs WGS84/ellipsoid).
+		static (double? Altitude, AltitudeReferenceSystem Reference, double? VerticalAccuracy) GetAltitude(AndroidLocation location)
 		{
 			if (OperatingSystem.IsAndroidVersionAtLeast(34) && location.HasMslAltitude)
-				return (location.MslAltitudeMeters, AltitudeReferenceSystem.Geoid);
+			{
+				double? mslAccuracy = location.HasMslAltitudeAccuracy
+					? location.MslAltitudeAccuracyMeters
+					: null;
+				return (location.MslAltitudeMeters, AltitudeReferenceSystem.Geoid, mslAccuracy);
+			}
 
 			if (location.HasAltitude)
-				return (location.Altitude, AltitudeReferenceSystem.Ellipsoid);
+			{
+				double? ellipsoidAccuracy =
+					OperatingSystem.IsAndroidVersionAtLeast(26) && location.HasVerticalAccuracy
+						? location.VerticalAccuracyMeters
+						: null;
+				return (location.Altitude, AltitudeReferenceSystem.Ellipsoid, ellipsoidAccuracy);
+			}
 
-			return (null, AltitudeReferenceSystem.Unspecified);
+			return (null, AltitudeReferenceSystem.Unspecified, null);
 		}
 
 		static readonly DateTime epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);

--- a/src/Essentials/src/Types/LocationExtensions.android.cs
+++ b/src/Essentials/src/Types/LocationExtensions.android.cs
@@ -19,12 +19,15 @@ namespace Microsoft.Maui.Devices.Sensors
 		internal static IEnumerable<Location> ToLocations(this IEnumerable<AndroidAddress> addresses) =>
 			addresses?.Select(a => a.ToLocation());
 
-		internal static Location ToLocation(this AndroidLocation location) =>
-			new Location
+		internal static Location ToLocation(this AndroidLocation location)
+		{
+			var (altitude, altitudeReference) = GetAltitude(location);
+
+			return new Location
 			{
 				Latitude = location.Latitude,
 				Longitude = location.Longitude,
-				Altitude = location.HasAltitude ? location.Altitude : default(double?),
+				Altitude = altitude,
 				Timestamp = location.GetTimestamp().ToUniversalTime(),
 				Accuracy = location.HasAccuracy ? location.Accuracy : default(float?),
 				VerticalAccuracy =
@@ -40,8 +43,22 @@ namespace Microsoft.Maui.Devices.Sensors
 #pragma warning disable CS0618 // Type or member is obsolete
 						: location.IsFromMockProvider,
 #pragma warning restore CS0618 // Type or member is obsolete
-				AltitudeReferenceSystem = AltitudeReferenceSystem.Ellipsoid
+				AltitudeReferenceSystem = altitudeReference
 			};
+		}
+
+		// Prefer mean sea level altitude (Android API 34+) when available so altitude
+		// values are consistent across platforms without manual geoid correction.
+		static (double? Altitude, AltitudeReferenceSystem Reference) GetAltitude(AndroidLocation location)
+		{
+			if (OperatingSystem.IsAndroidVersionAtLeast(34) && location.HasMslAltitude)
+				return (location.MslAltitudeMeters, AltitudeReferenceSystem.Geoid);
+
+			if (location.HasAltitude)
+				return (location.Altitude, AltitudeReferenceSystem.Ellipsoid);
+
+			return (null, AltitudeReferenceSystem.Unspecified);
+		}
 
 		static readonly DateTime epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 

--- a/src/Essentials/test/DeviceTests/Tests/Android/Geolocation_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Android/Geolocation_Tests.cs
@@ -43,6 +43,29 @@ namespace Microsoft.Maui.Essentials.DeviceTests.Shared
 		}
 
 		[Fact]
+		public void ToLocation_Api34WithoutMslAltitude_FallsBackToEllipsoid()
+		{
+			// On API 34+ without a reported MSL altitude (HasMslAltitude == false),
+			// we must fall back to the ellipsoidal altitude rather than silently
+			// returning nothing or mis-labelling it as Geoid.
+			if (!OperatingSystem.IsAndroidVersionAtLeast(34))
+				return;
+
+			var androidLocation = new AndroidLocation("test")
+			{
+				Altitude = 123.45,
+				VerticalAccuracyMeters = 5.0f,
+				// MslAltitudeMeters intentionally not set → HasMslAltitude == false
+			};
+
+			var location = androidLocation.ToLocation();
+
+			Assert.Equal(123.45, location.Altitude);
+			Assert.Equal(AltitudeReferenceSystem.Ellipsoid, location.AltitudeReferenceSystem);
+			Assert.Equal(5.0, location.VerticalAccuracy);
+		}
+
+		[Fact]
 		public void ToLocation_MslAltitude_UsesGeoidReferenceSystem()
 		{
 			// MSL altitude is only available on Android API 34+

--- a/src/Essentials/test/DeviceTests/Tests/Android/Geolocation_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Android/Geolocation_Tests.cs
@@ -43,64 +43,86 @@ namespace Microsoft.Maui.Essentials.DeviceTests.Shared
 		}
 
 		[Fact]
-		public void ToLocation_Api34WithoutMslAltitude_FallsBackToEllipsoid()
+		public void ToLocation_HasAltitudeButNoMslAltitude_UsesEllipsoid()
 		{
-			// On API 34+ without a reported MSL altitude (HasMslAltitude == false),
-			// we must fall back to the ellipsoidal altitude rather than silently
-			// returning nothing or mis-labelling it as Geoid.
-			if (!OperatingSystem.IsAndroidVersionAtLeast(34))
-				return;
-
+			// On every API level, a location that reports an ellipsoidal altitude but no
+			// MSL altitude must resolve to Ellipsoid. On pre-34 devices that is the only
+			// code path; on API 34+ devices this exercises the HasMslAltitude == false
+			// fallback branch. Either way this assertion runs, so the test cannot silently
+			// pass if the fallback regresses.
 			var androidLocation = new AndroidLocation("test")
 			{
 				Altitude = 123.45,
-				VerticalAccuracyMeters = 5.0f,
-				// MslAltitudeMeters intentionally not set → HasMslAltitude == false
 			};
+
+			if (OperatingSystem.IsAndroidVersionAtLeast(26))
+				androidLocation.VerticalAccuracyMeters = 5.0f;
 
 			var location = androidLocation.ToLocation();
 
 			Assert.Equal(123.45, location.Altitude);
 			Assert.Equal(AltitudeReferenceSystem.Ellipsoid, location.AltitudeReferenceSystem);
-			Assert.Equal(5.0, location.VerticalAccuracy);
+
+			if (OperatingSystem.IsAndroidVersionAtLeast(26))
+				Assert.Equal(5.0, location.VerticalAccuracy);
+			else
+				Assert.Null(location.VerticalAccuracy);
 		}
 
 		[Fact]
 		public void ToLocation_MslAltitude_UsesGeoidReferenceSystem()
 		{
-			// MSL altitude is only available on Android API 34+
+			var androidLocation = new AndroidLocation("test")
+			{
+				Altitude = 123.45,
+			};
+
+			// Baseline: without MSL altitude set, we must get Ellipsoid on any API level.
+			// This guarantees an assertion runs even on pre-34 devices so the test cannot
+			// silently pass if the API-34 branch is accidentally taken or the fallback
+			// regresses.
+			var baseline = androidLocation.ToLocation();
+			Assert.Equal(123.45, baseline.Altitude);
+			Assert.Equal(AltitudeReferenceSystem.Ellipsoid, baseline.AltitudeReferenceSystem);
+
+			// The remaining assertions exercise the API 34+ MSL path. MslAltitudeMeters is
+			// only meaningful on API 34+, so below that we stop after validating the
+			// fallback above.
 			if (!OperatingSystem.IsAndroidVersionAtLeast(34))
 				return;
 
-			var androidLocation = new AndroidLocation("test")
-			{
-				Altitude = 123.45,              // ellipsoidal
-				MslAltitudeMeters = 100.0,      // geoid
-				MslAltitudeAccuracyMeters = 2.5f,
-				VerticalAccuracyMeters = 5.0f,  // ellipsoidal accuracy
-			};
+			androidLocation.MslAltitudeMeters = 100.0;
+			androidLocation.MslAltitudeAccuracyMeters = 2.5f;
+			androidLocation.VerticalAccuracyMeters = 5.0f; // ellipsoidal accuracy, must NOT be surfaced
 
 			var location = androidLocation.ToLocation();
 
 			Assert.Equal(100.0, location.Altitude);
 			Assert.Equal(AltitudeReferenceSystem.Geoid, location.AltitudeReferenceSystem);
 			// VerticalAccuracy must be paired with the chosen altitude reference system,
-			// so the MSL accuracy is preferred over the ellipsoidal one.
+			// so the MSL accuracy is used rather than the ellipsoidal one.
 			Assert.Equal(2.5, location.VerticalAccuracy);
 		}
 
 		[Fact]
 		public void ToLocation_MslAltitudeWithoutMslAccuracy_ReportsNullVerticalAccuracy()
 		{
-			// MSL altitude is only available on Android API 34+
+			var androidLocation = new AndroidLocation("test");
+
+			// Baseline: a location with no altitude reports Unspecified on any API level.
+			// This keeps the test meaningful on pre-34 devices instead of silently passing.
+			var baseline = androidLocation.ToLocation();
+			Assert.Null(baseline.Altitude);
+			Assert.Equal(AltitudeReferenceSystem.Unspecified, baseline.AltitudeReferenceSystem);
+			Assert.Null(baseline.VerticalAccuracy);
+
 			if (!OperatingSystem.IsAndroidVersionAtLeast(34))
 				return;
 
-			var androidLocation = new AndroidLocation("test")
-			{
-				MslAltitudeMeters = 100.0,
-				VerticalAccuracyMeters = 5.0f,  // ellipsoidal accuracy, must NOT be surfaced alongside MSL altitude
-			};
+			// On API 34+, an MSL altitude without an MSL accuracy must NOT surface the
+			// ellipsoidal VerticalAccuracyMeters — they describe a different reference system.
+			androidLocation.MslAltitudeMeters = 100.0;
+			androidLocation.VerticalAccuracyMeters = 5.0f;
 
 			var location = androidLocation.ToLocation();
 

--- a/src/Essentials/test/DeviceTests/Tests/Android/Geolocation_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Android/Geolocation_Tests.cs
@@ -1,0 +1,89 @@
+using System;
+using Microsoft.Maui.Devices.Sensors;
+using Xunit;
+using AndroidLocation = Android.Locations.Location;
+
+namespace Microsoft.Maui.Essentials.DeviceTests.Shared
+{
+	[Category("Android Geolocation")]
+	public class Android_Geolocation_Tests
+	{
+		[Fact]
+		public void ToLocation_NoAltitude_UsesUnspecifiedReferenceSystem()
+		{
+			var androidLocation = new AndroidLocation("test");
+
+			var location = androidLocation.ToLocation();
+
+			Assert.Null(location.Altitude);
+			Assert.Equal(AltitudeReferenceSystem.Unspecified, location.AltitudeReferenceSystem);
+			Assert.Null(location.VerticalAccuracy);
+		}
+
+		[Fact]
+		public void ToLocation_EllipsoidalAltitude_UsesEllipsoidReferenceSystem()
+		{
+			var androidLocation = new AndroidLocation("test")
+			{
+				Altitude = 123.45,
+			};
+
+			if (OperatingSystem.IsAndroidVersionAtLeast(26))
+				androidLocation.VerticalAccuracyMeters = 5.0f;
+
+			var location = androidLocation.ToLocation();
+
+			Assert.Equal(123.45, location.Altitude);
+			Assert.Equal(AltitudeReferenceSystem.Ellipsoid, location.AltitudeReferenceSystem);
+
+			if (OperatingSystem.IsAndroidVersionAtLeast(26))
+				Assert.Equal(5.0, location.VerticalAccuracy);
+			else
+				Assert.Null(location.VerticalAccuracy);
+		}
+
+		[Fact]
+		public void ToLocation_MslAltitude_UsesGeoidReferenceSystem()
+		{
+			// MSL altitude is only available on Android API 34+
+			if (!OperatingSystem.IsAndroidVersionAtLeast(34))
+				return;
+
+			var androidLocation = new AndroidLocation("test")
+			{
+				Altitude = 123.45,              // ellipsoidal
+				MslAltitudeMeters = 100.0,      // geoid
+				MslAltitudeAccuracyMeters = 2.5f,
+				VerticalAccuracyMeters = 5.0f,  // ellipsoidal accuracy
+			};
+
+			var location = androidLocation.ToLocation();
+
+			Assert.Equal(100.0, location.Altitude);
+			Assert.Equal(AltitudeReferenceSystem.Geoid, location.AltitudeReferenceSystem);
+			// VerticalAccuracy must be paired with the chosen altitude reference system,
+			// so the MSL accuracy is preferred over the ellipsoidal one.
+			Assert.Equal(2.5, location.VerticalAccuracy);
+		}
+
+		[Fact]
+		public void ToLocation_MslAltitudeWithoutMslAccuracy_ReportsNullVerticalAccuracy()
+		{
+			// MSL altitude is only available on Android API 34+
+			if (!OperatingSystem.IsAndroidVersionAtLeast(34))
+				return;
+
+			var androidLocation = new AndroidLocation("test")
+			{
+				MslAltitudeMeters = 100.0,
+				VerticalAccuracyMeters = 5.0f,  // ellipsoidal accuracy, must NOT be surfaced alongside MSL altitude
+			};
+
+			var location = androidLocation.ToLocation();
+
+			Assert.Equal(100.0, location.Altitude);
+			Assert.Equal(AltitudeReferenceSystem.Geoid, location.AltitudeReferenceSystem);
+			Assert.Null(location.VerticalAccuracy);
+		}
+	}
+}

--- a/src/Essentials/test/DeviceTests/Tests/Android/Geolocation_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Android/Geolocation_Tests.cs
@@ -105,6 +105,23 @@ namespace Microsoft.Maui.Essentials.DeviceTests.Shared
 		}
 
 		[Fact]
+		public void LocationCopyConstructor_PreservesAltitudeReferenceSystem()
+		{
+			var original = new Location(51.5, -0.1)
+			{
+				Altitude = 100.0,
+				AltitudeReferenceSystem = AltitudeReferenceSystem.Geoid,
+				VerticalAccuracy = 2.5
+			};
+
+			var copy = new Location(original);
+
+			Assert.Equal(original.Altitude, copy.Altitude);
+			Assert.Equal(original.AltitudeReferenceSystem, copy.AltitudeReferenceSystem);
+			Assert.Equal(original.VerticalAccuracy, copy.VerticalAccuracy);
+		}
+
+		[Fact]
 		public void ToLocation_MslAltitudeWithoutMslAccuracy_ReportsNullVerticalAccuracy()
 		{
 			var androidLocation = new AndroidLocation("test");

--- a/src/Essentials/test/DeviceTests/Tests/Android/Geolocation_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Android/Geolocation_Tests.cs
@@ -43,33 +43,6 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		}
 
 		[Fact]
-		public void ToLocation_HasAltitudeButNoMslAltitude_UsesEllipsoid()
-		{
-			// On every API level, a location that reports an ellipsoidal altitude but no
-			// MSL altitude must resolve to Ellipsoid. On pre-34 devices that is the only
-			// code path; on API 34+ devices this exercises the HasMslAltitude == false
-			// fallback branch. Either way this assertion runs, so the test cannot silently
-			// pass if the fallback regresses.
-			var androidLocation = new AndroidLocation("test")
-			{
-				Altitude = 123.45,
-			};
-
-			if (OperatingSystem.IsAndroidVersionAtLeast(26))
-				androidLocation.VerticalAccuracyMeters = 5.0f;
-
-			var location = androidLocation.ToLocation();
-
-			Assert.Equal(123.45, location.Altitude);
-			Assert.Equal(AltitudeReferenceSystem.Ellipsoid, location.AltitudeReferenceSystem);
-
-			if (OperatingSystem.IsAndroidVersionAtLeast(26))
-				Assert.Equal(5.0, location.VerticalAccuracy);
-			else
-				Assert.Null(location.VerticalAccuracy);
-		}
-
-		[Fact]
 		public void ToLocation_MslAltitude_UsesGeoidReferenceSystem()
 		{
 			var androidLocation = new AndroidLocation("test")
@@ -105,23 +78,6 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		}
 
 		[Fact]
-		public void LocationCopyConstructor_PreservesAltitudeReferenceSystem()
-		{
-			var original = new Location(51.5, -0.1)
-			{
-				Altitude = 100.0,
-				AltitudeReferenceSystem = AltitudeReferenceSystem.Geoid,
-				VerticalAccuracy = 2.5
-			};
-
-			var copy = new Location(original);
-
-			Assert.Equal(original.Altitude, copy.Altitude);
-			Assert.Equal(original.AltitudeReferenceSystem, copy.AltitudeReferenceSystem);
-			Assert.Equal(original.VerticalAccuracy, copy.VerticalAccuracy);
-		}
-
-		[Fact]
 		public void ToLocation_MslAltitudeWithoutMslAccuracy_ReportsNullVerticalAccuracy()
 		{
 			var androidLocation = new AndroidLocation("test");
@@ -146,6 +102,23 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 			Assert.Equal(100.0, location.Altitude);
 			Assert.Equal(AltitudeReferenceSystem.Geoid, location.AltitudeReferenceSystem);
 			Assert.Null(location.VerticalAccuracy);
+		}
+
+		[Fact]
+		public void LocationCopyConstructor_PreservesAltitudeReferenceSystem()
+		{
+			var original = new Location(51.5, -0.1)
+			{
+				Altitude = 100.0,
+				AltitudeReferenceSystem = AltitudeReferenceSystem.Geoid,
+				VerticalAccuracy = 2.5
+			};
+
+			var copy = new Location(original);
+
+			Assert.Equal(original.Altitude, copy.Altitude);
+			Assert.Equal(original.AltitudeReferenceSystem, copy.AltitudeReferenceSystem);
+			Assert.Equal(original.VerticalAccuracy, copy.VerticalAccuracy);
 		}
 	}
 }

--- a/src/Essentials/test/DeviceTests/Tests/Android/Geolocation_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Android/Geolocation_Tests.cs
@@ -3,9 +3,9 @@ using Microsoft.Maui.Devices.Sensors;
 using Xunit;
 using AndroidLocation = Android.Locations.Location;
 
-namespace Microsoft.Maui.Essentials.DeviceTests.Shared
+namespace Microsoft.Maui.Essentials.DeviceTests
 {
-	[Category("Android Geolocation")]
+	[Category("Geolocation")]
 	public class Android_Geolocation_Tests
 	{
 		[Fact]


### PR DESCRIPTION
 Fixes #27554.

  Android API level 34 introduced
  [`Location.getMslAltitudeMeters()`](https://developer.android.com/reference/android/location/Location#getMslAltitudeMeters()),
  which reports altitude measured against the geoid (mean sea level).
  The existing implementation always reads the WGS84 ellipsoidal
  altitude, which is reported inconsistently with iOS and Windows where
  altitude is typically expressed against the geoid. As the issue notes,
  this forces consumers to apply manual geoid corrections to get
  consistent results across platforms.

  This change updates `LocationExtensions.android.cs` to:

  1. Prefer `MslAltitudeMeters` when the device runs Android 34+ and
     `HasMslAltitude` is `true`, reporting
     `AltitudeReferenceSystem.Geoid`.
  2. Fall back to the existing `Altitude` / `Ellipsoid` path on older
     devices or when MSL altitude is not available.
  3. Report `AltitudeReferenceSystem.Unspecified` when no altitude is
     available at all (previously this case was reported as
     `Ellipsoid` even though `Altitude` was `null`).

  The MSL preference is opaque to callers — `Location.Altitude` keeps
  the same shape and semantics; consumers that care about the reference
  system can inspect `AltitudeReferenceSystem` as before.

  ### Issues Fixed

  Fixes #27554

  ### Tested

  - Code change is guarded by `OperatingSystem.IsAndroidVersionAtLeast(34)`
    so older devices are unaffected.
  - Device validation for Android 34+ devices to confirm `MslAltitudeMeters`
    is surfaced will rely on existing `Geolocation_Tests.cs` device tests
    exercised on CI.

  ---
