### PR TITLE
[Android] Fix BlazorWebView back callback can swallow the first Back press when its callback is stale-enabled

### DIFF
--- a/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
+++ b/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
@@ -100,7 +100,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			if (Microsoft.Maui.ApplicationModel.Platform.CurrentActivity is ComponentActivity activity)
 			{
 				var weakPlatformView = new WeakReference<AWebView>(platformView);
-				_backPressedCallback = new BlazorWebViewBackCallback(weakPlatformView);
+				_backPressedCallback = new BlazorWebViewBackCallback(weakPlatformView, activity.OnBackPressedDispatcher);
 				activity.OnBackPressedDispatcher.AddCallback(activity, _backPressedCallback);
 			}
 		}
@@ -248,10 +248,12 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		sealed class BlazorWebViewBackCallback : OnBackPressedCallback
 		{
 			readonly WeakReference<AWebView> _weakWebView;
+			readonly OnBackPressedDispatcher _dispatcher;
 
-			public BlazorWebViewBackCallback(WeakReference<AWebView> weakWebView) : base(false)
+			public BlazorWebViewBackCallback(WeakReference<AWebView> weakWebView, OnBackPressedDispatcher dispatcher) : base(false)
 			{
 				_weakWebView = weakWebView;
+				_dispatcher = dispatcher;
 			}
 
 			public override void HandleOnBackPressed()
@@ -271,6 +273,10 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				// can't handle the press it must yield rather than silently consuming the event.
 				// UpdateBackNavigationState() will re-enable this callback on the next navigation.
 				Enabled = false;
+
+				// Redispatch this same back press so it is not swallowed when this callback was
+				// stale-enabled and no longer able to handle.
+				_dispatcher.OnBackPressed();
 			}
 		}
 	}

--- a/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.BackNavigation.cs
+++ b/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.BackNavigation.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.WebView.Maui;
 using Microsoft.Extensions.DependencyInjection;
@@ -43,6 +44,83 @@ public partial class BlazorWebViewTests
 			Assert.False(platformWebView.CanGoBack(),
 				"WebView should not be able to go back after initial page load");
 		});
+	}
+
+	[Fact]
+	public async Task BackCallbackConsumesFirstBackPressWhenStaleEnabledRepro()
+	{
+		EnsureHandlerCreated(additionalCreationActions: appBuilder =>
+		{
+			appBuilder.Services.AddMauiBlazorWebView();
+		});
+
+		var bwv = new BlazorWebViewWithCustomFiles
+		{
+			HostPage = "wwwroot/index.html",
+			CustomFiles = new Dictionary<string, string>
+			{
+				{ "index.html", TestStaticFilesContents.DefaultMauiIndexHtmlContent },
+			},
+		};
+		bwv.RootComponents.Add(new RootComponent { ComponentType = typeof(MauiBlazorWebView.DeviceTests.Components.NoOpComponent), Selector = "#app", });
+
+		await InvokeOnMainThreadAsync(async () =>
+		{
+			var activity = Microsoft.Maui.ApplicationModel.Platform.CurrentActivity as global::AndroidX.Activity.ComponentActivity;
+			Assert.NotNull(activity);
+
+			var lowerPriorityCallback = new RecordingBackPressedCallback();
+			activity.OnBackPressedDispatcher.AddCallback(activity, lowerPriorityCallback);
+
+			try
+			{
+				var bwvHandler = CreateHandler<BlazorWebViewHandler>(bwv);
+				var platformWebView = bwvHandler.PlatformView;
+				await WebViewHelpers.WaitForWebViewReady(platformWebView);
+
+				Assert.False(platformWebView.CanGoBack(), "The repro needs a BlazorWebView with no WebView history.");
+
+				var blazorBackCallback = GetRegisteredBackPressedCallback(bwvHandler);
+				blazorBackCallback.Enabled = true;
+
+				activity.OnBackPressedDispatcher.OnBackPressed();
+
+				Assert.Equal(1, lowerPriorityCallback.InvocationCount);
+				Assert.False(blazorBackCallback.Enabled);
+
+				activity.OnBackPressedDispatcher.OnBackPressed();
+
+				Assert.Equal(2, lowerPriorityCallback.InvocationCount);
+			}
+			finally
+			{
+				lowerPriorityCallback.Remove();
+				lowerPriorityCallback.Dispose();
+				bwv.Handler = null;
+			}
+		});
+	}
+
+	static global::AndroidX.Activity.OnBackPressedCallback GetRegisteredBackPressedCallback(BlazorWebViewHandler handler)
+	{
+		var field = typeof(BlazorWebViewHandler).GetField("_backPressedCallback", BindingFlags.Instance | BindingFlags.NonPublic);
+		Assert.NotNull(field);
+
+		return Assert.IsAssignableFrom<global::AndroidX.Activity.OnBackPressedCallback>(field.GetValue(handler));
+	}
+
+	sealed class RecordingBackPressedCallback : global::AndroidX.Activity.OnBackPressedCallback
+	{
+		public RecordingBackPressedCallback() : base(true)
+		{
+		}
+
+		public int InvocationCount { get; private set; }
+
+		public override void HandleOnBackPressed()
+		{
+			InvocationCount++;
+		}
 	}
 #endif
 }


### PR DESCRIPTION
<!-- Please keep the note below for people who find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment whether this change resolves your issue. Thank you!<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Issue Details
BlazorWebView back handling where a stale-enabled OnBackPressedCallback can consume the first Back press even when the WebView cannot go back. This happened after the move to OnBackPressedDispatcher callbacks, because the fallback path disabled the callback but did not forward the same Back event, so users had to press Back twice.

### Description of Change

<!-- Enter description of the fix in this section -->
The change fixes that by keeping the same callback model but updating fallback behavior. In BlazorWebViewHandler.Android.cs, the callback now has a dispatcher reference, and when it cannot handle back it sets Enabled = false and immediately calls OnBackPressedDispatcher.OnBackPressed(). That forwards the current Back press to the next handler/system right away instead of swallowing it. The callback still gets re-enabled through UpdateBackNavigationState() when navigation history changes, so predictive-back behavior remains correct.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #35573 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

**Tested the behavior in the following platforms.**
- [x] Android
- [ ] Windows
- [ ] iOS
- [ ] Mac

| Before  | After  |
|---------|--------|
| **Android**<br> <video src="https://github.com/user-attachments/assets/cfaf9bab-c2a9-4078-a888-1809e33ec53b" width="300" height="600"> | **Android**<br> <video src="https://github.com/user-attachments/assets/2de09a3c-aab5-4163-a7b3-46ce212f4993" width="300" height="600"> |
