### PR TITLE
Fix VisualElement.ChangeVisualState() gets stuck in Selected state

### DIFF
--- a/src/Compatibility/Core/src/Android/CollectionView/TemplatedItemViewHolder.cs
+++ b/src/Compatibility/Core/src/Android/CollectionView/TemplatedItemViewHolder.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 				return;
 			}
 
-			View.SetSelectedState(IsSelected);
+			View.IsItemSelected = IsSelected;
 		}
 
 		public void Recycle(ItemsView itemsView)

--- a/src/Compatibility/Core/src/Android/CollectionView/TemplatedItemViewHolder.cs
+++ b/src/Compatibility/Core/src/Android/CollectionView/TemplatedItemViewHolder.cs
@@ -31,9 +31,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 				return;
 			}
 
-			VisualStateManager.GoToState(View, IsSelected
-				? VisualStateManager.CommonStates.Selected
-				: VisualStateManager.CommonStates.Normal);
+			View.SetSelectedState(IsSelected);
 		}
 
 		public void Recycle(ItemsView itemsView)

--- a/src/Compatibility/Core/src/Windows/CollectionView/ItemContentControl.cs
+++ b/src/Compatibility/Core/src/Windows/CollectionView/ItemContentControl.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			if (formsElement == null)
 				return;
 
-			formsElement.SetSelectedState(isSelected);
+			formsElement.IsItemSelected = isSelected;
 		}
 
 		void OnViewMeasureInvalidated(object sender, EventArgs e)

--- a/src/Compatibility/Core/src/Windows/CollectionView/ItemContentControl.cs
+++ b/src/Compatibility/Core/src/Windows/CollectionView/ItemContentControl.cs
@@ -187,9 +187,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			if (formsElement == null)
 				return;
 
-			VisualStateManager.GoToState(formsElement, isSelected
-				? VisualStateManager.CommonStates.Selected
-				: VisualStateManager.CommonStates.Normal);
+			formsElement.SetSelectedState(isSelected);
 		}
 
 		void OnViewMeasureInvalidated(object sender, EventArgs e)

--- a/src/Compatibility/Core/src/iOS/CollectionView/TemplatedCell.cs
+++ b/src/Compatibility/Core/src/iOS/CollectionView/TemplatedCell.cs
@@ -295,7 +295,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 
 			if (element != null)
 			{
-				element.SetSelectedState(Selected);
+				element.IsItemSelected = Selected;
 			}
 		}
 	}

--- a/src/Compatibility/Core/src/iOS/CollectionView/TemplatedCell.cs
+++ b/src/Compatibility/Core/src/iOS/CollectionView/TemplatedCell.cs
@@ -295,9 +295,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 
 			if (element != null)
 			{
-				VisualStateManager.GoToState(element, Selected
-					? VisualStateManager.CommonStates.Selected
-					: VisualStateManager.CommonStates.Normal);
+				element.SetSelectedState(Selected);
 			}
 		}
 	}

--- a/src/Compatibility/Core/src/iOS/Renderers/UIContainerCell.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/UIContainerCell.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 		{
 			if (BindingContext is BaseShellItem baseShellItem && baseShellItem != null)
 			{
-				View.SetSelectedState(baseShellItem.IsChecked);
+				View.IsItemSelected = baseShellItem.IsChecked;
 			}
 		}
 

--- a/src/Compatibility/Core/src/iOS/Renderers/UIContainerCell.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/UIContainerCell.cs
@@ -107,10 +107,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 		{
 			if (BindingContext is BaseShellItem baseShellItem && baseShellItem != null)
 			{
-				if (baseShellItem.IsChecked)
-					VisualStateManager.GoToState(View, "Selected");
-				else
-					VisualStateManager.GoToState(View, "Normal");
+				View.SetSelectedState(baseShellItem.IsChecked);
 			}
 		}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutRecyclerAdapter.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutRecyclerAdapter.cs
@@ -308,10 +308,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			{
 				if (Element is BaseShellItem baseShellItem && baseShellItem != null)
 				{
-					if (baseShellItem.IsChecked)
-						VisualStateManager.GoToState(View, "Selected");
-					else
-						VisualStateManager.GoToState(View, "Normal");
+					View.SetSelectedState(baseShellItem.IsChecked);
 				}
 			}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutRecyclerAdapter.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutRecyclerAdapter.cs
@@ -308,7 +308,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			{
 				if (Element is BaseShellItem baseShellItem && baseShellItem != null)
 				{
-					View.SetSelectedState(baseShellItem.IsChecked);
+					View.IsItemSelected = baseShellItem.IsChecked;
 				}
 			}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/UIContainerCell.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/UIContainerCell.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		{
 			if (BindingContext is BaseShellItem baseShellItem && baseShellItem != null)
 			{
-				View.SetSelectedState(baseShellItem.IsChecked);
+				View.IsItemSelected = baseShellItem.IsChecked;
 			}
 		}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/UIContainerCell.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/UIContainerCell.cs
@@ -131,10 +131,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		{
 			if (BindingContext is BaseShellItem baseShellItem && baseShellItem != null)
 			{
-				if (baseShellItem.IsChecked)
-					VisualStateManager.GoToState(View, "Selected");
-				else
-					VisualStateManager.GoToState(View, "Normal");
+				View.SetSelectedState(baseShellItem.IsChecked);
 			}
 		}
 

--- a/src/Controls/src/Core/Handlers/Items/Android/TemplatedItemViewHolder.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/TemplatedItemViewHolder.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				return;
 			}
 
-			View.SetSelectedState(IsSelected);
+			View.IsItemSelected = IsSelected;
 		}
 
 		public void Recycle(ItemsView itemsView)

--- a/src/Controls/src/Core/Handlers/Items/Android/TemplatedItemViewHolder.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/TemplatedItemViewHolder.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				return;
 			}
 
+			View.IsItemSelected = IsSelected;
 			VisualStateManager.GoToState(View, IsSelected
 				? VisualStateManager.CommonStates.Selected
 				: VisualStateManager.CommonStates.Normal);

--- a/src/Controls/src/Core/Handlers/Items/Android/TemplatedItemViewHolder.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/TemplatedItemViewHolder.cs
@@ -29,10 +29,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				return;
 			}
 
-			View.IsItemSelected = IsSelected;
-			VisualStateManager.GoToState(View, IsSelected
-				? VisualStateManager.CommonStates.Selected
-				: VisualStateManager.CommonStates.Normal);
+			View.SetSelectedState(IsSelected);
 		}
 
 		public void Recycle(ItemsView itemsView)

--- a/src/Controls/src/Core/Handlers/Items/Tizen/ItemTemplateAdaptor.cs
+++ b/src/Controls/src/Core/Handlers/Items/Tizen/ItemTemplateAdaptor.cs
@@ -80,12 +80,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 						formsView.SetValue(VisualElement.IsFocusedPropertyKey, true);
 						break;
 					case ViewHolderState.Normal:
-						formsView.SetSelectedState(false);
+						formsView.IsItemSelected = false;
 						formsView.SetValue(VisualElement.IsFocusedPropertyKey, false);
 						break;
 					case ViewHolderState.Selected:
 						if (IsSelectable)
-							formsView.SetSelectedState(true);
+							formsView.IsItemSelected = true;
 						break;
 				}
 			}

--- a/src/Controls/src/Core/Handlers/Items/Tizen/ItemTemplateAdaptor.cs
+++ b/src/Controls/src/Core/Handlers/Items/Tizen/ItemTemplateAdaptor.cs
@@ -80,12 +80,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 						formsView.SetValue(VisualElement.IsFocusedPropertyKey, true);
 						break;
 					case ViewHolderState.Normal:
-						VisualStateManager.GoToState(formsView, VisualStateManager.CommonStates.Normal);
+						formsView.SetSelectedState(false);
 						formsView.SetValue(VisualElement.IsFocusedPropertyKey, false);
 						break;
 					case ViewHolderState.Selected:
 						if (IsSelectable)
-							VisualStateManager.GoToState(formsView, VisualStateManager.CommonStates.Selected);
+							formsView.SetSelectedState(true);
 						break;
 				}
 			}

--- a/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
@@ -342,6 +342,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			if (PlatformHandler?.VirtualView is VisualElement element)
 			{
+				element.IsItemSelected = Selected;
 				VisualStateManager.GoToState(element, Selected
 					? VisualStateManager.CommonStates.Selected
 					: VisualStateManager.CommonStates.Normal);

--- a/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
@@ -342,10 +342,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			if (PlatformHandler?.VirtualView is VisualElement element)
 			{
-				element.IsItemSelected = Selected;
-				VisualStateManager.GoToState(element, Selected
-					? VisualStateManager.CommonStates.Selected
-					: VisualStateManager.CommonStates.Normal);
+				element.SetSelectedState(Selected);
 			}
 		}
 

--- a/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
@@ -342,7 +342,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			if (PlatformHandler?.VirtualView is VisualElement element)
 			{
-				element.SetSelectedState(Selected);
+				element.IsItemSelected = Selected;
 			}
 		}
 

--- a/src/Controls/src/Core/Handlers/Items2/iOS/TemplatedCell2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/TemplatedCell2.cs
@@ -369,6 +369,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		{
 			if (PlatformHandler?.VirtualView is VisualElement element)
 			{
+				element.IsItemSelected = Selected;
 				VisualStateManager.GoToState(element, Selected
 					? VisualStateManager.CommonStates.Selected
 					: VisualStateManager.CommonStates.Normal);

--- a/src/Controls/src/Core/Handlers/Items2/iOS/TemplatedCell2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/TemplatedCell2.cs
@@ -369,7 +369,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		{
 			if (PlatformHandler?.VirtualView is VisualElement element)
 			{
-				element.SetSelectedState(Selected);
+				element.IsItemSelected = Selected;
 			}
 		}
 

--- a/src/Controls/src/Core/Handlers/Items2/iOS/TemplatedCell2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/TemplatedCell2.cs
@@ -267,7 +267,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 				virtualView.BindingContext = bindingContext;
 				itemsView.AddLogicalChild(virtualView);
-				
+
 				if (this.Selected)
 				{
 					UpdateVisualStates();
@@ -369,10 +369,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		{
 			if (PlatformHandler?.VirtualView is VisualElement element)
 			{
-				element.IsItemSelected = Selected;
-				VisualStateManager.GoToState(element, Selected
-					? VisualStateManager.CommonStates.Selected
-					: VisualStateManager.CommonStates.Normal);
+				element.SetSelectedState(Selected);
 			}
 		}
 

--- a/src/Controls/src/Core/Handlers/Shell/Windows/ShellFlyoutItemView.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ShellFlyoutItemView.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			if (_content?.BindingContext is BaseShellItem baseShellItem && baseShellItem != null)
 			{
-				_content.SetSelectedState(baseShellItem.IsChecked);
+				_content.IsItemSelected = baseShellItem.IsChecked;
 			}
 		}
 

--- a/src/Controls/src/Core/Handlers/Shell/Windows/ShellFlyoutItemView.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ShellFlyoutItemView.cs
@@ -141,10 +141,7 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			if (_content?.BindingContext is BaseShellItem baseShellItem && baseShellItem != null)
 			{
-				if (baseShellItem.IsChecked)
-					VisualStateManager.GoToState(_content, "Selected");
-				else
-					VisualStateManager.GoToState(_content, "Normal");
+				_content.SetSelectedState(baseShellItem.IsChecked);
 			}
 		}
 

--- a/src/Controls/src/Core/IndicatorView/IndicatorStackLayout.cs
+++ b/src/Controls/src/Core/IndicatorView/IndicatorStackLayout.cs
@@ -135,9 +135,7 @@ namespace Microsoft.Maui.Controls
 					: GetColorOrDefault(_indicatorView.IndicatorColor, Colors.Silver);
 
 
-				VisualStateManager.GoToState(visualElement, isSelected
-					? VisualStateManager.CommonStates.Selected
-					: VisualStateManager.CommonStates.Normal);
+				visualElement.SetSelectedState(isSelected);
 
 			}
 

--- a/src/Controls/src/Core/IndicatorView/IndicatorStackLayout.cs
+++ b/src/Controls/src/Core/IndicatorView/IndicatorStackLayout.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Maui.Controls
 					: GetColorOrDefault(_indicatorView.IndicatorColor, Colors.Silver);
 
 
-				visualElement.SetSelectedState(isSelected);
+				visualElement.IsItemSelected = isSelected;
 
 			}
 

--- a/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
@@ -261,6 +261,7 @@ namespace Microsoft.Maui.Controls.Platform
 			if (formsElement == null)
 				return;
 
+			formsElement.IsItemSelected = isSelected;
 			VisualStateManager.GoToState(formsElement, isSelected
 				? VisualStateManager.CommonStates.Selected
 				: VisualStateManager.CommonStates.Normal);

--- a/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
@@ -261,7 +261,7 @@ namespace Microsoft.Maui.Controls.Platform
 			if (formsElement == null)
 				return;
 
-			formsElement.SetSelectedState(isSelected);
+			formsElement.IsItemSelected = isSelected;
 		}
 
 		void OnViewMeasureInvalidated(object sender, EventArgs e)

--- a/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
@@ -261,10 +261,7 @@ namespace Microsoft.Maui.Controls.Platform
 			if (formsElement == null)
 				return;
 
-			formsElement.IsItemSelected = isSelected;
-			VisualStateManager.GoToState(formsElement, isSelected
-				? VisualStateManager.CommonStates.Selected
-				: VisualStateManager.CommonStates.Normal);
+			formsElement.SetSelectedState(isSelected);
 		}
 
 		void OnViewMeasureInvalidated(object sender, EventArgs e)

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -1656,33 +1656,23 @@ namespace Microsoft.Maui.Controls
 		bool _isItemSelected;
 
 		/// <summary>
-		/// Tracks whether this element has been explicitly put in the Selected visual state
-		/// by platform handlers (e.g., CollectionView, Shell flyout). This provides a non-circular
-		/// source of truth for ChangeVisualState() to preserve the Selected state during
-		/// pointer and focus transitions.
+		/// Gets or sets whether this element is in the Selected visual state.
+		/// Platform handlers (CollectionView, Shell flyout, IndicatorView) use this property
+		/// to select/deselect items. The setter includes an equality guard to avoid redundant
+		/// state recomputation and routes through <see cref="ChangeVisualState"/> so that
+		/// IsEnabled and other state priorities (Disabled, PointerOver, Normal) are respected.
 		/// </summary>
 		internal bool IsItemSelected
 		{
 			get => _isItemSelected;
-			set => _isItemSelected = value;
-		}
+			set
+			{
+				if (_isItemSelected == value)
+				{
+					return;
+				}
 
-		/// <summary>
-		/// Sets the selected state flag and transitions the visual state accordingly.
-		/// All platform code that selects/deselects items should use this single entry point
-		/// so that IsItemSelected and the VSM state are always kept in sync.
-		/// </summary>
-		internal void SetSelectedState(bool isSelected)
-		{
-			_isItemSelected = isSelected;
-			if (isSelected)
-			{
-				VisualStateManager.GoToState(this, VisualStateManager.CommonStates.Selected);
-			}
-			else
-			{
-				// Re-evaluate the full state chain so that PointerOver, Disabled, etc.
-				// are correctly applied instead of blindly going to Normal.
+				_isItemSelected = value;
 				ChangeVisualState();
 			}
 		}

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -1653,6 +1653,19 @@ namespace Microsoft.Maui.Controls
 		internal void ChangeVisualStateInternal() => ChangeVisualState();
 
 		bool _isPointerOver;
+		bool _isItemSelected;
+
+		/// <summary>
+		/// Tracks whether this element has been explicitly put in the Selected visual state
+		/// by platform handlers (e.g., CollectionView, Shell flyout). This provides a non-circular
+		/// source of truth for ChangeVisualState() to preserve the Selected state during
+		/// pointer and focus transitions.
+		/// </summary>
+		internal bool IsItemSelected
+		{
+			get => _isItemSelected;
+			set => _isItemSelected = value;
+		}
 
 		internal bool IsPointerOver
 		{
@@ -1665,8 +1678,10 @@ namespace Microsoft.Maui.Controls
 				return;
 
 			_isPointerOver = value;
-			if (callChangeVisualState)
+			if (callChangeVisualState && !_isItemSelected)
+			{
 				ChangeVisualState();
+			}
 		}
 
 		/// <summary>

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -1667,6 +1667,26 @@ namespace Microsoft.Maui.Controls
 			set => _isItemSelected = value;
 		}
 
+		/// <summary>
+		/// Sets the selected state flag and transitions the visual state accordingly.
+		/// All platform code that selects/deselects items should use this single entry point
+		/// so that IsItemSelected and the VSM state are always kept in sync.
+		/// </summary>
+		internal void SetSelectedState(bool isSelected)
+		{
+			_isItemSelected = isSelected;
+			if (isSelected)
+			{
+				VisualStateManager.GoToState(this, VisualStateManager.CommonStates.Selected);
+			}
+			else
+			{
+				// Re-evaluate the full state chain so that PointerOver, Disabled, etc.
+				// are correctly applied instead of blindly going to Normal.
+				ChangeVisualState();
+			}
+		}
+
 		internal bool IsPointerOver
 		{
 			get { return _isPointerOver; }
@@ -1678,10 +1698,8 @@ namespace Microsoft.Maui.Controls
 				return;
 
 			_isPointerOver = value;
-			if (callChangeVisualState && !_isItemSelected)
-			{
+			if (callChangeVisualState)
 				ChangeVisualState();
-			}
 		}
 
 		/// <summary>

--- a/src/Controls/src/Core/VisualStateManager.cs
+++ b/src/Controls/src/Core/VisualStateManager.cs
@@ -816,16 +816,7 @@ namespace Microsoft.Maui.Controls
 
 		internal static bool IsElementInSelectedState(this VisualElement element)
 		{
-			var groups = VisualStateManager.GetVisualStateGroups(element);
-			foreach (var group in groups)
-			{
-				if (group.CurrentState?.Name == VisualStateManager.CommonStates.Selected)
-				{
-					return true;
-				}
-			}
-
-			return false;
+			return element.IsItemSelected;
 		}
 	}
 

--- a/src/Controls/tests/Core.UnitTests/VisualStateManagerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualStateManagerTests.cs
@@ -656,7 +656,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			VisualStateManager.SetVisualStateGroups(element, groups);
 
 			// 1. Select the item (simulates CollectionView selection)
-			element.SetSelectedState(true);
+			element.IsItemSelected = true;
 			Assert.Equal(VisualStateManager.CommonStates.Selected, groups[0].CurrentState.Name);
 
 			// 2. Simulate pointer hover while selected — Selected takes priority
@@ -665,7 +665,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal(VisualStateManager.CommonStates.Selected, groups[0].CurrentState.Name);
 
 			// 3. Deselect while pointer is still hovering — should restore to PointerOver
-			element.SetSelectedState(false);
+			element.IsItemSelected = false;
 			Assert.Equal(VisualStateManager.CommonStates.PointerOver, groups[0].CurrentState.Name);
 		}
 
@@ -678,7 +678,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			VisualStateManager.SetVisualStateGroups(element, groups);
 
 			// Select the item (simulates Shell flyout item selection)
-			element.SetSelectedState(true);
+			element.IsItemSelected = true;
 			Assert.Equal(VisualStateManager.CommonStates.Selected, groups[0].CurrentState.Name);
 
 			// Pointer enters — Selected should be preserved
@@ -701,7 +701,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			VisualStateManager.SetVisualStateGroups(element, groups);
 
 			// Select the item
-			element.SetSelectedState(true);
+			element.IsItemSelected = true;
 			Assert.Equal(VisualStateManager.CommonStates.Selected, groups[0].CurrentState.Name);
 
 			// Disable — should go to Disabled
@@ -712,6 +712,48 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			// Re-enable — should restore to Selected since IsItemSelected is still true
 			element.IsEnabled = true;
 			Assert.Equal(VisualStateManager.CommonStates.Selected, groups[0].CurrentState.Name);
+		}
+
+		[Fact]
+		// https://github.com/dotnet/maui/issues/35399
+		public void SelectingWhileDisabledStaysDisabledUntilReEnabled()
+		{
+			var element = new Label();
+			var groups = CreateStateGroupsWithSelectedAndPointerOver();
+			VisualStateManager.SetVisualStateGroups(element, groups);
+
+			// Disable first
+			element.IsEnabled = false;
+			Assert.Equal(DisabledStateName, groups[0].CurrentState.Name);
+
+			// Select while disabled — visual state should remain Disabled
+			element.IsItemSelected = true;
+			Assert.Equal(DisabledStateName, groups[0].CurrentState.Name);
+
+			// Re-enable — now it should go to Selected
+			element.IsEnabled = true;
+			Assert.Equal(VisualStateManager.CommonStates.Selected, groups[0].CurrentState.Name);
+		}
+
+		[Fact]
+		// https://github.com/dotnet/maui/issues/35399
+		public void AssigningSameIsItemSelectedValueIsNoOp()
+		{
+			var element = new Label();
+			var groups = CreateStateGroupsWithSelectedAndPointerOver();
+			VisualStateManager.SetVisualStateGroups(element, groups);
+
+			// Select the item
+			element.IsItemSelected = true;
+			Assert.Equal(VisualStateManager.CommonStates.Selected, groups[0].CurrentState.Name);
+
+			// Manually set to Normal to detect if ChangeVisualState fires again
+			VisualStateManager.GoToState(element, VisualStateManager.CommonStates.Normal);
+			Assert.Equal(VisualStateManager.CommonStates.Normal, groups[0].CurrentState.Name);
+
+			// Assign same value — should be a no-op (equality guard)
+			element.IsItemSelected = true;
+			Assert.Equal(VisualStateManager.CommonStates.Normal, groups[0].CurrentState.Name);
 		}
 
 		static VisualStateGroupList CreateStateGroupsWithSelectedAndPointerOver()

--- a/src/Controls/tests/Core.UnitTests/VisualStateManagerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualStateManagerTests.cs
@@ -646,5 +646,96 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			VisualStateManager.GoToState(button, customStateName);
 			Assert.Equal(localColor, button.BackgroundColor);
 		}
+
+		[Fact]
+		// https://github.com/dotnet/maui/issues/35399
+		public void SelectHoverDeselectRestoresPointerOverState()
+		{
+			var element = new Label();
+			var groups = CreateStateGroupsWithSelectedAndPointerOver();
+			VisualStateManager.SetVisualStateGroups(element, groups);
+
+			// 1. Select the item (simulates CollectionView selection)
+			element.SetSelectedState(true);
+			Assert.Equal(VisualStateManager.CommonStates.Selected, groups[0].CurrentState.Name);
+
+			// 2. Simulate pointer hover while selected — Selected takes priority
+			SetIsPointerOver(element, true);
+			element.ChangeVisualState();
+			Assert.Equal(VisualStateManager.CommonStates.Selected, groups[0].CurrentState.Name);
+
+			// 3. Deselect while pointer is still hovering — should restore to PointerOver
+			element.SetSelectedState(false);
+			Assert.Equal(VisualStateManager.CommonStates.PointerOver, groups[0].CurrentState.Name);
+		}
+
+		[Fact]
+		// https://github.com/dotnet/maui/issues/35399
+		public void SelectedStatePreservedAcrossMouseHover()
+		{
+			var element = new Label();
+			var groups = CreateStateGroupsWithSelectedAndPointerOver();
+			VisualStateManager.SetVisualStateGroups(element, groups);
+
+			// Select the item (simulates Shell flyout item selection)
+			element.SetSelectedState(true);
+			Assert.Equal(VisualStateManager.CommonStates.Selected, groups[0].CurrentState.Name);
+
+			// Pointer enters — Selected should be preserved
+			SetIsPointerOver(element, true);
+			element.ChangeVisualState();
+			Assert.Equal(VisualStateManager.CommonStates.Selected, groups[0].CurrentState.Name);
+
+			// Pointer exits — Selected should still be preserved
+			SetIsPointerOver(element, false);
+			element.ChangeVisualState();
+			Assert.Equal(VisualStateManager.CommonStates.Selected, groups[0].CurrentState.Name);
+		}
+
+		[Fact]
+		// https://github.com/dotnet/maui/issues/35399
+		public void IsEnabledToggleWhileSelectedPreservesState()
+		{
+			var element = new Label();
+			var groups = CreateStateGroupsWithSelectedAndPointerOver();
+			VisualStateManager.SetVisualStateGroups(element, groups);
+
+			// Select the item
+			element.SetSelectedState(true);
+			Assert.Equal(VisualStateManager.CommonStates.Selected, groups[0].CurrentState.Name);
+
+			// Disable — should go to Disabled
+			element.IsEnabled = false;
+			Assert.Equal(DisabledStateName, groups[0].CurrentState.Name);
+			Assert.True(element.IsItemSelected); // selection flag preserved
+
+			// Re-enable — should restore to Selected since IsItemSelected is still true
+			element.IsEnabled = true;
+			Assert.Equal(VisualStateManager.CommonStates.Selected, groups[0].CurrentState.Name);
+		}
+
+		static VisualStateGroupList CreateStateGroupsWithSelectedAndPointerOver()
+		{
+			return new VisualStateGroupList
+			{
+				new VisualStateGroup
+				{
+					Name = CommonStatesGroupName,
+					States =
+					{
+						new VisualState { Name = NormalStateName },
+						new VisualState { Name = VisualStateManager.CommonStates.Selected },
+						new VisualState { Name = VisualStateManager.CommonStates.PointerOver },
+						new VisualState { Name = DisabledStateName },
+					}
+				}
+			};
+		}
+
+		static void SetIsPointerOver(VisualElement element, bool value)
+		{
+			var field = typeof(VisualElement).GetField("_isPointerOver", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+			field!.SetValue(element, value);
+		}
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/FeatureMatrix/VisualStateManager/VSMCollectionViewPage/VisualStateManagerCollectionViewPage.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/FeatureMatrix/VisualStateManager/VSMCollectionViewPage/VisualStateManagerCollectionViewPage.xaml.cs
@@ -73,7 +73,7 @@ public partial class VisualStateManagerCollectionViewPage : ContentPage
 		if (sender is VisualElement ve)
 		{
 			var bc = ve.BindingContext;
-			var isSelected = IsItemSelected(bc);
+			var isSelected = IsItemCurrentlySelected(bc);
 			VisualStateManager.GoToState(ve, isSelected ? "Selected" : "Normal");
 			CVState.Text = GetSelectedCount() > 0 ? $"State: Selected ({GetSelectedCount()})" : "State: Normal";
 		}
@@ -86,7 +86,7 @@ public partial class VisualStateManagerCollectionViewPage : ContentPage
 		return MyCollectionView.SelectedItem != null ? 1 : 0;
 	}
 
-	bool IsItemSelected(object item)
+	bool IsItemCurrentlySelected(object item)
 	{
 		if (item is null)
 			return false;
@@ -123,7 +123,7 @@ public partial class VisualStateManagerCollectionViewPage : ContentPage
 
 	void OnSetNormal(object sender, EventArgs e)
 	{
-		if(!MyCollectionView.IsEnabled)
+		if (!MyCollectionView.IsEnabled)
 		{
 			CVState.Text = "State: Disabled";
 			return;

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue35399.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue35399.cs
@@ -1,0 +1,129 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 35399, "VisualElement.ChangeVisualState() gets stuck in Selected state", PlatformAffected.All)]
+public class Issue35399 : TestContentPage
+{
+	const string SelectButtonId = "SelectButton";
+	const string DeselectButtonId = "DeselectButton";
+	const string StateLabelId = "StateLabel";
+
+	SelectableBox _box = null!;
+	Label _stateLabel = null!;
+
+	protected override void Init()
+	{
+		_stateLabel = new Label
+		{
+			AutomationId = StateLabelId,
+			HorizontalOptions = LayoutOptions.Center,
+			FontSize = 14
+		};
+
+		_box = new SelectableBox
+		{
+			HeightRequest = 100,
+			WidthRequest = 200,
+			HorizontalOptions = LayoutOptions.Center
+		};
+
+		Content = new VerticalStackLayout
+		{
+			Padding = 24,
+			Spacing = 16,
+			Children =
+			{
+				_box,
+				_stateLabel,
+				new HorizontalStackLayout
+				{
+					HorizontalOptions = LayoutOptions.Center,
+					Spacing = 12,
+					Children =
+					{
+						new Button { Text = "Select", AutomationId = SelectButtonId, Command = new Command(OnSelect) },
+						new Button { Text = "Deselect", AutomationId = DeselectButtonId, Command = new Command(OnDeselect) }
+					}
+				}
+			}
+		};
+	}
+
+	void OnSelect()
+	{
+		_box.IsSelected = true;
+		UpdateStateLabel();
+	}
+
+	void OnDeselect()
+	{
+		_box.IsSelected = false;
+		UpdateStateLabel();
+	}
+
+	void UpdateStateLabel()
+	{
+		var groups = VisualStateManager.GetVisualStateGroups(_box);
+		_stateLabel.Text = groups.Count > 0 ? (groups[0].CurrentState?.Name ?? "None") : "None";
+	}
+
+	// Reproduces the ChangeVisualState() pattern from the issue report:
+	// when IsSelected goes false, base.ChangeVisualState() is called while the VSM
+	// group's CurrentState is still "Selected", causing the base to re-apply it.
+	class SelectableBox : ContentView
+	{
+		public static readonly BindableProperty IsSelectedProperty =
+			BindableProperty.Create(
+				nameof(IsSelected),
+				typeof(bool),
+				typeof(SelectableBox),
+				defaultValue: false,
+				propertyChanged: (b, _, _) => ((SelectableBox)b).ChangeVisualState());
+
+		public bool IsSelected
+		{
+			get => (bool)GetValue(IsSelectedProperty);
+			set => SetValue(IsSelectedProperty, value);
+		}
+
+		public SelectableBox()
+		{
+			VisualStateManager.SetVisualStateGroups(this, new VisualStateGroupList
+			{
+				new VisualStateGroup
+				{
+					Name = "CommonStates",
+					States =
+					{
+						new VisualState
+						{
+							Name = VisualStateManager.CommonStates.Normal,
+							Setters = { new Setter { Property = BackgroundColorProperty, Value = Colors.LightGray } }
+						},
+						new VisualState
+						{
+							Name = VisualStateManager.CommonStates.Selected,
+							Setters = { new Setter { Property = BackgroundColorProperty, Value = Colors.MediumSeaGreen } }
+						},
+						new VisualState
+						{
+							Name = VisualStateManager.CommonStates.Disabled,
+							Setters = { new Setter { Property = BackgroundColorProperty, Value = Colors.DarkGray } }
+						}
+					}
+				}
+			});
+		}
+
+		protected internal override void ChangeVisualState()
+		{
+			if (IsSelected && IsEnabled)
+			{
+				VisualStateManager.GoToState(this, VisualStateManager.CommonStates.Selected);
+			}
+			else
+			{
+				base.ChangeVisualState();
+			}
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35399.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35399.cs
@@ -1,0 +1,38 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue35399 : _IssuesUITest
+{
+	public Issue35399(TestDevice device) : base(device) { }
+
+	public override string Issue => "VisualElement.ChangeVisualState() gets stuck in Selected state";
+
+	[Test]
+	[Category(UITestCategories.VisualStateManager)]
+	public void ChangeVisualStateShouldExitSelectedStateAfterDeselect()
+	{
+		App.WaitForElement(SelectButtonId);
+
+		// Transition to Selected state
+		App.Tap(SelectButtonId);
+		var stateAfterSelect = App.FindElement(StateLabelId).GetText();
+		Assert.That(stateAfterSelect, Is.EqualTo("Selected"),
+			"After selecting, the element should be in the Selected visual state.");
+
+		// Deselect: base.ChangeVisualState() should transition back to Normal.
+		// Regression: on .NET 10, IsElementInSelectedState() still reads "Selected" from
+		// the VSM group's CurrentState, causing base to re-apply Selected even though
+		// IsSelected is now false.
+		App.Tap(DeselectButtonId);
+		var stateAfterDeselect = App.FindElement(StateLabelId).GetText();
+		Assert.That(stateAfterDeselect, Is.EqualTo("Normal"),
+			"After deselecting, base.ChangeVisualState() must transition the element to Normal, not remain stuck in Selected.");
+	}
+
+	const string SelectButtonId = "SelectButton";
+	const string DeselectButtonId = "DeselectButton";
+	const string StateLabelId = "StateLabel";
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details:
When a custom control overrides ChangeVisualState() and applies the Selected state manually, calling base.ChangeVisualState()after the control is deselected causes the element to remain permanently stuck in the Selected visual state.

### Root Cause:
In .NET 10.0.60, a fix for #29815 modified ChangeVisualState() to check whether the element is currently in the "Selected" VSM state before transitioning to PointerOver or Normal. This check was implemented by reading VisualStateGroup.CurrentState?.Name via IsElementInSelectedState() — creating a circular dependency.

During a deselect, CurrentState is still "Selected" (it hasn't been cleared yet when ChangeVisualState() calls IsElementInSelectedState()). So isSelected = true → "Selected" is re-applied → element is stuck.


### Description of change:

- VisualElement.IsItemSelected (internal property) — has an equality guard to avoid redundant recomputation and routes through ChangeVisualState() so that state priorities (Disabled > Selected > PointerOver > Normal) are always respected.
- VisualStateManager.IsElementInSelectedState() — now simply returns element.IsItemSelected instead of reading CurrentState.

### Validated the behaviour in the following platforms
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Fixes
Fixes #35399 

### Screenshots
| Before  | After |
|---------|--------|
|  <video src="https://github.com/user-attachments/assets/0fe16315-5561-4b08-92bc-094b673579a9"> |   <video src="https://github.com/user-attachments/assets/52a0bc40-04f3-4e1f-b314-9726ae883f08">  |