### PR TITLE
[Testing]Revert 'Fix Preserve ScrollView offsets when Orientation changes to Neither'

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34583.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34583.cs
@@ -1,3 +1,4 @@
+#if TEST_FAILS_ON_WINDOWS // Issue link: https://github.com/dotnet/maui/issues/34671
 using System.Globalization;
 using NUnit.Framework;
 using UITest.Appium;
@@ -40,3 +41,4 @@ public class Issue34583 : _IssuesUITest
 		Assert.That(scrollY, Is.GreaterThan(0d), "ScrollY should remain non-zero after setting orientation to Neither.");
 	}
 }
+#endif

--- a/src/Core/src/Platform/Windows/ScrollViewerExtensions.cs
+++ b/src/Core/src/Platform/Windows/ScrollViewerExtensions.cs
@@ -20,20 +20,9 @@ namespace Microsoft.Maui.Platform
 		{
 			if (orientation == ScrollOrientation.Neither)
 			{
-				// Use Hidden (not Disabled) so WinUI keeps the current ContentOffset instead of
-				// resetting it to (0,0). ScrollMode.Disabled prevents further user scrolling while
-				// the orientation is Neither.
-				scrollViewer.HorizontalScrollBarVisibility = WScrollBarVisibility.Hidden;
-				scrollViewer.VerticalScrollBarVisibility = WScrollBarVisibility.Hidden;
-				scrollViewer.HorizontalScrollMode = ScrollMode.Disabled;
-				scrollViewer.VerticalScrollMode = ScrollMode.Disabled;
+				scrollViewer.HorizontalScrollBarVisibility = scrollViewer.VerticalScrollBarVisibility = WScrollBarVisibility.Disabled;
 				return;
 			}
-
-			// When leaving Neither, restore scroll modes to Auto so that they follow
-			// the ScrollBarVisibility settings applied below.
-			scrollViewer.HorizontalScrollMode = ScrollMode.Auto;
-			scrollViewer.VerticalScrollMode = ScrollMode.Auto;
 
 			if (visibility == ScrollBarVisibility.Default)
 			{


### PR DESCRIPTION
This pull request reverts the fix PR https://github.com/dotnet/maui/pull/34827 to fix the test failures on the Windows platform in the candidate PR https://github.com/dotnet/maui/pull/35234.

- Restricted the ScrollPositionIsPreservedWhenOrientationChangesToNeither test due to a bug issue https://github.com/dotnet/maui/issues/34671.

Test Case - VerifyScrollViewWithOrientationNeither

**Fixes:** https://github.com/dotnet/maui/pull/35234