### PR TITLE
[iOS, Mac] Fix Item spacing not properly applied between items in Horizontal LinearItemsLayout

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/iOS/GroupableItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/GroupableItemsViewController2.cs
@@ -102,6 +102,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 					UpdateDefaultSupplementaryView(DefaultCell2, elementKind, indexPath);
 					break;
 				case TemplatedCell2 TemplatedCell2:
+					// Set the scroll direction so GetMeasureConstraints constrains the correct axis.
+					// Without this, horizontal group headers default to Vertical and constrain their
+					// width to the estimated size (~30pt), causing text to wrap.
 					TemplatedCell2.ScrollDirection = ScrollDirection;
 					UpdateTemplatedSupplementaryView(TemplatedCell2, elementKind, indexPath);
 					break;

--- a/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
@@ -192,15 +192,6 @@ internal static class LayoutFactory2
 		var layoutConfiguration = new UICollectionViewCompositionalLayoutConfiguration();
 		layoutConfiguration.ScrollDirection = scrollDirection;
 
-		var interSectionSpacing = scrollDirection == UICollectionViewScrollDirection.Vertical
-			? verticalItemSpacing
-			: horizontalItemSpacing;
-
-		if (groupingInfo.IsGrouped && interSectionSpacing > 0)
-		{
-			layoutConfiguration.InterSectionSpacing = new NFloat(interSectionSpacing);
-		}
-
 		var layout = new CustomUICollectionViewCompositionalLayout(snapInfo, groupingInfo, headerFooterInfo, (sectionIndex, environment) =>
 		{
 			// Each item has a size
@@ -234,31 +225,6 @@ internal static class LayoutFactory2
 			else
 				section.InterGroupSpacing = new NFloat(horizontalItemSpacing);
 
-			if (groupingInfo.IsGrouped && interSectionSpacing > 0)
-			{
-				if (scrollDirection == UICollectionViewScrollDirection.Horizontal)
-				{
-					var leadingInset = groupingInfo.HasHeader ? new NFloat(interSectionSpacing) : new NFloat(0);
-					var trailingInset = groupingInfo.HasFooter ? new NFloat(interSectionSpacing) : new NFloat(0);
-
-					if (leadingInset > 0 || trailingInset > 0)
-					{
-						section.ContentInsets = new NSDirectionalEdgeInsets(0, leadingInset, 0, trailingInset);
-					}
-				}
-				else
-				{
-					// Vertical: top inset creates gap between header and first item,
-					// bottom inset creates gap between last item and footer.
-					var topInset = groupingInfo.HasHeader ? new NFloat(interSectionSpacing) : new NFloat(0);
-					var bottomInset = groupingInfo.HasFooter ? new NFloat(interSectionSpacing) : new NFloat(0);
-
-					if (topInset > 0 || bottomInset > 0)
-					{
-						section.ContentInsets = new NSDirectionalEdgeInsets(topInset, 0, bottomInset, 0);
-					}
-				}
-			}
 
 			section.BoundarySupplementaryItems = CreateSupplementaryItems(
 				groupingInfo,

--- a/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
@@ -90,6 +90,14 @@ internal static class LayoutFactory2
 		var layoutConfiguration = new UICollectionViewCompositionalLayoutConfiguration();
 		layoutConfiguration.ScrollDirection = scrollDirection;
 
+		// For grouped collections, add inter-section spacing to create the gap between the
+		// trailing/bottom edge of each section and the leading/top edge (header) of the next section.
+		// This mirrors CV1's GetInsetForSection right-inset (horizontal) / bottom-inset (vertical) approach.
+		if (groupingInfo.IsGrouped && itemSpacing > 0)
+		{
+			layoutConfiguration.InterSectionSpacing = new NFloat(itemSpacing);
+		}
+
 		//create global header and footer
 		layoutConfiguration.BoundarySupplementaryItems = CreateSupplementaryItems(null, layoutHeaderFooterInfo, scrollDirection, groupWidth, groupHeight);
 
@@ -133,6 +141,31 @@ internal static class LayoutFactory2
 			// On iOS 26.1+, the default (.automatic → .safeArea) actively insets cells at section level.
 			if (OperatingSystem.IsIOSVersionAtLeast(26))
 				section.ContentInsetsReference = UIContentInsetsReference.None;
+
+			// For grouped sections with a group header/footer, add content insets to create
+			// the gap between the header/footer supplementary item and the first/last item.
+			// InterSectionSpacing (set on layoutConfiguration above) handles the gap between sections.
+			if (groupingInfo.IsGrouped && itemSpacing > 0)
+			{
+				if (scrollDirection == UICollectionViewScrollDirection.Horizontal)
+				{
+					var leadingInset = groupingInfo.HasHeader ? new NFloat(itemSpacing) : new NFloat(0);
+					var trailingInset = groupingInfo.HasFooter ? new NFloat(itemSpacing) : new NFloat(0);
+
+					if (leadingInset > 0 || trailingInset > 0)
+						section.ContentInsets = new NSDirectionalEdgeInsets(0, leadingInset, 0, trailingInset);
+				}
+				else
+				{
+					// Vertical: top inset creates gap between header and first item,
+					// bottom inset creates gap between last item and footer.
+					var topInset = groupingInfo.HasHeader ? new NFloat(itemSpacing) : new NFloat(0);
+					var bottomInset = groupingInfo.HasFooter ? new NFloat(itemSpacing) : new NFloat(0);
+
+					if (topInset > 0 || bottomInset > 0)
+						section.ContentInsets = new NSDirectionalEdgeInsets(topInset, 0, bottomInset, 0);
+				}
+			}
 
 			// Create header and footer for group
 			section.BoundarySupplementaryItems = CreateSupplementaryItems(

--- a/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
@@ -153,7 +153,9 @@ internal static class LayoutFactory2
 					var trailingInset = groupingInfo.HasFooter ? new NFloat(itemSpacing) : new NFloat(0);
 
 					if (leadingInset > 0 || trailingInset > 0)
+					{
 						section.ContentInsets = new NSDirectionalEdgeInsets(0, leadingInset, 0, trailingInset);
+					}
 				}
 				else
 				{
@@ -163,7 +165,9 @@ internal static class LayoutFactory2
 					var bottomInset = groupingInfo.HasFooter ? new NFloat(itemSpacing) : new NFloat(0);
 
 					if (topInset > 0 || bottomInset > 0)
+					{
 						section.ContentInsets = new NSDirectionalEdgeInsets(topInset, 0, bottomInset, 0);
+					}
 				}
 			}
 
@@ -187,6 +191,15 @@ internal static class LayoutFactory2
 	{
 		var layoutConfiguration = new UICollectionViewCompositionalLayoutConfiguration();
 		layoutConfiguration.ScrollDirection = scrollDirection;
+
+		var interSectionSpacing = scrollDirection == UICollectionViewScrollDirection.Vertical
+			? verticalItemSpacing
+			: horizontalItemSpacing;
+
+		if (groupingInfo.IsGrouped && interSectionSpacing > 0)
+		{
+			layoutConfiguration.InterSectionSpacing = new NFloat(interSectionSpacing);
+		}
 
 		var layout = new CustomUICollectionViewCompositionalLayout(snapInfo, groupingInfo, headerFooterInfo, (sectionIndex, environment) =>
 		{
@@ -221,6 +234,31 @@ internal static class LayoutFactory2
 			else
 				section.InterGroupSpacing = new NFloat(horizontalItemSpacing);
 
+			if (groupingInfo.IsGrouped && interSectionSpacing > 0)
+			{
+				if (scrollDirection == UICollectionViewScrollDirection.Horizontal)
+				{
+					var leadingInset = groupingInfo.HasHeader ? new NFloat(interSectionSpacing) : new NFloat(0);
+					var trailingInset = groupingInfo.HasFooter ? new NFloat(interSectionSpacing) : new NFloat(0);
+
+					if (leadingInset > 0 || trailingInset > 0)
+					{
+						section.ContentInsets = new NSDirectionalEdgeInsets(0, leadingInset, 0, trailingInset);
+					}
+				}
+				else
+				{
+					// Vertical: top inset creates gap between header and first item,
+					// bottom inset creates gap between last item and footer.
+					var topInset = groupingInfo.HasHeader ? new NFloat(interSectionSpacing) : new NFloat(0);
+					var bottomInset = groupingInfo.HasFooter ? new NFloat(interSectionSpacing) : new NFloat(0);
+
+					if (topInset > 0 || bottomInset > 0)
+					{
+						section.ContentInsets = new NSDirectionalEdgeInsets(topInset, 0, bottomInset, 0);
+					}
+				}
+			}
 
 			section.BoundarySupplementaryItems = CreateSupplementaryItems(
 				groupingInfo,

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25859.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25859.xaml
@@ -2,32 +2,31 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 			 x:Class="Maui.Controls.Sample.Issues.Issue25859"
-			 xmlns:cv1="clr-namespace:Maui.Controls.Sample"
 			 xmlns:ns="clr-namespace:Maui.Controls.Sample.Issues">
 	<Grid RowDefinitions="*">
-		<cv1:CollectionView1 Grid.Row="0"
-							 x:Name="collectionView"
-							 AutomationId="collectionView"
-							 Background="Gray"
-							 HorizontalOptions="Center">
-			<cv1:CollectionView1.ItemsLayout>
-				<LinearItemsLayout Orientation="Horizontal"
+		<CollectionView Grid.Row="0"
+						x:Name="collectionView"
+						AutomationId="collectionView"
+						Background="Gray"
+						HorizontalOptions="Center">
+			<CollectionView.ItemsLayout>
+				<LinearItemsLayout Orientation="Vertical"
 								   ItemSpacing="10"/>
-			</cv1:CollectionView1.ItemsLayout>
-			<cv1:CollectionView1.ItemTemplate>
+			</CollectionView.ItemsLayout>
+			<CollectionView.ItemTemplate>
 				<DataTemplate>
 					<Label BackgroundColor="CornSilk"
 						   x:DataType="ns:Issue25859TestItem"
 						   Text="{Binding Name}"/>
 				</DataTemplate>
-			</cv1:CollectionView1.ItemTemplate>
-			<cv1:CollectionView1.GroupHeaderTemplate>
+			</CollectionView.ItemTemplate>
+			<CollectionView.GroupHeaderTemplate>
 				<DataTemplate>
 					<Label Text="{Binding Name}"
 						   x:DataType="ns:Issue25859ItemGroup"
 						   Background="YellowGreen"/>
 				</DataTemplate>
-			</cv1:CollectionView1.GroupHeaderTemplate>
-		</cv1:CollectionView1>
+			</CollectionView.GroupHeaderTemplate>
+		</CollectionView>
 	</Grid>
 </ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25859.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25859.xaml
@@ -10,7 +10,7 @@
 						Background="Gray"
 						HorizontalOptions="Center">
 			<CollectionView.ItemsLayout>
-				<LinearItemsLayout Orientation="Vertical"
+				<LinearItemsLayout Orientation="Horizontal"
 								   ItemSpacing="10"/>
 			</CollectionView.ItemsLayout>
 			<CollectionView.ItemTemplate>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details:
Item spacing is not correctly applied between the group header and the items in the CollectionView when using LinearItemsLayout.

### Root Cause:
The CollectionView2 iOS handler (Items2) was missing spacing logic for grouped collections. The UICollectionViewCompositionalLayout treats each group as a separate section. While section.InterGroupSpacing correctly applied ItemSpacing between items within a section, two spacing gaps were not handled:

- No spacing between sections — InterSectionSpacing was never set on the layout configuration, so the last item of one group appeared flush against the next group's header.

- No spacing between a group header/footer and its items — No ContentInsets were applied to push items away from the header/footer supplementary views within the same section.

Additionally, in GetViewForSupplementaryElement, the ScrollDirection was not set on TemplatedCell2 before measuring group headers/footers. It defaulted to Vertical, so GetMeasureConstraints constrained the width (to ~30pt estimated size) instead of the height for horizontal lists, causing header text to wrap incorrectly.



### Description of change:

- Set InterSectionSpacing on the UICollectionViewCompositionalLayoutConfiguration when the collection is grouped and ItemSpacing > 0, creating the gap between the end of one group and the header of the next group.

- Apply ContentInsets on each grouped section — leading/trailing insets for horizontal lists, top/bottom insets for vertical lists — to create the gap between the header/footer and the first/last item within the same section. Insets are only added when a header or footer actually exists.

- Set TemplatedCell2.ScrollDirection = ScrollDirection before calling UpdateTemplatedSupplementaryView, so GetMeasureConstraints constrains the correct axis when measuring group header/footer cells.

### Validated the behaviour in the following platforms
- [ ] Android
- [ ] Windows
- [x] iOS
- [x] Mac

### Fixes
Fixes #35429 

### Screenshots
| Before  | After |
|---------|--------|
|  <img src="https://github.com/user-attachments/assets/7ef2cedb-d478-4e98-ab3e-054115b5ed43"> |   <img src="https://github.com/user-attachments/assets/1f91672f-9b25-4328-92b4-e1f5dc2b0395">  |
