### PR TITLE
[Android & iOS] TabbedPage leaks with shared GradientBrush.

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
@@ -156,7 +156,10 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 				if (_currentBarBackground is GradientBrush currentGradientBrush)
 				{
-					currentGradientBrush.Parent = null;
+					if (ReferenceEquals(currentGradientBrush.Parent, Tabbed))
+					{
+						currentGradientBrush.Parent = null;
+					}
 					currentGradientBrush.InvalidateGradientBrushRequested -= OnBarBackgroundChanged;
 				}
 				_currentBarBackground = null;

--- a/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
@@ -154,6 +154,13 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 					tabbed.PagesChanged -= OnPagesChanged;
 				}
 
+				if (_currentBarBackground is GradientBrush currentGradientBrush)
+				{
+					currentGradientBrush.Parent = null;
+					currentGradientBrush.InvalidateGradientBrushRequested -= OnBarBackgroundChanged;
+				}
+				_currentBarBackground = null;
+
 				FinishedCustomizingViewControllers -= HandleFinishedCustomizingViewControllers;
 			}
 

--- a/src/Controls/src/Core/Platform/Android/TabbedPageManager.cs
+++ b/src/Controls/src/Core/Platform/Android/TabbedPageManager.cs
@@ -129,6 +129,13 @@ public class TabbedPageManager
 			
 			_viewPager.LayoutChange -= OnLayoutChanged;
 			_viewPager.Adapter = null;
+
+			if (_currentBarBackground is GradientBrush currentGradientBrush)
+			{
+				currentGradientBrush.Parent = null;
+				currentGradientBrush.InvalidateGradientBrushRequested -= OnBarBackgroundChanged;
+			}
+			_currentBarBackground = null;
 		}
 
 		Element = tabbedPage;

--- a/src/Controls/src/Core/Platform/Android/TabbedPageManager.cs
+++ b/src/Controls/src/Core/Platform/Android/TabbedPageManager.cs
@@ -132,7 +132,10 @@ public class TabbedPageManager
 
 			if (_currentBarBackground is GradientBrush currentGradientBrush)
 			{
-				currentGradientBrush.Parent = null;
+				if (ReferenceEquals(currentGradientBrush.Parent, Element))
+				{
+					currentGradientBrush.Parent = null;
+				}
 				currentGradientBrush.InvalidateGradientBrushRequested -= OnBarBackgroundChanged;
 			}
 			_currentBarBackground = null;

--- a/src/Controls/src/Core/Toolbar/Toolbar.Android.cs
+++ b/src/Controls/src/Core/Toolbar/Toolbar.Android.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.Controls
 		List<IMenuItem> _currentMenuItems = new List<IMenuItem>();
 		List<ToolbarItem> _currentToolbarItems = new List<ToolbarItem>();
 
-		Brush _currentBarBackground;
+		Brush? _currentBarBackground;
 		private int? _defaultStartInset;
 
 		NavigationRootManager? NavigationRootManager =>
@@ -33,6 +33,17 @@ namespace Microsoft.Maui.Controls
 			{
 				if (_platformTitleView != null)
 					_platformTitleView.Child = null;
+
+				if (_currentBarBackground is GradientBrush currentGradientBrush)
+				{
+					if (ReferenceEquals(currentGradientBrush.Parent, this))
+					{
+						currentGradientBrush.Parent = null;
+					}
+
+					currentGradientBrush.InvalidateGradientBrushRequested -= OnBarBackgroundChanged;
+				}
+				_currentBarBackground = null;
 
 				Controls.Platform.ToolbarExtensions.DisposeMenuItems(
 					oldHandler?.PlatformView as AToolbar,

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
@@ -502,6 +503,118 @@ namespace Microsoft.Maui.DeviceTests
 
 			Controls.PlatformConfiguration.AndroidSpecific.TabbedPage.SetIsSmoothScrollEnabled(tabs, isSmoothScrollEnabled);
 			return tabs;
+		}
+
+		// https://github.com/dotnet/maui/issues/35469
+		// When a TabbedPage.BarBackground is set from a shared GradientBrush (e.g. via an app-resource Style),
+		// removing the TabbedPage from the window must not leave a live subscription on the shared brush.
+		// The renderer/manager subscribes to GradientBrush.InvalidateGradientBrushRequested; if it fails to
+		// unsubscribe on disconnect the brush keeps the renderer alive, preventing GC.
+		[Fact(DisplayName = "TabbedPage renderer/manager does not leak shared GradientBrush subscriber on disconnect")]
+		public async Task TabbedPageDoesNotLeakGradientBrushSubscriberOnDisconnect()
+		{
+			SetupBuilder();
+
+			// Simulate a shared app-resource brush — this object lives beyond the TabbedPage.
+			var sharedBrush = new LinearGradientBrush(
+				new GradientStopCollection
+				{
+					new GradientStop(Colors.Teal, 0f),
+					new GradientStop(Colors.CornflowerBlue, 1f)
+				},
+				new Graphics.Point(0, 0),
+				new Graphics.Point(1, 1));
+
+			var tabbedPageRef = new WeakReference(null);
+			var handlerRef = new WeakReference(null);
+
+			var navPage = new NavigationPage(new ContentPage { Title = "Home" });
+
+			await CreateHandlerAndAddToWindow(new Window(navPage), async () =>
+			{
+				var tabbedPage = new TabbedPage
+				{
+					Title = "Tabbed",
+					BarBackground = sharedBrush,
+				};
+				tabbedPage.Children.Add(new ContentPage { Title = "Tab 1" });
+				tabbedPage.Children.Add(new ContentPage { Title = "Tab 2" });
+
+				// Push so the TabbedPage handler is created and subscribes to the brush.
+				await navPage.Navigation.PushModalAsync(tabbedPage);
+				await OnLoadedAsync(tabbedPage.Children[0]);
+
+				tabbedPageRef.Target = tabbedPage;
+				handlerRef.Target = tabbedPage.Handler;
+
+				// Pop — this should cause the renderer/manager to disconnect and unsubscribe.
+				await navPage.Navigation.PopModalAsync();
+			});
+
+			// After full GC the renderer/manager should be collected.
+			await AssertionExtensions.WaitForGC(handlerRef);
+
+			// The shared brush must have zero subscribers to InvalidateGradientBrushRequested.
+			// If the renderer/manager leaked, it would still be subscribed here.
+			var brushInvocationList = GetGradientBrushInvocationList(sharedBrush);
+			Assert.Empty(brushInvocationList);
+		}
+
+		// https://github.com/dotnet/maui/issues/35469
+		// Variant: BarBackground applied via a Style (the exact scenario from the bug report).
+		[Fact(DisplayName = "TabbedPage renderer/manager does not leak shared GradientBrush subscriber when BarBackground is set via Style")]
+		public async Task TabbedPageDoesNotLeakGradientBrushSubscriberWhenSetViaStyle()
+		{
+			SetupBuilder();
+
+			var sharedBrush = new LinearGradientBrush(
+				new GradientStopCollection
+				{
+					new GradientStop(Colors.DarkGreen, 0f),
+					new GradientStop(Colors.SteelBlue, 1f)
+				},
+				new Graphics.Point(0, 0),
+				new Graphics.Point(1, 1));
+
+			var barBackgroundStyle = new Style(typeof(TabbedPage))
+			{
+				Setters = { new Setter { Property = TabbedPage.BarBackgroundProperty, Value = sharedBrush } }
+			};
+
+			var handlerRef = new WeakReference(null);
+
+			var navPage = new NavigationPage(new ContentPage { Title = "Home" });
+
+			await CreateHandlerAndAddToWindow(new Window(navPage), async () =>
+			{
+				var tabbedPage = new TabbedPage { Style = barBackgroundStyle };
+				tabbedPage.Children.Add(new ContentPage { Title = "Tab 1" });
+				tabbedPage.Children.Add(new ContentPage { Title = "Tab 2" });
+
+				await navPage.Navigation.PushModalAsync(tabbedPage);
+				await OnLoadedAsync(tabbedPage.Children[0]);
+
+				handlerRef.Target = tabbedPage.Handler;
+
+				await navPage.Navigation.PopModalAsync();
+			});
+
+			await AssertionExtensions.WaitForGC(handlerRef);
+
+			var brushInvocationList = GetGradientBrushInvocationList(sharedBrush);
+			Assert.Empty(brushInvocationList);
+		}
+
+		static System.Delegate[] GetGradientBrushInvocationList(GradientBrush brush)
+		{
+			var field = typeof(GradientBrush).GetField(
+				"InvalidateGradientBrushRequested",
+				BindingFlags.Instance | BindingFlags.NonPublic);
+
+			if (field is null)
+				return [];
+
+			return (field.GetValue(brush) as MulticastDelegate)?.GetInvocationList() ?? [];
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
@@ -605,6 +605,52 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Empty(brushInvocationList);
 		}
 
+
+		// https://github.com/dotnet/maui/issues/35469
+		// Verifies that after a modal TabbedPage is popped, the shared GradientBrush
+		// has zero subscribers. DisconnectHandlers is NOT called on modal pop, so the
+		// fix must explicitly unsubscribe via the Disappearing/ViewDidDisappear lifecycle hook.
+		[Fact(DisplayName = "TabbedPage GradientBrush subscriber is removed after modal pop")]
+		public async Task TabbedPageGradientBrushSubscriberRemovedAfterModalPop()
+		{
+			SetupBuilder();
+
+			var sharedBrush = new LinearGradientBrush(
+				new GradientStopCollection
+				{
+					new GradientStop(Colors.Purple, 0f),
+					new GradientStop(Colors.Orange, 1f)
+				},
+				new Graphics.Point(0, 0),
+				new Graphics.Point(1, 1));
+
+			var navPage = new NavigationPage(new ContentPage { Title = "Home" });
+
+			await CreateHandlerAndAddToWindow(new Window(navPage), async () =>
+			{
+				var tabbedPage = new TabbedPage
+				{
+					Title = "Tabbed",
+					BarBackground = sharedBrush,
+				};
+				tabbedPage.Children.Add(new ContentPage { Title = "Tab 1" });
+				tabbedPage.Children.Add(new ContentPage { Title = "Tab 2" });
+
+				await navPage.Navigation.PushModalAsync(tabbedPage);
+				await OnLoadedAsync(tabbedPage.Children[0]);
+
+				// Confirm the brush has exactly one subscriber while the page is live.
+				Assert.Single(GetGradientBrushInvocationList(sharedBrush));
+
+				await navPage.Navigation.PopModalAsync();
+
+				// After pop completes, Disappearing/ViewDidDisappear must have fired
+				// and explicitly unsubscribed from the brush.
+				var invocationList = GetGradientBrushInvocationList(sharedBrush);
+				Assert.Empty(invocationList);
+			});
+		}
+
 		static System.Delegate[] GetGradientBrushInvocationList(GradientBrush brush)
 		{
 			var field = typeof(GradientBrush).GetField(

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
@@ -379,7 +379,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 #endif
 
-#if IOS 
+#if IOS
 		[Theory(Skip = "Test doesn't work on iOS yet; probably because of https://github.com/dotnet/maui/issues/10591")]
 #elif WINDOWS
 		[Theory(Skip = "Test doesn't work on Windows")]
@@ -551,8 +551,9 @@ namespace Microsoft.Maui.DeviceTests
 				await navPage.Navigation.PopModalAsync();
 			});
 
-			// After full GC the renderer/manager should be collected.
+			// After full GC the renderer/manager and the page itself should be collected.
 			await AssertionExtensions.WaitForGC(handlerRef);
+			await AssertionExtensions.WaitForGC(tabbedPageRef);
 
 			// The shared brush must have zero subscribers to InvalidateGradientBrushRequested.
 			// If the renderer/manager leaked, it would still be subscribed here.


### PR DESCRIPTION
<!-- Please keep the note below for people who find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment whether this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

This pull request addresses a memory leak issue involving `GradientBrush` subscriptions in the `TabbedPage` renderer/manager. It ensures that when a `TabbedPage` is removed from the window, any event subscriptions to a shared `GradientBrush` are properly cleaned up, preventing the renderer/manager from being kept alive unintentionally. The changes also add tests to verify this behavior.
### Description of Change
**Memory leak prevention and event unsubscription:**

* The `Dispose` method in `TabbedRenderer.cs` (iOS) and the `SetElement` method in `TabbedPageManager.cs` (Android) now explicitly unsubscribe from the `GradientBrush.InvalidateGradientBrushRequested` event and clear the brush's parent, ensuring no lingering references when the `TabbedPage` is disconnected. [[1]](diffhunk://#diff-9fde794f3d6a007e6182c0353ba2136323fb69141c1d880e49a42f9015274a53R157-R163) [[2]](diffhunk://#diff-c76199129810d626ed8ca8ea05723ccc0f9b73d76d7de83cb353e9cf3a01bbacR132-R138)

**Automated tests for leak prevention:**

* Added two tests to `TabbedPageTests.cs` that verify the renderer/manager does not leak a shared `GradientBrush` subscription when a `TabbedPage` is removed, both when the brush is set directly and when applied via a `Style`. These tests use reflection to check for remaining event subscribers and assert that none remain after GC.
* Introduced a helper method using reflection to inspect the invocation list of the `InvalidateGradientBrushRequested` event on a `GradientBrush` instance.
* Added the necessary `System.Reflection` import to support the new test utilities.



<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #35469 
### Tested the behavior in the following platforms

- [ ] Windows
- [x] Android
- [x] iOS
- [ ] Mac

| Android Before Issue Fix | Android After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/b421d3bd-be0f-4ec6-8198-fe6d9a43b9f4">  | <video src="https://github.com/user-attachments/assets/5fcc7cc5-078b-4975-abb0-5236f89d17d3"> |

| iOS Before Issue Fix | iOS After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/9150410d-f53b-4a3c-914c-611744535d75">  | <video src="https://github.com/user-attachments/assets/3aba2204-8272-4bdf-8553-baf92158812d"> |
<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
