### PR TITLE
[Android] Fix for Shell colors change before navigation completes on Android in .NET 10 

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellItemRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellItemRenderer.cs
@@ -154,9 +154,12 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		protected virtual bool ChangeSection(ShellSection shellSection)
 		{
-			// Update shell appearance based on the new shell section when switching between tabs
-			((IShellController)ShellContext.Shell).AppearanceChanged(shellSection, false);
-			return ((IShellItemController)ShellItem).ProposeSection(shellSection);
+			var result = ((IShellItemController)ShellItem).ProposeSection(shellSection);
+			if (result)
+			{
+				((IShellController)ShellContext.Shell).AppearanceChanged(shellSection, false);
+			}
+			return result;
 		}
 
 		protected virtual Drawable CreateItemBackgroundDrawable()


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue details
On Android (.NET MAUI 10), Shell toolbar colors are applied before navigation completes during tab/page transitions, causing the current page to briefly display the destination page’s colors. This is a regression from .NET MAUI 9 and results in incorrect visual behavior during navigation. 

### Root Cause
The issue occurs because of the toolbar appearance update being triggered before the tab navigation is fully completed when switching tabs in a Shell with TabBar. During the tab change, the destination tab colors are applied immediately while the previous tab content is still visible on screen, which causes a brief color flash. This is especially noticeable when different child pages use different toolbar colors. The behavior started after an earlier change where the appearance update was added during tab switching but executed before the section change was committed.
 
### Description of Change
The fix involves changing the execution order so the section change is committed first, and the appearance update happens only after the tab switch is successfully accepted. This ensures the Shell internal state is updated to the correct tab before applying the toolbar colors, preventing premature color changes while the previous tab is still visible. The update is also skipped when the tab switch is rejected or cancelled, so colors continue to refresh correctly on every tab switch, but now at the correct time.

### Why Tests were not added:

**Regarding the test case:** No automated test case was added for this fix, as the issue is a brief visual color flash that occurs during the tab-switch animation on Android and cannot be reliably captured through the existing automated test infrastructure.
 
Screenshot-based tests cannot consistently capture the exact transition frame where the issue occurs, and the current baseline comparison approach is unable to accurately differentiate correct and incorrect toolbar color timing during the animation.

Tested the behavior in the following platforms.
 
- [x] Android
- [ ] Mac
- [ ] iOS
- [ ] Windows

**Regression PR:** The PR [25870](https://github.com/dotnet/maui/pull/25870) as the primary regression source. PR [32882](https://github.com/dotnet/maui/pull/32882) appears to be a later overlapping change affecting Shell color timing.

The PR [25870](https://github.com/dotnet/maui/pull/25870) as the primary regression source. PR [32882](https://github.com/dotnet/maui/pull/32882) appears to be a later overlapping change affecting Shell color timing.

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/35060

### Output

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="270" height="600"  src="https://github.com/user-attachments/assets/44ea19d0-7aca-42b1-b936-506eb4609f33"> | <video width="270" height="600"  src="https://github.com/user-attachments/assets/f1c8b6b4-44b5-4f6b-9daa-988daa33b90c"> |