### PR TITLE
Fix for Issue33356NavigateShouldOccur failure

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRenderer.cs
@@ -175,6 +175,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 					if (!enabled)
 					{
+						_sendPopPending = false; // reset before returning
 						return false;
 					}
 
@@ -194,6 +195,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 					// hardware/system back button.
 					if (_context.Shell?.SendBackButtonPressed() == true)
 					{
+						_sendPopPending = false; // reset before returning
 						return false;
 					}
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/ShellNavigationFeatureTests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/ShellNavigationFeatureTests.cs
@@ -883,10 +883,6 @@ public class ShellNavigationFeatureTests : _GalleryUITest
 	[Test, Order(50)]
 	public void BackButtonBehavior_IsEnabled_False_BackButtonDoesNotNavigate()
 	{
-		if (iOS26OrHigher)
-        {
-            Assert.Ignore("Fails on iOS 26 due to bug issue: https://github.com/dotnet/maui/issues/34771");
-        }
 		App.WaitForElement("MainPageIdentityLabel");
 		App.WaitForElement("IsEnabledButton");
 		App.Tap("IsEnabledButton");
@@ -909,10 +905,6 @@ public class ShellNavigationFeatureTests : _GalleryUITest
 	[Test, Order(51)]
 	public void BackButtonBehavior_IsVisible_False_ProgrammaticNavStillWorks()
 	{
-		if (iOS26OrHigher)
-        {
-            Assert.Ignore("Fails on iOS 26 due to bug issue: https://github.com/dotnet/maui/issues/34771");
-        }
 		App.WaitForElement("MainPageIdentityLabel");
 		App.WaitForElement("IsVisibleButton");
 		App.Tap("IsVisibleButton");


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue details: 

**Failed case**: Issue33356NavigateShouldOccur

### Root Cause

On iOS 26+, _sendPopPending was introduced to prevent duplicate back navigation caused by changed UINavigationBardelegate behavior. However, in two early-return paths (BackButtonBehavior.IsEnabled == false and Shell.SendBackButtonPressed() == true), the flag was set to true but never reset, causing subsequent back navigations to be ignored.

### Fix Description

Reset _sendPopPending to false before returning from the affected early-return paths in SendPop(). This ensures the navigation guard is always released when GoToAsync("..") is not dispatched.

**Note:** The changes in this PR have already been merged into the inflight/Candidate branch.

PR link: #34890 