### PR TITLE
[Android] Fix increasing bottom gap in CollectionView while scrolling

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
@@ -38,6 +38,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		readonly DataChangeObserver _emptyCollectionObserver;
 		readonly DataChangeObserver _itemsUpdateScrollObserver;
 
+		// IMauiRecyclerView (Core) — true while the EmptyView adapter is active so that
+		// SafeArea inset logic can allow listeners on EmptyView items (#34634 gate exception).
+		bool IMauiRecyclerView.IsShowingEmptyView => _emptyViewAdapter != null && GetAdapter() == _emptyViewAdapter;
+
 		ScrollBarVisibility _defaultHorizontalScrollVisibility = ScrollBarVisibility.Default;
 		ScrollBarVisibility _defaultVerticalScrollVisibility = ScrollBarVisibility.Default;
 

--- a/src/Core/src/Platform/Android/MauiWindowInsetListener.cs
+++ b/src/Core/src/Platform/Android/MauiWindowInsetListener.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using Android.Content;
@@ -100,10 +101,13 @@ namespace Microsoft.Maui.Platform
 			{
 				// Skip setting listener on views inside nested scroll containers or AppBarLayout (except MaterialToolbar)
 				// We want the layout listener logic to get applied to the MaterialToolbar itself
-				// But we don't want any layout listeners to get applied to the children of MaterialToolbar (like the TitleView)
-				// For RecyclerView item templates, only allow listener attachment when SafeAreaEdges
-				// is explicitly customized. This avoids recycled item padding drift while preserving
-				// explicit per-item SafeAreaEdges scenarios.
+				// But we don't want any layout listeners to get applied to the children of MaterialToolbar (like the TitleView).
+				//
+				// For RecyclerView item templates, the same AView is reused across different bound MAUI elements
+				// during scrolling. Attaching the inset listener unconditionally caused recycled item views to
+				// carry stale inset-derived padding, which manifested as a progressive bottom gap (#34634/#34635).
+				// We therefore only attach when SafeAreaEdges is explicitly customized on the currently bound
+				// element — preserving per-item SafeAreaEdges customization while keeping recycle behavior safe.
 				if (view is not MaterialToolbar &&
 					(parent is AppBarLayout ||
 					parent is MauiScrollView ||
@@ -136,14 +140,32 @@ namespace Microsoft.Maui.Platform
 			return null;
 		}
 
+		// Per-element-type cache of SafeAreaEdges default values.
+		// The default value returned by ISafeAreaElement.SafeAreaEdgesDefaultValueCreator() is constant per
+		// implementing type (e.g. Layout -> Container, Border/ContentView/ContentPage -> None, ScrollView -> Default).
+		// The cache is therefore append-only and never needs invalidation. Caching by AView would be unsafe
+		// because RecyclerView rebinds the same AView to different MAUI elements during scrolling; caching
+		// by Type is independent of any individual instance.
+		static readonly ConcurrentDictionary<Type, SafeAreaEdges> _safeAreaEdgesDefaults = new();
+
 		static bool HasExplicitSafeAreaEdges(AView view)
 		{
 			if (view is not ICrossPlatformLayoutBacking { CrossPlatformLayout: ISafeAreaElement safeAreaElement })
 			{
 				return false;
 			}
-			
-			return safeAreaElement.SafeAreaEdges != safeAreaElement.SafeAreaEdgesDefaultValueCreator();
+
+			// Hoist the current value into a local: SafeAreaEdges is a BindableProperty getter that may lazily
+			// initialize state on first read, so we read it exactly once.
+			var current = safeAreaElement.SafeAreaEdges;
+			var defaultEdges = _safeAreaEdgesDefaults.GetOrAdd(
+				safeAreaElement.GetType(),
+				static (_, element) => element.SafeAreaEdgesDefaultValueCreator(),
+				safeAreaElement);
+
+			// Use the typed IEquatable<SafeAreaEdges>.Equals to stay independent of operator overloads
+			// in case SafeAreaEdges evolves (e.g. into a flags-style struct) in the future.
+			return !current.Equals(defaultEdges);
 		}
 
 		/// <summary>

--- a/src/Core/src/Platform/Android/MauiWindowInsetListener.cs
+++ b/src/Core/src/Platform/Android/MauiWindowInsetListener.cs
@@ -93,25 +93,26 @@ namespace Microsoft.Maui.Platform
 		/// </summary>
 		/// <param name="view">The view to find a listener for</param>
 		/// <returns>The local listener if view is in a registered view hierarchy, null otherwise</returns>
-		internal static MauiWindowInsetListener? FindListenerForView(AView view)
+		internal static MauiWindowInsetListener? FindListenerForView(AView view, bool applyRecyclerViewGate = false)
 		{
-			// Walk up the view hierarchy looking for a registered view
+			// Walk up the view hierarchy looking for a registered view.
+			// applyRecyclerViewGate=true (attachment only): skips RecyclerView items with default SafeAreaEdges
+			// to prevent recycled views retaining stale inset padding (#34634/#34635).
+			// Cleanup paths pass the default false so they always find listeners to reset.
 			var parent = view.Parent;
 			while (parent is not null)
 			{
-				// Skip setting listener on views inside nested scroll containers or AppBarLayout (except MaterialToolbar)
-				// We want the layout listener logic to get applied to the MaterialToolbar itself
-				// But we don't want any layout listeners to get applied to the children of MaterialToolbar (like the TitleView).
-				//
-				// For RecyclerView item templates, the same AView is reused across different bound MAUI elements
-				// during scrolling. Attaching the inset listener unconditionally caused recycled item views to
-				// carry stale inset-derived padding, which manifested as a progressive bottom gap (#34634/#34635).
-				// We therefore only attach when SafeAreaEdges is explicitly customized on the currently bound
-				// element — preserving per-item SafeAreaEdges customization while keeping recycle behavior safe.
+				// Skip views inside AppBarLayout or MauiScrollView (except MaterialToolbar itself).
 				if (view is not MaterialToolbar &&
-					(parent is AppBarLayout ||
-					parent is MauiScrollView ||
-					(parent is IMauiRecyclerView && !HasExplicitSafeAreaEdges(view))))
+					(parent is AppBarLayout || parent is MauiScrollView))
+				{
+					return null;
+				}
+
+				// Attachment gate: skip RecyclerView items with default SafeAreaEdges.
+				if (applyRecyclerViewGate &&
+					parent is IMauiRecyclerView &&
+					!HasExplicitSafeAreaEdges(view))
 				{
 					return null;
 				}
@@ -509,8 +510,8 @@ internal static class MauiWindowInsetListenerExtensions
 	/// <param name="context">The Android context to get the listener from</param>
 	public static bool TrySetMauiWindowInsetListener(this View view, Context context)
 	{
-		// Check if this view is contained within a registered view first
-		if (MauiWindowInsetListener.FindListenerForView(view) is MauiWindowInsetListener localListener)
+		// applyRecyclerViewGate=true: skips RecyclerView items with default SafeAreaEdges (#34634/#34635).
+		if (MauiWindowInsetListener.FindListenerForView(view, applyRecyclerViewGate: true) is MauiWindowInsetListener localListener)
 		{
 			ViewCompat.SetOnApplyWindowInsetsListener(view, localListener);
 			ViewCompat.SetWindowInsetsAnimationCallback(view, localListener);

--- a/src/Core/src/Platform/Android/MauiWindowInsetListener.cs
+++ b/src/Core/src/Platform/Android/MauiWindowInsetListener.cs
@@ -92,26 +92,39 @@ namespace Microsoft.Maui.Platform
 		/// Must be called on UI thread.
 		/// </summary>
 		/// <param name="view">The view to find a listener for</param>
+		/// <param name="applyRecyclerViewGate">
+		/// When true (attachment only), skips RecyclerView data-item views with default SafeAreaEdges
+		/// to prevent recycled views from retaining stale inset-derived padding (#34634/#34635).
+		/// Reset/cleanup callers must pass false (the default) so they can always find listeners
+		/// to clear stale padding regardless of the currently bound element's SafeAreaEdges.
+		/// </param>
 		/// <returns>The local listener if view is in a registered view hierarchy, null otherwise</returns>
 		internal static MauiWindowInsetListener? FindListenerForView(AView view, bool applyRecyclerViewGate = false)
 		{
-			// Walk up the view hierarchy looking for a registered view.
-			// applyRecyclerViewGate=true (attachment only): skips RecyclerView items with default SafeAreaEdges
-			// to prevent recycled views retaining stale inset padding (#34634/#34635).
-			// Cleanup paths pass the default false so they always find listeners to reset.
+			// Walk up the view hierarchy looking for a registered view
 			var parent = view.Parent;
 			while (parent is not null)
 			{
-				// Skip views inside AppBarLayout or MauiScrollView (except MaterialToolbar itself).
+				// Skip setting listener on views inside nested scroll containers or AppBarLayout (except MaterialToolbar)
+				// We want the layout listener logic to get applied to the MaterialToolbar itself
+				// But we don't want any layout listeners to get applied to the children of MaterialToolbar (like the TitleView).
 				if (view is not MaterialToolbar &&
-					(parent is AppBarLayout || parent is MauiScrollView))
+					(parent is AppBarLayout ||
+					parent is MauiScrollView))
 				{
 					return null;
 				}
 
-				// Attachment gate: skip RecyclerView items with default SafeAreaEdges.
+				// Attachment gate (applyRecyclerViewGate=true only): skip RecyclerView data-item views with default
+				// SafeAreaEdges to prevent recycled item views from carrying stale inset-derived padding (#34634/#34635).
+				// EmptyView items (IsShowingEmptyView=true) are exempt — they are never recycled across data rows
+				// so they safely receive the listener without risk of stale-padding accumulation.
+				// Reset/cleanup callers use the default applyRecyclerViewGate=false so they always find the listener
+				// needed to clear any previously applied padding when a view is detached or SafeAreaEdges changes.
 				if (applyRecyclerViewGate &&
-					parent is IMauiRecyclerView &&
+					view is not MaterialToolbar &&
+					parent is IMauiRecyclerView mauiRecyclerView &&
+					!mauiRecyclerView.IsShowingEmptyView &&
 					!HasExplicitSafeAreaEdges(view))
 				{
 					return null;
@@ -510,7 +523,8 @@ internal static class MauiWindowInsetListenerExtensions
 	/// <param name="context">The Android context to get the listener from</param>
 	public static bool TrySetMauiWindowInsetListener(this View view, Context context)
 	{
-		// applyRecyclerViewGate=true: skips RecyclerView items with default SafeAreaEdges (#34634/#34635).
+		// applyRecyclerViewGate=true: skip RecyclerView data-item views with default SafeAreaEdges
+		// to prevent recycled views from accumulating stale inset-derived padding (#34634/#34635).
 		if (MauiWindowInsetListener.FindListenerForView(view, applyRecyclerViewGate: true) is MauiWindowInsetListener localListener)
 		{
 			ViewCompat.SetOnApplyWindowInsetsListener(view, localListener);

--- a/src/Core/src/Platform/Android/MauiWindowInsetListener.cs
+++ b/src/Core/src/Platform/Android/MauiWindowInsetListener.cs
@@ -101,10 +101,13 @@ namespace Microsoft.Maui.Platform
 				// Skip setting listener on views inside nested scroll containers or AppBarLayout (except MaterialToolbar)
 				// We want the layout listener logic to get applied to the MaterialToolbar itself
 				// But we don't want any layout listeners to get applied to the children of MaterialToolbar (like the TitleView)
-				// CollectionView/CarouselView items are not excluded to enable per-item SafeAreaEdges control.
-				// Performance overhead is negligible due to early pass-through for items without insets.
+				// For RecyclerView item templates, only allow listener attachment when SafeAreaEdges
+				// is explicitly customized. This avoids recycled item padding drift while preserving
+				// explicit per-item SafeAreaEdges scenarios.
 				if (view is not MaterialToolbar &&
-					(parent is AppBarLayout || parent is MauiScrollView))
+					(parent is AppBarLayout ||
+					parent is MauiScrollView ||
+					(parent is IMauiRecyclerView && !HasExplicitSafeAreaEdges(view))))
 				{
 					return null;
 				}
@@ -131,6 +134,16 @@ namespace Microsoft.Maui.Platform
 			}
 
 			return null;
+		}
+
+		static bool HasExplicitSafeAreaEdges(AView view)
+		{
+			if (view is not ICrossPlatformLayoutBacking { CrossPlatformLayout: ISafeAreaElement safeAreaElement })
+			{
+				return false;
+			}
+			
+			return safeAreaElement.SafeAreaEdges != safeAreaElement.SafeAreaEdgesDefaultValueCreator();
 		}
 
 		/// <summary>


### PR DESCRIPTION
 <!-- Please let the below note in for people that find this PR -->
   > [!NOTE]
   > Are you waiting for the changes in this PR to be merged?
   > It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. 
  Thank you!
 
### Root Cause
While scrolling long CollectionView content on Android, an extra bottom gap appears and progressively increases during scrolling. This regression was introduced by PR #33908, which removed the `IMauiRecyclerView` exclusion in `MauiWindowInsetListener.FindListenerForView` so item templates could participate in safe-area inset handling.

As a side effect, RecyclerView item views began receiving the window-inset listener by default, allowing safe-area padding to be applied on item roots. Since RecyclerView reuses item views during scrolling, recycled views could retain stale inset-derived padding from previous bindings, resulting in a progressively growing bottom gap. 

### Description of Change
Reintroduced the `IMauiRecyclerView` guard in `MauiWindowInsetListener.FindListenerForView`, while preserving the per-item `SafeAreaEdges` capability added in PR #33908 for explicitly opted-in item roots.

`MauiWindowInsetListener.cs`

* `FindListenerForView` — when the parent is an `IMauiRecyclerView`, the inset listener is skipped unless the item root explicitly customizes `SafeAreaEdges`. This prevents recycled-item padding drift while preserving intentional safe-area scenarios.

* `HasExplicitSafeAreaEdges` (new helper) — returns `true` only when the platform view maps to an `ISafeAreaElement` whose current `SafeAreaEdges` differs from its default value, indicating an explicit developer opt-in. Default values are cached in a static `ConcurrentDictionary<Type, SafeAreaEdges>` using `GetOrAdd` to avoid repeated computation or per-call allocations. The comparison uses `IEquatable<SafeAreaEdges>.Equals(...)` on a hoisted local value to avoid boxing, repeated property reads, and to remain stable for future `SafeAreaEdges` type evolution.

### Issues Fixed
Fixes #34634     
 
Tested the behaviour in the following platforms
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Regression
This regression was introduced by PR #33908.

### Screenshots
| Before Issue Fix | After Issue Fix |
|------------------|-----------------|
| <video width="350" alt="withoutfix" src="https://github.com/user-attachments/assets/5f6dad90-7372-45ab-9e7c-46feb6042c6a" /> | <video width="350" alt="withfix" src="https://github.com/user-attachments/assets/5352b0d6-25d4-4bbf-a1f0-e6d09a00fe8e" /> |