### PR TITLE
[HybridWebView] Filter Android `message` events by source

### DIFF
--- a/src/Core/src/Handlers/HybridWebView/HybridWebView.js
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebView.js
@@ -35,15 +35,15 @@
         }
         else {
             // Android WebView
-            // Native -> JS messages are delivered via WebView.postWebMessage targeting the app
-            // origin. The resulting MessageEvent has source === null (no sending window) and,
-            // on current Chromium-based WebView, origin === window.location.origin. The
-            // `source === null` check is the load-bearing one — it is invariant across WebView
-            // versions and rejects every `window.postMessage` sender, including same-origin
-            // ones. The origin equality is best-effort defense-in-depth.
-            const expectedOrigin = window.location.origin;
+            // Native -> JS messages are delivered via WebView.postWebMessage. The resulting
+            // MessageEvent has source === null (no sending window) -- that's the invariant we
+            // can rely on across WebView versions. Drop any 'message' event whose source is
+            // a Window (e.g. a nested iframe calling window.parent.postMessage), which would
+            // otherwise be mistaken for a native message. NOTE: we intentionally do not check
+            // arg.origin here because Android WebView delivers postWebMessage events with an
+            // empty-string origin, not window.location.origin.
             window.addEventListener('message', (arg) => {
-                if (arg.source !== null || arg.origin !== expectedOrigin) {
+                if (arg.source !== null) {
                     console.warn(`HybridWebView: ignored 'message' event from unexpected sender (origin: '${arg.origin}').`);
                     return;
                 }

--- a/src/Core/src/Handlers/HybridWebView/HybridWebView.js
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebView.js
@@ -35,7 +35,18 @@
         }
         else {
             // Android WebView
+            // Native -> JS messages are delivered via WebView.postWebMessage targeting the app
+            // origin. The resulting MessageEvent has source === null (no sending window) and,
+            // on current Chromium-based WebView, origin === window.location.origin. The
+            // `source === null` check is the load-bearing one — it is invariant across WebView
+            // versions and rejects every `window.postMessage` sender, including same-origin
+            // ones. The origin equality is best-effort defense-in-depth.
+            const expectedOrigin = window.location.origin;
             window.addEventListener('message', (arg) => {
+                if (arg.source !== null || arg.origin !== expectedOrigin) {
+                    console.warn(`HybridWebView: ignored 'message' event from unexpected sender (origin: '${arg.origin}').`);
+                    return;
+                }
                 dispatchHybridWebViewMessage(arg.data);
             });
         }

--- a/src/Core/src/Handlers/HybridWebView/HybridWebView.ts
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebView.ts
@@ -87,7 +87,18 @@ interface DotNetInvokeResult {
             };
         } else {
             // Android WebView
-            window.addEventListener('message', (arg: any) => {
+            // Native -> JS messages are delivered via WebView.postWebMessage targeting the app
+            // origin. The resulting MessageEvent has source === null (no sending window) and,
+            // on current Chromium-based WebView, origin === window.location.origin. The
+            // `source === null` check is the load-bearing one — it is invariant across WebView
+            // versions and rejects every `window.postMessage` sender, including same-origin
+            // ones. The origin equality is best-effort defense-in-depth.
+            const expectedOrigin = window.location.origin;
+            window.addEventListener('message', (arg: MessageEvent) => {
+                if (arg.source !== null || arg.origin !== expectedOrigin) {
+                    console.warn(`HybridWebView: ignored 'message' event from unexpected sender (origin: '${arg.origin}').`);
+                    return;
+                }
                 dispatchHybridWebViewMessage(arg.data);
             });
         }

--- a/src/Core/src/Handlers/HybridWebView/HybridWebView.ts
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebView.ts
@@ -87,15 +87,15 @@ interface DotNetInvokeResult {
             };
         } else {
             // Android WebView
-            // Native -> JS messages are delivered via WebView.postWebMessage targeting the app
-            // origin. The resulting MessageEvent has source === null (no sending window) and,
-            // on current Chromium-based WebView, origin === window.location.origin. The
-            // `source === null` check is the load-bearing one — it is invariant across WebView
-            // versions and rejects every `window.postMessage` sender, including same-origin
-            // ones. The origin equality is best-effort defense-in-depth.
-            const expectedOrigin = window.location.origin;
+            // Native -> JS messages are delivered via WebView.postWebMessage. The resulting
+            // MessageEvent has source === null (no sending window) -- that's the invariant we
+            // can rely on across WebView versions. Drop any 'message' event whose source is
+            // a Window (e.g. a nested iframe calling window.parent.postMessage), which would
+            // otherwise be mistaken for a native message. NOTE: we intentionally do not check
+            // arg.origin here because Android WebView delivers postWebMessage events with an
+            // empty-string origin, not window.location.origin.
             window.addEventListener('message', (arg: MessageEvent) => {
-                if (arg.source !== null || arg.origin !== expectedOrigin) {
+                if (arg.source !== null) {
                     console.warn(`HybridWebView: ignored 'message' event from unexpected sender (origin: '${arg.origin}').`);
                     return;
                 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

HybridWebView generally expects all hosted code to be local app content, so this is general hardening -- it's just for correctness, not security enforcement.

On Android, the JS side subscribes to `window`'s `message` event to receive messages from .NET, but did not check where each event came from. Anything else on the page that calls `window.postMessage` (for example, a nested iframe posting to its parent) would be dispatched through `HybridWebViewMessageReceived` the same as a real native message.

Native messages arrive via `WebView.postWebMessage` and produce a `MessageEvent` with `source === null` (no sending window). Only dispatch when that's true; otherwise drop the event and log a warning so unexpected senders are visible during development. This rejects every `window.postMessage` caller, including same-origin iframes, and is the one invariant we can rely on across Android WebView versions.

(An earlier revision of this PR also gated on `origin === window.location.origin`. The existing `HybridWebViewTests_SendRawMessage` device test caught that this is wrong on Android: `postWebMessage` events arrive with an empty-string `origin`, not the page origin, so the equality check dropped all real native messages. The origin comparison has been removed.)

Windows (WebView2) and iOS/MacCatalyst (WKWebView) use platform-specific channels and are unaffected.

### Issues Fixed

N/A
