### PR TITLE
Improve code-review skill with regression prevention safeguards

### DIFF
--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -54,12 +54,12 @@ Standalone skill that evaluates PR code changes for correctness, safety, perform
 
 1. **Get the diff:**
    ```bash
-   gh pr diff <PR_NUMBER>
+   gh pr diff <PR_NUMBER> --repo dotnet/maui
    ```
 
 2. **Read full source files** for every changed file (not just diff hunks):
    ```bash
-   gh pr diff <PR_NUMBER> --name-only
+   gh pr diff <PR_NUMBER> --repo dotnet/maui --name-only
    # Then read each file in full
    ```
 
@@ -142,18 +142,21 @@ gh pr checks <PR_NUMBER> --repo dotnet/maui --required
 ```
 
 **Exit-code semantics (read this before classifying):** `gh pr checks --required` exit codes are NOT a reliable signal on their own — `gh` overloads them. **Always inspect stdout/stderr.**
-- Exit `0` is NOT a "clean pass" signal — checks marked `skipping` (e.g., `maui-pr skipping`) and PRs with zero required checks configured also exit `0`. Read the stdout rows for actual state.
-- Exit `1` is **overloaded**: it can mean (a) at least one required check is failing — stdout will list `fail` rows; OR (b) `gh` itself errored — typically with `GraphQL:`, `Could not resolve`, `HTTP 4xx/5xx`, or `error:` on stderr and no check rows on stdout. The two cases require different responses.
+- Exit `0` is NOT a "clean pass" signal — checks marked `skipping` (e.g., `maui-pr skipping`) also exit `0`. Read the stdout rows for actual state.
+- Exit `1` is **overloaded** with three cases that look similar but require different responses:
+  - **(a) Failing required check** — stdout lists one or more `fail` rows.
+  - **(b) Zero required checks configured for the branch** — stdout is empty and stderr says `no required checks reported on the '<branch>' branch`. This is a meaningful answer (the PR genuinely has no required gates), NOT a tool failure. Route to the *Skipped, pending, or empty result* bullet below.
+  - **(c) `gh` itself errored** — stdout has no check rows and stderr contains `GraphQL:`, `Could not resolve`, `HTTP 4xx/5xx`, or `error:`. Route to the tool-unavailable fallback at the bottom of this section.
 - Exit `8` means required checks are pending and `gh` is reporting normally.
 - Other non-zero exits (e.g., auth failure: `gh auth login`, network failure, `command not found`) DO indicate tool unavailability and should trigger the fallback at the bottom of this section.
 
-Classify based on the stdout row content (`pass`/`fail`/`skipping`/`pending`), not the exit code alone. If stdout has no check rows and stderr contains a `GraphQL:` / `Could not resolve` / `error:` message, treat as **tool-unavailable** (fallback), not as "failing checks".
+Classify based on the stdout row content (`pass`/`fail`/`skipping`/`pending`) **and** the stderr message, not the exit code alone. If stdout has no check rows and stderr contains a `GraphQL:` / `Could not resolve` / `error:` message, treat as **tool-unavailable** (fallback). If stdout has no check rows and stderr says `no required checks reported`, treat as **empty result** (not a tool failure).
 
 - **PR-caused failing check** (compile/build errors, test failures in modified code) → flag as ❌ Error and `NEEDS_CHANGES`. Surface this in the CI Status / Verdict sections; do NOT also generate per-line inline comments duplicating compiler output (the inline-comment rule in *Review Output Format* still applies).
 - **Pre-existing infra flake or known issue** (cross-reference with `azdo-build-investigator` skill if uncertain) → note in summary but still cap confidence per the table in Step 6
 - **Ambiguous** → invoke the `azdo-build-investigator` skill to determine root cause before finalizing
 - **PR description acknowledges the failure** → note that the author has documented the dependency; the failure still caps confidence
-- **Skipped, pending, or empty result** (required check listed as `skipping`/`pending`, or `gh` returns no required checks at all) → treat CI coverage as **undetermined**. Do not interpret an empty/skipped result as a passing build. Cap confidence at **low** and **do NOT post `LGTM`** — use `NEEDS_DISCUSSION` (per Rule #6, which prohibits LGTM on pending/undetermined CI as strictly as on red CI).
+- **Skipped, pending, or empty result** (required check listed as `skipping`/`pending`, or `gh` exits `1` with stderr `no required checks reported on the '<branch>' branch` and no stdout rows) → treat CI coverage as **undetermined**. Do not interpret an empty/skipped result as a passing build. Cap confidence at **low** and **do NOT post `LGTM`** — use `NEEDS_DISCUSSION` (per Rule #6, which prohibits LGTM on pending/undetermined CI as strictly as on red CI).
 
 **Never claim "clean build" or `LGTM` without running this step.** Apply the *tool-unavailable* fallback when `gh` cannot determine CI state — either because `gh` itself is missing/unauthenticated (`command not found`, `gh: To get started with GitHub CLI, please run: gh auth login`), or because the command returned a tool/API error instead of check rows (stderr contains `GraphQL:` / `Could not resolve` / `error:` / `HTTP 4xx/5xx` and stdout has no `pass`/`fail`/`skipping`/`pending` rows). In any of those cases, record the gap explicitly and cap verdict confidence at **low**.
 
@@ -273,7 +276,7 @@ Classify based on the stdout row content (`pass`/`fail`/`skipping`/`pending`), n
 5. **Prior ❌ Error findings override.** If any prior review flagged an ❌ Error-level issue (using this skill's severity taxonomy) that remains unresolved in the current code, verdict must be `NEEDS_CHANGES` regardless of your own assessment. Confirm the finding still applies to the current diff before applying the override.
 6. **Never LGTM if CI is red, pending, or undetermined.** If required CI checks are failing, invoke `azdo-build-investigator` to determine whether failures are PR-caused. Do not post `LGTM` until CI passes or failures are confirmed PR-unrelated. If required checks are pending, skipping, or absent, use `NEEDS_DISCUSSION` — code review alone does not warrant LGTM when CI hasn't run. Even when failures are confirmed PR-unrelated, the Step 6 confidence cap still applies (max **low**).
 7. **🚨 NEVER use `--approve` or `--request-changes` on GitHub.** Only post comments. Approval is a human decision.
-8. **Findings handling depends on environment.** In CI (`COMMENTS_VIA_FILE=true`), the code-review agent does NOT have the GitHub comment token; the pipeline posts on its behalf. The `maui-expert-reviewer` (Step 2) produces `CustomAgentLogsTmp/PRState/{PR}/PRAgent/inline-findings.json`, which `Review-PR.ps1` posts via `post-inline-review.ps1`; the code-review agent's wall-of-text summary is posted separately by `post-ai-summary-comment.ps1`. **Do NOT have the code-review agent emit, overwrite, or merge into `inline-findings.json`** — that file is the expert reviewer's responsibility, and overwriting it with markdown findings will break `post-inline-review.ps1`. In local invocation (no `COMMENTS_VIA_FILE`), the agent may post directly using its own `gh` credentials per the Step 2 `gh api ... reviews --method POST` command. In either mode, Rule #7 still applies: never `--approve` or `--request-changes`.
+8. **Findings handling depends on environment.** In CI (`COMMENTS_VIA_FILE=true`), the code-review agent does NOT have the GitHub comment token; the pipeline posts on its behalf. The `maui-expert-reviewer` sub-agent invoked in Step 2 is the *sole* producer of `CustomAgentLogsTmp/PRState/{PR}/PRAgent/inline-findings.json` (structured file:line JSON in GitHub Review API shape), which `Review-PR.ps1` posts via `post-inline-review.ps1`; the code-review skill's wall-of-text summary is posted separately by `post-ai-summary-comment.ps1`. **Do NOT have the wall-of-text-producing code-review agent emit, overwrite, or merge into `inline-findings.json` itself** — overwriting that file with prose findings will corrupt its JSON schema and break `post-inline-review.ps1`. (When the orchestrator pipeline says "write inline findings to `inline-findings.json`", it means: ensure the Step 2 expert reviewer ran and produced that file — not that the wall-of-text agent should author the JSON directly.) In local invocation (no `COMMENTS_VIA_FILE`), the agent may post directly using its own `gh` credentials per the Step 2 `gh api ... reviews --method POST` command. In either mode, Rule #7 still applies: never `--approve` or `--request-changes`.
 
 ---
 

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -116,11 +116,11 @@ Check for prior reviews on the same PR — from the Copilot PR reviewer bot, oth
 gh pr view <PR_NUMBER> --json reviews --jq '.reviews[] | "Reviewer: \(.author.login) | State: \(.state)\n\(.body[0:2000])\n---"'
 ```
 
-**If prior reviews flagged critical issues:**
+**If prior reviews flagged ❌ Error-level issues:**
 - Verify whether each critical finding was addressed in subsequent commits
 - If unresolved → verdict must be `NEEDS_CHANGES`
 - If status cannot be determined → default to unresolved (caution over optimism)
-- **NEVER silently drop or contradict a prior critical finding**
+- **NEVER silently drop or contradict a prior ❌ Error finding** — confirm it no longer applies to current code before dismissing
 
 ### Step 5: Blast Radius, Failure-Mode Probing, and Verdict
 
@@ -190,10 +190,10 @@ gh pr view <PR_NUMBER> --json reviews --jq '.reviews[] | "Reviewer: \(.author.lo
 **Agreement/disagreement:** [Where your assessment matches or differs]
 
 ### Prior Review Reconciliation
-| Prior Critical Finding | Source | Status | Evidence |
+| Prior ❌ Error Finding | Source | Status | Evidence |
 |------------------------|--------|--------|----------|
 | [finding] | [reviewer] | ✅ Fixed / ❌ Unresolved / 🔄 Obsolete | [evidence] |
-*(If no prior reviews with critical findings, state "No prior critical findings found.")*
+*(If no prior reviews with ❌ Error findings, state "No prior ❌ Error findings found.")*
 
 ### Blast Radius Assessment
 *(Required for infrastructure/handler/platform changes; omit for simple fixes)*
@@ -229,7 +229,8 @@ gh pr view <PR_NUMBER> --json reviews --jq '.reviews[] | "Reviewer: \(.author.lo
 2. **Failure-mode probing before finalizing.** Re-read all findings. For each warning, ask: "Would I be comfortable if this merged as-is?"
 3. **Never approve what you can't verify.** If the fix touches platform code you can't fully reason about, say so explicitly and use `NEEDS_DISCUSSION`.
 4. **LGTM means no ❌ Errors.** You can LGTM with 💡 Suggestions. You can LGTM with ⚠️ Warnings only if you've explained why they're acceptable.
-5. **Prior critical findings override.** If any prior review flagged a critical issue that remains unresolved, verdict must be `NEEDS_CHANGES` regardless of your own assessment.
+5. **Prior ❌ Error findings override.** If any prior review flagged an ❌ Error-level issue (using this skill's severity taxonomy) that remains unresolved in the current code, verdict must be `NEEDS_CHANGES` regardless of your own assessment. Confirm the finding still applies to the current diff before applying the override.
+6. **Never LGTM if CI is red.** If required CI checks are failing, invoke `azdo-build-investigator` to determine whether failures are PR-caused. Do not post `LGTM` until CI passes or failures are confirmed unrelated.
 6. **🚨 NEVER use `--approve` or `--request-changes` on GitHub.** Only post comments. Approval is a human decision.
 7. **Write findings to disk, do not post directly.** The agent does not have the GitHub comment token. Write findings to `CustomAgentLogsTmp/PRState/{PR}/PRAgent/` — the CI pipeline or posting scripts handle GitHub interaction.
 
@@ -262,11 +263,11 @@ In CI (`eng/pipelines/ci-copilot.yml`), `Review-PR.ps1` calls both `post-inline-
 
 - [ ] Full source files read (not just diffs)
 - [ ] Independent assessment formed before reading PR narrative
-- [ ] Prior reviews checked and critical findings reconciled (Step 4)
+- [ ] Prior reviews checked and ❌ Error findings reconciled (Step 4)
 - [ ] MAUI-specific checklist walked through for each applicable section
-- [ ] Blast radius assessed for infrastructure/handler/platform changes (Step 6)
-- [ ] Failure-mode probing completed with real scenarios, not softballs (Step 6)
+- [ ] Blast radius assessed for infrastructure/handler/platform changes (Step 5)
+- [ ] Failure-mode probing completed with real scenarios, not softballs (Step 5)
 - [ ] Findings categorized by severity (❌ / ⚠️ / 💡)
-- [ ] Confidence calibrated against blast radius and evidence tables (Step 6)
+- [ ] Confidence calibrated against blast radius and evidence tables (Step 5)
 - [ ] Verdict is consistent with findings AND prior review reconciliation
 - [ ] Output follows the format above

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -114,7 +114,7 @@ Check for prior reviews on the same PR — from the Copilot PR reviewer bot, oth
 
 ```bash
 # Surface 1: top-level review bodies (review-API stubs, verdicts, human reviewer prose):
-gh pr view <PR_NUMBER> --repo dotnet/maui --json reviews --jq '.reviews[] | select((.body // "") != "") | "Reviewer: \(.author.login) | State: \(.state)\n\(.body[0:10000])\n---"'
+gh pr view <PR_NUMBER> --repo dotnet/maui --json reviews --jq '.reviews[] | select((.body // "") != "") | "Reviewer: \(.author.login) | State: \(.state)\n\(.body)\n---"'
 
 # Surface 2: inline review comments (where MauiBot/Copilot/this skill post ❌/⚠️/💡 findings):
 gh api repos/dotnet/maui/pulls/<PR_NUMBER>/comments --paginate \
@@ -122,10 +122,10 @@ gh api repos/dotnet/maui/pulls/<PR_NUMBER>/comments --paginate \
 
 # Surface 3: PR issue comments (where AI Summary bots and prior round wall-of-text summaries post):
 gh api repos/dotnet/maui/issues/<PR_NUMBER>/comments --paginate \
-  --jq '.[] | "\(.user.login) @ \(.created_at)\n\(.body[0:5000])\n---"'
+  --jq '.[] | "\(.user.login) @ \(.created_at)\n\(.body)\n---"'
 ```
 
-Scan all three outputs for `❌` markers, `[major]`/`[moderate]` tags, or equivalent severity language from other reviewer formats.
+Scan all three outputs for `❌` markers, `[major]`/`[moderate]` tags, or equivalent severity language from other reviewer formats. Do NOT slice/truncate the body fields — long bot reviews routinely exceed 10K chars and have severity markers in the tail (empirically observed on this skill's own PRs: MauiBot reviews of 26K+ chars with `❌` markers past char 10000); truncating silently drops them and causes false `LGTM`.
 
 **If prior reviews flagged ❌ Error-level issues:**
 - Verify whether each ❌ Error finding was addressed in subsequent commits
@@ -145,18 +145,18 @@ gh pr checks <PR_NUMBER> --repo dotnet/maui --required
 - Exit `0` is NOT a "clean pass" signal — checks marked `skipping` (e.g., `maui-pr skipping`) also exit `0`. Read the stdout rows for actual state.
 - Exit `1` is **overloaded** with three cases that look similar but require different responses:
   - **(a) Failing required check** — stdout lists one or more `fail` rows.
-  - **(b) Zero required checks configured for the branch** — stdout is empty and stderr says `no required checks reported on the '<branch>' branch`. This is a meaningful answer (the PR genuinely has no required gates), NOT a tool failure. Route to the *Skipped, pending, or empty result* bullet below.
+  - **(b) Zero required checks for the branch** — stdout is empty and stderr contains the substring `checks reported` (specifically either `no checks reported on the '<branch>' branch` when the PR has zero checks of any kind, or `no required checks reported on the '<branch>' branch` when checks exist but none are required). Both shapes mean the PR has no required gates, NOT a tool failure. Route to the *Skipped, pending, or empty result* bullet below.
   - **(c) `gh` itself errored** — stdout has no check rows and stderr contains `GraphQL:`, `Could not resolve`, `HTTP 4xx/5xx`, or `error:`. Route to the tool-unavailable fallback at the bottom of this section.
 - Exit `8` means required checks are pending and `gh` is reporting normally.
 - Other non-zero exits (e.g., auth failure: `gh auth login`, network failure, `command not found`) DO indicate tool unavailability and should trigger the fallback at the bottom of this section.
 
-Classify based on the stdout row content (`pass`/`fail`/`skipping`/`pending`) **and** the stderr message, not the exit code alone. If stdout has no check rows and stderr contains a `GraphQL:` / `Could not resolve` / `error:` message, treat as **tool-unavailable** (fallback). If stdout has no check rows and stderr says `no required checks reported`, treat as **empty result** (not a tool failure).
+Classify based on the stdout row content (`pass`/`fail`/`skipping`/`pending`) **and** the stderr message, not the exit code alone. If stdout has no check rows and stderr contains a `GraphQL:` / `Could not resolve` / `error:` message, treat as **tool-unavailable** (fallback). If stdout has no check rows and stderr contains `checks reported` (either spelling — see (b) above), treat as **empty result** (not a tool failure).
 
 - **PR-caused failing check** (compile/build errors, test failures in modified code) → flag as ❌ Error and `NEEDS_CHANGES`. Surface this in the CI Status / Verdict sections; do NOT also generate per-line inline comments duplicating compiler output (the inline-comment rule in *Review Output Format* still applies).
 - **Pre-existing infra flake or known issue** (cross-reference with `azdo-build-investigator` skill if uncertain) → note in summary but still cap confidence per the table in Step 6
 - **Ambiguous** → invoke the `azdo-build-investigator` skill to determine root cause before finalizing
 - **PR description acknowledges the failure** → note that the author has documented the dependency; the failure still caps confidence
-- **Skipped, pending, or empty result** (required check listed as `skipping`/`pending`, or `gh` exits `1` with stderr `no required checks reported on the '<branch>' branch` and no stdout rows) → treat CI coverage as **undetermined**. Do not interpret an empty/skipped result as a passing build. Cap confidence at **low** and **do NOT post `LGTM`** — use `NEEDS_DISCUSSION` (per Rule #6, which prohibits LGTM on pending/undetermined CI as strictly as on red CI).
+- **Skipped, pending, or empty result** (required check listed as `skipping`/`pending`, or `gh` exits `1` with stderr containing `checks reported` — see Exit-1 case (b) — and no stdout rows) → treat CI coverage as **undetermined**. Do not interpret an empty/skipped result as a passing build. Cap confidence at **low** and **do NOT post `LGTM`** — use `NEEDS_DISCUSSION` (per Rule #6, which prohibits LGTM on pending/undetermined CI as strictly as on red CI).
 
 **Never claim "clean build" or `LGTM` without running this step.** Apply the *tool-unavailable* fallback when `gh` cannot determine CI state — either because `gh` itself is missing/unauthenticated (`command not found`, `gh: To get started with GitHub CLI, please run: gh auth login`), or because the command returned a tool/API error instead of check rows (stderr contains `GraphQL:` / `Could not resolve` / `error:` / `HTTP 4xx/5xx` and stdout has no `pass`/`fail`/`skipping`/`pending` rows). In any of those cases, record the gap explicitly and cap verdict confidence at **low**.
 

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -81,7 +81,7 @@ Delegate to the `maui-expert-reviewer` agent (`.github/agents/maui-expert-review
 - **If `COMMENTS_VIA_FILE=true`** (CI): Done. The pipeline calls `post-inline-review.ps1` to post findings using `GH_COMMENT_TOKEN`.
 - **If `COMMENTS_VIA_FILE` is unset** (local): Post inline findings directly:
   ```bash
-  COMMIT_SHA=$(gh pr view $PR_NUMBER --json headRefOid --jq .headRefOid)
+  COMMIT_SHA=$(gh pr view $PR_NUMBER --repo dotnet/maui --json headRefOid --jq .headRefOid)
   gh api repos/dotnet/maui/pulls/$PR_NUMBER/reviews \
     --method POST \
     --input <(jq -n \
@@ -114,7 +114,7 @@ Check for prior reviews on the same PR — from the Copilot PR reviewer bot, oth
 
 ```bash
 # Surface 1: top-level review bodies (review-API stubs, verdicts, human reviewer prose):
-gh pr view <PR_NUMBER> --json reviews --jq '.reviews[] | select((.body // "") != "") | "Reviewer: \(.author.login) | State: \(.state)\n\(.body[0:10000])\n---"'
+gh pr view <PR_NUMBER> --repo dotnet/maui --json reviews --jq '.reviews[] | select((.body // "") != "") | "Reviewer: \(.author.login) | State: \(.state)\n\(.body[0:10000])\n---"'
 
 # Surface 2: inline review comments (where MauiBot/Copilot/this skill post ❌/⚠️/💡 findings):
 gh api repos/dotnet/maui/pulls/<PR_NUMBER>/comments --paginate \
@@ -125,7 +125,7 @@ gh api repos/dotnet/maui/issues/<PR_NUMBER>/comments --paginate \
   --jq '.[] | "\(.user.login) @ \(.created_at)\n\(.body[0:5000])\n---"'
 ```
 
-Scan both outputs for `❌` markers, `[major]`/`[moderate]` tags, or equivalent severity language from other reviewer formats.
+Scan all three outputs for `❌` markers, `[major]`/`[moderate]` tags, or equivalent severity language from other reviewer formats.
 
 **If prior reviews flagged ❌ Error-level issues:**
 - Verify whether each ❌ Error finding was addressed in subsequent commits
@@ -138,14 +138,16 @@ Scan both outputs for `❌` markers, `[major]`/`[moderate]` tags, or equivalent 
 Before delivering a verdict, **collect the required-check status for the PR**. Don't infer CI state from absence of evidence and don't rely on prior commits' status.
 
 ```bash
-gh pr checks <PR_NUMBER> --required
+gh pr checks <PR_NUMBER> --repo dotnet/maui --required
 ```
 
-**Exit-code semantics (read this before classifying):** `gh pr checks --required` exits with code `1` if any required check is **failing**, `8` if any are **pending**, and `0` if no required checks are failing or pending. **Important:**
-- Exit `0` is NOT a "clean pass" signal — checks marked `skipping` (e.g., `maui-pr skipping`) and PRs with zero required checks configured also exit `0`. Always inspect the stdout rows.
-- Exit codes `1` and `8` mean `gh` ran successfully and is reporting check state — they do NOT mean `gh` is unavailable. Other non-zero exits (e.g., auth failure, network error, invalid PR number) DO indicate tool unavailability and should trigger the fallback at the bottom of this section.
+**Exit-code semantics (read this before classifying):** `gh pr checks --required` exit codes are NOT a reliable signal on their own — `gh` overloads them. **Always inspect stdout/stderr.**
+- Exit `0` is NOT a "clean pass" signal — checks marked `skipping` (e.g., `maui-pr skipping`) and PRs with zero required checks configured also exit `0`. Read the stdout rows for actual state.
+- Exit `1` is **overloaded**: it can mean (a) at least one required check is failing — stdout will list `fail` rows; OR (b) `gh` itself errored — typically with `GraphQL:`, `Could not resolve`, `HTTP 4xx/5xx`, or `error:` on stderr and no check rows on stdout. The two cases require different responses.
+- Exit `8` means required checks are pending and `gh` is reporting normally.
+- Other non-zero exits (e.g., auth failure: `gh auth login`, network failure, `command not found`) DO indicate tool unavailability and should trigger the fallback at the bottom of this section.
 
-Classify based on the stdout row content (`pass`/`fail`/`skipping`/`pending`), not the exit code alone.
+Classify based on the stdout row content (`pass`/`fail`/`skipping`/`pending`), not the exit code alone. If stdout has no check rows and stderr contains a `GraphQL:` / `Could not resolve` / `error:` message, treat as **tool-unavailable** (fallback), not as "failing checks".
 
 - **PR-caused failing check** (compile/build errors, test failures in modified code) → flag as ❌ Error and `NEEDS_CHANGES`. Surface this in the CI Status / Verdict sections; do NOT also generate per-line inline comments duplicating compiler output (the inline-comment rule in *Review Output Format* still applies).
 - **Pre-existing infra flake or known issue** (cross-reference with `azdo-build-investigator` skill if uncertain) → note in summary but still cap confidence per the table in Step 6
@@ -153,7 +155,7 @@ Classify based on the stdout row content (`pass`/`fail`/`skipping`/`pending`), n
 - **PR description acknowledges the failure** → note that the author has documented the dependency; the failure still caps confidence
 - **Skipped, pending, or empty result** (required check listed as `skipping`/`pending`, or `gh` returns no required checks at all) → treat CI coverage as **undetermined**. Do not interpret an empty/skipped result as a passing build. Cap confidence at **low** and **do NOT post `LGTM`** — use `NEEDS_DISCUSSION` (per Rule #6, which prohibits LGTM on pending/undetermined CI as strictly as on red CI).
 
-**Never claim "clean build" or `LGTM` without running this step.** Apply the *tool-unavailable* fallback ONLY if `gh` itself is missing or unauthenticated (e.g., `command not found`, `gh: To get started with GitHub CLI, please run: gh auth login`). In that case, record the gap explicitly and cap verdict confidence at **low**.
+**Never claim "clean build" or `LGTM` without running this step.** Apply the *tool-unavailable* fallback when `gh` cannot determine CI state — either because `gh` itself is missing/unauthenticated (`command not found`, `gh: To get started with GitHub CLI, please run: gh auth login`), or because the command returned a tool/API error instead of check rows (stderr contains `GraphQL:` / `Could not resolve` / `error:` / `HTTP 4xx/5xx` and stdout has no `pass`/`fail`/`skipping`/`pending` rows). In any of those cases, record the gap explicitly and cap verdict confidence at **low**.
 
 ### Step 6: Blast Radius, Failure-Mode Probing, and Verdict
 
@@ -271,13 +273,13 @@ Classify based on the stdout row content (`pass`/`fail`/`skipping`/`pending`), n
 5. **Prior ❌ Error findings override.** If any prior review flagged an ❌ Error-level issue (using this skill's severity taxonomy) that remains unresolved in the current code, verdict must be `NEEDS_CHANGES` regardless of your own assessment. Confirm the finding still applies to the current diff before applying the override.
 6. **Never LGTM if CI is red, pending, or undetermined.** If required CI checks are failing, invoke `azdo-build-investigator` to determine whether failures are PR-caused. Do not post `LGTM` until CI passes or failures are confirmed PR-unrelated. If required checks are pending, skipping, or absent, use `NEEDS_DISCUSSION` — code review alone does not warrant LGTM when CI hasn't run. Even when failures are confirmed PR-unrelated, the Step 6 confidence cap still applies (max **low**).
 7. **🚨 NEVER use `--approve` or `--request-changes` on GitHub.** Only post comments. Approval is a human decision.
-8. **Findings handling depends on environment.** In CI (`COMMENTS_VIA_FILE=true`), the agent does NOT have the GitHub comment token — write findings to `CustomAgentLogsTmp/PRState/{PR}/PRAgent/inline-findings.json` and let `Review-PR.ps1` post them via `post-inline-review.ps1`. In local invocation (no `COMMENTS_VIA_FILE`), the agent may post directly using its own `gh` credentials per the Step 2 `gh api ... reviews --method POST` command. In either mode, Rule #7 still applies: never `--approve` or `--request-changes`.
+8. **Findings handling depends on environment.** In CI (`COMMENTS_VIA_FILE=true`), the code-review agent does NOT have the GitHub comment token; the pipeline posts on its behalf. The `maui-expert-reviewer` (Step 2) produces `CustomAgentLogsTmp/PRState/{PR}/PRAgent/inline-findings.json`, which `Review-PR.ps1` posts via `post-inline-review.ps1`; the code-review agent's wall-of-text summary is posted separately by `post-ai-summary-comment.ps1`. **Do NOT have the code-review agent emit, overwrite, or merge into `inline-findings.json`** — that file is the expert reviewer's responsibility, and overwriting it with markdown findings will break `post-inline-review.ps1`. In local invocation (no `COMMENTS_VIA_FILE`), the agent may post directly using its own `gh` credentials per the Step 2 `gh api ... reviews --method POST` command. In either mode, Rule #7 still applies: never `--approve` or `--request-changes`.
 
 ---
 
 ## Posting the Review
 
-The agent writes findings to disk. Posting is done separately by `Review-PR.ps1`:
+In CI mode (`COMMENTS_VIA_FILE=true`) the agent writes findings to disk and posting is done separately by `Review-PR.ps1`. In local invocation (no `COMMENTS_VIA_FILE`) the agent may post directly per Rule #8 / Step 2.
 
 **Inline review comments** (preferred — findings at exact file:line):
 ```bash

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -110,11 +110,18 @@ Now read the PR description, linked issue, and comments. Treat these as **claims
 
 #### 🚨 Prior Review Reconciliation
 
-Check for prior reviews on the same PR — from the Copilot PR reviewer bot, other agents, or human reviewers:
+Check for prior reviews on the same PR — from the Copilot PR reviewer bot, other agents, or human reviewers. **You MUST query both surfaces** — top-level review bodies AND inline review comments. Most automated reviewers (MauiBot, Copilot bot, this skill's adversarial reviewer) post a stub like *"Expert Review — 3 findings, see inline comments for details"* at the top level and put the actual `❌`/`⚠️`/`💡` markers in inline comments. Querying only the top-level bodies will silently miss every Error finding posted that way.
 
 ```bash
+# Surface 1: top-level review bodies (summaries, verdicts, human reviewer prose):
 gh pr view <PR_NUMBER> --json reviews --jq '.reviews[] | select((.body // "") != "") | "Reviewer: \(.author.login) | State: \(.state)\n\(.body[0:10000])\n---"'
+
+# Surface 2: inline review comments (where MauiBot/Copilot/this skill post ❌/⚠️/💡 findings):
+gh api repos/<OWNER>/<REPO>/pulls/<PR_NUMBER>/comments --paginate \
+  --jq '.[] | "\(.user.login) @ \(.path):\(.line // .original_line // 0)\n\(.body)\n---"'
 ```
+
+Scan both outputs for `❌` markers, `[major]`/`[moderate]` tags, or equivalent severity language from other reviewer formats.
 
 **If prior reviews flagged ❌ Error-level issues:**
 - Verify whether each ❌ Error finding was addressed in subsequent commits
@@ -130,14 +137,17 @@ Before delivering a verdict, **collect the required-check status for the PR**. D
 gh pr checks <PR_NUMBER> --required
 ```
 
-Classify each failing check:
+**Exit-code semantics (read this before classifying):** `gh pr checks --required` exits with code `1` if any required check is failing, `8` if any are pending, and `0` if all required checks pass. **A non-zero exit means the tool succeeded and is reporting check status — it does NOT mean `gh` is unavailable.** Classify based on the stdout content (`pass`/`fail`/`skipping`/`pending`), not the exit code.
 
-- **PR-caused** (compile/build errors, test failures in modified code) → flag as ❌ Error and `NEEDS_CHANGES`
+Classify each row of stdout:
+
+- **PR-caused failing check** (compile/build errors, test failures in modified code) → flag as ❌ Error and `NEEDS_CHANGES`. Surface this in the CI Status / Verdict sections; do NOT also generate per-line inline comments duplicating compiler output (the inline-comment rule in *Review Output Format* still applies).
 - **Pre-existing infra flake or known issue** (cross-reference with `azdo-build-investigator` skill if uncertain) → note in summary but still cap confidence per the table in Step 6
 - **Ambiguous** → invoke the `azdo-build-investigator` skill to determine root cause before finalizing
 - **PR description acknowledges the failure** → note that the author has documented the dependency; the failure still caps confidence
+- **Skipped, pending, or empty result** (required check listed as `skipping`/`pending`, or `gh` returns no required checks at all) → treat CI coverage as **undetermined**. Do not interpret an empty/skipped result as a passing build. Cap confidence at **low** and prefer `NEEDS_DISCUSSION` over `LGTM`.
 
-**Never claim "clean build" or `LGTM` without running this step.** If `gh pr checks` is unavailable in your environment, record the gap explicitly in the output and cap verdict confidence at **low**.
+**Never claim "clean build" or `LGTM` without running this step.** Apply the *tool-unavailable* fallback ONLY if `gh` itself is missing or unauthenticated (e.g., `command not found`, `gh: To get started with GitHub CLI, please run: gh auth login`). In that case, record the gap explicitly and cap verdict confidence at **low**.
 
 ### Step 6: Blast Radius, Failure-Mode Probing, and Verdict
 
@@ -174,7 +184,7 @@ Classify each failing check:
 
 | Evidence | Confidence Cap |
 |----------|---------------|
-| CI red or pending | Max **low** — invoke `azdo-build-investigator` skill for CI analysis before finalizing |
+| CI red or pending | Max **low** — invoke `azdo-build-investigator` skill for CI analysis. Combined with Rule #6: LGTM is not permitted unless red failures are confirmed PR-unrelated. |
 | No relevant tests run (UITests skip PR builds) | Max **low** |
 | Prior ❌ Error findings unresolved | **NEEDS_CHANGES** (no LGTM) |
 
@@ -192,7 +202,7 @@ Classify each failing check:
 - Only comment on added/modified lines — don't flag pre-existing code
 - One issue per comment. If the same issue appears many times, flag once with a note listing all affected files
 - **Don't pile on.** 3 important comments > 15 nitpicks
-- **Don't flag what CI catches.** Skip compiler errors, formatting the linter will catch, etc.
+- **Don't duplicate CI output as inline comments.** Skip line-by-line compiler errors and linter findings in inline `file:line` comments — CI already surfaces those. CI-detected failures must still drive the verdict and appear in the CI Status / Verdict sections per Step 5; this rule only governs the *inline-comment* surface.
 - **Avoid false positives.** Verify the concern actually applies given full context. If unsure, phrase as a question.
 
 ```markdown
@@ -247,7 +257,7 @@ Classify each failing check:
 3. **Never approve what you can't verify.** If the fix touches platform code you can't fully reason about, say so explicitly and use `NEEDS_DISCUSSION`.
 4. **LGTM means no ❌ Errors.** You can LGTM with 💡 Suggestions. You can LGTM with ⚠️ Warnings only if you've explained why they're acceptable.
 5. **Prior ❌ Error findings override.** If any prior review flagged an ❌ Error-level issue (using this skill's severity taxonomy) that remains unresolved in the current code, verdict must be `NEEDS_CHANGES` regardless of your own assessment. Confirm the finding still applies to the current diff before applying the override.
-6. **Never LGTM if CI is red.** If required CI checks are failing, invoke `azdo-build-investigator` to determine whether failures are PR-caused. Do not post `LGTM` until CI passes or failures are confirmed unrelated.
+6. **Never LGTM if CI is red.** If required CI checks are failing, invoke `azdo-build-investigator` to determine whether failures are PR-caused. Do not post `LGTM` until CI passes or failures are confirmed PR-unrelated. Even when failures are confirmed PR-unrelated, the Step 6 confidence cap still applies (max **low**).
 7. **🚨 NEVER use `--approve` or `--request-changes` on GitHub.** Only post comments. Approval is a human decision.
 8. **Write findings to disk, do not post directly.** The agent does not have the GitHub comment token. Write findings to `CustomAgentLogsTmp/PRState/{PR}/PRAgent/` — the CI pipeline or posting scripts handle GitHub interaction.
 

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -122,30 +122,7 @@ gh pr view <PR_NUMBER> --json reviews --jq '.reviews[] | "Reviewer: \(.author.lo
 - If status cannot be determined → default to unresolved (caution over optimism)
 - **NEVER silently drop or contradict a prior critical finding**
 
-### Step 5: Check CI Status
-
-```bash
-# All checks (required + optional)
-gh pr checks <PR_NUMBER>
-
-# Required checks only — use this for the verdict gate
-gh pr checks <PR_NUMBER> --required
-```
-
-**🚨 HARD GATE: Never give `LGTM` if any required CI check is failing or pending.**
-
-| CI State | Allowed Verdict |
-|----------|----------------|
-| All required checks ✅ green | May proceed to verdict |
-| Any required check ❌ red | **`NEEDS_CHANGES`** — document which checks failed |
-| Required checks ⏳ pending | **`NEEDS_DISCUSSION`** — state "CI not yet complete" |
-| Only optional/informational checks red | May proceed, note the failures |
-
-**NEVER claim "No CI failures detected" or "Clean build" without actually running `gh pr checks`.** False CI claims have directly caused regressions to be approved and merged.
-
-**UITest awareness:** UITests do NOT run on PR builds in this repo — they only run post-merge. If the PR modifies HostApp pages, handler/extension code, or platform infrastructure, explicitly note: _"UITests do not run on PR builds. Startup and runtime behavior cannot be verified from CI alone."_
-
-### Step 6: Blast Radius, Failure-Mode Probing, and Verdict
+### Step 5: Blast Radius, Failure-Mode Probing, and Verdict
 
 #### Blast Radius Assessment
 
@@ -180,9 +157,8 @@ gh pr checks <PR_NUMBER> --required
 
 | Evidence | Confidence Cap |
 |----------|---------------|
-| CI red or pending | **NEEDS_CHANGES / NEEDS_DISCUSSION** (no LGTM) |
+| CI red or pending | Defer to `azdo-build-investigator` skill for CI analysis |
 | No relevant tests run (UITests skip PR builds) | Max **low** |
-| CI green but no UI/integration test coverage | Max **medium** |
 | Prior critical findings unresolved | **NEEDS_CHANGES** (no LGTM) |
 
 #### Deliver Verdict
@@ -219,11 +195,6 @@ gh pr checks <PR_NUMBER> --required
 | [finding] | [reviewer] | ✅ Fixed / ❌ Unresolved / 🔄 Obsolete | [evidence] |
 *(If no prior reviews with critical findings, state "No prior critical findings found.")*
 
-### CI Status
-- Required checks: ✅ / ❌ (which failed) / ⏳ (pending)
-- UITests: ⚠️ Not run on PR builds
-*(Must reflect actual `gh pr checks --required` output — never assume.)*
-
 ### Blast Radius Assessment
 *(Required for infrastructure/handler/platform changes; omit for simple fixes)*
 - Runs for all instances: [yes/no — explanation]
@@ -259,9 +230,8 @@ gh pr checks <PR_NUMBER> --required
 3. **Never approve what you can't verify.** If the fix touches platform code you can't fully reason about, say so explicitly and use `NEEDS_DISCUSSION`.
 4. **LGTM means no ❌ Errors.** You can LGTM with 💡 Suggestions. You can LGTM with ⚠️ Warnings only if you've explained why they're acceptable.
 5. **Prior critical findings override.** If any prior review flagged a critical issue that remains unresolved, verdict must be `NEEDS_CHANGES` regardless of your own assessment.
-6. **CI must be verified, not assumed.** Always run `gh pr checks --required` before delivering a verdict. Never claim CI is clean without evidence.
-7. **🚨 NEVER use `--approve` or `--request-changes` on GitHub.** Only post comments. Approval is a human decision.
-8. **Write findings to disk, do not post directly.** The agent does not have the GitHub comment token. Write findings to `CustomAgentLogsTmp/PRState/{PR}/PRAgent/` — the CI pipeline or posting scripts handle GitHub interaction.
+6. **🚨 NEVER use `--approve` or `--request-changes` on GitHub.** Only post comments. Approval is a human decision.
+7. **Write findings to disk, do not post directly.** The agent does not have the GitHub comment token. Write findings to `CustomAgentLogsTmp/PRState/{PR}/PRAgent/` — the CI pipeline or posting scripts handle GitHub interaction.
 
 ---
 
@@ -293,7 +263,6 @@ In CI (`eng/pipelines/ci-copilot.yml`), `Review-PR.ps1` calls both `post-inline-
 - [ ] Full source files read (not just diffs)
 - [ ] Independent assessment formed before reading PR narrative
 - [ ] Prior reviews checked and critical findings reconciled (Step 4)
-- [ ] CI status verified via `gh pr checks --required` — not assumed (Step 5)
 - [ ] MAUI-specific checklist walked through for each applicable section
 - [ ] Blast radius assessed for infrastructure/handler/platform changes (Step 6)
 - [ ] Failure-mode probing completed with real scenarios, not softballs (Step 6)

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -110,15 +110,19 @@ Now read the PR description, linked issue, and comments. Treat these as **claims
 
 #### 🚨 Prior Review Reconciliation
 
-Check for prior reviews on the same PR — from the Copilot PR reviewer bot, other agents, or human reviewers. **You MUST query both surfaces** — top-level review bodies AND inline review comments. Most automated reviewers (MauiBot, Copilot bot, this skill's adversarial reviewer) post a stub like *"Expert Review — 3 findings, see inline comments for details"* at the top level and put the actual `❌`/`⚠️`/`💡` markers in inline comments. Querying only the top-level bodies will silently miss every Error finding posted that way.
+Check for prior reviews on the same PR — from the Copilot PR reviewer bot, other agents, or human reviewers. **You MUST query all THREE surfaces** — top-level review bodies, inline review comments, AND PR issue comments. Different reviewers post findings to different surfaces: review-API bots (MauiBot, Copilot bot, this skill's adversarial reviewer) post stubs like *"Expert Review — 3 findings, see inline comments"* at the top level with the actual `❌`/`⚠️`/`💡` markers in inline comments; AI Summary bots and prior-round wall-of-text summaries post to the **issue-comments** surface (which the review API does NOT return). Querying any subset silently misses findings.
 
 ```bash
-# Surface 1: top-level review bodies (summaries, verdicts, human reviewer prose):
+# Surface 1: top-level review bodies (review-API stubs, verdicts, human reviewer prose):
 gh pr view <PR_NUMBER> --json reviews --jq '.reviews[] | select((.body // "") != "") | "Reviewer: \(.author.login) | State: \(.state)\n\(.body[0:10000])\n---"'
 
 # Surface 2: inline review comments (where MauiBot/Copilot/this skill post ❌/⚠️/💡 findings):
-gh api repos/<OWNER>/<REPO>/pulls/<PR_NUMBER>/comments --paginate \
+gh api repos/dotnet/maui/pulls/<PR_NUMBER>/comments --paginate \
   --jq '.[] | "\(.user.login) @ \(.path):\(.line // .original_line // 0)\n\(.body)\n---"'
+
+# Surface 3: PR issue comments (where AI Summary bots and prior round wall-of-text summaries post):
+gh api repos/dotnet/maui/issues/<PR_NUMBER>/comments --paginate \
+  --jq '.[] | "\(.user.login) @ \(.created_at)\n\(.body[0:5000])\n---"'
 ```
 
 Scan both outputs for `❌` markers, `[major]`/`[moderate]` tags, or equivalent severity language from other reviewer formats.
@@ -137,15 +141,17 @@ Before delivering a verdict, **collect the required-check status for the PR**. D
 gh pr checks <PR_NUMBER> --required
 ```
 
-**Exit-code semantics (read this before classifying):** `gh pr checks --required` exits with code `1` if any required check is failing, `8` if any are pending, and `0` if all required checks pass. **A non-zero exit means the tool succeeded and is reporting check status — it does NOT mean `gh` is unavailable.** Classify based on the stdout content (`pass`/`fail`/`skipping`/`pending`), not the exit code.
+**Exit-code semantics (read this before classifying):** `gh pr checks --required` exits with code `1` if any required check is **failing**, `8` if any are **pending**, and `0` if no required checks are failing or pending. **Important:**
+- Exit `0` is NOT a "clean pass" signal — checks marked `skipping` (e.g., `maui-pr skipping`) and PRs with zero required checks configured also exit `0`. Always inspect the stdout rows.
+- Exit codes `1` and `8` mean `gh` ran successfully and is reporting check state — they do NOT mean `gh` is unavailable. Other non-zero exits (e.g., auth failure, network error, invalid PR number) DO indicate tool unavailability and should trigger the fallback at the bottom of this section.
 
-Classify each row of stdout:
+Classify based on the stdout row content (`pass`/`fail`/`skipping`/`pending`), not the exit code alone.
 
 - **PR-caused failing check** (compile/build errors, test failures in modified code) → flag as ❌ Error and `NEEDS_CHANGES`. Surface this in the CI Status / Verdict sections; do NOT also generate per-line inline comments duplicating compiler output (the inline-comment rule in *Review Output Format* still applies).
 - **Pre-existing infra flake or known issue** (cross-reference with `azdo-build-investigator` skill if uncertain) → note in summary but still cap confidence per the table in Step 6
 - **Ambiguous** → invoke the `azdo-build-investigator` skill to determine root cause before finalizing
 - **PR description acknowledges the failure** → note that the author has documented the dependency; the failure still caps confidence
-- **Skipped, pending, or empty result** (required check listed as `skipping`/`pending`, or `gh` returns no required checks at all) → treat CI coverage as **undetermined**. Do not interpret an empty/skipped result as a passing build. Cap confidence at **low** and prefer `NEEDS_DISCUSSION` over `LGTM`.
+- **Skipped, pending, or empty result** (required check listed as `skipping`/`pending`, or `gh` returns no required checks at all) → treat CI coverage as **undetermined**. Do not interpret an empty/skipped result as a passing build. Cap confidence at **low** and **do NOT post `LGTM`** — use `NEEDS_DISCUSSION` (per Rule #6, which prohibits LGTM on pending/undetermined CI as strictly as on red CI).
 
 **Never claim "clean build" or `LGTM` without running this step.** Apply the *tool-unavailable* fallback ONLY if `gh` itself is missing or unauthenticated (e.g., `command not found`, `gh: To get started with GitHub CLI, please run: gh auth login`). In that case, record the gap explicitly and cap verdict confidence at **low**.
 
@@ -228,6 +234,12 @@ Classify each row of stdout:
 - Startup impact: [yes/no]
 - Static/shared state: [yes/no]
 
+### CI Status
+*(Required — record what `gh pr checks --required` returned per Step 5)*
+- Required-check result: [pass / fail / pending / skipping / no required checks]
+- Classification: [PR-caused failure ❌ / pre-existing flake / undetermined / PR-acknowledged]
+- Action taken: [none / invoked `azdo-build-investigator` / capped confidence]
+
 ### Findings
 
 #### ❌ Error — [Brief description]
@@ -257,9 +269,9 @@ Classify each row of stdout:
 3. **Never approve what you can't verify.** If the fix touches platform code you can't fully reason about, say so explicitly and use `NEEDS_DISCUSSION`.
 4. **LGTM means no ❌ Errors.** You can LGTM with 💡 Suggestions. You can LGTM with ⚠️ Warnings only if you've explained why they're acceptable.
 5. **Prior ❌ Error findings override.** If any prior review flagged an ❌ Error-level issue (using this skill's severity taxonomy) that remains unresolved in the current code, verdict must be `NEEDS_CHANGES` regardless of your own assessment. Confirm the finding still applies to the current diff before applying the override.
-6. **Never LGTM if CI is red.** If required CI checks are failing, invoke `azdo-build-investigator` to determine whether failures are PR-caused. Do not post `LGTM` until CI passes or failures are confirmed PR-unrelated. Even when failures are confirmed PR-unrelated, the Step 6 confidence cap still applies (max **low**).
+6. **Never LGTM if CI is red, pending, or undetermined.** If required CI checks are failing, invoke `azdo-build-investigator` to determine whether failures are PR-caused. Do not post `LGTM` until CI passes or failures are confirmed PR-unrelated. If required checks are pending, skipping, or absent, use `NEEDS_DISCUSSION` — code review alone does not warrant LGTM when CI hasn't run. Even when failures are confirmed PR-unrelated, the Step 6 confidence cap still applies (max **low**).
 7. **🚨 NEVER use `--approve` or `--request-changes` on GitHub.** Only post comments. Approval is a human decision.
-8. **Write findings to disk, do not post directly.** The agent does not have the GitHub comment token. Write findings to `CustomAgentLogsTmp/PRState/{PR}/PRAgent/` — the CI pipeline or posting scripts handle GitHub interaction.
+8. **Findings handling depends on environment.** In CI (`COMMENTS_VIA_FILE=true`), the agent does NOT have the GitHub comment token — write findings to `CustomAgentLogsTmp/PRState/{PR}/PRAgent/inline-findings.json` and let `Review-PR.ps1` post them via `post-inline-review.ps1`. In local invocation (no `COMMENTS_VIA_FILE`), the agent may post directly using its own `gh` credentials per the Step 2 `gh api ... reviews --method POST` command. In either mode, Rule #7 still applies: never `--approve` or `--request-changes`.
 
 ---
 

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -122,7 +122,24 @@ gh pr view <PR_NUMBER> --json reviews --jq '.reviews[] | select((.body // "") !=
 - If status cannot be determined → default to unresolved (caution over optimism)
 - **NEVER silently drop or contradict a prior ❌ Error finding** — confirm it no longer applies to current code before dismissing
 
-### Step 5: Blast Radius, Failure-Mode Probing, and Verdict
+### Step 5: Check CI Status
+
+Before delivering a verdict, **collect the required-check status for the PR**. Don't infer CI state from absence of evidence and don't rely on prior commits' status.
+
+```bash
+gh pr checks <PR_NUMBER> --required
+```
+
+Classify each failing check:
+
+- **PR-caused** (compile/build errors, test failures in modified code) → flag as ❌ Error and `NEEDS_CHANGES`
+- **Pre-existing infra flake or known issue** (cross-reference with `azdo-build-investigator` skill if uncertain) → note in summary but still cap confidence per the table in Step 6
+- **Ambiguous** → invoke the `azdo-build-investigator` skill to determine root cause before finalizing
+- **PR description acknowledges the failure** → note that the author has documented the dependency; the failure still caps confidence
+
+**Never claim "clean build" or `LGTM` without running this step.** If `gh pr checks` is unavailable in your environment, record the gap explicitly in the output and cap verdict confidence at **low**.
+
+### Step 6: Blast Radius, Failure-Mode Probing, and Verdict
 
 #### Blast Radius Assessment
 
@@ -265,9 +282,10 @@ In CI (`eng/pipelines/ci-copilot.yml`), `Review-PR.ps1` calls both `post-inline-
 - [ ] Independent assessment formed before reading PR narrative
 - [ ] Prior reviews checked and ❌ Error findings reconciled (Step 4)
 - [ ] MAUI-specific checklist walked through for each applicable section
-- [ ] Blast radius assessed for infrastructure/handler/platform changes (Step 5)
-- [ ] Failure-mode probing completed with real scenarios, not softballs (Step 5)
+- [ ] CI status collected via `gh pr checks --required` and classified (Step 5)
+- [ ] Blast radius assessed for infrastructure/handler/platform changes (Step 6)
+- [ ] Failure-mode probing completed with real scenarios, not softballs (Step 6)
 - [ ] Findings categorized by severity (❌ / ⚠️ / 💡)
-- [ ] Confidence calibrated against blast radius and evidence tables (Step 5)
+- [ ] Confidence calibrated against blast radius and evidence tables (Step 6)
 - [ ] Verdict is consistent with findings AND prior review reconciliation
 - [ ] Output follows the format above

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -113,11 +113,11 @@ Now read the PR description, linked issue, and comments. Treat these as **claims
 Check for prior reviews on the same PR — from the Copilot PR reviewer bot, other agents, or human reviewers:
 
 ```bash
-gh pr view <PR_NUMBER> --json reviews --jq '.reviews[] | "Reviewer: \(.author.login) | State: \(.state)\n\(.body[0:2000])\n---"'
+gh pr view <PR_NUMBER> --json reviews --jq '.reviews[] | select((.body // "") != "") | "Reviewer: \(.author.login) | State: \(.state)\n\(.body[0:10000])\n---"'
 ```
 
 **If prior reviews flagged ❌ Error-level issues:**
-- Verify whether each critical finding was addressed in subsequent commits
+- Verify whether each ❌ Error finding was addressed in subsequent commits
 - If unresolved → verdict must be `NEEDS_CHANGES`
 - If status cannot be determined → default to unresolved (caution over optimism)
 - **NEVER silently drop or contradict a prior ❌ Error finding** — confirm it no longer applies to current code before dismissing
@@ -157,9 +157,9 @@ gh pr view <PR_NUMBER> --json reviews --jq '.reviews[] | "Reviewer: \(.author.lo
 
 | Evidence | Confidence Cap |
 |----------|---------------|
-| CI red or pending | Defer to `azdo-build-investigator` skill for CI analysis |
+| CI red or pending | Max **low** — invoke `azdo-build-investigator` skill for CI analysis before finalizing |
 | No relevant tests run (UITests skip PR builds) | Max **low** |
-| Prior critical findings unresolved | **NEEDS_CHANGES** (no LGTM) |
+| Prior ❌ Error findings unresolved | **NEEDS_CHANGES** (no LGTM) |
 
 #### Deliver Verdict
 
@@ -231,8 +231,8 @@ gh pr view <PR_NUMBER> --json reviews --jq '.reviews[] | "Reviewer: \(.author.lo
 4. **LGTM means no ❌ Errors.** You can LGTM with 💡 Suggestions. You can LGTM with ⚠️ Warnings only if you've explained why they're acceptable.
 5. **Prior ❌ Error findings override.** If any prior review flagged an ❌ Error-level issue (using this skill's severity taxonomy) that remains unresolved in the current code, verdict must be `NEEDS_CHANGES` regardless of your own assessment. Confirm the finding still applies to the current diff before applying the override.
 6. **Never LGTM if CI is red.** If required CI checks are failing, invoke `azdo-build-investigator` to determine whether failures are PR-caused. Do not post `LGTM` until CI passes or failures are confirmed unrelated.
-6. **🚨 NEVER use `--approve` or `--request-changes` on GitHub.** Only post comments. Approval is a human decision.
-7. **Write findings to disk, do not post directly.** The agent does not have the GitHub comment token. Write findings to `CustomAgentLogsTmp/PRState/{PR}/PRAgent/` — the CI pipeline or posting scripts handle GitHub interaction.
+7. **🚨 NEVER use `--approve` or `--request-changes` on GitHub.** Only post comments. Approval is a human decision.
+8. **Write findings to disk, do not post directly.** The agent does not have the GitHub comment token. Write findings to `CustomAgentLogsTmp/PRState/{PR}/PRAgent/` — the CI pipeline or posting scripts handle GitHub interaction.
 
 ---
 

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -28,7 +28,7 @@ Standalone skill that evaluates PR code changes for correctness, safety, perform
 2. **Full-context** — Read entire source files, not just diffs. Check callers, consumers, and git history
 3. **Empirical grounding** — Reference specific code, line numbers, and call sites. No vague concerns
 4. **Severity calibration** — Distinguish errors from warnings from suggestions. Not everything is critical
-5. **Devil's advocate** — Challenge your own conclusions before finalizing
+5. **Failure-mode probing** — Challenge your own conclusions with real failure scenarios, not softballs
 
 ## Inputs
 
@@ -108,26 +108,84 @@ Now read the PR description, linked issue, and comments. Treat these as **claims
 2. If the PR claims a bug fix, verify the root cause analysis matches the code
 3. Check existing review comments to avoid duplicating feedback
 
+#### 🚨 Prior Review Reconciliation
+
+Check for prior reviews on the same PR — from the Copilot PR reviewer bot, other agents, or human reviewers:
+
+```bash
+gh pr view <PR_NUMBER> --json reviews --jq '.reviews[] | "Reviewer: \(.author.login) | State: \(.state)\n\(.body[0:2000])\n---"'
+```
+
+**If prior reviews flagged critical issues:**
+- Verify whether each critical finding was addressed in subsequent commits
+- If unresolved → verdict must be `NEEDS_CHANGES`
+- If status cannot be determined → default to unresolved (caution over optimism)
+- **NEVER silently drop or contradict a prior critical finding**
+
 ### Step 5: Check CI Status
 
 ```bash
+# All checks (required + optional)
 gh pr checks <PR_NUMBER>
+
+# Required checks only — use this for the verdict gate
+gh pr checks <PR_NUMBER> --required
 ```
 
-Review CI results. **Never post ✅ LGTM if any required CI check is failing.** If CI is failing:
-- If caused by the PR's code changes, flag as ❌ error
-- If a known infrastructure issue or pre-existing flake, note it but still use ⚠️
-- If the PR description acknowledges the failure, note it in the summary
+**🚨 HARD GATE: Never give `LGTM` if any required CI check is failing or pending.**
 
-### Step 6: Devil's Advocate and Verdict
+| CI State | Allowed Verdict |
+|----------|----------------|
+| All required checks ✅ green | May proceed to verdict |
+| Any required check ❌ red | **`NEEDS_CHANGES`** — document which checks failed |
+| Required checks ⏳ pending | **`NEEDS_DISCUSSION`** — state "CI not yet complete" |
+| Only optional/informational checks red | May proceed, note the failures |
 
-Before finalizing your verdict:
+**NEVER claim "No CI failures detected" or "Clean build" without actually running `gh pr checks`.** False CI claims have directly caused regressions to be approved and merged.
 
-1. **Challenge your findings** — For each issue you flagged, ask: "Am I sure, or am I guessing?"
-2. **Challenge your approval** — If you're leaning LGTM, ask: "What could go wrong that I'm not seeing?"
-3. **Check platform blind spots** — If the change touches platforms you can't fully reason about, say so explicitly
+**UITest awareness:** UITests do NOT run on PR builds in this repo — they only run post-merge. If the PR modifies HostApp pages, handler/extension code, or platform infrastructure, explicitly note: _"UITests do not run on PR builds. Startup and runtime behavior cannot be verified from CI alone."_
 
-Then deliver your verdict:
+### Step 6: Blast Radius, Failure-Mode Probing, and Verdict
+
+#### Blast Radius Assessment
+
+**Required when PR modifies:** handlers, platform extensions, toolbar/navigation code, page registration, static state, `PropertyChanged` subscriptions, or startup paths.
+
+| Question | Why It Matters |
+|----------|---------------|
+| Does this code run for ALL instances, or only when the new feature is used? | Feature code that runs unconditionally is the #1 cause of startup crashes |
+| Does this code run at app startup or page initialization? | Static fields initialized on first access can crash the app before any test page loads |
+| Are there new static/shared state fields that affect all pages/windows? | Static state survives handler disposal unless explicitly scoped |
+| What happens at startup with null/default values for new properties? | New BindableProperty with null default must not cause NullRef in platform code paths |
+
+#### Failure-Mode Probing
+
+**Do NOT ask easy rhetorical questions.** Probe genuinely challenging failure modes:
+
+- What happens if this code runs on items/pages that DON'T use the new feature?
+- What happens during handler disconnect/reconnect (navigation, Shell tab switch)?
+- What happens with null `Parent`, `Handler`, `BindingContext`, or `PlatformView`?
+- Can multiple subscriptions accumulate across handler lifecycle (missing unsubscribe)?
+- Does static state survive page disposal and get stale?
+
+#### Confidence Calibration
+
+| Blast Radius | Max Confidence |
+|-------------|----------------|
+| Localized change, non-startup, non-infrastructure | May be **high** |
+| Platform-specific handler/UI plumbing | Max **medium** |
+| Shared infrastructure, startup path, global static state | Max **low** |
+
+**Then cap by evidence:**
+
+| Evidence | Confidence Cap |
+|----------|---------------|
+| CI red or pending | **NEEDS_CHANGES / NEEDS_DISCUSSION** (no LGTM) |
+| No relevant tests run (UITests skip PR builds) | Max **low** |
+| CI green but no UI/integration test coverage | Max **medium** |
+| Prior critical findings unresolved | **NEEDS_CHANGES** (no LGTM) |
+
+#### Deliver Verdict
 
 - **`LGTM`** — Code is correct, safe, and consistent with MAUI patterns. Ready for human approval.
 - **`NEEDS_CHANGES`** — Concrete issues found that should be addressed before merge.
@@ -155,6 +213,23 @@ Then deliver your verdict:
 **Author claims:** [Summary of PR description]
 **Agreement/disagreement:** [Where your assessment matches or differs]
 
+### Prior Review Reconciliation
+| Prior Critical Finding | Source | Status | Evidence |
+|------------------------|--------|--------|----------|
+| [finding] | [reviewer] | ✅ Fixed / ❌ Unresolved / 🔄 Obsolete | [evidence] |
+*(If no prior reviews with critical findings, state "No prior critical findings found.")*
+
+### CI Status
+- Required checks: ✅ / ❌ (which failed) / ⏳ (pending)
+- UITests: ⚠️ Not run on PR builds
+*(Must reflect actual `gh pr checks --required` output — never assume.)*
+
+### Blast Radius Assessment
+*(Required for infrastructure/handler/platform changes; omit for simple fixes)*
+- Runs for all instances: [yes/no — explanation]
+- Startup impact: [yes/no]
+- Static/shared state: [yes/no]
+
 ### Findings
 
 #### ❌ Error — [Brief description]
@@ -166,11 +241,12 @@ Then deliver your verdict:
 #### 💡 Suggestion — [Brief description]
 [Explanation]
 
-### Devil's Advocate
-[Challenges to your own conclusions]
+### Failure-Mode Probing
+- [Probe]: [Answer — what actually happens in this scenario]
+- [Probe]: [Answer]
 
 ### Verdict: LGTM / NEEDS_CHANGES / NEEDS_DISCUSSION
-**Confidence:** high / medium / low
+**Confidence:** high / medium / low *(justified against calibration table)*
 **Summary:** [2-3 sentences explaining the verdict]
 ```
 
@@ -179,11 +255,13 @@ Then deliver your verdict:
 ## Verdict Consistency Rules
 
 1. **The verdict must match your most severe finding.** If you have any ❌ Error findings, the verdict must be `NEEDS_CHANGES`. If only ⚠️ Warnings, use judgment but explain.
-2. **Devil's advocate before finalizing.** Re-read all findings. For each warning, ask: "Would I be comfortable if this merged as-is?"
+2. **Failure-mode probing before finalizing.** Re-read all findings. For each warning, ask: "Would I be comfortable if this merged as-is?"
 3. **Never approve what you can't verify.** If the fix touches platform code you can't fully reason about, say so explicitly and use `NEEDS_DISCUSSION`.
 4. **LGTM means no ❌ Errors.** You can LGTM with 💡 Suggestions. You can LGTM with ⚠️ Warnings only if you've explained why they're acceptable.
-5. **🚨 NEVER use `--approve` or `--request-changes` on GitHub.** Only post comments. Approval is a human decision.
-6. **Write findings to disk, do not post directly.** The agent does not have the GitHub comment token. Write findings to `CustomAgentLogsTmp/PRState/{PR}/PRAgent/` — the CI pipeline or posting scripts handle GitHub interaction.
+5. **Prior critical findings override.** If any prior review flagged a critical issue that remains unresolved, verdict must be `NEEDS_CHANGES` regardless of your own assessment.
+6. **CI must be verified, not assumed.** Always run `gh pr checks --required` before delivering a verdict. Never claim CI is clean without evidence.
+7. **🚨 NEVER use `--approve` or `--request-changes` on GitHub.** Only post comments. Approval is a human decision.
+8. **Write findings to disk, do not post directly.** The agent does not have the GitHub comment token. Write findings to `CustomAgentLogsTmp/PRState/{PR}/PRAgent/` — the CI pipeline or posting scripts handle GitHub interaction.
 
 ---
 
@@ -214,8 +292,12 @@ In CI (`eng/pipelines/ci-copilot.yml`), `Review-PR.ps1` calls both `post-inline-
 
 - [ ] Full source files read (not just diffs)
 - [ ] Independent assessment formed before reading PR narrative
+- [ ] Prior reviews checked and critical findings reconciled (Step 4)
+- [ ] CI status verified via `gh pr checks --required` — not assumed (Step 5)
 - [ ] MAUI-specific checklist walked through for each applicable section
+- [ ] Blast radius assessed for infrastructure/handler/platform changes (Step 6)
+- [ ] Failure-mode probing completed with real scenarios, not softballs (Step 6)
 - [ ] Findings categorized by severity (❌ / ⚠️ / 💡)
-- [ ] Devil's advocate check performed
-- [ ] Verdict is consistent with findings
+- [ ] Confidence calibrated against blast radius and evidence tables (Step 6)
+- [ ] Verdict is consistent with findings AND prior review reconciliation
 - [ ] Output follows the format above

--- a/.github/skills/code-review/tests/eval.yaml
+++ b/.github/skills/code-review/tests/eval.yaml
@@ -85,10 +85,18 @@ scenarios:
   - name: "Blast radius - infrastructure changes get probed"
     prompt: "code review PR #35223 in dotnet/maui. This is a merged Android fix. Hypothesis to verify or refute: even after this PR, the back-navigation callback registration still runs unconditionally for all activities at startup."
     assertions:
+      # Analytical framing: the agent must use blast-radius vocabulary that does NOT appear in the prompt itself.
       - type: "output_matches"
-        pattern: "(blast radius|all instances|unconditional|callback registration)"
+        pattern: "(blast radius|all instances|every instance|each instance)"
+      # Confidence calibrated to the structured field shape; not just any 'medium'/'low' substring.
       - type: "output_matches"
         pattern: '\*\*Confidence:\*\*\s*(medium|low)'
+      # Refutation evidence: the agent must show it actually analyzed the code, using terms NOT in the prompt
+      # (the prompt contains 'unconditionally' and 'callback registration' — a parroting agent that just echoes
+      # those phrases must not pass). Notes: `\b` on 'conditional' prevents matching inside 'unconditional';
+      # 'no longer' catches phrasings like 'no longer unconditional' / 'no longer registered for all activities'.
+      - type: "output_matches"
+        pattern: '(\bconditional|guarded|gated|opt-in|opted in|refut|hypothesis is false|now scoped|no longer)'
     rubric:
       - "The agent assesses blast radius for handler/platform changes (does this run for all instances?)"
       - "The agent probes real failure modes, not softballs (e.g., handler disconnect, null PlatformView)"

--- a/.github/skills/code-review/tests/eval.yaml
+++ b/.github/skills/code-review/tests/eval.yaml
@@ -83,12 +83,15 @@ scenarios:
     timeout: 120
 
   - name: "Blast radius - infrastructure changes get probed"
-    prompt: "code review PR #32278 in dotnet/maui — I believe the handler changes affect platform extensions that run unconditionally at startup, even for controls that don't use the new feature"
+    prompt: "code review PR #35223 in dotnet/maui — this PR changes back-navigation callback registration on Android. Hypothesis: the registration may run unconditionally for all activities, not just those using predictive back. Please verify or refute."
     assertions:
       - type: "output_matches"
-        pattern: "(blast radius|all instances|startup|handler disconnect|unconditional)"
+        pattern: "(blast radius|all instances|unconditional|callback registration)"
+      - type: "output_matches"
+        pattern: "(medium|low)"
     rubric:
       - "The agent assesses blast radius for handler/platform changes (does this run for all instances?)"
       - "The agent probes real failure modes, not softballs (e.g., handler disconnect, null PlatformView)"
-      - "The confidence is calibrated — not 'high' for handler infrastructure changes"
+      - "The agent provides evidence-backed acceptance or refutation of the hypothesis — not just echoing it"
+      - "The confidence is calibrated — not 'high' for platform infrastructure changes"
     timeout: 300

--- a/.github/skills/code-review/tests/eval.yaml
+++ b/.github/skills/code-review/tests/eval.yaml
@@ -104,14 +104,17 @@ scenarios:
       - type: "output_matches"
         pattern: '(\b[Cc]onditional|[Gg]uarded|[Gg]ated|[Oo]pt-in|[Oo]pted in|[Hh]ypothesis is false|[Nn]ow scoped|[Nn]o longer|[Rr]efuted|[Rr]efutes|[Rr]efutation)'
       # Code-specific evidence: the agent must cite at least one concrete symbol from PR #35223's actual
-      # diff (none of these symbol names appear in the prompt, so they can only be produced by an agent that
-      # actually opened the code). Defeats the 3-line template parrot like:
+      # diff. Only MAUI-internal implementation symbols are accepted — generic AndroidX types like
+      # `OnBackPressedDispatcher`/`OnBackPressedCallback` and well-known MAUI base classes like
+      # `MauiAppCompatActivity` are easy to guess from the prompt's "back-navigation callback" hint
+      # without opening the code, so they're deliberately excluded. The remaining symbols only appear
+      # in this PR's actual diff. Defeats the 3-line template parrot like:
       #   ### Blast Radius Assessment
       #   **Confidence:** low
       #   Hypothesis is false.
       # which otherwise satisfies the analytical/confidence/refutation assertions without doing analysis.
       - type: "output_matches"
-        pattern: '(MauiOnBackPressedCallback|ShouldRegisterPredictiveBackCallback|OnBackPressedDispatcher|OnBackPressedCallback|IBackNavigationState|HandleOnBackPressed|MauiAppCompatActivity)'
+        pattern: '(MauiOnBackPressedCallback|ShouldRegisterPredictiveBackCallback|IBackNavigationState|HandleOnBackPressed)'
     rubric:
       - "The agent assesses blast radius for handler/platform changes (does this run for all instances?)"
       - "The agent probes real failure modes, not softballs (e.g., handler disconnect, null PlatformView)"

--- a/.github/skills/code-review/tests/eval.yaml
+++ b/.github/skills/code-review/tests/eval.yaml
@@ -82,17 +82,6 @@ scenarios:
       - "No severity markers (❌/⚠️/💡) or verdicts appear in the output"
     timeout: 120
 
-  - name: "CI verification - must run gh pr checks before verdict"
-    prompt: "code review PR #34024 in dotnet/maui"
-    assertions:
-      - type: "output_matches"
-        pattern: "(gh pr checks|CI Status)"
-    rubric:
-      - "The agent runs 'gh pr checks' or 'gh pr checks --required' to verify CI status before delivering a verdict"
-      - "The agent does NOT claim 'clean build' or 'no CI failures' without evidence from gh pr checks output"
-      - "The agent includes a CI Status section in its review output"
-    timeout: 300
-
   - name: "Blast radius - infrastructure changes get probed"
     prompt: "code review PR #32278 in dotnet/maui — this PR modifies handler code that affects platform extensions"
     assertions:

--- a/.github/skills/code-review/tests/eval.yaml
+++ b/.github/skills/code-review/tests/eval.yaml
@@ -81,3 +81,25 @@ scenarios:
       - "The agent provides a descriptive summary without triggering the full review workflow"
       - "No severity markers (❌/⚠️/💡) or verdicts appear in the output"
     timeout: 120
+
+  - name: "CI verification - must run gh pr checks before verdict"
+    prompt: "code review PR #34024 in dotnet/maui"
+    assertions:
+      - type: "output_matches"
+        pattern: "(gh pr checks|CI Status)"
+    rubric:
+      - "The agent runs 'gh pr checks' or 'gh pr checks --required' to verify CI status before delivering a verdict"
+      - "The agent does NOT claim 'clean build' or 'no CI failures' without evidence from gh pr checks output"
+      - "The agent includes a CI Status section in its review output"
+    timeout: 300
+
+  - name: "Blast radius - infrastructure changes get probed"
+    prompt: "code review PR #32278 in dotnet/maui — this PR modifies handler code that affects platform extensions"
+    assertions:
+      - type: "output_matches"
+        pattern: "(NEEDS_CHANGES|NEEDS_DISCUSSION)"
+    rubric:
+      - "The agent assesses blast radius for handler/platform changes (does this run for all instances?)"
+      - "The agent probes real failure modes, not softballs (e.g., handler disconnect, null PlatformView)"
+      - "The confidence is calibrated — not 'high' for handler infrastructure changes"
+    timeout: 300

--- a/.github/skills/code-review/tests/eval.yaml
+++ b/.github/skills/code-review/tests/eval.yaml
@@ -118,6 +118,62 @@ scenarios:
     rubric:
       - "The agent assesses blast radius for handler/platform changes (does this run for all instances?)"
       - "The agent probes real failure modes, not softballs (e.g., handler disconnect, null PlatformView)"
-      - "The agent refutes the hypothesis with evidence — the PR makes the registration conditional, so the post-PR claim is false"
+      - "The agent's evidence-based analysis correctly distinguishes that AddCallback registration remains unconditional while the callback's Enabled state is what was made conditional in this PR — the hypothesis is technically true about registration but behaviorally gated by Enabled"
       - "The confidence is calibrated — not 'high' for platform infrastructure changes"
+    timeout: 300
+
+  - name: "Prior review reconciliation - skill surfaces prior findings before verdict"
+    prompt: "code review PR #35685 in dotnet/maui"
+    assertions:
+      # The dedicated reconciliation section is a skill-specific structural marker.
+      # Baseline agents without the skill prose won't produce this section heading,
+      # and it's the locus where the skill demands prior ❌ findings be acknowledged
+      # before a verdict can be issued.
+      - type: "output_matches"
+        pattern: "[Pp]rior [Rr]eview [Rr]econciliation"
+      # Evidence the agent actually inspected the review history — must name at least
+      # one of the PR's real reviewers. PR #35685 has substantive reviews from
+      # PureWeen, JanKrivanek, T-Gro, kubaflo, plus MauiBot/Copilot AI Summary;
+      # a boilerplate "no prior findings" output would fail this when findings
+      # demonstrably exist across all three surfaces.
+      - type: "output_matches"
+        pattern: "([Pp]ure[Ww]een|[Jj]an[Kk]rivanek|[Tt]-?[Gg]ro|[Kk]ubaflo|[Mm]aui[Bb]ot|[Cc]opilot)"
+      # Verdict must be present
+      - type: "output_matches"
+        pattern: "(LGTM|NEEDS_CHANGES|NEEDS_DISCUSSION)"
+    rubric:
+      - "The agent queries all three review surfaces — top-level review bodies, inline review comments, AND PR issue comments — per the skill's Prior Review Reconciliation step (querying only one or two silently misses findings)"
+      - "The output has a 'Prior Review Reconciliation' section that explicitly names prior reviewers and their findings, not a boilerplate 'no prior findings' statement on a PR that demonstrably has them"
+      - "If prior ❌ Error-level findings exist, the agent verifies whether each was addressed in subsequent commits (the PR is merged, so they should be resolved — the agent must confirm, not assume)"
+      - "The agent never silently drops or contradicts a prior ❌ Error finding — every prior ❌ is either confirmed-addressed or carried forward into the verdict"
+    timeout: 300
+
+  - name: "CI hard gate - skill refuses LGTM when required checks are skipping"
+    prompt: "code review PR #35820 in dotnet/maui"
+    assertions:
+      # The dedicated CI Status section is a skill-specific structural marker.
+      # Baseline agents will often produce a verdict without ever inspecting
+      # required-check state; the skill's Step 5 mandates this query.
+      - type: "output_matches"
+        pattern: "[Cc][Ii] [Ss]tatus"
+      # Evidence the agent inspected required-check state — must reference the
+      # actual check or the skipping/undetermined classification. PR #35820 has
+      # license/cla=pass and maui-pr=skipping; `gh pr checks --required` exits 0
+      # with "All checks were successful" + 1 skipped. The skill Step 5 explicitly
+      # warns this exit-0-with-skipping pattern is NOT a clean pass.
+      - type: "output_matches"
+        pattern: "([Mm]aui-pr|[Ss]kip|[Ss]kipping|[Uu]ndetermined|--required)"
+      # The skill rules (Rule #6) prohibit LGTM when any required check is
+      # pending/skipping/undetermined. Skipped maui-pr means CI coverage is
+      # undetermined — the agent must NOT post LGTM.
+      - type: "output_not_contains"
+        value: "LGTM"
+      # Acceptable verdicts when required CI is undetermined
+      - type: "output_matches"
+        pattern: "(NEEDS_DISCUSSION|NEEDS_CHANGES)"
+    rubric:
+      - "The agent runs 'gh pr checks <PR> --required' (or equivalent) and reports the result in a dedicated CI Status section BEFORE delivering a verdict"
+      - "The agent classifies the result per the skill's exit-code semantics: maui-pr=skipping with exit 0 is undetermined, NOT a clean pass — the skill explicitly warns 'Exit 0 is NOT a clean pass signal' when skipping is present"
+      - "The agent does not post LGTM when any required check is skipping/pending/undetermined — verdict is NEEDS_DISCUSSION per Rule #6"
+      - "The agent does not claim 'clean build' or 'all checks pass' based on exit 0 alone — the 'All checks were successful' summary line from gh is misleading when a required check skipped"
     timeout: 300

--- a/.github/skills/code-review/tests/eval.yaml
+++ b/.github/skills/code-review/tests/eval.yaml
@@ -83,10 +83,10 @@ scenarios:
     timeout: 120
 
   - name: "Blast radius - infrastructure changes get probed"
-    prompt: "code review PR #32278 in dotnet/maui — this PR modifies handler code that affects platform extensions"
+    prompt: "code review PR #32278 in dotnet/maui — I believe the handler changes affect platform extensions that run unconditionally at startup, even for controls that don't use the new feature"
     assertions:
       - type: "output_matches"
-        pattern: "(NEEDS_CHANGES|NEEDS_DISCUSSION)"
+        pattern: "(blast radius|all instances|startup|handler disconnect|unconditional)"
     rubric:
       - "The agent assesses blast radius for handler/platform changes (does this run for all instances?)"
       - "The agent probes real failure modes, not softballs (e.g., handler disconnect, null PlatformView)"

--- a/.github/skills/code-review/tests/eval.yaml
+++ b/.github/skills/code-review/tests/eval.yaml
@@ -86,17 +86,22 @@ scenarios:
     prompt: "code review PR #35223 in dotnet/maui. This is a merged Android fix. Hypothesis to verify or refute: even after this PR, the back-navigation callback registration still runs unconditionally for all activities at startup."
     assertions:
       # Analytical framing: the agent must use blast-radius vocabulary that does NOT appear in the prompt itself.
+      # Case-tolerant character classes so the SKILL.md heading-style 'Blast Radius' (TitleCase) also matches.
       - type: "output_matches"
-        pattern: "(blast radius|all instances|every instance|each instance)"
+        pattern: "([Bb]last radius|[Aa]ll instances|[Ee]very instance|[Ee]ach instance)"
       # Confidence calibrated to the structured field shape; not just any 'medium'/'low' substring.
+      # Case-tolerant on the value so compliant outputs that capitalize 'Medium'/'Low' still pass.
       - type: "output_matches"
-        pattern: '\*\*Confidence:\*\*\s*(medium|low)'
+        pattern: '\*\*Confidence:\*\*\s*([Mm]edium|[Ll]ow)'
       # Refutation evidence: the agent must show it actually analyzed the code, using terms NOT in the prompt
-      # (the prompt contains 'unconditionally' and 'callback registration' — a parroting agent that just echoes
-      # those phrases must not pass). Notes: `\b` on 'conditional' prevents matching inside 'unconditional';
-      # 'no longer' catches phrasings like 'no longer unconditional' / 'no longer registered for all activities'.
+      # (the prompt contains 'unconditionally', 'callback registration', AND the trigger word 'refute' —
+      # a parroting agent that just echoes those phrases must not pass). Notes:
+      # - `\b` on 'conditional' prevents matching inside 'unconditional'
+      # - 'refuted'/'refutes'/'refutation' demonstrate completed analysis vs the prompt's bare 'refute' verb
+      #   (the prior 'refut' substring matched the prompt's 'verify or refute' and let parroting through)
+      # - 'no longer' catches phrasings like 'no longer unconditional' / 'no longer registered for all activities'
       - type: "output_matches"
-        pattern: '(\bconditional|guarded|gated|opt-in|opted in|refut|hypothesis is false|now scoped|no longer)'
+        pattern: '(\b[Cc]onditional|[Gg]uarded|[Gg]ated|[Oo]pt-in|[Oo]pted in|[Hh]ypothesis is false|[Nn]ow scoped|[Nn]o longer|[Rr]efuted|[Rr]efutes|[Rr]efutation)'
     rubric:
       - "The agent assesses blast radius for handler/platform changes (does this run for all instances?)"
       - "The agent probes real failure modes, not softballs (e.g., handler disconnect, null PlatformView)"

--- a/.github/skills/code-review/tests/eval.yaml
+++ b/.github/skills/code-review/tests/eval.yaml
@@ -23,7 +23,7 @@ scenarios:
       - type: "output_not_contains"
         value: "NEEDS_DISCUSSION"
       - type: "output_not_contains"
-        value: "Devil's Advocate"
+        value: "Failure-Mode Probing"
     rubric:
       - "The agent provides a plain summary without launching a structured multi-step review workflow"
       - "The agent does NOT walk through a multi-step review workflow"
@@ -83,15 +83,15 @@ scenarios:
     timeout: 120
 
   - name: "Blast radius - infrastructure changes get probed"
-    prompt: "code review PR #35223 in dotnet/maui — this PR changes back-navigation callback registration on Android. Hypothesis: the registration may run unconditionally for all activities, not just those using predictive back. Please verify or refute."
+    prompt: "code review PR #35223 in dotnet/maui. This is a merged Android fix. Hypothesis to verify or refute: even after this PR, the back-navigation callback registration still runs unconditionally for all activities at startup."
     assertions:
       - type: "output_matches"
         pattern: "(blast radius|all instances|unconditional|callback registration)"
       - type: "output_matches"
-        pattern: "(medium|low)"
+        pattern: '\*\*Confidence:\*\*\s*(medium|low)'
     rubric:
       - "The agent assesses blast radius for handler/platform changes (does this run for all instances?)"
       - "The agent probes real failure modes, not softballs (e.g., handler disconnect, null PlatformView)"
-      - "The agent provides evidence-backed acceptance or refutation of the hypothesis — not just echoing it"
+      - "The agent refutes the hypothesis with evidence — the PR makes the registration conditional, so the post-PR claim is false"
       - "The confidence is calibrated — not 'high' for platform infrastructure changes"
     timeout: 300

--- a/.github/skills/code-review/tests/eval.yaml
+++ b/.github/skills/code-review/tests/eval.yaml
@@ -86,9 +86,10 @@ scenarios:
     prompt: "code review PR #35223 in dotnet/maui. This is a merged Android fix. Hypothesis to verify or refute: even after this PR, the back-navigation callback registration still runs unconditionally for all activities at startup."
     assertions:
       # Analytical framing: the agent must use blast-radius vocabulary that does NOT appear in the prompt itself.
-      # Case-tolerant character classes so the SKILL.md heading-style 'Blast Radius' (TitleCase) also matches.
+      # Case-tolerant on every word so the SKILL.md heading-style "Blast Radius Assessment" (TitleCase)
+      # AND the template body "Runs for all instances:" both match.
       - type: "output_matches"
-        pattern: "([Bb]last radius|[Aa]ll instances|[Ee]very instance|[Ee]ach instance)"
+        pattern: "([Bb]last [Rr]adius|[Aa]ll [Ii]nstances|[Ee]very [Ii]nstance|[Ee]ach [Ii]nstance)"
       # Confidence calibrated to the structured field shape; not just any 'medium'/'low' substring.
       # Case-tolerant on the value so compliant outputs that capitalize 'Medium'/'Low' still pass.
       - type: "output_matches"
@@ -102,6 +103,15 @@ scenarios:
       # - 'no longer' catches phrasings like 'no longer unconditional' / 'no longer registered for all activities'
       - type: "output_matches"
         pattern: '(\b[Cc]onditional|[Gg]uarded|[Gg]ated|[Oo]pt-in|[Oo]pted in|[Hh]ypothesis is false|[Nn]ow scoped|[Nn]o longer|[Rr]efuted|[Rr]efutes|[Rr]efutation)'
+      # Code-specific evidence: the agent must cite at least one concrete symbol from PR #35223's actual
+      # diff (none of these symbol names appear in the prompt, so they can only be produced by an agent that
+      # actually opened the code). Defeats the 3-line template parrot like:
+      #   ### Blast Radius Assessment
+      #   **Confidence:** low
+      #   Hypothesis is false.
+      # which otherwise satisfies the analytical/confidence/refutation assertions without doing analysis.
+      - type: "output_matches"
+        pattern: '(MauiOnBackPressedCallback|ShouldRegisterPredictiveBackCallback|OnBackPressedDispatcher|OnBackPressedCallback|IBackNavigationState|HandleOnBackPressed|MauiAppCompatActivity)'
     rubric:
       - "The agent assesses blast radius for handler/platform changes (does this run for all instances?)"
       - "The agent probes real failure modes, not softballs (e.g., handler disconnect, null PlatformView)"


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Adds four process and structural invariants to the code-review skill, informed by systematic analysis of 372+ historical regressions and the lessons from PR #34669 (badge feature startup crash). Supersedes PR #34985 with changes fitted to the current codebase architecture.

### Changes

**SKILL.md — 4 new safeguards:**

1. **Prior review reconciliation** (Step 4) — Check for and reconcile ❌ Error findings from prior reviews before delivering a verdict. Never silently drop or contradict an earlier ❌ Error finding.

2. **CI verification hard gate** (Step 5) — Mandatory `gh pr checks <PR_NUMBER> --required` step before verdict formation. Classify failing checks as PR-caused / pre-existing flake / ambiguous (delegating to `azdo-build-investigator` when uncertain). Never claim "clean build" without evidence.

3. **Blast radius assessment** (Step 6) — Mandatory for handler/platform/infrastructure changes. Probe whether code runs for ALL instances or only feature users, startup impact, static state scope.

4. **Failure-mode probing** (Step 6) — Replaces "Devil's Advocate" with rigorous failure scenario analysis. Probes handler disconnect, null PlatformView, missing unsubscribe, stale static state.

**Also adds:**
- Confidence calibration tables (blast radius and evidence cap confidence level)
- Updated output format with Prior Review Reconciliation, CI Status, and Blast Radius sections
- New blast-radius eval scenario (PR #35223) asserting confidence is anchored to the structured `**Confidence:** medium|low` field
- Updated completion criteria checklist

### Context

Analysis of 372+ `regressed-in-*` issues revealed that most reviewer-missed regressions share structural patterns (feature code running unconditionally, unverified CI claims, contradicted prior findings). These safeguards encode the generalizable invariants — not incident-specific rules.

### Relationship to PR #34985

PR #34985 addressed the same problem but targeted a codebase state that has since changed (`review-rules.md` no longer exists, expert reviewer restructured). This PR takes the 4 strongest ideas from #34985 and integrates them into the current architecture.