### PR TITLE
Refactor: Replace duplicate SwipeView helpers with SwipeViewExtensions calls

### DIFF
--- a/src/Core/src/Platform/Android/MauiSwipeView.cs
+++ b/src/Core/src/Platform/Android/MauiSwipeView.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Maui.Platform
 			else
 				swipeDirection = diffY > 0 ? SwipeDirection.Down : SwipeDirection.Up;
 
-			var items = GetSwipeItemsByDirection(swipeDirection);
+			var items = Element?.GetSwipeItemsByDirection(swipeDirection);
 
 			if (items == null || items?.Count == 0)
 				return false;
@@ -272,42 +272,6 @@ namespace Microsoft.Maui.Platform
 			emptyContentView.SetBackgroundColor(Colors.Transparent.ToPlatform());
 
 			return emptyContentView;
-		}
-
-		ISwipeItems? GetSwipeItemsByDirection()
-		{
-			if (_swipeDirection.HasValue)
-				return GetSwipeItemsByDirection(_swipeDirection.Value);
-
-			return null;
-		}
-
-		ISwipeItems? GetSwipeItemsByDirection(SwipeDirection swipeDirection)
-		{
-			ISwipeItems? swipeItems = null;
-
-			switch (swipeDirection)
-			{
-				case SwipeDirection.Left:
-					swipeItems = Element?.RightItems;
-					break;
-				case SwipeDirection.Right:
-					swipeItems = Element?.LeftItems;
-					break;
-				case SwipeDirection.Up:
-					swipeItems = Element?.BottomItems;
-					break;
-				case SwipeDirection.Down:
-					swipeItems = Element?.TopItems;
-					break;
-			}
-
-			return swipeItems;
-		}
-
-		bool IsHorizontalSwipe()
-		{
-			return _swipeDirection == SwipeDirection.Left || _swipeDirection == SwipeDirection.Right;
 		}
 
 		static bool IsValidSwipeItems(ISwipeItems? swipeItems)
@@ -491,7 +455,7 @@ namespace Microsoft.Maui.Platform
 			if (_swipeDirection == null)
 				return false;
 
-			var swipeItems = GetSwipeItemsByDirection();
+			var swipeItems = Element?.GetSwipeItemsByDirection(_swipeDirection);
 			return IsValidSwipeItems(swipeItems);
 		}
 
@@ -544,7 +508,7 @@ namespace Microsoft.Maui.Platform
 			if (_contentView == null || _contentView.IsDisposed() || _actionView != null)
 				return;
 
-			ISwipeItems? items = GetSwipeItemsByDirection();
+			ISwipeItems? items = Element?.GetSwipeItemsByDirection(_swipeDirection);
 
 			if (items?.Count == 0 || items == null)
 				return;
@@ -606,7 +570,7 @@ namespace Microsoft.Maui.Platform
 			if (_actionView == null || childs == null || _contentView == null)
 				return;
 
-			var items = GetSwipeItemsByDirection();
+			var items = Element?.GetSwipeItemsByDirection(_swipeDirection);
 
 			if (items == null || items.Count == 0)
 				return;
@@ -987,7 +951,7 @@ namespace Microsoft.Maui.Platform
 
 			if (Math.Abs(_swipeOffset) >= swipeThresholdPercent)
 			{
-				var swipeItems = GetSwipeItemsByDirection();
+				var swipeItems = Element?.GetSwipeItemsByDirection(_swipeDirection);
 
 				if (swipeItems == null)
 					return;
@@ -1015,7 +979,7 @@ namespace Microsoft.Maui.Platform
 			if (Math.Abs(_swipeThreshold) > double.Epsilon)
 				return _swipeThreshold;
 
-			var swipeItems = GetSwipeItemsByDirection();
+			var swipeItems = Element?.GetSwipeItemsByDirection(_swipeDirection);
 
 			if (swipeItems == null)
 				return 0;
@@ -1037,7 +1001,7 @@ namespace Microsoft.Maui.Platform
 
 			float swipeThreshold = 0;
 
-			bool isHorizontal = IsHorizontalSwipe();
+			bool isHorizontal = _swipeDirection.IsHorizontalSwipe();
 
 			if (swipeItems.Mode == SwipeMode.Reveal)
 			{
@@ -1073,7 +1037,7 @@ namespace Microsoft.Maui.Platform
 
 		float CalculateSwipeThreshold()
 		{
-			var swipeItems = GetSwipeItemsByDirection();
+			var swipeItems = Element?.GetSwipeItemsByDirection(_swipeDirection);
 			if (swipeItems == null)
 				return SwipeViewExtensions.SwipeThreshold;
 
@@ -1096,7 +1060,7 @@ namespace Microsoft.Maui.Platform
 
 			if (useSwipeItemsSize)
 			{
-				var isHorizontalSwipe = IsHorizontalSwipe();
+				var isHorizontalSwipe = _swipeDirection.IsHorizontalSwipe();
 
 				return isHorizontalSwipe ? swipeItemsWidth : swipeItemsHeight;
 			}
@@ -1117,12 +1081,12 @@ namespace Microsoft.Maui.Platform
 
 		float GetRevealModeSwipeThreshold()
 		{
-			var swipeItems = GetSwipeItemsByDirection();
+			var swipeItems = Element?.GetSwipeItemsByDirection(_swipeDirection);
 
 			if (swipeItems == null)
 				return SwipeViewExtensions.SwipeThreshold;
 
-			bool isHorizontal = IsHorizontalSwipe();
+			bool isHorizontal = _swipeDirection.IsHorizontalSwipe();
 
 			float swipeItemsSize = 0;
 			bool hasSwipeItemView = false;
@@ -1171,7 +1135,7 @@ namespace Microsoft.Maui.Platform
 
 			var contentHeight = (float)_context.FromPixels(_contentView.Height);
 			var contentWidth = (float)_context.FromPixels(_contentView.Width);
-			bool isHorizontal = IsHorizontalSwipe();
+			bool isHorizontal = _swipeDirection.IsHorizontalSwipe();
 
 			if (isHorizontal)
 			{
@@ -1192,8 +1156,8 @@ namespace Microsoft.Maui.Platform
 			if (_contentView == null || Element == null)
 				return Size.Zero;
 
-			bool isHorizontal = IsHorizontalSwipe();
-			var items = GetSwipeItemsByDirection();
+			bool isHorizontal = _swipeDirection.IsHorizontalSwipe();
+			var items = Element.GetSwipeItemsByDirection(_swipeDirection);
 
 			if (items == null)
 				return Size.Zero;
@@ -1255,7 +1219,7 @@ namespace Microsoft.Maui.Platform
 				return 0f;
 
 			var contentHeight = (float)_context.FromPixels(_contentView.Height);
-			var items = GetSwipeItemsByDirection();
+			var items = Element?.GetSwipeItemsByDirection(_swipeDirection);
 
 			if (items == null)
 				return 0f;
@@ -1284,7 +1248,7 @@ namespace Microsoft.Maui.Platform
 			if (_isResettingSwipe)
 				return;
 
-			var swipeItems = GetSwipeItemsByDirection();
+			var swipeItems = Element?.GetSwipeItemsByDirection(_swipeDirection);
 
 			if (swipeItems == null || _actionView == null)
 				return;
@@ -1377,7 +1341,7 @@ namespace Microsoft.Maui.Platform
 					break;
 			}
 
-			var swipeItems = GetSwipeItemsByDirection();
+			var swipeItems = Element?.GetSwipeItemsByDirection(_swipeDirection);
 
 			if (swipeItems == null || swipeItems.Count == 0)
 				return;

--- a/src/Core/src/Platform/Tizen/MauiSwipeView.cs
+++ b/src/Core/src/Platform/Tizen/MauiSwipeView.cs
@@ -269,7 +269,7 @@ namespace Microsoft.Maui.Platform
 			if (_contentView == null || _actionView != null)
 				return;
 
-			ISwipeItems? items = GetSwipeItemsByDirection();
+			ISwipeItems? items = Element?.GetSwipeItemsByDirection(_swipeDirection);
 
 			if (items?.Count == 0 || items == null)
 				return;
@@ -302,7 +302,7 @@ namespace Microsoft.Maui.Platform
 						if (e.Touch.GetState(0) == TPointStateType.Up)
 						{
 							ExecuteSwipeItem(item);
-							if (GetSwipeItemsByDirection()?.SwipeBehaviorOnInvoked != SwipeBehaviorOnInvoked.RemainOpen)
+							if (Element?.GetSwipeItemsByDirection(_swipeDirection)?.SwipeBehaviorOnInvoked != SwipeBehaviorOnInvoked.RemainOpen)
 								ResetSwipe();
 						}
 
@@ -325,7 +325,7 @@ namespace Microsoft.Maui.Platform
 			_itemsWidth = 0;
 			_itemsHeight = 0;
 
-			var items = GetSwipeItemsByDirection();
+			var items = Element?.GetSwipeItemsByDirection(_swipeDirection);
 
 			if (items == null || items.Count == 0)
 				return;
@@ -540,7 +540,7 @@ namespace Microsoft.Maui.Platform
 					break;
 			}
 
-			var swipeItems = GetSwipeItemsByDirection();
+			var swipeItems = Element?.GetSwipeItemsByDirection(_swipeDirection);
 
 			if (swipeItems == null || swipeItems.Count == 0)
 				return;
@@ -600,8 +600,8 @@ namespace Microsoft.Maui.Platform
 			if (_contentView == null || Element == null)
 				return GSize.Zero;
 
-			bool isHorizontal = IsHorizontalSwipe();
-			var items = GetSwipeItemsByDirection();
+			bool isHorizontal = _swipeDirection.IsHorizontalSwipe();
+			var items = Element?.GetSwipeItemsByDirection(_swipeDirection);
 
 			if (items == null)
 				return GSize.Zero;
@@ -643,48 +643,13 @@ namespace Microsoft.Maui.Platform
 			return GSize.Zero;
 		}
 
-		ISwipeItems? GetSwipeItemsByDirection()
-		{
-			if (_swipeDirection.HasValue)
-				return GetSwipeItemsByDirection(_swipeDirection.Value);
-
-			return null;
-		}
-
-		ISwipeItems? GetSwipeItemsByDirection(SwipeDirection swipeDirection)
-		{
-			ISwipeItems? swipeItems = null;
-
-			switch (swipeDirection)
-			{
-				case SwipeDirection.Left:
-					swipeItems = Element?.RightItems;
-					break;
-				case SwipeDirection.Right:
-					swipeItems = Element?.LeftItems;
-					break;
-				case SwipeDirection.Up:
-					swipeItems = Element?.BottomItems;
-					break;
-				case SwipeDirection.Down:
-					swipeItems = Element?.TopItems;
-					break;
-			}
-			return swipeItems;
-		}
-
-		bool IsHorizontalSwipe()
-		{
-			return _swipeDirection == SwipeDirection.Left || _swipeDirection == SwipeDirection.Right;
-		}
-
 		float GetSwipeItemHeight()
 		{
 			if (_contentView == null)
 				return 0f;
 
 			var contentHeight = _contentView.SizeHeight.ToScaledDP();
-			var items = GetSwipeItemsByDirection();
+			var items = Element?.GetSwipeItemsByDirection(_swipeDirection);
 
 			if (items == null)
 				return 0f;
@@ -713,7 +678,7 @@ namespace Microsoft.Maui.Platform
 			if (_swipeDirection == null)
 				return false;
 
-			var swipeItems = GetSwipeItemsByDirection();
+			var swipeItems = Element?.GetSwipeItemsByDirection(_swipeDirection);
 			return IsValidSwipeItems(swipeItems);
 		}
 
@@ -811,7 +776,7 @@ namespace Microsoft.Maui.Platform
 			if (Math.Abs(_swipeThreshold) > double.Epsilon)
 				return _swipeThreshold;
 
-			var swipeItems = GetSwipeItemsByDirection();
+			var swipeItems = Element?.GetSwipeItemsByDirection(_swipeDirection);
 
 			if (swipeItems == null)
 				return 0;
@@ -833,7 +798,7 @@ namespace Microsoft.Maui.Platform
 
 			double swipeThreshold = 0;
 
-			bool isHorizontal = IsHorizontalSwipe();
+			bool isHorizontal = _swipeDirection.IsHorizontalSwipe();
 
 			if (swipeItems.Mode == SwipeMode.Reveal)
 			{
@@ -859,7 +824,7 @@ namespace Microsoft.Maui.Platform
 
 		double CalculateSwipeThreshold()
 		{
-			var swipeItems = GetSwipeItemsByDirection();
+			var swipeItems = Element?.GetSwipeItemsByDirection(_swipeDirection);
 			if (swipeItems == null)
 				return SwipeViewExtensions.SwipeThreshold;
 
@@ -882,7 +847,7 @@ namespace Microsoft.Maui.Platform
 
 			if (useSwipeItemsSize)
 			{
-				var isHorizontalSwipe = IsHorizontalSwipe();
+				var isHorizontalSwipe = _swipeDirection.IsHorizontalSwipe();
 
 				return isHorizontalSwipe ? swipeItemsWidth : swipeItemsHeight;
 			}
@@ -907,7 +872,7 @@ namespace Microsoft.Maui.Platform
 
 			var contentHeight = _contentView.SizeHeight.ToScaledDP();
 			var contentWidth = _contentView.SizeWidth.ToScaledDP();
-			bool isHorizontal = IsHorizontalSwipe();
+			bool isHorizontal = _swipeDirection.IsHorizontalSwipe();
 
 			if (isHorizontal)
 			{
@@ -932,7 +897,7 @@ namespace Microsoft.Maui.Platform
 
 			if (Math.Abs(_swipeOffset) >= swipeThresholdPercent)
 			{
-				var swipeItems = GetSwipeItemsByDirection();
+				var swipeItems = Element?.GetSwipeItemsByDirection(_swipeDirection);
 
 				if (swipeItems == null)
 					return;

--- a/src/Core/src/Platform/iOS/MauiSwipeView.cs
+++ b/src/Core/src/Platform/iOS/MauiSwipeView.cs
@@ -274,11 +274,6 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		bool IsHorizontalSwipe()
-		{
-			return _swipeDirection == SwipeDirection.Left || _swipeDirection == SwipeDirection.Right;
-		}
-
 		static bool IsValidSwipeItems(ISwipeItems? swipeItems)
 		{
 			return swipeItems != null && swipeItems.Any(GetIsVisible);
@@ -329,7 +324,7 @@ namespace Microsoft.Maui.Platform
 
 			_swipeItemsRect.Clear();
 
-			var items = GetSwipeItemsByDirection();
+			var items = Element.GetSwipeItemsByDirection(_swipeDirection);
 
 			if (items == null || items.Count == 0)
 				return;
@@ -544,37 +539,6 @@ namespace Microsoft.Maui.Platform
 			return _contentView.Frame.Contains(point);
 		}
 
-		ISwipeItems? GetSwipeItemsByDirection()
-		{
-			if (_swipeDirection.HasValue)
-				return GetSwipeItemsByDirection(_swipeDirection.Value);
-
-			return null;
-		}
-
-		ISwipeItems? GetSwipeItemsByDirection(SwipeDirection swipeDirection)
-		{
-			ISwipeItems? swipeItems = null;
-
-			switch (swipeDirection)
-			{
-				case SwipeDirection.Left:
-					swipeItems = Element?.RightItems;
-					break;
-				case SwipeDirection.Right:
-					swipeItems = Element?.LeftItems;
-					break;
-				case SwipeDirection.Up:
-					swipeItems = Element?.BottomItems;
-					break;
-				case SwipeDirection.Down:
-					swipeItems = Element?.TopItems;
-					break;
-			}
-
-			return swipeItems;
-		}
-
 		void Swipe(bool animated = false)
 		{
 			if (_contentView == null || Element == null)
@@ -766,7 +730,7 @@ namespace Microsoft.Maui.Platform
 
 			if (Math.Abs(_swipeOffset) >= swipeThresholdPercent)
 			{
-				var swipeItems = GetSwipeItemsByDirection();
+				var swipeItems = Element?.GetSwipeItemsByDirection(_swipeDirection);
 
 				if (swipeItems == null)
 					return;
@@ -883,7 +847,7 @@ namespace Microsoft.Maui.Platform
 			if (Math.Abs(_swipeThreshold) > double.Epsilon)
 				return _swipeThreshold;
 
-			var swipeItems = GetSwipeItemsByDirection();
+			var swipeItems = Element?.GetSwipeItemsByDirection(_swipeDirection);
 
 			if (swipeItems == null)
 				return 0;
@@ -904,7 +868,7 @@ namespace Microsoft.Maui.Platform
 				return threshold;
 
 			double swipeThreshold = 0;
-			bool isHorizontal = IsHorizontalSwipe();
+			bool isHorizontal = _swipeDirection.IsHorizontalSwipe();
 
 			if (swipeItems.Mode == SwipeMode.Reveal)
 			{
@@ -930,7 +894,7 @@ namespace Microsoft.Maui.Platform
 
 		double CalculateSwipeThreshold()
 		{
-			var swipeItems = GetSwipeItemsByDirection();
+			var swipeItems = Element?.GetSwipeItemsByDirection(_swipeDirection);
 			if (swipeItems == null || Element == null)
 				return SwipeViewExtensions.SwipeThreshold;
 
@@ -953,7 +917,7 @@ namespace Microsoft.Maui.Platform
 
 			if (useSwipeItemsSize)
 			{
-				var isHorizontalSwipe = IsHorizontalSwipe();
+				var isHorizontalSwipe = _swipeDirection.IsHorizontalSwipe();
 
 				return isHorizontalSwipe ? swipeItemsWidth : swipeItemsHeight;
 			}
@@ -975,7 +939,7 @@ namespace Microsoft.Maui.Platform
 		{
 			var swipeFrame = _contentView != null ? _contentView.Frame : Frame;
 
-			if (IsHorizontalSwipe())
+			if (_swipeDirection.IsHorizontalSwipe())
 			{
 				if (swipeThreshold > swipeFrame.Width)
 					swipeThreshold = swipeFrame.Width;
@@ -994,7 +958,7 @@ namespace Microsoft.Maui.Platform
 			if (_swipeDirection == null)
 				return false;
 
-			var swipeItems = GetSwipeItemsByDirection();
+			var swipeItems = Element?.GetSwipeItemsByDirection(_swipeDirection);
 			return MauiSwipeView.IsValidSwipeItems(swipeItems);
 		}
 
@@ -1022,7 +986,7 @@ namespace Microsoft.Maui.Platform
 			if (_isResettingSwipe)
 				return;
 
-			var swipeItems = GetSwipeItemsByDirection();
+			var swipeItems = Element?.GetSwipeItemsByDirection(_swipeDirection);
 
 			if (swipeItems == null || _swipeItemsRect == null)
 				return;
@@ -1147,7 +1111,7 @@ namespace Microsoft.Maui.Platform
 					break;
 			}
 
-			var swipeItems = GetSwipeItemsByDirection();
+			var swipeItems = Element?.GetSwipeItemsByDirection(_swipeDirection);
 
 			if (swipeItems is null || !swipeItems.Any(GetIsVisible))
 				return;


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

Replace private `GetSwipeItemsByDirection` / `IsHorizontalSwipe` helper methods in platform `MauiSwipeView` implementations (Android, Tizen, iOS) with calls to the existing `SwipeViewExtensions` methods.

All three platform files had identical private duplicates of methods already available in `SwipeViewExtensions`. This removes ~40 lines of duplicated logic per platform and makes the implementations consistent.

✅ `dotnet build src/Core/src/Core.csproj` passes on macOS.