### PR TITLE
Revert [Android] Fix CollectionView handler cleanup when DataTemplateSelector switches templates

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
@@ -66,10 +66,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				RemoveView(platformView);
 			}
 
-			// Capture the current platform view before disconnecting handlers, because
-			// DisconnectHandlers() may null out the handler's PlatformView/ContainerView.
-			View?.DisconnectHandlers();
-
 			Content = null;
 			_pixelSize = null;
 			_reportMeasure = null;

--- a/src/Controls/src/Core/Handlers/Items/Android/TemplatedItemViewHolder.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/TemplatedItemViewHolder.cs
@@ -42,14 +42,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			}
 
 			itemsView.RemoveLogicalChild(View);
-
-			// Disconnect and clear the handler via ItemContentView.Recycle(), which calls
-			// DisconnectHandlers() before releasing Content. Reset _selectedTemplate so the
-			// next Bind() call always goes through the templateChanging path and recreates
-			// the handler (since we just disconnected it).
-			_itemContentView.Recycle();
-			View = null; // clear reference to the disconnected view
-			_selectedTemplate = null; // force templateChanging=true on next Bind() to recreate the view
 		}
 
 		public void Bind(object itemBindingContext, ItemsView itemsView,

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32243.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32243.cs
@@ -1,3 +1,4 @@
+#if !ANDROID
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -31,3 +32,4 @@ public class Issue32243 : _IssuesUITest
 			"CollectionView should disconnect handlers from views belonging to the old DataTemplate after navigating back.");
 	}
 }
+#endif


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

Reverts Android fix from #34534

Fixes https://github.com/dotnet/maui/issues/35344
