### PR TITLE
Add unified navigation interception with WebNavigationTarget across all WebView types

### DIFF
--- a/src/BlazorWebView/src/Maui/Android/BlazorWebChromeClient.cs
+++ b/src/BlazorWebView/src/Maui/Android/BlazorWebChromeClient.cs
@@ -2,18 +2,32 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Android.Content;
-using Android.Net;
 using Android.OS;
 using Android.Webkit;
 using Microsoft.Maui;
 using Microsoft.Maui.Devices;
 using Microsoft.Maui.Storage;
 using File = Java.IO.File;
+using Uri = Android.Net.Uri;
 
 namespace Microsoft.AspNetCore.Components.WebView.Maui
 {
 	class BlazorWebChromeClient : WebChromeClient
 	{
+		private static readonly string AppOrigin = $"https://{BlazorWebView.AppHostAddress}/";
+		private static readonly System.Uri AppOriginUri = new(AppOrigin);
+
+		private readonly BlazorWebViewHandler? _handler;
+
+		public BlazorWebChromeClient()
+		{
+		}
+
+		public BlazorWebChromeClient(BlazorWebViewHandler handler)
+		{
+			_handler = handler;
+		}
+
 		public override bool OnCreateWindow(global::Android.Webkit.WebView? view, bool isDialog, bool isUserGesture, Message? resultMsg)
 		{
 			if (view?.Context is not null)
@@ -21,8 +35,37 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				// Intercept _blank target <a> tags to always open in device browser
 				// regardless of UrlLoadingStrategy.OpenInWebview
 				var requestUrl = view.GetHitTestResult().Extra;
-				var intent = new Intent(Intent.ActionView, Uri.Parse(requestUrl));
-				view.Context.StartActivity(intent);
+
+				if (!string.IsNullOrEmpty(requestUrl) && System.Uri.TryCreate(requestUrl, System.UriKind.RelativeOrAbsolute, out var uri))
+				{
+					var callbackArgs = UrlLoadingEventArgs.CreateWithDefaultLoadingStrategy(
+						uri,
+						AppOriginUri,
+						Microsoft.Maui.WebNavigationTarget.NewWindow);
+
+					if (_handler is not null)
+					{
+						_handler.UrlLoading(callbackArgs);
+						_handler.Logger.NavigationEvent(uri, callbackArgs.UrlLoadingStrategy);
+					}
+
+					if (callbackArgs.UrlLoadingStrategy == UrlLoadingStrategy.OpenExternally)
+					{
+						var intent = new Intent(Intent.ActionView, Uri.Parse(requestUrl));
+						view.Context.StartActivity(intent);
+					}
+					else if (callbackArgs.UrlLoadingStrategy == UrlLoadingStrategy.OpenInWebView)
+					{
+						view.LoadUrl(requestUrl!);
+					}
+					// CancelLoad: do nothing
+				}
+				else if (!string.IsNullOrEmpty(requestUrl))
+				{
+					// Fallback for non-parseable URIs: open externally
+					var intent = new Intent(Intent.ActionView, Uri.Parse(requestUrl));
+					view.Context.StartActivity(intent);
+				}
 			}
 
 			// We don't actually want to create a new WebView window so we just return false 

--- a/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
+++ b/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Threading.Tasks;
-using Android.Window;
 using Android.Webkit;
 using Android.Widget;
+using Android.Window;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			_webViewClient = new WebKitWebViewClient(this);
 			blazorAndroidWebView.SetWebViewClient(_webViewClient);
 
-			_webChromeClient = new BlazorWebChromeClient();
+			_webChromeClient = new BlazorWebChromeClient(this);
 			blazorAndroidWebView.SetWebChromeClient(_webChromeClient);
 
 			Logger.CreatedAndroidWebkitWebView();

--- a/src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs
+++ b/src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs
@@ -49,7 +49,10 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 
 			// This method never gets called for navigation to a new window ('_blank'),
 			// so we know we can safely invoke the UrlLoading event.
-			var callbackArgs = UrlLoadingEventArgs.CreateWithDefaultLoadingStrategy(uri, AppOriginUri);
+			var target = (request?.IsForMainFrame == true)
+				? Microsoft.Maui.WebNavigationTarget.MainFrame
+				: Microsoft.Maui.WebNavigationTarget.Frame;
+			var callbackArgs = UrlLoadingEventArgs.CreateWithDefaultLoadingStrategy(uri, AppOriginUri, target);
 			_webViewHandler.UrlLoading(callbackArgs);
 			_webViewHandler.Logger.NavigationEvent(uri, callbackArgs.UrlLoadingStrategy);
 

--- a/src/BlazorWebView/src/Maui/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Maui/BlazorWebView.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using System.Threading.Tasks;
 using System.Runtime.Versioning;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Maui;

--- a/src/BlazorWebView/src/Maui/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
-#nullable enable
+﻿#nullable enable
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Target.get -> Microsoft.Maui.WebNavigationTarget
 override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.ConnectHandler(Android.Webkit.WebView! platformView) -> void

--- a/src/BlazorWebView/src/Maui/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
-#nullable enable
+﻿#nullable enable
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Target.get -> Microsoft.Maui.WebNavigationTarget

--- a/src/BlazorWebView/src/Maui/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
-#nullable enable
+﻿#nullable enable
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Target.get -> Microsoft.Maui.WebNavigationTarget

--- a/src/BlazorWebView/src/Maui/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Target.get -> Microsoft.Maui.WebNavigationTarget

--- a/src/BlazorWebView/src/Maui/iOS/IOSWebViewManager.cs
+++ b/src/BlazorWebView/src/Maui/iOS/IOSWebViewManager.cs
@@ -274,12 +274,19 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				if (navigationAction.TargetFrame is null)
 				{
 					// Open in a new browser window regardless of UrlLoadingStrategy
-					strategy = UrlLoadingStrategy.OpenExternally;
+					var callbackArgs = UrlLoadingEventArgs.CreateWithDefaultLoadingStrategy(uri, BlazorWebViewHandler.AppOriginUri, Microsoft.Maui.WebNavigationTarget.NewWindow);
+					_webView.UrlLoading(callbackArgs);
+					_webView.Logger.NavigationEvent(uri, callbackArgs.UrlLoadingStrategy);
+					strategy = callbackArgs.UrlLoadingStrategy;
 				}
 				else
 				{
+					var target = navigationAction.TargetFrame.MainFrame
+						? Microsoft.Maui.WebNavigationTarget.MainFrame
+						: Microsoft.Maui.WebNavigationTarget.Frame;
+
 					// Invoke the UrlLoading event to allow overriding the default link handling behavior
-					var callbackArgs = UrlLoadingEventArgs.CreateWithDefaultLoadingStrategy(uri, BlazorWebViewHandler.AppOriginUri);
+					var callbackArgs = UrlLoadingEventArgs.CreateWithDefaultLoadingStrategy(uri, BlazorWebViewHandler.AppOriginUri, target);
 					_webView.UrlLoading(callbackArgs);
 					_webView.Logger.NavigationEvent(uri, callbackArgs.UrlLoadingStrategy);
 

--- a/src/BlazorWebView/src/SharedSource/UrlLoadingEventArgs.cs
+++ b/src/BlazorWebView/src/SharedSource/UrlLoadingEventArgs.cs
@@ -20,11 +20,31 @@ namespace Microsoft.AspNetCore.Components.WebView
 			return new(urlToLoad, strategy);
 		}
 
+#if WEBVIEW2_MAUI
+		internal static UrlLoadingEventArgs CreateWithDefaultLoadingStrategy(Uri urlToLoad, Uri appOriginUri, Microsoft.Maui.WebNavigationTarget target)
+		{
+			var strategy = appOriginUri.IsBaseOf(urlToLoad) ?
+				UrlLoadingStrategy.OpenInWebView :
+				UrlLoadingStrategy.OpenExternally;
+
+			return new(urlToLoad, strategy, target);
+		}
+#endif
+
 		private UrlLoadingEventArgs(Uri url, UrlLoadingStrategy urlLoadingStrategy)
 		{
 			Url = url;
 			UrlLoadingStrategy = urlLoadingStrategy;
 		}
+
+#if WEBVIEW2_MAUI
+		private UrlLoadingEventArgs(Uri url, UrlLoadingStrategy urlLoadingStrategy, Microsoft.Maui.WebNavigationTarget target)
+		{
+			Url = url;
+			UrlLoadingStrategy = urlLoadingStrategy;
+			Target = target;
+		}
+#endif
 
 		/// <summary>
 		/// Gets the <see cref="Url">URL</see> to be loaded.
@@ -41,5 +61,12 @@ namespace Microsoft.AspNetCore.Components.WebView
 		/// </para>
 		/// </summary>
 		public UrlLoadingStrategy UrlLoadingStrategy { get; set; }
+
+#if WEBVIEW2_MAUI
+		/// <summary>
+		/// Gets the navigation target indicating which frame initiated the navigation (main frame, iframe, or new window).
+		/// </summary>
+		public Microsoft.Maui.WebNavigationTarget Target { get; }
+#endif
 	}
 }

--- a/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
+++ b/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
@@ -303,6 +303,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 			};
 
 			_webview.CoreWebView2.NavigationStarting += CoreWebView2_NavigationStarting;
+			_webview.CoreWebView2.FrameNavigationStarting += CoreWebView2_FrameNavigationStarting;
 			_webview.CoreWebView2.NewWindowRequested += CoreWebView2_NewWindowRequested;
 
 			// The code inside blazor.webview.js is meant to be agnostic to specific webview technologies,
@@ -402,13 +403,54 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 			}
 		}
 
+		private void CoreWebView2_FrameNavigationStarting(object? sender, CoreWebView2NavigationStartingEventArgs args)
+		{
+			if (Uri.TryCreate(args.Uri, UriKind.RelativeOrAbsolute, out var uri))
+			{
+#if WEBVIEW2_MAUI
+				var callbackArgs = UrlLoadingEventArgs.CreateWithDefaultLoadingStrategy(uri, AppOriginUri, Microsoft.Maui.WebNavigationTarget.Frame);
+#else
+				var callbackArgs = UrlLoadingEventArgs.CreateWithDefaultLoadingStrategy(uri, AppOriginUri);
+#endif
+
+#if WEBVIEW2_WINFORMS || WEBVIEW2_WPF
+				_urlLoading?.Invoke(callbackArgs);
+#elif WEBVIEW2_MAUI
+				_blazorWebViewHandler.UrlLoading(callbackArgs);
+#endif
+				_logger.NavigationEvent(uri, callbackArgs.UrlLoadingStrategy);
+
+				if (callbackArgs.UrlLoadingStrategy == UrlLoadingStrategy.OpenExternally)
+				{
+					LaunchUriInExternalBrowser(uri);
+				}
+
+				args.Cancel = callbackArgs.UrlLoadingStrategy != UrlLoadingStrategy.OpenInWebView;
+			}
+		}
+
 		private void CoreWebView2_NewWindowRequested(object? sender, CoreWebView2NewWindowRequestedEventArgs args)
 		{
 			// Intercept _blank target <a> tags to always open in device browser.
-			// The ExternalLinkCallback is not invoked.
 			if (Uri.TryCreate(args.Uri, UriKind.RelativeOrAbsolute, out var uri))
 			{
+#if WEBVIEW2_MAUI
+				var callbackArgs = UrlLoadingEventArgs.CreateWithDefaultLoadingStrategy(uri, AppOriginUri, Microsoft.Maui.WebNavigationTarget.NewWindow);
+				_blazorWebViewHandler.UrlLoading(callbackArgs);
+				_logger.NavigationEvent(uri, callbackArgs.UrlLoadingStrategy);
+
+				if (callbackArgs.UrlLoadingStrategy == UrlLoadingStrategy.OpenExternally)
+				{
+					LaunchUriInExternalBrowser(uri);
+				}
+				else if (callbackArgs.UrlLoadingStrategy == UrlLoadingStrategy.OpenInWebView)
+				{
+					_webview.CoreWebView2.Navigate(args.Uri);
+				}
+				// CancelLoad: do nothing
+#else
 				LaunchUriInExternalBrowser(uri);
+#endif
 				args.Handled = true;
 			}
 		}

--- a/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
+++ b/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
@@ -380,7 +380,11 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 		{
 			if (Uri.TryCreate(args.Uri, UriKind.RelativeOrAbsolute, out var uri))
 			{
+#if WEBVIEW2_MAUI
+				var callbackArgs = UrlLoadingEventArgs.CreateWithDefaultLoadingStrategy(uri, AppOriginUri, Microsoft.Maui.WebNavigationTarget.MainFrame);
+#else
 				var callbackArgs = UrlLoadingEventArgs.CreateWithDefaultLoadingStrategy(uri, AppOriginUri);
+#endif
 
 #if WEBVIEW2_WINFORMS || WEBVIEW2_WPF
 				_urlLoading?.Invoke(callbackArgs);

--- a/src/Controls/src/Core/HybridWebView/HybridWebView.cs
+++ b/src/Controls/src/Core/HybridWebView/HybridWebView.cs
@@ -113,6 +113,22 @@ namespace Microsoft.Maui.Controls
 		/// </summary>
 		public event EventHandler<WebViewWebResourceRequestedEventArgs>? WebResourceRequested;
 
+		/// <inheritdoc/>
+		bool INavigatingAwareWebView.Navigating(WebViewNavigatingEventArgs args)
+		{
+			var platformArgs = new PlatformHybridWebViewNavigatingEventArgs(args);
+			var e = new HybridWebViewNavigatingEventArgs(args.Url, args.Target, platformArgs);
+			Navigating?.Invoke(this, e);
+			return e.Cancel;
+		}
+
+		/// <summary>
+		/// Raised when the web view is about to navigate to a new URL. Set <see cref="HybridWebViewNavigatingEventArgs.Cancel"/>
+		/// to <c>true</c> to prevent the navigation.
+		/// </summary>
+		public event EventHandler<HybridWebViewNavigatingEventArgs>? Navigating;
+
+
 		/// <summary>
 		/// Sends a raw message to the code running in the web view. Raw messages have no additional processing.
 		/// </summary>

--- a/src/Controls/src/Core/HybridWebView/HybridWebViewNavigatingEventArgs.cs
+++ b/src/Controls/src/Core/HybridWebView/HybridWebViewNavigatingEventArgs.cs
@@ -1,0 +1,43 @@
+﻿using System;
+
+namespace Microsoft.Maui.Controls
+{
+	/// <summary>
+	/// Provides data for the <see cref="HybridWebView.Navigating"/> event.
+	/// </summary>
+	public class HybridWebViewNavigatingEventArgs : EventArgs
+	{
+		/// <summary>
+		/// Initializes a new instance of <see cref="HybridWebViewNavigatingEventArgs"/>.
+		/// </summary>
+		/// <param name="url">The URI being navigated to.</param>
+		/// <param name="target">The frame target of the navigation.</param>
+		/// <param name="platformArgs">Platform-specific event arguments, or <c>null</c> if not available.</param>
+		public HybridWebViewNavigatingEventArgs(Uri? url, WebNavigationTarget target, PlatformHybridWebViewNavigatingEventArgs? platformArgs)
+		{
+			Url = url;
+			Target = target;
+			PlatformArgs = platformArgs;
+		}
+
+		/// <summary>
+		/// Gets the URI being navigated to.
+		/// </summary>
+		public Uri? Url { get; }
+
+		/// <summary>
+		/// Gets the frame target of the navigation (main frame, iframe, or new window).
+		/// </summary>
+		public WebNavigationTarget Target { get; }
+
+		/// <summary>
+		/// Gets or sets a value indicating whether the navigation should be cancelled.
+		/// </summary>
+		public bool Cancel { get; set; }
+
+		/// <summary>
+		/// Gets platform-specific event arguments that provide access to native navigation objects.
+		/// </summary>
+		public PlatformHybridWebViewNavigatingEventArgs? PlatformArgs { get; }
+	}
+}

--- a/src/Controls/src/Core/HybridWebView/PlatformHybridWebViewNavigatingEventArgs.cs
+++ b/src/Controls/src/Core/HybridWebView/PlatformHybridWebViewNavigatingEventArgs.cs
@@ -1,0 +1,71 @@
+﻿namespace Microsoft.Maui.Controls
+{
+	/// <summary>
+	/// Provides platform-specific information about the <see cref="HybridWebViewNavigatingEventArgs"/> event.
+	/// </summary>
+	public class PlatformHybridWebViewNavigatingEventArgs
+	{
+#if WINDOWS
+
+		internal PlatformHybridWebViewNavigatingEventArgs(WebViewNavigatingEventArgs args)
+		{
+			NavigationArgs = args.NavigationArgs;
+			NewWindowArgs = args.NewWindowArgs;
+		}
+
+		/// <summary>
+		/// Gets the native navigation starting event args. Non-null for MainFrame and Frame navigations.
+		/// </summary>
+		/// <remarks>
+		/// This is only available on Windows.
+		/// </remarks>
+		public global::Microsoft.Web.WebView2.Core.CoreWebView2NavigationStartingEventArgs? NavigationArgs { get; }
+
+		/// <summary>
+		/// Gets the native new window requested event args. Non-null for NewWindow navigations.
+		/// </summary>
+		/// <remarks>
+		/// This is only available on Windows.
+		/// </remarks>
+		public global::Microsoft.Web.WebView2.Core.CoreWebView2NewWindowRequestedEventArgs? NewWindowArgs { get; }
+
+#elif IOS || MACCATALYST
+
+		internal PlatformHybridWebViewNavigatingEventArgs(WebViewNavigatingEventArgs args)
+		{
+			NavigationAction = args.NavigationAction;
+		}
+
+		/// <summary>
+		/// Gets the native navigation action that triggered the event. Contains frame and request info.
+		/// </summary>
+		/// <remarks>
+		/// This is only available on iOS and Mac Catalyst.
+		/// </remarks>
+		public global::WebKit.WKNavigationAction NavigationAction { get; }
+
+#elif ANDROID
+
+		internal PlatformHybridWebViewNavigatingEventArgs(WebViewNavigatingEventArgs args)
+		{
+			Request = args.Request;
+		}
+
+		/// <summary>
+		/// Gets the native web resource request. Contains URL, headers, and IsForMainFrame info.
+		/// </summary>
+		/// <remarks>
+		/// This is only available on Android.
+		/// </remarks>
+		public global::Android.Webkit.IWebResourceRequest? Request { get; }
+
+#else
+
+		internal PlatformHybridWebViewNavigatingEventArgs(WebViewNavigatingEventArgs args)
+		{
+		}
+
+#endif
+	}
+}
+

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,13 +1,23 @@
 ﻿#nullable enable
-*REMOVED*~static readonly Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer.DefaultForegroundColor -> Microsoft.Maui.Graphics.Color
-*REMOVED*~static readonly Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer.DefaultTitleColor -> Microsoft.Maui.Graphics.Color
-~static Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer.DefaultForegroundColor.get -> Microsoft.Maui.Graphics.Color
-~static Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer.DefaultTitleColor.get -> Microsoft.Maui.Graphics.Color
-override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void
+Microsoft.Maui.Controls.HybridWebView.Navigating -> System.EventHandler<Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs!>?
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.Cancel.get -> bool
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.Cancel.set -> void
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.HybridWebViewNavigatingEventArgs(System.Uri? url, Microsoft.Maui.WebNavigationTarget target, Microsoft.Maui.Controls.PlatformHybridWebViewNavigatingEventArgs? platformArgs) -> void
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.PlatformArgs.get -> Microsoft.Maui.Controls.PlatformHybridWebViewNavigatingEventArgs?
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.Target.get -> Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.Url.get -> System.Uri?
+Microsoft.Maui.Controls.PlatformHybridWebViewNavigatingEventArgs
+Microsoft.Maui.Controls.PlatformHybridWebViewNavigatingEventArgs.Request.get -> Android.Webkit.IWebResourceRequest?
+override Microsoft.Maui.Controls.GraphicsView.OnBindingContextChanged() -> void
 ~override Microsoft.Maui.Controls.Handlers.Items.MauiRecyclerView<TItemsView, TAdapter, TItemsViewSource>.OnInterceptTouchEvent(Android.Views.MotionEvent e) -> bool
 ~override Microsoft.Maui.Controls.Handlers.Items.MauiRecyclerView<TItemsView, TAdapter, TItemsViewSource>.OnTouchEvent(Android.Views.MotionEvent e) -> bool
-override Microsoft.Maui.Controls.GraphicsView.OnBindingContextChanged() -> void
-override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.OnHiddenChanged(bool hidden) -> void
 ~override Microsoft.Maui.Controls.Handlers.Items.RecyclerViewScrollListener<TItemsView, TItemsViewSource>.OnScrollStateChanged(AndroidX.RecyclerView.Widget.RecyclerView recyclerView, int newState) -> void
 ~override Microsoft.Maui.Controls.Handlers.Items.SelectableItemsViewAdapter<TItemsView, TItemsSource>.IsSelectionEnabled(Android.Views.ViewGroup parent, int viewType) -> bool
+override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.OnHiddenChanged(bool hidden) -> void
+override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void
 override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
+~static Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer.DefaultForegroundColor.get -> Microsoft.Maui.Graphics.Color
+~static Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer.DefaultTitleColor.get -> Microsoft.Maui.Graphics.Color
+*REMOVED*~static readonly Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer.DefaultForegroundColor -> Microsoft.Maui.Graphics.Color
+*REMOVED*~static readonly Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer.DefaultTitleColor -> Microsoft.Maui.Graphics.Color

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -9,6 +9,11 @@ Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.Target.get -> Microsoft
 Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.Url.get -> System.Uri?
 Microsoft.Maui.Controls.PlatformHybridWebViewNavigatingEventArgs
 Microsoft.Maui.Controls.PlatformHybridWebViewNavigatingEventArgs.Request.get -> Android.Webkit.IWebResourceRequest?
+Microsoft.Maui.Controls.PlatformWebNavigatingEventArgs
+Microsoft.Maui.Controls.PlatformWebNavigatingEventArgs.Request.get -> Android.Webkit.IWebResourceRequest?
+~Microsoft.Maui.Controls.WebNavigatingEventArgs.PlatformArgs.get -> Microsoft.Maui.Controls.PlatformWebNavigatingEventArgs
+Microsoft.Maui.Controls.WebNavigatingEventArgs.Target.get -> Microsoft.Maui.WebNavigationTarget
+~Microsoft.Maui.Controls.WebNavigatingEventArgs.WebNavigatingEventArgs(Microsoft.Maui.WebNavigationEvent navigationEvent, Microsoft.Maui.Controls.WebViewSource source, string url, Microsoft.Maui.WebNavigationTarget target, Microsoft.Maui.Controls.PlatformWebNavigatingEventArgs platformArgs) -> void
 override Microsoft.Maui.Controls.GraphicsView.OnBindingContextChanged() -> void
 ~override Microsoft.Maui.Controls.Handlers.Items.MauiRecyclerView<TItemsView, TAdapter, TItemsViewSource>.OnInterceptTouchEvent(Android.Views.MotionEvent e) -> bool
 ~override Microsoft.Maui.Controls.Handlers.Items.MauiRecyclerView<TItemsView, TAdapter, TItemsViewSource>.OnTouchEvent(Android.Views.MotionEvent e) -> bool

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,13 +1,28 @@
-#nullable enable
-override Microsoft.Maui.Controls.Handlers.Items.MauiCollectionView.AddSubview(UIKit.UIView! view) -> void
-override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void
-override Microsoft.Maui.Controls.Handlers.Items2.CarouselViewController2.Dispose(bool disposing) -> void
-~override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
-override Microsoft.Maui.Controls.Platform.Compatibility.ShellTableViewController.LoadView() -> void
-*REMOVED*~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
+﻿#nullable enable
+Microsoft.Maui.Controls.HybridWebView.Navigating -> System.EventHandler<Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs!>?
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.Cancel.get -> bool
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.Cancel.set -> void
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.HybridWebViewNavigatingEventArgs(System.Uri? url, Microsoft.Maui.WebNavigationTarget target, Microsoft.Maui.Controls.PlatformHybridWebViewNavigatingEventArgs? platformArgs) -> void
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.PlatformArgs.get -> Microsoft.Maui.Controls.PlatformHybridWebViewNavigatingEventArgs?
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.Target.get -> Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.Url.get -> System.Uri?
+Microsoft.Maui.Controls.PlatformHybridWebViewNavigatingEventArgs
+Microsoft.Maui.Controls.PlatformHybridWebViewNavigatingEventArgs.NavigationAction.get -> WebKit.WKNavigationAction!
+Microsoft.Maui.Controls.PlatformWebNavigatingEventArgs
+Microsoft.Maui.Controls.PlatformWebNavigatingEventArgs.NavigationAction.get -> WebKit.WKNavigationAction!
+~Microsoft.Maui.Controls.WebNavigatingEventArgs.PlatformArgs.get -> Microsoft.Maui.Controls.PlatformWebNavigatingEventArgs
+Microsoft.Maui.Controls.WebNavigatingEventArgs.Target.get -> Microsoft.Maui.WebNavigationTarget
+~Microsoft.Maui.Controls.WebNavigatingEventArgs.WebNavigatingEventArgs(Microsoft.Maui.WebNavigationEvent navigationEvent, Microsoft.Maui.Controls.WebViewSource source, string url, Microsoft.Maui.WebNavigationTarget target, Microsoft.Maui.Controls.PlatformWebNavigatingEventArgs platformArgs) -> void
 override Microsoft.Maui.Controls.GraphicsView.OnBindingContextChanged() -> void
+override Microsoft.Maui.Controls.Handlers.Items.MauiCollectionView.AddSubview(UIKit.UIView! view) -> void
+override Microsoft.Maui.Controls.Handlers.Items2.CarouselViewController2.Dispose(bool disposing) -> void
 ~override Microsoft.Maui.Controls.Handlers.Items2.CollectionViewHandler2.DisconnectHandler(UIKit.UIView platformView) -> void
+override Microsoft.Maui.Controls.Handlers.Items2.StructuredItemsViewController2<TItemsView>.UpdateFlowDirection() -> void
+~override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
 override Microsoft.Maui.Controls.Platform.Compatibility.ShellItemRenderer.ViewDidAppear(bool animated) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.DidMoveToParentViewController(UIKit.UIViewController parent) -> void
+*REMOVED*~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
+override Microsoft.Maui.Controls.Platform.Compatibility.ShellTableViewController.LoadView() -> void
+override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void
 override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
-override Microsoft.Maui.Controls.Handlers.Items2.StructuredItemsViewController2<TItemsView>.UpdateFlowDirection() -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,13 +1,28 @@
-#nullable enable
-override Microsoft.Maui.Controls.Handlers.Items.MauiCollectionView.AddSubview(UIKit.UIView! view) -> void
-override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void
-override Microsoft.Maui.Controls.Handlers.Items2.CarouselViewController2.Dispose(bool disposing) -> void
-~override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
-override Microsoft.Maui.Controls.Platform.Compatibility.ShellTableViewController.LoadView() -> void
-*REMOVED*~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
+﻿#nullable enable
+Microsoft.Maui.Controls.HybridWebView.Navigating -> System.EventHandler<Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs!>?
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.Cancel.get -> bool
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.Cancel.set -> void
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.HybridWebViewNavigatingEventArgs(System.Uri? url, Microsoft.Maui.WebNavigationTarget target, Microsoft.Maui.Controls.PlatformHybridWebViewNavigatingEventArgs? platformArgs) -> void
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.PlatformArgs.get -> Microsoft.Maui.Controls.PlatformHybridWebViewNavigatingEventArgs?
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.Target.get -> Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.Url.get -> System.Uri?
+Microsoft.Maui.Controls.PlatformHybridWebViewNavigatingEventArgs
+Microsoft.Maui.Controls.PlatformHybridWebViewNavigatingEventArgs.NavigationAction.get -> WebKit.WKNavigationAction!
+Microsoft.Maui.Controls.PlatformWebNavigatingEventArgs
+Microsoft.Maui.Controls.PlatformWebNavigatingEventArgs.NavigationAction.get -> WebKit.WKNavigationAction!
+~Microsoft.Maui.Controls.WebNavigatingEventArgs.PlatformArgs.get -> Microsoft.Maui.Controls.PlatformWebNavigatingEventArgs
+Microsoft.Maui.Controls.WebNavigatingEventArgs.Target.get -> Microsoft.Maui.WebNavigationTarget
+~Microsoft.Maui.Controls.WebNavigatingEventArgs.WebNavigatingEventArgs(Microsoft.Maui.WebNavigationEvent navigationEvent, Microsoft.Maui.Controls.WebViewSource source, string url, Microsoft.Maui.WebNavigationTarget target, Microsoft.Maui.Controls.PlatformWebNavigatingEventArgs platformArgs) -> void
 override Microsoft.Maui.Controls.GraphicsView.OnBindingContextChanged() -> void
+override Microsoft.Maui.Controls.Handlers.Items.MauiCollectionView.AddSubview(UIKit.UIView! view) -> void
+override Microsoft.Maui.Controls.Handlers.Items2.CarouselViewController2.Dispose(bool disposing) -> void
 ~override Microsoft.Maui.Controls.Handlers.Items2.CollectionViewHandler2.DisconnectHandler(UIKit.UIView platformView) -> void
+override Microsoft.Maui.Controls.Handlers.Items2.StructuredItemsViewController2<TItemsView>.UpdateFlowDirection() -> void
+~override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
 override Microsoft.Maui.Controls.Platform.Compatibility.ShellItemRenderer.ViewDidAppear(bool animated) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.DidMoveToParentViewController(UIKit.UIViewController parent) -> void
+*REMOVED*~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
+override Microsoft.Maui.Controls.Platform.Compatibility.ShellTableViewController.LoadView() -> void
+override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void
 override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
-override Microsoft.Maui.Controls.Handlers.Items2.StructuredItemsViewController2<TItemsView>.UpdateFlowDirection() -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,4 +1,21 @@
 #nullable enable
+Microsoft.Maui.Controls.HybridWebView.Navigating -> System.EventHandler<Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs!>?
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.Cancel.get -> bool
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.Cancel.set -> void
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.HybridWebViewNavigatingEventArgs(System.Uri? url, Microsoft.Maui.WebNavigationTarget target, Microsoft.Maui.Controls.PlatformHybridWebViewNavigatingEventArgs? platformArgs) -> void
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.PlatformArgs.get -> Microsoft.Maui.Controls.PlatformHybridWebViewNavigatingEventArgs?
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.Target.get -> Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.Url.get -> System.Uri?
+Microsoft.Maui.Controls.PlatformHybridWebViewNavigatingEventArgs
+Microsoft.Maui.Controls.PlatformHybridWebViewNavigatingEventArgs.NavigationArgs.get -> Microsoft.Web.WebView2.Core.CoreWebView2NavigationStartingEventArgs?
+Microsoft.Maui.Controls.PlatformHybridWebViewNavigatingEventArgs.NewWindowArgs.get -> Microsoft.Web.WebView2.Core.CoreWebView2NewWindowRequestedEventArgs?
+Microsoft.Maui.Controls.PlatformWebNavigatingEventArgs
+Microsoft.Maui.Controls.PlatformWebNavigatingEventArgs.NavigationArgs.get -> Microsoft.Web.WebView2.Core.CoreWebView2NavigationStartingEventArgs?
+Microsoft.Maui.Controls.PlatformWebNavigatingEventArgs.NewWindowArgs.get -> Microsoft.Web.WebView2.Core.CoreWebView2NewWindowRequestedEventArgs?
+~Microsoft.Maui.Controls.WebNavigatingEventArgs.PlatformArgs.get -> Microsoft.Maui.Controls.PlatformWebNavigatingEventArgs
+Microsoft.Maui.Controls.WebNavigatingEventArgs.Target.get -> Microsoft.Maui.WebNavigationTarget
+~Microsoft.Maui.Controls.WebNavigatingEventArgs.WebNavigatingEventArgs(Microsoft.Maui.WebNavigationEvent navigationEvent, Microsoft.Maui.Controls.WebViewSource source, string url, Microsoft.Maui.WebNavigationTarget target, Microsoft.Maui.Controls.PlatformWebNavigatingEventArgs platformArgs) -> void
 ~override Microsoft.Maui.Controls.Handlers.Items.CarouselViewHandler.ScrollTo(Microsoft.Maui.Controls.ScrollToRequestEventArgs args) -> System.Threading.Tasks.Task
 override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void
 override Microsoft.Maui.Controls.GraphicsView.OnBindingContextChanged() -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,4 +1,17 @@
 #nullable enable
+Microsoft.Maui.Controls.HybridWebView.Navigating -> System.EventHandler<Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs!>?
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.Cancel.get -> bool
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.Cancel.set -> void
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.HybridWebViewNavigatingEventArgs(System.Uri? url, Microsoft.Maui.WebNavigationTarget target, Microsoft.Maui.Controls.PlatformHybridWebViewNavigatingEventArgs? platformArgs) -> void
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.PlatformArgs.get -> Microsoft.Maui.Controls.PlatformHybridWebViewNavigatingEventArgs?
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.Target.get -> Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.Url.get -> System.Uri?
+Microsoft.Maui.Controls.PlatformHybridWebViewNavigatingEventArgs
+Microsoft.Maui.Controls.PlatformWebNavigatingEventArgs
+~Microsoft.Maui.Controls.WebNavigatingEventArgs.PlatformArgs.get -> Microsoft.Maui.Controls.PlatformWebNavigatingEventArgs
+Microsoft.Maui.Controls.WebNavigatingEventArgs.Target.get -> Microsoft.Maui.WebNavigationTarget
+~Microsoft.Maui.Controls.WebNavigatingEventArgs.WebNavigatingEventArgs(Microsoft.Maui.WebNavigationEvent navigationEvent, Microsoft.Maui.Controls.WebViewSource source, string url, Microsoft.Maui.WebNavigationTarget target, Microsoft.Maui.Controls.PlatformWebNavigatingEventArgs platformArgs) -> void
 override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void
 override Microsoft.Maui.Controls.GraphicsView.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,4 +1,17 @@
 #nullable enable
+Microsoft.Maui.Controls.HybridWebView.Navigating -> System.EventHandler<Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs!>?
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.Cancel.get -> bool
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.Cancel.set -> void
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.HybridWebViewNavigatingEventArgs(System.Uri? url, Microsoft.Maui.WebNavigationTarget target, Microsoft.Maui.Controls.PlatformHybridWebViewNavigatingEventArgs? platformArgs) -> void
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.PlatformArgs.get -> Microsoft.Maui.Controls.PlatformHybridWebViewNavigatingEventArgs?
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.Target.get -> Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs.Url.get -> System.Uri?
+Microsoft.Maui.Controls.PlatformHybridWebViewNavigatingEventArgs
+Microsoft.Maui.Controls.PlatformWebNavigatingEventArgs
+~Microsoft.Maui.Controls.WebNavigatingEventArgs.PlatformArgs.get -> Microsoft.Maui.Controls.PlatformWebNavigatingEventArgs
+Microsoft.Maui.Controls.WebNavigatingEventArgs.Target.get -> Microsoft.Maui.WebNavigationTarget
+~Microsoft.Maui.Controls.WebNavigatingEventArgs.WebNavigatingEventArgs(Microsoft.Maui.WebNavigationEvent navigationEvent, Microsoft.Maui.Controls.WebViewSource source, string url, Microsoft.Maui.WebNavigationTarget target, Microsoft.Maui.Controls.PlatformWebNavigatingEventArgs platformArgs) -> void
 override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void
 override Microsoft.Maui.Controls.GraphicsView.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void

--- a/src/Controls/src/Core/WebView/PlatformWebNavigatingEventArgs.cs
+++ b/src/Controls/src/Core/WebView/PlatformWebNavigatingEventArgs.cs
@@ -1,0 +1,70 @@
+﻿namespace Microsoft.Maui.Controls
+{
+	/// <summary>
+	/// Provides platform-specific information about the <see cref="WebNavigatingEventArgs"/> event.
+	/// </summary>
+	public class PlatformWebNavigatingEventArgs
+	{
+#if WINDOWS
+
+		internal PlatformWebNavigatingEventArgs(WebViewNavigatingEventArgs args)
+		{
+			NavigationArgs = args.NavigationArgs;
+			NewWindowArgs = args.NewWindowArgs;
+		}
+
+		/// <summary>
+		/// Gets the native navigation starting event args. Non-null for MainFrame and Frame navigations.
+		/// </summary>
+		/// <remarks>
+		/// This is only available on Windows.
+		/// </remarks>
+		public global::Microsoft.Web.WebView2.Core.CoreWebView2NavigationStartingEventArgs? NavigationArgs { get; }
+
+		/// <summary>
+		/// Gets the native new window requested event args. Non-null for NewWindow navigations.
+		/// </summary>
+		/// <remarks>
+		/// This is only available on Windows.
+		/// </remarks>
+		public global::Microsoft.Web.WebView2.Core.CoreWebView2NewWindowRequestedEventArgs? NewWindowArgs { get; }
+
+#elif IOS || MACCATALYST
+
+		internal PlatformWebNavigatingEventArgs(WebViewNavigatingEventArgs args)
+		{
+			NavigationAction = args.NavigationAction;
+		}
+
+		/// <summary>
+		/// Gets the native navigation action that triggered the event. Contains frame and request info.
+		/// </summary>
+		/// <remarks>
+		/// This is only available on iOS and Mac Catalyst.
+		/// </remarks>
+		public global::WebKit.WKNavigationAction NavigationAction { get; }
+
+#elif ANDROID
+
+		internal PlatformWebNavigatingEventArgs(WebViewNavigatingEventArgs args)
+		{
+			Request = args.Request;
+		}
+
+		/// <summary>
+		/// Gets the native web resource request. Contains URL, headers, and IsForMainFrame info.
+		/// </summary>
+		/// <remarks>
+		/// This is only available on Android.
+		/// </remarks>
+		public global::Android.Webkit.IWebResourceRequest? Request { get; }
+
+#else
+
+		internal PlatformWebNavigatingEventArgs(WebViewNavigatingEventArgs args)
+		{
+		}
+
+#endif
+	}
+}

--- a/src/Controls/src/Core/WebView/WebNavigatingEventArgs.cs
+++ b/src/Controls/src/Core/WebView/WebNavigatingEventArgs.cs
@@ -17,8 +17,32 @@ namespace Microsoft.Maui.Controls
 		}
 
 		/// <summary>
+		/// Initializes a new instance of the <see cref="WebNavigatingEventArgs"/> class with target and platform args.
+		/// </summary>
+		/// <param name="navigationEvent">The type of navigation event.</param>
+		/// <param name="source">The source of the web view content.</param>
+		/// <param name="url">The URL being navigated to.</param>
+		/// <param name="target">The navigation target (main frame, iframe, or new window).</param>
+		/// <param name="platformArgs">Platform-specific event arguments.</param>
+		public WebNavigatingEventArgs(WebNavigationEvent navigationEvent, WebViewSource source, string url, WebNavigationTarget target, PlatformWebNavigatingEventArgs platformArgs) : base(navigationEvent, source, url)
+		{
+			Target = target;
+			PlatformArgs = platformArgs;
+		}
+
+		/// <summary>
 		/// Gets or sets a value indicating whether to cancel the navigation.
 		/// </summary>
 		public bool Cancel { get; set; }
+
+		/// <summary>
+		/// Gets the frame target of the navigation (main frame, iframe, or new window).
+		/// </summary>
+		public WebNavigationTarget Target { get; } = WebNavigationTarget.MainFrame;
+
+		/// <summary>
+		/// Gets the platform-specific event arguments for the navigation event.
+		/// </summary>
+		public PlatformWebNavigatingEventArgs PlatformArgs { get; }
 	}
 }

--- a/src/Controls/src/Core/WebView/WebView.cs
+++ b/src/Controls/src/Core/WebView/WebView.cs
@@ -21,15 +21,14 @@ namespace Microsoft.Maui.Controls
 	/// The WebView supports navigation events and JavaScript evaluation.
 	/// </remarks>
 	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
-	public partial class WebView : View, IWebViewController, IElementConfiguration<WebView>, IWebView
+	public partial class WebView : View, IWebViewController, IElementConfiguration<WebView>, IWebView, INavigatingAwareWebView
 	{
 		/// <summary>Bindable property for <see cref="Source"/>.</summary>
 		public static readonly BindableProperty SourceProperty = BindableProperty.Create(nameof(Source), typeof(WebViewSource), typeof(WebView), default(WebViewSource),
 			propertyChanging: (bindable, oldvalue, newvalue) =>
 			{
 				var source = oldvalue as WebViewSource;
-				if (source != null)
-					source.SourceChanged -= ((WebView)bindable).OnSourceChanged;
+				source?.SourceChanged -= ((WebView)bindable).OnSourceChanged;
 			}, propertyChanged: (bindable, oldvalue, newvalue) =>
 			{
 				var source = newvalue as WebViewSource;
@@ -358,6 +357,21 @@ namespace Microsoft.Maui.Controls
 		bool IWebView.Navigating(WebNavigationEvent evnt, string url)
 		{
 			var args = new WebNavigatingEventArgs(evnt, new UrlWebViewSource { Url = url }, url);
+			(this as IWebViewController)?.SendNavigating(args);
+
+			return args.Cancel;
+		}
+
+		/// <inheritdoc/>
+		bool INavigatingAwareWebView.Navigating(WebViewNavigatingEventArgs coreArgs)
+		{
+			var platformArgs = new PlatformWebNavigatingEventArgs(coreArgs);
+			var args = new WebNavigatingEventArgs(
+				WebNavigationEvent.NewPage,
+				new UrlWebViewSource { Url = coreArgs.Url?.ToString() ?? string.Empty },
+				coreArgs.Url?.ToString() ?? string.Empty,
+				coreArgs.Target,
+				platformArgs);
 			(this as IWebViewController)?.SendNavigating(args);
 
 			return args.Cancel;

--- a/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_Navigating.cs
+++ b/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_Navigating.cs
@@ -1,0 +1,193 @@
+﻿#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Maui.Handlers;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests;
+
+[Category(TestCategory.HybridWebView)]
+#if WINDOWS
+[Collection(WebViewsCollection)]
+#endif
+public partial class HybridWebViewTests_Navigating : HybridWebViewTestsBase
+{
+	[Fact]
+	public Task NavigatingEventFiresOnMainFrameNavigation() =>
+		RunTest("navigationtests.html", async (hybridWebView) =>
+		{
+			var navigatingFired = new TaskCompletionSource<HybridWebViewNavigatingEventArgs>();
+
+			hybridWebView.Navigating += (sender, args) =>
+			{
+				navigatingFired.TrySetResult(args);
+				args.Cancel = true; // Cancel to prevent actual navigation away
+			};
+
+			// Trigger a main frame navigation via JavaScript
+			await hybridWebView.EvaluateJavaScriptAsync("navigateMainFrame('https://example.com/')");
+
+			var result = await WaitForResult(navigatingFired);
+
+			Assert.NotNull(result);
+			Assert.Equal(WebNavigationTarget.MainFrame, result.Target);
+			Assert.NotNull(result.Url);
+			Assert.Equal("https://example.com/", result.Url.ToString());
+		});
+
+	[Fact]
+	public Task NavigatingEventCanCancelNavigation() =>
+		RunTest("navigationtests.html", async (hybridWebView) =>
+		{
+			var navigatingFired = new TaskCompletionSource<bool>();
+
+			hybridWebView.Navigating += (sender, args) =>
+			{
+				args.Cancel = true;
+				navigatingFired.TrySetResult(true);
+			};
+
+			// Try to navigate - should be blocked
+			await hybridWebView.EvaluateJavaScriptAsync("navigateMainFrame('https://example.com/')");
+
+			var fired = await WaitForResult(navigatingFired);
+			Assert.True(fired);
+
+			// Verify we're still on the original page by checking the DOM
+			var status = await hybridWebView.EvaluateJavaScriptAsync("document.getElementById('status')?.textContent");
+			Assert.Equal("ready", status);
+		});
+
+	[Fact]
+	public Task NavigatingEventFiresForIframeNavigation() =>
+		RunTest("navigationtests.html", async (hybridWebView) =>
+		{
+			var navigatingFired = new TaskCompletionSource<HybridWebViewNavigatingEventArgs>();
+
+			hybridWebView.Navigating += (sender, args) =>
+			{
+				// Only capture iframe navigations
+				if (args.Target == WebNavigationTarget.Frame)
+				{
+					navigatingFired.TrySetResult(args);
+				}
+				args.Cancel = true;
+			};
+
+			// Trigger an iframe navigation
+			await hybridWebView.EvaluateJavaScriptAsync("navigateIframe('https://example.com/')");
+
+			var result = await WaitForResult(navigatingFired);
+
+			Assert.NotNull(result);
+			Assert.Equal(WebNavigationTarget.Frame, result.Target);
+			Assert.NotNull(result.Url);
+			Assert.Contains("example.com", result.Url.Host);
+		});
+
+	[Fact]
+	public Task NavigatingEventFiresForNewWindow() =>
+		RunTest("navigationtests.html", async (hybridWebView) =>
+		{
+			var navigatingFired = new TaskCompletionSource<HybridWebViewNavigatingEventArgs>();
+
+			hybridWebView.Navigating += (sender, args) =>
+			{
+				if (args.Target == WebNavigationTarget.NewWindow)
+				{
+					navigatingFired.TrySetResult(args);
+				}
+				args.Cancel = true;
+			};
+
+			// Trigger window.open
+			await hybridWebView.EvaluateJavaScriptAsync("openNewWindow('https://example.com/')");
+
+			var result = await WaitForResult(navigatingFired);
+
+			Assert.NotNull(result);
+			Assert.Equal(WebNavigationTarget.NewWindow, result.Target);
+			Assert.NotNull(result.Url);
+			Assert.Contains("example.com", result.Url.Host);
+		});
+
+	[Fact]
+	public Task NavigatingEventProvidesCorrectUri() =>
+		RunTest("navigationtests.html", async (hybridWebView) =>
+		{
+			var navigatingFired = new TaskCompletionSource<HybridWebViewNavigatingEventArgs>();
+
+			hybridWebView.Navigating += (sender, args) =>
+			{
+				navigatingFired.TrySetResult(args);
+				args.Cancel = true;
+			};
+
+			var expectedUrl = "https://example.com/path?query=value#fragment";
+			await hybridWebView.EvaluateJavaScriptAsync($"navigateMainFrame('{expectedUrl}')");
+
+			var result = await WaitForResult(navigatingFired);
+
+			Assert.NotNull(result);
+			Assert.NotNull(result.Url);
+			Assert.Equal("example.com", result.Url.Host);
+			Assert.Equal("/path", result.Url.AbsolutePath);
+			Assert.Contains("query=value", result.Url.Query);
+		});
+
+	[Fact]
+	public Task NavigatingEventHasPlatformArgs() =>
+		RunTest("navigationtests.html", async (hybridWebView) =>
+		{
+			var navigatingFired = new TaskCompletionSource<HybridWebViewNavigatingEventArgs>();
+
+			hybridWebView.Navigating += (sender, args) =>
+			{
+				navigatingFired.TrySetResult(args);
+				args.Cancel = true;
+			};
+
+			await hybridWebView.EvaluateJavaScriptAsync("navigateMainFrame('https://example.com/')");
+
+			var result = await WaitForResult(navigatingFired);
+
+			Assert.NotNull(result);
+			Assert.NotNull(result.PlatformArgs);
+		});
+
+	[Fact]
+	public Task NavigatingEventNotFiredForLocalAppContent() =>
+		RunTest("navigationtests.html", async (hybridWebView) =>
+		{
+			var navigatingFired = false;
+
+			hybridWebView.Navigating += (sender, args) =>
+			{
+				navigatingFired = true;
+			};
+
+			// Request a local resource (app:// scheme) - should NOT fire Navigating
+			var result = await hybridWebView.EvaluateJavaScriptAsync("document.getElementById('status')?.textContent");
+			Assert.Equal("ready", result);
+
+			// Give a moment for any async events to fire
+			await Task.Delay(500);
+
+			Assert.False(navigatingFired, "Navigating event should not fire for local app content");
+		});
+
+	private static async Task<T> WaitForResult<T>(TaskCompletionSource<T> tcs, int timeoutMs = 5000)
+	{
+		using var cts = new CancellationTokenSource(timeoutMs);
+		var registration = cts.Token.Register(() => tcs.TrySetException(new TimeoutException("Timed out waiting for Navigating event")));
+		try
+		{
+			return await tcs.Task;
+		}
+		finally
+		{
+			await registration.DisposeAsync();
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/WebView/WebViewTests.NavigatingTarget.cs
+++ b/src/Controls/tests/DeviceTests/Elements/WebView/WebViewTests.NavigatingTarget.cs
@@ -1,0 +1,255 @@
+﻿#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.WebView)]
+#if WINDOWS
+	[Collection(WebViewsCollection)]
+#endif
+	public partial class WebViewTests : ControlsHandlerTestBase
+	{
+		[Fact]
+		public async Task NavigatingEventHasMainFrameTarget()
+		{
+			SetupBuilder();
+
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var navigatingFired = new TaskCompletionSource<WebNavigatingEventArgs>();
+
+				var webView = new WebView
+				{
+					WidthRequest = 100,
+					HeightRequest = 100,
+					Source = new HtmlWebViewSource
+					{
+						Html = @"<!DOCTYPE html><html><body>
+							<script>function nav() { window.location = 'https://example.com/'; }</script>
+							<p id='status'>ready</p>
+						</body></html>"
+					}
+				};
+
+				var handler = CreateHandler(webView);
+
+				await AttachAndRun(webView, async (handler) =>
+				{
+					// Wait for initial load
+					var loaded = new TaskCompletionSource<bool>();
+					webView.Navigated += (s, e) =>
+					{
+						if (e.Result == WebNavigationResult.Success)
+							loaded.TrySetResult(true);
+					};
+
+					using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+					cts.Token.Register(() => loaded.TrySetResult(false));
+					await loaded.Task;
+
+					// Now subscribe to Navigating
+					webView.Navigating += (s, e) =>
+					{
+						navigatingFired.TrySetResult(e);
+						e.Cancel = true;
+					};
+
+					// Trigger a main frame navigation
+					await webView.EvaluateJavaScriptAsync("nav()");
+
+					using var cts2 = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+					cts2.Token.Register(() => navigatingFired.TrySetCanceled());
+
+					var result = await navigatingFired.Task;
+
+					Assert.NotNull(result);
+					Assert.Equal(WebNavigationTarget.MainFrame, result.Target);
+					Assert.Contains("example.com", result.Url);
+				});
+			});
+		}
+
+		[Fact]
+		public async Task NavigatingEventHasPlatformArgs()
+		{
+			SetupBuilder();
+
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var navigatingFired = new TaskCompletionSource<WebNavigatingEventArgs>();
+
+				var webView = new WebView
+				{
+					WidthRequest = 100,
+					HeightRequest = 100,
+					Source = new HtmlWebViewSource
+					{
+						Html = @"<!DOCTYPE html><html><body>
+							<script>function nav() { window.location = 'https://example.com/'; }</script>
+							<p>test</p>
+						</body></html>"
+					}
+				};
+
+				var handler = CreateHandler(webView);
+
+				await AttachAndRun(webView, async (handler) =>
+				{
+					var loaded = new TaskCompletionSource<bool>();
+					webView.Navigated += (s, e) =>
+					{
+						if (e.Result == WebNavigationResult.Success)
+							loaded.TrySetResult(true);
+					};
+
+					using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+					cts.Token.Register(() => loaded.TrySetResult(false));
+					await loaded.Task;
+
+					webView.Navigating += (s, e) =>
+					{
+						navigatingFired.TrySetResult(e);
+						e.Cancel = true;
+					};
+
+					await webView.EvaluateJavaScriptAsync("window.location = 'https://example.com/'");
+
+					using var cts2 = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+					cts2.Token.Register(() => navigatingFired.TrySetCanceled());
+
+					var result = await navigatingFired.Task;
+
+					Assert.NotNull(result);
+					Assert.NotNull(result.PlatformArgs);
+				});
+			});
+		}
+
+#if WINDOWS
+		[Fact]
+		public async Task NavigatingEventHasFrameTarget()
+		{
+			SetupBuilder();
+
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var navigatingFired = new TaskCompletionSource<WebNavigatingEventArgs>();
+
+				var webView = new WebView
+				{
+					WidthRequest = 200,
+					HeightRequest = 200,
+					Source = new HtmlWebViewSource
+					{
+						Html = @"<!DOCTYPE html><html><body>
+							<iframe id='testframe' src='about:blank'></iframe>
+							<script>function navFrame() { document.getElementById('testframe').src = 'https://example.com/'; }</script>
+						</body></html>"
+					}
+				};
+
+				var handler = CreateHandler(webView);
+
+				await AttachAndRun(webView, async (handler) =>
+				{
+					var loaded = new TaskCompletionSource<bool>();
+					webView.Navigated += (s, e) =>
+					{
+						if (e.Result == WebNavigationResult.Success)
+							loaded.TrySetResult(true);
+					};
+
+					using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+					cts.Token.Register(() => loaded.TrySetResult(false));
+					await loaded.Task;
+
+					webView.Navigating += (s, e) =>
+					{
+						if (e.Target == WebNavigationTarget.Frame)
+						{
+							navigatingFired.TrySetResult(e);
+							e.Cancel = true;
+						}
+					};
+
+					await webView.EvaluateJavaScriptAsync("navFrame()");
+
+					using var cts2 = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+					cts2.Token.Register(() => navigatingFired.TrySetCanceled());
+
+					var result = await navigatingFired.Task;
+
+					Assert.NotNull(result);
+					Assert.Equal(WebNavigationTarget.Frame, result.Target);
+					Assert.Contains("example.com", result.Url);
+				});
+			});
+		}
+#endif
+
+		[Fact]
+		public async Task NavigatingEventHasNewWindowTarget()
+		{
+			SetupBuilder();
+
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var navigatingFired = new TaskCompletionSource<WebNavigatingEventArgs>();
+
+				var webView = new WebView
+				{
+					WidthRequest = 100,
+					HeightRequest = 100,
+					Source = new HtmlWebViewSource
+					{
+						Html = @"<!DOCTYPE html><html><body>
+							<script>function openWin() { window.open('https://example.com/', '_blank'); }</script>
+							<p>test</p>
+						</body></html>"
+					}
+				};
+
+				var handler = CreateHandler(webView);
+
+				await AttachAndRun(webView, async (handler) =>
+				{
+					var loaded = new TaskCompletionSource<bool>();
+					webView.Navigated += (s, e) =>
+					{
+						if (e.Result == WebNavigationResult.Success)
+							loaded.TrySetResult(true);
+					};
+
+					using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+					cts.Token.Register(() => loaded.TrySetResult(false));
+					await loaded.Task;
+
+					webView.Navigating += (s, e) =>
+					{
+						if (e.Target == WebNavigationTarget.NewWindow)
+						{
+							navigatingFired.TrySetResult(e);
+							e.Cancel = true;
+						}
+					};
+
+					await webView.EvaluateJavaScriptAsync("openWin()");
+
+					using var cts2 = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+					cts2.Token.Register(() => navigatingFired.TrySetCanceled());
+
+					var result = await navigatingFired.Task;
+
+					Assert.NotNull(result);
+					Assert.Equal(WebNavigationTarget.NewWindow, result.Target);
+					Assert.Contains("example.com", result.Url);
+				});
+			});
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Resources/Raw/HybridTestRoot/navigationtests.html
+++ b/src/Controls/tests/DeviceTests/Resources/Raw/HybridTestRoot/navigationtests.html
@@ -1,0 +1,27 @@
+﻿<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title>Navigation Tests</title>
+    <link rel="icon" href="data:,">
+    <script src="_framework/hybridwebview.js"></script>
+</head>
+<body>
+    <div id="status">ready</div>
+    <iframe id="testframe" style="width:100px;height:100px;"></iframe>
+    <script>
+        function navigateMainFrame(url) {
+            window.location.href = url;
+        }
+
+        function navigateIframe(url) {
+            document.getElementById('testframe').src = url;
+        }
+
+        function openNewWindow(url) {
+            window.open(url, '_blank');
+        }
+    </script>
+</body>
+</html>

--- a/src/Core/src/Core/IHybridWebView.cs
+++ b/src/Core/src/Core/IHybridWebView.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Maui
 {
-	public interface IHybridWebView : IView, IWebRequestInterceptingWebView, IInitializationAwareWebView
+	public interface IHybridWebView : IView, IWebRequestInterceptingWebView, IInitializationAwareWebView, INavigatingAwareWebView
 	{
 		/// <summary>
 		/// Specifies the file within the <see cref="HybridRoot"/> that should be served as the default file. The

--- a/src/Core/src/Core/INavigatingAwareWebView.cs
+++ b/src/Core/src/Core/INavigatingAwareWebView.cs
@@ -1,0 +1,18 @@
+namespace Microsoft.Maui;
+
+/// <summary>
+/// Interface for web views that support navigation interception.
+/// </summary>
+public interface INavigatingAwareWebView : IView
+{
+	/// <summary>
+	/// Invoked when the web view is about to navigate. This event can be used to intercept and cancel navigations.
+	/// </summary>
+	/// <param name="args">The event arguments containing the navigation details.</param>
+	/// <returns><c>true</c> if the navigation should be cancelled; otherwise, <c>false</c>.</returns>
+#if NETSTANDARD
+	bool Navigating(WebViewNavigatingEventArgs args);
+#else
+	bool Navigating(WebViewNavigatingEventArgs args) => false;
+#endif
+}

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Android.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Android.cs
@@ -71,6 +71,9 @@ namespace Microsoft.Maui.Handlers
 			var webViewClient = new MauiHybridWebViewClient(this);
 			PlatformView.SetWebViewClient(webViewClient);
 
+			var chromeClient = new HybridWebViewChromeClient(this);
+			PlatformView.SetWebChromeClient(chromeClient);
+
 			platformView.LoadUrl(new Uri(AppOriginUri, "/").ToString());
 		}
 
@@ -82,19 +85,54 @@ namespace Microsoft.Maui.Handlers
 				{
 					webViewClient.Disconnect();
 				}
-				//if (platformView.WebChromeClient is MauiWebChromeClient webChromeClient)
-				//{
-				//	webChromeClient.Disconnect();
-				//}
 			}
 
 			platformView.SetWebViewClient(null!);
-			//platformView.SetWebChromeClient(null);
+			platformView.SetWebChromeClient(null);
 
 			platformView.StopLoading();
 
 
 			base.DisconnectHandler(platformView);
+		}
+
+		sealed class HybridWebViewChromeClient : WebChromeClient
+		{
+			readonly WeakReference<HybridWebViewHandler> _handler;
+
+			public HybridWebViewChromeClient(HybridWebViewHandler handler)
+			{
+				_handler = new WeakReference<HybridWebViewHandler>(handler);
+			}
+
+			public override bool OnCreateWindow(AWebView? view, bool isDialog, bool isUserGesture, global::Android.OS.Message? resultMsg)
+			{
+				if (view is null || !_handler.TryGetTarget(out var handler))
+					return false;
+
+				var requestUrl = view.GetHitTestResult()?.Extra;
+				if (string.IsNullOrEmpty(requestUrl))
+					return false;
+
+				Uri.TryCreate(requestUrl, UriKind.RelativeOrAbsolute, out var uri);
+
+				if (handler.VirtualView is INavigatingAwareWebView navAware)
+				{
+					var args = new WebViewNavigatingEventArgs(uri, WebNavigationTarget.NewWindow, null);
+					bool cancel = navAware.Navigating(args);
+
+					if (!cancel)
+					{
+						view.LoadUrl(requestUrl);
+					}
+				}
+				else
+				{
+					view.LoadUrl(requestUrl);
+				}
+
+				return false;
+			}
 		}
 
 		internal static void EvaluateJavaScript(IHybridWebViewHandler handler, IHybridWebView hybridWebView, EvaluateJavaScriptAsyncRequest request)

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Windows.cs
@@ -107,6 +107,50 @@ namespace Microsoft.Maui.Handlers
 			// This prevents the WebView2.FlowDirection from being set, avoiding content mirroring
 		}
 
+		private void OnNavigationStarting(CoreWebView2NavigationStartingEventArgs args, WebNavigationTarget target)
+		{
+			var url = args.Uri;
+
+			// Don't intercept navigations to the app origin (local content)
+			if (!string.IsNullOrEmpty(url) && new Uri(url) is Uri uri && AppOriginUri.IsBaseOf(uri))
+			{
+				return;
+			}
+
+			var navUri = string.IsNullOrEmpty(url) ? null : new Uri(url);
+			var navArgs = new WebViewNavigatingEventArgs(navUri, target, args, null);
+
+			if (VirtualView is INavigatingAwareWebView navigatingView)
+			{
+				if (navigatingView.Navigating(navArgs))
+				{
+					args.Cancel = true;
+				}
+			}
+		}
+
+		private void OnNewWindowRequested(CoreWebView2NewWindowRequestedEventArgs args)
+		{
+			var url = args.Uri;
+			var navUri = string.IsNullOrEmpty(url) ? null : new Uri(url);
+			var navArgs = new WebViewNavigatingEventArgs(navUri, WebNavigationTarget.NewWindow, null, args);
+
+			bool cancel = false;
+			if (VirtualView is INavigatingAwareWebView navigatingView)
+			{
+				cancel = navigatingView.Navigating(navArgs);
+			}
+
+			// Always mark as handled - either we cancelled it or we don't want a new window
+			args.Handled = true;
+
+			// If not cancelled, load in the same WebView
+			if (!cancel && PlatformView?.CoreWebView2 is CoreWebView2 coreWebView2)
+			{
+				coreWebView2.Navigate(url);
+			}
+		}
+
 		private async void OnWebResourceRequested(CoreWebView2 sender, CoreWebView2WebResourceRequestedEventArgs eventArgs)
 		{
 			var url = eventArgs.Request.Uri;
@@ -330,6 +374,9 @@ namespace Microsoft.Maui.Handlers
 
 				webView.WebMessageReceived += OnWebMessageReceived;
 				webView.CoreWebView2.WebResourceRequested += OnWebResourceRequested;
+				webView.CoreWebView2.NavigationStarting += OnNavigationStarting;
+				webView.CoreWebView2.FrameNavigationStarting += OnFrameNavigationStarting;
+				webView.CoreWebView2.NewWindowRequested += OnNewWindowRequested;
 
 				return true;
 			}
@@ -337,6 +384,21 @@ namespace Microsoft.Maui.Handlers
 			private void OnWebResourceRequested(CoreWebView2 sender, CoreWebView2WebResourceRequestedEventArgs args)
 			{
 				Handler?.OnWebResourceRequested(sender, args);
+			}
+
+			private void OnNavigationStarting(CoreWebView2 sender, CoreWebView2NavigationStartingEventArgs args)
+			{
+				Handler?.OnNavigationStarting(args, WebNavigationTarget.MainFrame);
+			}
+
+			private void OnFrameNavigationStarting(CoreWebView2 sender, CoreWebView2NavigationStartingEventArgs args)
+			{
+				Handler?.OnNavigationStarting(args, WebNavigationTarget.Frame);
+			}
+
+			private void OnNewWindowRequested(CoreWebView2 sender, CoreWebView2NewWindowRequestedEventArgs args)
+			{
+				Handler?.OnNewWindowRequested(args);
 			}
 
 			public void Connect(Window window)
@@ -349,6 +411,9 @@ namespace Microsoft.Maui.Handlers
 			{
 				platformView.WebMessageReceived -= OnWebMessageReceived;
 				platformView.CoreWebView2.WebResourceRequested -= OnWebResourceRequested;
+				platformView.CoreWebView2.NavigationStarting -= OnNavigationStarting;
+				platformView.CoreWebView2.FrameNavigationStarting -= OnFrameNavigationStarting;
+				platformView.CoreWebView2.NewWindowRequested -= OnNewWindowRequested;
 
 				if (platformView.CoreWebView2 is CoreWebView2 webView2)
 				{

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
@@ -369,7 +369,9 @@ namespace Microsoft.Maui.Handlers
 				var requestUrl = navigationAction.Request.Url?.ToString();
 
 				// Allow navigations to the app origin (local content) without raising the event
+#pragma warning disable IL2026, IL3050 // AppOriginUri is a static field on the annotated outer class
 				if (!string.IsNullOrEmpty(requestUrl) && new Uri(requestUrl) is Uri uri && AppOriginUri.IsBaseOf(uri))
+#pragma warning restore IL2026, IL3050
 				{
 					decisionHandler(WKNavigationActionPolicy.Allow);
 					return;

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
@@ -109,6 +109,8 @@ namespace Microsoft.Maui.Handlers
 		{
 			base.ConnectHandler(platformView);
 
+			platformView.NavigationDelegate = new HybridWebViewNavigationDelegate(this);
+
 			using var nsUrl = new NSUrl(new Uri(AppOriginUri, "/").ToString());
 			using var request = new NSUrlRequest(nsUrl);
 
@@ -117,6 +119,7 @@ namespace Microsoft.Maui.Handlers
 
 		protected override void DisconnectHandler(WKWebView platformView)
 		{
+			platformView.NavigationDelegate = null!;
 			platformView.Configuration.UserContentController.RemoveScriptMessageHandler(ScriptMessageHandlerName);
 
 			base.DisconnectHandler(platformView);
@@ -339,6 +342,77 @@ namespace Microsoft.Maui.Handlers
 			[Export("webView:stopURLSchemeTask:")]
 			public void StopUrlSchemeTask(WKWebView webView, IWKUrlSchemeTask urlSchemeTask)
 			{
+			}
+		}
+
+		private sealed class HybridWebViewNavigationDelegate : NSObject, IWKNavigationDelegate
+		{
+			private readonly WeakReference<HybridWebViewHandler?> _handler;
+
+			public HybridWebViewNavigationDelegate(HybridWebViewHandler handler)
+			{
+				_handler = new(handler);
+			}
+
+			private HybridWebViewHandler? Handler => _handler.TryGetTarget(out var h) ? h : null;
+
+			[Export("webView:decidePolicyForNavigationAction:decisionHandler:")]
+			public void DecidePolicy(WKWebView webView, WKNavigationAction navigationAction, Action<WKNavigationActionPolicy> decisionHandler)
+			{
+				var handler = Handler;
+				if (handler is null)
+				{
+					decisionHandler(WKNavigationActionPolicy.Cancel);
+					return;
+				}
+
+				var requestUrl = navigationAction.Request.Url?.ToString();
+
+				// Allow navigations to the app origin (local content) without raising the event
+				if (!string.IsNullOrEmpty(requestUrl) && new Uri(requestUrl) is Uri uri && AppOriginUri.IsBaseOf(uri))
+				{
+					decisionHandler(WKNavigationActionPolicy.Allow);
+					return;
+				}
+
+				// Determine the navigation target
+				WebNavigationTarget target;
+				if (navigationAction.TargetFrame == null)
+				{
+					target = WebNavigationTarget.NewWindow;
+				}
+				else if (navigationAction.TargetFrame.MainFrame)
+				{
+					target = WebNavigationTarget.MainFrame;
+				}
+				else
+				{
+					target = WebNavigationTarget.Frame;
+				}
+
+				var navUri = string.IsNullOrEmpty(requestUrl) ? null : new Uri(requestUrl);
+				var args = new WebViewNavigatingEventArgs(navUri, target, navigationAction);
+
+				bool cancel = false;
+				if (handler.VirtualView is INavigatingAwareWebView navigatingView)
+				{
+					cancel = navigatingView.Navigating(args);
+				}
+
+				if (navigationAction.TargetFrame == null)
+				{
+					// For new window requests, if not cancelled, load in the same view
+					if (!cancel)
+					{
+						webView.LoadRequest(navigationAction.Request);
+					}
+					// Always cancel the original since WKWebView can't open new windows
+					decisionHandler(WKNavigationActionPolicy.Cancel);
+				}
+				else
+				{
+					decisionHandler(cancel ? WKNavigationActionPolicy.Cancel : WKNavigationActionPolicy.Allow);
+				}
 			}
 		}
 	}

--- a/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
@@ -146,13 +146,27 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 
-		protected internal bool NavigatingCanceled(string? url)
+		protected internal bool NavigatingCanceled(string? url, global::Android.Webkit.IWebResourceRequest? request = null)
 		{
 			if (VirtualView == null || string.IsNullOrWhiteSpace(url))
 				return true;
 
 			SyncPlatformCookies(url);
-			bool cancel = VirtualView.Navigating(CurrentNavigationEvent, url);
+
+			bool cancel;
+
+			// Use the new INavigatingAwareWebView interface if supported (provides Target + PlatformArgs)
+			if (request is not null && VirtualView is INavigatingAwareWebView navAware)
+			{
+				Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out var uri);
+				var target = (request.IsForMainFrame) ? WebNavigationTarget.MainFrame : WebNavigationTarget.Frame;
+				var args = new WebViewNavigatingEventArgs(uri, target, request);
+				cancel = navAware.Navigating(args);
+			}
+			else
+			{
+				cancel = VirtualView.Navigating(CurrentNavigationEvent, url);
+			}
 
 			// if the user disconnects from the handler we want to exit
 			if (!PlatformView.IsAlive())

--- a/src/Core/src/Handlers/WebView/WebViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.Windows.cs
@@ -67,7 +67,18 @@ namespace Microsoft.Maui.Handlers
 		{
 			if (Uri.TryCreate(args.Uri, UriKind.Absolute, out Uri? uri) && uri is not null)
 			{
-				bool cancel = VirtualView.Navigating(CurrentNavigationEvent, uri.AbsoluteUri);
+				bool cancel;
+
+				// Use INavigatingAwareWebView if available (provides Target + PlatformArgs)
+				if (VirtualView is INavigatingAwareWebView navAware)
+				{
+					var navArgs = new WebViewNavigatingEventArgs(uri, WebNavigationTarget.MainFrame, args, null);
+					cancel = navAware.Navigating(navArgs);
+				}
+				else
+				{
+					cancel = VirtualView.Navigating(CurrentNavigationEvent, uri.AbsoluteUri);
+				}
 
 				args.Cancel = cancel;
 
@@ -81,6 +92,38 @@ namespace Microsoft.Maui.Handlers
 				{
 					_navigationResult = WebNavigationResult.Success;
 				}
+			}
+		}
+
+		void OnFrameNavigationStarting(CoreWebView2 sender, CoreWebView2NavigationStartingEventArgs args)
+		{
+			if (VirtualView is INavigatingAwareWebView navAware && Uri.TryCreate(args.Uri, UriKind.Absolute, out Uri? uri))
+			{
+				var navArgs = new WebViewNavigatingEventArgs(uri, WebNavigationTarget.Frame, args, null);
+				bool cancel = navAware.Navigating(navArgs);
+				args.Cancel = cancel;
+			}
+		}
+
+		void OnNewWindowRequested(CoreWebView2 sender, CoreWebView2NewWindowRequestedEventArgs args)
+		{
+			if (VirtualView is INavigatingAwareWebView navAware && Uri.TryCreate(args.Uri, UriKind.Absolute, out Uri? uri))
+			{
+				var navArgs = new WebViewNavigatingEventArgs(uri, WebNavigationTarget.NewWindow, null, args);
+				bool cancel = navAware.Navigating(navArgs);
+
+				if (!cancel)
+				{
+					// Load in the same WebView if not cancelled
+					PlatformView?.CoreWebView2?.Navigate(args.Uri);
+				}
+
+				// Always mark as handled — we don't want WebView2 opening a new window
+				args.Handled = true;
+			}
+			else
+			{
+				args.Handled = true;
 			}
 		}
 
@@ -360,6 +403,8 @@ namespace Microsoft.Maui.Handlers
 				{
 					webView2.HistoryChanged -= OnHistoryChanged;
 					webView2.NavigationStarting -= OnNavigationStarting;
+					webView2.FrameNavigationStarting -= OnFrameNavigationStarting;
+					webView2.NewWindowRequested -= OnNewWindowRequested;
 					webView2.NavigationCompleted -= OnNavigationCompleted;
 					webView2.ProcessFailed -= OnProcessFailed;
 					webView2.Stop();
@@ -386,6 +431,8 @@ namespace Microsoft.Maui.Handlers
 			{
 				sender.CoreWebView2.HistoryChanged += OnHistoryChanged;
 				sender.CoreWebView2.NavigationStarting += OnNavigationStarting;
+				sender.CoreWebView2.FrameNavigationStarting += OnFrameNavigationStarting;
+				sender.CoreWebView2.NewWindowRequested += OnNewWindowRequested;
 				sender.CoreWebView2.NavigationCompleted += OnNavigationCompleted;
 				sender.CoreWebView2.ProcessFailed += OnProcessFailed;
 
@@ -424,6 +471,22 @@ namespace Microsoft.Maui.Handlers
 				if (Handler is WebViewHandler handler)
 				{
 					handler.OnNavigationStarting(sender, args);
+				}
+			}
+
+			void OnFrameNavigationStarting(CoreWebView2 sender, CoreWebView2NavigationStartingEventArgs args)
+			{
+				if (Handler is WebViewHandler handler)
+				{
+					handler.OnFrameNavigationStarting(sender, args);
+				}
+			}
+
+			void OnNewWindowRequested(CoreWebView2 sender, CoreWebView2NewWindowRequestedEventArgs args)
+			{
+				if (Handler is WebViewHandler handler)
+				{
+					handler.OnNewWindowRequested(sender, args);
 				}
 			}
 

--- a/src/Core/src/Platform/Android/MauiHybridWebViewClient.cs
+++ b/src/Core/src/Platform/Android/MauiHybridWebViewClient.cs
@@ -30,6 +30,33 @@ namespace Microsoft.Maui.Platform
 
 		private HybridWebViewHandler? Handler => _handler is not null && _handler.TryGetTarget(out var h) ? h : null;
 
+		public override bool ShouldOverrideUrlLoading(AWebView? view, IWebResourceRequest? request)
+		{
+			if (Handler is null || request?.Url is null)
+			{
+				return base.ShouldOverrideUrlLoading(view, request);
+			}
+
+			var uri = new Uri(request.Url.ToString()!);
+
+			// Don't intercept navigations to the app origin (local content)
+			if (HybridWebViewHandler.AppOriginUri.IsBaseOf(uri))
+			{
+				return false;
+			}
+
+			var target = request.IsForMainFrame ? WebNavigationTarget.MainFrame : WebNavigationTarget.Frame;
+			var args = new WebViewNavigatingEventArgs(uri, target, request);
+
+			if (Handler.VirtualView is INavigatingAwareWebView navigatingView)
+			{
+				return navigatingView.Navigating(args);
+			}
+
+			return false;
+		}
+
+
 		public override WebResourceResponse? ShouldInterceptRequest(AWebView? view, IWebResourceRequest? request)
 		{
 			var url = request?.Url?.ToString();

--- a/src/Core/src/Platform/Android/MauiWebChromeClient.cs
+++ b/src/Core/src/Platform/Android/MauiWebChromeClient.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Maui.Platform
 	public class MauiWebChromeClient : WebChromeClient
 	{
 		WeakReference<Activity> _activityRef;
+		WeakReference<IWebViewHandler> _handlerRef;
 		List<int> _requestCodes;
 		View _customView;
 		ICustomViewCallback _videoViewCallback;
@@ -28,8 +29,42 @@ namespace Microsoft.Maui.Platform
 			_ = handler ?? throw new ArgumentNullException(nameof(handler));
 
 			_originalOrientation = ScreenOrientation.Unspecified;
+			_handlerRef = new WeakReference<IWebViewHandler>(handler);
 
 			SetContext(handler);
+		}
+
+		public override bool OnCreateWindow(WebView view, bool isDialog, bool isUserGesture, global::Android.OS.Message resultMsg)
+		{
+			if (view is null || !_handlerRef.TryGetTarget(out var handler))
+				return false;
+
+			// Get the URL from the hit test result
+			var requestUrl = view.GetHitTestResult()?.Extra;
+			if (string.IsNullOrEmpty(requestUrl))
+				return false;
+
+			Uri.TryCreate(requestUrl, UriKind.RelativeOrAbsolute, out var uri);
+
+			// Use INavigatingAwareWebView if available to let devs intercept new window requests
+			if (handler.VirtualView is INavigatingAwareWebView navAware)
+			{
+				var args = new WebViewNavigatingEventArgs(uri, WebNavigationTarget.NewWindow, null);
+				bool cancel = navAware.Navigating(args);
+
+				if (!cancel)
+				{
+					// Load in the same WebView if not cancelled
+					view.LoadUrl(requestUrl);
+				}
+			}
+			else
+			{
+				// Fallback: load in same view
+				view.LoadUrl(requestUrl);
+			}
+
+			return false;
 		}
 
 		public override bool OnShowFileChooser(WebView webView, IValueCallback filePathCallback, FileChooserParams fileChooserParams)

--- a/src/Core/src/Platform/Android/MauiWebViewClient.cs
+++ b/src/Core/src/Platform/Android/MauiWebViewClient.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Platform
 			_navigationResult = WebNavigationResult.Success;
 		}
 		public override bool ShouldOverrideUrlLoading(WebView? view, IWebResourceRequest? request)
-			=> NavigatingCanceled(request?.Url?.ToString());
+			=> NavigatingCanceled(request?.Url?.ToString(), request);
 
 		public override void OnPageStarted(WebView? view, string? url, Bitmap? favicon)
 		{
@@ -94,8 +94,8 @@ namespace Microsoft.Maui.Platform
 			return base.OnRenderProcessGone(view, detail);
 		}
 
-		bool NavigatingCanceled(string? url) =>
-			!_handler.TryGetTarget(out var handler) || handler.NavigatingCanceled(url);
+		bool NavigatingCanceled(string? url, IWebResourceRequest? request = null) =>
+			!_handler.TryGetTarget(out var handler) || handler.NavigatingCanceled(url, request);
 
 		static bool IsBlankNavigation(string? url)
 		{

--- a/src/Core/src/Platform/iOS/MauiWebViewNavigationDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiWebViewNavigationDelegate.cs
@@ -145,7 +145,28 @@ namespace Microsoft.Maui.Platform
 			var request = navigationAction.Request;
 			var lastUrl = request.Url.ToString();
 
-			bool cancel = virtualView.Navigating(navEvent, lastUrl);
+			bool cancel;
+
+			// Use INavigatingAwareWebView if available (provides Target + PlatformArgs)
+			if (virtualView is INavigatingAwareWebView navAware)
+			{
+				Uri.TryCreate(lastUrl, UriKind.RelativeOrAbsolute, out var uri);
+				WebNavigationTarget target;
+				if (navigationAction.TargetFrame == null)
+					target = WebNavigationTarget.NewWindow;
+				else if (navigationAction.TargetFrame.MainFrame)
+					target = WebNavigationTarget.MainFrame;
+				else
+					target = WebNavigationTarget.Frame;
+
+				var args = new WebViewNavigatingEventArgs(uri, target, navigationAction);
+				cancel = navAware.Navigating(args);
+			}
+			else
+			{
+				cancel = virtualView.Navigating(navEvent, lastUrl);
+			}
+
 			platformView.UpdateCanGoBackForward(virtualView);
 
 			// Handle target="_blank" links - when TargetFrame is null, the link is meant to open in a new window

--- a/src/Core/src/Primitives/WebNavigationTarget.cs
+++ b/src/Core/src/Primitives/WebNavigationTarget.cs
@@ -1,0 +1,21 @@
+namespace Microsoft.Maui
+{
+	/// <summary>
+	/// Specifies the frame target of a web navigation.
+	/// </summary>
+	public enum WebNavigationTarget
+	{
+		/// <summary>
+		/// The navigation targets the main (top-level) frame.
+		/// </summary>
+		MainFrame,
+		/// <summary>
+		/// The navigation targets a child frame (e.g., an iframe).
+		/// </summary>
+		Frame,
+		/// <summary>
+		/// The navigation requests a new window (e.g., target="_blank" or window.open).
+		/// </summary>
+		NewWindow
+	}
+}

--- a/src/Core/src/Primitives/WebViewNavigatingEventArgs.cs
+++ b/src/Core/src/Primitives/WebViewNavigatingEventArgs.cs
@@ -1,0 +1,106 @@
+﻿using System;
+
+namespace Microsoft.Maui;
+
+/// <summary>
+/// Provides data for the <see cref="INavigatingAwareWebView.Navigating"/> event at the handler level.
+/// </summary>
+public class WebViewNavigatingEventArgs
+{
+#if WINDOWS
+
+	/// <summary>
+	/// Initializes a new instance for a navigation starting event on Windows.
+	/// </summary>
+	public WebViewNavigatingEventArgs(
+		Uri? url,
+		WebNavigationTarget target,
+		global::Microsoft.Web.WebView2.Core.CoreWebView2NavigationStartingEventArgs? navigationArgs,
+		global::Microsoft.Web.WebView2.Core.CoreWebView2NewWindowRequestedEventArgs? newWindowArgs)
+	{
+		Url = url;
+		Target = target;
+		NavigationArgs = navigationArgs;
+		NewWindowArgs = newWindowArgs;
+	}
+
+	/// <summary>
+	/// Gets the native navigation starting event args. Non-null for MainFrame and Frame navigations.
+	/// </summary>
+	public global::Microsoft.Web.WebView2.Core.CoreWebView2NavigationStartingEventArgs? NavigationArgs { get; }
+
+	/// <summary>
+	/// Gets the native new window requested event args. Non-null for NewWindow navigations.
+	/// </summary>
+	public global::Microsoft.Web.WebView2.Core.CoreWebView2NewWindowRequestedEventArgs? NewWindowArgs { get; }
+
+#elif IOS || MACCATALYST
+
+	/// <summary>
+	/// Initializes a new instance for a navigation action on iOS/Mac Catalyst.
+	/// </summary>
+	public WebViewNavigatingEventArgs(
+		Uri? url,
+		WebNavigationTarget target,
+		global::WebKit.WKNavigationAction navigationAction)
+	{
+		Url = url;
+		Target = target;
+		NavigationAction = navigationAction;
+	}
+
+	/// <summary>
+	/// Gets the native navigation action that triggered the event.
+	/// </summary>
+	public global::WebKit.WKNavigationAction NavigationAction { get; }
+
+#elif ANDROID
+
+	/// <summary>
+	/// Initializes a new instance for a navigation request on Android.
+	/// </summary>
+	public WebViewNavigatingEventArgs(
+		Uri? url,
+		WebNavigationTarget target,
+		global::Android.Webkit.IWebResourceRequest? request)
+	{
+		Url = url;
+		Target = target;
+		Request = request;
+	}
+
+	/// <summary>
+	/// Gets the native web resource request.
+	/// </summary>
+	public global::Android.Webkit.IWebResourceRequest? Request { get; }
+
+#else
+
+	/// <summary>
+	/// Initializes a new instance of <see cref="WebViewNavigatingEventArgs"/>.
+	/// </summary>
+	public WebViewNavigatingEventArgs(Uri? url, WebNavigationTarget target)
+	{
+		Url = url;
+		Target = target;
+	}
+
+#endif
+
+	/// <summary>
+	/// Gets the URI being navigated to.
+	/// </summary>
+	public Uri? Url { get; }
+
+	/// <summary>
+	/// Gets the frame target of the navigation.
+	/// </summary>
+	public WebNavigationTarget Target { get; }
+
+	/// <summary>
+	/// Gets or sets a value indicating whether the navigation should be cancelled.
+	/// </summary>
+	public bool Cancel { get; set; }
+}
+
+

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 ﻿#nullable enable
+*REMOVED*Microsoft.Maui.Handlers.WebViewHandler.NavigatingCanceled(string? url) -> bool
+Microsoft.Maui.Handlers.WebViewHandler.NavigatingCanceled(string? url, Android.Webkit.IWebResourceRequest? request = null) -> bool
 Microsoft.Maui.INavigatingAwareWebView
 Microsoft.Maui.INavigatingAwareWebView.Navigating(Microsoft.Maui.WebViewNavigatingEventArgs! args) -> bool
 Microsoft.Maui.PlatformDrawable
@@ -24,6 +26,7 @@ override Microsoft.Maui.Platform.LayoutViewGroup.HasOverlappingRendering.get -> 
 override Microsoft.Maui.Platform.MauiHybridWebView.OnAttachedToWindow() -> void
 override Microsoft.Maui.Platform.MauiHybridWebView.OnSizeChanged(int width, int height, int oldWidth, int oldHeight) -> void
 override Microsoft.Maui.Platform.MauiHybridWebViewClient.ShouldOverrideUrlLoading(Android.Webkit.WebView? view, Android.Webkit.IWebResourceRequest? request) -> bool
+~override Microsoft.Maui.Platform.MauiWebChromeClient.OnCreateWindow(Android.Webkit.WebView view, bool isDialog, bool isUserGesture, Android.OS.Message resultMsg) -> bool
 override Microsoft.Maui.Platform.MauiWebView.OnAttachedToWindow() -> void
 override Microsoft.Maui.Platform.MauiWebView.OnSizeChanged(int width, int height, int oldWidth, int oldHeight) -> void
 override Microsoft.Maui.Platform.WrapperView.HasOverlappingRendering.get -> bool

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,18 +1,32 @@
-#nullable enable
+﻿#nullable enable
+Microsoft.Maui.INavigatingAwareWebView
+Microsoft.Maui.INavigatingAwareWebView.Navigating(Microsoft.Maui.WebViewNavigatingEventArgs! args) -> bool
 Microsoft.Maui.PlatformDrawable
 Microsoft.Maui.PlatformDrawable.PlatformDrawable(Android.Content.Context? context) -> void
 Microsoft.Maui.PlatformDrawable.PlatformDrawable(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
-override Microsoft.Maui.PlatformDrawable.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
-override Microsoft.Maui.PlatformDrawable.ThresholdClass.get -> nint
-override Microsoft.Maui.PlatformDrawable.ThresholdType.get -> System.Type!
+Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.WebNavigationTarget.Frame = 1 -> Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.WebNavigationTarget.MainFrame = 0 -> Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.WebNavigationTarget.NewWindow = 2 -> Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.WebViewNavigatingEventArgs
+Microsoft.Maui.WebViewNavigatingEventArgs.Cancel.get -> bool
+Microsoft.Maui.WebViewNavigatingEventArgs.Cancel.set -> void
+Microsoft.Maui.WebViewNavigatingEventArgs.Request.get -> Android.Webkit.IWebResourceRequest?
+Microsoft.Maui.WebViewNavigatingEventArgs.Target.get -> Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.WebViewNavigatingEventArgs.Url.get -> System.Uri?
+Microsoft.Maui.WebViewNavigatingEventArgs.WebViewNavigatingEventArgs(System.Uri? url, Microsoft.Maui.WebNavigationTarget target, Android.Webkit.IWebResourceRequest? request) -> void
 *REMOVED*override Microsoft.Maui.Graphics.MauiDrawable.Dispose(bool disposing) -> void
 *REMOVED*override Microsoft.Maui.Graphics.MauiDrawable.OnBoundsChange(Android.Graphics.Rect! bounds) -> void
 *REMOVED*override Microsoft.Maui.Graphics.MauiDrawable.OnDraw(Android.Graphics.Drawables.Shapes.Shape? shape, Android.Graphics.Canvas? canvas, Android.Graphics.Paint? paint) -> void
 override Microsoft.Maui.Handlers.LabelHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Platform.ContentViewGroup.HasOverlappingRendering.get -> bool
 override Microsoft.Maui.Platform.LayoutViewGroup.HasOverlappingRendering.get -> bool
-override Microsoft.Maui.Platform.WrapperView.HasOverlappingRendering.get -> bool
 override Microsoft.Maui.Platform.MauiHybridWebView.OnAttachedToWindow() -> void
 override Microsoft.Maui.Platform.MauiHybridWebView.OnSizeChanged(int width, int height, int oldWidth, int oldHeight) -> void
+override Microsoft.Maui.Platform.MauiHybridWebViewClient.ShouldOverrideUrlLoading(Android.Webkit.WebView? view, Android.Webkit.IWebResourceRequest? request) -> bool
 override Microsoft.Maui.Platform.MauiWebView.OnAttachedToWindow() -> void
 override Microsoft.Maui.Platform.MauiWebView.OnSizeChanged(int width, int height, int oldWidth, int oldHeight) -> void
+override Microsoft.Maui.Platform.WrapperView.HasOverlappingRendering.get -> bool
+override Microsoft.Maui.PlatformDrawable.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Microsoft.Maui.PlatformDrawable.ThresholdClass.get -> nint
+override Microsoft.Maui.PlatformDrawable.ThresholdType.get -> System.Type!

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,4 +1,17 @@
 ﻿#nullable enable
+Microsoft.Maui.INavigatingAwareWebView
+Microsoft.Maui.INavigatingAwareWebView.Navigating(Microsoft.Maui.WebViewNavigatingEventArgs! args) -> bool
+Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.WebNavigationTarget.Frame = 1 -> Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.WebNavigationTarget.MainFrame = 0 -> Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.WebNavigationTarget.NewWindow = 2 -> Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.WebViewNavigatingEventArgs
+Microsoft.Maui.WebViewNavigatingEventArgs.Cancel.get -> bool
+Microsoft.Maui.WebViewNavigatingEventArgs.Cancel.set -> void
+Microsoft.Maui.WebViewNavigatingEventArgs.NavigationAction.get -> WebKit.WKNavigationAction!
+Microsoft.Maui.WebViewNavigatingEventArgs.Target.get -> Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.WebViewNavigatingEventArgs.Url.get -> System.Uri?
+Microsoft.Maui.WebViewNavigatingEventArgs.WebViewNavigatingEventArgs(System.Uri? url, Microsoft.Maui.WebNavigationTarget target, WebKit.WKNavigationAction! navigationAction) -> void
 override Microsoft.Maui.Handlers.LabelHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Handlers.ShapeViewHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Handlers.StepperHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,4 +1,17 @@
 ﻿#nullable enable
+Microsoft.Maui.INavigatingAwareWebView
+Microsoft.Maui.INavigatingAwareWebView.Navigating(Microsoft.Maui.WebViewNavigatingEventArgs! args) -> bool
+Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.WebNavigationTarget.Frame = 1 -> Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.WebNavigationTarget.MainFrame = 0 -> Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.WebNavigationTarget.NewWindow = 2 -> Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.WebViewNavigatingEventArgs
+Microsoft.Maui.WebViewNavigatingEventArgs.Cancel.get -> bool
+Microsoft.Maui.WebViewNavigatingEventArgs.Cancel.set -> void
+Microsoft.Maui.WebViewNavigatingEventArgs.NavigationAction.get -> WebKit.WKNavigationAction!
+Microsoft.Maui.WebViewNavigatingEventArgs.Target.get -> Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.WebViewNavigatingEventArgs.Url.get -> System.Uri?
+Microsoft.Maui.WebViewNavigatingEventArgs.WebViewNavigatingEventArgs(System.Uri? url, Microsoft.Maui.WebNavigationTarget target, WebKit.WKNavigationAction! navigationAction) -> void
 override Microsoft.Maui.Handlers.LabelHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Handlers.ShapeViewHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Handlers.StepperHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,2 +1,16 @@
 #nullable enable
+Microsoft.Maui.INavigatingAwareWebView
+Microsoft.Maui.INavigatingAwareWebView.Navigating(Microsoft.Maui.WebViewNavigatingEventArgs! args) -> bool
+Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.WebNavigationTarget.Frame = 1 -> Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.WebNavigationTarget.MainFrame = 0 -> Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.WebNavigationTarget.NewWindow = 2 -> Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.WebViewNavigatingEventArgs
+Microsoft.Maui.WebViewNavigatingEventArgs.Cancel.get -> bool
+Microsoft.Maui.WebViewNavigatingEventArgs.Cancel.set -> void
+Microsoft.Maui.WebViewNavigatingEventArgs.NavigationArgs.get -> Microsoft.Web.WebView2.Core.CoreWebView2NavigationStartingEventArgs?
+Microsoft.Maui.WebViewNavigatingEventArgs.NewWindowArgs.get -> Microsoft.Web.WebView2.Core.CoreWebView2NewWindowRequestedEventArgs?
+Microsoft.Maui.WebViewNavigatingEventArgs.Target.get -> Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.WebViewNavigatingEventArgs.Url.get -> System.Uri?
+Microsoft.Maui.WebViewNavigatingEventArgs.WebViewNavigatingEventArgs(System.Uri? url, Microsoft.Maui.WebNavigationTarget target, Microsoft.Web.WebView2.Core.CoreWebView2NavigationStartingEventArgs? navigationArgs, Microsoft.Web.WebView2.Core.CoreWebView2NewWindowRequestedEventArgs? newWindowArgs) -> void
 override Microsoft.Maui.Platform.MauiPasswordTextBox.OnCreateAutomationPeer() -> Microsoft.UI.Xaml.Automation.Peers.AutomationPeer!

--- a/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,1 +1,13 @@
 #nullable enable
+Microsoft.Maui.INavigatingAwareWebView
+Microsoft.Maui.INavigatingAwareWebView.Navigating(Microsoft.Maui.WebViewNavigatingEventArgs! args) -> bool
+Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.WebNavigationTarget.Frame = 1 -> Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.WebNavigationTarget.MainFrame = 0 -> Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.WebNavigationTarget.NewWindow = 2 -> Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.WebViewNavigatingEventArgs
+Microsoft.Maui.WebViewNavigatingEventArgs.Cancel.get -> bool
+Microsoft.Maui.WebViewNavigatingEventArgs.Cancel.set -> void
+Microsoft.Maui.WebViewNavigatingEventArgs.Target.get -> Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.WebViewNavigatingEventArgs.Url.get -> System.Uri?
+Microsoft.Maui.WebViewNavigatingEventArgs.WebViewNavigatingEventArgs(System.Uri? url, Microsoft.Maui.WebNavigationTarget target) -> void

--- a/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,1 +1,13 @@
-#nullable enable
+﻿#nullable enable
+Microsoft.Maui.INavigatingAwareWebView
+Microsoft.Maui.INavigatingAwareWebView.Navigating(Microsoft.Maui.WebViewNavigatingEventArgs! args) -> bool
+Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.WebNavigationTarget.Frame = 1 -> Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.WebNavigationTarget.MainFrame = 0 -> Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.WebNavigationTarget.NewWindow = 2 -> Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.WebViewNavigatingEventArgs
+Microsoft.Maui.WebViewNavigatingEventArgs.Cancel.get -> bool
+Microsoft.Maui.WebViewNavigatingEventArgs.Cancel.set -> void
+Microsoft.Maui.WebViewNavigatingEventArgs.Target.get -> Microsoft.Maui.WebNavigationTarget
+Microsoft.Maui.WebViewNavigatingEventArgs.Url.get -> System.Uri?
+Microsoft.Maui.WebViewNavigatingEventArgs.WebViewNavigatingEventArgs(System.Uri? url, Microsoft.Maui.WebNavigationTarget target) -> void


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Adds unified navigation interception with frame awareness (`WebNavigationTarget`) across all three WebView types: `WebView`, `HybridWebView`, and `BlazorWebView`.

## New Public APIs

### `Microsoft.Maui.WebNavigationTarget` (enum)

```csharp
namespace Microsoft.Maui;

public enum WebNavigationTarget
{
    MainFrame = 0,
    Frame = 1,
    NewWindow = 2,
}
```

### `Microsoft.Maui.INavigatingAwareWebView` (interface)

```csharp
namespace Microsoft.Maui;

public interface INavigatingAwareWebView
{
    bool Navigating(WebViewNavigatingEventArgs args);
}
```

### `Microsoft.Maui.WebViewNavigatingEventArgs` (Core handler-level args)

```csharp
namespace Microsoft.Maui;

public class WebViewNavigatingEventArgs
{
    public Uri? Url { get; }
    public WebNavigationTarget Target { get; }
    public bool Cancel { get; set; }

    // Android
    public WebViewNavigatingEventArgs(Uri? url, WebNavigationTarget target, Android.Webkit.IWebResourceRequest? request);
    public Android.Webkit.IWebResourceRequest? Request { get; }

    // iOS/Mac Catalyst
    public WebViewNavigatingEventArgs(Uri? url, WebNavigationTarget target, WebKit.WKNavigationAction navigationAction);
    public WebKit.WKNavigationAction NavigationAction { get; }

    // Windows
    public WebViewNavigatingEventArgs(Uri? url, WebNavigationTarget target,
        Microsoft.Web.WebView2.Core.CoreWebView2NavigationStartingEventArgs? navigationArgs,
        Microsoft.Web.WebView2.Core.CoreWebView2NewWindowRequestedEventArgs? newWindowArgs);
    public Microsoft.Web.WebView2.Core.CoreWebView2NavigationStartingEventArgs? NavigationArgs { get; }
    public Microsoft.Web.WebView2.Core.CoreWebView2NewWindowRequestedEventArgs? NewWindowArgs { get; }
}
```

### `Microsoft.Maui.Controls.HybridWebViewNavigatingEventArgs`

```csharp
namespace Microsoft.Maui.Controls;

public class HybridWebViewNavigatingEventArgs
{
    public HybridWebViewNavigatingEventArgs(Uri? url, WebNavigationTarget target, PlatformHybridWebViewNavigatingEventArgs? platformArgs);
    public Uri? Url { get; }
    public WebNavigationTarget Target { get; }
    public bool Cancel { get; set; }
    public PlatformHybridWebViewNavigatingEventArgs? PlatformArgs { get; }
}
```

### `Microsoft.Maui.Controls.PlatformHybridWebViewNavigatingEventArgs`

```csharp
namespace Microsoft.Maui.Controls;

public class PlatformHybridWebViewNavigatingEventArgs
{
    // Android
    public Android.Webkit.IWebResourceRequest? Request { get; }

    // iOS/Mac Catalyst
    public WebKit.WKNavigationAction NavigationAction { get; }

    // Windows
    public Microsoft.Web.WebView2.Core.CoreWebView2NavigationStartingEventArgs? NavigationArgs { get; }
    public Microsoft.Web.WebView2.Core.CoreWebView2NewWindowRequestedEventArgs? NewWindowArgs { get; }
}
```

### `Microsoft.Maui.Controls.WebNavigatingEventArgs` (enhanced existing)

```csharp
namespace Microsoft.Maui.Controls;

public class WebNavigatingEventArgs // existing class, new members
{
    // New constructor overload
    public WebNavigatingEventArgs(WebNavigationEvent navigationEvent, WebViewSource source, string url,
        WebNavigationTarget target, PlatformWebNavigatingEventArgs platformArgs);

    // New properties
    public WebNavigationTarget Target { get; }
    public PlatformWebNavigatingEventArgs PlatformArgs { get; }
}
```

### `Microsoft.Maui.Controls.PlatformWebNavigatingEventArgs`

```csharp
namespace Microsoft.Maui.Controls;

public class PlatformWebNavigatingEventArgs
{
    // Android
    public Android.Webkit.IWebResourceRequest? Request { get; }

    // iOS/Mac Catalyst
    public WebKit.WKNavigationAction NavigationAction { get; }

    // Windows
    public Microsoft.Web.WebView2.Core.CoreWebView2NavigationStartingEventArgs? NavigationArgs { get; }
    public Microsoft.Web.WebView2.Core.CoreWebView2NewWindowRequestedEventArgs? NewWindowArgs { get; }
}
```

### `Microsoft.Maui.Controls.HybridWebView` (new event)

```csharp
namespace Microsoft.Maui.Controls;

public partial class HybridWebView
{
    public event EventHandler<HybridWebViewNavigatingEventArgs>? Navigating;
}
```

### `Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs` (enhanced existing, MAUI only)

```csharp
namespace Microsoft.AspNetCore.Components.WebView;

public class UrlLoadingEventArgs // existing class, new member
{
    // New property (MAUI targets only, guarded by #if WEBVIEW2_MAUI)
    public WebNavigationTarget Target { get; }
}
```

## Platform coverage

| Platform | MainFrame | Frame | NewWindow |
|----------|-----------|-------|-----------|
| **Android** | `ShouldOverrideUrlLoading` (IsForMainFrame) | `ShouldOverrideUrlLoading` (!IsForMainFrame) | `OnCreateWindow` via ChromeClient |
| **iOS/Mac** | `DecidePolicy` (TargetFrame.MainFrame) | `DecidePolicy` (!MainFrame) | `DecidePolicy` (TargetFrame == null) |
| **Windows** | `NavigationStarting` | `FrameNavigationStarting` | `NewWindowRequested` |

## Usage examples

**HybridWebView** — block all external navigation:
```csharp
hybridWebView.Navigating += (sender, args) =>
{
    if (args.Target == WebNavigationTarget.NewWindow)
        args.Cancel = true; // Block popups
    else if (!trustedDomains.Contains(args.Url?.Host))
        args.Cancel = true; // Block untrusted navigations
};
```

**WebView** — intercept new window requests:
```csharp
webView.Navigating += (sender, args) =>
{
    if (args.Target == WebNavigationTarget.NewWindow)
    {
        args.Cancel = true;
        // Handle externally or navigate in-view
    }
};
```

**BlazorWebView** — distinguish frame navigations:
```csharp
blazorWebView.UrlLoading += (sender, args) =>
{
    if (args.Target == WebNavigationTarget.Frame)
        args.UrlLoadingStrategy = UrlLoadingStrategy.CancelLoad;
};
```

## Breaking changes

- **Windows WebView**: `FrameNavigationStarting` now fires `Navigating` events for iframe navigations that previously went unnoticed. Existing handlers that cancel external navigations will now also block iframe navigations to those URLs.
- **Windows WebView**: `NewWindowRequested` now fires `Navigating` with `Target = NewWindow` (previously was not interceptable).
- **Windows BlazorWebView**: `FrameNavigationStarting` now fires `UrlLoading` events for iframe navigations.
- **Windows BlazorWebView**: `NewWindowRequested` now fires `UrlLoading` with `Target = NewWindow` (previously hardcoded to open externally).
- **Android WebView**: `WebViewHandler.NavigatingCanceled(string?)` signature changed to `NavigatingCanceled(string?, IWebResourceRequest? = null)` (source-compatible, binary-breaking).