### PR TITLE
Avoid layout diagnostics allocations without listeners

### DIFF
--- a/src/Core/src/Diagnostics/DiagnosticsManager.cs
+++ b/src/Core/src/Diagnostics/DiagnosticsManager.cs
@@ -35,6 +35,8 @@ internal class DiagnosticsManager : IDiagnosticsManager
 
 	public ActivitySource ActivitySource { get; }
 
+	public bool HasActivityListeners => ActivitySource.HasListeners();
+
 	public Meter? Meter { get; }
 
 	public void GetTags(object source, out TagList tagList)

--- a/src/Core/src/Diagnostics/IDiagnosticsManager.cs
+++ b/src/Core/src/Diagnostics/IDiagnosticsManager.cs
@@ -7,6 +7,8 @@ internal interface IDiagnosticsManager
 {
 	ActivitySource ActivitySource { get; }
 
+	bool HasActivityListeners { get; }
+
 	Meter? Meter { get; }
 
 	void GetTags(object source, out TagList tagList);

--- a/src/Core/src/Diagnostics/Instrumentation/DiagnosticInstrumentation.cs
+++ b/src/Core/src/Diagnostics/Instrumentation/DiagnosticInstrumentation.cs
@@ -10,18 +10,52 @@ internal static class DiagnosticInstrumentation
 	/// </summary>
 	/// <param name="view">The view to instrument.</param>
 	/// <returns>Returns an instance of <see cref="LayoutMeasureInstrumentation"/> if instrumentation is supported; otherwise, null.</returns>
-	public static LayoutMeasureInstrumentation? StartLayoutMeasure(IView view) =>
-		RuntimeFeature.IsMeterSupported
-			? new LayoutMeasureInstrumentation(view)
-			: null;
+	public static LayoutMeasureInstrumentation? StartLayoutMeasure(IView view)
+	{
+		if (!RuntimeFeature.IsMeterSupported)
+		{
+			return null;
+		}
+
+		var diagnostics = view.GetMauiDiagnostics();
+		if (diagnostics is null)
+		{
+			return null;
+		}
+
+		var metrics = diagnostics.GetMetrics<LayoutDiagnosticMetrics>();
+		if (!diagnostics.HasActivityListeners && metrics?.IsMeasureEnabled != true)
+		{
+			return null;
+		}
+
+		return new LayoutMeasureInstrumentation(view, diagnostics, metrics);
+	}
 
 	/// <summary>
 	/// Starts layout arrange instrumentation for the specified view.
 	/// </summary>
 	/// <param name="view">The view to instrument.</param>
 	/// <returns>Returns an instance of <see cref="LayoutArrangeInstrumentation"/> if instrumentation is supported; otherwise, null.</returns>
-	public static LayoutArrangeInstrumentation? StartLayoutArrange(IView view) =>
-		RuntimeFeature.IsMeterSupported
-			? new LayoutArrangeInstrumentation(view)
-			: null;
+	public static LayoutArrangeInstrumentation? StartLayoutArrange(IView view)
+	{
+		if (!RuntimeFeature.IsMeterSupported)
+		{
+			return null;
+		}
+
+		var diagnostics = view.GetMauiDiagnostics();
+		if (diagnostics is null)
+		{
+			return null;
+		}
+
+		var metrics = diagnostics.GetMetrics<LayoutDiagnosticMetrics>();
+		if (!diagnostics.HasActivityListeners && metrics?.IsArrangeEnabled != true)
+		{
+			return null;
+		}
+
+		return new LayoutArrangeInstrumentation(view, diagnostics, metrics);
+	}
 }

--- a/src/Core/src/Diagnostics/Instrumentation/LayoutArrangeInstrumentation.cs
+++ b/src/Core/src/Diagnostics/Instrumentation/LayoutArrangeInstrumentation.cs
@@ -5,21 +5,57 @@ namespace Microsoft.Maui.Diagnostics;
 /// <summary>
 /// Instrumentation for the layout arrange phase of a view.
 /// </summary>
-readonly struct LayoutArrangeInstrumentation(IView view) : IDiagnosticInstrumentation
+readonly struct LayoutArrangeInstrumentation : System.IDisposable
 {
-	readonly Activity? _activity = view.StartDiagnosticActivity("Arrange");
+	readonly IView _view;
+	readonly IDiagnosticsManager _diagnostics;
+	readonly LayoutDiagnosticMetrics? _metrics;
+	readonly Activity? _activity;
+	readonly long _metricsStartTimestamp;
+
+	public LayoutArrangeInstrumentation(IView view, IDiagnosticsManager diagnostics, LayoutDiagnosticMetrics? metrics)
+	{
+		_view = view;
+		_diagnostics = diagnostics;
+		_metrics = metrics;
+
+		if (diagnostics.HasActivityListeners)
+		{
+			diagnostics.GetTags(view, out var tagList);
+			_activity = diagnostics.ActivitySource.StartActivity(
+				ActivityKind.Internal,
+				name: $"Arrange {view.GetType().Name}",
+				tags: tagList);
+		}
+		else
+		{
+			_activity = null;
+		}
+
+		_metricsStartTimestamp = metrics?.IsArrangeDurationEnabled == true
+			? Stopwatch.GetTimestamp()
+			: 0;
+	}
 
 	/// <summary>
 	/// Disposes the instrumentation and stops the diagnostic activity.
 	/// </summary>
-	public void Dispose() =>
-		view.StopDiagnostics(_activity, this);
+	public void Dispose()
+	{
+		var metrics = _metrics;
+		var recordDuration = _metricsStartTimestamp != 0 && metrics?.IsArrangeDurationEnabled == true;
+		var duration = recordDuration
+			? LayoutDiagnosticMetrics.GetElapsedNanoseconds(_metricsStartTimestamp)
+			: 0;
 
-	/// <summary>
-	/// Records the stopping of the instrumentation and publishes various metrics.
-	/// </summary>
-	/// <param name="diagnostics">The <see cref="IDiagnosticsManager"/> instance.</param>
-	/// <param name="tagList">The tags associated with the instrumentation.</param>
-	public void Stopped(IDiagnosticsManager diagnostics, in TagList tagList) =>
-		diagnostics.GetMetrics<LayoutDiagnosticMetrics>()?.RecordArrange(_activity?.Duration, in tagList);
+		_activity?.Stop();
+
+		if (metrics?.IsArrangeEnabled == true)
+		{
+			_diagnostics.GetTags(_view, out var tagList);
+			metrics.RecordArrange(duration, recordDuration, in tagList);
+		}
+
+		_activity?.Dispose();
+	}
 }

--- a/src/Core/src/Diagnostics/Instrumentation/LayoutArrangeInstrumentation.cs
+++ b/src/Core/src/Diagnostics/Instrumentation/LayoutArrangeInstrumentation.cs
@@ -11,6 +11,7 @@ readonly struct LayoutArrangeInstrumentation : System.IDisposable
 	readonly IDiagnosticsManager _diagnostics;
 	readonly LayoutDiagnosticMetrics? _metrics;
 	readonly Activity? _activity;
+	readonly bool _metricsDurationStarted;
 	readonly long _metricsStartTimestamp;
 
 	public LayoutArrangeInstrumentation(IView view, IDiagnosticsManager diagnostics, LayoutDiagnosticMetrics? metrics)
@@ -32,7 +33,8 @@ readonly struct LayoutArrangeInstrumentation : System.IDisposable
 			_activity = null;
 		}
 
-		_metricsStartTimestamp = metrics?.IsArrangeDurationEnabled == true
+		_metricsDurationStarted = metrics?.IsArrangeDurationEnabled == true;
+		_metricsStartTimestamp = _metricsDurationStarted
 			? Stopwatch.GetTimestamp()
 			: 0;
 	}
@@ -43,7 +45,7 @@ readonly struct LayoutArrangeInstrumentation : System.IDisposable
 	public void Dispose()
 	{
 		var metrics = _metrics;
-		var recordDuration = _metricsStartTimestamp != 0 && metrics?.IsArrangeDurationEnabled == true;
+		var recordDuration = _metricsDurationStarted && metrics?.IsArrangeDurationEnabled == true;
 		var duration = recordDuration
 			? LayoutDiagnosticMetrics.GetElapsedNanoseconds(_metricsStartTimestamp)
 			: 0;

--- a/src/Core/src/Diagnostics/Instrumentation/LayoutDiagnosticMetrics.cs
+++ b/src/Core/src/Diagnostics/Instrumentation/LayoutDiagnosticMetrics.cs
@@ -91,6 +91,14 @@ internal class LayoutDiagnosticMetrics : IDiagnosticMetrics
 	internal static int GetElapsedNanoseconds(long startTimestamp)
 	{
 		var elapsedTimestamp = Stopwatch.GetTimestamp() - startTimestamp;
-		return (int)(elapsedTimestamp * (1_000_000_000.0 / Stopwatch.Frequency));
+		if (elapsedTimestamp <= 0)
+		{
+			return 0;
+		}
+
+		var elapsedNanoseconds = elapsedTimestamp * (1_000_000_000.0 / Stopwatch.Frequency);
+		return elapsedNanoseconds >= int.MaxValue
+			? int.MaxValue
+			: (int)elapsedNanoseconds;
 	}
 }

--- a/src/Core/src/Diagnostics/Instrumentation/LayoutDiagnosticMetrics.cs
+++ b/src/Core/src/Diagnostics/Instrumentation/LayoutDiagnosticMetrics.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 
@@ -29,6 +28,18 @@ internal class LayoutDiagnosticMetrics : IDiagnosticMetrics
 	/// </summary>
 	internal Histogram<int>? ArrangeHistogram { get; private set; }
 
+	internal bool IsMeasureEnabled =>
+		MeasureCounter?.Enabled == true ||
+		MeasureHistogram?.Enabled == true;
+
+	internal bool IsMeasureDurationEnabled => MeasureHistogram?.Enabled == true;
+
+	internal bool IsArrangeEnabled =>
+		ArrangeCounter?.Enabled == true ||
+		ArrangeHistogram?.Enabled == true;
+
+	internal bool IsArrangeDurationEnabled => ArrangeHistogram?.Enabled == true;
+
 	/// <inheritdoc/>
 	public void Create(Meter meter)
 	{
@@ -42,38 +53,44 @@ internal class LayoutDiagnosticMetrics : IDiagnosticMetrics
 	/// <summary>
 	/// Records a measure operation with an optional duration and associated tags.
 	/// </summary>
-	/// <param name="duration">The duration of the measure operation.</param>
+	/// <param name="duration">The duration of the measure operation in nanoseconds.</param>
+	/// <param name="recordDuration">Whether a duration should be recorded.</param>
 	/// <param name="tagList">The tags associated with the measure operation.</param>
-	public void RecordMeasure(TimeSpan? duration, in TagList tagList)
+	public void RecordMeasure(int duration, bool recordDuration, in TagList tagList)
 	{
-		MeasureCounter?.Add(1, tagList);
-
-		if (duration is not null)
+		if (MeasureCounter?.Enabled == true)
 		{
-#if NET9_0_OR_GREATER
-			MeasureHistogram?.Record((int)duration.Value.TotalNanoseconds, tagList);
-#else
-			MeasureHistogram?.Record((int)(duration.Value.TotalMilliseconds * 1_000_000), tagList);
-#endif
+			MeasureCounter.Add(1, tagList);
+		}
+
+		if (recordDuration && MeasureHistogram?.Enabled == true)
+		{
+			MeasureHistogram.Record(duration, tagList);
 		}
 	}
 
 	/// <summary>
 	/// Records an arrange operation with an optional duration and associated tags.
 	/// </summary>
-	/// <param name="duration">The duration of the arrange operation.</param>
+	/// <param name="duration">The duration of the arrange operation in nanoseconds.</param>
+	/// <param name="recordDuration">Whether a duration should be recorded.</param>
 	/// <param name="tagList">The tags associated with the arrange operation.</param>
-	public void RecordArrange(TimeSpan? duration, in TagList tagList)
+	public void RecordArrange(int duration, bool recordDuration, in TagList tagList)
 	{
-		ArrangeCounter?.Add(1, tagList);
-
-		if (duration is not null)
+		if (ArrangeCounter?.Enabled == true)
 		{
-#if NET9_0_OR_GREATER
-			ArrangeHistogram?.Record((int)duration.Value.TotalNanoseconds, tagList);
-#else
-			ArrangeHistogram?.Record((int)(duration.Value.TotalMilliseconds * 1_000_000), tagList);
-#endif
+			ArrangeCounter.Add(1, tagList);
 		}
+
+		if (recordDuration && ArrangeHistogram?.Enabled == true)
+		{
+			ArrangeHistogram.Record(duration, tagList);
+		}
+	}
+
+	internal static int GetElapsedNanoseconds(long startTimestamp)
+	{
+		var elapsedTimestamp = Stopwatch.GetTimestamp() - startTimestamp;
+		return (int)(elapsedTimestamp * (1_000_000_000.0 / Stopwatch.Frequency));
 	}
 }

--- a/src/Core/src/Diagnostics/Instrumentation/LayoutMeasureInstrumentation.cs
+++ b/src/Core/src/Diagnostics/Instrumentation/LayoutMeasureInstrumentation.cs
@@ -5,21 +5,57 @@ namespace Microsoft.Maui.Diagnostics;
 /// <summary>
 /// Instrumentation for measuring layout operations in a view.
 /// </summary>
-readonly struct LayoutMeasureInstrumentation(IView view) : IDiagnosticInstrumentation
+readonly struct LayoutMeasureInstrumentation : System.IDisposable
 {
-	readonly Activity? _activity = view.StartDiagnosticActivity("Measure");
+	readonly IView _view;
+	readonly IDiagnosticsManager _diagnostics;
+	readonly LayoutDiagnosticMetrics? _metrics;
+	readonly Activity? _activity;
+	readonly long _metricsStartTimestamp;
+
+	public LayoutMeasureInstrumentation(IView view, IDiagnosticsManager diagnostics, LayoutDiagnosticMetrics? metrics)
+	{
+		_view = view;
+		_diagnostics = diagnostics;
+		_metrics = metrics;
+
+		if (diagnostics.HasActivityListeners)
+		{
+			diagnostics.GetTags(view, out var tagList);
+			_activity = diagnostics.ActivitySource.StartActivity(
+				ActivityKind.Internal,
+				name: $"Measure {view.GetType().Name}",
+				tags: tagList);
+		}
+		else
+		{
+			_activity = null;
+		}
+
+		_metricsStartTimestamp = metrics?.IsMeasureDurationEnabled == true
+			? Stopwatch.GetTimestamp()
+			: 0;
+	}
 
 	/// <summary>
 	/// Disposes the instrumentation and stops the diagnostic activity.
 	/// </summary>
-	public void Dispose() =>
-		view.StopDiagnostics(_activity, this);
+	public void Dispose()
+	{
+		var metrics = _metrics;
+		var recordDuration = _metricsStartTimestamp != 0 && metrics?.IsMeasureDurationEnabled == true;
+		var duration = recordDuration
+			? LayoutDiagnosticMetrics.GetElapsedNanoseconds(_metricsStartTimestamp)
+			: 0;
 
-	/// <summary>
-	/// Records the stopping of the instrumentation and publishes various metrics.
-	/// </summary>
-	/// <param name="diagnostics">The <see cref="IDiagnosticsManager"/> instance.</param>
-	/// <param name="tagList">The tags associated with the instrumentation.</param>
-	public void Stopped(IDiagnosticsManager diagnostics, in TagList tagList) =>
-		diagnostics.GetMetrics<LayoutDiagnosticMetrics>()?.RecordMeasure(_activity?.Duration, in tagList);
+		_activity?.Stop();
+
+		if (metrics?.IsMeasureEnabled == true)
+		{
+			_diagnostics.GetTags(_view, out var tagList);
+			metrics.RecordMeasure(duration, recordDuration, in tagList);
+		}
+
+		_activity?.Dispose();
+	}
 }

--- a/src/Core/src/Diagnostics/Instrumentation/LayoutMeasureInstrumentation.cs
+++ b/src/Core/src/Diagnostics/Instrumentation/LayoutMeasureInstrumentation.cs
@@ -11,6 +11,7 @@ readonly struct LayoutMeasureInstrumentation : System.IDisposable
 	readonly IDiagnosticsManager _diagnostics;
 	readonly LayoutDiagnosticMetrics? _metrics;
 	readonly Activity? _activity;
+	readonly bool _metricsDurationStarted;
 	readonly long _metricsStartTimestamp;
 
 	public LayoutMeasureInstrumentation(IView view, IDiagnosticsManager diagnostics, LayoutDiagnosticMetrics? metrics)
@@ -32,7 +33,8 @@ readonly struct LayoutMeasureInstrumentation : System.IDisposable
 			_activity = null;
 		}
 
-		_metricsStartTimestamp = metrics?.IsMeasureDurationEnabled == true
+		_metricsDurationStarted = metrics?.IsMeasureDurationEnabled == true;
+		_metricsStartTimestamp = _metricsDurationStarted
 			? Stopwatch.GetTimestamp()
 			: 0;
 	}
@@ -43,7 +45,7 @@ readonly struct LayoutMeasureInstrumentation : System.IDisposable
 	public void Dispose()
 	{
 		var metrics = _metrics;
-		var recordDuration = _metricsStartTimestamp != 0 && metrics?.IsMeasureDurationEnabled == true;
+		var recordDuration = _metricsDurationStarted && metrics?.IsMeasureDurationEnabled == true;
 		var duration = recordDuration
 			? LayoutDiagnosticMetrics.GetElapsedNanoseconds(_metricsStartTimestamp)
 			: 0;

--- a/src/Core/tests/Benchmarks/Benchmarks/LayoutDiagnosticsBenchmarker.cs
+++ b/src/Core/tests/Benchmarks/Benchmarks/LayoutDiagnosticsBenchmarker.cs
@@ -1,0 +1,148 @@
+﻿using BenchmarkDotNet.Attributes;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Hosting;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Hosting;
+
+namespace Microsoft.Maui.Benchmarks
+{
+	[MemoryDiagnoser]
+	public class LayoutDiagnosticsBenchmarker
+	{
+		const int SingleIterations = 1024;
+		const int SingleOperationsPerInvoke = SingleIterations * 2;
+		const int TreeChildCount = 100;
+		const int TreeIterations = 16;
+		const int TreeOperationsPerInvoke = TreeChildCount * TreeIterations * 2;
+
+		static readonly Rect ArrangeBounds = new(0, 0, 100, 100);
+		static readonly Rect TreeBounds = new(0, 0, 100, 2400);
+
+		MauiApp _app;
+		MauiContext _context;
+		IView _view;
+		ILayout _layout;
+
+		[GlobalSetup]
+		public void Setup()
+		{
+			var builder = MauiApp.CreateBuilder();
+			builder.UseMauiApp<Application>();
+
+			_app = builder.Build();
+			_context = new MauiContext(_app.Services);
+			_view = CreateProbeView(_context);
+
+			var layout = new VerticalStackLayout
+			{
+				Spacing = 0,
+			};
+
+			for (var i = 0; i < TreeChildCount; i++)
+			{
+				layout.Add(CreateProbeView(_context));
+			}
+
+			_layout = layout;
+		}
+
+		[GlobalCleanup]
+		public void Cleanup()
+		{
+			_app?.Dispose();
+		}
+
+		[Benchmark(OperationsPerInvoke = SingleOperationsPerInvoke)]
+		public double MeasureAndArrangeViewNoListener()
+		{
+			double checksum = 0;
+
+			for (var i = 0; i < SingleIterations; i++)
+			{
+				var measured = _view.Measure(100, 100);
+				var arranged = _view.Arrange(ArrangeBounds);
+				checksum += measured.Width + arranged.Height;
+			}
+
+			return checksum;
+		}
+
+		[Benchmark(OperationsPerInvoke = TreeOperationsPerInvoke)]
+		public double MeasureAndArrangeTreeNoListener()
+		{
+			double checksum = 0;
+
+			for (var i = 0; i < TreeIterations; i++)
+			{
+				var measured = _layout.CrossPlatformMeasure(100, 2400);
+				var arranged = _layout.CrossPlatformArrange(TreeBounds);
+				checksum += measured.Width + arranged.Height;
+			}
+
+			return checksum;
+		}
+
+		static ProbeView CreateProbeView(IMauiContext context)
+		{
+			var view = new ProbeView
+			{
+				Handler = new ProbeHandler(context),
+			};
+
+			return view;
+		}
+
+		sealed class ProbeView : View
+		{
+			protected override Size MeasureOverride(double widthConstraint, double heightConstraint) =>
+				new(42, 24);
+
+			protected override Size ArrangeOverride(Rect bounds)
+			{
+				Frame = bounds;
+				return bounds.Size;
+			}
+		}
+
+		sealed class ProbeHandler(IMauiContext context) : IViewHandler
+		{
+			public bool HasContainer { get; set; }
+
+			public object ContainerView => null;
+
+			public object PlatformView => null;
+
+			public IView VirtualView { get; private set; }
+
+			IElement IElementHandler.VirtualView => VirtualView;
+
+			public IMauiContext MauiContext { get; private set; } = context;
+
+			public void SetMauiContext(IMauiContext mauiContext) => MauiContext = mauiContext;
+
+			public void SetVirtualView(IElement view)
+			{
+				VirtualView = (IView)view;
+			}
+
+			public void UpdateValue(string property)
+			{
+			}
+
+			public void Invoke(string command, object args = null)
+			{
+			}
+
+			public void DisconnectHandler()
+			{
+			}
+
+			public Size GetDesiredSize(double widthConstraint, double heightConstraint) =>
+				new(42, 24);
+
+			public void PlatformArrange(Rect frame)
+			{
+			}
+		}
+	}
+}

--- a/src/Core/tests/UnitTests/Diagnostics/LayoutDiagnosticsTests.cs
+++ b/src/Core/tests/UnitTests/Diagnostics/LayoutDiagnosticsTests.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Diagnostics;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Hosting;
+using Xunit;
+
+namespace Microsoft.Maui.UnitTests.Diagnostics
+{
+	[Category(TestCategory.Core)]
+	public class LayoutDiagnosticsTests
+	{
+		const int AllocationIterations = 1024;
+		const string MeasureDurationInstrumentName = "maui.layout.measure_duration";
+		const string ArrangeDurationInstrumentName = "maui.layout.arrange_duration";
+
+		static readonly Rect ArrangeBounds = new Rect(0, 0, 100, 100);
+
+		[Fact]
+		public void MeasureAndArrangeDoNotAllocateWithoutListeners()
+		{
+			using var app = CreateMauiApp();
+			var view = CreateProbeView(new MauiContext(app.Services));
+			var iView = (IView)view;
+
+			for (var i = 0; i < 64; i++)
+			{
+				iView.Measure(100, 100);
+				iView.Arrange(ArrangeBounds);
+			}
+
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+			GC.Collect();
+
+			var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+			for (var i = 0; i < AllocationIterations; i++)
+			{
+				iView.Measure(100, 100);
+				iView.Arrange(ArrangeBounds);
+			}
+			var allocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+
+			Assert.Equal(0, allocated);
+		}
+
+		[Theory]
+		[InlineData(MeasureDurationInstrumentName)]
+		[InlineData(ArrangeDurationInstrumentName)]
+		public void DurationMetricsRecordWithoutActivityListeners(string instrumentName)
+		{
+			var measurements = new List<int>();
+
+			using var listener = new MeterListener();
+			listener.InstrumentPublished = (instrument, meterListener) =>
+			{
+				if (instrument.Meter.Name == "Microsoft.Maui" && instrument.Name == instrumentName)
+				{
+					meterListener.EnableMeasurementEvents(instrument);
+				}
+			};
+			listener.SetMeasurementEventCallback<int>((instrument, measurement, tags, state) =>
+			{
+				if (instrument.Meter.Name == "Microsoft.Maui" && instrument.Name == instrumentName)
+				{
+					measurements.Add(measurement);
+				}
+			});
+			listener.Start();
+
+			using var app = CreateMauiApp();
+			var view = CreateProbeView(new MauiContext(app.Services));
+			var iView = (IView)view;
+
+			if (instrumentName == MeasureDurationInstrumentName)
+			{
+				iView.Measure(100, 100);
+			}
+			else
+			{
+				iView.Arrange(ArrangeBounds);
+			}
+
+			var measurement = Assert.Single(measurements);
+			Assert.True(measurement >= 0);
+		}
+
+		[Fact]
+		public void ElapsedNanosecondsClampsToIntMaxValue()
+		{
+			var startTimestamp = Stopwatch.GetTimestamp() - (Stopwatch.Frequency * 3);
+
+			var elapsedNanoseconds = LayoutDiagnosticMetrics.GetElapsedNanoseconds(startTimestamp);
+
+			Assert.Equal(int.MaxValue, elapsedNanoseconds);
+		}
+
+		[Fact]
+		public void ElapsedNanosecondsReturnsZeroForNonPositiveElapsedTime()
+		{
+			var startTimestamp = Stopwatch.GetTimestamp() + Stopwatch.Frequency;
+
+			var elapsedNanoseconds = LayoutDiagnosticMetrics.GetElapsedNanoseconds(startTimestamp);
+
+			Assert.Equal(0, elapsedNanoseconds);
+		}
+
+		static MauiApp CreateMauiApp()
+		{
+			var builder = MauiApp.CreateBuilder();
+			builder.Services.AddSingleton<IMeterFactory, TestMeterFactory>();
+
+			return builder.Build();
+		}
+
+		static ProbeView CreateProbeView(IMauiContext context)
+		{
+			var view = new ProbeView
+			{
+				Handler = new ProbeHandler(context),
+			};
+
+			return view;
+		}
+
+		sealed class ProbeView : View
+		{
+			protected override Size MeasureOverride(double widthConstraint, double heightConstraint) =>
+				new Size(42, 24);
+
+			protected override Size ArrangeOverride(Rect bounds) =>
+				bounds.Size;
+		}
+
+		sealed class ProbeHandler : IViewHandler
+		{
+			public ProbeHandler(IMauiContext context)
+			{
+				MauiContext = context;
+			}
+
+			public bool HasContainer { get; set; }
+
+			public object ContainerView => null;
+
+			public object PlatformView => null;
+
+			public IView VirtualView { get; private set; }
+
+			IElement IElementHandler.VirtualView => VirtualView;
+
+			public IMauiContext MauiContext { get; private set; }
+
+			public void SetMauiContext(IMauiContext mauiContext) =>
+				MauiContext = mauiContext;
+
+			public void SetVirtualView(IElement view) =>
+				VirtualView = (IView)view;
+
+			public void UpdateValue(string property)
+			{
+			}
+
+			public void Invoke(string command, object args = null)
+			{
+			}
+
+			public void DisconnectHandler()
+			{
+			}
+
+			public Size GetDesiredSize(double widthConstraint, double heightConstraint) =>
+				new Size(42, 24);
+
+			public void PlatformArrange(Rect frame)
+			{
+			}
+		}
+
+		sealed class TestMeterFactory : IMeterFactory
+		{
+			readonly List<Meter> _meters = new List<Meter>();
+
+			public Meter Create(MeterOptions options)
+			{
+				var meter = new Meter(options);
+				_meters.Add(meter);
+
+				return meter;
+			}
+
+			public void Dispose()
+			{
+				foreach (var meter in _meters)
+				{
+					meter.Dispose();
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes layout diagnostics allocation churn in the no-consumer path.

In MAUI 10, `IView.Measure` / `IView.Arrange` could allocate on every call when `System.Diagnostics.Metrics.Meter.IsSupported == true`, even when no `ActivityListener` or `MeterListener` was consuming MAUI layout diagnostics. This change gates layout diagnostics work on actual consumers before constructing tags or instrumentation state:

- activity consumer: `ActivitySource.HasListeners()`
- metrics consumer: layout counter/histogram `Enabled`

The layout-specific instrumentation path now avoids the generic `IDiagnosticInstrumentation` stop path so the no-listener case avoids tag construction, struct boxing, and per-operation allocation.

Also adds a `LayoutDiagnosticsBenchmarker` covering single-view and layout-tree measure/arrange with no active diagnostics listener.

Benchmark command:

```bash
dotnet run --project src/Core/tests/Benchmarks/Core.Benchmarks.csproj -c Release -f net10.0 -- --filter "*LayoutDiagnosticsBenchmarker*" --job short
```

Results comparing the pre-patch merge base to this branch:

| Benchmark | Pre Mean | Post Mean | Time Change | Pre Alloc | Post Alloc | Alloc Change |
|---|---:|---:|---:|---:|---:|---:|
| `MeasureAndArrangeViewNoListener` | `106.983 ns` | `15.712 ns` | `-85.314%` | `376 B` | `0 B` | `-100.000%` |
| `MeasureAndArrangeTreeNoListener` | `155.880 ns` | `27.890 ns` | `-82.108%` | `392 B` | `0 B` | `-100.000%` |

### Issues Fixed

Fixes #35473
