### PR TITLE
Fix iOS toolbar empty badge indicator

### DIFF
--- a/src/Controls/src/Core/Compatibility/iOS/Extensions/ToolbarItemExtensions.cs
+++ b/src/Controls/src/Core/Compatibility/iOS/Extensions/ToolbarItemExtensions.cs
@@ -218,7 +218,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 #pragma warning disable CA1416 // Validate platform compatibility
 				UIBarButtonItemBadge badge;
 				if (badgeText.Length == 0)
-					badge = UIBarButtonItemBadge.Create(0); // Empty string shows as dot indicator
+					badge = UIBarButtonItemBadge.CreateIndicatorBadge();
 				else if (int.TryParse(badgeText, out var count) && count >= 0)
 					badge = UIBarButtonItemBadge.Create((nuint)count);
 				else

--- a/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarTests.iOS.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Compatibility.Platform.iOS;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class ToolbarTests
+	{
+		[Fact(DisplayName = "Empty BadgeText Updates To Indicator Badge")]
+		public Task EmptyBadgeTextUpdatesToIndicatorBadge()
+		{
+			if (!IsBarButtonItemBadgeSupported())
+				return Task.CompletedTask;
+
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var item = new ToolbarItem
+				{
+					Text = "Badge",
+					BadgeText = "3"
+				};
+
+				using var barButtonItem = item.ToUIBarButtonItem(forceName: true, forcePrimary: true);
+
+				item.BadgeText = string.Empty;
+
+#pragma warning disable CA1416 // Validate platform compatibility
+				Assert.NotNull(barButtonItem.Badge);
+				Assert.Null(barButtonItem.Badge.StringValue);
+#pragma warning restore CA1416
+			});
+		}
+
+		static bool IsBarButtonItemBadgeSupported()
+		{
+#if IOS
+			return OperatingSystem.IsIOSVersionAtLeast(26);
+#elif MACCATALYST
+			return OperatingSystem.IsMacCatalystVersionAtLeast(26);
+#else
+			return false;
+#endif
+		}
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

On iOS 26 and Mac Catalyst 26, `ToolbarItem.BadgeText = string.Empty` should render the documented empty indicator badge dot, while `null` hides the badge and non-empty values render badge content. The existing net11.0 implementation mapped the empty string to `UIBarButtonItemBadge.Create(0)`, which creates a numeric zero badge instead of the indicator badge.

This updates the empty-string branch to use `UIBarButtonItemBadge.CreateIndicatorBadge()` and keeps the existing null, numeric, string, `BadgeColor`, and `BadgeTextColor` behavior unchanged. It also adds focused iOS/MacCatalyst device coverage that verifies updating an existing numeric badge to an empty string produces a badge with no string value on supported OS versions.

Validation:

- `dotnet test src/Controls/tests/Core.UnitTests/Controls.Core.UnitTests.csproj -f net11.0 -p:TargetFrameworks=net11.0 --no-restore --filter FullyQualifiedName~ToolbarItemBadgeTests`
- `dotnet build src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj -f net11.0-ios -p:TargetFrameworks=net11.0-ios -p:RuntimeIdentifier=iossimulator-arm64 -p:IncludeIosTargetFrameworks=true -p:IncludeAndroidTargetFrameworks=false -p:IncludeMacCatalystTargetFrameworks=false -p:IncludeWindowsTargetFrameworks=false -p:IosTargetFrameworkVersion=26.2 -p:IosTargetFrameworkVersionSdkDefault=26.2 -p:NoWarn=CS1591%3BCS8622%3BCA1416%3BCA2200 --no-restore -v:minimal`

### Issues Fixed

N/A