### PR TITLE
Fix: Build fails when appicon is an empty (but valid) SVG

### DIFF
--- a/src/SingleProject/Resizetizer/src/SkiaSharpSvgTools.cs
+++ b/src/SingleProject/Resizetizer/src/SkiaSharpSvgTools.cs
@@ -35,7 +35,6 @@ namespace Microsoft.Maui.Resizetizer
 
 		public override void DrawUnscaled(SKCanvas canvas, float scale)
 		{
-			var size = GetOriginalSize();
 			if (scale >= 1)
 			{
 				// draw using default scaling
@@ -43,6 +42,7 @@ namespace Microsoft.Maui.Resizetizer
 			}
 			else
 			{
+				var size = GetOriginalSize();
 				if (size.IsEmpty)
 				{
 					throw new InvalidOperationException($"Cannot draw SVG file '{Filename}'. The SVG has no size. Ensure the SVG includes a viewBox attribute or both width and height attributes with valid dimensions.");

--- a/src/SingleProject/Resizetizer/src/SkiaSharpSvgTools.cs
+++ b/src/SingleProject/Resizetizer/src/SkiaSharpSvgTools.cs
@@ -36,10 +36,6 @@ namespace Microsoft.Maui.Resizetizer
 		public override void DrawUnscaled(SKCanvas canvas, float scale)
 		{
 			var size = GetOriginalSize();
-			if (size.IsEmpty)
-			{
-				throw new InvalidOperationException($"Cannot draw SVG file '{Filename}'. The SVG has no size. Ensure the SVG includes a viewBox attribute or both width and height attributes with valid dimensions.");
-			}
 			if (scale >= 1)
 			{
 				// draw using default scaling
@@ -47,6 +43,11 @@ namespace Microsoft.Maui.Resizetizer
 			}
 			else
 			{
+				if (size.IsEmpty)
+				{
+					throw new InvalidOperationException($"Cannot draw SVG file '{Filename}'. The SVG has no size. Ensure the SVG includes a viewBox attribute or both width and height attributes with valid dimensions.");
+				}
+
 				// vector scaling has rounding issues, so first draw as intended
 				var info = new SKImageInfo((int)size.Width, (int)size.Height);
 				using var surface = SKSurface.Create(info);

--- a/src/SingleProject/Resizetizer/test/UnitTests/ResizetizeImagesTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/ResizetizeImagesTests.cs
@@ -1029,6 +1029,24 @@ namespace Microsoft.Maui.Resizetizer.Tests
 
 			//	AssertFileSize(DestinationFilename, exWidth, exHeight);
 			//}
+
+			[Fact]
+			public void EmptySvgAppIconSucceeds_Issue35293()
+			{
+				var items = new[]
+				{
+					new TaskItem("images/appicon_empty.svg", new Dictionary<string, string>
+					{
+						["IsAppIcon"] = bool.TrueString,
+						["Link"] = "appicon",
+					}),
+				};
+
+				var task = GetNewTask(items);
+				var success = task.Execute();
+
+				Assert.True(success, LogErrorEvents.FirstOrDefault()?.Message);
+			}
 		}
 
 		public class ExecuteForiOS : ExecuteForPlatformApp

--- a/src/SingleProject/Resizetizer/test/UnitTests/ResizetizeImagesTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/ResizetizeImagesTests.cs
@@ -118,6 +118,24 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			}
 
 			[Fact]
+			public void EmptySvgAppIconSucceeds_Issue35293()
+			{
+				var items = new[]
+				{
+					new TaskItem("images/appicon_empty.svg", new Dictionary<string, string>
+					{
+						["IsAppIcon"] = bool.TrueString,
+						["Link"] = "appicon",
+					}),
+				};
+
+				var task = GetNewTask(items);
+				var success = task.Execute();
+
+				Assert.True(success, LogErrorEvents.FirstOrDefault()?.Message);
+			}
+
+			[Fact]
 			public void GenerationSkippedOnIncrementalBuild()
 			{
 				var items = new[]
@@ -1030,23 +1048,6 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			//	AssertFileSize(DestinationFilename, exWidth, exHeight);
 			//}
 
-			[Fact]
-			public void EmptySvgAppIconSucceeds_Issue35293()
-			{
-				var items = new[]
-				{
-					new TaskItem("images/appicon_empty.svg", new Dictionary<string, string>
-					{
-						["IsAppIcon"] = bool.TrueString,
-						["Link"] = "appicon",
-					}),
-				};
-
-				var task = GetNewTask(items);
-				var success = task.Execute();
-
-				Assert.True(success, LogErrorEvents.FirstOrDefault()?.Message);
-			}
 		}
 
 		public class ExecuteForiOS : ExecuteForPlatformApp

--- a/src/SingleProject/Resizetizer/test/UnitTests/images/appicon_empty.svg
+++ b/src/SingleProject/Resizetizer/test/UnitTests/images/appicon_empty.svg
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="456" height="456" viewBox="0 0 456 456" version="1.1" xmlns="http://www.w3.org/2000/svg">
+</svg>


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!


<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details
Build fails with InvalidOperationException when using an empty (but valid) SVG as the app icon. The SVG has width, height, and viewBox but no drawn shapes inside.

### Root Cause
PR #33194 moved the size.IsEmpty check to run before both code paths in DrawUnscaled, but size (from CullRect) is only needed in the downscale path. Empty SVGs have a zero CullRect even with valid declared dimensions, so the check incorrectly blocks the upscale path that never uses size.

### Description of Change
Moved the size.IsEmpty check from before both branches into only the else (downscale) branch where size is actually used. The scale >= 1 path calls DrawPicture directly, which harmlessly draws nothing for empty SVGs, producing a valid transparent image.
 

Validated the behavior in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
### Issues Fixed
  
Fixes #35293 

### Output  ScreenShot

|Before|After|
|--|--|
| <video src="https://github.com/user-attachments/assets/cf8040d6-9b0f-4867-bd4a-1713ea41d1d5" >| <video src="https://github.com/user-attachments/assets/97c09d5e-b2cc-4a13-b5a3-dc056dacba78">|