### PR TITLE
[iOS] Fix VoiceOver dropping child labels on layouts with SemanticProperties.Hint or TapGestureRecognizer

### DIFF
--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Maui.Controls.Platform
 		UIAccessibilityTrait _addedFlags;
 		bool? _defaultAccessibilityRespondsToUserInteraction;
 		bool _setIsAccessibilityElement;
+		bool _setAccessibilityActivateCallback;
 
 		double _previousScale = 1.0;
 		ShouldReceiveTouchProxy? _proxy;
@@ -117,6 +118,19 @@ namespace Microsoft.Maui.Controls.Platform
 
 			_interactions.Clear();
 			_gestureRecognizers.Clear();
+
+			if (PlatformView is not null)
+			{
+				if (_setIsAccessibilityElement)
+				{
+					PlatformView.ShouldGroupAccessibilityChildren = false;
+				}
+
+				if (_setAccessibilityActivateCallback && PlatformView is Microsoft.Maui.Platform.MauiView mv)
+				{
+					mv.AccessibilityActivateCallback = null;
+				}
+			}
 
 			_dragAndDropDelegate?.Disconnect();
 			_dragAndDropDelegate = null;
@@ -662,25 +676,28 @@ namespace Microsoft.Maui.Controls.Platform
 
 				// Ensure container views are marked as accessibility elements so VoiceOver
 				// can announce the Button trait and make the container focusable for VoiceOver.
-				if (!PlatformView.IsAccessibilityElement && _handler.VirtualView is ILayout)
+				if (!PlatformView.ShouldGroupAccessibilityChildren && _handler.VirtualView is ILayout)
 				{
-					PlatformView.IsAccessibilityElement = true;
+					PlatformView.ShouldGroupAccessibilityChildren = true;
 					_setIsAccessibilityElement = true;
+				}
 
-					// Register a direct activation callback for reliable VoiceOver activation on macOS Catalyst.
-					// UIKit's default accessibilityActivate() simulates touch events which are intermittently
-					// unreliable for UITapGestureRecognizer on Catalyst. We bypass that path by directly
-					// invoking SendTapped on the MAUI TapGestureRecognizer.
-					if (PlatformView is Microsoft.Maui.Platform.MauiView mauiView && _handler.VirtualView is View)
+				// UIKit's default accessibilityActivate() simulates touch events which are intermittently
+				// unreliable for UITapGestureRecognizer (especially on macOS Catalyst). Bypass that path
+				// by directly invoking SendTapped on the MAUI TapGestureRecognizer for both iOS and Catalyst.
+				// This is decoupled from the grouping block above so it also registers when
+				// SemanticExtensions already set ShouldGroupAccessibilityChildren (layout with Hint + gesture).
+				if (PlatformView is Microsoft.Maui.Platform.MauiView mauiView &&
+					_handler.VirtualView is ILayout)
+				{
+					var weakThis = new WeakReference<GesturePlatformManager>(this);
+
+					mauiView.AccessibilityActivateCallback = () =>
 					{
-						var weakThis = new WeakReference<GesturePlatformManager>(this);
-
-						mauiView.AccessibilityActivateCallback = () =>
+						if (!weakThis.TryGetTarget(out var manager))
 						{
-							if (!weakThis.TryGetTarget(out var manager))
-							{
-								return false;
-							}
+							return false;
+						}
 
 							var view = manager._handler?.VirtualView as View;
 
@@ -695,9 +712,10 @@ namespace Microsoft.Maui.Controls.Platform
 								return true;
 							}
 
-							return false;
-						};
-					}
+						return false;
+					};
+
+					_setAccessibilityActivateCallback = true;
 				}
 
 				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13)
@@ -921,16 +939,16 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				PlatformView.AccessibilityTraits &= ~_addedFlags;
 
-				// Reset IsAccessibilityElement if we promoted this container when the gesture was added
+				// Reset ShouldGroupAccessibilityChildren if we promoted this container when the gesture was added
 				if (_setIsAccessibilityElement)
 				{
-					PlatformView.IsAccessibilityElement = false;
+					PlatformView.ShouldGroupAccessibilityChildren = false;
+				}
 
-					// Clear the direct activation callback registered when we promoted this container
-					if (PlatformView is Microsoft.Maui.Platform.MauiView mv)
-					{
-						mv.AccessibilityActivateCallback = null;
-					}
+				// Clear the macOS Catalyst direct activation callback if we registered one
+				if (_setAccessibilityActivateCallback && PlatformView is Microsoft.Maui.Platform.MauiView mv)
+				{
+					mv.AccessibilityActivateCallback = null;
 				}
 
 				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13))
@@ -943,6 +961,7 @@ namespace Microsoft.Maui.Controls.Platform
 			_addedFlags = UIAccessibilityTrait.None;
 			_defaultAccessibilityRespondsToUserInteraction = null;
 			_setIsAccessibilityElement = false;
+			_setAccessibilityActivateCallback = false;
 			LoadRecognizers();
 		}
 

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
@@ -676,19 +676,28 @@ namespace Microsoft.Maui.Controls.Platform
 
 				// Ensure container views are marked as accessibility elements so VoiceOver
 				// can announce the Button trait and make the container focusable for VoiceOver.
-				if (!PlatformView.ShouldGroupAccessibilityChildren && _handler.VirtualView is ILayout)
+				// Skip if IsAccessibilityElement is already true (e.g. set by SemanticExtensions for a
+				// Hint/Description on this layout) — when the container is already a leaf accessibility
+				// element, ShouldGroupAccessibilityChildren is ignored by UIKit and would be redundant.
+				if (!PlatformView.ShouldGroupAccessibilityChildren
+					&& !PlatformView.IsAccessibilityElement
+					&& _handler.VirtualView is global::Microsoft.Maui.ILayout)
 				{
 					PlatformView.ShouldGroupAccessibilityChildren = true;
 					_setIsAccessibilityElement = true;
 				}
 
 				// UIKit's default accessibilityActivate() simulates touch events which are intermittently
-				// unreliable for UITapGestureRecognizer (especially on macOS Catalyst). Bypass that path
-				// by directly invoking SendTapped on the MAUI TapGestureRecognizer for both iOS and Catalyst.
-				// This is decoupled from the grouping block above so it also registers when
-				// SemanticExtensions already set ShouldGroupAccessibilityChildren (layout with Hint + gesture).
+				// unreliable for UITapGestureRecognizer (especially on macOS Catalyst Ctrl+Option+Space).
+				// Bypass that path by directly invoking SendTapped on the MAUI TapGestureRecognizer for
+				// both iOS and Catalyst. VoiceOver activation is a single semantic event — UIKit's
+				// simulated-touch path also does not honor NumberOfTapsRequired > 1 from a VoiceOver
+				// activation, so the direct path does not regress that scenario and makes activation
+				// reliable across both platforms.
+				// This block is decoupled from the grouping block above so it also registers when
+				// SemanticExtensions already promoted the container (layout with Hint + gesture).
 				if (PlatformView is Microsoft.Maui.Platform.MauiView mauiView &&
-					_handler.VirtualView is ILayout)
+					_handler.VirtualView is global::Microsoft.Maui.ILayout)
 				{
 					var weakThis = new WeakReference<GesturePlatformManager>(this);
 
@@ -699,18 +708,18 @@ namespace Microsoft.Maui.Controls.Platform
 							return false;
 						}
 
-							var view = manager._handler?.VirtualView as View;
+						var view = manager._handler?.VirtualView as View;
 
-							if (view is null)
-							{
-								return false;
-							}
+						if (view is null)
+						{
+							return false;
+						}
 
-							if (view.HasAccessibleTapGesture(out var tap))
-							{
-								tap.SendTapped(view);
-								return true;
-							}
+						if (view.HasAccessibleTapGesture(out var tap))
+						{
+							tap.SendTapped(view);
+							return true;
+						}
 
 						return false;
 					};

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Maui.Controls.Platform
 		WeakReference<PlatformView>? _platformView;
 		UIAccessibilityTrait _addedFlags;
 		bool? _defaultAccessibilityRespondsToUserInteraction;
+		bool? _defaultShouldGroupAccessibilityChildren;
 		bool _setShouldGroupAccessibilityChildren;
 		bool _setAccessibilityActivateCallback;
 
@@ -671,10 +672,22 @@ namespace Microsoft.Maui.Controls.Platform
 				// Skip if IsAccessibilityElement is already true (e.g. set by SemanticExtensions for a
 				// Hint/Description on this layout) — when the container is already a leaf accessibility
 				// element, ShouldGroupAccessibilityChildren is ignored by UIKit and would be redundant.
+				//
+				// LIMITATION (Path A — gesture-only, no Hint/Description): Setting
+				// ShouldGroupAccessibilityChildren = true alone does NOT make the layout focusable to
+				// VoiceOver; UIKit only focuses views whose IsAccessibilityElement is true. So for a
+				// tappable layout without any Semantics set, VoiceOver still navigates directly to the
+				// individual children, the Button trait above is silenced, and the
+				// AccessibilityActivateCallback registered below is never reached via VoiceOver.
+				// This is a pre-existing UIKit constraint, intentionally not addressed by this fix
+				// (which targets the Hint scenario from issue #34380).
 				if (!PlatformView.ShouldGroupAccessibilityChildren
 					&& !PlatformView.IsAccessibilityElement
 					&& _handler.VirtualView is global::Microsoft.Maui.ILayout)
 				{
+					// Capture the pre-existing value so cleanup can restore it (mirrors the
+					// _defaultAccessibilityRespondsToUserInteraction pattern below).
+					_defaultShouldGroupAccessibilityChildren = PlatformView.ShouldGroupAccessibilityChildren;
 					PlatformView.ShouldGroupAccessibilityChildren = true;
 					_setShouldGroupAccessibilityChildren = true;
 				}
@@ -706,6 +719,14 @@ namespace Microsoft.Maui.Controls.Platform
 						var view = manager._handler?.VirtualView as View;
 
 						if (view is null)
+						{
+							return false;
+						}
+
+						// Honor the same gates UIKit's touch dispatch would have applied. VoiceOver
+						// activation bypasses UIKit's hit-testing/touch path, so without these
+						// guards a disabled or input-transparent layout would still fire its tap.
+						if (!view.IsEnabled || view.InputTransparent)
 						{
 							return false;
 						}
@@ -969,7 +990,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 			if (_setShouldGroupAccessibilityChildren)
 			{
-				PlatformView.ShouldGroupAccessibilityChildren = false;
+				PlatformView.ShouldGroupAccessibilityChildren = _defaultShouldGroupAccessibilityChildren ?? false;
 			}
 
 			if (_setAccessibilityActivateCallback && PlatformView is Microsoft.Maui.Platform.MauiView mv)
@@ -979,6 +1000,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 			_setShouldGroupAccessibilityChildren = false;
 			_setAccessibilityActivateCallback = false;
+			_defaultShouldGroupAccessibilityChildren = null;
 		}
 
 		void OnElementChanged(object sender, VisualElementChangedEventArgs e)

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Maui.Controls.Platform
 		WeakReference<PlatformView>? _platformView;
 		UIAccessibilityTrait _addedFlags;
 		bool? _defaultAccessibilityRespondsToUserInteraction;
+		bool _setIsAccessibilityElement;
 
 		double _previousScale = 1.0;
 		ShouldReceiveTouchProxy? _proxy;
@@ -658,6 +659,47 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				PlatformView.AccessibilityTraits |= UIAccessibilityTrait.Button;
 				_addedFlags |= UIAccessibilityTrait.Button;
+
+				// Ensure container views are marked as accessibility elements so VoiceOver
+				// can announce the Button trait and make the container focusable for VoiceOver.
+				if (!PlatformView.IsAccessibilityElement && _handler.VirtualView is ILayout)
+				{
+					PlatformView.IsAccessibilityElement = true;
+					_setIsAccessibilityElement = true;
+
+					// Register a direct activation callback for reliable VoiceOver activation on macOS Catalyst.
+					// UIKit's default accessibilityActivate() simulates touch events which are intermittently
+					// unreliable for UITapGestureRecognizer on Catalyst. We bypass that path by directly
+					// invoking SendTapped on the MAUI TapGestureRecognizer.
+					if (PlatformView is Microsoft.Maui.Platform.MauiView mauiView && _handler.VirtualView is View)
+					{
+						var weakThis = new WeakReference<GesturePlatformManager>(this);
+
+						mauiView.AccessibilityActivateCallback = () =>
+						{
+							if (!weakThis.TryGetTarget(out var manager))
+							{
+								return false;
+							}
+
+							var view = manager._handler?.VirtualView as View;
+
+							if (view is null)
+							{
+								return false;
+							}
+
+							if (view.HasAccessibleTapGesture(out var tap))
+							{
+								tap.SendTapped(view);
+								return true;
+							}
+
+							return false;
+						};
+					}
+				}
+
 				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13)
 #if TVOS
 				|| OperatingSystem.IsTvOSVersionAtLeast(11)
@@ -879,6 +921,18 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				PlatformView.AccessibilityTraits &= ~_addedFlags;
 
+				// Reset IsAccessibilityElement if we promoted this container when the gesture was added
+				if (_setIsAccessibilityElement)
+				{
+					PlatformView.IsAccessibilityElement = false;
+
+					// Clear the direct activation callback registered when we promoted this container
+					if (PlatformView is Microsoft.Maui.Platform.MauiView mv)
+					{
+						mv.AccessibilityActivateCallback = null;
+					}
+				}
+
 				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13))
 				{
 					if (_defaultAccessibilityRespondsToUserInteraction != null)
@@ -888,6 +942,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 			_addedFlags = UIAccessibilityTrait.None;
 			_defaultAccessibilityRespondsToUserInteraction = null;
+			_setIsAccessibilityElement = false;
 			LoadRecognizers();
 		}
 

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.Controls.Platform
 		WeakReference<PlatformView>? _platformView;
 		UIAccessibilityTrait _addedFlags;
 		bool? _defaultAccessibilityRespondsToUserInteraction;
-		bool _setIsAccessibilityElement;
+		bool _setShouldGroupAccessibilityChildren;
 		bool _setAccessibilityActivateCallback;
 
 		double _previousScale = 1.0;
@@ -121,15 +121,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 			if (PlatformView is not null)
 			{
-				if (_setIsAccessibilityElement)
-				{
-					PlatformView.ShouldGroupAccessibilityChildren = false;
-				}
-
-				if (_setAccessibilityActivateCallback && PlatformView is Microsoft.Maui.Platform.MauiView mv)
-				{
-					mv.AccessibilityActivateCallback = null;
-				}
+				ResetAccessibilityPromotionFlags();
 			}
 
 			_dragAndDropDelegate?.Disconnect();
@@ -684,7 +676,7 @@ namespace Microsoft.Maui.Controls.Platform
 					&& _handler.VirtualView is global::Microsoft.Maui.ILayout)
 				{
 					PlatformView.ShouldGroupAccessibilityChildren = true;
-					_setIsAccessibilityElement = true;
+					_setShouldGroupAccessibilityChildren = true;
 				}
 
 				// UIKit's default accessibilityActivate() simulates touch events which are intermittently
@@ -696,6 +688,9 @@ namespace Microsoft.Maui.Controls.Platform
 				// reliable across both platforms.
 				// This block is decoupled from the grouping block above so it also registers when
 				// SemanticExtensions already promoted the container (layout with Hint + gesture).
+				// Note: Only Microsoft.Maui.Platform.MauiView exposes AccessibilityActivateCallback,
+				// so layouts whose platform view is not a MauiView (e.g. Border, ScrollView, custom
+				// container handlers) fall back to UIKit's default simulated-touch activation path.
 				if (PlatformView is Microsoft.Maui.Platform.MauiView mauiView &&
 					_handler.VirtualView is global::Microsoft.Maui.ILayout)
 				{
@@ -948,17 +943,7 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				PlatformView.AccessibilityTraits &= ~_addedFlags;
 
-				// Reset ShouldGroupAccessibilityChildren if we promoted this container when the gesture was added
-				if (_setIsAccessibilityElement)
-				{
-					PlatformView.ShouldGroupAccessibilityChildren = false;
-				}
-
-				// Clear the macOS Catalyst direct activation callback if we registered one
-				if (_setAccessibilityActivateCallback && PlatformView is Microsoft.Maui.Platform.MauiView mv)
-				{
-					mv.AccessibilityActivateCallback = null;
-				}
+				ResetAccessibilityPromotionFlags();
 
 				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13))
 				{
@@ -969,9 +954,31 @@ namespace Microsoft.Maui.Controls.Platform
 
 			_addedFlags = UIAccessibilityTrait.None;
 			_defaultAccessibilityRespondsToUserInteraction = null;
-			_setIsAccessibilityElement = false;
-			_setAccessibilityActivateCallback = false;
 			LoadRecognizers();
+		}
+
+		// Reverts any accessibility-related state this manager set on the platform view when a
+		// tap gesture was wired up. Called from both Disconnect() and the gesture-collection-changed
+		// path so the two stay in sync.
+		void ResetAccessibilityPromotionFlags()
+		{
+			if (PlatformView is null)
+			{
+				return;
+			}
+
+			if (_setShouldGroupAccessibilityChildren)
+			{
+				PlatformView.ShouldGroupAccessibilityChildren = false;
+			}
+
+			if (_setAccessibilityActivateCallback && PlatformView is Microsoft.Maui.Platform.MauiView mv)
+			{
+				mv.AccessibilityActivateCallback = null;
+			}
+
+			_setShouldGroupAccessibilityChildren = false;
+			_setAccessibilityActivateCallback = false;
 		}
 
 		void OnElementChanged(object sender, VisualElementChangedEventArgs e)

--- a/src/Controls/tests/DeviceTests/Elements/Accessibility/AccessibilityTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Accessibility/AccessibilityTests.iOS.cs
@@ -1,4 +1,3 @@
-#if IOS || MACCATALYST
 using System;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
@@ -120,4 +119,4 @@ namespace Microsoft.Maui.DeviceTests
 		}
 	}
 }
-#endif
+

--- a/src/Controls/tests/DeviceTests/Elements/Accessibility/AccessibilityTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Accessibility/AccessibilityTests.iOS.cs
@@ -1,0 +1,123 @@
+#if IOS || MACCATALYST
+using System;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Hosting;
+using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Microsoft.Maui.Platform;
+using UIKit;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	// Regression tests for https://github.com/dotnet/maui/issues/34380
+	// [iOS] VoiceOver does not correctly describe a View with GestureRecognizers when it has
+	// SemanticProperties.Hint and child Labels — should synthesize an accessibility label from
+	// children, promote the layout to an accessibility element, and route VoiceOver activation
+	// to the layout's TapGestureRecognizer.
+	public partial class AccessibilityTests
+	{
+		[Category(TestCategory.Accessibility)]
+		[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
+		public class Issue34380Tests : ControlsHandlerTestBase
+		{
+			void SetupBuilder()
+			{
+				EnsureHandlerCreated(builder =>
+				{
+					builder.ConfigureMauiHandlers(handlers =>
+					{
+						handlers.AddMauiControlsHandlers();
+						handlers.AddHandler(typeof(Window), typeof(WindowHandlerStub));
+					});
+				});
+			}
+
+			[Fact("Layout with Hint and child Labels synthesizes a combined AccessibilityLabel")]
+			public async Task LayoutWithHintAndChildLabels_SynthesizesAccessibilityLabel()
+			{
+				SetupBuilder();
+
+				var layout = new VerticalStackLayout();
+				layout.Add(new Label { Text = "First line" });
+				layout.Add(new Label { Text = "Second line" });
+				SemanticProperties.SetHint(layout, "Activates the action");
+
+				var page = new ContentPage { Content = layout };
+
+				await CreateHandlerAndAddToWindow<IWindowHandler>(page, async (handler) =>
+				{
+					await Task.Delay(100);
+
+					var platformView = (UIView)layout.Handler.PlatformView;
+
+					Assert.True(platformView.IsAccessibilityElement,
+						"Layout with Hint should be promoted to an accessibility element.");
+
+					Assert.False(string.IsNullOrEmpty(platformView.AccessibilityLabel),
+						"AccessibilityLabel should be synthesized from child Labels.");
+
+					Assert.Contains("First line", platformView.AccessibilityLabel, StringComparison.Ordinal);
+					Assert.Contains("Second line", platformView.AccessibilityLabel, StringComparison.Ordinal);
+
+					Assert.Equal("Activates the action", platformView.AccessibilityHint);
+				});
+			}
+
+			[Fact("Layout with TapGestureRecognizer (no Hint) sets ShouldGroupAccessibilityChildren")]
+			public async Task LayoutWithTapGesture_SetsShouldGroupAccessibilityChildren()
+			{
+				SetupBuilder();
+
+				var layout = new VerticalStackLayout();
+				layout.Add(new Label { Text = "Tap me" });
+
+				var tap = new TapGestureRecognizer();
+				layout.GestureRecognizers.Add(tap);
+
+				var page = new ContentPage { Content = layout };
+
+				await CreateHandlerAndAddToWindow<IWindowHandler>(page, async (handler) =>
+				{
+					await Task.Delay(100);
+
+					var platformView = (UIView)layout.Handler.PlatformView;
+
+					Assert.True(platformView.ShouldGroupAccessibilityChildren,
+						"Layout with TapGestureRecognizer should group accessibility children so the tap target is reachable by VoiceOver.");
+				});
+			}
+
+			[Fact("AccessibilityActivate on a layout with TapGestureRecognizer fires the gesture")]
+			public async Task AccessibilityActivate_InvokesTapGesture()
+			{
+				SetupBuilder();
+
+				var layout = new VerticalStackLayout();
+				layout.Add(new Label { Text = "Tap" });
+				SemanticProperties.SetHint(layout, "Tap to act");
+
+				bool tapped = false;
+				var tap = new TapGestureRecognizer();
+				tap.Tapped += (s, e) => tapped = true;
+				layout.GestureRecognizers.Add(tap);
+
+				var page = new ContentPage { Content = layout };
+
+				await CreateHandlerAndAddToWindow<IWindowHandler>(page, async (handler) =>
+				{
+					await Task.Delay(100);
+
+					var platformView = (UIView)layout.Handler.PlatformView;
+					var activated = platformView.AccessibilityActivate();
+
+					Assert.True(activated, "AccessibilityActivate should report that the activation was handled.");
+					Assert.True(tapped, "TapGestureRecognizer.Tapped should fire when VoiceOver activates the layout.");
+				});
+			}
+		}
+	}
+}
+#endif

--- a/src/Core/src/Platform/iOS/MauiView.cs
+++ b/src/Core/src/Platform/iOS/MauiView.cs
@@ -909,6 +909,36 @@ namespace Microsoft.Maui.Platform
 		}
 
 		/// <summary>
+		/// When true, <see cref="AccessibilityLabel"/>'s getter synthesizes the label on demand
+		/// from the layout's children instead of returning a stored snapshot. Set by
+		/// <see cref="SemanticExtensions.UpdateSemantics(UIView, IView)"/> when this layout was
+		/// promoted to an accessibility element with a Hint but no explicit Description, so that
+		/// child text changes are picked up on each VoiceOver focus. See PR #35590 review
+		/// comment r3291149230.
+		/// </summary>
+		internal bool SynthesizeAccessibilityLabelFromChildren { get; set; }
+
+		/// <inheritdoc/>
+		public override string? AccessibilityLabel
+		{
+			get
+			{
+				if (SynthesizeAccessibilityLabelFromChildren
+					&& CrossPlatformLayout is ILayout layout)
+				{
+					var synthesized = SemanticExtensions.SynthesizeAccessibilityLabelFromChildren(layout);
+					if (!string.IsNullOrWhiteSpace(synthesized))
+					{
+						return synthesized;
+					}
+				}
+
+				return base.AccessibilityLabel;
+			}
+			set => base.AccessibilityLabel = value;
+		}
+
+		/// <summary>
 		/// Optional callback invoked by <see cref="AccessibilityActivate"/> when VoiceOver activates this view.
 		/// Set by GesturePlatformManager for container layouts with tap gestures to bypass UIKit's
 		/// simulated-touch path, which can be intermittently unreliable on macOS Catalyst.

--- a/src/Core/src/Platform/iOS/MauiView.cs
+++ b/src/Core/src/Platform/iOS/MauiView.cs
@@ -907,5 +907,28 @@ namespace Microsoft.Maui.Platform
 				}
 			}
 		}
+
+		/// <summary>
+		/// Optional callback invoked by <see cref="AccessibilityActivate"/> when VoiceOver activates this view.
+		/// Set by GesturePlatformManager for container layouts with tap gestures to bypass UIKit's
+		/// simulated-touch path, which can be intermittently unreliable on macOS Catalyst.
+		/// </summary>
+		[System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Memory", "MEM0002",
+			Justification = "Callback captures only a WeakReference<GesturePlatformManager>, which is not an NSObject. No circular strong NSObject reference is created.")]
+		internal Func<bool>? AccessibilityActivateCallback { get; set; }
+
+		/// <inheritdoc/>
+		public override bool AccessibilityActivate()
+		{
+			// Prefer direct MAUI gesture invocation over UIKit's simulated-touch mechanism.
+			// On macOS Catalyst, the simulated-touch path for UITapGestureRecognizer is
+			// intermittently unreliable when VoiceOver activates a container with Ctrl+Option+Space.
+			if (AccessibilityActivateCallback?.Invoke() == true)
+			{
+				return true;
+			}
+
+			return base.AccessibilityActivate();
+		}
 	}
 }

--- a/src/Core/src/Platform/iOS/SemanticExtensions.cs
+++ b/src/Core/src/Platform/iOS/SemanticExtensions.cs
@@ -156,23 +156,7 @@ namespace Microsoft.Maui.Platform
 					platformView.IsAccessibilityElement = true;
 			}
 
-			var accessibilityTraits = platformView.AccessibilityTraits;
-			var hasHeader = (accessibilityTraits & UIAccessibilityTrait.Header) == UIAccessibilityTrait.Header;
-
-			if (semantics.IsHeading)
-			{
-				if (!hasHeader)
-				{
-					platformView.AccessibilityTraits = accessibilityTraits | UIAccessibilityTrait.Header;
-				}
-			}
-			else
-			{
-				if (hasHeader)
-				{
-					platformView.AccessibilityTraits = accessibilityTraits & ~UIAccessibilityTrait.Header;
-				}
-			}
+			UpdateSemanticsHeading(platformView, semantics);
 		}
 
 		static void UpdateSemanticsHeading(UIView platformView, Semantics semantics)

--- a/src/Core/src/Platform/iOS/SemanticExtensions.cs
+++ b/src/Core/src/Platform/iOS/SemanticExtensions.cs
@@ -86,13 +86,15 @@ namespace Microsoft.Maui.Platform
 				return;
 			}
 
-			// For layout containers with Hint or Description set, synthesize an AccessibilityLabel
-			// from the MAUI virtual children's text so VoiceOver reads both the children's content
-			// AND the container's hint in a single announcement — matching Android TalkBack behavior.
+			// For layout containers with a Hint set, synthesize an AccessibilityLabel from the MAUI
+			// virtual children's text so VoiceOver reads both the children's content AND the
+			// container's hint in a single announcement — matching Android TalkBack behavior.
 			// We read from the virtual view tree (not platformView.Subviews) to avoid timing issues:
 			// UpdateSemantics can be called before platform children are attached.
+			// Note: We gate on Hint only (not Description) to preserve the existing contract for
+			// Description-only layouts, which already read just the Description text today.
 			if (view is ILayout layout &&
-				(!string.IsNullOrWhiteSpace(semantics.Hint) || !string.IsNullOrWhiteSpace(semantics.Description)))
+				!string.IsNullOrWhiteSpace(semantics.Hint))
 			{
 				var synthesizedLabel = SynthesizeAccessibilityLabelFromChildren(layout);
 
@@ -227,8 +229,13 @@ namespace Microsoft.Maui.Platform
 
 					sb.Append(childDesc);
 				}
-				else if (child is IText textElement && !string.IsNullOrWhiteSpace(textElement.Text))
+				else if (child is IText textElement
+					&& child is not ITextInput
+					&& !string.IsNullOrWhiteSpace(textElement.Text))
 				{
+					// Skip ITextInput (Entry/Editor/SearchBar): their .Text is user input which
+					// would leak into the layout's accessibility label and never refresh as the
+					// user types. Entries/editors are independently focusable anyway.
 					if (sb.Length > 0)
 					{
 						sb.Append(", ");

--- a/src/Core/src/Platform/iOS/SemanticExtensions.cs
+++ b/src/Core/src/Platform/iOS/SemanticExtensions.cs
@@ -120,6 +120,15 @@ namespace Microsoft.Maui.Platform
 				// "[children text], [hint]" as a single focus unit.
 				platformView.IsAccessibilityElement = true;
 
+				// If a TapGestureRecognizer was wired up first, GesturePlatformManager may have
+				// already set ShouldGroupAccessibilityChildren=true. Clear it now: once the layout
+				// is a leaf accessibility element the grouping flag is redundant, and some iOS
+				// versions silently drop the parent's accessibilityLabel/hint when both are set.
+				platformView.ShouldGroupAccessibilityChildren = false;
+
+				// Safe to early-return: an ILayout MAUI view never produces a UISearchBar/UIControl/
+				// UIStepper/UIPageControl platform view, so the internal UpdateSemantics branches for
+				// those types are not applicable here. Heading trait is explicitly applied below.
 				UpdateSemanticsHeading(platformView, semantics);
 				return;
 			}
@@ -181,18 +190,29 @@ namespace Microsoft.Maui.Platform
 		}
 
 		/// <summary>
+		/// Maximum recursion depth for <see cref="CollectChildrenText"/>. Caps traversal of deeply
+		/// nested layouts so pathological hierarchies cannot stall accessibility updates.
+		/// </summary>
+		const int MaxChildTextRecursionDepth = 10;
+
+		/// <summary>
 		/// Synthesizes an accessibility label by collecting text from all IText children in the layout.
 		/// Uses the MAUI virtual view tree (not platform subviews) to avoid timing issues.
 		/// </summary>
 		static string? SynthesizeAccessibilityLabelFromChildren(ILayout layout)
 		{
 			var sb = new StringBuilder();
-			CollectChildrenText(layout, sb);
+			CollectChildrenText(layout, sb, depth: 0);
 			return sb.Length > 0 ? sb.ToString() : null;
 		}
 
-		static void CollectChildrenText(ILayout layout, StringBuilder sb)
+		static void CollectChildrenText(ILayout layout, StringBuilder sb, int depth)
 		{
+			if (depth >= MaxChildTextRecursionDepth)
+			{
+				return;
+			}
+
 			for (int i = 0; i < layout.Count; i++)
 			{
 				var child = layout[i];
@@ -219,7 +239,7 @@ namespace Microsoft.Maui.Platform
 				else if (child is ILayout childLayout)
 				{
 					// Recurse into nested layouts to collect text from their children
-					CollectChildrenText(childLayout, sb);
+					CollectChildrenText(childLayout, sb, depth + 1);
 				}
 			}
 		}

--- a/src/Core/src/Platform/iOS/SemanticExtensions.cs
+++ b/src/Core/src/Platform/iOS/SemanticExtensions.cs
@@ -1,4 +1,5 @@
-﻿using UIKit;
+﻿using System.Text;
+using UIKit;
 
 namespace Microsoft.Maui.Platform
 {
@@ -76,8 +77,55 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		public static void UpdateSemantics(this UIView platformView, IView view) =>
-			UpdateSemantics(platformView, view?.Semantics);
+		public static void UpdateSemantics(this UIView platformView, IView view)
+		{
+			var semantics = view?.Semantics;
+
+			if (semantics is null)
+			{
+				return;
+			}
+
+			// For layout containers with Hint or Description set, synthesize an AccessibilityLabel
+			// from the MAUI virtual children's text so VoiceOver reads both the children's content
+			// AND the container's hint in a single announcement — matching Android TalkBack behavior.
+			// We read from the virtual view tree (not platformView.Subviews) to avoid timing issues:
+			// UpdateSemantics can be called before platform children are attached.
+			if (view is ILayout layout &&
+				(!string.IsNullOrWhiteSpace(semantics.Hint) || !string.IsNullOrWhiteSpace(semantics.Description)))
+			{
+				var synthesizedLabel = SynthesizeAccessibilityLabelFromChildren(layout);
+
+				if (!string.IsNullOrWhiteSpace(synthesizedLabel))
+				{
+					// If there's an explicit Description, prepend it to the children's text
+					if (!string.IsNullOrWhiteSpace(semantics.Description))
+					{
+						platformView.AccessibilityLabel = $"{semantics.Description}, {synthesizedLabel}";
+					}
+					else
+					{
+						platformView.AccessibilityLabel = synthesizedLabel;
+					}
+				}
+				else
+				{
+					// No children text found — fall back to Description only
+					platformView.AccessibilityLabel = semantics.Description;
+				}
+
+				platformView.AccessibilityHint = semantics.Hint;
+
+				// Make the container the primary accessibility element so VoiceOver announces
+				// "[children text], [hint]" as a single focus unit.
+				platformView.IsAccessibilityElement = true;
+
+				UpdateSemanticsHeading(platformView, semantics);
+				return;
+			}
+
+			UpdateSemantics(platformView, semantics);
+		}
 
 		internal static void UpdateSemantics(this UIView platformView, Semantics? semantics)
 		{
@@ -123,6 +171,71 @@ namespace Microsoft.Maui.Platform
 				if (hasHeader)
 				{
 					platformView.AccessibilityTraits = accessibilityTraits & ~UIAccessibilityTrait.Header;
+				}
+			}
+		}
+
+		static void UpdateSemanticsHeading(UIView platformView, Semantics semantics)
+		{
+			var accessibilityTraits = platformView.AccessibilityTraits;
+			var hasHeader = (accessibilityTraits & UIAccessibilityTrait.Header) == UIAccessibilityTrait.Header;
+
+			if (semantics.IsHeading)
+			{
+				if (!hasHeader)
+				{
+					platformView.AccessibilityTraits = accessibilityTraits | UIAccessibilityTrait.Header;
+				}
+			}
+			else
+			{
+				if (hasHeader)
+				{
+					platformView.AccessibilityTraits = accessibilityTraits & ~UIAccessibilityTrait.Header;
+				}
+			}
+		}
+
+		/// <summary>
+		/// Synthesizes an accessibility label by collecting text from all IText children in the layout.
+		/// Uses the MAUI virtual view tree (not platform subviews) to avoid timing issues.
+		/// </summary>
+		static string? SynthesizeAccessibilityLabelFromChildren(ILayout layout)
+		{
+			var sb = new StringBuilder();
+			CollectChildrenText(layout, sb);
+			return sb.Length > 0 ? sb.ToString() : null;
+		}
+
+		static void CollectChildrenText(ILayout layout, StringBuilder sb)
+		{
+			for (int i = 0; i < layout.Count; i++)
+			{
+				var child = layout[i];
+
+				// Prefer explicit SemanticProperties.Description over raw text
+				if (child.Semantics?.Description is string childDesc && !string.IsNullOrWhiteSpace(childDesc))
+				{
+					if (sb.Length > 0)
+					{
+						sb.Append(", ");
+					}
+
+					sb.Append(childDesc);
+				}
+				else if (child is IText textElement && !string.IsNullOrWhiteSpace(textElement.Text))
+				{
+					if (sb.Length > 0)
+					{
+						sb.Append(", ");
+					}
+
+					sb.Append(textElement.Text);
+				}
+				else if (child is ILayout childLayout)
+				{
+					// Recurse into nested layouts to collect text from their children
+					CollectChildrenText(childLayout, sb);
 				}
 			}
 		}

--- a/src/Core/src/Platform/iOS/SemanticExtensions.cs
+++ b/src/Core/src/Platform/iOS/SemanticExtensions.cs
@@ -86,40 +86,37 @@ namespace Microsoft.Maui.Platform
 				return;
 			}
 
-			// For layout containers with a Hint set, synthesize an AccessibilityLabel from the MAUI
-			// virtual children's text so VoiceOver reads both the children's content AND the
-			// container's hint in a single announcement — matching Android TalkBack behavior.
-			// We read from the virtual view tree (not platformView.Subviews) to avoid timing issues:
-			// UpdateSemantics can be called before platform children are attached.
-			// Note: We gate on Hint only (not Description) to preserve the existing contract for
-			// Description-only layouts, which already read just the Description text today.
+			// For layout containers with a Hint set, decide on an AccessibilityLabel that gives
+			// VoiceOver the children's content (matching Android TalkBack behavior).
+			// - If the developer explicitly set Description, respect it as the label — don't
+			//   second-guess by appending children. This preserves the pre-fix contract for
+			//   apps that deliberately set Description as a curated summary.
+			// - If only Hint is set (no Description), synthesize a label from the children's
+			//   text so VoiceOver reads "[children], [hint]" instead of just "[hint]".
+			// We gate on Hint only (not Description) so Description-only layouts retain their
+			// existing legacy-path behavior.
 			if (view is ILayout layout &&
 				!string.IsNullOrWhiteSpace(semantics.Hint))
 			{
-				var synthesizedLabel = SynthesizeAccessibilityLabelFromChildren(layout);
-
-				if (!string.IsNullOrWhiteSpace(synthesizedLabel))
+				if (!string.IsNullOrWhiteSpace(semantics.Description))
 				{
-					// If there's an explicit Description, prepend it to the children's text
-					if (!string.IsNullOrWhiteSpace(semantics.Description))
-					{
-						platformView.AccessibilityLabel = $"{semantics.Description}, {synthesizedLabel}";
-					}
-					else
-					{
-						platformView.AccessibilityLabel = synthesizedLabel;
-					}
+					// Explicit Description wins — honor the developer's curated label.
+					platformView.AccessibilityLabel = semantics.Description;
 				}
 				else
 				{
-					// No children text found — fall back to Description only
-					platformView.AccessibilityLabel = semantics.Description;
+					// No explicit Description; synthesize from children so VoiceOver isn't left
+					// reading only the Hint (which would silence the layout's actual content).
+					var synthesizedLabel = SynthesizeAccessibilityLabelFromChildren(layout);
+					platformView.AccessibilityLabel = !string.IsNullOrWhiteSpace(synthesizedLabel)
+						? synthesizedLabel
+						: null;
 				}
 
 				platformView.AccessibilityHint = semantics.Hint;
 
 				// Make the container the primary accessibility element so VoiceOver announces
-				// "[children text], [hint]" as a single focus unit.
+				// "[label], [hint]" as a single focus unit.
 				platformView.IsAccessibilityElement = true;
 
 				// If a TapGestureRecognizer was wired up first, GesturePlatformManager may have
@@ -133,6 +130,21 @@ namespace Microsoft.Maui.Platform
 				// those types are not applicable here. Heading trait is explicitly applied below.
 				UpdateSemanticsHeading(platformView, semantics);
 				return;
+			}
+
+			// If a layout previously had Hint set (triggering the synthesis branch above which
+			// promotes the layout to an accessibility element) and the Hint/Description was later
+			// cleared, restore the layout to a non-leaf so VoiceOver can navigate into its children
+			// again. Layouts default to IsAccessibilityElement=false; the legacy path below only
+			// flips it to true and never back to false, so without this reset the layout would
+			// remain a silent leaf.
+			if (view is ILayout
+				&& platformView is not UIControl
+				&& string.IsNullOrWhiteSpace(semantics.Hint)
+				&& string.IsNullOrWhiteSpace(semantics.Description)
+				&& platformView.IsAccessibilityElement)
+			{
+				platformView.IsAccessibilityElement = false;
 			}
 
 			UpdateSemantics(platformView, semantics);

--- a/src/Core/src/Platform/iOS/SemanticExtensions.cs
+++ b/src/Core/src/Platform/iOS/SemanticExtensions.cs
@@ -81,8 +81,21 @@ namespace Microsoft.Maui.Platform
 		{
 			var semantics = view?.Semantics;
 
+			// Null semantics (e.g. ClearValue): reverse any previous promotion so the layout
+			// stops announcing stale content and its children become navigable again.
 			if (semantics is null)
 			{
+				if (view is ILayout && platformView is not UIControl && platformView.IsAccessibilityElement)
+				{
+					platformView.IsAccessibilityElement = false;
+					platformView.AccessibilityLabel = null;
+					platformView.AccessibilityHint = null;
+					if (platformView is MauiView clearedMauiView)
+					{
+						clearedMauiView.SynthesizeAccessibilityLabelFromChildren = false;
+					}
+				}
+
 				return;
 			}
 
@@ -102,11 +115,21 @@ namespace Microsoft.Maui.Platform
 				{
 					// Explicit Description wins — honor the developer's curated label.
 					platformView.AccessibilityLabel = semantics.Description;
+					if (platformView is MauiView mauiViewWithDesc)
+					{
+						mauiViewWithDesc.SynthesizeAccessibilityLabelFromChildren = false;
+					}
+				}
+				else if (platformView is MauiView mauiViewLayout)
+				{
+					// Defer synthesis to MauiView.AccessibilityLabel's getter so child text changes
+					// are picked up on each VoiceOver focus (avoids stale one-shot snapshot).
+					mauiViewLayout.SynthesizeAccessibilityLabelFromChildren = true;
+					mauiViewLayout.AccessibilityLabel = null;
 				}
 				else
 				{
-					// No explicit Description; synthesize from children so VoiceOver isn't left
-					// reading only the Hint (which would silence the layout's actual content).
+					// Non-MauiView platform view (rare for ILayout): fall back to one-shot snapshot.
 					var synthesizedLabel = SynthesizeAccessibilityLabelFromChildren(layout);
 					platformView.AccessibilityLabel = !string.IsNullOrWhiteSpace(synthesizedLabel)
 						? synthesizedLabel
@@ -145,6 +168,10 @@ namespace Microsoft.Maui.Platform
 				&& platformView.IsAccessibilityElement)
 			{
 				platformView.IsAccessibilityElement = false;
+				if (platformView is MauiView demotedMauiView)
+				{
+					demotedMauiView.SynthesizeAccessibilityLabelFromChildren = false;
+				}
 			}
 
 			UpdateSemantics(platformView, semantics);
@@ -213,7 +240,7 @@ namespace Microsoft.Maui.Platform
 		/// Synthesizes an accessibility label by collecting text from all IText children in the layout.
 		/// Uses the MAUI virtual view tree (not platform subviews) to avoid timing issues.
 		/// </summary>
-		static string? SynthesizeAccessibilityLabelFromChildren(ILayout layout)
+		internal static string? SynthesizeAccessibilityLabelFromChildren(ILayout layout)
 		{
 			var sb = new StringBuilder();
 			CollectChildrenText(layout, sb, depth: 0);
@@ -230,6 +257,13 @@ namespace Microsoft.Maui.Platform
 			for (int i = 0; i < layout.Count; i++)
 			{
 				var child = layout[i];
+
+				// Skip non-visible children: once the parent is a leaf accessibility element,
+				// the platform only sees the synthesized string, so hidden text must be filtered here.
+				if (child.Visibility != Visibility.Visible)
+				{
+					continue;
+				}
 
 				// Prefer explicit SemanticProperties.Description over raw text
 				if (child.Semantics?.Description is string childDesc && !string.IsNullOrWhiteSpace(childDesc))

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -4,5 +4,6 @@ override Microsoft.Maui.Handlers.ShapeViewHandler.GetDesiredSize(double widthCon
 override Microsoft.Maui.Handlers.StepperHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Platform.MauiTextView.TextAlignment.get -> UIKit.UITextAlignment
 override Microsoft.Maui.Platform.MauiTextView.TextAlignment.set -> void
+override Microsoft.Maui.Platform.MauiView.AccessibilityActivate() -> bool
 override Microsoft.Maui.Platform.MauiView.DidUpdateFocus(UIKit.UIFocusUpdateContext! context, UIKit.UIFocusAnimationCoordinator! coordinator) -> void
 static Microsoft.Maui.Handlers.DatePickerHandler.MapFlowDirection(Microsoft.Maui.Handlers.IDatePickerHandler! handler, Microsoft.Maui.IDatePicker! datePicker) -> void

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -5,5 +5,7 @@ override Microsoft.Maui.Handlers.StepperHandler.GetDesiredSize(double widthConst
 override Microsoft.Maui.Platform.MauiTextView.TextAlignment.get -> UIKit.UITextAlignment
 override Microsoft.Maui.Platform.MauiTextView.TextAlignment.set -> void
 override Microsoft.Maui.Platform.MauiView.AccessibilityActivate() -> bool
+override Microsoft.Maui.Platform.MauiView.AccessibilityLabel.get -> string?
+override Microsoft.Maui.Platform.MauiView.AccessibilityLabel.set -> void
 override Microsoft.Maui.Platform.MauiView.DidUpdateFocus(UIKit.UIFocusUpdateContext! context, UIKit.UIFocusAnimationCoordinator! coordinator) -> void
 static Microsoft.Maui.Handlers.DatePickerHandler.MapFlowDirection(Microsoft.Maui.Handlers.IDatePickerHandler! handler, Microsoft.Maui.IDatePicker! datePicker) -> void

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -4,5 +4,6 @@ override Microsoft.Maui.Handlers.ShapeViewHandler.GetDesiredSize(double widthCon
 override Microsoft.Maui.Handlers.StepperHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Platform.MauiTextView.TextAlignment.get -> UIKit.UITextAlignment
 override Microsoft.Maui.Platform.MauiTextView.TextAlignment.set -> void
+override Microsoft.Maui.Platform.MauiView.AccessibilityActivate() -> bool
 override Microsoft.Maui.Platform.MauiView.DidUpdateFocus(UIKit.UIFocusUpdateContext! context, UIKit.UIFocusAnimationCoordinator! coordinator) -> void
 static Microsoft.Maui.Handlers.DatePickerHandler.MapFlowDirection(Microsoft.Maui.Handlers.IDatePickerHandler! handler, Microsoft.Maui.IDatePicker! datePicker) -> void

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -5,5 +5,7 @@ override Microsoft.Maui.Handlers.StepperHandler.GetDesiredSize(double widthConst
 override Microsoft.Maui.Platform.MauiTextView.TextAlignment.get -> UIKit.UITextAlignment
 override Microsoft.Maui.Platform.MauiTextView.TextAlignment.set -> void
 override Microsoft.Maui.Platform.MauiView.AccessibilityActivate() -> bool
+override Microsoft.Maui.Platform.MauiView.AccessibilityLabel.get -> string?
+override Microsoft.Maui.Platform.MauiView.AccessibilityLabel.set -> void
 override Microsoft.Maui.Platform.MauiView.DidUpdateFocus(UIKit.UIFocusUpdateContext! context, UIKit.UIFocusAnimationCoordinator! coordinator) -> void
 static Microsoft.Maui.Handlers.DatePickerHandler.MapFlowDirection(Microsoft.Maui.Handlers.IDatePickerHandler! handler, Microsoft.Maui.IDatePicker! datePicker) -> void


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
On iOS and MacCatalyst, when a container layout (for example, VerticalStackLayout) has SemanticProperties.Hint set, with or without a TapGestureRecognizer, VoiceOver focuses the entire layout as a single accessibility element but reads only the Hint, ignoring all child label text.
On Android, TalkBack handles the same layout correctly by reading the child text followed by the hint.

### Root Cause
iOS accessibility uses a flat accessibility model. A UIView can either behave as:

- a leaf accessibility element, where VoiceOver reads the view’s AccessibilityLabel and AccessibilityHint while hiding its children, or
- a container, where child elements are read individually but the container’s own label and hint are ignored.

It cannot behave as both at the same time. The previous MAUI implementation in SemanticExtensions.UpdateSemantics marked layouts with Hint or Description as IsAccessibilityElement = true and assigned AccessibilityHint = Hint, but never populated AccessibilityLabel. As a result, VoiceOver read only the hint, while all child content was hidden because the layout became a leaf accessibility element.

**Why Android is unaffected**
Android accessibility uses a hierarchical accessibility model. TalkBack walks the native view tree and reads both parent and child accessibility content together.
For example, on a VerticalStackLayout with Hint = "more info" containing two labels, TalkBack naturally announces:
"[label1], [label2], more info". There is no parent/child exclusivity like on iOS. The MAUI Android implementation sets accessibility properties such as ContentDescription and ImportantForAccessibility per view, and TalkBack correctly combines them while traversing the tree.

### Description of Change
**SemanticExtensions.cs:** For ILayout views with Hint set, the fix now populates AccessibilityLabel before promoting the layout to an accessibility element. If Description is provided, it is used directly as the label. Otherwise, the label is synthesized from child IText content. This allows VoiceOver to read both the layout content and the hint together as a single focus unit.
The fix also resets IsAccessibilityElement back to false when both Hint and Description are later cleared from the layout.
**GesturePlatformManager.iOS.cs:** The existing ShouldGroupAccessibilityChildren value is now captured before modification and restored during cleanup.
Also added an AccessibilityActivateCallback registration on MauiView to improve MacCatalyst Ctrl+Option+Space tap reliability, since UIKit’s default activation path is unreliable on Catalyst.
**MauiView.cs:** Added AccessibilityActivateCallback : Func<bool>? and overrode AccessibilityActivate() so the callback can invoke TapGestureRecognizer.SendTapped() directly.

### Issues Fixed
Fixes https://github.com/dotnet/maui/issues/34380

### Screenshots

**iOS:**
| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/3e45feaa-ef89-4e20-b29b-20618ea7770e"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/092db6da-9ce6-48d1-a8b3-902f403e8c75"> |

**Mac:**
| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/43f4e5bc-82a6-40e7-89c6-542f5a246fc2"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/13c213c5-22d1-4bfe-8252-a6a015e358fc"> |