### PR TITLE
Make MSIX install in Windows test cake script resilient

### DIFF
--- a/eng/devices/windows.cake
+++ b/eng/devices/windows.cake
@@ -350,19 +350,33 @@ Task("testOnly")
 		var cerPath = cerPaths.First();
 		Information($"Found MSIX, installing: {msixPath}");
 
+		int InstallAppxPackage(FilePath path) {
+			var absPath = MakeAbsolute(path).FullPath;
+			Information("Installing MSIX: {0}", absPath);
+			// $ProgressPreference='SilentlyContinue' suppresses Add-AppxPackage's
+			// progress output which otherwise chokes cake's stdout pipe.
+			return StartProcess("powershell",
+				"-NoProfile -Command \"$ProgressPreference='SilentlyContinue'; Add-AppxPackage -Path '" + absPath + "'; if (-not $?) { exit 1 }\"");
+		}
+
 		// Install dependencies
 		var dependencies = GetFiles(projectDir.FullPath + "/**/AppPackages/**/Dependencies/x64/*.msix");
 		foreach (var dep in dependencies) {
-			Information("Installing Dependency MSIX: {0}", dep);
 			try {
-				StartProcess("powershell", "Add-AppxPackage -Path \"" + MakeAbsolute(dep).FullPath + "\"");
-			} catch { 
+				var depExit = InstallAppxPackage(dep);
+				if (depExit != 0) {
+					Warning($"Failed to install dependency (exit code {depExit}): {dep}");
+				}
+			} catch {
 				Warning($"Failed to install dependency: {dep}");
 			}
 		}
 
 		// Install the DeviceTests app
-		StartProcess("powershell", "Add-AppxPackage -Path \"" + MakeAbsolute(msixPath).FullPath + "\"");
+		var installExit = InstallAppxPackage(msixPath);
+		if (installExit != 0) {
+			throw new Exception($"Failed to install app MSIX (exit code {installExit}): {msixPath}");
+		}
 
 		if (isControlsProjectTestRun)
 		{


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

Make the MSIX install step in `eng/devices/windows.cake` more resilient:

- `Add-AppxPackage`'s progress output floods cake's stdout pipe and makes the captured log unreadable in agent harnesses that don't render a console. Suppress it via `$ProgressPreference='SilentlyContinue'`.
- Check the install exit code: dependency failures now warn (previously silently ignored, since `StartProcess` returns the exit code rather than throwing), and app install failures now throw with the actual exit code (previously discarded entirely).

I noticed this while working on https://github.com/dotnet/maui/pull/29905 when Copilot got confused by the text-mode progress characters that got rendered when the output was redirected when Copilot ran the cake script.