### PR TITLE
[net11.0] Move feature switch RHCO items to static evaluation to fix IL3050 on Android NativeAOT

### DIFF
--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -325,6 +325,7 @@
     <MauiImplicitCastOperatorsUsageViaReflectionSupport Condition="'$(MauiImplicitCastOperatorsUsageViaReflectionSupport)' == ''">false</MauiImplicitCastOperatorsUsageViaReflectionSupport>
     <MauiEnableXamlCBindingWithSourceCompilation Condition="'$(MauiEnableXamlCBindingWithSourceCompilation)' == ''">true</MauiEnableXamlCBindingWithSourceCompilation>
     <MauiHybridWebViewSupported Condition="'$(MauiHybridWebViewSupported)' == ''">false</MauiHybridWebViewSupported>
+    <MauiCssEnabled Condition="'$(MauiCssEnabled)' == '' and '$(EnableDefaultCssItems)' != 'true'">false</MauiCssEnabled>
     <!-- FIXME: https://github.com/xamarin/xamarin-macios/issues/22065 -->
     <MobileAggressiveAttributeTrimming Condition="'$(PublishAot)' == 'true' and '$(MobileAggressiveAttributeTrimming)' == ''">false</MobileAggressiveAttributeTrimming>
 
@@ -365,6 +366,10 @@
                                     Condition="'$(MauiHybridWebViewSupported)' != ''"
                                     Value="$(MauiHybridWebViewSupported)"
                                     Trim="true" />
+    <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsCssEnabled"
+                                    Condition="'$(MauiCssEnabled)' != ''"
+                                    Value="$(MauiCssEnabled)"
+                                    Trim="true" />
     <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.AreNamescopesSupported"
                                     Condition="'$(MauiNamescopesSupported)' != ''"
                                     Value="$(MauiNamescopesSupported)"
@@ -384,17 +389,6 @@
   </ItemGroup>
 
   <Target Name="_MauiPrepareForILLink" BeforeTargets="PrepareForILLink;_GenerateRuntimeConfigurationFilesInputCache;XamlC">
-    <!-- MauiCssEnabled depends on @(MauiCss) item list which cannot be evaluated
-         in a static PropertyGroup condition (MSB4099). -->
-    <PropertyGroup Condition="'$(PublishAot)' == 'true' or '$(TrimMode)' == 'full'">
-      <MauiCssEnabled Condition="'$(MauiCssEnabled)' == '' and '@(MauiCss->Count())' == '0'">false</MauiCssEnabled>
-    </PropertyGroup>
-    <ItemGroup>
-      <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsCssEnabled"
-                                      Condition="'$(MauiCssEnabled)' != ''"
-                                      Value="$(MauiCssEnabled)"
-                                      Trim="true" />
-    </ItemGroup>
     <!-- Validate _EnableMauiAspire usage - warn when user manually sets it in optimized builds where it conflicts with intended behavior -->
     <Warning
       Code="MA002"

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -329,6 +329,9 @@
     <!-- FIXME: https://github.com/xamarin/xamarin-macios/issues/22065 -->
     <MobileAggressiveAttributeTrimming Condition="'$(PublishAot)' == 'true' and '$(MobileAggressiveAttributeTrimming)' == ''">false</MobileAggressiveAttributeTrimming>
 
+    <!-- Capture user-specified value before setting the default, so the MA002
+         warning can detect external overrides. -->
+    <_EnableMauiAspireUserOverride>$(_EnableMauiAspire)</_EnableMauiAspireUserOverride>
     <!-- Set _EnableMauiAspire based on whether optimizations are enabled when not already set -->
     <_EnableMauiAspire Condition="'$(_EnableMauiAspire)' == '' and '$(Optimize)' != 'true'">true</_EnableMauiAspire>
     <_EnableMauiAspire Condition="'$(_EnableMauiAspire)' == ''">false</_EnableMauiAspire>
@@ -390,7 +393,7 @@
     <Warning
       Code="MA002"
       Text="The _EnableMauiAspire property should not be set manually. Using Aspire outside the Debug configuration may introduce performance and security risks in production. This property is automatically configured based on build configuration."
-      Condition="'$(_EnableMauiAspire)' != '' and '$(Optimize)' == 'true' and '$(MauiDisableAspireValidation)' != 'True'"/>
+      Condition="'$(_EnableMauiAspireUserOverride)' != '' and '$(Optimize)' == 'true' and '$(MauiDisableAspireValidation)' != 'True'"/>
   </Target>
 
   <!--

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -325,7 +325,6 @@
     <MauiImplicitCastOperatorsUsageViaReflectionSupport Condition="'$(MauiImplicitCastOperatorsUsageViaReflectionSupport)' == ''">false</MauiImplicitCastOperatorsUsageViaReflectionSupport>
     <MauiEnableXamlCBindingWithSourceCompilation Condition="'$(MauiEnableXamlCBindingWithSourceCompilation)' == ''">true</MauiEnableXamlCBindingWithSourceCompilation>
     <MauiHybridWebViewSupported Condition="'$(MauiHybridWebViewSupported)' == ''">false</MauiHybridWebViewSupported>
-    <MauiCssEnabled Condition="'$(MauiCssEnabled)' == '' and '@(MauiCss->Count())' == '0'">false</MauiCssEnabled>
     <!-- FIXME: https://github.com/xamarin/xamarin-macios/issues/22065 -->
     <MobileAggressiveAttributeTrimming Condition="'$(PublishAot)' == 'true' and '$(MobileAggressiveAttributeTrimming)' == ''">false</MobileAggressiveAttributeTrimming>
 
@@ -366,10 +365,6 @@
                                     Condition="'$(MauiHybridWebViewSupported)' != ''"
                                     Value="$(MauiHybridWebViewSupported)"
                                     Trim="true" />
-    <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsCssEnabled"
-                                    Condition="'$(MauiCssEnabled)' != ''"
-                                    Value="$(MauiCssEnabled)"
-                                    Trim="true" />
     <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.AreNamescopesSupported"
                                     Condition="'$(MauiNamescopesSupported)' != ''"
                                     Value="$(MauiNamescopesSupported)"
@@ -389,6 +384,17 @@
   </ItemGroup>
 
   <Target Name="_MauiPrepareForILLink" BeforeTargets="PrepareForILLink;_GenerateRuntimeConfigurationFilesInputCache;XamlC">
+    <!-- MauiCssEnabled depends on @(MauiCss) item list which cannot be evaluated
+         in a static PropertyGroup condition (MSB4099). -->
+    <PropertyGroup Condition="'$(PublishAot)' == 'true' or '$(TrimMode)' == 'full'">
+      <MauiCssEnabled Condition="'$(MauiCssEnabled)' == '' and '@(MauiCss->Count())' == '0'">false</MauiCssEnabled>
+    </PropertyGroup>
+    <ItemGroup>
+      <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsCssEnabled"
+                                      Condition="'$(MauiCssEnabled)' != ''"
+                                      Value="$(MauiCssEnabled)"
+                                      Trim="true" />
+    </ItemGroup>
     <!-- Validate _EnableMauiAspire usage - warn when user manually sets it in optimized builds where it conflicts with intended behavior -->
     <Warning
       Code="MA002"

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -306,81 +306,91 @@
            Text="The %24(TargetFrameworkVersion) for $(ProjectName) ($(TargetFrameworkVersion)) is less than the minimum required %24(TargetFrameworkVersion) for Microsoft.Maui ($(MinTargetFrameworkVersionForMaui)). You need to increase the %24(TargetFrameworkVersion) for $(ProjectName)."   />
   </Target>
 
+  <!--
+    Feature switch property defaults and RuntimeHostConfigurationOption items.
+    These are defined statically (outside of a target) so they are visible at
+    evaluation time, before _PrepareTrimConfiguration snapshots RHCO items into
+    _TrimmerFeatureSettings. Previously these lived inside _MauiPrepareForILLink
+    (BeforeTargets="PrepareForILLink"), but that fires after _PrepareTrimConfiguration
+    runs, so ILC never received - -feature flags for MAUI switches on Android NativeAOT.
+    See https://github.com/dotnet/runtime/issues/127017
+  -->
+  <PropertyGroup>
+    <MauiEnableIVisualAssemblyScanning Condition="'$(MauiEnableIVisualAssemblyScanning)' == ''">false</MauiEnableIVisualAssemblyScanning>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(PublishAot)' == 'true' or '$(TrimMode)' == 'full'">
+    <MauiShellSearchResultsRendererDisplayMemberNameSupported Condition="'$(MauiShellSearchResultsRendererDisplayMemberNameSupported)' == ''">false</MauiShellSearchResultsRendererDisplayMemberNameSupported>
+    <MauiQueryPropertyAttributeSupport Condition="'$(MauiQueryPropertyAttributeSupport)' == ''">false</MauiQueryPropertyAttributeSupport>
+    <MauiImplicitCastOperatorsUsageViaReflectionSupport Condition="'$(MauiImplicitCastOperatorsUsageViaReflectionSupport)' == ''">false</MauiImplicitCastOperatorsUsageViaReflectionSupport>
+    <MauiEnableXamlCBindingWithSourceCompilation Condition="'$(MauiEnableXamlCBindingWithSourceCompilation)' == ''">true</MauiEnableXamlCBindingWithSourceCompilation>
+    <MauiHybridWebViewSupported Condition="'$(MauiHybridWebViewSupported)' == ''">false</MauiHybridWebViewSupported>
+    <MauiCssEnabled Condition="'$(MauiCssEnabled)' == '' and '@(MauiCss->Count())' == '0'">false</MauiCssEnabled>
+    <!-- FIXME: https://github.com/xamarin/xamarin-macios/issues/22065 -->
+    <MobileAggressiveAttributeTrimming Condition="'$(PublishAot)' == 'true' and '$(MobileAggressiveAttributeTrimming)' == ''">false</MobileAggressiveAttributeTrimming>
+
+    <!-- Set _EnableMauiAspire based on whether optimizations are enabled when not already set -->
+    <_EnableMauiAspire Condition="'$(_EnableMauiAspire)' == '' and '$(Optimize)' != 'true'">true</_EnableMauiAspire>
+    <_EnableMauiAspire Condition="'$(_EnableMauiAspire)' == ''">false</_EnableMauiAspire>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsIVisualAssemblyScanningEnabled"
+                                    Condition="'$(MauiEnableIVisualAssemblyScanning)' != ''"
+                                    Value="$(MauiEnableIVisualAssemblyScanning)"
+                                    Trim="true" />
+    <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsShellSearchResultsRendererDisplayMemberNameSupported"
+                                    Condition="'$(MauiShellSearchResultsRendererDisplayMemberNameSupported)' != ''"
+                                    Value="$(MauiShellSearchResultsRendererDisplayMemberNameSupported)"
+                                    Trim="true" />
+    <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsQueryPropertyAttributeSupported"
+                                    Condition="'$(MauiQueryPropertyAttributeSupport)' != ''"
+                                    Value="$(MauiQueryPropertyAttributeSupport)"
+                                    Trim="true" />
+    <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsImplicitCastOperatorsUsageViaReflectionSupported"
+                                    Condition="'$(MauiImplicitCastOperatorsUsageViaReflectionSupport)' != ''"
+                                    Value="$(MauiImplicitCastOperatorsUsageViaReflectionSupport)"
+                                    Trim="true" />
+    <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.AreBindingInterceptorsSupported"
+                                    Condition="'$(_MauiBindingInterceptorsSupport)' != ''"
+                                    Value="$(_MauiBindingInterceptorsSupport)"
+                                    Trim="true" />
+    <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsXamlCBindingWithSourceCompilationEnabled"
+                                    Condition="'$(MauiEnableXamlCBindingWithSourceCompilation)' != ''"
+                                    Value="$(MauiEnableXamlCBindingWithSourceCompilation)"
+                                    Trim="false" />
+    <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsHybridWebViewSupported"
+                                    Condition="'$(MauiHybridWebViewSupported)' != ''"
+                                    Value="$(MauiHybridWebViewSupported)"
+                                    Trim="true" />
+    <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsCssEnabled"
+                                    Condition="'$(MauiCssEnabled)' != ''"
+                                    Value="$(MauiCssEnabled)"
+                                    Trim="true" />
+    <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.AreNamescopesSupported"
+                                    Condition="'$(MauiNamescopesSupported)' != ''"
+                                    Value="$(MauiNamescopesSupported)"
+                                    Trim="true" />
+    <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.EnableDiagnostics"
+                                    Condition="'$(EnableDiagnostics)' != ''"
+                                    Value="$(EnableDiagnostics)"
+                                    Trim="true" />
+    <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.EnableMauiAspire"
+                                    Condition="'$(_EnableMauiAspire)' != ''"
+                                    Value="$(_EnableMauiAspire)"
+                                    Trim="true" />
+    <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsMaterial3Enabled"
+                                    Condition="'$(UseMaterial3)' != ''"
+                                    Value="$(UseMaterial3)"
+                                    Trim="true" />
+  </ItemGroup>
+
   <Target Name="_MauiPrepareForILLink" BeforeTargets="PrepareForILLink;_GenerateRuntimeConfigurationFilesInputCache;XamlC">
-    <PropertyGroup>
-      <MauiEnableIVisualAssemblyScanning Condition="'$(MauiEnableIVisualAssemblyScanning)' == ''">false</MauiEnableIVisualAssemblyScanning>
-    </PropertyGroup>
-    
     <!-- Validate _EnableMauiAspire usage - warn when user manually sets it in optimized builds where it conflicts with intended behavior -->
     <Warning
       Code="MA002"
       Text="The _EnableMauiAspire property should not be set manually. Using Aspire outside the Debug configuration may introduce performance and security risks in production. This property is automatically configured based on build configuration."
       Condition="'$(_EnableMauiAspire)' != '' and '$(Optimize)' == 'true' and '$(MauiDisableAspireValidation)' != 'True'"/>
-    
-    <PropertyGroup Condition="'$(PublishAot)' == 'true' or '$(TrimMode)' == 'full'">
-      <MauiShellSearchResultsRendererDisplayMemberNameSupported Condition="'$(MauiShellSearchResultsRendererDisplayMemberNameSupported)' == ''">false</MauiShellSearchResultsRendererDisplayMemberNameSupported>
-      <MauiQueryPropertyAttributeSupport Condition="'$(MauiQueryPropertyAttributeSupport)' == ''">false</MauiQueryPropertyAttributeSupport>
-      <MauiImplicitCastOperatorsUsageViaReflectionSupport Condition="'$(MauiImplicitCastOperatorsUsageViaReflectionSupport)' == ''">false</MauiImplicitCastOperatorsUsageViaReflectionSupport>
-      <MauiEnableXamlCBindingWithSourceCompilation Condition="'$(MauiEnableXamlCBindingWithSourceCompilation)' == ''">true</MauiEnableXamlCBindingWithSourceCompilation>
-      <MauiHybridWebViewSupported Condition="'$(MauiHybridWebViewSupported)' == ''">false</MauiHybridWebViewSupported>
-      <MauiCssEnabled Condition="'$(MauiCssEnabled)' == '' and '@(MauiCss->Count())' == '0'">false</MauiCssEnabled>
-      <!-- FIXME: https://github.com/xamarin/xamarin-macios/issues/22065 -->
-      <MobileAggressiveAttributeTrimming Condition="'$(PublishAot)' == 'true' and '$(MobileAggressiveAttributeTrimming)' == ''">false</MobileAggressiveAttributeTrimming>
-      
-      <!-- Set _EnableMauiAspire based on whether optimizations are enabled when not already set -->
-      <_EnableMauiAspire Condition="'$(_EnableMauiAspire)' == '' and '$(Optimize)' != 'true'">true</_EnableMauiAspire>
-      <_EnableMauiAspire Condition="'$(_EnableMauiAspire)' == ''">false</_EnableMauiAspire>
-    </PropertyGroup>
-    <ItemGroup>
-      <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsIVisualAssemblyScanningEnabled"
-                                      Condition="'$(MauiEnableIVisualAssemblyScanning)' != ''"
-                                      Value="$(MauiEnableIVisualAssemblyScanning)"
-                                      Trim="true" />
-      <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsShellSearchResultsRendererDisplayMemberNameSupported"
-                                      Condition="'$(MauiShellSearchResultsRendererDisplayMemberNameSupported)' != ''"
-                                      Value="$(MauiShellSearchResultsRendererDisplayMemberNameSupported)"
-                                      Trim="true" />
-      <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsQueryPropertyAttributeSupported"
-                                      Condition="'$(MauiQueryPropertyAttributeSupport)' != ''"
-                                      Value="$(MauiQueryPropertyAttributeSupport)"
-                                      Trim="true" />
-      <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsImplicitCastOperatorsUsageViaReflectionSupported"
-                                      Condition="'$(MauiImplicitCastOperatorsUsageViaReflectionSupport)' != ''"
-                                      Value="$(MauiImplicitCastOperatorsUsageViaReflectionSupport)"
-                                      Trim="true" />
-      <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.AreBindingInterceptorsSupported"
-                                      Condition="'$(_MauiBindingInterceptorsSupport)' != ''"
-                                      Value="$(_MauiBindingInterceptorsSupport)"
-                                      Trim="true" />
-      <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsXamlCBindingWithSourceCompilationEnabled"
-                                      Condition="'$(MauiEnableXamlCBindingWithSourceCompilation)' != ''"
-                                      Value="$(MauiEnableXamlCBindingWithSourceCompilation)"
-                                      Trim="false" />
-      <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsHybridWebViewSupported"
-                                      Condition="'$(MauiHybridWebViewSupported)' != ''"
-                                      Value="$(MauiHybridWebViewSupported)"
-                                      Trim="true" />
-      <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsCssEnabled"
-                                      Condition="'$(MauiCssEnabled)' != ''"
-                                      Value="$(MauiCssEnabled)"
-                                      Trim="true" />
-      <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.AreNamescopesSupported"
-                                      Condition="'$(MauiNamescopesSupported)' != ''"
-                                      Value="$(MauiNamescopesSupported)"
-                                      Trim="true" />
-      <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.EnableDiagnostics"
-                                      Condition="'$(EnableDiagnostics)' != ''"
-                                      Value="$(EnableDiagnostics)"
-                                      Trim="true" />
-      <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.EnableMauiAspire"
-                                      Condition="'$(_EnableMauiAspire)' != ''"
-                                      Value="$(_EnableMauiAspire)"
-                                      Trim="true" />
-      <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsMaterial3Enabled"
-                                      Condition="'$(UseMaterial3)' != ''"
-                                      Value="$(UseMaterial3)"
-                                      Trim="true" />
-    </ItemGroup>
   </Target>
 
   <!--


### PR DESCRIPTION
> [!NOTE]
> This PR was created with assistance from AI.

## Summary

Move `RuntimeHostConfigurationOption` items and their property defaults out of the `_MauiPrepareForILLink` target into static `PropertyGroup`/`ItemGroup` blocks evaluated at import time. This requires no runtime changes.

## Problem

dotnet/runtime#124801 moved the `RuntimeHostConfigurationOption` → `_TrimmerFeatureSettings` conversion from `PrepareForILLink` into an earlier internal target (`_PrepareTrimConfiguration`). MAUI's `_MauiPrepareForILLink` hooks `BeforeTargets="PrepareForILLink"`, which fires *after* the snapshot. ILC never receives `--feature` flags for MAUI's switches on Android NativeAOT, causing spurious IL3050 warnings for `HybridWebViewHandler`.

## Fix

The property conditions (`PublishAot`, `TrimMode`, `Optimize`) are all static project properties available at evaluation time — there's no reason for these to be set inside a target. Moving them to static blocks makes them visible before any targets run, so `_PrepareTrimConfiguration` picks them up regardless of target ordering.

A sentinel property (`_EnableMauiAspireUserOverride`) captures the user-specified `_EnableMauiAspire` value before the default is set, so the MA002 warning correctly detects external overrides without false positives from MAUI's own default.

The `Warning` task (MA002 Aspire validation) remains in `_MauiPrepareForILLink` since MSBuild tasks require a target context.

This approach requires **no runtime changes**.

## Verified

Tested locally with an Android NativeAOT MAUI app:
- **Before**: `--feature:Microsoft.Maui.RuntimeFeature.IsHybridWebViewSupported=false` missing from ILC rsp → IL3050
- **After**: `--feature` flag present → IL3050 suppressed by FeatureGuard

Fixes dotnet/runtime#127017

cc @sbomer @simonrozsival @MichalStrehovsky