### PR TITLE
Fix /review trigger when comment has leading whitespace

### DIFF
--- a/.github/workflows/review-trigger.yml
+++ b/.github/workflows/review-trigger.yml
@@ -27,14 +27,38 @@ on:
         default: 'main'
 
 jobs:
+  # Coarse pre-filter that decides whether the comment is a /review command.
+  # Doing this in a tiny job (rather than only in the trigger-review job-level `if`)
+  # lets us match the command robustly with a bash regex — GitHub expression syntax
+  # has no trim/regex, so it can't reliably handle leading whitespace, tabs, or
+  # newlines that may precede the slash command (e.g. when users paste it).
+  match:
+    if: github.event_name == 'workflow_dispatch' || github.event.issue.pull_request
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      matched: ${{ steps.check.outputs.matched }}
+    steps:
+      - name: Match /review command
+        id: check
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "matched=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Match `/review` as the first non-whitespace token, optionally followed by args.
+          # Allows arbitrary leading whitespace (spaces, tabs, newlines).
+          if [[ "${COMMENT_BODY}" =~ ^[[:space:]]*/review([[:space:]]|$) ]]; then
+            echo "matched=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "matched=false" >> "$GITHUB_OUTPUT"
+          fi
+
   trigger-review:
-    # For issue_comment: only run on PR comments that are exactly '/review' or start with '/review '
-    # For workflow_dispatch: always run
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.issue.pull_request &&
-       (github.event.comment.body == '/review' ||
-        startsWith(github.event.comment.body, '/review ')))
+    needs: match
+    if: needs.match.outputs.matched == 'true'
     runs-on: ubuntu-latest
     concurrency:
       group: review-trigger-${{ github.event.issue.number || inputs.pr_number }}
@@ -76,8 +100,11 @@ jobs:
             PIPELINE_REF="${INPUT_PIPELINE_REF:-main}"
           else
             PR_NUMBER="${{ github.event.issue.number }}"
-            # Strip the '/review' prefix and parse remaining args
-            ARGS=$(echo "${COMMENT_BODY}" | sed -n 's|^/review[[:space:]]*||p' | tr -s ' ')
+            # Trim any leading whitespace (spaces/tabs/newlines) the user may have
+            # accidentally typed before the slash command, then strip the '/review'
+            # prefix and parse remaining args.
+            TRIMMED_BODY=$(printf '%s' "${COMMENT_BODY}" | sed -e 's/^[[:space:]]*//')
+            ARGS=$(echo "${TRIMMED_BODY}" | sed -n 's|^/review[[:space:]]*||p' | tr -s ' ')
             PLATFORM=""
             PIPELINE_REF="main"
             # Parse args: positional platform, --branch <ref>, --platform <name>


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Problem

The `/review` slash command in `.github/workflows/review-trigger.yml` is silently skipped when the comment body has any **leading whitespace** before `/review`.

Concrete example:
- Comment posted on #35432: https://github.com/dotnet/maui/pull/35432#issuecomment-4444995859
- Body (raw bytes): `' /review -b feature/regression-check'` — note the leading space (`0x20`).
- Result: workflow run https://github.com/dotnet/maui/actions/runs/25824871590 → **skipped**.

### Root cause

The job-level guard was:

```yaml
if: >-
  github.event_name == 'workflow_dispatch' ||
  (github.event.issue.pull_request &&
   (github.event.comment.body == '/review' ||
    startsWith(github.event.comment.body, '/review ')))
```

`startsWith(' /review ...', '/review ')` returns `false`, so the job is skipped. GitHub expression syntax has no `trim` or regex, so we can't fix this purely at the expression level. The `Parse parameters` step had the same blind spot — `sed -n 's|^/review[[:space:]]*||p'` produces empty `ARGS` if the body doesn't start with `/review`.

### Fix

1. **New tiny `match` pre-filter job** that uses a bash regex (`^[[:space:]]*/review([[:space:]]|$)`) to decide whether the comment is a `/review` command. It allows arbitrary leading whitespace (spaces, tabs, newlines) but still requires `/review` to be a standalone token (won't match `/reviewfoo` or comments that merely mention `/review` mid-sentence).
2. **`trigger-review` now `needs: match`** and gates on its output, keeping the rest of the job structure intact.
3. **Trim leading whitespace before `sed`** in `Parse parameters`, so flag/positional parsing works on prefixed comments like ` /review -b feature/foo`.

### Verification

Local check of the regex against representative inputs:

| Body                                | Should match | Matches |
|-------------------------------------|--------------|---------|
| `/review`                           | yes          | yes     |
| `/review android`                   | yes          | yes     |
| ` /review -b feature/regression-check` (the failing case) | yes | yes |
| `\t/review`                         | yes          | yes     |
| `   /review -p ios`                 | yes          | yes     |
| `/reviewfoo`                        | no           | no      |
| `please /review this`               | no           | no      |
| `not a command`                     | no           | no      |

The full end-to-end behavior will be exercised by the next `/review` invocation on a PR that targets this branch.
