### PR TITLE
 [Android] Fix ScrollTo regression when IsGrouped true on CollectionView

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
@@ -461,6 +461,13 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		private static object FindBoundItemInGroup(ScrollToRequestEventArgs args, IGroupableItemsViewSource groupItemSource)
 		{
+			// When no group index is specified (groupIndex < 0), fall back to flat index lookup.
+			// This handles the case where ScrollTo(index) is called without a group on a grouped CollectionView.
+			if (args.GroupIndex < 0)
+			{
+				return groupItemSource.GetItem(args.Index);
+			}
+
 			var group = groupItemSource.GetGroupItemsViewSource(args.GroupIndex);
 
 			// GetItem calls AdjustIndexRequest, which subtracts 1 if we have a  header (UngroupedItemsSource does not do this)

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue35313.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue35313.cs
@@ -1,0 +1,112 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 35313, "ScrollTo(0) not working on grouped CollectionView", PlatformAffected.Android)]
+public class Issue35313 : ContentPage
+{
+	CollectionView _collectionView;
+	List<Issue35313ItemGroup> _groups;
+
+	public Issue35313()
+	{
+		_groups = [];
+		for (int g = 1; g <= 5; g++)
+		{
+			var group = new Issue35313ItemGroup { Key = $"Group {g}" };
+			for (int i = 1; i <= 10; i++)
+				group.Add(new Issue35313Item { Name = $"Group {g} — Item {i}" });
+			_groups.Add(group);
+		}
+
+		_collectionView = new CollectionView
+		{
+			AutomationId = "CollectionView",
+			IsGrouped = true,
+			ItemsSource = _groups,
+			GroupHeaderTemplate = new DataTemplate(() =>
+			{
+				var label = new Label
+				{
+					Padding = new Thickness(8, 4),
+					BackgroundColor = Colors.LightGray,
+					FontAttributes = FontAttributes.Bold
+				};
+				label.SetBinding(Label.TextProperty, "Key");
+				label.SetBinding(Label.AutomationIdProperty, "Key");
+				return label;
+			}),
+			ItemTemplate = new DataTemplate(() =>
+			{
+				var label = new Label { Padding = new Thickness(16, 8) };
+				label.SetBinding(Label.TextProperty, "Name");
+				label.SetBinding(Label.AutomationIdProperty, "Name");
+				return label;
+			})
+		};
+
+		var buttonStart = new Button
+		{
+			Text = "Start",
+			AutomationId = "ScrollToStartButton",
+			Command = new Command(() => _collectionView.ScrollTo(0))
+		};
+
+		var buttonFirstItem = new Button
+		{
+			Text = "First item",
+			AutomationId = "ScrollToFirstItemButton",
+			Command = new Command(() =>
+			{
+				var firstGroup = _groups[0];
+				_collectionView.ScrollTo(firstGroup[0], firstGroup, ScrollToPosition.Start, animate: true);
+			})
+		};
+
+		var buttonLastItem = new Button
+		{
+			Text = "Last item",
+			AutomationId = "ScrollToLastItemButton",
+			Command = new Command(() =>
+			{
+				var lastGroup = _groups[^1];
+				_collectionView.ScrollTo(lastGroup[^1], lastGroup, ScrollToPosition.End, animate: true);
+			})
+		};
+
+		var buttonEnd = new Button
+		{
+			Text = "End",
+			AutomationId = "ScrollToEndButton",
+			Command = new Command(() => _collectionView.ScrollTo(54))
+		};
+
+		var buttonRow = new HorizontalStackLayout
+		{
+			Padding = new Thickness(8),
+			Spacing = 8,
+			Children = { buttonStart, buttonFirstItem, buttonLastItem, buttonEnd }
+		};
+
+		Content = new Grid
+		{
+			RowDefinitions =
+			{
+				new RowDefinition { Height = GridLength.Auto },
+				new RowDefinition { Height = GridLength.Star },
+			},
+			Children = { buttonRow, _collectionView }
+		};
+
+		Grid.SetRow(buttonRow, 0);
+		Grid.SetRow(_collectionView, 1);
+	}
+}
+
+public class Issue35313Item
+{
+	public string Name { get; set; } = string.Empty;
+}
+
+public class Issue35313ItemGroup : List<Issue35313Item>
+{
+	public string Key { get; set; } = string.Empty;
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35313.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35313.cs
@@ -1,0 +1,32 @@
+#if ANDROID
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue35313 : _IssuesUITest
+{
+	public Issue35313(TestDevice device) : base(device) { }
+
+	public override string Issue => "ScrollTo(0) not working on grouped CollectionView";
+
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void GroupedCollectionViewScrollToIndexZeroShouldScrollToStart()
+	{
+		App.WaitForElement("ScrollToEndButton");
+
+		// Scroll to the end so the top is off screen
+		App.Tap("ScrollToEndButton");
+		App.WaitForElement("Group 5 — Item 10");
+
+		// ScrollTo(0) on a grouped CollectionView — this is the regression
+		// Without the fix it silently does nothing on Android
+		App.Tap("ScrollToStartButton");
+
+		// Group 1 header should be visible after scrolling to index 0
+		App.WaitForElement("Group 1");
+	}
+}
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35313.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35313.cs
@@ -1,4 +1,4 @@
-#if ANDROID
+#if ANDROID // Open Issue For iOS, MacCatalyst and Windows : https://github.com/dotnet/maui/issues/35326
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;


### PR DESCRIPTION
<!-- Please keep the note below for people who find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment whether this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

This pull request addresses a regression where calling `ScrollTo(0)` on a grouped `CollectionView` did not work as expected on Android. The changes add a fix to the `MauiRecyclerView` handler to properly handle this case, and introduce both a sample test page and a UI test to verify 

**Regression cause:** PR #31553 fixed an `ArgumentOutOfRangeException` for invalid group indices by adding a null-safety bounds check in `FindBoundItemInGroup`. However, it inadvertently removed the `groupIndex < 
0` fallback that handled the valid case of `ScrollTo(index)` with no group specified. As a result, `GetGroupItemsViewSource(-1)` returns `null`, causing `DetermineTargetPosition` to return `InvalidPosition (-1)` and
 the scroll to silently abort
 
### Description of Change
 **Bug fix for grouped CollectionView scroll:**

* Updated `DetermineTargetPosition` in `MauiRecyclerView.cs` to correctly handle `ScrollTo(index)` when no group index is specified, ensuring flat index lookup works for grouped `CollectionView`.

### New test coverage:

* Added a new sample page `Issue35313.cs` that demonstrates and allows manual testing of `ScrollTo` behavior on grouped `CollectionView`.
* Added a UI test in `TestCases.Shared.Tests/Tests/Issues/Issue35313.cs` to automatically verify that `ScrollTo(0)` scrolls to the start of a grouped `CollectionView` on Android.


<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #35313
### Tested the behavior in the following platforms

- [ ] Windows
- [x] Android
- [ ] iOS
- [ ] Mac

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/7f2afc20-73a5-4eba-b3a3-46f924322bfc">  | <video src="https://github.com/user-attachments/assets/ee03ff51-d187-4e3a-8069-64faf58ab60d"> |
<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
