### PR TITLE
[Testing] Replace retryDelay with retryTimeout in UI tests

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18751.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18751.cs
@@ -17,8 +17,8 @@ public class Issue18751 : _IssuesUITest
 	public void Issue18751Test()
 	{
 		App.WaitForElement("WaitForStubControl");
-		// Load images and hide scrollbar.
-		// The test passes if you are able to see the image, name, and location of each monkey.
-		VerifyScreenshot(retryDelay: TimeSpan.FromSeconds(2));
+		// CollectionView uses virtualization which loads images synchronously once items are visible.
+		// Use retryTimeout to adaptively wait for any timing variance.
+		VerifyScreenshot(retryTimeout: TimeSpan.FromSeconds(2));
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18896.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18896.cs
@@ -26,8 +26,9 @@ public class Issue18896 : _IssuesUITest
 #else
 		App.ScrollUp(ListView);
 #endif
-		// Load images and hide scrollbar.
-		// The test passes if you are able to see the image, name, and location of each monkey.
-		VerifyScreenshot(retryDelay: TimeSpan.FromSeconds(2));
+		// ListView with HasUnevenRows may have variable height row rendering that requires
+		// additional time for images to load and scrollbar to disappear.
+		// Use retryTimeout to adaptively wait for the UI to stabilize.
+		VerifyScreenshot(retryTimeout: TimeSpan.FromSeconds(3));
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

Replaces `retryDelay` with `retryTimeout` in 2 UI test files. This is a clean replacement for PR #33809, which had merge conflicts because most of its changes were already applied.

### Changes

| File | Change |
|------|--------|
| Issue18751 | `retryDelay`→`retryTimeout` + CollectionView timing comment |
| Issue18896 | `retryDelay`→`retryTimeout` (2s→3s) + ListView timing comment |

### Context

The original PR #33809 applied Copilot code review suggestions from #33749 to replace `Thread.Sleep`/`Task.Delay` with `retryTimeout` across 9 files. 7 of those changes were already merged, leaving only these 2 files with the stale `retryDelay` parameter.

Supersedes #33809.