### PR TITLE
Stop PR Review Queue workflow from running on forks and @-pinging PR authors

### DIFF
--- a/.github/skills/find-reviewable-pr/scripts/query-reviewable-prs.ps1
+++ b/.github/skills/find-reviewable-pr/scripts/query-reviewable-prs.ps1
@@ -1219,14 +1219,18 @@ function Format-Markdown-Output {
             $title = $rawTitle.Replace('|', '\|')
             $link = "[#$($pr.Number)]($($pr.URL))"
             $turnCol = "$($pr.TurnIcon) $($pr.TurnDetail)"
+            # Wrap author handles in backticks so GitHub renders them as inline code
+            # rather than as @mentions — this issue is for MAUI team triage tracking,
+            # not a notification firehose to every PR author each day.
+            $author = "``@$($pr.Author)``"
             if ($showMilestone -and $showTurn) {
-                [void]$md.AppendLine("| $link | $title | @$($pr.Author) | $($pr.Milestone) | $turnCol | $($pr.Platform) | $($pr.Age)d |")
+                [void]$md.AppendLine("| $link | $title | $author | $($pr.Milestone) | $turnCol | $($pr.Platform) | $($pr.Age)d |")
             } elseif ($showMilestone) {
-                [void]$md.AppendLine("| $link | $title | @$($pr.Author) | $($pr.Milestone) | $($pr.Platform) | $($pr.Age)d | $($pr.Updated)d ago |")
+                [void]$md.AppendLine("| $link | $title | $author | $($pr.Milestone) | $($pr.Platform) | $($pr.Age)d | $($pr.Updated)d ago |")
             } elseif ($showTurn) {
-                [void]$md.AppendLine("| $link | $title | @$($pr.Author) | $turnCol | $($pr.Platform) | $($pr.Age)d |")
+                [void]$md.AppendLine("| $link | $title | $author | $turnCol | $($pr.Platform) | $($pr.Age)d |")
             } else {
-                [void]$md.AppendLine("| $link | $title | @$($pr.Author) | $($pr.Platform) | $($pr.Age)d | $($pr.Updated)d ago |")
+                [void]$md.AppendLine("| $link | $title | $author | $($pr.Platform) | $($pr.Age)d | $($pr.Updated)d ago |")
             }
         }
         [void]$md.AppendLine("")

--- a/.github/workflows/pr-review-queue.yml
+++ b/.github/workflows/pr-review-queue.yml
@@ -20,7 +20,9 @@ concurrency:
 jobs:
   generate-report:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
+    # Guard: only run in dotnet/maui — prevents the scheduled run from firing
+    # in forks and pinging fork owners with duplicate queue issues.
+    if: github.repository_owner == 'dotnet' && github.event_name != 'pull_request'
     permissions:
       contents: read
       issues: write
@@ -86,7 +88,7 @@ jobs:
   # Dry-run on PRs: validate the script works without creating issues
   validate:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.repository_owner == 'dotnet' && github.event_name == 'pull_request'
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Problem

Two issues with the daily "PR Review Queue" automation:

### 1. Workflow runs in forks and creates duplicate tracking issues

`.github/workflows/pr-review-queue.yml` had no fork guard, so the daily scheduled run (`cron: "0 8 * * 1-5"`) was firing in active forks of dotnet/maui as well as in upstream. The `gh issue create --repo ${{ github.repository }}` step targets the running repo, so each fork ended up with its own `[PR Review Queue]` issue alongside the legitimate dotnet/maui one — e.g. `PureWeen/maui#105` and `dotnet/maui#35732` for the same day, both pinging the fork owner.

### 2. Every PR author gets @-mentioned daily

The markdown table emitted each PR author handle as a raw `@username`, which GitHub parses as a real mention. Each daily run created a new issue and notified every PR author — community contributors, partner devs, bots — even though the issue is purely an internal MAUI-team triage artifact.

## Changes

**`.github/workflows/pr-review-queue.yml`** — Add the same `github.repository_owner == 'dotnet'` guard already used by 8 other dotnet-owned workflows in this repo (`backport.yml`, `rebase.yml`, `locker.yml`, `dogfood-comment.yml`, `maestro-changelog.yml`, `inclusive-heat-sensor.yml`, `dotnet-format-daily.yml`, `dotnet-autoformat-pr-push.yml`). Applied to both jobs:
  - `generate-report` — stops the scheduled issue creation on forks.
  - `validate` — stops fork-internal PRs from spending CI on the dry-run.

**`.github/skills/find-reviewable-pr/scripts/query-reviewable-prs.ps1`** — Wrap author handles in backticks (`` `@username` ``) in all four table-row formats. GitHub does not parse mentions inside code spans, so no notifications fire, but the table still reads naturally as a list of author handles.

## Verification

- YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`).
- PowerShell escape verified — `"``@$($pr.Author)``"` renders as `` `@PureWeen` ``.
- Existing renderer logic for `$showMilestone` / `$showTurn` variants left intact; only the author cell changed.

## Out of scope

Other automation in this repo was checked and is already fork-safe:
- The gh-aw `*.lock.yml` files (`agentic-labeler`, `daily-repo-status`, `copilot-evaluate-tests`) and `agentics-maintenance.yml` are auto-generated (`DO NOT EDIT`) and have their own pre-activation role checks.
- `review-trigger.yml` is implicitly fork-safe via its actor-permission check.