### PR TITLE
[iOS/Mac] Fix Entry clear button retaining tint color after TextColor is reset to null

### DIFF
--- a/src/Core/src/Platform/iOS/TextFieldExtensions.cs
+++ b/src/Core/src/Platform/iOS/TextFieldExtensions.cs
@@ -231,17 +231,25 @@ namespace Microsoft.Maui.Platform
 				{
 					// Setting TintColor to null allows the system to automatically apply the appropriate color based on the current theme (light or dark mode)
 					clearButton.TintColor = null;
+					// SetImage(null) releases the custom tinted bitmap so UIKit restores its system default.
+					// The color path (else branch) reads ImageForState(.Highlighted) to get that original
+					// image as the source for tinting. Without these calls, TintColor=null has no visual effect.
 					clearButton.SetImage(null, UIControlState.Normal);
 					clearButton.SetImage(null, UIControlState.Highlighted);
 				}
 				else
 				{
+					// On a null→color transition, UIKit restores the system image after SetImage(null),
+					// so ImageForState(Highlighted) returns the system clear button image as the tinting source.
 					UIImage? defaultClearImage = clearButton.ImageForState(UIControlState.Highlighted);
 					clearButton.TintColor = entry.TextColor.ToPlatform();
 
 					var tintedClearImage = GetClearButtonTintImage(defaultClearImage, entry.TextColor.ToPlatform());
-					clearButton.SetImage(tintedClearImage, UIControlState.Normal);
-					clearButton.SetImage(tintedClearImage, UIControlState.Highlighted);
+					if (tintedClearImage is not null)
+					{
+						clearButton.SetImage(tintedClearImage, UIControlState.Normal);
+						clearButton.SetImage(tintedClearImage, UIControlState.Highlighted);
+					}
 				}
 			}
 		}

--- a/src/Core/src/Platform/iOS/TextFieldExtensions.cs
+++ b/src/Core/src/Platform/iOS/TextFieldExtensions.cs
@@ -227,8 +227,6 @@ namespace Microsoft.Maui.Platform
 		{
 			if (textField.ValueForKey(new NSString("clearButton")) is UIButton clearButton)
 			{
-				UIImage? defaultClearImage = clearButton.ImageForState(UIControlState.Highlighted);
-
 				if (entry.TextColor is null)
 				{
 					// Setting TintColor to null allows the system to automatically apply the appropriate color based on the current theme (light or dark mode)
@@ -238,6 +236,7 @@ namespace Microsoft.Maui.Platform
 				}
 				else
 				{
+					UIImage? defaultClearImage = clearButton.ImageForState(UIControlState.Highlighted);
 					clearButton.TintColor = entry.TextColor.ToPlatform();
 
 					var tintedClearImage = GetClearButtonTintImage(defaultClearImage, entry.TextColor.ToPlatform());

--- a/src/Core/src/Platform/iOS/TextFieldExtensions.cs
+++ b/src/Core/src/Platform/iOS/TextFieldExtensions.cs
@@ -227,7 +227,7 @@ namespace Microsoft.Maui.Platform
 		{
 			if (textField.ValueForKey(new NSString("clearButton")) is UIButton clearButton)
 			{
-				UIImage defaultClearImage = clearButton.ImageForState(UIControlState.Highlighted);
+				UIImage? defaultClearImage = clearButton.ImageForState(UIControlState.Highlighted);
 
 				if (entry.TextColor is null)
 				{
@@ -247,8 +247,13 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		internal static UIImage? GetClearButtonTintImage(UIImage image, UIColor color)
+		internal static UIImage? GetClearButtonTintImage(UIImage? image, UIColor color)
 		{
+			if (image is null)
+			{
+				return null;
+			}
+
 			var size = image.Size;
 
 			var renderer = new UIGraphicsImageRenderer(size, new UIGraphicsImageRendererFormat()

--- a/src/Core/src/Platform/iOS/TextFieldExtensions.cs
+++ b/src/Core/src/Platform/iOS/TextFieldExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.CompilerServices;
 using CoreGraphics;
 using Foundation;
 using Microsoft.Maui.Graphics;
@@ -10,8 +9,6 @@ namespace Microsoft.Maui.Platform
 {
 	public static class TextFieldExtensions
 	{
-		static readonly ConditionalWeakTable<UITextField, UIImage> s_defaultClearButtonImages = new();
-
 		public static void UpdateText(this UITextField textField, IEntry entry)
 		{
 			textField.Text = entry.Text;
@@ -230,46 +227,24 @@ namespace Microsoft.Maui.Platform
 		{
 			if (textField.ValueForKey(new NSString("clearButton")) is UIButton clearButton)
 			{
-				var defaultClearImage = GetDefaultClearButtonImage(textField, clearButton);
-
-				if (defaultClearImage is null)
-				{
-					return;
-				}
+				UIImage defaultClearImage = clearButton.ImageForState(UIControlState.Highlighted);
 
 				if (entry.TextColor is null)
 				{
 					// Setting TintColor to null allows the system to automatically apply the appropriate color based on the current theme (light or dark mode)
 					clearButton.TintColor = null;
-					clearButton.SetImage(defaultClearImage, UIControlState.Normal);
-					clearButton.SetImage(defaultClearImage, UIControlState.Highlighted);
+					clearButton.SetImage(null, UIControlState.Normal);
+					clearButton.SetImage(null, UIControlState.Highlighted);
 				}
 				else
 				{
-					var textColor = entry.TextColor.ToPlatform();
-					clearButton.TintColor = textColor;
+					clearButton.TintColor = entry.TextColor.ToPlatform();
 
-					var tintedClearImage = GetClearButtonTintImage(defaultClearImage, textColor);
+					var tintedClearImage = GetClearButtonTintImage(defaultClearImage, entry.TextColor.ToPlatform());
 					clearButton.SetImage(tintedClearImage, UIControlState.Normal);
 					clearButton.SetImage(tintedClearImage, UIControlState.Highlighted);
 				}
 			}
-		}
-
-		static UIImage? GetDefaultClearButtonImage(UITextField textField, UIButton clearButton)
-		{
-			if (s_defaultClearButtonImages.TryGetValue(textField, out var defaultImage))
-			{
-				return defaultImage;
-			}
-
-			defaultImage = clearButton.ImageForState(UIControlState.Normal)
-				?? clearButton.ImageForState(UIControlState.Highlighted);
-
-			if (defaultImage is not null)
-				s_defaultClearButtonImages.Add(textField, defaultImage);
-
-			return defaultImage;
 		}
 
 		internal static UIImage? GetClearButtonTintImage(UIImage image, UIColor color)

--- a/src/Core/src/Platform/iOS/TextFieldExtensions.cs
+++ b/src/Core/src/Platform/iOS/TextFieldExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using CoreGraphics;
 using Foundation;
 using Microsoft.Maui.Graphics;
@@ -9,6 +10,8 @@ namespace Microsoft.Maui.Platform
 {
 	public static class TextFieldExtensions
 	{
+		static readonly ConditionalWeakTable<UITextField, UIImage> s_defaultClearButtonImages = new();
+
 		public static void UpdateText(this UITextField textField, IEntry entry)
 		{
 			textField.Text = entry.Text;
@@ -227,22 +230,46 @@ namespace Microsoft.Maui.Platform
 		{
 			if (textField.ValueForKey(new NSString("clearButton")) is UIButton clearButton)
 			{
-				UIImage defaultClearImage = clearButton.ImageForState(UIControlState.Highlighted);
+				var defaultClearImage = GetDefaultClearButtonImage(textField, clearButton);
+
+				if (defaultClearImage is null)
+				{
+					return;
+				}
 
 				if (entry.TextColor is null)
 				{
 					// Setting TintColor to null allows the system to automatically apply the appropriate color based on the current theme (light or dark mode)
 					clearButton.TintColor = null;
+					clearButton.SetImage(defaultClearImage, UIControlState.Normal);
+					clearButton.SetImage(defaultClearImage, UIControlState.Highlighted);
 				}
 				else
 				{
-					clearButton.TintColor = entry.TextColor.ToPlatform();
+					var textColor = entry.TextColor.ToPlatform();
+					clearButton.TintColor = textColor;
 
-					var tintedClearImage = GetClearButtonTintImage(defaultClearImage, entry.TextColor.ToPlatform());
+					var tintedClearImage = GetClearButtonTintImage(defaultClearImage, textColor);
 					clearButton.SetImage(tintedClearImage, UIControlState.Normal);
 					clearButton.SetImage(tintedClearImage, UIControlState.Highlighted);
 				}
 			}
+		}
+
+		static UIImage? GetDefaultClearButtonImage(UITextField textField, UIButton clearButton)
+		{
+			if (s_defaultClearButtonImages.TryGetValue(textField, out var defaultImage))
+			{
+				return defaultImage;
+			}
+
+			defaultImage = clearButton.ImageForState(UIControlState.Normal)
+				?? clearButton.ImageForState(UIControlState.Highlighted);
+
+			if (defaultImage is not null)
+				s_defaultClearButtonImages.Add(textField, defaultImage);
+
+			return defaultImage;
 		}
 
 		internal static UIImage? GetClearButtonTintImage(UIImage image, UIColor color)

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
@@ -106,45 +106,29 @@ namespace Microsoft.Maui.DeviceTests
 			await AttachAndRun(entry, async (handler) =>
 			{
 				await AssertEventually(() => handler.PlatformView.IsLoaded());
-				handler.PlatformView.BecomeFirstResponder();
+				Assert.True(handler.PlatformView.BecomeFirstResponder());
+				await AssertEventually(() => handler.PlatformView.IsFirstResponder);
 
 				var clearButton = GetNativeClearButton(handler);
 				Assert.NotNull(clearButton);
 
-				// Use ImageView.Image — reflects the actual displayed image (SetImage calls),
-				// unlike ImageForState which returns UIKit's internal cached value for this private button.
-				var defaultImage = clearButton.ImageView is not null
-					? clearButton.ImageView.Image
-					: clearButton.ImageForState(UIControlState.Highlighted);
+				var defaultImage = clearButton.ImageForState(UIControlState.Normal);
 				Assert.NotNull(defaultImage);
+				Assert.Equal(UIImageRenderingMode.AlwaysOriginal, defaultImage.RenderingMode);
 
-				// Apply purple text color — clear button should switch to the tinted (baked-in) image.
 				entry.TextColor = Colors.Purple;
 				handler.UpdateValue(nameof(IEntry.TextColor));
 
-				var tintedImage = clearButton.ImageView is not null
-					? clearButton.ImageView.Image
-					: clearButton.ImageForState(UIControlState.Highlighted);
+				var tintedImage = clearButton.ImageForState(UIControlState.Normal);
 				Assert.NotNull(tintedImage);
+				Assert.Equal(UIImageRenderingMode.Automatic, tintedImage.RenderingMode);
 
-				// Guard: tinting must have changed the underlying bitmap, otherwise the final assertion would
-				// be vacuously true.  CGImage.Handle compares the native Core Graphics object pointer, which
-				// is stable even when UIKit wraps the same native image in different managed objects.
-				Assert.NotEqual(defaultImage.CGImage?.Handle, tintedImage.CGImage?.Handle);
-
-				// Reset TextColor to null — without the fix the tinted image stays; with the fix it restores.
 				entry.TextColor = null;
 				handler.UpdateValue(nameof(IEntry.TextColor));
-				
-				var resetImage = clearButton.ImageView is not null
-					? clearButton.ImageView.Image
-					: clearButton.ImageForState(UIControlState.Highlighted);
-				Assert.NotNull(resetImage);
 
-				// Core assertion: the original default image's underlying CGImage must be restored.
-				// UIImage pointer identity (Handle) is unreliable after SetImage()/ImageView.Image
-				// round-trips — UIKit may vend a different managed wrapper for the same native object.
-				Assert.Equal(defaultImage.CGImage?.Handle, resetImage.CGImage?.Handle);
+				var resetImage = clearButton.ImageForState(UIControlState.Normal);
+				Assert.NotNull(resetImage);
+				Assert.Equal(UIImageRenderingMode.AlwaysOriginal, resetImage.RenderingMode);
 			});
 		}
 

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
@@ -126,9 +126,20 @@ namespace Microsoft.Maui.DeviceTests
 				entry.TextColor = null;
 				handler.UpdateValue(nameof(IEntry.TextColor));
 
+				// UIKit restores the original AlwaysOriginal system image when SetImage(null) is called
+				// on this private clearButton — ImageForState(.Highlighted) must return non-null for re-tinting to work.
 				var resetImage = clearButton.ImageForState(UIControlState.Normal);
 				Assert.NotNull(resetImage);
 				Assert.Equal(UIImageRenderingMode.AlwaysOriginal, resetImage.RenderingMode);
+
+				entry.TextColor = Colors.Blue;
+				handler.UpdateValue(nameof(IEntry.TextColor));
+
+				// Verify re-tinting works after reset (null→color→null→color)
+				// Confirms ImageForState(.Highlighted) returns the original after SetImage(null)
+				var retintedImage = clearButton.ImageForState(UIControlState.Normal);
+				Assert.NotNull(retintedImage);
+				Assert.Equal(UIImageRenderingMode.Automatic, retintedImage.RenderingMode);
 			});
 		}
 

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
@@ -93,6 +93,61 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(xplatCharacterSpacing, values.PlatformViewValue);
 		}
 
+		[Fact(DisplayName = "Clear button image resets when TextColor is null")]
+		public async Task ClearButtonImageResetsWhenTextColorIsNull()
+		{
+			EntryStub entry = new EntryStub
+			{
+				Text = "MAUI",
+				ClearButtonVisibility = ClearButtonVisibility.WhileEditing,
+				TextColor = null
+			};
+
+			await AttachAndRun(entry, async (handler) =>
+			{
+				await AssertEventually(() => handler.PlatformView.IsLoaded());
+				handler.PlatformView.BecomeFirstResponder();
+
+				var clearButton = GetNativeClearButton(handler);
+				Assert.NotNull(clearButton);
+
+				// Use ImageView.Image — reflects the actual displayed image (SetImage calls),
+				// unlike ImageForState which returns UIKit's internal cached value for this private button.
+				var defaultImage = clearButton.ImageView is not null
+					? clearButton.ImageView.Image
+					: clearButton.ImageForState(UIControlState.Highlighted);
+				Assert.NotNull(defaultImage);
+
+				// Apply purple text color — clear button should switch to the tinted (baked-in) image.
+				entry.TextColor = Colors.Purple;
+				handler.UpdateValue(nameof(IEntry.TextColor));
+
+				var tintedImage = clearButton.ImageView is not null
+					? clearButton.ImageView.Image
+					: clearButton.ImageForState(UIControlState.Highlighted);
+				Assert.NotNull(tintedImage);
+
+				// Guard: tinting must have changed the underlying bitmap, otherwise the final assertion would
+				// be vacuously true.  CGImage.Handle compares the native Core Graphics object pointer, which
+				// is stable even when UIKit wraps the same native image in different managed objects.
+				Assert.NotEqual(defaultImage.CGImage?.Handle, tintedImage.CGImage?.Handle);
+
+				// Reset TextColor to null — without the fix the tinted image stays; with the fix it restores.
+				entry.TextColor = null;
+				handler.UpdateValue(nameof(IEntry.TextColor));
+				
+				var resetImage = clearButton.ImageView is not null
+					? clearButton.ImageView.Image
+					: clearButton.ImageForState(UIControlState.Highlighted);
+				Assert.NotNull(resetImage);
+
+				// Core assertion: the original default image's underlying CGImage must be restored.
+				// UIImage pointer identity (Handle) is unreliable after SetImage()/ImageView.Image
+				// round-trips — UIKit may vend a different managed wrapper for the same native object.
+				Assert.Equal(defaultImage.CGImage?.Handle, resetImage.CGImage?.Handle);
+			});
+		}
+
 		[Fact]
 		public async Task NextMovesToNextEntry()
 		{
@@ -831,6 +886,9 @@ namespace Microsoft.Maui.DeviceTests
 
 		bool GetNativeClearButtonVisibility(EntryHandler entryHandler) =>
 			GetNativeEntry(entryHandler).ClearButtonMode == UITextFieldViewMode.WhileEditing;
+
+		static UIButton GetNativeClearButton(EntryHandler entryHandler) =>
+			GetNativeEntry(entryHandler).ValueForKey(new NSString("clearButton")) as UIButton;
 
 		UITextAlignment GetNativeHorizontalTextAlignment(EntryHandler entryHandler) =>
 			GetNativeEntry(entryHandler).TextAlignment;


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
- When the TextColor of the Entry control is set to a custom color, both the text and the Clear button update accordingly. However, when the TextColor is reset to null, only the text color reverts to the default, while the Clear button continues to display the previously applied color on iOS and Mac platform. This indicates that the Clear button is not properly restoring its default appearance when the TextColor property is cleared.

### Root Cause

- When TextColor was reset to null, TintColor was correctly cleared — but the tinted bitmap previously pinned via SetImage() remained in place. UIKit never regained ownership of the clear button image because SetImage(null) was never called, leaving the stale tinted image visible regardless of theme.

### Description of Change

- In UpdateClearButtonColor, added SetImage(null) for both Normal and Highlighted states in the null path, so UIKit reclaims the clear button image and automatically applies the correct system image for the current light/dark theme.
- Added a null guard (if (image is null) return null) in GetClearButtonTintImage and updated the parameter to UIImage? as a defensive measure.

### Issues Fixed
Fixes #35076

### Validated the behaviour in the following platforms

- [ ] Windows
- [ ] Android
- [x] iOS
- [x] Mac

### Output
| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/1d78ecaf-e062-45f5-baa4-b5a63ecf6cfd"> | <video src="https://github.com/user-attachments/assets/0e2afb20-774a-45d1-a6d1-9396f700e7f3"> |