### PR TITLE
Integrate code-review into pr-review pipeline (firewall architecture)

### DIFF
--- a/.github/pr-review/pr-preflight.md
+++ b/.github/pr-review/pr-preflight.md
@@ -52,7 +52,7 @@ gh pr view XXXXX --json comments --jq '.comments[] | select(.body | contains("Fi
      name="code-review",
      description="Code review for PR",
      agent_type="general-purpose",
-     mode="sync",
+     mode="background",
      prompt="""
        Run the code-review skill for PR #XXXXX.
        Follow the full 6-step workflow in .github/skills/code-review/SKILL.md.

--- a/.github/pr-review/pr-preflight.md
+++ b/.github/pr-review/pr-preflight.md
@@ -76,7 +76,7 @@ gh pr view XXXXX --json comments --jq '.comments[] | select(.body | contains("Fi
 - Blast radius assessment summary
 - The overall verdict and confidence level
 
-> 🔥 **FIREWALL:** Code-review findings go to **Report only**. They are NOT passed to Try-Fix models as hints, conclusions, or structured findings. Try-Fix models receive domain knowledge through ambient `.instructions.md` files instead (see Phase 2 in `pr-review/SKILL.md`).
+> 🔥 **FIREWALL:** Code-review findings go to **Report only**. They are NOT passed to Try-Fix models as hints, conclusions, or structured findings. Try-Fix models receive domain knowledge through `review-rules.md` and ambient `.instructions.md` files instead (see Phase 2 in `pr-review/SKILL.md`).
 
 ---
 

--- a/.github/pr-review/pr-preflight.md
+++ b/.github/pr-review/pr-preflight.md
@@ -37,7 +37,7 @@ gh pr view XXXXX --json comments --jq '.comments[] | select(.body | contains("Fi
 
 ## Part B: Code Review (Step 7)
 
-> **Purpose:** Perform deep code analysis using the `code-review` skill to surface correctness issues, safety concerns, and MAUI convention violations BEFORE Try-Fix explores alternatives. These findings guide Try-Fix models toward higher-quality fixes.
+> **Purpose:** Perform deep code analysis using the `code-review` skill to surface correctness issues, safety concerns, and MAUI convention violations. These findings are consumed by the Report phase for a richer recommendation — they are NOT passed to Try-Fix models (to preserve independent exploration).
 
 > **🚨 Independence-first requirement:** Step 7 MUST be invoked as a **separate sub-agent** (via the `task` tool with `agent_type: "general-purpose"`) so the code-review skill can form its assessment from the code BEFORE reading any PR narrative. The sub-agent receives ONLY the PR number — not the context gathered in Part A. This prevents anchoring bias.
 >
@@ -61,28 +61,22 @@ gh pr view XXXXX --json comments --jq '.comments[] | select(.body | contains("Fi
    )
    ```
 
-   The sub-agent internally follows the code-review skill's 6-step workflow:
-   1. Gather code context (independence-first — reads code BEFORE PR description)
-   2. Load MAUI review rules from `.github/skills/code-review/references/review-rules.md`
-   3. Form independent assessment
-   4. Reconcile with PR narrative and prior reviews
-   5. Check CI status
-   6. Blast radius, failure-mode probing, and verdict
+   The sub-agent internally follows the code-review skill's 6-step workflow (see `.github/skills/code-review/SKILL.md` for details).
 
 **If Step 7 fails, times out, or returns malformed output:**
 - Write `pre-flight/code-review.md` with: `## Code Review: SKIPPED\n\nReason: {failure description}`
 - Set verdict to `SKIPPED` in the Code Review Summary section of `content.md`
-- Omit `hints` from Try-Fix prompts (the `hints` field becomes optional when code review is unavailable)
-- Do NOT apply the code-review hard gate in Phase 3 (Report) — treat as if code review was not run
+- Do NOT apply the code-review signal in Phase 3 (Report) — treat as if code review was not run
 
 **Store the sub-agent's full output** in `pre-flight/code-review.md` — use the exact output format from the code-review skill (do NOT reformat or summarize into a different template).
 
-**Extract key items for Try-Fix consumption** and add to `content.md`:
+**Extract key items for Report consumption** and add to `content.md`:
 - All ❌ Error findings (with file:line references)
 - All ⚠️ Warning findings (with file:line references)
-- Failure-mode probes and their answers
 - Blast radius assessment summary
 - The overall verdict and confidence level
+
+> 🔥 **FIREWALL:** Code-review findings go to **Report only**. They are NOT passed to Try-Fix models as hints, conclusions, or structured findings. Try-Fix models receive domain knowledge through ambient `.instructions.md` files instead (see Phase 2 in `pr-review/SKILL.md`).
 
 ---
 
@@ -125,7 +119,8 @@ Write `code-review.md` — the exact output from the code-review sub-agent, in t
 
 ## Common Mistakes
 
-- ❌ Skipping the code-review step — it provides critical findings for Try-Fix
+- ❌ Skipping the code-review step — it provides critical findings for Report
 - ❌ Reading the PR description before code in Step 7 — independence-first prevents anchoring bias
+- ❌ Passing code-review findings to Try-Fix — they go to Report ONLY (firewall)
 - ❌ Running tests — that's the Gate phase
 - ❌ Proposing fixes — save fix ideas for Try-Fix phase

--- a/.github/pr-review/pr-report.md
+++ b/.github/pr-review/pr-report.md
@@ -26,8 +26,8 @@
    | 1 | Gate failed (tests fail with fix) | `⚠️ REQUEST CHANGES` — fix doesn't work |
    | 2 | Alternative fix found via Try-Fix that is simpler/better | `⚠️ REQUEST CHANGES` — suggest alternative |
    | 3 | Code review verdict is `NEEDS_CHANGES` AND try-fix models independently flagged same concerns | `⚠️ REQUEST CHANGES` — corroborated code quality issues |
-   | 4 | Code review verdict is `NEEDS_CHANGES` but concerns are uncorroborated AND findings are significant (safety, correctness, memory leaks) | `⚠️ REQUEST CHANGES` — include code review concerns, note they are uncorroborated |
-   | 5 | Code review verdict is `NEEDS_CHANGES` but concerns are uncorroborated AND findings are minor (style, naming, suggestions) | `✅ APPROVE with notes` — surface code review concerns but do not block |
+   | 4 | Code review verdict is `NEEDS_CHANGES` but concerns are uncorroborated AND findings are significant (any ❌ Error, or ⚠️ Warnings about safety/correctness/memory leaks) | `⚠️ REQUEST CHANGES` — include code review concerns, note they are uncorroborated |
+   | 5 | Code review verdict is `NEEDS_CHANGES` but concerns are uncorroborated AND findings are minor (⚠️ Warnings about style/naming, 💡 Suggestions only) | `✅ APPROVE with notes` — surface code review concerns but do not block |
    | 6 | Code review verdict is `NEEDS_DISCUSSION` | `⚠️ REQUEST CHANGES` — include code review concerns for human judgment |
    | 7 | PR's fix selected AND Gate passed AND code review LGTM or SKIPPED | `✅ APPROVE` |
 
@@ -55,7 +55,7 @@ mkdir -p CustomAgentLogsTmp/PRState/{PRNumber}/PRAgent/report
 
 Write `content.md`:
 ```markdown
-## {✅/⚠️} Final Recommendation: {APPROVE/REQUEST CHANGES}
+## {✅/⚠️} Final Recommendation: {APPROVE / APPROVE with notes / REQUEST CHANGES}
 
 ### Phase Status
 | Phase | Status | Notes |

--- a/.github/pr-review/pr-report.md
+++ b/.github/pr-review/pr-report.md
@@ -13,7 +13,7 @@
 - Phases 1-2 (Pre-Flight, Try-Fix) must be complete before starting
 - Gate result is available from the prompt (ran separately before this skill)
 - **Read `pre-flight/content.md`** to get the code-review summary (verdict, confidence, error/warning counts)
-- Optionally read `pre-flight/code-review.md` for full findings if needed for the recommendation
+- Optionally read `pre-flight/code-review.md` for full findings if verdict is `NEEDS_CHANGES` or `NEEDS_DISCUSSION`
 
 ---
 
@@ -23,15 +23,16 @@
 
    | Priority | Condition | Recommendation |
    |----------|-----------|----------------|
-   | 1 | Code review verdict is `NEEDS_CHANGES` (any ❌ errors) | `⚠️ REQUEST CHANGES` — code review found errors |
-   | 2 | Gate failed (tests fail with fix) | `⚠️ REQUEST CHANGES` — fix doesn't work |
-   | 3 | Alternative fix found via Try-Fix that is simpler/better | `⚠️ REQUEST CHANGES` — suggest alternative |
-   | 4 | Code review verdict is `NEEDS_DISCUSSION` | `⚠️ REQUEST CHANGES` — include code review concerns |
-   | 5 | PR's fix selected AND Gate passed AND code review LGTM or SKIPPED | `✅ APPROVE` |
+   | 1 | Gate failed (tests fail with fix) | `⚠️ REQUEST CHANGES` — fix doesn't work |
+   | 2 | Alternative fix found via Try-Fix that is simpler/better | `⚠️ REQUEST CHANGES` — suggest alternative |
+   | 3 | Code review verdict is `NEEDS_CHANGES` AND try-fix models independently flagged same concerns | `⚠️ REQUEST CHANGES` — corroborated code quality issues |
+   | 4 | Code review verdict is `NEEDS_CHANGES` but try-fix models did NOT flag same concerns | `⚠️ REQUEST CHANGES` — include code review concerns, note they are uncorroborated |
+   | 5 | Code review verdict is `NEEDS_DISCUSSION` | `⚠️ REQUEST CHANGES` — include code review concerns for human judgment |
+   | 6 | PR's fix selected AND Gate passed AND code review LGTM or SKIPPED | `✅ APPROVE` |
 
-   **🚨 Hard gate:** If the code review (from Pre-Flight) has verdict `NEEDS_CHANGES`, the final recommendation MUST be `REQUEST CHANGES` regardless of Gate or Try-Fix results. Code-review ❌ Errors cannot be overridden by passing tests alone.
+   **Code review is advisory, not a hard gate.** Code-review findings are a strong signal that should be surfaced and explained, but they do not automatically override passing tests + try-fix results. The Report should explain the code-review concerns and let human reviewers decide.
 
-   **Code review SKIPPED:** If the code-review sub-agent failed or timed out (verdict = `SKIPPED`), the hard gate does NOT apply. Proceed as if code review was not available — base the recommendation on Gate and Try-Fix results only. Note in the report that code review was unavailable.
+   **Code review SKIPPED:** If the code-review sub-agent failed or timed out (verdict = `SKIPPED`), proceed as if code review was not available — base the recommendation on Gate and Try-Fix results only. Note in the report that code review was unavailable.
 
 2. **Write output files** — Save recommendation to `content.md`
 
@@ -60,8 +61,11 @@ Write `content.md`:
 | Try-Fix | ✅ COMPLETE | {N} attempts, {M} passing |
 | Report | ✅ COMPLETE | |
 
-### Code Review Impact on Try-Fix
-{Brief description of how code-review findings influenced try-fix exploration. Did any model specifically address a code review ❌ Error? Did failure-mode probes reveal issues that guided fix approaches?}
+### Convergence Analysis
+{Did try-fix models independently flag the same issues as code-review? If multiple independent sources agree on an issue, it's a high-confidence finding. If only code-review flagged it, note it's uncorroborated and flag for human review.}
+
+### Code Review Impact
+{Summary of code-review findings and how they influenced the recommendation. If code-review found issues that try-fix models also encountered, note the corroboration.}
 
 ### Summary
 {Brief summary of the review}
@@ -70,7 +74,7 @@ Write `content.md`:
 {Root cause analysis}
 
 ### Fix Quality
-{Assessment of the fix — informed by both gate results and code review findings}
+{Assessment of the fix — informed by gate results, try-fix comparison, and code review findings}
 ```
 
 ---

--- a/.github/pr-review/pr-report.md
+++ b/.github/pr-review/pr-report.md
@@ -26,11 +26,16 @@
    | 1 | Gate failed (tests fail with fix) | `⚠️ REQUEST CHANGES` — fix doesn't work |
    | 2 | Alternative fix found via Try-Fix that is simpler/better | `⚠️ REQUEST CHANGES` — suggest alternative |
    | 3 | Code review verdict is `NEEDS_CHANGES` AND try-fix models independently flagged same concerns | `⚠️ REQUEST CHANGES` — corroborated code quality issues |
-   | 4 | Code review verdict is `NEEDS_CHANGES` but try-fix models did NOT flag same concerns | `⚠️ REQUEST CHANGES` — include code review concerns, note they are uncorroborated |
-   | 5 | Code review verdict is `NEEDS_DISCUSSION` | `⚠️ REQUEST CHANGES` — include code review concerns for human judgment |
-   | 6 | PR's fix selected AND Gate passed AND code review LGTM or SKIPPED | `✅ APPROVE` |
+   | 4 | Code review verdict is `NEEDS_CHANGES` but concerns are uncorroborated AND findings are significant (safety, correctness, memory leaks) | `⚠️ REQUEST CHANGES` — include code review concerns, note they are uncorroborated |
+   | 5 | Code review verdict is `NEEDS_CHANGES` but concerns are uncorroborated AND findings are minor (style, naming, suggestions) | `✅ APPROVE with notes` — surface code review concerns but do not block |
+   | 6 | Code review verdict is `NEEDS_DISCUSSION` | `⚠️ REQUEST CHANGES` — include code review concerns for human judgment |
+   | 7 | PR's fix selected AND Gate passed AND code review LGTM or SKIPPED | `✅ APPROVE` |
 
-   **Code review is advisory, not a hard gate.** Code-review findings are a strong signal that should be surfaced and explained, but they do not automatically override passing tests + try-fix results. The Report should explain the code-review concerns and let human reviewers decide.
+   **Code review is advisory, not a hard gate.** Code-review findings are a strong signal that should be surfaced and explained, but they do not automatically override passing tests + try-fix results. Rows 4 and 5 distinguish between significant uncorroborated findings (safety, correctness — still block) and minor uncorroborated findings (style, naming — approve with notes). The Report should always explain the code-review concerns and let human reviewers decide.
+
+   **Corroboration** = a try-fix model's fix or failure analysis addresses the same code location AND concern type as a code-review finding, arrived at without seeing that finding. Uncorroborated findings are expected to be common (try-fix explores fixes, not code quality) and are still valuable signals.
+
+   **Even when Rows 1–2 fire**, always populate the Convergence Analysis and Code Review Impact sections if code review has findings.
 
    **Code review SKIPPED:** If the code-review sub-agent failed or timed out (verdict = `SKIPPED`), proceed as if code review was not available — base the recommendation on Gate and Try-Fix results only. Note in the report that code review was unavailable.
 

--- a/.github/skills/pr-review/SKILL.md
+++ b/.github/skills/pr-review/SKILL.md
@@ -74,17 +74,19 @@ Phase 2 uses these 4 AI models (run SEQUENTIALLY — they modify the same files)
 
 Gather context from the issue, PR, comments, classify changed files, and **perform a deep code review** using the `code-review` skill.
 
-Pre-Flight now has two parts:
+Pre-Flight has two parts:
 - **Part A (Steps 1–6):** Context gathering — read issue, PR, comments, classify files
-- **Part B (Step 7):** Code review — independence-first code analysis using `.github/skills/code-review/SKILL.md` and `.github/skills/code-review/references/review-rules.md`
+- **Part B (Step 7):** Code review — independence-first code analysis using `.github/skills/code-review/SKILL.md`
+
+**Part B can run in parallel with Phase 2** — code-review evaluates the PR's fix while try-fix explores alternatives. Neither needs the other's output. Report is the only phase that needs both.
 
 **Outputs:**
 - `pre-flight/content.md` — Context + code review summary
-- `pre-flight/code-review.md` — Full code-review output (findings, blast radius, failure-mode probes, verdict)
+- `pre-flight/code-review.md` — Full code-review output (findings, blast radius, verdict)
+
+> 🔥 **FIREWALL:** Code-review findings flow to **Report only**. They are NOT passed to Try-Fix models. Try-Fix models receive domain knowledge through ambient `.instructions.md` files and `review-rules.md`, not through code-review's PR-specific conclusions.
 
 **Gate:** None — always runs.
-
-**Why code review runs here:** The code-review findings (❌ Errors, ⚠️ Warnings, failure-mode probes, blast radius) become **structured hints for Phase 2 (Try-Fix)**. Instead of each model starting from scratch, they receive concrete code concerns to address, leading to higher-quality fix exploration.
 
 ---
 
@@ -98,7 +100,7 @@ Even if the PR's fix looks correct and Gate passed, you MUST still run all 4 mod
 
 ### 🚨 CRITICAL: try-fix is Independent of PR's Fix
 
-"Independent" means each model explores a **different fix approach** from the PR's fix — not that models are isolated from code-review context. Code-review findings are provided as advisory background to improve fix quality.
+"Independent" means each model explores a **different fix approach** from the PR's fix. Models are NOT isolated from domain knowledge — they load `.instructions.md` files and `review-rules.md` for MAUI-specific patterns. But they do NOT receive code-review's PR-specific conclusions (verdict, error findings, etc.) — that would anchor all 4 models identically.
 
 The purpose is NOT to re-test the PR's fix, but to:
 1. **Generate independent fix ideas** — What would YOU do to fix this bug?
@@ -132,26 +134,16 @@ prompt: |
   - target_files:
     - src/{area}/{file1}.cs
     - src/{area}/{file2}.cs
-  - hints: |
-      Code review found the following concerns (advisory — use to inform your approach, not as a checklist):
-      Errors:
-        - {❌ Error finding 1 with file:line reference}
-      # Include warnings ONLY if relevant to the root cause:
-      # Warnings:
-      #   - {⚠️ Warning — omit if unrelated to root cause}
-      Failure modes:
-        - {Failure mode 1}: {What happens in this scenario}
-      Blast radius: {Summary — e.g., "Runs for ALL toolbar items at startup, not just badged ones"}
-      Code review verdict: {LGTM / NEEDS_CHANGES / NEEDS_DISCUSSION} (confidence: {high/medium/low})
+
+  Before designing your fix, load the MAUI domain knowledge from
+  .github/skills/code-review/references/review-rules.md — apply relevant rules
+  to ensure your fix follows established MAUI patterns (handler lifecycle,
+  memory management, threading, platform conventions, etc.).
 
   Generate ONE independent fix idea. Review the PR's fix first to ensure your approach is DIFFERENT.
-  "Independent" means exploring a different fix approach — the code review context above is background
-  information to help you make better decisions, not a constraint on your exploration.
 ```
 
-**Include code review context in the `hints` field** (try-fix's documented optional input). If Pre-Flight code review found no issues, use `hints: "Code review found no issues (verdict: LGTM)"`. If code review was SKIPPED, omit the `hints` field entirely.
-
-**Selectivity:** Only include ❌ Error findings and failure-mode probes that are relevant to the bug being fixed. Omit 💡 Suggestions. Include ⚠️ Warnings only if directly related to the root cause.
+**🚫 Do NOT include code-review findings, verdict, or error details in try-fix prompts.** Each model must independently analyze the code and apply domain rules. Code-review's PR-specific conclusions are firewalled to Report only.
 
 **Wait for each to complete before starting the next.**
 
@@ -260,8 +252,8 @@ CustomAgentLogsTmp/PRState/{PRNumber}/PRAgent/
 |-------|--------------|------------|------------|
 | Gate (pre-run) | `pr-gate.md` | Verify tests (run by Review-PR.ps1) | Result passed in prompt — if missing, document and continue |
 | 1. Pre-Flight | `pr-preflight.md` | Read issue + PR context + **code review** | Skip missing info; if code review fails, set verdict to SKIPPED |
-| 2. Try-Fix | `try-fix` skill (×4) | **4-model exploration with code-review hints (MANDATORY)** | Skip failing models, continue |
-| 3. Report | `pr-report.md` | Write review recommendation | Never skip |
+| 2. Try-Fix | `try-fix` skill (×4) | **4-model exploration with domain knowledge (MANDATORY)** | Skip failing models, continue |
+| 3. Report | `pr-report.md` | Write review recommendation (advisory, not hard gate) | Never skip |
 
 ---
 

--- a/.github/skills/pr-review/SKILL.md
+++ b/.github/skills/pr-review/SKILL.md
@@ -78,7 +78,7 @@ Pre-Flight has two parts:
 - **Part A (Steps 1–6):** Context gathering — read issue, PR, comments, classify files
 - **Part B (Step 7):** Code review — independence-first code analysis using `.github/skills/code-review/SKILL.md`
 
-**Part B can run in parallel with Phase 2** — code-review evaluates the PR's fix while try-fix explores alternatives. Neither needs the other's output. Report is the only phase that needs both.
+**Execution sequencing:** Part A must complete first — Phase 2 needs its output (`{bug description}`, `{platform}`, `{target_files}`). After Part A completes, Part B and Phase 2 can run in parallel: launch Part B as `mode: "background"`, then start Phase 2 (try-fix) immediately. Await Part B completion before starting Phase 3 (Report), which needs both outputs. Individual try-fix attempts within Phase 2 remain sequential.
 
 **Outputs:**
 - `pre-flight/content.md` — Context + code review summary

--- a/.github/skills/try-fix/SKILL.md
+++ b/.github/skills/try-fix/SKILL.md
@@ -220,7 +220,7 @@ Select-String -Path "$OUTPUT_DIR/baseline.log" -Pattern "Baseline established"
 
 Read the target files to understand the code.
 
-**Load MAUI domain knowledge** from `.github/skills/code-review/references/review-rules.md` — this contains patterns distilled from 28k maintainer review comments across 142 high-discussion PRs. Apply relevant rules (handler lifecycle, memory management, threading, platform conventions) when analyzing the code and designing your fix. You don't need to check every rule — focus on the ones relevant to the files you're modifying.
+**Load MAUI domain knowledge** from `.github/skills/code-review/references/review-rules.md` — this contains patterns distilled from 28k maintainer review comments across 142 high-discussion PRs. Apply relevant rules (handler lifecycle, memory management, threading, platform conventions) when analyzing the code and designing your fix. You don't need to check every rule — focus on the ones relevant to the files you're modifying. If the file is unavailable, proceed using your general MAUI knowledge.
 
 **Verify the platform code path before implementing.** Check which platform-specific file actually executes for the target scenario:
 - Files named `.iOS.cs` compile for both iOS AND MacCatalyst

--- a/.github/skills/try-fix/SKILL.md
+++ b/.github/skills/try-fix/SKILL.md
@@ -220,6 +220,8 @@ Select-String -Path "$OUTPUT_DIR/baseline.log" -Pattern "Baseline established"
 
 Read the target files to understand the code.
 
+**Load MAUI domain knowledge** from `.github/skills/code-review/references/review-rules.md` — this contains patterns distilled from 28k maintainer review comments across 142 high-discussion PRs. Apply relevant rules (handler lifecycle, memory management, threading, platform conventions) when analyzing the code and designing your fix. You don't need to check every rule — focus on the ones relevant to the files you're modifying.
+
 **Verify the platform code path before implementing.** Check which platform-specific file actually executes for the target scenario:
 - Files named `.iOS.cs` compile for both iOS AND MacCatalyst
 - Files named `.Android.cs` only compile for Android

--- a/.github/skills/try-fix/SKILL.md
+++ b/.github/skills/try-fix/SKILL.md
@@ -55,7 +55,7 @@ All inputs are provided by the invoker (CI, agent, or user).
 | Test command | Yes | **Repository-specific script** to build and test. Use `BuildAndRunHostApp.ps1` for UI tests, `Run-DeviceTests.ps1` for device tests, or `dotnet test` for unit tests. The correct command is determined by the test type detected in the PR. **ALWAYS use the appropriate script - NEVER manually build/compile.** |
 | Target files | Yes | Files to investigate for the fix |
 | Platform | Yes | Target platform (`android`, `ios`, `windows`, `maccatalyst`) |
-| Hints | Optional | Suggested approaches, prior attempts, or areas to focus on |
+| Hints | Optional | Suggested approaches, prior attempts, or areas to focus on. ⚠️ When invoked from `pr-review`, hints must NOT contain code-review verdict or error findings — domain knowledge only (firewall constraint; see `pr-review/SKILL.md`). |
 | Baseline | Optional | Git ref or instructions for establishing broken state (default: current state) |
 
 ## Outputs


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Integrates the `code-review` skill into the `pr-review` orchestrator with a **firewall architecture** that separates domain knowledge from PR-specific conclusions.

**Architecture:** [Full analysis gist](https://gist.github.com/PureWeen/fbd842390b471c2230018f47a57eb97a)

**Key principle:** Try-fix models get **domain knowledge** (review rules) but NOT code-review's **PR-specific conclusions** (verdict, error findings). This preserves multi-model independence.

### Changes

| File | What |
|------|------|
| `pr-preflight.md` | Add Part B: code-review sub-agent with independence-first, SKIPPED fallback, firewall |
| `pr-report.md` | Priority-ordered decision table (advisory, not hard gate), convergence analysis |
| `pr-review/SKILL.md` | Wire code-review into flow, add review-rules.md loading for try-fix, firewall enforcement |
| `code-review/SKILL.md` | Update description |

### Relation to other PRs
- **PR #34994**: Similar goal but passes conclusions as hints (anchoring) + hard gate. This PR takes the firewall approach.
- **PR #35062**: Upgrades the review engine. This PR wires the pipeline plumbing that #35062 will plug into.
