### PR TITLE
Fix iOS Shell tab badge styling

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellItemRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellItemRenderer.cs
@@ -355,11 +355,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				var renderer = RendererForShellContent(shellSection);
 				if (renderer is not null)
 				{
-					var index = ViewControllers.ToList().IndexOf(renderer.ViewController);
-					if (index >= 0 && TabBar?.Items is not null && index < TabBar.Items.Length)
-					{
-						UpdateTabBarItemBadge(TabBar.Items[index], shellSection);
-					}
+					UpdateTabBarItemBadge(renderer.ViewController.TabBarItem, shellSection);
 				}
 			}
 		}
@@ -406,8 +402,11 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			}
 		}
 
-		static void UpdateTabBarItemBadge(UITabBarItem tabBarItem, ShellSection shellSection)
+		internal static void UpdateTabBarItemBadge(UITabBarItem tabBarItem, ShellSection shellSection)
 		{
+			if (tabBarItem is null)
+				return;
+
 			var badgeText = shellSection.BadgeText;
 			tabBarItem.BadgeValue = badgeText is null ? null : (badgeText.Length > 0 ? badgeText : "");
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellItemRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellItemRenderer.cs
@@ -355,7 +355,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				var renderer = RendererForShellContent(shellSection);
 				if (renderer is not null)
 				{
-					UpdateTabBarItemBadge(renderer.ViewController.TabBarItem, shellSection);
+					UpdateTabBarItemBadge(renderer.ViewController.TabBarItem, shellSection, TabBar);
 				}
 			}
 		}
@@ -397,12 +397,12 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				for (int tabIndex = 0; tabIndex < items.Count; tabIndex++)
 				{
 					TabBar.Items[tabIndex].Enabled = items[tabIndex].IsEnabled;
-					UpdateTabBarItemBadge(TabBar.Items[tabIndex], items[tabIndex]);
+					UpdateTabBarItemBadge(TabBar.Items[tabIndex], items[tabIndex], TabBar);
 				}
 			}
 		}
 
-		internal static void UpdateTabBarItemBadge(UITabBarItem tabBarItem, ShellSection shellSection)
+		internal static void UpdateTabBarItemBadge(UITabBarItem tabBarItem, ShellSection shellSection, UITabBar tabBar = null)
 		{
 			if (tabBarItem is null)
 				return;
@@ -431,6 +431,73 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			{
 				tabBarItem.SetBadgeTextAttributes(null, UIControlState.Normal);
 			}
+
+			if (OperatingSystem.IsIOSVersionAtLeast(15) || OperatingSystem.IsMacCatalystVersionAtLeast(15))
+				UpdateTabBarItemBadgeAppearance(tabBarItem, tabBar, badgeColor, badgeTextColor);
+		}
+
+		[System.Runtime.Versioning.SupportedOSPlatform("ios15.0")]
+		[System.Runtime.Versioning.SupportedOSPlatform("maccatalyst15.0")]
+		static void UpdateTabBarItemBadgeAppearance(UITabBarItem tabBarItem, UITabBar tabBar, Color badgeColor, Color badgeTextColor)
+		{
+			if (badgeColor is null && badgeTextColor is null)
+			{
+				tabBarItem.StandardAppearance = null;
+				tabBarItem.ScrollEdgeAppearance = null;
+				return;
+			}
+
+			var standardAppearance = CreateTabBarBadgeAppearance(tabBarItem.StandardAppearance, tabBar?.StandardAppearance);
+			UpdateTabBarItemBadgeAppearance(standardAppearance, badgeColor, badgeTextColor);
+			tabBarItem.StandardAppearance = standardAppearance;
+
+			var scrollEdgeAppearance = CreateTabBarBadgeAppearance(tabBarItem.ScrollEdgeAppearance, tabBar?.ScrollEdgeAppearance ?? tabBar?.StandardAppearance);
+			UpdateTabBarItemBadgeAppearance(scrollEdgeAppearance, badgeColor, badgeTextColor);
+			tabBarItem.ScrollEdgeAppearance = scrollEdgeAppearance;
+		}
+
+		[System.Runtime.Versioning.SupportedOSPlatform("ios15.0")]
+		[System.Runtime.Versioning.SupportedOSPlatform("maccatalyst15.0")]
+		static UITabBarAppearance CreateTabBarBadgeAppearance(UITabBarAppearance itemAppearance, UITabBarAppearance tabBarAppearance)
+		{
+			if (itemAppearance is not null)
+				return new UITabBarAppearance(itemAppearance);
+
+			if (tabBarAppearance is not null)
+				return new UITabBarAppearance(tabBarAppearance);
+
+			var appearance = new UITabBarAppearance();
+			appearance.ConfigureWithDefaultBackground();
+			return appearance;
+		}
+
+		[System.Runtime.Versioning.SupportedOSPlatform("ios15.0")]
+		[System.Runtime.Versioning.SupportedOSPlatform("maccatalyst15.0")]
+		static void UpdateTabBarItemBadgeAppearance(UITabBarAppearance appearance, Color badgeColor, Color badgeTextColor)
+		{
+			UpdateTabBarItemBadgeAppearance(appearance.StackedLayoutAppearance, badgeColor, badgeTextColor);
+			UpdateTabBarItemBadgeAppearance(appearance.InlineLayoutAppearance, badgeColor, badgeTextColor);
+			UpdateTabBarItemBadgeAppearance(appearance.CompactInlineLayoutAppearance, badgeColor, badgeTextColor);
+		}
+
+		[System.Runtime.Versioning.SupportedOSPlatform("ios15.0")]
+		[System.Runtime.Versioning.SupportedOSPlatform("maccatalyst15.0")]
+		static void UpdateTabBarItemBadgeAppearance(UITabBarItemAppearance appearance, Color badgeColor, Color badgeTextColor)
+		{
+			UpdateTabBarItemBadgeAppearance(appearance.Normal, badgeColor, badgeTextColor);
+			UpdateTabBarItemBadgeAppearance(appearance.Selected, badgeColor, badgeTextColor);
+			UpdateTabBarItemBadgeAppearance(appearance.Disabled, badgeColor, badgeTextColor);
+			UpdateTabBarItemBadgeAppearance(appearance.Focused, badgeColor, badgeTextColor);
+		}
+
+		[System.Runtime.Versioning.SupportedOSPlatform("ios15.0")]
+		[System.Runtime.Versioning.SupportedOSPlatform("maccatalyst15.0")]
+		static void UpdateTabBarItemBadgeAppearance(UITabBarItemStateAppearance appearance, Color badgeColor, Color badgeTextColor)
+		{
+			appearance.BadgeBackgroundColor = badgeColor?.ToPlatform();
+			appearance.WeakBadgeTextAttributes = badgeTextColor is null
+				? new NSDictionary()
+				: new UIStringAttributes { ForegroundColor = badgeTextColor.ToPlatform() }.Dictionary;
 		}
 
 		void UpdateIsInMoreTabForRenderers()

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellItemRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellItemRenderer.cs
@@ -355,7 +355,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				var renderer = RendererForShellContent(shellSection);
 				if (renderer is not null)
 				{
-					UpdateTabBarItemBadge(renderer.ViewController.TabBarItem, shellSection, TabBar);
+					UpdateTabBarItemBadge(renderer.ViewController?.TabBarItem, shellSection, TabBar);
 				}
 			}
 		}
@@ -495,9 +495,20 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		static void UpdateTabBarItemBadgeAppearance(UITabBarItemStateAppearance appearance, Color badgeColor, Color badgeTextColor)
 		{
 			appearance.BadgeBackgroundColor = badgeColor?.ToPlatform();
-			appearance.WeakBadgeTextAttributes = badgeTextColor is null
-				? new NSDictionary()
-				: new UIStringAttributes { ForegroundColor = badgeTextColor.ToPlatform() }.Dictionary;
+
+			if (badgeTextColor is not null)
+			{
+				appearance.WeakBadgeTextAttributes = new UIStringAttributes { ForegroundColor = badgeTextColor.ToPlatform() }.Dictionary;
+				return;
+			}
+
+			var badgeTextAttributes = appearance.WeakBadgeTextAttributes;
+			if (badgeTextAttributes?[UIStringAttributeKey.ForegroundColor] is null)
+				return;
+
+			var mutableBadgeTextAttributes = new NSMutableDictionary(badgeTextAttributes);
+			mutableBadgeTextAttributes.Remove(UIStringAttributeKey.ForegroundColor);
+			appearance.WeakBadgeTextAttributes = mutableBadgeTextAttributes;
 		}
 
 		void UpdateIsInMoreTabForRenderers()

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRenderer.cs
@@ -602,7 +602,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				var image = TabbedViewExtensions.AutoResizeTabBarImage(TraitCollection, icon?.Value);
 				TabBarItem = new UITabBarItem(ShellSection.Title, image, null);
 				TabBarItem.AccessibilityIdentifier = ShellSection.AutomationId ?? ShellSection.Title;
-				ShellItemRenderer.UpdateTabBarItemBadge(TabBarItem, ShellSection);
+				ShellItemRenderer.UpdateTabBarItemBadge(TabBarItem, ShellSection, TabBarController?.TabBar);
 			});
 		}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRenderer.cs
@@ -602,6 +602,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				var image = TabbedViewExtensions.AutoResizeTabBarImage(TraitCollection, icon?.Value);
 				TabBarItem = new UITabBarItem(ShellSection.Title, image, null);
 				TabBarItem.AccessibilityIdentifier = ShellSection.AutomationId ?? ShellSection.Title;
+				ShellItemRenderer.UpdateTabBarItemBadge(TabBarItem, ShellSection);
 			});
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellBadgeTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellBadgeTests.iOS.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Maui.DeviceTests
 			SetupBuilder();
 
 			var badgeColor = Color.FromArgb("#00C853");
-			var badgeTextColor = Color.FromArgb("#111111");
+			var badgeTextColor = Color.FromArgb("#FF00FF");
 			var tab = CreateBadgeTab("Tab1", "white_tab.png", badgeColor, badgeTextColor);
 
 			var shell = await CreateShellAsync(shell =>
@@ -106,6 +106,40 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				await OnLoadedAsync(shell.CurrentPage);
 				await AssertEventually(() => NativeTabBarItemHasBadgeColors(tab, badgeColor, null), timeout: 2000);
+			});
+		}
+
+		[Fact(DisplayName = "Shell Tab Badge Text Color Clears To Default")]
+		public async Task ShellTabBadgeTextColorClearsToDefault()
+		{
+			SetupBuilder();
+
+			var badgeColor = Color.FromArgb("#00C853");
+			var badgeTextColor = Color.FromArgb("#111111");
+			var tab = CreateBadgeTab("Tab1", "white_tab.png", badgeColor, badgeTextColor);
+
+			var shell = await CreateShellAsync(shell =>
+			{
+				shell.Items.Add(new TabBar()
+				{
+					Items =
+					{
+						tab,
+						CreateBadgeTab("Tab2", "white_tab.png", Colors.Red, Colors.White)
+					}
+				});
+			});
+
+			await CreateHandlerAndAddToWindow<ShellRenderer>(shell, async (handler) =>
+			{
+				await OnLoadedAsync(shell.CurrentPage);
+				await AssertEventually(() => NativeTabBarItemHasBadgeColors(tab, badgeColor, badgeTextColor), timeout: 2000);
+
+				tab.BadgeTextColor = null;
+
+				await AssertEventually(() =>
+					NativeTabBarItemHasBadgeColors(tab, badgeColor, null) &&
+					!NativeTabBarItemHasBadgeAppearanceTextColor(tab, badgeTextColor), timeout: 2000);
 			});
 		}
 
@@ -186,6 +220,17 @@ namespace Microsoft.Maui.DeviceTests
 				TabBarAppearanceHasBadgeColors(tabBarItem.ScrollEdgeAppearance, badgeColor, badgeTextColor);
 		}
 
+		bool NativeTabBarItemHasBadgeAppearanceTextColor(ShellSection item, Color badgeTextColor)
+		{
+			if (!OperatingSystem.IsIOSVersionAtLeast(15) && !OperatingSystem.IsMacCatalystVersionAtLeast(15))
+				return false;
+
+			var tabBarItem = GetRendererTabBarItem(item);
+			return tabBarItem is not null &&
+				(TabBarAppearanceHasBadgeTextColor(tabBarItem.StandardAppearance, badgeTextColor) ||
+				TabBarAppearanceHasBadgeTextColor(tabBarItem.ScrollEdgeAppearance, badgeTextColor));
+		}
+
 		bool TabBarAppearanceHasBadgeColors(UITabBarAppearance appearance, Color badgeColor, Color badgeTextColor)
 		{
 			if (appearance is null)
@@ -204,6 +249,22 @@ namespace Microsoft.Maui.DeviceTests
 				TabBarItemStateAppearanceHasBadgeColors(appearance.Focused, badgeColor, badgeTextColor);
 		}
 
+		bool TabBarAppearanceHasBadgeTextColor(UITabBarAppearance appearance, Color badgeTextColor)
+		{
+			return appearance is not null &&
+				(TabBarItemAppearanceHasBadgeTextColor(appearance.StackedLayoutAppearance, badgeTextColor) ||
+				TabBarItemAppearanceHasBadgeTextColor(appearance.InlineLayoutAppearance, badgeTextColor) ||
+				TabBarItemAppearanceHasBadgeTextColor(appearance.CompactInlineLayoutAppearance, badgeTextColor));
+		}
+
+		bool TabBarItemAppearanceHasBadgeTextColor(UITabBarItemAppearance appearance, Color badgeTextColor)
+		{
+			return TabBarItemStateAppearanceHasBadgeTextColor(appearance.Normal, badgeTextColor) ||
+				TabBarItemStateAppearanceHasBadgeTextColor(appearance.Selected, badgeTextColor) ||
+				TabBarItemStateAppearanceHasBadgeTextColor(appearance.Disabled, badgeTextColor) ||
+				TabBarItemStateAppearanceHasBadgeTextColor(appearance.Focused, badgeTextColor);
+		}
+
 		bool TabBarItemStateAppearanceHasBadgeColors(UITabBarItemStateAppearance appearance, Color badgeColor, Color badgeTextColor)
 		{
 			if (!ColorComparison.ARGBEquivalent(appearance.BadgeBackgroundColor, badgeColor.ToPlatform()))
@@ -214,6 +275,12 @@ namespace Microsoft.Maui.DeviceTests
 			if (badgeTextColor is null)
 				return true;
 
+			return ColorComparison.ARGBEquivalent(foregroundColor, badgeTextColor.ToPlatform());
+		}
+
+		bool TabBarItemStateAppearanceHasBadgeTextColor(UITabBarItemStateAppearance appearance, Color badgeTextColor)
+		{
+			var foregroundColor = appearance.WeakBadgeTextAttributes?[UIStringAttributeKey.ForegroundColor] as UIColor;
 			return ColorComparison.ARGBEquivalent(foregroundColor, badgeTextColor.ToPlatform());
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellBadgeTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellBadgeTests.iOS.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.Controls.Platform.Compatibility;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Platform;
+using UIKit;
+using Xunit;
+using static Microsoft.Maui.DeviceTests.AssertHelpers;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.ShellBadge)]
+	[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
+	public class ShellBadgeTests : ControlsHandlerTestBase
+	{
+		[Fact(DisplayName = "Shell Tab Badge Colors Apply To Native Tab Bar Item")]
+		public async Task ShellTabBadgeColorsApplyToNativeTabBarItem()
+		{
+			SetupBuilder();
+
+			var badgeColor = Color.FromArgb("#00C853");
+			var badgeTextColor = Color.FromArgb("#111111");
+			var tab = CreateBadgeTab("Tab1", "white_tab.png", badgeColor, badgeTextColor);
+
+			var shell = await CreateShellAsync(shell =>
+			{
+				shell.Items.Add(new TabBar()
+				{
+					Items =
+					{
+						tab,
+						CreateBadgeTab("Tab2", "white_tab.png", Colors.Red, Colors.White)
+					}
+				});
+			});
+
+			await CreateHandlerAndAddToWindow<ShellRenderer>(shell, async (handler) =>
+			{
+				await OnLoadedAsync(shell.CurrentPage);
+				await AssertEventually(() => NativeTabBarItemHasBadgeColors(tab, badgeColor, badgeTextColor), timeout: 2000);
+			});
+		}
+
+		[Fact(DisplayName = "Shell Tab Badge Colors Persist After Native Tab Bar Item Updates")]
+		public async Task ShellTabBadgeColorsPersistAfterNativeTabBarItemUpdates()
+		{
+			SetupBuilder();
+
+			var badgeColor = Color.FromArgb("#00C853");
+			var badgeTextColor = Color.FromArgb("#111111");
+			var tab = CreateBadgeTab("Tab1", "white_tab.png", badgeColor, badgeTextColor);
+
+			var shell = await CreateShellAsync(shell =>
+			{
+				shell.Items.Add(new TabBar()
+				{
+					Items =
+					{
+						tab,
+						CreateBadgeTab("Tab2", "white_tab.png", Colors.Red, Colors.White)
+					}
+				});
+			});
+
+			await CreateHandlerAndAddToWindow<ShellRenderer>(shell, async (handler) =>
+			{
+				await OnLoadedAsync(shell.CurrentPage);
+				await AssertEventually(() => NativeTabBarItemHasBadgeColors(tab, badgeColor, badgeTextColor), timeout: 2000);
+
+				tab.Title = "UpdatedTab1";
+				tab.Icon = "green.png";
+
+				await AssertEventually(() =>
+				{
+					var tabBarItem = GetRendererTabBarItem(tab);
+					return tabBarItem?.Title == "UpdatedTab1" &&
+						NativeTabBarItemHasBadgeColors(tab, badgeColor, badgeTextColor);
+				}, timeout: 2000);
+			});
+		}
+
+		void SetupBuilder()
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.SetupShellHandlers();
+			});
+		}
+
+		Task<Shell> CreateShellAsync(Action<Shell> action) =>
+			InvokeOnMainThreadAsync(() =>
+			{
+				var shell = new Shell();
+				action(shell);
+				return shell;
+			});
+
+		Tab CreateBadgeTab(string title, string icon, Color badgeColor, Color badgeTextColor)
+		{
+			return new Tab()
+			{
+				Title = title,
+				Icon = icon,
+				BadgeText = "7",
+				BadgeColor = badgeColor,
+				BadgeTextColor = badgeTextColor,
+				Items =
+				{
+					new ShellContent()
+					{
+						Title = title,
+						Content = new ContentPage()
+					}
+				}
+			};
+		}
+
+		UITabBarItem GetRendererTabBarItem(ShellSection item)
+		{
+			var shellItem = item.Parent as ShellItem;
+			var shell = shellItem.Parent as Shell;
+			var shellContext = shell.Handler as IShellContext;
+			var shellItemRenderer = shellContext?.CurrentShellItemRenderer as ShellItemRenderer;
+			var sectionRenderer = shellItemRenderer?.ViewControllers
+				.OfType<ShellSectionRenderer>()
+				.FirstOrDefault(renderer => renderer.ShellSection == item);
+
+			return sectionRenderer?.ViewController.TabBarItem;
+		}
+
+		bool NativeTabBarItemHasBadgeColors(ShellSection item, Color badgeColor, Color badgeTextColor)
+		{
+			var tabBarItem = GetRendererTabBarItem(item);
+			if (tabBarItem is null || tabBarItem.BadgeValue != item.BadgeText)
+				return false;
+
+			var badgeAttributes = tabBarItem.GetBadgeTextAttributes(UIControlState.Normal);
+			return ColorComparison.ARGBEquivalent(tabBarItem.BadgeColor, badgeColor.ToPlatform()) &&
+				ColorComparison.ARGBEquivalent(badgeAttributes?.ForegroundColor, badgeTextColor.ToPlatform());
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellBadgeTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellBadgeTests.iOS.cs
@@ -82,6 +82,33 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact(DisplayName = "Shell Tab Badge Background Color Applies With Default Text Color")]
+		public async Task ShellTabBadgeBackgroundColorAppliesWithDefaultTextColor()
+		{
+			SetupBuilder();
+
+			var badgeColor = Color.FromArgb("#00C853");
+			var tab = CreateBadgeTab("Tab1", "white_tab.png", badgeColor, null);
+
+			var shell = await CreateShellAsync(shell =>
+			{
+				shell.Items.Add(new TabBar()
+				{
+					Items =
+					{
+						tab,
+						CreateBadgeTab("Tab2", "white_tab.png", Colors.Red, Colors.White)
+					}
+				});
+			});
+
+			await CreateHandlerAndAddToWindow<ShellRenderer>(shell, async (handler) =>
+			{
+				await OnLoadedAsync(shell.CurrentPage);
+				await AssertEventually(() => NativeTabBarItemHasBadgeColors(tab, badgeColor, null), timeout: 2000);
+			});
+		}
+
 		void SetupBuilder()
 		{
 			EnsureHandlerCreated(builder =>
@@ -138,8 +165,56 @@ namespace Microsoft.Maui.DeviceTests
 				return false;
 
 			var badgeAttributes = tabBarItem.GetBadgeTextAttributes(UIControlState.Normal);
-			return ColorComparison.ARGBEquivalent(tabBarItem.BadgeColor, badgeColor.ToPlatform()) &&
-				ColorComparison.ARGBEquivalent(badgeAttributes?.ForegroundColor, badgeTextColor.ToPlatform());
+
+			if (!ColorComparison.ARGBEquivalent(tabBarItem.BadgeColor, badgeColor.ToPlatform()))
+				return false;
+
+			if (badgeTextColor is not null && !ColorComparison.ARGBEquivalent(badgeAttributes?.ForegroundColor, badgeTextColor.ToPlatform()))
+			{
+				return false;
+			}
+
+			return NativeTabBarItemHasBadgeAppearance(tabBarItem, badgeColor, badgeTextColor);
+		}
+
+		bool NativeTabBarItemHasBadgeAppearance(UITabBarItem tabBarItem, Color badgeColor, Color badgeTextColor)
+		{
+			if (!OperatingSystem.IsIOSVersionAtLeast(15) && !OperatingSystem.IsMacCatalystVersionAtLeast(15))
+				return true;
+
+			return TabBarAppearanceHasBadgeColors(tabBarItem.StandardAppearance, badgeColor, badgeTextColor) &&
+				TabBarAppearanceHasBadgeColors(tabBarItem.ScrollEdgeAppearance, badgeColor, badgeTextColor);
+		}
+
+		bool TabBarAppearanceHasBadgeColors(UITabBarAppearance appearance, Color badgeColor, Color badgeTextColor)
+		{
+			if (appearance is null)
+				return false;
+
+			return TabBarItemAppearanceHasBadgeColors(appearance.StackedLayoutAppearance, badgeColor, badgeTextColor) &&
+				TabBarItemAppearanceHasBadgeColors(appearance.InlineLayoutAppearance, badgeColor, badgeTextColor) &&
+				TabBarItemAppearanceHasBadgeColors(appearance.CompactInlineLayoutAppearance, badgeColor, badgeTextColor);
+		}
+
+		bool TabBarItemAppearanceHasBadgeColors(UITabBarItemAppearance appearance, Color badgeColor, Color badgeTextColor)
+		{
+			return TabBarItemStateAppearanceHasBadgeColors(appearance.Normal, badgeColor, badgeTextColor) &&
+				TabBarItemStateAppearanceHasBadgeColors(appearance.Selected, badgeColor, badgeTextColor) &&
+				TabBarItemStateAppearanceHasBadgeColors(appearance.Disabled, badgeColor, badgeTextColor) &&
+				TabBarItemStateAppearanceHasBadgeColors(appearance.Focused, badgeColor, badgeTextColor);
+		}
+
+		bool TabBarItemStateAppearanceHasBadgeColors(UITabBarItemStateAppearance appearance, Color badgeColor, Color badgeTextColor)
+		{
+			if (!ColorComparison.ARGBEquivalent(appearance.BadgeBackgroundColor, badgeColor.ToPlatform()))
+				return false;
+
+			var foregroundColor = appearance.WeakBadgeTextAttributes?[UIStringAttributeKey.ForegroundColor] as UIColor;
+
+			if (badgeTextColor is null)
+				return true;
+
+			return ColorComparison.ARGBEquivalent(foregroundColor, badgeTextColor.ToPlatform());
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellBadgeTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellBadgeTests.iOS.cs
@@ -12,7 +12,7 @@ using static Microsoft.Maui.DeviceTests.AssertHelpers;
 
 namespace Microsoft.Maui.DeviceTests
 {
-	[Category(TestCategory.ShellBadge)]
+	[Category(TestCategory.Shell)]
 	[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
 	public class ShellBadgeTests : ControlsHandlerTestBase
 	{

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellBadgeTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellBadgeTests.iOS.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Maui.DeviceTests
 			SetupBuilder();
 
 			var badgeColor = Color.FromArgb("#00C853");
-			var badgeTextColor = Color.FromArgb("#FF00FF");
+			var badgeTextColor = Color.FromArgb("#111111");
 			var tab = CreateBadgeTab("Tab1", "white_tab.png", badgeColor, badgeTextColor);
 
 			var shell = await CreateShellAsync(shell =>
@@ -115,7 +115,7 @@ namespace Microsoft.Maui.DeviceTests
 			SetupBuilder();
 
 			var badgeColor = Color.FromArgb("#00C853");
-			var badgeTextColor = Color.FromArgb("#111111");
+			var badgeTextColor = Color.FromArgb("#FF00FF");
 			var tab = CreateBadgeTab("Tab1", "white_tab.png", badgeColor, badgeTextColor);
 
 			var shell = await CreateShellAsync(shell =>

--- a/src/Controls/tests/DeviceTests/TestCategory.cs
+++ b/src/Controls/tests/DeviceTests/TestCategory.cs
@@ -43,7 +43,6 @@
 		public const string SearchBar = "SearchBar";
 		public const string Shape = "Shape";
 		public const string Shell = "Shell";
-		public const string ShellBadge = "ShellBadge";
 		public const string Slider = "Slider";
 		public const string SwipeView = "SwipeView";
 		public const string TabbedPage = "TabbedPage";

--- a/src/Controls/tests/DeviceTests/TestCategory.cs
+++ b/src/Controls/tests/DeviceTests/TestCategory.cs
@@ -43,6 +43,7 @@
 		public const string SearchBar = "SearchBar";
 		public const string Shape = "Shape";
 		public const string Shell = "Shell";
+		public const string ShellBadge = "ShellBadge";
 		public const string Slider = "Slider";
 		public const string SwipeView = "SwipeView";
 		public const string TabbedPage = "TabbedPage";


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Fixes iOS Shell tab badge styling so `BadgeColor` and `BadgeTextColor` are applied to the actual native `UITabBarItem` used by each Shell section, including the `UITabBarAppearance` badge state values that drive rendering on iOS 15+ / iOS 26.

`ShellSectionRenderer` can asynchronously create or replace its `TabBarItem` after loading the tab icon. That path only restored title/accessibility metadata, so custom badge colors could be lost and iOS would render default red/white badges. This change reuses the existing Shell badge helper after the native item is created, updates badge property changes through the renderer's current `ViewController.TabBarItem`, and keeps null badge colors on the system defaults.

## Screenshots

Before/after screenshots were captured locally on iPhone 17 Pro iOS 26.2:

- `shell-badge-before.png` — visible default iOS red/white Shell tab badges before the fix
- `shell-badge-after.png` — visible green `#00C853` Shell tab badges with dark `#111111` text after the fix
- `shell-toolbar-badges-sandbox.png` — Sandbox sample showing Shell tab badges and primary ToolbarItem badges styled consistently after the appearance fix

**Before**
<img width="1206" height="405" alt="shell-badge-before" src="https://github.com/user-attachments/assets/b4293495-28cb-4461-9142-65fddac0a446" />

**After**
<img width="1206" height="460" alt="shell-badge-after" src="https://github.com/user-attachments/assets/f4934954-263f-4271-9759-45d8aac63297" />

**Full with ToolBarIcon**
<img width="1206" height="2622" alt="shell-toolbar-badges-sandbox-rerun-20260521-1605" src="https://github.com/user-attachments/assets/371eaee3-853e-4cc9-9b5d-31f9a2aaccab" />

## Testing

- `dotnet build src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj -c Release -f net11.0-ios -r iossimulator-arm64 /p:CodesignRequireProvisioningProfile=false /p:ValidateXcodeVersion=false /p:TreatWarningsAsErrors=false`
- `dotnet xharness apple test --app artifacts/bin/Controls.DeviceTests/Release/net11.0-ios/iossimulator-arm64/Microsoft.Maui.Controls.DeviceTests.app --target ios-simulator-64_26.2 --device 07C63EC0-C474-428F-A850-30D7D9D2D991 -o artifacts/log/shell-ios --timeout 00:30:00 -v --set-env=TestFilter=Category=Shell` — `205 Passed, 0 Failed`
- `PATH="$PWD/CustomAgentLogsTmp/Sandbox/bin:$PATH" _MauiDotNetVersion=10.0 MtouchLink=SdkOnly pwsh .github/scripts/BuildAndRunSandbox.ps1 -Platform ios -DeviceUdid 07C63EC0-C474-428F-A850-30D7D9D2D991`