### PR TITLE
Fix CI for ValidateKeyboardRuntime_SwitchContainerToSoftInput_WhileKeyboardOpen test failure in May 4th Candidate

### DIFF
--- a/src/Core/src/Platform/iOS/MauiView.cs
+++ b/src/Core/src/Platform/iOS/MauiView.cs
@@ -312,6 +312,18 @@ namespace Microsoft.Maui.Platform
 				UIKeyboard.WillHideNotification,
 				OnKeyboardWillHide);
 			_keyboardWillHideObserver = new WeakReference<NSObject>(hideObserver);
+
+			// When switching to SoftInput while keyboard is already open, iOS may not
+			// emit a new WillShow. Rehydrate from global keyboard tracking.
+			if (!_isKeyboardShowing
+				&& KeyboardAutoManagerScroll.IsKeyboardShowing
+				&& !KeyboardAutoManagerScroll.KeyboardFrame.IsEmpty)
+			{
+				_keyboardFrame = KeyboardAutoManagerScroll.KeyboardFrame;
+				_isKeyboardShowing = true;
+				_safeAreaInvalidated = true;
+				SetNeedsLayout();
+			}
 		}
 
 		void UnsubscribeFromKeyboardNotifications()


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Issue Details
PR #35083 fixed the stale safe area issue when switching from All to Container while the keyboard was open.
But that change introduced a regression for the opposite runtime flow.
 
On iOS, when switching from Container to SoftInput while the keyboard is already open, MauiView may not receive a new keyboard show event. Because the keyboard state was cleared during unsubscribe, the view can miss the current keyboard state and fail to apply the expected keyboard-related bottom inset.

### Description of Change

<!-- Enter description of the fix in this section -->
This change updates iOS keyboard handling in MauiView.cs:312. When switching to SoftInput while the keyboard is already open, it restores keyboard state immediately and refreshes layout, so safe area updates correctly.

### Issues Fixed
* ValidateKeyboardRuntime_SwitchContainerToSoftInput_WhileKeyboardOpen
