### PR TITLE
[Windows] Border: Keyboard tap support for TapGestureRecognizer

### DIFF
--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -12,6 +12,7 @@ using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.UI.Input;
 using Windows.Storage.Streams;
+using Windows.System;
 
 namespace Microsoft.Maui.Controls.Platform
 {
@@ -398,6 +399,65 @@ namespace Microsoft.Maui.Controls.Platform
 					if (gestureRecognizers.FirstGestureOrDefault<DropGestureRecognizer>() is { } dropGesture)
 					{
 						dropGesture.PropertyChanged -= HandleDragAndDropGesturePropertyChanged;
+					}
+				}
+			}
+
+			// Reset tab stop state when clearing gesture handlers for Border
+			UpdateContentPanelIsTapStop(false);
+		}
+
+		// Sets or resets the IsTabStop property on ContentPanel (Border) when gesture recognizers are added or removed for border.
+		// This allows Border to be focusable when it has TapGestureRecognizers for keyboard accessibility.
+		void UpdateContentPanelIsTapStop(bool canAllowTabStop)
+		{
+			if (_control is ContentPanel contentPanel && contentPanel.CrossPlatformLayout is IBorderView)
+			{
+				bool isSubscribed = (_subscriptionFlags & SubscriptionFlags.ContentPanelKeyDownSubscribed) != 0;
+
+				if (canAllowTabStop && !isSubscribed)
+				{
+					contentPanel.IsTabStop = true;
+					contentPanel.KeyDown += ContentPanelOnKeyDown;
+					_subscriptionFlags |= SubscriptionFlags.ContentPanelKeyDownSubscribed;
+				}
+				else if (!canAllowTabStop && isSubscribed)
+				{
+					contentPanel.IsTabStop = false;
+					contentPanel.KeyDown -= ContentPanelOnKeyDown;
+					_subscriptionFlags &= ~SubscriptionFlags.ContentPanelKeyDownSubscribed;
+				}
+			}
+		}
+
+		// Handle Enter and Space key presses to trigger TapGestureRecognizers on Border for keyboard accessibility
+		// This is only applicable when the Border has TapGestureRecognizers attached
+		void ContentPanelOnKeyDown(object sender, KeyRoutedEventArgs e)
+		{
+			if (e.Key == VirtualKey.Enter || e.Key == VirtualKey.Space)
+			{
+				if (Element is View view)
+				{
+					IEnumerable<TapGestureRecognizer> tapGestures = view.GestureRecognizers.GetGesturesFor<TapGestureRecognizer>(recognizer =>
+						recognizer.NumberOfTapsRequired == 1 &&
+						(recognizer.Buttons & ButtonsMask.Primary) == ButtonsMask.Primary);
+
+					bool handled = false;
+
+					foreach (var recognizer in tapGestures)
+					{
+						recognizer.SendTapped(view, (relativeTo) =>
+						{
+							// Keyboard taps have no physical position, use Point.Zero
+							// consistent with Android keyboard behavior.
+							return Point.Zero;
+						});
+						handled = true;
+					}
+
+					if (handled)
+					{
+						e.Handled = true;
 					}
 				}
 			}
@@ -976,7 +1036,11 @@ namespace Microsoft.Maui.Controls.Platform
 
 			var children = (view as IGestureController)?.GetChildElements(Point.Zero);
 
-			if (gestures.HasAnyGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 1)
+			bool hasSelfTapGestures = gestures.HasAnyGesturesFor<TapGestureRecognizer>(g =>
+				g.NumberOfTapsRequired == 1 &&
+				(g.Buttons & ButtonsMask.Primary) == ButtonsMask.Primary);
+
+			if (hasSelfTapGestures
 				|| children?.GetChildGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 1).Any() == true)
 			{
 				_subscriptionFlags |= SubscriptionFlags.ContainerTapAndRightTabEventSubscribed;
@@ -992,6 +1056,10 @@ namespace Microsoft.Maui.Controls.Platform
 				}
 
 				_container.RightTapped += OnTap;
+
+				// Only enable tab stop when the border itself has tap gestures (not just children).
+				// Children should handle their own keyboard focus independently.
+				UpdateContentPanelIsTapStop(hasSelfTapGestures);
 			}
 			else
 			{
@@ -1117,7 +1185,7 @@ namespace Microsoft.Maui.Controls.Platform
 		}
 
 		[Flags]
-		enum SubscriptionFlags : byte
+		enum SubscriptionFlags : ushort
 		{
 			None = 0,
 			ContainerDragEventsSubscribed = 1,
@@ -1127,7 +1195,8 @@ namespace Microsoft.Maui.Controls.Platform
 			ContainerTapAndRightTabEventSubscribed = 1 << 4,
 			ContainerDoubleTapEventSubscribed = 1 << 5,
 			ControlTapEventSubscribed = 1 << 6,
-			ControlDoubleTapEventSubscribed = 1 << 7
+			ControlDoubleTapEventSubscribed = 1 << 7,
+			ContentPanelKeyDownSubscribed = 1 << 8
 		}
 	}
 }

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -115,6 +115,9 @@ namespace Microsoft.Maui.Controls.Platform
 					{
 						_control.DoubleTapped -= HandleDoubleTapped;
 					}
+
+					// Ensure KeyDown handler on the old ContentPanel (Border) is detached before reassigning _control.
+					UpdateContentPanelIsTapStop(false);
 				}
 
 				_control = value;
@@ -438,6 +441,11 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				if (Element is View view)
 				{
+					if (!view.IsEnabled)
+					{
+						return;
+					}
+
 					IEnumerable<TapGestureRecognizer> tapGestures = view.GestureRecognizers.GetGesturesFor<TapGestureRecognizer>(recognizer =>
 						recognizer.NumberOfTapsRequired == 1 &&
 						(recognizer.Buttons & ButtonsMask.Primary) == ButtonsMask.Primary);
@@ -1036,11 +1044,14 @@ namespace Microsoft.Maui.Controls.Platform
 
 			var children = (view as IGestureController)?.GetChildElements(Point.Zero);
 
-			bool hasSelfTapGestures = gestures.HasAnyGesturesFor<TapGestureRecognizer>(g =>
+			bool hasSelfSingleTap = gestures.HasAnyGesturesFor<TapGestureRecognizer>(g =>
+				g.NumberOfTapsRequired == 1);
+
+			bool hasSelfPrimarySingleTap = gestures.HasAnyGesturesFor<TapGestureRecognizer>(g =>
 				g.NumberOfTapsRequired == 1 &&
 				(g.Buttons & ButtonsMask.Primary) == ButtonsMask.Primary);
 
-			if (hasSelfTapGestures
+			if (hasSelfSingleTap
 				|| children?.GetChildGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 1).Any() == true)
 			{
 				_subscriptionFlags |= SubscriptionFlags.ContainerTapAndRightTabEventSubscribed;
@@ -1057,9 +1068,10 @@ namespace Microsoft.Maui.Controls.Platform
 
 				_container.RightTapped += OnTap;
 
-				// Only enable tab stop when the border itself has tap gestures (not just children).
-				// Children should handle their own keyboard focus independently.
-				UpdateContentPanelIsTapStop(hasSelfTapGestures);
+				// Only enable tab stop when the border itself has a primary-button single-tap gesture.
+				// Children should handle their own keyboard focus independently, and secondary-only
+				// gestures are not activated via Enter/Space.
+				UpdateContentPanelIsTapStop(hasSelfPrimarySingleTap);
 			}
 			else
 			{

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -21,6 +21,10 @@ namespace Microsoft.Maui.Controls.Platform
 		readonly IPlatformViewHandler _handler;
 		readonly NotifyCollectionChangedEventHandler _collectionChangedHandler;
 		readonly List<uint> _fingers = new List<uint>();
+		// Tracks tap recognizers that currently have HandleTapGestureRecognizerPropertyChanged subscribed.
+		// Using an explicit set ensures removed recognizers are unsubscribed even after they leave GestureRecognizers,
+		// preventing stale PropertyChanged subscriptions from keeping this manager alive (memory leak fix).
+		readonly HashSet<TapGestureRecognizer> _subscribedTapRecognizers = new();
 		FrameworkElement? _container;
 		FrameworkElement? _control;
 		VisualElement? _element;
@@ -414,10 +418,11 @@ namespace Microsoft.Maui.Controls.Platform
 					{
 						dropGesture.PropertyChanged -= HandleDragAndDropGesturePropertyChanged;
 					}
-					foreach (var tapGesture in gestureRecognizers.GetGesturesFor<TapGestureRecognizer>())
+					foreach (var tapGesture in _subscribedTapRecognizers)
 					{
 						tapGesture.PropertyChanged -= HandleTapGestureRecognizerPropertyChanged;
 					}
+					_subscribedTapRecognizers.Clear();
 				}
 			}
 
@@ -1087,11 +1092,21 @@ namespace Microsoft.Maui.Controls.Platform
 				g.NumberOfTapsRequired == 1 &&
 				(g.Buttons & ButtonsMask.Primary) == ButtonsMask.Primary);
 
-			// Subscribe to property changes on all tap recognizers so IsTabStop stays in sync
+			// Unsubscribe all previously tracked tap recognizers before re-subscribing.
+			// This ensures removed recognizers (no longer in GestureRecognizers) are detached —
+			// they would be missed if we only iterated the current collection here.
+			foreach (var oldTapGesture in _subscribedTapRecognizers)
+			{
+				oldTapGesture.PropertyChanged -= HandleTapGestureRecognizerPropertyChanged;
+			}
+			_subscribedTapRecognizers.Clear();
+
+			// Subscribe to property changes on all current tap recognizers so IsTabStop stays in sync
 			// when Buttons or NumberOfTapsRequired change at runtime without a collection change.
 			foreach (var tapGesture in gestures.GetGesturesFor<TapGestureRecognizer>())
 			{
 				tapGesture.PropertyChanged += HandleTapGestureRecognizerPropertyChanged;
+				_subscribedTapRecognizers.Add(tapGesture);
 			}
 
 			if (hasSelfSingleTap

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -116,7 +116,10 @@ namespace Microsoft.Maui.Controls.Platform
 						_control.DoubleTapped -= HandleDoubleTapped;
 					}
 
-					// Ensure KeyDown handler on the old ContentPanel (Border) is detached before reassigning _control.
+					// Needed for handler re-use or hot-reload: if _control is reassigned while a KeyDown
+					// subscription is live, detach it from the old ContentPanel before the swap.
+					// During Dispose this is a no-op because ClearContainerEventHandlers() already
+					// cleared ContentPanelKeyDownSubscribed before Control is set to null.
 					UpdateContentPanelIsTapStop(false);
 				}
 
@@ -302,12 +305,20 @@ namespace Microsoft.Maui.Controls.Platform
 					gestureRecognizersBefore.CollectionChanged -= _collectionChangedHandler;
 				}
 
+				// Unsubscribe from the old element before swapping, to avoid stale callbacks.
+				_element?.PropertyChanged -= HandleElementPropertyChanged;
+
 				_element = value;
 
 				if (_element is View && ElementGestureRecognizers is { } gestureRecognizersAfter)
 				{
 					gestureRecognizersAfter.CollectionChanged += _collectionChangedHandler;
 				}
+
+				// Subscribe to IsEnabled changes so Border keyboard focus state stays in sync
+				// when IsEnabled is toggled at runtime (ContentPanel is a Panel, not a Control,
+				// so MapIsEnabled does not propagate IsEnabled to it automatically).
+				_element?.PropertyChanged += HandleElementPropertyChanged;
 			}
 		}
 
@@ -403,6 +414,10 @@ namespace Microsoft.Maui.Controls.Platform
 					{
 						dropGesture.PropertyChanged -= HandleDragAndDropGesturePropertyChanged;
 					}
+					foreach (var tapGesture in gestureRecognizers.GetGesturesFor<TapGestureRecognizer>())
+					{
+						tapGesture.PropertyChanged -= HandleTapGestureRecognizerPropertyChanged;
+					}
 				}
 			}
 
@@ -416,16 +431,19 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			if (_control is ContentPanel contentPanel && contentPanel.CrossPlatformLayout is IBorderView)
 			{
+				// A disabled Border must not be keyboard-focusable even if it has a TapGestureRecognizer.
+				// ContentPanel derives from Panel, so MapIsEnabled does not propagate IsEnabled to it.
+				bool shouldEnable = canAllowTabStop && (Element is not View v || v.IsEnabled);
 				bool isSubscribed = (_subscriptionFlags & SubscriptionFlags.ContentPanelKeyDownSubscribed) != 0;
 
-				if (canAllowTabStop && !isSubscribed)
+				if (shouldEnable && !isSubscribed)
 				{
 					contentPanel.IsTabStop = true;
 					contentPanel.UseSystemFocusVisuals = true;
 					contentPanel.KeyDown += ContentPanelOnKeyDown;
 					_subscriptionFlags |= SubscriptionFlags.ContentPanelKeyDownSubscribed;
 				}
-				else if (!canAllowTabStop && isSubscribed)
+				else if (!shouldEnable && isSubscribed)
 				{
 					contentPanel.IsTabStop = false;
 					contentPanel.UseSystemFocusVisuals = false;
@@ -1069,6 +1087,13 @@ namespace Microsoft.Maui.Controls.Platform
 				g.NumberOfTapsRequired == 1 &&
 				(g.Buttons & ButtonsMask.Primary) == ButtonsMask.Primary);
 
+			// Subscribe to property changes on all tap recognizers so IsTabStop stays in sync
+			// when Buttons or NumberOfTapsRequired change at runtime without a collection change.
+			foreach (var tapGesture in gestures.GetGesturesFor<TapGestureRecognizer>())
+			{
+				tapGesture.PropertyChanged += HandleTapGestureRecognizerPropertyChanged;
+			}
+
 			if (hasSelfSingleTap
 				|| children?.GetChildGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 1).Any() == true)
 			{
@@ -1203,6 +1228,27 @@ namespace Microsoft.Maui.Controls.Platform
 				e.PropertyName == DropGestureRecognizer.AllowDropProperty.PropertyName)
 			{
 				UpdateDragAndDropGestureRecognizers();
+			}
+		}
+
+		void HandleElementPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName == VisualElement.IsEnabledProperty.PropertyName
+				&& _control is ContentPanel { CrossPlatformLayout: IBorderView })
+			{
+				// ContentPanel derives from Panel, so MapIsEnabled does not propagate to it.
+				// Recompute keyboard focus state when IsEnabled changes at runtime.
+				UpdatingGestureRecognizers();
+			}
+		}
+
+		void HandleTapGestureRecognizerPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName is nameof(TapGestureRecognizer.NumberOfTapsRequired) or nameof(TapGestureRecognizer.Buttons)
+				&& _control is ContentPanel { CrossPlatformLayout: IBorderView })
+			{
+				// Recompute keyboard focus state when tap recognizer properties change at runtime.
+				UpdatingGestureRecognizers();
 			}
 		}
 

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -13,6 +13,7 @@ using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.UI.Input;
 using Windows.Storage.Streams;
 using Windows.System;
+using Windows.UI.Core;
 
 namespace Microsoft.Maui.Controls.Platform
 {
@@ -480,6 +481,17 @@ namespace Microsoft.Maui.Controls.Platform
 
 			if (e.Key == VirtualKey.Enter || e.Key == VirtualKey.Space)
 			{
+				// Suppress modifier chords (Ctrl+Enter, Shift+Space, Alt+Space, etc.).
+				// Alt+Space is the Windows system menu accelerator — consuming it would break OS behavior.
+				// Standard WinUI controls (e.g. Button) do not activate on modifier+key chords.
+				// Pattern follows MauiPasswordTextBox.cs which uses the same API for Ctrl detection.
+				if (InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down) ||
+					InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down) ||
+					InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Menu).HasFlag(CoreVirtualKeyStates.Down))
+				{
+					return;
+				}
+
 				if (Element is View view)
 				{
 					if (!view.IsEnabled)

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -421,12 +421,14 @@ namespace Microsoft.Maui.Controls.Platform
 				if (canAllowTabStop && !isSubscribed)
 				{
 					contentPanel.IsTabStop = true;
+					contentPanel.UseSystemFocusVisuals = true;
 					contentPanel.KeyDown += ContentPanelOnKeyDown;
 					_subscriptionFlags |= SubscriptionFlags.ContentPanelKeyDownSubscribed;
 				}
 				else if (!canAllowTabStop && isSubscribed)
 				{
 					contentPanel.IsTabStop = false;
+					contentPanel.UseSystemFocusVisuals = false;
 					contentPanel.KeyDown -= ContentPanelOnKeyDown;
 					_subscriptionFlags &= ~SubscriptionFlags.ContentPanelKeyDownSubscribed;
 				}

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -437,9 +437,10 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			if (_control is ContentPanel contentPanel && contentPanel.CrossPlatformLayout is IBorderView)
 			{
-				// A disabled Border must not be keyboard-focusable even if it has a TapGestureRecognizer.
+				// A disabled or input-transparent Border must not be keyboard-focusable even if it has a TapGestureRecognizer.
 				// ContentPanel derives from Panel, so MapIsEnabled does not propagate IsEnabled to it.
-				bool shouldEnable = canAllowTabStop && (Element is not View v || v.IsEnabled);
+				// InputTransparent on Windows only disables hit-testing (mouse), not tab navigation — guard it explicitly.
+				bool shouldEnable = canAllowTabStop && (Element is not View v || (v.IsEnabled && !v.InputTransparent));
 				bool isSubscribed = (_subscriptionFlags & SubscriptionFlags.ContentPanelKeyDownSubscribed) != 0;
 
 				if (shouldEnable && !isSubscribed)
@@ -494,7 +495,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 				if (Element is View view)
 				{
-					if (!view.IsEnabled)
+					if (!view.IsEnabled || view.InputTransparent)
 					{
 						return;
 					}
@@ -1260,11 +1261,13 @@ namespace Microsoft.Maui.Controls.Platform
 
 		void HandleElementPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
 		{
-			if (e.PropertyName == VisualElement.IsEnabledProperty.PropertyName
+			if ((e.PropertyName == VisualElement.IsEnabledProperty.PropertyName ||
+				 e.PropertyName == VisualElement.InputTransparentProperty.PropertyName)
 				&& _control is ContentPanel { CrossPlatformLayout: IBorderView })
 			{
 				// ContentPanel derives from Panel, so MapIsEnabled does not propagate to it.
-				// Recompute keyboard focus state when IsEnabled changes at runtime.
+				// InputTransparent on Windows only disables hit-testing, not tab navigation — recompute here.
+				// Recompute keyboard focus state when IsEnabled or InputTransparent changes at runtime.
 				UpdatingGestureRecognizers();
 			}
 		}

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -437,6 +437,22 @@ namespace Microsoft.Maui.Controls.Platform
 		// This is only applicable when the Border has TapGestureRecognizers attached
 		void ContentPanelOnKeyDown(object sender, KeyRoutedEventArgs e)
 		{
+			// Only handle events originating directly from the ContentPanel (i.e. the Border itself is focused).
+			// KeyDown is a bubbling routed event; without this guard a child element's unhandled Enter/Space
+			// would bubble up and spuriously fire the Border's TapGestureRecognizer.
+			if (!ReferenceEquals(e.OriginalSource, sender))
+			{
+				return;
+			}
+
+			// Ignore auto-repeat events fired while the key is held down.
+			// KeyDown fires repeatedly for a single held key press; we only want to act once per press,
+			// consistent with Android's OnKeyPress which acts on KeyEventActions.Up.
+			if (e.KeyStatus.WasKeyDown)
+			{
+				return;
+			}
+
 			if (e.Key == VirtualKey.Enter || e.Key == VirtualKey.Space)
 			{
 				if (Element is View view)

--- a/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.Windows.cs
@@ -78,6 +78,36 @@ namespace Microsoft.Maui.DeviceTests
 			   });
 		}
 
+		[Theory(DisplayName = "Border ContentPanel IsTabStop reflects TapGestureRecognizer state")]
+		[InlineData(false)]
+		[InlineData(true)]
+		public async Task ContentPanelIsTabStopReflectsTapGestureRecognizer(bool hasTapGestureRecognizer)
+		{
+			SetupBuilder();
+
+			var border = new Border()
+			{
+				Content = new Label
+				{
+					Text = "Focusable Border"
+				},
+				StrokeShape = new Rectangle(),
+				WidthRequest = 300,
+				HeightRequest = 100
+			};
+
+			if (hasTapGestureRecognizer)
+			{
+				border.GestureRecognizers.Add(new TapGestureRecognizer());
+			}
+
+			await AttachAndRun(border, handler =>
+			{
+				var contentPanel = GetNativeBorder(handler as BorderHandler);
+				Assert.Equal(hasTapGestureRecognizer, contentPanel.IsTabStop);
+			});
+		}
+
 		ContentPanel GetNativeBorder(BorderHandler borderHandler) =>
 			borderHandler.PlatformView;
 

--- a/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.Windows.cs
@@ -108,6 +108,95 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact(DisplayName = "Border ContentPanel IsTabStop is false when Border is disabled")]
+		public async Task ContentPanelIsTabStopFalseWhenBorderIsDisabled()
+		{
+			SetupBuilder();
+
+			var border = new Border()
+			{
+				Content = new Label
+				{
+					Text = "Disabled Border"
+				},
+				StrokeShape = new Rectangle(),
+				WidthRequest = 300,
+				HeightRequest = 100,
+				IsEnabled = false
+			};
+
+			border.GestureRecognizers.Add(new TapGestureRecognizer());
+
+			await AttachAndRun(border, handler =>
+			{
+				var contentPanel = GetNativeBorder(handler as BorderHandler);
+				Assert.False(contentPanel.IsTabStop);
+			});
+		}
+
+		[Fact(DisplayName = "Border ContentPanel IsTabStop resets to false when TapGestureRecognizer is removed at runtime")]
+		public async Task ContentPanelIsTabStopResetsOnRuntimeRecognizerRemoval()
+		{
+			SetupBuilder();
+
+			var tapRecognizer = new TapGestureRecognizer();
+			var border = new Border()
+			{
+				Content = new Label
+				{
+					Text = "Border"
+				},
+				StrokeShape = new Rectangle(),
+				WidthRequest = 300,
+				HeightRequest = 100
+			};
+
+			border.GestureRecognizers.Add(tapRecognizer);
+
+			await AttachAndRun(border, async handler =>
+			{
+				var contentPanel = GetNativeBorder(handler as BorderHandler);
+				Assert.True(contentPanel.IsTabStop);
+
+				await InvokeOnMainThreadAsync(() => border.GestureRecognizers.Remove(tapRecognizer));
+
+				Assert.False(contentPanel.IsTabStop);
+			});
+		}
+
+		[Fact(DisplayName = "Border ContentPanel IsTabStop updates when TapGestureRecognizer Buttons changes at runtime")]
+		public async Task ContentPanelIsTabStopUpdatesOnRecognizerButtonsChange()
+		{
+			SetupBuilder();
+
+			var tapRecognizer = new TapGestureRecognizer { Buttons = ButtonsMask.Primary };
+			var border = new Border()
+			{
+				Content = new Label { Text = "Border" },
+				StrokeShape = new Rectangle(),
+				WidthRequest = 300,
+				HeightRequest = 100
+			};
+
+			border.GestureRecognizers.Add(tapRecognizer);
+
+			await AttachAndRun(border, async handler =>
+			{
+				var contentPanel = GetNativeBorder(handler as BorderHandler);
+
+				// Primary single-tap → should be keyboard-focusable
+				Assert.True(contentPanel.IsTabStop);
+
+				// Change to Secondary-only → no longer keyboard-actionable
+				await InvokeOnMainThreadAsync(() => tapRecognizer.Buttons = ButtonsMask.Secondary);
+				Assert.False(contentPanel.IsTabStop);
+
+				// Restore to Primary → keyboard-focusable again
+				await InvokeOnMainThreadAsync(() => tapRecognizer.Buttons = ButtonsMask.Primary);
+				Assert.True(contentPanel.IsTabStop);
+			});
+		}
+
 		ContentPanel GetNativeBorder(BorderHandler borderHandler) =>
 			borderHandler.PlatformView;
 

--- a/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.Windows.cs
@@ -7,7 +7,6 @@ using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using Microsoft.UI.Composition;
 using Microsoft.UI.Xaml.Hosting;
-using Windows.UI.Input.Preview.Injection;
 using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
@@ -310,45 +309,6 @@ namespace Microsoft.Maui.DeviceTests
 				var contentPanel = GetNativeBorder(handler as BorderHandler);
 				// Child gestures must not promote the parent Border into the tab order.
 				Assert.False(contentPanel.IsTabStop);
-			});
-		}
-
-		[Theory(DisplayName = "Border ContentPanel fires TapGestureRecognizer on keyboard activation")]
-		[InlineData(13)]  // Enter
-		[InlineData(32)]  // Space
-		public async Task ContentPanelFiresTapGestureRecognizerOnKeyPress(ushort virtualKey)
-		{
-			SetupBuilder();
-
-			var tcs = new TaskCompletionSource<bool>();
-			var border = new Border()
-			{
-				Content = new Label { Text = "Border" },
-				StrokeShape = new Rectangle(),
-				WidthRequest = 300,
-				HeightRequest = 100
-			};
-
-			var tapRecognizer = new TapGestureRecognizer();
-			tapRecognizer.Tapped += (s, e) => tcs.TrySetResult(true);
-			border.GestureRecognizers.Add(tapRecognizer);
-
-			await AttachAndRun(border, async handler =>
-			{
-				var contentPanel = GetNativeBorder(handler as BorderHandler);
-				var injector = InputInjector.TryCreate();
-				Assert.NotNull(injector);
-
-				await InvokeOnMainThreadAsync(() => contentPanel.Focus(Microsoft.UI.Xaml.FocusState.Programmatic));
-
-				injector.InjectKeyboardInput(new[]
-				{
-					new InjectedInputKeyboardInfo { VirtualKey = virtualKey },
-					new InjectedInputKeyboardInfo { VirtualKey = virtualKey, KeyOptions = InjectedInputKeyOptions.KeyUp }
-				});
-
-				var tapFired = await Task.WhenAny(tcs.Task, Task.Delay(3000)) == tcs.Task;
-				Assert.True(tapFired, "TapGestureRecognizer.Tapped did not fire within timeout");
 			});
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.Windows.cs
@@ -7,6 +7,7 @@ using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using Microsoft.UI.Composition;
 using Microsoft.UI.Xaml.Hosting;
+using Windows.UI.Input.Preview.Injection;
 using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
@@ -227,6 +228,126 @@ namespace Microsoft.Maui.DeviceTests
 				// Re-enable at runtime → must re-enter the tab order
 				await InvokeOnMainThreadAsync(() => border.IsEnabled = true);
 				Assert.True(contentPanel.IsTabStop);
+			});
+		}
+
+		[Fact(DisplayName = "Border ContentPanel IsTabStop is false when Border is InputTransparent")]
+		public async Task ContentPanelIsTabStopFalseWhenBorderIsInputTransparent()
+		{
+			SetupBuilder();
+
+			var border = new Border()
+			{
+				Content = new Label { Text = "InputTransparent Border" },
+				StrokeShape = new Rectangle(),
+				WidthRequest = 300,
+				HeightRequest = 100,
+				InputTransparent = true
+			};
+
+			border.GestureRecognizers.Add(new TapGestureRecognizer());
+
+			await AttachAndRun(border, handler =>
+			{
+				var contentPanel = GetNativeBorder(handler as BorderHandler);
+				// InputTransparent=true must keep Border out of the tab order even with a recognizer present.
+				Assert.False(contentPanel.IsTabStop);
+			});
+		}
+
+		[Fact(DisplayName = "Border ContentPanel IsTabStop updates when InputTransparent toggles at runtime")]
+		public async Task ContentPanelIsTabStopUpdatesOnRuntimeInputTransparentToggle()
+		{
+			SetupBuilder();
+
+			var border = new Border()
+			{
+				Content = new Label { Text = "Border" },
+				StrokeShape = new Rectangle(),
+				WidthRequest = 300,
+				HeightRequest = 100,
+				InputTransparent = false
+			};
+
+			border.GestureRecognizers.Add(new TapGestureRecognizer());
+
+			await AttachAndRun(border, async handler =>
+			{
+				var contentPanel = GetNativeBorder(handler as BorderHandler);
+
+				// InputTransparent=false + has recognizer → should be keyboard-focusable
+				Assert.True(contentPanel.IsTabStop);
+
+				// Set InputTransparent=true at runtime → must leave the tab order
+				await InvokeOnMainThreadAsync(() => border.InputTransparent = true);
+				Assert.False(contentPanel.IsTabStop);
+
+				// Restore InputTransparent=false at runtime → must re-enter the tab order
+				await InvokeOnMainThreadAsync(() => border.InputTransparent = false);
+				Assert.True(contentPanel.IsTabStop);
+			});
+		}
+
+		[Fact(DisplayName = "Border ContentPanel IsTabStop is false when TapGestureRecognizer is only on a child element")]
+		public async Task ContentPanelIsTabStopFalseWhenGestureIsOnChild()
+		{
+			SetupBuilder();
+
+			var childLabel = new Label { Text = "Child with gesture" };
+			childLabel.GestureRecognizers.Add(new TapGestureRecognizer());
+
+			var border = new Border()
+			{
+				Content = childLabel,
+				StrokeShape = new Rectangle(),
+				WidthRequest = 300,
+				HeightRequest = 100
+			};
+
+			// Border itself has NO GestureRecognizers — only the child does.
+			await AttachAndRun(border, handler =>
+			{
+				var contentPanel = GetNativeBorder(handler as BorderHandler);
+				// Child gestures must not promote the parent Border into the tab order.
+				Assert.False(contentPanel.IsTabStop);
+			});
+		}
+
+		[Fact(DisplayName = "Border ContentPanel fires TapGestureRecognizer on Enter key press")]
+		public async Task ContentPanelFiresTapGestureRecognizerOnEnterKey()
+		{
+			SetupBuilder();
+
+			var tappedCount = 0;
+			var border = new Border()
+			{
+				Content = new Label { Text = "Border" },
+				StrokeShape = new Rectangle(),
+				WidthRequest = 300,
+				HeightRequest = 100
+			};
+
+			var tapRecognizer = new TapGestureRecognizer();
+			tapRecognizer.Tapped += (s, e) => tappedCount++;
+			border.GestureRecognizers.Add(tapRecognizer);
+
+			await AttachAndRun(border, async handler =>
+			{
+				var contentPanel = GetNativeBorder(handler as BorderHandler);
+				var injector = InputInjector.TryCreate();
+				if (injector == null)
+					return;
+
+				await InvokeOnMainThreadAsync(() => contentPanel.Focus(Microsoft.UI.Xaml.FocusState.Programmatic));
+
+				injector.InjectKeyboardInput(new[]
+				{
+					new InjectedInputKeyboardInfo { VirtualKey = 13 },                                        // Enter KeyDown
+					new InjectedInputKeyboardInfo { VirtualKey = 13, KeyOptions = InjectedInputKeyOptions.KeyUp }  // Enter KeyUp
+				});
+
+				await Task.Delay(100);
+				Assert.Equal(1, tappedCount);
 			});
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.Windows.cs
@@ -313,12 +313,14 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Fact(DisplayName = "Border ContentPanel fires TapGestureRecognizer on Enter key press")]
-		public async Task ContentPanelFiresTapGestureRecognizerOnEnterKey()
+		[Theory(DisplayName = "Border ContentPanel fires TapGestureRecognizer on keyboard activation")]
+		[InlineData(13)]  // Enter
+		[InlineData(32)]  // Space
+		public async Task ContentPanelFiresTapGestureRecognizerOnKeyPress(ushort virtualKey)
 		{
 			SetupBuilder();
 
-			var tappedCount = 0;
+			var tcs = new TaskCompletionSource<bool>();
 			var border = new Border()
 			{
 				Content = new Label { Text = "Border" },
@@ -328,26 +330,25 @@ namespace Microsoft.Maui.DeviceTests
 			};
 
 			var tapRecognizer = new TapGestureRecognizer();
-			tapRecognizer.Tapped += (s, e) => tappedCount++;
+			tapRecognizer.Tapped += (s, e) => tcs.TrySetResult(true);
 			border.GestureRecognizers.Add(tapRecognizer);
 
 			await AttachAndRun(border, async handler =>
 			{
 				var contentPanel = GetNativeBorder(handler as BorderHandler);
 				var injector = InputInjector.TryCreate();
-				if (injector == null)
-					return;
+				Assert.NotNull(injector);
 
 				await InvokeOnMainThreadAsync(() => contentPanel.Focus(Microsoft.UI.Xaml.FocusState.Programmatic));
 
 				injector.InjectKeyboardInput(new[]
 				{
-					new InjectedInputKeyboardInfo { VirtualKey = 13 },                                        // Enter KeyDown
-					new InjectedInputKeyboardInfo { VirtualKey = 13, KeyOptions = InjectedInputKeyOptions.KeyUp }  // Enter KeyUp
+					new InjectedInputKeyboardInfo { VirtualKey = virtualKey },
+					new InjectedInputKeyboardInfo { VirtualKey = virtualKey, KeyOptions = InjectedInputKeyOptions.KeyUp }
 				});
 
-				await Task.Delay(100);
-				Assert.Equal(1, tappedCount);
+				var tapFired = await Task.WhenAny(tcs.Task, Task.Delay(3000)) == tcs.Task;
+				Assert.True(tapFired, "TapGestureRecognizer.Tapped did not fire within timeout");
 			});
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.Windows.cs
@@ -197,6 +197,39 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact(DisplayName = "Border ContentPanel IsTabStop updates when IsEnabled toggles at runtime")]
+		public async Task ContentPanelIsTabStopUpdatesOnRuntimeIsEnabledToggle()
+		{
+			SetupBuilder();
+
+			var border = new Border()
+			{
+				Content = new Label { Text = "Border" },
+				StrokeShape = new Rectangle(),
+				WidthRequest = 300,
+				HeightRequest = 100,
+				IsEnabled = true
+			};
+
+			border.GestureRecognizers.Add(new TapGestureRecognizer());
+
+			await AttachAndRun(border, async handler =>
+			{
+				var contentPanel = GetNativeBorder(handler as BorderHandler);
+
+				// Enabled + has recognizer → should be keyboard-focusable
+				Assert.True(contentPanel.IsTabStop);
+
+				// Disable at runtime → must leave the tab order
+				await InvokeOnMainThreadAsync(() => border.IsEnabled = false);
+				Assert.False(contentPanel.IsTabStop);
+
+				// Re-enable at runtime → must re-enter the tab order
+				await InvokeOnMainThreadAsync(() => border.IsEnabled = true);
+				Assert.True(contentPanel.IsTabStop);
+			});
+		}
+
 		ContentPanel GetNativeBorder(BorderHandler borderHandler) =>
 			borderHandler.PlatformView;
 


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

This PR is the second half of the split from #27713. It adds keyboard interaction support for `Border` on Windows, allowing users to activate a `Border` with a `TapGestureRecognizer` using the keyboard.

A `Border` with a single-tap, primary-button `TapGestureRecognizer` is now keyboard actionable on Windows:

  * `ContentPanel.IsTabStop` is set to `true`, allowing the `Border` to participate in tab navigation.
  * Pressing **Enter** or **Space** while the `Border` has focus invokes the attached `TapGestureRecognizer` through `SendTapped`, using `Point.Zero` as the tap position, matching Android’s keyboard-tap behavior.

The tab-stop state stays synchronized with the gesture collection:

  * Adding a qualifying `TapGestureRecognizer` enables tab-stop behavior and subscribes to `KeyDown`.
  * Removing all qualifying recognizers, or clearing handlers, disables tab-stop behavior and unsubscribes from `KeyDown`.

Only gestures attached directly to the `Border` make it keyboard actionable. Gestures attached to child elements do not promote the parent `Border` into a tab stop, since child elements manage their own keyboard focus independently.

Internal bookkeeping updates:

  * `SubscriptionFlags` was widened from `byte` to `ushort`.
  * Added a new `ContentPanelKeyDownSubscribed` flag to track the `KeyDown` subscription lifecycle and prevent duplicate event subscriptions or removals.

### How it works

On Windows, a MAUI Border is rendered by a native ContentPanel that, by default, does not participate in keyboard navigation or connect KeyDown events to MAUI gestures. Because of this, a Border with a TapGestureRecognizer was clickable but not keyboard accessible. This PR adds that missing behavior in GesturePlatformManager.Windows.

- **When to enable:** UpdatingGestureRecognizers now sets hasSelfTapGestures = true only when the Border itself has a single-tap TapGestureRecognizer with a Primary button mask. Gestures on child elements do not promote the parent Border to a tab stop.
- **Toggling tab-stop and KeyDown:** UpdateContentPanelIsTapStop(bool) manages both ContentPanel.IsTabStop and the ContentPanelOnKeyDown subscription, guarded by CrossPlatformLayout is IBorderView. A new SubscriptionFlags.ContentPanelKeyDownSubscribed flag prevents duplicate attach/detach, and the enum was widened from byte to ushort to support the new flag. ClearContainerEventHandlers calls the helper with false so teardown resets the state.
- **Handling the key:** ContentPanelOnKeyDown listens for Enter and Space, retrieves matching TapGestureRecognizers from the View, calls SendTapped(view, _ => Point.Zero), and sets e.Handled = true if any recognizer is triggered. Point.Zero is used intentionally because keyboard taps do not have a physical pointer location, matching Android’s keyboard-tap convention.

### Note:
AutomationPeer support for Border was submitted separately in #35577 against main. Once that change flows into net11.0, the keyboard-actionable Border introduced here will also be properly exposed to UI Automation, completing the end-to-end accessibility support for Border on Windows.

### Issues Fixed
Fixes https://github.com/dotnet/maui/issues/27627