### PR TITLE
[iOS/MacCatalyst] Fix Entry clear button appearing dimmed compared to TextColor

### DIFF
--- a/src/Core/src/Platform/iOS/TextFieldExtensions.cs
+++ b/src/Core/src/Platform/iOS/TextFieldExtensions.cs
@@ -229,7 +229,10 @@ namespace Microsoft.Maui.Platform
 			{
 				if (entry.TextColor is null)
 				{
-					// Setting TintColor to null allows the system to automatically apply the appropriate color based on the current theme (light or dark mode)
+					// Release any custom image so UIKit restores its own system clear button appearance.
+					// Setting TintColor to null alone is not enough — the template image persists.
+					clearButton.SetImage(null, UIControlState.Normal);
+					clearButton.SetImage(null, UIControlState.Highlighted);
 					clearButton.TintColor = null;
 					// SetImage(null) releases the custom tinted bitmap so UIKit restores its system default.
 					// The color path (else branch) reads ImageForState(.Highlighted) to get that original
@@ -239,49 +242,21 @@ namespace Microsoft.Maui.Platform
 				}
 				else
 				{
-					// On a null→color transition, UIKit restores the system image after SetImage(null),
-					// so ImageForState(Highlighted) returns the system clear button image as the tinting source.
-					UIImage? defaultClearImage = clearButton.ImageForState(UIControlState.Highlighted);
-					clearButton.TintColor = entry.TextColor.ToPlatform();
+					// Use AlwaysTemplate rendering so UIKit fills the icon at full opacity with TintColor,
+					// bypassing the semi-transparent pixels baked into the system clear button icon.
+					UIImage? sourceImage = clearButton.ImageForState(UIControlState.Normal)
+						?? clearButton.ImageForState(UIControlState.Highlighted);
 
-					var tintedClearImage = GetClearButtonTintImage(defaultClearImage, entry.TextColor.ToPlatform());
-					if (tintedClearImage is not null)
+					if (sourceImage is not null)
 					{
-						clearButton.SetImage(tintedClearImage, UIControlState.Normal);
-						clearButton.SetImage(tintedClearImage, UIControlState.Highlighted);
+						UIImage templateImage = sourceImage.ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);
+						clearButton.SetImage(templateImage, UIControlState.Normal);
+						clearButton.SetImage(templateImage, UIControlState.Highlighted);
 					}
+
+					clearButton.TintColor = entry.TextColor.ToPlatform();
 				}
 			}
-		}
-
-		internal static UIImage? GetClearButtonTintImage(UIImage? image, UIColor color)
-		{
-			if (image is null)
-			{
-				return null;
-			}
-
-			var size = image.Size;
-
-			var renderer = new UIGraphicsImageRenderer(size, new UIGraphicsImageRendererFormat()
-			{
-				Opaque = false,
-				Scale = UIScreen.MainScreen.Scale,
-			});
-
-			if (renderer is null)
-			{
-				return null;
-			}
-
-			return renderer.CreateImage((context) =>
-			{
-				image.Draw(CGPoint.Empty, CGBlendMode.Normal, 1.0f);
-				color.ColorWithAlpha(1.0f).SetFill();
-
-				var rect = new CGRect(CGPoint.Empty.X, CGPoint.Empty.Y, image.Size.Width, image.Size.Height);
-				context?.FillRect(rect, CGBlendMode.SourceIn);
-			});
 		}
 
 		internal static void AddMauiDoneAccessoryView(this UITextField textField, IViewHandler handler)

--- a/src/Core/src/Platform/iOS/TextFieldExtensions.cs
+++ b/src/Core/src/Platform/iOS/TextFieldExtensions.cs
@@ -234,11 +234,6 @@ namespace Microsoft.Maui.Platform
 					clearButton.SetImage(null, UIControlState.Normal);
 					clearButton.SetImage(null, UIControlState.Highlighted);
 					clearButton.TintColor = null;
-					// SetImage(null) releases the custom tinted bitmap so UIKit restores its system default.
-					// The color path (else branch) reads ImageForState(.Highlighted) to get that original
-					// image as the source for tinting. Without these calls, TintColor=null has no visual effect.
-					clearButton.SetImage(null, UIControlState.Normal);
-					clearButton.SetImage(null, UIControlState.Highlighted);
 				}
 				else
 				{

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Maui.DeviceTests
 
 				var tintedImage = clearButton.ImageForState(UIControlState.Normal);
 				Assert.NotNull(tintedImage);
-				Assert.Equal(UIImageRenderingMode.Automatic, tintedImage.RenderingMode);
+				Assert.Equal(UIImageRenderingMode.AlwaysTemplate, tintedImage.RenderingMode);
 
 				entry.TextColor = null;
 				handler.UpdateValue(nameof(IEntry.TextColor));
@@ -139,7 +139,7 @@ namespace Microsoft.Maui.DeviceTests
 				// Confirms ImageForState(.Highlighted) returns the original after SetImage(null)
 				var retintedImage = clearButton.ImageForState(UIControlState.Normal);
 				Assert.NotNull(retintedImage);
-				Assert.Equal(UIImageRenderingMode.Automatic, retintedImage.RenderingMode);
+				Assert.Equal(UIImageRenderingMode.AlwaysTemplate, retintedImage.RenderingMode);
 			});
 		}
 

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
@@ -809,6 +809,42 @@ namespace Microsoft.Maui.DeviceTests
 			return entry.AttributedText.GetCharacterSpacing();
 		}
 
+		[Fact(DisplayName = "Entry ClearButton uses template rendering tinted to TextColor")]
+		public async Task EntryClearButtonUsesTemplateRenderingTintedToTextColor()
+		{
+			var entry = new EntryStub
+			{
+				Text = "hello",
+				TextColor = Colors.Blue,
+				ClearButtonVisibility = ClearButtonVisibility.WhileEditing,
+			};
+
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var handler = CreateHandler<EntryHandler>(entry);
+				var textField = GetNativeEntry(handler);
+
+				await textField.AttachAndRun(async () =>
+				{
+					textField.BecomeFirstResponder();
+
+					UIButton clearButton = null;
+					await AssertEventually(() =>
+					{
+						clearButton = textField.ValueForKey(new NSString("clearButton")) as UIButton;
+						return clearButton?.ImageForState(UIControlState.Normal) is not null;
+					}, timeout: 2000);
+
+					Assert.NotNull(clearButton);
+					Assert.Equal(Colors.Blue.ToPlatform(), clearButton.TintColor);
+
+					var image = clearButton.ImageForState(UIControlState.Normal);
+					Assert.NotNull(image);
+					Assert.Equal(UIImageRenderingMode.AlwaysTemplate, image.RenderingMode);
+				});
+			});
+		}
+
 		static UITextField GetNativeEntry(EntryHandler entryHandler) =>
 			(UITextField)entryHandler.PlatformView;
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
- When an Entry control has a TextColor set and ClearButtonVisibility is enabled, the clear button (✕) appears faded/dimmed compared to the TextColor.

### Root Cause

- The system clear button icon uses UIImageRenderingMode.AlwaysOriginal, which causes UIKit to completely ignore TintColor. The original code attempted to work around this by compositing a tinted copy of the icon using CGBlendMode.SourceIn, but this compositing approach produces a faded/pastel result instead of the full-opacity color.

### Description of Change
- Replace the broken CGBlendMode.SourceIn compositing approach with UIImageRenderingMode.AlwaysTemplate, which tells UIKit to render the icon as a solid color silhouette using TintColor at full opacity. When TextColor is null, call SetImage(null) to fully release the custom image and restore UIKit's default system appearance.

### Issues Fixed
Fixes #35517

### Validated the behaviour in the following platforms

- [ ] Windows
- [ ] Android
- [x] iOS
- [x] Mac

### Output
| Platform | Before | After |
|----------|----------|----------|
| iOS | <img src="https://github.com/user-attachments/assets/3f4ac9be-0ec8-429b-8bdd-d381163d8119"> | <img src="https://github.com/user-attachments/assets/4a8897c3-0fc0-4ebf-9bf7-0aef1d359dff"> |
| Mac | <img src="https://github.com/user-attachments/assets/2a6c890a-7a72-4d5c-b7c8-fbbd6fa4cb32"> | <img src="https://github.com/user-attachments/assets/2a2318a4-b1dd-4ef5-8907-20befb57c907"> |