### PR TITLE
[Material3] Expose Material Handlers and Helpers as Public

### DIFF
--- a/src/Controls/src/Core/Editor/Editor.Android.cs
+++ b/src/Controls/src/Core/Editor/Editor.Android.cs
@@ -19,8 +19,7 @@ namespace Microsoft.Maui.Controls
 			Platform.EditTextExtensions.UpdateText(handler.PlatformView, editor);
 		}
 
-		// TODO: Material3 - make it public in .net 11
-		internal static void MapText(EditorHandler2 handler, Editor editor)
+		public static void MapText(EditorHandler2 handler, Editor editor)
 		{
 			if (handler.PlatformView is null)
 			{

--- a/src/Controls/src/Core/Entry/Entry.Android.cs
+++ b/src/Controls/src/Core/Entry/Entry.Android.cs
@@ -30,9 +30,8 @@ namespace Microsoft.Maui.Controls
 			Platform.EditTextExtensions.UpdateText(handler.PlatformView, entry);
 		}
 
-		// TODO: Material3: Make it public in .NET 11
 		// MaterialEntryHandler-specific overloads
-		internal static void MapImeOptions(EntryHandler2 handler, Entry entry)
+		public static void MapImeOptions(EntryHandler2 handler, Entry entry)
 		{
 			if (handler.PlatformView?.EditText is null)
 			{
@@ -42,8 +41,7 @@ namespace Microsoft.Maui.Controls
 			Platform.EditTextExtensions.UpdateImeOptions(handler.PlatformView.EditText, entry);
 		}
 
-		// TODO: Material3: Make it public in .NET 11
-		internal static void MapText(EntryHandler2 handler, Entry entry)
+		public static void MapText(EntryHandler2 handler, Entry entry)
 		{
 			if (handler.PlatformView?.EditText is null)
 			{

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 *REMOVED*~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> System.Collections.Generic.IList<Microsoft.Maui.Controls.VisualStateGroup>
 *REMOVED*~static readonly Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer.DefaultForegroundColor -> Microsoft.Maui.Graphics.Color
 *REMOVED*~static readonly Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer.DefaultTitleColor -> Microsoft.Maui.Graphics.Color
@@ -97,3 +97,7 @@ Microsoft.Maui.Controls.BoxView.~BoxView() -> void
 ~Microsoft.Maui.Controls.BoxView.Fill.get -> Microsoft.Maui.Controls.Brush
 ~Microsoft.Maui.Controls.BoxView.Fill.set -> void
 ~static readonly Microsoft.Maui.Controls.BoxView.FillProperty -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.Editor.MapText(Microsoft.Maui.Handlers.EditorHandler2 handler, Microsoft.Maui.Controls.Editor editor) -> void
+~static Microsoft.Maui.Controls.Entry.MapImeOptions(Microsoft.Maui.Handlers.EntryHandler2 handler, Microsoft.Maui.Controls.Entry entry) -> void
+~static Microsoft.Maui.Controls.Entry.MapText(Microsoft.Maui.Handlers.EntryHandler2 handler, Microsoft.Maui.Controls.Entry entry) -> void
+~static Microsoft.Maui.Controls.SearchBar.MapText(Microsoft.Maui.Handlers.SearchBarHandler2 handler, Microsoft.Maui.Controls.SearchBar searchBar) -> void

--- a/src/Controls/src/Core/SearchBar/SearchBar.Android.cs
+++ b/src/Controls/src/Core/SearchBar/SearchBar.Android.cs
@@ -14,8 +14,7 @@ namespace Microsoft.Maui.Controls
 		}
 
 		// Material3 specific overload for SearchBarHandler2
-		// TODO: Material3: Make it public in .NET 11
-		internal static void MapText(SearchBarHandler2 handler, SearchBar searchBar)
+		public static void MapText(SearchBarHandler2 handler, SearchBar searchBar)
 		{
 			if (handler.PlatformView?.EditText is null)
 			{

--- a/src/Core/src/Handlers/ActivityIndicator/ActivityIndicatorHandler.Android.cs
+++ b/src/Core/src/Handlers/ActivityIndicator/ActivityIndicatorHandler.Android.cs
@@ -19,8 +19,7 @@ namespace Microsoft.Maui.Handlers
 		}
 	}
 
-	// TODO: material3 - make it public in .net 11
-	internal class ActivityIndicatorHandler2 : ActivityIndicatorHandler
+	public class ActivityIndicatorHandler2 : ActivityIndicatorHandler
 	{
 		protected override MaterialActivityIndicator CreatePlatformView()
 		{

--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler2.Android.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler2.Android.cs
@@ -6,8 +6,7 @@ using Google.Android.Material.DatePicker;
 
 namespace Microsoft.Maui.Handlers;
 
-// TODO: material3 - make it public in .net 11
-internal class DatePickerHandler2 : ViewHandler<IDatePicker, MauiMaterialDatePicker>
+public class DatePickerHandler2 : ViewHandler<IDatePicker, MauiMaterialDatePicker>
 {
     internal MaterialDatePicker? _dialog;
     internal bool _isUpdatingIsOpen;
@@ -295,8 +294,7 @@ internal class DatePickerHandler2 : ViewHandler<IDatePicker, MauiMaterialDatePic
     }
 }
 
-// TODO: material3 - make it public in .net 11
-internal class MaterialDatePickerPositiveButtonClickListener : Java.Lang.Object, IMaterialPickerOnPositiveButtonClickListener
+public class MaterialDatePickerPositiveButtonClickListener : Java.Lang.Object, IMaterialPickerOnPositiveButtonClickListener
 {
     readonly WeakReference<DatePickerHandler2> _handler;
 
@@ -326,8 +324,7 @@ internal class MaterialDatePickerPositiveButtonClickListener : Java.Lang.Object,
     }
 }
 
-// TODO: material3 - make it public in .net 11
-internal class MaterialDatePickerDismissListener : Java.Lang.Object, IDialogInterfaceOnDismissListener
+public class MaterialDatePickerDismissListener : Java.Lang.Object, IDialogInterfaceOnDismissListener
 {
     readonly WeakReference<DatePickerHandler2> _handler;
 

--- a/src/Core/src/Handlers/Editor/EditorHandler2.Android.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler2.Android.cs
@@ -7,8 +7,7 @@ using static Android.Views.View;
 
 namespace Microsoft.Maui.Handlers;
 
-// TODO: Material3 - make it public in .net 11
-internal class EditorHandler2 : ViewHandler<IEditor, MauiMaterialEditText>
+public class EditorHandler2 : ViewHandler<IEditor, MauiMaterialEditText>
 {
 	bool _set;
 

--- a/src/Core/src/Handlers/Entry/EntryHandler2.Android.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler2.Android.cs
@@ -9,8 +9,7 @@ using static Android.Widget.TextView;
 
 namespace Microsoft.Maui.Handlers;
 
-// TODO: Material3: Make it public in .NET 11
-internal class EntryHandler2 : ViewHandler<IEntry, MauiMaterialTextInputLayout>
+public class EntryHandler2 : ViewHandler<IEntry, MauiMaterialTextInputLayout>
 {
 	ClearButtonClickListener? _clearButtonClickListener;
 	ColorStateList? _defaultHintTextColors;

--- a/src/Core/src/Handlers/Image/ImageHandler2.Android.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler2.Android.cs
@@ -2,8 +2,7 @@ using Google.Android.Material.ImageView;
 
 namespace Microsoft.Maui.Handlers;
 
-// TODO: make it public in .net 11
-internal class ImageHandler2 : ImageHandler
+public class ImageHandler2 : ImageHandler
 {
     protected override ShapeableImageView CreatePlatformView()
     {

--- a/src/Core/src/Handlers/Label/LabelHandler.Android.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.Android.cs
@@ -127,8 +127,7 @@ namespace Microsoft.Maui.Handlers
 		}
 	}
 
-	// TODO: Material3 - make it public in .net 11
-	internal class LabelHandler2 : LabelHandler
+	public class LabelHandler2 : LabelHandler
 	{
 		protected override MauiMaterialTextView CreatePlatformView()
 		{

--- a/src/Core/src/Handlers/Picker/PickerHandler2.Android.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler2.Android.cs
@@ -7,8 +7,7 @@ using AResource = Android.Resource;
 
 namespace Microsoft.Maui.Handlers;
 
-// TODO: Material3 - make it public in .net 11
-internal partial class PickerHandler2 : ViewHandler<IPicker, MauiMaterialPicker>
+public partial class PickerHandler2 : ViewHandler<IPicker, MauiMaterialPicker>
 {
 	AppCompatAlertDialog? _dialog;
 

--- a/src/Core/src/Handlers/ProgressBar/ProgressBarHandler2.Android.cs
+++ b/src/Core/src/Handlers/ProgressBar/ProgressBarHandler2.Android.cs
@@ -2,8 +2,7 @@ using Google.Android.Material.ProgressIndicator;
 
 namespace Microsoft.Maui.Handlers;
 
-// TODO: Material3 - make it public in .net 11
-internal class ProgressBarHandler2 : ProgressBarHandler
+public class ProgressBarHandler2 : ProgressBarHandler
 {
 	protected override LinearProgressIndicator CreatePlatformView()
 	{

--- a/src/Core/src/Handlers/RadioButton/RadioButtonHandler2.Android.cs
+++ b/src/Core/src/Handlers/RadioButton/RadioButtonHandler2.Android.cs
@@ -2,8 +2,7 @@ using Google.Android.Material.RadioButton;
 
 namespace Microsoft.Maui.Handlers;
 
-// TODO: Material3 - make it public in .net 11
-internal class RadioButtonHandler2 : RadioButtonHandler
+public class RadioButtonHandler2 : RadioButtonHandler
 {
 	protected override MaterialRadioButton CreatePlatformView()
 	{

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler2.Android.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler2.Android.cs
@@ -9,8 +9,7 @@ using AView = Android.Views.View;
 
 namespace Microsoft.Maui.Handlers;
 
-// TODO: material3 - make it public in .net 11
-internal class SearchBarHandler2 : ViewHandler<ISearchBar, MauiMaterialSearchBarTextInputLayout>
+public class SearchBarHandler2 : ViewHandler<ISearchBar, MauiMaterialSearchBarTextInputLayout>
 {
     public static PropertyMapper<ISearchBar, SearchBarHandler2> Mapper =
     new(ViewMapper)

--- a/src/Core/src/Handlers/Slider/SliderHandler2.Android.cs
+++ b/src/Core/src/Handlers/Slider/SliderHandler2.Android.cs
@@ -3,8 +3,7 @@ using Google.Android.Material.Slider;
 
 namespace Microsoft.Maui.Handlers;
 
-// TODO: Material3: Make it public in .NET 11
-internal class SliderHandler2 : ViewHandler<ISlider, Slider>
+public class SliderHandler2 : ViewHandler<ISlider, Slider>
 {
     public static PropertyMapper<ISlider, SliderHandler2> Mapper =
             new(ViewMapper)

--- a/src/Core/src/Handlers/Switch/SwitchHandler2.Android.cs
+++ b/src/Core/src/Handlers/Switch/SwitchHandler2.Android.cs
@@ -2,8 +2,7 @@ using Google.Android.Material.MaterialSwitch;
 
 namespace Microsoft.Maui.Handlers;
 
-// TODO: material3 - make it public in .net 11
-internal class SwitchHandler2 : SwitchHandler
+public class SwitchHandler2 : SwitchHandler
 {
 	public static new PropertyMapper<ISwitch, SwitchHandler2> Mapper =
   	new(SwitchHandler.Mapper)

--- a/src/Core/src/Handlers/TimePicker/TimePickerHandler2.Android.cs
+++ b/src/Core/src/Handlers/TimePicker/TimePickerHandler2.Android.cs
@@ -7,8 +7,7 @@ using Google.Android.Material.TimePicker;
 
 namespace Microsoft.Maui.Handlers;
 
-// TODO: Material3: Make it public in .NET 11
-internal partial class TimePickerHandler2 : ViewHandler<ITimePicker, MauiMaterialTimePicker>
+public partial class TimePickerHandler2 : ViewHandler<ITimePicker, MauiMaterialTimePicker>
 {
     internal MaterialTimePicker? _dialog;
     internal bool _isUpdatingIsOpen;
@@ -238,7 +237,7 @@ internal partial class TimePickerHandler2 : ViewHandler<ITimePicker, MauiMateria
             && VirtualView.Format == "t" || VirtualView.Format == "HH:mm");
 }
 
-internal class MaterialTimePickerPositiveButtonClickListener : Java.Lang.Object, View.IOnClickListener
+public class MaterialTimePickerPositiveButtonClickListener : Java.Lang.Object, View.IOnClickListener
 {
     readonly WeakReference<TimePickerHandler2> _handler;
 
@@ -262,7 +261,7 @@ internal class MaterialTimePickerPositiveButtonClickListener : Java.Lang.Object,
     }
 }
 
-internal class MaterialTimePickerDismissListener : Java.Lang.Object, IDialogInterfaceOnDismissListener
+public class MaterialTimePickerDismissListener : Java.Lang.Object, IDialogInterfaceOnDismissListener
 {
     readonly WeakReference<TimePickerHandler2> _handler;
 

--- a/src/Core/src/Platform/Android/DatePickerExtensions.cs
+++ b/src/Core/src/Platform/Android/DatePickerExtensions.cs
@@ -78,18 +78,17 @@ namespace Microsoft.Maui.Platform
 			platformDatePicker.Text = datePicker.Date?.ToString(datePicker.Format) ?? string.Empty;
 		}
 
-		// TODO: material3 - make it public in .net 11
-		internal static void UpdateDate(this MauiMaterialDatePicker platformDatePicker, IDatePicker datePicker)
+		public static void UpdateDate(this MauiMaterialDatePicker platformDatePicker, IDatePicker datePicker)
 		{
 			platformDatePicker.SetText(datePicker);
 		}
 
-		internal static void UpdateFormat(this MauiMaterialDatePicker platformDatePicker, IDatePicker datePicker)
+		public static void UpdateFormat(this MauiMaterialDatePicker platformDatePicker, IDatePicker datePicker)
 		{
 			platformDatePicker.SetText(datePicker);
 		}
 
-		internal static void UpdateTextColor(this MauiMaterialDatePicker platformDatePicker, IDatePicker datePicker)
+		public static void UpdateTextColor(this MauiMaterialDatePicker platformDatePicker, IDatePicker datePicker)
 		{
 			var textColor = datePicker.TextColor;
 

--- a/src/Core/src/Platform/Android/Material3Controls/MauiMaterialDatePicker.cs
+++ b/src/Core/src/Platform/Android/Material3Controls/MauiMaterialDatePicker.cs
@@ -11,8 +11,7 @@ using static Android.Views.View;
 
 namespace Microsoft.Maui.Platform;
 
-// TODO: material3 - make it public in .net 11
-internal class MauiMaterialDatePicker : TextInputEditText, IOnClickListener
+public class MauiMaterialDatePicker : TextInputEditText, IOnClickListener
 {
     public MauiMaterialDatePicker(Context context) : base(MauiMaterialContextThemeWrapper.Create(context))
     {

--- a/src/Core/src/Platform/Android/Material3Controls/MauiMaterialEditText.cs
+++ b/src/Core/src/Platform/Android/Material3Controls/MauiMaterialEditText.cs
@@ -7,8 +7,7 @@ using Google.Android.Material.TextField;
 
 namespace Microsoft.Maui.Platform;
 
-// TODO: Material3 - make it public in .net 11
-internal class MauiMaterialEditText : TextInputEditText
+public class MauiMaterialEditText : TextInputEditText
 {
 	public event EventHandler? SelectionChanged;
 
@@ -50,8 +49,7 @@ internal class MauiMaterialEditText : TextInputEditText
 	}
 }
 
-// TODO: Material3: Make it public in .NET 11
-internal class MauiMaterialTextInputLayout : TextInputLayout
+public class MauiMaterialTextInputLayout : TextInputLayout
 {
 	public MauiMaterialTextInputLayout(Context context) : base(context)
 	{

--- a/src/Core/src/Platform/Android/Material3Controls/MauiMaterialPicker.cs
+++ b/src/Core/src/Platform/Android/Material3Controls/MauiMaterialPicker.cs
@@ -5,8 +5,7 @@ using Google.Android.Material.TextField;
 
 namespace Microsoft.Maui.Platform;
 
-// TODO: Material3 - make it public in .net 11
-internal class MauiMaterialPicker : MauiMaterialPickerBase
+public class MauiMaterialPicker : MauiMaterialPickerBase
 {
 	public MauiMaterialPicker(Context context) : base(context)
 	{
@@ -24,8 +23,7 @@ internal class MauiMaterialPicker : MauiMaterialPickerBase
 	}
 }
 
-// TODO: Material3 - make it public in .net 11
-internal class MauiMaterialPickerBase : TextInputEditText
+public class MauiMaterialPickerBase : TextInputEditText
 {
 	public MauiMaterialPickerBase(Context context) : base(MauiMaterialContextThemeWrapper.Create(context))
 	{

--- a/src/Core/src/Platform/Android/Material3Controls/MauiMaterialTextView.cs
+++ b/src/Core/src/Platform/Android/Material3Controls/MauiMaterialTextView.cs
@@ -5,8 +5,7 @@ using Java.Lang;
 
 namespace Microsoft.Maui.Platform;
 
-// TODO: Material3 - make it public in .net 11
-internal class MauiMaterialTextView : MaterialTextView
+public class MauiMaterialTextView : MaterialTextView
 {
 	// Track text type to optimize layout events - FormattedText needs span recalculation, plain text doesn't
 	bool _isFormatted;

--- a/src/Core/src/Platform/Android/MaterialActivityIndicator.cs
+++ b/src/Core/src/Platform/Android/MaterialActivityIndicator.cs
@@ -6,8 +6,7 @@ using Google.Android.Material.ProgressIndicator;
 
 namespace Microsoft.Maui.Platform;
 
-// TODO: material3 - make it public in .net 11
-internal class MaterialActivityIndicator : CircularProgressIndicator
+public class MaterialActivityIndicator : CircularProgressIndicator
 {
     public MaterialActivityIndicator(Context context)
      : base(MauiMaterialContextThemeWrapper.Create(context))

--- a/src/Core/src/Platform/Android/MauiMaterialContextThemeWrapper.cs
+++ b/src/Core/src/Platform/Android/MauiMaterialContextThemeWrapper.cs
@@ -3,7 +3,7 @@ using Android.Views;
 
 namespace Microsoft.Maui.Platform;
 
-internal class MauiMaterialContextThemeWrapper : ContextThemeWrapper
+public class MauiMaterialContextThemeWrapper : ContextThemeWrapper
 {
     // IsMaterial3Enabled Flag needed for Control Level theming. App Level theming is handled in MauiAppCompatActivity
     public MauiMaterialContextThemeWrapper(Context context)

--- a/src/Core/src/Platform/Android/MauiMaterialSearchBarTextInputLayout.cs
+++ b/src/Core/src/Platform/Android/MauiMaterialSearchBarTextInputLayout.cs
@@ -5,8 +5,7 @@ using Google.Android.Material.TextField;
 
 namespace Microsoft.Maui.Platform;
 
-// TODO: material3 - make it public in .net 11
-internal class MauiMaterialSearchBarTextInputLayout : TextInputLayout
+public class MauiMaterialSearchBarTextInputLayout : TextInputLayout
 {
     public MauiMaterialSearchBarTextInputLayout(Context context) : base(context)
     {
@@ -47,8 +46,7 @@ internal class MauiMaterialSearchBarTextInputLayout : TextInputLayout
     }
 }
 
-// TODO: material3 - make it public in .net 11
-internal class MauiMaterialSearchBarTextInputEditText : TextInputEditText
+public class MauiMaterialSearchBarTextInputEditText : TextInputEditText
 {
     public event EventHandler? SelectionChanged;
     public MauiMaterialSearchBarTextInputEditText(Context context) : base(context)

--- a/src/Core/src/Platform/Android/MauiMaterialTimePicker.cs
+++ b/src/Core/src/Platform/Android/MauiMaterialTimePicker.cs
@@ -10,8 +10,7 @@ using static Android.Views.View;
 
 namespace Microsoft.Maui.Platform;
 
-// TODO: material3 - make it public in .net 11
-internal class MauiMaterialTimePicker : TextInputEditText, IOnClickListener
+public class MauiMaterialTimePicker : TextInputEditText, IOnClickListener
 {
     public MauiMaterialTimePicker(Context context) : base(MauiMaterialContextThemeWrapper.Create(context))
     {

--- a/src/Core/src/Platform/Android/PickerExtensions.cs
+++ b/src/Core/src/Platform/Android/PickerExtensions.cs
@@ -43,20 +43,17 @@ namespace Microsoft.Maui.Platform
 			alertDialog.UpdateFlowDirectionCore(platformPicker);
 		}
 
-		// TODO: Material3 - make it public in .net 11
-		internal static void UpdateTitle(this MauiMaterialPicker platformPicker, IPicker picker)
+		public static void UpdateTitle(this MauiMaterialPicker platformPicker, IPicker picker)
 		{
 			UpdatePicker(platformPicker, picker);
 		}
 
-		// TODO: Material3 - make it public in .net 11
-		internal static void UpdateTitleColor(this MauiMaterialPicker platformPicker, IPicker picker)
+		public static void UpdateTitleColor(this MauiMaterialPicker platformPicker, IPicker picker)
 		{
 			platformPicker.UpdateTitleColorCore(picker);
 		}
 
-		// TODO: Material3 - make it public in .net 11
-		internal static void UpdateSelectedIndex(this MauiMaterialPicker platformPicker, IPicker picker)
+		public static void UpdateSelectedIndex(this MauiMaterialPicker platformPicker, IPicker picker)
 		{
 			UpdatePicker(platformPicker, picker);
 		}
@@ -71,8 +68,7 @@ namespace Microsoft.Maui.Platform
 			alertDialog.UpdateFlowDirectionCore(platformPicker);
 		}
 
-		// TODO: Material3 - make it public in .net 11
-		internal static void UpdateTitleColorCore(this AppCompatEditText platformPicker, IPicker picker)
+		public static void UpdateTitleColorCore(this AppCompatEditText platformPicker, IPicker picker)
 		{
 			var titleColor = picker.TitleColor;
 
@@ -89,8 +85,7 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		// TODO: Material3 - make it public in .net 11
-		internal static void UpdatePickerCore(this AppCompatEditText platformPicker, IPicker picker)
+		public static void UpdatePickerCore(this AppCompatEditText platformPicker, IPicker picker)
 		{
 			platformPicker.Hint = picker.Title;
 
@@ -104,8 +99,7 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		// TODO: Material3 - make it public in .net 11
-		internal static void UpdateFlowDirectionCore(this AppCompatAlertDialog alertDialog, AppCompatEditText platformPicker)
+		public static void UpdateFlowDirectionCore(this AppCompatAlertDialog alertDialog, AppCompatEditText platformPicker)
 		{
 			var platformLayoutDirection = platformPicker.LayoutDirection;
 

--- a/src/Core/src/Platform/Android/SearchViewExtensions.cs
+++ b/src/Core/src/Platform/Android/SearchViewExtensions.cs
@@ -292,8 +292,7 @@ namespace Microsoft.Maui.Platform
 		}
 
 		// material3 searchbar extension methods
-		// TODO: material3 - make it public in .net 11
-		internal static void UpdateText(this EditText editText, ISearchBar searchBar)
+		public static void UpdateText(this EditText editText, ISearchBar searchBar)
 		{
 			// Check if text is already the same to prevent unnecessary updates and TextWatcher loops
 			var currentText = editText.Text ?? string.Empty;
@@ -307,7 +306,7 @@ namespace Microsoft.Maui.Platform
 			editText.Text = newText;
 		}
 
-		internal static void UpdateBackground(this TextInputLayout textInputLayout, ISearchBar searchBar)
+		public static void UpdateBackground(this TextInputLayout textInputLayout, ISearchBar searchBar)
 		{
 			var background = searchBar.Background;
 
@@ -351,7 +350,7 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		internal static void UpdateCancelButtonColor(this TextInputLayout textInputLayout, ISearchBar searchBar)
+		public static void UpdateCancelButtonColor(this TextInputLayout textInputLayout, ISearchBar searchBar)
 		{
 			// For TextInputLayout, the cancel/clear button is the end icon
 			if (searchBar.CancelButtonColor is not null)
@@ -392,7 +391,7 @@ namespace Microsoft.Maui.Platform
 			return true;
 		}
 
-		internal static void UpdateReturnType(this EditText editText, ISearchBar searchBar)
+		public static void UpdateReturnType(this EditText editText, ISearchBar searchBar)
 		{
 			editText.ImeOptions = searchBar.ReturnType.ToPlatform();
 

--- a/src/Core/src/Platform/Android/SwitchExtensions.cs
+++ b/src/Core/src/Platform/Android/SwitchExtensions.cs
@@ -34,8 +34,7 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		// TODO: material3 - make it public in .net 11
-		internal static void UpdateTrackColor(this MSwitch materialSwitch, ISwitch view)
+		public static void UpdateTrackColor(this MSwitch materialSwitch, ISwitch view)
 		{
 			// Cache the original theme tint before first modification 
 			// so it can be restored when TrackColor is cleared.
@@ -61,7 +60,7 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		internal static void UpdateThumbColor(this MSwitch materialSwitch, ISwitch view)
+		public static void UpdateThumbColor(this MSwitch materialSwitch, ISwitch view)
 		{
 			// Cache the original theme tint before first modification 
 			// so it can be restored when ThumbColor is cleared.

--- a/src/Core/src/Platform/Android/TimePickerExtensions.cs
+++ b/src/Core/src/Platform/Android/TimePickerExtensions.cs
@@ -9,15 +9,13 @@ public static class TimePickerExtensions
 	public static void UpdateFormat(this MauiTimePicker mauiTimePicker, ITimePicker timePicker)
 		=> SetTimeImpl(mauiTimePicker, timePicker);
 
-	// TODO: Material3: Make it public in .NET 11
-	internal static void UpdateFormat(this MauiMaterialTimePicker mauiTimePicker, ITimePicker timePicker)
+	public static void UpdateFormat(this MauiMaterialTimePicker mauiTimePicker, ITimePicker timePicker)
 		=> SetTimeImpl(mauiTimePicker, timePicker);
 
 	public static void UpdateTime(this MauiTimePicker mauiTimePicker, ITimePicker timePicker)
 		=> SetTimeImpl(mauiTimePicker, timePicker);
 
-	// TODO: Material3: Make it public in .NET 11
-	internal static void UpdateTime(this MauiMaterialTimePicker mauiTimePicker, ITimePicker timePicker)
+	public static void UpdateTime(this MauiMaterialTimePicker mauiTimePicker, ITimePicker timePicker)
 		=> SetTimeImpl(mauiTimePicker, timePicker);
 
 	internal static void SetTime(this MauiTimePicker mauiTimePicker, ITimePicker timePicker)
@@ -29,8 +27,7 @@ public static class TimePickerExtensions
 	public static void UpdateTextColor(this MauiTimePicker platformTimePicker, ITimePicker timePicker)
 		=> UpdateTextColorImpl(platformTimePicker, timePicker);
 
-	// TODO: Material3: Make it public in .NET 11
-	internal static void UpdateTextColor(this MauiMaterialTimePicker platformTimePicker, ITimePicker timePicker)
+	public static void UpdateTextColor(this MauiMaterialTimePicker platformTimePicker, ITimePicker timePicker)
 		=> UpdateTextColorImpl(platformTimePicker, timePicker);
 
 	static void SetTimeImpl(AppCompatEditText editText, ITimePicker timePicker)

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,14 +1,271 @@
 #nullable enable
+Microsoft.Maui.Handlers.ActivityIndicatorHandler2
+Microsoft.Maui.Handlers.ActivityIndicatorHandler2.ActivityIndicatorHandler2() -> void
+Microsoft.Maui.Handlers.DatePickerHandler2
+Microsoft.Maui.Handlers.DatePickerHandler2.DatePickerHandler2() -> void
+Microsoft.Maui.Handlers.EditorHandler2
+Microsoft.Maui.Handlers.EditorHandler2.EditorHandler2() -> void
+Microsoft.Maui.Handlers.EntryHandler2
+Microsoft.Maui.Handlers.EntryHandler2.EntryHandler2() -> void
+Microsoft.Maui.Handlers.ImageHandler2
+Microsoft.Maui.Handlers.ImageHandler2.ImageHandler2() -> void
+Microsoft.Maui.Handlers.LabelHandler2
+Microsoft.Maui.Handlers.LabelHandler2.LabelHandler2() -> void
+Microsoft.Maui.Handlers.MaterialDatePickerDismissListener
+Microsoft.Maui.Handlers.MaterialDatePickerDismissListener.MaterialDatePickerDismissListener(Microsoft.Maui.Handlers.DatePickerHandler2! handler) -> void
+Microsoft.Maui.Handlers.MaterialDatePickerDismissListener.OnDismiss(Android.Content.IDialogInterface? dialog) -> void
+Microsoft.Maui.Handlers.MaterialDatePickerPositiveButtonClickListener
+Microsoft.Maui.Handlers.MaterialDatePickerPositiveButtonClickListener.MaterialDatePickerPositiveButtonClickListener(Microsoft.Maui.Handlers.DatePickerHandler2! handler) -> void
+Microsoft.Maui.Handlers.MaterialDatePickerPositiveButtonClickListener.OnPositiveButtonClick(Java.Lang.Object? selection) -> void
+Microsoft.Maui.Handlers.MaterialTimePickerDismissListener
+Microsoft.Maui.Handlers.MaterialTimePickerDismissListener.MaterialTimePickerDismissListener(Microsoft.Maui.Handlers.TimePickerHandler2! handler) -> void
+Microsoft.Maui.Handlers.MaterialTimePickerDismissListener.OnDismiss(Android.Content.IDialogInterface? dialog) -> void
+Microsoft.Maui.Handlers.MaterialTimePickerPositiveButtonClickListener
+Microsoft.Maui.Handlers.MaterialTimePickerPositiveButtonClickListener.MaterialTimePickerPositiveButtonClickListener(Microsoft.Maui.Handlers.TimePickerHandler2! handler) -> void
+Microsoft.Maui.Handlers.MaterialTimePickerPositiveButtonClickListener.OnClick(Android.Views.View? v) -> void
+Microsoft.Maui.Handlers.PickerHandler._dialog -> AndroidX.AppCompat.App.AlertDialog?
+Microsoft.Maui.Handlers.PickerHandler2
+Microsoft.Maui.Handlers.PickerHandler2.PickerHandler2() -> void
+Microsoft.Maui.Handlers.ProgressBarHandler2
+Microsoft.Maui.Handlers.ProgressBarHandler2.ProgressBarHandler2() -> void
+Microsoft.Maui.Handlers.RadioButtonHandler2
+Microsoft.Maui.Handlers.RadioButtonHandler2.RadioButtonHandler2() -> void
+Microsoft.Maui.Handlers.SearchBarHandler2
+Microsoft.Maui.Handlers.SearchBarHandler2.QueryEditor.get -> Android.Widget.EditText?
+Microsoft.Maui.Handlers.SearchBarHandler2.SearchBarHandler2() -> void
+Microsoft.Maui.Handlers.SliderHandler2
+Microsoft.Maui.Handlers.SliderHandler2.SliderHandler2() -> void
+Microsoft.Maui.Handlers.SwitchHandler2
+Microsoft.Maui.Handlers.SwitchHandler2.SwitchHandler2() -> void
+Microsoft.Maui.Handlers.TimePickerHandler2
+Microsoft.Maui.Handlers.TimePickerHandler2.TimePickerHandler2() -> void
+Microsoft.Maui.Platform.MaterialActivityIndicator
+Microsoft.Maui.Platform.MaterialActivityIndicator.MaterialActivityIndicator(Android.Content.Context! context) -> void
+Microsoft.Maui.Platform.MaterialActivityIndicator.MaterialActivityIndicator(Android.Content.Context! context, Android.Util.IAttributeSet? attrs) -> void
+Microsoft.Maui.Platform.MaterialActivityIndicator.MaterialActivityIndicator(Android.Content.Context! context, Android.Util.IAttributeSet? attrs, int defStyleAttr) -> void
+Microsoft.Maui.Platform.MaterialActivityIndicator.MaterialActivityIndicator(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Microsoft.Maui.Platform.MauiMaterialContextThemeWrapper
+Microsoft.Maui.Platform.MauiMaterialContextThemeWrapper.MauiMaterialContextThemeWrapper(Android.Content.Context! context) -> void
+Microsoft.Maui.Platform.MauiMaterialDatePicker
+Microsoft.Maui.Platform.MauiMaterialDatePicker.HidePicker.get -> System.Action?
+Microsoft.Maui.Platform.MauiMaterialDatePicker.HidePicker.set -> void
+Microsoft.Maui.Platform.MauiMaterialDatePicker.MauiMaterialDatePicker(Android.Content.Context! context) -> void
+Microsoft.Maui.Platform.MauiMaterialDatePicker.MauiMaterialDatePicker(Android.Content.Context! context, Android.Util.IAttributeSet? attrs) -> void
+Microsoft.Maui.Platform.MauiMaterialDatePicker.MauiMaterialDatePicker(Android.Content.Context! context, Android.Util.IAttributeSet? attrs, int defStyleAttr) -> void
+Microsoft.Maui.Platform.MauiMaterialDatePicker.MauiMaterialDatePicker(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Microsoft.Maui.Platform.MauiMaterialDatePicker.OnClick(Android.Views.View? v) -> void
+Microsoft.Maui.Platform.MauiMaterialDatePicker.ShowPicker.get -> System.Action?
+Microsoft.Maui.Platform.MauiMaterialDatePicker.ShowPicker.set -> void
+Microsoft.Maui.Platform.MauiMaterialEditText
+Microsoft.Maui.Platform.MauiMaterialEditText.MauiMaterialEditText(Android.Content.Context! context) -> void
+Microsoft.Maui.Platform.MauiMaterialEditText.MauiMaterialEditText(Android.Content.Context! context, Android.Util.IAttributeSet? attrs) -> void
+Microsoft.Maui.Platform.MauiMaterialEditText.MauiMaterialEditText(Android.Content.Context! context, Android.Util.IAttributeSet? attrs, int defStyleAttr) -> void
+Microsoft.Maui.Platform.MauiMaterialEditText.MauiMaterialEditText(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Microsoft.Maui.Platform.MauiMaterialEditText.SelectionChanged -> System.EventHandler?
+Microsoft.Maui.Platform.MauiMaterialPicker
+Microsoft.Maui.Platform.MauiMaterialPicker.MauiMaterialPicker(Android.Content.Context! context) -> void
+Microsoft.Maui.Platform.MauiMaterialPickerBase
+Microsoft.Maui.Platform.MauiMaterialPickerBase.MauiMaterialPickerBase(Android.Content.Context! context) -> void
+Microsoft.Maui.Platform.MauiMaterialSearchBarTextInputEditText
+Microsoft.Maui.Platform.MauiMaterialSearchBarTextInputEditText.MauiMaterialSearchBarTextInputEditText(Android.Content.Context! context) -> void
+Microsoft.Maui.Platform.MauiMaterialSearchBarTextInputEditText.SelectionChanged -> System.EventHandler?
+Microsoft.Maui.Platform.MauiMaterialSearchBarTextInputLayout
+Microsoft.Maui.Platform.MauiMaterialSearchBarTextInputLayout.MauiMaterialSearchBarTextInputLayout(Android.Content.Context! context) -> void
+Microsoft.Maui.Platform.MauiMaterialSearchBarTextInputLayout.UpdateCloseButtonVisibility(bool hasText) -> void
+Microsoft.Maui.Platform.MauiMaterialTextInputLayout
+Microsoft.Maui.Platform.MauiMaterialTextInputLayout.MauiMaterialTextInputLayout(Android.Content.Context! context) -> void
+Microsoft.Maui.Platform.MauiMaterialTextInputLayout.MauiMaterialTextInputLayout(Android.Content.Context! context, Android.Util.IAttributeSet? attrs) -> void
+Microsoft.Maui.Platform.MauiMaterialTextInputLayout.MauiMaterialTextInputLayout(Android.Content.Context! context, Android.Util.IAttributeSet? attrs, int defStyleAttr) -> void
+Microsoft.Maui.Platform.MauiMaterialTextInputLayout.MauiMaterialTextInputLayout(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Microsoft.Maui.Platform.MauiMaterialTextView
+Microsoft.Maui.Platform.MauiMaterialTextView.MauiMaterialTextView(Android.Content.Context! context) -> void
+Microsoft.Maui.Platform.MauiMaterialTimePicker
+Microsoft.Maui.Platform.MauiMaterialTimePicker.HidePicker.get -> System.Action?
+Microsoft.Maui.Platform.MauiMaterialTimePicker.HidePicker.set -> void
+Microsoft.Maui.Platform.MauiMaterialTimePicker.MauiMaterialTimePicker(Android.Content.Context! context) -> void
+Microsoft.Maui.Platform.MauiMaterialTimePicker.MauiMaterialTimePicker(Android.Content.Context! context, Android.Util.IAttributeSet? attrs) -> void
+Microsoft.Maui.Platform.MauiMaterialTimePicker.MauiMaterialTimePicker(Android.Content.Context! context, Android.Util.IAttributeSet? attrs, int defStyleAttr) -> void
+Microsoft.Maui.Platform.MauiMaterialTimePicker.MauiMaterialTimePicker(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Microsoft.Maui.Platform.MauiMaterialTimePicker.OnClick(Android.Views.View? v) -> void
+Microsoft.Maui.Platform.MauiMaterialTimePicker.ShowPicker.get -> System.Action?
+Microsoft.Maui.Platform.MauiMaterialTimePicker.ShowPicker.set -> void
 Microsoft.Maui.PlatformDrawable
 Microsoft.Maui.PlatformDrawable.PlatformDrawable(Android.Content.Context? context) -> void
 Microsoft.Maui.PlatformDrawable.PlatformDrawable(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
-override Microsoft.Maui.PlatformDrawable.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
-override Microsoft.Maui.PlatformDrawable.ThresholdClass.get -> nint
-override Microsoft.Maui.PlatformDrawable.ThresholdType.get -> System.Type!
 *REMOVED*override Microsoft.Maui.Graphics.MauiDrawable.Dispose(bool disposing) -> void
 *REMOVED*override Microsoft.Maui.Graphics.MauiDrawable.OnBoundsChange(Android.Graphics.Rect! bounds) -> void
 *REMOVED*override Microsoft.Maui.Graphics.MauiDrawable.OnDraw(Android.Graphics.Drawables.Shapes.Shape? shape, Android.Graphics.Canvas? canvas, Android.Graphics.Paint? paint) -> void
+override Microsoft.Maui.Handlers.ActivityIndicatorHandler2.CreatePlatformView() -> Microsoft.Maui.Platform.MaterialActivityIndicator!
+override Microsoft.Maui.Handlers.ActivityIndicatorHandler2.PlatformArrange(Microsoft.Maui.Graphics.Rect frame) -> void
+override Microsoft.Maui.Handlers.DatePickerHandler2.ConnectHandler(Microsoft.Maui.Platform.MauiMaterialDatePicker! platformView) -> void
+override Microsoft.Maui.Handlers.DatePickerHandler2.CreatePlatformView() -> Microsoft.Maui.Platform.MauiMaterialDatePicker!
+override Microsoft.Maui.Handlers.DatePickerHandler2.DisconnectHandler(Microsoft.Maui.Platform.MauiMaterialDatePicker! platformView) -> void
+override Microsoft.Maui.Handlers.EditorHandler2.ConnectHandler(Microsoft.Maui.Platform.MauiMaterialEditText! platformView) -> void
+override Microsoft.Maui.Handlers.EditorHandler2.CreatePlatformView() -> Microsoft.Maui.Platform.MauiMaterialEditText!
+override Microsoft.Maui.Handlers.EditorHandler2.DisconnectHandler(Microsoft.Maui.Platform.MauiMaterialEditText! platformView) -> void
+override Microsoft.Maui.Handlers.EditorHandler2.PlatformArrange(Microsoft.Maui.Graphics.Rect frame) -> void
+override Microsoft.Maui.Handlers.EditorHandler2.SetVirtualView(Microsoft.Maui.IView! view) -> void
+override Microsoft.Maui.Handlers.EntryHandler2.ConnectHandler(Microsoft.Maui.Platform.MauiMaterialTextInputLayout! platformView) -> void
+override Microsoft.Maui.Handlers.EntryHandler2.CreatePlatformView() -> Microsoft.Maui.Platform.MauiMaterialTextInputLayout!
+override Microsoft.Maui.Handlers.EntryHandler2.DisconnectHandler(Microsoft.Maui.Platform.MauiMaterialTextInputLayout! platformView) -> void
+override Microsoft.Maui.Handlers.EntryHandler2.SetVirtualView(Microsoft.Maui.IView! view) -> void
+override Microsoft.Maui.Handlers.ImageHandler2.CreatePlatformView() -> Google.Android.Material.ImageView.ShapeableImageView!
 override Microsoft.Maui.Handlers.LabelHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+override Microsoft.Maui.Handlers.LabelHandler2.CreatePlatformView() -> Microsoft.Maui.Platform.MauiMaterialTextView!
+override Microsoft.Maui.Handlers.PickerHandler2.ConnectHandler(Microsoft.Maui.Platform.MauiMaterialPicker! platformView) -> void
+override Microsoft.Maui.Handlers.PickerHandler2.CreatePlatformView() -> Microsoft.Maui.Platform.MauiMaterialPicker!
+override Microsoft.Maui.Handlers.PickerHandler2.DisconnectHandler(Microsoft.Maui.Platform.MauiMaterialPicker! platformView) -> void
+override Microsoft.Maui.Handlers.ProgressBarHandler2.CreatePlatformView() -> Google.Android.Material.ProgressIndicator.LinearProgressIndicator!
+override Microsoft.Maui.Handlers.RadioButtonHandler2.CreatePlatformView() -> Google.Android.Material.RadioButton.MaterialRadioButton!
+override Microsoft.Maui.Handlers.SearchBarHandler2.ConnectHandler(Microsoft.Maui.Platform.MauiMaterialSearchBarTextInputLayout! platformView) -> void
+override Microsoft.Maui.Handlers.SearchBarHandler2.CreatePlatformView() -> Microsoft.Maui.Platform.MauiMaterialSearchBarTextInputLayout!
+override Microsoft.Maui.Handlers.SearchBarHandler2.DisconnectHandler(Microsoft.Maui.Platform.MauiMaterialSearchBarTextInputLayout! platformView) -> void
+override Microsoft.Maui.Handlers.SliderHandler2.ConnectHandler(Google.Android.Material.Slider.Slider! platformView) -> void
+override Microsoft.Maui.Handlers.SliderHandler2.CreatePlatformView() -> Google.Android.Material.Slider.Slider!
+override Microsoft.Maui.Handlers.SliderHandler2.DisconnectHandler(Google.Android.Material.Slider.Slider! platformView) -> void
+override Microsoft.Maui.Handlers.SwitchHandler2.CreatePlatformView() -> Google.Android.Material.MaterialSwitch.MaterialSwitch!
+override Microsoft.Maui.Handlers.TimePickerHandler2.ConnectHandler(Microsoft.Maui.Platform.MauiMaterialTimePicker! platformView) -> void
+override Microsoft.Maui.Handlers.TimePickerHandler2.CreatePlatformView() -> Microsoft.Maui.Platform.MauiMaterialTimePicker!
+override Microsoft.Maui.Handlers.TimePickerHandler2.DisconnectHandler(Microsoft.Maui.Platform.MauiMaterialTimePicker! platformView) -> void
+override Microsoft.Maui.Platform.MaterialActivityIndicator.OnMeasure(int widthMeasureSpec, int heightMeasureSpec) -> void
+override Microsoft.Maui.Platform.MauiMaterialDatePicker.DefaultMovementMethod.get -> Android.Text.Method.IMovementMethod?
+override Microsoft.Maui.Platform.MauiMaterialEditText.OnMeasure(int widthMeasureSpec, int heightMeasureSpec) -> void
+override Microsoft.Maui.Platform.MauiMaterialEditText.OnSelectionChanged(int selStart, int selEnd) -> void
+override Microsoft.Maui.Platform.MauiMaterialPicker.Dispose(bool disposing) -> void
+override Microsoft.Maui.Platform.MauiMaterialPickerBase.DefaultMovementMethod.get -> Android.Text.Method.IMovementMethod?
+override Microsoft.Maui.Platform.MauiMaterialSearchBarTextInputEditText.OnMeasure(int widthMeasureSpec, int heightMeasureSpec) -> void
+override Microsoft.Maui.Platform.MauiMaterialSearchBarTextInputEditText.OnSelectionChanged(int selStart, int selEnd) -> void
+override Microsoft.Maui.Platform.MauiMaterialSearchBarTextInputLayout.OnMeasure(int widthMeasureSpec, int heightMeasureSpec) -> void
+override Microsoft.Maui.Platform.MauiMaterialTextInputLayout.OnMeasure(int widthMeasureSpec, int heightMeasureSpec) -> void
+override Microsoft.Maui.Platform.MauiMaterialTextView.OnLayout(bool changed, int left, int top, int right, int bottom) -> void
+override Microsoft.Maui.Platform.MauiMaterialTextView.SetText(Java.Lang.ICharSequence? text, Android.Widget.TextView.BufferType? type) -> void
+override Microsoft.Maui.Platform.MauiMaterialTimePicker.DefaultMovementMethod.get -> Android.Text.Method.IMovementMethod?
+override Microsoft.Maui.PlatformDrawable.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Microsoft.Maui.PlatformDrawable.ThresholdClass.get -> nint
+override Microsoft.Maui.PlatformDrawable.ThresholdType.get -> System.Type!
 static Microsoft.Maui.GridLength.implicit operator Microsoft.Maui.GridLength(string! value) -> Microsoft.Maui.GridLength
-Microsoft.Maui.Handlers.PickerHandler._dialog -> AndroidX.AppCompat.App.AlertDialog?
+static Microsoft.Maui.Handlers.DatePickerHandler2.CommandMapper -> Microsoft.Maui.CommandMapper<Microsoft.Maui.IDatePicker!, Microsoft.Maui.Handlers.DatePickerHandler2!>!
+static Microsoft.Maui.Handlers.DatePickerHandler2.Mapper -> Microsoft.Maui.PropertyMapper<Microsoft.Maui.IDatePicker!, Microsoft.Maui.Handlers.DatePickerHandler2!>!
+static Microsoft.Maui.Handlers.EditorHandler2.CommandMapper -> Microsoft.Maui.CommandMapper<Microsoft.Maui.IEditor!, Microsoft.Maui.Handlers.EditorHandler2!>!
+static Microsoft.Maui.Handlers.EditorHandler2.MapBackground(Microsoft.Maui.Handlers.EditorHandler2! handler, Microsoft.Maui.IEditor! editor) -> void
+static Microsoft.Maui.Handlers.EditorHandler2.MapCharacterSpacing(Microsoft.Maui.Handlers.EditorHandler2! handler, Microsoft.Maui.IEditor! editor) -> void
+static Microsoft.Maui.Handlers.EditorHandler2.MapCursorPosition(Microsoft.Maui.Handlers.EditorHandler2! handler, Microsoft.Maui.ITextInput! editor) -> void
+static Microsoft.Maui.Handlers.EditorHandler2.MapFont(Microsoft.Maui.Handlers.EditorHandler2! handler, Microsoft.Maui.IEditor! editor) -> void
+static Microsoft.Maui.Handlers.EditorHandler2.MapHorizontalTextAlignment(Microsoft.Maui.Handlers.EditorHandler2! handler, Microsoft.Maui.IEditor! editor) -> void
+static Microsoft.Maui.Handlers.EditorHandler2.MapIsReadOnly(Microsoft.Maui.Handlers.EditorHandler2! handler, Microsoft.Maui.IEditor! editor) -> void
+static Microsoft.Maui.Handlers.EditorHandler2.MapIsSpellCheckEnabled(Microsoft.Maui.Handlers.EditorHandler2! handler, Microsoft.Maui.IEditor! editor) -> void
+static Microsoft.Maui.Handlers.EditorHandler2.MapIsTextPredictionEnabled(Microsoft.Maui.Handlers.EditorHandler2! handler, Microsoft.Maui.IEditor! editor) -> void
+static Microsoft.Maui.Handlers.EditorHandler2.MapKeyboard(Microsoft.Maui.Handlers.EditorHandler2! handler, Microsoft.Maui.IEditor! editor) -> void
+static Microsoft.Maui.Handlers.EditorHandler2.MapMaxLength(Microsoft.Maui.Handlers.EditorHandler2! handler, Microsoft.Maui.IEditor! editor) -> void
+static Microsoft.Maui.Handlers.EditorHandler2.MapPlaceholder(Microsoft.Maui.Handlers.EditorHandler2! handler, Microsoft.Maui.IEditor! editor) -> void
+static Microsoft.Maui.Handlers.EditorHandler2.MapPlaceholderColor(Microsoft.Maui.Handlers.EditorHandler2! handler, Microsoft.Maui.IEditor! editor) -> void
+static Microsoft.Maui.Handlers.EditorHandler2.MapSelectionLength(Microsoft.Maui.Handlers.EditorHandler2! handler, Microsoft.Maui.ITextInput! editor) -> void
+static Microsoft.Maui.Handlers.EditorHandler2.MapText(Microsoft.Maui.Handlers.EditorHandler2! handler, Microsoft.Maui.IEditor! editor) -> void
+static Microsoft.Maui.Handlers.EditorHandler2.MapTextColor(Microsoft.Maui.Handlers.EditorHandler2! handler, Microsoft.Maui.IEditor! editor) -> void
+static Microsoft.Maui.Handlers.EditorHandler2.MapVerticalTextAlignment(Microsoft.Maui.Handlers.EditorHandler2! handler, Microsoft.Maui.IEditor! editor) -> void
+static Microsoft.Maui.Handlers.EditorHandler2.Mapper -> Microsoft.Maui.PropertyMapper<Microsoft.Maui.IEditor!, Microsoft.Maui.Handlers.EditorHandler2!>!
+static Microsoft.Maui.Handlers.EntryHandler2.CommandMapper -> Microsoft.Maui.CommandMapper<Microsoft.Maui.IEntry!, Microsoft.Maui.Handlers.EntryHandler2!>!
+static Microsoft.Maui.Handlers.EntryHandler2.MapBackground(Microsoft.Maui.Handlers.EntryHandler2! handler, Microsoft.Maui.IEntry! entry) -> void
+static Microsoft.Maui.Handlers.EntryHandler2.MapCharacterSpacing(Microsoft.Maui.Handlers.EntryHandler2! handler, Microsoft.Maui.IEntry! entry) -> void
+static Microsoft.Maui.Handlers.EntryHandler2.MapClearButtonVisibility(Microsoft.Maui.Handlers.EntryHandler2! handler, Microsoft.Maui.IEntry! entry) -> void
+static Microsoft.Maui.Handlers.EntryHandler2.MapCursorPosition(Microsoft.Maui.Handlers.EntryHandler2! handler, Microsoft.Maui.IEntry! entry) -> void
+static Microsoft.Maui.Handlers.EntryHandler2.MapFlowDirection(Microsoft.Maui.Handlers.EntryHandler2! handler, Microsoft.Maui.IEntry! entry) -> void
+static Microsoft.Maui.Handlers.EntryHandler2.MapFont(Microsoft.Maui.Handlers.EntryHandler2! handler, Microsoft.Maui.IEntry! entry) -> void
+static Microsoft.Maui.Handlers.EntryHandler2.MapHorizontalTextAlignment(Microsoft.Maui.Handlers.EntryHandler2! handler, Microsoft.Maui.IEntry! entry) -> void
+static Microsoft.Maui.Handlers.EntryHandler2.MapIsPassword(Microsoft.Maui.Handlers.EntryHandler2! handler, Microsoft.Maui.IEntry! entry) -> void
+static Microsoft.Maui.Handlers.EntryHandler2.MapIsReadOnly(Microsoft.Maui.Handlers.EntryHandler2! handler, Microsoft.Maui.IEntry! entry) -> void
+static Microsoft.Maui.Handlers.EntryHandler2.MapIsSpellCheckEnabled(Microsoft.Maui.Handlers.EntryHandler2! handler, Microsoft.Maui.IEntry! entry) -> void
+static Microsoft.Maui.Handlers.EntryHandler2.MapIsTextPredictionEnabled(Microsoft.Maui.Handlers.EntryHandler2! handler, Microsoft.Maui.IEntry! entry) -> void
+static Microsoft.Maui.Handlers.EntryHandler2.MapKeyboard(Microsoft.Maui.Handlers.EntryHandler2! handler, Microsoft.Maui.IEntry! entry) -> void
+static Microsoft.Maui.Handlers.EntryHandler2.MapMaxLength(Microsoft.Maui.Handlers.EntryHandler2! handler, Microsoft.Maui.IEntry! entry) -> void
+static Microsoft.Maui.Handlers.EntryHandler2.MapPlaceholder(Microsoft.Maui.Handlers.EntryHandler2! handler, Microsoft.Maui.IEntry! entry) -> void
+static Microsoft.Maui.Handlers.EntryHandler2.MapPlaceholderColor(Microsoft.Maui.Handlers.EntryHandler2! handler, Microsoft.Maui.IEntry! entry) -> void
+static Microsoft.Maui.Handlers.EntryHandler2.MapReturnType(Microsoft.Maui.Handlers.EntryHandler2! handler, Microsoft.Maui.IEntry! entry) -> void
+static Microsoft.Maui.Handlers.EntryHandler2.MapSelectionLength(Microsoft.Maui.Handlers.EntryHandler2! handler, Microsoft.Maui.IEntry! entry) -> void
+static Microsoft.Maui.Handlers.EntryHandler2.MapText(Microsoft.Maui.Handlers.EntryHandler2! handler, Microsoft.Maui.IEntry! entry) -> void
+static Microsoft.Maui.Handlers.EntryHandler2.MapTextColor(Microsoft.Maui.Handlers.EntryHandler2! handler, Microsoft.Maui.IEntry! entry) -> void
+static Microsoft.Maui.Handlers.EntryHandler2.MapVerticalTextAlignment(Microsoft.Maui.Handlers.EntryHandler2! handler, Microsoft.Maui.IEntry! entry) -> void
+static Microsoft.Maui.Handlers.EntryHandler2.Mapper -> Microsoft.Maui.PropertyMapper<Microsoft.Maui.IEntry!, Microsoft.Maui.Handlers.EntryHandler2!>!
+static Microsoft.Maui.Handlers.PickerHandler2.CommandMapper -> Microsoft.Maui.CommandMapper<Microsoft.Maui.IPicker!, Microsoft.Maui.Handlers.PickerHandler2!>!
+static Microsoft.Maui.Handlers.PickerHandler2.MapBackground(Microsoft.Maui.Handlers.PickerHandler2! handler, Microsoft.Maui.IPicker! picker) -> void
+static Microsoft.Maui.Handlers.PickerHandler2.MapCharacterSpacing(Microsoft.Maui.Handlers.PickerHandler2! handler, Microsoft.Maui.IPicker! picker) -> void
+static Microsoft.Maui.Handlers.PickerHandler2.MapFocus(Microsoft.Maui.Handlers.PickerHandler2! handler, Microsoft.Maui.IPicker! picker, object? args) -> void
+static Microsoft.Maui.Handlers.PickerHandler2.MapFont(Microsoft.Maui.Handlers.PickerHandler2! handler, Microsoft.Maui.IPicker! picker) -> void
+static Microsoft.Maui.Handlers.PickerHandler2.MapHorizontalTextAlignment(Microsoft.Maui.Handlers.PickerHandler2! handler, Microsoft.Maui.IPicker! picker) -> void
+static Microsoft.Maui.Handlers.PickerHandler2.MapIsOpen(Microsoft.Maui.Handlers.PickerHandler2! handler, Microsoft.Maui.IPicker! picker) -> void
+static Microsoft.Maui.Handlers.PickerHandler2.MapItems(Microsoft.Maui.Handlers.PickerHandler2! handler, Microsoft.Maui.IPicker! picker) -> void
+static Microsoft.Maui.Handlers.PickerHandler2.MapSelectedIndex(Microsoft.Maui.Handlers.PickerHandler2! handler, Microsoft.Maui.IPicker! picker) -> void
+static Microsoft.Maui.Handlers.PickerHandler2.MapTextColor(Microsoft.Maui.Handlers.PickerHandler2! handler, Microsoft.Maui.IPicker! picker) -> void
+static Microsoft.Maui.Handlers.PickerHandler2.MapTitle(Microsoft.Maui.Handlers.PickerHandler2! handler, Microsoft.Maui.IPicker! picker) -> void
+static Microsoft.Maui.Handlers.PickerHandler2.MapTitleColor(Microsoft.Maui.Handlers.PickerHandler2! handler, Microsoft.Maui.IPicker! picker) -> void
+static Microsoft.Maui.Handlers.PickerHandler2.MapUnfocus(Microsoft.Maui.Handlers.PickerHandler2! handler, Microsoft.Maui.IPicker! picker, object? args) -> void
+static Microsoft.Maui.Handlers.PickerHandler2.MapVerticalTextAlignment(Microsoft.Maui.Handlers.PickerHandler2! handler, Microsoft.Maui.IPicker! picker) -> void
+static Microsoft.Maui.Handlers.PickerHandler2.Mapper -> Microsoft.Maui.PropertyMapper<Microsoft.Maui.IPicker!, Microsoft.Maui.Handlers.PickerHandler2!>!
+static Microsoft.Maui.Handlers.SearchBarHandler2.CommandMapper -> Microsoft.Maui.CommandMapper<Microsoft.Maui.ISearchBar!, Microsoft.Maui.Handlers.SearchBarHandler2!>!
+static Microsoft.Maui.Handlers.SearchBarHandler2.MapBackground(Microsoft.Maui.Handlers.SearchBarHandler2! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
+static Microsoft.Maui.Handlers.SearchBarHandler2.MapCancelButtonColor(Microsoft.Maui.Handlers.SearchBarHandler2! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
+static Microsoft.Maui.Handlers.SearchBarHandler2.MapCharacterSpacing(Microsoft.Maui.Handlers.SearchBarHandler2! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
+static Microsoft.Maui.Handlers.SearchBarHandler2.MapCursorPosition(Microsoft.Maui.Handlers.SearchBarHandler2! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
+static Microsoft.Maui.Handlers.SearchBarHandler2.MapFlowDirection(Microsoft.Maui.Handlers.SearchBarHandler2! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
+static Microsoft.Maui.Handlers.SearchBarHandler2.MapFocus(Microsoft.Maui.Handlers.SearchBarHandler2! handler, Microsoft.Maui.ISearchBar! searchBar, object? args) -> void
+static Microsoft.Maui.Handlers.SearchBarHandler2.MapFont(Microsoft.Maui.Handlers.SearchBarHandler2! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
+static Microsoft.Maui.Handlers.SearchBarHandler2.MapHorizontalTextAlignment(Microsoft.Maui.Handlers.SearchBarHandler2! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
+static Microsoft.Maui.Handlers.SearchBarHandler2.MapIsEnabled(Microsoft.Maui.Handlers.SearchBarHandler2! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
+static Microsoft.Maui.Handlers.SearchBarHandler2.MapIsReadOnly(Microsoft.Maui.Handlers.SearchBarHandler2! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
+static Microsoft.Maui.Handlers.SearchBarHandler2.MapIsSpellCheckEnabled(Microsoft.Maui.Handlers.SearchBarHandler2! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
+static Microsoft.Maui.Handlers.SearchBarHandler2.MapIsTextPredictionEnabled(Microsoft.Maui.Handlers.SearchBarHandler2! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
+static Microsoft.Maui.Handlers.SearchBarHandler2.MapKeyboard(Microsoft.Maui.Handlers.SearchBarHandler2! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
+static Microsoft.Maui.Handlers.SearchBarHandler2.MapMaxLength(Microsoft.Maui.Handlers.SearchBarHandler2! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
+static Microsoft.Maui.Handlers.SearchBarHandler2.MapPlaceholder(Microsoft.Maui.Handlers.SearchBarHandler2! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
+static Microsoft.Maui.Handlers.SearchBarHandler2.MapPlaceholderColor(Microsoft.Maui.Handlers.SearchBarHandler2! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
+static Microsoft.Maui.Handlers.SearchBarHandler2.MapReturnType(Microsoft.Maui.Handlers.SearchBarHandler2! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
+static Microsoft.Maui.Handlers.SearchBarHandler2.MapSearchIconColor(Microsoft.Maui.Handlers.SearchBarHandler2! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
+static Microsoft.Maui.Handlers.SearchBarHandler2.MapSelectionLength(Microsoft.Maui.Handlers.SearchBarHandler2! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
+static Microsoft.Maui.Handlers.SearchBarHandler2.MapText(Microsoft.Maui.Handlers.SearchBarHandler2! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
+static Microsoft.Maui.Handlers.SearchBarHandler2.MapTextColor(Microsoft.Maui.Handlers.SearchBarHandler2! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
+static Microsoft.Maui.Handlers.SearchBarHandler2.MapVerticalTextAlignment(Microsoft.Maui.Handlers.SearchBarHandler2! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
+static Microsoft.Maui.Handlers.SearchBarHandler2.Mapper -> Microsoft.Maui.PropertyMapper<Microsoft.Maui.ISearchBar!, Microsoft.Maui.Handlers.SearchBarHandler2!>!
+static Microsoft.Maui.Handlers.SliderHandler2.CommandMapper -> Microsoft.Maui.CommandMapper<Microsoft.Maui.ISlider!, Microsoft.Maui.Handlers.SliderHandler2!>!
+static Microsoft.Maui.Handlers.SliderHandler2.MapMaximum(Microsoft.Maui.Handlers.SliderHandler2! handler, Microsoft.Maui.ISlider! slider) -> void
+static Microsoft.Maui.Handlers.SliderHandler2.MapMaximumTrackColor(Microsoft.Maui.Handlers.SliderHandler2! handler, Microsoft.Maui.ISlider! slider) -> void
+static Microsoft.Maui.Handlers.SliderHandler2.MapMinimum(Microsoft.Maui.Handlers.SliderHandler2! handler, Microsoft.Maui.ISlider! slider) -> void
+static Microsoft.Maui.Handlers.SliderHandler2.MapMinimumTrackColor(Microsoft.Maui.Handlers.SliderHandler2! handler, Microsoft.Maui.ISlider! slider) -> void
+static Microsoft.Maui.Handlers.SliderHandler2.MapThumbColor(Microsoft.Maui.Handlers.SliderHandler2! handler, Microsoft.Maui.ISlider! slider) -> void
+static Microsoft.Maui.Handlers.SliderHandler2.MapThumbImageSource(Microsoft.Maui.Handlers.SliderHandler2! handler, Microsoft.Maui.ISlider! slider) -> void
+static Microsoft.Maui.Handlers.SliderHandler2.MapValue(Microsoft.Maui.Handlers.SliderHandler2! handler, Microsoft.Maui.ISlider! slider) -> void
+static Microsoft.Maui.Handlers.SliderHandler2.Mapper -> Microsoft.Maui.PropertyMapper<Microsoft.Maui.ISlider!, Microsoft.Maui.Handlers.SliderHandler2!>!
+static Microsoft.Maui.Handlers.SwitchHandler2.CommandMapper -> Microsoft.Maui.CommandMapper<Microsoft.Maui.ISwitch!, Microsoft.Maui.Handlers.SwitchHandler2!>!
+static Microsoft.Maui.Handlers.SwitchHandler2.MapThumbColor(Microsoft.Maui.Handlers.ISwitchHandler! handler, Microsoft.Maui.ISwitch! view) -> void
+static Microsoft.Maui.Handlers.SwitchHandler2.MapTrackColor(Microsoft.Maui.Handlers.ISwitchHandler! handler, Microsoft.Maui.ISwitch! view) -> void
+static Microsoft.Maui.Handlers.SwitchHandler2.Mapper -> Microsoft.Maui.PropertyMapper<Microsoft.Maui.ISwitch!, Microsoft.Maui.Handlers.SwitchHandler2!>!
+static Microsoft.Maui.Handlers.TimePickerHandler2.CommandMapper -> Microsoft.Maui.CommandMapper<Microsoft.Maui.ITimePicker!, Microsoft.Maui.Handlers.TimePickerHandler2!>!
+static Microsoft.Maui.Handlers.TimePickerHandler2.MapBackground(Microsoft.Maui.Handlers.TimePickerHandler2! handler, Microsoft.Maui.ITimePicker! timePicker) -> void
+static Microsoft.Maui.Handlers.TimePickerHandler2.MapCharacterSpacing(Microsoft.Maui.Handlers.TimePickerHandler2! handler, Microsoft.Maui.ITimePicker! picker) -> void
+static Microsoft.Maui.Handlers.TimePickerHandler2.MapFont(Microsoft.Maui.Handlers.TimePickerHandler2! handler, Microsoft.Maui.ITimePicker! picker) -> void
+static Microsoft.Maui.Handlers.TimePickerHandler2.MapFormat(Microsoft.Maui.Handlers.TimePickerHandler2! handler, Microsoft.Maui.ITimePicker! picker) -> void
+static Microsoft.Maui.Handlers.TimePickerHandler2.MapIsOpen(Microsoft.Maui.Handlers.TimePickerHandler2! handler, Microsoft.Maui.ITimePicker! picker) -> void
+static Microsoft.Maui.Handlers.TimePickerHandler2.MapTextColor(Microsoft.Maui.Handlers.TimePickerHandler2! handler, Microsoft.Maui.ITimePicker! picker) -> void
+static Microsoft.Maui.Handlers.TimePickerHandler2.MapTime(Microsoft.Maui.Handlers.TimePickerHandler2! handler, Microsoft.Maui.ITimePicker! picker) -> void
+static Microsoft.Maui.Handlers.TimePickerHandler2.Mapper -> Microsoft.Maui.PropertyMapper<Microsoft.Maui.ITimePicker!, Microsoft.Maui.Handlers.TimePickerHandler2!>!
+static Microsoft.Maui.Platform.DatePickerExtensions.UpdateDate(this Microsoft.Maui.Platform.MauiMaterialDatePicker! platformDatePicker, Microsoft.Maui.IDatePicker! datePicker) -> void
+static Microsoft.Maui.Platform.DatePickerExtensions.UpdateFormat(this Microsoft.Maui.Platform.MauiMaterialDatePicker! platformDatePicker, Microsoft.Maui.IDatePicker! datePicker) -> void
+static Microsoft.Maui.Platform.DatePickerExtensions.UpdateTextColor(this Microsoft.Maui.Platform.MauiMaterialDatePicker! platformDatePicker, Microsoft.Maui.IDatePicker! datePicker) -> void
+static Microsoft.Maui.Platform.MauiMaterialContextThemeWrapper.Create(Android.Content.Context! context) -> Microsoft.Maui.Platform.MauiMaterialContextThemeWrapper!
+static Microsoft.Maui.Platform.PickerExtensions.UpdateFlowDirectionCore(this AndroidX.AppCompat.App.AlertDialog! alertDialog, AndroidX.AppCompat.Widget.AppCompatEditText! platformPicker) -> void
+static Microsoft.Maui.Platform.PickerExtensions.UpdatePickerCore(this AndroidX.AppCompat.Widget.AppCompatEditText! platformPicker, Microsoft.Maui.IPicker! picker) -> void
+static Microsoft.Maui.Platform.PickerExtensions.UpdateSelectedIndex(this Microsoft.Maui.Platform.MauiMaterialPicker! platformPicker, Microsoft.Maui.IPicker! picker) -> void
+static Microsoft.Maui.Platform.PickerExtensions.UpdateTitle(this Microsoft.Maui.Platform.MauiMaterialPicker! platformPicker, Microsoft.Maui.IPicker! picker) -> void
+static Microsoft.Maui.Platform.PickerExtensions.UpdateTitleColor(this Microsoft.Maui.Platform.MauiMaterialPicker! platformPicker, Microsoft.Maui.IPicker! picker) -> void
+static Microsoft.Maui.Platform.PickerExtensions.UpdateTitleColorCore(this AndroidX.AppCompat.Widget.AppCompatEditText! platformPicker, Microsoft.Maui.IPicker! picker) -> void
+static Microsoft.Maui.Platform.SearchViewExtensions.UpdateBackground(this Google.Android.Material.TextField.TextInputLayout! textInputLayout, Microsoft.Maui.ISearchBar! searchBar) -> void
+static Microsoft.Maui.Platform.SearchViewExtensions.UpdateCancelButtonColor(this Google.Android.Material.TextField.TextInputLayout! textInputLayout, Microsoft.Maui.ISearchBar! searchBar) -> void
+static Microsoft.Maui.Platform.SearchViewExtensions.UpdateReturnType(this Android.Widget.EditText! editText, Microsoft.Maui.ISearchBar! searchBar) -> void
+static Microsoft.Maui.Platform.SearchViewExtensions.UpdateText(this Android.Widget.EditText! editText, Microsoft.Maui.ISearchBar! searchBar) -> void
+static Microsoft.Maui.Platform.SwitchExtensions.UpdateThumbColor(this Google.Android.Material.MaterialSwitch.MaterialSwitch! materialSwitch, Microsoft.Maui.ISwitch! view) -> void
+static Microsoft.Maui.Platform.SwitchExtensions.UpdateTrackColor(this Google.Android.Material.MaterialSwitch.MaterialSwitch! materialSwitch, Microsoft.Maui.ISwitch! view) -> void
+static Microsoft.Maui.Platform.TimePickerExtensions.UpdateFormat(this Microsoft.Maui.Platform.MauiMaterialTimePicker! mauiTimePicker, Microsoft.Maui.ITimePicker! timePicker) -> void
+static Microsoft.Maui.Platform.TimePickerExtensions.UpdateTextColor(this Microsoft.Maui.Platform.MauiMaterialTimePicker! platformTimePicker, Microsoft.Maui.ITimePicker! timePicker) -> void
+static Microsoft.Maui.Platform.TimePickerExtensions.UpdateTime(this Microsoft.Maui.Platform.MauiMaterialTimePicker! mauiTimePicker, Microsoft.Maui.ITimePicker! timePicker) -> void
 static Microsoft.Maui.SafeAreaEdges.Container.get -> Microsoft.Maui.SafeAreaEdges
+virtual Microsoft.Maui.Handlers.DatePickerHandler2.CreateDatePickerDialog(int year, int month, int day) -> Google.Android.Material.DatePicker.MaterialDatePicker?
+virtual Microsoft.Maui.Handlers.TimePickerHandler2.CreateTimePickerDialog(int hour, int minute) -> Google.Android.Material.TimePicker.MaterialTimePicker?


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Descripton of Change

This pull request makes a set of Material 3 controls and related handler classes public, transitioning them from internal to public API. This is part of the planned public API exposure for .NET 11, allowing developers to directly use and extend these Material 3 controls and handlers in their Android applications. 

Fixes #35124 

**Material 3 Handler and Control Classes Now Public:**

* Made the following handler classes public: `ActivityIndicatorHandler2`, `DatePickerHandler2`, `EditorHandler2`, `EntryHandler2`, `ImageHandler2`, `LabelHandler2`, `PickerHandler2`, `ProgressBarHandler2`, `RadioButtonHandler2`, `SearchBarHandler2`, `SliderHandler2`, `SwitchHandler2`, `TimePickerHandler2` 
* Made related listener classes public: `MaterialDatePickerPositiveButtonClickListener`, `MaterialDatePickerDismissListener`, `MaterialTimePickerPositiveButtonClickListener`, `MaterialTimePickerDismissListener`.
* Made Material 3 platform controls public: `MauiMaterialDatePicker`, `MauiMaterialEditText`, `MauiMaterialTextInputLayout`.

**Public API Surface Updates:**

* Updated `PublicAPI.Unshipped.txt` to include the newly public methods on `Editor`, `Entry`, and `SearchBar`.

**Mapping and Extension Methods Now Public:**

* Changed several mapping methods from internal to public so they can be used externally, including `MapText` and `MapImeOptions` for `EditorHandler2`, `EntryHandler2`, and `SearchBarHandler2`.
* Made extension methods for `MauiMaterialDatePicker` public: `UpdateDate`, `UpdateFormat`, and `UpdateTextColor`.

These changes collectively make Material 3 controls and handlers available for public use and extension, as planned for .NET 11.

