### PR TITLE
Recompile agentic-labeler.lock.yml (PR #35540 follow-up)

### DIFF
--- a/.github/workflows/agentic-labeler.lock.yml
+++ b/.github/workflows/agentic-labeler.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"25f05a99807f9b9ce12f5e913def0aacf51ac4549604235e68785ddee87cea36","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"f0dcf0c370b3394379b70e53a2a3403dead8398f60c1309ac45b577ffcda2b88","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"bc56a0cad2f450c562810785ef38649c04db812a","version":"v0.72.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -226,20 +226,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_8c999442c670d5c8_EOF'
+          cat << 'GH_AW_PROMPT_743c5d383f2d0aa9_EOF'
           <system>
-          GH_AW_PROMPT_8c999442c670d5c8_EOF
+          GH_AW_PROMPT_743c5d383f2d0aa9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_8c999442c670d5c8_EOF'
+          cat << 'GH_AW_PROMPT_743c5d383f2d0aa9_EOF'
           <safe-output-tools>
-          Tools: add_labels, missing_tool, missing_data, noop
+          Tools: add_labels(max:10), missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_8c999442c670d5c8_EOF
+          GH_AW_PROMPT_743c5d383f2d0aa9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_8c999442c670d5c8_EOF'
+          cat << 'GH_AW_PROMPT_743c5d383f2d0aa9_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -268,12 +268,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_8c999442c670d5c8_EOF
+          GH_AW_PROMPT_743c5d383f2d0aa9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_8c999442c670d5c8_EOF'
+          cat << 'GH_AW_PROMPT_743c5d383f2d0aa9_EOF'
           </system>
           {{#runtime-import .github/workflows/agentic-labeler.md}}
-          GH_AW_PROMPT_8c999442c670d5c8_EOF
+          GH_AW_PROMPT_743c5d383f2d0aa9_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -476,15 +476,15 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_578695910d40f8af_EOF'
-          {"add_labels":{"max":1},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_578695910d40f8af_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_4c1846c75451650e_EOF'
+          {"add_labels":{"max":10},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_4c1846c75451650e_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "add_labels": " CONSTRAINTS: Maximum 1 label(s) can be added."
+                "add_labels": " CONSTRAINTS: Maximum 10 label(s) can be added."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -662,7 +662,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_bfbe7efc8a380964_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_3d165cd00ea2d38e_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -706,7 +706,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_bfbe7efc8a380964_EOF
+          GH_AW_MCP_CONFIG_3d165cd00ea2d38e_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1335,7 +1335,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_labels\":{\"max\":1},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_labels\":{\"max\":10},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"report_incomplete\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Follow-up to #35540. That PR fixed the `add-labels` truncation bug by changing the source `.md` from `max: 1` to `max: 10`, but did **not** regenerate the compiled `.lock.yml`. The deployed workflow on `main` therefore still embeds the old config and continues to silently drop all but one label per labeler run.

Running `gh aw compile .github/workflows/agentic-labeler.md` locally produces this 17-line diff in the lock file. The substantive changes are:

- `frontmatter_hash` updated to match the new `.md` source (so the lock file no longer fails the `ERR_CONFIG: Lock file outdated` check on every dispatch)
- safe-outputs `config.json` now emits `{"add_labels":{"max":10}}` (was `{"add_labels":{"max":1}}`)
- the agent system prompt now declares `add_labels(max:10)`, so the orchestrator knows it can return multiple labels in one call
- heredoc delimiters rotate as expected on every recompile

No behaviour changes beyond what #35540 already intended. This is purely the missing `gh aw compile` output.

## Verification

1. Before this PR: every `gh workflow run agentic-labeler.lock.yml` dispatch fails with `ERR_CONFIG: Lock file ... is outdated! The workflow file ... frontmatter has changed.` (confirmed across 26 attempted backfill dispatches on the affected items in #35540 audit).
2. With this PR locally, `git diff` shows only the lock file changed; no `.md` modifications.
3. After merge, dispatching the workflow once via `gh workflow run agentic-labeler.lock.yml --repo dotnet/maui --ref main -f issue_number=<N>` against an affected item should now successfully apply multiple `area-*` + `platform/*` labels in a single run (matching #35540 intent).

## Why this happened

PR #35540 was a documentation-style line-edit on the source `.md` and the author appears to have skipped the mandatory `gh aw compile` step. The repo currently has no CI check that recompiles the lock file and rejects out-of-sync commits — adding such a guard is a separate follow-up.

The misleading guidance in `~/.agents/skills/gh-aw-guide` (which contributed to the original `max: 1` bug) is being reviewed in parallel via a multi-model audit — fixes will land in a separate PR against that skill repo.