### PR TITLE
Fix: Prevent permanently hung TaskCompletionSource in MapEvaluateJavaScriptAsync

### DIFF
--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.cs
@@ -393,42 +393,49 @@ namespace Microsoft.Maui.Handlers
 				return;
 			}
 
-			var script = request.Script;
-			// Make all the platforms mimic Android's implementation, which is by far the most complete.
-			if (!OperatingSystem.IsAndroid())
+			try
 			{
-				script = WebViewHelper.EscapeJsString(script);
-
-				if (!OperatingSystem.IsWindows())
+				var script = request.Script;
+				// Make all the platforms mimic Android's implementation, which is by far the most complete.
+				if (!OperatingSystem.IsAndroid())
 				{
-					// Use JSON.stringify() method to converts a JavaScript value to a JSON string
-					script = "try{JSON.stringify(eval('" + script + "'))}catch(e){'null'};";
+					script = WebViewHelper.EscapeJsString(script);
+
+					if (!OperatingSystem.IsWindows())
+					{
+						// Use JSON.stringify() method to converts a JavaScript value to a JSON string
+						script = "try{JSON.stringify(eval('" + script + "'))}catch(e){'null'};";
+					}
+					else
+					{
+						script = "try{eval('" + script + "')}catch(e){'null'};";
+					}
 				}
-				else
+
+				// Use the handler command to evaluate the JS
+				var innerRequest = new EvaluateJavaScriptAsyncRequest(script);
+				EvaluateJavaScript(handler, hybridWebView, innerRequest);
+
+				var result = await innerRequest.Task;
+
+				//if the js function errored or returned null/undefined treat it as null
+				if (result == "null")
 				{
-					script = "try{eval('" + script + "')}catch(e){'null'};";
+					result = null;
 				}
+				//JSON.stringify wraps the result in literal quotes, we just want the actual returned result
+				//note that if the js function returns the string "null" we will get here and not above
+				else if (result != null)
+				{
+					result = result.Trim('"');
+				}
+
+				request.SetResult(result!);
 			}
-
-			// Use the handler command to evaluate the JS
-			var innerRequest = new EvaluateJavaScriptAsyncRequest(script);
-			EvaluateJavaScript(handler, hybridWebView, innerRequest);
-
-			var result = await innerRequest.Task;
-
-			//if the js function errored or returned null/undefined treat it as null
-			if (result == "null")
+			catch (Exception ex)
 			{
-				result = null;
+				request.SetException(ex);
 			}
-			//JSON.stringify wraps the result in literal quotes, we just want the actual returned result
-			//note that if the js function returns the string "null" we will get here and not above
-			else if (result != null)
-			{
-				result = result.Trim('"');
-			}
-
-			request.SetResult(result!);
 
 		}
 #endif

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.cs
@@ -381,14 +381,15 @@ namespace Microsoft.Maui.Handlers
 #if PLATFORM && !TIZEN
 		public static async void MapEvaluateJavaScriptAsync(IHybridWebViewHandler handler, IHybridWebView hybridWebView, object? arg)
 		{
-			if (arg is not EvaluateJavaScriptAsyncRequest request ||
-				handler.PlatformView is not MauiHybridWebView hybridPlatformWebView)
+			if (arg is not EvaluateJavaScriptAsyncRequest request)
 			{
 				return;
 			}
 
-			if (handler.PlatformView is null)
+			if (handler.PlatformView is not MauiHybridWebView hybridPlatformWebView)
 			{
+				// PlatformView is not available (e.g. handler was disconnected or never connected to the
+				// expected platform view). Cancel the request so the caller's await does not hang forever.
 				request.SetCanceled();
 				return;
 			}
@@ -416,6 +417,12 @@ namespace Microsoft.Maui.Handlers
 				var innerRequest = new EvaluateJavaScriptAsyncRequest(script);
 				EvaluateJavaScript(handler, hybridWebView, innerRequest);
 
+				// NOTE: If the platform-specific EvaluateJavaScript implementation never completes
+				// innerRequest (e.g. the underlying WebView was torn down or failed to initialize and
+				// the platform silently skips the evaluation without throwing), this await will hang.
+				// All current platform implementations either complete the request or throw, but new
+				// platform paths must take care to always complete innerRequest. A future improvement
+				// could add a CancellationToken-based timeout here.
 				var result = await innerRequest.Task;
 
 				//if the js function errored or returned null/undefined treat it as null


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

Wrap `MapEvaluateJavaScriptAsync` in `HybridWebViewHandler.cs` with a `try/catch` that calls `request.SetException` on failure.

Without this, any exception thrown inside the handler leaves the `TaskCompletionSource` in the `EvaluateJavaScriptAsyncRequest` permanently in a non-completed state, causing the awaiting caller to hang forever. The fix propagates the exception to the caller via `SetException`.

✅ `dotnet build src/Core/src/Core.csproj` passes on macOS.