### PR TITLE
Fix SwipeViews with invoked properties crash the app in Release mode

### DIFF
--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -1342,7 +1342,14 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 
 			if (methodDef.IsVirtual)
 			{
-				yield return Create(Ldarg_0);
+				// ldvirtftn needs the object whose vtable drives virtual dispatch.
+				// In a DataTemplate context, Ldarg_0 is the anonymous nested class, not the root
+				// XAML element — using it causes iOS/Mac Full AOT to crash on virtual handlers.
+				// The delegate target (already on the stack) IS the correct vtable object, so
+				// dup it: stack goes [target] → [target, target], ldvirtftn pops one, leaving
+				// [target, ftn] for the delegate ctor.
+				if (!methodDef.IsStatic)
+					yield return Create(Dup);
 				yield return Create(Ldvirtftn, handlerRef);
 			}
 			else

--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -1340,7 +1340,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 					throw new InvalidProgramException();
 			}
 
-			if (methodDef.IsVirtual)
+			if (methodDef.IsVirtual && !methodDef.IsStatic)
 			{
 				// ldvirtftn needs the object whose vtable drives virtual dispatch.
 				// In a DataTemplate context, Ldarg_0 is the anonymous nested class, not the root
@@ -1348,8 +1348,9 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				// The delegate target (already on the stack) IS the correct vtable object, so
 				// dup it: stack goes [parent, target] → [parent, target, target], ldvirtftn pops one, leaving
 				// [parent, target, ftn] for the delegate ctor.
-				if (!methodDef.IsStatic)
-					yield return Create(Dup);
+				// Static methods (including C# 11+ interface static-abstract members) are never
+				// virtual-dispatched; fall through to ldftn below.
+				yield return Create(Dup);
 				yield return Create(Ldvirtftn, handlerRef);
 			}
 			else

--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -1280,9 +1280,9 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			//			IL_0008:  ldarg.0 
 			//
 			//			IL_0009:  ldftn instance void class Microsoft.Maui.Controls.Xaml.XamlcTests.MyPage::OnButtonClicked(object, class [mscorlib]System.EventArgs)
-			//OR, if the handler is virtual
-			//			IL_000x:  ldarg.0 
-			//			IL_0009:  ldvirtftn instance void class Microsoft.Maui.Controls.Xaml.XamlcTests.MyPage::OnButtonClicked(object, class [mscorlib]System.EventArgs)
+			//OR, if the handler is virtual (non-static)
+			//			IL_000x:  dup          ; copy target already on stack
+			//			IL_000y:  ldvirtftn instance void class Microsoft.Maui.Controls.Xaml.XamlcTests.MyPage::OnButtonClicked(object, class [mscorlib]System.EventArgs)
 			//
 			//			IL_000f:  newobj instance void class [mscorlib]System.EventHandler::'.ctor'(object, native int)
 			//			IL_0014:  callvirt instance void class [Microsoft.Maui.Controls]Microsoft.Maui.Controls.Button::add_Clicked(class [mscorlib]System.EventHandler)
@@ -1346,8 +1346,8 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				// In a DataTemplate context, Ldarg_0 is the anonymous nested class, not the root
 				// XAML element — using it causes iOS/Mac Full AOT to crash on virtual handlers.
 				// The delegate target (already on the stack) IS the correct vtable object, so
-				// dup it: stack goes [target] → [target, target], ldvirtftn pops one, leaving
-				// [target, ftn] for the delegate ctor.
+				// dup it: stack goes [parent, target] → [parent, target, target], ldvirtftn pops one, leaving
+				// [parent, target, ftn] for the delegate ctor.
 				if (!methodDef.IsStatic)
 					yield return Create(Dup);
 				yield return Create(Ldvirtftn, handlerRef);

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui18055.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui18055.xaml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui18055">
+    <ContentPage.Resources>
+        <DataTemplate x:Key="virtualHandlerTemplate">
+            <local:ElementWithEvent Clicked="HandleVirtualClicked" />
+        </DataTemplate>
+    </ContentPage.Resources>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui18055.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui18055.xaml.cs
@@ -10,8 +10,8 @@ public partial class Maui18055 : ContentPage
 {
 	public Maui18055() => InitializeComponent();
 
-	public int baseForVirtualClicked;
-	protected virtual void HandleVirtualClicked(object sender, EventArgs e) => baseForVirtualClicked++;
+	public int BaseForVirtualClicked;
+	protected virtual void HandleVirtualClicked(object sender, EventArgs e) => BaseForVirtualClicked++;
 
 	[Collection("Issue")]
 	public class Tests
@@ -25,16 +25,16 @@ public partial class Maui18055 : ContentPage
 		internal void VirtualHandlerInDataTemplateCallsOverride(XamlInflator inflator)
 		{
 			var page = new SubMaui18055(inflator);
-			Assert.Equal(0, page.baseForVirtualClicked);
-			Assert.Equal(0, page.overrideClicked);
+			Assert.Equal(0, page.BaseForVirtualClicked);
+			Assert.Equal(0, page.OverrideClicked);
 
 			var template = (Microsoft.Maui.Controls.DataTemplate)page.Resources["virtualHandlerTemplate"];
 			var element = (ElementWithEvent)template.CreateContent();
 			element.SendClicked();
 
 			// Override must be called; base must NOT be called.
-			Assert.Equal(1, page.overrideClicked);
-			Assert.Equal(0, page.baseForVirtualClicked);
+			Assert.Equal(1, page.OverrideClicked);
+			Assert.Equal(0, page.BaseForVirtualClicked);
 		}
 	}
 }
@@ -43,6 +43,6 @@ class SubMaui18055 : Maui18055
 {
 	public SubMaui18055(XamlInflator inflator) : base(inflator) { }
 
-	public int overrideClicked;
-	protected override void HandleVirtualClicked(object sender, EventArgs e) => overrideClicked++;
+	public int OverrideClicked;
+	protected override void HandleVirtualClicked(object sender, EventArgs e) => OverrideClicked++;
 }

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui18055.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui18055.xaml.cs
@@ -1,0 +1,48 @@
+using System;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+// Regression test for https://github.com/dotnet/maui/issues/18055
+// XamlC must use Dup (not Ldarg_0) before ldvirtftn when wiring virtual event handlers
+// inside a DataTemplate, so the correct vtable object is used for virtual dispatch.
+public partial class Maui18055 : ContentPage
+{
+	public Maui18055() => InitializeComponent();
+
+	public int baseForVirtualClicked;
+	protected virtual void HandleVirtualClicked(object sender, EventArgs e) => baseForVirtualClicked++;
+
+	[Collection("Issue")]
+	public class Tests
+	{
+		[Theory]
+		[XamlInflatorData]
+		// Verifies that a virtual handler wired inside a DataTemplate dispatches to the override,
+		// not the base class. Without the fix, XamlC emitted Ldarg_0 (the anonymous DataTemplate
+		// class) as the ldvirtftn vtable source — causing wrong dispatch on JIT and a hard crash
+		// on iOS/macOS Full AOT.
+		internal void VirtualHandlerInDataTemplateCallsOverride(XamlInflator inflator)
+		{
+			var page = new SubMaui18055(inflator);
+			Assert.Equal(0, page.baseForVirtualClicked);
+			Assert.Equal(0, page.overrideClicked);
+
+			var template = (Microsoft.Maui.Controls.DataTemplate)page.Resources["virtualHandlerTemplate"];
+			var element = (ElementWithEvent)template.CreateContent();
+			element.SendClicked();
+
+			// Override must be called; base must NOT be called.
+			Assert.Equal(1, page.overrideClicked);
+			Assert.Equal(0, page.baseForVirtualClicked);
+		}
+	}
+}
+
+class SubMaui18055 : Maui18055
+{
+	public SubMaui18055(XamlInflator inflator) : base(inflator) { }
+
+	public int overrideClicked;
+	protected override void HandleVirtualClicked(object sender, EventArgs e) => overrideClicked++;
+}


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue details
When a virtual XAML event handler is wired inside a DataTemplate (for example, SwipeItem.Invoked) and the handler is defined in a base class and overridden in a derived class, the app crashes in Release builds on iOS/macOS and may also behave incorrectly on Android. This occurs due to a bug in XamlC's IL code generator (SetPropertiesVisitor.cs), where the ldvirtftn instruction receives the wrong vtable object (the anonymous DataTemplate class instead of the root XAML element), causing runtime failure with Full AOT compilation.

### Root Cause

The issue occurs because of incorrect IL generation in SetPropertiesVisitor.ConnectEvent() when wiring a virtual event handler inside a DataTemplate.

When XamlC compiles a DataTemplate, it generates an anonymous nested class (e.g., <InitializeComponent>_anonXamlCDataTemplate_1) with a LoadDataTemplate() method where event wiring happens. For virtual handlers, XamlC must emit ldvirtftn, which requires the actual page object as the vtable source to resolve the correct overridden method.

The bug was that the code always pushed Ldarg_0 as the vtable object. Inside LoadDataTemplate(), Ldarg_0 is the anonymous class, not the root page. This causes ldvirtftn to look up the virtual method on the wrong vtable, so the override on the generic subclass is never found. On iOS Full AOT, this causes a hard crash; on Android and Windows, the JIT silently calls the base class method instead of the override.
 
### Description of Change

The fix involves replacing the extra Ldarg_0 push before ldvirtftn with a Dup instruction, which reuses the delegate target object that is already correctly loaded on the stack just above this code.

The delegate target (the root page) is already on the stack, correctly resolved via context.Root for both the top-level and DataTemplate contexts. Dup copies that same object for ldvirtftn, ensuring virtual dispatch always targets the actual page's vtable, and the overridden method on the generic subclass is found correctly on all platforms.
 
**Windows platform behavior:**
 
The issue does not occur on the Windows platform. Based on analysis, even though Windows does not crash, the behavior before the fix was technically undefined, as it relied on the JIT being lenient. If the method resolution happened to pick the base class version instead of the override, the logic would silently be incorrect without any error. The fix makes the IL correct and explicit for all platforms.

Tested the behavior in the following platforms.
 
- [x] iOS
- [x] Mac
- [ ] Android
- [ ] Windows

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/18055

### Output

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="270" height="600"  src="https://github.com/user-attachments/assets/6bc99f45-7114-4ce5-9a75-d98d3c014882"> | <video width="270" height="600"  src="https://github.com/user-attachments/assets/00cd3e91-cb1b-4a9a-9df9-1a2538d2ec56"> |