### PR TITLE
[net11.0] Workaround #35665: use DI handler registration for CheckBox

### DIFF
--- a/src/Controls/src/Core/CheckBox/CheckBox.cs
+++ b/src/Controls/src/Core/CheckBox/CheckBox.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Maui.Controls
 	/// Use the <see cref="IsChecked"/> property to determine or set the state.
 	/// </remarks>
 	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
-	[ElementHandler<CheckBoxHandler>]
 	public partial class CheckBox : View, IElementConfiguration<CheckBox>, IBorderElement, IColorElement, ICheckBox, ICommandElement
 	{
 		readonly Lazy<PlatformConfigurationRegistry<CheckBox>> _platformConfigurationRegistry;

--- a/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
@@ -121,6 +121,7 @@ public static partial class AppHostBuilderExtensions
 		handlersCollection.AddHandler<Application, ApplicationHandler>();
 		handlersCollection.AddHandler<BoxView, BoxViewHandler>();
 		handlersCollection.AddHandler<Button, ButtonHandler>();
+		handlersCollection.AddHandler<CheckBox, CheckBoxHandler>();
 		handlersCollection.AddHandler<GraphicsView, GraphicsViewHandler>();
 		handlersCollection.AddHandler<Layout, LayoutHandler>();
 		handlersCollection.AddHandler<ScrollView, ScrollViewHandler>();


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description

Workaround for #35665.

The `[ElementHandler<CheckBoxHandler>]` attribute on `CheckBox` causes handler resolution to fail on .NET 11 preview MAUI templates on Android **Release** builds across all runtime flavors:

- **CoreCLR Default** — `System.TypeLoadException` when the generic attribute is enumerated (`GenericArguments[0] ... violates the constraint of type parameter 'THandler'`).
- **Mono Default** / **NativeAOT** — `HandlerNotFoundException`, since the attribute isn't found and no DI registration exists.

`CheckBox` was the **only** type using `[ElementHandler<T>]`. This PR removes the attribute and restores the regular DI handler registration (`AddHandler<CheckBox, CheckBoxHandler>()`), which unblocks the failing template builds.

The `[ElementHandler<T>]` attribute mechanism itself will undergo a major refactoring in #29952, so this is intentionally a minimal, targeted workaround rather than a fix of the attribute path.

### Issues Fixed

Fixes #35665
