### PR TITLE
Fix: Make SafeAreaEdges.Container publicly accessible

### DIFF
--- a/src/Core/src/Primitives/SafeAreaEdges.cs
+++ b/src/Core/src/Primitives/SafeAreaEdges.cs
@@ -126,9 +126,9 @@ namespace Microsoft.Maui
 		public static SafeAreaEdges All { get; } = new(SafeAreaRegions.All);
 
 		/// <summary>
-		/// A <see cref="SafeAreaEdges"/> with all edges set to <see cref="SafeAreaRegions.All"/>.
+		/// A <see cref="SafeAreaEdges"/> with all edges set to <see cref="SafeAreaRegions.Container"/>.
 		/// </summary>
-		internal static SafeAreaEdges Container { get; } = new(SafeAreaRegions.Container);
+		public static SafeAreaEdges Container { get; } = new(SafeAreaRegions.Container);
 
 		public static bool operator ==(SafeAreaEdges left, SafeAreaEdges right)
 		{

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -16,3 +16,4 @@ override Microsoft.Maui.Platform.MauiHybridWebView.OnAttachedToWindow() -> void
 override Microsoft.Maui.Platform.MauiHybridWebView.OnSizeChanged(int width, int height, int oldWidth, int oldHeight) -> void
 override Microsoft.Maui.Platform.MauiWebView.OnAttachedToWindow() -> void
 override Microsoft.Maui.Platform.MauiWebView.OnSizeChanged(int width, int height, int oldWidth, int oldHeight) -> void
+static Microsoft.Maui.SafeAreaEdges.Container.get -> Microsoft.Maui.SafeAreaEdges

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -6,3 +6,4 @@ override Microsoft.Maui.Platform.MauiTextView.TextAlignment.get -> UIKit.UITextA
 override Microsoft.Maui.Platform.MauiTextView.TextAlignment.set -> void
 override Microsoft.Maui.Platform.MauiView.DidUpdateFocus(UIKit.UIFocusUpdateContext! context, UIKit.UIFocusAnimationCoordinator! coordinator) -> void
 static Microsoft.Maui.Handlers.DatePickerHandler.MapFlowDirection(Microsoft.Maui.Handlers.IDatePickerHandler! handler, Microsoft.Maui.IDatePicker! datePicker) -> void
+static Microsoft.Maui.SafeAreaEdges.Container.get -> Microsoft.Maui.SafeAreaEdges

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -6,3 +6,4 @@ override Microsoft.Maui.Platform.MauiTextView.TextAlignment.get -> UIKit.UITextA
 override Microsoft.Maui.Platform.MauiTextView.TextAlignment.set -> void
 override Microsoft.Maui.Platform.MauiView.DidUpdateFocus(UIKit.UIFocusUpdateContext! context, UIKit.UIFocusAnimationCoordinator! coordinator) -> void
 static Microsoft.Maui.Handlers.DatePickerHandler.MapFlowDirection(Microsoft.Maui.Handlers.IDatePickerHandler! handler, Microsoft.Maui.IDatePicker! datePicker) -> void
+static Microsoft.Maui.SafeAreaEdges.Container.get -> Microsoft.Maui.SafeAreaEdges

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 #nullable enable
 override Microsoft.Maui.Platform.MauiPasswordTextBox.OnCreateAutomationPeer() -> Microsoft.UI.Xaml.Automation.Peers.AutomationPeer!
+static Microsoft.Maui.SafeAreaEdges.Container.get -> Microsoft.Maui.SafeAreaEdges

--- a/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+static Microsoft.Maui.SafeAreaEdges.Container.get -> Microsoft.Maui.SafeAreaEdges

--- a/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+static Microsoft.Maui.SafeAreaEdges.Container.get -> Microsoft.Maui.SafeAreaEdges

--- a/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+static Microsoft.Maui.SafeAreaEdges.Container.get -> Microsoft.Maui.SafeAreaEdges


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details

- SafeAreaEdges.Container is not accessible in code-behind, even though the Safe Area documentation hints at it as the equivalent behavior to .NET 9.

### Root Cause
- The SafeAreaEdges.Container static property was declared internal, so although the .NET 10 Safe Area documentation advertises it as the equivalent of the .NET 9 default safe-area behavior, consumers could not reference it from code-behind — unlike its public siblings SafeAreaEdges.None, .All, and .SoftInput.

### Description of Change

This pull request makes the `Container` property of the `SafeAreaEdges` class publicly accessible and exposes it in the public API surface for all supported platforms. This allows consumers to easily obtain a `SafeAreaEdges` instance representing the container region.

API Changes:

* Changed the `SafeAreaEdges.Container` property from `internal` to `public`, making it accessible to library consumers. (`src/Core/src/Primitives/SafeAreaEdges.cs`)

Public API Surface Updates:

* Added `static Microsoft.Maui.SafeAreaEdges.Container.get -> Microsoft.Maui.SafeAreaEdges` to the public API files for all platforms, including .NET, .NET Standard, Android, iOS, Mac Catalyst, and Windows. (`src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt`, `src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt`, `src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt`, `src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt`, `src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt`, `src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt`, `src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt`)

### Issues Fixed
Fixes #35501


