### PR TITLE
[Inflight/Candidate][iOS & Mac] Fix for Editor height inconsistency when VerticalTextAlignment is Center or End on iOS and MacCatalyst

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.iOS.cs
@@ -64,6 +64,45 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Theory]
+		[InlineData(TextAlignment.Start, TextAlignment.Start)]
+		[InlineData(TextAlignment.Center, TextAlignment.Start)]
+		[InlineData(TextAlignment.End, TextAlignment.Start)]
+		[InlineData(TextAlignment.Start, TextAlignment.Center)]
+		[InlineData(TextAlignment.Center, TextAlignment.Center)]
+		[InlineData(TextAlignment.End, TextAlignment.Center)]
+		[InlineData(TextAlignment.Start, TextAlignment.End)]
+		[InlineData(TextAlignment.Center, TextAlignment.End)]
+		[InlineData(TextAlignment.End, TextAlignment.End)]
+		[Description("Editor height should honour HeightRequest for all text alignment combinations when placed in an infinite height constraint layout.")]
+		public async Task EditorHeightIsConsistentAcrossAllTextAlignments(TextAlignment horizontal, TextAlignment vertical)
+		{
+			SetupBuilder();
+
+			const double heightRequest = 100;
+
+			var editor = new Editor
+			{
+				Text = "testing",
+				HeightRequest = heightRequest,
+				HorizontalTextAlignment = horizontal,
+				VerticalTextAlignment = vertical,
+			};
+
+			var layout = new VerticalStackLayout
+			{
+				Children = { editor }
+			};
+
+			await AttachAndRun<LayoutHandler>(layout, async (_) =>
+			{
+				var frame = editor.Frame;
+				await WaitForUIUpdate(frame, editor);
+
+				Assert.Equal(heightRequest, editor.Height, tolerance: 1.0);
+			});
+		}
+
 		[Fact]
 		[Description("Editor with AutoSize=TextChanges should continue to grow after a simulated rotation (width constraint change)")]
 		public async Task AutoSizeTextChangesEditorGrowsAfterRotation()

--- a/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
@@ -55,6 +55,13 @@ namespace Microsoft.Maui.Handlers
 
 		public override Size GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
+			// When the height constraint is infinite, the handler substitutes a finite value.
+			// This flag tracks whether the substitute came from SizeThatFits (a content measurement,
+			// not a real bound). If so, the cap at the bottom must be skipped — the base already
+			// returns the correct size. When the substitute is Bounds.Height (a real frame bound),
+			// the flag stays false and the cap applies to preserve scrollability.
+			bool heightSubstitutedFromSizeThatFits = false;
+
 			if (double.IsInfinity(widthConstraint) || double.IsInfinity(heightConstraint))
 			{
 				// If we drop an infinite value into base.GetDesiredSize for the Editor, we'll
@@ -72,31 +79,29 @@ namespace Microsoft.Maui.Handlers
 				{
 					var currentHeight = (double)PlatformView.Bounds.Height;
 
-					// NOTE: Bounds and ContentSize reflect the pre-rotation frame at this point.
-					// The check is intentionally based on the previous layout state to detect
-					// scrollable Editors that should not grow after cache invalidation (#35114).
-					// When content overflows the frame and auto-growth is off, cap the height
-					// to the current frame height to preserve scrollability after rotation (#35114).
-					// Skip when AllowAutoGrowth is set (AutoSize=TextChanges) — Editor should grow freely.
+					// When content overflows the current frame and auto-growth is disabled,
+					// use Bounds.Height as the constraint to preserve scrollability after rotation.
+					// Editors with AutoSize=TextChanges (AllowAutoGrowth=true) are exempt.
 					if (!PlatformView.AllowAutoGrowth
 						&& currentHeight > 0
 						&& PlatformView.ContentSize.Height > currentHeight)
 					{
-						heightConstraint = currentHeight;
+						heightConstraint = currentHeight; // real bound — cap will apply
 					}
 					else
 					{
 						heightConstraint = sizeThatFits.Height;
+						heightSubstitutedFromSizeThatFits = true; // not a real bound — cap will be skipped
 					}
 				}
 			}
 
 			var result = base.GetDesiredSize(widthConstraint, heightConstraint);
 
-			// Cap applies even for finite constraints: UITextView.SizeThatFits (UIScrollView subclass)
-			// ignores the height argument and always returns full content height.
-			// Capping here ensures GetDesiredSize honours the caller's constraint.
-			if (result.Height > heightConstraint)
+			// Clamp the result to the constraint only when it represents a real upper bound.
+			// UITextView (a UIScrollView subclass) ignores the height in SizeThatFits and always
+			// returns full content height, so clamping is needed for caller- or frame-derived bounds.
+			if (!heightSubstitutedFromSizeThatFits && result.Height > heightConstraint)
 			{
 				return new Size(result.Width, heightConstraint);
 			}


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue details

When an Editor with a HeightRequest is placed inside a VerticalStackLayout on iOS and macOS, setting VerticalTextAlignment to Center or End causes the Editor to render at the wrong height instead of the requested size. The Editor appears significantly shorter than expected, while VerticalTextAlignment.Start renders correctly. This inconsistency makes it impossible to rely on HeightRequest when using vertical text alignment on these platforms.

### Root Cause

The issue occurs because of the way UITextView (which is a UIScrollView subclass) interacts with the handler's height measurement logic. When VerticalTextAlignment is set to Center or End, the platform view sets a negative ContentOffset internally to position the text. This negative offset alters the internal scroll state of the UITextView, causing SizeThatFits to return a smaller value than expected.
 
The handler uses this value as a substitute for the infinite height constraint before calling the base size calculation. A cap in the handler then incorrectly clamps the correctly resolved HeightRequest value down to this smaller SizeThatFits-derived value, overriding the developer's intent.

### Description of Change

The fix involves introducing a boolean flag heightSubstitutedFromSizeThatFits that tracks whether the height constraint was substituted from a SizeThatFits measurement or from a real upper bound such as Bounds.Height. When the constraint is a real bound (used to preserve Editor scrollability after device rotation), the existing cap is applied as before.
 
When the constraint was derived from SizeThatFits (a content measurement, not a limit), the flag is set and the cap is skipped, allowing the base implementation to return the correct size that already honours HeightRequest via ResolveConstraints. This ensures HeightRequest is respected across all text alignment combinations without breaking the existing scrollability behaviour.

### Regression PR

PR https://github.com/dotnet/maui/pull/35309

Tested the behavior in the following platforms.
 
- [x] iOS
- [x] Mac
- [ ] Android
- [ ] Windows

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/35615

### Output

|Platform|Before|After|
|--|--|--|
|Mac|<video src="https://github.com/user-attachments/assets/5cf40c1c-429b-4374-82e4-ca815b364d21"> |<video src="https://github.com/user-attachments/assets/aa7885b5-e618-45a9-a5b0-599bcc4697bc">|
|iOS|<video src="https://github.com/user-attachments/assets/5e613e0c-eedd-405c-ae1e-dfa9e60e154b">|<video src="https://github.com/user-attachments/assets/74b5d0a6-ea11-46ca-a415-eca08b0212b0">|
