### PR TITLE
Sync Blazor templates with aspnetcore net11-pre4

### DIFF
--- a/src/Templates/src/templates/maui-blazor-solution/.template.config/template.json
+++ b/src/Templates/src/templates/maui-blazor-solution/.template.config/template.json
@@ -65,7 +65,8 @@
       "copyOnly": [
         "**/wwwroot/lib/bootstrap/**",
         "**/*.svg",
-        "**/*.ttf"
+        "**/*.ttf",
+        "**/*.razor.js"
       ],
       "modifiers": [
         {
@@ -289,7 +290,10 @@
         "sourceVariableName": "kestrelHttpPort",
         "fallbackVariableName": "kestrelHttpPortGenerated"
       },
-      "replaces": "5500"
+      "replaces": "5500",
+      "onlyIf": [{
+        "after": "localhost:"
+      }]
     },
     "kestrelHttpsPort": {
       "type": "parameter",
@@ -311,7 +315,10 @@
         "sourceVariableName": "kestrelHttpsPort",
         "fallbackVariableName": "kestrelHttpsPortGenerated"
       },
-      "replaces": "5501"
+      "replaces": "5501",
+      "onlyIf": [{
+        "after": "localhost:"
+      }]
     },
     "iisHttpPort": {
       "type": "parameter",

--- a/src/Templates/src/templates/maui-blazor-solution/MauiApp.1.Shared/Layout/NavMenu.razor
+++ b/src/Templates/src/templates/maui-blazor-solution/MauiApp.1.Shared/Layout/NavMenu.razor
@@ -4,6 +4,7 @@
 @inject NavigationManager NavigationManager
 
 ##endif*@
+@* NavMenu.razor.js is also loaded early from index.html so the document-level delegated collapse handler is ready before Hybrid renders this menu (no SSR prerender). The module is idempotent via globalThis.__mauiNavMenuCollapseInitialized, so listeners register once. *@
 <script type="module" src="_content/MauiApp.1.Shared/Layout/NavMenu.razor.js"></script>
 
 <div class="top-row ps-3 navbar navbar-dark">

--- a/src/Templates/src/templates/maui-blazor-solution/MauiApp.1.Shared/Layout/NavMenu.razor.js
+++ b/src/Templates/src/templates/maui-blazor-solution/MauiApp.1.Shared/Layout/NavMenu.razor.js
@@ -1,9 +1,12 @@
 // Handle navigation menu toggle
-const navScrollable = document.getElementById("nav-scrollable");
-const navToggler = document.querySelector(".navbar-toggler");
+if (!globalThis.__mauiNavMenuCollapseInitialized) {
+    globalThis.__mauiNavMenuCollapseInitialized = true;
 
-if (navScrollable && navToggler) {
-    navScrollable.addEventListener("click", function() {
-        navToggler.click();
+    document.addEventListener("click", function(event) {
+        const target = event.target;
+
+        if (target instanceof Element && target.closest("#nav-scrollable")) {
+            document.querySelector(".navbar-toggler")?.click();
+        }
     });
 }

--- a/src/Templates/src/templates/maui-blazor-solution/MauiApp.1.Shared/Layout/NavMenu.razor.js
+++ b/src/Templates/src/templates/maui-blazor-solution/MauiApp.1.Shared/Layout/NavMenu.razor.js
@@ -6,7 +6,11 @@ if (!globalThis.__mauiNavMenuCollapseInitialized) {
         const target = event.target;
 
         if (target instanceof Element && target.closest("#nav-scrollable")) {
-            document.querySelector(".navbar-toggler")?.click();
+            const navToggler = document.querySelector(".navbar-toggler");
+
+            if (navToggler instanceof HTMLInputElement && navToggler.checked) {
+                navToggler.click();
+            }
         }
     });
 }

--- a/src/Templates/src/templates/maui-blazor-solution/MauiApp.1.Web.Client/MauiApp.1.Web.Client.csproj
+++ b/src/Templates/src/templates/maui-blazor-solution/MauiApp.1.Web.Client/MauiApp.1.Web.Client.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="MS_COMPONENTS_WEBASSEMBLY_VERSION" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.0" Condition="'$(IndividualLocalAuth)' == 'True'" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="MS_COMPONENTS_WEBASSEMBLY_VERSION" Condition="'$(IndividualLocalAuth)' == 'True'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Templates/src/templates/maui-blazor-solution/MauiApp.1.Web.Client/Program.Main.cs
+++ b/src/Templates/src/templates/maui-blazor-solution/MauiApp.1.Web.Client/Program.Main.cs
@@ -20,7 +20,7 @@ class Program
         #if (IndividualLocalAuth)
         builder.Services.AddAuthorizationCore();
         builder.Services.AddCascadingAuthenticationState();
-        builder.Services.AddSingleton<AuthenticationStateProvider, PersistentAuthenticationStateProvider>();
+        builder.Services.AddAuthenticationStateDeserialization();
 
         #endif
         await builder.Build().RunAsync();

--- a/src/Templates/src/templates/maui-blazor-solution/MauiApp.1.Web.Client/Program.cs
+++ b/src/Templates/src/templates/maui-blazor-solution/MauiApp.1.Web.Client/Program.cs
@@ -14,7 +14,7 @@ builder.Services.AddSingleton<IFormFactor, FormFactor>();
 #if (IndividualLocalAuth)
 builder.Services.AddAuthorizationCore();
 builder.Services.AddCascadingAuthenticationState();
-builder.Services.AddSingleton<AuthenticationStateProvider, PersistentAuthenticationStateProvider>();
+builder.Services.AddAuthenticationStateDeserialization();
 
 #endif
 await builder.Build().RunAsync();

--- a/src/Templates/src/templates/maui-blazor-solution/MauiApp.1.Web/Components/Layout/ReconnectModal.razor
+++ b/src/Templates/src/templates/maui-blazor-solution/MauiApp.1.Web/Components/Layout/ReconnectModal.razor
@@ -25,11 +25,11 @@
         <p class="components-pause-visible">
             The session has been paused by the server.
         </p>
-        <button id="components-resume-button" class="components-pause-visible">
+        <p class="components-resume-failed-visible">
+            Failed to resume the session.<br />Please retry or reload the page.
+        </p>
+        <button id="components-resume-button" class="components-pause-visible components-resume-failed-visible">
             Resume
         </button>
-        <p class="components-resume-failed-visible">
-            Failed to resume the session.<br />Please reload the page.
-        </p>
     </div>
 </dialog>

--- a/src/Templates/src/templates/maui-blazor-solution/MauiApp.1.Web/Components/Layout/ReconnectModal.razor.css
+++ b/src/Templates/src/templates/maui-blazor-solution/MauiApp.1.Web/Components/Layout/ReconnectModal.razor.css
@@ -31,13 +31,10 @@
     opacity: 0;
     transition: display 0.5s allow-discrete, overlay 0.5s allow-discrete;
     animation: components-reconnect-modal-fadeOutOpacity 0.5s both;
-    &[open]
-
-{
-    animation: components-reconnect-modal-slideUp 1.5s cubic-bezier(.05, .89, .25, 1.02) 0.3s, components-reconnect-modal-fadeInOpacity 0.5s ease-in-out 0.3s;
-    animation-fill-mode: both;
-}
-
+    &[open] {
+        animation: components-reconnect-modal-slideUp 1.5s cubic-bezier(.05, .89, .25, 1.02) 0.3s, components-reconnect-modal-fadeInOpacity 0.5s ease-in-out 0.3s;
+        animation-fill-mode: both;
+    }
 }
 
 #components-reconnect-modal::backdrop {

--- a/src/Templates/src/templates/maui-blazor-solution/MauiApp.1.Web/Components/Layout/ReconnectModal.razor.js
+++ b/src/Templates/src/templates/maui-blazor-solution/MauiApp.1.Web/Components/Layout/ReconnectModal.razor.js
@@ -52,7 +52,7 @@ async function resume() {
             location.reload();
         }
     } catch {
-        location.reload();
+        reconnectModal.classList.replace("components-reconnect-paused", "components-reconnect-resume-failed");
     }
 }
 

--- a/src/Templates/src/templates/maui-blazor-solution/MauiApp.1/wwwroot/index.html
+++ b/src/Templates/src/templates/maui-blazor-solution/MauiApp.1/wwwroot/index.html
@@ -21,6 +21,9 @@
     <div id="app">Loading...</div>
 
     <script src="_framework/blazor.webview.js" autostart="false"></script>
+<!--#if (SampleContent) -->
+    <script type="module" src="_content/MauiApp.1.Shared/Layout/NavMenu.razor.js"></script>
+<!--#endif -->
 
 </body>
 

--- a/src/Templates/src/templates/maui-blazor-solution/MauiApp.1/wwwroot/index.html
+++ b/src/Templates/src/templates/maui-blazor-solution/MauiApp.1/wwwroot/index.html
@@ -22,6 +22,7 @@
 
     <script src="_framework/blazor.webview.js" autostart="false"></script>
 <!--#if (SampleContent) -->
+    <!-- NavMenu.razor.js is also loaded by NavMenu.razor; this early load registers the document-level delegated collapse handler before Hybrid renders the menu (no SSR prerender). The module is idempotent via globalThis.__mauiNavMenuCollapseInitialized, so listeners register once. -->
     <script type="module" src="_content/MauiApp.1.Shared/Layout/NavMenu.razor.js"></script>
 <!--#endif -->
 

--- a/src/Templates/src/templates/maui-blazor/.template.config/template.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/template.json
@@ -52,7 +52,8 @@
       "copyOnly": [
         "**/wwwroot/lib/bootstrap/**",
         "**/*.svg",
-        "**/*.ttf"
+        "**/*.ttf",
+        "**/*.razor.js"
       ],
       "modifiers": [
         {

--- a/src/Templates/src/templates/maui-blazor/Components/Layout/NavMenu.razor
+++ b/src/Templates/src/templates/maui-blazor/Components/Layout/NavMenu.razor
@@ -1,4 +1,5 @@
-﻿<script type="module" src="Components/Layout/NavMenu.razor.js"></script>
+﻿@* NavMenu.razor.js is also loaded early from index.html so the document-level delegated collapse handler is ready before Hybrid renders this menu (no SSR prerender). The module is idempotent via globalThis.__mauiNavMenuCollapseInitialized, so listeners register once. *@
+<script type="module" src="Components/Layout/NavMenu.razor.js"></script>
 
 <div class="top-row ps-3 navbar navbar-dark">
     <div class="container-fluid">

--- a/src/Templates/src/templates/maui-blazor/Components/Layout/NavMenu.razor.js
+++ b/src/Templates/src/templates/maui-blazor/Components/Layout/NavMenu.razor.js
@@ -1,9 +1,12 @@
 // Handle navigation menu toggle
-const navScrollable = document.getElementById("nav-scrollable");
-const navToggler = document.querySelector(".navbar-toggler");
+if (!globalThis.__mauiNavMenuCollapseInitialized) {
+    globalThis.__mauiNavMenuCollapseInitialized = true;
 
-if (navScrollable && navToggler) {
-    navScrollable.addEventListener("click", function() {
-        navToggler.click();
+    document.addEventListener("click", function(event) {
+        const target = event.target;
+
+        if (target instanceof Element && target.closest("#nav-scrollable")) {
+            document.querySelector(".navbar-toggler")?.click();
+        }
     });
 }

--- a/src/Templates/src/templates/maui-blazor/Components/Layout/NavMenu.razor.js
+++ b/src/Templates/src/templates/maui-blazor/Components/Layout/NavMenu.razor.js
@@ -6,7 +6,11 @@ if (!globalThis.__mauiNavMenuCollapseInitialized) {
         const target = event.target;
 
         if (target instanceof Element && target.closest("#nav-scrollable")) {
-            document.querySelector(".navbar-toggler")?.click();
+            const navToggler = document.querySelector(".navbar-toggler");
+
+            if (navToggler instanceof HTMLInputElement && navToggler.checked) {
+                navToggler.click();
+            }
         }
     });
 }

--- a/src/Templates/src/templates/maui-blazor/wwwroot/index.html
+++ b/src/Templates/src/templates/maui-blazor/wwwroot/index.html
@@ -26,6 +26,9 @@
     </div>
 
     <script src="_framework/blazor.webview.js" autostart="false"></script>
+<!--#if (SampleContent) -->
+    <script type="module" src="Components/Layout/NavMenu.razor.js"></script>
+<!--#endif -->
 
 </body>
 

--- a/src/Templates/src/templates/maui-blazor/wwwroot/index.html
+++ b/src/Templates/src/templates/maui-blazor/wwwroot/index.html
@@ -27,6 +27,7 @@
 
     <script src="_framework/blazor.webview.js" autostart="false"></script>
 <!--#if (SampleContent) -->
+    <!-- NavMenu.razor.js is also loaded by NavMenu.razor; this early load registers the document-level delegated collapse handler before Hybrid renders the menu (no SSR prerender). The module is idempotent via globalThis.__mauiNavMenuCollapseInitialized, so listeners register once. -->
     <script type="module" src="Components/Layout/NavMenu.razor.js"></script>
 <!--#endif -->
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Syncs both MAUI Blazor templates (`maui-blazor` and `maui-blazor-web`) with upstream changes from `dotnet/aspnetcore` BlazorWeb-CSharp template (`release/10.0` → `main`/net11-pre4).

## Changes

### Both templates
- **NavMenu.razor**: Replace inline `onclick` handler with `id="nav-scrollable"` + JS module (CSP compliance)
- **NEW NavMenu.razor.js**: Co-located JS click handler for nav toggle
- **template.json**: Add `**/*.razor.js` to `copyOnly` so template engine emits co-located JS files

### `maui-blazor` (standalone)
- **index.html**: Add `<script>` reference for NavMenu.razor.js

### `maui-blazor-solution` (multi-project)
- **App.razor**: `<base href="/" />` → `<BasePath />` component
- **ReconnectModal.razor**: Resume button ordering + resume-failed-visible class
- **ReconnectModal.razor.js**: Resume failure shows state instead of force-reload
- **ReconnectModal.razor.css**: Fix `&[open]` CSS nesting indentation
- **Error.razor**: `[PersistentState]` on RequestId, `public`, `??=` assignment
- **_Imports.razor** (Web): Add `@using Microsoft.AspNetCore.Components.Endpoints`
- **template.json**: Add `onlyIf` localhost constraint on port replacers
- **Web.Client Program.cs/Main.cs**: `PersistentAuthenticationStateProvider` → `AddAuthenticationStateDeserialization()`
- **index.html**: Add NavMenu.razor.js script reference

### Not synced (intentional)
- Account/Identity pages (not in MAUI templates)
- Data/migrations (not in MAUI templates)
- Localize files (auto-generated)