### PR TITLE
Clarify SR vs preview channel mapping in dependency-flow skill

### DIFF
--- a/.github/skills/dependency-flow/SKILL.md
+++ b/.github/skills/dependency-flow/SKILL.md
@@ -36,20 +36,24 @@ Pattern: `.NET X.0.Yxx SDK` (e.g., `.NET 10.0.1xx SDK`)
 
 These are configured via default channel mappings — builds are **automatically** added when they complete on a mapped branch.
 
-**Branch → channel mapping rules:**
+**Common branch → channel patterns (not exhaustive — always verify with the command below):**
 - **Servicing release branches** (`release/X.0.Yxx-srN`) all map to the **single** general SDK channel for that band (e.g., `release/10.0.1xx-sr6`, `release/10.0.1xx-sr7`, etc. all map to `.NET 10.0.1xx SDK`). There is **no** `.NET X.0.Yxx SDK SRn` channel — do not invent one.
 - **Preview release branches** (`release/X.0.Yxx-previewN`) map to dedicated per-preview channels (e.g., `release/11.0.1xx-preview3` → `.NET 11.0.1xx SDK Preview 3`).
+- **RC release branches** (`release/X.0.Yxx-rcN`) map to dedicated per-RC channels (e.g., `.NET 10.0.1xx SDK RC 2`). MAUI defaults for these are only active during the corresponding pre-release cycle.
 - **Main/development branches** (`main`, `netN.0`, `release/X.0.Yxx`) map to the general SDK channel for that band.
+- **Other shapes** also exist in dotnet/maui from time to time — point-sub-release branches (`-rc2.1`, `-preview6.1`), `inflight/*` mirrors, and vendor-suffixed branches (e.g., `release/10.0.1xx-meaipreview1`). Do not assume the four bullets above are complete — always check.
 
 **Always verify by listing existing mappings before constructing a command:**
 ```bash
 darc get-default-channels --source-repo https://github.com/dotnet/maui
 ```
-Find a sibling branch (e.g., the previous SR) and copy its channel exactly.
+Find a sibling branch (e.g., the previous SR, the previous RC, or the previous preview) and copy its channel exactly.
 
 ### Adding a new branch to the default channel mapping
 
 Common case: a new servicing release branch is created (e.g., `release/10.0.1xx-sr7`) and needs to be added so its builds flow automatically.
+
+⚠️ `add-default-channel` is in the explicit-confirmation list below. Show the user the exact command and wait for approval before running:
 
 ```bash
 darc add-default-channel \
@@ -57,8 +61,6 @@ darc add-default-channel \
   --branch release/10.0.1xx-sr7 \
   --repo https://github.com/dotnet/maui
 ```
-
-⚠️ `add-default-channel` is in the explicit-confirmation list below. Show the user the exact command and wait for approval before running.
 
 ### Workload Release Channels (manual promotion)
 Pattern: `.NET X Workload Release` (e.g., `.NET 10 Workload Release`)

--- a/.github/skills/dependency-flow/SKILL.md
+++ b/.github/skills/dependency-flow/SKILL.md
@@ -34,7 +34,31 @@ MAUI uses two types of channels:
 ### SDK Channels (automatic)
 Pattern: `.NET X.0.Yxx SDK` (e.g., `.NET 10.0.1xx SDK`)
 
-These are configured via default channel mappings — builds are **automatically** added when they complete on a mapped branch. Preview releases use `.NET X.0.Yxx SDK Preview N`.
+These are configured via default channel mappings — builds are **automatically** added when they complete on a mapped branch.
+
+**Branch → channel mapping rules:**
+- **Servicing release branches** (`release/X.0.Yxx-srN`) all map to the **single** general SDK channel for that band (e.g., `release/10.0.1xx-sr6`, `release/10.0.1xx-sr7`, etc. all map to `.NET 10.0.1xx SDK`). There is **no** `.NET X.0.Yxx SDK SRn` channel — do not invent one.
+- **Preview release branches** (`release/X.0.Yxx-previewN`) map to dedicated per-preview channels (e.g., `release/11.0.1xx-preview3` → `.NET 11.0.1xx SDK Preview 3`).
+- **Main/development branches** (`main`, `netN.0`, `release/X.0.Yxx`) map to the general SDK channel for that band.
+
+**Always verify by listing existing mappings before constructing a command:**
+```bash
+darc get-default-channels --source-repo https://github.com/dotnet/maui
+```
+Find a sibling branch (e.g., the previous SR) and copy its channel exactly.
+
+### Adding a new branch to the default channel mapping
+
+Common case: a new servicing release branch is created (e.g., `release/10.0.1xx-sr7`) and needs to be added so its builds flow automatically.
+
+```bash
+darc add-default-channel \
+  --channel ".NET 10.0.1xx SDK" \
+  --branch release/10.0.1xx-sr7 \
+  --repo https://github.com/dotnet/maui
+```
+
+⚠️ `add-default-channel` is in the explicit-confirmation list below. Show the user the exact command and wait for approval before running.
 
 ### Workload Release Channels (manual promotion)
 Pattern: `.NET X Workload Release` (e.g., `.NET 10 Workload Release`)

--- a/.github/skills/dependency-flow/SKILL.md
+++ b/.github/skills/dependency-flow/SKILL.md
@@ -39,7 +39,7 @@ These are configured via default channel mappings — builds are **automatically
 **Common branch → channel patterns (not exhaustive — always verify with the command below):**
 - **Servicing release branches** (`release/X.0.Yxx-srN`) all map to the **single** general SDK channel for that band (e.g., `release/10.0.1xx-sr6`, `release/10.0.1xx-sr7`, etc. all map to `.NET 10.0.1xx SDK`). There is **no** `.NET X.0.Yxx SDK SRn` channel — do not invent one.
 - **Preview release branches** (`release/X.0.Yxx-previewN`) map to dedicated per-preview channels (e.g., `release/11.0.1xx-preview3` → `.NET 11.0.1xx SDK Preview 3`).
-- **RC release branches** (`release/X.0.Yxx-rcN`) map to dedicated per-RC channels (e.g., `.NET 10.0.1xx SDK RC 2`). MAUI defaults for these are only active during the corresponding pre-release cycle.
+- **RC release branches** (`release/X.0.Yxx-rcN`) use dedicated per-RC channels (e.g., `.NET 10.0.1xx SDK RC 2`) **only while their cycle is active** — these default mappings are removed after the RC ships, so `get-default-channels` will show no RC sibling to copy from. If you can't find a sibling, stop and ask release engineering rather than guessing the channel name.
 - **Main/development branches** (`main`, `netN.0`, `release/X.0.Yxx`) map to the general SDK channel for that band.
 - **Other shapes** also exist in dotnet/maui from time to time — point-sub-release branches (`-rc2.1`, `-preview6.1`), `inflight/*` mirrors, and vendor-suffixed branches (e.g., `release/10.0.1xx-meaipreview1`). Do not assume the four bullets above are complete — always check.
 
@@ -47,7 +47,7 @@ These are configured via default channel mappings — builds are **automatically
 ```bash
 darc get-default-channels --source-repo https://github.com/dotnet/maui
 ```
-Find a sibling branch (e.g., the previous SR, the previous RC, or the previous preview) and copy its channel exactly.
+Find a sibling branch (e.g., the previous SR or the previous preview) and copy its channel exactly. If no sibling exists (common for RC branches outside an active cycle), stop and ask release engineering — do not guess the channel name.
 
 ### Adding a new branch to the default channel mapping
 

--- a/.github/skills/dependency-flow/SKILL.md
+++ b/.github/skills/dependency-flow/SKILL.md
@@ -39,7 +39,7 @@ These are configured via default channel mappings — builds are **automatically
 **Common branch → channel patterns (not exhaustive — always verify with the command below):**
 - **Servicing release branches** (`release/X.0.Yxx-srN`) all map to the **single** general SDK channel for that band (e.g., `release/10.0.1xx-sr6`, `release/10.0.1xx-sr7`, etc. all map to `.NET 10.0.1xx SDK`). There is **no** `.NET X.0.Yxx SDK SRn` channel — do not invent one.
 - **Preview release branches** (`release/X.0.Yxx-previewN`) map to dedicated per-preview channels (e.g., `release/11.0.1xx-preview3` → `.NET 11.0.1xx SDK Preview 3`).
-- **RC release branches** (`release/X.0.Yxx-rcN`) use dedicated per-RC channels (e.g., `.NET 10.0.1xx SDK RC 2`) **only while their cycle is active** — these default mappings are removed after the RC ships, so `get-default-channels` will show no RC sibling to copy from. If you can't find a sibling, stop and ask release engineering rather than guessing the channel name.
+- **RC release branches** (`release/X.0.Yxx-rcN`) use dedicated per-RC channels (e.g., `.NET 10.0.1xx SDK RC 2`) **only while their cycle is active** — these default mappings are removed after the RC ships, so `get-default-channels` will show no RC sibling to copy from. If you can't find a sibling, stop and tell the user to escalate to release engineering — do not guess the channel name.
 - **Main/development branches** (`main`, `netN.0`, `release/X.0.Yxx`) map to the general SDK channel for that band.
 - **Other shapes** also exist in dotnet/maui from time to time — point-sub-release branches (`-rc2.1`, `-preview6.1`), `inflight/*` mirrors, and vendor-suffixed branches (e.g., `release/10.0.1xx-meaipreview1`). Do not assume the four bullets above are complete — always check.
 
@@ -47,7 +47,7 @@ These are configured via default channel mappings — builds are **automatically
 ```bash
 darc get-default-channels --source-repo https://github.com/dotnet/maui
 ```
-Find a sibling branch (e.g., the previous SR or the previous preview) and copy its channel exactly. If no sibling exists (common for RC branches outside an active cycle), stop and ask release engineering — do not guess the channel name.
+Find a sibling branch (e.g., the previous SR or the previous preview) and copy its channel exactly. If no sibling exists (common for RC branches outside an active cycle), stop and tell the user that release engineering needs to configure the channel mapping — do not guess the channel name.
 
 ### Adding a new branch to the default channel mapping
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Clarifies the SR vs preview channel mapping rules in the `dependency-flow` skill so future agent runs don't invent non-existent channel names.

## Background

While answering a question about the `darc` command to add `release/10.0.1xx-sr7` to the maestro feed, the agent initially looked for a SR-specific channel. There isn't one — every `release/X.0.Yxx-srN` MAUI branch maps to the **single** general `.NET X.0.Yxx SDK` channel. Only `-previewN` branches get dedicated per-preview channels (e.g., `release/11.0.1xx-preview3` → `.NET 11.0.1xx SDK Preview 3`).

Verified via `darc get-default-channels --source-repo https://github.com/dotnet/maui`:
- All of `release/9.0.1xx-sr1` … `release/9.0.1xx-sr12` → `.NET 9.0.1xx SDK`
- All of `release/10.0.1xx-sr1` … `release/10.0.1xx-sr6` → `.NET 10.0.1xx SDK`
- `release/11.0.1xx-preview3` → `.NET 11.0.1xx SDK Preview 3`
- `release/11.0.1xx-preview4` → `.NET 11.0.1xx SDK Preview 4`

## Changes

Updates `.github/skills/dependency-flow/SKILL.md`:

1. **Branch → channel mapping rules** — explicit rules for SR, preview, and main/dev branches, with a "do not invent" guard against fabricating SR-specific channels.
2. **Verification step** — tells the agent to always run `darc get-default-channels --source-repo …` and copy a sibling branch's channel exactly before constructing a command.
3. **Worked example** — adds the canonical `darc add-default-channel` invocation for a new SR branch.
