### PR TITLE
[inflight/current] Fixes a CS0111 build failure in RadioButton.cs caused by a duplicate OnPropertyChanged override

### DIFF
--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -3,7 +3,6 @@
 override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void
 ~override Microsoft.Maui.Controls.RadioButton.OnPropertyChanged(string propertyName = null) -> void
 override Microsoft.Maui.Controls.GraphicsView.OnBindingContextChanged() -> void
-~override Microsoft.Maui.Controls.RadioButton.OnPropertyChanged(string propertyName = null) -> void
 override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.Handlers.Items.CarouselViewHandler.UpdateEmptyViewVisibility() -> void
 ~override Microsoft.Maui.Controls.SwipeItems.OnPropertyChanged(string propertyName = null) -> void

--- a/src/Controls/src/Core/RadioButton/RadioButton.cs
+++ b/src/Controls/src/Core/RadioButton/RadioButton.cs
@@ -398,22 +398,6 @@ namespace Microsoft.Maui.Controls
 			base.ChangeVisualState();
 		}
 
-#if ANDROID || WINDOWS
-		protected override void OnPropertyChanged([CallerMemberName] string propertyName = null)
-		{
-			base.OnPropertyChanged(propertyName);
-
-			if (propertyName == BorderColorProperty.PropertyName)
-			{
-				Handler?.UpdateValue(nameof(IRadioButton.StrokeColor));
-			}
-			else if (propertyName == BorderWidthProperty.PropertyName)
-			{
-				Handler?.UpdateValue(nameof(IRadioButton.StrokeThickness));
-			}
-		}
-#endif
-
 		[Obsolete("Use MeasureOverride instead")]
 		protected override SizeRequest OnMeasure(double widthConstraint, double heightConstraint)
 		{


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue:

- CS0111 build failure in RadioButton.cs caused by a duplicate OnPropertyChanged override in the inflight/current branch

<!-- Enter description of the fix in this section -->

### Root Cause
`RadioButton.cs` contained **two** `OnPropertyChanged([CallerMemberName] string propertyName = null)` overrides with identical bodies:

1. An **unconditional** override (line 375).
2. A second override wrapped in `#if ANDROID || WINDOWS` (line 402).
### Description of Change

- Removed the redundant [#if ANDROID || WINDOWS](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)-guarded [OnPropertyChanged](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) override. The remaining unconditional override has identical logic, so runtime behavior is unchanged on all platforms — only the duplicate definition is gone.

| Before| After |
|----------|----------|
| <img src="https://github.com/user-attachments/assets/76e72a10-5335-4484-b296-c495b778959d"> | <img src="https://github.com/user-attachments/assets/855d34f9-efd9-44f1-b4dc-3b84f9a5a094"> |




<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
