### PR TITLE
[Testing] The Windows WebView category is removed from CI because WebView2 is not connected in Appium.

### DIFF
--- a/eng/pipelines/common/ui-tests.yml
+++ b/eng/pipelines/common/ui-tests.yml
@@ -42,6 +42,31 @@ parameters:
     - 'ViewBaseTests,VisualStateManager,Window'
     - 'WebView'
 
+  # Windows-specific category groups — WebView is excluded because it runs too long on Windows CI
+  windowsCategoryGroupsToTest:
+    - 'Accessibility,ActionSheet,ActivityIndicator,Animation,AppLinks'
+    - 'Border,BoxView,Brush,Button'
+    - 'CarouselView'
+    - 'Cells,CheckBox,ContextActions,CustomRenderers,DatePicker,Dispatcher,DisplayAlert,DisplayPrompt,DragAndDrop'
+    - 'CollectionView'
+    - 'Entry'
+    - 'Editor,Effects,Essentials,FlyoutPage,Focus,Fonts,Frame,Gestures,GraphicsView'
+    - 'Image,ImageButton,IndicatorView,InputTransparent,IsEnabled,IsVisible'
+    - 'Label'
+    - 'Layout'
+    - 'Lifecycle,ManualReview,Maps'
+    - 'ListView'
+    - 'Navigation'
+    - 'Page,Performance,Picker,ProgressBar'
+    - 'RadioButton,RefreshView'
+    - 'SafeAreaEdges,Shadow'
+    - 'ScrollView'
+    - 'SearchBar,Shape,Slider'
+    - 'SoftInput,Stepper,Switch,SwipeView'
+    - 'Shell'
+    - 'TabbedPage,TableView,TimePicker,TitleView,ToolbarItem,Triggers'
+    - 'ViewBaseTests,VisualStateManager,Window'
+
   projects:
     - name: name
       desc: Human Description
@@ -457,7 +482,7 @@ stages:
               - job: winui_ui_tests_${{ project.name }}
                 strategy:
                   matrix:
-                    ${{ each categoryGroup in parameters.categoryGroupsToTest }}:
+                    ${{ each categoryGroup in parameters.windowsCategoryGroupsToTest }}:
                       ${{ categoryGroup }}:
                         CATEGORYGROUP: ${{ categoryGroup }}
                 timeoutInMinutes: ${{ parameters.timeoutInMinutes }} # how long to run the job before automatically cancelling

--- a/eng/pipelines/common/ui-tests.yml
+++ b/eng/pipelines/common/ui-tests.yml
@@ -42,7 +42,7 @@ parameters:
     - 'ViewBaseTests,VisualStateManager,Window'
     - 'WebView'
 
-  # Windows-specific category groups — WebView is excluded because it runs too long on Windows CI
+  # Windows-specific category groups — WebView is excluded because it runs too long on Windows CI. Issue - https://github.com/dotnet/maui/issues/35334
   windowsCategoryGroupsToTest:
     - 'Accessibility,ActionSheet,ActivityIndicator,Animation,AppLinks'
     - 'Border,BoxView,Brush,Button'

--- a/eng/pipelines/common/ui-tests.yml
+++ b/eng/pipelines/common/ui-tests.yml
@@ -42,31 +42,6 @@ parameters:
     - 'ViewBaseTests,VisualStateManager,Window'
     - 'WebView'
 
-  # Windows-specific category groups — WebView is excluded because it runs too long on Windows CI. Issue - https://github.com/dotnet/maui/issues/35334
-  windowsCategoryGroupsToTest:
-    - 'Accessibility,ActionSheet,ActivityIndicator,Animation,AppLinks'
-    - 'Border,BoxView,Brush,Button'
-    - 'CarouselView'
-    - 'Cells,CheckBox,ContextActions,CustomRenderers,DatePicker,Dispatcher,DisplayAlert,DisplayPrompt,DragAndDrop'
-    - 'CollectionView'
-    - 'Entry'
-    - 'Editor,Effects,Essentials,FlyoutPage,Focus,Fonts,Frame,Gestures,GraphicsView'
-    - 'Image,ImageButton,IndicatorView,InputTransparent,IsEnabled,IsVisible'
-    - 'Label'
-    - 'Layout'
-    - 'Lifecycle,ManualReview,Maps'
-    - 'ListView'
-    - 'Navigation'
-    - 'Page,Performance,Picker,ProgressBar'
-    - 'RadioButton,RefreshView'
-    - 'SafeAreaEdges,Shadow'
-    - 'ScrollView'
-    - 'SearchBar,Shape,Slider'
-    - 'SoftInput,Stepper,Switch,SwipeView'
-    - 'Shell'
-    - 'TabbedPage,TableView,TimePicker,TitleView,ToolbarItem,Triggers'
-    - 'ViewBaseTests,VisualStateManager,Window'
-
   projects:
     - name: name
       desc: Human Description
@@ -482,9 +457,12 @@ stages:
               - job: winui_ui_tests_${{ project.name }}
                 strategy:
                   matrix:
-                    ${{ each categoryGroup in parameters.windowsCategoryGroupsToTest }}:
-                      ${{ categoryGroup }}:
-                        CATEGORYGROUP: ${{ categoryGroup }}
+                    # WebView is excluded on Windows: Appium driver cannot attach to WebView2
+                    # (appium/appium#22217 / dotnet/maui#35334). Remove this filter once fixed.
+                    ${{ each categoryGroup in parameters.categoryGroupsToTest }}:
+                      ${{ if ne(categoryGroup, 'WebView') }}:
+                        ${{ categoryGroup }}:
+                          CATEGORYGROUP: ${{ categoryGroup }}
                 timeoutInMinutes: ${{ parameters.timeoutInMinutes }} # how long to run the job before automatically cancelling
                 workspace:
                   clean: all


### PR DESCRIPTION
### Description of Changes

- Recently, the Appium driver has not been connecting properly to the native WebView2 control on Windows. While running locally using Appium Inspector with the WebView control, the inspector is unable to recognize the WebView and displays an error.

- Due to this Appium driver issue, the WebView lane in CI takes a long time to run (approximately 3 hours) and eventually gets cancelled. As a temporary workaround, the WebView lane has been temporarily removed from the Windows CI pipeline to allow the CI process to complete more quickly.
<img width="649" height="294" alt="image" src="https://github.com/user-attachments/assets/68df006b-56d6-4bfa-870a-a4184f5b18b7" />
<img width="576" height="430" alt="image" src="https://github.com/user-attachments/assets/40c222e8-4935-450d-be7e-5ee9245e9eb1" />


**Issue:** https://github.com/dotnet/maui/issues/35334