### PR TITLE
Fix Android ToolbarItem badge positioning

### DIFF
--- a/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
@@ -336,7 +336,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 				try
 				{
-					BadgeUtils.AttachBadgeDrawable(badge, anchorView, null);
+					BadgeUtils.AttachBadgeDrawable(badge, toolbar, menuItemId);
 				}
 				catch (Java.Lang.Exception)
 				{
@@ -359,7 +359,7 @@ namespace Microsoft.Maui.Controls.Platform
 				{
 					try
 					{
-						BadgeUtils.DetachBadgeDrawable(existingBadge, anchorView);
+						BadgeUtils.DetachBadgeDrawable(existingBadge, toolbar, menuItemId);
 					}
 					catch (Java.Lang.Exception)
 					{
@@ -533,7 +533,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 			SetSemanticProperties(item, toolbar.FindViewById(menuitem.ItemId));
 
-			if (item.Order != ToolbarItemOrder.Secondary && !string.IsNullOrEmpty(item.BadgeText))
+			if (item.Order != ToolbarItemOrder.Secondary && item.BadgeText is not null)
 				UpdateToolbarItemBadge(toolbar, menuitem, item);
 		}
 

--- a/src/Controls/src/Core/Toolbar/ToolbarItem.cs
+++ b/src/Controls/src/Core/Toolbar/ToolbarItem.cs
@@ -110,7 +110,7 @@ public class ToolbarItem : MenuItem
 	/// This is a bindable property.
 	/// </summary>
 	/// <remarks>
-	/// This property is only effective when <see cref="BadgeText"/> is set to a non-empty value.
+	/// This property is only effective when <see cref="BadgeText"/> is not <see langword="null"/>.
 	/// </remarks>
 	public Color BadgeColor
 	{


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Fixes Android `ToolbarItem` badge placement by using Material Components' toolbar-specific `BadgeUtils.AttachBadgeDrawable`/`DetachBadgeDrawable` overloads. Those overloads apply the standard toolbar action menu badge offsets (`12dp` horizontal and `12dp` vertical) so badges do not sit too far in the corner.

This does **not** require apps to opt into the optional Compatibility.Material package. MAUI Android already references `Xamarin.Google.Android.Material` through `Microsoft.Maui.Core`, and the existing ToolbarItem badge implementation was already using `BadgeDrawable`/`BadgeUtils`; this PR only switches to the toolbar-specific overloads.

Also fixes initial toolbar creation so `BadgeText=""` renders the supported dot badge instead of being skipped. This matches the documented model: `null` hides the badge, empty string shows a dot badge, and non-empty string shows text/count.

### Issues Fixed

- Fixes Android `ToolbarItem` badge positioning on toolbar action items.

| Before | After |
|--------|--------|
| <img width="1080" height="2340" alt="Android ToolbarItem badges before fix" src="https://github.com/user-attachments/assets/df767c3f-6573-46b7-a787-6dd0487e520e" /> | <img width="1080" height="2340" alt="Android ToolbarItem badges after fix" src="https://github.com/user-attachments/assets/c092263e-f9aa-42f7-9276-2e345c359145" /> |