### PR TITLE
Fix Android Shell top inset when nav bar is hidden

### DIFF
--- a/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
@@ -9,11 +9,14 @@ using Android.Graphics.Drawables;
 using Android.Text;
 using Android.Text.Style;
 using Android.Views;
+using AndroidX.CoordinatorLayout.Widget;
 using AndroidX.AppCompat.Graphics.Drawable;
 using AndroidX.AppCompat.Widget;
 using AndroidX.Core.View;
 using AndroidX.Core.View.Accessibility;
+using Google.Android.Material.AppBar;
 using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Platform;
 using Microsoft.Maui.Primitives;
 using AGraphics = Android.Graphics;
 using ATextView = global::Android.Widget.TextView;
@@ -54,7 +57,26 @@ namespace Microsoft.Maui.Controls.Platform
 			}
 
 			nativeToolbar.LayoutParameters = lp;
-			AndroidX.Core.View.ViewCompat.RequestApplyInsets(nativeToolbar);
+
+			var appBarLayout = nativeToolbar.Parent.GetParentOfType<AppBarLayout>();
+			var rootCoordinator = appBarLayout?.Parent.GetParentOfType<CoordinatorLayout>();
+
+			nativeToolbar.MaybeRequestLayout();
+			appBarLayout?.MaybeRequestLayout();
+			rootCoordinator?.MaybeRequestLayout();
+
+			if (rootCoordinator is not null)
+			{
+				ViewCompat.RequestApplyInsets(rootCoordinator);
+			}
+			else if (appBarLayout is not null)
+			{
+				ViewCompat.RequestApplyInsets(appBarLayout);
+			}
+			else
+			{
+				ViewCompat.RequestApplyInsets(nativeToolbar);
+			}
 		}
 
 		public static void UpdateTitleIcon(this AToolbar nativeToolbar, Toolbar toolbar)

--- a/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.Android.cs
+++ b/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.Android.cs
@@ -8,6 +8,7 @@ using AndroidX.AppCompat.Graphics.Drawable;
 using AndroidX.AppCompat.View.Menu;
 using AndroidX.AppCompat.Widget;
 using AndroidX.CoordinatorLayout.Widget;
+using AndroidX.Core.View;
 using AndroidX.Fragment.App;
 using Google.Android.Material.AppBar;
 using Microsoft.Maui.Controls;
@@ -211,6 +212,36 @@ namespace Microsoft.Maui.DeviceTests
 					.LayoutParameters?.Height > 0;
 		}
 
+		protected static WindowInsetsCompat CreateTopCutoutInsets(int statusBarTopInset, int displayCutoutTopInset)
+		{
+			return new WindowInsetsCompat.Builder()
+				.SetInsets(WindowInsetsCompat.Type.SystemBars(), AndroidX.Core.Graphics.Insets.Of(0, statusBarTopInset, 0, 0))
+				.SetInsets(WindowInsetsCompat.Type.DisplayCutout(), AndroidX.Core.Graphics.Insets.Of(0, displayCutoutTopInset, 0, 0))
+				.Build();
+		}
+
+		protected static void AssertTopInsets(WindowInsetsCompat insets, int expectedSystemBarsTop, int expectedDisplayCutoutTop, string message)
+		{
+			Assert.NotNull(insets);
+
+			var systemBars = insets.GetInsets(WindowInsetsCompat.Type.SystemBars());
+			var displayCutout = insets.GetInsets(WindowInsetsCompat.Type.DisplayCutout());
+
+			Assert.True(
+				(systemBars?.Top ?? 0) == expectedSystemBarsTop && (displayCutout?.Top ?? 0) == expectedDisplayCutoutTop,
+				$"{message} Actual SystemBars.Top={(systemBars?.Top ?? 0)}, DisplayCutout.Top={(displayCutout?.Top ?? 0)}.");
+		}
+
+		protected static CapturingWindowInsetsListener AttachCapturingWindowInsetsListener(AView rootView, AView descendantView)
+		{
+			var originalListener = MauiWindowInsetListener.FindListenerForView(descendantView)
+				?? throw new InvalidOperationException("Unable to locate the MauiWindowInsetListener for the current test view hierarchy.");
+
+			var capturingListener = new CapturingWindowInsetsListener(originalListener);
+			ViewCompat.SetOnApplyWindowInsetsListener(rootView, capturingListener);
+			return capturingListener;
+		}
+
 		protected bool IsBackButtonVisible(IElementHandler handler)
 		{
 			if (GetPlatformToolbar(handler)?.NavigationIcon is DrawerArrowDrawable dad)
@@ -228,6 +259,28 @@ namespace Microsoft.Maui.DeviceTests
 
 			var expectedYInPixels = context.ToPixels(expectedTranslationY);
 			Assert.Equal(expectedYInPixels, nativeView.TranslationY, precision: 1);
+		}
+
+		protected sealed class CapturingWindowInsetsListener : Java.Lang.Object, IOnApplyWindowInsetsListener
+		{
+			readonly MauiWindowInsetListener _innerListener;
+
+			internal CapturingWindowInsetsListener(MauiWindowInsetListener innerListener)
+			{
+				_innerListener = innerListener ?? throw new ArgumentNullException(nameof(innerListener));
+			}
+
+			public int InvocationCount { get; private set; }
+
+			public WindowInsetsCompat LastAppliedInsets { get; private set; }
+
+			public WindowInsetsCompat OnApplyWindowInsets(AView v, WindowInsetsCompat insets)
+			{
+				var appliedInsets = _innerListener.OnApplyWindowInsets(v, insets) ?? insets;
+				LastAppliedInsets = appliedInsets;
+				InvocationCount++;
+				return appliedInsets;
+			}
 		}
 
 		class WindowTestFragment : Fragment

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Android.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Maui.DeviceTests
 				var platformToolbar = GetPlatformToolbar(handler);
 				var rootCoordinator = handler.MauiContext?.GetNavigationRootManager()?.RootView as CoordinatorLayout;
 				var appBar = rootCoordinator?.FindViewById<AppBarLayout>(Resource.Id.navigationlayout_appbar);
-				var listener = new MauiWindowInsetListener();
+				var capturingListener = AttachCapturingWindowInsetsListener(rootCoordinator, platformToolbar);
 
 				Assert.NotNull(platformToolbar);
 				Assert.NotNull(rootCoordinator);
@@ -155,14 +155,20 @@ namespace Microsoft.Maui.DeviceTests
 					timeout: 2000,
 					message: "Toolbar did not render before navigating to the page with the navigation bar hidden.");
 
-				var insetsWhenVisible = listener.OnApplyWindowInsets(rootCoordinator, syntheticInsets);
+				ViewCompat.DispatchApplyWindowInsets(rootCoordinator, syntheticInsets);
+
+				await AssertEventually(() => capturingListener.InvocationCount > 0,
+					timeout: 2000,
+					message: "The NavigationPage root did not receive the initial synthetic window insets dispatch.");
 
 				await AssertEventually(() => appBar.PaddingTop == displayCutoutTopInset,
 					timeout: 2000,
 					message: "AppBar never received the synthetic display cutout top inset while the NavigationPage navigation bar was visible.");
 
-				AssertTopInsets(insetsWhenVisible, expectedSystemBarsTop: 0, expectedDisplayCutoutTop: 0,
+				AssertTopInsets(capturingListener.LastAppliedInsets, expectedSystemBarsTop: 0, expectedDisplayCutoutTop: 0,
 					message: "Visible NavigationPage app bar should consume the synthetic top insets.");
+
+				var visibleInsetsInvocationCount = capturingListener.InvocationCount;
 
 				await navPage.Navigation.PushAsync(hiddenNavBarPage);
 				await OnLoadedAsync(hiddenNavBarPage);
@@ -176,37 +182,15 @@ namespace Microsoft.Maui.DeviceTests
 					timeout: 2000,
 					message: "Toolbar did not fully collapse after navigating to a page with NavigationPage.HasNavigationBar set to false.");
 
-				var insetsWhenHidden = listener.OnApplyWindowInsets(rootCoordinator, syntheticInsets);
-
-				await AssertEventually(() => appBar.PaddingTop == 0,
+				await AssertEventually(() => capturingListener.InvocationCount > visibleInsetsInvocationCount && appBar.PaddingTop == 0,
 					timeout: 2000,
-					message: "AppBar retained top inset padding after navigating to a page with the NavigationPage navigation bar hidden.");
+					message: "Navigating to a page with the navigation bar hidden did not trigger an inset redispatch that cleared the AppBar top padding.");
 
-				AssertTopInsets(insetsWhenHidden,
+				AssertTopInsets(capturingListener.LastAppliedInsets,
 					expectedSystemBarsTop: statusBarTopInset,
 					expectedDisplayCutoutTop: displayCutoutTopInset,
 					message: "Hidden NavigationPage app bar should stop consuming the synthetic top insets.");
 			});
-		}
-
-		static WindowInsetsCompat CreateTopCutoutInsets(int statusBarTopInset, int displayCutoutTopInset)
-		{
-			return new WindowInsetsCompat.Builder()
-				.SetInsets(WindowInsetsCompat.Type.SystemBars(), AndroidX.Core.Graphics.Insets.Of(0, statusBarTopInset, 0, 0))
-				.SetInsets(WindowInsetsCompat.Type.DisplayCutout(), AndroidX.Core.Graphics.Insets.Of(0, displayCutoutTopInset, 0, 0))
-				.Build();
-		}
-
-		static void AssertTopInsets(WindowInsetsCompat insets, int expectedSystemBarsTop, int expectedDisplayCutoutTop, string message)
-		{
-			Assert.NotNull(insets);
-
-			var systemBars = insets.GetInsets(WindowInsetsCompat.Type.SystemBars());
-			var displayCutout = insets.GetInsets(WindowInsetsCompat.Type.DisplayCutout());
-
-			Assert.True(
-				(systemBars?.Top ?? 0) == expectedSystemBarsTop && (displayCutout?.Top ?? 0) == expectedDisplayCutoutTop,
-				$"{message} Actual SystemBars.Top={(systemBars?.Top ?? 0)}, DisplayCutout.Top={(displayCutout?.Top ?? 0)}.");
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Android.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using AndroidX.CoordinatorLayout.Widget;
 using Google.Android.Material.AppBar;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
@@ -12,6 +13,7 @@ using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using Xunit;
+using AndroidX.Core.View;
 using static Microsoft.Maui.DeviceTests.AssertHelpers;
 
 namespace Microsoft.Maui.DeviceTests
@@ -109,6 +111,102 @@ namespace Microsoft.Maui.DeviceTests
 					fragmentManagerField.GetValue(tab2SnManager) == null,
 					message: "StackNavigationManager fields were not cleared after Disconnect()");
 			});
+		}
+
+		[Fact(DisplayName = "NavigationPage push to hidden navigation bar clears app bar inset padding")]
+		public async Task PushingToPageWithoutNavigationBarClearsAppBarInsetPadding()
+		{
+			SetupBuilder();
+			const int statusBarTopInset = 24;
+			const int displayCutoutTopInset = 96;
+
+			var rootPage = new ContentPage
+			{
+				Title = "Visible Page",
+				Content = new Label { Text = "Root Content" }
+			};
+
+			var hiddenNavBarPage = new ContentPage
+			{
+				Title = "Hidden Page",
+				Content = new Label { Text = "Hidden Content" }
+			};
+
+			NavigationPage.SetHasNavigationBar(hiddenNavBarPage, false);
+
+			var syntheticInsets = CreateTopCutoutInsets(statusBarTopInset, displayCutoutTopInset);
+			var navPage = new NavigationPage(rootPage);
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), async (handler) =>
+			{
+				await OnLoadedAsync(rootPage);
+				await OnNavigatedToAsync(rootPage);
+
+				var platformToolbar = GetPlatformToolbar(handler);
+				var rootCoordinator = handler.MauiContext?.GetNavigationRootManager()?.RootView as CoordinatorLayout;
+				var appBar = rootCoordinator?.FindViewById<AppBarLayout>(Resource.Id.navigationlayout_appbar);
+				var listener = new MauiWindowInsetListener();
+
+				Assert.NotNull(platformToolbar);
+				Assert.NotNull(rootCoordinator);
+				Assert.NotNull(appBar);
+
+				await AssertEventually(() => platformToolbar.LayoutParameters?.Height > 0,
+					timeout: 2000,
+					message: "Toolbar did not render before navigating to the page with the navigation bar hidden.");
+
+				var insetsWhenVisible = listener.OnApplyWindowInsets(rootCoordinator, syntheticInsets);
+
+				await AssertEventually(() => appBar.PaddingTop == displayCutoutTopInset,
+					timeout: 2000,
+					message: "AppBar never received the synthetic display cutout top inset while the NavigationPage navigation bar was visible.");
+
+				AssertTopInsets(insetsWhenVisible, expectedSystemBarsTop: 0, expectedDisplayCutoutTop: 0,
+					message: "Visible NavigationPage app bar should consume the synthetic top insets.");
+
+				await navPage.Navigation.PushAsync(hiddenNavBarPage);
+				await OnLoadedAsync(hiddenNavBarPage);
+				await OnNavigatedToAsync(hiddenNavBarPage);
+
+				await AssertEventually(() =>
+				{
+					var currentToolbar = GetPlatformToolbar(handler);
+					return currentToolbar?.LayoutParameters?.Height == 0 && currentToolbar.Height == 0;
+				},
+					timeout: 2000,
+					message: "Toolbar did not fully collapse after navigating to a page with NavigationPage.HasNavigationBar set to false.");
+
+				var insetsWhenHidden = listener.OnApplyWindowInsets(rootCoordinator, syntheticInsets);
+
+				await AssertEventually(() => appBar.PaddingTop == 0,
+					timeout: 2000,
+					message: "AppBar retained top inset padding after navigating to a page with the NavigationPage navigation bar hidden.");
+
+				AssertTopInsets(insetsWhenHidden,
+					expectedSystemBarsTop: statusBarTopInset,
+					expectedDisplayCutoutTop: displayCutoutTopInset,
+					message: "Hidden NavigationPage app bar should stop consuming the synthetic top insets.");
+			});
+		}
+
+		static WindowInsetsCompat CreateTopCutoutInsets(int statusBarTopInset, int displayCutoutTopInset)
+		{
+			return new WindowInsetsCompat.Builder()
+				.SetInsets(WindowInsetsCompat.Type.SystemBars(), AndroidX.Core.Graphics.Insets.Of(0, statusBarTopInset, 0, 0))
+				.SetInsets(WindowInsetsCompat.Type.DisplayCutout(), AndroidX.Core.Graphics.Insets.Of(0, displayCutoutTopInset, 0, 0))
+				.Build();
+		}
+
+		static void AssertTopInsets(WindowInsetsCompat insets, int expectedSystemBarsTop, int expectedDisplayCutoutTop, string message)
+		{
+			Assert.NotNull(insets);
+
+			var systemBars = insets.GetInsets(WindowInsetsCompat.Type.SystemBars());
+			var displayCutout = insets.GetInsets(WindowInsetsCompat.Type.DisplayCutout());
+
+			Assert.True(
+				(systemBars?.Top ?? 0) == expectedSystemBarsTop && (displayCutout?.Top ?? 0) == expectedDisplayCutoutTop,
+				$"{message} Actual SystemBars.Top={(systemBars?.Top ?? 0)}, DisplayCutout.Top={(displayCutout?.Top ?? 0)}.");
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Android.cs
@@ -186,6 +186,15 @@ namespace Microsoft.Maui.DeviceTests
 					timeout: 2000,
 					message: "Navigating to a page with the navigation bar hidden did not trigger an inset redispatch that cleared the AppBar top padding.");
 
+				// Re-dispatch the synthetic insets now that the nav bar is hidden so we can assert
+				// with known values that the app bar no longer consumes the top insets.
+				var hiddenInsetsInvocationCount = capturingListener.InvocationCount;
+				ViewCompat.DispatchApplyWindowInsets(rootCoordinator, syntheticInsets);
+
+				await AssertEventually(() => capturingListener.InvocationCount > hiddenInsetsInvocationCount,
+					timeout: 2000,
+					message: "Expected an additional inset dispatch after re-injecting synthetic insets post-nav-bar-hide.");
+
 				AssertTopInsets(capturingListener.LastAppliedInsets,
 					expectedSystemBarsTop: statusBarTopInset,
 					expectedDisplayCutoutTop: displayCutoutTopInset,

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Android.cs
@@ -121,6 +121,8 @@ namespace Microsoft.Maui.DeviceTests
 		public async Task HiddenShellNavigationBarClearsAppBarInsetPadding()
 		{
 			SetupBuilder();
+			const int statusBarTopInset = 24;
+			const int displayCutoutTopInset = 96;
 
 			var contentPage = new ContentPage()
 			{
@@ -128,7 +130,7 @@ namespace Microsoft.Maui.DeviceTests
 				Content = new Label { Text = "Content" }
 			};
 
-			Shell.SetNavBarIsVisible(contentPage, false);
+			var syntheticInsets = CreateTopCutoutInsets(statusBarTopInset, displayCutoutTopInset);
 
 			var shell = await CreateShellAsync(shell =>
 			{
@@ -142,17 +144,62 @@ namespace Microsoft.Maui.DeviceTests
 
 				var platformToolbar = GetPlatformToolbar(handler);
 				var appBar = platformToolbar.Parent.GetParentOfType<AppBarLayout>();
+				var rootCoordinator = appBar?.Parent.GetParentOfType<CoordinatorLayout>();
+				var listener = new MauiWindowInsetListener();
 
 				Assert.NotNull(appBar);
+				Assert.NotNull(rootCoordinator);
 
-				await AssertEventually(() => platformToolbar.LayoutParameters?.Height == 0,
+				await AssertEventually(() => platformToolbar.LayoutParameters?.Height > 0,
 					timeout: 2000,
-					message: "Toolbar did not collapse after Shell.NavBarIsVisible was set to false.");
+					message: "Toolbar did not render before Shell.NavBarIsVisible was toggled.");
+
+				var insetsWhenVisible = listener.OnApplyWindowInsets(rootCoordinator, syntheticInsets);
+
+				await AssertEventually(() => appBar.PaddingTop == displayCutoutTopInset,
+					timeout: 2000,
+					message: "AppBar never received the synthetic display cutout top inset before the Shell navigation bar was hidden.");
+
+				AssertTopInsets(insetsWhenVisible, expectedSystemBarsTop: 0, expectedDisplayCutoutTop: 0,
+					message: "Visible Shell app bar should consume the synthetic top insets.");
+
+				Shell.SetNavBarIsVisible(contentPage, false);
+
+				await AssertEventually(() => platformToolbar.LayoutParameters?.Height == 0 && platformToolbar.Height == 0,
+					timeout: 2000,
+					message: "Toolbar did not fully collapse after Shell.NavBarIsVisible was set to false.");
+
+				var insetsWhenHidden = listener.OnApplyWindowInsets(rootCoordinator, syntheticInsets);
 
 				await AssertEventually(() => appBar.PaddingTop == 0,
 					timeout: 2000,
 					message: "AppBar retained top inset padding after the Shell navigation bar was hidden.");
+
+				AssertTopInsets(insetsWhenHidden,
+					expectedSystemBarsTop: statusBarTopInset,
+					expectedDisplayCutoutTop: displayCutoutTopInset,
+					message: "Hidden Shell app bar should stop consuming the synthetic top insets.");
 			});
+		}
+
+		static WindowInsetsCompat CreateTopCutoutInsets(int statusBarTopInset, int displayCutoutTopInset)
+		{
+			return new WindowInsetsCompat.Builder()
+				.SetInsets(WindowInsetsCompat.Type.SystemBars(), AndroidX.Core.Graphics.Insets.Of(0, statusBarTopInset, 0, 0))
+				.SetInsets(WindowInsetsCompat.Type.DisplayCutout(), AndroidX.Core.Graphics.Insets.Of(0, displayCutoutTopInset, 0, 0))
+				.Build();
+		}
+
+		static void AssertTopInsets(WindowInsetsCompat insets, int expectedSystemBarsTop, int expectedDisplayCutoutTop, string message)
+		{
+			Assert.NotNull(insets);
+
+			var systemBars = insets.GetInsets(WindowInsetsCompat.Type.SystemBars());
+			var displayCutout = insets.GetInsets(WindowInsetsCompat.Type.DisplayCutout());
+
+			Assert.True(
+				(systemBars?.Top ?? 0) == expectedSystemBarsTop && (displayCutout?.Top ?? 0) == expectedDisplayCutoutTop,
+				$"{message} Actual SystemBars.Top={(systemBars?.Top ?? 0)}, DisplayCutout.Top={(displayCutout?.Top ?? 0)}.");
 		}
 
 		protected async Task CheckFlyoutState(ShellRenderer handler, bool desiredState)

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Android.cs
@@ -117,6 +117,44 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact(DisplayName = "Hidden Shell navigation bar clears app bar inset padding")]
+		public async Task HiddenShellNavigationBarClearsAppBarInsetPadding()
+		{
+			SetupBuilder();
+
+			var contentPage = new ContentPage()
+			{
+				Title = "Test",
+				Content = new Label { Text = "Content" }
+			};
+
+			Shell.SetNavBarIsVisible(contentPage, false);
+
+			var shell = await CreateShellAsync(shell =>
+			{
+				shell.CurrentItem = new FlyoutItem() { Items = { contentPage } };
+			});
+
+			await CreateHandlerAndAddToWindow<ShellRenderer>(shell, async (handler) =>
+			{
+				await OnLoadedAsync(contentPage);
+				await OnNavigatedToAsync(contentPage);
+
+				var platformToolbar = GetPlatformToolbar(handler);
+				var appBar = platformToolbar.Parent.GetParentOfType<AppBarLayout>();
+
+				Assert.NotNull(appBar);
+
+				await AssertEventually(() => platformToolbar.LayoutParameters?.Height == 0,
+					timeout: 2000,
+					message: "Toolbar did not collapse after Shell.NavBarIsVisible was set to false.");
+
+				await AssertEventually(() => appBar.PaddingTop == 0,
+					timeout: 2000,
+					message: "AppBar retained top inset padding after the Shell navigation bar was hidden.");
+			});
+		}
+
 		protected async Task CheckFlyoutState(ShellRenderer handler, bool desiredState)
 		{
 			var drawerLayout = GetDrawerLayout(handler);

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Android.cs
@@ -179,6 +179,15 @@ namespace Microsoft.Maui.DeviceTests
 					timeout: 2000,
 					message: "Shell.NavBarIsVisible did not trigger an inset redispatch that cleared the AppBar top padding.");
 
+				// Re-dispatch the synthetic insets now that the nav bar is hidden so we can assert
+				// with known values that the app bar no longer consumes the top insets.
+				var hiddenInsetsInvocationCount = capturingListener.InvocationCount;
+				ViewCompat.DispatchApplyWindowInsets(rootCoordinator, syntheticInsets);
+
+				await AssertEventually(() => capturingListener.InvocationCount > hiddenInsetsInvocationCount,
+					timeout: 2000,
+					message: "Expected an additional inset dispatch after re-injecting synthetic insets post-nav-bar-hide.");
+
 				AssertTopInsets(capturingListener.LastAppliedInsets,
 					expectedSystemBarsTop: statusBarTopInset,
 					expectedDisplayCutoutTop: displayCutoutTopInset,

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Android.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Maui.DeviceTests
 				var platformToolbar = GetPlatformToolbar(handler);
 				var appBar = platformToolbar.Parent.GetParentOfType<AppBarLayout>();
 				var rootCoordinator = appBar?.Parent.GetParentOfType<CoordinatorLayout>();
-				var listener = new MauiWindowInsetListener();
+				var capturingListener = AttachCapturingWindowInsetsListener(rootCoordinator, platformToolbar);
 
 				Assert.NotNull(appBar);
 				Assert.NotNull(rootCoordinator);
@@ -154,14 +154,20 @@ namespace Microsoft.Maui.DeviceTests
 					timeout: 2000,
 					message: "Toolbar did not render before Shell.NavBarIsVisible was toggled.");
 
-				var insetsWhenVisible = listener.OnApplyWindowInsets(rootCoordinator, syntheticInsets);
+				ViewCompat.DispatchApplyWindowInsets(rootCoordinator, syntheticInsets);
+
+				await AssertEventually(() => capturingListener.InvocationCount > 0,
+					timeout: 2000,
+					message: "The Shell root did not receive the initial synthetic window insets dispatch.");
 
 				await AssertEventually(() => appBar.PaddingTop == displayCutoutTopInset,
 					timeout: 2000,
 					message: "AppBar never received the synthetic display cutout top inset before the Shell navigation bar was hidden.");
 
-				AssertTopInsets(insetsWhenVisible, expectedSystemBarsTop: 0, expectedDisplayCutoutTop: 0,
+				AssertTopInsets(capturingListener.LastAppliedInsets, expectedSystemBarsTop: 0, expectedDisplayCutoutTop: 0,
 					message: "Visible Shell app bar should consume the synthetic top insets.");
+
+				var visibleInsetsInvocationCount = capturingListener.InvocationCount;
 
 				Shell.SetNavBarIsVisible(contentPage, false);
 
@@ -169,37 +175,15 @@ namespace Microsoft.Maui.DeviceTests
 					timeout: 2000,
 					message: "Toolbar did not fully collapse after Shell.NavBarIsVisible was set to false.");
 
-				var insetsWhenHidden = listener.OnApplyWindowInsets(rootCoordinator, syntheticInsets);
-
-				await AssertEventually(() => appBar.PaddingTop == 0,
+				await AssertEventually(() => capturingListener.InvocationCount > visibleInsetsInvocationCount && appBar.PaddingTop == 0,
 					timeout: 2000,
-					message: "AppBar retained top inset padding after the Shell navigation bar was hidden.");
+					message: "Shell.NavBarIsVisible did not trigger an inset redispatch that cleared the AppBar top padding.");
 
-				AssertTopInsets(insetsWhenHidden,
+				AssertTopInsets(capturingListener.LastAppliedInsets,
 					expectedSystemBarsTop: statusBarTopInset,
 					expectedDisplayCutoutTop: displayCutoutTopInset,
 					message: "Hidden Shell app bar should stop consuming the synthetic top insets.");
 			});
-		}
-
-		static WindowInsetsCompat CreateTopCutoutInsets(int statusBarTopInset, int displayCutoutTopInset)
-		{
-			return new WindowInsetsCompat.Builder()
-				.SetInsets(WindowInsetsCompat.Type.SystemBars(), AndroidX.Core.Graphics.Insets.Of(0, statusBarTopInset, 0, 0))
-				.SetInsets(WindowInsetsCompat.Type.DisplayCutout(), AndroidX.Core.Graphics.Insets.Of(0, displayCutoutTopInset, 0, 0))
-				.Build();
-		}
-
-		static void AssertTopInsets(WindowInsetsCompat insets, int expectedSystemBarsTop, int expectedDisplayCutoutTop, string message)
-		{
-			Assert.NotNull(insets);
-
-			var systemBars = insets.GetInsets(WindowInsetsCompat.Type.SystemBars());
-			var displayCutout = insets.GetInsets(WindowInsetsCompat.Type.DisplayCutout());
-
-			Assert.True(
-				(systemBars?.Top ?? 0) == expectedSystemBarsTop && (displayCutout?.Top ?? 0) == expectedDisplayCutoutTop,
-				$"{message} Actual SystemBars.Top={(systemBars?.Top ?? 0)}, DisplayCutout.Top={(displayCutout?.Top ?? 0)}.");
 		}
 
 		protected async Task CheckFlyoutState(ShellRenderer handler, bool desiredState)

--- a/src/Core/src/Platform/Android/MauiWindowInsetListener.cs
+++ b/src/Core/src/Platform/Android/MauiWindowInsetListener.cs
@@ -237,20 +237,12 @@ namespace Microsoft.Maui.Platform
 				}
 			}
 
-			// Check if AppBarLayout has meaningful content
-			bool appBarHasContent = appBarLayout?.MeasuredHeight > 0;
-			if (!appBarHasContent && appBarLayout is not null)
-			{
-				for (int i = 0; i < appBarLayout.ChildCount; i++)
-				{
-					var child = appBarLayout.GetChildAt(i);
-					if (child?.MeasuredHeight > 0)
-					{
-						appBarHasContent = true;
-						break;
-					}
-				}
-			}
+			// Check if AppBarLayout has meaningful content.
+			// When the Shell toolbar is hidden we set its height to 0, but the AppBarLayout can still
+			// retain previously applied top padding. If we key off MeasuredHeight alone, that stale
+			// padding makes the app bar look "non-empty" and we keep consuming the top inset,
+			// leaving a blank gap on cutout devices.
+			bool appBarHasContent = HasVisibleAppBarContent(appBarLayout);
 
 			// Apply padding to AppBarLayout based on content and system insets
 			if (appBarLayout is not null)
@@ -306,6 +298,37 @@ namespace Microsoft.Maui.Platform
 				?.SetInsets(WindowInsetsCompat.Type.SystemBars(), newSystemBars)
 				?.SetInsets(WindowInsetsCompat.Type.DisplayCutout(), newDisplayCutout)
 				?.Build() ?? insets;
+		}
+
+		static bool HasVisibleAppBarContent(AppBarLayout? appBarLayout)
+		{
+			if (appBarLayout is null || appBarLayout.Visibility == ViewStates.Gone)
+			{
+				return false;
+			}
+
+			var measuredContentHeight = Math.Max(0, appBarLayout.MeasuredHeight - appBarLayout.PaddingTop - appBarLayout.PaddingBottom);
+			if (measuredContentHeight > 0)
+			{
+				return true;
+			}
+
+			for (int i = 0; i < appBarLayout.ChildCount; i++)
+			{
+				var child = appBarLayout.GetChildAt(i);
+				if (child is null || child.Visibility == ViewStates.Gone)
+				{
+					continue;
+				}
+
+				var childContentHeight = Math.Max(0, child.MeasuredHeight - child.PaddingTop - child.PaddingBottom);
+				if (childContentHeight > 0 || child.Height > 0 || child.LayoutParameters?.Height > 0)
+				{
+					return true;
+				}
+			}
+
+			return false;
 		}
 
 		public void TrackView(AView view)

--- a/src/Core/src/Platform/Android/MauiWindowInsetListener.cs
+++ b/src/Core/src/Platform/Android/MauiWindowInsetListener.cs
@@ -316,13 +316,13 @@ namespace Microsoft.Maui.Platform
 				}
 
 				var childLayoutHeight = child.LayoutParameters?.Height ?? 0;
-				var childContentHeight = Math.Max(0, child.MeasuredHeight - child.PaddingTop - child.PaddingBottom);
-				if (childContentHeight > 0 || child.Height > 0 || childLayoutHeight > 0)
+				if (child is MaterialToolbar && childLayoutHeight == 0)
 				{
-					return true;
+					continue;
 				}
 
-				if (child is MaterialToolbar && childLayoutHeight != 0)
+				var childContentHeight = Math.Max(0, child.MeasuredHeight - child.PaddingTop - child.PaddingBottom);
+				if (childContentHeight > 0 || child.Height > 0 || childLayoutHeight > 0)
 				{
 					return true;
 				}

--- a/src/Core/src/Platform/Android/MauiWindowInsetListener.cs
+++ b/src/Core/src/Platform/Android/MauiWindowInsetListener.cs
@@ -307,12 +307,6 @@ namespace Microsoft.Maui.Platform
 				return false;
 			}
 
-			var measuredContentHeight = Math.Max(0, appBarLayout.MeasuredHeight - appBarLayout.PaddingTop - appBarLayout.PaddingBottom);
-			if (measuredContentHeight > 0)
-			{
-				return true;
-			}
-
 			for (int i = 0; i < appBarLayout.ChildCount; i++)
 			{
 				var child = appBarLayout.GetChildAt(i);
@@ -323,10 +317,16 @@ namespace Microsoft.Maui.Platform
 
 				var childLayoutHeight = child.LayoutParameters?.Height ?? 0;
 				var childContentHeight = Math.Max(0, child.MeasuredHeight - child.PaddingTop - child.PaddingBottom);
-				if (childContentHeight > 0 || child.Height > 0 || childLayoutHeight != 0)
+				if (childContentHeight > 0 || child.Height > 0 || childLayoutHeight > 0)
 				{
 					return true;
 				}
+
+				if (child is MaterialToolbar && childLayoutHeight != 0)
+				{
+					return true;
+				}
+
 			}
 
 			return false;

--- a/src/Core/src/Platform/Android/MauiWindowInsetListener.cs
+++ b/src/Core/src/Platform/Android/MauiWindowInsetListener.cs
@@ -321,8 +321,9 @@ namespace Microsoft.Maui.Platform
 					continue;
 				}
 
+				var childLayoutHeight = child.LayoutParameters?.Height ?? 0;
 				var childContentHeight = Math.Max(0, child.MeasuredHeight - child.PaddingTop - child.PaddingBottom);
-				if (childContentHeight > 0 || child.Height > 0 || child.LayoutParameters?.Height > 0)
+				if (childContentHeight > 0 || child.Height > 0 || childLayoutHeight != 0)
 				{
 					return true;
 				}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

Fixes a Shell Android inset regression where hiding the navigation bar could leave a blank top gap on devices with a display cutout.

Fixes #35103

## What changed

- update Android app bar inset handling to detect real visible app bar content instead of relying on measured height that can be inflated by stale padding
- request layout and inset reapplication from the toolbar parent/app bar root when Shell toolbar visibility changes
- add an Android Shell device regression test for hidden navigation bars retaining top inset padding

## Verification

- built `Microsoft.Maui` and `Microsoft.Maui.Controls` for Android successfully
- ran Android Controls Shell device tests on an emulator via direct instrumentation: 70 passed, 0 failed
- verified `HiddenShellNavigationBarClearsAppBarInsetPadding` passed
