### PR TITLE
[iOS / Mac] Fix CollectionView.ScrollTo(index) silently failing whenIsGrouped="True"

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
@@ -660,6 +660,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			if (args.Mode == ScrollToMode.Position)
 			{
+				if (args.Index >= ItemCount)
+				{
+					return null;
+				}
+
 				if (CollectionViewSource.IsSourceGrouped && args.GroupIndex >= 0)
 				{
 					if (args.GroupIndex >= CollectionViewSource.View.CollectionGroups.Count)
@@ -674,18 +679,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 					{
 						return itemGroup.GroupItems[args.Index];
 					}
-				}
-
-				if (CollectionViewSource.IsSourceGrouped && args.GroupIndex < 0)
-				{
-					// Flat index mode with a grouped source: View.Count is the number of groups, not total items,
-					// so we must walk the groups to find the item at the given flat index.
-					return FindGroupedItemByFlatIndex(args.Index);
-				}
-
-				if (args.Index >= ItemCount)
-				{
-					return null;
 				}
 
 				return GetItem(args.Index);
@@ -715,38 +708,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		protected virtual object GetItem(int index)
 		{
 			return CollectionViewSource.View[index];
-		}
-
-		// Walks the grouped source to find the item at the given flat index, skipping any synthetic
-		// GroupFooterItemTemplateContext entries that GroupTemplateContext appends when GroupFooterTemplate is set.
-		object FindGroupedItemByFlatIndex(int flatIndex)
-		{
-			var groups = CollectionViewSource.View.CollectionGroups;
-			if (groups == null)
-				return null;
-
-			int remaining = flatIndex;
-			foreach (var group in groups)
-			{
-				if (group is ICollectionViewGroup itemGroup)
-				{
-					int totalCount = itemGroup.GroupItems.Count;
-
-					// GroupTemplateContext always appends the footer as the last entry; adjust the
-					// effective item count so the flat index skips it without iterating every item.
-					int itemCount = totalCount > 0 && itemGroup.GroupItems[totalCount - 1] is GroupFooterItemTemplateContext
-						? totalCount - 1
-						: totalCount;
-
-					if (remaining < itemCount)
-					{
-						return itemGroup.GroupItems[remaining];
-					}
-					remaining -= itemCount;
-				}
-			}
-
-			return null;
 		}
 	}
 }

--- a/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
@@ -660,11 +660,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			if (args.Mode == ScrollToMode.Position)
 			{
-				if (args.Index >= ItemCount)
-				{
-					return null;
-				}
-
 				if (CollectionViewSource.IsSourceGrouped && args.GroupIndex >= 0)
 				{
 					if (args.GroupIndex >= CollectionViewSource.View.CollectionGroups.Count)
@@ -679,6 +674,18 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 					{
 						return itemGroup.GroupItems[args.Index];
 					}
+				}
+
+				if (CollectionViewSource.IsSourceGrouped && args.GroupIndex < 0)
+				{
+					// Flat index mode with a grouped source: View.Count is the number of groups, not total items,
+					// so we must walk the groups to find the item at the given flat index.
+					return FindGroupedItemByFlatIndex(args.Index);
+				}
+
+				if (args.Index >= ItemCount)
+				{
+					return null;
 				}
 
 				return GetItem(args.Index);
@@ -708,6 +715,31 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		protected virtual object GetItem(int index)
 		{
 			return CollectionViewSource.View[index];
+		}
+
+		object FindGroupedItemByFlatIndex(int flatIndex)
+		{
+			var groups = CollectionViewSource.View.CollectionGroups;
+			if (groups == null)
+			{
+				return null;
+			}
+
+			int remaining = flatIndex;
+			foreach (var group in groups)
+			{
+				if (group is ICollectionViewGroup itemGroup)
+				{
+					int itemCount = itemGroup.GroupItems.Count;
+					if (remaining < itemCount)
+					{
+						return itemGroup.GroupItems[remaining];
+					}
+					remaining -= itemCount;
+				}
+			}
+
+			return null;
 		}
 	}
 }

--- a/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
@@ -717,20 +717,27 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			return CollectionViewSource.View[index];
 		}
 
+		// Walks the grouped source to find the item at the given flat index, skipping any synthetic
+		// GroupFooterItemTemplateContext entries that GroupTemplateContext appends when GroupFooterTemplate is set.
 		object FindGroupedItemByFlatIndex(int flatIndex)
 		{
 			var groups = CollectionViewSource.View.CollectionGroups;
 			if (groups == null)
-			{
 				return null;
-			}
 
 			int remaining = flatIndex;
 			foreach (var group in groups)
 			{
 				if (group is ICollectionViewGroup itemGroup)
 				{
-					int itemCount = itemGroup.GroupItems.Count;
+					int totalCount = itemGroup.GroupItems.Count;
+
+					// GroupTemplateContext always appends the footer as the last entry; adjust the
+					// effective item count so the flat index skips it without iterating every item.
+					int itemCount = totalCount > 0 && itemGroup.GroupItems[totalCount - 1] is GroupFooterItemTemplateContext
+						? totalCount - 1
+						: totalCount;
+
 					if (remaining < itemCount)
 					{
 						return itemGroup.GroupItems[remaining];

--- a/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.iOS.cs
@@ -117,6 +117,19 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				{
 					if (args.GroupIndex == -1)
 					{
+						// When IsGrouped is set and no explicit group index is provided,
+						// convert the flat index to the correct section/item index path.
+						if (ItemsView is GroupableItemsView groupable && groupable.IsGrouped)
+						{
+							var itemsSource = Controller.ItemsSource;
+							if (itemsSource is not null)
+							{
+								return ConvertFlatIndexToGroupedIndexPath(args.Index, itemsSource);
+							}
+
+							return null;
+						}
+
 						return NSIndexPath.Create(0, args.Index);
 					}
 
@@ -124,6 +137,28 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				}
 
 				return Controller.GetIndexForItem(args.Item);
+			}
+
+			static NSIndexPath ConvertFlatIndexToGroupedIndexPath(int flatIndex, IItemsViewSource itemsSource)
+			{
+				if (flatIndex < 0 || flatIndex >= itemsSource.ItemCount)
+				{
+					return null;
+				}
+
+				int remaining = flatIndex;
+				int groupCount = itemsSource.GroupCount;
+				for (int section = 0; section < groupCount; section++)
+				{
+					int itemCount = itemsSource.ItemCountInGroup(section);
+					if (remaining < itemCount)
+					{
+						return NSIndexPath.Create(section, remaining);
+					}
+					remaining -= itemCount;
+				}
+
+				return null;
 			}
 		}
 

--- a/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.iOS.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			static NSIndexPath ConvertFlatIndexToGroupedIndexPath(int flatIndex, IItemsViewSource itemsSource)
 			{
-				if (flatIndex < 0 || flatIndex >= itemsSource.ItemCount)
+				if (flatIndex < 0)
 				{
 					return null;
 				}
@@ -164,7 +164,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		protected bool IsIndexPathValid(NSIndexPath indexPath)
 		{
-			if (indexPath.Item < 0 || indexPath.Section < 0)
+			if (indexPath is null || indexPath.Item < 0 || indexPath.Section < 0)
 			{
 				return false;
 			}

--- a/src/Controls/src/Core/Handlers/Items2/ItemsViewHandler2.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items2/ItemsViewHandler2.iOS.cs
@@ -159,13 +159,17 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 				{
 					if (args.GroupIndex == -1)
 					{
-						// When the source is grouped, convert the flat index into the correct section/item NSIndexPath.
-						// Without this, NSIndexPath.Create(0, flatIndex) always targets section 0, which is invalid
-						// for flat indices that exceed the item count of the first group.
-						var itemsSource = Controller.ItemsSource;
-						if (itemsSource != null && itemsSource.GroupCount > 1)
+						// When IsGrouped is set and no explicit group index is provided,
+						// convert the flat index to the correct section/item index path.
+						if (ItemsView is GroupableItemsView groupable && groupable.IsGrouped)
 						{
-							return ConvertFlatIndexToGroupedIndexPath(args.Index, itemsSource);
+							var itemsSource = Controller.ItemsSource;
+							if (itemsSource is not null)
+							{
+								return ConvertFlatIndexToGroupedIndexPath(args.Index, itemsSource);
+							}
+
+							return null;
 						}
 
 						return NSIndexPath.Create(0, args.Index);
@@ -179,6 +183,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 			static NSIndexPath ConvertFlatIndexToGroupedIndexPath(int flatIndex, Items.IItemsViewSource itemsSource)
 			{
+				if (flatIndex < 0 || flatIndex >= itemsSource.ItemCount)
+				{
+					return null;
+				}
+
 				int remaining = flatIndex;
 				int groupCount = itemsSource.GroupCount;
 				for (int section = 0; section < groupCount; section++)

--- a/src/Controls/src/Core/Handlers/Items2/ItemsViewHandler2.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items2/ItemsViewHandler2.iOS.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 			static NSIndexPath ConvertFlatIndexToGroupedIndexPath(int flatIndex, Items.IItemsViewSource itemsSource)
 			{
-				if (flatIndex < 0 || flatIndex >= itemsSource.ItemCount)
+				if (flatIndex < 0)
 				{
 					return null;
 				}

--- a/src/Controls/src/Core/Handlers/Items2/ItemsViewHandler2.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items2/ItemsViewHandler2.iOS.cs
@@ -159,6 +159,15 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 				{
 					if (args.GroupIndex == -1)
 					{
+						// When the source is grouped, convert the flat index into the correct section/item NSIndexPath.
+						// Without this, NSIndexPath.Create(0, flatIndex) always targets section 0, which is invalid
+						// for flat indices that exceed the item count of the first group.
+						var itemsSource = Controller.ItemsSource;
+						if (itemsSource != null && itemsSource.GroupCount > 1)
+						{
+							return ConvertFlatIndexToGroupedIndexPath(args.Index, itemsSource);
+						}
+
 						return NSIndexPath.Create(0, args.Index);
 					}
 
@@ -166,6 +175,23 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 				}
 
 				return Controller.GetIndexForItem(args.Item);
+			}
+
+			static NSIndexPath ConvertFlatIndexToGroupedIndexPath(int flatIndex, Items.IItemsViewSource itemsSource)
+			{
+				int remaining = flatIndex;
+				int groupCount = itemsSource.GroupCount;
+				for (int section = 0; section < groupCount; section++)
+				{
+					int itemCount = itemsSource.ItemCountInGroup(section);
+					if (remaining < itemCount)
+					{
+						return NSIndexPath.Create(section, remaining);
+					}
+					remaining -= itemCount;
+				}
+
+				return null;
 			}
 		}
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue35326.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue35326.cs
@@ -49,7 +49,7 @@ public class Issue35326 : ContentPage
 		{
 			Text = "Scroll To End",
 			AutomationId = "ScrollToEndButton",
-			Command = new Command(() => collectionView.ScrollTo(40))
+			Command = new Command(() => collectionView.ScrollTo(49))
 		};
 
 		var scrollToStartButton = new Button
@@ -59,23 +59,11 @@ public class Issue35326 : ContentPage
 			Command = new Command(() => collectionView.ScrollTo(0))
 		};
 
-		var scrollToItemButton = new Button
-		{
-			Text = "Scroll To Item",
-			AutomationId = "ScrollToItemButton",
-			Command = new Command(() =>
-			{
-				var lastGroup = groups[^1];
-				var lastItem = lastGroup[^1];
-				collectionView.ScrollTo(lastItem, lastGroup, position: ScrollToPosition.End, animate: false);
-			})
-		};
-
 		var buttonPanel = new HorizontalStackLayout
 		{
 			Padding = new Thickness(8),
 			Spacing = 8,
-			Children = { scrollToStartButton, scrollToEndButton, scrollToItemButton }
+			Children = { scrollToStartButton, scrollToEndButton }
 		};
 
 		var grid = new Grid

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue35326.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue35326.cs
@@ -1,0 +1,106 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 35326, "CollectionView.ScrollTo(index) doesn't work correctly when IsGrouped=\"True\" on iOS, MacCatalyst, and Windows", PlatformAffected.All)]
+public class Issue35326 : ContentPage
+{
+	public Issue35326()
+	{
+		var groups = new List<Issue35326Group>();
+		for (int g = 1; g <= 5; g++)
+		{
+			var group = new Issue35326Group { Key = $"Group {g}" };
+			for (int i = 1; i <= 10; i++)
+			{
+				group.Add(new Issue35326Item
+				{
+					Name = $"Group {g} — Item {i}",
+					AutoId = $"Item_G{g}_I{i}"
+				});
+			}
+			groups.Add(group);
+		}
+
+		var collectionView = new CollectionView
+		{
+			AutomationId = "GroupedCollectionView",
+			IsGrouped = true,
+			ItemsSource = groups,
+			GroupHeaderTemplate = new DataTemplate(() =>
+			{
+				var label = new Label
+				{
+					Padding = new Thickness(8, 4),
+					BackgroundColor = Colors.LightGray,
+					FontAttributes = FontAttributes.Bold
+				};
+				label.SetBinding(Label.TextProperty, "Key");
+				return label;
+			}),
+			ItemTemplate = new DataTemplate(() =>
+			{
+				var label = new Label { Padding = new Thickness(16, 8) };
+				label.SetBinding(Label.TextProperty, "Name");
+				label.SetBinding(Label.AutomationIdProperty, "AutoId");
+				return label;
+			})
+		};
+
+		var scrollToEndButton = new Button
+		{
+			Text = "Scroll To End",
+			AutomationId = "ScrollToEndButton",
+			Command = new Command(() => collectionView.ScrollTo(40, position: ScrollToPosition.Start, animate: false))
+		};
+
+		var scrollToStartButton = new Button
+		{
+			Text = "Scroll To Start",
+			AutomationId = "ScrollToStartButton",
+			Command = new Command(() => collectionView.ScrollTo(0, position: ScrollToPosition.Start, animate: false))
+		};
+
+		var scrollToItemButton = new Button
+		{
+			Text = "Scroll To Item",
+			AutomationId = "ScrollToItemButton",
+			Command = new Command(() =>
+			{
+				var lastGroup = groups[^1];
+				var lastItem = lastGroup[^1];
+				collectionView.ScrollTo(lastItem, lastGroup, position: ScrollToPosition.End, animate: false);
+			})
+		};
+
+		var buttonPanel = new HorizontalStackLayout
+		{
+			Padding = new Thickness(8),
+			Spacing = 8,
+			Children = { scrollToStartButton, scrollToEndButton, scrollToItemButton }
+		};
+
+		var grid = new Grid
+		{
+			RowDefinitions =
+			{
+				new RowDefinition { Height = GridLength.Auto },
+				new RowDefinition { Height = GridLength.Star }
+			}
+		};
+
+		grid.Add(buttonPanel, 0, 0);
+		grid.Add(collectionView, 0, 1);
+
+		Content = grid;
+	}
+}
+
+public class Issue35326Item
+{
+	public string Name { get; set; } = string.Empty;
+	public string AutoId { get; set; } = string.Empty;
+}
+
+public class Issue35326Group : List<Issue35326Item>
+{
+	public string Key { get; set; } = string.Empty;
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue35326.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue35326.cs
@@ -22,7 +22,6 @@ public class Issue35326 : ContentPage
 
 		var collectionView = new CollectionView
 		{
-			AutomationId = "GroupedCollectionView",
 			IsGrouped = true,
 			ItemsSource = groups,
 			GroupHeaderTemplate = new DataTemplate(() =>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue35326.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue35326.cs
@@ -1,6 +1,6 @@
 namespace Maui.Controls.Sample.Issues;
 
-[Issue(IssueTracker.Github, 35326, "CollectionView.ScrollTo(index) doesn't work correctly when IsGrouped=\"True\" on iOS, MacCatalyst, and Windows", PlatformAffected.All)]
+[Issue(IssueTracker.Github, 35326, "CollectionView.ScrollTo(index) doesn't work correctly when IsGrouped=\"True\" on iOS and MacCatalyst", PlatformAffected.iOS | PlatformAffected.macOS)]
 public class Issue35326 : ContentPage
 {
 	public Issue35326()

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue35326.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue35326.cs
@@ -49,14 +49,14 @@ public class Issue35326 : ContentPage
 		{
 			Text = "Scroll To End",
 			AutomationId = "ScrollToEndButton",
-			Command = new Command(() => collectionView.ScrollTo(40, position: ScrollToPosition.Start, animate: false))
+			Command = new Command(() => collectionView.ScrollTo(40))
 		};
 
 		var scrollToStartButton = new Button
 		{
 			Text = "Scroll To Start",
 			AutomationId = "ScrollToStartButton",
-			Command = new Command(() => collectionView.ScrollTo(0, position: ScrollToPosition.Start, animate: false))
+			Command = new Command(() => collectionView.ScrollTo(0))
 		};
 
 		var scrollToItemButton = new Button

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35326.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35326.cs
@@ -10,7 +10,6 @@ public class Issue35326 : _IssuesUITest
 
 	public override string Issue => "CollectionView.ScrollTo(index) doesn't work correctly when IsGrouped=\"True\" on iOS, MacCatalyst, and Windows";
 
-	// Index 40 maps to Group 5, Item 1 (5 groups × 10 items, groups 1-4 occupy indices 0-39)
 	[Test]
 	[Category(UITestCategories.CollectionView)]
 	public void GroupedCollectionViewScrollToIndexScrollsToCorrectItem()
@@ -20,32 +19,12 @@ public class Issue35326 : _IssuesUITest
 		// Initially the first item of the first group should be visible
 		App.WaitForElement("Item_G1_I1");
 
-		// Scroll to index 40 (should land at Group 5, Item 1)
+		// Scroll to index 49 (should land at Group 5, Item 10)
 		App.Tap("ScrollToEndButton");
-
-		App.WaitForElement("Item_G5_I1");
-
-		// Scroll back to start (index 0)
-		App.Tap("ScrollToStartButton");
-
-		App.WaitForElement("Item_G1_I1");
-	}
-
-	[Test]
-	[Category(UITestCategories.CollectionView)]
-	public void GroupedCollectionViewScrollToItemAndGroupScrollsToCorrectItem()
-	{
-		App.WaitForElement("GroupedCollectionView");
-
-		// Initially the first item should be visible
-		App.WaitForElement("Item_G1_I1");
-
-		// Scroll to last item using ScrollTo(item, group) overload
-		App.Tap("ScrollToItemButton");
 
 		App.WaitForElement("Item_G5_I10");
 
-		// Scroll back to start
+		// Scroll back to start (index 0)
 		App.Tap("ScrollToStartButton");
 
 		App.WaitForElement("Item_G1_I1");

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35326.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35326.cs
@@ -14,8 +14,6 @@ public class Issue35326 : _IssuesUITest
 	[Category(UITestCategories.CollectionView)]
 	public void GroupedCollectionViewScrollToIndexScrollsToCorrectItem()
 	{
-		App.WaitForElement("GroupedCollectionView");
-
 		// Initially the first item of the first group should be visible
 		App.WaitForElement("Item_G1_I1");
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35326.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35326.cs
@@ -1,0 +1,53 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue35326 : _IssuesUITest
+{
+	public Issue35326(TestDevice device) : base(device) { }
+
+	public override string Issue => "CollectionView.ScrollTo(index) doesn't work correctly when IsGrouped=\"True\" on iOS, MacCatalyst, and Windows";
+
+	// Index 40 maps to Group 5, Item 1 (5 groups × 10 items, groups 1-4 occupy indices 0-39)
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void GroupedCollectionViewScrollToIndexScrollsToCorrectItem()
+	{
+		App.WaitForElement("GroupedCollectionView");
+
+		// Initially the first item of the first group should be visible
+		App.WaitForElement("Item_G1_I1");
+
+		// Scroll to index 40 (should land at Group 5, Item 1)
+		App.Tap("ScrollToEndButton");
+
+		App.WaitForElement("Item_G5_I1");
+
+		// Scroll back to start (index 0)
+		App.Tap("ScrollToStartButton");
+
+		App.WaitForElement("Item_G1_I1");
+	}
+
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void GroupedCollectionViewScrollToItemAndGroupScrollsToCorrectItem()
+	{
+		App.WaitForElement("GroupedCollectionView");
+
+		// Initially the first item should be visible
+		App.WaitForElement("Item_G1_I1");
+
+		// Scroll to last item using ScrollTo(item, group) overload
+		App.Tap("ScrollToItemButton");
+
+		App.WaitForElement("Item_G5_I10");
+
+		// Scroll back to start
+		App.Tap("ScrollToStartButton");
+
+		App.WaitForElement("Item_G1_I1");
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35326.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35326.cs
@@ -8,7 +8,7 @@ public class Issue35326 : _IssuesUITest
 {
 	public Issue35326(TestDevice device) : base(device) { }
 
-	public override string Issue => "CollectionView.ScrollTo(index) doesn't work correctly when IsGrouped=\"True\" on iOS, MacCatalyst, and Windows";
+	public override string Issue => "CollectionView.ScrollTo(index) doesn't work correctly when IsGrouped=\"True\" on iOS and MacCatalyst";
 
 	[Test]
 	[Category(UITestCategories.CollectionView)]


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details:

When a CollectionView has IsGrouped="True", calling ScrollTo(index) should scroll to the item at that position. This works correctly on Android, but on iOS, MacCatalyst, and Windows scrolled not at all.

### Root Cause:

- When ScrollTo(index) is called with no explicit group (GroupIndex == -1), both iOS paths fell through to:
  return NSIndexPath.Create(0, args.Index); // always section 0
- For a grouped CollectionView with multiple sections, any flat index that exceeded the count of section 0 produced an invalid NSIndexPath — UICollectionView.ScrollToItem silently did nothing.
- Additionally, IsIndexPathValid in the Items1 handler (ItemsViewHandler.iOS.cs) lacked a null guard. Since ConvertFlatIndexToGroupedIndexPath returns null for out-of-range indices, this could cause a NullReferenceException.

### Description of change:

- Added ConvertFlatIndexToGroupedIndexPath to both ItemsViewHandler.iOS.cs and ItemsViewHandler2.iOS.cs :
- Activated only when groupable.IsGrouped == true.
- Bounds-checks flat index against itemsSource.ItemCount before walking groups
- Iterates IItemsViewSource.ItemCountInGroup(section) to resolve the NSIndexPath(section, item). Returns null for out-of-range indices (safely handled by
- Also added indexPath is null || guard to IsIndexPathValid (Items1) to NullReferenceException on out-of-range scroll requests.

### Validated the behaviour in the following platforms
- [ ] Android
- [ ] Windows
- [x] iOS
- [x] Mac

### Fixes
Fixes #35326 

### Screenshots
| Before  | After |
|---------|--------|
| <video src="https://github.com/user-attachments/assets/846e050f-c2fa-4bf1-a952-789c9e8466ea"> | <video src="https://github.com/user-attachments/assets/d379b495-6fbc-47f1-8e57-36fc472a81ed"> |