### PR TITLE
Fix incorrect DestinationPage in NavigationPage OnNavigatingFrom events

### DIFF
--- a/src/Controls/src/Core/NavigationPage/NavigationPage.Legacy.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPage.Legacy.cs
@@ -25,7 +25,8 @@ namespace Microsoft.Maui.Controls
 
 			var page = (Page)InternalChildren.Last();
 			var previousPage = CurrentPage;
-			SendNavigating(NavigationType.Pop, previousPage);
+			var destinationPage = (Page)InternalChildren[InternalChildren.Count - 2];
+			SendNavigating(NavigationType.Pop, previousPage, destinationPage);
 			var removedPage = await RemoveAsyncInner(page, animated, fast);
 			SendNavigated(previousPage, NavigationType.Pop);
 			return removedPage;
@@ -153,7 +154,7 @@ namespace Microsoft.Maui.Controls
 				return;
 
 			var previousPage = CurrentPage;
-			SendNavigating(NavigationType.PopToRoot, previousPage);
+			SendNavigating(NavigationType.PopToRoot, previousPage, RootPage);
 			FireDisappearing(CurrentPage);
 			FireAppearing((Page)InternalChildren[0]);
 
@@ -187,8 +188,8 @@ namespace Microsoft.Maui.Controls
 
 			var previousPage = CurrentPage;
 			var navigationType = DetermineNavigationType();
-			
-			SendNavigating(navigationType, previousPage);
+
+			SendNavigating(navigationType, previousPage, page);
 			FireDisappearing(CurrentPage);
 			FireAppearing(page);
 
@@ -203,8 +204,8 @@ namespace Microsoft.Maui.Controls
 
 				if (args.Task != null)
 					await args.Task;
-			} 
-			
+			}
+
 			SendNavigated(previousPage, navigationType);
 			Pushed?.Invoke(this, args);
 		}

--- a/src/Controls/src/Core/NavigationPage/NavigationPage.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPage.cs
@@ -415,9 +415,12 @@ namespace Microsoft.Maui.Controls
 			CurrentPage.SendNavigatedTo(new NavigatedToEventArgs(previousPage, navigationType));
 		}
 
-		void SendNavigating(NavigationType navigationType, Page navigatingFrom = null)
+		void SendNavigating(NavigationType navigationType, Page navigatingFrom = null, Page destinationPage = null)
 		{
-			(navigatingFrom ?? CurrentPage)?.SendNavigatingFrom(new NavigatingFromEventArgs(CurrentPage, navigationType));
+			var fromPage = navigatingFrom ?? CurrentPage;
+			var toPage = destinationPage ?? CurrentPage;
+
+			fromPage?.SendNavigatingFrom(new NavigatingFromEventArgs(toPage, navigationType));
 		}
 
 
@@ -834,7 +837,7 @@ namespace Microsoft.Maui.Controls
 				await Owner.SendHandlerUpdateAsync(animated,
 					() =>
 					{
-						Owner.SendNavigating(NavigationType.Pop, currentPage);
+						Owner.SendNavigating(NavigationType.Pop, currentPage, newCurrentPage);
 						Owner.FireDisappearing(currentPage);
 						Owner.RemoveFromInnerChildren(currentPage);
 						Owner.CurrentPage = newCurrentPage;
@@ -868,7 +871,7 @@ namespace Microsoft.Maui.Controls
 				return Owner.SendHandlerUpdateAsync(animated,
 					() =>
 					{
-						Owner.SendNavigating(NavigationType.PopToRoot, previousPage);
+						Owner.SendNavigating(NavigationType.PopToRoot, previousPage, newPage);
 						Owner.FireDisappearing(previousPage);
 						var lastIndex = NavigationStack.Count - 1;
 						while (lastIndex > 0)
@@ -905,7 +908,7 @@ namespace Microsoft.Maui.Controls
 						Owner.NavigationType = navigationType;
 						// Move the SendNavigating here so that it's fired prior to the stack being modified
 						// This ensures consistent event ordering across all platforms (iOS, Catalyst, Android, Windows)
-						Owner.SendNavigating(navigationType, previousPage);
+						Owner.SendNavigating(navigationType, previousPage, root);
 						Owner.PushPage(root);
 					},
 					() =>

--- a/src/Controls/src/Core/NavigationPage/NavigationPage.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPage.cs
@@ -415,10 +415,10 @@ namespace Microsoft.Maui.Controls
 			CurrentPage.SendNavigatedTo(new NavigatedToEventArgs(previousPage, navigationType));
 		}
 
-		void SendNavigating(NavigationType navigationType, Page navigatingFrom = null, Page destinationPage = null)
+		void SendNavigating(NavigationType navigationType, Page navigatingFrom, Page destinationPage)
 		{
 			var fromPage = navigatingFrom ?? CurrentPage;
-			var toPage = destinationPage ?? CurrentPage;
+			var toPage = destinationPage;
 
 			fromPage?.SendNavigatingFrom(new NavigatingFromEventArgs(toPage, navigationType));
 		}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue35613.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue35613.cs
@@ -1,19 +1,62 @@
+using System.Diagnostics;
+using System.Text;
+
 namespace Maui.Controls.Sample.Issues;
 
 [Issue(IssueTracker.Github, 35613, "OnNavigatingFrom with a NavigationPage always has an incorrect DestinationPage parameter", PlatformAffected.All)]
 public class Issue35613 : NavigationPage
 {
+    static readonly List<string> s_logEntries = new();
+    static event Action LogChanged;
+
     public Issue35613()
     {
         Navigation.PushAsync(new Issue35613FirstPage());
+    }
+
+    public static void AppendLog(string message)
+    {
+        s_logEntries.Add(message);
+        Debug.WriteLine($"ISSUE35613: {message}");
+        Console.WriteLine($"ISSUE35613: {message}");
+        RaiseLogChanged();
+    }
+
+    public static void ClearLog()
+    {
+        s_logEntries.Clear();
+        RaiseLogChanged();
+    }
+
+    public static void SubscribeToLogChanged(Action callback)
+    {
+        LogChanged += callback;
+    }
+
+    public static void UnsubscribeFromLogChanged(Action callback)
+    {
+        LogChanged -= callback;
+    }
+
+    public static string GetLogText()
+    {
+        var builder = new StringBuilder();
+        foreach (var entry in s_logEntries)
+        {
+            builder.AppendLine(entry);
+        }
+        return builder.ToString();
+    }
+
+    static void RaiseLogChanged()
+    {
+        LogChanged?.Invoke();
     }
 }
 
 public class Issue35613FirstPage : TestContentPage
 {
-    Label _onNavigatingToLabel;
-    Label _onNavigatingFromLabel;
-    Label _onNavigatedFromLabel;
+    Editor _logEditor;
 
     public Issue35613FirstPage()
     {
@@ -29,22 +72,16 @@ public class Issue35613FirstPage : TestContentPage
         };
         navigateButton.Clicked += OnNavigateButtonClicked;
 
-        _onNavigatingToLabel = new Label
+        _logEditor = new Editor
         {
-            Text = "-",
-            AutomationId = "Issue35613_First_OnNavigatingToLabel"
-        };
-
-        _onNavigatingFromLabel = new Label
-        {
-            Text = "-",
-            AutomationId = "Issue35613_First_OnNavigatingFromLabel"
-        };
-
-        _onNavigatedFromLabel = new Label
-        {
-            Text = "-",
-            AutomationId = "Issue35613_First_OnNavigatedFromLabel"
+            AutomationId = "Issue35613_LogEditor",
+            IsReadOnly = true,
+            IsSpellCheckEnabled = false,
+            IsTextPredictionEnabled = false,
+            AutoSize = EditorAutoSizeOption.TextChanges,
+            MinimumHeightRequest = 220,
+            FontFamily = "Courier New",
+            FontSize = 12
         };
 
         Content = new VerticalStackLayout
@@ -53,14 +90,23 @@ public class Issue35613FirstPage : TestContentPage
             Children =
             {
                 navigateButton,
-                new Label { Text = "NavigatingToEventArgs", FontAttributes = FontAttributes.Bold },
-                _onNavigatingToLabel,
-                new Label { Text = "NavigatingFromEventArgs", FontAttributes = FontAttributes.Bold },
-                _onNavigatingFromLabel,
-                new Label { Text = "NavigatedFromEventArgs", FontAttributes = FontAttributes.Bold },
-                _onNavigatedFromLabel,
+                new Label { Text = "Event Log:", FontAttributes = FontAttributes.Bold },
+                _logEditor,
             }
         };
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        Issue35613.SubscribeToLogChanged(RefreshLogEditor);
+        RefreshLogEditor();
+    }
+
+    protected override void OnDisappearing()
+    {
+        Issue35613.UnsubscribeFromLogChanged(RefreshLogEditor);
+        base.OnDisappearing();
     }
 
     protected override void OnNavigatedTo(NavigatedToEventArgs args)
@@ -68,7 +114,7 @@ public class Issue35613FirstPage : TestContentPage
         base.OnNavigatedTo(args);
 
         var previousPage = args.PreviousPage?.GetType().Name ?? "Null";
-        _onNavigatingToLabel.Text = $"PreviousPage: {previousPage}, NavigationType: {args.NavigationType}";
+        Issue35613.AppendLog($"OnNavigatedTo FirstPage [{args.NavigationType}], PreviousPage={previousPage}");
     }
 
     protected override void OnNavigatingFrom(NavigatingFromEventArgs args)
@@ -76,7 +122,7 @@ public class Issue35613FirstPage : TestContentPage
         base.OnNavigatingFrom(args);
 
         var destinationPage = args.DestinationPage?.GetType().Name ?? "Null";
-        _onNavigatingFromLabel.Text = $"DestinationPage: {destinationPage}, NavigationType: {args.NavigationType}";
+        Issue35613.AppendLog($"OnNavigatingFrom FirstPage [{args.NavigationType}], DestinationPage={destinationPage}");
     }
 
     protected override void OnNavigatedFrom(NavigatedFromEventArgs args)
@@ -84,20 +130,25 @@ public class Issue35613FirstPage : TestContentPage
         base.OnNavigatedFrom(args);
 
         var destinationPage = args.DestinationPage?.GetType().Name ?? "Null";
-        _onNavigatedFromLabel.Text = $"DestinationPage: {destinationPage}, NavigationType: {args.NavigationType}";
+        Issue35613.AppendLog($"OnNavigatedFrom FirstPage [{args.NavigationType}], DestinationPage={destinationPage}");
     }
 
     void OnNavigateButtonClicked(object sender, EventArgs e)
     {
         Navigation.PushAsync(new Issue35613SecondPage());
     }
+
+    void RefreshLogEditor()
+    {
+        if (_logEditor is null)
+            return;
+        _logEditor.Text = Issue35613.GetLogText();
+    }
 }
 
 public class Issue35613SecondPage : TestContentPage
 {
-    Label _onNavigatingToLabel;
-    Label _onNavigatingFromLabel;
-    Label _onNavigatedFromLabel;
+    Editor _logEditor;
 
     public Issue35613SecondPage()
     {
@@ -113,22 +164,23 @@ public class Issue35613SecondPage : TestContentPage
         };
         navigateBackButton.Clicked += OnNavigateBackButtonClicked;
 
-        _onNavigatingToLabel = new Label
+        var navigateToThirdButton = new Button
         {
-            Text = "-",
-            AutomationId = "Issue35613_Second_OnNavigatingToLabel"
+            Text = "Navigate to Third Page",
+            AutomationId = "Issue35613_NavigateToThirdButton"
         };
+        navigateToThirdButton.Clicked += OnNavigateToThirdButtonClicked;
 
-        _onNavigatingFromLabel = new Label
+        _logEditor = new Editor
         {
-            Text = "-",
-            AutomationId = "Issue35613_Second_OnNavigatingFromLabel"
-        };
-
-        _onNavigatedFromLabel = new Label
-        {
-            Text = "-",
-            AutomationId = "Issue35613_Second_OnNavigatedFromLabel"
+            AutomationId = "Issue35613_Second_LogEditor",
+            IsReadOnly = true,
+            IsSpellCheckEnabled = false,
+            IsTextPredictionEnabled = false,
+            AutoSize = EditorAutoSizeOption.TextChanges,
+            MinimumHeightRequest = 220,
+            FontFamily = "Courier New",
+            FontSize = 12
         };
 
         Content = new VerticalStackLayout
@@ -137,14 +189,24 @@ public class Issue35613SecondPage : TestContentPage
             Children =
             {
                 navigateBackButton,
-                new Label { Text = "NavigatingToEventArgs", FontAttributes = FontAttributes.Bold },
-                _onNavigatingToLabel,
-                new Label { Text = "NavigatingFromEventArgs", FontAttributes = FontAttributes.Bold },
-                _onNavigatingFromLabel,
-                new Label { Text = "NavigatedFromEventArgs", FontAttributes = FontAttributes.Bold },
-                _onNavigatedFromLabel,
+                navigateToThirdButton,
+                new Label { Text = "Event Log:", FontAttributes = FontAttributes.Bold },
+                _logEditor,
             }
         };
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        Issue35613.SubscribeToLogChanged(RefreshLogEditor);
+        RefreshLogEditor();
+    }
+
+    protected override void OnDisappearing()
+    {
+        Issue35613.UnsubscribeFromLogChanged(RefreshLogEditor);
+        base.OnDisappearing();
     }
 
     protected override void OnNavigatedTo(NavigatedToEventArgs args)
@@ -152,7 +214,7 @@ public class Issue35613SecondPage : TestContentPage
         base.OnNavigatedTo(args);
 
         var previousPage = args.PreviousPage?.GetType().Name ?? "Null";
-        _onNavigatingToLabel.Text = $"PreviousPage: {previousPage}, NavigationType: {args.NavigationType}";
+        Issue35613.AppendLog($"OnNavigatedTo SecondPage [{args.NavigationType}], PreviousPage={previousPage}");
     }
 
     protected override void OnNavigatingFrom(NavigatingFromEventArgs args)
@@ -160,7 +222,7 @@ public class Issue35613SecondPage : TestContentPage
         base.OnNavigatingFrom(args);
 
         var destinationPage = args.DestinationPage?.GetType().Name ?? "Null";
-        _onNavigatingFromLabel.Text = $"DestinationPage: {destinationPage}, NavigationType: {args.NavigationType}";
+        Issue35613.AppendLog($"OnNavigatingFrom SecondPage [{args.NavigationType}], DestinationPage={destinationPage}");
     }
 
     protected override void OnNavigatedFrom(NavigatedFromEventArgs args)
@@ -168,11 +230,115 @@ public class Issue35613SecondPage : TestContentPage
         base.OnNavigatedFrom(args);
 
         var destinationPage = args.DestinationPage?.GetType().Name ?? "Null";
-        _onNavigatedFromLabel.Text = $"DestinationPage: {destinationPage}, NavigationType: {args.NavigationType}";
+        Issue35613.AppendLog($"OnNavigatedFrom SecondPage [{args.NavigationType}], DestinationPage={destinationPage}");
     }
 
     void OnNavigateBackButtonClicked(object sender, EventArgs e)
     {
         Navigation.PopAsync();
+    }
+
+    void OnNavigateToThirdButtonClicked(object sender, EventArgs e)
+    {
+        Navigation.PushAsync(new Issue35613ThirdPage());
+    }
+
+    void RefreshLogEditor()
+    {
+        if (_logEditor is null)
+            return;
+        _logEditor.Text = Issue35613.GetLogText();
+    }
+}
+
+public class Issue35613ThirdPage : TestContentPage
+{
+    Editor _logEditor;
+
+    public Issue35613ThirdPage()
+    {
+        Title = "Issue35613 Third";
+    }
+
+    protected override void Init()
+    {
+        var popToRootButton = new Button
+        {
+            Text = "Pop To Root",
+            AutomationId = "Issue35613_PopToRootButton"
+        };
+        popToRootButton.Clicked += OnPopToRootButtonClicked;
+
+        _logEditor = new Editor
+        {
+            AutomationId = "Issue35613_Third_LogEditor",
+            IsReadOnly = true,
+            IsSpellCheckEnabled = false,
+            IsTextPredictionEnabled = false,
+            AutoSize = EditorAutoSizeOption.TextChanges,
+            MinimumHeightRequest = 220,
+            FontFamily = "Courier New",
+            FontSize = 12
+        };
+
+        Content = new VerticalStackLayout
+        {
+            Padding = 12,
+            Children =
+            {
+                popToRootButton,
+                new Label { Text = "Event Log:", FontAttributes = FontAttributes.Bold },
+                _logEditor,
+            }
+        };
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        Issue35613.SubscribeToLogChanged(RefreshLogEditor);
+        RefreshLogEditor();
+    }
+
+    protected override void OnDisappearing()
+    {
+        Issue35613.UnsubscribeFromLogChanged(RefreshLogEditor);
+        base.OnDisappearing();
+    }
+
+    protected override void OnNavigatedTo(NavigatedToEventArgs args)
+    {
+        base.OnNavigatedTo(args);
+
+        var previousPage = args.PreviousPage?.GetType().Name ?? "Null";
+        Issue35613.AppendLog($"OnNavigatedTo ThirdPage [{args.NavigationType}], PreviousPage={previousPage}");
+    }
+
+    protected override void OnNavigatingFrom(NavigatingFromEventArgs args)
+    {
+        base.OnNavigatingFrom(args);
+
+        var destinationPage = args.DestinationPage?.GetType().Name ?? "Null";
+        Issue35613.AppendLog($"OnNavigatingFrom ThirdPage [{args.NavigationType}], DestinationPage={destinationPage}");
+    }
+
+    protected override void OnNavigatedFrom(NavigatedFromEventArgs args)
+    {
+        base.OnNavigatedFrom(args);
+
+        var destinationPage = args.DestinationPage?.GetType().Name ?? "Null";
+        Issue35613.AppendLog($"OnNavigatedFrom ThirdPage [{args.NavigationType}], DestinationPage={destinationPage}");
+    }
+
+    void OnPopToRootButtonClicked(object sender, EventArgs e)
+    {
+        Navigation.PopToRootAsync();
+    }
+
+    void RefreshLogEditor()
+    {
+        if (_logEditor is null)
+            return;
+        _logEditor.Text = Issue35613.GetLogText();
     }
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue35613.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue35613.cs
@@ -1,0 +1,178 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 35613, "OnNavigatingFrom with a NavigationPage always has an incorrect DestinationPage parameter", PlatformAffected.All)]
+public class Issue35613 : NavigationPage
+{
+    public Issue35613()
+    {
+        Navigation.PushAsync(new Issue35613FirstPage());
+    }
+}
+
+public class Issue35613FirstPage : TestContentPage
+{
+    Label _onNavigatingToLabel;
+    Label _onNavigatingFromLabel;
+    Label _onNavigatedFromLabel;
+
+    public Issue35613FirstPage()
+    {
+        Title = "Issue35613 First";
+    }
+
+    protected override void Init()
+    {
+        var navigateButton = new Button
+        {
+            Text = "Navigate to Second Page",
+            AutomationId = "Issue35613_NavigateButton"
+        };
+        navigateButton.Clicked += OnNavigateButtonClicked;
+
+        _onNavigatingToLabel = new Label
+        {
+            Text = "-",
+            AutomationId = "Issue35613_First_OnNavigatingToLabel"
+        };
+
+        _onNavigatingFromLabel = new Label
+        {
+            Text = "-",
+            AutomationId = "Issue35613_First_OnNavigatingFromLabel"
+        };
+
+        _onNavigatedFromLabel = new Label
+        {
+            Text = "-",
+            AutomationId = "Issue35613_First_OnNavigatedFromLabel"
+        };
+
+        Content = new VerticalStackLayout
+        {
+            Padding = 12,
+            Children =
+            {
+                navigateButton,
+                new Label { Text = "NavigatingToEventArgs", FontAttributes = FontAttributes.Bold },
+                _onNavigatingToLabel,
+                new Label { Text = "NavigatingFromEventArgs", FontAttributes = FontAttributes.Bold },
+                _onNavigatingFromLabel,
+                new Label { Text = "NavigatedFromEventArgs", FontAttributes = FontAttributes.Bold },
+                _onNavigatedFromLabel,
+            }
+        };
+    }
+
+    protected override void OnNavigatedTo(NavigatedToEventArgs args)
+    {
+        base.OnNavigatedTo(args);
+
+        var previousPage = args.PreviousPage?.GetType().Name ?? "Null";
+        _onNavigatingToLabel.Text = $"PreviousPage: {previousPage}, NavigationType: {args.NavigationType}";
+    }
+
+    protected override void OnNavigatingFrom(NavigatingFromEventArgs args)
+    {
+        base.OnNavigatingFrom(args);
+
+        var destinationPage = args.DestinationPage?.GetType().Name ?? "Null";
+        _onNavigatingFromLabel.Text = $"DestinationPage: {destinationPage}, NavigationType: {args.NavigationType}";
+    }
+
+    protected override void OnNavigatedFrom(NavigatedFromEventArgs args)
+    {
+        base.OnNavigatedFrom(args);
+
+        var destinationPage = args.DestinationPage?.GetType().Name ?? "Null";
+        _onNavigatedFromLabel.Text = $"DestinationPage: {destinationPage}, NavigationType: {args.NavigationType}";
+    }
+
+    void OnNavigateButtonClicked(object sender, EventArgs e)
+    {
+        Navigation.PushAsync(new Issue35613SecondPage());
+    }
+}
+
+public class Issue35613SecondPage : TestContentPage
+{
+    Label _onNavigatingToLabel;
+    Label _onNavigatingFromLabel;
+    Label _onNavigatedFromLabel;
+
+    public Issue35613SecondPage()
+    {
+        Title = "Issue35613 Second";
+    }
+
+    protected override void Init()
+    {
+        var navigateBackButton = new Button
+        {
+            Text = "Navigate Back",
+            AutomationId = "Issue35613_NavigateBackButton"
+        };
+        navigateBackButton.Clicked += OnNavigateBackButtonClicked;
+
+        _onNavigatingToLabel = new Label
+        {
+            Text = "-",
+            AutomationId = "Issue35613_Second_OnNavigatingToLabel"
+        };
+
+        _onNavigatingFromLabel = new Label
+        {
+            Text = "-",
+            AutomationId = "Issue35613_Second_OnNavigatingFromLabel"
+        };
+
+        _onNavigatedFromLabel = new Label
+        {
+            Text = "-",
+            AutomationId = "Issue35613_Second_OnNavigatedFromLabel"
+        };
+
+        Content = new VerticalStackLayout
+        {
+            Padding = 12,
+            Children =
+            {
+                navigateBackButton,
+                new Label { Text = "NavigatingToEventArgs", FontAttributes = FontAttributes.Bold },
+                _onNavigatingToLabel,
+                new Label { Text = "NavigatingFromEventArgs", FontAttributes = FontAttributes.Bold },
+                _onNavigatingFromLabel,
+                new Label { Text = "NavigatedFromEventArgs", FontAttributes = FontAttributes.Bold },
+                _onNavigatedFromLabel,
+            }
+        };
+    }
+
+    protected override void OnNavigatedTo(NavigatedToEventArgs args)
+    {
+        base.OnNavigatedTo(args);
+
+        var previousPage = args.PreviousPage?.GetType().Name ?? "Null";
+        _onNavigatingToLabel.Text = $"PreviousPage: {previousPage}, NavigationType: {args.NavigationType}";
+    }
+
+    protected override void OnNavigatingFrom(NavigatingFromEventArgs args)
+    {
+        base.OnNavigatingFrom(args);
+
+        var destinationPage = args.DestinationPage?.GetType().Name ?? "Null";
+        _onNavigatingFromLabel.Text = $"DestinationPage: {destinationPage}, NavigationType: {args.NavigationType}";
+    }
+
+    protected override void OnNavigatedFrom(NavigatedFromEventArgs args)
+    {
+        base.OnNavigatedFrom(args);
+
+        var destinationPage = args.DestinationPage?.GetType().Name ?? "Null";
+        _onNavigatedFromLabel.Text = $"DestinationPage: {destinationPage}, NavigationType: {args.NavigationType}";
+    }
+
+    void OnNavigateBackButtonClicked(object sender, EventArgs e)
+    {
+        Navigation.PopAsync();
+    }
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35613.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35613.cs
@@ -1,0 +1,46 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue35613 : _IssuesUITest
+{
+    public override string Issue => "OnNavigatingFrom with a NavigationPage always has an incorrect DestinationPage parameter";
+
+    public Issue35613(TestDevice device) : base(device)
+    {
+    }
+
+    [Test]
+    [Category(UITestCategories.Navigation)]
+    public void VerifyNavigatingToAndNavigatingFromArgs()
+    {
+        App.WaitForElement("Issue35613_NavigateButton");
+
+        App.WaitForElement("Issue35613_First_OnNavigatingToLabel");
+        var firstNavigatingToBeforePush = App.FindElement("Issue35613_First_OnNavigatingToLabel").GetText();
+        Assert.That(firstNavigatingToBeforePush, Is.EqualTo("PreviousPage: Null, NavigationType: Push"));
+
+        var firstNavigatingFromBeforePush = App.FindElement("Issue35613_First_OnNavigatingFromLabel").GetText();
+        Assert.That(firstNavigatingFromBeforePush, Is.EqualTo("-"));
+
+        App.Tap("Issue35613_NavigateButton");
+
+        App.WaitForElement("Issue35613_Second_OnNavigatingToLabel");
+        var secondNavigatingToAfterPush = App.FindElement("Issue35613_Second_OnNavigatingToLabel").GetText();
+        Assert.That(secondNavigatingToAfterPush, Is.EqualTo("PreviousPage: Issue35613FirstPage, NavigationType: Push"));
+
+        var secondNavigatingFromBeforePop = App.FindElement("Issue35613_Second_OnNavigatingFromLabel").GetText();
+        Assert.That(secondNavigatingFromBeforePop, Is.EqualTo("-"));
+
+        App.Tap("Issue35613_NavigateBackButton");
+
+        App.WaitForElement("Issue35613_First_OnNavigatingToLabel");
+        var firstNavigatingToAfterPop = App.FindElement("Issue35613_First_OnNavigatingToLabel").GetText();
+        Assert.That(firstNavigatingToAfterPop, Is.EqualTo("PreviousPage: Issue35613SecondPage, NavigationType: Pop"));
+
+        var firstNavigatingFromAfterPop = App.FindElement("Issue35613_First_OnNavigatingFromLabel").GetText();
+        Assert.That(firstNavigatingFromAfterPop, Is.EqualTo("DestinationPage: Issue35613SecondPage, NavigationType: Push"));
+    }
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35613.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35613.cs
@@ -16,52 +16,47 @@ public class Issue35613 : _IssuesUITest
     [Category(UITestCategories.Navigation)]
     public void VerifyNavigatingToAndNavigatingFromArgsForPopAndPopToRoot()
     {
+        // First page is shown — navigate to second
         App.WaitForElement("Issue35613_NavigateButton");
-
-        App.WaitForElement("Issue35613_First_OnNavigatingToLabel");
-        var firstNavigatingToBeforePush = App.FindElement("Issue35613_First_OnNavigatingToLabel").GetText();
-        Assert.That(firstNavigatingToBeforePush, Is.EqualTo("PreviousPage: Null, NavigationType: Push"));
-
-        var firstNavigatingFromBeforePush = App.FindElement("Issue35613_First_OnNavigatingFromLabel").GetText();
-        Assert.That(firstNavigatingFromBeforePush, Is.EqualTo("-"));
-
         App.Tap("Issue35613_NavigateButton");
 
-        App.WaitForElement("Issue35613_Second_OnNavigatingToLabel");
-        var secondNavigatingToAfterPush = App.FindElement("Issue35613_Second_OnNavigatingToLabel").GetText();
-        Assert.That(secondNavigatingToAfterPush, Is.EqualTo("PreviousPage: Issue35613FirstPage, NavigationType: Push"));
+        // Second page: verify Push events from First→Second
+        App.WaitForElement("Issue35613_Second_LogEditor");
+        var secondLog = App.FindElement("Issue35613_Second_LogEditor").GetText();
+        Assert.That(secondLog, Does.Contain("OnNavigatingFrom FirstPage [Push], DestinationPage=Issue35613SecondPage"));
+        Assert.That(secondLog, Does.Contain("OnNavigatedFrom FirstPage [Push], DestinationPage=Issue35613SecondPage"));
+        Assert.That(secondLog, Does.Contain("OnNavigatedTo SecondPage [Push], PreviousPage=Issue35613FirstPage"));
 
-        var secondNavigatingFromBeforePop = App.FindElement("Issue35613_Second_OnNavigatingFromLabel").GetText();
-        Assert.That(secondNavigatingFromBeforePop, Is.EqualTo("-"));
-
+        // Navigate to third
         App.Tap("Issue35613_NavigateToThirdButton");
 
-        App.WaitForElement("Issue35613_Third_OnNavigatingToLabel");
-        var thirdNavigatingToAfterPush = App.FindElement("Issue35613_Third_OnNavigatingToLabel").GetText();
-        Assert.That(thirdNavigatingToAfterPush, Is.EqualTo("PreviousPage: Issue35613SecondPage, NavigationType: Push"));
+        // Third page: verify Push events from Second→Third
+        App.WaitForElement("Issue35613_Third_LogEditor");
+        var thirdLog = App.FindElement("Issue35613_Third_LogEditor").GetText();
+        Assert.That(thirdLog, Does.Contain("OnNavigatingFrom SecondPage [Push], DestinationPage=Issue35613ThirdPage"));
+        Assert.That(thirdLog, Does.Contain("OnNavigatedFrom SecondPage [Push], DestinationPage=Issue35613ThirdPage"));
+        Assert.That(thirdLog, Does.Contain("OnNavigatedTo ThirdPage [Push], PreviousPage=Issue35613SecondPage"));
 
-        var secondNavigatingFromAfterPushToThird = App.FindElement("Issue35613_Second_OnNavigatingFromLabel").GetText();
-        Assert.That(secondNavigatingFromAfterPushToThird, Is.EqualTo("DestinationPage: Issue35613ThirdPage, NavigationType: Push"));
-
+        // PopToRoot back to first
         App.Tap("Issue35613_PopToRootButton");
 
-        App.WaitForElement("Issue35613_First_OnNavigatingToLabel");
-        var firstNavigatingToAfterPopToRoot = App.FindElement("Issue35613_First_OnNavigatingToLabel").GetText();
-        Assert.That(firstNavigatingToAfterPopToRoot, Is.EqualTo("PreviousPage: Issue35613ThirdPage, NavigationType: PopToRoot"));
+        // First page: verify PopToRoot events
+        App.WaitForElement("Issue35613_LogEditor");
+        var firstLogAfterPopToRoot = App.FindElement("Issue35613_LogEditor").GetText();
+        Assert.That(firstLogAfterPopToRoot, Does.Contain("OnNavigatingFrom ThirdPage [PopToRoot], DestinationPage=Issue35613FirstPage"));
+        Assert.That(firstLogAfterPopToRoot, Does.Contain("OnNavigatedFrom ThirdPage [PopToRoot], DestinationPage=Issue35613FirstPage"));
+        Assert.That(firstLogAfterPopToRoot, Does.Contain("OnNavigatedTo FirstPage [PopToRoot], PreviousPage=Issue35613ThirdPage"));
 
-        var thirdNavigatingFromAfterPopToRoot = App.FindElement("Issue35613_Third_OnNavigatingFromLabel").GetText();
-        Assert.That(thirdNavigatingFromAfterPopToRoot, Is.EqualTo("DestinationPage: Issue35613FirstPage, NavigationType: PopToRoot"));
-
+        // Navigate to second again, then pop back
         App.Tap("Issue35613_NavigateButton");
-
-        App.WaitForElement("Issue35613_Second_OnNavigatingToLabel");
+        App.WaitForElement("Issue35613_Second_LogEditor");
         App.Tap("Issue35613_NavigateBackButton");
 
-        App.WaitForElement("Issue35613_First_OnNavigatingToLabel");
-        var firstNavigatingToAfterPop = App.FindElement("Issue35613_First_OnNavigatingToLabel").GetText();
-        Assert.That(firstNavigatingToAfterPop, Is.EqualTo("PreviousPage: Issue35613SecondPage, NavigationType: Pop"));
-
-        var firstNavigatingFromAfterPop = App.FindElement("Issue35613_First_OnNavigatingFromLabel").GetText();
-        Assert.That(firstNavigatingFromAfterPop, Is.EqualTo("DestinationPage: Issue35613SecondPage, NavigationType: Push"));
+        // First page: verify Pop events from Second→First
+        App.WaitForElement("Issue35613_LogEditor");
+        var firstLogAfterPop = App.FindElement("Issue35613_LogEditor").GetText();
+        Assert.That(firstLogAfterPop, Does.Contain("OnNavigatingFrom SecondPage [Pop], DestinationPage=Issue35613FirstPage"));
+        Assert.That(firstLogAfterPop, Does.Contain("OnNavigatedFrom SecondPage [Pop], DestinationPage=Issue35613FirstPage"));
+        Assert.That(firstLogAfterPop, Does.Contain("OnNavigatedTo FirstPage [Pop], PreviousPage=Issue35613SecondPage"));
     }
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35613.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35613.cs
@@ -14,7 +14,7 @@ public class Issue35613 : _IssuesUITest
 
     [Test]
     [Category(UITestCategories.Navigation)]
-    public void VerifyNavigatingToAndNavigatingFromArgs()
+    public void VerifyNavigatingToAndNavigatingFromArgsForPopAndPopToRoot()
     {
         App.WaitForElement("Issue35613_NavigateButton");
 
@@ -34,6 +34,27 @@ public class Issue35613 : _IssuesUITest
         var secondNavigatingFromBeforePop = App.FindElement("Issue35613_Second_OnNavigatingFromLabel").GetText();
         Assert.That(secondNavigatingFromBeforePop, Is.EqualTo("-"));
 
+        App.Tap("Issue35613_NavigateToThirdButton");
+
+        App.WaitForElement("Issue35613_Third_OnNavigatingToLabel");
+        var thirdNavigatingToAfterPush = App.FindElement("Issue35613_Third_OnNavigatingToLabel").GetText();
+        Assert.That(thirdNavigatingToAfterPush, Is.EqualTo("PreviousPage: Issue35613SecondPage, NavigationType: Push"));
+
+        var secondNavigatingFromAfterPushToThird = App.FindElement("Issue35613_Second_OnNavigatingFromLabel").GetText();
+        Assert.That(secondNavigatingFromAfterPushToThird, Is.EqualTo("DestinationPage: Issue35613ThirdPage, NavigationType: Push"));
+
+        App.Tap("Issue35613_PopToRootButton");
+
+        App.WaitForElement("Issue35613_First_OnNavigatingToLabel");
+        var firstNavigatingToAfterPopToRoot = App.FindElement("Issue35613_First_OnNavigatingToLabel").GetText();
+        Assert.That(firstNavigatingToAfterPopToRoot, Is.EqualTo("PreviousPage: Issue35613ThirdPage, NavigationType: PopToRoot"));
+
+        var thirdNavigatingFromAfterPopToRoot = App.FindElement("Issue35613_Third_OnNavigatingFromLabel").GetText();
+        Assert.That(thirdNavigatingFromAfterPopToRoot, Is.EqualTo("DestinationPage: Issue35613FirstPage, NavigationType: PopToRoot"));
+
+        App.Tap("Issue35613_NavigateButton");
+
+        App.WaitForElement("Issue35613_Second_OnNavigatingToLabel");
         App.Tap("Issue35613_NavigateBackButton");
 
         App.WaitForElement("Issue35613_First_OnNavigatingToLabel");


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details
In .NET MAUI, when navigating between pages using NavigationPage, the OnNavigatingFrom event fires with the wrong destination page. For example, navigating from Page A to Page B gives DestinationPage = A instead of B. 

### Root Cause
The method SendNavigating() inside NavigationPage was always using CurrentPage (the page you're leaving) as the destination in the event. At the time the event fires, CurrentPage hasn't changed yet — so the destination always pointed to itself instead of the actual next page.

### Description of Change
Added a destinationPage parameter to SendNavigating() and updated all call sites to pass the correct target page — the pushed page for Push, the page below for Pop, and the root page for PopToRoot. This fix covers both the modern handler path and the legacy renderer path.

Validated the behavior in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
### Issues Fixed
  
Fixes #35613 

### Output  ScreenShot

iOS
|Before|After|
|--|--|
| <video src="https://github.com/user-attachments/assets/8304a2f4-16be-471a-b1e3-d00381222a8d" >| <video src="https://github.com/user-attachments/assets/3299f0c1-c74d-4c8a-8d90-e3bedf214eb5">|


Android
|Before|After|
|--|--|
| <video src="https://github.com/user-attachments/assets/dce2fae4-f788-49f3-9305-2390779771a2" >| <video src="https://github.com/user-attachments/assets/fcef7592-c747-4902-ae91-5b7da60c61d3">|
