### PR TITLE
[iOS, Mac] Fix Shell back button history menu does not update after runtime change

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
@@ -209,12 +209,11 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			if (ToolbarReady() && _context?.Shell?.Toolbar is not null)
 			{
 				NavigationItem.Title = _context.Shell.Toolbar.Title;
+				return;
 			}
-			else if (Page?.IsSet(Page.TitleProperty) == true)
-			{
-				// Update back-stack pages so iOS back button/history menu reflects title changes
-				NavigationItem.Title = Page.Title;
-			}
+
+			// Update back-stack pages so iOS back button/history menu reflects title changes
+			NavigationItem.Title = Page?.Title;
 		}
 
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
@@ -200,12 +200,21 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		protected virtual void UpdateTitle()
 		{
-			if (!ToolbarReady() || NavigationItem is null || _context?.Shell?.Toolbar is null)
+
+			if (NavigationItem is null)
 			{
 				return;
 			}
 
-			NavigationItem.Title = _context.Shell.Toolbar.Title;
+			if (ToolbarReady() && _context?.Shell?.Toolbar is not null)
+			{
+				NavigationItem.Title = _context.Shell.Toolbar.Title;
+			}
+			else if (Page?.IsSet(Page.TitleProperty) == true)
+			{
+				// Update back-stack pages so iOS back button/history menu reflects title changes
+				NavigationItem.Title = Page.Title;
+			}
 		}
 
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue35471.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue35471.cs
@@ -1,0 +1,67 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 35471, "iOS Shell back button history menu does not update after runtime culture change", PlatformAffected.iOS | PlatformAffected.macOS)]
+public class Issue35471 : TestShell
+{
+	ContentPage _rootPage;
+
+	protected override void Init()
+	{
+		_rootPage = CreateContentPage("HomePage");
+		_rootPage.Title = "Home";
+
+		var navigateButton = new Button
+		{
+			AutomationId = "NavigateToDetail",
+			Text = "Go to Detail Page",
+			Command = new Command(async () =>
+			{
+				await Navigation.PushAsync(new Issue35471DetailPage(_rootPage));
+			})
+		};
+
+		_rootPage.Content = new VerticalStackLayout
+		{
+			Padding = 20,
+			Spacing = 10,
+			Children =
+			{
+				new Label { Text = "Root Page", AutomationId = "RootPageLabel" },
+				navigateButton
+			}
+		};
+	}
+
+	class Issue35471DetailPage : ContentPage
+	{
+		readonly ContentPage _previousPage;
+
+		public Issue35471DetailPage(ContentPage previousPage)
+		{
+			_previousPage = previousPage;
+			Title = "Detail";
+
+			var changeTitleButton = new Button
+			{
+				AutomationId = "ChangePreviousPageTitle",
+				Text = "Change Previous Page Title (simulate culture change)",
+				Command = new Command(() =>
+				{
+					// Simulate runtime culture change by updating the previous page's title
+					_previousPage.Title = "Accueil";
+				})
+			};
+
+			Content = new VerticalStackLayout
+			{
+				Padding = 20,
+				Spacing = 10,
+				Children =
+				{
+					new Label { Text = "Detail Page", FontSize = 20 },
+					changeTitleButton
+				}
+			};
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35471.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35471.cs
@@ -1,3 +1,5 @@
+// iOS/MacCatalyst only: The fix updates UINavigationItem.Title for back-stack pages,
+// which iOS uses to display the back button text. This is an Apple platform-specific behavior.
 #if IOS || MACCATALYST
 using NUnit.Framework;
 using UITest.Appium;
@@ -17,6 +19,14 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		[Category(UITestCategories.Shell)]
 		public void ShellBackButtonHistoryUpdatesAfterTitleChange()
 		{
+			// iOS 26+ no longer exposes the back button title text via accessibility,
+			// so there is no reliable way to assert the updated title in a UI test.
+			if (App is AppiumIOSApp iosApp && HelperExtensions.IsIOS26OrHigher(iosApp))
+			{
+				Assert.Ignore("iOS 26+ does not expose back button title text via accessibility");
+			}
+
+			// Navigate to Detail page
 			App.WaitForElement("NavigateToDetail");
 			App.Tap("NavigateToDetail");
 
@@ -24,18 +34,10 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 			App.WaitForElement("ChangePreviousPageTitle");
 			App.Tap("ChangePreviousPageTitle");
 
-			// The back button should now show "Accueil" (updated title).
-			// Without the fix, it still shows "Home" (stale title).
-			if (App is AppiumIOSApp iosApp && HelperExtensions.IsIOS26OrHigher(iosApp))
-			{
-				App.TapBackArrow(); // iOS 26+: no text on back button
-			}
-			else
-			{
-				App.TapBackArrow("Accueil");
-			}
-
-			// Verify we navigated back to root
+			// Verify back button now shows updated title "Accueil"
+			// Without the fix, UINavigationItem.Title is stale and still shows "Home"
+			App.WaitForElement("Accueil");
+			App.Tap("Accueil");
 			App.WaitForElement("RootPageLabel");
 		}
 	}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35471.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35471.cs
@@ -1,0 +1,37 @@
+#if IOS || MACCATALYST
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue35471 : _IssuesUITest
+	{
+		public override string Issue => "iOS Shell back button history menu does not update after runtime culture change";
+
+		public Issue35471(TestDevice device) : base(device)
+		{
+		}
+
+		[Test]
+		[Category(UITestCategories.Shell)]
+		public void ShellBackButtonHistoryUpdatesAfterTitleChange()
+		{
+			App.WaitForElement("NavigateToDetail");
+			App.Tap("NavigateToDetail");
+
+			// Change the previous page's title (simulates runtime culture change)
+			App.WaitForElement("ChangePreviousPageTitle");
+			App.Tap("ChangePreviousPageTitle");
+
+			// The back button should now show "Accueil" (updated title).
+			// Without the fix, it still shows "Home" (stale title).
+			App.WaitForElement("Accueil");
+			App.Tap("Accueil");
+
+			// Verify we navigated back to root
+			App.WaitForElement("RootPageLabel");
+		}
+	}
+}
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35471.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35471.cs
@@ -26,8 +26,14 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 			// The back button should now show "Accueil" (updated title).
 			// Without the fix, it still shows "Home" (stale title).
-			App.WaitForElement("Accueil");
-			App.Tap("Accueil");
+			if (App is AppiumIOSApp iosApp && HelperExtensions.IsIOS26OrHigher(iosApp))
+			{
+				App.TapBackArrow(); // iOS 26+: no text on back button
+			}
+			else
+			{
+				App.TapBackArrow("Accueil");
+			}
 
 			// Verify we navigated back to root
 			App.WaitForElement("RootPageLabel");


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Issue Details

- iOS Shell back button doesn't update its title when a back-stack page's Title changes at runtime (e.g., after locale/culture change). Shows stale text.

### Root Cause of the issue

- UpdateTitle() in ShellPageRendererTracker.cs is guarded by ToolbarReady() which returns false for non-visible pages → early return → UINavigationItem.Title never updated for back-stack pages.

### Description of Change

### Bug Fix: Shell Navigation Title Updates

* Updated the `UpdateTitle` method in `ShellPageRendererTracker.cs` to set the navigation item title to the current page's title if the toolbar is not ready, ensuring that back button/history menus show the correct title after runtime changes.

### Test Coverage

* Added a new UI test case `Issue35471` to verify that the back button history updates when the previous page's title changes at runtime, specifically simulating a culture change.
* Added a sample issue page (`Issue35471`) to manually reproduce and test the scenario where the previous page's title is updated and the change should be reflected in the navigation UI.

<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #35471

### Tested the behaviour in the following platforms

- [ ] - Windows 
- [ ] - Android
- [x] - iOS
- [x] - Mac

### Output

| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/243560ab-b8e4-42c7-9ae7-4a0681812cac"> | <video src="https://github.com/user-attachments/assets/af1d1343-eb05-414a-9a53-6eb862a5ded2"> |








<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
