### PR TITLE
[Android] Fix DragGestureRecognizer DragStarting Command/Event fired prematurely

### DIFF
--- a/.github/skills/find-reviewable-pr/scripts/query-reviewable-prs.ps1
+++ b/.github/skills/find-reviewable-pr/scripts/query-reviewable-prs.ps1
@@ -1219,14 +1219,18 @@ function Format-Markdown-Output {
             $title = $rawTitle.Replace('|', '\|')
             $link = "[#$($pr.Number)]($($pr.URL))"
             $turnCol = "$($pr.TurnIcon) $($pr.TurnDetail)"
+            # Wrap author handles in backticks so GitHub renders them as inline code
+            # rather than as @mentions — this issue is for MAUI team triage tracking,
+            # not a notification firehose to every PR author each day.
+            $author = "``@$($pr.Author)``"
             if ($showMilestone -and $showTurn) {
-                [void]$md.AppendLine("| $link | $title | @$($pr.Author) | $($pr.Milestone) | $turnCol | $($pr.Platform) | $($pr.Age)d |")
+                [void]$md.AppendLine("| $link | $title | $author | $($pr.Milestone) | $turnCol | $($pr.Platform) | $($pr.Age)d |")
             } elseif ($showMilestone) {
-                [void]$md.AppendLine("| $link | $title | @$($pr.Author) | $($pr.Milestone) | $($pr.Platform) | $($pr.Age)d | $($pr.Updated)d ago |")
+                [void]$md.AppendLine("| $link | $title | $author | $($pr.Milestone) | $($pr.Platform) | $($pr.Age)d | $($pr.Updated)d ago |")
             } elseif ($showTurn) {
-                [void]$md.AppendLine("| $link | $title | @$($pr.Author) | $turnCol | $($pr.Platform) | $($pr.Age)d |")
+                [void]$md.AppendLine("| $link | $title | $author | $turnCol | $($pr.Platform) | $($pr.Age)d |")
             } else {
-                [void]$md.AppendLine("| $link | $title | @$($pr.Author) | $($pr.Platform) | $($pr.Age)d | $($pr.Updated)d ago |")
+                [void]$md.AppendLine("| $link | $title | $author | $($pr.Platform) | $($pr.Age)d | $($pr.Updated)d ago |")
             }
         }
         [void]$md.AppendLine("")

--- a/.github/workflows/pr-review-queue.yml
+++ b/.github/workflows/pr-review-queue.yml
@@ -20,7 +20,9 @@ concurrency:
 jobs:
   generate-report:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
+    # Guard: only run in dotnet/maui — prevents the scheduled run from firing
+    # in forks and pinging fork owners with duplicate queue issues.
+    if: github.repository_owner == 'dotnet' && github.event_name != 'pull_request'
     permissions:
       contents: read
       issues: write
@@ -86,7 +88,7 @@ jobs:
   # Dry-run on PRs: validate the script works without creating issues
   validate:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.repository_owner == 'dotnet' && github.event_name == 'pull_request'
     permissions:
       contents: read
       pull-requests: read

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -124,7 +124,10 @@ stages:
               skipAndroidPlatformApis: true
               onlyAndroidPlatformDefaultApis: true
               skipAndroidEmulatorImages: ${{ ne(parameters.Platform, 'android') }}
-              skipAndroidCreateAvds: ${{ ne(parameters.Platform, 'android') }}
+              # AVD is created by the inline 'Create AVD and boot Android Emulator' script below
+              # with specific config (playstore image variant, partition shrink, ADB key pre-auth)
+              # that ProvisionAndroidSdkAvdCreateAvds doesn't replicate.
+              skipAndroidCreateAvds: true
               androidEmulatorApiLevel: '30'
               skipSimulatorSetup: ${{ or(eq(parameters.Platform, 'android'), eq(parameters.Platform, 'windows'), eq(parameters.Platform, 'catalyst')) }}
               skipCertificates: true
@@ -871,7 +874,10 @@ stages:
               skipAndroidPlatformApis: true
               onlyAndroidPlatformDefaultApis: true
               skipAndroidEmulatorImages: ${{ ne(parameters.Platform, 'android') }}
-              skipAndroidCreateAvds: ${{ ne(parameters.Platform, 'android') }}
+              # AVD is created by the inline 'Create AVD and boot Android Emulator' script below
+              # with specific config (playstore image variant, partition shrink, ADB key pre-auth)
+              # that ProvisionAndroidSdkAvdCreateAvds doesn't replicate.
+              skipAndroidCreateAvds: true
               androidEmulatorApiLevel: '30'
               skipSimulatorSetup: ${{ or(eq(parameters.Platform, 'android'), eq(parameters.Platform, 'windows'), eq(parameters.Platform, 'catalyst')) }}
               skipCertificates: true

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -15,6 +15,15 @@ variables:
   value: 26.0.1
 - name: POWERSHELL_VERSION
   value: 7.4.0
+# Workaround for PowerShell/PowerShell#20802 (open since Nov 2023):
+# pwsh 7.4.x intermittently aborts at startup on macOS with
+#   'Call to procargs failed with errno 5'
+# because AttemptExecPwshLogin() races on sysctl(KERN_PROCARGS2).
+# Setting __PWSH_LOGIN_CHECKED makes pwsh short-circuit the login-shell
+# detection that triggers the racy syscall (see Program.cs in PowerShell repo).
+# Hit on internal dnceng dotnet-maui build 2990586 (release/11.0.1xx-preview5).
+- name: __PWSH_LOGIN_CHECKED
+  value: '1'
 # Localization variables
 - name: LocBranchPrefix
   value: 'loc-hb'

--- a/src/Controls/src/Core/Platform/Android/InnerGestureListener.cs
+++ b/src/Controls/src/Core/Platform/Android/InnerGestureListener.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Maui.Controls.Platform
 			if (HasAnyGestures())
 			{
 				// If we have any gestures to listen for, we need to return true to show we're interested in the rest
-				// of the events.
+				// of the events.		
 				return true;
 			}
 

--- a/src/Controls/src/Core/Platform/Android/InnerGestureListener.cs
+++ b/src/Controls/src/Core/Platform/Android/InnerGestureListener.cs
@@ -112,10 +112,12 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			SetStartingPosition(e);
 
-			if (HasAnyGestures())
+			if (HasAnyGestures() || EnableLongPressGestures)
 			{
-				// If we have any gestures to listen for, we need to return true to show we're interested in the rest
-				// of the events.		
+				// If we have any gestures to listen for (including drag gestures that use long press),
+				// we need to return true to show we're interested in the rest of the events.
+				// Without consuming ACTION_DOWN, the view won't receive ACTION_UP which is needed
+				// to cancel the long-press timer for quick taps.
 				return true;
 			}
 

--- a/src/Controls/src/Core/Platform/Android/InnerGestureListener.cs
+++ b/src/Controls/src/Core/Platform/Android/InnerGestureListener.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 		bool HasAnyGestures()
 		{
-			return (_panGestureHandler?.HasAnyGestures() ?? false) || (_tapGestureHandler?.HasAnyGestures() ?? false) || (_swipeGestureHandler?.HasAnyGestures() ?? false);
+			return (_panGestureHandler?.HasAnyGestures() ?? false) || (_tapGestureHandler?.HasAnyGestures() ?? false) || (_swipeGestureHandler?.HasAnyGestures() ?? false) || (_dragAndDropGestureHandler?.HasAnyDragGestures() ?? false);
 		}
 
 		// This is needed because GestureRecognizer callbacks can be delayed several hundred milliseconds
@@ -112,12 +112,10 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			SetStartingPosition(e);
 
-			if (HasAnyGestures() || EnableLongPressGestures)
+			if (HasAnyGestures())
 			{
-				// If we have any gestures to listen for (including drag gestures that use long press),
-				// we need to return true to show we're interested in the rest of the events.
-				// Without consuming ACTION_DOWN, the view won't receive ACTION_UP which is needed
-				// to cancel the long-press timer for quick taps.
+				// If we have any gestures to listen for, we need to return true to show we're interested in the rest
+				// of the events.
 				return true;
 			}
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue35752.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue35752.cs
@@ -27,13 +27,31 @@ public class Issue35752 : TestContentPage
 			statusLabel.Text = "DragStarting fired";
 		};
 
-		var dragBox = new BoxView
+		var dragBox = new Label
 		{
 			HeightRequest = 100,
 			WidthRequest = 200,
 			BackgroundColor = Colors.Blue,
 			AutomationId = "DragBox",
+			Text = "Drag Me",
+			TextColor = Colors.White,
+			HorizontalTextAlignment = TextAlignment.Center,
+			VerticalTextAlignment = TextAlignment.Center,
 			GestureRecognizers = { dragRecognizer }
+		};
+
+		var dropRecognizer = new DropGestureRecognizer();
+		var dropBox = new Label
+		{
+			HeightRequest = 100,
+			WidthRequest = 200,
+			BackgroundColor = Colors.Green,
+			AutomationId = "DropBox",
+			Text = "Drop Here",
+			TextColor = Colors.White,
+			HorizontalTextAlignment = TextAlignment.Center,
+			VerticalTextAlignment = TextAlignment.Center,
+			GestureRecognizers = { dropRecognizer }
 		};
 
 		var instructions = new Label
@@ -51,6 +69,7 @@ public class Issue35752 : TestContentPage
 			{
 				instructions,
 				dragBox,
+				dropBox,
 				new Label { Text = "Status:" },
 				statusLabel,
 				new Label { Text = "DragStart count:" },

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue35752.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue35752.cs
@@ -1,0 +1,61 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 35752, "Android DragGestureRecognizer DragStarting fires prematurely on tap", PlatformAffected.Android)]
+public class Issue35752 : TestContentPage
+{
+	protected override void Init()
+	{
+		var statusLabel = new Label
+		{
+			Text = "Ready",
+			AutomationId = "StatusLabel"
+		};
+
+		var dragCountLabel = new Label
+		{
+			Text = "0",
+			AutomationId = "DragStartCount"
+		};
+
+		int dragStartCount = 0;
+
+		var dragRecognizer = new DragGestureRecognizer();
+		dragRecognizer.DragStarting += (s, e) =>
+		{
+			dragStartCount++;
+			dragCountLabel.Text = dragStartCount.ToString();
+			statusLabel.Text = "DragStarting fired";
+		};
+
+		var dragBox = new BoxView
+		{
+			HeightRequest = 100,
+			WidthRequest = 200,
+			BackgroundColor = Colors.Blue,
+			AutomationId = "DragBox",
+			GestureRecognizers = { dragRecognizer }
+		};
+
+		var instructions = new Label
+		{
+			Text = "Quick tap the blue box - DragStarting should NOT fire. " +
+				   "Long press or drag it - DragStarting SHOULD fire.",
+			AutomationId = "TestLoaded"
+		};
+
+		Content = new VerticalStackLayout
+		{
+			Spacing = 20,
+			Padding = new Thickness(20),
+			Children =
+			{
+				instructions,
+				dragBox,
+				new Label { Text = "Status:" },
+				statusLabel,
+				new Label { Text = "DragStart count:" },
+				dragCountLabel
+			}
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35752.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35752.cs
@@ -13,14 +13,14 @@ public class Issue35752 : _IssuesUITest
 	{ }
 
 	[Test]
-	[Category(UITestCategories.Gestures)]
+	[Category(UITestCategories.DragAndDrop)]
 	public void DragStartingShouldNotFireOnTapButShouldFireOnDrag()
 	{
 		App.WaitForElement("TestLoaded");
 
 		App.Tap("DragBox");
 
-		Thread.Sleep(400);
+		Thread.Sleep(600);
 
 		var dragCount = App.WaitForElement("DragStartCount").GetText();
 		Assert.That(dragCount, Is.EqualTo("0"),

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35752.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35752.cs
@@ -1,0 +1,43 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue35752 : _IssuesUITest
+{
+	public override string Issue => "Android DragGestureRecognizer DragStarting fires prematurely on tap";
+
+	public Issue35752(TestDevice device)
+		: base(device)
+	{ }
+
+	[Test]
+	[Category(UITestCategories.Gestures)]
+	public void DragStartingShouldNotFireOnTapButShouldFireOnDrag()
+	{
+		App.WaitForElement("TestLoaded");
+
+		App.Tap("DragBox");
+
+		Thread.Sleep(400);
+
+		var dragCount = App.WaitForElement("DragStartCount").GetText();
+		Assert.That(dragCount, Is.EqualTo("0"),
+			"DragStarting should not fire on a quick tap");
+
+		// Initiate drag - DragStarting SHOULD fire
+		// Mobile platforms (Android/iOS) use long press to start drag
+		// Desktop platforms (Mac/Windows) use press + move
+		var rect = App.WaitForElement("DragBox").GetRect();
+#if ANDROID || IOS
+		App.LongPress("DragBox");
+#else
+		App.DragCoordinates(rect.CenterX(), rect.CenterY(), rect.CenterX() + 100, rect.CenterY());
+#endif
+
+		dragCount = App.WaitForElement("DragStartCount").GetText();
+		Assert.That(dragCount, Is.EqualTo("1"),
+			"DragStarting should fire when drag is initiated");
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35752.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35752.cs
@@ -27,14 +27,7 @@ public class Issue35752 : _IssuesUITest
 			"DragStarting should not fire on a quick tap");
 
 		// Initiate drag - DragStarting SHOULD fire
-		// Mobile platforms (Android/iOS) use long press to start drag
-		// Desktop platforms (Mac/Windows) use press + move
-		var rect = App.WaitForElement("DragBox").GetRect();
-#if ANDROID || IOS
-		App.LongPress("DragBox");
-#else
-		App.DragCoordinates(rect.CenterX(), rect.CenterY(), rect.CenterX() + 100, rect.CenterY());
-#endif
+		App.DragAndDrop("DragBox", "DropBox");
 
 		dragCount = App.WaitForElement("DragStartCount").GetText();
 		Assert.That(dragCount, Is.EqualTo("1"),


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details

- On Android, a view that has only a DragGestureRecognizer  incorrectly raises DragStarting on a quick tap. The drag event fires after the user lifts their finger, even though no long-press or drag motion occurred.

### Root Cause of the issue

- Android's native `GestureDetector` starts an internal long-press timer (~400ms) on `ACTION_DOWN`. It relies on receiving `ACTION_UP` to cancel that timer when the user lifts their finger quickly (tap).
 
 - **Key fact:** If a view does NOT consume `ACTION_DOWN` (returns `e.Handled = false`), Android stops delivering subsequent touch events (`ACTION_MOVE`, `ACTION_UP`) to that view.
 
 ### Before Regression
 
 `e.Handled` was always `true` in `OnPlatformViewTouched`, so drag-only views always consumed `ACTION_DOWN`.
 
 - **Tap:** `ACTION_DOWN` consumed → timer starts → finger lifts → `ACTION_UP` delivered → timer cancelled → no DragStarting 
 - **Long press:** `ACTION_DOWN` consumed → timer starts → finger stays → timer expires → `OnLongPress()` → DragStarting fires 
 
 ### After Regression
 
 PR [#21547](https://github.com/dotnet/maui/pull/21547) changed to `e.Handled = OnTouchEvent(e.Event)`, which returns the result of `InnerGestureListener.OnDown()`. The `OnDown()` method checks `HasAnyGestures()` which only considers Pan/Tap/Swipe — **not Drag**. So for drag-only views, `OnDown()` returns `false` → `e.Handled = false`.
 
 - **Tap:** `ACTION_DOWN` NOT consumed → timer starts → finger lifts → `ACTION_UP` **never delivered** → timer never cancelled → timer expires → DragStarting fires 
 - **Long press:** Same as tap — DragStarting fires regardless of touch duration 
 

### Description of Change
**Gesture Handling Improvements:**

- Updated the `HasAnyGestures()` method in `InnerGestureListener` to include a check for drag gestures using the `_dragAndDropGestureHandler?.HasAnyDragGestures()` condition, ensuring drag gestures are properly distinguished from taps.

**Testing and Verification:**

- Added a new test page (`Issue35752`) in `TestCases.HostApp` that visually and programmatically demonstrates the issue and its resolution, allowing manual verification that `DragStarting` only fires on drag, not on tap.
- Introduced an automated UI test in `TestCases.Shared.Tests` to assert that `DragStarting` does not fire on a quick tap but does fire on an actual drag, preventing regressions.
<!-- Enter description of the fix in this section -->

### Regression details
The regression was introduced by PR [21547](https://github.com/dotnet/maui/pull/21547)
### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #35752

### Tested the behaviour in the following platforms

- [x] - Windows 
- [x] - Android
- [x] - iOS
- [x] - Mac

| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/5ada0f41-2532-4a35-8377-44c49f4d3a71"> | <video src="https://github.com/user-attachments/assets/4a0cd419-1269-4cd6-a9a6-ad533581326b"> |








<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
