### PR TITLE
[Windows] Fix COMException when restoring a ScrollView as ContentPage.Content after swapping it out

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue35277.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue35277.cs
@@ -1,0 +1,56 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 35277, "COMException when restoring a page content after swapping it out", PlatformAffected.UWP)]
+public class Issue35277 : ContentPage
+{
+	ScrollView _originalScrollView;
+
+	public Issue35277()
+	{
+		var swapButton = new Button
+		{
+			Text = "Swap and Restore",
+			HorizontalOptions = LayoutOptions.Center,
+			AutomationId = "SwapAndRestoreButton"
+		};
+		swapButton.Clicked += OnSwapAndRestoreClicked;
+
+		_originalScrollView = new ScrollView
+		{
+			Content = new VerticalStackLayout
+			{
+				Spacing = 20,
+				VerticalOptions = LayoutOptions.Center,
+				Children =
+				{
+					swapButton,
+					new Label
+					{
+						Text = "Original Content",
+						HorizontalOptions = LayoutOptions.Center,
+						AutomationId = "OriginalLabel"
+					}
+				}
+			}
+		};
+
+		Content = _originalScrollView;
+	}
+
+	void OnSwapAndRestoreClicked(object sender, EventArgs e)
+	{
+		var savedScrollView = _originalScrollView;
+		Content = new Label
+		{
+			Text = "Temporary Content",
+			HorizontalOptions = LayoutOptions.Center,
+			VerticalOptions = LayoutOptions.Center,
+			AutomationId = "TemporaryLabel"
+		};
+
+		Microsoft.Maui.ApplicationModel.MainThread.BeginInvokeOnMainThread(() =>
+		{
+			Content = savedScrollView;
+		});
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35277.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35277.cs
@@ -1,0 +1,22 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue35277 : _IssuesUITest
+{
+	public Issue35277(TestDevice device) : base(device) { }
+
+	public override string Issue => "COMException when restoring a page content after swapping it out";
+
+	[Test]
+	[Category(UITestCategories.ScrollView)]
+	public void ScrollViewContentShouldRestoreWithoutCOMException()
+	{
+		App.WaitForElement("SwapAndRestoreButton");
+		App.Tap("SwapAndRestoreButton");
+		// If no COMException is thrown, the original ScrollView content (with the button) restores successfully
+		App.WaitForElement("SwapAndRestoreButton");
+	}
+}

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
@@ -149,20 +149,23 @@ namespace Microsoft.Maui.Handlers
 				{
 					currentPaddingLayer.CachedChildren.Clear();
 				}
-				
+
 				return;
 			}
+
+			if (currentPaddingLayer is not null)
+			{
+				currentPaddingLayer.CachedChildren.Clear();
+			}
+
+			// Detach the old handler if it exists (prevents WinUI COM exception on reuse)
+			scrollView.PresentedContent.Handler?.DisconnectHandler();
 
 			var nativeContent = scrollView.PresentedContent.ToPlatform(handler.MauiContext);
 
 			if (currentPaddingLayer is not null)
 			{
-				// Only update if content has changed or is missing
-				if (currentPaddingLayer.CachedChildren.Count == 0 || currentPaddingLayer.CachedChildren[0] != nativeContent)
-				{
-					currentPaddingLayer.CachedChildren.Clear();
-					currentPaddingLayer.CachedChildren.Add(nativeContent);
-				}
+				currentPaddingLayer.CachedChildren.Add(nativeContent);
 			}
 			else
 			{


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
Restoring a previously used ScrollView as ContentPage.Content after swapping it out throws System.Runtime.InteropServices.COMException: 'No installed components were detected.' on Windows only.

### Regression PR
https://github.com/dotnet/maui/pull/30047

### How it regressed:
**Before PR 30047:** Swapping away from a ScrollView left its handler intact. On restore, the same handler was reused, so no new ContentPanel was created and the inner content’s native parent remained valid. No crash.
**After PR 30047:** Swapping away destroys the ScrollView’s handler. On restore, a new ScrollViewHandler is created, which calls ToPlatform() on the inner content without first disconnecting its stale handler. As a result, the inner content’s native view still has Parent = old ContentPanel, leading to a COMException.
 
### Root Cause
When ContentPage.Content = savedScrollView restores a previously used ScrollView:

- ContentViewHandler.UpdateContent (PR #30047) disconnects the ScrollView’s handler and calls ToPlatform(), creating a new ScrollViewHandler.
- The new handler’s MapContent → UpdateContentPanel calls scrollView.PresentedContent.ToPlatform().
- PresentedContent (e.g., VerticalStackLayout) still holds its old handler, whose WinUI native element has its Parent set to the previous visual tree’s ContentPanel.
- WinUI throws a COMException at paddingShim.CachedChildren.Add(nativeContent) because an element with an existing parent cannot be added to a new parent.

### Description of Changes

- Added scrollView.PresentedContent.Handler?.DisconnectHandler() before calling ToPlatform() in ScrollViewHandler.UpdateContentPanel, aligning with the pattern used in ContentViewHandler.Windows.cs and BorderHandler.Windows.cs.
- Added currentPaddingLayer.CachedChildren.Clear() before DisconnectHandler() to unparent the existing native view and ensure a clean state before handler teardown.
- Removed the CachedChildren[0] != nativeContent optimization check, as ToPlatform() always returns a new native view instance after DisconnectHandler(), making the condition redundant.

### Why Is This ScrollView-Specific?

Every other handler clears its inner content during disconnect, but ScrollViewHandler does not. When MAUI destroys a handler, the inner native view is expected to be detached so that Parent = null. LayoutHandler and ContentViewHandler clear CachedChildren, while RefreshViewHandler sets contentPanel.Content = null, all of which correctly unparent the native view. However, ScrollViewHandler only unsubscribes an event and leaves the inner view attached to the old paddingShim. Later, when the same view is added to a new ScrollViewHandler, WinUI detects that Parent != null and throws a COMException.

### Issues Fixed
Fixes #35277

### Screenshots

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/3d3ea98d-23f4-4216-b28f-01f16cdb178b"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/eefdf29d-e34a-47cb-81b0-1a694f79e1d4"> |