### PR TITLE
[ci] Set __PWSH_LOGIN_CHECKED to avoid macOS pwsh 'procargs failed' startup crashes

### DIFF
--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -13,6 +13,15 @@ variables:
   value: 26.4
 - name: POWERSHELL_VERSION
   value: 7.4.0
+# Workaround for PowerShell/PowerShell#20802 (open since Nov 2023):
+# pwsh 7.4.x intermittently aborts at startup on macOS with
+#   'Call to procargs failed with errno 5'
+# because AttemptExecPwshLogin() races on sysctl(KERN_PROCARGS2).
+# Setting __PWSH_LOGIN_CHECKED makes pwsh short-circuit the login-shell
+# detection that triggers the racy syscall (see Program.cs in PowerShell repo).
+# Hit on internal dnceng dotnet-maui build 2990586 (release/11.0.1xx-preview5).
+- name: __PWSH_LOGIN_CHECKED
+  value: '1'
 # Localization variables
 - name: LocBranchPrefix
   value: 'loc-hb'


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

PowerShell 7.4.x intermittently crashes at startup on macOS with:

```
Call to 'procargs' failed with errno 5
Unhandled exception. Microsoft.PowerShell.ManagedPSEntry+StartupException
   at Microsoft.PowerShell.ManagedPSEntry.ThrowOnFailure(String call, Int32 code)
   at Microsoft.PowerShell.ManagedPSEntry.AttemptExecPwshLogin(String[] args)
   at Microsoft.PowerShell.ManagedPSEntry.Main(String[] args)
```

This is [PowerShell/PowerShell#20802](https://github.com/PowerShell/PowerShell/issues/20802),
open and untriaged since November 2023. The crash happens in `AttemptExecPwshLogin`,
which on macOS calls `sysctl(KERN_PROCARGS2)` to inspect its own `argv[0]` and
decide whether pwsh was launched as a login shell. That `sysctl` call races
intermittently and returns errno 5, aborting startup before pwsh reads any user
script.

## Repro / impact

Hit on the internal `dotnet-maui` pipeline (definition 1095), build **2990586**,
during release-prep for `release/11.0.1xx-preview5`:

> `##[section]Starting: Provision Android SDK - Common Packages` →
> `Call to 'procargs' failed with errno 5` → task fails.

A rerun on a different agent passed, but every macOS `pwsh:` step in the
pipeline (~45 sites across the macOS-touching pipelines) is now a known flake
risk for `preview6` and `.NET 12` builds.

## Fix

PowerShell itself ships a short-circuit for this code path:

```csharp
// src/powershell/Program.cs in PowerShell/PowerShell
private const string LOGIN_ENV_VAR_NAME = "__PWSH_LOGIN_CHECKED";

if (Environment.GetEnvironmentVariable(LOGIN_ENV_VAR_NAME) != null)
{
    Environment.SetEnvironmentVariable(LOGIN_ENV_VAR_NAME, null);
    return;  // skips the racy sysctl(KERN_PROCARGS2) entirely
}
```

Setting `__PWSH_LOGIN_CHECKED=1` makes pwsh skip the racy syscall. This PR
declares it as a pipeline-level variable in `eng/pipelines/common/variables.yml`
(included by every macOS-touching pipeline — `ci.yml`, `ci-official.yml`,
`ci-uitests.yml`, `ci-device-tests.yml`, `ci-copilot.yml`, `device-tests.yml`,
`ui-tests.yml`, `handlers.yml`), so every `pwsh:` / `PowerShell@2` step in
every job inherits it.

This is safe because:

* CI never launches pwsh as a login shell (no `-Login` flag, no leading `-` in
  argv[0]), so the skipped code would have returned `false` from `IsLogin()`
  and done nothing visible anyway — we just avoid the broken syscall.
* The env var is consumed inside `AttemptExecPwshLogin` itself
  (`SetEnvironmentVariable(..., null)`), so nested pwsh-launches-pwsh
  scenarios still get the protection from a fresh AzDO-set value on each task.
* The read is inside a `#if UNIX` block; Windows pwsh ignores it entirely.

## Related macOS-agent flakes (out of scope for this PR)

The same agent pool has produced other, *unrelated* macOS-side flakes during
this release-prep window (e.g. `IDEDownloadableMetalToolchainCoordinator: Failed
to remount` and `iOS 26.2 platform not installed` on builds 2990581 and
2990384). Those are dnceng agent-image issues and are not addressed here —
this PR fixes one specific class of macOS flake (pwsh startup race), not
all of them.

## Backport plan

* This PR: `net11.0` (primary — release-prep branch).
* Cherry-pick to `main` once merged (clean apply verified locally).
