### PR TITLE
Use Azure Artifacts feed only in CI, standard repos locally

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -101,6 +101,14 @@ When referencing or triggering CI pipelines, use these current pipeline names:
 
 **⚠️ Old pipeline names** (e.g., `MAUI-UITests-public`, `MAUI-public`) are **outdated** and should NOT be used. Always use the names above.
 
+### Gradle / Maven Dependency Failures (CFSClean)
+
+The official CI build uses CFSClean network isolation which blocks `repo.maven.apache.org`. All Gradle/Maven dependencies resolve through the `dotnet-public-maven` Azure Artifacts feed.
+
+**If CI fails with Gradle 401 errors** like `"No local versions of package"` or `"Please provide authentication to save package from upstream"`, it means a Maven package hasn't been ingested into the feed yet. **Fix:** run `./eng/ingest-maven-deps.sh` locally to pre-populate the feed. See `src/Core/AndroidNative/settings.gradle` for details.
+
+**Do NOT upgrade Gradle past 8.x** — the Android SDK's `net.android.init.gradle.kts` is incompatible with Gradle 9.x (`dotnet/android#10738`).
+
 ### Code Formatting
 
 Always format code before committing:

--- a/.github/instructions/android.instructions.md
+++ b/.github/instructions/android.instructions.md
@@ -4,6 +4,9 @@ applyTo:
   - "**/Android/**/*.cs"
   - "**/Platforms/Android/**/*.cs"
   - "**/Platform/Android/**/*.cs"
+  - "**/AndroidNative/**"
+  - "eng/init.gradle"
+  - "eng/ingest-maven-deps.sh"
 ---
 
 # Android Platform Development Guidelines
@@ -123,3 +126,8 @@ protected override void DisconnectHandler(RecyclerView platformView)
 | Listener not working | Check lifecycle (register/unregister) |
 | Memory leak | Ensure Dispose() called on Java.Lang.Object |
 | Threading error | Use `platformView.Post()` for UI thread |
+| Gradle 401 / Maven dependency failure | Run `./eng/ingest-maven-deps.sh` — see `copilot-instructions.md` |
+
+## Gradle / Maven Dependency Failures
+
+CI uses CFSClean which blocks Maven Central. All deps go through the `dotnet-public-maven` Azure Artifacts feed. If a new package hasn't been ingested, CI fails with `XAGRDL0000` / 401. Run `./eng/ingest-maven-deps.sh` locally to fix. Do NOT upgrade Gradle past 8.x (`dotnet/android#10738`).

--- a/.github/skills/azdo-build-investigator/SKILL.md
+++ b/.github/skills/azdo-build-investigator/SKILL.md
@@ -66,6 +66,26 @@ If available, use the `mcp-binlog-tool` MCP server to analyze downloaded `.binlo
 | `error CS####` | `maui-pr` | C# compiler error — check file/line |
 | `error XA####` | `maui-pr` | Android build error |
 | `XamlC` | `maui-pr` | XAML compiler — usually missing type or bad binding |
+| `error XAGRDL0000` / `401` / `No local versions` | `maui-pr` or official build | Gradle/Maven feed issue — see below |
 | `XHarness timeout` | `maui-pr-devicetests` Helix logs | Test killed by infrastructure; may be transient |
 | `No test result files found` | `maui-pr-devicetests` Helix logs | Tests never ran or app crashed on launch |
 | UI test screenshot diff | `maui-pr-uitests` | Visual regression; check baseline images |
+
+### Gradle / Maven / CFSClean Failures
+
+**Error signatures:**
+```
+error XAGRDL0000: Could not resolve com.android.tools.build:gradle:8.11.1
+  > Received status code 401: Unauthorized - No local versions of package
+```
+```
+error XAGRDL0000: Could not GET '...pkgs.dev.azure.com/.../maven/v1/...'
+  > Unauthorized - Please provide authentication to save package from upstream
+```
+
+**Fix:** Tell the user to run `./eng/ingest-maven-deps.sh` locally to pre-ingest packages into the feed.
+
+**Do NOT:**
+- Remove CFSClean from `ci-official.yml` — security compliance requirement
+- Upgrade Gradle past 8.x — `dotnet/android#10738`
+- Add `mavenCentral()` or `google()` back — use the Azure Artifacts feed

--- a/eng/ingest-maven-deps.sh
+++ b/eng/ingest-maven-deps.sh
@@ -33,6 +33,7 @@
 #
 # Prerequisites:
 #   - JDK 17+
+#   - python3 (for JSON parsing)
 #   - .NET Azure Artifacts credential provider installed
 #     (https://github.com/microsoft/artifacts-credprovider#installation)
 #

--- a/eng/ingest-maven-deps.sh
+++ b/eng/ingest-maven-deps.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# Ingest Maven/Gradle dependencies into the dotnet-public-maven Azure Artifacts feed.
+#
+# WHY THIS IS NEEDED:
+#   CI builds run under CFSClean network isolation which blocks direct access to
+#   Maven Central (repo.maven.apache.org). All Maven dependencies are resolved
+#   through the dotnet-public-maven Azure Artifacts feed instead. However, this
+#   feed requires an authenticated request the FIRST time a package is pulled
+#   from upstream Maven Central — after that, anyone can read it anonymously.
+#
+#   The CI pipeline's credential provider plugin (com.microsoft.azure.artifacts.
+#   credprovider) skips authentication in Azure Pipelines (TF_BUILD=True), so
+#   new packages MUST be pre-ingested locally before CI can use them.
+#
+# WHEN TO RUN:
+#   After adding or updating any Maven/Gradle dependency in
+#   src/Core/AndroidNative/build.gradle or settings.gradle.
+#
+# HOW IT WORKS:
+#   1. Acquires an auth token via the .NET Azure Artifacts credential provider
+#   2. Pre-ingests platform-specific artifacts (e.g. aapt2) for all OS variants
+#      (macOS/Linux/Windows) since Gradle only resolves the local OS classifier
+#   3. Runs the Gradle build with --refresh-dependencies to bypass local cache
+#      and force actual downloads through the feed (which triggers ingestion)
+#   4. For packages that Gradle's credential provider can't reach (e.g. AGP's
+#      internal detachedConfiguration scopes), falls back to curl with Bearer
+#      token to force-ingest the specific package URLs
+#
+# COMMON PITFALL:
+#   Running ./gradlew build without --refresh-dependencies may appear to succeed
+#   but actually resolves from ~/.gradle/caches/ (local cache from prior builds
+#   that used mavenCentral() directly). This does NOT ingest into the feed.
+#
+# Prerequisites:
+#   - JDK 17+
+#   - .NET Azure Artifacts credential provider installed
+#     (https://github.com/microsoft/artifacts-credprovider#installation)
+#
+# Usage:
+#   ./eng/ingest-maven-deps.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ANDROID_DIR="$REPO_ROOT/src/Core/AndroidNative"
+FEED_URL="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1"
+CRED_PROVIDER="$HOME/.nuget/plugins/netcore/CredentialProvider.Microsoft/CredentialProvider.Microsoft.dll"
+
+echo "=== Maven Dependency Ingestion for dotnet-public-maven ==="
+echo ""
+
+# Step 1: Get auth token
+echo "Acquiring auth token..."
+if [ ! -f "$CRED_PROVIDER" ]; then
+    echo "ERROR: Azure Artifacts credential provider not found at $CRED_PROVIDER"
+    echo "Install it from: https://github.com/microsoft/artifacts-credprovider#installation"
+    exit 1
+fi
+
+TOKEN=$(dotnet "$CRED_PROVIDER" -U "$FEED_URL" -F Json -N true -I true 2>/dev/null \
+    | python3 -c "import json,sys; print(json.load(sys.stdin).get('Password',''))" 2>/dev/null)
+
+if [ -z "$TOKEN" ]; then
+    echo "ERROR: Failed to acquire auth token. Make sure you're signed in to Azure DevOps."
+    exit 1
+fi
+echo "Token acquired."
+
+# Step 2: Ingest platform-specific artifacts for all OS variants
+# Gradle only resolves the classifier for the current OS (e.g. aapt2-osx.jar on macOS).
+# CI builds on Windows/Linux need their variants pre-ingested too.
+echo ""
+echo "Step 1/3: Ingesting cross-platform artifacts..."
+AAPT2_VERSION="8.11.1-12782657"
+for classifier in osx linux windows; do
+    for ext in jar pom; do
+        url="$FEED_URL/com/android/tools/build/aapt2/$AAPT2_VERSION/aapt2-$AAPT2_VERSION-$classifier.$ext"
+        code=$(curl -s -o /dev/null -w "%{http_code}" --oauth2-bearer "$TOKEN" "$url" 2>/dev/null)
+        echo "  aapt2-$AAPT2_VERSION-$classifier.$ext: $code"
+    done
+done
+
+# Step 3: Run Gradle build with refresh to ingest via credential provider
+echo ""
+echo "Step 2/3: Running Gradle build with --refresh-dependencies..."
+cd "$ANDROID_DIR"
+if ! ./gradlew build --no-daemon --refresh-dependencies \
+    -Dazure.artifacts.credprovider.nonInteractive=true \
+    -Dazure.artifacts.credprovider.isRetry=true 2>&1 | tail -20; then
+    echo "WARNING: Initial Gradle build failed (expected if packages need ingestion). Continuing..."
+fi
+
+# Step 4: Loop — build, find missing packages, curl-ingest them
+echo ""
+echo "Step 3/3: Ingesting any remaining packages via REST API..."
+for i in $(seq 1 30); do
+    result=$(./gradlew build --no-daemon \
+        -Dazure.artifacts.credprovider.nonInteractive=true 2>&1 || true)
+
+    if echo "$result" | grep -q "BUILD SUCCESSFUL"; then
+        echo "All dependencies ingested successfully! ✅"
+        exit 0
+    fi
+
+    # Extract failed URLs and curl them with auth
+    urls=$(echo "$result" | grep "Could not GET\|Could not HEAD" \
+        | sed "s/.*'\(https:[^']*\)'.*/\1/" | sort -u | grep "pkgs.dev.azure.com" || true)
+    count=$(echo "$urls" | grep -c "https" 2>/dev/null || echo "0")
+
+    if [ "$count" = "0" ]; then
+        # No feed URLs failing — might be a different error
+        echo "Build failed but not due to feed issues. Check build output."
+        echo "$result" | grep -i "error" | grep -v "warning" | head -5
+        exit 1
+    fi
+
+    echo "  Run $i: ingesting $count packages..."
+    echo "$urls" | while read url; do
+        [ -z "$url" ] && continue
+        code=$(curl -s -o /dev/null -w "%{http_code}" --oauth2-bearer "$TOKEN" "$url" 2>/dev/null)
+        if [ "$code" = "200" ]; then
+            echo "    ✅ $(basename "$url")"
+        else
+            echo "    ❌ ($code) $(basename "$url")"
+        fi
+    done
+done
+
+echo "WARNING: Reached max iterations. Some packages may still need ingestion."
+exit 1

--- a/eng/init.gradle
+++ b/eng/init.gradle
@@ -1,5 +1,5 @@
-// Redirect Maven Central and Google Maven to Azure Artifacts feed
-// for CFSClean network isolation compliance.
+// Redirect Maven Central, Google Maven, and the Gradle Plugin Portal
+// to Azure Artifacts feed for CFSClean network isolation compliance.
 // See: https://aka.ms/1es/netiso/CFS
 allprojects {
     repositories {

--- a/eng/init.gradle
+++ b/eng/init.gradle
@@ -1,0 +1,24 @@
+// Redirect Maven Central and Google Maven to Azure Artifacts feed
+// for CFSClean network isolation compliance.
+// See: https://aka.ms/1es/netiso/CFS
+allprojects {
+    repositories {
+        def azureFeed = findByName("dotnet-public-maven") ?: maven {
+            url "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1"
+            name "dotnet-public-maven"
+        }
+
+        all { ArtifactRepository repo ->
+            if (repo != azureFeed &&
+                repo instanceof MavenArtifactRepository &&
+                (repo.url.toString().contains(".maven.org") ||
+                    repo.url.toString().contains("maven.apache.org") ||
+                    repo.url.toString().contains("maven.google.com") ||
+                    repo.url.toString().contains("dl.google.com") ||
+                    repo.url.toString().contains("plugins.gradle.org"))) {
+                    project.logger.warn "Replacing repository ${repo.url} with Azure Artifacts feed ${azureFeed.url}."
+                    remove repo
+                }
+        }
+    }
+}

--- a/eng/pipelines/common/cache-gradle.yml
+++ b/eng/pipelines/common/cache-gradle.yml
@@ -39,3 +39,14 @@ steps:
       "gradle" | "v1" | "$(Agent.OS)" | ${{ parameters.checkoutDirectory }}/src/Core/AndroidNative/gradle/wrapper/gradle-wrapper.properties
       "gradle" | "v1" | "$(Agent.OS)"
     path: $(GRADLE_USER_HOME)
+
+# Copy init.gradle AFTER cache restore so it is not overwritten by a stale cached copy
+- script: |
+    cp "${{ parameters.checkoutDirectory }}/eng/init.gradle" "$(GRADLE_USER_HOME)/init.gradle"
+  displayName: install Gradle init script (Linux/macOS)
+  condition: ne(variables['Agent.OS'], 'Windows_NT')
+
+- pwsh: |
+    Copy-Item "${{ parameters.checkoutDirectory }}/eng/init.gradle" (Join-Path "$(GRADLE_USER_HOME)" "init.gradle")
+  displayName: install Gradle init script (Windows)
+  condition: eq(variables['Agent.OS'], 'Windows_NT')

--- a/src/Core/AndroidNative/build.gradle
+++ b/src/Core/AndroidNative/build.gradle
@@ -1,8 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-        google()
-        mavenCentral()
+        maven {
+            url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
+            name = 'dotnet-public-maven'
+        }
     }
     dependencies {
         classpath "com.android.tools.build:gradle:8.11.1"

--- a/src/Core/AndroidNative/build.gradle
+++ b/src/Core/AndroidNative/build.gradle
@@ -1,9 +1,15 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
+    def isCI = System.getenv('TF_BUILD') == 'True' || System.getenv('CI') != null
     repositories {
-        maven {
-            url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
-            name = 'dotnet-public-maven'
+        if (isCI) {
+            maven {
+                url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
+                name = 'dotnet-public-maven'
+            }
+        } else {
+            google()
+            mavenCentral()
         }
     }
     dependencies {

--- a/src/Core/AndroidNative/gradle/wrapper/gradle-wrapper.properties
+++ b/src/Core/AndroidNative/gradle/wrapper/gradle-wrapper.properties
@@ -1,3 +1,9 @@
+# DO NOT upgrade Gradle beyond 8.x without verifying that the Microsoft.Android.Sdk
+# version used by this branch supports it. The Android SDK generates a
+# net.android.init.gradle.kts script that has a Kotlin type mismatch (String? vs Any)
+# incompatible with Gradle 9.x's stricter type checking. The fix is merged upstream
+# (dotnet/android#10738) but must ship in the Android SDK version referenced by this
+# branch before Gradle can be upgraded.
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip

--- a/src/Core/AndroidNative/settings.gradle
+++ b/src/Core/AndroidNative/settings.gradle
@@ -1,16 +1,40 @@
+// All Maven dependencies are resolved through the dnceng Azure Artifacts feed
+// (dotnet-public-maven) for CFSClean network isolation compliance. The feed
+// proxies Maven Central, Google Maven, and Gradle Plugin Portal.
+//
+// IMPORTANT: New packages must be ingested into the feed before CI can use them.
+// The CI credential provider plugin skips auth in Azure Pipelines, so packages
+// that aren't already in the feed will fail with 401. After adding or updating
+// dependencies, run:
+//
+//   ./eng/ingest-maven-deps.sh
+//
+// See: https://aka.ms/1es/netiso/CFS
+
 pluginManagement {
     repositories {
-        google()
-        mavenCentral()
-        gradlePluginPortal()
+        maven {
+            url = 'https://pkgs.dev.azure.com/artifacts-public/PublicTools/_packaging/AzureArtifacts/maven/v1'
+            name = 'AzureArtifacts'
+        }
+        maven {
+            url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
+            name = 'dotnet-public-maven'
+        }
     }
+}
+
+plugins {
+    id 'com.microsoft.azure.artifacts.credprovider' version '1.1.1'
 }
 
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.PREFER_PROJECT)
     repositories {
-        google()
-        mavenCentral()
+        maven {
+            url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
+            name = 'dotnet-public-maven'
+        }
     }
 }
 

--- a/src/Core/AndroidNative/settings.gradle
+++ b/src/Core/AndroidNative/settings.gradle
@@ -1,6 +1,7 @@
-// All Maven dependencies are resolved through the dnceng Azure Artifacts feed
-// (dotnet-public-maven) for CFSClean network isolation compliance. The feed
-// proxies Maven Central, Google Maven, and Gradle Plugin Portal.
+// Project Maven dependencies are resolved through the dnceng Azure Artifacts
+// feed (dotnet-public-maven) for CFSClean network isolation compliance. The feed
+// proxies Maven Central, Google Maven, and Gradle Plugin Portal. The credential
+// provider plugin is fetched from a separate Azure Artifacts feed (artifacts-public).
 //
 // IMPORTANT: New packages must be ingested into the feed before CI can use them.
 // The CI credential provider plugin skips auth in Azure Pipelines, so packages

--- a/src/Core/AndroidNative/settings.gradle
+++ b/src/Core/AndroidNative/settings.gradle
@@ -1,40 +1,37 @@
-// Project Maven dependencies are resolved through the dnceng Azure Artifacts
-// feed (dotnet-public-maven) for CFSClean network isolation compliance. The feed
-// proxies Maven Central, Google Maven, and Gradle Plugin Portal. The credential
-// provider plugin is fetched from a separate Azure Artifacts feed (artifacts-public).
+// In CI (CFSClean network isolation), Maven dependencies resolve through the
+// dnceng Azure Artifacts feed (dotnet-public-maven). Locally, standard Maven
+// Central and Google Maven are used for faster builds.
 //
-// IMPORTANT: New packages must be ingested into the feed before CI can use them.
-// The CI credential provider plugin skips auth in Azure Pipelines, so packages
-// that aren't already in the feed will fail with 401. After adding or updating
-// dependencies, run:
-//
-//   ./eng/ingest-maven-deps.sh
-//
+// When adding or updating dependencies, run eng/ingest-maven-deps.sh to
+// pre-populate the Azure Artifacts feed for CI.
 // See: https://aka.ms/1es/netiso/CFS
 
 pluginManagement {
     repositories {
-        maven {
-            url = 'https://pkgs.dev.azure.com/artifacts-public/PublicTools/_packaging/AzureArtifacts/maven/v1'
-            name = 'AzureArtifacts'
-        }
-        maven {
-            url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
-            name = 'dotnet-public-maven'
+        if (System.getenv('TF_BUILD') == 'True') {
+            maven {
+                url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
+                name = 'dotnet-public-maven'
+            }
+        } else {
+            google()
+            mavenCentral()
+            gradlePluginPortal()
         }
     }
-}
-
-plugins {
-    id 'com.microsoft.azure.artifacts.credprovider' version '1.1.1'
 }
 
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.PREFER_PROJECT)
     repositories {
-        maven {
-            url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
-            name = 'dotnet-public-maven'
+        if (System.getenv('TF_BUILD') == 'True') {
+            maven {
+                url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
+                name = 'dotnet-public-maven'
+            }
+        } else {
+            google()
+            mavenCentral()
         }
     }
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Problem

PR #35169 switched all Gradle repos to the Azure Artifacts feed unconditionally. This causes **10+ minute local builds** because the credential provider plugin adds significant auth overhead (MSAL token acquisition, feed latency vs direct Maven Central).

## Fix

Use `google()`/`mavenCentral()` locally and only switch to the Azure Artifacts feed when `TF_BUILD=True` (Azure Pipelines with CFSClean). This keeps local builds fast while CI remains compliant.

The `init.gradle` still handles the Android SDK bindings Gradle targets redirection in CI via the pipeline template.

## Verified
- Local build uses standard Maven repos (fast)
- CI sets `TF_BUILD=True` which activates the Azure Artifacts feed