### PR TITLE
Fix for WebView leaks when reusing a shared WebViewSource

### DIFF
--- a/src/Controls/src/Core/WebView/WebViewSource.cs
+++ b/src/Controls/src/Core/WebView/WebViewSource.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Maui.Controls
 	[TypeConverter(typeof(WebViewSourceTypeConverter))]
 	public abstract class WebViewSource : BindableObject, IWebViewSource
 	{
+		readonly WeakEventManager _weakEventManager = new WeakEventManager();
+
 		public static implicit operator WebViewSource(Uri url)
 		{
 			return new UrlWebViewSource { Url = url?.AbsoluteUri };
@@ -23,9 +25,7 @@ namespace Microsoft.Maui.Controls
 
 		protected void OnSourceChanged()
 		{
-			EventHandler eh = SourceChanged;
-			if (eh != null)
-				eh(this, EventArgs.Empty);
+			_weakEventManager.HandleEvent(this, EventArgs.Empty, nameof(SourceChanged));
 		}
 
 		/// <summary>
@@ -35,7 +35,11 @@ namespace Microsoft.Maui.Controls
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public abstract void Load(IWebViewDelegate renderer);
 
-		internal event EventHandler SourceChanged;
+		internal event EventHandler SourceChanged
+		{
+			add { _weakEventManager.AddEventHandler(value); }
+			remove { _weakEventManager.RemoveEventHandler(value); }
+		}
 
 		private sealed class WebViewSourceTypeConverter : TypeConverter
 		{

--- a/src/Controls/tests/Core.UnitTests/WebViewUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WebViewUnitTests.cs
@@ -187,6 +187,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			GC.Collect();
 
 			Assert.False(weakRef.IsAlive, "WebView should be GC-eligible after handler disconnect even when a shared HtmlWebViewSource is still alive.");
+			GC.KeepAlive(sharedSource); // ensure JIT does not elide sharedSource before the GC cycle
 		}
 
 		// A shared UrlWebViewSource must not keep WebViews alive after their handler is disconnected.
@@ -201,6 +202,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			GC.Collect();
 
 			Assert.False(weakRef.IsAlive, "WebView should be GC-eligible after handler disconnect even when a shared UrlWebViewSource is still alive.");
+			GC.KeepAlive(sharedSource); // ensure JIT does not elide sharedSource before the GC cycle
 		}
 
 		// Multiple WebViews sharing one source must all be GC-eligible after their handlers are disconnected.
@@ -215,7 +217,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			GC.Collect();
 
 			for (int i = 0; i < weakRefs.Length; i++)
+			{
 				Assert.False(weakRefs[i].IsAlive, $"WebView[{i}] should be GC-eligible after handler disconnect even when a shared WebViewSource is still alive.");
+			}
+			GC.KeepAlive(sharedSource); // ensure JIT does not elide sharedSource before the GC cycle
 		}
 
 		[MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Controls/tests/Core.UnitTests/WebViewUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WebViewUnitTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Runtime.CompilerServices;
 using Microsoft.Maui.Controls.PlatformConfiguration;
 using Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific;
 using Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific;
@@ -172,6 +173,72 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			defaultWebView.Source = "http://xamarin.com";
 
 			Assert.NotNull(defaultWebView.Cookies);
+		}
+
+		// A shared WebViewSource must not keep WebViews alive after their handler is disconnected.
+		[Fact]
+		public void SharedHtmlSourceDoesNotPreventWebViewGC()
+		{
+			var sharedSource = new HtmlWebViewSource { Html = "<html/>" };
+			var weakRef = CreateWebViewWithSharedSource(sharedSource);
+
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+			GC.Collect();
+
+			Assert.False(weakRef.IsAlive, "WebView should be GC-eligible after handler disconnect even when a shared HtmlWebViewSource is still alive.");
+		}
+
+		// A shared UrlWebViewSource must not keep WebViews alive after their handler is disconnected.
+		[Fact]
+		public void SharedUrlSourceDoesNotPreventWebViewGC()
+		{
+			var sharedSource = new UrlWebViewSource { Url = "https://microsoft.com" };
+			var weakRef = CreateWebViewWithSharedSource(sharedSource);
+
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+			GC.Collect();
+
+			Assert.False(weakRef.IsAlive, "WebView should be GC-eligible after handler disconnect even when a shared UrlWebViewSource is still alive.");
+		}
+
+		// Multiple WebViews sharing one source must all be GC-eligible after their handlers are disconnected.
+		[Fact]
+		public void MultipleWebViewsWithSharedSourceAreAllGCEligible()
+		{
+			var sharedSource = new HtmlWebViewSource { Html = "<html/>" };
+			var weakRefs = CreateMultipleWebViewsWithSharedSource(sharedSource);
+
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+			GC.Collect();
+
+			for (int i = 0; i < weakRefs.Length; i++)
+				Assert.False(weakRefs[i].IsAlive, $"WebView[{i}] should be GC-eligible after handler disconnect even when a shared WebViewSource is still alive.");
+		}
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		static WeakReference CreateWebViewWithSharedSource(WebViewSource source)
+		{
+			var webView = new WebView { Source = source };
+			webView.Handler = new HandlerStub();
+			webView.Handler = null; // simulate page pop / handler disconnect
+			return new WeakReference(webView);
+		}
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		static WeakReference[] CreateMultipleWebViewsWithSharedSource(WebViewSource source)
+		{
+			var weakRefs = new WeakReference[5];
+			for (int i = 0; i < weakRefs.Length; i++)
+			{
+				var webView = new WebView { Source = source };
+				webView.Handler = new HandlerStub();
+				webView.Handler = null; // simulate page pop
+				weakRefs[i] = new WeakReference(webView);
+			}
+			return weakRefs;
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/WebViewUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WebViewUnitTests.cs
@@ -227,8 +227,16 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		static WeakReference CreateWebViewWithSharedSource(WebViewSource source)
 		{
 			var webView = new WebView { Source = source };
+
+			// Simulate a full page lifecycle (attach handler, then disconnect on page pop).
+			// The retention path under test is created by "Source = source": the propertyChanged
+			// callback subscribes WebView.OnSourceChanged to the shared source's SourceChanged
+			// event. Attaching and then nulling the handler mirrors what the framework does when
+			// a page is pushed and subsequently popped, giving the WebView a realistic lifetime
+			// before GC eligibility is asserted.
 			webView.Handler = new HandlerStub();
-			webView.Handler = null; // simulate page pop / handler disconnect
+			webView.Handler = null;
+
 			return new WeakReference(webView);
 		}
 
@@ -239,8 +247,11 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			for (int i = 0; i < weakRefs.Length; i++)
 			{
 				var webView = new WebView { Source = source };
+
+				// Simulate page pop for each WebView — see CreateWebViewWithSharedSource for details.
 				webView.Handler = new HandlerStub();
-				webView.Handler = null; // simulate page pop
+				webView.Handler = null;
+
 				weakRefs[i] = new WeakReference(webView);
 			}
 			return weakRefs;


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!


<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details

When a WebViewSource instance is shared across multiple WebView controls, navigating away from the page does not release the associated WebView instances from memory. As a result, the WebView, page, and related binding context objects remain retained, leading to a memory leak.

### Root Cause

The issue occurs because of the WebView.SourceProperty.propertyChanged callback subscribing to the WebViewSource.SourceChanged event using a strong event reference. This creates a retention chain between WebViewSource and the WebView, preventing the garbage collector from releasing the page and its associated objects after navigation.

### Description of Change

The fix involves replacing the strong event subscription in WebViewSource.SourceChanged with a WeakEventManagerimplementation, similar to the existing ImageSource pattern in MAUI. This ensures that shared WebViewSource instances maintain only weak references to subscribers, allowing WebView instances and related page objects to be garbage-collected correctly after navigation. 

Additionally, regression unit tests were added to validate that shared HtmlWebViewSource and UrlWebViewSource objects no longer prevent garbage collection.

Validated the behavior in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
### Issues Fixed
  
Fixes https://github.com/dotnet/maui/issues/35483

### Output  ScreenShot

|Platform|Before|After|
|--|--|--|
|Android| <video src="https://github.com/user-attachments/assets/40fbd8ee-478f-4474-ac3b-6694632beedc" >| <video src="https://github.com/user-attachments/assets/510e1ae4-c3c4-4978-a13e-d94e2f7d940b">|
|Mac|<video src="https://github.com/user-attachments/assets/a3e95721-f3e7-4e86-8a1e-5a381d7b9bb4"> |<video src="https://github.com/user-attachments/assets/f41207d6-2b1d-491e-8dea-520ee3694fc5">|
|iOS|<video src="https://github.com/user-attachments/assets/82aa8758-4228-481c-88bb-5a4b663dfe7d">|<video src="https://github.com/user-attachments/assets/065a0574-2afb-465c-85a5-ffe79bbe37a0">|
|Windows|<video src="https://github.com/user-attachments/assets/8e4f31d6-e9b9-4f00-8ed7-38d4675864cf">|<video src="https://github.com/user-attachments/assets/a0373b79-31fc-4fdd-8867-22a4372a6e6a"> |