### PR TITLE
[Revert] [iOS] Fixed CollectionView Scroll Jitter for TextType HTML Labels

### DIFF
--- a/src/Controls/src/Core/Platform/iOS/Extensions/LabelExtensions.cs
+++ b/src/Controls/src/Core/Platform/iOS/Extensions/LabelExtensions.cs
@@ -1,7 +1,6 @@
 ﻿#nullable disable
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
-using Microsoft.Maui.Controls.Handlers.Items2;
 using Microsoft.Maui.Controls.Internals;
 using ObjCRuntime;
 using UIKit;
@@ -17,37 +16,22 @@ namespace Microsoft.Maui.Controls.Platform
 			switch (label.TextType)
 			{
 				case TextType.Html:
-					// NOTE: Setting HTML text like this will crash with some sort of consistency error.
-					// when inside a CV1 (CollectionView/CarouselView handler v1) layout pass.
+					// NOTE: Setting HTML text this will crash with some sort of consistency error.
 					// https://github.com/dotnet/maui/issues/25946
-					// CV2 (the default handler in .NET 10) does NOT have this crash.
-					if (IsPlatformLabelInsideCV2Cell(platformLabel))
+					// Here we have to dispatch back the the main queue to avoid the crash.
+					// This is observed with CarouselView 1 but not with 2, so hopefully this
+					// will be just disappear once we switch.
+					CoreFoundation.DispatchQueue.MainQueue.DispatchAsync(() =>
 					{
-						// Synchronous: safe in CV2, avoids the two-pass jitter.
-						// No InvalidateMeasure needed — text is already correct when measured.
 						platformLabel.UpdateTextHtml(text);
 
-						if (label.Handler is LabelHandler labelHandlerSync)
-						{
-							Label.MapFormatting(labelHandlerSync, label);
-						}
-					}
-					else
-					{
-						CoreFoundation.DispatchQueue.MainQueue.DispatchAsync(() =>
-						{
-							platformLabel.UpdateTextHtml(text);
+						if (label.Handler is LabelHandler labelHandler)
+							Label.MapFormatting(labelHandler, label);
 
-							if (label.Handler is LabelHandler labelHandler)
-							{
-								Label.MapFormatting(labelHandler, label);
-							}
-
-							// NOTE: Because we are updating text outside the normal layout
-							// pass, we need to invalidate the measure for the next pass.
-							label.InvalidateMeasure();
-						});
-					}
+						// NOTE: Because we are updating text outside the normal layout
+						// pass, we need to invalidate the measure for the next pass.
+						label.InvalidateMeasure();
+					});
 					break;
 
 				default:
@@ -64,21 +48,6 @@ namespace Microsoft.Maui.Controls.Platform
 					}
 					break;
 			}
-		}
-
-		// Walks the native UIKit superview chain to determine if this UILabel lives inside a CV2 cell.
-		static bool IsPlatformLabelInsideCV2Cell(UILabel platformLabel)
-		{
-			var superview = platformLabel.Superview;
-			while (superview is not null)
-			{
-				if (superview is ItemsViewCell2)
-				{
-					return true;
-				}
-				superview = superview.Superview;
-			}
-			return false;
 		}
 	}
 }


### PR DESCRIPTION
<!-- Please keep the note below for people who find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment whether this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

 This PR reverts the changes introduced by #34383, which caused an NSInternalInconsistencyException during fast scrolling when a Label has TextType="HTML" inside a CV2 CollectionView on iOS.
 
 ### Root Cause of the Regression
 
 PR #34383 applied NSAttributedString HTML initialization synchronously inside cellForItemAtIndexPath. Per Apple's documentation, NSAttributedString HTML init uses WebKit internally, which pumps the CFRunLoop even on the main thread. This causes UIKit re-entrancy during UICollectionView's data source call, resulting in NSInternalInconsistencyException.
 
### Description of Change
**iOS Label HTML Text Handling Simplification:**

* Removed conditional logic that checked whether a `UILabel` was inside a CV2 (CollectionView/CarouselView v2) cell, and always dispatches HTML text updates asynchronously to the main queue to prevent crashes.
* Deleted the helper method `IsPlatformLabelInsideCV2Cell` and its associated code, further simplifying the update logic.
* Cleaned up unused imports by removing the reference to `Microsoft.Maui.Controls.Handlers.Items2`.



<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->
Regression introduced by PR https://github.com/dotnet/maui/pull/34383
### Failure test case: 

- AppShouldNotCrash

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
