### PR TITLE
Fix milestone detection for inflight PRs that missed release cutoff

### DIFF
--- a/.github/scripts/Fix-MilestoneDrift.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.ps1
@@ -592,6 +592,36 @@ function Invoke-AnalyzeSinglePr([int]$PrNum, [string]$ReleaseTag, [string]$Repo)
                 $preIter = if ($versionInfo.PreIter) { $versionInfo.PreIter } else { 0 }
                 $preDisplay = if ($versionInfo.PreLabel) { " ($($versionInfo.PreLabel)$($versionInfo.PreIter))" } else { "" }
                 Write-Host "  Version from Versions.props at merge commit: $ReleaseTag$preDisplay"
+
+                # Step 2b: For PRs merged to inflight/* branches, verify the PR
+                # actually shipped in the detected version. Inflight PRs have merge
+                # commits on the inflight branch (not the release branch), so we check
+                # by PR number in the tag's commit range instead of commit ancestry.
+                if ($pr.BaseRef -match '^inflight/' -and $ReleaseTag) {
+                    $allTags = Get-AllTags $Repo
+                    if ($ReleaseTag -in $allTags) {
+                        $prev = Find-PreviousTag $ReleaseTag $allTags
+                        $prsInTag = if ($prev) {
+                            Get-PrNumbersBetweenTags $prev $ReleaseTag $Repo
+                        } else {
+                            Get-PrNumbersReachableFromTag $ReleaseTag $Repo
+                        }
+                        if ($PrNum -notin $prsInTag) {
+                            # PR number not found in the tag range — PR missed this release
+                            $patch = Get-PatchVersion $ReleaseTag
+                            $major = if ($ReleaseTag -match '^(\d+)\.') { [int]$Matches[1] } else { $detectedMajor }
+                            $nextPatch = $patch + 10
+                            $nextTag = "$major.0.$nextPatch"
+                            Write-Host "  ⚠️  PR #$PrNum merged to $($pr.BaseRef) but is NOT in tag $ReleaseTag — advancing to $nextTag"
+                            $ReleaseTag = $nextTag
+                            $versionInfo = $null  # Clear so downstream uses $ReleaseTag
+                            $preLabel = $null
+                            $preIter = 0
+                        } else {
+                            Write-Host "  ✅ PR #$PrNum merged to $($pr.BaseRef) and found in tag $ReleaseTag (via candidate)"
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Fixes milestone detection for PRs that merge to `inflight/*` branches but miss the release tag cutoff.

### Problem

When a PR merges to `inflight/current` or `inflight/candidate`, the milestone script reads `Versions.props` at the merge commit to determine the version. But `Versions.props` only tells us what version was *being developed* — not whether the PR actually *shipped*. PRs that merge to inflight after the candidate cutoff get incorrectly milestoned to the already-shipped release.

Example: PR #34959 merged to `inflight/candidate` during the SR6 development period. But the April 14th candidate (#34885) merged to main *after* the `10.0.60` tag was cut, so #34959 did not ship in SR6. The script was incorrectly milestoning it to SR6.

### Fix

After detecting the version from `Versions.props`, check if the PR number appears in the tag's commit range (searching commit messages for `(#NNNNN)` patterns — the same approach the tag-based mode uses). If the tag exists but the PR is not in the range, advance to the next SR version.

This correctly handles:
- ✅ Inflight PRs that shipped via a candidate merge (found in tag range → keep version)
- ✅ Inflight PRs that missed the cutoff (not in tag range → advance to next SR)
- ✅ PRs merged directly to main (no inflight check needed)
- ✅ PRs found on release branches (detected by `Find-ReleaseBranchForCommit`)