### PR TITLE
ci: skip provision AVD creation in ci-copilot.yml (inline script owns it)

### DIFF
--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -122,7 +122,10 @@ stages:
               skipAndroidPlatformApis: true
               onlyAndroidPlatformDefaultApis: true
               skipAndroidEmulatorImages: ${{ ne(parameters.Platform, 'android') }}
-              skipAndroidCreateAvds: ${{ ne(parameters.Platform, 'android') }}
+              # AVD is created by the inline 'Create AVD and boot Android Emulator' script below
+              # with specific config (playstore image variant, partition shrink, ADB key pre-auth)
+              # that ProvisionAndroidSdkAvdCreateAvds doesn't replicate.
+              skipAndroidCreateAvds: true
               androidEmulatorApiLevel: '30'
               skipSimulatorSetup: ${{ or(eq(parameters.Platform, 'android'), eq(parameters.Platform, 'windows'), eq(parameters.Platform, 'catalyst')) }}
               skipCertificates: true
@@ -803,7 +806,10 @@ stages:
               skipAndroidPlatformApis: true
               onlyAndroidPlatformDefaultApis: true
               skipAndroidEmulatorImages: ${{ ne(parameters.Platform, 'android') }}
-              skipAndroidCreateAvds: ${{ ne(parameters.Platform, 'android') }}
+              # AVD is created by the inline 'Create AVD and boot Android Emulator' script below
+              # with specific config (playstore image variant, partition shrink, ADB key pre-auth)
+              # that ProvisionAndroidSdkAvdCreateAvds doesn't replicate.
+              skipAndroidCreateAvds: true
               androidEmulatorApiLevel: '30'
               skipSimulatorSetup: ${{ or(eq(parameters.Platform, 'android'), eq(parameters.Platform, 'windows'), eq(parameters.Platform, 'catalyst')) }}
               skipCertificates: true


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

Follow-up to @kubaflo's review on #35687.

## What

In `eng/pipelines/ci-copilot.yml`, when `parameters.Platform == 'android'`, the Android AVD was being created twice:

1. **First**, via `common/provision.yml` running the `ProvisionAndroidSdkAvdCreateAvds` MSBuild target — because `skipAndroidCreateAvds: ${{ ne(parameters.Platform, 'android') }}` evaluated to `false` for Android. That target invokes `dotnet android avd create --name "Emulator_30" … --force`.
2. **Then**, the inline `Create AVD and boot Android Emulator` script ran `avdmanager create avd -n Emulator_30 -k "system-images;android-30;google_apis_playstore;x86_64" --device "Nexus 5X" --force`.

Both create the same AVD name with `--force`, so the second silently overwrites the first — no error, just ~30–60s wasted on every Copilot review pipeline run for Android.

The inline script is the canonical source of truth: it pins the `google_apis_playstore` image variant, the `Nexus 5X` device profile, the `disk.dataPartition.size=2048m` shrink, and ADB key pre-auth. None of those are applied by `ProvisionAndroidSdkAvdCreateAvds`. So the right fix is to skip the provision step entirely and let the inline script own AVD creation.

## Change

Pinned `skipAndroidCreateAvds: true` (with an explanatory comment) at both call sites of `common/provision.yml` in `ci-copilot.yml` (the ReviewPR stage and the Deep stage). The inline `avdmanager` blocks are untouched.

This is the AVD-creation portion of #35376 being reverted — the inline script that same PR added already handles AVD creation, so the provision-step AVD creation was redundant.

## Scope

This change is scoped to **`ci-copilot.yml`** only — the Copilot review pipeline. It does **not** touch the required gating pipelines:
- `maui-pr`
- `maui-pr-devicetests`
- `maui-pr-uitests`

## Follow-up

Needs to be ported to `net11.0` afterward via the automated `merge/main-to-net11.0` flow.
