### PR TITLE
 [Windows] Fix VerifyAllIndicatorDotsShowShadowsWhenIndicatorSize test failure on candidate branch

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			// covers the grouped case. For a CarouselView at a non-zero Position, scrolling to
 			// the first item would override the intended initial position and trigger cascading
 			// PositionChanged / CurrentItemChanged events (https://github.com/dotnet/maui/issues/29529).
-			if (isReset && (VirtualView is not CarouselView carouselView || carouselView.Position != 0))
+			if (isReset && (ItemsView is not CarouselView carouselView || carouselView.Position != 0))
 			{
 				return;
 			}

--- a/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
@@ -143,20 +143,17 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			bool isReset = @event?.CollectionChange == global::Windows.Foundation.Collections.CollectionChange.Reset;
 			bool isGrouped = CollectionViewSource?.IsSourceGrouped == true;
 
-			// Grouped sources cannot be processed during a Reset. The flattened projection
-			// backing the CollectionView may still be rebuilding while VectorChanged fires,
-			// and indexing into it can raise E_CHANGED_STATE / COMException. Deferring is
-			// also unsafe because the projection may be torn down before the dispatched
-			// lambda runs, so we skip the scroll entirely.
-			if (isGrouped && isReset)
-			{
-				return;
-			}
-
-			// CarouselView manages its own initial scroll when a non-zero Position is set.
-			// Scrolling to the first item here would override that intent and trigger
-			// cascading PositionChanged / CurrentItemChanged events.
-			if (isReset && VirtualView is CarouselView carouselView && carouselView.Position != 0)
+			// Skip the deferred ScrollIntoView on Reset except for CarouselView at Position 0.
+			// For a plain CollectionView, the deferred ScrollIntoView(view[0]) races with a
+			// user-initiated ScrollTo on the page-pop path and can pollute OnScrolled indices.
+			// For a grouped CollectionView, the flattened projection backing the view may still
+			// be rebuilding when VectorChanged fires, and indexing into it can raise
+			// E_CHANGED_STATE / COMException (https://github.com/dotnet/maui/issues/17969).
+			// CarouselView does not support grouping, so the not-CarouselView check below also
+			// covers the grouped case. For a CarouselView at a non-zero Position, scrolling to
+			// the first item would override the intended initial position and trigger cascading
+			// PositionChanged / CurrentItemChanged events (https://github.com/dotnet/maui/issues/29529).
+			if (isReset && (VirtualView is not CarouselView carouselView || carouselView.Position != 0))
 			{
 				return;
 			}

--- a/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
@@ -140,21 +140,26 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				return;
 			}
 
-			// Reset notifications are unsafe to process because WinUI may still be rebuilding
-			// the internal projection. Accessing indexes during Reset can trigger
-			// E_CHANGED_STATE / COMException.
-			if (@event?.CollectionChange == global::Windows.Foundation.Collections.CollectionChange.Reset)
-			{
-				return;
-			}
+			bool isReset = @event?.CollectionChange == global::Windows.Foundation.Collections.CollectionChange.Reset;
+			bool isGrouped = CollectionViewSource?.IsSourceGrouped == true;
 
-			// Grouped CollectionViews are backed by a flattened projection that may still be
-			// mutating while VectorChanged is firing. Accessing indexes synchronously can
-			// trigger STATUS_STOWED_EXCEPTION / E_CHANGED_STATE.
-			//
-			// Non-grouped views (e.g. CarouselView) should remain synchronous to avoid
-			// regressions where deferred scrolling changes the intended position.
-			bool shouldDefer = CollectionViewSource?.IsSourceGrouped == true;
+			// Grouped sources cannot be processed during a Reset. The flattened projection
+			// backing the CollectionView may still be rebuilding while VectorChanged fires,
+			// and indexing into it can raise E_CHANGED_STATE / COMException. Deferring is
+			// also unsafe because the projection may be torn down before the dispatched
+			// lambda runs, so we skip the scroll entirely.
+			if (isGrouped && isReset)
+				return;
+
+			// CarouselView manages its own initial scroll when a non-zero Position is set.
+			// Scrolling to the first item here would override that intent and trigger
+			// cascading PositionChanged / CurrentItemChanged events.
+			if (isReset && VirtualView is CarouselView carouselView && carouselView.Position != 0)
+				return;
+
+			// Defer when WinUI may still be mutating the projection (grouped sources, or any
+			// Reset notification) so the scroll runs against a settled state.
+			bool shouldDefer = isGrouped || isReset;
 
 			if (shouldDefer)
 			{

--- a/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
@@ -149,13 +149,17 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			// also unsafe because the projection may be torn down before the dispatched
 			// lambda runs, so we skip the scroll entirely.
 			if (isGrouped && isReset)
+			{
 				return;
+			}
 
 			// CarouselView manages its own initial scroll when a non-zero Position is set.
 			// Scrolling to the first item here would override that intent and trigger
 			// cascading PositionChanged / CurrentItemChanged events.
 			if (isReset && VirtualView is CarouselView carouselView && carouselView.Position != 0)
+			{
 				return;
+			}
 
 			// Defer when WinUI may still be mutating the projection (grouped sources, or any
 			// Reset notification) so the scroll runs against a settled state.
@@ -166,7 +170,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				var dispatcherQueue = PlatformView?.DispatcherQueue;
 
 				if (dispatcherQueue is null)
+				{
 					return;
+				}
 
 				dispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Normal, ScrollIntoViewIfNeeded);
 			}


### PR DESCRIPTION
 <!-- Please let the below note in for people that find this PR -->
   > [!NOTE]
   > Are you waiting for the changes in this PR to be merged?
   > It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. 
  Thank you!
 
### Root Cause
PR #35398 protected grouped CollectionView from a mid-mutation `COMException` by short-circuiting `OnItemsVectorChanged` whenever WinUI raised `CollectionChange.Reset`. However, the Reset bail was applied unconditionally, preventing the corrective `ScrollIntoView(...)` logic used by `KeepItemsInView` / `KeepLastItemInView` from running for non-grouped controls as well.

On Windows, `LoopableCollectionView` — the projection backing `CarouselView` — emits a full `CollectionChange.Reset` whenever the underlying `ObservableItemTemplateCollection` is rebuilt, including immediately after the initial `ItemsSource` assignment. Since the corrective scroll never executed after Reset, `CarouselView` and the connected `IndicatorView` remained on the wrong projected item, causing `VerifyAllIndicatorDotsShowShadowsWhenIndicatorSize` to fail because the expected indicator dots were not rendered for the visible item.
 
### Description of Change
The fix replaces the unconditional Reset bail in `OnItemsVectorChanged` with three layered guards:

1. **Grouped + Reset → bail**
   Preserves the original `COMException` protection added in PR #35398 for grouped sources where the flattened projection can expose stale indices during rebuild.

2. **CarouselView + Reset + `Position != 0` → bail**
   Preserves the `Issue29529VerifyPreviousPositionOnInsert` fix from PR #35398. Without this guard, the deferred `ScrollIntoView(view[0])` call overrides the user-defined initial `Position` and reintroduces the cascading `PositionChanged` / `CurrentItemChanged` behavior.

3. **All other Reset cases → defer through `DispatcherQueue.TryEnqueue`**
   Restores the corrective `ScrollIntoViewIfNeeded()` behavior after WinUI finishes rebuilding `LoopableCollectionView`. The shared helper revalidates lifecycle state (`VirtualView`, `ListViewBase`, `CollectionViewSource?.View`, and `view?.Count`) before executing the scroll, ensuring the deferred path remains lifecycle-safe and null-safe.

### Issues Fixed
Fixes `VerifyAllIndicatorDotsShowShadowsWhenIndicatorSize` test failure on candidate branch  
 
Tested the behaviour in the following platforms
- [ ] Android
- [x] Windows
- [ ] iOS
- [ ] Mac