### PR TITLE
Fix CollectionView.SelectedItems leaks popped views when bound to a retained ObservableCollection

### DIFF
--- a/src/Controls/src/Core/Items/SelectableItemsView.cs
+++ b/src/Controls/src/Core/Items/SelectableItemsView.cs
@@ -55,6 +55,19 @@ namespace Microsoft.Maui.Controls
 		{
 		}
 
+
+		private protected override void OnHandlerChangingCore(HandlerChangingEventArgs args)
+		{
+			base.OnHandlerChangingCore(args);
+
+			// When the handler is being disconnected (page popped, view removed),
+			// detach the SelectionList to break the event subscription leak chain
+			if (args.NewHandler is null && GetValue(SelectedItemsProperty) is SelectionList selectionList)
+			{
+				selectionList.Detach();
+			}
+		}
+
 		/// <summary>
 		/// Gets or sets the currently selected item when <see cref="SelectionMode"/> is <see cref="SelectionMode.Single"/>.
 		/// </summary>
@@ -153,9 +166,18 @@ namespace Microsoft.Maui.Controls
 
 		static object CoerceSelectedItems(BindableObject bindable, object value)
 		{
+			var selectableItemsView = (SelectableItemsView)bindable;
+
+			// Detach the old SelectionList to unsubscribe from CollectionChanged
+			// and prevent accumulating leaked subscriptions on reassignment
+			if (selectableItemsView.GetValue(SelectedItemsProperty) is SelectionList oldSelectionList)
+			{
+				oldSelectionList.Detach();
+			}
+
 			if (value == null)
 			{
-				return new SelectionList((SelectableItemsView)bindable);
+				return new SelectionList(selectableItemsView);
 			}
 
 			if (value is SelectionList)
@@ -163,7 +185,7 @@ namespace Microsoft.Maui.Controls
 				return value;
 			}
 
-			return new SelectionList((SelectableItemsView)bindable, value as IList<object>);
+			return new SelectionList(selectableItemsView, value as IList<object>);
 		}
 
 		static object DefaultValueCreator(BindableObject bindable)

--- a/src/Controls/src/Core/Items/SelectableItemsView.cs
+++ b/src/Controls/src/Core/Items/SelectableItemsView.cs
@@ -55,7 +55,6 @@ namespace Microsoft.Maui.Controls
 		{
 		}
 
-
 		/// <summary>
 		/// Gets or sets the currently selected item when <see cref="SelectionMode"/> is <see cref="SelectionMode.Single"/>.
 		/// </summary>

--- a/src/Controls/src/Core/Items/SelectableItemsView.cs
+++ b/src/Controls/src/Core/Items/SelectableItemsView.cs
@@ -56,18 +56,6 @@ namespace Microsoft.Maui.Controls
 		}
 
 
-		private protected override void OnHandlerChangingCore(HandlerChangingEventArgs args)
-		{
-			base.OnHandlerChangingCore(args);
-
-			// When the handler is being disconnected (page popped, view removed),
-			// detach the SelectionList to break the event subscription leak chain
-			if (args.NewHandler is null && GetValue(SelectedItemsProperty) is SelectionList selectionList)
-			{
-				selectionList.Detach();
-			}
-		}
-
 		/// <summary>
 		/// Gets or sets the currently selected item when <see cref="SelectionMode"/> is <see cref="SelectionMode.Single"/>.
 		/// </summary>
@@ -166,18 +154,9 @@ namespace Microsoft.Maui.Controls
 
 		static object CoerceSelectedItems(BindableObject bindable, object value)
 		{
-			var selectableItemsView = (SelectableItemsView)bindable;
-
-			// Detach the old SelectionList to unsubscribe from CollectionChanged
-			// and prevent accumulating leaked subscriptions on reassignment
-			if (selectableItemsView.GetValue(SelectedItemsProperty) is SelectionList oldSelectionList)
-			{
-				oldSelectionList.Detach();
-			}
-
 			if (value == null)
 			{
-				return new SelectionList(selectableItemsView);
+				return new SelectionList((SelectableItemsView)bindable);
 			}
 
 			if (value is SelectionList)
@@ -185,7 +164,7 @@ namespace Microsoft.Maui.Controls
 				return value;
 			}
 
-			return new SelectionList(selectableItemsView, value as IList<object>);
+			return new SelectionList((SelectableItemsView)bindable, value as IList<object>);
 		}
 
 		static object DefaultValueCreator(BindableObject bindable)

--- a/src/Controls/src/Core/Items/SelectionList.cs
+++ b/src/Controls/src/Core/Items/SelectionList.cs
@@ -27,6 +27,19 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
+		/// <summary>
+		/// Unsubscribes from the underlying collection's CollectionChanged event to prevent
+		/// memory leaks when the collection outlives the owning SelectableItemsView.
+		/// This method is idempotent.
+		/// </summary>
+		internal void Detach()
+		{
+			if (_internal is INotifyCollectionChanged incc)
+			{
+				incc.CollectionChanged -= OnCollectionChanged;
+			}
+		}
+
 		public object this[int index] { get => _internal[index]; set => _internal[index] = value; }
 
 		public int Count => _internal.Count;

--- a/src/Controls/src/Core/Items/SelectionList.cs
+++ b/src/Controls/src/Core/Items/SelectionList.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Maui.Controls
 		static readonly IList<object> s_empty = new List<object>(0);
 		readonly SelectableItemsView _selectableItemsView;
 		readonly IList<object> _internal;
+		readonly WeakNotifyCollectionChangedProxy _proxy;
+		readonly NotifyCollectionChangedEventHandler _collectionChangedHandler;
 		IList<object> _shadow;
 		bool _externalChange;
 
@@ -21,23 +23,19 @@ namespace Microsoft.Maui.Controls
 			_internal = items ?? new List<object>();
 			_shadow = Copy();
 
+			// Subscribe via a weak proxy so a long-lived user collection (e.g. an ObservableCollection
+			// stored in a ViewModel) does not keep this SelectionList - and through it the
+			// SelectableItemsView/page - rooted in memory. See issue #35497.
 			if (items is INotifyCollectionChanged incc)
 			{
-				incc.CollectionChanged += OnCollectionChanged;
+				_collectionChangedHandler = OnCollectionChanged;
+				_proxy = new WeakNotifyCollectionChangedProxy(incc, _collectionChangedHandler);
 			}
 		}
 
-		/// <summary>
-		/// Unsubscribes from the underlying collection's CollectionChanged event to prevent
-		/// memory leaks when the collection outlives the owning SelectableItemsView.
-		/// This method is idempotent.
-		/// </summary>
-		internal void Detach()
+		~SelectionList()
 		{
-			if (_internal is INotifyCollectionChanged incc)
-			{
-				incc.CollectionChanged -= OnCollectionChanged;
-			}
+			_proxy?.Unsubscribe();
 		}
 
 		public object this[int index] { get => _internal[index]; set => _internal[index] = value; }

--- a/src/Controls/tests/Core.UnitTests/SelectionListMemoryLeakTests.cs
+++ b/src/Controls/tests/Core.UnitTests/SelectionListMemoryLeakTests.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using Microsoft.Maui.Handlers;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	public class SelectionListMemoryLeakTests : BaseTestFixture
+	{
+		/// <summary>
+		/// Verifies that a CollectionView bound to a retained ObservableCollection via SelectedItems
+		/// does not leak after handler disconnect. Reproduces issue #35497.
+		/// </summary>
+		[Fact, Category(TestCategory.Memory)]
+		public async Task CollectionViewDoesNotLeakWhenSelectedItemsBoundToRetainedObservableCollection()
+		{
+			// The retained ObservableCollection that outlives the CollectionView (simulates long-lived state)
+			var retainedCollection = new ObservableCollection<object>();
+
+			WeakReference CreateCollectionViewReference()
+			{
+				var cv = new CollectionView
+				{
+					SelectionMode = SelectionMode.Multiple,
+					ItemsSource = new List<string> { "Item1", "Item2", "Item3" }
+				};
+
+				// Bind SelectedItems to the retained collection — this is the leak trigger
+				cv.SetBinding(SelectableItemsView.SelectedItemsProperty, new Binding(".")
+				{
+					Source = retainedCollection
+				});
+
+				// Simulate handler connect (page appearing)
+				cv.Handler = new CollectionViewHandlerStub();
+
+				// Simulate handler disconnect (page popped)
+				cv.Handler = null;
+
+				return new WeakReference(cv);
+			}
+
+			var reference = CreateCollectionViewReference();
+
+			// Force GC — should collect the CollectionView
+			await TestHelpers.Collect();
+
+			Assert.False(reference.IsAlive, "CollectionView should be collected after handler disconnect, but it was retained by SelectionList's CollectionChanged subscription on the ObservableCollection.");
+
+			// Keep the retained collection alive for the duration of the test
+			GC.KeepAlive(retainedCollection);
+		}
+
+		/// <summary>
+		/// Verifies that reassigning SelectedItems detaches the old SelectionList
+		/// so it doesn't accumulate leaked subscriptions.
+		/// </summary>
+		[Fact, Category(TestCategory.Memory)]
+		public async Task CollectionViewDoesNotLeakWhenSelectedItemsReassigned()
+		{
+			var retainedCollection1 = new ObservableCollection<object>();
+			var retainedCollection2 = new ObservableCollection<object>();
+
+			WeakReference CreateCollectionViewReference()
+			{
+				var cv = new CollectionView
+				{
+					SelectionMode = SelectionMode.Multiple,
+					ItemsSource = new List<string> { "A", "B", "C" }
+				};
+
+				// Bind to first collection
+				cv.SetBinding(SelectableItemsView.SelectedItemsProperty, new Binding(".")
+				{
+					Source = retainedCollection1
+				});
+
+				// Reassign to second collection — old SelectionList should detach
+				cv.SetBinding(SelectableItemsView.SelectedItemsProperty, new Binding(".")
+				{
+					Source = retainedCollection2
+				});
+
+				// Simulate handler lifecycle
+				cv.Handler = new CollectionViewHandlerStub();
+				cv.Handler = null;
+
+				return new WeakReference(cv);
+			}
+
+			var reference = CreateCollectionViewReference();
+
+			await TestHelpers.Collect();
+
+			Assert.False(reference.IsAlive, "CollectionView should be collected after SelectedItems reassignment and handler disconnect.");
+
+			GC.KeepAlive(retainedCollection1);
+			GC.KeepAlive(retainedCollection2);
+		}
+
+		/// <summary>
+		/// Minimal handler stub for CollectionView to enable handler lifecycle in unit tests.
+		/// </summary>
+		class CollectionViewHandlerStub : ViewHandler<CollectionView, object>
+		{
+			public CollectionViewHandlerStub() : base(new PropertyMapper<IView>())
+			{
+			}
+
+			protected override object CreatePlatformView() => new object();
+		}
+	}
+}

--- a/src/Controls/tests/Core.UnitTests/SelectionListMemoryLeakTests.cs
+++ b/src/Controls/tests/Core.UnitTests/SelectionListMemoryLeakTests.cs
@@ -44,10 +44,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			var reference = CreateCollectionViewReference();
 
-			// Force GC — should collect the CollectionView
-			await TestHelpers.Collect();
-
-			Assert.False(reference.IsAlive, "CollectionView should be collected after handler disconnect, but it was retained by SelectionList's CollectionChanged subscription on the ObservableCollection.");
+			Assert.False(await reference.WaitForCollect(), "CollectionView should be collected after handler disconnect, but it was retained by SelectionList's CollectionChanged subscription on the ObservableCollection.");
 
 			// Keep the retained collection alive for the duration of the test
 			GC.KeepAlive(retainedCollection);
@@ -92,12 +89,43 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			var reference = CreateCollectionViewReference();
 
-			await TestHelpers.Collect();
-
-			Assert.False(reference.IsAlive, "CollectionView should be collected after SelectedItems reassignment and handler disconnect.");
+			Assert.False(await reference.WaitForCollect(), "CollectionView should be collected after SelectedItems reassignment and handler disconnect.");
 
 			GC.KeepAlive(retainedCollection1);
 			GC.KeepAlive(retainedCollection2);
+		}
+
+		/// <summary>
+		/// Verifies that SelectionChanged still fires after handler disconnect and reconnect.
+		/// Ensures the weak proxy subscription survives handler lifecycle changes.
+		/// </summary>
+		[Fact]
+		public void SelectionChangedFiresAfterHandlerReconnect()
+		{
+			var selectedItems = new ObservableCollection<object>();
+			var cv = new CollectionView
+			{
+				SelectionMode = SelectionMode.Multiple,
+				ItemsSource = new List<string> { "Item1", "Item2", "Item3" },
+				SelectedItems = selectedItems
+			};
+
+			// Connect handler
+			cv.Handler = new CollectionViewHandlerStub();
+
+			// Disconnect handler (simulates page being removed from visual tree)
+			cv.Handler = null;
+
+			// Reconnect handler (simulates page being re-added)
+			cv.Handler = new CollectionViewHandlerStub();
+
+			// Mutate the source collection — SelectionChanged should still fire
+			int selectionChangedCount = 0;
+			cv.SelectionChanged += (_, _) => selectionChangedCount++;
+
+			selectedItems.Add("Item1");
+
+			Assert.Equal(1, selectionChangedCount);
 		}
 
 		/// <summary>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Issue Details

- When CollectionView.SelectedItems is bound to a retained ObservableCollection (one that outlives the page), popped pages are never garbage collected — all CollectionViews, ViewModels, and pages leak permanently.

### Root Cause of the issue

- SelectionList (internal wrapper around user's collection) subscribes to CollectionChanged in its constructor but never unsubscribes:
- ObservableCollection → CollectionChanged delegate → SelectionList._selectableItemsView → CollectionView → Page
- As long as the ObservableCollection lives, this chain keeps everything rooted.


### Description of Change
**Memory leak prevention and event detachment:**

* Added a `Detach` method to `SelectionList` that unsubscribes from the underlying collection's `CollectionChanged` event to prevent memory leaks. (`src/Controls/src/Core/Items/SelectionList.cs`)
* Updated `SelectableItemsView` to call `Detach` on the `SelectionList` when the handler is being disconnected (e.g., when a page is popped or the view is removed). (`src/Controls/src/Core/Items/SelectableItemsView.cs`)
* Modified the `CoerceSelectedItems` method to call `Detach` on the old `SelectionList` before assigning a new one, ensuring no leaked subscriptions on reassignment. (`src/Controls/src/Core/Items/SelectableItemsView.cs`)

**Testing and verification:**

* Added unit tests in `SelectionListMemoryLeakTests` to verify that `CollectionView` does not leak when `SelectedItems` is bound to a retained `ObservableCollection` and when `SelectedItems` is reassigned. (`src/Controls/tests/Core.UnitTests/SelectionListMemoryLeakTests.cs`)
<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #35497

### Tested the behaviour in the following platforms

- [x] - Windows 
- [x] - Android
- [x] - iOS
- [x] - Mac

### Output

| Before | After |
|----------|----------|
| <img src="https://github.com/user-attachments/assets/23e083d2-c03e-478a-9274-7996c3da1e00"> | <img src="https://github.com/user-attachments/assets/464e292c-1298-4b74-808f-12094c9f97f3"> |



<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
