### PR TITLE
Document Maestro subscription authoring & lifecycle in dependency-flow skill

### DIFF
--- a/.github/skills/dependency-flow/SKILL.md
+++ b/.github/skills/dependency-flow/SKILL.md
@@ -191,7 +191,8 @@ This section covers how MAUI's Maestro subscriptions are authored, modified, and
 | `net11.0` | android, macios, dotnet | `.NET 11.0.1xx SDK` | everyDay, batchable |
 | `net11.0` | dotnet-optimization | `.NET 11` | everyWeek |
 | `main` | xharness | `.NET Eng - Latest` | everyWeek |
-| `release/11.0.1xx-previewN` (when active) | android, macios, dotnet | `.NET 11.0.1xx SDK Preview N` | everyDay, batchable |
+| `release/11.0.1xx-previewN` (when active) | android, macios | `.NET 11.0.1xx SDK Preview N` | everyDay, batchable |
+| `release/11.0.1xx-previewN` (when active) | dotnet | `.NET 11.0.1xx SDK Preview N` | none, batchable |
 
 Always verify the current state with `darc get-subscriptions --target-repo https://github.com/dotnet/maui` before making changes — the baseline above ages out.
 

--- a/.github/skills/dependency-flow/SKILL.md
+++ b/.github/skills/dependency-flow/SKILL.md
@@ -200,13 +200,26 @@ Always verify the current state with `darc get-subscriptions --target-repo https
 `darc add-subscription` defaults to opening **one PR per call**. The cleaner pattern is to share a single topic branch across all three calls, **review the staged diff**, and open ONE PR at the end. Note the explicit review step — without it, an agent can silently create a PR with the wrong channel, target branch, or source repo (the exact failure class this section is trying to prevent).
 
 ```bash
-# Pick a topic branch name once
-BRANCH=users/<alias>/maui-preview5-subs
+# Pick a topic branch name once. Quote the assignment so the angle-bracket
+# placeholders aren't parsed as shell redirection if literally pasted.
+BRANCH="users/<alias>/maui-preview5-subs"
 
 # 1. Stage all 3 subs on the same branch with --no-pr (each call appends one entry).
 #    Do NOT pass -q here — leave the per-call confirmation prompts in so you eyeball
 #    each set of inputs (channel, source, target branch) before darc commits.
-for SRC in android macios dotnet; do
+#
+#    Frequency choice is NOT uniform across the 3 source repos. Always verify
+#    against the prior preview's production config (`darc get-subscriptions
+#    --target-repo https://github.com/dotnet/maui --target-branch release/<prev>`)
+#    before staging. The pattern actually shipped for Preview 5 (per merged
+#    maestro-configuration PR #61723) was:
+#      dotnet/android  → everyDay  (small daily deltas, batched)
+#      dotnet/macios   → everyDay  (small daily deltas, batched)
+#      dotnet/dotnet   → none      (VMR is large; manual trigger only via
+#                                   `darc trigger-subscriptions --id <guid>`)
+#    Copying this loop verbatim with `everyDay` for the VMR will produce noisy
+#    daily PRs against the preview branch.
+for SRC in android macios; do
   darc add-subscription \
     --no-pr \
     --configuration-branch "$BRANCH" \
@@ -217,6 +230,17 @@ for SRC in android macios dotnet; do
     --update-frequency everyDay \
     --batchable
 done
+
+# dotnet/dotnet (VMR) — manual frequency on preview branches.
+darc add-subscription \
+  --no-pr \
+  --configuration-branch "$BRANCH" \
+  --channel ".NET 11.0.1xx SDK Preview 5" \
+  --source-repo https://github.com/dotnet/dotnet \
+  --target-repo https://github.com/dotnet/maui \
+  --target-branch release/11.0.1xx-preview5 \
+  --update-frequency none \
+  --batchable
 ```
 
 ```bash
@@ -247,15 +271,29 @@ echo "Draft PR: https://dev.azure.com/dnceng/internal/_git/maestro-configuration
 #    in the diff:
 #   - Exactly 3 new subscription blocks were added to
 #     configuration/subscriptions/dotnet-maui.yml
-#   - Channel string contains the "Preview N" / "preview N" stage qualifier
-#     (case-insensitive — see "Channel-name casing gotcha" below — but the bare
-#     ".NET 11.0.1xx SDK" without a stage qualifier is WRONG)
+#   - Channel string matches the EXACT band+stage for this preview, modulo
+#     casing of the "Preview"/"preview" token only (see "Channel-name casing
+#     gotcha" below). For a release/11.0.1xx-preview5 target, the only
+#     acceptable channels are ".NET 11.0.1xx SDK Preview 5" or
+#     ".NET 11.0.1xx SDK preview 5". REJECT all of:
+#       - ".NET 11.0.1xx SDK"                  (bare — CI-main channel, the
+#                                               PR #35364 failure class)
+#       - ".NET 10.0.1xx SDK Preview 5"        (wrong band — would flow 10.x
+#                                               assets into an 11.x preview branch)
+#       - ".NET 11.0.1xx SDK Preview 4"        (wrong stage number)
+#     Pattern: ".NET <band> SDK <Preview|preview> <N>" where <band> matches
+#     the target branch's band (10.0.1xx, 11.0.1xx, ...) and <N> matches the
+#     preview number in the target branch name.
 #   - Source Repository URL is one of dotnet/android, dotnet/dotnet, dotnet/macios
 #   - Target Repository URL is https://github.com/dotnet/maui
 #   - Target Branch is release/11.0.1xx-preview5
-#   - Update Frequency: everyDay
+#   - Update Frequency: everyDay for android/macios; none for dotnet (VMR)
 #   - Batchable: true
-# If any of these are wrong, abandon the draft PR and re-stage from step 1.
+# If any of these are wrong, abandon the draft PR AND start over with a NEW
+# $BRANCH name (e.g., append "-v2") before restaging from step 1. Re-running
+# step 1 with the same --configuration-branch APPENDS to the existing branch
+# rather than replacing it, which produces duplicate or mixed entries that can
+# sneak past a casual re-review of the AzDO diff.
 # Do NOT mark the PR ready for review until this check passes.
 ```
 
@@ -314,7 +352,9 @@ maestro_channels(filter="preview 5")
 Verify ingestion before triggering:
 
 ```bash
-darc get-subscriptions --ids <new-guid>
+# Quote <new-guid> so the angle brackets aren't parsed as shell redirection
+# if literally pasted.
+darc get-subscriptions --ids "<new-guid>"
 # If this returns the subscription, BAR has ingested it and trigger-subscriptions will work.
 ```
 

--- a/.github/skills/dependency-flow/SKILL.md
+++ b/.github/skills/dependency-flow/SKILL.md
@@ -388,6 +388,6 @@ When standing up a new preview, **confirm the new preview's subs are in place be
 | Branch-for-preview (release branch just created) | Add default-channel mapping | `darc add-default-channel --channel ".NET 11.0.1xx SDK Preview N" --branch release/11.0.1xx-previewN --repo https://github.com/dotnet/maui` |
 | Same phase | Add 3 maui subs in one PR | Combined-PR pattern (see above) |
 | Same phase | Optional: enable standard automerge | **Hand off to release engineering** — do not run `set-repository-policies` from this skill. See "Optional merge policies for batchable subs" above. |
-| Mid-cycle | Verify a sub exists | `darc get-subscriptions --ids <guid>` or MCP `maestro_subscription(subscriptionId=...)` |
-| Mid-cycle | Trigger a single sub | `darc trigger-subscriptions --id <guid>` (config PR must be merged first) |
+| Mid-cycle | Verify a sub exists | `darc get-subscriptions --ids "<guid>"` or MCP `maestro_subscription(subscriptionId=...)` |
+| Mid-cycle | Trigger a single sub | `darc trigger-subscriptions --id "<guid>"` (config PR must be merged first) |
 | Preview-ship | Cleanup prior preview | One PR removing per-preview subscription file, per-preview default-channel file, and the 24 lines for that preview in `dotnet-maui.yml`. Reference [PR 61033](https://dev.azure.com/dnceng/internal/_git/maestro-configuration/pullrequest/61033). |

--- a/.github/skills/dependency-flow/SKILL.md
+++ b/.github/skills/dependency-flow/SKILL.md
@@ -197,13 +197,15 @@ Always verify the current state with `darc get-subscriptions --target-repo https
 
 ### The combined-PR pattern for start-of-preview (3 subs in 1 PR)
 
-`darc add-subscription` defaults to opening **one PR per call**. The cleaner pattern is to share a single topic branch across all three calls and open ONE PR at the end:
+`darc add-subscription` defaults to opening **one PR per call**. The cleaner pattern is to share a single topic branch across all three calls, **review the staged diff**, and open ONE PR at the end. Note the explicit review step — without it, an agent can silently create a PR with the wrong channel, target branch, or source repo (the exact failure class this section is trying to prevent).
 
 ```bash
 # Pick a topic branch name once
 BRANCH=users/<alias>/maui-preview5-subs
 
-# 1. Stage all 3 subs on the same branch with --no-pr (each call appends one entry)
+# 1. Stage all 3 subs on the same branch with --no-pr (each call appends one entry).
+#    Do NOT pass -q here — leave the per-call confirmation prompts in so you eyeball
+#    each set of inputs (channel, source, target branch) before darc commits.
 for SRC in android macios dotnet; do
   darc add-subscription \
     --no-pr \
@@ -213,11 +215,29 @@ for SRC in android macios dotnet; do
     --target-repo https://github.com/dotnet/maui \
     --target-branch release/11.0.1xx-preview5 \
     --update-frequency everyDay \
-    --batchable \
-    -q
+    --batchable
 done
+```
 
-# 2. Open ONE PR against production
+```bash
+# 2. REQUIRED: review the staged diff against production before opening the PR.
+#    This is the gate that prevents a wrong-channel/wrong-branch sub from going live.
+git fetch origin "$BRANCH":"$BRANCH"
+git diff origin/production..."$BRANCH" -- configuration/subscriptions/dotnet-maui.yml
+
+# Confirm in the diff output:
+#   - Exactly 3 new subscription blocks were added
+#   - Channel reads ".NET 11.0.1xx SDK Preview 5" (NOT ".NET 11.0.1xx SDK")
+#   - Source Repository URL is one of dotnet/android, dotnet/dotnet, dotnet/macios
+#   - Target Repository URL is https://github.com/dotnet/maui
+#   - Target Branch is release/11.0.1xx-preview5
+#   - Update Frequency: everyDay
+#   - Batchable: true
+# Stop and re-stage if any of these are wrong. Do NOT proceed to step 3 without this check.
+```
+
+```bash
+# 3. Open ONE PR against production (only after step 2 passes)
 az repos pr create \
   --organization https://dev.azure.com/dnceng \
   --project internal \
@@ -228,7 +248,7 @@ az repos pr create \
   --description "..."
 ```
 
-⚠️ `add-subscription` is in the explicit-confirmation list below — show the user the exact commands and wait for approval before running. `-q` skips the per-call confirmation prompt, so be especially deliberate about the inputs.
+⚠️ `add-subscription` is in the explicit-confirmation list below — show the user the exact commands and wait for approval before running each step. Never combine all three steps into one un-reviewed script.
 
 **Exemplars:**
 - [PR 60474](https://dev.azure.com/dnceng/internal/_git/maestro-configuration/pullrequest/60474) — Preview 4. Manual-combine of 3 separate PRs (older pattern).
@@ -285,16 +305,11 @@ darc get-subscriptions --ids <new-guid>
 
 Adding batchable subscriptions without merge policies on the target branch produces a `darc add-subscription` warning. The warning is harmless — Maestro PRs still open. If you skip the policy, each batched PR must be reviewed/merged manually.
 
-To enable standard automerge (so Maestro PRs auto-merge when CI passes):
+🚨 **Do NOT run `darc set-repository-policies` from this skill.** That command is in the **NEVER run** list above because merge-policy changes affect repo security, and an agent should not infer that "documenting it as a narrow exception" amounts to standing authorization. If standard-automerge on a new preview branch is genuinely desired:
 
-```bash
-darc set-repository-policies \
-  --repo https://github.com/dotnet/maui \
-  --branch release/11.0.1xx-preview5 \
-  --standard-automerge
-```
-
-⚠️ `set-repository-policies` is in the **NEVER run** list above as a general rule (because merge-policy changes affect repo security). Standing up a **brand-new preview branch's merge policy** is a documented narrow exception. Show the user the exact command and wait for explicit approval before running. Outside this exception, defer to release engineering.
+1. Tell the user the warning came from `darc add-subscription` and is non-blocking.
+2. Direct them to **file a request with release engineering** (the owners of `set-repository-policies` for `dotnet/maui`) to enable `--standard-automerge` on the new preview branch.
+3. Do not propose, draft, or run the `set-repository-policies` command yourself, even with confirmation prompts. Hand it off.
 
 ### Cleanup at preview-ship
 
@@ -314,7 +329,7 @@ When standing up a new preview, **confirm the new preview's subs are in place be
 |-------|--------|----------------|
 | Branch-for-preview (release branch just created) | Add default-channel mapping | `darc add-default-channel --channel ".NET 11.0.1xx SDK Preview N" --branch release/11.0.1xx-previewN --repo https://github.com/dotnet/maui` |
 | Same phase | Add 3 maui subs in one PR | Combined-PR pattern (see above) |
-| Same phase | Optional: enable standard automerge | `darc set-repository-policies ... --standard-automerge` (narrow exception, confirmation required) |
+| Same phase | Optional: enable standard automerge | **Hand off to release engineering** — do not run `set-repository-policies` from this skill. See "Optional merge policies for batchable subs" above. |
 | Mid-cycle | Verify a sub exists | `darc get-subscriptions --ids <guid>` or MCP `maestro_subscription(subscriptionId=...)` |
 | Mid-cycle | Trigger a single sub | `darc trigger-subscriptions --id <guid>` (config PR must be merged first) |
 | Preview-ship | Cleanup prior preview | One PR removing per-preview subscription file, per-preview default-channel file, and the 24 lines for that preview in `dotnet-maui.yml`. Reference [PR 61033](https://dev.azure.com/dnceng/internal/_git/maestro-configuration/pullrequest/61033). |

--- a/.github/skills/dependency-flow/SKILL.md
+++ b/.github/skills/dependency-flow/SKILL.md
@@ -38,7 +38,7 @@ These are configured via default channel mappings — builds are **automatically
 
 **Common branch → channel patterns (not exhaustive — always verify with the command below):**
 - **Servicing release branches** (`release/X.0.Yxx-srN`) all map to the **single** general SDK channel for that band (e.g., `release/10.0.1xx-sr6`, `release/10.0.1xx-sr7`, etc. all map to `.NET 10.0.1xx SDK`). There is **no** `.NET X.0.Yxx SDK SRn` channel — do not invent one.
-- **Preview release branches** (`release/X.0.Yxx-previewN`) map to dedicated per-preview channels (e.g., `release/11.0.1xx-preview3` → `.NET 11.0.1xx SDK Preview 3`).
+- **Preview release branches** (`release/X.0.Yxx-previewN`) map to dedicated per-preview channels (e.g., `release/11.0.1xx-preview3` → `.NET 11.0.1xx SDK Preview 3`). See **Subscription Authoring & Lifecycle** below for how to wire a new preview channel into the maui subscription set, including the [PR #35364](https://github.com/dotnet/maui/pull/35364) channel/branch mismatch trap.
 - **RC release branches** (`release/X.0.Yxx-rcN`) use dedicated per-RC channels (e.g., `.NET 10.0.1xx SDK RC 2`) **only while their cycle is active** — these default mappings are removed after the RC ships, so `get-default-channels` will show no RC sibling to copy from. If you can't find a sibling, stop and tell the user to escalate to release engineering — do not guess the channel name.
 - **Main/development branches** (`main`, `netN.0`, `release/X.0.Yxx`) map to the general SDK channel for that band.
 - **Other shapes** also exist in dotnet/maui from time to time — point-sub-release branches (`-rc2.1`, `-preview6.1`), `inflight/*` mirrors, and vendor-suffixed branches (e.g., `release/10.0.1xx-meaipreview1`). Do not assume the four bullets above are complete — always check.
@@ -167,3 +167,154 @@ This means adding the build to the **Workload Release** channel, which makes ass
 - The `add-build-to-channel` command triggers a promotion build that publishes assets
 - This promotion can take several minutes — poll with `get-asset` to check
 - If `get-asset` shows no feed/channel, the build hasn't been promoted yet
+
+## Subscription Authoring & Lifecycle (`maestro-configuration`)
+
+This section covers how MAUI's Maestro subscriptions are authored, modified, and retired. The skill above is about *querying* dependency flow; this section is about *changing* it.
+
+### Where subscriptions live
+
+| Item | Location |
+|------|----------|
+| Org / project / repo | `https://dev.azure.com/dnceng/internal/_git/maestro-configuration` |
+| MAUI-targeted subs | `configuration/subscriptions/dotnet-maui.yml` |
+| Cross-repo per-preview subs | `configuration/subscriptions/11.0.1xx-previewN.yml` (deleted at preview-ship) |
+| Default channel mappings | `configuration/default-channels/dotnet-maui.yml` and `configuration/default-channels/11.0.1xx-previewN.yml` |
+| Active config branch | `production` — Maestro/BAR only ingests config from `production`. Subscriptions are **inert** until the config PR merges. |
+
+### MAUI subscription baseline (as of 2026-06-02)
+
+| Target branch | Source repos | Channel | Frequency |
+|---------------|--------------|---------|-----------|
+| `net10.0` | android, macios | `.NET 10.0.1xx SDK` | everyBuild |
+| `net10.0` | dotnet | `.NET 10.0.1xx SDK` | everyDay |
+| `net11.0` | android, macios, dotnet | `.NET 11.0.1xx SDK` | everyDay, batchable |
+| `net11.0` | dotnet-optimization | `.NET 11` | everyWeek |
+| `main` | xharness | `.NET Eng - Latest` | everyWeek |
+| `release/11.0.1xx-previewN` (when active) | android, macios, dotnet | `.NET 11.0.1xx SDK Preview N` | everyDay, batchable |
+
+Always verify the current state with `darc get-subscriptions --target-repo https://github.com/dotnet/maui` before making changes — the baseline above ages out.
+
+### The combined-PR pattern for start-of-preview (3 subs in 1 PR)
+
+`darc add-subscription` defaults to opening **one PR per call**. The cleaner pattern is to share a single topic branch across all three calls and open ONE PR at the end:
+
+```bash
+# Pick a topic branch name once
+BRANCH=users/<alias>/maui-preview5-subs
+
+# 1. Stage all 3 subs on the same branch with --no-pr (each call appends one entry)
+for SRC in android macios dotnet; do
+  darc add-subscription \
+    --no-pr \
+    --configuration-branch "$BRANCH" \
+    --channel ".NET 11.0.1xx SDK Preview 5" \
+    --source-repo "https://github.com/dotnet/$SRC" \
+    --target-repo https://github.com/dotnet/maui \
+    --target-branch release/11.0.1xx-preview5 \
+    --update-frequency everyDay \
+    --batchable \
+    -q
+done
+
+# 2. Open ONE PR against production
+az repos pr create \
+  --organization https://dev.azure.com/dnceng \
+  --project internal \
+  --repository maestro-configuration \
+  --source-branch "$BRANCH" \
+  --target-branch production \
+  --title "Add subscriptions for .NET 11.0.1xx SDK Preview 5 => dotnet/maui (android, macios, dotnet)" \
+  --description "..."
+```
+
+⚠️ `add-subscription` is in the explicit-confirmation list below — show the user the exact commands and wait for approval before running. `-q` skips the per-call confirmation prompt, so be especially deliberate about the inputs.
+
+**Exemplars:**
+- [PR 60474](https://dev.azure.com/dnceng/internal/_git/maestro-configuration/pullrequest/60474) — Preview 4. Manual-combine of 3 separate PRs (older pattern).
+- [PR 61723](https://dev.azure.com/dnceng/internal/_git/maestro-configuration/pullrequest/61723) — Preview 5. Single shared `--configuration-branch` (cleaner pattern).
+
+Either pattern produces the same end state: 3 commits, each adding 8 lines to `dotnet-maui.yml`, totaling 24 lines.
+
+### Failure mode: channel ↔ branch mismatch ([PR #35364](https://github.com/dotnet/maui/pull/35364) trap)
+
+**Symptom:** a Maestro-generated dependency PR targeting `release/11.0.1xx-previewN` brings in CI-main package stamps instead of preview-stamped builds. Example from PR #35364:
+- Brought in `dotnet/android 36.99.0-ci.main.314` (CI-main) instead of a `-net11-p5`-stamped Preview 5 build.
+- Brought in `dotnet/macios 26.5.11527-net11-p5` because that's what was on the CI-main channel, not the Preview 5 channel.
+
+**Root cause:** the `release/11.0.1xx-previewN` branch was fed only by the general `.NET 11.0.1xx SDK` channel (which collects CI-main builds of the source repos), because no `.NET 11.0.1xx SDK Preview N` subscription existed yet for MAUI.
+
+**Detection during PR review:** when reviewing or creating any Maestro PR into a preview branch, confirm the *source build's channel* matches the *target branch's stage* in the release cycle. The MAUI repo's preview branches MUST be fed by preview channels, never the general `.NET 11.0.1xx SDK` channel.
+
+```bash
+# Quick sanity check
+darc get-subscriptions \
+  --target-repo https://github.com/dotnet/maui \
+  --target-branch release/11.0.1xx-previewN
+# Channel must read ".NET 11.0.1xx SDK Preview N", not ".NET 11.0.1xx SDK"
+```
+
+**Fix:** add Preview N subscriptions per the combined-PR pattern above.
+
+### Channel-name casing gotcha
+
+The same channel appears with two casings depending on tool/file:
+- `.NET 11.0.1xx SDK Preview 5` (capital P) — typical in `darc` output and most YAML
+- `.NET 11.0.1xx SDK preview 5` (lowercase p) — appears in some per-preview YAML files (e.g., `configuration/subscriptions/11.0.1xx-preview5.yml`)
+
+Always confirm exact casing before constructing a command:
+
+```bash
+darc get-channels | grep -i "preview 5"
+# or MCP:
+maestro_channels(filter="preview 5")
+```
+
+### The "subscription not active until the config PR merges" trap
+
+`darc trigger-subscriptions --id <new-guid>` will return `not found` until the config PR merges into `production` and BAR ingests it. This is by design — Maestro reads subscription config only from the `production` branch.
+
+Verify ingestion before triggering:
+
+```bash
+darc get-subscriptions --ids <new-guid>
+# If this returns the subscription, BAR has ingested it and trigger-subscriptions will work.
+```
+
+### Optional merge policies for batchable subs
+
+Adding batchable subscriptions without merge policies on the target branch produces a `darc add-subscription` warning. The warning is harmless — Maestro PRs still open. If you skip the policy, each batched PR must be reviewed/merged manually.
+
+To enable standard automerge (so Maestro PRs auto-merge when CI passes):
+
+```bash
+darc set-repository-policies \
+  --repo https://github.com/dotnet/maui \
+  --branch release/11.0.1xx-preview5 \
+  --standard-automerge
+```
+
+⚠️ `set-repository-policies` is in the **NEVER run** list above as a general rule (because merge-policy changes affect repo security). Standing up a **brand-new preview branch's merge policy** is a documented narrow exception. Show the user the exact command and wait for explicit approval before running. Outside this exception, defer to release engineering.
+
+### Cleanup at preview-ship
+
+At the end of a preview cycle, the prior preview's subs and default-channels are bulk-removed in **one cleanup PR**. This is normal and expected — it keeps the config tidy as previews ship.
+
+Exemplar: [PR 61033](https://dev.azure.com/dnceng/internal/_git/maestro-configuration/pullrequest/61033) (Matt Mitchell, 2026-05-13) removed:
+- `configuration/subscriptions/11.0.1xx-preview2.yml` (88 lines)
+- `configuration/subscriptions/11.0.1xx-preview4.yml` (401 lines)
+- The 24 preview-4 lines from `configuration/subscriptions/dotnet-maui.yml`
+- Matching files in `configuration/default-channels/`
+
+When standing up a new preview, **confirm the new preview's subs are in place before removing the old preview's** to avoid a flow gap.
+
+## Quick reference: lifecycle commands by phase
+
+| Phase | Action | Command sketch |
+|-------|--------|----------------|
+| Branch-for-preview (release branch just created) | Add default-channel mapping | `darc add-default-channel --channel ".NET 11.0.1xx SDK Preview N" --branch release/11.0.1xx-previewN --repo https://github.com/dotnet/maui` |
+| Same phase | Add 3 maui subs in one PR | Combined-PR pattern (see above) |
+| Same phase | Optional: enable standard automerge | `darc set-repository-policies ... --standard-automerge` (narrow exception, confirmation required) |
+| Mid-cycle | Verify a sub exists | `darc get-subscriptions --ids <guid>` or MCP `maestro_subscription(subscriptionId=...)` |
+| Mid-cycle | Trigger a single sub | `darc trigger-subscriptions --id <guid>` (config PR must be merged first) |
+| Preview-ship | Cleanup prior preview | One PR removing per-preview subscription file, per-preview default-channel file, and the 24 lines for that preview in `dotnet-maui.yml`. Reference [PR 61033](https://dev.azure.com/dnceng/internal/_git/maestro-configuration/pullrequest/61033). |

--- a/.github/skills/dependency-flow/SKILL.md
+++ b/.github/skills/dependency-flow/SKILL.md
@@ -220,35 +220,52 @@ done
 ```
 
 ```bash
-# 2. REQUIRED: review the staged diff against production before opening the PR.
-#    This is the gate that prevents a wrong-channel/wrong-branch sub from going live.
-git fetch origin "$BRANCH":"$BRANCH"
-git diff origin/production..."$BRANCH" -- configuration/subscriptions/dotnet-maui.yml
-
-# Confirm in the diff output:
-#   - Exactly 3 new subscription blocks were added
-#   - Channel reads ".NET 11.0.1xx SDK Preview 5" (NOT ".NET 11.0.1xx SDK")
-#   - Source Repository URL is one of dotnet/android, dotnet/dotnet, dotnet/macios
-#   - Target Repository URL is https://github.com/dotnet/maui
-#   - Target Branch is release/11.0.1xx-preview5
-#   - Update Frequency: everyDay
-#   - Batchable: true
-# Stop and re-stage if any of these are wrong. Do NOT proceed to step 3 without this check.
-```
-
-```bash
-# 3. Open ONE PR against production (only after step 2 passes)
-az repos pr create \
+# 2. Open ONE PR against production AS DRAFT.
+#    The draft state IS the review gate — the PR cannot be merged (and the YAML
+#    cannot be ingested by BAR) until you explicitly mark it ready for review.
+#    Reviewing in the AzDO "Files changed" UI is more reliable than a local-git
+#    diff, because `--no-pr --configuration-branch` pushes to
+#    dnceng/internal/maestro-configuration, not to the maui worktree's `origin`,
+#    so `git fetch origin "$BRANCH"` / `git diff origin/production...` would not
+#    work from a dotnet/maui clone (the only context where this skill loads).
+PR_ID=$(az repos pr create \
   --organization https://dev.azure.com/dnceng \
   --project internal \
   --repository maestro-configuration \
   --source-branch "$BRANCH" \
   --target-branch production \
+  --draft true \
   --title "Add subscriptions for .NET 11.0.1xx SDK Preview 5 => dotnet/maui (android, macios, dotnet)" \
-  --description "..."
+  --description "..." \
+  --query pullRequestId -o tsv)
+
+echo "Draft PR: https://dev.azure.com/dnceng/internal/_git/maestro-configuration/pullrequest/$PR_ID"
 ```
 
-⚠️ `add-subscription` is in the explicit-confirmation list below — show the user the exact commands and wait for approval before running each step. Never combine all three steps into one un-reviewed script.
+```bash
+# 3. REQUIRED gate: open the draft PR's "Files changed" view in AzDO and confirm
+#    in the diff:
+#   - Exactly 3 new subscription blocks were added to
+#     configuration/subscriptions/dotnet-maui.yml
+#   - Channel string contains the "Preview N" / "preview N" stage qualifier
+#     (case-insensitive — see "Channel-name casing gotcha" below — but the bare
+#     ".NET 11.0.1xx SDK" without a stage qualifier is WRONG)
+#   - Source Repository URL is one of dotnet/android, dotnet/dotnet, dotnet/macios
+#   - Target Repository URL is https://github.com/dotnet/maui
+#   - Target Branch is release/11.0.1xx-preview5
+#   - Update Frequency: everyDay
+#   - Batchable: true
+# If any of these are wrong, abandon the draft PR and re-stage from step 1.
+# Do NOT mark the PR ready for review until this check passes.
+```
+
+```bash
+# 4. After the human reviewer confirms the diff in the AzDO UI, mark the draft
+#    PR ready for review (either in the AzDO UI, or via the command below).
+az repos pr update --organization https://dev.azure.com/dnceng --id "$PR_ID" --draft false
+```
+
+⚠️ `add-subscription` is in the explicit-confirmation list above — show the user the exact commands and wait for approval before running each step. Never combine all four steps into one un-reviewed script.
 
 **Exemplars:**
 - [PR 60474](https://dev.azure.com/dnceng/internal/_git/maestro-configuration/pullrequest/60474) — Preview 4. Manual-combine of 3 separate PRs (older pattern).


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

Captures the Preview 5 dependency-update learnings (PR #35364 and the resulting [maestro-configuration PR 61723](https://dev.azure.com/dnceng/internal/_git/maestro-configuration/pullrequest/61723)) in the `dependency-flow` skill so the next preview cycle has a documented runbook to follow.

The skill previously covered *querying* dependency flow (feeds, channels, build promotion). It didn't cover *authoring or retiring* subscriptions, which left a gap: the team didn't know that targeting `release/11.0.1xx-preview5` with the `.NET 11.0.1xx SDK` channel was wrong, and the agentic workflow had no documented runbook for adding subscriptions at the start of a preview cycle.

## Changes

Appends two new sections to `.github/skills/dependency-flow/SKILL.md` (and adds one cross-reference from the existing "Preview release branches" bullet to the new lifecycle content). No existing prose was rewritten.

### New section: `Subscription Authoring & Lifecycle (maestro-configuration)`

Covers:

- **Where subscriptions live** — `dnceng/internal` → `maestro-configuration` → `configuration/subscriptions/dotnet-maui.yml` (and the per-preview cross-repo files). Notes that BAR only ingests config from the `production` branch, so subs are inert until merge.
- **MAUI subscription baseline** — current state table (`net10.0`, `net11.0`, `main`, active preview branches) with channels and frequencies.
- **The combined-PR pattern for start-of-preview** — full worked example using `darc add-subscription --no-pr --configuration-branch <shared>` for each of the 3 source repos, then ONE PR via `az repos pr create`. References [PR 60474](https://dev.azure.com/dnceng/internal/_git/maestro-configuration/pullrequest/60474) (Preview 4, older manual-combine pattern) and [PR 61723](https://dev.azure.com/dnceng/internal/_git/maestro-configuration/pullrequest/61723) (Preview 5, cleaner single-branch pattern).
- **The PR #35364 channel/branch mismatch trap** — symptom (CI-main package stamps flowing into a preview branch), root cause (missing preview channel sub), detection check, and fix.
- **Channel-name casing gotcha** — `.NET 11.0.1xx SDK Preview 5` vs `.NET 11.0.1xx SDK preview 5` (both appear in the wild).
- **"Subscription not active until the config PR merges" trap** — `darc trigger-subscriptions` returns `not found` until BAR ingests from `production`. Verify with `darc get-subscriptions --ids <guid>` first.
- **Optional `--standard-automerge` merge policy** — documented as a narrow exception to the existing `set-repository-policies` deny-list, specifically for standing up a new preview branch.
- **Bulk preview-ship cleanup pattern** — references [PR 61033](https://dev.azure.com/dnceng/internal/_git/maestro-configuration/pullrequest/61033) showing the typical end-of-preview cleanup (per-preview subscription file, per-preview default-channel file, and the 24 maui-specific lines in `dotnet-maui.yml`).

### New section: `Quick reference: lifecycle commands by phase`

Compact table mapping each lifecycle phase (branch-for-preview / mid-cycle / preview-ship) to the right command.

## Out of scope

- No changes to `maestro-configuration` itself (PR 61723 is already open there).
- No subscription triggers, no PR mutations, no pipeline changes.
- The companion update to issue #35711 (release-readiness TODOs) is being handled in a separate workstream.

## Test plan

Documentation-only change to a skill markdown file. Verified the file renders correctly and that the cross-reference from the existing "MAUI Channel Naming" section points at the new content.