### PR TITLE
Security: Remove hardcoded Bing Maps API key from Geocoding tests and sample

### DIFF
--- a/src/Essentials/samples/Samples/Startup.cs
+++ b/src/Essentials/samples/Samples/Startup.cs
@@ -21,8 +21,16 @@ namespace Samples
 					essentials.UseVersionTracking();
 #if WINDOWS
 					var mapToken = Environment.GetEnvironmentVariable("BING_MAPS_API_KEY");
-					if (!string.IsNullOrEmpty(mapToken))
+					if (!string.IsNullOrWhiteSpace(mapToken))
+					{
 						essentials.UseMapServiceToken(mapToken);
+					}
+					else
+					{
+						// Windows Maps/Geocoding requires a map service token. Set the
+						// BING_MAPS_API_KEY environment variable before running the sample.
+						Console.WriteLine("BING_MAPS_API_KEY is not set. Windows Maps/Geocoding features in this sample require a valid map service token.");
+					}
 #endif
 					essentials.AddAppAction("app_info", "App Info", icon: "app_info_action_icon");
 					essentials.AddAppAction("battery_info", "Battery Info");

--- a/src/Essentials/samples/Samples/Startup.cs
+++ b/src/Essentials/samples/Samples/Startup.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls.Compatibility;
 using Microsoft.Maui.Controls.Hosting;
@@ -19,7 +20,9 @@ namespace Samples
 				{
 					essentials.UseVersionTracking();
 #if WINDOWS
-					essentials.UseMapServiceToken("RJHqIE53Onrqons5CNOx~FrDr3XhjDTyEXEjng-CRoA~Aj69MhNManYUKxo6QcwZ0wmXBtyva0zwuHB04rFYAPf7qqGJ5cHb03RCDw1jIW8l");
+					var mapToken = Environment.GetEnvironmentVariable("BING_MAPS_API_KEY");
+					if (!string.IsNullOrEmpty(mapToken))
+						essentials.UseMapServiceToken(mapToken);
 #endif
 					essentials.AddAppAction("app_info", "App Info", icon: "app_info_action_icon");
 					essentials.AddAppAction("battery_info", "Battery Info");

--- a/src/Essentials/test/DeviceTests/Tests/Geocoding_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Geocoding_Tests.cs
@@ -12,7 +12,9 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		public Geocoding_Tests()
 		{
 #if WINDOWS_UWP || WINDOWS
-			ApplicationModel.Platform.MapServiceToken = "RJHqIE53Onrqons5CNOx~FrDr3XhjDTyEXEjng-CRoA~Aj69MhNManYUKxo6QcwZ0wmXBtyva0zwuHB04rFYAPf7qqGJ5cHb03RCDw1jIW8l";
+			var mapToken = Environment.GetEnvironmentVariable("BING_MAPS_API_KEY");
+			if (!string.IsNullOrEmpty(mapToken))
+				ApplicationModel.Platform.MapServiceToken = mapToken;
 #endif
 		}
 

--- a/src/Essentials/test/DeviceTests/Tests/Geocoding_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Geocoding_Tests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		{
 #if WINDOWS_UWP || WINDOWS
 			var mapToken = Environment.GetEnvironmentVariable("BING_MAPS_API_KEY");
-			if (!string.IsNullOrEmpty(mapToken))
+			if (!string.IsNullOrWhiteSpace(mapToken))
 				ApplicationModel.Platform.MapServiceToken = mapToken;
 #endif
 		}


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

**Security fix**: Remove the hardcoded Bing Maps API key from test and sample code.

- `src/Essentials/test/DeviceTests/Tests/Geocoding_Tests.cs`: Replace hardcoded key with `Environment.GetEnvironmentVariable("BING_MAPS_API_KEY")`
- `src/Essentials/samples/Samples/Startup.cs`: Use env var instead of literal key

The hardcoded key was committed in plain text. Moving to an environment variable prevents accidental key exposure in forks and CI logs.