### PR TITLE
Add UI test category detection to maui-pr-uitests pipeline

### DIFF
--- a/eng/pipelines/ci-uitests.yml
+++ b/eng/pipelines/ci-uitests.yml
@@ -64,6 +64,16 @@ parameters:
     type: boolean
     default: false
 
+  - name: prNumber
+    displayName: 'PR number (run UI tests for a specific PR)'
+    type: string
+    default: ' '
+
+  - name: categories
+    displayName: 'UI test categories to run (comma-separated, e.g. "Button,Label"). Leave empty for all.'
+    type: string
+    default: ' '
+
   # Internal pools (dnceng)
   - name: androidPoolInternal
     type: object
@@ -168,6 +178,8 @@ stages:
       # BuildNativeAOT is false by default, but true in devdiv environment
       BuildNativeAOT: ${{ or(parameters.BuildNativeAOT, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}
       RunNativeAOT: ${{ parameters.RunNativeAOT }}
+      prNumber: ${{ parameters.prNumber }}
+      categories: ${{ parameters.categories }}
       ${{ if or(parameters.BuildEverything, ne(variables['Build.Reason'], 'PullRequest')) }}:
         androidApiLevels: [ 30 ]
         iosVersions: [ '18.5', 'latest' ]

--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -17,28 +17,112 @@ parameters:
   checkoutDirectory: $(System.DefaultWorkingDirectory)
 
 steps:
+# EARLY CHECK: Determine if this category group should run tests
+# This runs FIRST to avoid wasting time on provisioning if no tests will run
+# Also calculates matching categories to avoid duplicating this logic later
+- pwsh: |
+    $testFilterParam = $env:CATEGORY_GROUP
+    $testFilterFallback = $env:TEST_FILTER_PARAM
+    $detectedCategories = $env:DETECTED_CATEGORIES
+    # Engage filtering whenever discovery actually emitted detected categories.
+    # That happens for real PR builds AND for manual queues that pass -PrNumber.
+    # When no upstream stage produced the variable, AzDO leaves the literal
+    # placeholder '$(DETECTED_CATEGORIES)' in the env value — detect that via
+    # StartsWith. We can't compare against the literal placeholder in a
+    # single-quoted string here because AzDO pre-expands $(...) macros in the
+    # entire script body before pwsh runs.
+    $detectedCategoriesSet = -not [string]::IsNullOrWhiteSpace($detectedCategories) -and -not $detectedCategories.StartsWith('$(')
+    $isPR = $env:BUILD_REASON -eq "PullRequest"
+    $shouldFilter = $isPR -or $detectedCategoriesSet
+
+    # When detection ran but found NOTHING relevant, UITestCategoryList is set to 'NONE'.
+    # In that case skip ALL jobs — there are no categories to test.
+    $noneDetected = $detectedCategoriesSet -and $detectedCategories -eq 'NONE'
+
+    Write-Host "=== Early Category Check ==="
+    Write-Host "Build Reason: $env:BUILD_REASON"
+    Write-Host "Category Group (from matrix): '$testFilterParam'"
+    Write-Host "Test Filter (from parameter): '$testFilterFallback'"
+    Write-Host "Detected Categories: '$detectedCategories' (filter engaged: $shouldFilter, none detected: $noneDetected)"
+    
+    # Use testFilter parameter as fallback when CATEGORYGROUP is not set or not expanded
+    # When CATEGORYGROUP variable doesn't exist, it shows as literal '$(CATEGORYGROUP)'
+    $categoryGroupNotSet = [string]::IsNullOrWhiteSpace($testFilterParam) -or $testFilterParam -eq '$(CATEGORYGROUP)'
+    if ($categoryGroupNotSet -and -not [string]::IsNullOrWhiteSpace($testFilterFallback)) {
+        $testFilterParam = $testFilterFallback
+        Write-Host "Using testFilter parameter as category: '$testFilterParam'"
+    }
+    
+    $shouldRun = $true
+    $matchingCategoriesResult = $testFilterParam  # Default: use all categories from this group
+
+    # NONE means detection ran successfully but no categories matched — skip everything
+    if ($noneDetected) {
+        $shouldRun = $false
+        $matchingCategoriesResult = ""
+        Write-Host "##[warning]No UI test categories detected for this PR — SKIPPING all tests"
+    }
+    # For builds with detected categories, check if this category group has any matches
+    elseif ($shouldFilter -and $detectedCategoriesSet -and -not [string]::IsNullOrWhiteSpace($testFilterParam)) {
+        $categoryList = $testFilterParam -split ","
+        $detectedList = $detectedCategories -split ","
+        $matchingCategories = @()
+        
+        foreach ($cat in $categoryList) {
+            $cat = $cat.Trim()
+            foreach ($det in $detectedList) {
+                $det = $det.Trim()
+                if ($cat -ieq $det) {
+                    $matchingCategories += $cat
+                    Write-Host "Match found: '$cat'"
+                    break
+                }
+            }
+        }
+        
+        if ($matchingCategories.Count -eq 0) {
+            $shouldRun = $false
+            $matchingCategoriesResult = ""
+            Write-Host "##[warning]No matching categories - SKIPPING all steps for this job"
+            Write-Host "Category group '$testFilterParam' does not contain any detected categories: $detectedCategories"
+        } else {
+            $matchingCategoriesResult = $matchingCategories -join ","
+            Write-Host "Matching categories for this job: $matchingCategoriesResult"
+        }
+    }
+    
+    Write-Host "Should run tests: $shouldRun"
+    Write-Host "##vso[task.setvariable variable=SHOULD_RUN_TESTS]$shouldRun"
+    Write-Host "##vso[task.setvariable variable=MATCHING_CATEGORIES]$matchingCategoriesResult"
+  displayName: 'Check if category should run'
+  env:
+    CATEGORY_GROUP: $(CATEGORYGROUP)
+    TEST_FILTER_PARAM: ${{ parameters.testFilter }}
+    DETECTED_CATEGORIES: $(DETECTED_CATEGORIES)
+    BUILD_REASON: $(Build.Reason)
+
 - task: DownloadPipelineArtifact@2
-  condition: and(ne('${{ parameters.platform }}' , 'windows'), eq('${{ parameters.runtimeVariant }}' , 'Mono'), eq('${{ parameters.useMaterial3 }}', 'false'))
+  condition: and(succeeded(), eq(variables['SHOULD_RUN_TESTS'], 'True'), ne('${{ parameters.platform }}' , 'windows'), eq('${{ parameters.runtimeVariant }}' , 'Mono'), eq('${{ parameters.useMaterial3 }}', 'false'))
   inputs:
     artifact: ui-tests-samples
 
 - task: DownloadPipelineArtifact@2
-  condition: and(ne('${{ parameters.platform }}' , 'windows'), eq('${{ parameters.runtimeVariant }}' , 'Mono'), eq('${{ parameters.useMaterial3 }}', 'true'))
+  condition: and(succeeded(), eq(variables['SHOULD_RUN_TESTS'], 'True'), ne('${{ parameters.platform }}' , 'windows'), eq('${{ parameters.runtimeVariant }}' , 'Mono'), eq('${{ parameters.useMaterial3 }}', 'true'))
   inputs:
     artifact: ui-tests-samples-material3
 
 - task: DownloadPipelineArtifact@2
-  condition: and(ne('${{ parameters.platform }}' , 'windows'), eq('${{ parameters.runtimeVariant }}' , 'NativeAOT'))
+  condition: and(succeeded(), eq(variables['SHOULD_RUN_TESTS'], 'True'), ne('${{ parameters.platform }}' , 'windows'), eq('${{ parameters.runtimeVariant }}' , 'NativeAOT'))
   inputs:
     artifact: ui-tests-samples-nativeaot
 
 - task: DownloadPipelineArtifact@2
-  condition: and(ne('${{ parameters.platform }}' , 'windows'), eq('${{ parameters.runtimeVariant }}' , 'CoreCLR'), eq('${{ parameters.useMaterial3 }}', 'false'))
+  condition: and(succeeded(), eq(variables['SHOULD_RUN_TESTS'], 'True'), ne('${{ parameters.platform }}' , 'windows'), eq('${{ parameters.runtimeVariant }}' , 'CoreCLR'), eq('${{ parameters.useMaterial3 }}', 'false'))
   inputs:
     artifact: ui-tests-samples-coreclr
 
 - task: DownloadPipelineArtifact@2
-  condition: eq('${{ parameters.platform }}' , 'windows')
+  condition: and(succeeded(), eq(variables['SHOULD_RUN_TESTS'], 'True'), eq('${{ parameters.platform }}' , 'windows'))
   inputs:
     artifact: ui-tests-samples-windows
 
@@ -47,17 +131,21 @@ steps:
       chmod +x $(System.DefaultWorkingDirectory)/eng/scripts/clean-bot.sh
       $(System.DefaultWorkingDirectory)/eng/scripts/clean-bot.sh
     displayName: 'Clean bot'
+    condition: and(succeeded(), eq(variables['SHOULD_RUN_TESTS'], 'True'))
     continueOnError: true
     timeoutInMinutes: 60
 
 - ${{ if and(ne(parameters.buildType, 'buildOnly'), eq(parameters.platform, 'android')) }}:
   - template: enable-kvm.yml
+    parameters:
+      extraCondition: eq(variables['SHOULD_RUN_TESTS'], 'True')
 
 - ${{ if eq(parameters.platform, 'catalyst')}}:
   - bash: |
       chmod +x $(System.DefaultWorkingDirectory)/eng/scripts/disable-notification-center.sh
       $(System.DefaultWorkingDirectory)/eng/scripts/disable-notification-center.sh
     displayName: 'Disable Notification Center'
+    condition: and(succeeded(), eq(variables['SHOULD_RUN_TESTS'], 'True'))
     continueOnError: true
     timeoutInMinutes: 60
 
@@ -81,7 +169,7 @@ steps:
       openSslArgs: '' # Do not use legacy openssl for Catalyst builds
 
 - task: PowerShell@2
-  condition: and(ne('${{ parameters.platform }}', 'windows'), ne('${{ parameters.platform }}', 'android'))
+  condition: and(succeeded(), eq(variables['SHOULD_RUN_TESTS'], 'True'), ne('${{ parameters.platform }}', 'windows'), ne('${{ parameters.platform }}', 'android'))
   inputs:
     targetType: 'inline'
     script: |
@@ -93,6 +181,7 @@ steps:
 
 - pwsh: ./build.ps1 --target=dotnet --configuration="${{ parameters.configuration }}" --verbosity=diagnostic
   displayName: 'Install .NET'
+  condition: and(succeeded(), eq(variables['SHOULD_RUN_TESTS'], 'True'))
   retryCountOnTaskFailure: 2
   env:
     DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
@@ -100,15 +189,17 @@ steps:
 
 - pwsh: echo "##vso[task.prependpath]$(DotNet.Dir)"
   displayName: 'Add .NET to PATH'
+  condition: and(succeeded(), eq(variables['SHOULD_RUN_TESTS'], 'True'))
 
 # AzDO hosted agents default to 1024x768; set something bigger for Windows UI tests
 - pwsh: |
     $scriptPath = Join-Path "$(System.DefaultWorkingDirectory)" "eng" "scripts" "Set-ScreenResolution.ps1"
     & $scriptPath -Width 1920 -Height 1080
-  condition: eq('${{ parameters.platform }}' , 'windows')
+  condition: and(succeeded(), eq(variables['SHOULD_RUN_TESTS'], 'True'), eq('${{ parameters.platform }}' , 'windows'))
   displayName: "Set screen resolution"
 
 - task: UseNode@1
+  condition: and(succeeded(), eq(variables['SHOULD_RUN_TESTS'], 'True'))
   inputs:
     version: "20.3.1"
   displayName: "Install node"
@@ -117,6 +208,7 @@ steps:
     $skipAppiumDoctor = if ($IsMacOS -or $IsLinux) { "true" } else { "false" }
     dotnet build ./src/Provisioning/Provisioning.csproj -t:ProvisionAppium -p:SkipAppiumDoctor="$skipAppiumDoctor" -bl:"$(LogDirectory)/provision-appium.binlog"
   displayName: "Install Appium"
+  condition: and(succeeded(), eq(variables['SHOULD_RUN_TESTS'], 'True'))
   continueOnError: false
   retryCountOnTaskFailure: 2
   timeoutInMinutes: 10
@@ -138,12 +230,18 @@ steps:
 
     $testFilter = ""
     $testConfigrationArgs = "${{ parameters.testConfigurationArgs }}"
-
-    "${{ parameters.testFilter }}".Split(",") | ForEach {
-      $testFilter += "TestCategory=" + $_ + "|"
+    
+    # Use MATCHING_CATEGORIES from early check (already filtered for PR category detection)
+    $testFilterParam = $env:MATCHING_CATEGORIES
+    
+    Write-Host "Categories to run (from early check): '$testFilterParam'"
+    
+    if ($testFilterParam) {
+      $testFilterParam.Split(",") | ForEach {
+        $testFilter += "TestCategory=" + $_ + "|"
+      }
+      $testFilter = $testFilter.TrimEnd("|")
     }
-
-    $testFilter = $testFilter.TrimEnd("|")
 
     # Cake does not allow empty parameters, so check if our filter is empty before adding it
     if ($testConfigrationArgs) {
@@ -162,10 +260,12 @@ steps:
 
     Invoke-Expression $command  
   displayName: $(Agent.JobName)
+  condition: and(succeeded(), eq(variables['SHOULD_RUN_TESTS'], 'True'))
   ${{ if ne(parameters.platform, 'android')}}:
     retryCountOnTaskFailure: 1
   env:
     APPIUM_HOME: $(APPIUM_HOME)
+    MATCHING_CATEGORIES: $(MATCHING_CATEGORIES)
 
 - bash: |
     cat ${BASH_SOURCE[0]}

--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -137,8 +137,6 @@ steps:
 
 - ${{ if and(ne(parameters.buildType, 'buildOnly'), eq(parameters.platform, 'android')) }}:
   - template: enable-kvm.yml
-    parameters:
-      extraCondition: eq(variables['SHOULD_RUN_TESTS'], 'True')
 
 - ${{ if eq(parameters.platform, 'catalyst')}}:
   - bash: |

--- a/eng/pipelines/common/ui-tests.yml
+++ b/eng/pipelines/common/ui-tests.yml
@@ -274,7 +274,9 @@ stages:
 
   - stage: android_ui_tests_material3
     displayName: Android UITests Material3
-    dependsOn: build_ui_tests_material3
+    dependsOn:
+      - build_ui_tests_material3
+      - discover_ui_test_categories
     jobs:
       - ${{ each project in parameters.projects }}:
         - ${{ if ne(project.android, '') }}:
@@ -289,6 +291,7 @@ stages:
                 variables:
                   REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
                   APPIUM_HOME: $(System.DefaultWorkingDirectory)/.appium/
+                  DETECTED_CATEGORIES: $[ stageDependencies.discover_ui_test_categories.detect.outputs['DetectCategories.UITestCategoryList'] ]
                 steps:
                   - template: ui-tests-steps.yml
                     parameters:

--- a/eng/pipelines/common/ui-tests.yml
+++ b/eng/pipelines/common/ui-tests.yml
@@ -14,6 +14,8 @@ parameters:
   skipProvisioning: true
   BuildNativeAOT: false # Parameter to control whether NativeAOT artifacts should be built
   RunNativeAOT: false # Parameter to control whether NativeAOT UI tests should run
+  prNumber: ' ' # Optional: PR number for testing category detection from a manual queue
+  categories: ' ' # Optional: comma-separated categories to run (bypasses auto-detection). Empty = all.
   categoryGroupsToTest:
     # Make sure that this list is always up-to-date with src/Controls/tests/TestCases.Shared.Tests/UITestCategories.cs
     # we might want to improve this somehow depending on how much the categories change over time
@@ -52,9 +54,42 @@ parameters:
       app: /optional/path/to/app.csproj
 
 stages:
+  - stage: discover_ui_test_categories
+    displayName: Discover UI Test Categories
+    condition: |
+      or(
+        eq(variables['Build.Reason'], 'PullRequest'),
+        ne(trim('${{ parameters.prNumber }}'), '')
+      )
+    jobs:
+      - job: detect
+        displayName: Detect category filters
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - checkout: self
+            fetchDepth: 200
+          - task: PowerShell@2
+            name: DetectCategories
+            displayName: Determine UI test categories for PRs
+            env:
+              SYSTEM_PULLREQUEST_TARGETBRANCH: $(System.PullRequest.TargetBranch)
+              MANUAL_PR_NUMBER: ${{ parameters.prNumber }}
+              MANUAL_CATEGORIES: ${{ parameters.categories }}
+            inputs:
+              pwsh: true
+              filePath: $(System.DefaultWorkingDirectory)/eng/scripts/detect-ui-test-categories.ps1
+              arguments: '-TargetBranch "$env:SYSTEM_PULLREQUEST_TARGETBRANCH" -PrNumber "$env:MANUAL_PR_NUMBER" -Categories "$env:MANUAL_CATEGORIES"'
+
   - stage: build_ui_tests
     displayName: Build UITests Sample App
-    dependsOn: []
+    dependsOn:
+      - discover_ui_test_categories
+    condition: |
+      or(
+        ne(variables['Build.Reason'], 'PullRequest'),
+        in(dependencies.discover_ui_test_categories.result, 'Succeeded', 'Skipped')
+      )
     jobs:
       - job: build_ui_tests
         displayName: Build Sample App
@@ -141,7 +176,9 @@ stages:
 
   - stage: android_ui_tests
     displayName: Android UITests
-    dependsOn: build_ui_tests
+    dependsOn:
+      - build_ui_tests
+      - discover_ui_test_categories
     jobs:
       - ${{ each project in parameters.projects }}:
         - ${{ if ne(project.android, '') }}:
@@ -161,6 +198,8 @@ stages:
                 variables:
                   REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
                   APPIUM_HOME: $(System.DefaultWorkingDirectory)/.appium/
+                  # Access detected categories directly from stage dependency
+                  DETECTED_CATEGORIES: $[ stageDependencies.discover_ui_test_categories.detect.outputs['DetectCategories.UITestCategoryList'] ]
                 steps:
                   - template: ui-tests-steps.yml
                     parameters:
@@ -173,7 +212,6 @@ stages:
                       ${{ if not(eq(api, 27)) }}:
                         device: android-emulator-64_${{ api }}
                       provisionatorChannel: ${{ parameters.provisionatorChannel }}
-                      testFilter: $(CATEGORYGROUP)
                       skipProvisioning: ${{ parameters.skipProvisioning }}
                   
                   # Collect and publish Android snapshot diffs
@@ -185,7 +223,9 @@ stages:
 
   - stage: android_ui_tests_coreclr
     displayName: Android UITests CoreClr
-    dependsOn: build_ui_tests_coreclr
+    dependsOn:
+      - build_ui_tests_coreclr
+      - discover_ui_test_categories
     jobs:
       - ${{ each project in parameters.projects }}:
         - ${{ if ne(project.android, '') }}:
@@ -205,6 +245,7 @@ stages:
                 variables:
                   REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
                   APPIUM_HOME: $(System.DefaultWorkingDirectory)/.appium/
+                  DETECTED_CATEGORIES: $[ stageDependencies.discover_ui_test_categories.detect.outputs['DetectCategories.UITestCategoryList'] ]
                 steps:
                   - template: ui-tests-steps.yml
                     parameters:
@@ -218,7 +259,6 @@ stages:
                         device: android-emulator-64_${{ api }}
                       provisionatorChannel: ${{ parameters.provisionatorChannel }}
                       agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
-                      testFilter: $(CATEGORYGROUP)
                       headless: ${{ parameters.headless }}
                       skipProvisioning: ${{ parameters.skipProvisioning }}
                       runtimeVariant: "CoreCLR"
@@ -271,7 +311,9 @@ stages:
 
   - stage: ios_ui_tests_mono
     displayName: iOS UITests Mono
-    dependsOn: build_ui_tests
+    dependsOn:
+      - build_ui_tests
+      - discover_ui_test_categories
     jobs:
       - ${{ each project in parameters.projects }}:
         - ${{ if ne(project.ios, '') }}:
@@ -291,6 +333,7 @@ stages:
                 variables:
                   REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
                   APPIUM_HOME: $(System.DefaultWorkingDirectory)/.appium/
+                  DETECTED_CATEGORIES: $[ stageDependencies.discover_ui_test_categories.detect.outputs['DetectCategories.UITestCategoryList'] ]
                 steps:
                   - template: ui-tests-steps.yml
                     parameters:
@@ -307,7 +350,6 @@ stages:
                         device: ios-simulator-64_${{ version }}
                       provisionatorChannel: ${{ parameters.provisionatorChannel }}
                       runtimeVariant : "Mono"
-                      testFilter: $(CATEGORYGROUP)
                       headless: ${{ parameters.headless }}
                       skipProvisioning: ${{ parameters.skipProvisioning }}
                   
@@ -319,7 +361,19 @@ stages:
 
   - stage: ios_ui_tests_mono_cv1
     displayName: iOS UITests Mono CollectionView1
-    dependsOn: build_ui_tests
+    dependsOn:
+      - discover_ui_test_categories
+      - build_ui_tests
+    condition: |
+      and(
+        succeeded('build_ui_tests'),
+        or(
+          ne(variables['Build.Reason'], 'PullRequest'),
+          eq(dependencies.discover_ui_test_categories.result, 'Skipped'),
+          eq(stageDependencies.discover_ui_test_categories.detect.outputs['DetectCategories.UITestCategoryList'], ''),
+          contains(stageDependencies.discover_ui_test_categories.detect.outputs['DetectCategories.UITestCategoryList'], 'CollectionView')
+        )
+      )
     jobs:
       - ${{ each project in parameters.projects }}:
         - ${{ if ne(project.ios, '') }}:
@@ -334,6 +388,7 @@ stages:
                 variables:
                   REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
                   APPIUM_HOME: $(System.DefaultWorkingDirectory)/.appium/
+                  DETECTED_CATEGORIES: $[ stageDependencies.discover_ui_test_categories.detect.outputs['DetectCategories.UITestCategoryList'] ]
                 steps:
                   - template: ui-tests-steps.yml
                     parameters:
@@ -363,7 +418,19 @@ stages:
 
   - stage: ios_ui_tests_mono_carv1
     displayName: iOS UITests Mono CarouselView1
-    dependsOn: build_ui_tests
+    dependsOn:
+      - discover_ui_test_categories
+      - build_ui_tests
+    condition: |
+      and(
+        succeeded('build_ui_tests'),
+        or(
+          ne(variables['Build.Reason'], 'PullRequest'),
+          eq(dependencies.discover_ui_test_categories.result, 'Skipped'),
+          eq(stageDependencies.discover_ui_test_categories.detect.outputs['DetectCategories.UITestCategoryList'], ''),
+          contains(stageDependencies.discover_ui_test_categories.detect.outputs['DetectCategories.UITestCategoryList'], 'CarouselView')
+        )
+      )
     jobs:
       - ${{ each project in parameters.projects }}:
         - ${{ if ne(project.ios, '') }}:
@@ -378,6 +445,7 @@ stages:
                 variables:
                   REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
                   APPIUM_HOME: $(System.DefaultWorkingDirectory)/.appium/
+                  DETECTED_CATEGORIES: $[ stageDependencies.discover_ui_test_categories.detect.outputs['DetectCategories.UITestCategoryList'] ]
                 steps:
                   - template: ui-tests-steps.yml
                     parameters:
@@ -408,7 +476,9 @@ stages:
   - ${{ if and(eq(parameters.BuildNativeAOT, true), eq(parameters.RunNativeAOT, true)) }}:
     - stage: ios_ui_tests_nativeaot
       displayName: iOS UITests NativeAOT
-      dependsOn: build_ui_tests_nativeaot
+      dependsOn:
+        - build_ui_tests_nativeaot
+        - discover_ui_test_categories
       jobs:
         - ${{ each project in parameters.projects }}:
           - ${{ if ne(project.ios, '') }}:
@@ -428,6 +498,7 @@ stages:
                   variables:
                     REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
                     APPIUM_HOME: $(System.DefaultWorkingDirectory)/.appium/
+                    DETECTED_CATEGORIES: $[ stageDependencies.discover_ui_test_categories.detect.outputs['DetectCategories.UITestCategoryList'] ]
                   steps:
                     - template: ui-tests-steps.yml
                       parameters:
@@ -444,13 +515,14 @@ stages:
                           device: ios-simulator-64_${{ version }}
                         provisionatorChannel: ${{ parameters.provisionatorChannel }}
                         runtimeVariant : "NativeAOT"
-                        testFilter: $(CATEGORYGROUP)
                         headless: ${{ parameters.headless }}
                         skipProvisioning: ${{ parameters.skipProvisioning }}
 
   - stage: winui_ui_tests
     displayName: WinUI UITests
-    dependsOn: build_ui_tests_windows
+    dependsOn:
+      - build_ui_tests_windows
+      - discover_ui_test_categories
     jobs:
       - ${{ each project in parameters.projects }}:
         - ${{ if ne(project.winui, '') }}:
@@ -467,6 +539,7 @@ stages:
                 pool: ${{ parameters.windowsPool }}
                 variables:
                   APPIUM_HOME: $(System.DefaultWorkingDirectory)\.appium\
+                  DETECTED_CATEGORIES: $[ stageDependencies.discover_ui_test_categories.detect.outputs['DetectCategories.UITestCategoryList'] ]
                 steps:
                   - template: ui-tests-steps.yml
                     parameters:
@@ -476,7 +549,6 @@ stages:
                       path: ${{ project.winui }}
                       app: ${{ project.app }}
                       provisionatorChannel: ${{ parameters.provisionatorChannel }}
-                      testFilter: $(CATEGORYGROUP)
                       skipProvisioning: ${{ parameters.skipProvisioning }}
                   
                   # Collect and publish Windows snapshot diffs
@@ -487,7 +559,9 @@ stages:
 
   - stage: mac_ui_tests
     displayName: macOS UITests
-    dependsOn: build_ui_tests
+    dependsOn:
+      - build_ui_tests
+      - discover_ui_test_categories
     jobs:
       - ${{ each project in parameters.projects }}:
         - ${{ if ne(project.mac, '') }}:
@@ -505,6 +579,7 @@ stages:
                 variables:
                   REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
                   APPIUM_HOME: $(System.DefaultWorkingDirectory)/.appium/
+                  DETECTED_CATEGORIES: $[ stageDependencies.discover_ui_test_categories.detect.outputs['DetectCategories.UITestCategoryList'] ]
                 steps:
                   - template: ui-tests-steps.yml
                     parameters:
@@ -514,7 +589,6 @@ stages:
                       path: ${{ project.mac }}
                       app: ${{ project.app }}
                       provisionatorChannel: ${{ parameters.provisionatorChannel }}
-                      testFilter: $(CATEGORYGROUP)
                       skipProvisioning: ${{ parameters.skipProvisioning }}
                   
                   # Collect and publish Mac snapshot diffs

--- a/eng/pipelines/common/ui-tests.yml
+++ b/eng/pipelines/common/ui-tests.yml
@@ -86,9 +86,12 @@ stages:
     dependsOn:
       - discover_ui_test_categories
     condition: |
-      or(
-        ne(variables['Build.Reason'], 'PullRequest'),
-        in(dependencies.discover_ui_test_categories.result, 'Succeeded', 'Skipped')
+      and(
+        or(
+          ne(variables['Build.Reason'], 'PullRequest'),
+          in(dependencies.discover_ui_test_categories.result, 'Succeeded', 'Skipped')
+        ),
+        ne(dependencies.discover_ui_test_categories.outputs['detect.DetectCategories.UITestCategoryList'], 'NONE')
       )
     jobs:
       - job: build_ui_tests

--- a/eng/scripts/detect-ui-test-categories.ps1
+++ b/eng/scripts/detect-ui-test-categories.ps1
@@ -212,7 +212,9 @@ $pathToCategoryMap = @(
     @{ Pattern = 'src/Controls/src/Core/TapGesture';          Category = 'Gestures' }
     @{ Pattern = 'src/Controls/src/Core/PointerGesture';      Category = 'Gestures' }
     @{ Pattern = 'src/Controls/src/Core/DragGesture';         Category = 'DragAndDrop' }
+    @{ Pattern = 'src/Controls/src/Core/DragGesture';         Category = 'Gestures' }
     @{ Pattern = 'src/Controls/src/Core/DropGesture';         Category = 'DragAndDrop' }
+    @{ Pattern = 'src/Controls/src/Core/DropGesture';         Category = 'Gestures' }
     @{ Pattern = 'src/Controls/src/Core/Image.';              Category = 'Image' }
     @{ Pattern = 'src/Controls/src/Core/ImageButton';         Category = 'ImageButton' }
     @{ Pattern = 'src/Controls/src/Core/IndicatorView';       Category = 'IndicatorView' }

--- a/eng/scripts/detect-ui-test-categories.ps1
+++ b/eng/scripts/detect-ui-test-categories.ps1
@@ -1,0 +1,402 @@
+[CmdletBinding()]
+param(
+    [string]$TargetBranch,
+    [string]$PrNumber,
+    [string]$Categories,
+    [string]$AiCategories,
+    [string]$TestRoot = "src/Controls/tests/TestCases.Shared.Tests"
+)
+
+# Normalize PrNumber: strip whitespace; AzDO often passes a placeholder space when the parameter is unset.
+if (-not [string]::IsNullOrWhiteSpace($PrNumber)) {
+    $PrNumber = $PrNumber.Trim()
+} else {
+    $PrNumber = $null
+}
+
+# Normalize Categories parameter
+if (-not [string]::IsNullOrWhiteSpace($Categories)) {
+    $Categories = $Categories.Trim()
+} else {
+    $Categories = $null
+}
+
+# Normalize AiCategories parameter (from AI reasoning during pre-flight)
+if (-not [string]::IsNullOrWhiteSpace($AiCategories)) {
+    $AiCategories = $AiCategories.Trim()
+} else {
+    $AiCategories = $null
+}
+
+$buildReason = $env:BUILD_REASON
+if ([string]::IsNullOrWhiteSpace($buildReason)) {
+    $buildReason = $env:SYSTEM_REASON
+}
+
+$isManualPrTest = -not [string]::IsNullOrWhiteSpace($PrNumber)
+
+# When categories are explicitly provided, skip auto-detection entirely.
+# This lets triage/maintainers run specific categories via manual queue.
+if (-not [string]::IsNullOrWhiteSpace($Categories)) {
+    $catList = @($Categories -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+    Write-Host "##[section]Categories provided via parameter: $($catList -join ', '). Skipping auto-detection." -ForegroundColor Green
+    $matrix = [ordered]@{}
+    $index = 0
+    foreach ($cat in ($catList | Sort-Object)) {
+        $matrix["Category_$index"] = @{ CATEGORYGROUP = $cat }
+        $index++
+    }
+    $matrixJson = $matrix | ConvertTo-Json -Depth 5
+    Write-Host "##vso[task.setvariable variable=UITestCategoryMatrix;isOutput=true]$matrixJson"
+    Write-Host "##vso[task.setvariable variable=UITestCategoryList;isOutput=true]$($catList -join ',')"
+    return
+}
+
+if ($buildReason -ne 'PullRequest' -and -not $isManualPrTest) {
+    Write-Host "Build reason '$buildReason' is not PullRequest and no -PrNumber override was provided. Running all categories." -ForegroundColor Cyan
+    return
+}
+
+if ([string]::IsNullOrWhiteSpace($TargetBranch)) {
+    $TargetBranch = $env:SYSTEM_PULLREQUEST_TARGETBRANCH
+}
+
+# Determine the PR number for label / API lookups.
+$prNumberForLookup = $env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER
+if ([string]::IsNullOrWhiteSpace($prNumberForLookup) -and $isManualPrTest) {
+    $prNumberForLookup = $PrNumber
+}
+$repoName = $env:BUILD_REPOSITORY_NAME
+if ([string]::IsNullOrWhiteSpace($repoName)) {
+    $repoName = 'dotnet/maui'
+}
+
+# Helper: build authenticated GitHub API headers.
+function Get-GitHubHeaders {
+    $h = @{ 'User-Agent' = 'maui-ui-test-detector' }
+    if (-not [string]::IsNullOrWhiteSpace($env:GH_TOKEN)) {
+        $h['Authorization'] = "Bearer $env:GH_TOKEN"
+    } else {
+        Write-Host "⚠️ No GitHub token available (set GH_TOKEN env var)" -ForegroundColor Yellow
+    }
+    return $h
+}
+
+# Helper: invoke a REST call with retries for transient failures.
+function Invoke-WithRetry {
+    param([string]$Uri, [hashtable]$Headers, [int]$MaxRetries = 3, [int]$DelaySeconds = 10)
+    for ($attempt = 1; $attempt -le $MaxRetries; $attempt++) {
+        try {
+            return Invoke-RestMethod -Uri $Uri -Headers $Headers -Method Get -TimeoutSec 30
+        } catch {
+            Write-Host "##[warning]Attempt $attempt/$MaxRetries failed: $($_.Exception.Message)"
+            if ($attempt -lt $MaxRetries) {
+                Write-Host "Retrying in ${DelaySeconds}s..."
+                Start-Sleep -Seconds $DelaySeconds
+            } else {
+                throw
+            }
+        }
+    }
+}
+
+# Manual-test override: when -PrNumber is provided, fetch the PR's base/head from GitHub
+# and replay the same diff that a normal PR build would see.
+if ($isManualPrTest) {
+    try {
+        $prUrl = "https://api.github.com/repos/$repoName/pulls/$PrNumber"
+        Write-Host "##[section]Manual PR test mode (PrNumber=$PrNumber). Fetching PR metadata from $prUrl" -ForegroundColor Yellow
+        $pr = Invoke-WithRetry -Uri $prUrl -Headers (Get-GitHubHeaders)
+        $TargetBranch = $pr.base.ref
+        $headRef = $pr.head.ref
+        $headSha = $pr.head.sha
+        $baseRepoCloneUrl = $pr.base.repo.clone_url
+        $headRepoCloneUrl = $pr.head.repo.clone_url
+        Write-Host "PR #$PrNumber : $($pr.head.repo.full_name)/$headRef ($headSha) -> $($pr.base.repo.full_name)/$TargetBranch" -ForegroundColor Cyan
+
+        # Fetch base branch from the base repo.
+        git remote remove _detect_base 2>$null | Out-Null
+        git remote add _detect_base $baseRepoCloneUrl
+        git fetch _detect_base "$TargetBranch" --no-tags --prune --depth=200 | Out-Null
+        git update-ref refs/remotes/origin/$TargetBranch _detect_base/$TargetBranch | Out-Null
+
+        # Fetch head commit (works for forks too) and check it out so the diff reflects the PR changes.
+        git remote remove _detect_head 2>$null | Out-Null
+        git remote add _detect_head $headRepoCloneUrl
+        git fetch _detect_head "$headSha" --no-tags --depth=200 | Out-Null
+        git checkout --quiet $headSha | Out-Null
+    } catch {
+        Write-Host "##[warning]Manual PR test setup failed: $($_.Exception.Message). Falling back to running ALL categories."
+        return
+    }
+}
+
+# Escape hatch: PR label "run-all-uitests" forces the full category matrix to run.
+if (-not [string]::IsNullOrWhiteSpace($prNumberForLookup)) {
+    try {
+        $labelsUrl = "https://api.github.com/repos/$repoName/issues/$prNumberForLookup/labels"
+        Write-Host "Checking PR labels at $labelsUrl" -ForegroundColor Cyan
+        $labels = Invoke-WithRetry -Uri $labelsUrl -Headers (Get-GitHubHeaders)
+        $labelNames = @($labels | ForEach-Object { $_.name })
+        Write-Host "PR labels: $([string]::Join(', ', $labelNames))" -ForegroundColor Cyan
+        if ($labelNames -contains 'run-all-uitests') {
+            Write-Host "##[section]Label 'run-all-uitests' present. Running ALL UI test categories (detection bypassed)." -ForegroundColor Yellow
+            return
+        }
+    } catch {
+        Write-Host "##[warning]Failed to query PR labels: $($_.Exception.Message). Continuing with category detection."
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($TargetBranch)) {
+    Write-Host "##[warning]Unable to determine target branch for comparison."
+    Write-Host "##[section]FALLBACK: All UI test categories will run for this PR."
+    return
+}
+
+$targetBranch = $TargetBranch -replace '^refs/heads/', ''
+
+Write-Host "Fetching target branch 'origin/${targetBranch}' for diff analysis..." -ForegroundColor Cyan
+try {
+    git fetch origin "${targetBranch}" --no-tags --prune --depth=200 | Out-Null
+} catch {
+    Write-Host "##[warning]Failed to fetch origin/${targetBranch}: $($_.Exception.Message)"
+    Write-Host "##[section]FALLBACK: All UI test categories will run for this PR."
+    return
+}
+
+$mergeBase = $null
+try {
+    $mergeBase = (git merge-base HEAD "origin/${targetBranch}").Trim()
+} catch {
+    Write-Host "##[warning]Could not determine merge base with origin/${targetBranch}: $($_.Exception.Message)"
+    Write-Host "##[section]FALLBACK: All UI test categories will run for this PR."
+    return
+}
+
+if ([string]::IsNullOrWhiteSpace($mergeBase)) {
+    Write-Host "##[warning]Merge base calculation returned empty result."
+    Write-Host "##[section]FALLBACK: All UI test categories will run for this PR."
+    return
+}
+
+Write-Host "Calculating diff between $mergeBase and HEAD limited to '$TestRoot'..." -ForegroundColor Cyan
+$diff = git diff --diff-filter=AMR --unified=0 $mergeBase HEAD -- "$TestRoot"
+
+# Also get the full file list for Tier 2 source-path mapping
+$allChangedFiles = @(git diff --diff-filter=AMR --name-only $mergeBase HEAD)
+Write-Host "Total changed files in PR: $($allChangedFiles.Count)" -ForegroundColor Cyan
+
+# ============================================================================
+# TIER 2: Source-path-to-category mapping table
+# Maps product code paths to UI test categories by naming conventions.
+# ============================================================================
+
+$pathToCategoryMap = @(
+    @{ Pattern = 'src/Controls/src/Core/Button';              Category = 'Button' }
+    @{ Pattern = 'src/Controls/src/Core/Border';              Category = 'Border' }
+    @{ Pattern = 'src/Controls/src/Core/BoxView';             Category = 'BoxView' }
+    @{ Pattern = 'src/Controls/src/Core/CarouselView';        Category = 'CarouselView' }
+    @{ Pattern = 'src/Controls/src/Core/Handlers/Items';      Category = 'CollectionView' }
+    @{ Pattern = 'src/Controls/src/Core/Handlers/Items2';     Category = 'CollectionView' }
+    @{ Pattern = 'src/Controls/src/Core/CheckBox';            Category = 'CheckBox' }
+    @{ Pattern = 'src/Controls/src/Core/DatePicker';          Category = 'DatePicker' }
+    @{ Pattern = 'src/Controls/src/Core/Editor';              Category = 'Editor' }
+    @{ Pattern = 'src/Controls/src/Core/Entry';               Category = 'Entry' }
+    @{ Pattern = 'src/Controls/src/Core/FlyoutPage';          Category = 'FlyoutPage' }
+    @{ Pattern = 'src/Controls/src/Core/Frame';               Category = 'Frame' }
+    @{ Pattern = 'src/Controls/src/Core/GestureRecognizer';   Category = 'Gestures' }
+    @{ Pattern = 'src/Controls/src/Core/PanGesture';          Category = 'Gestures' }
+    @{ Pattern = 'src/Controls/src/Core/PinchGesture';        Category = 'Gestures' }
+    @{ Pattern = 'src/Controls/src/Core/SwipeGesture';        Category = 'Gestures' }
+    @{ Pattern = 'src/Controls/src/Core/TapGesture';          Category = 'Gestures' }
+    @{ Pattern = 'src/Controls/src/Core/PointerGesture';      Category = 'Gestures' }
+    @{ Pattern = 'src/Controls/src/Core/DragGesture';         Category = 'DragAndDrop' }
+    @{ Pattern = 'src/Controls/src/Core/DropGesture';         Category = 'DragAndDrop' }
+    @{ Pattern = 'src/Controls/src/Core/Image.';              Category = 'Image' }
+    @{ Pattern = 'src/Controls/src/Core/ImageButton';         Category = 'ImageButton' }
+    @{ Pattern = 'src/Controls/src/Core/IndicatorView';       Category = 'IndicatorView' }
+    @{ Pattern = 'src/Controls/src/Core/Label';               Category = 'Label' }
+    @{ Pattern = 'src/Controls/src/Core/Layout';              Category = 'Layout' }
+    @{ Pattern = 'src/Controls/src/Core/Grid';                Category = 'Layout' }
+    @{ Pattern = 'src/Controls/src/Core/StackLayout';         Category = 'Layout' }
+    @{ Pattern = 'src/Controls/src/Core/FlexLayout';          Category = 'Layout' }
+    @{ Pattern = 'src/Controls/src/Core/AbsoluteLayout';      Category = 'Layout' }
+    @{ Pattern = 'src/Controls/src/Core/ListView';            Category = 'ListView' }
+    @{ Pattern = 'src/Controls/src/Core/NavigationPage';      Category = 'Navigation' }
+    @{ Pattern = 'src/Controls/src/Core/Page';                Category = 'Page' }
+    @{ Pattern = 'src/Controls/src/Core/ContentPage';         Category = 'Page' }
+    @{ Pattern = 'src/Controls/src/Core/Picker';              Category = 'Picker' }
+    @{ Pattern = 'src/Controls/src/Core/ProgressBar';         Category = 'ProgressBar' }
+    @{ Pattern = 'src/Controls/src/Core/RadioButton';         Category = 'RadioButton' }
+    @{ Pattern = 'src/Controls/src/Core/RefreshView';         Category = 'RefreshView' }
+    @{ Pattern = 'src/Controls/src/Core/ScrollView';          Category = 'ScrollView' }
+    @{ Pattern = 'src/Controls/src/Core/SearchBar';           Category = 'SearchBar' }
+    @{ Pattern = 'src/Controls/src/Core/Handlers/Shapes';     Category = 'Shape' }
+    @{ Pattern = 'src/Controls/src/Core/Shapes';              Category = 'Shape' }
+    @{ Pattern = 'src/Controls/src/Core/Shell';               Category = 'Shell' }
+    @{ Pattern = 'src/Controls/src/Core/Handlers/Shell';      Category = 'Shell' }
+    @{ Pattern = 'src/Controls/src/Core/Slider';              Category = 'Slider' }
+    @{ Pattern = 'src/Controls/src/Core/Stepper';             Category = 'Stepper' }
+    @{ Pattern = 'src/Controls/src/Core/Switch';              Category = 'Switch' }
+    @{ Pattern = 'src/Controls/src/Core/SwipeView';           Category = 'SwipeView' }
+    @{ Pattern = 'src/Controls/src/Core/TabbedPage';          Category = 'TabbedPage' }
+    @{ Pattern = 'src/Controls/src/Core/TableView';           Category = 'TableView' }
+    @{ Pattern = 'src/Controls/src/Core/TimePicker';          Category = 'TimePicker' }
+    @{ Pattern = 'src/Controls/src/Core/ToolbarItem';         Category = 'ToolbarItem' }
+    @{ Pattern = 'src/Controls/src/Core/WebView';             Category = 'WebView' }
+    @{ Pattern = 'src/Controls/src/Core/Window';              Category = 'Window' }
+    @{ Pattern = 'src/Controls/src/Core/VisualStateManager';  Category = 'VisualStateManager' }
+    @{ Pattern = 'src/Controls/src/Core/Shadow';              Category = 'Shadow' }
+    @{ Pattern = 'src/Controls/src/Core/Brush';               Category = 'Brush' }
+    @{ Pattern = 'src/Core/src/Handlers/HybridWebView';       Category = 'WebView' }
+    @{ Pattern = 'src/Core/src/Platform/';                    Category = 'ViewBaseTests' }
+    @{ Pattern = 'src/Core/src/Handlers/';                    Category = 'ViewBaseTests' }
+    @{ Pattern = 'src/Essentials/';                           Category = 'Essentials' }
+    @{ Pattern = 'src/Controls/src/Core/Handlers/FlyoutPage'; Category = 'FlyoutPage' }
+    @{ Pattern = 'src/Controls/src/Core/Handlers/TabbedPage'; Category = 'TabbedPage' }
+    @{ Pattern = 'src/Controls/src/Core/Handlers/NavigationPage'; Category = 'Navigation' }
+    @{ Pattern = 'src/Controls/src/Core/SafeArea';            Category = 'SafeAreaEdges' }
+    @{ Pattern = 'src/Controls/src/Core/Platform/iOS/Extensions/SafeArea'; Category = 'SafeAreaEdges' }
+)
+
+if ([string]::IsNullOrWhiteSpace($diff)) {
+    Write-Host "No changes detected under '$TestRoot'." -ForegroundColor Cyan
+} else {
+    Write-Host "Test file changes detected under '$TestRoot'." -ForegroundColor Green
+}
+
+$categoryPattern = '^\+\s*\[Category\((?<value>[^\)]*)\)'
+$addedCategories = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+
+# ============================================================================
+# TIER 1: Scan test file diffs for [Category] attributes
+# ============================================================================
+
+if (-not [string]::IsNullOrWhiteSpace($diff)) {
+    foreach ($line in $diff -split "`n") {
+        if ($line -match $categoryPattern) {
+            $rawValue = $Matches['value'].Trim()
+            if ([string]::IsNullOrWhiteSpace($rawValue)) {
+                continue
+            }
+
+            if ($rawValue -match '^UITestCategories\.(?<name>[A-Za-z0-9_]+)$') {
+                $category = $Matches['name']
+            } elseif ($rawValue -match '^["''](?<name>[A-Za-z0-9_ -]+)["'']$') {
+                $category = $Matches['name']
+            } else {
+                if ($rawValue -match 'nameof\(UITestCategories\.(?<name>[A-Za-z0-9_]+)\)') {
+                    $category = $Matches['name']
+                } else {
+                    $message = "Unrecognized category expression '$rawValue'. Expected formats: UITestCategories.<Name>, nameof(UITestCategories.<Name>), or a quoted string."
+                    Write-Host "##[error]$message"
+                    throw $message
+                }
+            }
+
+            $category = $category.Trim()
+            if (-not [string]::IsNullOrWhiteSpace($category)) {
+                $addedCategories.Add($category) | Out-Null
+            }
+        }
+    }
+
+    if ($addedCategories.Count -eq 0) {
+        # Scan modified test files for existing [Category] attributes
+        Write-Host "No new Category attributes in diff. Scanning modified files for existing categories..." -ForegroundColor Cyan
+        $modifiedFiles = @(git diff --diff-filter=AMR --name-only $mergeBase HEAD -- "$TestRoot" | Where-Object { $_ -match '\.cs$' })
+        foreach ($file in $modifiedFiles) {
+            if (-not (Test-Path $file)) { continue }
+            $content = Get-Content $file -Raw
+            $fileMatches = [regex]::Matches($content, '\[Category\(([^\)]*)\)')
+            foreach ($m in $fileMatches) {
+                $rawValue = $m.Groups[1].Value.Trim()
+                if ([string]::IsNullOrWhiteSpace($rawValue)) { continue }
+                if ($rawValue -match '^UITestCategories\.(?<name>[A-Za-z0-9_]+)$') {
+                    $cat = $Matches['name']
+                } elseif ($rawValue -match '^["''](?<name>[A-Za-z0-9_ -]+)["'']$') {
+                    $cat = $Matches['name']
+                } elseif ($rawValue -match 'nameof\(UITestCategories\.(?<name>[A-Za-z0-9_]+)\)') {
+                    $cat = $Matches['name']
+                } else { continue }
+                $cat = $cat.Trim()
+                if (-not [string]::IsNullOrWhiteSpace($cat)) {
+                    $addedCategories.Add($cat) | Out-Null
+                }
+            }
+        }
+    }
+
+    if ($addedCategories.Count -gt 0) {
+        Write-Host "Tier 1 (test files): $([string]::Join(', ', $addedCategories))" -ForegroundColor Green
+    }
+}
+
+# ============================================================================
+# TIER 2: Source-path heuristic mapping (product code → categories)
+# ============================================================================
+
+$tier2Categories = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+$touchesControls = $false
+
+foreach ($file in $allChangedFiles) {
+    if ($file -like 'src/Controls/*' -or $file -like 'src/Core/*' -or $file -like 'src/Essentials/*') {
+        $touchesControls = $true
+    }
+    foreach ($mapping in $pathToCategoryMap) {
+        if ($file -like "$($mapping.Pattern)*") {
+            $tier2Categories.Add($mapping.Category) | Out-Null
+        }
+    }
+}
+
+if ($tier2Categories.Count -gt 0) {
+    Write-Host "Tier 2 (source paths): $([string]::Join(', ', $tier2Categories))" -ForegroundColor Green
+    foreach ($c in $tier2Categories) { $addedCategories.Add($c) | Out-Null }
+}
+
+# ============================================================================
+# TIER 3: AI-provided categories (from pre-flight reasoning)
+# ============================================================================
+
+if (-not [string]::IsNullOrWhiteSpace($AiCategories)) {
+    $aiCatList = @($AiCategories -split '[,\n]' | ForEach-Object { ($_ -replace '\s*[-—].*$', '').Trim() } | Where-Object { $_ -and $_ -ne 'NONE' })
+    if ($aiCatList.Count -gt 0) {
+        Write-Host "Tier 3 (AI reasoning): $([string]::Join(', ', $aiCatList))" -ForegroundColor Green
+        foreach ($c in $aiCatList) { $addedCategories.Add($c) | Out-Null }
+    }
+}
+
+# ============================================================================
+# FINAL DECISION
+# ============================================================================
+
+if ($addedCategories.Count -eq 0) {
+    if ($touchesControls) {
+        # Changed files under src/Controls/ but couldn't map to specific categories — run all
+        Write-Host "Changed files touch Controls/Core/Essentials but no specific categories identified. Running all." -ForegroundColor Yellow
+        return
+    } else {
+        # No UI-relevant changes at all
+        Write-Host "No UI-relevant changes detected. No UI test categories to run." -ForegroundColor Cyan
+        Write-Host "##vso[task.setvariable variable=UITestCategoryList;isOutput=true]NONE"
+        return
+    }
+}
+
+Write-Host "Detected categories from PR changes: $([string]::Join(', ', $addedCategories))" -ForegroundColor Green
+
+# Build matrix JSON expected by Azure Pipelines strategy matrix (CATEGORYGROUP values)
+$matrix = [ordered]@{}
+$index = 0
+foreach ($category in ($addedCategories | Sort-Object)) {
+    $key = "Category_$index"
+    $matrix[$key] = @{ CATEGORYGROUP = $category }
+    $index++
+}
+
+$matrixJson = $matrix | ConvertTo-Json -Depth 5
+
+Write-Host "##vso[task.setvariable variable=UITestCategoryMatrix;isOutput=true]$matrixJson"
+Write-Host "##vso[task.setvariable variable=UITestCategoryList;isOutput=true]$([string]::Join(',', ($addedCategories | Sort-Object)))"


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## What this does

**Before:** Every PR runs ~24,000 UI tests across all categories (~2+ hours).

**After:** The pipeline detects which UI test categories a PR actually touches and only runs those. A PR that changes `Button` code only runs Button tests (~400 tests, ~30 min). Docs-only PRs skip UI tests entirely.

## How it works

1. A new **Discover** stage analyzes the PR diff before test stages run
2. It detects relevant categories using:
   - **Test file attributes** — `[Category(UITestCategories.X)]` in changed/existing test files (supports combined attributes like `[Category(X), Order(1)]`)
   - **Source-path mapping** — 60+ patterns map product code to categories (e.g. `Shell/` → Shell, `Button*` → Button, `DragGesture*` → Gestures + DragAndDrop)
   - **AI categories** — optional `-AiCategories` parameter for external input
3. Each test job checks if its category group matches — if not, it **skips** in seconds
4. If `NONE` detected (docs-only, build scripts) — build stages are skipped too
5. If no specific categories identified but `src/Controls/` changed — runs full matrix (safe default)

### Escape hatches

- Add `run-all-uitests` label to any PR → forces full matrix
- Queue manually with `categories` parameter → run specific categories
- Queue with `prNumber` parameter → test detection against any PR

## Files

| File | What it does |
|------|-------------|
| `eng/scripts/detect-ui-test-categories.ps1` | 3-tier detection script with path mapping, retry on GitHub API failures |
| `eng/pipelines/common/ui-tests.yml` | Discover stage, build stage skip on NONE, cross-stage variable propagation |
| `eng/pipelines/common/ui-tests-steps.yml` | Per-job filter gate — early check before provisioning/test execution |
| `eng/pipelines/ci-uitests.yml` | `prNumber` + `categories` queue-time parameters |

## Validation runs

### Latest batch (Apr 26) — 6 builds, all succeeded ✅

Each build correctly **detected categories** from the PR diff. Non-matching jobs started but **skipped all test steps** in ~2min (vs 60-100min for matching jobs).

| PR | Categories Detected | Build | Result |
|----|-------------------|-------|--------|
| #35031 (Shell memory leak) | `Shell` | [1397058](https://dnceng-public.visualstudio.com/public/_build/results?buildId=1397058) | ✅ Shell jobs ran ~100min, all others skipped steps |
| #34997 (RadioButton gradient) | `RadioButton,ViewBaseTests` | [1397062](https://dnceng-public.visualstudio.com/public/_build/results?buildId=1397062) | ✅ |
| #34980 (DatePicker rotation) | `ViewBaseTests` | [1397065](https://dnceng-public.visualstudio.com/public/_build/results?buildId=1397065) | ✅ |
| #34974 (Picker CharacterSpacing) | `ViewBaseTests` | [1397067](https://dnceng-public.visualstudio.com/public/_build/results?buildId=1397067) | ✅ |
| #34923 (SwipeView threshold) | `SwipeView,ViewBaseTests` | [1397069](https://dnceng-public.visualstudio.com/public/_build/results?buildId=1397069) | ✅ |
| #34845 (RefreshView binding) | `RefreshView,ViewBaseTests` | [1397071](https://dnceng-public.visualstudio.com/public/_build/results?buildId=1397071) | ✅ |

### Earlier batch — 5 builds

| PR | Categories Detected | Build | Result |
|----|-------------------|-------|--------|
| #35131 | `Shell` | [1396744](https://dnceng-public.visualstudio.com/public/_build/results?buildId=1396744) | ✅ Succeeded |
| #35129 | `Shell` | [1396745](https://dnceng-public.visualstudio.com/public/_build/results?buildId=1396745) | ✅ Succeeded |
| #35087 | `SwipeView,ViewBaseTests` | [1396746](https://dnceng-public.visualstudio.com/public/_build/results?buildId=1396746) | ❌ Test failures |
| #35092 | `ViewBaseTests,WebView` | [1396747](https://dnceng-public.visualstudio.com/public/_build/results?buildId=1396747) | ❌ Test failures |
| #35083 | `SafeAreaEdges,ViewBaseTests` | [1396748](https://dnceng-public.visualstudio.com/public/_build/results?buildId=1396748) | ✅ Succeeded |

### Category detection accuracy (30+ PRs validated)

| PR | Detected | Tests run | vs Full matrix |
|----|----------|-----------|----------------|
| #35009 | ToolbarItem | 467 | 24,000 |
| #34997 | RadioButton | 496 | 24,000 |
| #35079 | SearchBar,Shell | 2,218 | 24,000 |
| #34637 | Shape | 505 | 24,000 |
| #35072 | Navigation,Shell | 2,540 | 24,000 |
| #34980 | ViewBaseTests | 553 | 24,000 |
| #31672 | CarouselView,CollectionView | 4,451 | 24,000 |