### PR TITLE
Fix DragGestureRecognizer.DropCompleted event not firing in Android platform

### DIFF
--- a/src/Compatibility/Core/src/Android/DragAndDropGestureHandler.cs
+++ b/src/Compatibility/Core/src/Android/DragAndDropGestureHandler.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 		public void SetupHandlerForDrop()
 		{
-			if (HasAnyDropGestures() || HasAnyDragGestures())
+			if (HasAnyDropGestures())
 				GetControl()?.SetOnDragListener(this);
 			else
 				GetControl()?.SetOnDragListener(null);

--- a/src/Compatibility/Core/src/Android/DragAndDropGestureHandler.cs
+++ b/src/Compatibility/Core/src/Android/DragAndDropGestureHandler.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 		public void SetupHandlerForDrop()
 		{
-			if (HasAnyDropGestures())
+			if (HasAnyDropGestures() || HasAnyDragGestures())
 				GetControl()?.SetOnDragListener(this);
 			else
 				GetControl()?.SetOnDragListener(null);

--- a/src/Controls/src/Core/Platform/Android/DragAndDropGestureHandler.cs
+++ b/src/Controls/src/Core/Platform/Android/DragAndDropGestureHandler.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 		public void SetupHandlerForDrop()
 		{
-			if (HasAnyDropGestures() || HasAnyDragGestures())
+			if (HasAnyDropGestures())
 				GetControl()?.SetOnDragListener(this);
 			else
 				GetControl()?.SetOnDragListener(null);
@@ -131,11 +131,24 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				case DragAction.Ended:
 					{
-						_currentCustomLocalStateData = null;
-						if (dragSourceElement is View vSource)
-						{
-							HandleDropCompleted(vSource, new PlatformDropCompletedEventArgs(v, e));
-						}
+							// DragAction.Ended may be raised by a non-source view on Android.
+							// Always target the actual drag source recognizer, but only once per drag.
+							if (dragSourceElement is View vSource && !localStateData.DropCompletedSent)
+							{
+								HandleDropCompleted(vSource, new PlatformDropCompletedEventArgs(v, e));
+								localStateData.DropCompletedSent = true;
+							}
+
+							// Unregister temporary source listener when the source view receives Ended.
+							if (dragSourceElement is View sourceView && GetView() == sourceView)
+							{
+								if (!HasAnyDropGestures())
+								{
+									GetControl()?.SetOnDragListener(null);
+								}
+							}
+
+							_currentCustomLocalStateData = null;
 					}
 					break;
 				case DragAction.Started:
@@ -348,6 +361,14 @@ namespace Microsoft.Maui.Controls.Platform
 				else
 					dragFlags = 256 | 1; // use the value of enums since the enums are not supported here
 
+				// Register as OnDragListener BEFORE starting the drag so that this view receives
+				// DragAction.Ended and can fire DropCompleted. Only needed for drag-source-only
+				// views (no DropGestureRecognizer) since drop targets are already registered via
+				// SetupHandlerForDrop. Registering here (not in SetupHandlerForDrop) ensures
+				// sibling labels don't intercept drop events intended for the parent drop target.
+				if (!HasAnyDropGestures())
+					GetControl()?.SetOnDragListener(this);
+
 				if (OperatingSystem.IsAndroidVersionAtLeast(24))
 					v.StartDragAndDrop(data, dragShadowBuilder, localData, dragFlags);
 				else
@@ -382,6 +403,7 @@ namespace Microsoft.Maui.Controls.Platform
 			public DataPackage DataPackage { get; set; }
 			public DataPackageOperation AcceptedOperation { get; set; } = DataPackageOperation.Copy;
 			public VisualElement SourceElement { get; set; }
+			public bool DropCompletedSent { get; set; }
 		}
 	}
 }

--- a/src/Controls/src/Core/Platform/Android/DragAndDropGestureHandler.cs
+++ b/src/Controls/src/Core/Platform/Android/DragAndDropGestureHandler.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 		public void SetupHandlerForDrop()
 		{
-			if (HasAnyDropGestures())
+			if (HasAnyDropGestures() || HasAnyDragGestures())
 				GetControl()?.SetOnDragListener(this);
 			else
 				GetControl()?.SetOnDragListener(null);

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue17554.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue17554.cs
@@ -1,0 +1,50 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 17554, "[Android] DragGestureRecognizer.DropCompleted event not firing", PlatformAffected.Android)]
+public class Issue17554 : ContentPage
+{
+	public Issue17554()
+	{
+		var statusLabel = new Label
+		{
+			AutomationId = "StatusLabel",
+			Text = "No events fired"
+		};
+
+		var dragSource = new Label
+		{
+			Text = "Drag Me",
+			AutomationId = "DragSource",
+			BackgroundColor = Colors.LightBlue,
+			HeightRequest = 100,
+			WidthRequest = 200,
+			HorizontalTextAlignment = TextAlignment.Center,
+			VerticalTextAlignment = TextAlignment.Center
+		};
+
+		var dragGesture = new DragGestureRecognizer();
+		dragGesture.DragStarting += (s, e) => statusLabel.Text = "DragStarting";
+		dragGesture.DropCompleted += (s, e) => statusLabel.Text = "DropCompleted";
+		dragSource.GestureRecognizers.Add(dragGesture);
+
+		// This is intentionally a plain view with NO DropGestureRecognizer,
+		// which is the scenario where Android fails to fire DropCompleted.
+		var nonDropTarget = new Label
+		{
+			Text = "Drop here (no drop target)",
+			AutomationId = "NonDropTarget",
+			BackgroundColor = Colors.LightGray,
+			HeightRequest = 100,
+			WidthRequest = 200,
+			HorizontalTextAlignment = TextAlignment.Center,
+			VerticalTextAlignment = TextAlignment.Center
+		};
+
+		Content = new VerticalStackLayout
+		{
+			Padding = 20,
+			Spacing = 20,
+			Children = { dragSource, nonDropTarget, statusLabel }
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue17554.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue17554.cs
@@ -1,0 +1,23 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+[Category(UITestCategories.DragAndDrop)]
+public class Issue17554 : _IssuesUITest
+{
+	public Issue17554(TestDevice testDevice) : base(testDevice) { }
+
+	public override string Issue => "[Android] DragGestureRecognizer.DropCompleted event not firing";
+
+	[Test]
+	public void DropCompletedFiresWhenDroppingOnNonDropTarget()
+	{
+		App.WaitForElement("DragSource");
+		App.WaitForElement("NonDropTarget");
+
+		App.DragAndDrop("DragSource", "NonDropTarget");
+		App.WaitForElement("DropCompleted");
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details:

DragGestureRecognizer.DropCompleted event not firing in Android platform
       
### Root Cause:

DragAndDropGestureHandler.SetupHandlerForDrop() only called SetOnDragListener(this) when the view had a DropGestureRecognizer. On Android, DragAction.Ended is only delivered to views that have a drag listener registered. A view with only a DragGestureRecognizer (no DropGestureRecognizer) never registered a listener → never received DragAction.Ended → HandleDropCompleted never called → DropCompleted event never fired.

### Description of Change:

 The fix is in src/Controls/src/Core/Platform/Android/DragAndDropGestureHandler.cs. Modified the listener registration for drag-source-only views (those with no DropGestureRecognizer) is now done just before StartDragAndDrop() is called, scoping it to the active drag and preventing sibling views in the same layout from accidentally becoming drag listeners. In the DragAction.Ended handler, the fix always dispatches DropCompleted to the tracked dragSourceElement regardless of which view received the event — since on Android, DragAction.Ended can arrive on a non-source view first. A one-shot DropCompletedSent flag on the local drag state prevents the event from firing more than once. Once the source view receives DragAction.Ended, the temporary listener is unregistered to restore the original state.

**Tested the behavior in the following platforms: **

- [x] Android
- [ ] Windows
- [ ] iOS
- [ ] Mac

### Reference:

N/A

### Issues Fixed:

Fixes  #17554          

### Screenshots
| Before  | After  |
|---------|--------|
| <Video width="300" height="600"  src="https://github.com/user-attachments/assets/243dec05-a560-4d26-87dd-cb6e8b99ab27" /> | <Video width="300" height="600" src="https://github.com/user-attachments/assets/3137deb3-4f45-476e-8e96-15661609c546" /> |