### PR TITLE
Fix ShellContent badge propagation

### DIFF
--- a/src/Controls/src/Core/Shell/ShellSection.cs
+++ b/src/Controls/src/Core/Shell/ShellSection.cs
@@ -309,6 +309,9 @@ namespace Microsoft.Maui.Controls
 			shellSection.SetBinding(TitleProperty, static (BaseShellItem item) => item.Title, BindingMode.OneWay, source: shellContent);
 			shellSection.SetBinding(IconProperty, static (BaseShellItem item) => item.Icon, BindingMode.OneWay, source: shellContent);
 			shellSection.SetBinding(FlyoutIconProperty, static (BaseShellItem item) => item.FlyoutIcon, BindingMode.OneWay, source: shellContent);
+			shellSection.SetBinding(BadgeTextProperty, static (BaseShellItem item) => item.BadgeText, BindingMode.OneWay, source: shellContent);
+			shellSection.SetBinding(BadgeColorProperty, static (BaseShellItem item) => item.BadgeColor, BindingMode.OneWay, source: shellContent);
+			shellSection.SetBinding(BadgeTextColorProperty, static (BaseShellItem item) => item.BadgeTextColor, BindingMode.OneWay, source: shellContent);
 
 			return shellSection;
 		}

--- a/src/Controls/tests/Core.UnitTests/ShellBadgeTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellBadgeTests.cs
@@ -93,6 +93,54 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public void BadgePropertiesPropagateFromShellContentToImplicitShellSection()
+		{
+			var shellContent = new ShellContent
+			{
+				BadgeText = "3",
+				BadgeColor = Colors.Red,
+				BadgeTextColor = Colors.White
+			};
+
+			var tabBar = new TabBar();
+			tabBar.Items.Add(shellContent);
+			var shellSection = tabBar.Items[0];
+
+			Assert.Equal("3", shellSection.BadgeText);
+			Assert.Equal(Colors.Red, shellSection.BadgeColor);
+			Assert.Equal(Colors.White, shellSection.BadgeTextColor);
+		}
+
+		[Fact]
+		public void BadgePropertyChangesPropagateFromShellContentToImplicitShellSection()
+		{
+			var shellContent = new ShellContent
+			{
+				BadgeText = "3",
+				BadgeColor = Colors.Red,
+				BadgeTextColor = Colors.White
+			};
+
+			var shellSection = ShellSection.CreateFromShellContent(shellContent);
+
+			shellContent.BadgeText = "";
+			shellContent.BadgeColor = Colors.Blue;
+			shellContent.BadgeTextColor = Colors.Black;
+
+			Assert.Equal("", shellSection.BadgeText);
+			Assert.Equal(Colors.Blue, shellSection.BadgeColor);
+			Assert.Equal(Colors.Black, shellSection.BadgeTextColor);
+
+			shellContent.BadgeText = null;
+			shellContent.BadgeColor = null;
+			shellContent.BadgeTextColor = null;
+
+			Assert.Null(shellSection.BadgeText);
+			Assert.Null(shellSection.BadgeColor);
+			Assert.Null(shellSection.BadgeTextColor);
+		}
+
+		[Fact]
 		public void BadgeTextWorksOnShellItem()
 		{
 			var shellItem = new ShellItem();


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary
- Bind `BadgeText`, `BadgeColor`, and `BadgeTextColor` from `ShellContent` to the implicit `ShellSection` created for TabBar items.
- Add unit coverage for initial and runtime badge property propagation.

Fixes #35448

## Testing
- `bash ./eng/common/dotnet.sh test src/Controls/tests/Core.UnitTests/Controls.Core.UnitTests.csproj -f net11.0 --filter FullyQualifiedName~ShellBadgeTests --verbosity minimal -p:IncludeAndroidTargetFrameworks=false -p:IncludeIosTargetFrameworks=false -p:IncludeMacCatalystTargetFrameworks=false -p:IncludeWindowsTargetFrameworks=false -p:IncludeTizenTargetFrameworks=false -p:IncludeMacOSTargetFrameworks=false`