### PR TITLE
Skip Authenticode for ReconnectModal.razor.js; add catalog signing

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -25,6 +25,18 @@
     <FileSignInfo Include="SegoeUI-Semibold.ttf" CertificateName="3PartyScriptsSHA2" />
   </ItemGroup>
 
+  <ItemGroup Label="Customer-modifiable template files">
+    <!-- Skip Authenticode - this JS is included in customer applications and users edit it.
+         Covered by catalog signing (.cat) instead - see GenerateCatalogFiles target in
+         src/Templates/src/Microsoft.Maui.Templates.csproj. -->
+    <FileSignInfo Include="ReconnectModal.razor.js" CertificateName="None" />
+  </ItemGroup>
+
+  <ItemGroup Label="Catalog signing">
+    <!-- Sign catalog files that cover customer-modifiable template content -->
+    <FileExtensionSignInfo Include=".cat" CertificateName="Microsoft400" />
+  </ItemGroup>
+
   <ItemGroup>
     <ItemsToSign Include="$(ArtifactsShippingPackagesDir)\**\*.msi" Condition="'$(PostBuildSign)' != 'true'" />
     <ItemsToSign Include="$(ArtifactsShippingPackagesDir)**\*.wixpack.zip" Condition="'$(PostBuildSign)' != 'true'" />
@@ -32,4 +44,4 @@
     <ItemsToSign Include="$(ArtifactsShippingPackagesDir)\**\*.zip" Condition="'$(PostBuildSign)' != 'true'" />
     <ItemsToSignPostBuild Include="$(ArtifactsShippingPackagesDir)\**\*.zip" Condition="'$(PostBuildSign)' == 'true'" />
   </ItemGroup>
-</Project>   
+</Project>

--- a/eng/generate-catalog.ps1
+++ b/eng/generate-catalog.ps1
@@ -1,0 +1,102 @@
+<#
+.SYNOPSIS
+    Generates a catalog (.cat) file for customer-modifiable template content.
+.DESCRIPTION
+    Recursively scans a directory for files matching a filter and produces a
+    Catalog Definition File (.cdf), then runs makecat.exe to create the .cat.
+
+    Used to catalog-sign files that cannot use direct Authenticode signing
+    because customers are expected to modify them (e.g., template .js files).
+.PARAMETER RootPath
+    The directory containing files to include in the catalog.
+.PARAMETER CatOutputPath
+    The path where makecat.exe will create the .cat file.
+.PARAMETER Filter
+    Comma-separated file filter patterns (e.g., '*.js' or '*.js,*.ttf'). Default: '*.*'.
+.PARAMETER ErrorIfMakecatNotFound
+    Throws an error when makecat.exe is not found instead of warning and skipping.
+    Use in CI/official builds.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$RootPath,
+
+    [Parameter(Mandatory)]
+    [string]$CatOutputPath,
+
+    [string]$Filter = '*.*',
+
+    [switch]$ErrorIfMakecatNotFound
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $RootPath)) {
+    Write-Error "Root path not found: $RootPath"
+    return
+}
+
+$CdfPath = [System.IO.Path]::ChangeExtension($CatOutputPath, '.cdf')
+
+# Ensure output directory exists
+$catDir = Split-Path $CatOutputPath -Parent
+if ($catDir -and -not (Test-Path $catDir)) {
+    New-Item -ItemType Directory -Path $catDir -Force | Out-Null
+}
+
+$files = Get-ChildItem -Path $RootPath -Recurse -Include ($Filter -split ',') -File
+if ($files.Count -eq 0) {
+    Write-Warning "No files matching '$Filter' found under $RootPath - skipping catalog generation."
+    return
+}
+
+# Build the CDF content
+$cdfContent = @()
+$cdfContent += "[CatalogHeader]"
+$cdfContent += "Name=$CatOutputPath"
+$cdfContent += "CatalogVersion=2"
+$cdfContent += "HashAlgorithms=SHA256"
+$cdfContent += ""
+$cdfContent += "[CatalogFiles]"
+
+$i = 0
+foreach ($f in $files) {
+    $ext = $f.Extension.TrimStart('.').ToLower()
+    $label = "${ext}_${i}_" + ($f.Name -replace '[^\w\.-]', '_')
+    $cdfContent += "<hash>$label=$($f.FullName)"
+    $i++
+}
+
+$cdfContent | Set-Content -Path $CdfPath -Encoding ASCII
+Write-Host "Generated CDF with $($files.Count) file(s) matching '$Filter' at $CdfPath"
+
+# Find makecat.exe (ships with Windows SDK)
+$makecat = Get-Command makecat.exe -ErrorAction SilentlyContinue
+if (-not $makecat) {
+    $sdkRoot = "${env:ProgramFiles(x86)}\Windows Kits\10\bin"
+    if (Test-Path $sdkRoot) {
+        $makecat = Get-ChildItem -Path $sdkRoot -Recurse -Filter 'makecat.exe' -File |
+            Where-Object { $_.DirectoryName -match 'x64' } |
+            Sort-Object DirectoryName -Descending |
+            Select-Object -First 1
+    }
+}
+
+if (-not $makecat) {
+    if ($ErrorIfMakecatNotFound) {
+        throw "makecat.exe not found. Catalog signing requires the Windows SDK."
+    }
+    Write-Warning "makecat.exe not found - skipping catalog generation. Install Windows SDK for catalog signing."
+    return
+}
+
+$makecatPath = if ($makecat -is [System.Management.Automation.CommandInfo]) { $makecat.Source } else { $makecat.FullName }
+Write-Host "Using makecat.exe at: $makecatPath"
+
+& $makecatPath $CdfPath
+if ($LASTEXITCODE -ne 0) {
+    throw "makecat.exe failed with exit code $LASTEXITCODE"
+}
+
+Write-Host "Generated catalog file: $CatOutputPath"

--- a/src/Templates/src/Microsoft.Maui.Templates.csproj
+++ b/src/Templates/src/Microsoft.Maui.Templates.csproj
@@ -121,4 +121,30 @@
   <!-- this target will get replaced by the nuget -->
   <Target Name="LocalizeTemplatesAfterBuild" />
 
+  <!--
+    Generate a catalog (.cat) file for customer-modifiable template content.
+    The .cat is signed by Arcade (FileExtensionSignInfo in eng/Signing.props)
+    while the .js files themselves are marked CertificateName="None" because
+    customers are expected to edit them.
+    Windows-only: makecat.exe ships with the Windows SDK.
+  -->
+  <Target Name="GenerateCatalogFiles"
+          AfterTargets="Build"
+          BeforeTargets="Pack"
+          Condition="'$(OS)' == 'Windows_NT'">
+    <PropertyGroup>
+      <_TemplateContentRoot>$(MSBuildProjectDirectory)\templates\</_TemplateContentRoot>
+      <_CatOutputPath>$(IntermediateOutputPath)maui-template-content.cat</_CatOutputPath>
+    </PropertyGroup>
+
+    <Exec Command="pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File &quot;$(MSBuildThisFileDirectory)..\..\..\eng\generate-catalog.ps1&quot; -RootPath &quot;$(_TemplateContentRoot)&quot; -CatOutputPath &quot;$(_CatOutputPath)&quot; -Filter &quot;*.js&quot; -ErrorIfMakecatNotFound"
+          IgnoreExitCode="false" />
+
+    <ItemGroup>
+      <Content Include="$(_CatOutputPath)" Pack="true" PackagePath="content" />
+      <FileWrites Include="$(_CatOutputPath)" />
+      <FileWrites Include="$(IntermediateOutputPath)maui-template-content.cdf" />
+    </ItemGroup>
+  </Target>
+
 </Project>


### PR DESCRIPTION
ReconnectModal.razor.js is a customer-modifiable template file in the maui-blazor-solution template. Users edit it after project creation, so Authenticode signing is inappropriate -- it would break on modification.

This PR:

- Sets `CertificateName=None` for ReconnectModal.razor.js to skip Authenticode signing.
- Adds `eng/generate-catalog.ps1` to produce a `.cat` file covering `*.js` template content via `makecat.exe`.
- Adds a `GenerateCatalogFiles` MSBuild target in `Microsoft.Maui.Templates.csproj` that runs after Build/before Pack (Windows-only). The `.cat` is included in the NuGet package.
- Adds `FileExtensionSignInfo` for `.cat` (Microsoft400) in `eng/Signing.props` so Arcade signs the catalog file.

The `.cat` provides integrity verification for the JS files without blocking customer modifications. This addresses VS signing compliance scan findings for the `mauitemplatesnet*` payloads (ReconnectModal.razor.js flagged as unsigned).