### PR TITLE
[net11.0] Target Android 37.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -162,13 +162,13 @@
     <TvosTargetFrameworkVersionSdkDefault>26.4</TvosTargetFrameworkVersionSdkDefault>
     <MacCatalystTargetFrameworkVersionSdkDefault>26.4</MacCatalystTargetFrameworkVersionSdkDefault>
     <MacosTargetFrameworkVersionSdkDefault>26.4</MacosTargetFrameworkVersionSdkDefault>
-    <AndroidTargetFrameworkVersionSdkDefault>36.1</AndroidTargetFrameworkVersionSdkDefault>
+    <AndroidTargetFrameworkVersionSdkDefault>37.0</AndroidTargetFrameworkVersionSdkDefault>
     <!-- Current .NET -->
     <IosTargetFrameworkVersion>26.4</IosTargetFrameworkVersion>
     <TvosTargetFrameworkVersion>26.4</TvosTargetFrameworkVersion>
     <MacCatalystTargetFrameworkVersion>26.4</MacCatalystTargetFrameworkVersion>
     <MacosTargetFrameworkVersion>26.4</MacosTargetFrameworkVersion>
-    <AndroidTargetFrameworkVersion>36.1</AndroidTargetFrameworkVersion>
+    <AndroidTargetFrameworkVersion>37.0</AndroidTargetFrameworkVersion>
     <WindowsTargetFrameworkVersion>10.0.19041.0</WindowsTargetFrameworkVersion>
     <Windows2TargetFrameworkVersion>10.0.20348.0</Windows2TargetFrameworkVersion>
     <TizenTargetFrameworkVersion>7.0</TizenTargetFrameworkVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -204,7 +204,9 @@
     <AndroidSdkApiLevels Include="33" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" />
     <AndroidSdkApiLevels Include="34" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" />
     <AndroidSdkApiLevels Include="35" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" />
-    <AndroidSdkApiLevels Include="36" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" IsDefault="True" />
+    <AndroidSdkApiLevels Include="36" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" />
+    <AndroidSdkApiLevels Include="36.1" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" />
+    <AndroidSdkApiLevels Include="37" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" IsDefault="True" />
   </ItemGroup>
   <PropertyGroup>
     <!-- arcade -->


### PR DESCRIPTION
## Description

Update the `net11.0` Android target framework version from `36.1` to `37.0` and make Android API 37 the default SDK API level for MAUI builds.

This matches dotnet/android's .NET 11 Android 37 change: https://github.com/dotnet/android/pull/11254. That PR made `net11.0-android37` the default Android target and removed the 36.1 workload pack definitions, so MAUI needs to generate `net11.0-android37.0` when building against current dotnet/android packs.

## Validation

Evaluated `MauiPlatforms` locally and confirmed it now includes `net11.0-android37.0` instead of `net11.0-android36.1`.
