### PR TITLE
[HouseKeeping] Fix inconsistant namespace in HostApp

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22075.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22075.cs
@@ -2,7 +2,7 @@
 using UITest.Appium;
 using UITest.Core;
 
-namespace Microsoft.Maui.TestCases.Tests.Issue
+namespace Microsoft.Maui.TestCases.Tests.Issues
 {
 	public class Issue22075 : _IssuesUITest
 	{

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28968.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28968.cs
@@ -2,7 +2,7 @@ using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
-namespace Microsoft.Maui.TestCases.Tests.Tests.Issues;
+namespace Microsoft.Maui.TestCases.Tests.Issues;
 
 public class Issue28968 : _IssuesUITest
 {

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29588.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29588.cs
@@ -2,7 +2,7 @@ using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
-namespace Microsoft.Maui.TestCases.Tests.Tests.Issues;
+namespace Microsoft.Maui.TestCases.Tests.Issues;
 
 internal class Issue29588 : _IssuesUITest
 {

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33227.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33227.cs
@@ -3,7 +3,7 @@ using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
-namespace Maui.Controls.TestCases.Tests.Issues;
+namespace Microsoft.Maui.TestCases.Tests.Issues;
 
 public class Issue33227 : _IssuesUITest
 {


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

<!-- Enter description of the fix in this section -->
This pull request standardizes the namespace declarations for several test case files related to issues in the test suite. The changes ensure that all files use the correct `Microsoft.Maui.TestCases.Tests.Issues` namespace, improving consistency and maintainability.

**Namespace corrections:**

* Changed the namespace in `Issue22075.cs` from `Microsoft.Maui.TestCases.Tests.Issue` to `Microsoft.Maui.TestCases.Tests.Issues` to match the naming convention.
* Updated the namespace in `Issue28968.cs` from `Microsoft.Maui.TestCases.Tests.Tests.Issues` to `Microsoft.Maui.TestCases.Tests.Issues`.
* Updated the namespace in `Issue29588.cs` from `Microsoft.Maui.TestCases.Tests.Tests.Issues` to `Microsoft.Maui.TestCases.Tests.Issues`.
* Changed the namespace in `Issue33227.cs` from `Maui.Controls.TestCases.Tests.Issues` to `Microsoft.Maui.TestCases.Tests.Issues`.

