### PR TITLE
docs: Fix hardcoded path and add library overview in Essentials.AI README

### DIFF
--- a/src/AI/src/Essentials.AI/README.md
+++ b/src/AI/src/Essentials.AI/README.md
@@ -1,14 +1,44 @@
+# Microsoft.Maui.Essentials.AI
+
+## Overview
+
+`Microsoft.Maui.Essentials.AI` is an **experimental** .NET MAUI library that provides cross-platform APIs for working with on-device AI and local models. It exposes platform AI capabilities (such as Apple Intelligence on iOS/macOS) through a unified `Microsoft.Extensions.AI`-compatible interface, so you can use the same `IChatClient` and embedding abstractions across all platforms.
+
+### Supported platforms
+
+| Platform | Support |
+|----------|---------|
+| iOS | ✅ (Apple Intelligence / Core ML) |
+| macOS (Mac Catalyst) | ✅ (Apple Intelligence / Core ML) |
+| Android | ✅ |
+| Windows | ✅ |
+
+### Add to your project
+
+```xml
+<PackageReference Include="Microsoft.Maui.Essentials.AI" Version="*-*" />
+```
+
+> **Note:** This package is always released as a preview (e.g. `x.y.z-preview.n`) even when the rest of .NET MAUI ships a stable version.
+
+### Sample app
+
+See `src/AI/samples/Essentials.AI.Sample/` for a complete example — an AI-powered trip-planner using a multi-agent workflow with streaming responses.
+
+---
+
 ## Generating Files
 
 To generate the API definitions files:
 
-```
+```bash
 dotnet build src/AI/src/Essentials.AI/Essentials.AI.csproj -f net10.0-ios26.0
 
+# Replace <repo-root> with the absolute path to your local maui repository root
 sharpie bind \
   --output=src/AI/src/Essentials.AI/Platform/MaciOS \
   --namespace=Microsoft.Maui.Essentials.AI \
   --sdk=iphoneos26.1 \
   --scope=. \
-  src/AI/src/Essentials.AI/Users/matthew/Documents/GitHub/maui/artifacts/obj/Essentials.AI/Debug/net10.0-ios26.0/xcode/EssentialsAI-485fe/archives/EssentialsAIiOS.xcarchive/Products/Library/Frameworks/EssentialsAI.framework/Headers/EssentialsAI-Swift.h
+  <repo-root>/artifacts/obj/Essentials.AI/Debug/net10.0-ios26.0/xcode/EssentialsAI-485fe/archives/EssentialsAIiOS.xcarchive/Products/Library/Frameworks/EssentialsAI.framework/Headers/EssentialsAI-Swift.h
 ```

--- a/src/AI/src/Essentials.AI/README.md
+++ b/src/AI/src/Essentials.AI/README.md
@@ -2,28 +2,29 @@
 
 ## Overview
 
-`Microsoft.Maui.Essentials.AI` is an **experimental** .NET MAUI library that provides cross-platform APIs for working with on-device AI and local models. It exposes platform AI capabilities (such as Apple Intelligence on iOS/macOS) through a unified `Microsoft.Extensions.AI`-compatible interface, so you can use the same `IChatClient` and embedding abstractions across all platforms.
+`Microsoft.Maui.Essentials.AI` is an **experimental** .NET MAUI library that exposes platform on-device AI capabilities through a unified `Microsoft.Extensions.AI`-compatible interface. Today it ships built-in `IChatClient` and `IEmbeddingGenerator` implementations on Apple platforms (via Apple Intelligence and Core ML / Natural Language). The package builds for Android and Windows as well, but no built-in on-device providers are wired up for those platforms yet.
 
 ### Supported platforms
 
 | Platform | Support |
 |----------|---------|
 | iOS | ✅ (Apple Intelligence / Core ML) |
-| macOS (Mac Catalyst) | ✅ (Apple Intelligence / Core ML) |
-| Android | ✅ |
-| Windows | ✅ |
+| Mac Catalyst | ✅ (Apple Intelligence / Core ML) |
+| macOS | ✅ (Apple Intelligence / Core ML) |
+| Android | 🚧 Planned (no built-in provider yet) |
+| Windows | 🚧 Planned (no built-in provider yet) |
 
 ### Add to your project
 
 ```xml
-<PackageReference Include="Microsoft.Maui.Essentials.AI" Version="*-*" />
+<PackageReference Include="Microsoft.Maui.Essentials.AI" Version="10.0.0-preview.1" />
 ```
 
-> **Note:** This package is always released as a preview (e.g. `x.y.z-preview.n`) even when the rest of .NET MAUI ships a stable version.
+> **Note:** This package is always released as a preview (e.g. `x.y.z-preview.n`) even when the rest of .NET MAUI ships a stable version. Replace the version above with the latest `*-preview.*` available on NuGet, or omit `Version` entirely if you use [Central Package Management](https://learn.microsoft.com/nuget/consume-packages/central-package-management).
 
 ### Sample app
 
-See `src/AI/samples/Essentials.AI.Sample/` for a complete example — an AI-powered trip-planner using a multi-agent workflow with streaming responses.
+See `src/AI/samples/Essentials.AI.Sample/` for a complete example — an AI-powered trip-planner using a multi-agent workflow with streaming responses. Note that this sample demonstrates a **cloud-based** multi-agent pattern and requires Azure OpenAI / OpenAI credentials; it does not exercise the on-device `AppleIntelligenceChatClient` that ships with this package.
 
 ---
 
@@ -34,11 +35,12 @@ To generate the API definitions files:
 ```bash
 dotnet build src/AI/src/Essentials.AI/Essentials.AI.csproj -f net10.0-ios26.0
 
-# Replace <repo-root> with the absolute path to your local maui repository root
+# Run from the repository root. The 'EssentialsAI-XXXXX' folder name is generated per build —
+# locate yours under artifacts/obj/Essentials.AI/Debug/<TFM>/xcode/ before running this command.
 sharpie bind \
   --output=src/AI/src/Essentials.AI/Platform/MaciOS \
   --namespace=Microsoft.Maui.Essentials.AI \
   --sdk=iphoneos26.1 \
   --scope=. \
-  <repo-root>/artifacts/obj/Essentials.AI/Debug/net10.0-ios26.0/xcode/EssentialsAI-485fe/archives/EssentialsAIiOS.xcarchive/Products/Library/Frameworks/EssentialsAI.framework/Headers/EssentialsAI-Swift.h
+  artifacts/obj/Essentials.AI/Debug/net10.0-ios26.0/xcode/EssentialsAI-XXXXX/archives/EssentialsAIiOS.xcarchive/Products/Library/Frameworks/EssentialsAI.framework/Headers/EssentialsAI-Swift.h
 ```


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

Two improvements to `src/AI/src/Essentials.AI/README.md`:

1. **Remove hardcoded absolute path**: Replace machine-specific path with a relative path that works in any environment
2. **Add library overview**: Add a short description explaining what the Essentials.AI library provides, so readers understand the purpose of the package at a glance