### PR TITLE
[Windows] Add Automation Id support for Layouts. 

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.Windows.cs
@@ -6,7 +6,9 @@ using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Platform;
+using Microsoft.UI.Xaml.Automation.Peers;
 using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
@@ -26,5 +28,100 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.Equal(view.InputTransparent, !handler.PlatformView.IsHitTestVisible);
 			}
 		}
+
+		void SetupLayoutBuilder()
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler<Grid, LayoutHandler>();
+					handlers.AddHandler<VerticalStackLayout, LayoutHandler>();
+					handlers.AddHandler<HorizontalStackLayout, LayoutHandler>();
+					handlers.AddHandler<AbsoluteLayout, LayoutHandler>();
+				});
+			});
+		}
+
+		[Fact(DisplayName = "LayoutPanel creates a MauiLayoutAutomationPeer")]
+		public async Task LayoutPanelCreatesMauiLayoutAutomationPeer()
+		{
+			SetupLayoutBuilder();
+
+			var grid = new Grid();
+
+			await AttachAndRun(grid, (LayoutHandler handler) =>
+			{
+				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(handler.PlatformView);
+				Assert.IsType<MauiLayoutAutomationPeer>(peer);
+			});
+		}
+
+		[Fact(DisplayName = "LayoutPanel AutomationPeer control type is Pane")]
+		public async Task LayoutPanelAutomationPeerControlTypeIsPane()
+		{
+			SetupLayoutBuilder();
+
+			var grid = new Grid();
+
+			await AttachAndRun(grid, (LayoutHandler handler) =>
+			{
+				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(handler.PlatformView);
+				Assert.Equal(AutomationControlType.Pane, peer.GetAutomationControlType());
+			});
+		}
+
+		[Theory(DisplayName = "LayoutPanel class name reflects cross-platform layout type")]
+		[InlineData(typeof(Grid), "Grid")]
+		[InlineData(typeof(VerticalStackLayout), "VerticalStackLayout")]
+		[InlineData(typeof(HorizontalStackLayout), "HorizontalStackLayout")]
+		[InlineData(typeof(AbsoluteLayout), "AbsoluteLayout")]
+		public async Task LayoutPanelClassNameReflectsCrossPlatformType(Type layoutType, string expectedClassName)
+		{
+			SetupLayoutBuilder();
+
+			var layout = (Layout)Activator.CreateInstance(layoutType)!;
+
+			await AttachAndRun(layout, (LayoutHandler handler) =>
+			{
+				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(handler.PlatformView);
+				Assert.Equal(expectedClassName, peer.GetClassName());
+			});
+		}
+
+		[Theory(DisplayName = "LayoutPanel with AutomationId is exposed in automation tree")]
+		[InlineData(true)]
+		[InlineData(false)]
+		public async Task LayoutPanelWithAutomationIdIsExposedInTree(bool hasAutomationId)
+		{
+			SetupLayoutBuilder();
+
+			var grid = new Grid();
+			if (hasAutomationId)
+				grid.AutomationId = "TestGrid";
+
+			await AttachAndRun(grid, (LayoutHandler handler) =>
+			{
+				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(handler.PlatformView);
+				Assert.Equal(hasAutomationId, peer.IsControlElement());
+				Assert.Equal(hasAutomationId, peer.IsContentElement());
+			});
+		}
+
+		[Fact(DisplayName = "LayoutPanel AutomationPeer is not keyboard focusable")]
+		public async Task LayoutPanelAutomationPeerIsNotKeyboardFocusable()
+		{
+			SetupLayoutBuilder();
+
+			var grid = new Grid();
+
+			await AttachAndRun(grid, (LayoutHandler handler) =>
+			{
+				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(handler.PlatformView);
+				Assert.False(peer.IsKeyboardFocusable());
+			});
+		}
 	}
 }
+
+

--- a/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.Windows.cs
@@ -39,6 +39,8 @@ namespace Microsoft.Maui.DeviceTests
 					handlers.AddHandler<VerticalStackLayout, LayoutHandler>();
 					handlers.AddHandler<HorizontalStackLayout, LayoutHandler>();
 					handlers.AddHandler<AbsoluteLayout, LayoutHandler>();
+					handlers.AddHandler<FlexLayout, LayoutHandler>();
+					handlers.AddHandler<StackLayout, LayoutHandler>();
 				});
 			});
 		}
@@ -76,15 +78,28 @@ namespace Microsoft.Maui.DeviceTests
 		[InlineData(typeof(VerticalStackLayout), "VerticalStackLayout")]
 		[InlineData(typeof(HorizontalStackLayout), "HorizontalStackLayout")]
 		[InlineData(typeof(AbsoluteLayout), "AbsoluteLayout")]
+		[InlineData(typeof(FlexLayout), "FlexLayout")]
+		[InlineData(typeof(StackLayout), "StackLayout")]
 		public async Task LayoutPanelClassNameReflectsCrossPlatformType(Type layoutType, string expectedClassName)
 		{
 			SetupLayoutBuilder();
 
 			var layout = (Layout)Activator.CreateInstance(layoutType)!;
 
-			await AttachAndRun(layout, (LayoutHandler handler) =>
+			// FlexLayout._root is only initialized when it has a MAUI parent.
+			// Wrap it in a VerticalStackLayout so OnParentSet() fires before layout runs.
+			Layout root = layout is FlexLayout
+				? new VerticalStackLayout { layout }
+				: layout;
+
+			await AttachAndRun(root, (LayoutHandler handler) =>
 			{
-				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(handler.PlatformView);
+				// For FlexLayout, find the inner FlexLayout's platform view via its handler
+				var targetView = layout is FlexLayout
+					? (layout.Handler as LayoutHandler)?.PlatformView ?? handler.PlatformView
+					: handler.PlatformView;
+
+				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(targetView);
 				Assert.Equal(expectedClassName, peer.GetClassName());
 			});
 		}

--- a/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.Windows.cs
@@ -118,7 +118,6 @@ namespace Microsoft.Maui.DeviceTests
 			await AttachAndRun(grid, (LayoutHandler handler) =>
 			{
 				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(handler.PlatformView);
-				Assert.Equal(hasAutomationId, peer.IsControlElement());
 				Assert.Equal(hasAutomationId, peer.IsContentElement());
 			});
 		}
@@ -134,6 +133,28 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(handler.PlatformView);
 				Assert.False(peer.IsKeyboardFocusable());
+			});
+		}
+
+		[Fact(DisplayName = "LayoutPanel IsControlElement and IsContentElement update when AutomationId is set at runtime")]
+		public async Task LayoutPanelAutomationPeerUpdatesWhenAutomationIdChangesAtRuntime()
+		{
+			SetupLayoutBuilder();
+
+			var grid = new Grid();
+
+			await AttachAndRun(grid, (LayoutHandler handler) =>
+			{
+				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(handler.PlatformView);
+
+				// Initially no AutomationId — should NOT be exposed
+				Assert.False(peer.IsContentElement());
+
+				// Set AutomationId at runtime — should now be exposed.
+				// Note: MAUI AutomationId is write-once (Element.cs enforces this),
+				// so we can only test the transition from unset → set, not set → cleared.
+				grid.AutomationId = "DynamicGrid";
+				Assert.True(peer.IsContentElement());
 			});
 		}
 	}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue4715.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue4715.cs
@@ -1,0 +1,129 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 4715, "[Windows] Layout containers not visible to UI automation", PlatformAffected.UWP)]
+public class Issue4715 : ContentPage
+{
+	public Issue4715()
+	{
+		var scrollView = new ScrollView
+		{
+			Content = new VerticalStackLayout
+			{
+				Spacing = 10,
+				Padding = new Thickness(16),
+				Children =
+				{
+					new Label
+					{
+						Text = "Layout Automation Peer Test",
+						FontSize = 18,
+						FontAttributes = FontAttributes.Bold,
+						AutomationId = "PageTitle"
+					},
+
+					// Grid with AutomationId
+					new Grid
+					{
+						AutomationId = "TestGrid",
+						BackgroundColor = Colors.LightBlue,
+						HeightRequest = 60,
+						Children =
+						{
+							new Label { Text = "Grid", VerticalOptions = LayoutOptions.Center, HorizontalOptions = LayoutOptions.Center }
+						}
+					},
+
+					// VerticalStackLayout with AutomationId
+					new VerticalStackLayout
+					{
+						AutomationId = "TestVerticalStackLayout",
+						BackgroundColor = Colors.LightGreen,
+						Children =
+						{
+							new Label { Text = "VerticalStackLayout", Padding = new Thickness(8) }
+						}
+					},
+
+					// HorizontalStackLayout with AutomationId
+					new HorizontalStackLayout
+					{
+						AutomationId = "TestHorizontalStackLayout",
+						BackgroundColor = Colors.LightYellow,
+						Children =
+						{
+							new Label { Text = "HorizontalStackLayout", Padding = new Thickness(8) }
+						}
+					},
+
+					// FlexLayout with AutomationId
+					new FlexLayout
+					{
+						AutomationId = "TestFlexLayout",
+						BackgroundColor = Colors.LightPink,
+						HeightRequest = 60,
+						Children =
+						{
+							new Label { Text = "FlexLayout", Margin = new Thickness(8) }
+						}
+					},
+
+					// AbsoluteLayout with AutomationId
+					new AbsoluteLayout
+					{
+						AutomationId = "TestAbsoluteLayout",
+						BackgroundColor = Colors.LightSteelBlue,
+						HeightRequest = 60,
+						Children =
+						{
+							new Label
+							{
+								Text = "AbsoluteLayout",
+								Margin = new Thickness(8)
+							}
+						}
+					},
+
+					// Nested layout — outer has AutomationId, inner is anonymous
+					new Grid
+					{
+						AutomationId = "TestNestedOuterGrid",
+						BackgroundColor = Colors.Lavender,
+						HeightRequest = 80,
+						Children =
+						{
+							new VerticalStackLayout
+							{
+								// No AutomationId — anonymous inner layout
+								Children =
+								{
+									new Label { Text = "Nested: Outer Grid (named)", HorizontalOptions = LayoutOptions.Center },
+									new Label { Text = "Inner VerticalStackLayout (anonymous)", HorizontalOptions = LayoutOptions.Center, FontSize = 11 }
+								}
+							}
+						}
+					},
+
+					// Anonymous layout — no AutomationId, should NOT be found by Appium
+					new Grid
+					{
+						BackgroundColor = Colors.LightGray,
+						HeightRequest = 60,
+						Children =
+						{
+							new Label { Text = "Anonymous Grid (no AutomationId)", VerticalOptions = LayoutOptions.Center, HorizontalOptions = LayoutOptions.Center }
+						}
+					},
+
+					// Sentinel label to confirm page has loaded
+					new Label
+					{
+						Text = "All layouts rendered",
+						AutomationId = "WaitForStubControl"
+					}
+				}
+			}
+		};
+
+		Content = scrollView;
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue4715.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue4715.cs
@@ -1,0 +1,82 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue4715 : _IssuesUITest
+{
+	public Issue4715(TestDevice device) : base(device) { }
+
+	public override string Issue => "[Windows] Layout containers not visible to UI automation";
+
+	[Test]
+	[Category(UITestCategories.Layout)]
+	public void GridWithAutomationIdIsFoundByAppium()
+	{
+		App.WaitForElement("WaitForStubControl");
+
+		// Grid with AutomationId must be visible in the UIA tree
+		App.WaitForElement("TestGrid");
+	}
+
+	[Test]
+	[Category(UITestCategories.Layout)]
+	public void VerticalStackLayoutWithAutomationIdIsFoundByAppium()
+	{
+		App.WaitForElement("WaitForStubControl");
+
+		// VerticalStackLayout with AutomationId must be visible in the UIA tree
+		App.WaitForElement("TestVerticalStackLayout");
+	}
+
+	[Test]
+	[Category(UITestCategories.Layout)]
+	public void HorizontalStackLayoutWithAutomationIdIsFoundByAppium()
+	{
+		App.WaitForElement("WaitForStubControl");
+
+		// HorizontalStackLayout with AutomationId must be visible in the UIA tree
+		App.WaitForElement("TestHorizontalStackLayout");
+	}
+
+	[Test]
+	[Category(UITestCategories.Layout)]
+	public void FlexLayoutWithAutomationIdIsFoundByAppium()
+	{
+		App.WaitForElement("WaitForStubControl");
+
+		// FlexLayout with AutomationId must be visible in the UIA tree
+		App.WaitForElement("TestFlexLayout");
+	}
+
+	[Test]
+	[Category(UITestCategories.Layout)]
+	public void AbsoluteLayoutWithAutomationIdIsFoundByAppium()
+	{
+		App.WaitForElement("WaitForStubControl");
+
+		// AbsoluteLayout with AutomationId must be visible in the UIA tree
+		App.WaitForElement("TestAbsoluteLayout");
+	}
+
+	[Test]
+	[Category(UITestCategories.Layout)]
+	public void NestedOuterLayoutWithAutomationIdIsFoundByAppium()
+	{
+		App.WaitForElement("WaitForStubControl");
+
+		// Outer nested Grid with AutomationId must be visible
+		App.WaitForElement("TestNestedOuterGrid");
+	}
+
+	[Test]
+	[Category(UITestCategories.Layout)]
+	public void AnonymousLayoutWithoutAutomationIdIsNotFoundByAppium()
+	{
+		App.WaitForElement("WaitForStubControl");
+
+		// Anonymous Grid (no AutomationId) must NOT be found in the UIA tree
+		App.WaitForNoElement("Anonymous Grid");
+	}
+}

--- a/src/Core/src/Platform/Windows/LayoutPanel.cs
+++ b/src/Core/src/Platform/Windows/LayoutPanel.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using WRect = global::Windows.Foundation.Rect;
@@ -11,6 +12,11 @@ namespace Microsoft.Maui.Platform
 	{
 		Canvas? _backgroundLayer;
 		public bool ClipsToBounds { get; set; }
+
+		protected override AutomationPeer OnCreateAutomationPeer()
+		{
+			return new MauiLayoutAutomationPeer(this);
+		}
 
 		// TODO: Possibly reconcile this code with ViewHandlerExtensions.LayoutVirtualView
 		// If you make changes here please review if those changes should also

--- a/src/Core/src/Platform/Windows/MauiLayoutAutomationPeer.cs
+++ b/src/Core/src/Platform/Windows/MauiLayoutAutomationPeer.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Platform
 	// TODO: Make this class public in .NET11.0
 	internal partial class MauiLayoutAutomationPeer : FrameworkElementAutomationPeer
 	{
-		internal MauiLayoutAutomationPeer(Panel owner) : base(owner) { }
+		internal MauiLayoutAutomationPeer(LayoutPanel owner) : base(owner) { }
 
 		// Returns the cross-platform layout type name (e.g. "Grid", "VerticalStackLayout") so
 		// accessibility tools can distinguish between different layout types. Falls back to "Panel"
@@ -33,9 +33,9 @@ namespace Microsoft.Maui.Platform
 		// Layouts are never keyboard-focusable — they are structural containers, not interactive elements.
 		protected override bool IsKeyboardFocusableCore() => false;
 
-		// Expose in the Control View only when an AutomationId is explicitly set by the developer,
-		// indicating they intentionally opted this layout into the automation tree.
-		protected override bool IsControlElementCore() => HasAutomationId();
+		// Always expose in the Control View so that Narrator can read SemanticProperties.Description
+		// even when no AutomationId is set.
+		protected override bool IsControlElementCore() => true;
 
 		// Expose in the Content View only when an AutomationId is explicitly set by the developer.
 		protected override bool IsContentElementCore() => HasAutomationId();

--- a/src/Core/src/Platform/Windows/MauiLayoutAutomationPeer.cs
+++ b/src/Core/src/Platform/Windows/MauiLayoutAutomationPeer.cs
@@ -1,0 +1,53 @@
+#nullable enable
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Microsoft.Maui.Platform
+{
+	// TODO: Make this class public in .NET11.0
+	internal partial class MauiLayoutAutomationPeer : FrameworkElementAutomationPeer
+	{
+		internal MauiLayoutAutomationPeer(Panel owner) : base(owner) { }
+
+		// Returns the cross-platform layout type name (e.g. "Grid", "VerticalStackLayout") so
+		// accessibility tools can distinguish between different layout types. Falls back to "Panel"
+		// when the cross-platform layout is unavailable.
+		protected override string GetClassNameCore()
+		{
+			if (Owner is MauiPanel panel)
+			{
+				return panel.CrossPlatformLayout?.GetType().Name ?? nameof(Panel);
+			}
+
+			return nameof(Panel);
+		}
+
+		// Layouts are structural containers — AutomationControlType.Pane signals to screen readers
+		// that this is a grouping/container element, not an interactive control.
+		protected override AutomationControlType GetAutomationControlTypeCore()
+		{
+			return AutomationControlType.Pane;
+		}
+
+		// Layouts are never keyboard-focusable — they are structural containers, not interactive elements.
+		protected override bool IsKeyboardFocusableCore() => false;
+
+		// Expose in the Control View only when an AutomationId is explicitly set by the developer,
+		// indicating they intentionally opted this layout into the automation tree.
+		protected override bool IsControlElementCore() => HasAutomationId();
+
+		// Expose in the Content View only when an AutomationId is explicitly set by the developer.
+		protected override bool IsContentElementCore() => HasAutomationId();
+
+		bool HasAutomationId()
+		{
+			if (Owner is not Panel panel)
+			{
+				return false;
+			}
+
+			return !string.IsNullOrEmpty(AutomationProperties.GetAutomationId(panel));
+		}
+	}
+}

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 #nullable enable
+override Microsoft.Maui.Platform.LayoutPanel.OnCreateAutomationPeer() -> Microsoft.UI.Xaml.Automation.Peers.AutomationPeer!
 override Microsoft.Maui.Platform.MauiPasswordTextBox.OnCreateAutomationPeer() -> Microsoft.UI.Xaml.Automation.Peers.AutomationPeer!


### PR DESCRIPTION
<!-- Please keep the note below for people who find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment whether this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
This pull request adds a custom automation peer to `LayoutPanel` on Windows to improve accessibility support for layout containers in .NET MAUI. The new `MauiLayoutAutomationPeer` provides more accurate class names, control types, and automation exposure for layouts, and includes comprehensive tests to validate this behavior.
### Description of Change
**Accessibility improvements for layout containers:**

* Added a new internal class `MauiLayoutAutomationPeer` that customizes accessibility for layout containers by overriding methods such as `GetClassNameCore`, `GetAutomationControlTypeCore`, `IsKeyboardFocusableCore`, `IsControlElementCore`, and `IsContentElementCore`. This ensures screen readers and automation tools receive accurate information about layout elements.
* Overrode `OnCreateAutomationPeer()` in `LayoutPanel` to return an instance of `MauiLayoutAutomationPeer`, enabling the new accessibility behavior. [[1]](diffhunk://#diff-5aa44e4d2e39e6615cdb0384b23aa3df7323a5ad3fd2cc545a0d59c99f1fc985R16-R20) [[2]](diffhunk://#diff-c710daaba40199243111fcb8a8d5185e939c757b00785b0780d5217c8cf757e5R2)

**Test coverage for layout automation:**

* Added a suite of tests in `LayoutTests.Windows.cs` to verify that the correct automation peer is created, the control type is set to `Pane`, the class name reflects the cross-platform layout type, and that automation tree exposure and keyboard focusability behave as expected. Tests also cover runtime changes to `AutomationId`.

**Dependency and using updates:**

* Updated using directives in relevant files to include automation peer namespaces required for the new functionality. [[1]](diffhunk://#diff-453047cf9d895169547b2b8498bd8e60caa11236407c58a46687fba420e01cfeR9-R11) [[2]](diffhunk://#diff-5aa44e4d2e39e6615cdb0384b23aa3df7323a5ad3fd2cc545a0d59c99f1fc985R2)



<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #4715 
### Tested the behavior in the following platforms

- [x] Windows
- [ ] Android
- [ ] iOS
- [ ] Mac

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <img width="1911" height="927" alt="image (9)" src="https://github.com/user-attachments/assets/21e08b36-b426-4654-ad6a-46bba853d646" />  | <img width="1911" height="927" alt="Screenshot 2026-05-19 193253" src="https://github.com/user-attachments/assets/e6c70a98-ae64-4a58-a9d5-700174c13411" />|
<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
