### PR TITLE
[iOS] Suppress IL2026 trim warnings on HybridWebViewHandler nested classes

### DIFF
--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
@@ -127,6 +127,7 @@ namespace Microsoft.Maui.Handlers
 #if !NETSTANDARD
 		[RequiresDynamicCode(DynamicFeatures)]
 #endif
+		[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The iOS Managed Registrar references this NSObject subclass in <Module>..cctor(). The RequiresUnreferencedCode is for callers instantiating this type, not for the registrar's type registration.")]
 		private sealed class WebViewScriptMessageHandler : NSObject, IWKScriptMessageHandler
 		{
 			private readonly WeakReference<HybridWebViewHandler?> _webViewHandler;
@@ -149,6 +150,7 @@ namespace Microsoft.Maui.Handlers
 #if !NETSTANDARD
 		[RequiresDynamicCode(DynamicFeatures)]
 #endif
+		[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The iOS Managed Registrar references this NSObject subclass in <Module>..cctor(). The RequiresUnreferencedCode is for callers instantiating this type, not for the registrar's type registration.")]
 		private class SchemeHandler : NSObject, IWKUrlSchemeHandler
 		{
 			private readonly WeakReference<HybridWebViewHandler?> _webViewHandler;


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Fixes #35260

When building a MAUI template app with `TrimMode=full` and `TreatWarningsAsErrors=true` on iOS, ILLink produces IL2026 errors from `<Module>..cctor()` — the iOS Managed Registrar — referencing `HybridWebViewHandler.SchemeHandler` and `HybridWebViewHandler.WebViewScriptMessageHandler`. Both nested classes are NSObject subclasses marked with `[RequiresUnreferencedCode]` for their dynamic JSON serialization usage.

The managed registrar generates code that registers all NSObject subclasses but doesn't actually invoke the trim-unsafe code paths. Since we can't modify the managed registrar (that's in xamarin-macios), we suppress IL2026 at the MAUI level.

## Changes

Added `[UnconditionalSuppressMessage("Trimming", "IL2026", ...)]` to both nested classes in `HybridWebViewHandler.iOS.cs`:
- `WebViewScriptMessageHandler` 
- `SchemeHandler`

This follows the same pattern used by PRs #34958 and #34986 which suppressed IL3050 (NativeAOT) warnings on these same classes.