### PR TITLE
[Testing] Fixed Build error on inflight/ candidate PR 35716

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue7814.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue7814.cs
@@ -14,6 +14,8 @@ public class Issue7814 : TestContentPage
 		_verticalOffsetLabel = CreateOffsetLabel("Issue7814VerticalScrollYLabel", VerticalOffsetPrefix);
 		_horizontalOffsetLabel = CreateOffsetLabel("Issue7814HorizontalScrollXLabel", HorizontalOffsetPrefix);
 
+		Grid.SetColumn(_horizontalOffsetLabel, 1);
+
 		var outerScrollView = new ScrollView
 		{
 			AutomationId = "Issue7814OuterScrollView",
@@ -21,6 +23,7 @@ public class Issue7814 : TestContentPage
 			Content = CreateScrollableContent()
 		};
 		outerScrollView.Scrolled += (_, e) => UpdateOffset(_verticalOffsetLabel, VerticalOffsetPrefix, e.ScrollY);
+		Grid.SetRow(outerScrollView, 1);
 
 		Content = new Grid
 		{
@@ -42,10 +45,10 @@ public class Issue7814 : TestContentPage
 					Children =
 					{
 						_verticalOffsetLabel,
-						_horizontalOffsetLabel.Column(1)
+						_horizontalOffsetLabel
 					}
 				},
-				outerScrollView.Row(1)
+				outerScrollView
 			}
 		};
 	}


### PR DESCRIPTION
This pull request makes layout adjustments to the `Issue7814` test case to improve clarity and maintainability. The main changes involve explicitly setting the grid positions of UI elements instead of using extension methods, which helps make the layout logic more transparent.

**Layout adjustments:**

* Explicitly set the column for `_horizontalOffsetLabel` using `Grid.SetColumn` instead of the `.Column(1)` extension method. [[1]](diffhunk://#diff-a564b2a91bf588cf9e13398f6e1dcfac2f9345c027b39d5accbc02f9792360daR17-R26) [[2]](diffhunk://#diff-a564b2a91bf588cf9e13398f6e1dcfac2f9345c027b39d5accbc02f9792360daL45-R51)
* Explicitly set the row for `outerScrollView` using `Grid.SetRow` instead of the `.Row(1)` extension method. [[1]](diffhunk://#diff-a564b2a91bf588cf9e13398f6e1dcfac2f9345c027b39d5accbc02f9792360daR17-R26) [[2]](diffhunk://#diff-a564b2a91bf588cf9e13398f6e1dcfac2f9345c027b39d5accbc02f9792360daL45-R51)