### PR TITLE
Fix CI failure for CollectionView Scrolling Feature Tests due to PR #35379

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			var platformView = PlatformView;
 
-			if (platformView != null)
+			if (platformView != null && platformView.Handle != IntPtr.Zero)
 			{
 				RemoveView(platformView);
 			}

--- a/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
@@ -61,7 +61,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			var platformView = PlatformView;
 
-			if (platformView is not null && platformView.Handle != IntPtr.Zero)
+			if (this.IsAlive() &&
+				platformView.IsAlive() &&
+				platformView.Parent == this)
 			{
 				RemoveView(platformView);
 			}

--- a/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			var platformView = PlatformView;
 
-			if (platformView != null && platformView.Handle != IntPtr.Zero)
+			if (platformView is not null && platformView.Handle != IntPtr.Zero)
 			{
 				RemoveView(platformView);
 			}


### PR DESCRIPTION
### Issue Details
After PR #35379 , CollectionView Scrolling feature matrix tests started failing in CI on Android.

### Description of Change

<!-- Enter description of the fix in this section -->
During recycling, the code could attempt to remove a native view even after its Android handle was already disposed (invalid JNI handle), which can cause instability and intermittent failures under heavy scrolling/recycle paths, checks platformView is not null and its native handle is valid (Handle != IntPtr.Zero) before calling RemoveView.

### Fixes 
* CollectionView_ScrollingFeatureTests
