### PR TITLE
Fix pill-shaped focus ring on macOS 26

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34899.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34899.cs
@@ -1,6 +1,6 @@
 namespace Maui.Controls.Sample.Issues;
 
-[Issue(IssueTracker.Github, 34899, ".Net 10 Picker item not centered and wrong focus outline of Entry on Mac", PlatformAffected.macOS)]
+[Issue(IssueTracker.Github, 34899, ".Net 10 Picker item not centered and wrong focus outline of Entry/Picker on Mac", PlatformAffected.macOS)]
 public class Issue34899 : ContentPage
 {
 	public Issue34899()
@@ -27,6 +27,16 @@ public class Issue34899 : ContentPage
 			AutomationId = "Issue34899Entry"
 		};
 
+		// Label used by PickerSelectedItemShouldBeCentered test to measure horizontal alignment.
+		// Its horizontal center must stay aligned with the picker's horizontal center.
+		var centerLabel = new Label
+		{
+			Text = "Picker Title Center Reference",
+			HorizontalTextAlignment = TextAlignment.Center,
+			HorizontalOptions = LayoutOptions.Fill,
+			AutomationId = "Issue34899PickerCenterLabel"
+		};
+
 		Content = new VerticalStackLayout
 		{
 			Padding = 20,
@@ -34,6 +44,7 @@ public class Issue34899 : ContentPage
 			Children =
 			{
 				picker,
+				centerLabel,
 				entry
 			}
 		};

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34899.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34899.cs
@@ -1,0 +1,41 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 34899, ".Net 10 Picker item not centered and wrong focus outline of Entry on Mac", PlatformAffected.macOS)]
+public class Issue34899 : ContentPage
+{
+	public Issue34899()
+	{
+		var picker = new Picker
+		{
+			Title = "Select a Monkey",
+			AutomationId = "Issue34899Picker",
+			ItemsSource = new List<string>
+			{
+				"Baboon",
+				"Capuchin Monkey",
+				"Blue Monkey",
+				"Squirrel Monkey",
+				"Golden Lion Tamarin",
+				"Howler Monkey",
+				"Japanese Macaque"
+			}
+		};
+
+		var entry = new Entry
+		{
+			Placeholder = "Type something here",
+			AutomationId = "Issue34899Entry"
+		};
+
+		Content = new VerticalStackLayout
+		{
+			Padding = 20,
+			Spacing = 20,
+			Children =
+			{
+				picker,
+				entry
+			}
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34899.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34899.cs
@@ -5,36 +5,10 @@ public class Issue34899 : ContentPage
 {
 	public Issue34899()
 	{
-		var picker = new Picker
-		{
-			Title = "Select a Monkey",
-			AutomationId = "Issue34899Picker",
-			ItemsSource = new List<string>
-			{
-				"Baboon",
-				"Capuchin Monkey",
-				"Blue Monkey",
-				"Squirrel Monkey",
-				"Golden Lion Tamarin",
-				"Howler Monkey",
-				"Japanese Macaque"
-			}
-		};
-
 		var entry = new Entry
 		{
 			Placeholder = "Type something here",
 			AutomationId = "Issue34899Entry"
-		};
-
-		// Label used by PickerSelectedItemShouldBeCentered test to measure horizontal alignment.
-		// Its horizontal center must stay aligned with the picker's horizontal center.
-		var centerLabel = new Label
-		{
-			Text = "Picker Title Center Reference",
-			HorizontalTextAlignment = TextAlignment.Center,
-			HorizontalOptions = LayoutOptions.Fill,
-			AutomationId = "Issue34899PickerCenterLabel"
 		};
 
 		Content = new VerticalStackLayout
@@ -43,8 +17,6 @@ public class Issue34899 : ContentPage
 			Spacing = 20,
 			Children =
 			{
-				picker,
-				centerLabel,
 				entry
 			}
 		};

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34899.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34899.cs
@@ -1,0 +1,32 @@
+#if MACCATALYST
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue34899 : _IssuesUITest
+{
+	public Issue34899(TestDevice testDevice) : base(testDevice) { }
+
+	public override string Issue => ".Net 10 Picker item not centered and wrong focus outline of Entry on Mac";
+
+	[Test]
+	[Category(UITestCategories.Entry)]
+	public void EntryFocusOutlineShouldAlignWithBorder()
+	{
+		App.WaitForElement("Issue34899Entry");
+		App.Tap("Issue34899Entry");
+		VerifyScreenshot();
+	}
+
+	[Test]
+	[Category(UITestCategories.Picker)]
+	public void PickerFocusOutlineShouldAlignWithBorder()
+	{
+		App.WaitForElement("Issue34899Picker");
+		App.Tap("Issue34899Picker");
+		VerifyScreenshot();
+	}
+}
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34899.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34899.cs
@@ -9,7 +9,12 @@ public class Issue34899 : _IssuesUITest
 {
 	public Issue34899(TestDevice testDevice) : base(testDevice) { }
 
-	public override string Issue => ".Net 10 Picker item not centered and wrong focus outline of Entry on Mac";
+	public override string Issue => ".Net 10 Picker item not centered and wrong focus outline of Entry/Picker on Mac";
+
+	// On macOS 26+ (Tahoe / Liquid Glass), UITextField with BorderStyle=RoundedRect
+	// renders a pill/capsule-shaped focus ring that doesn't match the visible border.
+	// These tests verify the FocusEffect override correctly rounds the focus ring
+	// to match the visible rectangular border shape.
 
 	[Test]
 	[Category(UITestCategories.Entry)]

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34899.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34899.cs
@@ -24,14 +24,5 @@ public class Issue34899 : _IssuesUITest
 		App.Tap("Issue34899Entry");
 		VerifyScreenshot();
 	}
-
-	[Test]
-	[Category(UITestCategories.Picker)]
-	public void PickerFocusOutlineShouldAlignWithBorder()
-	{
-		App.WaitForElement("Issue34899Picker");
-		App.Tap("Issue34899Picker");
-		VerifyScreenshot();
-	}
 }
 #endif

--- a/src/Core/src/Platform/iOS/MauiTextField.cs
+++ b/src/Core/src/Platform/iOS/MauiTextField.cs
@@ -24,18 +24,24 @@ namespace Microsoft.Maui.Platform
 			base.WillMoveToWindow(window);
 		}
 
-		// On iOS/macOS 26+, UITextField with BorderStyle = RoundedRect renders with a
-		// pill/capsule-shaped focus ring due to the new "Liquid Glass" design language.
-		// We set FocusEffect in LayoutSubviews (not via property getter) so that Bounds
-		// is guaranteed to be non-zero when the path is created.
 		public override void LayoutSubviews()
 		{
 			base.LayoutSubviews();
 
-			if ((OperatingSystem.IsMacCatalystVersionAtLeast(26) || OperatingSystem.IsIOSVersionAtLeast(26))
-				&& Bounds.Width > 0 && Bounds.Height > 0)
+			// On iOS/MacCatalyst 26+, the system's default keyboard focus halo around a
+			// UITextField with BorderStyle == RoundedRect renders as a fully rounded
+			// (pill-shaped) outline that doesn't match the field's actual corner radius.
+			// Provide a custom UIFocusHaloEffect whose path follows the field's
+			// rounded-rect bounds so the halo aligns with the border.
+			// See: https://developer.apple.com/documentation/uikit/uifocushaloeffect
+			if ((OperatingSystem.IsIOSVersionAtLeast(26) || OperatingSystem.IsMacCatalystVersionAtLeast(26))
+			 && BorderStyle == UITextBorderStyle.RoundedRect
+			 && Bounds.Width > 0 && Bounds.Height > 0)
 			{
-				base.FocusEffect = UIFocusHaloEffect.Create(UIBezierPath.FromRoundedRect(Bounds, 8.0f));
+				// UITextField's RoundedRect border uses an approximately 5pt corner radius.
+				const float roundedRectCornerRadius = 5f;
+				var path = UIBezierPath.FromRoundedRect(Bounds, roundedRectCornerRadius);
+				FocusEffect = UIFocusHaloEffect.Create(path);
 			}
 		}
 

--- a/src/Core/src/Platform/iOS/MauiTextField.cs
+++ b/src/Core/src/Platform/iOS/MauiTextField.cs
@@ -26,17 +26,17 @@ namespace Microsoft.Maui.Platform
 
 		// On iOS/macOS 26+, UITextField with BorderStyle = RoundedRect renders with a
 		// pill/capsule-shaped focus ring due to the new "Liquid Glass" design language.
-		// Override FocusEffect to return a UIFocusHaloEffect with a traditional 10pt
-		// rounded rect shape so the focus ring matches the visible border shape.
-		public override UIFocusEffect? FocusEffect
+		// We set FocusEffect in LayoutSubviews (not via property getter) so that Bounds
+		// is guaranteed to be non-zero when the path is created.
+		public override void LayoutSubviews()
 		{
-			get
+			base.LayoutSubviews();
+
+			if ((OperatingSystem.IsMacCatalystVersionAtLeast(26) || OperatingSystem.IsIOSVersionAtLeast(26))
+				&& Bounds.Width > 0 && Bounds.Height > 0)
 			{
-				if (OperatingSystem.IsMacCatalystVersionAtLeast(26) || OperatingSystem.IsIOSVersionAtLeast(26))
-					return UIFocusHaloEffect.Create(UIBezierPath.FromRoundedRect(Bounds, 8.0f));
-				return base.FocusEffect;
+				base.FocusEffect = UIFocusHaloEffect.Create(UIBezierPath.FromRoundedRect(Bounds, 8.0f));
 			}
-			set => base.FocusEffect = value;
 		}
 
 		public override string? Text

--- a/src/Core/src/Platform/iOS/MauiTextField.cs
+++ b/src/Core/src/Platform/iOS/MauiTextField.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Maui.Platform
 		const float roundedRectCornerRadius = 5f;
 
 		CGSize _lastFocusHaloBoundsSize;
+		UITextBorderStyle _lastFocusHaloBorderStyle;
 
 		public MauiTextField(CGRect frame)
 			: base(frame)
@@ -38,14 +39,22 @@ namespace Microsoft.Maui.Platform
 			// Provide a custom UIFocusHaloEffect whose path follows the field's
 			// rounded-rect bounds so the halo aligns with the border.
 			// See: https://developer.apple.com/documentation/uikit/uifocushaloeffect
-			if (OperatingSystem.IsMacCatalystVersionAtLeast(26)
-			 && BorderStyle == UITextBorderStyle.RoundedRect
-			 && Bounds.Width > 0 && Bounds.Height > 0
-			 && Bounds.Size != _lastFocusHaloBoundsSize)
+			if (OperatingSystem.IsMacCatalystVersionAtLeast(26))
 			{
-				_lastFocusHaloBoundsSize = Bounds.Size;
-				var path = UIBezierPath.FromRoundedRect(Bounds, roundedRectCornerRadius);
-				FocusEffect = UIFocusHaloEffect.Create(path);
+				if (BorderStyle == UITextBorderStyle.RoundedRect
+				 && Bounds.Width > 0 && Bounds.Height > 0
+				 && (Bounds.Size != _lastFocusHaloBoundsSize || BorderStyle != _lastFocusHaloBorderStyle))
+				{
+					_lastFocusHaloBoundsSize = Bounds.Size;
+					_lastFocusHaloBorderStyle = BorderStyle;
+					var path = UIBezierPath.FromRoundedRect(Bounds, roundedRectCornerRadius);
+					FocusEffect = UIFocusHaloEffect.Create(path);
+				}
+				else if (BorderStyle != UITextBorderStyle.RoundedRect && _lastFocusHaloBorderStyle == UITextBorderStyle.RoundedRect)
+				{
+					_lastFocusHaloBorderStyle = BorderStyle;
+					FocusEffect = null;
+				}
 			}
 		}
 

--- a/src/Core/src/Platform/iOS/MauiTextField.cs
+++ b/src/Core/src/Platform/iOS/MauiTextField.cs
@@ -24,6 +24,21 @@ namespace Microsoft.Maui.Platform
 			base.WillMoveToWindow(window);
 		}
 
+		// On iOS/macOS 26+, UITextField with BorderStyle = RoundedRect renders with a
+		// pill/capsule-shaped focus ring due to the new "Liquid Glass" design language.
+		// Override FocusEffect to return a UIFocusHaloEffect with a traditional 10pt
+		// rounded rect shape so the focus ring matches the visible border shape.
+		public override UIFocusEffect? FocusEffect
+		{
+			get
+			{
+				if (OperatingSystem.IsMacCatalystVersionAtLeast(26) || OperatingSystem.IsIOSVersionAtLeast(26))
+					return UIFocusHaloEffect.Create(UIBezierPath.FromRoundedRect(Bounds, 8.0f));
+				return base.FocusEffect;
+			}
+			set => base.FocusEffect = value;
+		}
+
 		public override string? Text
 		{
 			get => base.Text;

--- a/src/Core/src/Platform/iOS/MauiTextField.cs
+++ b/src/Core/src/Platform/iOS/MauiTextField.cs
@@ -9,6 +9,10 @@ namespace Microsoft.Maui.Platform
 
 	public class MauiTextField : UITextField, IUIViewLifeCycleEvents
 	{
+		// UITextField's RoundedRect border uses an approximately 5pt corner radius.
+		const float roundedRectCornerRadius = 5f;
+
+		CGSize _lastFocusHaloBoundsSize;
 
 		public MauiTextField(CGRect frame)
 			: base(frame)
@@ -28,18 +32,18 @@ namespace Microsoft.Maui.Platform
 		{
 			base.LayoutSubviews();
 
-			// On iOS/MacCatalyst 26+, the system's default keyboard focus halo around a
+			// On MacCatalyst 26+, the system's default keyboard focus halo around a
 			// UITextField with BorderStyle == RoundedRect renders as a fully rounded
 			// (pill-shaped) outline that doesn't match the field's actual corner radius.
 			// Provide a custom UIFocusHaloEffect whose path follows the field's
 			// rounded-rect bounds so the halo aligns with the border.
 			// See: https://developer.apple.com/documentation/uikit/uifocushaloeffect
-			if ((OperatingSystem.IsIOSVersionAtLeast(26) || OperatingSystem.IsMacCatalystVersionAtLeast(26))
+			if (OperatingSystem.IsMacCatalystVersionAtLeast(26)
 			 && BorderStyle == UITextBorderStyle.RoundedRect
-			 && Bounds.Width > 0 && Bounds.Height > 0)
+			 && Bounds.Width > 0 && Bounds.Height > 0
+			 && Bounds.Size != _lastFocusHaloBoundsSize)
 			{
-				// UITextField's RoundedRect border uses an approximately 5pt corner radius.
-				const float roundedRectCornerRadius = 5f;
+				_lastFocusHaloBoundsSize = Bounds.Size;
 				var path = UIBezierPath.FromRoundedRect(Bounds, roundedRectCornerRadius);
 				FocusEffect = UIFocusHaloEffect.Create(path);
 			}

--- a/src/Core/src/Platform/iOS/NoCaretField.cs
+++ b/src/Core/src/Platform/iOS/NoCaretField.cs
@@ -20,18 +20,24 @@ namespace Microsoft.Maui.Platform
 			return RectangleF.Empty;
 		}
 
-		// On iOS/macOS 26+, UITextField with BorderStyle = RoundedRect renders with a
-		// pill/capsule-shaped focus ring due to the new "Liquid Glass" design language.
-		// We set FocusEffect in LayoutSubviews (not via property getter) so that Bounds
-		// is guaranteed to be non-zero when the path is created.
 		public override void LayoutSubviews()
 		{
 			base.LayoutSubviews();
 
-			if ((OperatingSystem.IsMacCatalystVersionAtLeast(26) || OperatingSystem.IsIOSVersionAtLeast(26))
-				&& Bounds.Width > 0 && Bounds.Height > 0)
+			// On iOS/MacCatalyst 26+, the system's default keyboard focus halo around a
+			// UITextField with BorderStyle == RoundedRect renders as a fully rounded
+			// (pill-shaped) outline that doesn't match the field's actual corner radius.
+			// Provide a custom UIFocusHaloEffect whose path follows the field's
+			// rounded-rect bounds so the halo aligns with the border.
+			// See: https://developer.apple.com/documentation/uikit/uifocushaloeffect
+			if ((OperatingSystem.IsIOSVersionAtLeast(26) || OperatingSystem.IsMacCatalystVersionAtLeast(26))
+			 && BorderStyle == UITextBorderStyle.RoundedRect
+			 && Bounds.Width > 0 && Bounds.Height > 0)
 			{
-				base.FocusEffect = UIFocusHaloEffect.Create(UIBezierPath.FromRoundedRect(Bounds, 8.0f));
+				// UITextField's RoundedRect border uses an approximately 5pt corner radius.
+				const float roundedRectCornerRadius = 5f;
+				var path = UIBezierPath.FromRoundedRect(Bounds, roundedRectCornerRadius);
+				FocusEffect = UIFocusHaloEffect.Create(path);
 			}
 		}
 

--- a/src/Core/src/Platform/iOS/NoCaretField.cs
+++ b/src/Core/src/Platform/iOS/NoCaretField.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Maui.Platform
 		const float roundedRectCornerRadius = 5f;
 
 		CoreGraphics.CGSize _lastFocusHaloBoundsSize;
+		UITextBorderStyle _lastFocusHaloBorderStyle;
 
 		public NoCaretField() : base(new RectangleF())
 		{
@@ -35,14 +36,22 @@ namespace Microsoft.Maui.Platform
 			// Provide a custom UIFocusHaloEffect whose path follows the field's
 			// rounded-rect bounds so the halo aligns with the border.
 			// See: https://developer.apple.com/documentation/uikit/uifocushaloeffect
-			if (OperatingSystem.IsMacCatalystVersionAtLeast(26)
-			 && BorderStyle == UITextBorderStyle.RoundedRect
-			 && Bounds.Width > 0 && Bounds.Height > 0
-			 && Bounds.Size != _lastFocusHaloBoundsSize)
+			if (OperatingSystem.IsMacCatalystVersionAtLeast(26))
 			{
-				_lastFocusHaloBoundsSize = Bounds.Size;
-				var path = UIBezierPath.FromRoundedRect(Bounds, roundedRectCornerRadius);
-				FocusEffect = UIFocusHaloEffect.Create(path);
+				if (BorderStyle == UITextBorderStyle.RoundedRect
+				 && Bounds.Width > 0 && Bounds.Height > 0
+				 && (Bounds.Size != _lastFocusHaloBoundsSize || BorderStyle != _lastFocusHaloBorderStyle))
+				{
+					_lastFocusHaloBoundsSize = Bounds.Size;
+					_lastFocusHaloBorderStyle = BorderStyle;
+					var path = UIBezierPath.FromRoundedRect(Bounds, roundedRectCornerRadius);
+					FocusEffect = UIFocusHaloEffect.Create(path);
+				}
+				else if (BorderStyle != UITextBorderStyle.RoundedRect && _lastFocusHaloBorderStyle == UITextBorderStyle.RoundedRect)
+				{
+					_lastFocusHaloBorderStyle = BorderStyle;
+					FocusEffect = null;
+				}
 			}
 		}
 

--- a/src/Core/src/Platform/iOS/NoCaretField.cs
+++ b/src/Core/src/Platform/iOS/NoCaretField.cs
@@ -8,6 +8,11 @@ namespace Microsoft.Maui.Platform
 {
 	public class NoCaretField : UITextField, IUIViewLifeCycleEvents
 	{
+		// UITextField's RoundedRect border uses an approximately 5pt corner radius.
+		const float roundedRectCornerRadius = 5f;
+
+		CoreGraphics.CGSize _lastFocusHaloBoundsSize;
+
 		public NoCaretField() : base(new RectangleF())
 		{
 			SpellCheckingType = UITextSpellCheckingType.No;
@@ -24,18 +29,18 @@ namespace Microsoft.Maui.Platform
 		{
 			base.LayoutSubviews();
 
-			// On iOS/MacCatalyst 26+, the system's default keyboard focus halo around a
+			// On MacCatalyst 26+, the system's default keyboard focus halo around a
 			// UITextField with BorderStyle == RoundedRect renders as a fully rounded
 			// (pill-shaped) outline that doesn't match the field's actual corner radius.
 			// Provide a custom UIFocusHaloEffect whose path follows the field's
 			// rounded-rect bounds so the halo aligns with the border.
 			// See: https://developer.apple.com/documentation/uikit/uifocushaloeffect
-			if ((OperatingSystem.IsIOSVersionAtLeast(26) || OperatingSystem.IsMacCatalystVersionAtLeast(26))
+			if (OperatingSystem.IsMacCatalystVersionAtLeast(26)
 			 && BorderStyle == UITextBorderStyle.RoundedRect
-			 && Bounds.Width > 0 && Bounds.Height > 0)
+			 && Bounds.Width > 0 && Bounds.Height > 0
+			 && Bounds.Size != _lastFocusHaloBoundsSize)
 			{
-				// UITextField's RoundedRect border uses an approximately 5pt corner radius.
-				const float roundedRectCornerRadius = 5f;
+				_lastFocusHaloBoundsSize = Bounds.Size;
 				var path = UIBezierPath.FromRoundedRect(Bounds, roundedRectCornerRadius);
 				FocusEffect = UIFocusHaloEffect.Create(path);
 			}

--- a/src/Core/src/Platform/iOS/NoCaretField.cs
+++ b/src/Core/src/Platform/iOS/NoCaretField.cs
@@ -20,6 +20,21 @@ namespace Microsoft.Maui.Platform
 			return RectangleF.Empty;
 		}
 
+		// On iOS/macOS 26+, UITextField with BorderStyle = RoundedRect renders with a
+		// pill/capsule-shaped focus ring due to the new "Liquid Glass" design language.
+		// Override FocusEffect to return a UIFocusHaloEffect with a traditional 8pt
+		// rounded rect shape so the focus ring matches the visible border shape.
+		public override UIFocusEffect? FocusEffect
+		{
+			get
+			{
+				if (OperatingSystem.IsMacCatalystVersionAtLeast(26) || OperatingSystem.IsIOSVersionAtLeast(26))
+					return UIFocusHaloEffect.Create(UIBezierPath.FromRoundedRect(Bounds, 8.0f));
+				return base.FocusEffect;
+			}
+			set => base.FocusEffect = value;
+		}
+
 		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]
 		EventHandler? _movedToWindow;
 		event EventHandler? IUIViewLifeCycleEvents.MovedToWindow

--- a/src/Core/src/Platform/iOS/NoCaretField.cs
+++ b/src/Core/src/Platform/iOS/NoCaretField.cs
@@ -22,17 +22,17 @@ namespace Microsoft.Maui.Platform
 
 		// On iOS/macOS 26+, UITextField with BorderStyle = RoundedRect renders with a
 		// pill/capsule-shaped focus ring due to the new "Liquid Glass" design language.
-		// Override FocusEffect to return a UIFocusHaloEffect with a traditional 8pt
-		// rounded rect shape so the focus ring matches the visible border shape.
-		public override UIFocusEffect? FocusEffect
+		// We set FocusEffect in LayoutSubviews (not via property getter) so that Bounds
+		// is guaranteed to be non-zero when the path is created.
+		public override void LayoutSubviews()
 		{
-			get
+			base.LayoutSubviews();
+
+			if ((OperatingSystem.IsMacCatalystVersionAtLeast(26) || OperatingSystem.IsIOSVersionAtLeast(26))
+				&& Bounds.Width > 0 && Bounds.Height > 0)
 			{
-				if (OperatingSystem.IsMacCatalystVersionAtLeast(26) || OperatingSystem.IsIOSVersionAtLeast(26))
-					return UIFocusHaloEffect.Create(UIBezierPath.FromRoundedRect(Bounds, 8.0f));
-				return base.FocusEffect;
+				base.FocusEffect = UIFocusHaloEffect.Create(UIBezierPath.FromRoundedRect(Bounds, 8.0f));
 			}
-			set => base.FocusEffect = value;
 		}
 
 		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -3,6 +3,8 @@ override Microsoft.Maui.Handlers.LabelHandler.GetDesiredSize(double widthConstra
 override Microsoft.Maui.Handlers.ProgressBarHandler.NeedsContainer.get -> bool
 override Microsoft.Maui.Handlers.ShapeViewHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Handlers.StepperHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+override Microsoft.Maui.Platform.MauiTextField.LayoutSubviews() -> void
+override Microsoft.Maui.Platform.NoCaretField.LayoutSubviews() -> void
 override Microsoft.Maui.Platform.MauiTextView.TextAlignment.get -> UIKit.UITextAlignment
 override Microsoft.Maui.Platform.MauiTextView.TextAlignment.set -> void
 override Microsoft.Maui.Platform.MauiView.DidUpdateFocus(UIKit.UIFocusUpdateContext! context, UIKit.UIFocusAnimationCoordinator! coordinator) -> void

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -11,5 +11,4 @@ static Microsoft.Maui.Handlers.EditorHandler.MapBackground(Microsoft.Maui.Handle
 static Microsoft.Maui.Handlers.EntryHandler.MapBackground(Microsoft.Maui.Handlers.IEntryHandler! handler, Microsoft.Maui.IEntry! entry) -> void
 static Microsoft.Maui.Handlers.DatePickerHandler.MapFlowDirection(Microsoft.Maui.Handlers.IDatePickerHandler! handler, Microsoft.Maui.IDatePicker! datePicker) -> void
 override Microsoft.Maui.Platform.MauiTextField.LayoutSubviews() -> void
-override Microsoft.Maui.Platform.MauiView.DidUpdateFocus(UIKit.UIFocusUpdateContext! context, UIKit.UIFocusAnimationCoordinator! coordinator) -> void
 override Microsoft.Maui.Platform.NoCaretField.LayoutSubviews() -> void

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -10,3 +10,6 @@ static Microsoft.Maui.Handlers.RadioButtonHandler.MapBackground(Microsoft.Maui.H
 static Microsoft.Maui.Handlers.EditorHandler.MapBackground(Microsoft.Maui.Handlers.IEditorHandler! handler, Microsoft.Maui.IEditor! editor) -> void
 static Microsoft.Maui.Handlers.EntryHandler.MapBackground(Microsoft.Maui.Handlers.IEntryHandler! handler, Microsoft.Maui.IEntry! entry) -> void
 static Microsoft.Maui.Handlers.DatePickerHandler.MapFlowDirection(Microsoft.Maui.Handlers.IDatePickerHandler! handler, Microsoft.Maui.IDatePicker! datePicker) -> void
+override Microsoft.Maui.Platform.MauiTextField.LayoutSubviews() -> void
+override Microsoft.Maui.Platform.MauiView.DidUpdateFocus(UIKit.UIFocusUpdateContext! context, UIKit.UIFocusAnimationCoordinator! coordinator) -> void
+override Microsoft.Maui.Platform.NoCaretField.LayoutSubviews() -> void

--- a/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.iOS.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
@@ -196,6 +197,57 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			var mauiPicker = GetNativePicker(pickerHandler);
 			return mauiPicker.AttributedText.GetCharacterSpacing();
+		}
+
+		[Fact(DisplayName = "RoundedRect Picker Focus Halo Uses RoundedRect Shape on MacCatalyst 26+")]
+		public async Task RoundedRectPickerFocusHaloUsesRoundedRectShapeOnMacCatalyst26()
+		{
+			if (!OperatingSystem.IsMacCatalystVersionAtLeast(26))
+				return;
+
+			var picker = new PickerStub
+			{
+				Title = "Select an Item"
+			};
+
+			var values = await GetValueAsync(picker, handler =>
+			{
+				handler.PlatformArrange(new Rect(0, 0, 220, 44));
+				var nativePicker = GetNativePicker(handler);
+				nativePicker.LayoutSubviews();
+
+				var focusEffect = nativePicker.FocusEffect;
+				var expectedRounded = UIFocusHaloEffect.Create(UIBezierPath.FromRoundedRect(nativePicker.Bounds, 5f));
+				var expectedCapsule = UIFocusHaloEffect.Create(UIBezierPath.FromRoundedRect(nativePicker.Bounds, nativePicker.Bounds.Height / 2));
+
+				var matchesExpectedRoundedShape = focusEffect?.IsEqual(expectedRounded) ?? false;
+				var matchesCapsuleShape = focusEffect?.IsEqual(expectedCapsule) ?? false;
+
+				nativePicker.BorderStyle = UITextBorderStyle.None;
+				nativePicker.LayoutSubviews();
+				var clearsWhenNotRoundedRect = nativePicker.FocusEffect is null;
+
+				nativePicker.BorderStyle = UITextBorderStyle.RoundedRect;
+				nativePicker.LayoutSubviews();
+				var restoresWhenRoundedRect = nativePicker.FocusEffect is not null;
+
+				return new
+				{
+					BorderStyle = nativePicker.BorderStyle,
+					HasFocusEffect = focusEffect is not null,
+					MatchesExpectedRoundedShape = matchesExpectedRoundedShape,
+					MatchesCapsuleShape = matchesCapsuleShape,
+					ClearsWhenNotRoundedRect = clearsWhenNotRoundedRect,
+					RestoresWhenRoundedRect = restoresWhenRoundedRect
+				};
+			});
+
+			Assert.Equal(UITextBorderStyle.RoundedRect, values.BorderStyle);
+			Assert.True(values.HasFocusEffect);
+			Assert.True(values.ClearsWhenNotRoundedRect);
+			Assert.True(values.RestoresWhenRoundedRect);
+			Assert.True(values.MatchesExpectedRoundedShape);
+			Assert.False(values.MatchesCapsuleShape);
 		}
 
 		MauiPicker GetNativePicker(PickerHandler pickerHandler) =>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details:

Entry/Picker focus outline is misaligned with the control border, border radius of focus outline is too large

### Root Cause:
On macOS (Liquid Glass), Apple changed UIKit so that a UITextField with BorderStyle = RoundedRect renders its keyboard focus ring as a fully rounded pill/capsule shape — instead of following the field's actual corner radius. This is the new
UIFocusHaloEffect behavior introduced in the Liquid Glass design language (WWDC 2025).
 
### Description of change: 
Overrode LayoutSubviews() in MauiTextField and NoCaretField to set a custom UIFocusHaloEffect whose path is a UIBezierPath.FromRoundedRect(Bounds, 5f). This matches UIKit's own RoundedRect corner radius so the halo aligns with the grey border.

### Validated the behaviour in the following platforms
- [ ] Android
- [ ] Windows
- [ ] iOS
- [x] Mac

### Fixes 
Fixes #34899 

### Screenshots
| Before  | After |
|---------|--------|
|  <video src="https://github.com/user-attachments/assets/5b76f345-0af2-4d35-84d6-855bac2d1a70"> |   <video src="https://github.com/user-attachments/assets/4d485a92-3bf0-48be-99c5-c351040ce373">  |
