### PR TITLE
Fix RemovePossibleQueryString to also strip URL fragments

### DIFF
--- a/src/Essentials/src/Types/Shared/WebUtils.shared.cs
+++ b/src/Essentials/src/Types/Shared/WebUtils.shared.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Maui
 	static class WebUtils
 	{
 #if !NETSTANDARD
+		static readonly char[] s_queryOrFragmentDelimiters = new[] { '?', '#' };
+
 		internal static string RemovePossibleQueryString(string? url)
 		{
 			if (string.IsNullOrEmpty(url))
@@ -15,7 +17,7 @@ namespace Microsoft.Maui
 				return string.Empty;
 			}
 
-			var indexOfQueryString = url.IndexOf('?', StringComparison.Ordinal);
+			var indexOfQueryString = url.IndexOfAny(s_queryOrFragmentDelimiters);
 			return (indexOfQueryString == -1)
 				? url
 				: url.Substring(0, indexOfQueryString);

--- a/src/Essentials/test/UnitTests/WebUtils_Tests.cs
+++ b/src/Essentials/test/UnitTests/WebUtils_Tests.cs
@@ -110,6 +110,10 @@ namespace Tests
 		[InlineData("https://example.com", "https://example.com")]
 		[InlineData("https://example.com?foo=bar", "https://example.com")]
 		[InlineData("https://example.com/path?query=1&other=2", "https://example.com/path")]
+		[InlineData("https://example.com/index.html#code=abc", "https://example.com/index.html")]
+		[InlineData("https://example.com/path?query=1#frag", "https://example.com/path")]
+		[InlineData("https://example.com/path#frag?notquery", "https://example.com/path")]
+		[InlineData("https://0.0.0.1/index.html#code=1234asdf", "https://0.0.0.1/index.html")]
 		public void RemovePossibleQueryString_ReturnsExpected(string? input, string expected)
 		{
 			var result = Microsoft.Maui.WebUtils.RemovePossibleQueryString(input);


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

`WebUtils.RemovePossibleQueryString` only stripped query strings (`?`) but not URL fragments (`#`). This caused HybridWebView to fail loading local files when the URL contained a fragment identifier (e.g. `index.html#code=abc`).

The fix uses `IndexOfAny` to find the first `?` or `#` delimiter and strips everything from that point forward.

Supersedes #31597.

### Issues Fixed

Fixes #31472