### PR TITLE
[HouseKeeping] Fix inconsistant owner type of DropCommandProperty

### DIFF
--- a/.github/skills/find-reviewable-pr/scripts/query-reviewable-prs.ps1
+++ b/.github/skills/find-reviewable-pr/scripts/query-reviewable-prs.ps1
@@ -1219,14 +1219,18 @@ function Format-Markdown-Output {
             $title = $rawTitle.Replace('|', '\|')
             $link = "[#$($pr.Number)]($($pr.URL))"
             $turnCol = "$($pr.TurnIcon) $($pr.TurnDetail)"
+            # Wrap author handles in backticks so GitHub renders them as inline code
+            # rather than as @mentions — this issue is for MAUI team triage tracking,
+            # not a notification firehose to every PR author each day.
+            $author = "``@$($pr.Author)``"
             if ($showMilestone -and $showTurn) {
-                [void]$md.AppendLine("| $link | $title | @$($pr.Author) | $($pr.Milestone) | $turnCol | $($pr.Platform) | $($pr.Age)d |")
+                [void]$md.AppendLine("| $link | $title | $author | $($pr.Milestone) | $turnCol | $($pr.Platform) | $($pr.Age)d |")
             } elseif ($showMilestone) {
-                [void]$md.AppendLine("| $link | $title | @$($pr.Author) | $($pr.Milestone) | $($pr.Platform) | $($pr.Age)d | $($pr.Updated)d ago |")
+                [void]$md.AppendLine("| $link | $title | $author | $($pr.Milestone) | $($pr.Platform) | $($pr.Age)d | $($pr.Updated)d ago |")
             } elseif ($showTurn) {
-                [void]$md.AppendLine("| $link | $title | @$($pr.Author) | $turnCol | $($pr.Platform) | $($pr.Age)d |")
+                [void]$md.AppendLine("| $link | $title | $author | $turnCol | $($pr.Platform) | $($pr.Age)d |")
             } else {
-                [void]$md.AppendLine("| $link | $title | @$($pr.Author) | $($pr.Platform) | $($pr.Age)d | $($pr.Updated)d ago |")
+                [void]$md.AppendLine("| $link | $title | $author | $($pr.Platform) | $($pr.Age)d | $($pr.Updated)d ago |")
             }
         }
         [void]$md.AppendLine("")

--- a/.github/workflows/pr-review-queue.yml
+++ b/.github/workflows/pr-review-queue.yml
@@ -20,7 +20,9 @@ concurrency:
 jobs:
   generate-report:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
+    # Guard: only run in dotnet/maui — prevents the scheduled run from firing
+    # in forks and pinging fork owners with duplicate queue issues.
+    if: github.repository_owner == 'dotnet' && github.event_name != 'pull_request'
     permissions:
       contents: read
       issues: write
@@ -86,7 +88,7 @@ jobs:
   # Dry-run on PRs: validate the script works without creating issues
   validate:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.repository_owner == 'dotnet' && github.event_name == 'pull_request'
     permissions:
       contents: read
       pull-requests: read

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -124,7 +124,10 @@ stages:
               skipAndroidPlatformApis: true
               onlyAndroidPlatformDefaultApis: true
               skipAndroidEmulatorImages: ${{ ne(parameters.Platform, 'android') }}
-              skipAndroidCreateAvds: ${{ ne(parameters.Platform, 'android') }}
+              # AVD is created by the inline 'Create AVD and boot Android Emulator' script below
+              # with specific config (playstore image variant, partition shrink, ADB key pre-auth)
+              # that ProvisionAndroidSdkAvdCreateAvds doesn't replicate.
+              skipAndroidCreateAvds: true
               androidEmulatorApiLevel: '30'
               skipSimulatorSetup: ${{ or(eq(parameters.Platform, 'android'), eq(parameters.Platform, 'windows'), eq(parameters.Platform, 'catalyst')) }}
               skipCertificates: true
@@ -871,7 +874,10 @@ stages:
               skipAndroidPlatformApis: true
               onlyAndroidPlatformDefaultApis: true
               skipAndroidEmulatorImages: ${{ ne(parameters.Platform, 'android') }}
-              skipAndroidCreateAvds: ${{ ne(parameters.Platform, 'android') }}
+              # AVD is created by the inline 'Create AVD and boot Android Emulator' script below
+              # with specific config (playstore image variant, partition shrink, ADB key pre-auth)
+              # that ProvisionAndroidSdkAvdCreateAvds doesn't replicate.
+              skipAndroidCreateAvds: true
               androidEmulatorApiLevel: '30'
               skipSimulatorSetup: ${{ or(eq(parameters.Platform, 'android'), eq(parameters.Platform, 'windows'), eq(parameters.Platform, 'catalyst')) }}
               skipCertificates: true

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -15,6 +15,15 @@ variables:
   value: 26.0.1
 - name: POWERSHELL_VERSION
   value: 7.4.0
+# Workaround for PowerShell/PowerShell#20802 (open since Nov 2023):
+# pwsh 7.4.x intermittently aborts at startup on macOS with
+#   'Call to procargs failed with errno 5'
+# because AttemptExecPwshLogin() races on sysctl(KERN_PROCARGS2).
+# Setting __PWSH_LOGIN_CHECKED makes pwsh short-circuit the login-shell
+# detection that triggers the racy syscall (see Program.cs in PowerShell repo).
+# Hit on internal dnceng dotnet-maui build 2990586 (release/11.0.1xx-preview5).
+- name: __PWSH_LOGIN_CHECKED
+  value: '1'
 # Localization variables
 - name: LocBranchPrefix
   value: 'loc-hb'

--- a/src/Controls/src/Core/DragAndDrop/DropGestureRecognizer.cs
+++ b/src/Controls/src/Core/DragAndDrop/DropGestureRecognizer.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty DragLeaveCommandParameterProperty = BindableProperty.Create(nameof(DragLeaveCommandParameter), typeof(object), typeof(DropGestureRecognizer), null);
 
 		/// <summary>Bindable property for <see cref="DropCommand"/>.</summary>
-		public static readonly BindableProperty DropCommandProperty = BindableProperty.Create(nameof(DropCommand), typeof(ICommand), typeof(DragGestureRecognizer), null);
+		public static readonly BindableProperty DropCommandProperty = BindableProperty.Create(nameof(DropCommand), typeof(ICommand), typeof(DropGestureRecognizer), null);
 
 		/// <summary>Bindable property for <see cref="DropCommandParameter"/>.</summary>
 		public static readonly BindableProperty DropCommandParameterProperty = BindableProperty.Create(nameof(DropCommandParameter), typeof(object), typeof(DropGestureRecognizer), null);


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

<!-- Enter description of the fix in this section -->
This pull request corrects the owner type for the `DropCommandProperty` bindable property in the `DropGestureRecognizer` class. The change ensures that the property is properly associated with `DropGestureRecognizer` instead of the incorrect `DragGestureRecognizer`. This improves property binding and avoids potential runtime issues. 

- **Bug Fix:**
  * Corrected the owner type for `DropCommandProperty` to `DropGestureRecognizer` in `DropGestureRecognizer.cs`.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
