### PR TITLE
Fix iOS CollectionView stale layout invalidations

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -265,7 +265,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				if (visibleCells[n] is TemplatedCell { MeasureInvalidated: true } cell)
 				{
 					var indexPath = CollectionView.IndexPathForCell(cell);
-					if (ItemsSource.IsIndexPathValid(indexPath))
+					if (indexPath is not null && ItemsSource.IsIndexPathValid(indexPath))
 					{
 						invalidatedIndexPaths ??= [];
 						invalidatedIndexPaths.Add(indexPath);

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			if (_isEmpty)
 			{
-				_measurementCells?.Clear();
+				ClearMeasurementCells();
 				ItemsViewLayout?.ClearCellSizeCache();
 			}
 
@@ -257,19 +257,23 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		void InvalidateLayoutIfItemsMeasureChanged()
 		{
 			var visibleCells = CollectionView.VisibleCells;
-			List<TemplatedCell> invalidatedCells = null;
+			List<NSIndexPath> invalidatedIndexPaths = null;
 
 			var visibleCellsLength = visibleCells.Length;
 			for (int n = 0; n < visibleCellsLength; n++)
 			{
 				if (visibleCells[n] is TemplatedCell { MeasureInvalidated: true } cell)
 				{
-					invalidatedCells ??= [];
-					invalidatedCells.Add(cell);
+					var indexPath = CollectionView.IndexPathForCell(cell);
+					if (ItemsSource.IsIndexPathValid(indexPath))
+					{
+						invalidatedIndexPaths ??= [];
+						invalidatedIndexPaths.Add(indexPath);
+					}
 				}
 			}
 
-			if (invalidatedCells is not null)
+			if (invalidatedIndexPaths is not null)
 			{
 				// GridLayout has a special positioning override when there's only one item
 				// so we have to invalidate the layout entirely to trigger that special case.
@@ -280,7 +284,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				else
 				{
 					var layoutInvalidationContext = new UICollectionViewFlowLayoutInvalidationContext();
-					layoutInvalidationContext.InvalidateItems(invalidatedCells.Select(CollectionView.IndexPathForCell).ToArray());
+					layoutInvalidationContext.InvalidateItems(invalidatedIndexPaths.ToArray());
 					CollectionView.CollectionViewLayout.InvalidateLayout(layoutInvalidationContext);
 				}
 			}
@@ -419,7 +423,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public virtual void UpdateItemsSource()
 		{
-			_measurementCells?.Clear();
+			ClearMeasurementCells();
 			ItemsViewLayout?.ClearCellSizeCache();
 			ItemsSource?.Dispose();
 			ItemsSource = CreateItemsViewSource();
@@ -432,7 +436,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		internal void DisposeItemsSource()
 		{
-			_measurementCells?.Clear();
+			ClearMeasurementCells();
 			ItemsViewLayout?.ClearCellSizeCache();
 			ItemsSource?.Dispose();
 			ItemsSource = new EmptySource();
@@ -512,6 +516,20 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			cell.LayoutAttributesChanged += CellLayoutAttributesChanged;
 
 			ItemsViewLayout.PrepareCellForLayout(cell);
+		}
+
+		void ClearMeasurementCells()
+		{
+			if (_measurementCells is not null)
+			{
+				foreach (var measurementCell in _measurementCells.Values)
+				{
+					measurementCell.LayoutAttributesChanged -= CellLayoutAttributesChanged;
+					measurementCell.Unbind();
+				}
+
+				_measurementCells.Clear();
+			}
 		}
 
 		public virtual NSIndexPath GetIndexForItem(object item)

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -520,16 +520,13 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		void ClearMeasurementCells()
 		{
-			if (_measurementCells is not null)
+			foreach (var measurementCell in _measurementCells.Values)
 			{
-				foreach (var measurementCell in _measurementCells.Values)
-				{
-					measurementCell.LayoutAttributesChanged -= CellLayoutAttributesChanged;
-					measurementCell.Unbind();
-				}
-
-				_measurementCells.Clear();
+				measurementCell.LayoutAttributesChanged -= CellLayoutAttributesChanged;
+				measurementCell.Unbind();
 			}
+
+			_measurementCells.Clear();
 		}
 
 		public virtual NSIndexPath GetIndexForItem(object item)

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -211,22 +211,26 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		{
 			var collectionView = CollectionView;
 			var visibleCells = collectionView.VisibleCells;
-			List<TemplatedCell2> invalidatedCells = null;
+			List<NSIndexPath> invalidatedIndexPaths = null;
 
 			var visibleCellsLength = visibleCells.Length;
 			for (int n = 0; n < visibleCellsLength; n++)
 			{
 				if (visibleCells[n] is TemplatedCell2 { MeasureInvalidated: true } cell)
 				{
-					invalidatedCells ??= [];
-					invalidatedCells.Add(cell);
+					var indexPath = CollectionView.IndexPathForCell(cell);
+					if (indexPath is not null && Items.IndexPathHelpers.IsIndexPathValid(ItemsSource, indexPath))
+					{
+						invalidatedIndexPaths ??= [];
+						invalidatedIndexPaths.Add(indexPath);
+					}
 				}
 			}
 
-			if (invalidatedCells is not null)
+			if (invalidatedIndexPaths is not null)
 			{
 				var layoutInvalidationContext = new UICollectionViewLayoutInvalidationContext();
-				layoutInvalidationContext.InvalidateItems(invalidatedCells.Select(CollectionView.IndexPathForCell).ToArray());
+				layoutInvalidationContext.InvalidateItems(invalidatedIndexPaths.ToArray());
 				collectionView.CollectionViewLayout.InvalidateLayout(layoutInvalidationContext);
 			}
 		}

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -218,7 +218,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			{
 				if (visibleCells[n] is TemplatedCell2 { MeasureInvalidated: true } cell)
 				{
-					var indexPath = CollectionView.IndexPathForCell(cell);
+					var indexPath = collectionView.IndexPathForCell(cell);
 					if (indexPath is not null && Items.IndexPathHelpers.IsIndexPathValid(ItemsSource, indexPath))
 					{
 						invalidatedIndexPaths ??= [];

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
@@ -251,10 +251,17 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.False(source.IsIndexPathValid(invalidSection));
 		}
 
-		[Fact]
-		public async Task ClearingItemsSourceAfterCellMeasureInvalidationDoesNotCrash()
+		private async Task ClearingItemsSourceAfterCellMeasureInvalidationDoesNotCrashHelper<THandler>()
+			where THandler : class, IElementHandler
 		{
-			SetupBuilder();
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler<CollectionView, THandler>();
+					handlers.AddHandler<Label, LabelHandler>();
+				});
+			});
 
 			var labels = new List<Label>();
 			var items = new ObservableCollection<string>
@@ -286,19 +293,37 @@ namespace Microsoft.Maui.DeviceTests
 
 			var frame = collectionView.Frame;
 
-			await CreateHandlerAndAddToWindow<CollectionViewHandler>(collectionView, async handler =>
+			await CreateHandlerAndAddToWindow<THandler>(collectionView, async handler =>
 			{
 				await WaitForUIUpdate(frame, collectionView);
 
 				Assert.NotEmpty(labels);
 
-				labels[0].Text = "one with enough extra text to invalidate the measured cell size";
+				// Change text of all the labels to force a relayout, including those that were
+				// only used for measurement cell. Now we should be sure that all visible cells
+				// have their MeasureInvalidate == true.
+				foreach (var label in labels)
+					label.Text = label.Text + " with enough extra text to invalidate the measured cell size";
+				// Add another item to force an animation
 				items.Add("five");
+				// Reset the data source to force another animation and a layout pass
 				collectionView.ItemsSource = null;
 
 				await Task.Delay(100);
-				handler.PlatformView.LayoutIfNeeded();
+				((UIView)handler.PlatformView).LayoutIfNeeded();
 			});
+		}
+
+		[Fact(DisplayName = "CollectionView Does Not Crash After Reseting Source With Running Animation")]
+		public Task ClearingItemsSourceAfterCellMeasureInvalidationDoesNotCrash()
+		{
+			return ClearingItemsSourceAfterCellMeasureInvalidationDoesNotCrashHelper<CollectionViewHandler>();
+		}
+
+		[Fact(DisplayName = "CollectionViewHandler2 Does Not Crash After Reseting Source With Running Animation")]
+		public Task ClearingItemsSourceAfterCellMeasureInvalidationDoesNotCrash2()
+		{
+			return ClearingItemsSourceAfterCellMeasureInvalidationDoesNotCrashHelper<CollectionViewHandler2>();
 		}
 
 		[Fact(DisplayName = "CollectionView Does Not Leak With Default ItemsLayout")]

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
@@ -301,7 +301,7 @@ namespace Microsoft.Maui.DeviceTests
 
 				// Change text of all the labels to force a relayout, including those that were
 				// only used for measurement cell. Now we should be sure that all visible cells
-				// have their MeasureInvalidate == true.
+				// have their MeasureInvalidated == true.
 				foreach (var label in labels)
 					label.Text = label.Text + " with enough extra text to invalidate the measured cell size";
 				// Add another item to force an animation
@@ -314,13 +314,13 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Fact(DisplayName = "CollectionView Does Not Crash After Reseting Source With Running Animation")]
+		[Fact(DisplayName = "CollectionView Does Not Crash After Resetting Source With Running Animation")]
 		public Task ClearingItemsSourceAfterCellMeasureInvalidationDoesNotCrash()
 		{
 			return ClearingItemsSourceAfterCellMeasureInvalidationDoesNotCrashHelper<CollectionViewHandler>();
 		}
 
-		[Fact(DisplayName = "CollectionViewHandler2 Does Not Crash After Reseting Source With Running Animation")]
+		[Fact(DisplayName = "CollectionViewHandler2 Does Not Crash After Resetting Source With Running Animation")]
 		public Task ClearingItemsSourceAfterCellMeasureInvalidationDoesNotCrash2()
 		{
 			return ClearingItemsSourceAfterCellMeasureInvalidationDoesNotCrashHelper<CollectionViewHandler2>();

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
@@ -251,6 +251,56 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.False(source.IsIndexPathValid(invalidSection));
 		}
 
+		[Fact]
+		public async Task ClearingItemsSourceAfterCellMeasureInvalidationDoesNotCrash()
+		{
+			SetupBuilder();
+
+			var labels = new List<Label>();
+			var items = new ObservableCollection<string>
+			{
+				"one",
+				"two",
+				"three",
+				"four"
+			};
+
+			var collectionView = new CollectionView
+			{
+				HeightRequest = 200,
+				WidthRequest = 300,
+				ItemsSource = items,
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var label = new Label
+					{
+						LineBreakMode = LineBreakMode.WordWrap
+					};
+
+					label.SetBinding(Label.TextProperty, ".");
+					labels.Add(label);
+
+					return label;
+				})
+			};
+
+			var frame = collectionView.Frame;
+
+			await CreateHandlerAndAddToWindow<CollectionViewHandler>(collectionView, async handler =>
+			{
+				await WaitForUIUpdate(frame, collectionView);
+
+				Assert.NotEmpty(labels);
+
+				labels[0].Text = "one with enough extra text to invalidate the measured cell size";
+				items.Add("five");
+				collectionView.ItemsSource = null;
+
+				await Task.Delay(100);
+				handler.PlatformView.LayoutIfNeeded();
+			});
+		}
+
 		[Fact(DisplayName = "CollectionView Does Not Leak With Default ItemsLayout")]
 		public async Task CollectionViewDoesNotLeakWithDefaultItemsLayout()
 		{

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
@@ -309,8 +309,13 @@ namespace Microsoft.Maui.DeviceTests
 				// Reset the data source to force another animation and a layout pass
 				collectionView.ItemsSource = null;
 
-				await Task.Delay(100);
-				((UIView)handler.PlatformView).LayoutIfNeeded();
+				var platformView = (UIView)handler.PlatformView;
+				var uiCollectionView = platformView as UICollectionView ?? platformView.Subviews.OfType<UICollectionView>().FirstOrDefault();
+				Assert.NotNull(uiCollectionView);
+				// Force synchronous flush of the ItemsSource reloading
+				await uiCollectionView.PerformBatchUpdatesAsync(() => { });
+				// Force a layout
+				platformView.LayoutIfNeeded();
 			});
 		}
 


### PR DESCRIPTION
### Description of Change

There are two related races in the iOS CollectionView handler when the item source changes while cells are still participating in UIKit layout.

The first race happens after a visible templated cell invalidates its measure. MAUI records that state on the cell and the next ViewWillLayoutSubviews pass asks UICollectionViewFlowLayout to invalidate exactly those changed items. Previously the handler collected the cells first and converted them back to index paths later, at the point where the invalidation context was created. If the bound ItemsSource had changed in the meantime, for example an observable source inserted items and the view then cleared or replaced ItemsSource before the next layout pass, UIKit could still report a visible cell whose current index path no longer existed in MAUI's new ItemsSource. Passing that stale index path to InvalidateItems leaves UICollectionView and the data source with inconsistent item counts and can crash during layout.

Fix that path by resolving each invalidated visible cell to an NSIndexPath immediately and keeping only paths that are still valid for the current ItemsSource. The invalidation context is then built from the validated paths. This preserves targeted invalidation for normal measure changes, while dropping cells that belong to the previous source state and cannot be safely invalidated by item path anymore.

The second race involves measurement cells. ItemsViewController keeps prototype templated cells in _measurementCells so their realized content can be transferred to real UICollectionView cells. When an ItemsSource update, empty-source transition, or source disposal clears that dictionary, the old code only removed the references. Those measurement cells could still be bound to item view models and still subscribed to LayoutAttributesChanged. Later binding or property changes from that stale content could propagate measure/layout invalidations through cells that are no longer owned by the active source state. In the worst case this combines with UIKit's pending layout work after ReloadData or source clearing and contributes to the same stale layout invalidation problem; it can also keep disconnected measurement content behaving as if it were still live.

Fix that by centralizing measurement-cell clearing. Before the cache is cleared, each cached cell is detached from the layout-attribute event and unbound so its BindingContext is removed and future measure invalidations from that stale measured content do not flow back into the CollectionView layout.

The regression test reproduces the important ordering: a templated CollectionView is displayed, a visible label changes text so the cell measure is invalidated, the observable source mutates, and ItemsSource is immediately cleared before UIKit finishes its next layout pass. The test forces layout afterward and verifies this no longer crashes.

### Issues Fixed

Fixes #35244
