### PR TITLE
HybridWebView: require [HybridJSInvokable] attribute to gate .NET method invocation from JavaScript

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/HybridWebViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/HybridWebViewPage.xaml.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
+using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 
 namespace Maui.Controls.Sample.Pages
@@ -144,23 +145,27 @@ namespace Maui.Controls.Sample.Pages
 				_hybridWebViewPage = hybridWebViewPage;
 			}
 
-			public void DoSyncWork()
+			[HybridJSInvokable]
+		public void DoSyncWork()
 			{
 				Debug.WriteLine("DoSyncWork");
 			}
 
-			public void DoSyncWorkParams(int i, string s)
+			[HybridJSInvokable]
+		public void DoSyncWorkParams(int i, string s)
 			{
 				Debug.WriteLine($"DoSyncWorkParams: {i}, {s}");
 			}
 
-			public string DoSyncWorkReturn()
+			[HybridJSInvokable]
+		public string DoSyncWorkReturn()
 			{
 				Debug.WriteLine("DoSyncWorkReturn");
 				return "Hello from C#!";
 			}
 
-			public SyncReturn DoSyncWorkParamsReturn(int i, string s)
+			[HybridJSInvokable]
+		public SyncReturn DoSyncWorkParamsReturn(int i, string s)
 			{
 				Debug.WriteLine($"DoSyncWorkParamsReturn: {i}, {s}");
 				return new SyncReturn
@@ -170,51 +175,57 @@ namespace Maui.Controls.Sample.Pages
 				};
 			}
 
-			public async Task DoAsyncWork()
+			[HybridJSInvokable]
+		public async Task DoAsyncWork()
 			{
 				await Task.Delay(1000);
 				Debug.WriteLine("DoAsyncWork");
 			}
 
-			public async Task DoAsyncWorkParams(int i, string s)
+			[HybridJSInvokable]
+		public async Task DoAsyncWorkParams(int i, string s)
 			{
 				await Task.Delay(1000);
 				Debug.WriteLine($"DoAsyncWorkParams: {i}, {s}");
 			}
 
-			public async Task<string> DoAsyncWorkReturn()
+			[HybridJSInvokable]
+		public async Task<string> DoAsyncWorkReturn()
 			{
 				await Task.Delay(1000);
 				Debug.WriteLine("DoAsyncWorkReturn");
 				return "Hello from C#!";
 			}
 
-			public async Task<SyncReturn> DoAsyncWorkParamsReturn(int i, string s)
+			[HybridJSInvokable]
+		public async Task<SyncReturn> DoAsyncWorkParamsReturn(int i, string s)
+		{
+			await Task.Delay(1000);
+			Debug.WriteLine($"DoAsyncWorkParamsReturn: {i}, {s}");
+			return new SyncReturn
 			{
-				await Task.Delay(1000);
-				Debug.WriteLine($"DoAsyncWorkParamsReturn: {i}, {s}");
-				return new SyncReturn
-				{
-					Message = "Hello from C#! " + s,
-					Value = i,
-				};
-			}
-
-			// Demo method that throws an exception to showcase error handling
-			public void ThrowException()
-			{
-				Debug.WriteLine("ThrowException called - about to throw");
-				throw new InvalidOperationException("This is a test exception thrown from C# code!");
-			}
-
-			// Demo async method that throws an exception
-			public async Task<string> ThrowExceptionAsync()
-			{
-				Debug.WriteLine("ThrowExceptionAsync called - about to throw");
-				await Task.Delay(100);
-				throw new ArgumentException("This is an async test exception thrown from C# code!");
-			}
+				Message = "Hello from C#! " + s,
+				Value = i,
+			};
 		}
+
+		// Demo method that throws an exception to showcase error handling
+		[HybridJSInvokable]
+		public void ThrowException()
+		{
+			Debug.WriteLine("ThrowException called - about to throw");
+			throw new InvalidOperationException("This is a test exception thrown from C# code!");
+		}
+
+		// Demo async method that throws an exception
+		[HybridJSInvokable]
+		public async Task<string> ThrowExceptionAsync()
+		{
+			Debug.WriteLine("ThrowExceptionAsync called - about to throw");
+			await Task.Delay(100);
+			throw new ArgumentException("This is an async test exception thrown from C# code!");
+		}
+	}
 
 		public class SyncReturn
 		{

--- a/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_ExceptionHandling.cs
+++ b/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_ExceptionHandling.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 using System;
 using System.Threading.Tasks;
+using Microsoft.Maui;
 using Xunit;
 
 namespace Microsoft.Maui.DeviceTests;
@@ -100,18 +101,21 @@ public partial class HybridWebViewTests_ExceptionHandling : HybridWebViewTestsBa
 	{
 		public string? LastMethodCalled { get; private set; }
 
+		[HybridJSInvokable]
 		public void ThrowException()
 		{
 			LastMethodCalled = nameof(ThrowException);
 			throw new InvalidOperationException("Test exception message");
 		}
 
+		[HybridJSInvokable]
 		public void ThrowCustomException()
 		{
 			LastMethodCalled = nameof(ThrowCustomException);
 			throw new ArgumentException("Custom argument exception");
 		}
 
+		[HybridJSInvokable]
 		public async Task ThrowExceptionAsync()
 		{
 			LastMethodCalled = nameof(ThrowExceptionAsync);
@@ -119,6 +123,7 @@ public partial class HybridWebViewTests_ExceptionHandling : HybridWebViewTestsBa
 			throw new InvalidOperationException("Async test exception");
 		}
 
+		[HybridJSInvokable]
 		public string SuccessMethod()
 		{
 			LastMethodCalled = nameof(SuccessMethod);

--- a/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_InvokeDotNetFails.cs
+++ b/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_InvokeDotNetFails.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using Xunit;
 
@@ -125,6 +126,7 @@ public class HybridWebViewTests_InvokeDotNet : HybridWebViewTestsBase
 
 		public string? TestResult { get; set; }
 
+        [HybridJSInvokable]
         public void TestMethod(string param)
         {
 			ParamValues.Add(param);

--- a/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_SetInvokeJavaScriptTarget.cs
+++ b/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_SetInvokeJavaScriptTarget.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using Microsoft.Maui;
 using Xunit;
 
 namespace Microsoft.Maui.DeviceTests;
@@ -40,23 +41,27 @@ public partial class HybridWebViewTests_SetInvokeJavaScriptTarget : HybridWebVie
 
 		public string? LastMethodCalled { get; private set; }
 
+		[HybridJSInvokable]
 		public void Invoke_NoParam_NoReturn()
 		{
 			UpdateLastMethodCalled();
 		}
 
+		[HybridJSInvokable]
 		public object? Invoke_NoParam_ReturnNull()
 		{
 			UpdateLastMethodCalled();
 			return null;
 		}
 
+		[HybridJSInvokable]
 		public async Task Invoke_NoParam_ReturnTask()
 		{
 			await Task.Delay(1);
 			UpdateLastMethodCalled();
 		}
 
+		[HybridJSInvokable]
 		public async Task<object?> Invoke_NoParam_ReturnTaskNull()
 		{
 			await Task.Delay(1);
@@ -64,6 +69,7 @@ public partial class HybridWebViewTests_SetInvokeJavaScriptTarget : HybridWebVie
 			return null;
 		}
 
+		[HybridJSInvokable]
 		public async Task<int> Invoke_NoParam_ReturnTaskValueType()
 		{
 			await Task.Delay(1);
@@ -71,6 +77,7 @@ public partial class HybridWebViewTests_SetInvokeJavaScriptTarget : HybridWebVie
 			return 2;
 		}
 
+		[HybridJSInvokable]
 		public async Task<ComputationResult> Invoke_NoParam_ReturnTaskComplex()
 		{
 			await Task.Delay(1);
@@ -78,6 +85,7 @@ public partial class HybridWebViewTests_SetInvokeJavaScriptTarget : HybridWebVie
 			return NewComplexResult;
 		}
 
+		[HybridJSInvokable]
 		public int Invoke_OneParam_ReturnValueType(Dictionary<string, int> dict)
 		{
 			Assert.NotNull(dict);
@@ -88,6 +96,7 @@ public partial class HybridWebViewTests_SetInvokeJavaScriptTarget : HybridWebVie
 			return dict.Count;
 		}
 
+		[HybridJSInvokable]
 		public Dictionary<string, int> Invoke_OneParam_ReturnDictionary(Dictionary<string, int> dict)
 		{
 			Assert.NotNull(dict);
@@ -99,6 +108,7 @@ public partial class HybridWebViewTests_SetInvokeJavaScriptTarget : HybridWebVie
 			return dict;
 		}
 
+		[HybridJSInvokable]
 		public ComputationResult Invoke_NullParam_ReturnComplex(object obj)
 		{
 			Assert.Null(obj);
@@ -106,6 +116,7 @@ public partial class HybridWebViewTests_SetInvokeJavaScriptTarget : HybridWebVie
 			return NewComplexResult;
 		}
 
+		[HybridJSInvokable]
 		public void Invoke_ManyParams_NoReturn(Dictionary<string, int> dict, string str, object obj, ComputationResult computationResult, int[] arr)
 		{
 			Assert.NotNull(dict);

--- a/src/Core/src/Handlers/HybridWebView/HybridJSInvokableAttribute.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridJSInvokableAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Microsoft.Maui;
+
+/// <summary>
+/// Marks a public instance method as invokable from JavaScript via HybridWebView.
+/// Only methods decorated with this attribute can be called from JavaScript using <c>HybridWebView.InvokeDotNet()</c>.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method)]
+public sealed class HybridJSInvokableAttribute : Attribute
+{
+}

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.cs
@@ -272,9 +272,9 @@ namespace Microsoft.Maui.Handlers
 
 			// get the method and its parameters from the .NET object instance
 			var dotnetMethod = targetType.GetMethod(requestMethodName, BindingFlags.Public | BindingFlags.Instance | BindingFlags.InvokeMethod);
-			if (dotnetMethod is null)
+			if (dotnetMethod is null || dotnetMethod.GetCustomAttribute<HybridJSInvokableAttribute>() is null)
 			{
-				throw new InvalidOperationException($"The method {requestMethodName} couldn't be found on the {nameof(jsInvokeTarget)} of type {jsInvokeTarget.GetType().FullName}.");
+				throw new InvalidOperationException($"The method '{requestMethodName}' is not available for invocation from JavaScript.");
 			}
 			var dotnetParams = dotnetMethod.GetParameters();
 			if (requestParams is not null && dotnetParams.Length != requestParams.Length)

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -16,3 +16,5 @@ override Microsoft.Maui.Platform.MauiHybridWebView.OnAttachedToWindow() -> void
 override Microsoft.Maui.Platform.MauiHybridWebView.OnSizeChanged(int width, int height, int oldWidth, int oldHeight) -> void
 override Microsoft.Maui.Platform.MauiWebView.OnAttachedToWindow() -> void
 override Microsoft.Maui.Platform.MauiWebView.OnSizeChanged(int width, int height, int oldWidth, int oldHeight) -> void
+Microsoft.Maui.HybridJSInvokableAttribute
+Microsoft.Maui.HybridJSInvokableAttribute.HybridJSInvokableAttribute() -> void

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -6,3 +6,5 @@ override Microsoft.Maui.Platform.MauiTextView.TextAlignment.get -> UIKit.UITextA
 override Microsoft.Maui.Platform.MauiTextView.TextAlignment.set -> void
 override Microsoft.Maui.Platform.MauiView.DidUpdateFocus(UIKit.UIFocusUpdateContext! context, UIKit.UIFocusAnimationCoordinator! coordinator) -> void
 static Microsoft.Maui.Handlers.DatePickerHandler.MapFlowDirection(Microsoft.Maui.Handlers.IDatePickerHandler! handler, Microsoft.Maui.IDatePicker! datePicker) -> void
+Microsoft.Maui.HybridJSInvokableAttribute
+Microsoft.Maui.HybridJSInvokableAttribute.HybridJSInvokableAttribute() -> void

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -6,3 +6,5 @@ override Microsoft.Maui.Platform.MauiTextView.TextAlignment.get -> UIKit.UITextA
 override Microsoft.Maui.Platform.MauiTextView.TextAlignment.set -> void
 override Microsoft.Maui.Platform.MauiView.DidUpdateFocus(UIKit.UIFocusUpdateContext! context, UIKit.UIFocusAnimationCoordinator! coordinator) -> void
 static Microsoft.Maui.Handlers.DatePickerHandler.MapFlowDirection(Microsoft.Maui.Handlers.IDatePickerHandler! handler, Microsoft.Maui.IDatePicker! datePicker) -> void
+Microsoft.Maui.HybridJSInvokableAttribute
+Microsoft.Maui.HybridJSInvokableAttribute.HybridJSInvokableAttribute() -> void

--- a/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.Maui.HybridJSInvokableAttribute
+Microsoft.Maui.HybridJSInvokableAttribute.HybridJSInvokableAttribute() -> void

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
 #nullable enable
 override Microsoft.Maui.Platform.MauiPasswordTextBox.OnCreateAutomationPeer() -> Microsoft.UI.Xaml.Automation.Peers.AutomationPeer!
+Microsoft.Maui.HybridJSInvokableAttribute
+Microsoft.Maui.HybridJSInvokableAttribute.HybridJSInvokableAttribute() -> void

--- a/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.Maui.HybridJSInvokableAttribute
+Microsoft.Maui.HybridJSInvokableAttribute.HybridJSInvokableAttribute() -> void

--- a/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.Maui.HybridJSInvokableAttribute
+Microsoft.Maui.HybridJSInvokableAttribute.HybridJSInvokableAttribute() -> void

--- a/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.Maui.HybridJSInvokableAttribute
+Microsoft.Maui.HybridJSInvokableAttribute.HybridJSInvokableAttribute() -> void


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

Introduces a `[HybridJSInvokable]` attribute (mirroring Blazor's `[JSInvokable]`) that must be applied to any public method intended to be callable from JavaScript via `HybridWebView.InvokeDotNet()`.

**Problem:** `InvokeDotNetMethodAsync` in `HybridWebViewHandler.cs` previously resolved the target method via `GetMethod(name, BindingFlags.Public | BindingFlags.Instance)` with no further filtering. This exposed the entire public API surface of the `InvokeJavaScriptTarget` object to any JavaScript caller — including inherited `System.Object` methods (`Equals`, `GetHashCode`, `ToString`) and any unintended business-logic methods. The error path also leaked the fully qualified type name via `FullName` in the JSON response returned to JavaScript.

**Fix:**
- Add `[HybridJSInvokable]` attribute (`[AttributeUsage(AttributeTargets.Method)] public sealed class HybridJSInvokableAttribute : Attribute`)
- Reject `GetMethod` results that do not carry `[HybridJSInvokable]`
- Fix the error message to not include `jsInvokeTarget.GetType().FullName`
- Annotate all invokable methods in samples and device tests

## Files changed

| File | Change |
|---|---|
| `src/Core/src/Handlers/HybridWebView/HybridJSInvokableAttribute.cs` | New attribute class |
| `src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.cs` | Attribute gate + error message fix |
| `src/Core/src/PublicAPI/*/PublicAPI.Unshipped.txt` | New public API entries (all 8 TFMs) |
| `src/Controls/samples/Controls.Sample/Pages/Controls/HybridWebViewPage.xaml.cs` | `[HybridJSInvokable]` on `DotNetMethods` methods |
| `src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_SetInvokeJavaScriptTarget.cs` | `[HybridJSInvokable]` on `TestDotNetMethods` methods |
| `src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_ExceptionHandling.cs` | `[HybridJSInvokable]` on `TestExceptionMethods` methods |
| `src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_InvokeDotNetFails.cs` | `[HybridJSInvokable]` on `InvokeTarget.TestMethod` |

## Testing

- All 806 existing Core unit tests pass (`dotnet test src/Core/tests/UnitTests/Core.UnitTests.csproj`)
- Build clean with `TreatWarningsAsErrors=true` for `netstandard2.0` and `netstandard2.1`
- Existing device tests (`HybridWebViewTests_SetInvokeJavaScriptTarget`, `HybridWebViewTests_ExceptionHandling`) validate that decorated methods continue to work correctly
- Methods **without** `[HybridJSInvokable]` now throw `InvalidOperationException("The method 'X' is not available for invocation from JavaScript.")`