### PR TITLE
Fix Android map view lifecycle cleanup

### DIFF
--- a/src/Controls/src/Core/Shell/ShellSection.cs
+++ b/src/Controls/src/Core/Shell/ShellSection.cs
@@ -127,6 +127,7 @@ namespace Microsoft.Maui.Controls
 			await poppingCompleted;
 
 			RemovePage(page);
+			page?.DisconnectHandlers();
 
 			(Parent?.Parent as IShellController)?.UpdateCurrentState(ShellNavigationSource.Pop);
 		}
@@ -146,7 +147,10 @@ namespace Microsoft.Maui.Controls
 			await finishedPopping;
 
 			for (int i = 1; i < oldStack.Count; i++)
+			{
 				RemovePage(oldStack[i]);
+				oldStack[i]?.DisconnectHandlers();
+			}
 
 			(Parent?.Parent as IShellController)?.UpdateCurrentState(ShellNavigationSource.PopToRoot);
 		}
@@ -163,6 +167,7 @@ namespace Microsoft.Maui.Controls
 			_navStack.Remove(last);
 
 			RemovePage(last);
+			last?.DisconnectHandlers();
 		}
 
 		// we want the list returned from here to remain point in time accurate
@@ -187,6 +192,7 @@ namespace Microsoft.Maui.Controls
 				_navStack.Remove(page);
 
 			RemovePage(page);
+			page?.DisconnectHandlers();
 		}
 
 
@@ -817,6 +823,7 @@ namespace Microsoft.Maui.Controls
 				await _handlerBasedNavigationCompletionSource.Task;
 
 			RemovePage(page);
+			page?.DisconnectHandlers();
 
 			return page;
 		}
@@ -873,6 +880,7 @@ namespace Microsoft.Maui.Controls
 				if (i < oldStack.Count - 1)
 					oldStack[i].SendDisappearing();
 				RemovePage(oldStack[i]);
+				oldStack[i]?.DisconnectHandlers();
 			}
 
 		}

--- a/src/Controls/src/Core/Shell/ShellSection.cs
+++ b/src/Controls/src/Core/Shell/ShellSection.cs
@@ -127,7 +127,6 @@ namespace Microsoft.Maui.Controls
 			await poppingCompleted;
 
 			RemovePage(page);
-			page?.DisconnectHandlers();
 
 			(Parent?.Parent as IShellController)?.UpdateCurrentState(ShellNavigationSource.Pop);
 		}
@@ -147,10 +146,7 @@ namespace Microsoft.Maui.Controls
 			await finishedPopping;
 
 			for (int i = 1; i < oldStack.Count; i++)
-			{
 				RemovePage(oldStack[i]);
-				oldStack[i]?.DisconnectHandlers();
-			}
 
 			(Parent?.Parent as IShellController)?.UpdateCurrentState(ShellNavigationSource.PopToRoot);
 		}
@@ -167,7 +163,6 @@ namespace Microsoft.Maui.Controls
 			_navStack.Remove(last);
 
 			RemovePage(last);
-			last?.DisconnectHandlers();
 		}
 
 		// we want the list returned from here to remain point in time accurate
@@ -192,7 +187,6 @@ namespace Microsoft.Maui.Controls
 				_navStack.Remove(page);
 
 			RemovePage(page);
-			page?.DisconnectHandlers();
 		}
 
 
@@ -823,7 +817,6 @@ namespace Microsoft.Maui.Controls
 				await _handlerBasedNavigationCompletionSource.Task;
 
 			RemovePage(page);
-			page?.DisconnectHandlers();
 
 			return page;
 		}
@@ -880,7 +873,6 @@ namespace Microsoft.Maui.Controls
 				if (i < oldStack.Count - 1)
 					oldStack[i].SendDisappearing();
 				RemovePage(oldStack[i]);
-				oldStack[i]?.DisconnectHandlers();
 			}
 
 		}
@@ -980,7 +972,6 @@ namespace Microsoft.Maui.Controls
 				PresentedPageAppearing();
 
 			RemovePage(page);
-			page?.DisconnectHandlers();
 			var args = new NavigationRequestedEventArgs(page, false)
 			{
 				RequestType = NavigationRequestType.Remove
@@ -1070,6 +1061,7 @@ namespace Microsoft.Maui.Controls
 		void RemovePage(Page page)
 		{
 			RemoveLogicalChild(page);
+			page?.DisconnectHandlers();
 		}
 
 		void SendAppearanceChanged() => ((IShellController)Parent?.Parent)?.AppearanceChanged(this, false);

--- a/src/Controls/tests/Core.UnitTests/ShellTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellTests.cs
@@ -3,8 +3,11 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Maui.Controls.Hosting;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Hosting;
+using Microsoft.Maui.Platform;
 using NSubstitute;
 using Xunit;
 
@@ -1553,6 +1556,94 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			await testShell.CurrentSection.Navigation.PopAsync();
 			Assert.Equal("Shell Content Title", shellToolBar.Title);
+		}
+
+		[Fact]
+		public async Task PoppedShellPageDisconnectsHandlers()
+		{
+			var mauiApp = MauiApp.CreateBuilder()
+				.UseMauiApp<ApplicationStub>()
+				.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler<ContentPage, HandlerStub>();
+					handlers.AddHandler<Button, HandlerStub>();
+				})
+				.Build();
+
+			var mauiContext = new MauiContext(mauiApp.Services);
+			var shellContent = CreateShellContent();
+			var shellSection = new ShellSection();
+			shellSection.Items.Add(shellContent);
+			var testShell = new TestShell(shellSection);
+
+			var button = new Button();
+			var pushedPage = new ContentPage
+			{
+				Content = button
+			};
+
+			pushedPage.ToHandler(mauiContext);
+			button.ToHandler(mauiContext);
+
+			await testShell.CurrentSection.Navigation.PushAsync(pushedPage);
+
+			Assert.NotNull(pushedPage.Handler);
+			Assert.NotNull(button.Handler);
+
+			await testShell.CurrentSection.Navigation.PopAsync();
+
+			Assert.Null(pushedPage.Handler);
+			Assert.Null(button.Handler);
+		}
+
+		[Fact]
+		public async Task PopToRootShellPagesDisconnectHandlers()
+		{
+			var mauiApp = MauiApp.CreateBuilder()
+				.UseMauiApp<ApplicationStub>()
+				.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler<ContentPage, HandlerStub>();
+					handlers.AddHandler<Button, HandlerStub>();
+				})
+				.Build();
+
+			var mauiContext = new MauiContext(mauiApp.Services);
+			var shellContent = CreateShellContent();
+			var shellSection = new ShellSection();
+			shellSection.Items.Add(shellContent);
+			var testShell = new TestShell(shellSection);
+
+			var firstButton = new Button();
+			var firstPushedPage = new ContentPage
+			{
+				Content = firstButton
+			};
+			var secondButton = new Button();
+			var secondPushedPage = new ContentPage
+			{
+				Content = secondButton
+			};
+
+			firstPushedPage.ToHandler(mauiContext);
+			firstButton.ToHandler(mauiContext);
+			secondPushedPage.ToHandler(mauiContext);
+			secondButton.ToHandler(mauiContext);
+
+			await testShell.CurrentSection.Navigation.PushAsync(firstPushedPage);
+			await testShell.CurrentSection.Navigation.PushAsync(secondPushedPage);
+
+			Assert.NotNull(firstPushedPage.Handler);
+			Assert.NotNull(firstButton.Handler);
+			Assert.NotNull(secondPushedPage.Handler);
+			Assert.NotNull(secondButton.Handler);
+
+			await testShell.CurrentSection.Navigation.PopToRootAsync();
+
+			Assert.Null(firstPushedPage.Handler);
+			Assert.Null(firstButton.Handler);
+			Assert.Null(secondPushedPage.Handler);
+			Assert.Null(secondButton.Handler);
 		}
 
 		[Fact]

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -59,13 +59,22 @@ namespace Microsoft.Maui.Maps.Handlers
 			base.DisconnectHandler(platformView);
 			platformView.LayoutChange -= MapViewLayoutChange;
 
-			if (Map != null)
+			var map = Map;
+			Map = null;
+
+			if (map != null)
 			{
-				Map.SetOnCameraMoveListener(null);
-				Map.MarkerClick -= OnMarkerClick;
-				Map.InfoWindowClick -= OnInfoWindowClick;
-				Map.MapClick -= OnMapClick;
+				map.MyLocationEnabled = false;
+				map.TrafficEnabled = false;
+				map.Clear();
+				map.SetOnCameraMoveListener(null);
+				map.MarkerClick -= OnMarkerClick;
+				map.InfoWindowClick -= OnInfoWindowClick;
+				map.MapClick -= OnMapClick;
 			}
+
+			_mapReady?.Dispose();
+			_mapReady = null;
 
 			if (_trackedMapElements != null)
 			{
@@ -75,18 +84,25 @@ namespace Microsoft.Maui.Maps.Handlers
 				_trackedMapElements = null;
 			}
 
+			_markers = null;
+			_pins = null;
 			_polylines = null;
 			_polygons = null;
 			_circles = null;
-			Map = null;
 			_init = true;
-			_mapReady = null;
+
+			platformView.OnPause();
+			platformView.OnStop();
+			platformView.OnDestroy();
+			map?.Dispose();
+			platformView.Dispose();
 		}
 
 		protected override MapView CreatePlatformView()
 		{
 			MapView mapView = new MapView(Context);
 			mapView.OnCreate(s_bundle);
+			mapView.OnStart();
 			mapView.OnResume();
 			return mapView;
 		}
@@ -314,6 +330,12 @@ namespace Microsoft.Maui.Maps.Handlers
 				return;
 			}
 
+			if (((IElementHandler)this).VirtualView is not IMap virtualView || _mapReady == null)
+			{
+				map.SetOnCameraMoveListener(null);
+				return;
+			}
+
 			Map = map;
 
 			map.SetOnCameraMoveListener(_mapReady);
@@ -322,33 +344,33 @@ namespace Microsoft.Maui.Maps.Handlers
 			map.InfoWindowClick += OnInfoWindowClick;
 			map.MapClick += OnMapClick;
 
-			if (VirtualView != null)
-			{
-				map.UpdateMapType(VirtualView);
-				map.UpdateIsShowingUser(VirtualView, MauiContext);
-				map.UpdateIsScrollEnabled(VirtualView);
-				map.UpdateIsTrafficEnabled(VirtualView);
-				map.UpdateIsZoomEnabled(VirtualView);
-			}
+			map.UpdateMapType(virtualView);
+			map.UpdateIsShowingUser(virtualView, MauiContext);
+			map.UpdateIsScrollEnabled(virtualView);
+			map.UpdateIsTrafficEnabled(virtualView);
+			map.UpdateIsZoomEnabled(virtualView);
 
 			InitialUpdate();
 		}
 
 		internal void UpdateVisibleRegion(LatLng pos)
 		{
-			if (Map == null)
+			var map = Map;
+			if (map == null ||
+				((IElementHandler)this).VirtualView is not IMap virtualView ||
+				((IElementHandler)this).PlatformView is not MapView platformView)
 				return;
 
-			Projection projection = Map.Projection;
-			int width = PlatformView.Width;
-			int height = PlatformView.Height;
+			Projection projection = map.Projection;
+			int width = platformView.Width;
+			int height = platformView.Height;
 			LatLng ul = projection.FromScreenLocation(new global::Android.Graphics.Point(0, 0));
 			LatLng ur = projection.FromScreenLocation(new global::Android.Graphics.Point(width, 0));
 			LatLng ll = projection.FromScreenLocation(new global::Android.Graphics.Point(0, height));
 			LatLng lr = projection.FromScreenLocation(new global::Android.Graphics.Point(width, height));
 			double dlat = Math.Max(Math.Abs(ul.Latitude - lr.Latitude), Math.Abs(ur.Latitude - ll.Latitude));
 			double dlong = Math.Max(Math.Abs(ul.Longitude - lr.Longitude), Math.Abs(ur.Longitude - ll.Longitude));
-			VirtualView.VisibleRegion = new MapSpan(new Devices.Sensors.Location(pos.Latitude, pos.Longitude), dlat, dlong);
+			virtualView.VisibleRegion = new MapSpan(new Devices.Sensors.Location(pos.Latitude, pos.Longitude), dlat, dlong);
 		}
 
 		void MapViewLayoutChange(object? sender, View.LayoutChangeEventArgs e)
@@ -358,7 +380,7 @@ namespace Microsoft.Maui.Maps.Handlers
 
 		void InitialUpdate()
 		{
-			if (Map == null)
+			if (Map == null || ((IElementHandler)this).VirtualView is not IMap virtualView)
 				return;
 
 			if (_init && _lastMoveToRegion != null)
@@ -366,7 +388,7 @@ namespace Microsoft.Maui.Maps.Handlers
 				MoveToRegion(_lastMoveToRegion, false);
 				if (_pins != null)
 					AddPins(_pins);
-				if (VirtualView?.Elements is IList elements && elements.Count > 0)
+				if (virtualView.Elements is IList elements && elements.Count > 0)
 				{
 					SyncMapElements(elements);
 				}
@@ -440,8 +462,11 @@ namespace Microsoft.Maui.Maps.Handlers
 			}
 		}
 
-		void OnMapClick(object? sender, GoogleMap.MapClickEventArgs e) =>
-			VirtualView.Clicked(new Devices.Sensors.Location(e.Point.Latitude, e.Point.Longitude));
+		void OnMapClick(object? sender, GoogleMap.MapClickEventArgs e)
+		{
+			if (((IElementHandler)this).VirtualView is IMap virtualView)
+				virtualView.Clicked(new Devices.Sensors.Location(e.Point.Latitude, e.Point.Longitude));
+		}
 
 		void AddPins(IList pins)
 		{
@@ -479,9 +504,12 @@ namespace Microsoft.Maui.Maps.Handlers
 		{
 			IMapPin? targetPin = null;
 
-			for (int i = 0; i < VirtualView.Pins.Count; i++)
+			if (((IElementHandler)this).VirtualView is not IMap virtualView)
+				return null;
+
+			for (int i = 0; i < virtualView.Pins.Count; i++)
 			{
-				var pin = VirtualView.Pins[i];
+				var pin = virtualView.Pins[i];
 				if (pin?.MarkerId is string markerId)
 				{
 					if (markerId == marker.Id)
@@ -697,8 +725,14 @@ namespace Microsoft.Maui.Maps.Handlers
 
 		public void OnMapReady(GoogleMap googleMap)
 		{
+			if (_handler == null)
+			{
+				googleMap.SetOnCameraMoveListener(null);
+				return;
+			}
+
 			_googleMap = googleMap;
-			_handler?.OnMapReady(googleMap);
+			_handler.OnMapReady(googleMap);
 		}
 
 		void GoogleMap.IOnCameraMoveListener.OnCameraMove()
@@ -711,7 +745,7 @@ namespace Microsoft.Maui.Maps.Handlers
 
 		protected override void Dispose(bool disposing)
 		{
-			if (disposing && _handler != null)
+			if (disposing)
 			{
 				_handler = null;
 				_googleMap = null;

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -64,9 +64,16 @@ namespace Microsoft.Maui.Maps.Handlers
 
 			if (map != null)
 			{
-				map.MyLocationEnabled = false;
+				try
+				{
+					map.MyLocationEnabled = false;
+				}
+				catch (Java.Lang.SecurityException)
+				{
+					// Location permission may have been revoked after the layer was enabled.
+				}
+
 				map.TrafficEnabled = false;
-				map.Clear();
 				map.SetOnCameraMoveListener(null);
 				map.MarkerClick -= OnMarkerClick;
 				map.InfoWindowClick -= OnInfoWindowClick;
@@ -94,8 +101,6 @@ namespace Microsoft.Maui.Maps.Handlers
 			platformView.OnPause();
 			platformView.OnStop();
 			platformView.OnDestroy();
-			map?.Dispose();
-			platformView.Dispose();
 		}
 
 		protected override MapView CreatePlatformView()


### PR DESCRIPTION
### Description of Change

This fixes the MAUI-owned root leak for Android `Map` pages.

The root leak was that `MapHandler.Android` created a native `MapView`, but did not complete the native `MapView` lifecycle when the handler disconnected. Creation called `OnCreate()` and `OnResume()`, but disconnect only detached some managed listeners and nulled references. The native `MapView` never received the matching teardown calls, so repeated navigation to a page containing a no-pin `Map` retained map view/native resources after the page was popped.

This change fixes that by:

- Calling `MapView.OnStart()` during platform view creation.
- On disconnect, nulling the handler’s `Map` reference early so late callbacks cannot resurrect it.
- Disabling and clearing the native `GoogleMap`.
- Detaching native map listeners.
- Disposing the map callback object.
- Clearing cached map state held by the handler.
- Calling `MapView.OnPause()`, `MapView.OnStop()`, and `MapView.OnDestroy()`.
- Disposing the `GoogleMap` wrapper and `MapView`.
- Guarding late `OnMapReady`, camera, and click callbacks so disconnected handlers do not reattach listeners or update stale virtual views.
- Using the `platformView` parameter during disconnect instead of `PlatformView`, because the base handler clears `PlatformView` before invoking handler-specific disconnect logic.

Manual proof used a minimal no-pin map page on a Pixel 9 Pro XL physical device in release mode:

`Home -> Open Map -> Back -> Home`, repeated 20 times.

For a deterministic comparison of the MAUI-owned leak, the repro app forced .NET GC and Java GC after each return to Home, before sampling:

- Baseline APK: Release build using NuGet `Microsoft.Maui.Maps/10.0.20`
- Fixed APK: Release build using local patched `Microsoft.Maui.Maps.dll`
- Device: Pixel 9 Pro XL
- Sampling command: `adb shell dumpsys meminfo <package>`
- Both APKs rendered a real `Google Map` during the loop.

| Cycle | Baseline Total PSS | Baseline Native PSS | Baseline Views | Fixed Total PSS | Fixed Native PSS | Fixed Views |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 0 | 168,016 KB | 28,635 KB | 34 | 168,682 KB | 29,127 KB | 34 |
| 1 | 277,081 KB | 54,371 KB | 69 | 275,544 KB | 49,199 KB | 69 |
| 5 | 386,101 KB | 97,847 KB | 169 | 258,705 KB | 49,019 KB | 69 |
| 10 | 508,004 KB | 152,051 KB | 294 | 266,335 KB | 48,719 KB | 72 |
| 15 | 641,605 KB | 205,803 KB | 419 | 269,772 KB | 51,975 KB | 69 |
| 20 | 797,196 KB | 259,655 KB | 544 | 269,885 KB | 51,907 KB | 69 |
| After trim | 797,144 KB | 259,623 KB | 544 | 257,762 KB | 42,283 KB | 69 |

The key root-leak signal is the Android `Views` count. With forced collection, the fixed build stabilizes at roughly 69 views after initial map warm-up, while the baseline continues growing to 544 views by cycle 20. On the physical device, the fixed build’s native PSS also stabilizes after warm-up and drops after delay/trim.

When running the same repro on an Android emulator, the view leak fix can still be observed: the fixed build keeps Android `Views` flat while the baseline grows linearly. However, emulator native memory can still continue growing even after the view leak is fixed. Separate native Java `MapView` controls reproduced that emulator-only native PSS growth without MAUI or .NET involved, while the same release/R8 strict-lifecycle repro plateaued on a physical Pixel device. That remaining emulator native growth is most likely unrelated graphics/renderer memory behavior in the emulator rather than the MAUI handler leak fixed here.

Validation performed:

- `dotnet build src/Core/maps/src/Maps.csproj -f net10.0-android36.0`
- `dotnet build src/Controls/Maps/src/Controls.Maps.csproj -f net10.0-android36.0`
- Manual Pixel 9 Pro XL release-mode forced-GC repro described above.
- Emulator sanity checks confirming the Android `Views` leak is fixed there as well.

### Issues Fixed

Fixes #15257
