### PR TITLE
Fix Android foreground geolocation update distance

### DIFF
--- a/.github/skills/find-reviewable-pr/scripts/query-reviewable-prs.ps1
+++ b/.github/skills/find-reviewable-pr/scripts/query-reviewable-prs.ps1
@@ -1219,14 +1219,18 @@ function Format-Markdown-Output {
             $title = $rawTitle.Replace('|', '\|')
             $link = "[#$($pr.Number)]($($pr.URL))"
             $turnCol = "$($pr.TurnIcon) $($pr.TurnDetail)"
+            # Wrap author handles in backticks so GitHub renders them as inline code
+            # rather than as @mentions — this issue is for MAUI team triage tracking,
+            # not a notification firehose to every PR author each day.
+            $author = "``@$($pr.Author)``"
             if ($showMilestone -and $showTurn) {
-                [void]$md.AppendLine("| $link | $title | @$($pr.Author) | $($pr.Milestone) | $turnCol | $($pr.Platform) | $($pr.Age)d |")
+                [void]$md.AppendLine("| $link | $title | $author | $($pr.Milestone) | $turnCol | $($pr.Platform) | $($pr.Age)d |")
             } elseif ($showMilestone) {
-                [void]$md.AppendLine("| $link | $title | @$($pr.Author) | $($pr.Milestone) | $($pr.Platform) | $($pr.Age)d | $($pr.Updated)d ago |")
+                [void]$md.AppendLine("| $link | $title | $author | $($pr.Milestone) | $($pr.Platform) | $($pr.Age)d | $($pr.Updated)d ago |")
             } elseif ($showTurn) {
-                [void]$md.AppendLine("| $link | $title | @$($pr.Author) | $turnCol | $($pr.Platform) | $($pr.Age)d |")
+                [void]$md.AppendLine("| $link | $title | $author | $turnCol | $($pr.Platform) | $($pr.Age)d |")
             } else {
-                [void]$md.AppendLine("| $link | $title | @$($pr.Author) | $($pr.Platform) | $($pr.Age)d | $($pr.Updated)d ago |")
+                [void]$md.AppendLine("| $link | $title | $author | $($pr.Platform) | $($pr.Age)d | $($pr.Updated)d ago |")
             }
         }
         [void]$md.AppendLine("")

--- a/.github/workflows/pr-review-queue.yml
+++ b/.github/workflows/pr-review-queue.yml
@@ -20,7 +20,9 @@ concurrency:
 jobs:
   generate-report:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
+    # Guard: only run in dotnet/maui — prevents the scheduled run from firing
+    # in forks and pinging fork owners with duplicate queue issues.
+    if: github.repository_owner == 'dotnet' && github.event_name != 'pull_request'
     permissions:
       contents: read
       issues: write
@@ -86,7 +88,7 @@ jobs:
   # Dry-run on PRs: validate the script works without creating issues
   validate:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.repository_owner == 'dotnet' && github.event_name == 'pull_request'
     permissions:
       contents: read
       pull-requests: read

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -124,7 +124,10 @@ stages:
               skipAndroidPlatformApis: true
               onlyAndroidPlatformDefaultApis: true
               skipAndroidEmulatorImages: ${{ ne(parameters.Platform, 'android') }}
-              skipAndroidCreateAvds: ${{ ne(parameters.Platform, 'android') }}
+              # AVD is created by the inline 'Create AVD and boot Android Emulator' script below
+              # with specific config (playstore image variant, partition shrink, ADB key pre-auth)
+              # that ProvisionAndroidSdkAvdCreateAvds doesn't replicate.
+              skipAndroidCreateAvds: true
               androidEmulatorApiLevel: '30'
               skipSimulatorSetup: ${{ or(eq(parameters.Platform, 'android'), eq(parameters.Platform, 'windows'), eq(parameters.Platform, 'catalyst')) }}
               skipCertificates: true
@@ -871,7 +874,10 @@ stages:
               skipAndroidPlatformApis: true
               onlyAndroidPlatformDefaultApis: true
               skipAndroidEmulatorImages: ${{ ne(parameters.Platform, 'android') }}
-              skipAndroidCreateAvds: ${{ ne(parameters.Platform, 'android') }}
+              # AVD is created by the inline 'Create AVD and boot Android Emulator' script below
+              # with specific config (playstore image variant, partition shrink, ADB key pre-auth)
+              # that ProvisionAndroidSdkAvdCreateAvds doesn't replicate.
+              skipAndroidCreateAvds: true
               androidEmulatorApiLevel: '30'
               skipSimulatorSetup: ${{ or(eq(parameters.Platform, 'android'), eq(parameters.Platform, 'windows'), eq(parameters.Platform, 'catalyst')) }}
               skipCertificates: true

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -15,6 +15,15 @@ variables:
   value: 26.0.1
 - name: POWERSHELL_VERSION
   value: 7.4.0
+# Workaround for PowerShell/PowerShell#20802 (open since Nov 2023):
+# pwsh 7.4.x intermittently aborts at startup on macOS with
+#   'Call to procargs failed with errno 5'
+# because AttemptExecPwshLogin() races on sysctl(KERN_PROCARGS2).
+# Setting __PWSH_LOGIN_CHECKED makes pwsh short-circuit the login-shell
+# detection that triggers the racy syscall (see Program.cs in PowerShell repo).
+# Hit on internal dnceng dotnet-maui build 2990586 (release/11.0.1xx-preview5).
+- name: __PWSH_LOGIN_CHECKED
+  value: '1'
 # Localization variables
 - name: LocBranchPrefix
   value: 'loc-hb'

--- a/src/Essentials/src/Geolocation/Geolocation.android.cs
+++ b/src/Essentials/src/Geolocation/Geolocation.android.cs
@@ -200,7 +200,7 @@ namespace Microsoft.Maui.Devices.Sensors
 			var minTimeMilliseconds = (long)request.MinimumTime.TotalMilliseconds;
 
 			foreach (var provider in listeningProviders)
-				LocationManager.RequestLocationUpdates(provider, minTimeMilliseconds, providerInfo.Accuracy, continuousListener, looper);
+				LocationManager.RequestLocationUpdates(provider, minTimeMilliseconds, 0, continuousListener, looper);
 
 			return true;
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Stops Android foreground geolocation listening from using the desired accuracy distance as the platform minimum movement threshold. `MinimumTime` now controls the requested update cadence without imposing a hidden 50m+ distance gate for `GeolocationAccuracy.Best`.

The existing accuracy value is still used by the listener to filter out locations that do not satisfy the requested accuracy.

### Issues Fixed

Fixes #22683

### Validation

- Built `src/Essentials/src/Essentials.csproj` for `net10.0-android36.0`.

### Manual regression coverage

Automated Android device coverage for this exact regression would require controlling mock location updates from the test app/device environment, which is not reliable in the current Essentials device-test setup. Please validate the PR artifacts with the issue repro or Essentials geolocation sample:

1. Install this PR's artifacts using the dogfood instructions above.
2. Start foreground listening with `new GeolocationListeningRequest(GeolocationAccuracy.Best, TimeSpan.FromSeconds(1))`.
3. Keep the app in the foreground and send or perform multiple location changes that remain within 50 meters of the previous position.
4. Confirm `LocationChanged` continues firing for those sub-50m updates instead of stopping after the initial GPS/network callbacks.
5. Confirm updates still include high-accuracy locations; locations whose reported accuracy is worse than the requested accuracy can still be filtered by the existing listener accuracy check.