### PR TITLE
Fix Shell CoordinatorLayout 0x0 after repeated navigation cycles on Android

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellSectionRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellSectionRenderer.cs
@@ -247,9 +247,18 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		{
 			base.OnHiddenChanged(hidden);
 			
-			if (!hidden && _shellToolbar?.Handler != null)
+			if (!hidden)
 			{
-				_shellToolbar.Handler.UpdateValue(nameof(Toolbar.TitleView));
+				// When the fragment becomes visible after being hidden (e.g., after a pop navigation),
+				// explicitly request layout on the root view. Under rapid navigation cycles, the
+				// Choreographer may not process layout passes between fragment transactions, leaving
+				// the CoordinatorLayout at 0x0 dimensions. This ensures a layout pass is scheduled.
+				_rootView?.RequestLayout();
+
+				if (_shellToolbar?.Handler != null)
+				{
+					_shellToolbar.Handler.UpdateValue(nameof(Toolbar.TitleView));
+				}
 			}
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Android.cs
@@ -751,5 +751,161 @@ namespace Microsoft.Maui.DeviceTests
 			pagerParent.CurrentItem = shellSection.Items.IndexOf(shellContent);
 			await OnNavigatedToAsync(page);
 		}
+
+		[Fact(DisplayName = "Shell CoordinatorLayout restores dimensions after push/pop navigation cycles")]
+		public async Task CoordinatorLayoutHasDimensionsAfterPushPopCycles()
+		{
+			// This test verifies that the Shell's CoordinatorLayout gets properly laid out
+			// after being hidden (push) and shown (pop) via fragment transactions.
+			// Bug: After many rapid push/pop cycles, the CoordinatorLayout can end up at 0x0
+			// because OnHiddenChanged doesn't call RequestLayout on the root view.
+			SetupBuilder();
+
+			var page1 = new ContentPage { Title = "Home", Content = new Label { Text = "Home" } };
+			var page2 = new ContentPage { Title = "Pushed" };
+
+			var shell = await CreateShellAsync((shell) =>
+			{
+				shell.Items.Add(new TabBar()
+				{
+					Items =
+					{
+						new ShellContent()
+						{
+							Route = "Home",
+							Content = page1
+						},
+					}
+				});
+			});
+
+			await CreateHandlerAndAddToWindow<ShellHandler>(shell, async (handler) =>
+			{
+				await OnLoadedAsync(page1);
+
+				// Get the CoordinatorLayout (root view of ShellSectionRenderer)
+				var platformView = (page1.Handler as IPlatformViewHandler).PlatformView;
+				var coordinatorLayout = platformView.GetParentOfType<CoordinatorLayout>();
+				Assert.NotNull(coordinatorLayout);
+
+				// Verify initial dimensions are valid
+				Assert.True(coordinatorLayout.Width > 0, $"Initial CoordinatorLayout Width should be > 0 but was {coordinatorLayout.Width}");
+				Assert.True(coordinatorLayout.Height > 0, $"Initial CoordinatorLayout Height should be > 0 but was {coordinatorLayout.Height}");
+
+				var expectedWidth = coordinatorLayout.Width;
+				var expectedHeight = coordinatorLayout.Height;
+
+				// Do push/pop navigation cycles without animation
+				Routing.RegisterRoute("testpush", typeof(ContentPage));
+				try
+				{
+					for (int i = 0; i < 20; i++)
+					{
+						await shell.GoToAsync("testpush", false);
+						await shell.GoToAsync("..", false);
+					}
+				}
+				finally
+				{
+					Routing.UnRegisterRoute("testpush");
+				}
+
+				// After cycles, wait for any pending layout pass
+				await Task.Delay(100);
+				await InvokeOnMainThreadAsync(() => { });
+
+				// Verify CoordinatorLayout still has correct dimensions
+				Assert.True(coordinatorLayout.Width > 0,
+					$"CoordinatorLayout Width should be > 0 after navigation cycles but was {coordinatorLayout.Width}");
+				Assert.True(coordinatorLayout.Height > 0,
+					$"CoordinatorLayout Height should be > 0 after navigation cycles but was {coordinatorLayout.Height}");
+				Assert.Equal(expectedWidth, coordinatorLayout.Width);
+				Assert.Equal(expectedHeight, coordinatorLayout.Height);
+			});
+		}
+
+		[Fact(DisplayName = "Shell CoordinatorLayout recovers dimensions when shown after layout was invalidated while hidden")]
+		public async Task CoordinatorLayoutRecoversDimensionsWhenShownAfterLayoutInvalidation()
+		{
+			// This test simulates the scenario where the CoordinatorLayout's layout
+			// becomes invalid while it's hidden during push navigation, and verifies
+			// that showing it again (pop) properly triggers a re-layout.
+			// This is the core bug: if the Choreographer couldn't run between hide/show cycles,
+			// the CoordinatorLayout's stale 0x0 dimensions are never refreshed.
+			SetupBuilder();
+
+			var page1 = new ContentPage { Title = "Home", Content = new Label { Text = "Home" } };
+
+			var shell = await CreateShellAsync((shell) =>
+			{
+				shell.Items.Add(new TabBar()
+				{
+					Items =
+					{
+						new ShellContent()
+						{
+							Route = "Home",
+							Content = page1
+						},
+					}
+				});
+			});
+
+			await CreateHandlerAndAddToWindow<ShellHandler>(shell, async (handler) =>
+			{
+				await OnLoadedAsync(page1);
+
+				// Get the CoordinatorLayout
+				var platformView = (page1.Handler as IPlatformViewHandler).PlatformView;
+				var coordinatorLayout = platformView.GetParentOfType<CoordinatorLayout>();
+				Assert.NotNull(coordinatorLayout);
+
+				// Verify initial dimensions
+				Assert.True(coordinatorLayout.Width > 0, "Initial width > 0");
+				Assert.True(coordinatorLayout.Height > 0, "Initial height > 0");
+				var expectedWidth = coordinatorLayout.Width;
+				var expectedHeight = coordinatorLayout.Height;
+
+				// Push a page (this hides the ShellSectionRenderer fragment)
+				Routing.RegisterRoute("testpush2", typeof(ContentPage));
+				try
+				{
+					await shell.GoToAsync("testpush2", false);
+
+					// While the ShellSectionRenderer is hidden, force the CoordinatorLayout
+					// to have 0x0 bounds. This simulates what happens when the layout system
+					// couldn't process a layout pass between rapid hide/show cycles.
+					await InvokeOnMainThreadAsync(() =>
+					{
+						coordinatorLayout.Layout(0, 0, 0, 0);
+					});
+
+					// Verify it's now at 0x0
+					Assert.Equal(0, coordinatorLayout.Width);
+					Assert.Equal(0, coordinatorLayout.Height);
+
+					// Pop back (this shows the ShellSectionRenderer fragment)
+					// OnHiddenChanged(false) should trigger RequestLayout to restore dimensions
+					await shell.GoToAsync("..", false);
+
+					// Wait for layout pass to complete
+					await Task.Delay(200);
+					await InvokeOnMainThreadAsync(() => { });
+					await Task.Delay(100);
+
+					// Verify CoordinatorLayout has recovered its dimensions
+					Assert.True(coordinatorLayout.Width > 0,
+						$"CoordinatorLayout Width should recover after pop but was {coordinatorLayout.Width}");
+					Assert.True(coordinatorLayout.Height > 0,
+						$"CoordinatorLayout Height should recover after pop but was {coordinatorLayout.Height}");
+					Assert.Equal(expectedWidth, coordinatorLayout.Width);
+					Assert.Equal(expectedHeight, coordinatorLayout.Height);
+				}
+				finally
+				{
+					Routing.UnRegisterRoute("testpush2");
+				}
+			});
+		}
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue99999.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue99999.cs
@@ -7,40 +7,29 @@ public class Issue99999 : Shell
 	{
 		FlyoutBehavior = FlyoutBehavior.Disabled;
 
-		// Create a Shell with TabBar containing multiple tabs
-		// This exercises ShellSectionRenderer.OnHiddenChanged when switching tabs
-		var tab1Page = new ContentPage
+		// Pre-register routes
+		Routing.RegisterRoute("testroute", typeof(Issue99999TargetPage));
+		Routing.RegisterRoute("finalpage", typeof(Issue99999FinalPage));
+
+		var mainPage = new ContentPage
 		{
-			Title = "Tab 1",
+			Title = "Shell Layout Test",
 			Content = CreateMainContent()
 		};
 
-		var tab2Page = new ContentPage
+		var shellContent = new ShellContent
 		{
-			Title = "Tab 2",
-			Content = new Label
-			{
-				Text = "Tab 2 Content",
-				AutomationId = "Tab2Label",
-				HorizontalOptions = LayoutOptions.Center,
-				VerticalOptions = LayoutOptions.Center
-			}
+			Content = mainPage,
+			Title = "Main",
+			Route = "Main"
 		};
 
-		var tabBar = new TabBar();
+		var shellSection = new ShellSection { Title = "Home" };
+		shellSection.Items.Add(shellContent);
 
-		var shellSection1 = new ShellSection { Title = "Home", Route = "home" };
-		shellSection1.Items.Add(new ShellContent { Content = tab1Page, Route = "main" });
-		tabBar.Items.Add(shellSection1);
-
-		var shellSection2 = new ShellSection { Title = "Other", Route = "other" };
-		shellSection2.Items.Add(new ShellContent { Content = tab2Page, Route = "tab2" });
-		tabBar.Items.Add(shellSection2);
-
-		Items.Add(tabBar);
-
-		// Register the route for push navigation
-		Routing.RegisterRoute("navtarget", typeof(Issue99999TargetPage));
+		var shellItem = new ShellItem();
+		shellItem.Items.Add(shellSection);
+		Items.Add(shellItem);
 	}
 
 	StackLayout CreateMainContent()
@@ -53,10 +42,9 @@ public class Issue99999 : Shell
 			Margin = new Thickness(20, 10)
 		};
 
-		// Button that runs rapid push/pop cycles combined with tab switches
 		var runCyclesButton = new Button
 		{
-			Text = "Run Cycles",
+			Text = "Run Rapid Cycles",
 			AutomationId = "RunCyclesButton",
 			Margin = new Thickness(20, 10)
 		};
@@ -68,24 +56,21 @@ public class Issue99999 : Shell
 
 			try
 			{
-				// Cycle pattern: push/pop on tab1, switch to tab2, switch back, repeat
-				// This exercises both fragment Hide/Show (tab switch) and fragment Add/Remove (push/pop)
-				for (int i = 0; i < 10; i++)
+				// Run rapid push/pop cycles without animation.
+				// This exercises the fragment Hide/Show path on the ShellSectionRenderer.
+				// The bug manifests when the CoordinatorLayout goes GONE→VISIBLE many times
+				// and the Choreographer can't run layout passes between transitions.
+				for (int i = 0; i < 20; i++)
 				{
-					// Push and pop on current tab
-					await Current.GoToAsync("navtarget");
-					await Current.GoToAsync("..");
-
-					// Switch to other tab and back (triggers ShellSectionRenderer.OnHiddenChanged)
-					await Current.GoToAsync("//other");
-					await Current.GoToAsync("//home");
+					await Current.GoToAsync("testroute", false);
+					await Current.GoToAsync("..", false);
 				}
 
-				statusLabel.Text = "Cycles done";
+				statusLabel.Text = "CyclesDone";
 			}
 			catch (Exception ex)
 			{
-				statusLabel.Text = $"ERROR: {ex.Message}";
+				statusLabel.Text = $"ERROR: {ex.GetType().Name}: {ex.Message}";
 			}
 			finally
 			{
@@ -93,17 +78,16 @@ public class Issue99999 : Shell
 			}
 		};
 
-		// Button to navigate to target page (for verification after cycles)
 		var navigateButton = new Button
 		{
-			Text = "Navigate",
+			Text = "Navigate After Cycles",
 			AutomationId = "NavigateButton",
 			Margin = new Thickness(20, 10)
 		};
 
 		navigateButton.Clicked += async (s, e) =>
 		{
-			await Current.GoToAsync("navtarget");
+			await Current.GoToAsync("finalpage");
 		};
 
 		return new StackLayout
@@ -123,45 +107,47 @@ public class Issue99999TargetPage : ContentPage
 	public Issue99999TargetPage()
 	{
 		Title = "Target Page";
-
-		var contentLabel = new Label
+		Content = new Label
 		{
-			Text = "Target Page Content",
-			AutomationId = "TargetPageLabel",
+			Text = "Target",
+			HorizontalOptions = LayoutOptions.Center,
+			VerticalOptions = LayoutOptions.Center
+		};
+	}
+}
+
+public class Issue99999FinalPage : ContentPage
+{
+	public Issue99999FinalPage()
+	{
+		Title = "Final Page";
+
+		var sizeInfo = new Label
+		{
+			Text = "Size: waiting...",
+			AutomationId = "FinalPageSizeLabel",
 			FontSize = 20,
 			HorizontalOptions = LayoutOptions.Center,
 			VerticalOptions = LayoutOptions.Center
 		};
 
-		var goBackButton = new Button
-		{
-			Text = "Go Back",
-			AutomationId = "GoBackButton",
-			Margin = new Thickness(20, 10)
-		};
-
-		goBackButton.Clicked += async (s, e) =>
-		{
-			await Shell.Current.GoToAsync("..");
-		};
-
-		var sizeInfo = new Label
-		{
-			Text = "Size: waiting...",
-			AutomationId = "SizeInfoLabel",
-			FontSize = 14,
-			Margin = new Thickness(20, 5)
-		};
-
 		var layout = new VerticalStackLayout
 		{
-			AutomationId = "TargetPageLayout",
+			AutomationId = "FinalPageLayout",
 			HorizontalOptions = LayoutOptions.Fill,
 			VerticalOptions = LayoutOptions.Fill,
-			Children = { contentLabel, sizeInfo, goBackButton }
+			Children = { sizeInfo }
 		};
 
 		Content = layout;
+
+		// Report page dimensions once laid out (or report -1x-1 if never laid out)
+		Loaded += async (s, e) =>
+		{
+			// Wait 3 seconds — if the bug is present, layout never happens
+			await Task.Delay(3000);
+			sizeInfo.Text = $"Size: {Width}x{Height}";
+		};
 
 		SizeChanged += (s, e) =>
 		{

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue99999.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue99999.cs
@@ -1,0 +1,171 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 99999, "Shell CoordinatorLayout 0x0 after repeated GoToAsync navigation cycles on Android", PlatformAffected.Android)]
+public class Issue99999 : Shell
+{
+	public Issue99999()
+	{
+		FlyoutBehavior = FlyoutBehavior.Disabled;
+
+		// Create a Shell with TabBar containing multiple tabs
+		// This exercises ShellSectionRenderer.OnHiddenChanged when switching tabs
+		var tab1Page = new ContentPage
+		{
+			Title = "Tab 1",
+			Content = CreateMainContent()
+		};
+
+		var tab2Page = new ContentPage
+		{
+			Title = "Tab 2",
+			Content = new Label
+			{
+				Text = "Tab 2 Content",
+				AutomationId = "Tab2Label",
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center
+			}
+		};
+
+		var tabBar = new TabBar();
+
+		var shellSection1 = new ShellSection { Title = "Home", Route = "home" };
+		shellSection1.Items.Add(new ShellContent { Content = tab1Page, Route = "main" });
+		tabBar.Items.Add(shellSection1);
+
+		var shellSection2 = new ShellSection { Title = "Other", Route = "other" };
+		shellSection2.Items.Add(new ShellContent { Content = tab2Page, Route = "tab2" });
+		tabBar.Items.Add(shellSection2);
+
+		Items.Add(tabBar);
+
+		// Register the route for push navigation
+		Routing.RegisterRoute("navtarget", typeof(Issue99999TargetPage));
+	}
+
+	StackLayout CreateMainContent()
+	{
+		var statusLabel = new Label
+		{
+			Text = "Ready",
+			AutomationId = "StatusLabel",
+			FontSize = 16,
+			Margin = new Thickness(20, 10)
+		};
+
+		// Button that runs rapid push/pop cycles combined with tab switches
+		var runCyclesButton = new Button
+		{
+			Text = "Run Cycles",
+			AutomationId = "RunCyclesButton",
+			Margin = new Thickness(20, 10)
+		};
+
+		runCyclesButton.Clicked += async (s, e) =>
+		{
+			runCyclesButton.IsEnabled = false;
+			statusLabel.Text = "Running...";
+
+			try
+			{
+				// Cycle pattern: push/pop on tab1, switch to tab2, switch back, repeat
+				// This exercises both fragment Hide/Show (tab switch) and fragment Add/Remove (push/pop)
+				for (int i = 0; i < 10; i++)
+				{
+					// Push and pop on current tab
+					await Current.GoToAsync("navtarget");
+					await Current.GoToAsync("..");
+
+					// Switch to other tab and back (triggers ShellSectionRenderer.OnHiddenChanged)
+					await Current.GoToAsync("//other");
+					await Current.GoToAsync("//home");
+				}
+
+				statusLabel.Text = "Cycles done";
+			}
+			catch (Exception ex)
+			{
+				statusLabel.Text = $"ERROR: {ex.Message}";
+			}
+			finally
+			{
+				runCyclesButton.IsEnabled = true;
+			}
+		};
+
+		// Button to navigate to target page (for verification after cycles)
+		var navigateButton = new Button
+		{
+			Text = "Navigate",
+			AutomationId = "NavigateButton",
+			Margin = new Thickness(20, 10)
+		};
+
+		navigateButton.Clicked += async (s, e) =>
+		{
+			await Current.GoToAsync("navtarget");
+		};
+
+		return new StackLayout
+		{
+			Children =
+			{
+				statusLabel,
+				runCyclesButton,
+				navigateButton
+			}
+		};
+	}
+}
+
+public class Issue99999TargetPage : ContentPage
+{
+	public Issue99999TargetPage()
+	{
+		Title = "Target Page";
+
+		var contentLabel = new Label
+		{
+			Text = "Target Page Content",
+			AutomationId = "TargetPageLabel",
+			FontSize = 20,
+			HorizontalOptions = LayoutOptions.Center,
+			VerticalOptions = LayoutOptions.Center
+		};
+
+		var goBackButton = new Button
+		{
+			Text = "Go Back",
+			AutomationId = "GoBackButton",
+			Margin = new Thickness(20, 10)
+		};
+
+		goBackButton.Clicked += async (s, e) =>
+		{
+			await Shell.Current.GoToAsync("..");
+		};
+
+		var sizeInfo = new Label
+		{
+			Text = "Size: waiting...",
+			AutomationId = "SizeInfoLabel",
+			FontSize = 14,
+			Margin = new Thickness(20, 5)
+		};
+
+		var layout = new VerticalStackLayout
+		{
+			AutomationId = "TargetPageLayout",
+			HorizontalOptions = LayoutOptions.Fill,
+			VerticalOptions = LayoutOptions.Fill,
+			Children = { contentLabel, sizeInfo, goBackButton }
+		};
+
+		Content = layout;
+
+		SizeChanged += (s, e) =>
+		{
+			sizeInfo.Text = $"Size: {Width}x{Height}";
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue99999.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue99999.cs
@@ -1,0 +1,47 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue99999 : _IssuesUITest
+{
+	public override string Issue => "Shell CoordinatorLayout 0x0 after repeated GoToAsync navigation cycles on Android";
+
+	public Issue99999(TestDevice testDevice) : base(testDevice)
+	{
+	}
+
+	[Test]
+	[Category(UITestCategories.Shell)]
+	public void ShellPageHasLayoutAfterRepeatedNavigationCycles()
+	{
+		// Wait for the main page
+		App.WaitForElement("RunCyclesButton");
+
+		// Run 10 cycles of: push/pop + tab switch + tab switch back
+		// This exercises ShellSectionRenderer.OnHiddenChanged which is the suspected root cause
+		App.Tap("RunCyclesButton");
+
+		// Wait for cycles to complete
+		App.WaitForElement("NavigateButton", timeout: TimeSpan.FromSeconds(60));
+
+		// Now navigate to the target page - this is where the bug would manifest
+		App.Tap("NavigateButton");
+		App.WaitForElement("TargetPageLabel", timeout: TimeSpan.FromSeconds(10));
+
+		// Verify the target page has non-zero dimensions
+		var rect = App.WaitForElement("TargetPageLabel").GetRect();
+		Assert.That(rect.Width, Is.GreaterThan(0),
+			"Target page label width should be > 0 after repeated navigation cycles");
+		Assert.That(rect.Height, Is.GreaterThan(0),
+			"Target page label height should be > 0 after repeated navigation cycles");
+
+		// Check page size reported by the app
+		var sizeText = App.FindElement("SizeInfoLabel").GetText();
+		Assert.That(sizeText, Does.Not.Contain("-1"),
+			$"Page should have valid dimensions after navigation cycles but got: {sizeText}");
+		Assert.That(sizeText, Does.Not.Contain("0x0"),
+			$"Page should not have 0x0 dimensions after navigation cycles but got: {sizeText}");
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue99999.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue99999.cs
@@ -19,29 +19,61 @@ public class Issue99999 : _IssuesUITest
 		// Wait for the main page
 		App.WaitForElement("RunCyclesButton");
 
-		// Run 10 cycles of: push/pop + tab switch + tab switch back
-		// This exercises ShellSectionRenderer.OnHiddenChanged which is the suspected root cause
+		// Run 20 rapid push/pop cycles
 		App.Tap("RunCyclesButton");
 
-		// Wait for cycles to complete
-		App.WaitForElement("NavigateButton", timeout: TimeSpan.FromSeconds(60));
+		// Wait for cycles to complete — poll status label for up to 60 seconds
+		bool cyclesComplete = false;
+		string statusText = "";
+		for (int i = 0; i < 30; i++)
+		{
+			Thread.Sleep(2000);
+			try
+			{
+				var el = App.FindElement("StatusLabel");
+				statusText = el.GetText() ?? "";
+				if (statusText == "CyclesDone" || statusText.StartsWith("ERROR"))
+				{
+					cyclesComplete = true;
+					break;
+				}
+			}
+			catch
+			{
+				// Element might not be accessible during rapid navigation
+			}
+		}
 
-		// Now navigate to the target page - this is where the bug would manifest
+		Assert.That(cyclesComplete, Is.True,
+			$"Cycles did not complete within timeout. Last status: {statusText}");
+		Assert.That(statusText, Is.EqualTo("CyclesDone"),
+			$"Cycles should complete successfully but got: {statusText}");
+
+		// Navigate to a fresh page - this is where the bug manifests
 		App.Tap("NavigateButton");
-		App.WaitForElement("TargetPageLabel", timeout: TimeSpan.FromSeconds(10));
 
-		// Verify the target page has non-zero dimensions
-		var rect = App.WaitForElement("TargetPageLabel").GetRect();
-		Assert.That(rect.Width, Is.GreaterThan(0),
-			"Target page label width should be > 0 after repeated navigation cycles");
-		Assert.That(rect.Height, Is.GreaterThan(0),
-			"Target page label height should be > 0 after repeated navigation cycles");
+		// Wait for the final page to appear
+		App.WaitForElement("FinalPageSizeLabel", timeout: TimeSpan.FromSeconds(15));
 
-		// Check page size reported by the app
-		var sizeText = App.FindElement("SizeInfoLabel").GetText();
+		// Wait for size to be reported (Loaded handler waits 3s then updates label)
+		Thread.Sleep(5000);
+
+		// Check the reported page dimensions
+		var sizeText = App.FindElement("FinalPageSizeLabel").GetText() ?? "null";
+
+		// The bug causes Width=-1, Height=-1 (never laid out)
 		Assert.That(sizeText, Does.Not.Contain("-1"),
-			$"Page should have valid dimensions after navigation cycles but got: {sizeText}");
+			$"Page should have valid dimensions after rapid navigation cycles but got: {sizeText}");
 		Assert.That(sizeText, Does.Not.Contain("0x0"),
-			$"Page should not have 0x0 dimensions after navigation cycles but got: {sizeText}");
+			$"Page should not have 0x0 dimensions but got: {sizeText}");
+		Assert.That(sizeText, Does.Not.Contain("waiting"),
+			$"Page size should have been reported but label still says: {sizeText}");
+
+		// Also verify the element has a non-zero rect via Appium
+		var rect = App.FindElement("FinalPageSizeLabel").GetRect();
+		Assert.That(rect.Width, Is.GreaterThan(0),
+			"Final page label width should be > 0");
+		Assert.That(rect.Height, Is.GreaterThan(0),
+			"Final page label height should be > 0");
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

When using Shell navigation with repeated `GoToAsync`/`GoToAsync("..")` cycles on Android, the Shell's `CoordinatorLayout` can end up at 0×0 dimensions. This occurs when rapid fragment Hide/Show transactions saturate the Android Looper, preventing Choreographer layout passes from running between transitions.

After the CoordinatorLayout loses its dimensions, any NEW navigation to a different route results in a page that:
- IS attached to the window (`IsAttachedToWindow = true`)
- DOES fire the `Loaded` event
- But NEVER gets laid out (`IsLaidOut = false`, Width=0, Height=0)

### Root Cause

During Shell push/pop navigation on Android:
1. **Push**: `ShellSectionRenderer` fragment is hidden via `HideEx()` (sets `View.GONE`)
2. **Pop**: Fragment is shown via `ShowEx()` (sets `View.VISIBLE`)

When `setVisibility(VISIBLE)` is called from `GONE`, Android automatically triggers `requestLayout()`. Normally the Choreographer processes this in the next frame. However, under rapid navigation cycles (e.g., test frameworks running many tests sequentially), the Looper can be saturated with fragment transactions, and the layout request may get consumed without an actual measure/layout pass occurring on the CoordinatorLayout.

### Fix

Added an explicit `_rootView?.RequestLayout()` call in `ShellSectionRenderer.OnHiddenChanged` when the fragment becomes visible (`!hidden`). This is:
- **Cheap**: `RequestLayout()` is idempotent — if a layout is already scheduled, it's a no-op
- **Defensive**: Ensures the CoordinatorLayout always gets a fresh layout pass after being unhidden
- **Targeted**: Only fires on the specific transition that causes the bug (GONE → VISIBLE)

### View tree when bug manifests

```
FrameLayout (1080×2424) ← full size
  └─ CoordinatorLayout (0×0) ← BUG: should be 1080×2424
    └─ ShellPageContainer (0×0)
      └─ ContentViewGroup (0×0) ← page attached but never laid out
```

## Changes

- **`ShellSectionRenderer.cs`**: Added `_rootView?.RequestLayout()` in `OnHiddenChanged(!hidden)`
- **`ShellTests.Android.cs`**: Device tests verifying CoordinatorLayout dimensions after push/pop cycles
- **`Issue99999.cs` (HostApp + NUnit)**: UI regression test exercising rapid Shell navigation cycles