### PR TITLE
Use Azure Artifacts feed only in CI, standard repos locally

### DIFF
--- a/eng/ingest-maven-deps.sh
+++ b/eng/ingest-maven-deps.sh
@@ -68,6 +68,10 @@ if [ -z "$TOKEN" ]; then
 fi
 echo "Token acquired."
 
+# Force Gradle to use the Azure Artifacts feed (same as CI) so that
+# dependency resolution goes through the feed and triggers ingestion.
+export TF_BUILD=True
+
 # Step 2: Ingest platform-specific artifacts for all OS variants
 # Gradle only resolves the classifier for the current OS (e.g. aapt2-osx.jar on macOS).
 # CI builds on Windows/Linux need their variants pre-ingested too.

--- a/eng/ingest-maven-deps.sh
+++ b/eng/ingest-maven-deps.sh
@@ -70,6 +70,7 @@ echo "Token acquired."
 
 # Force Gradle to use the Azure Artifacts feed (same as CI) so that
 # dependency resolution goes through the feed and triggers ingestion.
+# Required because settings.gradle gates repo selection on TF_BUILD.
 export TF_BUILD=True
 
 # Step 2: Ingest platform-specific artifacts for all OS variants

--- a/src/Core/AndroidNative/build.gradle
+++ b/src/Core/AndroidNative/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-        if (System.getenv('TF_BUILD') == 'True') {
+        if ((System.getenv('TF_BUILD') ?: '').equalsIgnoreCase('true')) {
             maven {
                 url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
                 name = 'dotnet-public-maven'

--- a/src/Core/AndroidNative/build.gradle
+++ b/src/Core/AndroidNative/build.gradle
@@ -1,9 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-        maven {
-            url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
-            name = 'dotnet-public-maven'
+        if (System.getenv('TF_BUILD') == 'True') {
+            maven {
+                url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
+                name = 'dotnet-public-maven'
+            }
+        } else {
+            google()
+            mavenCentral()
         }
     }
     dependencies {

--- a/src/Core/AndroidNative/settings.gradle
+++ b/src/Core/AndroidNative/settings.gradle
@@ -8,7 +8,7 @@
 
 pluginManagement {
     repositories {
-        if (System.getenv('TF_BUILD') == 'True') {
+        if ((System.getenv('TF_BUILD') ?: '').equalsIgnoreCase('true')) {
             maven {
                 url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
                 name = 'dotnet-public-maven'
@@ -24,7 +24,7 @@ pluginManagement {
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.PREFER_PROJECT)
     repositories {
-        if (System.getenv('TF_BUILD') == 'True') {
+        if ((System.getenv('TF_BUILD') ?: '').equalsIgnoreCase('true')) {
             maven {
                 url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
                 name = 'dotnet-public-maven'

--- a/src/Core/AndroidNative/settings.gradle
+++ b/src/Core/AndroidNative/settings.gradle
@@ -1,40 +1,37 @@
-// Project Maven dependencies are resolved through the dnceng Azure Artifacts
-// feed (dotnet-public-maven) for CFSClean network isolation compliance. The feed
-// proxies Maven Central, Google Maven, and Gradle Plugin Portal. The credential
-// provider plugin is fetched from a separate Azure Artifacts feed (artifacts-public).
+// In CI (CFSClean network isolation), Maven dependencies resolve through the
+// dnceng Azure Artifacts feed (dotnet-public-maven). Locally, standard Maven
+// Central and Google Maven are used for faster builds.
 //
-// IMPORTANT: New packages must be ingested into the feed before CI can use them.
-// The CI credential provider plugin skips auth in Azure Pipelines, so packages
-// that aren't already in the feed will fail with 401. After adding or updating
-// dependencies, run:
-//
-//   ./eng/ingest-maven-deps.sh
-//
+// When adding or updating dependencies, run eng/ingest-maven-deps.sh to
+// pre-populate the Azure Artifacts feed for CI.
 // See: https://aka.ms/1es/netiso/CFS
 
 pluginManagement {
     repositories {
-        maven {
-            url = 'https://pkgs.dev.azure.com/artifacts-public/PublicTools/_packaging/AzureArtifacts/maven/v1'
-            name = 'AzureArtifacts'
-        }
-        maven {
-            url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
-            name = 'dotnet-public-maven'
+        if (System.getenv('TF_BUILD') == 'True') {
+            maven {
+                url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
+                name = 'dotnet-public-maven'
+            }
+        } else {
+            google()
+            mavenCentral()
+            gradlePluginPortal()
         }
     }
-}
-
-plugins {
-    id 'com.microsoft.azure.artifacts.credprovider' version '1.1.1'
 }
 
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.PREFER_PROJECT)
     repositories {
-        maven {
-            url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
-            name = 'dotnet-public-maven'
+        if (System.getenv('TF_BUILD') == 'True') {
+            maven {
+                url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
+                name = 'dotnet-public-maven'
+            }
+        } else {
+            google()
+            mavenCentral()
         }
     }
 }

--- a/src/Core/AndroidNative/settings.gradle
+++ b/src/Core/AndroidNative/settings.gradle
@@ -2,8 +2,12 @@
 // dnceng Azure Artifacts feed (dotnet-public-maven). Locally, standard Maven
 // Central and Google Maven are used for faster builds.
 //
-// When adding or updating dependencies, run eng/ingest-maven-deps.sh to
-// pre-populate the Azure Artifacts feed for CI.
+// IMPORTANT: New packages must be ingested before CI can use them.
+// If CI fails with "Could not GET ... 401", the package is not yet in the feed.
+// Run ./eng/ingest-maven-deps.sh after adding or updating any Maven dependency.
+//
+// In CI, eng/init.gradle (injected by cache-gradle.yml) also handles
+// project-level repo substitution for Android SDK binding targets.
 // See: https://aka.ms/1es/netiso/CFS
 
 pluginManagement {


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Problem

PR #35169 switched all Gradle repos to the Azure Artifacts feed unconditionally. This causes **10+ minute local Android builds** because the credential provider plugin adds significant auth overhead (MSAL token acquisition, feed latency vs direct Maven Central).

Reported by team members in India experiencing builds that never complete.

## Fix

Use `google()`/`mavenCentral()` for local builds and only switch to the Azure Artifacts feed when `TF_BUILD=True` (Azure Pipelines with CFSClean network isolation).

```groovy
if (System.getenv('TF_BUILD') == 'True') {
    // Azure Artifacts feed for CI
} else {
    // Standard Maven repos for local dev
}
```

This also removes the credential provider plugin dependency for local builds since it's not needed when using standard Maven repos.

The `init.gradle` still handles the Android SDK bindings Gradle targets redirection in CI via the pipeline template.

## Verified
- ✅ Local build uses standard Maven repos (fast, no credential provider overhead)
- ✅ CI sets `TF_BUILD=True` which activates the Azure Artifacts feed