### PR TITLE
[Testing] Fix for flaky UITests in CI that occasionally fail

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/WebViewFeatureTests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/WebViewFeatureTests.cs
@@ -39,7 +39,7 @@ public class WebViewFeatureTests : _GalleryUITest
 			{
 				App.WaitForElement(Apply);
 				App.Tap(Apply);
-				App.WaitForElement(Options);
+				App.WaitForElementTillPageNavigationSettled(Options);
 				return;
 			}
 			catch (Exception ex)
@@ -70,12 +70,10 @@ public class WebViewFeatureTests : _GalleryUITest
 		App.WaitForElement("HtmlSourceButton");
 		App.Tap("HtmlSourceButton");
 		TapApplyAndWaitForMainPage();
-		App.WaitForElement(Options);
 		App.Tap(Options);
 		App.WaitForElement("MicrosoftUrlButton");
 		App.Tap("MicrosoftUrlButton");
 		TapApplyAndWaitForMainPage();
-		App.WaitForElement(Options);
 		App.Tap(Options);
 		App.WaitForElement("GithubUrlButton");
 		App.Tap("GithubUrlButton");

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/WebViewFeatureTests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/WebViewFeatureTests.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Maui.TestCases.Tests;
 
 public class WebViewFeatureTests : _GalleryUITest
 {
+	const int ApplyTapMaxAttempts = 3;
 	public const string WebViewFeatureMatrix = "WebView Feature Matrix";
 	public override string GalleryPageName => WebViewFeatureMatrix;
 	public const string Options = "Options";
@@ -28,6 +29,28 @@ public class WebViewFeatureTests : _GalleryUITest
 	{
 	}
 
+	public void TapApplyAndWaitForMainPage()
+	{
+		Exception? lastError = null;
+
+		for (var attempt = 1; attempt <= ApplyTapMaxAttempts; attempt++)
+		{
+			try
+			{
+				App.WaitForElement(Apply);
+				App.Tap(Apply);
+				App.WaitForElement(Options);
+				return;
+			}
+			catch (Exception ex)
+			{
+				lastError = ex;
+			}
+		}
+
+		Assert.Fail($"Failed to tap '{Apply}' toolbar item and return to main page after {ApplyTapMaxAttempts} attempts. Last error: {lastError}");
+	}
+
 	[Test, Order(1)]
 	[Category(UITestCategories.WebView)]
 	public void WebView_ValidateDefaultValues_VerifyInitialState()
@@ -46,20 +69,17 @@ public class WebViewFeatureTests : _GalleryUITest
 		App.Tap(Options);
 		App.WaitForElement("HtmlSourceButton");
 		App.Tap("HtmlSourceButton");
-		App.WaitForElement(Apply);
-		App.Tap(Apply);
+		TapApplyAndWaitForMainPage();
 		App.WaitForElement(Options);
 		App.Tap(Options);
 		App.WaitForElement("MicrosoftUrlButton");
 		App.Tap("MicrosoftUrlButton");
-		App.WaitForElement(Apply);
-		App.Tap(Apply);
+		TapApplyAndWaitForMainPage();
 		App.WaitForElement(Options);
 		App.Tap(Options);
 		App.WaitForElement("GithubUrlButton");
 		App.Tap("GithubUrlButton");
-		App.WaitForElement(Apply);
-		App.Tap(Apply);
+		TapApplyAndWaitForMainPage();
 		App.WaitForElement(CanGoBackLabel, timeout: TimeSpan.FromSeconds(3));
 		Assert.That(App.FindElement(CanGoBackLabel).GetText(), Is.EqualTo("True"));
 		App.WaitForElement(GoBackButton);
@@ -78,8 +98,7 @@ public class WebViewFeatureTests : _GalleryUITest
 		App.Tap(Options);
 		App.WaitForElement(HtmlSourceButton);
 		App.Tap(HtmlSourceButton);
-		App.WaitForElement(Apply);
-		App.Tap(Apply);
+		TapApplyAndWaitForMainPage();
 		App.WaitForElement(EvaluateJSButton);
 		App.Tap(EvaluateJSButton);
 		App.WaitForElement(JSResultLabel);
@@ -95,9 +114,7 @@ public class WebViewFeatureTests : _GalleryUITest
 		App.Tap(Options);
 		App.WaitForElement(GithubUrlButton);
 		App.Tap(GithubUrlButton);
-		App.WaitForElement(Apply);
-		App.Tap(Apply);
-		App.WaitForElementTillPageNavigationSettled(Options);
+		TapApplyAndWaitForMainPage();
 		var navigatingText = App.FindElement(NavigatingStatusLabel).GetText();
 		Assert.That(navigatingText, Is.Not.Null.And.Not.Empty);
 	}
@@ -110,9 +127,7 @@ public class WebViewFeatureTests : _GalleryUITest
 		App.Tap(Options);
 		App.WaitForElement(GithubUrlButton);
 		App.Tap(GithubUrlButton);
-		App.WaitForElement(Apply);
-		App.Tap(Apply);
-		App.WaitForElementTillPageNavigationSettled(Options);
+		TapApplyAndWaitForMainPage();
 		var navigatedText = App.FindElement(NavigatedStatusLabel).GetText();
 		Assert.That(navigatedText, Is.EqualTo("Navigated: Success"));
 	}
@@ -125,9 +140,7 @@ public class WebViewFeatureTests : _GalleryUITest
 		App.Tap(Options);
 		App.WaitForElement(HtmlSourceButton);
 		App.Tap(HtmlSourceButton);
-		App.WaitForElement(Apply);
-		App.Tap(Apply);
-		App.WaitForElementTillPageNavigationSettled(Options);
+		TapApplyAndWaitForMainPage();
 		var navigatingText = App.FindElement(NavigatingStatusLabel).GetText();
 		Assert.That(navigatingText, Is.Not.Null.And.Not.Empty);
 	}
@@ -140,9 +153,7 @@ public class WebViewFeatureTests : _GalleryUITest
 		App.Tap(Options);
 		App.WaitForElement(HtmlSourceButton);
 		App.Tap(HtmlSourceButton);
-		App.WaitForElement(Apply);
-		App.Tap(Apply);
-		App.WaitForElementTillPageNavigationSettled(Options);
+		TapApplyAndWaitForMainPage();
 		var navigatedText = App.FindElement(NavigatedStatusLabel).GetText();
 		Assert.That(navigatedText, Is.EqualTo("Navigated: Success"));
 	}
@@ -157,9 +168,7 @@ public class WebViewFeatureTests : _GalleryUITest
 		App.Tap(AddTestCookieButton);
 		App.WaitForElement(HtmlSourceButton);
 		App.Tap(HtmlSourceButton);
-		App.WaitForElement(Apply);
-		App.Tap(Apply);
-		App.WaitForElementTillPageNavigationSettled(Options);
+		TapApplyAndWaitForMainPage();
 		var cookiesStatusText = App.FindElement(CookieStatusMainLabel).GetText();
 		Assert.That(cookiesStatusText, Does.Contain("Domain: localhost").And.Contain("Count: 1").And.Contain("DotNetMAUICookie = My cookie"));
 	}
@@ -174,9 +183,7 @@ public class WebViewFeatureTests : _GalleryUITest
 		App.Tap(GithubUrlButton);
 		App.WaitForElement(AddTestCookieButton);
 		App.Tap(AddTestCookieButton);
-		App.WaitForElement(Apply);
-		App.Tap(Apply);
-		App.WaitForElementTillPageNavigationSettled(Options);
+		TapApplyAndWaitForMainPage();
 		var cookiesStatusText = App.FindElement(CookieStatusMainLabel).GetText();
 		Assert.That(cookiesStatusText, Does.Contain("Domain: github.com").And.Contain("Count: 1").And.Contain("DotNetMAUICookie = My cookie"));
 	}
@@ -191,9 +198,7 @@ public class WebViewFeatureTests : _GalleryUITest
 		App.Tap(AddTestCookieButton);
 		App.WaitForElement(HtmlSourceButton);
 		App.Tap(HtmlSourceButton);
-		App.WaitForElement(Apply);
-		App.Tap(Apply);
-		App.WaitForElementTillPageNavigationSettled(Options);
+		TapApplyAndWaitForMainPage();
 		App.WaitForElement(EvaluateJSButton);
 		App.Tap(EvaluateJSButton);
 		App.WaitForElement(JSResultLabel);
@@ -211,9 +216,7 @@ public class WebViewFeatureTests : _GalleryUITest
 		App.Tap(Options);
 		App.WaitForElement(ClearCookiesButton);
 		App.Tap(ClearCookiesButton);
-		App.WaitForElement(Apply);
-		App.Tap(Apply);
-		App.WaitForElementTillPageNavigationSettled(Options);
+		TapApplyAndWaitForMainPage();
 		var clearCookiesText = App.FindElement(CookieStatusMainLabel).GetText();
 		Assert.That(clearCookiesText, Is.EqualTo("No cookies available."));
 	}
@@ -226,8 +229,7 @@ public class WebViewFeatureTests : _GalleryUITest
 		App.Tap(Options);
 		App.WaitForElement(GithubUrlButton);
 		App.Tap(GithubUrlButton);
-		App.WaitForElement(Apply);
-		App.Tap(Apply);
+		TapApplyAndWaitForMainPage();
 		App.WaitForElement("ReloadButton");
 		App.Tap("ReloadButton");
 		var navigatedText = App.FindElement(NavigatedStatusLabel).GetText();
@@ -243,8 +245,7 @@ public class WebViewFeatureTests : _GalleryUITest
 		App.Tap(Options);
 		App.WaitForElement(HtmlSourceButton);
 		App.Tap(HtmlSourceButton);
-		App.WaitForElement(Apply);
-		App.Tap(Apply);
+		TapApplyAndWaitForMainPage();
 		App.WaitForElement("ReloadButton");
 		App.Tap("ReloadButton");
 		var navigatedText = App.FindElement(NavigatedStatusLabel).GetText();
@@ -260,8 +261,7 @@ public class WebViewFeatureTests : _GalleryUITest
 		App.Tap(Options);
 		App.WaitForElement("LoadPage1Button");
 		App.Tap("LoadPage1Button");
-		App.WaitForElement(Apply);
-		App.Tap(Apply);
+		TapApplyAndWaitForMainPage();
 		App.WaitForElement(EvaluateJSButton);
 		App.Tap(EvaluateJSButton);
 		App.WaitForElement(JSResultLabel);
@@ -277,8 +277,7 @@ public class WebViewFeatureTests : _GalleryUITest
 		App.Tap(Options);
 		App.WaitForElement("LoadMultiplePagesButton");
 		App.Tap("LoadMultiplePagesButton");
-		App.WaitForElement(Apply);
-		App.Tap(Apply);
+		TapApplyAndWaitForMainPage();
 		App.WaitForElement(EvaluateJSButton);
 		App.Tap(EvaluateJSButton);
 		App.WaitForElement(JSResultLabel);
@@ -296,9 +295,7 @@ public class WebViewFeatureTests : _GalleryUITest
 		App.Tap(GithubUrlButton);
 		App.WaitForElement("IsVisibleFalse");
 		App.Tap("IsVisibleFalse");
-		App.WaitForElement(Apply);
-		App.Tap(Apply);
-		App.WaitForElementTillPageNavigationSettled(Options);
+		TapApplyAndWaitForMainPage();
 		App.WaitForNoElement(WebViewControl);
 	}
 
@@ -311,9 +308,7 @@ public class WebViewFeatureTests : _GalleryUITest
 		App.Tap(Options);
 		App.WaitForElement("ShadowTrue");
 		App.Tap("ShadowTrue");
-		App.WaitForElement(Apply);
-		App.Tap(Apply);
-		App.WaitForElementTillPageNavigationSettled(Options, timeout: TimeSpan.FromSeconds(3));
+		TapApplyAndWaitForMainPage();
 		VerifyScreenshot(tolerance: 0.5, retryTimeout: TimeSpan.FromSeconds(2));
 	}
 #endif


### PR DESCRIPTION
This pull request improves the reliability and maintainability of `WebViewFeatureTests` by introducing a shared helper method for handling the `"Apply"` button flow.

### What changed

* Added a new helper method, `TapApplyAndWaitForMainPage`, which:

  * Taps the `"Apply"` button
  * Waits for the main page to load
  * Retries up to three times to handle temporary UI failures

* Replaced all direct `"Apply"` button tap-and-wait logic in the tests with the new helper method, ensuring consistent behavior across the test suite.

### Maintainability improvements

* Added the `ApplyTapMaxAttempts` constant to centralize retry configuration and make future updates easier.

### Benefits

These changes make the UI tests more stable, reduce duplicated code, and centralize the logic for interacting with the `"Apply"` button.
