### PR TITLE
Update SDK pin to 10.0.108 and align global.json with dotnet repo patterns

### DIFF
--- a/.github/workflows/bump-global-json.yml
+++ b/.github/workflows/bump-global-json.yml
@@ -29,7 +29,7 @@ jobs:
         sudo apt-get install libxml2-utils
         DOTNET_VERSION=$(xmllint --xpath '/Project/PropertyGroup/MicrosoftNETSdkPackageVersion/text()' eng/Versions.props)
 
-        jq --arg v "$DOTNET_VERSION" '.tools.dotnet = $v | .sdk.version = $v' global.json > global.json.tmp
+        jq --arg v "$DOTNET_VERSION" '.tools.dotnet = $v' global.json > global.json.tmp
         mv global.json.tmp global.json
         if git diff --exit-code -- global.json; then
           echo "No global.json update necessary"

--- a/.github/workflows/bump-global-json.yml
+++ b/.github/workflows/bump-global-json.yml
@@ -29,7 +29,7 @@ jobs:
         sudo apt-get install libxml2-utils
         DOTNET_VERSION=$(xmllint --xpath '/Project/PropertyGroup/MicrosoftNETSdkPackageVersion/text()' eng/Versions.props)
 
-        jq '.tools.dotnet = "'$DOTNET_VERSION'"' global.json > global.json.tmp
+        jq --arg v "$DOTNET_VERSION" '.tools.dotnet = $v | .sdk.version = $v' global.json > global.json.tmp
         mv global.json.tmp global.json
         if git diff --exit-code -- global.json; then
           echo "No global.json update necessary"

--- a/global.json
+++ b/global.json
@@ -3,9 +3,6 @@
     "dotnet": "10.0.108"
   },
   "sdk": {
-    "version": "10.0.108",
-    "allowPrerelease": false,
-    "rollForward": "patch",
     "paths": [
       ".dotnet",
       "$host$"

--- a/global.json
+++ b/global.json
@@ -1,8 +1,11 @@
 {
   "tools": {
-    "dotnet": "10.0.100-rtm.25523.113"
+    "dotnet": "10.0.108"
   },
   "sdk": {
+    "version": "10.0.108",
+    "allowPrerelease": false,
+    "rollForward": "patch",
     "paths": [
       ".dotnet",
       "$host$"


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

The `main` branch SDK pin in `global.json` was stale (`10.0.100-rtm.25523.113`) and had no automation to keep it updated (no Maestro subscription from `dotnet/dotnet` targets `main`).

This PR bumps `tools.dotnet` to stable `10.0.108` and fixes the `bump-global-json.yml` workflow to use proper `--arg` quoting.

**Why not add `sdk.version`?** MAUI's CI uses custom `sdk.paths` (`.dotnet`, `$host$`) with `eng/common/tools.sh` provisioning. Adding `sdk.version` creates a hard CLI constraint that fails in post-build steps where the `.dotnet/` path isn't resolved. Other dotnet repos (runtime, roslyn) don't use custom paths, so their `sdk.version` works fine. MAUI should continue relying only on `tools.dotnet`.

**Changes:**
- Bump `tools.dotnet` from `10.0.100-rtm.25523.113` to `10.0.108` (stable)
- Fix `bump-global-json.yml` jq to use proper `--arg` quoting (was fragile string interpolation)

**Context:**
- Production artifacts are built from `net10.0`/release branches (which have active Maestro subscriptions)
- The merge flow from main to net10.0 resets version files, so this change does not affect production builds
- `main` will still need periodic manual SDK bumps unless a Maestro subscription is added

### Issues Fixed

N/A - Infrastructure/security hygiene improvement.