### PR TITLE
[iOS] Fix Shell - opened keyboard on modal page shifts parent page/frame behind modal after update to 10.0.60

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
@@ -1335,8 +1335,11 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				if (NavigationItem?.TitleView is TitleViewContainer tvc)
 					tvc.Disconnect();
 
-				_keyboardWillHideObserver?.Dispose();
-				_keyboardWillHideObserver = null;
+				if (_keyboardWillHideObserver is not null)
+				{
+					NSNotificationCenter.DefaultCenter.RemoveObserver(_keyboardWillHideObserver);
+					_keyboardWillHideObserver = null;
+				}
 			}
 
 			_context = null;

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
@@ -1335,11 +1335,8 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				if (NavigationItem?.TitleView is TitleViewContainer tvc)
 					tvc.Disconnect();
 
-				if (_keyboardWillHideObserver is not null)
-				{
-					NSNotificationCenter.DefaultCenter.RemoveObserver(_keyboardWillHideObserver);
-					_keyboardWillHideObserver = null;
-				}
+				_keyboardWillHideObserver?.Dispose();
+				_keyboardWillHideObserver = null;
 			}
 
 			_context = null;

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
@@ -1237,14 +1237,33 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				return;
 
 			var navController = ViewController.NavigationController;
+
+			// The keyboard observer is global — every live tracker receives every UIKeyboard hide
+			// event. If a modal view controller is currently presented over this nav controller,
+			// the keyboard belongs to that modal (e.g. a transparent Shell page with an Entry
+			// presented via Shell.GoToAsync). Return WITHOUT consuming _pendingKeyboardNavigation
+			// so the flag stays armed for a genuine page-load keyboard event on this tracker.
+			if (navController.PresentedViewController is not null)
+				return;
+
 			var navBar = navController.NavigationBar;
 
 			if (navBar.Hidden || navBar.Frame.Height <= 0)
+			{
+				// No nav bar means the misposition scenario cannot occur; consume the flag so a
+				// later unrelated keyboard hide does not re-trigger this correction.
+				_pendingKeyboardNavigation = false;
 				return;
+			}
 
-			// Don't interfere with SearchHandler's keyboard management when it's active
+			// Don't interfere with SearchHandler's keyboard management when it's active.
+			// Consume the flag here too — leaving it armed risks running the fix on a later,
+			// unrelated keyboard dismissal.
 			if (_searchController?.Active == true)
+			{
+				_pendingKeyboardNavigation = false;
 				return;
+			}
 
 			var currentFrame = ViewController.View.Frame;
 			var navBarBottom = navBar.Frame.Bottom;

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
@@ -1241,8 +1241,10 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			// The keyboard observer is global — every live tracker receives every UIKeyboard hide
 			// event. If a modal view controller is currently presented over this nav controller,
 			// the keyboard belongs to that modal (e.g. a transparent Shell page with an Entry
-			// presented via Shell.GoToAsync). Return WITHOUT consuming _pendingKeyboardNavigation
-			// so the flag stays armed for a genuine page-load keyboard event on this tracker.
+			// presented via Shell.GoToAsync). Return WITHOUT consuming _pendingKeyboardNavigation:
+			// this modal is transient, and the flag must remain armed for a genuine keyboard hide
+			// on this tracker after the modal is dismissed. The correction gate below
+			// (currentFrame.Y == 0 and related checks) is what prevents false positives.
 			if (navController.PresentedViewController is not null)
 				return;
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue35401.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue35401.cs
@@ -76,11 +76,11 @@ public class Issue35401ModalPage : ContentPage
 		Shell.SetPresentationMode(this, PresentationMode.ModalNotAnimated);
 		BackgroundColor = Color.FromArgb("#80000000");
 
-		var editor = new Editor
+		var entry = new Entry
 		{
 			Placeholder = "Enter text here",
 			HeightRequest = 120,
-			AutomationId = "ModalEditor"
+			AutomationId = "ModalEntry"
 		};
 
 		var closeButton = new Button
@@ -106,7 +106,7 @@ public class Issue35401ModalPage : ContentPage
 					{
 						Padding = 16,
 						Spacing = 12,
-						Children = { editor, closeButton }
+						Children = { entry, closeButton }
 					}
 				}
 			}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue35401.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue35401.cs
@@ -1,0 +1,115 @@
+using Microsoft.Maui.Controls.Shapes;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 35401, "Modal page keyboard dismissal causes parent Shell page layout to offset on iOS", PlatformAffected.iOS)]
+public class Issue35401 : Shell
+{
+	public Issue35401()
+	{
+		Routing.RegisterRoute(nameof(Issue35401Level2Page), typeof(Issue35401Level2Page));
+		Routing.RegisterRoute(nameof(Issue35401ModalPage), typeof(Issue35401ModalPage));
+
+		var tab = new Tab { Title = "Main" };
+		tab.Items.Add(new ShellContent
+		{
+			Title = "Main",
+			ContentTemplate = new DataTemplate(() => new Issue35401Level1Page())
+		});
+		Items.Add(tab);
+	}
+}
+
+public class Issue35401Level1Page : ContentPage
+{
+	public Issue35401Level1Page()
+	{
+		Title = "Level1";
+		Shell.SetBackButtonBehavior(this, new BackButtonBehavior { IsVisible = false });
+
+		var scrollContent = new VerticalStackLayout { Padding = 16, Spacing = 10 };
+		scrollContent.Add(new Button
+		{
+			Text = "Go to Level2",
+			AutomationId = "GoToLevel2Button",
+			Command = new Command(async () => await Shell.Current.GoToAsync(nameof(Issue35401Level2Page), false))
+		});
+		for (int i = 1; i <= 20; i++)
+			scrollContent.Add(new Label { Text = $"Item {i:D2}", FontSize = 16 });
+
+		Content = new ScrollView { Content = scrollContent };
+	}
+}
+
+public class Issue35401Level2Page : ContentPage
+{
+	public Issue35401Level2Page()
+	{
+		Title = "Level2";
+
+		var titleLabel = new Label
+		{
+			Text = "Level2 Page",
+			FontSize = 24,
+			FontAttributes = FontAttributes.Bold,
+			AutomationId = "Level2Title"
+		};
+
+		var scrollContent = new VerticalStackLayout { Padding = 16, Spacing = 10 };
+		scrollContent.Add(titleLabel);
+		scrollContent.Add(new Button
+		{
+			Text = "Open Modal",
+			AutomationId = "OpenModalButton",
+			Command = new Command(async () => await Shell.Current.GoToAsync(nameof(Issue35401ModalPage), false))
+		});
+		for (int i = 1; i <= 20; i++)
+			scrollContent.Add(new Label { Text = $"Detail Item {i:D2}", FontSize = 16 });
+
+		Content = new ScrollView { Content = scrollContent };
+	}
+}
+
+public class Issue35401ModalPage : ContentPage
+{	public Issue35401ModalPage()
+	{
+		Shell.SetPresentationMode(this, PresentationMode.ModalNotAnimated);
+		BackgroundColor = Color.FromArgb("#80000000");
+
+		var editor = new Editor
+		{
+			Placeholder = "Enter text here",
+			HeightRequest = 120,
+			AutomationId = "ModalEditor"
+		};
+
+		var closeButton = new Button
+		{
+			Text = "Close",
+			AutomationId = "CloseModalButton",
+			Command = new Command(async () => await Shell.Current.GoToAsync("..", false))
+		};
+
+		Content = new Grid
+		{
+			Children =
+			{
+				new Border
+				{
+					Margin = new Thickness(16),
+					BackgroundColor = Colors.White,
+					StrokeShape = new RoundRectangle { CornerRadius = 16 },
+					StrokeThickness = 0,
+					HorizontalOptions = LayoutOptions.Fill,
+					VerticalOptions = LayoutOptions.Center,
+					Content = new VerticalStackLayout
+					{
+						Padding = 16,
+						Spacing = 12,
+						Children = { editor, closeButton }
+					}
+				}
+			}
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35401.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35401.cs
@@ -27,25 +27,31 @@ public class Issue35401 : _IssuesUITest
 		App.WaitForElement("OpenModalButton");
 		App.Tap("OpenModalButton");
 
-		// Focus the Editor inside the modal to trigger the software keyboard
-		App.WaitForElement("ModalEditor");
-		App.Tap("ModalEditor");
+		// Focus the Entry inside the modal to trigger the software keyboard
+		App.WaitForElement("ModalEntry");
+		App.Tap("ModalEntry");
 
 		// The bug only manifests when UIKeyboardWillHideNotification fires.
 		// On simulators with a hardware keyboard connected, the software keyboard
 		// does not appear and no notification is sent — skip rather than false-pass.
 		if (!App.WaitForKeyboardToShow(TimeSpan.FromSeconds(5)))
 		{
-			Assert.Ignore("Software keyboard did not appear in this test environment. " +
-				"Run on a device (or simulator with software keyboard enabled) to verify " +
-				"the regression from PR #33958 is fixed.");
-			return;
+			// Retry focus once for environments where the first tap does not consistently
+			// bring up the software keyboard.
+			App.Tap("ModalEntry");
+
+			if (!App.WaitForKeyboardToShow(TimeSpan.FromSeconds(5)))
+			{
+				Assert.Ignore("Software keyboard did not appear in this test environment. " +
+					"Run on a device (or simulator with software keyboard enabled) to verify " +
+					"the regression from PR #33958 is fixed.");
+				return;
+			}
 		}
 
 		// Dismiss the keyboard — this fires UIKeyboardWillHideNotification, which
 		// previously triggered an incorrect frame adjustment on the underlying Shell page.
-		App.Tap("Done");
-		App.WaitForKeyboardToHide();
+		App.DismissKeyboard();
 
 		// Close the modal
 		App.WaitForElement("CloseModalButton");

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35401.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35401.cs
@@ -1,0 +1,65 @@
+#if IOS
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue35401 : _IssuesUITest
+{
+	public Issue35401(TestDevice device) : base(device) { }
+
+	public override string Issue => "Modal page keyboard dismissal causes parent Shell page layout to offset on iOS";
+
+	[Test]
+	[Category(UITestCategories.Shell)]
+	public void ParentPageShouldNotOffsetAfterModalKeyboardDismissal()
+	{
+		// Navigate from Level1 to Level2
+		App.WaitForElement("GoToLevel2Button");
+		App.Tap("GoToLevel2Button");
+
+		// Capture the Y position of the Level2 title before opening the modal
+		App.WaitForElement("Level2Title");
+		var titleRectBefore = App.WaitForElement("Level2Title").GetRect();
+
+		// Open the transparent modal page
+		App.WaitForElement("OpenModalButton");
+		App.Tap("OpenModalButton");
+
+		// Focus the Editor inside the modal to trigger the software keyboard
+		App.WaitForElement("ModalEditor");
+		App.Tap("ModalEditor");
+
+		// The bug only manifests when UIKeyboardWillHideNotification fires.
+		// On simulators with a hardware keyboard connected, the software keyboard
+		// does not appear and no notification is sent — skip rather than false-pass.
+		if (!App.WaitForKeyboardToShow(TimeSpan.FromSeconds(5)))
+		{
+			Assert.Ignore("Software keyboard did not appear in this test environment. " +
+				"Run on a device (or simulator with software keyboard enabled) to verify " +
+				"the regression from PR #33958 is fixed.");
+			return;
+		}
+
+		// Dismiss the keyboard — this fires UIKeyboardWillHideNotification, which
+		// previously triggered an incorrect frame adjustment on the underlying Shell page.
+		App.Tap("Done");
+		App.WaitForKeyboardToHide();
+
+		// Close the modal
+		App.WaitForElement("CloseModalButton");
+		App.Tap("CloseModalButton");
+
+		// Level2 page should be visible again with its layout intact
+		App.WaitForElement("Level2Title");
+		var titleRectAfter = App.WaitForElement("Level2Title").GetRect();
+
+		// The title Y position must not have shifted — regression from PR #33958 caused
+		// OnKeyboardWillHide to reposition the underlying Shell page when the modal's
+		// keyboard was dismissed.
+		Assert.That(titleRectAfter.Y, Is.EqualTo(titleRectBefore.Y),
+			"Level2 page title shifted vertically after modal keyboard was dismissed — layout offset regression (PR #33958)");
+	}
+}
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35401.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35401.cs
@@ -1,4 +1,4 @@
-#if IOS
+#if IOS || ANDROID // This test is only for Android and iOS because the issue is specifically related to on-screen keyboard behavior which is only available on mobile platforms.
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -52,11 +52,11 @@ public class Issue35401 : _IssuesUITest
 		// Dismiss the keyboard — this fires UIKeyboardWillHideNotification, which
 		// previously triggered an incorrect frame adjustment on the underlying Shell page.
 		App.DismissKeyboard();
-
-		// Close the modal
+#if IOS
+		// In iOS the modal page remains visible after keyboard dismissal, so close it to reveal the underlying page and verify its layout is intact. On Android, the modal is dismissed immediately when the keyboard is dismissed, so no extra tap is needed.
 		App.WaitForElement("CloseModalButton");
 		App.Tap("CloseModalButton");
-
+#endif
 		// Level2 page should be visible again with its layout intact
 		App.WaitForElement("Level2Title");
 		var titleRectAfter = App.WaitForElement("Level2Title").GetRect();


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details:

When the keyboard opens in the modal, the parent page/frame behind the modal shifts in the shell.
       
### Root Cause:

 PR #33958 added an OnKeyboardWillHide handler to ShellPageRendererTracker to fix an iOS timing bug where a Shell page view would land at Y=0 (underneath the navigation bar) when the keyboard dismissed during a page navigation. The handler worked by detecting this misposition and correcting the view frame. However, the observer was registered using UIKeyboard.Notifications.ObserveWillHide — a global notification that fires for every live ShellPageRendererTracker instance whenever any keyboard is dismissed, regardless of which page triggered it.
 
  This becomes a problem when a transparent modal page is presented via Shell.GoToAsync. In iOS, modal presentation does not push the modal onto the navigation controller's view controller stack — it sits above the stack as a separate presented view controller. This means navController.TopViewController still points to the underlying Shell page, so the existing guard ViewController == navController.TopViewController evaluated to true for the page behind the modal. With _pendingKeyboardNavigation still armed from the page's initial load, dismissing the keyboard inside the modal triggered the frame correction on the underlying page, causing the visible vertical offset reported in the issue.
 
  Two secondary bugs compounded this: the SearchHandler early-return and the hidden-nav-bar early-return both exited the method without clearing _pendingKeyboardNavigation, leaving the flag permanently armed after those paths — meaning any future keyboard dismissal could incorrectly fire the frame correction long after the intended one-shot timing window had passed.

### Description of Change:

The fix adds a single guard at the top of OnKeyboardWillHide: if navController.PresentedViewController is not null, the method returns immediately without clearing _pendingKeyboardNavigation. Using PresentedViewController is the idiomatic UIKit way to detect that a modal is covering the navigation controller, and returning without consuming the flag ensures the original page-load correction still works if a keyboard event fires on this page after the modal is dismissed. The two secondary leaks are also patched both the hidden-nav-bar path and the SearchHandler path now explicitly set _pendingKeyboardNavigation = false before returning, so the flag is always consumed once the correction window is definitively over.

**Tested the behavior in the following platforms:**

- [x] Android
- [ ] Windows
- [x] iOS
- [ ] Mac

### Reference:

N/A

### Issues Fixed:

Fixes  #35401         

### Screenshots
| Before  | After  |
|---------|--------|
|   <Video src="https://github.com/user-attachments/assets/a9da8996-3caf-4932-a5ca-a22dc72a302c" Width="300" Height="600"/>   |   <Video src="https://github.com/user-attachments/assets/503ced7d-24de-4410-aaf2-63c684211564" Width="300" Height="600"/>  |

