### PR TITLE
[ci] Use macOS 26 hosted image for preview5

### DIFF
--- a/eng/pipelines/ci-official.yml
+++ b/eng/pipelines/ci-official.yml
@@ -49,7 +49,7 @@ parameters:
   type: object
   default:
     name: Azure Pipelines
-    vmImage: macOS-15
+    vmImage: macOS-26
     os: macOS
 
 resources:

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -22,7 +22,7 @@ variables:
   value: $[or( eq(variables['Sign'], 'true'), in(variables['Build.SourceBranch'], 'refs/heads/net9.0', 'refs/heads/net10.0', 'refs/heads/main', 'refs/heads/inflight/current' ), startsWith(variables['Build.SourceBranch'], 'refs/tags/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/') )]
 # Common Agent Pools in use
 - name: HostedMacImage
-  value: macOS-15
+  value: macOS-26
 - name: HostedWindowsImage
   value: windows-2022
 - name: LogDirectory

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -22,7 +22,7 @@ variables:
   value: $[or( eq(variables['Sign'], 'true'), in(variables['Build.SourceBranch'], 'refs/heads/net9.0', 'refs/heads/net10.0', 'refs/heads/main', 'refs/heads/inflight/current' ), startsWith(variables['Build.SourceBranch'], 'refs/tags/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/') )]
 # Common Agent Pools in use
 - name: HostedMacImage
-  value: macOS-26
+  value: macOS-15
 - name: HostedWindowsImage
   value: windows-2022
 - name: LogDirectory


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary
- Use the macOS 26 hosted image for the MAUI pipeline mac agent image on preview5.

## Context
Pipeline 1095 Pack macOS is running on macOS 15.7.7 and failing native iOS archive/Xcode tooling. Azure Pipelines now has macOS-26/Tahoe public preview available.

## Testing
- Not run (pipeline variable-only change).
