### PR TITLE
Fix agentic-labeler truncating labels to 1 per call

### DIFF
--- a/.github/workflows/agentic-labeler.md
+++ b/.github/workflows/agentic-labeler.md
@@ -43,10 +43,9 @@ network: defaults
 
 safe-outputs:
   add-labels:
-    # Blast-radius cap: the prompt instructs exactly one call to add_labels,
-    # so cap the number of accepted calls at 1. (Each single call may carry
-    # multiple label names in its `labels` array.)
-    max: 1
+    # Blast-radius cap: allow up to 10 labels per call so area + platform
+    # labels all survive in a single add_labels invocation.
+    max: 10
   # This workflow is labeling-only — never create issues for agent-side
   # status events (noop, missing tool, incomplete run, failure). Those
   # paths default to opening tracker issues, which would contradict the


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

One-line fix: `max: 1` → `max: 10` in the agentic-labeler safe-output config.

`max: 1` limited the number of labels per call to 1, silently dropping `platform/*` labels whenever the agent also selected an `area-*` label (which was every time).