### PR TITLE
[MacCatalyst] Fix CollectionView Header/Footer Not Expanding to Content Width

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/iOS/GroupableItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/GroupableItemsViewController2.cs
@@ -102,6 +102,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 					UpdateDefaultSupplementaryView(DefaultCell2, elementKind, indexPath);
 					break;
 				case TemplatedCell2 TemplatedCell2:
+					TemplatedCell2.ScrollDirection = ScrollDirection;
 					UpdateTemplatedSupplementaryView(TemplatedCell2, elementKind, indexPath);
 					break;
 			}

--- a/src/Controls/src/Core/Handlers/Items2/iOS/StructuredItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/StructuredItemsViewController2.cs
@@ -86,6 +86,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 					UpdateDefaultSupplementaryView(defaultCell, elementKind);
 					break;
 				case TemplatedCell2 templatedCell:
+					templatedCell.ScrollDirection = ScrollDirection;
 					UpdateTemplatedSupplementaryView(templatedCell, elementKind);
 					break;
 			}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue35113.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue35113.cs
@@ -1,0 +1,42 @@
+using System.Collections.ObjectModel;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 35113, "CV2 header/footer view width is not expanded to its content width on iOS/macOS", PlatformAffected.iOS | PlatformAffected.macOS)]
+public class Issue35113 : ContentPage
+{
+	public Issue35113()
+	{
+		var items = new ObservableCollection<string>();
+		for (int i = 0; i < 12; i++)
+			items.Add($"Item {i}");
+
+		// Header label with no explicit WidthRequest so it must self-size to its content width.
+		// With the bug: ScrollDirection defaults to Vertical on the supplementary TemplatedCell2.
+		// GetMeasureConstraints() constrains width to preferredAttributes.Size.Width (~30pt from
+		// LayoutFactory2's estimated value). The label text is clipped/invisible at 30pt and
+		// is absent from the accessibility tree — WaitForElement times out.
+		// With the fix: ScrollDirection = Horizontal is set, width is unconstrained, the label
+		// expands to its full content width and becomes accessible in the UI tree.
+		Content = new CollectionView2
+		{
+			ItemsLayout = new GridItemsLayout(3, ItemsLayoutOrientation.Horizontal),
+			Header = new Label
+			{
+				Text = "This Is A Header",
+				AutomationId = "Issue35113Header",
+				BackgroundColor = Colors.LightBlue,
+				FontSize = 24,
+				Padding = new Thickness(8),
+			},
+			ItemTemplate = new DataTemplate(() =>
+			{
+				var label = new Label { Padding = 8 };
+				label.SetBinding(Label.TextProperty, ".");
+				return new Border { Content = label, Padding = 4 };
+			}),
+			ItemsSource = items,
+			AutomationId = "Issue35113CollectionView",
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue35113.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue35113.cs
@@ -8,7 +8,7 @@ public class Issue35113 : ContentPage
 	public Issue35113()
 	{
 		var items = new ObservableCollection<string>();
-		for (int i = 0; i < 12; i++)
+		for (int i = 0; i < 2; i++)
 			items.Add($"Item {i}");
 
 		// Header label with no explicit WidthRequest so it must self-size to its content width.
@@ -26,6 +26,14 @@ public class Issue35113 : ContentPage
 				Text = "This Is A Header",
 				AutomationId = "Issue35113Header",
 				BackgroundColor = Colors.LightBlue,
+				FontSize = 24,
+				Padding = new Thickness(8),
+			},
+			Footer = new Label
+			{
+				Text = "This Is A Footer",
+				AutomationId = "Issue35113Footer",
+				BackgroundColor = Colors.LightGreen,
 				FontSize = 24,
 				Padding = new Thickness(8),
 			},

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35113.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35113.cs
@@ -1,0 +1,29 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue35113 : _IssuesUITest
+{
+	public override string Issue => "CV2 header/footer view width is not expanded to its content width on iOS/macOS";
+
+	public Issue35113(TestDevice device) : base(device) { }
+
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void HorizontalGridHeaderExpandsToContentWidth()
+	{
+		// With the bug: the header's supplementary cell is constrained to ~30pt wide
+		// (LayoutFactory2 estimated value) because ScrollDirection is never set on
+		// TemplatedCell2. The header Label "This Is A Header" at FontSize=24 wraps
+		// into a narrow column — GetRect().Width should be near 30pt.
+		// With the fix: ScrollDirection is set correctly, the header self-sizes to
+		// content width — GetRect().Width should be well over 100pt.
+		App.WaitForElement("Issue35113Header");
+		var rect = App.FindElement("Issue35113Header").GetRect();
+		Assert.That(rect.Width, Is.GreaterThan(100),
+			$"Header width {rect.Width} should be > 100 when fully expanded. " +
+			"If ~30, ScrollDirection was not set on the supplementary TemplatedCell2.");
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35113.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35113.cs
@@ -26,4 +26,17 @@ public class Issue35113 : _IssuesUITest
 			$"Header width {rect.Width} should be > 100 when fully expanded. " +
 			"If ~30, ScrollDirection was not set on the supplementary TemplatedCell2.");
 	}
+
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void HorizontalGridFooterExpandsToContentWidth()
+	{
+		App.WaitForElement("Issue35113CollectionView");
+		App.ScrollTo("Issue35113Footer");
+		App.WaitForElement("Issue35113Footer");
+		var rect = App.FindElement("Issue35113Footer").GetRect();
+		Assert.That(rect.Width, Is.GreaterThan(100),
+			$"Footer width {rect.Width} should be > 100 when fully expanded. " +
+			"If ~30, ScrollDirection was not set on the supplementary TemplatedCell2.");
+	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details:

CollectionView's  Header / Footer is not expanded to its content width in iOS and Mac platform
       
### Root Cause:

In the iOS/MacCatalyst CollectionView2 implementation, StructuredItemsViewController2 and GroupableItemsViewController2 both have a GetViewForSupplementaryElement() method responsible for creating header and footer views. When a TemplatedCell2 is dequeued as a supplementary view, its ScrollDirection property was never set — it silently defaulted to UICollectionViewScrollDirection.Vertical. This was an oversight, because regular item cells in GetCell() already correctly assigned ScrollDirection. The missing assignment fed through to GetMeasureConstraints() in TemplatedCell2, which uses ScrollDirection to decide how to constrain the cell during measurement: for a horizontal grid, a Vertical direction incorrectly constrains the cell's width to the estimated value (~30pt from LayoutFactory2) instead of leaving it unconstrained, causing header/footer labels to be clipped to a tiny width and become inaccessible in the UI tree.

### Description of Change:

The fix is a one-line addition in each of the two affected view controllers, mirroring the pattern already used in GetCell(). In StructuredItemsViewController2.GetViewForSupplementaryElement(), templatedCell.ScrollDirection = ScrollDirection is set before calling UpdateTemplatedSupplementaryView. The same line is added in GroupableItemsViewController2.GetViewForSupplementaryElement() for group header/footer cells. With ScrollDirection correctly propagated, GetMeasureConstraints() leaves the width unconstrained for horizontal grids, allowing headers and footers to self-size to their full content width. Vertical layouts are unaffected since they already defaulted to Vertical, and the change has no impact on Android or Windows as Items2 is iOS/MacCatalyst-only.

**Tested the behavior in the following platforms: **

- [ ] Android
- [ ] Windows
- [x] iOS
- [x] Mac

### Reference:

N/A

### Issues Fixed:

Fixes #35113, #28030             

### Screenshots
| Before  | After  |
|---------|--------|
| <img width="400" height="500"  src="https://github.com/user-attachments/assets/319d97f0-a4b9-4b00-bc9a-670fd44fd86f" /> | <img width="400" height="500" alt="After_31553" src="https://github.com/user-attachments/assets/710a0fca-0c92-48fd-a91f-697d9e0d6b86" /> |