### PR TITLE
[release/10.0.1xx-sr7] Fix BackButtonBehavior_IconOverride_CustomIconShownOnBackButton on iOS 26

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/ShellNavigationFeatureTests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/ShellNavigationFeatureTests.cs
@@ -917,10 +917,6 @@ public class ShellNavigationFeatureTests : _GalleryUITest
 	[Test, Order(52)]
 	public void BackButtonBehavior_IconOverride_CustomIconShownOnBackButton()
 	{
-		if (iOS26OrHigher)
-        {
-            NavigateToDetail1AndWait();
-        }
 		App.WaitForElement("Detail1GoBackButton");
 		App.Tap("Detail1GoBackButton");
 		App.WaitForElement("MainPageIdentityLabel");


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue

UI test `BackButtonBehavior_IconOverride_CustomIconShownOnBackButton` fails on iOS 26 (vlatest) on the `release/10.0.1xx-sr7` branch.

- Build: [1427432](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1427432) (`maui-pr-uitests` on SR7 head `bdca474345`)
- Failed twice (both attempts) — deterministic, not flaky
- Failure: `System.TimeoutException : Timed out waiting for element...` at `ShellNavigationFeatureTests.cs:line 922`
- Other platforms (Android API 30, iOS 18.5, MacCatalyst) all pass

### Root cause

PR #35521 backported the `_sendPopPending` product fix from #34890 to SR7 and **removed** the `Assert.Ignore` from tests 50 and 51 (since the product is now fixed and those tests should pass on iOS 26).

It left in place an obsolete iOS 26 workaround in test 52:

```csharp
[Test, Order(52)]
public void BackButtonBehavior_IconOverride_CustomIconShownOnBackButton()
{
    if (iOS26OrHigher)
    {
        NavigateToDetail1AndWait();   // ← obsolete after #35521
    }
    App.WaitForElement("Detail1GoBackButton");
    ...
```

That workaround was originally needed when test 51 was being skipped on iOS 26 (so test 52 started from Main and had to navigate to Detail1 itself).

Now that #35521 un-ignored test 51, the flow on iOS 26 is:
1. Test 51 runs, calls `NavigateToDetail1AndWait()` and ends with `ShellScreenshot()` — UI is on **Detail1**, no reset
2. Test 52 starts on Detail1, hits `if (iOS26OrHigher)` and tries to navigate **Main → Detail1**
3. But we're already on Detail1, so `NavigateToDetail1Button` isn't visible → `TimeoutException`

This is purely a test state-leak bug — not a product regression.

### Fix

Remove the now-redundant `iOS26OrHigher` block from test 52. After the removal, test 52 starts by tapping `Detail1GoBackButton` directly, which is correct because:
- Test 51 leaves the UI on Detail1
- `Detail1GoBackButton` is a custom page-content button (created via `ShellNavHelper.CreateNavButton(..., "Detail1GoBackButton")` in `ShellNavigationControlPage.xaml.cs`), **not** the shell back arrow — it is unaffected by test 51's `IsVisibleButton` toggle (which sets `BackButtonBehavior.IsVisible=false` on the shell back arrow)

### Diff

```diff
 [Test, Order(52)]
 public void BackButtonBehavior_IconOverride_CustomIconShownOnBackButton()
 {
-    if (iOS26OrHigher)
-    {
-        NavigateToDetail1AndWait();
-    }
     App.WaitForElement("Detail1GoBackButton");
     App.Tap("Detail1GoBackButton");
     ...
```

### Follow-up (main)

`main` and `net11.0` have the **opposite** asymmetry: the product fix (`_sendPopPending` reset) is already there, but tests 50 and 51 still carry the `Assert.Ignore` (so iOS 26 coverage for those scenarios is silently skipped). When those `Assert.Ignore` lines get removed, the same workaround should also be removed from test 52 — otherwise main will hit the same failure this PR fixes here.

### Validation

- Tested locally: only the obsolete branch is removed; remaining test body matches the iOS 18.5 / Android / MacCatalyst flow that already passes
- The 4 deleted lines were dead code on every other platform anyway (`iOS26OrHigher` is false there)
- No product code touched
