### PR TITLE
[iOS & Mac] CarouselViewController2 leaks on iOS/MacCatalyst due to unremoved orientation notification observer 

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
@@ -69,8 +69,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		{
 			InitializeCarouselViewLoopManager();
 			base.ViewDidLoad();
-			// Subscribe to orientation change notifications; store the token so it can be removed later.
-			_orientationObserver = NSNotificationCenter.DefaultCenter.AddObserver(UIDevice.OrientationDidChangeNotification, DeviceOrientationChanged);
 		}
 
 		void DeviceOrientationChanged(NSNotification notification)
@@ -229,6 +227,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			_oldViews = new List<View>();
 
 			SubscribeCollectionItemsSourceChanged(ItemsSource);
+
+			// Re-register on every attach for proper Setup/TearDown symmetry.
+			// ViewDidLoad is called only once, but TearDown removes the observer on every detach.
+			_orientationObserver = NSNotificationCenter.DefaultCenter.AddObserver(UIDevice.OrientationDidChangeNotification, DeviceOrientationChanged);
 		}
 
 		internal void UpdateIsScrolling(bool isScrolling)
@@ -784,6 +786,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		{
 			if (disposing)
 			{
+				if (_orientationObserver is not null)
+				{
+					NSNotificationCenter.DefaultCenter.RemoveObserver(_orientationObserver);
+					_orientationObserver = null;
+				}
 				_scrollDebounce?.Cancel();
 				_scrollDebounce?.Dispose();
 				_scrollDebounce = null;

--- a/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		bool _wasDetachedFromWindow = false;
 		CarouselViewLoopManager _carouselViewLoopManager;
 		CancellationTokenSource _scrollDebounce;
+		NSObject _orientationObserver;
 
 		// We need to keep track of the old views to update the visual states
 		// if this is null we are not attached to the window
@@ -68,8 +69,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		{
 			InitializeCarouselViewLoopManager();
 			base.ViewDidLoad();
-			// Subscribe to orientation change notifications
-			NSNotificationCenter.DefaultCenter.AddObserver(UIDevice.OrientationDidChangeNotification, DeviceOrientationChanged);
+			// Subscribe to orientation change notifications; store the token so it can be removed later.
+			_orientationObserver = NSNotificationCenter.DefaultCenter.AddObserver(UIDevice.OrientationDidChangeNotification, DeviceOrientationChanged);
 		}
 
 		void DeviceOrientationChanged(NSNotification notification)
@@ -203,8 +204,13 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			InitialPositionSet = false;
 
 			UnsubscribeCollectionItemsSourceChanged(ItemsSource);
-			// Clean up orientation notification observer
-			NSNotificationCenter.DefaultCenter.RemoveObserver(this, UIDevice.OrientationDidChangeNotification, null);
+			// Remove the block-based observer using the stored token (RemoveObserver(this,...) does not remove block observers).
+			if (_orientationObserver is not null)
+			{
+				NSNotificationCenter.DefaultCenter.RemoveObserver(_orientationObserver);
+				_orientationObserver.Dispose();
+				_orientationObserver = null;
+			}
 			_carouselViewLoopManager?.Dispose();
 			_carouselViewLoopManager = null;
 			_isUpdating = false;

--- a/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
@@ -208,7 +208,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			if (_orientationObserver is not null)
 			{
 				NSNotificationCenter.DefaultCenter.RemoveObserver(_orientationObserver);
-				_orientationObserver.Dispose();
 				_orientationObserver = null;
 			}
 			_carouselViewLoopManager?.Dispose();

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -503,8 +503,10 @@ public class MemoryTests : ControlsHandlerTestBase
 			controllerReference = new WeakReference(handler.Controller);
 
 			// Null locals so they don't keep objects alive across the scope boundary.
+			// page.Content still references carousel, so null page too.
 			handler = null;
 			carousel = null;
+			page = null;
 
 			await navPage.Navigation.PopAsync();
 		});

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -462,6 +462,66 @@ public class MemoryTests : ControlsHandlerTestBase
 		await AssertionExtensions.WaitForGC(viewReference, handlerReference);
 	}
 
+	// https://github.com/dotnet/maui/issues/35472
+	// CarouselViewController2 leaked because the block-based NSNotificationCenter observer token was
+	// discarded and the subsequent RemoveObserver(this,...) call targeted the wrong observer type.
+#if IOS || MACCATALYST
+	[Fact("CarouselViewController2 Controller Does Not Leak After Navigation Pop (Issue 35472)")]
+	public async Task CarouselViewController2ControllerDoesNotLeakAfterNavigationPop()
+	{
+		SetupBuilder();
+
+		WeakReference viewReference = null;
+		WeakReference handlerReference = null;
+		WeakReference controllerReference = null;
+
+		var navPage = new NavigationPage(new ContentPage { Title = "Root" });
+
+		await CreateHandlerAndAddToWindow(new Window(navPage), async () =>
+		{
+			var carousel = new CarouselView2
+			{
+				ItemsSource = Enumerable.Range(1, 5).Select(static i => $"Item {i}").ToList(),
+				ItemTemplate = new DataTemplate(static () => new Label
+				{
+					HorizontalTextAlignment = TextAlignment.Center,
+					VerticalTextAlignment = TextAlignment.Center
+				})
+			};
+
+			var page = new ContentPage { Content = carousel };
+			await navPage.Navigation.PushAsync(page);
+
+			// Allow the handler + controller to be fully created before capturing references.
+			await Task.Delay(500);
+
+			var handler = carousel.Handler as CarouselViewHandler2;
+			Assert.NotNull(handler);
+
+			viewReference = new WeakReference(carousel);
+			handlerReference = new WeakReference(handler);
+			controllerReference = new WeakReference(handler.Controller);
+
+			// Null locals so they don't keep objects alive across the scope boundary.
+			handler = null;
+			carousel = null;
+
+			await navPage.Navigation.PopAsync();
+		});
+
+		// Post the orientation notification to exercise the observer-removal path that was broken.
+		Foundation.NSNotificationCenter.DefaultCenter.PostNotificationName(
+			UIKit.UIDevice.OrientationDidChangeNotification,
+			UIKit.UIDevice.CurrentDevice);
+
+		await AssertionExtensions.WaitForGC(viewReference, handlerReference, controllerReference);
+
+		Assert.False(viewReference.IsAlive, "CarouselView should have been garbage collected");
+		Assert.False(handlerReference.IsAlive, "CarouselViewHandler2 should have been garbage collected");
+		Assert.False(controllerReference.IsAlive, "CarouselViewController2 should have been garbage collected (orientation observer was not properly removed before fix)");
+	}
+#endif
+
 	[Theory("Cells Do Not Leak")]
 #pragma warning disable CS0618 // Type or member is obsolete
 	[InlineData(typeof(TextCell))]


### PR DESCRIPTION
<!-- Please keep the note below for people who find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment whether this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

This pull request addresses a memory leak in `CarouselViewController2` on iOS/MacCatalyst caused by improper cleanup of the orientation change observer. The fix ensures that the observer token is stored and properly removed, preventing the controller from being retained after navigation. A new regression test is also added to verify the fix.
### Description of Change

**Bug fix: Proper observer cleanup in `CarouselViewController2`**
- Store the observer token returned by `NSNotificationCenter.AddObserver` in the `_orientationObserver` field, allowing for correct removal later. [[1]](diffhunk://#diff-f2d56fd867f9466701484a1239e77c550c399114dacbf89da74710c420d7fc14R23) [[2]](diffhunk://#diff-f2d56fd867f9466701484a1239e77c550c399114dacbf89da74710c420d7fc14L71-R73)
- Update the `TearDown` method to remove the observer using the stored token, ensuring the block-based observer is properly cleaned up and preventing memory leaks.

**Testing: Regression test for memory leak**
- Add a new test, `CarouselViewController2ControllerDoesNotLeakAfterNavigationPop`, to confirm that `CarouselViewController2` and related objects are garbage collected after navigation, verifying the observer is correctly removed and the leak is resolved.

<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #35472 
### Tested the behavior in the following platforms

- [ ] Windows
- [ ] Android
- [x] iOS
- [x] Mac

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/221d9ca5-6ac6-464c-8113-64fc6023a9e2">  | <video src="https://github.com/user-attachments/assets/cbd6d010-2f2f-4854-a8a4-e06097badca3"> |
<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
