### PR TITLE
[Windows] Fix Issue29529VerifyPreviousPositionOnInsert test failure on candidate branch

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
@@ -130,45 +130,76 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			// Use the nullable IViewHandler.VirtualView (not the typed property) for the null
 			// check. The typed VirtualView throws InvalidOperationException if base.VirtualView
 			// is null, which can happen if the handler was disconnected before this event fires.
-			if (((IViewHandler)this).VirtualView is null)
+			if (((IViewHandler)this).VirtualView is null || ListViewBase is null)
 				return;
 
-			if (sender is not ItemCollection items)
-				return;
+			var mode = VirtualView.ItemsUpdatingScrollMode;
 
-			ListViewBase.DispatcherQueue.TryEnqueue(() =>
+			if (mode != ItemsUpdatingScrollMode.KeepItemsInView && mode != ItemsUpdatingScrollMode.KeepLastItemInView)
 			{
-				// The lambda is dispatched asynchronously. By the time it runs, the handler may
-				// have been disconnected (e.g. by element.DisconnectHandlers() in
-				// CleanUpCollectionViewSource), setting base.VirtualView to null. The typed
-				// VirtualView property throws in that case, so use the nullable interface accessor
-				// here to safely bail out instead of crashing (issue #9075).
-				if (((IViewHandler)this).VirtualView is null || ListViewBase is null)
-				{
+				return;
+			}
+
+			// Reset notifications are unsafe to process because WinUI may still be rebuilding
+			// the internal projection. Accessing indexes during Reset can trigger
+			// E_CHANGED_STATE / COMException.
+			if (@event?.CollectionChange == global::Windows.Foundation.Collections.CollectionChange.Reset)
+			{
+				return;
+			}
+
+			// Grouped CollectionViews are backed by a flattened projection that may still be
+			// mutating while VectorChanged is firing. Accessing indexes synchronously can
+			// trigger STATUS_STOWED_EXCEPTION / E_CHANGED_STATE.
+			//
+			// Non-grouped views (e.g. CarouselView) should remain synchronous to avoid
+			// regressions where deferred scrolling changes the intended position.
+			bool shouldDefer = CollectionViewSource?.IsSourceGrouped == true;
+
+			if (shouldDefer)
+			{
+				var dispatcherQueue = PlatformView?.DispatcherQueue;
+
+				if (dispatcherQueue is null)
 					return;
-				}
 
-				var itemsCount = items.Count;
+				dispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Normal, ScrollIntoViewIfNeeded);
+			}
+			else
+			{
+				ScrollIntoViewIfNeeded();
+			}
+		}
 
-				if (itemsCount == 0)
-				{
-					return;
-				}
+		void ScrollIntoViewIfNeeded()
+		{
+			// Handler may have been disconnected before deferred execution runs
+			if (((IViewHandler)this).VirtualView is null || ListViewBase is null)
+				return;
 
-				if (VirtualView.ItemsUpdatingScrollMode == ItemsUpdatingScrollMode.KeepItemsInView)
-				{
-					var firstItem = items[0];
-					// Keeps the first item in the list displayed when new items are added.
-					ListViewBase.ScrollIntoView(firstItem);
-				}
+			var view = CollectionViewSource?.View;
+			var itemsCount = view?.Count ?? 0;
 
-				if (VirtualView.ItemsUpdatingScrollMode == ItemsUpdatingScrollMode.KeepLastItemInView)
-				{
-					var lastItem = items[itemsCount - 1];
-					// Adjusts the scroll offset to keep the last item in the list displayed when new items are added.
-					ListViewBase.ScrollIntoView(lastItem, ScrollIntoViewAlignment.Leading);
-				}
-			});
+			if (itemsCount == 0)
+			{
+				return;
+			}
+
+			// Re-read the mode here (rather than capturing it from the caller) so the
+			// deferred path picks up the latest value if it changed between enqueue and
+			// drain, and so this helper has no implicit dependency on caller state.
+			var mode = VirtualView.ItemsUpdatingScrollMode;
+
+			if (mode == ItemsUpdatingScrollMode.KeepItemsInView)
+			{
+				// Keeps the first item visible when items are inserted
+				ListViewBase.ScrollIntoView(view[0]);
+			}
+			else if (mode == ItemsUpdatingScrollMode.KeepLastItemInView)
+			{
+				// Keeps the last item visible when items are appended
+				ListViewBase.ScrollIntoView(view[itemsCount - 1], ScrollIntoViewAlignment.Leading);
+			}
 		}
 
 		protected abstract ListViewBase SelectListViewBase();


### PR DESCRIPTION
 <!-- Please let the below note in for people that find this PR -->
   > [!NOTE]
   > Are you waiting for the changes in this PR to be merged?
   > It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. 
  Thank you!
 
### Root Cause
On Windows, grouped CollectionView mutations rebuild WinUI’s internal flattened `ItemCollection` in stages while still raising `VectorChanged` synchronously mid-mutation. MAUI’s `OnItemsVectorChanged` handler calls `ScrollIntoView(...)` during this unstable state, re-entering WinUI while its projection is partially rebuilt, which triggers an uncatchable `STATUS_STOWED_EXCEPTION (0xc000027b)` surfaced as `COMException`.

PR #24867 avoided the crash by unconditionally deferring `ScrollIntoView` through `DispatcherQueue.TryEnqueue`, but this introduced a regression in CarouselView (#29529 ), where the deferred callback overwrote the correct initial `Position` with stale values and triggered incorrect `PositionChanged` / `CurrentItemChanged` cascades.
 
### Description of Change
The fix scopes the deferred `ScrollIntoView` path only to grouped CollectionView scenarios while preserving synchronous behavior for non-grouped controls like CarouselView.

`OnItemsVectorChanged` now performs lifecycle and mode validation checks, skips unstable `CollectionChange.Reset` events, and uses `CollectionViewSource.IsSourceGrouped` as the discriminator. Grouped sources defer `ScrollIntoViewIfNeeded()` through `DispatcherQueue.TryEnqueue` to avoid WinUI mid-mutation crashes, while non-grouped sources continue using the synchronous path to preserve existing CarouselView behavior and avoid reintroducing #29529 .

The shared `ScrollIntoViewIfNeeded()` helper revalidates lifecycle state, reads the latest projection from `CollectionViewSource.View`, and applies the appropriate scroll behavior for `KeepItemsInView` and `KeepLastItemInView` modes.

### Issues Fixed
Fixes `Issue29529VerifyPreviousPositionOnInsert` test failure on candidate branch  
 
Tested the behaviour in the following platforms
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac