### PR TITLE
[ci] Use common macOS 26 hosted image

### DIFF
--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -36,7 +36,7 @@ parameters:
     default:
       name: AcesShared
       demands:
-        - ImageOverride -equals ACES_VM_SharedPool_Tahoe
+        - ImageOverride -equals $(AcesMacImageOverride)
 
   - name: macPool
     type: object

--- a/eng/pipelines/ci-device-tests.yml
+++ b/eng/pipelines/ci-device-tests.yml
@@ -92,14 +92,14 @@ parameters:
   default:
     name: AcesShared
     demands:
-      - ImageOverride -equals ACES_VM_SharedPool_Tahoe
+      - ImageOverride -equals $(AcesMacImageOverride)
 
 - name: macOSPoolPublic
   type: object
   default:
     name: AcesShared
     demands:
-      - ImageOverride -equals ACES_VM_SharedPool_Tahoe
+      - ImageOverride -equals $(AcesMacImageOverride)
 
 - name: targetFrameworkVersions
   type: object
@@ -142,4 +142,3 @@ stages:
           skipProvisioning: true
           skipXcode: false
           skipSimulatorSetup: false
-

--- a/eng/pipelines/ci-official.yml
+++ b/eng/pipelines/ci-official.yml
@@ -49,7 +49,7 @@ parameters:
   type: object
   default:
     name: Azure Pipelines
-    vmImage: macOS-15
+    vmImage: $(HostedMacImage)
     os: macOS
 
 resources:

--- a/eng/pipelines/ci-uitests.yml
+++ b/eng/pipelines/ci-uitests.yml
@@ -110,7 +110,7 @@ parameters:
     default:
       name: AcesShared
       demands:
-        - ImageOverride -equals ACES_VM_SharedPool_Tahoe
+        - ImageOverride -equals $(AcesMacImageOverride)
   
   - name: androidPoolLinuxPublic
     type: object
@@ -124,7 +124,7 @@ parameters:
     default:
       name: AcesShared
       demands:
-        - ImageOverride -equals ACES_VM_SharedPool_Tahoe
+        - ImageOverride -equals $(AcesMacImageOverride)
   
   - name: windowsBuildPoolPublic
     type: object
@@ -184,5 +184,3 @@ stages:
           ios: $(System.DefaultWorkingDirectory)/src/Controls/tests/TestCases.iOS.Tests/Controls.TestCases.iOS.Tests.csproj
           winui: $(System.DefaultWorkingDirectory)/src/Controls/tests/TestCases.WinUI.Tests/Controls.TestCases.WinUI.Tests.csproj
           mac: $(System.DefaultWorkingDirectory)/src/Controls/tests/TestCases.Mac.Tests/Controls.TestCases.Mac.Tests.csproj
-
-

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -76,7 +76,7 @@ parameters:
     sln: '$(Build.SourcesDirectory)/Microsoft.Maui.sln'
   - name: AcesShared
     demands:
-        - ImageOverride -equals ACES_VM_SharedPool_Tahoe
+        - ImageOverride -equals $(AcesMacImageOverride)
     os: macOS
     buildScript: $(_buildScriptMacOS)
     sln: '$(Build.SourcesDirectory)/Microsoft.Maui-mac.slnf'
@@ -106,7 +106,7 @@ parameters:
     public:
       name: AcesShared
       demands:
-        - ImageOverride -equals ACES_VM_SharedPool_Tahoe
+        - ImageOverride -equals $(AcesMacImageOverride)
       label: macOS
 # Switch back to this once XCode 26.2 is available on Azure Pipelines
 #     name: Azure Pipelines

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -22,7 +22,7 @@ variables:
   value: $[or( eq(variables['Sign'], 'true'), in(variables['Build.SourceBranch'], 'refs/heads/net9.0', 'refs/heads/net10.0', 'refs/heads/main', 'refs/heads/inflight/current' ), startsWith(variables['Build.SourceBranch'], 'refs/tags/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/') )]
 # Common Agent Pools in use
 - name: HostedMacImage
-  value: macOS-15
+  value: macOS-26
 - name: HostedWindowsImage
   value: windows-2022
 - name: LogDirectory

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -1,3 +1,8 @@
+parameters:
+- name: hostedMacImage
+  type: string
+  default: macOS-26
+
 variables:
 - name: BuildVersion
   value: $[counter('buildversion-counter', 5000)]
@@ -21,18 +26,17 @@ variables:
 - name: signingCondition
   value: $[or( eq(variables['Sign'], 'true'), in(variables['Build.SourceBranch'], 'refs/heads/net9.0', 'refs/heads/net10.0', 'refs/heads/main', 'refs/heads/inflight/current' ), startsWith(variables['Build.SourceBranch'], 'refs/tags/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/') )]
 # Common Agent Pools in use
-# HostedMacImage is the source of truth for the current macOS generation.
-# Azure Pipelines uses vmImage labels while AcesShared uses ImageOverride names.
-# Add/update the AcesMacImageOverride mapping below whenever HostedMacImage changes
-# so both pool providers move to the same macOS/Xcode generation together.
+# hostedMacImage is the source of truth for Azure Pipelines hosted macOS image lanes.
+# Keep the AcesMacImageOverride mapping below aligned so AcesShared lanes target
+# the corresponding macOS/Xcode generation.
 - name: HostedMacImage
-  value: macOS-26
-- ${{ if eq(variables['HostedMacImage'], 'macOS-26') }}:
+  value: ${{ parameters.hostedMacImage }}
+- ${{ if eq(parameters.hostedMacImage, 'macOS-26') }}:
   - name: AcesMacImageOverride
     value: ACES_VM_SharedPool_Tahoe
-- ${{ if ne(variables['HostedMacImage'], 'macOS-26') }}:
+- ${{ if ne(parameters.hostedMacImage, 'macOS-26') }}:
   - name: AcesMacImageOverride
-    value: Unsupported_HostedMacImage_$(HostedMacImage)_Update_AcesMacImageOverride
+    value: Unsupported_HostedMacImage_${{ parameters.hostedMacImage }}_Update_AcesMacImageOverride
 - name: HostedWindowsImage
   value: windows-2022
 - name: LogDirectory

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -21,8 +21,18 @@ variables:
 - name: signingCondition
   value: $[or( eq(variables['Sign'], 'true'), in(variables['Build.SourceBranch'], 'refs/heads/net9.0', 'refs/heads/net10.0', 'refs/heads/main', 'refs/heads/inflight/current' ), startsWith(variables['Build.SourceBranch'], 'refs/tags/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/') )]
 # Common Agent Pools in use
+# HostedMacImage is the source of truth for the current macOS generation.
+# Azure Pipelines uses vmImage labels while AcesShared uses ImageOverride names.
+# Add/update the AcesMacImageOverride mapping below whenever HostedMacImage changes
+# so both pool providers move to the same macOS/Xcode generation together.
 - name: HostedMacImage
   value: macOS-26
+- ${{ if eq(variables['HostedMacImage'], 'macOS-26') }}:
+  - name: AcesMacImageOverride
+    value: ACES_VM_SharedPool_Tahoe
+- ${{ if ne(variables['HostedMacImage'], 'macOS-26') }}:
+  - name: AcesMacImageOverride
+    value: Unsupported_HostedMacImage_$(HostedMacImage)_Update_AcesMacImageOverride
 - name: HostedWindowsImage
   value: windows-2022
 - name: LogDirectory
@@ -69,6 +79,4 @@ variables:
     - group: AzureDevOps-Artifact-Feeds-Pats
     - ${{ if eq(variables['Build.DefinitionName'], 'dotnet-maui') }}:
       - group: Publish-Build-Assets # This variable group contains secrets to publis to BAR
-
-
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description
Updates the shared `HostedMacImage` pipeline variable to `macOS-26` and makes the official internal macOS pack lane consume that variable. The internal build pipeline already consumed `$(HostedMacImage)`, so both internal MAUI pack lanes now share one hosted macOS image setting.

This also makes `HostedMacImage` the source of truth for the AcesShared macOS image mapping. `AcesMacImageOverride` is derived from `HostedMacImage`, and the public AcesShared Tahoe demands now use `$(AcesMacImageOverride)` instead of hard-coding `ACES_VM_SharedPool_Tahoe`. If `HostedMacImage` is bumped without adding the matching Aces mapping, the Aces demand resolves to an unsupported image name so the pipeline fails instead of silently using a stale macOS generation.

## Validation
- Local diff/grep only for YAML changes
- `git diff --check`
