### PR TITLE
[inflight/current] Fix CS0111 duplicate GetNativeCharacterSpacing in PickerHandlerTests.iOS

### DIFF
--- a/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.iOS.cs
@@ -244,12 +244,6 @@ namespace Microsoft.Maui.DeviceTests
 			return mauiPicker.TextColor;
 		}
 
-		double GetNativeCharacterSpacing(PickerHandler pickerHandler)
-		{
-			var mauiPicker = GetNativePicker(pickerHandler);
-			return mauiPicker.AttributedText.GetCharacterSpacing();
-		}
-
 		UIControlContentVerticalAlignment GetNativeVerticalTextAlignment(PickerHandler pickerHandler) =>
 			GetNativePicker(pickerHandler).VerticalAlignment;
 	}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause

- PRs #34957 and #34974 each independently added an identical GetNativeCharacterSpacing(PickerHandler) helper method to PickerHandlerTests.iOS.cs at different locations in the file, so when the two PRs were combined the changes merged without a textual conflict and left two identical method definitions inside the PickerHandlerTests class, which the C# compiler rejected with error CS0111 ("type already defines a member with the same parameter types").

### Description of Change
- Removed the duplicate GetNativeCharacterSpacing(PickerHandler) method from PickerHandlerTests.iOS.cs, keeping a single definition of the helper so the Core.DeviceTests project compiles cleanly.


### Output
| Before | After |
|----------|----------|
| <img src="https://github.com/user-attachments/assets/36b5a616-6567-4488-9cee-f456c13f8b60"> | <img src="https://github.com/user-attachments/assets/7f9d1c93-42e5-4d51-bd38-ac8e44fc1d55"> |