### PR TITLE
[Windows] Border: Add AutomationPeer support

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.Windows.cs
@@ -6,6 +6,7 @@ using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using Microsoft.UI.Composition;
+using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Hosting;
 using Xunit;
 
@@ -80,6 +81,37 @@ namespace Microsoft.Maui.DeviceTests
 
 		ContentPanel GetNativeBorder(BorderHandler borderHandler) =>
 			borderHandler.PlatformView;
+
+		[Fact(DisplayName = "Border is excluded from Control view by default (AutomationId alone does not opt in)")]
+		public async Task BorderExcludedFromControlViewByDefault()
+		{
+			SetupBuilder();
+
+			var border = new Border { AutomationId = "TestBorder" };
+
+			await AttachAndRun(border, (BorderHandler handler) =>
+			{
+				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(handler.PlatformView);
+
+				Assert.Equal("TestBorder", peer.GetAutomationId());
+				Assert.False(peer.IsControlElement());
+			});
+		}
+
+		[Fact(DisplayName = "Border opts into Control view when SemanticProperties.Description is set")]
+		public async Task BorderOptsIntoControlViewWhenDescriptionIsSet()
+		{
+			SetupBuilder();
+
+			var border = new Border();
+			SemanticProperties.SetDescription(border, "Welcome card");
+
+			await AttachAndRun(border, (BorderHandler handler) =>
+			{
+				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(handler.PlatformView);
+				Assert.True(peer.IsControlElement());
+			});
+		}
 
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.Windows.cs
@@ -93,6 +93,10 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(handler.PlatformView);
 
+				// Prove the new MauiBorderAutomationPeer is in use, not the default ContentPanel peer.
+				Assert.Equal("Border", peer.GetClassName());
+				Assert.Equal(AutomationControlType.Pane, peer.GetAutomationControlType());
+
 				Assert.Equal("TestBorder", peer.GetAutomationId());
 				Assert.False(peer.IsControlElement());
 			});
@@ -109,6 +113,11 @@ namespace Microsoft.Maui.DeviceTests
 			await AttachAndRun(border, (BorderHandler handler) =>
 			{
 				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(handler.PlatformView);
+
+				// Prove the new MauiBorderAutomationPeer is in use, not the default ContentPanel peer.
+				Assert.Equal("Border", peer.GetClassName());
+				Assert.Equal(AutomationControlType.Pane, peer.GetAutomationControlType());
+
 				Assert.True(peer.IsControlElement());
 			});
 		}

--- a/src/Controls/tests/DeviceTests/Elements/ContentView/ContentViewTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ContentView/ContentViewTests.Windows.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		static AutomationPeer GetOrCreateAutomationPeer(ContentPanel contentPanel)
-			=> new ContentPanel.ContentPanelAutomationPeer(contentPanel);
+			=> new ContentPanelAutomationPeer(contentPanel);
 
 		[Fact(DisplayName = "ContentView With Description Prevents Duplicate Narrator Announcements")]
 		public async Task ContentViewWithDescriptionHidesChildrenFromNarrator()

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue27627.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue27627.cs
@@ -12,17 +12,30 @@ public partial class Issue27627 : ContentPage
 			AutomationId = "TestBorder",
 			VerticalOptions = LayoutOptions.Center,
 			HeightRequest = 100,
+			Padding = new Thickness(10),
 			Stroke = Colors.Red
 		};
 
 		var label = new Label
 		{
-			Text = "Test Label",
+			Text = "Welcome to Maui!",
+			AutomationId = "TestLabel",
 			HorizontalOptions = LayoutOptions.Center,
 			VerticalOptions = LayoutOptions.Center
 		};
 
-		border.Content = label;
+		var nestedBorder = new Border
+		{
+			Stroke = Colors.Blue,
+			AutomationId = "NestedBorder",
+			StrokeThickness = 2,
+			Padding = new Thickness(10),
+			HorizontalOptions = LayoutOptions.Center,
+			VerticalOptions = LayoutOptions.Center,
+		};
+
+		nestedBorder.Content = label;
+		border.Content = nestedBorder;
 
 		grid.Children.Add(border);
 		Content = grid;

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue27627.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue27627.cs
@@ -1,0 +1,30 @@
+﻿namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 27627, "[Windows] Border Automation Peer", PlatformAffected.UWP)]
+public partial class Issue27627 : ContentPage
+{
+	public Issue27627()
+	{
+		var grid = new Grid();
+
+		var border = new Border
+		{
+			AutomationId = "TestBorder",
+			VerticalOptions = LayoutOptions.Center,
+			HeightRequest = 100,
+			Stroke = Colors.Red
+		};
+
+		var label = new Label
+		{
+			Text = "Test Label",
+			HorizontalOptions = LayoutOptions.Center,
+			VerticalOptions = LayoutOptions.Center
+		};
+
+		border.Content = label;
+
+		grid.Children.Add(border);
+		Content = grid;
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue27627.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue27627.cs
@@ -15,6 +15,8 @@ public partial class Issue27627 : ContentPage
 			Padding = new Thickness(10),
 			Stroke = Colors.Red
 		};
+		SemanticProperties.SetDescription(border, "Outer test border");
+		AutomationProperties.SetIsInAccessibleTree(border, true);
 
 		var label = new Label
 		{
@@ -33,6 +35,8 @@ public partial class Issue27627 : ContentPage
 			HorizontalOptions = LayoutOptions.Center,
 			VerticalOptions = LayoutOptions.Center,
 		};
+		SemanticProperties.SetDescription(nestedBorder, "Nested test border");
+		AutomationProperties.SetIsInAccessibleTree(nestedBorder, true);
 
 		nestedBorder.Content = label;
 		border.Content = nestedBorder;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27627.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27627.cs
@@ -1,0 +1,22 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue27627 : _IssuesUITest
+	{
+		public override string Issue => "[Windows] Border Automation Peer";
+
+		public Issue27627(TestDevice device)
+		: base(device)
+		{ }
+
+		[Test]
+		[Category(UITestCategories.Border)]
+		public void VerifyBorderAutomationPeer()
+		{
+			App.WaitForElement("TestBorder");
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27627.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27627.cs
@@ -16,7 +16,14 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		[Category(UITestCategories.Border)]
 		public void VerifyBorderAutomationPeer()
 		{
+			// Check whether the parent Border is found or not
 			App.WaitForElement("TestBorder");
+
+			// Check whether the nested Border is found or not
+			App.WaitForElement("NestedBorder");
+
+			// Check whether the Label inside the nested Border is found or not
+			App.WaitForElement("TestLabel");
 		}
 	}
 }

--- a/src/Core/src/Platform/Windows/ContentPanel.cs
+++ b/src/Core/src/Platform/Windows/ContentPanel.cs
@@ -15,7 +15,6 @@ using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Hosting;
 using Microsoft.UI.Xaml.Shapes;
 using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Automation.Peers;
 
 namespace Microsoft.Maui.Platform
 {
@@ -76,6 +75,11 @@ namespace Microsoft.Maui.Platform
 			{
 				return new MauiBorderAutomationPeer(this);
 			}
+			else if (CrossPlatformLayout is IContentView)
+			{
+				// Custom automation peer prevents duplicate announcements when AutomationProperties.Name is set
+				return new ContentPanelAutomationPeer(this);
+			}
 
 			return base.OnCreateAutomationPeer();
 		}
@@ -89,25 +93,6 @@ namespace Microsoft.Maui.Platform
 
 			RegisterPropertyChangedCallback(BackgroundProperty, OnBackgroundPropertyChanged);
 			EnsureHitTestBackground();
-		}
-
-		// Custom automation peer prevents duplicate announcements when AutomationProperties.Name is set
-		protected override AutomationPeer OnCreateAutomationPeer() => new ContentPanelAutomationPeer(this);
-
-		internal partial class ContentPanelAutomationPeer : FrameworkElementAutomationPeer
-		{
-			internal ContentPanelAutomationPeer(ContentPanel owner) : base(owner) { }
-
-			bool HasDescription => !string.IsNullOrWhiteSpace(AutomationProperties.GetName(Owner));
-
-			protected override AutomationControlType GetAutomationControlTypeCore() =>
-				HasDescription ? AutomationControlType.Text : AutomationControlType.Custom;
-
-			protected override string GetLocalizedControlTypeCore() =>
-				HasDescription ? string.Empty : base.GetLocalizedControlTypeCore() ?? string.Empty;
-
-			protected override IList<AutomationPeer>? GetChildrenCore() =>
-				HasDescription ? null : base.GetChildrenCore();
 		}
 
 		void ContentPanelSizeChanged(object sender, SizeChangedEventArgs e)

--- a/src/Core/src/Platform/Windows/ContentPanel.cs
+++ b/src/Core/src/Platform/Windows/ContentPanel.cs
@@ -15,6 +15,7 @@ using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Hosting;
 using Microsoft.UI.Xaml.Shapes;
 using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Automation.Peers;
 
 namespace Microsoft.Maui.Platform
 {
@@ -67,6 +68,16 @@ namespace Microsoft.Maui.Platform
 			UpdateClip(_borderStroke?.Shape, size.Width, size.Height);
 
 			return size;
+		}
+
+		protected override AutomationPeer OnCreateAutomationPeer()
+		{
+			if (this.CrossPlatformLayout is not null && CrossPlatformLayout is IBorderView)
+			{
+				return new MauiBorderAutomationPeer(this);
+			}
+
+			return base.OnCreateAutomationPeer();
 		}
 
 		public ContentPanel()

--- a/src/Core/src/Platform/Windows/ContentPanel.cs
+++ b/src/Core/src/Platform/Windows/ContentPanel.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Maui.Platform
 
 		protected override AutomationPeer OnCreateAutomationPeer()
 		{
-			if (this.CrossPlatformLayout is not null && CrossPlatformLayout is IBorderView)
+			if (CrossPlatformLayout is IBorderView)
 			{
 				return new MauiBorderAutomationPeer(this);
 			}

--- a/src/Core/src/Platform/Windows/ContentPanelAutomationPeer.cs
+++ b/src/Core/src/Platform/Windows/ContentPanelAutomationPeer.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
+
+namespace Microsoft.Maui.Platform
+{
+	internal partial class ContentPanelAutomationPeer : FrameworkElementAutomationPeer
+	{
+		internal ContentPanelAutomationPeer(ContentPanel owner) : base(owner) { }
+
+		bool HasDescription => !string.IsNullOrWhiteSpace(AutomationProperties.GetName(Owner));
+
+		protected override AutomationControlType GetAutomationControlTypeCore() =>
+			HasDescription ? AutomationControlType.Text : AutomationControlType.Custom;
+
+		protected override string GetLocalizedControlTypeCore() =>
+			HasDescription ? string.Empty : base.GetLocalizedControlTypeCore() ?? string.Empty;
+
+		protected override IList<AutomationPeer>? GetChildrenCore() =>
+			HasDescription ? null : base.GetChildrenCore();
+	}
+}

--- a/src/Core/src/Platform/Windows/MauiBorderAutomationPeer.cs
+++ b/src/Core/src/Platform/Windows/MauiBorderAutomationPeer.cs
@@ -1,22 +1,24 @@
 ﻿using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 
-public class MauiBorderAutomationPeer : FrameworkElementAutomationPeer
+namespace Microsoft.Maui.Platform
 {
-    public MauiBorderAutomationPeer(Panel owner) : base(owner) { }
+	public class MauiBorderAutomationPeer : FrameworkElementAutomationPeer
+	{
+		public MauiBorderAutomationPeer(Panel owner) : base(owner) { }
 
-    protected override AutomationControlType GetAutomationControlTypeCore()
-    {
-        return AutomationControlType.Pane;
-    }
+		protected override AutomationControlType GetAutomationControlTypeCore()
+		{
+			return AutomationControlType.Pane;
+		}
 
-    protected override string GetClassNameCore()
-    {
-        return nameof(Panel);
-    }
+		protected override string GetClassNameCore()
+		{
+			return nameof(Panel);
+		}
 
-    protected override bool IsControlElementCore() => true;
+		protected override bool IsControlElementCore() => true;
 
-    protected override bool IsContentElementCore() => true;
-
+		protected override bool IsContentElementCore() => true;
+	}
 }

--- a/src/Core/src/Platform/Windows/MauiBorderAutomationPeer.cs
+++ b/src/Core/src/Platform/Windows/MauiBorderAutomationPeer.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Controls;
+
+public class MauiBorderAutomationPeer : FrameworkElementAutomationPeer
+{
+    public MauiBorderAutomationPeer(Panel owner) : base(owner) { }
+
+    protected override AutomationControlType GetAutomationControlTypeCore()
+    {
+        return AutomationControlType.Pane;
+    }
+
+    protected override string GetClassNameCore()
+    {
+        return nameof(Panel);
+    }
+
+    protected override bool IsControlElementCore() => true;
+
+    protected override bool IsContentElementCore() => true;
+
+}

--- a/src/Core/src/Platform/Windows/MauiBorderAutomationPeer.cs
+++ b/src/Core/src/Platform/Windows/MauiBorderAutomationPeer.cs
@@ -3,9 +3,10 @@ using Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.Maui.Platform
 {
-	public class MauiBorderAutomationPeer : FrameworkElementAutomationPeer
+	// TODO: Make this class public in .NET 10.0. Issue Link: https://github.com/dotnet/maui/issues/30205
+	internal class MauiBorderAutomationPeer : FrameworkElementAutomationPeer
 	{
-		public MauiBorderAutomationPeer(Panel owner) : base(owner) { }
+		internal MauiBorderAutomationPeer(Panel owner) : base(owner) { }
 
 		protected override AutomationControlType GetAutomationControlTypeCore()
 		{

--- a/src/Core/src/Platform/Windows/MauiBorderAutomationPeer.cs
+++ b/src/Core/src/Platform/Windows/MauiBorderAutomationPeer.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Platform
 	// TODO: Make this class public in .NET11.0. Issue Link: https://github.com/dotnet/maui/issues/30205
 	internal partial class MauiBorderAutomationPeer : FrameworkElementAutomationPeer
 	{
-		internal MauiBorderAutomationPeer(Panel owner) : base(owner) { }
+		internal MauiBorderAutomationPeer(ContentPanel owner) : base(owner) { }
 
 		protected override AutomationControlType GetAutomationControlTypeCore()
 		{
@@ -16,6 +16,11 @@ namespace Microsoft.Maui.Platform
 
 		protected override string GetClassNameCore()
 		{
+			if (Owner is ContentPanel panel)
+			{
+				return panel.CrossPlatformLayout?.GetType().Name ?? nameof(Panel);
+			}
+
 			return nameof(Panel);
 		}
 

--- a/src/Core/src/Platform/Windows/MauiBorderAutomationPeer.cs
+++ b/src/Core/src/Platform/Windows/MauiBorderAutomationPeer.cs
@@ -1,10 +1,11 @@
-﻿using Microsoft.UI.Xaml.Automation.Peers;
+﻿using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.Maui.Platform
 {
-	// TODO: Make this class public in .NET 10.0. Issue Link: https://github.com/dotnet/maui/issues/30205
-	internal class MauiBorderAutomationPeer : FrameworkElementAutomationPeer
+	// TODO: Make this class public in .NET11.0. Issue Link: https://github.com/dotnet/maui/issues/30205
+	internal partial class MauiBorderAutomationPeer : FrameworkElementAutomationPeer
 	{
 		internal MauiBorderAutomationPeer(Panel owner) : base(owner) { }
 
@@ -20,6 +21,16 @@ namespace Microsoft.Maui.Platform
 
 		protected override bool IsControlElementCore() => true;
 
-		protected override bool IsContentElementCore() => true;
+		protected override bool IsContentElementCore() => HasAutomationId();
+
+		bool HasAutomationId()
+		{
+			if (Owner is not ContentPanel contentPanel)
+			{
+				return false;
+			}
+
+			return !string.IsNullOrEmpty(AutomationProperties.GetAutomationId(contentPanel));
+		}
 	}
 }

--- a/src/Core/src/Platform/Windows/MauiBorderAutomationPeer.cs
+++ b/src/Core/src/Platform/Windows/MauiBorderAutomationPeer.cs
@@ -24,18 +24,52 @@ namespace Microsoft.Maui.Platform
 			return nameof(Panel);
 		}
 
-		protected override bool IsControlElementCore() => true;
-
-		protected override bool IsContentElementCore() => HasAutomationId();
-
-		bool HasAutomationId()
+		// Border is a structural container — excluded from the Control view by default so screen
+		// readers don't stop on every nested Border. Opt in via AutomationProperties.IsInAccessibleTree
+		// or SemanticProperties.Description / Hint. See MauiLayoutAutomationPeer for rationale.
+		protected override bool IsControlElementCore()
 		{
-			if (Owner is not ContentPanel contentPanel)
+			if (Owner is not ContentPanel panel)
 			{
 				return false;
 			}
 
-			return !string.IsNullOrEmpty(AutomationProperties.GetAutomationId(contentPanel));
+			var accessibilityView = panel.ReadLocalValue(AutomationProperties.AccessibilityViewProperty);
+
+			// Explicit opt-out (IsInAccessibleTree="False" -> AccessibilityView.Raw) wins over any opt-in signal.
+			if (accessibilityView is AccessibilityView.Raw)
+			{
+				return false;
+			}
+			else if (accessibilityView is AccessibilityView.Control or AccessibilityView.Content)
+			{
+				return true;
+			}
+
+			if (!string.IsNullOrEmpty(AutomationProperties.GetName(panel)))
+			{
+				return true;
+			}
+
+			if (!string.IsNullOrEmpty(AutomationProperties.GetHelpText(panel)))
+			{
+				return true;
+			}
+
+			return false;
+		}
+
+		// Content view requires explicit opt-in via AutomationProperties.IsInAccessibleTree="True".
+		// AutomationId alone is treated as a test-only hook (visible in the raw view only).
+		protected override bool IsContentElementCore()
+		{
+			if (Owner is not ContentPanel panel)
+			{
+				return false;
+			}
+
+			var accessibilityView = panel.ReadLocalValue(AutomationProperties.AccessibilityViewProperty);
+			return accessibilityView is AccessibilityView.Content;
 		}
 	}
 }


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change
This PR is the first part of the split from #27713. It adds an AutomationPeer for the Windows Border (ContentPanel) so the control is properly exposed to UI Automation and accessibility tools while avoiding unnecessary noise in the screen-reader reading order.

- Added a new internal MauiBorderAutomationPeer derived from FrameworkElementAutomationPeer.
- Overrode ContentPanel.OnCreateAutomationPeer() to return MauiBorderAutomationPeer only when CrossPlatformLayout is IBorderView. Other ContentPanel usages continue using the default behavior.
- This peer is needed because Panel (the base class of ContentPanel) does not provide a default AutomationPeer, so Border was previously missing or not exposed correctly in the UIA tree.
- The peer follows an opt-in model for the screen-reader Control view, aligned with the layout AutomationPeer improvements from #35597.

Added explicit opt-out handling so AutomationProperties.IsInAccessibleTree="False" always takes precedence over any opt-in signal, matching native WinUI Border behavior.

### How It Works

On Windows, a MAUI Border is rendered using a native ContentPanel derived from Panel. UI Automation discovers elements by calling OnCreateAutomationPeer() on the native control and then querying the returned peer for details such as control type, class name, automation ID, accessible name, and Control / Content view membership.

- **Peer entry point:** ContentPanel.OnCreateAutomationPeer() now returns MauiBorderAutomationPeer only when CrossPlatformLayout is IBorderView. All other ContentPanel usages continue using the default behavior, so the change is scoped only to Border.
- **What the peer provides:** UI Automation queries methods like GetAutomationControlTypeCore, GetClassNameCore, IsControlElementCore, and IsContentElementCore. Existing MAUI mappings for AutomationId, SemanticProperties.Description, and Hint continue through the base peer implementation.
- **Control View vs Content View:** IsControlElementCore() is opt-in. It returns true only when the developer explicitly marks the Border as meaningful to accessibility tools using SemanticProperties.Description, SemanticProperties.Hint, or AutomationProperties.IsInAccessibleTree="True". This keeps decorative or structural Borders out of the screen-reader reading order. IsContentElementCore() requires explicit IsInAccessibleTree="True". AutomationId alone is treated as a UI-testing hook and does not move the Border into the accessibility views.
- **Explicit opt-out:** When AutomationProperties.IsInAccessibleTree="False" is set (AccessibilityView.Raw), both IsControlElementCore() and IsContentElementCore() immediately return false before evaluating any opt-in signals. This matches native WinUI Border behavior where an explicit opt-out always takes priority.
- **Class name:** GetClassNameCore() returns the cross-platform layout type name, such as "Border" or a derived type name like "MyBorder", instead of the generic native "Panel" name.


### Overridden Core Methods and Purpose

**1. GetAutomationControlTypeCore()**
Returns AutomationControlType.Pane, which is the most suitable type for a layout container that is not an interactive control like a button or checkbox. This allows accessibility tools to treat the element as a structural container.
**2. GetClassNameCore()**
Returns the cross-platform control type name (for example, "Border") using panel.CrossPlatformLayout?.GetType().Name, with a fallback to nameof(Panel). This exposes the MAUI control name instead of the generic native Panel.
**3. IsControlElementCore() (opt-in + opt-out)**
Returns false immediately when AccessibilityView.Raw is set (IsInAccessibleTree="False"). Otherwise, it returns true when AccessibilityView is Control or Content (IsInAccessibleTree="True"), or when AutomationProperties.Name (SemanticProperties.Description) or AutomationProperties.HelpText (SemanticProperties.Hint) is set. If none of these conditions are met, it returns false, keeping structural or decorative Borders out of the Control view.
**4. IsContentElementCore() (explicit opt-in only)**
Returns false when AccessibilityView.Raw is set. Otherwise, it returns true only when AccessibilityView.Content is set (IsInAccessibleTree="True"). AutomationId alone does not move the Border into the Content view.

### Issues Fixed

Fixes #27627