### PR TITLE
[net11.0] Narrow HybridWebView trim annotations to dynamic methods only

### DIFF
--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Windows.cs
@@ -218,12 +218,22 @@ namespace Microsoft.Maui.Handlers
 						return (Stream: null, ContentType: null, StatusCode: 400, Reason: "Bad Request");
 					}
 
-					// Invoke the method
-					var contentBytes = await InvokeDotNetAsync(streamBody: requestBody);
-					if (contentBytes is not null)
+					// Invoke the method (gated by RuntimeFeature.IsHybridWebViewSupported so the trimmer
+					// can prove this trim/AOT-unsafe path is dead when the feature switch is disabled
+					// via $(MauiHybridWebViewSupported)=false, which is the default under
+					// PublishAot=true and TrimMode=full).
+					if (RuntimeFeature.IsHybridWebViewSupported)
 					{
-						var ras = await CopyContentToRandomAccessStreamAsync(contentBytes.AsBuffer());
-						return (Stream: ras, ContentType: "application/json", StatusCode: 200, Reason: "OK");
+						var contentBytes = await InvokeDotNetAsync(streamBody: requestBody);
+						if (contentBytes is not null)
+						{
+							var ras = await CopyContentToRandomAccessStreamAsync(contentBytes.AsBuffer());
+							return (Stream: ras, ContentType: "application/json", StatusCode: 200, Reason: "OK");
+						}
+					}
+					else
+					{
+						return (Stream: null, ContentType: null, StatusCode: 404, Reason: "Not Found");
 					}
 				}
 
@@ -281,10 +291,6 @@ namespace Microsoft.Maui.Handlers
 			return ras;
 		}
 
-		[RequiresUnreferencedCode(DynamicFeatures)]
-#if !NETSTANDARD
-		[RequiresDynamicCode(DynamicFeatures)]
-#endif
 		private sealed class HybridWebView2Proxy
 		{
 			private WeakReference<Window>? _window;

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.cs
@@ -44,10 +44,6 @@ using System.Runtime.ExceptionServices;
 
 namespace Microsoft.Maui.Handlers
 {
-	[RequiresUnreferencedCode(DynamicFeatures)]
-#if !NETSTANDARD
-	[RequiresDynamicCode(DynamicFeatures)]
-#endif
 	public partial class HybridWebViewHandler : IHybridWebViewHandler
 	{
 		internal const string DynamicFeatures = "HybridWebView uses dynamic System.Text.Json serialization features.";
@@ -184,6 +180,10 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 
+		[RequiresUnreferencedCode(DynamicFeatures)]
+#if !NETSTANDARD
+		[RequiresDynamicCode(DynamicFeatures)]
+#endif
 		internal async Task<byte[]?> InvokeDotNetAsync(Stream? streamBody = null, string? stringBody = null)
 		{
 			try
@@ -225,6 +225,10 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 
+		[RequiresUnreferencedCode(DynamicFeatures)]
+#if !NETSTANDARD
+		[RequiresDynamicCode(DynamicFeatures)]
+#endif
 		private static DotNetInvokeResult CreateInvokeResult(object? result)
 		{
 			// null invoke result means an empty result
@@ -262,6 +266,10 @@ namespace Microsoft.Maui.Handlers
 			};
 		}
 
+		[RequiresUnreferencedCode(DynamicFeatures)]
+#if !NETSTANDARD
+		[RequiresDynamicCode(DynamicFeatures)]
+#endif
 		private static async Task<object?> InvokeDotNetMethodAsync(
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type targetType,
 			object jsInvokeTarget,

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
@@ -122,11 +122,6 @@ namespace Microsoft.Maui.Handlers
 			base.DisconnectHandler(platformView);
 		}
 
-
-		[RequiresUnreferencedCode(DynamicFeatures)]
-#if !NETSTANDARD
-		[RequiresDynamicCode(DynamicFeatures)]
-#endif
 		private sealed class WebViewScriptMessageHandler : NSObject, IWKScriptMessageHandler
 		{
 			private readonly WeakReference<HybridWebViewHandler?> _webViewHandler;
@@ -145,10 +140,6 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 
-		[RequiresUnreferencedCode(DynamicFeatures)]
-#if !NETSTANDARD
-		[RequiresDynamicCode(DynamicFeatures)]
-#endif
 		private class SchemeHandler : NSObject, IWKUrlSchemeHandler
 		{
 			private readonly WeakReference<HybridWebViewHandler?> _webViewHandler;
@@ -291,11 +282,21 @@ namespace Microsoft.Maui.Handlers
 							return (null, null, StatusCode: 400);
 						}
 
-						// Invoke the method
-						var contentBytes = await Handler.InvokeDotNetAsync(streamBody: requestBody);
-						if (contentBytes is not null)
+						// Invoke the method (gated by RuntimeFeature.IsHybridWebViewSupported so the trimmer
+						// can prove this trim/AOT-unsafe path is dead when the feature switch is disabled
+						// via $(MauiHybridWebViewSupported)=false, which is the default under
+						// PublishAot=true and TrimMode=full).
+						if (RuntimeFeature.IsHybridWebViewSupported)
 						{
-							return (NSData.FromArray(contentBytes), "application/json", StatusCode: 200);
+							var contentBytes = await Handler.InvokeDotNetAsync(streamBody: requestBody);
+							if (contentBytes is not null)
+							{
+								return (NSData.FromArray(contentBytes), "application/json", StatusCode: 200);
+							}
+						}
+						else
+						{
+							return (null, null, StatusCode: 404);
 						}
 					}
 

--- a/src/Core/src/Platform/Android/MauiHybridWebView.cs
+++ b/src/Core/src/Platform/Android/MauiHybridWebView.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis;
 using Android.Content;
 using Android.Graphics;
 using Android.Webkit;
@@ -8,10 +7,6 @@ using AWebView = Android.Webkit.WebView;
 
 namespace Microsoft.Maui.Platform
 {
-	[RequiresUnreferencedCode(HybridWebViewHandler.DynamicFeatures)]
-#if !NETSTANDARD
-	[RequiresDynamicCode(HybridWebViewHandler.DynamicFeatures)]
-#endif
 	public class MauiHybridWebView : AWebView, IHybridPlatformWebView
 	{
 		private readonly WeakReference<HybridWebViewHandler> _handler;

--- a/src/Core/src/Platform/Android/MauiHybridWebViewClient.cs
+++ b/src/Core/src/Platform/Android/MauiHybridWebViewClient.cs
@@ -15,10 +15,6 @@ using AWebView = Android.Webkit.WebView;
 
 namespace Microsoft.Maui.Platform
 {
-	[RequiresUnreferencedCode(HybridWebViewHandler.DynamicFeatures)]
-#if !NETSTANDARD
-	[RequiresDynamicCode(HybridWebViewHandler.DynamicFeatures)]
-#endif
 	public class MauiHybridWebViewClient : WebViewClient
 	{
 		private readonly WeakReference<HybridWebViewHandler?> _handler;
@@ -122,9 +118,18 @@ namespace Microsoft.Maui.Platform
 					return new WebResourceResponse(null, "UTF-8", 400, "Bad Request", null, null);
 				}
 
-				var contentBytesTask = Handler.InvokeDotNetAsync(stringBody: requestBody);
-				var responseStream = new AsyncStream(contentBytesTask, logger);
-				return new WebResourceResponse("application/json", "UTF-8", 200, "OK", GetHeaders("application/json"), responseStream);
+				// Invoke the method (gated by RuntimeFeature.IsHybridWebViewSupported so the trimmer
+				// can prove this trim/AOT-unsafe path is dead when the feature switch is disabled
+				// via $(MauiHybridWebViewSupported)=false, which is the default under
+				// PublishAot=true and TrimMode=full).
+				if (RuntimeFeature.IsHybridWebViewSupported)
+				{
+					var contentBytesTask = Handler.InvokeDotNetAsync(stringBody: requestBody);
+					var responseStream = new AsyncStream(contentBytesTask, logger);
+					return new WebResourceResponse("application/json", "UTF-8", 200, "OK", GetHeaders("application/json"), responseStream);
+				}
+
+				return new WebResourceResponse(null, "UTF-8", 404, "Not Found", null, null);
 			}
 
 			// 2. If nothing found yet, try to get static content from the asset path

--- a/src/Core/src/Platform/Windows/MauiHybridWebView.cs
+++ b/src/Core/src/Platform/Windows/MauiHybridWebView.cs
@@ -1,15 +1,10 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.Web.WebView2.Core;
 
 namespace Microsoft.Maui.Platform
 {
-	[RequiresUnreferencedCode(HybridWebViewHandler.DynamicFeatures)]
-#if !NETSTANDARD
-	[RequiresDynamicCode(HybridWebViewHandler.DynamicFeatures)]
-#endif
 	public partial class MauiHybridWebView : WebView2, IHybridPlatformWebView
 	{
 		private readonly WeakReference<HybridWebViewHandler> _handler;


### PR DESCRIPTION
## Description

The class-level `[RequiresUnreferencedCode]` / `[RequiresDynamicCode]` on `HybridWebViewHandler` propagated through Apple's static registrar. `WebViewScriptMessageHandler` and `SchemeHandler` are `NSObject`-derived with `[Export]` members, so the registrar-emitted `<Module>..cctor()` referenced RUC/RDC-annotated members. ILLink raised IL2026 on each such reference and, because the integration tests build with `TreatWarningsAsErrors=true` and `TrimMode=full`, the warnings turned into errors and broke the iOS / MacCatalyst trim and AOT legs.

### Fix

- Drop class-level attributes from `HybridWebViewHandler` and from every NSObject/`[Export]`-bearing inner class (`WebViewScriptMessageHandler`, `SchemeHandler` on iOS; `HybridWebView2Proxy` on Windows; `MauiHybridWebViewClient` on Android).
- Drop class-level attributes from the platform `MauiHybridWebView` types (Android, Windows) so `HybridWebViewHandler.CreatePlatformView()` no longer triggers IL2026/IL3050 against the trivial ctor. iOS `MauiHybridWebView` already had no class-level attributes.
- Apply attributes at the method level on the only members that are actually trim/AOT-unsafe: `InvokeDotNetAsync`, `CreateInvokeResult`, `InvokeDotNetMethodAsync`.
- Gate every platform call to `InvokeDotNetAsync` (iOS `SchemeHandler.GetResponseBytesAsync`, Windows `GetResponseStreamAsync`, Android `MauiHybridWebViewClient.GetResponse`) with `if (RuntimeFeature.IsHybridWebViewSupported)`.

Fixes #34867
