### PR TITLE
Enable internal Xcode provisioning for SR6

### DIFF
--- a/eng/pipelines/ci-uitests.yml
+++ b/eng/pipelines/ci-uitests.yml
@@ -150,6 +150,11 @@ stages:
 
   - template: common/ui-tests.yml
     parameters:
+      # Enable provisioning on internal so Xcode gets selected/installed correctly
+      ${{ if eq(variables['internalProvisioning'], 'true') }}:
+        skipProvisioning: false
+      ${{ else }}:
+        skipProvisioning: true
       # Select pools based on pipeline - internal vs public
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         androidPool: ${{ parameters.androidPoolInternal }}

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -34,7 +34,7 @@ variables:
 - name: provisionator.xcode
   value: 'eng/provisioning/xcode.csx'
 - name: internalProvisioning
-  value: false
+  value: true
 - name: provisionator.extraArguments
   value: '-vvvv'
 - name: DotNet.Dir

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -8,11 +8,11 @@ variables:
 - name: DOTNET_VERSION
   value: 10.0.100
 - name: REQUIRED_XCODE
-  value: 26.0.1
+  value: 26.4
 - name: DEVICETESTS_REQUIRED_XCODE
-  value: 26.0.1
+  value: 26.4
 - name: XCODE
-  value: 26.0.1
+  value: 26.4
 - name: POWERSHELL_VERSION
   value: 7.4.0
 # Localization variables


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Sets `internalProvisioning` to `true` in `variables.yml` so that the provisionator step runs on internal CI agents and selects Xcode 26.0.1 (matching `REQUIRED_XCODE`).

### Problem

Internal dnceng agents default to Xcode 16.4 (the system default on macOS 15.7.4 Sequoia). The Xcode provisioning step was skipped because `internalProvisioning` was `false`. This causes iOS snapshot UITest baselines (generated on public agents with Xcode 26.4) to mismatch on internal CI.

### Fix

Enable the provisionator so internal builds select Xcode 26.0.1, aligning simulator rendering with public CI.