### PR TITLE
[Android] [Candidate Fix] Shell: Fix handler disconnect timing to preserve WebView navigation and memory leak fix

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFragmentContainer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFragmentContainer.cs
@@ -35,9 +35,10 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		{
 			base.OnDestroyView();
 			((IShellContentController)ShellContentTab).RecyclePage(_page);
-			// Recursively disconnect handlers on the page and its child elements
-			// to prevent memory leaks when Shell items are cleared
-			_page?.DisconnectHandlers();
+			// Only disconnect when ShellContent is removed from the Shell hierarchy (e.g. Shell.Items.Clear()).
+			// During normal navigation the page is still cached and will be reused.
+			if (ShellContentTab?.FindParentOfType<Shell>() == null)
+				_page?.DisconnectHandlers();
 			_page = null;
 		}
 	}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Root Cause of the Regression
PR #35031 disconnected page handlers in OnDestroyView(). OnDestroyView() runs on normal navigation too. WebView handlers got disconnected too early. That broke WebViewDisposesProperly on Android.


### Description of Change
Keep logic in OnDestroyView(), but add a guard. Disconnect only if ShellContent is no longer under Shell. Normal navigation skips disconnect, so page reuse stays safe. Shell.Items.Clear() still disconnects handlers and avoids leaks.

 
### Issues Fixed
UI Test

Android:
WebViewDisposesProperly