### PR TITLE
Fix: Wrap LoadHtml/LoadUrl async void in try/catch on Windows WebView

### DIFF
--- a/src/Core/src/Platform/Windows/MauiWebView.cs
+++ b/src/Core/src/Platform/Windows/MauiWebView.cs
@@ -46,58 +46,65 @@ namespace Microsoft.Maui.Platform
 
 		public async void LoadHtml(string? html, string? baseUrl)
 		{
-			var mapBaseDirectory = false;
-			if (string.IsNullOrEmpty(baseUrl))
+			try
 			{
-				baseUrl = LocalScheme;
-				mapBaseDirectory = true;
+				var mapBaseDirectory = false;
+				if (string.IsNullOrEmpty(baseUrl))
+				{
+					baseUrl = LocalScheme;
+					mapBaseDirectory = true;
+				}
+
+				await EnsureCoreWebView2Async();
+
+				if (mapBaseDirectory)
+				{
+					CoreWebView2.SetVirtualHostNameToFolderMapping(
+						LocalHostName,
+						ApplicationPath,
+						Web.WebView2.Core.CoreWebView2HostResourceAccessKind.Allow);
+				}
+
+				// Insert script to set the base tag
+				var script = GetBaseTagInsertionScript(baseUrl);
+				var htmlWithScript = $"{script}\n{html}";
+
+				NavigateToString(htmlWithScript);
 			}
-
-			await EnsureCoreWebView2Async();
-
-			if (mapBaseDirectory)
+			catch (Exception ex)
 			{
-				CoreWebView2.SetVirtualHostNameToFolderMapping(
-					LocalHostName,
-					ApplicationPath,
-					Web.WebView2.Core.CoreWebView2HostResourceAccessKind.Allow);
+				Debug.WriteLine(nameof(MauiWebView), $"Failed to load HTML: {ex}");
 			}
-
-			// Insert script to set the base tag
-			var script = GetBaseTagInsertionScript(baseUrl);
-			var htmlWithScript = $"{script}\n{html}";
-
-			NavigateToString(htmlWithScript);
 		}
 
 		public async void LoadUrl(string? url)
 		{
-			Uri uri = new Uri(url ?? string.Empty, UriKind.RelativeOrAbsolute);
-
-			if (!uri.IsAbsoluteUri ||
-				IsUriWithLocalScheme(uri.AbsoluteUri))
-			{
-				await EnsureCoreWebView2Async();
-
-				CoreWebView2.SetVirtualHostNameToFolderMapping(
-					LocalHostName,
-					ApplicationPath,
-					Web.WebView2.Core.CoreWebView2HostResourceAccessKind.Allow);
-
-				if (!uri.IsAbsoluteUri)
-					uri = new Uri(LocalScheme + url, UriKind.RelativeOrAbsolute);
-			}
-
-			if (_handler?.TryGetTarget(out var handler) ?? false)
-				await handler.SyncPlatformCookies(uri.AbsoluteUri);
-
 			try
 			{
+				Uri uri = new Uri(url ?? string.Empty, UriKind.RelativeOrAbsolute);
+
+				if (!uri.IsAbsoluteUri ||
+					IsUriWithLocalScheme(uri.AbsoluteUri))
+				{
+					await EnsureCoreWebView2Async();
+
+					CoreWebView2.SetVirtualHostNameToFolderMapping(
+						LocalHostName,
+						ApplicationPath,
+						Web.WebView2.Core.CoreWebView2HostResourceAccessKind.Allow);
+
+					if (!uri.IsAbsoluteUri)
+						uri = new Uri(LocalScheme + url, UriKind.RelativeOrAbsolute);
+				}
+
+				if (_handler?.TryGetTarget(out var handler) ?? false)
+					await handler.SyncPlatformCookies(uri.AbsoluteUri);
+
 				Source = uri;
 			}
 			catch (Exception exc)
 			{
-				Debug.WriteLine(nameof(MauiWebView), $"Failed to load: {uri} {exc}");
+				Debug.WriteLine(nameof(MauiWebView), $"Failed to load: {url} {exc}");
 			}
 		}
 

--- a/src/Core/src/Platform/Windows/MauiWebView.cs
+++ b/src/Core/src/Platform/Windows/MauiWebView.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Text;
+using Microsoft.Extensions.Logging;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.UI.Xaml.Controls;
 using Windows.ApplicationModel;
@@ -73,7 +73,8 @@ namespace Microsoft.Maui.Platform
 			}
 			catch (Exception ex)
 			{
-				Debug.WriteLine(nameof(MauiWebView), $"Failed to load HTML: {ex}");
+				if (_handler?.TryGetTarget(out var handler) ?? false)
+					handler.MauiContext?.CreateLogger<MauiWebView>()?.LogWarning(ex, "Failed to load HTML");
 			}
 		}
 
@@ -104,7 +105,8 @@ namespace Microsoft.Maui.Platform
 			}
 			catch (Exception exc)
 			{
-				Debug.WriteLine(nameof(MauiWebView), $"Failed to load: {url} {exc}");
+				if (_handler?.TryGetTarget(out var handler) ?? false)
+					handler.MauiContext?.CreateLogger<MauiWebView>()?.LogWarning(exc, "Unable to Load Url {url}", url);
 			}
 		}
 


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

Wrap the `LoadHtml` and `LoadUrl` `async void` event handlers in `MauiWebView.cs` (Windows) with `try/catch` blocks.

`async void` methods that throw will crash the process because the exception has nowhere to propagate. Catching the exception and logging it instead makes the failure observable without crashing.

**Note**: This change is Windows-only (`src/Core/src/Platform/Windows/MauiWebView.cs`). Compile verification on macOS was skipped; CI will verify the Windows build.