### PR TITLE
Use dotnet cake for SDK provisioning to fix workload resolver issues

### DIFF
--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -1,7 +1,8 @@
 <Project ToolsVersion="4.0"
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Target Name="InitInternalTooling" AfterTargets="Restore">
+  <Target Name="InitInternalTooling" AfterTargets="Restore"
+      Condition=" '$(SkipInitInternalTooling)' != 'true' ">
     <Message Text="Installing the workloads" Importance="high" />
     <!-- <MSBuild Projects="$(RepoRoot)src/DotNet/DotNet.csproj" Targets="Build" /> -->
     <Exec

--- a/eng/pipelines/arcade/stage-build.yml
+++ b/eng/pipelines/arcade/stage-build.yml
@@ -80,8 +80,12 @@ stages:
               - ${{ each pair in step }}:
                   ${{ pair.key }}: ${{ pair.value }}
 
-            - script: ${{ BuildPlatform.buildScript }} -restore -build -configuration ${{ BuildConfiguration }} -projects "${{ parameters.buildTaskProjects }}" /p:ArchiveTests=false /p:TreatWarningsAsErrors=$(TreatWarningsAsErrors) /bl:$(Build.Arcade.LogsPath)${{ BuildConfiguration }}/buildtasks_${{ BuildPlatform.os }}.binlog $(_OfficialBuildIdArgs)
-              displayName: 🛠️ Build BuildTasks
+            - script: dotnet cake --target=dotnet-buildtasks --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
+              displayName: 🛠️ Provision SDK & Build BuildTasks
+              retryCountOnTaskFailure: 3
+              env:
+                DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
+                PRIVATE_BUILD: $(PrivateBuild)
 
-            - script: ${{ BuildPlatform.buildScript }} -restore -build -configuration ${{ BuildConfiguration }} /p:ArchiveTests=false /p:TreatWarningsAsErrors=$(TreatWarningsAsErrors) /bl:$(Build.Arcade.LogsPath)${{ BuildConfiguration }}/build_${{ BuildPlatform.os }}.binlog $(_OfficialBuildIdArgs)
+            - script: ${{ BuildPlatform.buildScript }} -restore -build -configuration ${{ BuildConfiguration }} /p:ArchiveTests=false /p:TreatWarningsAsErrors=$(TreatWarningsAsErrors) /p:SkipInitInternalTooling=true /bl:$(Build.Arcade.LogsPath)${{ BuildConfiguration }}/build_${{ BuildPlatform.os }}.binlog $(_OfficialBuildIdArgs)
               displayName: 🛠️ Build Microsoft.Maui.sln

--- a/eng/pipelines/arcade/stage-device-tests.yml
+++ b/eng/pipelines/arcade/stage-device-tests.yml
@@ -122,10 +122,14 @@ stages:
               ${{ pair.key }}: ${{ pair.value }}
 
         # Run on public pipeline
-        - script: $(_buildScriptMacOS) -restore -build -configuration $(_BuildConfig) -projects '$(Build.SourcesDirectory)/Microsoft.Maui.BuildTasks.slnf' /bl:BuildBuildTasks.binlog $(_OfficialBuildIdArgs)
-          displayName: Build BuildTasks
+        - script: dotnet cake --target=dotnet-buildtasks --configuration="$(_BuildConfig)" --verbosity=diagnostic
+          displayName: Provision SDK & Build BuildTasks
+          retryCountOnTaskFailure: 3
+          env:
+            DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
+            PRIVATE_BUILD: $(PrivateBuild)
 
-        - script: $(_buildScriptMacOS) -restore -build -configuration $(_BuildConfig) /p:BuildDeviceTests=true /bl:BuildDeviceTests.binlog
+        - script: $(_buildScriptMacOS) -restore -build -configuration $(_BuildConfig) /p:BuildDeviceTests=true /p:SkipInitInternalTooling=true /bl:BuildDeviceTests.binlog
           displayName: Build DeviceTests
 
         - publish: ${{ parameters.checkoutDirectory }}/artifacts/bin
@@ -335,10 +339,14 @@ stages:
               ${{ pair.key }}: ${{ pair.value }}
 
         # Run on public pipeline
-        - script: $(_buildScriptMacOS) -restore -build -configuration $(_BuildConfig) -projects '$(Build.SourcesDirectory)/Microsoft.Maui.BuildTasks.slnf' /bl:BuildBuildTasks.binlog $(_OfficialBuildIdArgs)
-          displayName: Build BuildTasks
+        - script: dotnet cake --target=dotnet-buildtasks --configuration="$(_BuildConfig)" --verbosity=diagnostic
+          displayName: Provision SDK & Build BuildTasks
+          retryCountOnTaskFailure: 3
+          env:
+            DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
+            PRIVATE_BUILD: $(PrivateBuild)
 
-        - script: $(_buildScriptMacOS) -restore -build -configuration $(_BuildConfig) /p:BuildDeviceTests=true /p:UseMonoRuntime=false /bl:BuildDeviceTests.binlog
+        - script: $(_buildScriptMacOS) -restore -build -configuration $(_BuildConfig) /p:BuildDeviceTests=true /p:UseMonoRuntime=false /p:SkipInitInternalTooling=true /bl:BuildDeviceTests.binlog
           displayName: Build DeviceTests (CoreCLR)
 
         - publish: ${{ parameters.checkoutDirectory }}/artifacts/bin
@@ -549,9 +557,10 @@ stages:
             displayName: 'Restore .NET tools'
             retryCountOnTaskFailure: 3
 
-          # Install .NET SDK and workloads using Arcade build script
-          - script: ./build.cmd -restore -configuration Release
-            displayName: 'Install .NET'
+          # Provision SDK, workloads, and build BuildTasks using Cake
+          # (separate processes for provisioning and building)
+          - script: dotnet cake --target=dotnet-buildtasks --configuration="Release" --verbosity=diagnostic
+            displayName: Provision SDK & Build BuildTasks
             retryCountOnTaskFailure: 3
             env:
               DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
@@ -559,10 +568,6 @@ stages:
 
           - pwsh: echo "##vso[task.prependpath]$(DotNet.Dir)"
             displayName: 'Add .NET to PATH'
-
-          # Build BuildTasks first (need -restore to ensure SDK is available)
-          - script: ./build.cmd -restore -build -configuration Release -projects Microsoft.Maui.BuildTasks.slnf
-            displayName: Build the MSBuild Tasks
 
           # Build Unpackaged tests FIRST (self-contained .exe for direct execution)
           # Must build unpackaged BEFORE packaged so we can save the publish output

--- a/eng/pipelines/arcade/stage-helix-tests.yml
+++ b/eng/pipelines/arcade/stage-helix-tests.yml
@@ -84,10 +84,14 @@ stages:
             - ${{ each pair in step }}:
                 ${{ pair.key }}: ${{ pair.value }}
 
-          - script: $(_buildScript) -restore -build -configuration ${{ BuildConfiguration }} -projects "${{ parameters.buildTaskProjects }}" /p:ArchiveTests=false /p:TreatWarningsAsErrors=$(TreatWarningsAsErrors) /bl:$(Build.Arcade.LogsPath)${{ BuildConfiguration }}/buildtasks.binlog $(_OfficialBuildIdArgs)
-            displayName: 🛠️ Build BuildTasks
+          - script: dotnet cake --target=dotnet-buildtasks --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
+            displayName: 🛠️ Provision SDK & Build BuildTasks
+            retryCountOnTaskFailure: 3
+            env:
+              DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
+              PRIVATE_BUILD: $(PrivateBuild)
 
-          - script: $(_msbuildCommand) "${{ parameters.helixProject }}" -warnAsError 0 -restore /p:Configuration=${{ BuildConfiguration }} /p:HelixInternal="${{ parameters.helixInternal }}" /p:TestRunNameSuffix="_${{ BuildConfiguration }}" /bl:$(Build.Arcade.LogsPath)${{ BuildConfiguration }}/helix_tests.binlog ${{ parameters.extraHelixArguments }}
+          - script: $(_msbuildCommand) "${{ parameters.helixProject }}" -warnAsError 0 -restore /p:Configuration=${{ BuildConfiguration }} /p:HelixInternal="${{ parameters.helixInternal }}" /p:TestRunNameSuffix="_${{ BuildConfiguration }}" /p:SkipInitInternalTooling=true /bl:$(Build.Arcade.LogsPath)${{ BuildConfiguration }}/helix_tests.binlog ${{ parameters.extraHelixArguments }}
             displayName: Run Helix Tests
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops

--- a/eng/pipelines/arcade/stage-pack.yml
+++ b/eng/pipelines/arcade/stage-pack.yml
@@ -69,7 +69,14 @@ stages:
           - ${{ each pair in step }}:
               ${{ pair.key }}: ${{ pair.value }}
 
-        - script: $(_buildScriptMacOS) -restore -pack -configuration $(_BuildConfig) /bl:$(Build.Arcade.LogsPath)/$(_BuildConfig)/pack-mac.binlog $(_OfficialBuildIdArgs)
+        - script: dotnet cake --target=dotnet --configuration="$(_BuildConfig)" --verbosity=diagnostic
+          displayName: Provision SDK & Workloads
+          retryCountOnTaskFailure: 3
+          env:
+            DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
+            PRIVATE_BUILD: $(PrivateBuild)
+
+        - script: $(_buildScriptMacOS) -restore -pack -configuration $(_BuildConfig) /p:SkipInitInternalTooling=true /bl:$(Build.Arcade.LogsPath)/$(_BuildConfig)/pack-mac.binlog $(_OfficialBuildIdArgs)
           displayName: Pack
 
         - task: CopyFiles@2
@@ -136,18 +143,25 @@ stages:
             artifact: MacNativeArtifacts
             path: '$(Build.SourcesDirectory)/artifacts/bin'
 
+        - script: dotnet cake --target=dotnet --configuration="$(_BuildConfig)" --verbosity=diagnostic
+          displayName: Provision SDK & Workloads
+          retryCountOnTaskFailure: 3
+          env:
+            DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
+            PRIVATE_BUILD: $(PrivateBuild)
+
         # Run on public pipeline
         - ${{ if not(parameters.enableMicrobuild) }}:
-          - script: $(_buildScript) -restore -pack -publish $(_PublishArgs) -configuration $(_BuildConfig) /bl:$(Build.Arcade.LogsPath)/$(_BuildConfig)/pack.binlog $(_OfficialBuildIdArgs)
+          - script: $(_buildScript) -restore -pack -publish $(_PublishArgs) -configuration $(_BuildConfig) /p:SkipInitInternalTooling=true /bl:$(Build.Arcade.LogsPath)/$(_BuildConfig)/pack.binlog $(_OfficialBuildIdArgs)
             displayName: Pack & Publish
 
         # Run on internal pipeline
         - ${{ if and(not(parameters.runAsPublic) , parameters.enableMicrobuild) }}:
-          - script: $(_buildScript) -restore -pack -sign $(_SignArgs) -configuration $(_BuildConfig) /bl:$(Build.Arcade.LogsPath)/$(_BuildConfig)/pack.binlog $(_OfficialBuildIdArgs)
+          - script: $(_buildScript) -restore -pack -sign $(_SignArgs) -configuration $(_BuildConfig) /p:SkipInitInternalTooling=true /bl:$(Build.Arcade.LogsPath)/$(_BuildConfig)/pack.binlog $(_OfficialBuildIdArgs)
             displayName: Pack, Sign
 
           # only for workloads
-          - script: $(_buildScript) -restore -build -sign $(_SignArgs) -publish $(_PublishArgs) -configuration $(_BuildConfig) /bl:$(Build.Arcade.LogsPath)/$(_BuildConfig)/build-workloads.binlog -projects src/Workload/workloads.csproj $(_OfficialBuildIdArgs)
+          - script: $(_buildScript) -restore -build -sign $(_SignArgs) -publish $(_PublishArgs) -configuration $(_BuildConfig) /p:SkipInitInternalTooling=true /bl:$(Build.Arcade.LogsPath)/$(_BuildConfig)/build-workloads.binlog -projects src/Workload/workloads.csproj $(_OfficialBuildIdArgs)
             displayName: Build Workloads, Sign & Publish
 
         - task: CopyFiles@2

--- a/eng/pipelines/arcade/stage-unit-tests.yml
+++ b/eng/pipelines/arcade/stage-unit-tests.yml
@@ -35,8 +35,12 @@ stages:
           base64Encode: true
           outputVariableName: dotnetbuilds-internal-container-read-token-base64
       
-      - script: ${{ job.buildScript }} -restore -build -configuration ${{ parameters.buildConfig }} -projects "${{ parameters.buildTaskProjects }}" /p:ArchiveTests=false /p:TreatWarningsAsErrors=$(TreatWarningsAsErrors) /bl:$(Build.Arcade.LogsPath)${{ parameters.buildConfig }}/buildtasks.binlog $(_OfficialBuildIdArgs)
-        displayName: 🛠️ Build BuildTasks
+      - script: dotnet cake --target=dotnet-buildtasks --configuration="${{ parameters.buildConfig }}" --verbosity=diagnostic
+        displayName: 🛠️ Provision SDK & Build BuildTasks
+        retryCountOnTaskFailure: 3
+        env:
+          DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
+          PRIVATE_BUILD: $(PrivateBuild)
 
       - template: /eng/pipelines/common/run-dotnet-preview.yml
         parameters:

--- a/src/DotNet/DotNet.csproj
+++ b/src/DotNet/DotNet.csproj
@@ -192,6 +192,23 @@
     <_WorkloadIds Include="tizen" Condition=" '$(IncludeTizenTargetFrameworks)' == 'true' " />
   </ItemGroup>
 
+  <!-- Remove stale workload manifest bands left by the SDK installer.
+       Some SDK versions bundle manifests from older preview bands that reference
+       non-existent packs, causing NETSDK1178 errors. We remove any band
+       that doesn't match the current DotNetSdkManifestsFolder. -->
+  <Target Name="_CleanStaleWorkloadManifestBands"
+      AfterTargets="_InstallDotNet"
+      BeforeTargets="_AcquireWorkloadManifests"
+      Condition=" Exists('$(DotNetDirectory)sdk-manifests') ">
+    <ItemGroup>
+      <_AllManifestBands Include="$([System.IO.Directory]::GetDirectories('$(DotNetDirectory)sdk-manifests'))" />
+      <_StaleManifestBands Include="@(_AllManifestBands)" Condition="'%(Filename)' != '$(DotNetSdkManifestsFolder)'" />
+    </ItemGroup>
+    <Message Text="Removing stale workload manifest band: %(Filename)" Importance="High"
+        Condition="'@(_StaleManifestBands)' != ''" />
+    <RemoveDir Directories="@(_StaleManifestBands)" />
+  </Target>
+
   <Target Name="_AcquireWorkloadManifests"
       Inputs="$(_Inputs);Dependencies/Workloads.csproj"
       Outputs="$(DotNetSdkManifestsDirectory).stamp">


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

MSBuild caches workload manifests at **evaluation time** and cannot refresh mid-build. When the SDK bundles stale manifests from older preview bands ([dotnet/sdk#53234](https://github.com/dotnet/sdk/issues/53234)), this causes NETSDK1178 errors because the cached state references non-existent packs.

MAUI's `InitInternalTooling` target (eng/Tools.props) provisions workloads inside `AfterTargets="Restore"` — but by that point MSBuild already cached the stale workload state. The MSBuild SDK explicitly states: *"For workload installation actions, we expect to be running under a NEW PROCESS."*

This PR aligns MAUI's CI with that design by using `dotnet cake` (which runs each task as a separate `dotnet` process) instead of `build.sh` (single MSBuild process) for SDK provisioning.

## Changes

1. **Switch BuildTasks steps to `dotnet cake --target=dotnet-buildtasks`** — Provisions SDK and builds BuildTasks as separate processes (fresh workload resolver state each time)
2. **Add `dotnet cake --target=dotnet` before Pack stages** — Provisions SDK/workloads before the pack step
3. **Add `SkipInitInternalTooling` condition to eng/Tools.props** — Prevents redundant DotNet.csproj re-runs that cause MSB3026 file-lock timeouts when Cake already provisioned
4. **Pass `/p:SkipInitInternalTooling=true`** from all pipeline steps that run after Cake provisioning
5. **Add `_CleanStaleWorkloadManifestBands` target to DotNet.csproj** — Removes stale manifest bands as defense-in-depth (becomes a no-op once dotnet/sdk#53234 fix flows through)
6. **Remove redundant `build.cmd` SDK install** from Windows device tests (Cake handles it)

## Why This Works

Device tests already use this exact `dotnet cake` pattern and it works. The Cake build file (`eng/cake/dotnet.cake`) runs `DotNet.csproj` as process #1 (provisioning), then `BuildTasks.slnf` as process #2 (building) — each with fresh workload resolver state.

## Files Changed

| File | Change |
|------|--------|
| `eng/Tools.props` | `SkipInitInternalTooling` condition |
| `src/DotNet/DotNet.csproj` | `_CleanStaleWorkloadManifestBands` target |
| `eng/pipelines/arcade/stage-build.yml` | Cake + SkipInitInternalTooling |
| `eng/pipelines/arcade/stage-pack.yml` | Cake provisioning + SkipInitInternalTooling |
| `eng/pipelines/arcade/stage-helix-tests.yml` | Cake + SkipInitInternalTooling |
| `eng/pipelines/arcade/stage-unit-tests.yml` | Cake provisioning |
| `eng/pipelines/arcade/stage-device-tests.yml` | Cake + SkipInitInternalTooling + remove redundant build.cmd |

## Context

- Validated on `release/11.0.1xx-preview4` branch (PR #35171) — all Build, Pack, and Helix jobs pass
- Root cause analysis: [dotnet/sdk#53234](https://github.com/dotnet/sdk/issues/53234) (stale manifest bundling, already fixed upstream)
- dotnet/android and dotnet/macios don't hit this because they use Make-based builds with natural process separation