### PR TITLE
 Fix OnNavigatedTo not firing after PopModalAsync when tab is changed inside modal

### DIFF
--- a/src/Controls/src/Core/Page/Page.cs
+++ b/src/Controls/src/Core/Page/Page.cs
@@ -853,6 +853,7 @@ namespace Microsoft.Maui.Controls
 
 		internal void SendNavigatedTo(NavigatedToEventArgs args)
 		{
+			// Prevent duplicate OnNavigatedTo during a single navigation burst (fixes #23902).
 			if (HasNavigatedTo)
 			{
 				return;
@@ -861,7 +862,21 @@ namespace Microsoft.Maui.Controls
 			HasNavigatedTo = true;
 			NavigatedTo?.Invoke(this, args);
 			OnNavigatedTo(args);
-			(this as IPageContainer<Page>)?.CurrentPage?.SendNavigatedTo(args);
+
+			// Cascade to child page (e.g. TabbedPage → CurrentPage).
+			// On Pop, reset the child flag first — a prior tab change while a modal was open
+			// can leave it true, which would incorrectly block the pop-return (fixes #35756).
+			// PopToRoot is excluded: SendNavigatedFrom already resets all flags before PopToRoot cascades.
+			var containerChild = (this as IPageContainer<Page>)?.CurrentPage;
+			if (containerChild is not null)
+			{
+				if (args.NavigationType == NavigationType.Pop)
+				{
+					containerChild.HasNavigatedTo = false;
+				}
+
+				containerChild.SendNavigatedTo(args);
+			}
 		}
 
 		internal void SendNavigatingFrom(NavigatingFromEventArgs args)

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue35756.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue35756.cs
@@ -1,0 +1,126 @@
+using Microsoft.Maui.Controls;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 35756, "OnNavigatedTo does not fire after PopModalAsync when tab was changed from inside the modal", PlatformAffected.All)]
+	public class Issue35756TabbedPage : TabbedPage
+	{
+		public Issue35756TabbedPage()
+		{
+			Title = "Issue35756";
+			Children.Add(new Issue35756Tab1Page());
+			Children.Add(new Issue35756Tab2Page(this));
+		}
+	}
+
+	public class Issue35756Tab1Page : ContentPage
+	{
+		readonly Label _navigatedToCountLabel;
+		int _navigatedToCount;
+
+		public Issue35756Tab1Page()
+		{
+			Title = "Tab 1";
+			_navigatedToCountLabel = new Label
+			{
+				AutomationId = "Tab1NavigatedToCount",
+				Text = "NavigatedTo count: 0"
+			};
+			Content = new StackLayout
+			{
+				Padding = 20,
+				Children =
+				{
+					new Label { Text = "Tab 1", FontSize = 18, AutomationId = "Tab1Content" },
+					_navigatedToCountLabel
+				}
+			};
+		}
+
+		protected override void OnNavigatedTo(NavigatedToEventArgs args)
+		{
+			base.OnNavigatedTo(args);
+			_navigatedToCount++;
+			_navigatedToCountLabel.Text = $"NavigatedTo count: {_navigatedToCount}";
+		}
+	}
+
+	public class Issue35756Tab2Page : ContentPage
+	{
+		readonly TabbedPage _tabbedPage;
+
+		public Issue35756Tab2Page(TabbedPage tabbedPage)
+		{
+			Title = "Tab 2";
+			_tabbedPage = tabbedPage;
+
+			var pushModalButton = new Button
+			{
+				Text = "Push Modal",
+				AutomationId = "PushModalButton"
+			};
+			pushModalButton.Clicked += OnPushModalClicked;
+
+			Content = new StackLayout
+			{
+				Padding = 20,
+				Children =
+				{
+					new Label { Text = "Tab 2", FontSize = 18, AutomationId = "Tab2Content" },
+					pushModalButton
+				}
+			};
+		}
+
+		async void OnPushModalClicked(object sender, EventArgs e)
+		{
+			await Navigation.PushModalAsync(new Issue35756ModalPage(_tabbedPage));
+		}
+	}
+
+	public class Issue35756ModalPage : ContentPage
+	{
+		readonly TabbedPage _tabbedPage;
+
+		public Issue35756ModalPage(TabbedPage tabbedPage)
+		{
+			Title = "Modal";
+			_tabbedPage = tabbedPage;
+
+			var switchTabButton = new Button
+			{
+				Text = "Switch to Tab 1",
+				AutomationId = "SwitchToTab1Button"
+			};
+			switchTabButton.Clicked += OnSwitchToTab1Clicked;
+
+			var closeModalButton = new Button
+			{
+				Text = "Close Modal",
+				AutomationId = "CloseModalButton"
+			};
+			closeModalButton.Clicked += OnCloseModalClicked;
+
+			Content = new StackLayout
+			{
+				Padding = 20,
+				Children =
+				{
+					new Label { Text = "Modal Page", FontSize = 18, AutomationId = "ModalContent" },
+					switchTabButton,
+					closeModalButton
+				}
+			};
+		}
+
+		void OnSwitchToTab1Clicked(object sender, EventArgs e)
+		{
+			_tabbedPage.CurrentPage = _tabbedPage.Children[0];
+		}
+
+		async void OnCloseModalClicked(object sender, EventArgs e)
+		{
+			await Navigation.PopModalAsync();
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35756.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35756.cs
@@ -1,0 +1,32 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue35756 : _IssuesUITest
+{
+	public Issue35756(TestDevice device) : base(device) { }
+
+	public override string Issue => "OnNavigatedTo does not fire after PopModalAsync when tab was changed from inside the modal";
+
+	[Test]
+	[Category(UITestCategories.TabbedPage)]
+	public void OnNavigatedToFiresAfterPopModalWhenTabChangedFromInsideModal()
+	{
+		App.WaitForElement("Tab1Content");
+		Assert.That(App.WaitForElement("Tab1NavigatedToCount").GetText(), Is.EqualTo("NavigatedTo count: 1"));
+
+		App.TapTab("Tab 2");
+		App.WaitForElement("Tab2Content");
+		App.Tap("PushModalButton");
+		App.WaitForElement("ModalContent");
+
+		App.Tap("SwitchToTab1Button");
+
+		App.Tap("CloseModalButton");
+		App.WaitForElement("Tab1Content");
+
+		Assert.That(App.WaitForElement("Tab1NavigatedToCount").GetText(), Is.EqualTo("NavigatedTo count: 3"));
+	}
+}


### PR DESCRIPTION
 <!-- Please let the below note in for people that find this PR -->
   > [!NOTE]
   > Are you waiting for the changes in this PR to be merged?
   > It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. 
  Thank you!
 
### Root Cause
When a modal is closed through `PopModalAsync`, the framework cascades `SendNavigatedTo(Pop)` down to the current child of the `TabbedPage` (for example, `Tab1`). Inside `SendNavigatedTo`, a guard (`if (HasNavigatedTo) return`) prevents duplicate `OnNavigatedTo` events from firing. This guard was introduced in PR #31931  to fix issue #23902 .

The issue occurs when the user switches tabs while a modal is open. That tab switch triggers a normal `Replace` navigation within the `TabbedPage`, which sets `Tab1.HasNavigatedTo = true`. Later, when the modal is closed, `SendNavigatedFrom` is invoked only on the modal page itself — the tab child pages never receive `SendNavigatedFrom`, so their `HasNavigatedTo` flags are not reset.

As a result, when the subsequent `Pop` cascade reaches `Tab1`, its `HasNavigatedTo` flag is still `true` from the earlier in-modal tab switch. The duplicate-event guard therefore incorrectly suppresses the `OnNavigatedTo` event that should fire when returning to the page after the modal closes.

 
### Description of Change
Updated `Page.SendNavigatedTo` so that when navigation cascades into a container child page, the child’s `HasNavigatedTo` flag is reset before cascading — but only for `NavigationType.Pop`.

`Pop` represents returning to an existing page and should always trigger a legitimate new `OnNavigatedTo` event. `Push` and `Replace` flows remain unchanged, preserving the original duplicate-event protection introduced for issue #23902.
 
### Regression details
The regression was introduced by PR #[31931](https://github.com/dotnet/maui/pull/31931)

### Issues Fixed
Fixes #35756   
 
Tested the behaviour in the following platforms
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Screenshots
| Before Issue Fix | After Issue Fix |
|------------------|-----------------|
| <video width="350" alt="withoutfix" src="https://github.com/user-attachments/assets/d458c5ae-2ee5-4604-b61a-eb8846b90111" /> | <video width="350" alt="withfix" src="https://github.com/user-attachments/assets/93320bc6-1e24-4885-b964-f3bc0ad8aac5" /> |