### PR TITLE
[review.agent] Wrap review summary and inline comments in collapsible <details> blocks

### DIFF
--- a/.github/workflows/shared/review-shared.md
+++ b/.github/workflows/shared/review-shared.md
@@ -137,7 +137,46 @@ Before posting inline comments, validate **both**:
 
 **Cap inline comments at 30** (the safe-output limit). If more than 30 findings, post the 30 most severe inline and include the rest in the review summary body.
 
-The review body must include:
+#### Collapsible formatting (required)
+
+Wrap **both** the review summary body and every inline comment body in `<details>` blocks so reviewers see one-line headers in the timeline by default and only expand what's relevant. This keeps low-severity findings out of the way without filtering them.
+
+**Review summary body** (passed to `submit_pull_request_review`) — must follow this exact structure:
+
+```html
+## 🤖 Expert Code Review
+
+<details>
+<summary>{verdictDot} <strong>{verdictLabel}</strong> — <a href="https://github.com/{owner}/{repo}/commit/{commitFull}"><code>{commitSha7}</code></a> · <strong>{prTitle}</strong></summary>
+
+[full review body: methodology, overall assessment, findings table, discarded findings, test coverage, summary]
+
+</details>
+```
+
+Where:
+- `{verdictDot}` / `{verdictLabel}` is one of: `🟢 LGTM` (no 🔴/🟡 findings), `🟡 Changes Suggested` (any 🟡 MODERATE), `🔴 Changes Required` (any 🔴 CRITICAL), `🟠 Discussion Needed` (architectural concerns flagged).
+- `{commitSha7}` is the 7-character short SHA of the head commit being reviewed; `{commitFull}` is the full SHA used in the link.
+- `{prTitle}` is the PR title at the time of review.
+- Use `<details open>` (open by default) when the verdict is 🔴 or 🟡 so reviewers see findings without an extra click. Use `<details>` (closed) for 🟢 LGTM.
+- Do **not** include a timestamp or finding-count tally in the summary line.
+
+**Inline comment bodies** (each `create_pull_request_review_comment` call) — must follow this exact structure:
+
+```html
+<details>
+<summary>{severityDot} <strong>{severityLabel}</strong> — {one-line headline} ({N}/3 reviewers)</summary>
+
+[full finding body: explanation, references, recommendation]
+
+</details>
+```
+
+Where `{severityDot}` / `{severityLabel}` is `🔴 CRITICAL`, `🟡 MODERATE`, or `🟢 MINOR`. Always closed by default — the summary line carries enough information to decide whether to expand.
+
+#### Required body content
+
+The review body inside the `<details>` block must include:
 - All findings ranked by severity (🔴 CRITICAL, 🟡 MODERATE, 🟢 MINOR)
 - Consensus markers (e.g., "3/3 reviewers", "2/3 reviewers") for each finding
 - Methodology note: "3 independent reviewers with adversarial consensus"


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

Wraps the **Expert Code Review** workflow's output (review summary body + every inline comment body) in collapsible `<details>` blocks so reviewers see a one-line header in the timeline by default and only expand what's relevant. Reduces noise on PRs with many MINOR findings **without filtering any content** — everything is one click away.

This addresses the readability problem visible on PRs like [#33007](https://github.com/dotnet/maui/pull/33007#pullrequestreview-4196020689), where 4 inline comments + a long summary scroll past every conversation-tab visit.

## What changed

`.github/workflows/shared/review-shared.md` Step 4 — orchestrator instructions now require:

**Review summary body** (`submit_pull_request_review`):

```html
## 🤖 Expert Code Review

<details>
<summary>{verdictDot} <strong>{verdictLabel}</strong> — <a href="https://github.com/{owner}/{repo}/commit/{commitFull}"><code>{commitSha7}</code></a> · <strong>{prTitle}</strong></summary>

[full body]

</details>
```

- `{verdictDot}` / `{verdictLabel}`: 🟢 LGTM | 🟡 Changes Suggested | 🔴 Changes Required | 🟠 Discussion Needed
- `<details open>` for 🔴/🟡 (so findings are visible without a click); `<details>` (closed) for 🟢
- No timestamp, no finding-count tally — just verdict + commit + PR title

**Inline comments** (each `create_pull_request_review_comment`):

```html
<details>
<summary>{severityDot} <strong>{severityLabel}</strong> — {one-line headline} ({N}/3 reviewers)</summary>

[full body]

</details>
```

Always closed by default — the headline carries enough info to decide whether to expand.

## Preview

A live preview is posted on closed PR #35190 — see review [#4196553207](https://github.com/dotnet/maui/pull/35190#pullrequestreview-4196553207). The two inline comments under it have additionally been minimized via GraphQL `minimizeComment(classifier: OUTDATED)` to demonstrate the optional "Show minimized comment" UX in the Files Changed tab (not part of this PR — would require a follow-up post-step in the workflow).

## Notes

- This is a **prompt-body** change in `review-shared.md` (after the frontmatter `---`). Per gh-aw, only frontmatter changes affect the lock-file hash, so **no `gh aw compile` is required**.
- No frontmatter, no safe-outputs, no permissions changed.
- No code changes — only orchestration-prompt text the agent follows when posting reviews.

## How to test

1. Trigger the workflow against an existing open PR that has multiple findings:
   ```bash
   gh workflow run review.agent.yml -R dotnet/maui -f pr_number=<PR_NUMBER> --ref copilot/collapsible-review-comments
   ```
   (Or comment `/review` on the PR after enabling slash-command from this branch.)
2. Watch the run at https://github.com/dotnet/maui/actions/workflows/review.agent.lock.yml
3. Open the PR and verify:
   - Conversation tab shows `## 🤖 Expert Code Review` heading + a single collapsed `<details>` line with verdict, commit short SHA, and PR title.
   - Files Changed tab shows each inline comment as a collapsed `<details>` thread.
   - 🔴/🟡 reviews open by default; 🟢 LGTM stays closed.

A safe target is a small recently-merged PR — re-running on a closed PR is fine and produces a comparable preview comment without affecting open work.
