### PR TITLE
Add try/catch to async void StartUrlSchemeTask in HybridWebViewHandler.iOS.cs

### DIFF
--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
@@ -180,33 +180,41 @@ namespace Microsoft.Maui.Handlers
 				{
 					logger?.LogDebug("Request for {Url} will be handled by .NET MAUI.", url);
 
-					// 2.a. Check if the request is for a local resource
-					var (bytes, contentType, statusCode) = await GetResponseBytesAsync(url, urlSchemeTask.Request, logger);
-
-					// 2.b. Return the response header
-					using var dic = new NSMutableDictionary<NSString, NSString>();
-					if (contentType is not null)
+					try
 					{
-						dic[(NSString)"Content-Type"] = (NSString)contentType;
+						// 2.a. Check if the request is for a local resource
+						var (bytes, contentType, statusCode) = await GetResponseBytesAsync(url, urlSchemeTask.Request, logger);
+
+						// 2.b. Return the response header
+						using var dic = new NSMutableDictionary<NSString, NSString>();
+						if (contentType is not null)
+						{
+							dic[(NSString)"Content-Type"] = (NSString)contentType;
+						}
+						if (bytes?.Length > 0)
+						{
+							// Disable local caching which would otherwise prevent user scripts from executing correctly.
+							dic[(NSString)"Cache-Control"] = (NSString)"no-cache, max-age=0, must-revalidate, no-store";
+							dic[(NSString)"Content-Length"] = (NSString)bytes.Length.ToString(CultureInfo.InvariantCulture);
+						}
+
+						using var response = new NSHttpUrlResponse(urlSchemeTask.Request.Url, statusCode, "HTTP/1.1", dic);
+						urlSchemeTask.DidReceiveResponse(response);
+
+						// 2.c. Return the body
+						if (bytes?.Length > 0)
+						{
+							urlSchemeTask.DidReceiveData(bytes);
+						}
+
+						// 2.d. Finish the task
+						urlSchemeTask.DidFinish();
 					}
-					if (bytes?.Length > 0)
+					catch (Exception ex)
 					{
-						// Disable local caching which would otherwise prevent user scripts from executing correctly.
-						dic[(NSString)"Cache-Control"] = (NSString)"no-cache, max-age=0, must-revalidate, no-store";
-						dic[(NSString)"Content-Length"] = (NSString)bytes.Length.ToString(CultureInfo.InvariantCulture);
+						logger?.LogError(ex, "Error handling URL scheme task for {Url}.", url);
+						urlSchemeTask.DidFailWithError(new NSError(new NSString("HybridWebViewError"), -1, null));
 					}
-
-					using var response = new NSHttpUrlResponse(urlSchemeTask.Request.Url, statusCode, "HTTP/1.1", dic);
-					urlSchemeTask.DidReceiveResponse(response);
-
-					// 2.c. Return the body
-					if (bytes?.Length > 0)
-					{
-						urlSchemeTask.DidReceiveData(bytes);
-					}
-
-					// 2.d. Finish the task
-					urlSchemeTask.DidFinish();
 				}
 
 				// 3. If the request is not handled by the app nor is it a local source, then we let the WKWebView


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

`StartUrlSchemeTask` in `HybridWebViewHandler.iOS.cs` is an `async void` event handler that awaits `GetResponseBytesAsync` with no try/catch. Apple's WKURLSchemeHandler contract requires that every started task is completed by exactly one call to either `DidFinish()` or `DidFailWithError()`. If an exception is thrown (e.g. `ObjectDisposedException` during handler teardown, `IOException` reading an asset), neither is called — causing WKWebView to hang indefinitely and the unhandled exception to propagate to the OS unhandled-exception handler.

## Changes

- Wrapped the `await GetResponseBytesAsync` + `DidReceiveResponse`/`DidReceiveData`/`DidFinish` block in a try/catch in `HybridWebViewHandler.iOS.cs`.
- In the catch block, calls `urlSchemeTask.DidFailWithError(new NSError(...))` to satisfy Apple's WKURLSchemeHandler contract and logs the exception via the existing logger.

## Testing

Build the iOS target and run existing HybridWebView device tests in `src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj`.
