### PR TITLE
Destroy Android WebView on handler disconnect

### DIFF
--- a/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net;
+using Android.Views;
 using Android.Webkit;
 using static Android.Views.ViewGroup;
 using AWebView = Android.Webkit.WebView;
@@ -67,8 +68,12 @@ namespace Microsoft.Maui.Handlers
 			platformView.SetWebChromeClient(null);
 
 			platformView.StopLoading();
+			if (platformView.Parent is ViewGroup parent)
+				parent.RemoveView(platformView);
+			platformView.RemoveAllViews();
 
 			base.DisconnectHandler(platformView);
+			platformView.Destroy();
 		}
 
 		public static void MapSource(IWebViewHandler handler, IWebView webView)

--- a/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
@@ -64,7 +64,6 @@ namespace Microsoft.Maui.Handlers
 					webChromeClient.Disconnect();
 			}
 
-			platformView.SetWebViewClient(null!);
 			platformView.SetWebChromeClient(null);
 
 			platformView.StopLoading();

--- a/src/Core/tests/DeviceTests/Handlers/WebView/WebViewHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/WebView/WebViewHandlerTests.Android.cs
@@ -1,8 +1,12 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Android.Content;
+using Android.Views;
 using Android.Webkit;
+using Android.Widget;
 using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Platform;
 using Xunit;
 using AWebView = Android.Webkit.WebView;
 
@@ -15,5 +19,62 @@ namespace Microsoft.Maui.DeviceTests
 
 		string GetNativeSource(WebViewHandler webViewHandler) =>
 			GetNativeWebView(webViewHandler).Url;
+
+		[Fact(DisplayName = "DisconnectHandler Destroys Native WebView")]
+		public async Task DisconnectHandlerDestroysNativeWebView()
+		{
+			var originalFactory = WebViewHandler.PlatformViewFactory;
+
+			try
+			{
+				await InvokeOnMainThreadAsync(() =>
+				{
+					DestroyTrackingMauiWebView platformView = null;
+
+					WebViewHandler.PlatformViewFactory = handler =>
+					{
+						platformView = new DestroyTrackingMauiWebView((WebViewHandler)handler, handler.MauiContext!.Context!);
+						return platformView;
+					};
+
+					var webView = new WebViewStub();
+					var handler = CreateHandler(webView);
+					var parent = new FrameLayout(handler.MauiContext!.Context!);
+					parent.AddView(handler.PlatformView);
+
+					Assert.Same(parent, handler.PlatformView.Parent);
+
+					((IElementHandler)handler).DisconnectHandler();
+
+					var destroyTrackingWebView = platformView ?? throw new InvalidOperationException("Expected the WebView factory to create a platform view.");
+					Assert.True(destroyTrackingWebView.DestroyCalled);
+					Assert.Null(destroyTrackingWebView.ParentWhenDestroyed);
+					Assert.Equal(0, parent.ChildCount);
+				});
+			}
+			finally
+			{
+				WebViewHandler.PlatformViewFactory = originalFactory;
+			}
+		}
+
+		class DestroyTrackingMauiWebView : MauiWebView
+		{
+			public DestroyTrackingMauiWebView(WebViewHandler handler, Context context)
+				: base(handler, context)
+			{
+			}
+
+			public bool DestroyCalled { get; private set; }
+
+			public IViewParent ParentWhenDestroyed { get; private set; }
+
+			public override void Destroy()
+			{
+				DestroyCalled = true;
+				ParentWhenDestroyed = Parent;
+				base.Destroy();
+			}
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Updates the Android `WebViewHandler` disconnect path to fully tear down the native `Android.Webkit.WebView` when the handler is disconnected.

The handler now stops loading, removes the `WebView` from its parent if attached, removes child views, runs the base disconnect logic, and then calls `Destroy()` on the native `WebView`. This prevents detached Android WebView/Chromium instances from remaining alive after navigation/page pop scenarios.

Adds an Android device test that verifies disconnecting the handler calls `Destroy()` and removes the platform view from its parent before destruction.

### Issues Fixed

Fixes #18021