### PR TITLE
Fix iOS infinite layout invalidation loop from bit-exact Frame equality (#35142)

### DIFF
--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -1866,6 +1866,17 @@ namespace Microsoft.Maui.Controls
 		EventHandler? _unloaded;
 		bool _watchingPlatformLoaded;
 		Rect _frame = new Rect(0, 0, -1, -1);
+
+		// Tolerance used by the Frame setter to absorb ULP-level non-determinism in measured/arranged
+		// bounds (e.g. iOS UILabel.SizeThatFits returning bit-different doubles across consecutive
+		// passes). Without this tolerance, sub-ULP differences propagate as Width/Height
+		// PropertyChanged and SizeChanged events, which can drive iOS layoutSubviews into a
+		// non-converging 2-cycle. See https://github.com/dotnet/maui/issues/35142. The threshold is
+		// well above ~10⁻¹³ ULP at typical layout magnitudes and well below sub-pixel resolution on
+		// any current device (a 3× display's pixel is ~0.333pt). Mirrors the precedent set by
+		// SafeAreaPadding.EqualsAtPixelLevel for issues #32586 and #33934.
+		const double FrameEqualityEpsilon = 1e-9;
+
 		event EventHandler? _windowChanged;
 		event EventHandler? _platformContainerViewChanged;
 
@@ -1878,7 +1889,7 @@ namespace Microsoft.Maui.Controls
 			get => _frame;
 			set
 			{
-				if (_frame == value)
+				if (_frame.EqualsApproximately(value, FrameEqualityEpsilon))
 					return;
 
 				UpdateBoundsComponents(value);

--- a/src/Controls/tests/Core.UnitTests/VisualElementTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualElementTests.cs
@@ -307,5 +307,44 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal(2, heightMapperCalled);
 			Assert.Equal(2, widthMapperCalled);
 		}
+
+		// Regression test for dotnet/maui#35142: on iOS, ULP-level non-determinism in
+		// VerticalStackLayout/Label measurement (CoreText subpixel rounding) propagates through
+		// Grid("*,Auto") star-row arithmetic into a child's Frame. The bit-exact Rect equality
+		// in the Frame setter then re-runs UpdateBoundsComponents, which fires Width/Height
+		// PropertyChanged on every ~10 ULP delta. UIKit reschedules layoutSubviews and the loop
+		// never converges. The values below are the actual border heights captured in the repro
+		// trace (see https://github.com/dotnet/maui/issues/35142).
+		[Fact]
+		public void FrameAssignmentIgnoresSubPixelDifferences()
+		{
+			var rectA = new Rect(0, 0, 390, 556.00000063578295);
+			var rectB = new Rect(0, 0, 390, 556.00000063578273); // ~22 ULP different from rectA
+
+			var element = new Label();
+			element.Frame = rectA;
+
+			int sizeChangedCount = 0;
+			int heightPropertyChangedCount = 0;
+			int widthPropertyChangedCount = 0;
+			element.SizeChanged += (_, _) => sizeChangedCount++;
+			element.PropertyChanged += (_, e) =>
+			{
+				if (e.PropertyName == VisualElement.HeightProperty.PropertyName)
+				{
+					heightPropertyChangedCount++;
+				}
+				else if (e.PropertyName == VisualElement.WidthProperty.PropertyName)
+				{
+					widthPropertyChangedCount++;
+				}
+			};
+
+			element.Frame = rectB;
+
+			Assert.Equal(0, sizeChangedCount);
+			Assert.Equal(0, heightPropertyChangedCount);
+			Assert.Equal(0, widthPropertyChangedCount);
+		}
 	}
 }

--- a/src/Graphics/src/Graphics/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Microsoft.Maui.Graphics.Rect.EqualsApproximately(Microsoft.Maui.Graphics.Rect other, double epsilon) -> bool

--- a/src/Graphics/src/Graphics/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Microsoft.Maui.Graphics.Rect.EqualsApproximately(Microsoft.Maui.Graphics.Rect other, double epsilon) -> bool

--- a/src/Graphics/src/Graphics/Rect.cs
+++ b/src/Graphics/src/Graphics/Rect.cs
@@ -76,6 +76,22 @@ namespace Microsoft.Maui.Graphics
 			return X.Equals(other.X) && Y.Equals(other.Y) && Width.Equals(other.Width) && Height.Equals(other.Height);
 		}
 
+		/// <summary>
+		/// Determines whether each component of this rectangle is within <paramref name="epsilon"/>
+		/// of the corresponding component of <paramref name="other"/>. Use this to compare rectangles
+		/// produced by floating-point arithmetic where bit-exact equality would treat ULP-level
+		/// differences as material changes.
+		/// </summary>
+		/// <param name="other">The rectangle to compare against.</param>
+		/// <param name="epsilon">The maximum absolute difference, per component, that is treated as equal.</param>
+		public bool EqualsApproximately(Rect other, double epsilon)
+		{
+			return Math.Abs(X - other.X) <= epsilon
+				&& Math.Abs(Y - other.Y) <= epsilon
+				&& Math.Abs(Width - other.Width) <= epsilon
+				&& Math.Abs(Height - other.Height) <= epsilon;
+		}
+
 		public override bool Equals(object obj)
 		{
 			if (obj is null)

--- a/src/Graphics/tests/Graphics.Tests/RectTests.cs
+++ b/src/Graphics/tests/Graphics.Tests/RectTests.cs
@@ -1,0 +1,47 @@
+using Xunit;
+
+namespace Microsoft.Maui.Graphics.Tests
+{
+	public class RectTests
+	{
+		[Fact]
+		public void EqualsApproximatelyReturnsTrueForIdenticalRects()
+		{
+			var rect = new Rect(10, 20, 30, 40);
+			Assert.True(rect.EqualsApproximately(new Rect(10, 20, 30, 40), epsilon: 1e-9));
+		}
+
+		[Fact]
+		public void EqualsApproximatelyAbsorbsUlpDifferences()
+		{
+			// Values from the dotnet/maui#35142 trace: border heights captured on consecutive
+			// iOS layoutSubviews passes that differ by ~22 ULP.
+			var a = new Rect(0, 0, 390, 556.00000063578295);
+			var b = new Rect(0, 0, 390, 556.00000063578273);
+
+			Assert.False(a.Equals(b)); // bit-exact equality treats them as different
+			Assert.True(a.EqualsApproximately(b, epsilon: 1e-9));
+		}
+
+		[Fact]
+		public void EqualsApproximatelyReturnsFalseWhenAnyComponentExceedsEpsilon()
+		{
+			var rect = new Rect(0, 0, 100, 100);
+			const double epsilon = 1e-9;
+
+			Assert.False(rect.EqualsApproximately(new Rect(0 + 2 * epsilon, 0, 100, 100), epsilon));
+			Assert.False(rect.EqualsApproximately(new Rect(0, 0 + 2 * epsilon, 100, 100), epsilon));
+			Assert.False(rect.EqualsApproximately(new Rect(0, 0, 100 + 2 * epsilon, 100), epsilon));
+			Assert.False(rect.EqualsApproximately(new Rect(0, 0, 100, 100 + 2 * epsilon), epsilon));
+		}
+
+		[Fact]
+		public void EqualsApproximatelyTreatsHalfEpsilonDifferenceAsEqual()
+		{
+			var rect = new Rect(0, 0, 100, 100);
+			const double epsilon = 1e-9;
+
+			Assert.True(rect.EqualsApproximately(new Rect(0, 0, 100, 100 + epsilon * 0.5), epsilon));
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

`VisualElement.Frame`'s setter uses `Rect`'s bit-exact equality (`Rect.Equals` on doubles) to decide whether to enter `UpdateBoundsComponents`. On iOS, ULP-level non-determinism from `UILabel.SizeThatFits` / CoreText propagates through `VerticalStackLayout` accumulation and `Grid(\"*\",\"Auto\")` star-row arithmetic into a child's `Frame`, producing a `Rect` that differs from the cached one by ~10–22 ULP.

Bit-exact equality treats those rects as different, fires `Width`/`Height` `PropertyChanged` + `SizeChanged`, layout invalidates, UIKit reschedules `layoutSubviews`, and the cycle repeats without converging. The UI thread becomes permanently stuck.

This change adds `Rect.EqualsApproximately(other, epsilon)` (non-breaking, no change to `Rect.Equals` / `==`) and uses it in the `Frame` setter with `epsilon = 1e-9` — well above ~10⁻¹³ ULP at typical layout magnitudes and well below sub-pixel resolution on any current iOS device (a 3× display's pixel is ~0.333pt). It mirrors the precedent set by `SafeAreaPadding.EqualsAtPixelLevel`, introduced for issues #32586 and #33934 to fix the analogous infinite-layout-cycle problem on the safe-area path.

#### Captured per-cycle pattern from the repro (G17 precision)

\`\`\`text
*** PROPCHG border Height=556.00000063578295
*** SIZECHG border 390x556.00000063578295
*** PROPCHG vstack Y=566.00000063578295
*** PROPCHG vstack Height=149.99999936421713
*** SIZECHG vstack 370x149.99999936421713

*** PROPCHG border Height=556.00000063578273
*** SIZECHG border 390x556.00000063578273
*** PROPCHG vstack Y=566.00000063578273
*** PROPCHG vstack Height=149.99999936421725
*** SIZECHG vstack 370x149.99999936421725
\`\`\`

The two heights toggle indefinitely (~22 ULP for the border, ~12 ULP for the vstack) and never converge.

### Issues Fixed

Fixes #35142

### Tests

Two new test files exercise both the loop trigger and the new helper:

- **`VisualElementTests.FrameAssignmentIgnoresSubPixelDifferences`** — uses the actual border heights captured in the repro trace (`556.00000063578295` vs `556.00000063578273`). On unmodified \`main\` the test fails (\`SizeChanged\` fires after the second \`Frame\` assignment); after the fix it passes.
- **\`RectTests\`** — focused coverage of \`Rect.EqualsApproximately\` (identical, ULP-different, beyond-epsilon, half-epsilon).

Local results on macOS / .NET 10:

- Controls.Core.UnitTests: 5544 passed, 30 pre-existing skipped, 0 failed
- Core.UnitTests: 806 passed, 3 pre-existing skipped, 0 failed
- Graphics.Tests: 376 passed, 0 failed (4 new \`RectTests\` included)

### End-to-end verification

A minimal MauiReactor repro (\`Grid(\"*,Auto\", \"*\", Border, VerticalStackLayout-of-labels)\`) reliably froze the UI thread on iPhone 16e simulator within ~1 second. With the fix, the same repro renders and stays responsive — no \`PROPCHG\` flood, no freeze.