### PR TITLE
Fix polygon points collection handler leak

### DIFF
--- a/src/Controls/src/Core/Handlers/Shapes/Polygon/PolygonHandler.Android.cs
+++ b/src/Controls/src/Core/Handlers/Shapes/Polygon/PolygonHandler.Android.cs
@@ -9,15 +9,16 @@ namespace Microsoft.Maui.Controls.Handlers
 		protected override void ConnectHandler(MauiShapeView nativeView)
 		{
 			if (VirtualView is Polygon polygon)
-				polygon.Points.CollectionChanged += OnPointsCollectionChanged;
+			{
+				UpdatePointsSubscription(polygon.Points);
+			}
 
 			base.ConnectHandler(nativeView);
 		}
 
 		protected override void DisconnectHandler(MauiShapeView nativeView)
 		{
-			if (VirtualView is Polygon polygon)
-				polygon.Points.CollectionChanged -= OnPointsCollectionChanged;
+			ClearPointsSubscription();
 
 			base.DisconnectHandler(nativeView);
 		}
@@ -29,6 +30,11 @@ namespace Microsoft.Maui.Controls.Handlers
 
 		public static void MapPoints(IShapeViewHandler handler, Polygon polygon)
 		{
+			if (handler is PolygonHandler polygonHandler)
+			{
+				polygonHandler.UpdatePointsSubscription(polygon.Points);
+			}
+
 			handler.PlatformView?.InvalidateShape(polygon);
 		}
 
@@ -45,9 +51,5 @@ namespace Microsoft.Maui.Controls.Handlers
 			handler.PlatformView?.InvalidateShape(polygon);
 		}
 
-		void OnPointsCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
-		{
-			PlatformView?.InvalidateShape(VirtualView);
-		}
 	}
 }

--- a/src/Controls/src/Core/Handlers/Shapes/Polygon/PolygonHandler.Tizen.cs
+++ b/src/Controls/src/Core/Handlers/Shapes/Polygon/PolygonHandler.Tizen.cs
@@ -9,15 +9,16 @@ namespace Microsoft.Maui.Controls.Handlers
 		protected override void ConnectHandler(MauiShapeView nativeView)
 		{
 			if (VirtualView is Polygon polygon)
-				polygon.Points.CollectionChanged += OnPointsCollectionChanged;
+			{
+				UpdatePointsSubscription(polygon.Points);
+			}
 
 			base.ConnectHandler(nativeView);
 		}
 
 		protected override void DisconnectHandler(MauiShapeView nativeView)
 		{
-			if (VirtualView is Polygon polygon)
-				polygon.Points.CollectionChanged -= OnPointsCollectionChanged;
+			ClearPointsSubscription();
 
 			base.DisconnectHandler(nativeView);
 		}
@@ -29,6 +30,11 @@ namespace Microsoft.Maui.Controls.Handlers
 
 		public static void MapPoints(IShapeViewHandler handler, Polygon polygon)
 		{
+			if (handler is PolygonHandler polygonHandler)
+			{
+				polygonHandler.UpdatePointsSubscription(polygon.Points);
+			}
+
 			handler.PlatformView?.InvalidateShape(polygon);
 		}
 
@@ -45,9 +51,5 @@ namespace Microsoft.Maui.Controls.Handlers
 			handler.PlatformView?.InvalidateShape(polygon);
 		}
 
-		void OnPointsCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
-		{
-			PlatformView?.InvalidateShape(VirtualView);
-		}
 	}
 }

--- a/src/Controls/src/Core/Handlers/Shapes/Polygon/PolygonHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shapes/Polygon/PolygonHandler.Windows.cs
@@ -11,15 +11,16 @@ namespace Microsoft.Maui.Controls.Handlers
 		protected override void ConnectHandler(W2DGraphicsView nativeView)
 		{
 			if (VirtualView is Polygon polygon)
-				polygon.Points.CollectionChanged += OnPointsCollectionChanged;
+			{
+				UpdatePointsSubscription(polygon.Points);
+			}
 
 			base.ConnectHandler(nativeView);
 		}
 
 		protected override void DisconnectHandler(W2DGraphicsView nativeView)
 		{
-			if (VirtualView is Polygon polygon)
-				polygon.Points.CollectionChanged -= OnPointsCollectionChanged;
+			ClearPointsSubscription();
 
 			base.DisconnectHandler(nativeView);
 		}
@@ -31,6 +32,11 @@ namespace Microsoft.Maui.Controls.Handlers
 
 		public static void MapPoints(IShapeViewHandler handler, Polygon polygon)
 		{
+			if (handler is PolygonHandler polygonHandler)
+			{
+				polygonHandler.UpdatePointsSubscription(polygon.Points);
+			}
+
 			handler.PlatformView?.InvalidateShape(polygon);
 		}
 
@@ -47,9 +53,5 @@ namespace Microsoft.Maui.Controls.Handlers
 			handler.PlatformView?.InvalidateShape(polygon);
 		}
 
-		void OnPointsCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
-		{
-			PlatformView?.InvalidateShape(VirtualView);
-		}
 	}
 }

--- a/src/Controls/src/Core/Handlers/Shapes/Polygon/PolygonHandler.cs
+++ b/src/Controls/src/Core/Handlers/Shapes/Polygon/PolygonHandler.cs
@@ -1,10 +1,14 @@
 ﻿#nullable disable
+using System.Collections.Specialized;
+using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Shapes;
 
 namespace Microsoft.Maui.Controls.Handlers
 {
 	public partial class PolygonHandler : ShapeViewHandler
 	{
+		PointCollection _subscribedPoints;
+
 		public static new IPropertyMapper<Polygon, IShapeViewHandler> Mapper = new PropertyMapper<Polygon, IShapeViewHandler>(ShapeViewHandler.Mapper)
 		{
 			[nameof(IShapeView.Shape)] = MapShape,
@@ -20,6 +24,40 @@ namespace Microsoft.Maui.Controls.Handlers
 		public PolygonHandler(IPropertyMapper mapper) : base(mapper ?? Mapper)
 		{
 
+		}
+
+		void UpdatePointsSubscription(PointCollection points)
+		{
+			if (ReferenceEquals(_subscribedPoints, points))
+			{
+				return;
+			}
+
+			ClearPointsSubscription();
+
+			if (points is null)
+			{
+				return;
+			}
+
+			_subscribedPoints = points;
+			_subscribedPoints.CollectionChanged += OnPointsCollectionChanged;
+		}
+
+		void ClearPointsSubscription()
+		{
+			if (_subscribedPoints is null)
+			{
+				return;
+			}
+
+			_subscribedPoints.CollectionChanged -= OnPointsCollectionChanged;
+			_subscribedPoints = null;
+		}
+
+		void OnPointsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+		{
+			UpdateValue(nameof(Polygon.Points));
 		}
 	}
 }

--- a/src/Controls/src/Core/Handlers/Shapes/Polygon/PolygonHandler.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Shapes/Polygon/PolygonHandler.iOS.cs
@@ -9,15 +9,16 @@ namespace Microsoft.Maui.Controls.Handlers
 		protected override void ConnectHandler(MauiShapeView nativeView)
 		{
 			if (VirtualView is Polygon polygon)
-				polygon.Points.CollectionChanged += OnPointsCollectionChanged;
+			{
+				UpdatePointsSubscription(polygon.Points);
+			}
 
 			base.ConnectHandler(nativeView);
 		}
 
 		protected override void DisconnectHandler(MauiShapeView nativeView)
 		{
-			if (VirtualView is Polygon polygon)
-				polygon.Points.CollectionChanged -= OnPointsCollectionChanged;
+			ClearPointsSubscription();
 
 			base.DisconnectHandler(nativeView);
 		}
@@ -29,6 +30,11 @@ namespace Microsoft.Maui.Controls.Handlers
 
 		public static void MapPoints(IShapeViewHandler handler, Polygon polygon)
 		{
+			if (handler is PolygonHandler polygonHandler)
+			{
+				polygonHandler.UpdatePointsSubscription(polygon.Points);
+			}
+
 			handler.PlatformView?.InvalidateShape(polygon);
 		}
 
@@ -45,9 +51,5 @@ namespace Microsoft.Maui.Controls.Handlers
 			handler.PlatformView?.InvalidateShape(polygon);
 		}
 
-		void OnPointsCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
-		{
-			PlatformView?.InvalidateShape(VirtualView);
-		}
 	}
 }

--- a/src/Controls/src/Core/Handlers/Shapes/Polyline/PolylineHandler.Android.cs
+++ b/src/Controls/src/Core/Handlers/Shapes/Polyline/PolylineHandler.Android.cs
@@ -9,15 +9,16 @@ namespace Microsoft.Maui.Controls.Handlers
 		protected override void ConnectHandler(MauiShapeView nativeView)
 		{
 			if (VirtualView is Polyline polyline)
-				polyline.Points.CollectionChanged += OnPointsCollectionChanged;
+			{
+				UpdatePointsSubscription(polyline.Points);
+			}
 
 			base.ConnectHandler(nativeView);
 		}
 
 		protected override void DisconnectHandler(MauiShapeView nativeView)
 		{
-			if (VirtualView is Polyline polyline)
-				polyline.Points.CollectionChanged -= OnPointsCollectionChanged;
+			ClearPointsSubscription();
 
 			base.DisconnectHandler(nativeView);
 		}
@@ -29,6 +30,11 @@ namespace Microsoft.Maui.Controls.Handlers
 
 		public static void MapPoints(IShapeViewHandler handler, Polyline polyline)
 		{
+			if (handler is PolylineHandler polylineHandler)
+			{
+				polylineHandler.UpdatePointsSubscription(polyline.Points);
+			}
+
 			handler.PlatformView?.InvalidateShape(polyline);
 		}
 
@@ -45,9 +51,5 @@ namespace Microsoft.Maui.Controls.Handlers
 			handler.PlatformView?.InvalidateShape(polyline);
 		}
 
-		void OnPointsCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
-		{
-			PlatformView?.InvalidateShape(VirtualView);
-		}
 	}
 }

--- a/src/Controls/src/Core/Handlers/Shapes/Polyline/PolylineHandler.Tizen.cs
+++ b/src/Controls/src/Core/Handlers/Shapes/Polyline/PolylineHandler.Tizen.cs
@@ -9,15 +9,16 @@ namespace Microsoft.Maui.Controls.Handlers
 		protected override void ConnectHandler(MauiShapeView nativeView)
 		{
 			if (VirtualView is Polyline polyline)
-				polyline.Points.CollectionChanged += OnPointsCollectionChanged;
+			{
+				UpdatePointsSubscription(polyline.Points);
+			}
 
 			base.ConnectHandler(nativeView);
 		}
 
 		protected override void DisconnectHandler(MauiShapeView nativeView)
 		{
-			if (VirtualView is Polyline polyline)
-				polyline.Points.CollectionChanged -= OnPointsCollectionChanged;
+			ClearPointsSubscription();
 
 			base.DisconnectHandler(nativeView);
 		}
@@ -29,6 +30,11 @@ namespace Microsoft.Maui.Controls.Handlers
 
 		public static void MapPoints(IShapeViewHandler handler, Polyline polyline)
 		{
+			if (handler is PolylineHandler polylineHandler)
+			{
+				polylineHandler.UpdatePointsSubscription(polyline.Points);
+			}
+
 			handler.PlatformView?.InvalidateShape(polyline);
 		}
 
@@ -45,9 +51,5 @@ namespace Microsoft.Maui.Controls.Handlers
 			handler.PlatformView?.InvalidateShape(polyline);
 		}
 
-		void OnPointsCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
-		{
-			PlatformView?.InvalidateShape(VirtualView);
-		}
 	}
 }

--- a/src/Controls/src/Core/Handlers/Shapes/Polyline/PolylineHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shapes/Polyline/PolylineHandler.Windows.cs
@@ -11,15 +11,16 @@ namespace Microsoft.Maui.Controls.Handlers
 		protected override void ConnectHandler(W2DGraphicsView nativeView)
 		{
 			if (VirtualView is Polyline polyline)
-				polyline.Points.CollectionChanged += OnPointsCollectionChanged;
+			{
+				UpdatePointsSubscription(polyline.Points);
+			}
 
 			base.ConnectHandler(nativeView);
 		}
 
 		protected override void DisconnectHandler(W2DGraphicsView nativeView)
 		{
-			if (VirtualView is Polyline polyline)
-				polyline.Points.CollectionChanged -= OnPointsCollectionChanged;
+			ClearPointsSubscription();
 
 			base.DisconnectHandler(nativeView);
 		}
@@ -31,6 +32,11 @@ namespace Microsoft.Maui.Controls.Handlers
 
 		public static void MapPoints(IShapeViewHandler handler, Polyline polyline)
 		{
+			if (handler is PolylineHandler polylineHandler)
+			{
+				polylineHandler.UpdatePointsSubscription(polyline.Points);
+			}
+
 			handler.PlatformView?.InvalidateShape(polyline);
 		}
 
@@ -47,9 +53,5 @@ namespace Microsoft.Maui.Controls.Handlers
 			handler.PlatformView?.InvalidateShape(polyline);
 		}
 
-		void OnPointsCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
-		{
-			PlatformView?.InvalidateShape(VirtualView);
-		}
 	}
 }

--- a/src/Controls/src/Core/Handlers/Shapes/Polyline/PolylineHandler.cs
+++ b/src/Controls/src/Core/Handlers/Shapes/Polyline/PolylineHandler.cs
@@ -1,10 +1,14 @@
 ﻿#nullable disable
+using System.Collections.Specialized;
+using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Shapes;
 
 namespace Microsoft.Maui.Controls.Handlers
 {
 	public partial class PolylineHandler : ShapeViewHandler
 	{
+		PointCollection _subscribedPoints;
+
 		public static new IPropertyMapper<Polyline, IShapeViewHandler> Mapper = new PropertyMapper<Polyline, IShapeViewHandler>(ShapeViewHandler.Mapper)
 		{
 			[nameof(IShapeView.Shape)] = MapShape,
@@ -20,6 +24,40 @@ namespace Microsoft.Maui.Controls.Handlers
 		public PolylineHandler(IPropertyMapper mapper) : base(mapper ?? Mapper)
 		{
 
+		}
+
+		void UpdatePointsSubscription(PointCollection points)
+		{
+			if (ReferenceEquals(_subscribedPoints, points))
+			{
+				return;
+			}
+
+			ClearPointsSubscription();
+
+			if (points is null)
+			{
+				return;
+			}
+
+			_subscribedPoints = points;
+			_subscribedPoints.CollectionChanged += OnPointsCollectionChanged;
+		}
+
+		void ClearPointsSubscription()
+		{
+			if (_subscribedPoints is null)
+			{
+				return;
+			}
+
+			_subscribedPoints.CollectionChanged -= OnPointsCollectionChanged;
+			_subscribedPoints = null;
+		}
+
+		void OnPointsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+		{
+			UpdateValue(nameof(Polyline.Points));
 		}
 	}
 }

--- a/src/Controls/src/Core/Handlers/Shapes/Polyline/PolylineHandler.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Shapes/Polyline/PolylineHandler.iOS.cs
@@ -9,15 +9,16 @@ namespace Microsoft.Maui.Controls.Handlers
 		protected override void ConnectHandler(MauiShapeView nativeView)
 		{
 			if (VirtualView is Polyline polyline)
-				polyline.Points.CollectionChanged += OnPointsCollectionChanged;
+			{
+				UpdatePointsSubscription(polyline.Points);
+			}
 
 			base.ConnectHandler(nativeView);
 		}
 
 		protected override void DisconnectHandler(MauiShapeView nativeView)
 		{
-			if (VirtualView is Polyline polyline)
-				polyline.Points.CollectionChanged -= OnPointsCollectionChanged;
+			ClearPointsSubscription();
 
 			base.DisconnectHandler(nativeView);
 		}
@@ -29,6 +30,11 @@ namespace Microsoft.Maui.Controls.Handlers
 
 		public static void MapPoints(IShapeViewHandler handler, Polyline polyline)
 		{
+			if (handler is PolylineHandler polylineHandler)
+			{
+				polylineHandler.UpdatePointsSubscription(polyline.Points);
+			}
+
 			handler.PlatformView?.InvalidateShape(polyline);
 		}
 
@@ -45,9 +51,5 @@ namespace Microsoft.Maui.Controls.Handlers
 			handler.PlatformView?.InvalidateShape(polyline);
 		}
 
-		void OnPointsCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
-		{
-			PlatformView?.InvalidateShape(VirtualView);
-		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -354,9 +354,13 @@ public class MemoryTests : ControlsHandlerTestBase
 		SetupBuilder();
 
 		var result = await InvokeOnMainThreadAsync(() => CreateAndDisconnectShapeWithReplacedPoints(type));
+		var rootedOriginalPoints = result.RootedOriginalPoints;
 
+		// Keep the original collection rooted and fire its event; the broken implementation
+		// still has the disconnected handler subscribed to this old collection.
+		await InvokeOnMainThreadAsync(() => rootedOriginalPoints.Add(new Point(50, 50)));
 		await AssertionExtensions.WaitForGC(result.ShapeReference, result.HandlerReference, result.PlatformViewReference);
-		GC.KeepAlive(result.RootedOriginalPoints);
+		GC.KeepAlive(rootedOriginalPoints);
 	}
 
 	[MethodImpl(MethodImplOptions.NoInlining)]
@@ -840,4 +844,3 @@ sealed class AnimationPage : ContentPage
 
 	}
 }
-

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Controls;
@@ -11,6 +12,7 @@ using Microsoft.Maui.Controls.Handlers.Items;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Controls.Shapes;
 using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Graphics;
 #if IOS || MACCATALYST
 using Microsoft.Maui.Controls.Handlers.Items2;
 #endif
@@ -343,6 +345,104 @@ public class MemoryTests : ControlsHandlerTestBase
 
 		await AssertionExtensions.WaitForGC(viewReference, handlerReference, platformViewReference);
 	}
+
+	[Theory("Polygon and Polyline Points Replacement Does Not Leak Handler")]
+	[InlineData(typeof(Polygon))]
+	[InlineData(typeof(Polyline))]
+	public async Task ShapeHandlerDoesNotLeakWhenPointsReplaced(Type type)
+	{
+		SetupBuilder();
+
+		var result = await InvokeOnMainThreadAsync(() => CreateAndDisconnectShapeWithReplacedPoints(type));
+
+		await AssertionExtensions.WaitForGC(result.ShapeReference, result.HandlerReference, result.PlatformViewReference);
+		GC.KeepAlive(result.RootedOriginalPoints);
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	ShapePointsLeakProbeResult CreateAndDisconnectShapeWithReplacedPoints(Type type)
+	{
+		var originalPoints = CreatePointCollection(0);
+		var shape = CreateShapeWithPoints(type, originalPoints);
+		var layout = new Grid();
+
+		layout.Add(shape);
+		CreateHandler<LayoutHandler>(layout);
+
+		var handler = shape.Handler ?? throw new InvalidOperationException($"{type.Name} did not get a handler.");
+		var platformView = handler.PlatformView ?? throw new InvalidOperationException($"{type.Name} handler did not get a platform view.");
+
+		SetShapePoints(shape, CreatePointCollection(20));
+
+		var result = new ShapePointsLeakProbeResult(
+			new WeakReference(shape),
+			new WeakReference(handler),
+			new WeakReference(platformView),
+			originalPoints);
+
+		layout.Remove(shape);
+		handler.DisconnectHandler();
+		shape.Handler = null;
+
+		return result;
+	}
+
+	static Shape CreateShapeWithPoints(Type type, PointCollection points)
+	{
+		if (type == typeof(Polygon))
+		{
+			return new Polygon
+			{
+				Points = points,
+				WidthRequest = 120,
+				HeightRequest = 90
+			};
+		}
+
+		if (type == typeof(Polyline))
+		{
+			return new Polyline
+			{
+				Points = points,
+				WidthRequest = 120,
+				HeightRequest = 90
+			};
+		}
+
+		throw new ArgumentException($"Unsupported shape type: {type}", nameof(type));
+	}
+
+	static void SetShapePoints(Shape shape, PointCollection points)
+	{
+		switch (shape)
+		{
+			case Polygon polygon:
+				polygon.Points = points;
+				break;
+			case Polyline polyline:
+				polyline.Points = points;
+				break;
+			default:
+				throw new ArgumentException($"Unsupported shape: {shape.GetType().Name}", nameof(shape));
+		}
+	}
+
+	static PointCollection CreatePointCollection(double offset)
+	{
+		return
+		[
+			new Point(10 + offset, 10),
+			new Point(100 + offset, 20),
+			new Point(75 + offset, 80),
+			new Point(15 + offset, 70)
+		];
+	}
+
+	sealed record ShapePointsLeakProbeResult(
+		WeakReference ShapeReference,
+		WeakReference HandlerReference,
+		WeakReference PlatformViewReference,
+		PointCollection RootedOriginalPoints);
 
 	[Theory("CollectionView Header/Footer Doesn't Leak")]
 	[InlineData(typeof(CollectionView))]


### PR DESCRIPTION
### Description of Change

Fixes a memory leak in `PolygonHandler` and `PolylineHandler` when the shape's `Points` collection is replaced after the handler subscribes to `Points.CollectionChanged`.

The handlers now track the exact `PointCollection` instance they are subscribed to, unsubscribe from the previous collection when `Points` changes, and clear the subscription during disconnect. This prevents the original `PointCollection` from keeping the shape, handler, and platform view alive after disconnect.

The fix is applied across Android, iOS/MacCatalyst, Windows, and Tizen handlers. A device memory regression test was added for both `Polygon` and `Polyline`.

### Issues Fixed

Fixes #35387