### PR TITLE
[iOS] Fix ShellFeatureMatrix test failures on candidate branch

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
@@ -224,9 +224,13 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				var headerBehavior = _context.Shell.FlyoutHeaderBehavior;
 				if (headerBehavior == FlyoutHeaderBehavior.Default || headerBehavior == FlyoutHeaderBehavior.Fixed)
 				{
-					// For Default/Fixed, the scroll view is positioned below the header,
-					// so no top content inset is needed.
+					// For Default/Fixed, the scroll view frame is positioned below the header by LayoutContent,
+					// so no top content inset is needed and no content offset compensation should be applied.
+					// Applying the compensation (offset = oldInset - 0) would incorrectly scroll the content
+					// down by the old inset amount, hiding the first flyout item behind the header.
 					ScrollView.ContentInset = new UIEdgeInsets(0, 0, 0, 0);
+					UpdateVerticalScrollMode();
+					return;
 				}
 				else
 				{


### PR DESCRIPTION
### Root Cause
SetHeaderContentInset() in ShellFlyoutLayoutManager.cs contains an offset compensation block that executes for all FlyoutHeaderBehavior values. This logic was originally intended for Scroll and CollapseOnScroll, where the inset changes dynamically during scrolling.
PR #34936 introduced a frame-based layout for Default and Fixed, but the compensation logic was not excluded for those modes. As a result, it still computes a non-zero offset adjustment based on the inset change and incorrectly shifts the content upward.

**Regression PR:** https://github.com/dotnet/maui/pull/34936

### Test name:
VerifyShellFlyout_HeightAndWidthWithBackgroundColor
VerifyShellFlyout_BackgroundColorWithHeaderAndFooter
VerifyShellFlyout_BackgroundImageWithHeaderAndFooter
VerifyShellFlyout_DisplayOptionsWithHeaderAndFooter, VerifyShellFlyout_DisplayOptionsWithHeaderTemplateAndFooterTemplate

### How the Regression Occurred
PR #34936 updated SetHeaderContentInset() to set ContentInset.Top = 0 for Default and Fixed behaviors, since the scroll frame now starts physically below the header. However, the existing offset compensation block later in the same method continued to run for all behaviors.
When a header is applied at runtime, this block reads the previous inset value, calculates the difference from the new inset (0), and applies that delta to ContentOffset.Y. This unintentionally scrolls the item list upward, causing the first item to disappear behind the header.

### Description of Changes
After setting ContentInset to zero:

- Added UpdateVerticalScrollMode() to apply the current scroll mode before exiting the method.
- Added an early return to prevent execution of the offset compensation block for Default and Fixed behaviors.

No other logic was modified. The Scroll and CollapseOnScroll path, including the compensation block itself, remains unchanged from PR #34936, preserving the intended collapsing-header behavior.

### Test result
| Before Issue Fix | After Issue Fix |
|----------|----------|
| <img width="800" height="220"  src="https://github.com/user-attachments/assets/8a99dc67-b772-4ad2-b829-b7e8d51b7345"> | <img width="800" height="220"  src="https://github.com/user-attachments/assets/488cd0e7-5a30-41a3-aaba-b7924459cf32"> |