### PR TITLE
[Housekeeping] Remove hardcoded net10 TargetFramework values

### DIFF
--- a/src/AI/tests/Essentials.AI.Benchmarks/Essentials.AI.Benchmarks.csproj
+++ b/src/AI/tests/Essentials.AI.Benchmarks/Essentials.AI.Benchmarks.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Configuration>Release</Configuration>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(_MauiDotNetTfm)</TargetFramework>
     <AssemblyName>Essentials.AI.Benchmarks</AssemblyName>
     <RootNamespace>Microsoft.Maui.Essentials.AI.Benchmarks</RootNamespace>
     <IsPackable>false</IsPackable>

--- a/src/Controls/tests/Xaml.Benchmarks/Microsoft.Maui.Controls.Xaml.Benchmarks.csproj
+++ b/src/Controls/tests/Xaml.Benchmarks/Microsoft.Maui.Controls.Xaml.Benchmarks.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Configuration>Release</Configuration>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(_MauiDotNetTfm)</TargetFramework>
     <AssemblyName>Microsoft.Maui.Controls.Xaml.Benchmarks</AssemblyName>
     <Nullable>enable</Nullable>
     <EnablePreviewFeatures>True</EnablePreviewFeatures>


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->
This pull request updates the target framework configuration for two benchmark projects to use a variable instead of a hardcoded value. This change makes the projects more flexible and consistent with the rest of the build system.

Project configuration updates:

* Updated the `TargetFramework` property in `Essentials.AI.Benchmarks.csproj` and `Microsoft.Maui.Controls.Xaml.Benchmarks.csproj` to use `$(_MauiDotNetTfm)` instead of the hardcoded `net10.0` value, allowing the framework version to be centrally managed. [[1]](diffhunk://#diff-bb90ff6b46cbc934e22f9b129b4643f2b20d96fcb7db5d24777f0bd6dc8135a4L6-R6) [[2]](diffhunk://#diff-3dbcca1f11be7f8a65e453b1ecd2149c566ebe11a209a499d1b1a253b935c6adL6-R6)

Fixes #

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

| Before | After|
|--|--|
|<img width="1474" height="363" alt="image" src="https://github.com/user-attachments/assets/4aa5d092-c45b-4da1-94a4-e99ef9ba6f50" /> |   <img width="1474" height="363" alt="image" src="https://github.com/user-attachments/assets/819a36dd-9493-4c34-ac2e-2300d94dafaa" /> |