### PR TITLE
[iOS/macCatalyst] [Candidate Fix] Editor shadow and theme regression caused by BackgroundColor reset on initial handler connection

### DIFF
--- a/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
@@ -3,6 +3,7 @@ using CoreGraphics;
 using Foundation;
 using Microsoft.Maui.Devices;
 using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Platform;
 using UIKit;
 
 namespace Microsoft.Maui.Handlers
@@ -97,12 +98,8 @@ namespace Microsoft.Maui.Handlers
 			}
 			else if (editor.Background.IsNullOrEmpty())
 			{
-				// Skip resetting during initial setup to preserve shadow rendering and native default appearance.
-				if (handler.IsConnectingHandler())
-					return;
-
 				platformView.RemoveBackgroundLayer();
-				platformView.BackgroundColor = null;
+				platformView.BackgroundColor = ColorExtensions.BackgroundColor;
 			}
 			else
 			{

--- a/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
@@ -97,6 +97,10 @@ namespace Microsoft.Maui.Handlers
 			}
 			else if (editor.Background.IsNullOrEmpty())
 			{
+				// Skip resetting during initial setup to preserve shadow rendering and native default appearance.
+				if (handler.IsConnectingHandler())
+					return;
+
 				platformView.RemoveBackgroundLayer();
 				platformView.BackgroundColor = null;
 			}

--- a/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
@@ -62,10 +62,6 @@ namespace Microsoft.Maui.Handlers
 			}
 			else if (entry.Background.IsNullOrEmpty())
 			{
-				// Skip resetting during initial setup to preserve shadow rendering and native default appearance.
-				if (handler.IsConnectingHandler())
-					return;
-
 				platformView.RemoveBackgroundLayer();
 				platformView.BackgroundColor = null;
 				return;

--- a/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
@@ -62,6 +62,10 @@ namespace Microsoft.Maui.Handlers
 			}
 			else if (entry.Background.IsNullOrEmpty())
 			{
+				// Skip resetting during initial setup to preserve shadow rendering and native default appearance.
+				if (handler.IsConnectingHandler())
+					return;
+
 				platformView.RemoveBackgroundLayer();
 				platformView.BackgroundColor = null;
 				return;


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Root Cause of the Regression
PR #34741's MapBackground overrides call platformView.BackgroundColor = null during initial handler connection (when Background is null by default), making Editor controls transparent at startup — breaking shadow rendering and app-theme color bindings.


### Description of Change
In EditorHandler.iOS.cs, replaced platformView.BackgroundColor = null with platformView.BackgroundColor = ColorExtensions.BackgroundColor (UIColor.SystemBackground) so the Editor restores the system's adaptive default color instead of becoming transparent. This preserves shadow rendering on initial load and correctly responds to light/dark theme changes.

 
### Issues Fixed
UI Test

iOS:
VerifyEditorPlaceholderWithShadow, VerifyEditor_WithShadow, ShadowsDontRespectControlShape 
 
Mac:
VerifyEditorPlaceholderWithShadow, VerifyEditor_WithShadow, ShadowsDontRespectControlShape, EditorAndEntryInputFieldsShouldChangeColorsOnAppThemeChange, EntryAndEditorPlaceholderTextColorAppThemeBindingUpdatesOnThemeChange, EntryAndEditorTextColorAppThemeBindingUpdatesOnThemeChange - Fails due to this PR - https://github.com/dotnet/maui/pull/34741