### PR TITLE
Skip request-interception tests that hit echo.free.beeceptor.com

### DIFF
--- a/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.RequestInterception.cs
+++ b/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.RequestInterception.cs
@@ -93,13 +93,14 @@ public partial class BlazorWebViewTests
 			}
 		});
 
-	[Theory]
 #if !ANDROID // Custom schemes are not supported on Android
 #if !WINDOWS // TODO: There seems to be a bug with the implementation in the WASDK version of WebView2
+	[Theory]
 	[InlineData("app://echoservice/")]
 #endif
 #endif
 #if !IOS && !MACCATALYST // Cannot intercept https requests on iOS/MacCatalyst
+	[Theory(Skip = "Flaky due to external service dependency (echo.free.beeceptor.com). See https://github.com/dotnet/maui/issues/33927")]
 	[InlineData("https://echo.free.beeceptor.com/sample-request")]
 #endif
 	public Task RequestsCanBeInterceptedAndCustomDataReturnedForDifferentHosts(string uriBase) =>
@@ -287,13 +288,14 @@ public partial class BlazorWebViewTests
 			Assert.Equal(ExpectedHeaderValue, actualHeaderValue);
 		});
 
-	[Theory]
 #if !ANDROID // Custom schemes are not supported on Android
 #if !WINDOWS // TODO: There seems to be a bug with the implementation in the WASDK version of WebView2
+	[Theory]
 	[InlineData("app://echoservice/")]
 #endif
 #endif
 #if !IOS && !MACCATALYST // Cannot intercept https requests on iOS/MacCatalyst
+	[Theory(Skip = "Flaky due to external service dependency (echo.free.beeceptor.com). See https://github.com/dotnet/maui/issues/33927")]
 	[InlineData("https://echo.free.beeceptor.com/sample-request")]
 #endif
 	public Task RequestsCanBeInterceptedAndCancelledForDifferentHosts(string uriBase) =>
@@ -330,13 +332,14 @@ public partial class BlazorWebViewTests
 			Assert.True(result);
 		});
 
-	[Theory]
 #if !ANDROID // Custom schemes are not supported on Android
 #if !WINDOWS // TODO: There seems to be a bug with the implementation in the WASDK version of WebView2
+	[Theory]
 	[InlineData("app://echoservice/")]
 #endif
 #endif
 #if !IOS && !MACCATALYST // Cannot intercept https requests on iOS/MacCatalyst
+	[Theory(Skip = "Flaky due to external service dependency (echo.free.beeceptor.com). See https://github.com/dotnet/maui/issues/33927")]
 	[InlineData("https://echo.free.beeceptor.com/sample-request")]
 #endif
 	public Task RequestsCanBeInterceptedAndCaseInsensitiveHeadersRead(string uriBase) =>

--- a/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_Interception.cs
+++ b/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_Interception.cs
@@ -280,13 +280,14 @@ public partial class HybridWebViewTests_Interception : HybridWebViewTestsBase
 			Assert.Equal(ExpectedHeaderValue, actualHeaderValue);
 		});
 
-	[Theory]
 #if !ANDROID // Custom schemes are not supported on Android
 #if !WINDOWS // TODO: There seems to be a bug with the implementation in the WASDK version of WebView2
+	[Theory]
 	[InlineData("app://echoservice/", "RequestsWithCustomSchemeCanBeIntercepted")]
 #endif
 #endif
 #if !IOS && !MACCATALYST // Cannot intercept https requests on iOS/MacCatalyst
+	[Theory(Skip = "Flaky due to external service dependency (echo.free.beeceptor.com). See https://github.com/dotnet/maui/issues/33927")]
 	[InlineData("https://echo.free.beeceptor.com/", "RequestsCanBeIntercepted")]
 #endif
 	public Task RequestsCanBeInterceptedAndCancelledForDifferentHosts(string uriBase, string function) =>


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Several request-interception device tests were running an `[InlineData("https://echo.free.beeceptor.com/...")]` row on Windows and Android Helix queues even though that external service is known to be flaky (tracked in #33927). The sibling tests in the same files already skip that scenario; these four were missed:

- `BlazorWebViewTests.RequestsCanBeInterceptedAndCustomDataReturnedForDifferentHosts`
- `BlazorWebViewTests.RequestsCanBeInterceptedAndCancelledForDifferentHosts`
- `BlazorWebViewTests.RequestsCanBeInterceptedAndCaseInsensitiveHeadersRead`
- `HybridWebViewTests_Interception.RequestsCanBeInterceptedAndCancelledForDifferentHosts`

Reflection on the built `Microsoft.Maui.Controls.DeviceTests.dll` (net10.0-windows10.0.19041.0) confirmed each of these methods had a `Microsoft.Maui.TheoryAttribute` with **no** `Skip` and the `https://echo.free.beeceptor.com/` `InlineData` attached — they would attempt a real outbound TLS request from the Helix worker whenever interception did not fire.

### Fix

Split the single `[Theory]` into two: one inside the `#if !ANDROID && !WINDOWS` block (paired with the `app://echoservice/` row) and one inside the `#if !IOS && !MACCATALYST` block carrying `Skip = "Flaky due to external service dependency (echo.free.beeceptor.com). See https://github.com/dotnet/maui/issues/33927"` (paired with the `https://` row).

This matches the convention already used by the three other sibling methods (`CustomDataReturned`, `HeadersAdded`, `CaseInsensitiveHeadersRead` in `HybridWebViewTests_Interception.cs`).

Importantly, **iOS / MacCatalyst coverage is preserved** — only the `https://` rows are skipped. The `app://echoservice/` rows are fully self-contained (the OS cannot resolve the `app://` scheme, so the request never touches the network — it is satisfied entirely by the `WebResourceRequested` handler inside the test).

### Per-TFM safety check

The custom `Microsoft.Maui.TheoryAttribute` has `AllowMultiple = false`, and the `#if` guards make the two `[Theory]` attributes mutually exclusive across every TFM in `MauiDeviceTestsPlatforms`:

| TFM | `[Theory]` (app://) | `[Theory(Skip)]` (https://) |
|---|---|---|
| net10.0-android | excluded | included |
| net10.0-windows10.x | excluded | included |
| net10.0-ios | included | excluded |
| net10.0-maccatalyst | included | excluded |

### Issues Fixed

Related to #33927.