### PR TITLE
[Android] Fix RadialGradientBrush crash on Android when view has zero size

### DIFF
--- a/.github/skills/find-reviewable-pr/scripts/query-reviewable-prs.ps1
+++ b/.github/skills/find-reviewable-pr/scripts/query-reviewable-prs.ps1
@@ -1219,14 +1219,18 @@ function Format-Markdown-Output {
             $title = $rawTitle.Replace('|', '\|')
             $link = "[#$($pr.Number)]($($pr.URL))"
             $turnCol = "$($pr.TurnIcon) $($pr.TurnDetail)"
+            # Wrap author handles in backticks so GitHub renders them as inline code
+            # rather than as @mentions — this issue is for MAUI team triage tracking,
+            # not a notification firehose to every PR author each day.
+            $author = "``@$($pr.Author)``"
             if ($showMilestone -and $showTurn) {
-                [void]$md.AppendLine("| $link | $title | @$($pr.Author) | $($pr.Milestone) | $turnCol | $($pr.Platform) | $($pr.Age)d |")
+                [void]$md.AppendLine("| $link | $title | $author | $($pr.Milestone) | $turnCol | $($pr.Platform) | $($pr.Age)d |")
             } elseif ($showMilestone) {
-                [void]$md.AppendLine("| $link | $title | @$($pr.Author) | $($pr.Milestone) | $($pr.Platform) | $($pr.Age)d | $($pr.Updated)d ago |")
+                [void]$md.AppendLine("| $link | $title | $author | $($pr.Milestone) | $($pr.Platform) | $($pr.Age)d | $($pr.Updated)d ago |")
             } elseif ($showTurn) {
-                [void]$md.AppendLine("| $link | $title | @$($pr.Author) | $turnCol | $($pr.Platform) | $($pr.Age)d |")
+                [void]$md.AppendLine("| $link | $title | $author | $turnCol | $($pr.Platform) | $($pr.Age)d |")
             } else {
-                [void]$md.AppendLine("| $link | $title | @$($pr.Author) | $($pr.Platform) | $($pr.Age)d | $($pr.Updated)d ago |")
+                [void]$md.AppendLine("| $link | $title | $author | $($pr.Platform) | $($pr.Age)d | $($pr.Updated)d ago |")
             }
         }
         [void]$md.AppendLine("")

--- a/.github/workflows/pr-review-queue.yml
+++ b/.github/workflows/pr-review-queue.yml
@@ -20,7 +20,9 @@ concurrency:
 jobs:
   generate-report:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
+    # Guard: only run in dotnet/maui — prevents the scheduled run from firing
+    # in forks and pinging fork owners with duplicate queue issues.
+    if: github.repository_owner == 'dotnet' && github.event_name != 'pull_request'
     permissions:
       contents: read
       issues: write
@@ -86,7 +88,7 @@ jobs:
   # Dry-run on PRs: validate the script works without creating issues
   validate:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.repository_owner == 'dotnet' && github.event_name == 'pull_request'
     permissions:
       contents: read
       pull-requests: read

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -124,7 +124,10 @@ stages:
               skipAndroidPlatformApis: true
               onlyAndroidPlatformDefaultApis: true
               skipAndroidEmulatorImages: ${{ ne(parameters.Platform, 'android') }}
-              skipAndroidCreateAvds: ${{ ne(parameters.Platform, 'android') }}
+              # AVD is created by the inline 'Create AVD and boot Android Emulator' script below
+              # with specific config (playstore image variant, partition shrink, ADB key pre-auth)
+              # that ProvisionAndroidSdkAvdCreateAvds doesn't replicate.
+              skipAndroidCreateAvds: true
               androidEmulatorApiLevel: '30'
               skipSimulatorSetup: ${{ or(eq(parameters.Platform, 'android'), eq(parameters.Platform, 'windows'), eq(parameters.Platform, 'catalyst')) }}
               skipCertificates: true
@@ -871,7 +874,10 @@ stages:
               skipAndroidPlatformApis: true
               onlyAndroidPlatformDefaultApis: true
               skipAndroidEmulatorImages: ${{ ne(parameters.Platform, 'android') }}
-              skipAndroidCreateAvds: ${{ ne(parameters.Platform, 'android') }}
+              # AVD is created by the inline 'Create AVD and boot Android Emulator' script below
+              # with specific config (playstore image variant, partition shrink, ADB key pre-auth)
+              # that ProvisionAndroidSdkAvdCreateAvds doesn't replicate.
+              skipAndroidCreateAvds: true
               androidEmulatorApiLevel: '30'
               skipSimulatorSetup: ${{ or(eq(parameters.Platform, 'android'), eq(parameters.Platform, 'windows'), eq(parameters.Platform, 'catalyst')) }}
               skipCertificates: true

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -15,6 +15,15 @@ variables:
   value: 26.0.1
 - name: POWERSHELL_VERSION
   value: 7.4.0
+# Workaround for PowerShell/PowerShell#20802 (open since Nov 2023):
+# pwsh 7.4.x intermittently aborts at startup on macOS with
+#   'Call to procargs failed with errno 5'
+# because AttemptExecPwshLogin() races on sysctl(KERN_PROCARGS2).
+# Setting __PWSH_LOGIN_CHECKED makes pwsh short-circuit the login-shell
+# detection that triggers the racy syscall (see Program.cs in PowerShell repo).
+# Hit on internal dnceng dotnet-maui build 2990586 (release/11.0.1xx-preview5).
+- name: __PWSH_LOGIN_CHECKED
+  value: '1'
 # Localization variables
 - name: LocBranchPrefix
   value: 'loc-hb'

--- a/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformDrawableStyle.java
+++ b/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformDrawableStyle.java
@@ -106,6 +106,13 @@ public class PlatformDrawableStyle {
             paint.setShader(null);
             paint.setColor(this.solidColor);
         } else if (this.paintType == PlatformPaintType.LINEAR || this.paintType == PlatformPaintType.RADIAL) {
+            if (width <= 0 || height <= 0) {
+                // Cannot create a gradient shader for a zero-size view; render transparent.
+                paint.setShader(null);
+                paint.setColor(Color.TRANSPARENT);
+                return;
+            }
+
             // Reset the color to its default value so that a shader can be applied on top of it
             paint.setColor(Color.BLACK);
             paint.setShader(getShader(width, height));

--- a/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformDrawableStyle.java
+++ b/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformDrawableStyle.java
@@ -60,6 +60,10 @@ public class PlatformDrawableStyle {
             return null;
         }
 
+        if (width == 0 && height == 0) {
+            return null;
+        }
+
         if (width != this.shaderWidth || height != this.shaderHeight) {
             this.shaderWidth = width;
             this.shaderHeight = height;
@@ -106,13 +110,6 @@ public class PlatformDrawableStyle {
             paint.setShader(null);
             paint.setColor(this.solidColor);
         } else if (this.paintType == PlatformPaintType.LINEAR || this.paintType == PlatformPaintType.RADIAL) {
-            if (width <= 0 || height <= 0) {
-                // Cannot create a gradient shader for a zero-size view; render transparent.
-                paint.setShader(null);
-                paint.setColor(Color.TRANSPARENT);
-                return;
-            }
-
             // Reset the color to its default value so that a shader can be applied on top of it
             paint.setColor(Color.BLACK);
             paint.setShader(getShader(width, height));

--- a/src/Core/tests/DeviceTests/Graphics/GraphicsTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Graphics/GraphicsTests.Android.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Graphics;
 using Xunit;
 
 namespace Microsoft.Maui.DeviceTests;
@@ -6,6 +7,28 @@ namespace Microsoft.Maui.DeviceTests;
 [Category(TestCategory.Graphics)]
 public partial class GraphicsTests : TestBase
 {
+	[Fact]
+	public void RadialGradientWithZeroSizeDoesNotThrow()
+	{
+		var paint = new RadialGradientPaintStub(Colors.Red, Colors.Blue)
+		{
+			Center = new Point(0.5, 0.5),
+			Radius = 0.5
+		};
+
+		var context = global::Android.App.Application.Context;
+		using var drawable = new Microsoft.Maui.Graphics.MauiDrawable(context);
+
+		drawable.SetBounds(0, 0, 0, 0);
+		drawable.SetBackground(paint);
+
+		using var bitmap = global::Android.Graphics.Bitmap.CreateBitmap(1, 1, global::Android.Graphics.Bitmap.Config.Argb8888!);
+		using var canvas = new global::Android.Graphics.Canvas(bitmap);
+
+		var ex = Record.Exception(() => drawable.Draw(canvas));
+		Assert.Null(ex);
+	}
+
 	[Theory]
 	[InlineData(0, 0, 0, 0)]
 	[InlineData(10, 10, 100, 100)]


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
- If a RadialGradientBrush is applied to a zero-size control on Android, the app faults with **Java.Lang.IllegalArgumentException: 'ending radius must be > 0'**

### Root Cause
- PR #31567 refactored gradient shader creation into the new PlatformDrawableStyle.java but missed porting the zero-size guard (if (_width == 0 && _height == 0) return;) that existed in the old MauiDrawable.Android.cs — specifically in SetLinearGradientPaint and SetRadialGradientPaint. Without this guard, getShader() is called during initial layout when width = 0 and height = 0, producing radius = 0 and causing IllegalArgumentException: radius must be > 0 from Android's RadialGradient constructor.

### Description of Change
-  In PlatformDrawableStyle.getShader(), added an early return of null when width == 0 && height == 0, preventing LinearGradient/RadialGradient from being constructed with zero dimensions.

### Issues Fixed
Fixes #35753

### Validated the behaviour in the following platforms

- [ ] Windows
- [x] Android
- [ ] iOS
- [ ] Mac

### Output
| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/58d6cdd5-1cbf-4125-b248-eb312daeb7e3"> | <video src="https://github.com/user-attachments/assets/a136e3b7-35f9-48dc-aca5-36c215d32c1a"> |