### PR TITLE
Fix indefinite hang in MapEvaluateJavaScriptAsync when inner task faults

### DIFF
--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.cs
@@ -393,43 +393,49 @@ namespace Microsoft.Maui.Handlers
 				return;
 			}
 
-			var script = request.Script;
-			// Make all the platforms mimic Android's implementation, which is by far the most complete.
-			if (!OperatingSystem.IsAndroid())
+			try
 			{
-				script = WebViewHelper.EscapeJsString(script);
-
-				if (!OperatingSystem.IsWindows())
+				var script = request.Script;
+				// Make all the platforms mimic Android's implementation, which is by far the most complete.
+				if (!OperatingSystem.IsAndroid())
 				{
-					// Use JSON.stringify() method to converts a JavaScript value to a JSON string
-					script = "try{JSON.stringify(eval('" + script + "'))}catch(e){'null'};";
+					script = WebViewHelper.EscapeJsString(script);
+
+					if (!OperatingSystem.IsWindows())
+					{
+						// Use JSON.stringify() method to converts a JavaScript value to a JSON string
+						script = "try{JSON.stringify(eval('" + script + "'))}catch(e){'null'};";
+					}
+					else
+					{
+						script = "try{eval('" + script + "')}catch(e){'null'};";
+					}
 				}
-				else
+
+				// Use the handler command to evaluate the JS
+				var innerRequest = new EvaluateJavaScriptAsyncRequest(script);
+				EvaluateJavaScript(handler, hybridWebView, innerRequest);
+
+				var result = await innerRequest.Task;
+
+				//if the js function errored or returned null/undefined treat it as null
+				if (result == "null")
 				{
-					script = "try{eval('" + script + "')}catch(e){'null'};";
+					result = null;
 				}
+				//JSON.stringify wraps the result in literal quotes, we just want the actual returned result
+				//note that if the js function returns the string "null" we will get here and not above
+				else if (result != null)
+				{
+					result = result.Trim('"');
+				}
+
+				request.SetResult(result!);
 			}
-
-			// Use the handler command to evaluate the JS
-			var innerRequest = new EvaluateJavaScriptAsyncRequest(script);
-			EvaluateJavaScript(handler, hybridWebView, innerRequest);
-
-			var result = await innerRequest.Task;
-
-			//if the js function errored or returned null/undefined treat it as null
-			if (result == "null")
+			catch (Exception ex)
 			{
-				result = null;
+				request.SetException(ex);
 			}
-			//JSON.stringify wraps the result in literal quotes, we just want the actual returned result
-			//note that if the js function returns the string "null" we will get here and not above
-			else if (result != null)
-			{
-				result = result.Trim('"');
-			}
-
-			request.SetResult(result!);
-
 		}
 #endif
 


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

In `HybridWebViewHandler.cs`, `MapEvaluateJavaScriptAsync` had no `try/catch`. If the inner `await innerRequest.Task` faulted (JS engine error, cancellation, etc.), the outer `EvaluateJavaScriptAsyncRequest` TaskCompletionSource was never given a result, exception, or cancellation — any caller awaiting `request.Task` would hang indefinitely.

The sibling method `MapInvokeJavaScriptAsync` already has the correct pattern: it wraps the body in `try/catch` and calls `invokeJavaScriptRequest.SetException(ex)` on failure.

## Changes

- Wrap the body of `MapEvaluateJavaScriptAsync` (after the early-return guards) in `try { } catch (Exception ex) { request.SetException(ex); }`, mirroring the `MapInvokeJavaScriptAsync` pattern.

## Files Changed

- `src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.cs`