### PR TITLE
Move HybridWebView trimmer attributes from class-level to method-level

### DIFF
--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Windows.cs
@@ -188,7 +188,7 @@ namespace Microsoft.Maui.Handlers
 				}
 
 				// 1.b. Try special InvokeDotNet path
-				if (relativePath == InvokeDotNetPath)
+				if (relativePath == InvokeDotNetPath && RuntimeFeature.IsHybridWebViewSupported)
 				{
 					logger?.LogDebug("Request for {Url} will be handled by the .NET method invoker.", url);
 
@@ -281,10 +281,6 @@ namespace Microsoft.Maui.Handlers
 			return ras;
 		}
 
-		[RequiresUnreferencedCode(DynamicFeatures)]
-#if !NETSTANDARD
-		[RequiresDynamicCode(DynamicFeatures)]
-#endif
 		private sealed class HybridWebView2Proxy
 		{
 			private WeakReference<Window>? _window;

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Windows.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading.Tasks;

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.cs
@@ -44,10 +44,6 @@ using System.Runtime.ExceptionServices;
 
 namespace Microsoft.Maui.Handlers
 {
-	[RequiresUnreferencedCode(DynamicFeatures)]
-#if !NETSTANDARD
-	[RequiresDynamicCode(DynamicFeatures)]
-#endif
 	public partial class HybridWebViewHandler : IHybridWebViewHandler
 	{
 		internal const string DynamicFeatures = "HybridWebView uses dynamic System.Text.Json serialization features.";
@@ -184,6 +180,10 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 
+		[RequiresUnreferencedCode(DynamicFeatures)]
+#if !NETSTANDARD
+		[RequiresDynamicCode(DynamicFeatures)]
+#endif
 		internal async Task<byte[]?> InvokeDotNetAsync(Stream? streamBody = null, string? stringBody = null)
 		{
 			try
@@ -225,6 +225,10 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 
+		[RequiresUnreferencedCode(DynamicFeatures)]
+#if !NETSTANDARD
+		[RequiresDynamicCode(DynamicFeatures)]
+#endif
 		private static DotNetInvokeResult CreateInvokeResult(object? result)
 		{
 			// null invoke result means an empty result
@@ -262,6 +266,10 @@ namespace Microsoft.Maui.Handlers
 			};
 		}
 
+		[RequiresUnreferencedCode(DynamicFeatures)]
+#if !NETSTANDARD
+		[RequiresDynamicCode(DynamicFeatures)]
+#endif
 		private static async Task<object?> InvokeDotNetMethodAsync(
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type targetType,
 			object jsInvokeTarget,

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
@@ -123,10 +123,6 @@ namespace Microsoft.Maui.Handlers
 		}
 
 
-		[RequiresUnreferencedCode(DynamicFeatures)]
-#if !NETSTANDARD
-		[RequiresDynamicCode(DynamicFeatures)]
-#endif
 		private sealed class WebViewScriptMessageHandler : NSObject, IWKScriptMessageHandler
 		{
 			private readonly WeakReference<HybridWebViewHandler?> _webViewHandler;
@@ -145,10 +141,6 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 
-		[RequiresUnreferencedCode(DynamicFeatures)]
-#if !NETSTANDARD
-		[RequiresDynamicCode(DynamicFeatures)]
-#endif
 		private class SchemeHandler : NSObject, IWKUrlSchemeHandler
 		{
 			private readonly WeakReference<HybridWebViewHandler?> _webViewHandler;
@@ -261,7 +253,7 @@ namespace Microsoft.Maui.Handlers
 					}
 
 					// 1.b. Try special InvokeDotNet path
-					if (relativePath == InvokeDotNetPath)
+					if (relativePath == InvokeDotNetPath && RuntimeFeature.IsHybridWebViewSupported)
 					{
 						logger?.LogDebug("Request for {Url} will be handled by the .NET method invoker.", url);
 

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Runtime.Versioning;

--- a/src/Core/src/Platform/Android/MauiHybridWebView.cs
+++ b/src/Core/src/Platform/Android/MauiHybridWebView.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis;
 using Android.Content;
 using Android.Webkit;
 using AUri = Android.Net.Uri;

--- a/src/Core/src/Platform/Android/MauiHybridWebView.cs
+++ b/src/Core/src/Platform/Android/MauiHybridWebView.cs
@@ -7,10 +7,6 @@ using AWebView = Android.Webkit.WebView;
 
 namespace Microsoft.Maui.Platform
 {
-	[RequiresUnreferencedCode(HybridWebViewHandler.DynamicFeatures)]
-#if !NETSTANDARD
-	[RequiresDynamicCode(HybridWebViewHandler.DynamicFeatures)]
-#endif
 	public class MauiHybridWebView : AWebView, IHybridPlatformWebView
 	{
 		private readonly WeakReference<HybridWebViewHandler> _handler;

--- a/src/Core/src/Platform/Android/MauiHybridWebViewClient.cs
+++ b/src/Core/src/Platform/Android/MauiHybridWebViewClient.cs
@@ -15,10 +15,6 @@ using AWebView = Android.Webkit.WebView;
 
 namespace Microsoft.Maui.Platform
 {
-	[RequiresUnreferencedCode(HybridWebViewHandler.DynamicFeatures)]
-#if !NETSTANDARD
-	[RequiresDynamicCode(HybridWebViewHandler.DynamicFeatures)]
-#endif
 	public class MauiHybridWebViewClient : WebViewClient
 	{
 		private readonly WeakReference<HybridWebViewHandler?> _handler;
@@ -95,7 +91,7 @@ namespace Microsoft.Maui.Platform
 			}
 
 			// 1.b. Try special InvokeDotNet path
-			if (relativePath == HybridWebViewHandler.InvokeDotNetPath)
+			if (relativePath == HybridWebViewHandler.InvokeDotNetPath && RuntimeFeature.IsHybridWebViewSupported)
 			{
 				logger?.LogDebug("Request for {Url} will be handled by the .NET method invoker.", fullUrl);
 

--- a/src/Core/src/Platform/Android/MauiHybridWebViewClient.cs
+++ b/src/Core/src/Platform/Android/MauiHybridWebViewClient.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
 using System.Web;

--- a/src/Core/src/Platform/Windows/MauiHybridWebView.cs
+++ b/src/Core/src/Platform/Windows/MauiHybridWebView.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.Web.WebView2.Core;

--- a/src/Core/src/Platform/Windows/MauiHybridWebView.cs
+++ b/src/Core/src/Platform/Windows/MauiHybridWebView.cs
@@ -6,10 +6,6 @@ using Microsoft.Web.WebView2.Core;
 
 namespace Microsoft.Maui.Platform
 {
-	[RequiresUnreferencedCode(HybridWebViewHandler.DynamicFeatures)]
-#if !NETSTANDARD
-	[RequiresDynamicCode(HybridWebViewHandler.DynamicFeatures)]
-#endif
 	public partial class MauiHybridWebView : WebView2, IHybridPlatformWebView
 	{
 		private readonly WeakReference<HybridWebViewHandler> _handler;


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Move `[RequiresUnreferencedCode]` and `[RequiresDynamicCode]` from class-level to method-level on `HybridWebViewHandler` and remove them entirely from platform types that are trim-safe.

### Problem

The iOS/macCatalyst Managed Registrar generates code in `<Module>..cctor()` that references all `NSObject` subclasses, including `SchemeHandler` and `WebViewScriptMessageHandler`. These nested classes had class-level `[RequiresUnreferencedCode]`, which caused IL2026 errors from the registrar's type registration code — errors that could never be resolved via feature switches.

Similarly, Android's `MauiHybridWebViewClient` (extending `WebViewClient`) had the same problem.

This caused failures in:
- `RunOniOS_MauiReleaseTrimFull` integration test (TrimMode=full)
- `PublishNativeAOTRootAllMauiAssemblies` integration test (rooting all assemblies)

### Fix

**Only three methods** on `HybridWebViewHandler` are actually trim-unsafe (they use reflection and runtime JSON serialization):
- `InvokeDotNetAsync`
- `InvokeDotNetMethodAsync`
- `CreateInvokeResult`

All other code (message receiving, URL scheme handling for static files, platform view wrappers) is trim-safe — it only uses source-generated JSON contexts.

**Changes:**
1. Removed class-level RUCA from `HybridWebViewHandler`, `MauiHybridWebViewClient`, `MauiHybridWebView` (Android/Windows), and all nested platform classes
2. Added method-level RUCA to the three methods that actually need it
3. Guarded `InvokeDotNetAsync` calls on all platforms with `RuntimeFeature.IsHybridWebViewSupported` — a `[FeatureGuard]` for `RequiresUnreferencedCode`. When the switch is false (`TrimMode=full` or `PublishAot=true`), the trimmer removes the unsafe code path entirely.
