### PR TITLE
 Fix RelativeSource Binding is NULL with XAML SourceGen and IsAotCompatible in iOS Release Mode

### DIFF
--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -531,6 +531,17 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				return false;
 			}
 
+			// When the binding has an explicit RelativeSource or x:Reference source, x:DataType
+			// inherited from an ancestor (e.g. a DataTemplate) describes the template-item type,
+			// not the actual binding source. Attempting to compile against that type would produce
+			// a false XC0045 "property not found" warning and a broken TypedBinding.
+			// Only compile if x:DataType was written directly on the binding node itself,
+			// where the developer explicitly annotates the source type.
+			// Mirrors the same logic in KnownMarkups.ProvideValueForBindingExtension.
+			bool xDataTypeIsOnBindingNode = n == node;
+			if (HasRelativeOrReferenceSource(node) && !xDataTypeIsOnBindingNode)
+				return false;
+
 			if (xDataTypeIsInOuterScope)
 			{
 				context.LoggingHelper.LogWarningOrError(BindingWithXDataTypeFromOuterScope, context.XamlFilePath, node.LineNumber, node.LinePosition, 0, 0, null);
@@ -638,6 +649,21 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 					&& node.TryGetPropertyName(parentNode, out var propertyName)
 					&& propertyName.NamespaceURI == ""
 					&& propertyName.LocalName == nameof(BindableObject.BindingContext);
+			}
+
+			// Returns true when the binding's Source property is a RelativeSource or x:Reference.
+			// When Source is explicitly set, x:DataType inherited from an ancestor DataTemplate
+			// describes template items — not the actual binding source type.
+			static bool HasRelativeOrReferenceSource(ElementNode bindingNode)
+			{
+				if (!bindingNode.Properties.TryGetValue(new XmlName("", "Source"), out INode sourceNode))
+					return false;
+
+				return sourceNode is ElementNode sourceElementNode
+					&& sourceElementNode.XmlType.Name is "RelativeSourceExtension"
+						or "RelativeSource"
+						or "ReferenceExtension"
+						or "Reference";
 			}
 
 			bool DoesNotInheritDataType(ElementNode node)

--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -540,7 +540,9 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			// Mirrors the same logic in KnownMarkups.ProvideValueForBindingExtension (SourceGen).
 			bool xDataTypeIsOnBindingNode = n == node;
 			if (HasRelativeOrReferenceSource(node) && !xDataTypeIsOnBindingNode)
+			{
 				return false;
+			}
 
 			if (xDataTypeIsInOuterScope)
 			{
@@ -661,7 +663,9 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			{
 				if (!bindingNode.Properties.TryGetValue(new XmlName("", "Source"), out INode sourceNode)
 					&& !bindingNode.Properties.TryGetValue(new XmlName(null, "Source"), out sourceNode))
+				{
 					return false;
+				}
 
 				return sourceNode is ElementNode sourceElementNode
 					&& sourceElementNode.XmlType.Name is "RelativeSourceExtension"

--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -531,17 +531,15 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				return false;
 			}
 
-			// When the binding has a RelativeSource (e.g. AncestorType), x:DataType inherited
-			// from an ancestor DataTemplate describes the template-item type, not the actual
-			// binding source. Attempting to compile against that type would produce a false
-			// XC0045 "property not found" warning and a broken TypedBinding.
+			// When the binding has a RelativeSource (e.g. AncestorType) or x:Reference Source,
+			// x:DataType inherited from an ancestor DataTemplate describes the template-item type,
+			// not the actual binding source. Attempting to compile against that type would produce
+			// a false XC0045 "property not found" warning and a broken TypedBinding.
 			// Only compile if x:DataType was written directly on the binding node itself,
 			// where the developer explicitly annotates the source type.
-			// Note: x:Reference bindings are NOT guarded here — the developer's x:DataType on
-			// the referenced element's ancestor intentionally describes the source type there.
-			// Mirrors the same logic in KnownMarkups.ProvideValueForBindingExtension.
+			// Mirrors the same logic in KnownMarkups.ProvideValueForBindingExtension (SourceGen).
 			bool xDataTypeIsOnBindingNode = n == node;
-			if (HasRelativeSource(node) && !xDataTypeIsOnBindingNode)
+			if (HasRelativeOrReferenceSource(node) && !xDataTypeIsOnBindingNode)
 				return false;
 
 			if (xDataTypeIsInOuterScope)
@@ -654,9 +652,12 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			}
 
 			// Returns true when the binding's Source property is a RelativeSource or x:Reference.
-			// When Source is explicitly set to a RelativeSource, x:DataType inherited from an
+			// When Source is a RelativeSource or x:Reference, x:DataType inherited from an
 			// ancestor DataTemplate describes template items — not the actual binding source type.
-			static bool HasRelativeSource(ElementNode bindingNode)
+			// This matches the behaviour in KnownMarkups.ProvideValueForBindingExtension (SourceGen)
+			// and the runtime BindingExtension.ProvideValue (which already sets DataType=null for
+			// all non-RelativeBindingSource sources, including x:Reference resolved objects).
+			static bool HasRelativeOrReferenceSource(ElementNode bindingNode)
 			{
 				if (!bindingNode.Properties.TryGetValue(new XmlName("", "Source"), out INode sourceNode)
 					&& !bindingNode.Properties.TryGetValue(new XmlName(null, "Source"), out sourceNode))
@@ -664,7 +665,9 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 
 				return sourceNode is ElementNode sourceElementNode
 					&& sourceElementNode.XmlType.Name is "RelativeSourceExtension"
-						or "RelativeSource";
+						or "RelativeSource"
+						or "ReferenceExtension"
+						or "Reference";
 			}
 
 			bool DoesNotInheritDataType(ElementNode node)

--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -524,56 +524,65 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				n = GetParent(n);
 			}
 
-			if (dataTypeNode is null)
-			{
-				context.LoggingHelper.LogWarningOrError(BindingWithoutDataType, context.XamlFilePath, node.LineNumber, node.LinePosition, 0, 0, null);
+			bool xDataTypeIsOnBindingNode = n == node;
 
+			if (IsRelativeSourceWithoutAncestorType(node, context, module))
+			{
 				return false;
 			}
 
-			// When the binding has a RelativeSource (e.g. AncestorType) or x:Reference Source,
-			// x:DataType inherited from an ancestor DataTemplate describes the template-item type,
-			// not the actual binding source. Attempting to compile against that type would produce
-			// a false XC0045 "property not found" warning and a broken TypedBinding.
-			// Only compile if x:DataType was written directly on the binding node itself,
-			// where the developer explicitly annotates the source type.
-			// Mirrors the same logic in KnownMarkups.ProvideValueForBindingExtension (SourceGen).
-			bool xDataTypeIsOnBindingNode = n == node;
+			TypeReference tSourceRef = null;
 			if (HasRelativeOrReferenceSource(node) && !xDataTypeIsOnBindingNode)
 			{
-				return false;
+				if (!TryGetRelativeSourceAncestorTypeReference(node, context, module, out tSourceRef))
+				{
+					return false;
+				}
 			}
 
-			if (xDataTypeIsInOuterScope)
+			if (tSourceRef is null)
 			{
-				context.LoggingHelper.LogWarningOrError(BindingWithXDataTypeFromOuterScope, context.XamlFilePath, node.LineNumber, node.LinePosition, 0, 0, null);
-				// continue compilation
+				if (dataTypeNode is null)
+				{
+					context.LoggingHelper.LogWarningOrError(BindingWithoutDataType, context.XamlFilePath, node.LineNumber, node.LinePosition, 0, 0, null);
+
+					return false;
+				}
+
+				if (xDataTypeIsInOuterScope)
+				{
+					context.LoggingHelper.LogWarningOrError(BindingWithXDataTypeFromOuterScope, context.XamlFilePath, node.LineNumber, node.LinePosition, 0, 0, null);
+					// continue compilation
+				}
+
+				if (   dataTypeNode is ElementNode enode
+					&& enode.XmlType.NamespaceUri == XamlParser.X2009Uri
+					&& enode.XmlType.Name == nameof(Xaml.NullExtension))
+				{
+					context.LoggingHelper.LogWarningOrError(BindingWithNullDataType, context.XamlFilePath, node.LineNumber, node.LinePosition, 0, 0, null);
+					return false;
+				}
+
+				if ((dataTypeNode as ValueNode)?.Value is not string dataType)
+					throw new BuildException(XDataTypeSyntax, dataTypeNode as IXmlLineInfo, null);
+
+				XmlType dtXType = null;
+				try
+				{
+					dtXType = TypeArgumentsParser.ParseSingle(dataType, node.NamespaceResolver, dataTypeNode as IXmlLineInfo)
+						?? throw new BuildException(XDataTypeSyntax, dataTypeNode as IXmlLineInfo, null);
+				}
+				catch (XamlParseException)
+				{
+					var prefix = dataType.Contains(":") ? dataType.Substring(0, dataType.IndexOf(":", StringComparison.Ordinal)) : "";
+					throw new BuildException(XmlnsUndeclared, dataTypeNode as IXmlLineInfo, null, prefix);
+				}
+
+				tSourceRef = dtXType.GetTypeReference(context.Cache, module, (IXmlLineInfo)node);
+				if (tSourceRef == null)
+					return false;
 			}
 
-			if (   dataTypeNode is ElementNode enode
-				&& enode.XmlType.NamespaceUri == XamlParser.X2009Uri
-				&& enode.XmlType.Name == nameof(Xaml.NullExtension))
-			{
-				context.LoggingHelper.LogWarningOrError(BindingWithNullDataType, context.XamlFilePath, node.LineNumber, node.LinePosition, 0, 0, null);
-				return false;
-			}
-
-			if ((dataTypeNode as ValueNode)?.Value is not string dataType)
-				throw new BuildException(XDataTypeSyntax, dataTypeNode as IXmlLineInfo, null);
-
-			XmlType dtXType = null;
-			try
-			{
-				dtXType = TypeArgumentsParser.ParseSingle(dataType, node.NamespaceResolver, dataTypeNode as IXmlLineInfo)
-					?? throw new BuildException(XDataTypeSyntax, dataTypeNode as IXmlLineInfo, null);
-			}
-			catch (XamlParseException)
-			{
-				var prefix = dataType.Contains(":") ? dataType.Substring(0, dataType.IndexOf(":", StringComparison.Ordinal)) : "";
-				throw new BuildException(XmlnsUndeclared, dataTypeNode as IXmlLineInfo, null, prefix);
-			}
-
-			var tSourceRef = dtXType.GetTypeReference(context.Cache, module, (IXmlLineInfo)node);
 			if (tSourceRef == null)
 				return false; //throw
 
@@ -672,6 +681,110 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 						or "RelativeSource"
 						or "ReferenceExtension"
 						or "Reference";
+			}
+
+			static bool IsRelativeSourceWithoutAncestorType(ElementNode bindingNode, ILContext context, ModuleDefinition module)
+			{
+				if (!TryGetRelativeSourceNode(bindingNode, out var relativeSourceNode))
+				{
+					return false;
+				}
+
+				return !TryGetRelativeSourceAncestorTypeReference(bindingNode, context, module, out _);
+			}
+
+			static bool TryGetRelativeSourceAncestorTypeReference(ElementNode bindingNode, ILContext context, ModuleDefinition module, out TypeReference ancestorType)
+			{
+				ancestorType = null;
+
+				if (!TryGetRelativeSourceNode(bindingNode, out var relativeSourceNode))
+				{
+					return false;
+				}
+
+				if (!relativeSourceNode.Properties.TryGetValue(new XmlName("", "AncestorType"), out INode ancestorTypeNode)
+					&& !relativeSourceNode.Properties.TryGetValue(new XmlName(null, "AncestorType"), out ancestorTypeNode)
+					&& !relativeSourceNode.Properties.TryGetValue(new XmlName(XamlParser.MauiUri, "AncestorType"), out ancestorTypeNode))
+				{
+					return false;
+				}
+
+				if (ancestorTypeNode is ElementNode ancestorTypeElement)
+				{
+					if (context.TypeExtensions.TryGetValue(ancestorTypeElement, out var mappedType))
+					{
+						ancestorType = module.ImportReference(mappedType);
+						return true;
+					}
+
+					if (!TryGetTypeNameFromTypeExtensionNode(ancestorTypeElement, out var typeName))
+					{
+						return false;
+					}
+
+					return TryResolveTypeFromName(typeName, ancestorTypeElement, context, module, out ancestorType);
+				}
+
+				if (ancestorTypeNode is ValueNode { Value: string directTypeName })
+				{
+					return TryResolveTypeFromName(directTypeName, bindingNode, context, module, out ancestorType);
+				}
+
+				return false;
+			}
+
+			static bool TryGetRelativeSourceNode(ElementNode bindingNode, out ElementNode relativeSourceNode)
+			{
+				relativeSourceNode = null;
+
+				if ((!bindingNode.Properties.TryGetValue(new XmlName("", "Source"), out INode sourceNode)
+						&& !bindingNode.Properties.TryGetValue(new XmlName(null, "Source"), out sourceNode))
+					|| sourceNode is not ElementNode sourceElementNode)
+				{
+					return false;
+				}
+
+				if (sourceElementNode.XmlType.Name is not "RelativeSourceExtension" and not "RelativeSource")
+				{
+					return false;
+				}
+
+				relativeSourceNode = sourceElementNode;
+				return true;
+			}
+
+			static bool TryGetTypeNameFromTypeExtensionNode(ElementNode typeNode, out string typeName)
+			{
+				typeName = null;
+
+				if (!typeNode.Properties.TryGetValue(new XmlName("", "TypeName"), out INode typeNameNode)
+					&& !typeNode.Properties.TryGetValue(new XmlName(null, "TypeName"), out typeNameNode)
+					&& !typeNode.Properties.TryGetValue(new XmlName(XamlParser.MauiUri, "TypeName"), out typeNameNode)
+					&& typeNode.CollectionItems.Count == 1)
+				{
+					typeNameNode = typeNode.CollectionItems[0];
+				}
+
+				typeName = (typeNameNode as ValueNode)?.Value as string;
+				return !string.IsNullOrEmpty(typeName);
+			}
+
+			static bool TryResolveTypeFromName(string typeName, ElementNode namespaceNode, ILContext context, ModuleDefinition module, out TypeReference typeReference)
+			{
+				typeReference = null;
+
+				XmlType xmlType;
+				try
+				{
+					xmlType = TypeArgumentsParser.ParseSingle(typeName, namespaceNode.NamespaceResolver, namespaceNode as IXmlLineInfo);
+				}
+				catch (XamlParseException)
+				{
+					return false;
+				}
+
+				typeReference = xmlType?.GetTypeReference(context.Cache, module, namespaceNode as IXmlLineInfo);
+				return typeReference is not null;
 			}
 
 			bool DoesNotInheritDataType(ElementNode node)

--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -531,15 +531,17 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				return false;
 			}
 
-			// When the binding has an explicit RelativeSource or x:Reference source, x:DataType
-			// inherited from an ancestor (e.g. a DataTemplate) describes the template-item type,
-			// not the actual binding source. Attempting to compile against that type would produce
-			// a false XC0045 "property not found" warning and a broken TypedBinding.
+			// When the binding has a RelativeSource (e.g. AncestorType), x:DataType inherited
+			// from an ancestor DataTemplate describes the template-item type, not the actual
+			// binding source. Attempting to compile against that type would produce a false
+			// XC0045 "property not found" warning and a broken TypedBinding.
 			// Only compile if x:DataType was written directly on the binding node itself,
 			// where the developer explicitly annotates the source type.
+			// Note: x:Reference bindings are NOT guarded here — the developer's x:DataType on
+			// the referenced element's ancestor intentionally describes the source type there.
 			// Mirrors the same logic in KnownMarkups.ProvideValueForBindingExtension.
 			bool xDataTypeIsOnBindingNode = n == node;
-			if (HasRelativeOrReferenceSource(node) && !xDataTypeIsOnBindingNode)
+			if (HasRelativeSource(node) && !xDataTypeIsOnBindingNode)
 				return false;
 
 			if (xDataTypeIsInOuterScope)
@@ -652,18 +654,17 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			}
 
 			// Returns true when the binding's Source property is a RelativeSource or x:Reference.
-			// When Source is explicitly set, x:DataType inherited from an ancestor DataTemplate
-			// describes template items — not the actual binding source type.
-			static bool HasRelativeOrReferenceSource(ElementNode bindingNode)
+			// When Source is explicitly set to a RelativeSource, x:DataType inherited from an
+			// ancestor DataTemplate describes template items — not the actual binding source type.
+			static bool HasRelativeSource(ElementNode bindingNode)
 			{
-				if (!bindingNode.Properties.TryGetValue(new XmlName("", "Source"), out INode sourceNode))
+				if (!bindingNode.Properties.TryGetValue(new XmlName("", "Source"), out INode sourceNode)
+					&& !bindingNode.Properties.TryGetValue(new XmlName(null, "Source"), out sourceNode))
 					return false;
 
 				return sourceNode is ElementNode sourceElementNode
 					&& sourceElementNode.XmlType.Name is "RelativeSourceExtension"
-						or "RelativeSource"
-						or "ReferenceExtension"
-						or "Reference";
+						or "RelativeSource";
 			}
 
 			bool DoesNotInheritDataType(ElementNode node)

--- a/src/Controls/src/SourceGen/KnownMarkups.cs
+++ b/src/Controls/src/SourceGen/KnownMarkups.cs
@@ -425,7 +425,7 @@ internal class KnownMarkups
 				expression += $", source:global::Microsoft.Maui.Controls.RelativeBindingSource.TemplatedParent";
 			}
 			else
-			{
+            {
 				if (markupNode.Properties.TryGetValue(new XmlName(null, "Source"), out var sourceNode))
 					expression += $", source: {getNodeValue(sourceNode, context.Compilation.GetTypeByMetadataName("System.String")!).ValueAccessor}";
 				expression += ") {";
@@ -435,7 +435,7 @@ internal class KnownMarkups
 					expression += $"FallbackValue = {getNodeValue(fallbackValueNode, context.Compilation.GetTypeByMetadataName("System.Object")!).ValueAccessor}, ";
 				if (markupNode.Properties.TryGetValue(new XmlName(null, "TargetNullValue"), out var targetNullValueNode))
 					expression += $"TargetNullValue = {getNodeValue(targetNullValueNode, context.Compilation.GetTypeByMetadataName("System.Object")!).ValueAccessor}, ";
-			}
+            }
 
 			expression += "}";
 			value = expression;
@@ -896,6 +896,7 @@ internal class KnownMarkups
 
 				var propertyType = typeandconverter?.type ?? propertySymbol?.Type;
 				var converter = typeandconverter?.converter;
+				
 				// If no converter from BP, check the property's TypeConverter attribute
 				if (converter == null && propertySymbol != null)
 				{
@@ -924,6 +925,7 @@ internal class KnownMarkups
 				return true;
 			}
 		}
+		
 		// If we get here and getNodeValue is provided, use it as fallback
 		if (getNodeValue != null)
 		{

--- a/src/Controls/src/SourceGen/KnownMarkups.cs
+++ b/src/Controls/src/SourceGen/KnownMarkups.cs
@@ -341,20 +341,25 @@ internal class KnownMarkups
 		returnType = context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.BindingBase")!;
 		ITypeSymbol? dataTypeSymbol = null;
 
-		// When Source is explicitly set (RelativeSource or x:Reference), x:DataType usually does not
-		// describe the actual source — skip compilation and fall back to runtime binding.
-		// Exception: when x:DataType is written directly on the Binding node itself (not inherited
-		// from an ancestor), the developer is explicitly annotating the source's type.
-		// In that case we CAN compile a TypedBinding, which avoids reflection and is AOT/trim safe.
+		// When Source is explicitly set, inherited x:DataType usually does not describe the actual source.
+		// RelativeSource with AncestorType is the exception: AncestorType defines the source type.
+		// RelativeSource Self should never compile to TypedBinding because the source is the view itself.
 		bool hasExplicitSource = HasExplicitBindingSource(markupNode);
-		bool xDataTypeOnBindingNode = hasExplicitSource && markupNode.Properties.ContainsKey(XmlName.xDataType);
+		bool xDataTypeOnBindingNode = markupNode.Properties.ContainsKey(XmlName.xDataType);
+		bool isRelativeSourceWithoutAncestorType = IsRelativeSourceWithoutAncestorType(markupNode, context);
 
 		context.Variables.TryGetValue(markupNode, out ILocalValue? extVariable);
 
-		if ((!hasExplicitSource || xDataTypeOnBindingNode)
-			&& extVariable is not null)
+		if (!isRelativeSourceWithoutAncestorType && extVariable is not null)
 		{
-			TryGetXDataType(markupNode, context, out dataTypeSymbol);
+			if (!hasExplicitSource || xDataTypeOnBindingNode)
+			{
+				TryGetXDataType(markupNode, context, out dataTypeSymbol);
+			}
+			else if (TryGetRelativeSourceAncestorType(markupNode, context, out var ancestorType))
+			{
+				dataTypeSymbol = ancestorType;
+			}
 
 			if (dataTypeSymbol is not null)
 			{
@@ -631,6 +636,97 @@ internal class KnownMarkups
 				&& node.TryGetPropertyName(parentNode, out var propertyName)
 				&& propertyName.NamespaceURI == ""
 				&& propertyName.LocalName == "BindingContext";
+		}
+
+		static bool IsRelativeSourceWithoutAncestorType(ElementNode bindingNode, SourceGenContext context)
+		{
+			if (!TryGetRelativeSourceNode(bindingNode, out var relativeSourceNode))
+			{
+				return false;
+			}
+
+			return !TryGetRelativeSourceAncestorType(bindingNode, context, out _);
+		}
+
+		static bool TryGetRelativeSourceAncestorType(ElementNode bindingNode, SourceGenContext context, out ITypeSymbol? ancestorType)
+		{
+			ancestorType = null;
+
+			if (!TryGetRelativeSourceNode(bindingNode, out var relativeSourceNode))
+			{
+				return false;
+			}
+
+			if (!relativeSourceNode.Properties.TryGetValue(new XmlName("", "AncestorType"), out INode? ancestorTypeNode)
+				&& !relativeSourceNode.Properties.TryGetValue(new XmlName(null, "AncestorType"), out ancestorTypeNode)
+				&& !relativeSourceNode.Properties.TryGetValue(new XmlName(XamlParser.MauiUri, "AncestorType"), out ancestorTypeNode))
+			{
+				return false;
+			}
+
+			if (ancestorTypeNode is ElementNode typeExtNode)
+			{
+				if (context.Types.TryGetValue(typeExtNode, out var resolvedType))
+				{
+					ancestorType = resolvedType;
+					return true;
+				}
+
+				if (!typeExtNode.Properties.TryGetValue(new XmlName("", "TypeName"), out INode? typeNameNode)
+					&& !typeExtNode.Properties.TryGetValue(new XmlName(null, "TypeName"), out typeNameNode)
+					&& !typeExtNode.Properties.TryGetValue(new XmlName(XamlParser.MauiUri, "TypeName"), out typeNameNode)
+					&& typeExtNode.CollectionItems.Count == 1)
+				{
+					typeNameNode = typeExtNode.CollectionItems[0];
+				}
+
+				if (typeNameNode is ValueNode { Value: string typeName } && !IsNullOrEmpty(typeName))
+				{
+					XmlType xmlType = TypeArgumentsParser.ParseSingle(typeName, typeExtNode.NamespaceResolver, typeExtNode as IXmlLineInfo);
+					if (xmlType.TryResolveTypeSymbol(null, context.Compilation, context.XmlnsCache, context.TypeCache, out var resolvedAncestorType)
+						&& resolvedAncestorType is not null)
+					{
+						ancestorType = resolvedAncestorType;
+						context.Types[typeExtNode] = resolvedAncestorType;
+						return true;
+					}
+				}
+
+				return false;
+			}
+
+			if (ancestorTypeNode is ValueNode { Value: string directTypeName } && !IsNullOrEmpty(directTypeName))
+			{
+				XmlType xmlType = TypeArgumentsParser.ParseSingle(directTypeName, bindingNode.NamespaceResolver, bindingNode as IXmlLineInfo);
+				if (xmlType.TryResolveTypeSymbol(null, context.Compilation, context.XmlnsCache, context.TypeCache, out var resolvedAncestorType)
+					&& resolvedAncestorType is not null)
+				{
+					ancestorType = resolvedAncestorType;
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		static bool TryGetRelativeSourceNode(ElementNode bindingNode, out ElementNode relativeSourceNode)
+		{
+			relativeSourceNode = null!;
+
+			if ((!bindingNode.Properties.TryGetValue(new XmlName("", "Source"), out INode? sourceNode)
+					&& !bindingNode.Properties.TryGetValue(new XmlName(null, "Source"), out sourceNode))
+				|| sourceNode is not ElementNode sourceElementNode)
+			{
+				return false;
+			}
+
+			if (sourceElementNode.XmlType.Name is not "RelativeSourceExtension" and not "RelativeSource")
+			{
+				return false;
+			}
+
+			relativeSourceNode = sourceElementNode;
+			return true;
 		}
 
 		// Checks if the binding has a Source property set to RelativeSource or x:Reference.

--- a/src/Controls/src/SourceGen/KnownMarkups.cs
+++ b/src/Controls/src/SourceGen/KnownMarkups.cs
@@ -56,7 +56,7 @@ internal class KnownMarkups
 			value = string.Empty;
 			return false;
 		}
-		
+
 		var field = typeSymbol!.GetAllFields(membername, context).FirstOrDefault(f => f.IsStatic);
 		var property = typeSymbol!.GetAllProperties(membername, context).FirstOrDefault(p => p.IsStatic);
 
@@ -152,7 +152,7 @@ internal class KnownMarkups
 		if (!markupNode.Properties.TryGetValue(new XmlName("", "AncestorType"), out ancestorTypeNode)
 			&& !markupNode.Properties.TryGetValue(new XmlName(null, "AncestorType"), out ancestorTypeNode))
 			markupNode.Properties.TryGetValue(new XmlName(XamlParser.MauiUri, "AncestorType"), out ancestorTypeNode);
-		
+
 		if (ancestorTypeNode is not null)
 		{
 			if (ancestorTypeNode is ElementNode typeExtNode)
@@ -260,7 +260,7 @@ internal class KnownMarkups
 		}
 	}
 
-	public static bool ProvideValueForDynamicResourceExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context,  NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
+	public static bool ProvideValueForDynamicResourceExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context, NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
 	{
 		returnType = context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.Internals.DynamicResource")!;
 		string? key = null;
@@ -326,7 +326,7 @@ internal class KnownMarkups
 		}
 	}
 
-	internal static bool ProvideValueForTemplateBindingExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context,  NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
+	internal static bool ProvideValueForTemplateBindingExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context, NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
 	{
 		return ProvideValueForBindingExtension(markupNode, writer, context, isTemplateBinding: true, getNodeValue, out returnType, out value);
 	}
@@ -336,18 +336,22 @@ internal class KnownMarkups
 		return ProvideValueForBindingExtension(markupNode, writer, context, isTemplateBinding: false, getNodeValue, out returnType, out value);
 	}
 
-	private static bool ProvideValueForBindingExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context, bool isTemplateBinding,  NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
+	private static bool ProvideValueForBindingExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context, bool isTemplateBinding, NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
 	{
 		returnType = context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.BindingBase")!;
 		ITypeSymbol? dataTypeSymbol = null;
-		
-		// When Source is explicitly set (RelativeSource or x:Reference), x:DataType does not describe
-		// the actual source — skip compilation and fall back to runtime binding.
+
+		// When Source is explicitly set (RelativeSource or x:Reference), x:DataType usually does not
+		// describe the actual source — skip compilation and fall back to runtime binding.
+		// Exception: when x:DataType is written directly on the Binding node itself (not inherited
+		// from an ancestor), the developer is explicitly annotating the source's type.
+		// In that case we CAN compile a TypedBinding, which avoids reflection and is AOT/trim safe.
 		bool hasExplicitSource = HasExplicitBindingSource(markupNode);
-		
+		bool xDataTypeOnBindingNode = hasExplicitSource && markupNode.Properties.ContainsKey(XmlName.xDataType);
+
 		context.Variables.TryGetValue(markupNode, out ILocalValue? extVariable);
-		
-		if (   !hasExplicitSource
+
+		if ((!hasExplicitSource || xDataTypeOnBindingNode)
 			&& extVariable is not null)
 		{
 			TryGetXDataType(markupNode, context, out dataTypeSymbol);
@@ -421,7 +425,7 @@ internal class KnownMarkups
 				expression += $", source:global::Microsoft.Maui.Controls.RelativeBindingSource.TemplatedParent";
 			}
 			else
-            {
+			{
 				if (markupNode.Properties.TryGetValue(new XmlName(null, "Source"), out var sourceNode))
 					expression += $", source: {getNodeValue(sourceNode, context.Compilation.GetTypeByMetadataName("System.String")!).ValueAccessor}";
 				expression += ") {";
@@ -431,7 +435,7 @@ internal class KnownMarkups
 					expression += $"FallbackValue = {getNodeValue(fallbackValueNode, context.Compilation.GetTypeByMetadataName("System.Object")!).ValueAccessor}, ";
 				if (markupNode.Properties.TryGetValue(new XmlName(null, "TargetNullValue"), out var targetNullValueNode))
 					expression += $"TargetNullValue = {getNodeValue(targetNullValueNode, context.Compilation.GetTypeByMetadataName("System.Object")!).ValueAccessor}, ";
-            }
+			}
 
 			expression += "}";
 			value = expression;
@@ -892,7 +896,7 @@ internal class KnownMarkups
 
 				var propertyType = typeandconverter?.type ?? propertySymbol?.Type;
 				var converter = typeandconverter?.converter;
-				
+
 				// If no converter from BP, check the property's TypeConverter attribute
 				if (converter == null && propertySymbol != null)
 				{
@@ -921,7 +925,7 @@ internal class KnownMarkups
 				return true;
 			}
 		}
-		
+
 		// If we get here and getNodeValue is provided, use it as fallback
 		if (getNodeValue != null)
 		{

--- a/src/Controls/src/SourceGen/KnownMarkups.cs
+++ b/src/Controls/src/SourceGen/KnownMarkups.cs
@@ -56,6 +56,7 @@ internal class KnownMarkups
 			value = string.Empty;
 			return false;
 		}
+		
 		var field = typeSymbol!.GetAllFields(membername, context).FirstOrDefault(f => f.IsStatic);
 		var property = typeSymbol!.GetAllProperties(membername, context).FirstOrDefault(p => p.IsStatic);
 
@@ -151,6 +152,7 @@ internal class KnownMarkups
 		if (!markupNode.Properties.TryGetValue(new XmlName("", "AncestorType"), out ancestorTypeNode)
 			&& !markupNode.Properties.TryGetValue(new XmlName(null, "AncestorType"), out ancestorTypeNode))
 			markupNode.Properties.TryGetValue(new XmlName(XamlParser.MauiUri, "AncestorType"), out ancestorTypeNode);
+		
 		if (ancestorTypeNode is not null)
 		{
 			if (ancestorTypeNode is ElementNode typeExtNode)
@@ -258,7 +260,7 @@ internal class KnownMarkups
 		}
 	}
 
-	public static bool ProvideValueForDynamicResourceExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context,NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
+	public static bool ProvideValueForDynamicResourceExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context,  NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
 	{
 		returnType = context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.Internals.DynamicResource")!;
 		string? key = null;
@@ -324,7 +326,7 @@ internal class KnownMarkups
 		}
 	}
 
-	internal static bool ProvideValueForTemplateBindingExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context,NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
+	internal static bool ProvideValueForTemplateBindingExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context,  NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
 	{
 		return ProvideValueForBindingExtension(markupNode, writer, context, isTemplateBinding: true, getNodeValue, out returnType, out value);
 	}
@@ -334,7 +336,7 @@ internal class KnownMarkups
 		return ProvideValueForBindingExtension(markupNode, writer, context, isTemplateBinding: false, getNodeValue, out returnType, out value);
 	}
 
-	private static bool ProvideValueForBindingExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context, bool isTemplateBinding,NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
+	private static bool ProvideValueForBindingExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context, bool isTemplateBinding,  NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
 	{
 		returnType = context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.BindingBase")!;
 		ITypeSymbol? dataTypeSymbol = null;

--- a/src/Controls/src/SourceGen/KnownMarkups.cs
+++ b/src/Controls/src/SourceGen/KnownMarkups.cs
@@ -56,7 +56,6 @@ internal class KnownMarkups
 			value = string.Empty;
 			return false;
 		}
-
 		var field = typeSymbol!.GetAllFields(membername, context).FirstOrDefault(f => f.IsStatic);
 		var property = typeSymbol!.GetAllProperties(membername, context).FirstOrDefault(p => p.IsStatic);
 
@@ -152,7 +151,6 @@ internal class KnownMarkups
 		if (!markupNode.Properties.TryGetValue(new XmlName("", "AncestorType"), out ancestorTypeNode)
 			&& !markupNode.Properties.TryGetValue(new XmlName(null, "AncestorType"), out ancestorTypeNode))
 			markupNode.Properties.TryGetValue(new XmlName(XamlParser.MauiUri, "AncestorType"), out ancestorTypeNode);
-
 		if (ancestorTypeNode is not null)
 		{
 			if (ancestorTypeNode is ElementNode typeExtNode)
@@ -260,7 +258,7 @@ internal class KnownMarkups
 		}
 	}
 
-	public static bool ProvideValueForDynamicResourceExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context, NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
+	public static bool ProvideValueForDynamicResourceExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context,NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
 	{
 		returnType = context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.Internals.DynamicResource")!;
 		string? key = null;
@@ -326,7 +324,7 @@ internal class KnownMarkups
 		}
 	}
 
-	internal static bool ProvideValueForTemplateBindingExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context, NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
+	internal static bool ProvideValueForTemplateBindingExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context,NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
 	{
 		return ProvideValueForBindingExtension(markupNode, writer, context, isTemplateBinding: true, getNodeValue, out returnType, out value);
 	}
@@ -336,7 +334,7 @@ internal class KnownMarkups
 		return ProvideValueForBindingExtension(markupNode, writer, context, isTemplateBinding: false, getNodeValue, out returnType, out value);
 	}
 
-	private static bool ProvideValueForBindingExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context, bool isTemplateBinding, NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
+	private static bool ProvideValueForBindingExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context, bool isTemplateBinding,NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
 	{
 		returnType = context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.BindingBase")!;
 		ITypeSymbol? dataTypeSymbol = null;
@@ -896,7 +894,6 @@ internal class KnownMarkups
 
 				var propertyType = typeandconverter?.type ?? propertySymbol?.Type;
 				var converter = typeandconverter?.converter;
-
 				// If no converter from BP, check the property's TypeConverter attribute
 				if (converter == null && propertySymbol != null)
 				{
@@ -925,7 +922,6 @@ internal class KnownMarkups
 				return true;
 			}
 		}
-
 		// If we get here and getNodeValue is provided, use it as fallback
 		if (getNodeValue != null)
 		{

--- a/src/Controls/src/Xaml/MarkupExtensions/BindingExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/BindingExtension.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Maui.Controls.Xaml
 					//       the template item, not the ancestor — set DataType to null to avoid false
 					//       mismatch failures (see https://github.com/dotnet/maui/issues/35564).
 					DataType = Source is null || (Source is RelativeBindingSource
-						&& dataTypeProvider is XamlDataTypeProvider { IsDataTypeOnBindingNode: true })
+						&& dataTypeProvider is IXamlDataTypeProviderWithBindingNodeInfo { IsDataTypeOnBindingNode: true })
 						? bindingXDataType
 						: null,
 				};

--- a/src/Controls/src/Xaml/MarkupExtensions/BindingExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/BindingExtension.cs
@@ -2,6 +2,7 @@ using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Controls.Xaml.Internals;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
@@ -83,11 +84,13 @@ namespace Microsoft.Maui.Controls.Xaml
 			BindingBase CreateBinding()
 			{
 				Type bindingXDataType = null;
+				IXamlDataTypeProvider dataTypeProvider = null;
 				if (serviceProvider is not null &&
 					(serviceProvider.GetService(typeof(IXamlTypeResolver)) is IXamlTypeResolver typeResolver)
-					&& (serviceProvider.GetService(typeof(IXamlDataTypeProvider)) is IXamlDataTypeProvider dataTypeProvider)
-					&& dataTypeProvider.BindingDataType != null)
+					&& (serviceProvider.GetService(typeof(IXamlDataTypeProvider)) is IXamlDataTypeProvider dtProvider)
+					&& dtProvider.BindingDataType != null)
 				{
+					dataTypeProvider = dtProvider;
 					typeResolver.TryResolve(dataTypeProvider.BindingDataType, out bindingXDataType);
 				}
 				return new Binding(Path, Mode, Converter, ConverterParameter, StringFormat, Source)
@@ -95,17 +98,25 @@ namespace Microsoft.Maui.Controls.Xaml
 					UpdateSourceEventName = UpdateSourceEventName,
 					FallbackValue = FallbackValue,
 					TargetNullValue = TargetNullValue,
-					// When Source is set to a concrete element reference (e.g. x:Reference), the
-					// DataType from IXamlDataTypeProvider reflects the DataTemplate item type, not
-					// the explicit source type. Assigning that mismatched DataType causes
-					// BindingExpression.Apply to null-out the binding source when
-					// IsXamlCBindingWithSourceCompilationEnabled is true (.NET 10 default for
-					// AOT/trimmed builds). See https://github.com/dotnet/maui/issues/33291.
+					// When Source is set to any explicit source, the DataType from
+					// IXamlDataTypeProvider may reflect the DataTemplate item type (inherited from an
+					// ancestor DataTemplate) rather than the explicit source type. Assigning that
+					// mismatched DataType causes BindingExpression.Apply to null-out the binding
+					// source when IsXamlCBindingWithSourceCompilationEnabled is true (.NET 10 default
+					// for AOT/trimmed builds).
 					//
-					// RelativeBindingSource is excluded: the developer likely set x:DataType on
-					// the binding to describe the expected type of the resolved ancestor, and
-					// that validation should be preserved.
-					DataType = (Source is null || Source is RelativeBindingSource) ? bindingXDataType : null,
+					// - Source=null           → DataType applies (BindingContext IS described by x:DataType)
+					// - Source={x:Reference}  → DataType must be null (see https://github.com/dotnet/maui/issues/33291)
+					// - Source={RelativeSource AncestorType=...}
+					//     • x:DataType was set *directly* on the Binding itself: the developer explicitly
+					//       typed the binding source, so preserve DataType for the type-mismatch check.
+					//     • x:DataType was *inherited* from a DataTemplate ancestor: the type describes
+					//       the template item, not the ancestor — set DataType to null to avoid false
+					//       mismatch failures (see https://github.com/dotnet/maui/issues/35564).
+					DataType = Source is null || (Source is RelativeBindingSource
+						&& dataTypeProvider is XamlDataTypeProvider { IsDataTypeOnBindingNode: true })
+						? bindingXDataType
+						: null,
 				};
 			}
 		}

--- a/src/Controls/src/Xaml/MarkupExtensions/BindingExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/BindingExtension.cs
@@ -93,6 +93,9 @@ namespace Microsoft.Maui.Controls.Xaml
 					dataTypeProvider = dtProvider;
 					typeResolver.TryResolve(dataTypeProvider.BindingDataType, out bindingXDataType);
 				}
+				// Runtime inflation still creates a string-path Binding. This path is intentionally
+				// not trim-safe for AOT (it is reflection-based and carries trim warnings).
+				// SourceGen/XamlC TypedBinding generation is the trim-safe path.
 				return new Binding(Path, Mode, Converter, ConverterParameter, StringFormat, Source)
 				{
 					UpdateSourceEventName = UpdateSourceEventName,

--- a/src/Controls/src/Xaml/XamlServiceProvider.cs
+++ b/src/Controls/src/Xaml/XamlServiceProvider.cs
@@ -320,7 +320,18 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 		public void Add(string prefix, string ns) => namespaces.Add(prefix, ns);
 	}
 
-	public class XamlDataTypeProvider : IXamlDataTypeProvider
+	/// <summary>
+	/// Extended internal interface for <see cref="IXamlDataTypeProvider"/> implementations
+	/// that can report whether the x:DataType was declared directly on the binding node
+	/// (as opposed to being inherited from an ancestor such as a DataTemplate).
+	/// This avoids a concrete cast to <see cref="XamlDataTypeProvider"/> in consumers.
+	/// </summary>
+	internal interface IXamlDataTypeProviderWithBindingNodeInfo : IXamlDataTypeProvider
+	{
+		bool IsDataTypeOnBindingNode { get; }
+	}
+
+	public class XamlDataTypeProvider : IXamlDataTypeProviderWithBindingNodeInfo
 	{
 		public XamlDataTypeProvider(string dataType) => this.dataType = dataType;
 
@@ -404,6 +415,7 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 		}
 		string dataType;
 		string IXamlDataTypeProvider.BindingDataType => dataType;
+		bool IXamlDataTypeProviderWithBindingNodeInfo.IsDataTypeOnBindingNode => IsDataTypeOnBindingNode;
 		internal HydrationContext Context { get; }
 
 		/// <summary>

--- a/src/Controls/src/Xaml/XamlServiceProvider.cs
+++ b/src/Controls/src/Xaml/XamlServiceProvider.cs
@@ -387,6 +387,9 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 			// - x:DataType on the binding itself
 			// - SKIP looking for x:DataType on the parent
 			// - continue looking for x:DataType on the parent's parent...
+			// Note: skipNode = GetParent(node), so skipNode CANNOT equal firstNode (= node).
+			// The first loop iteration always checks the binding node itself for x:DataType,
+			// regardless of whether it is a BindingContext binding.
 			ElementNode skipNode = null;
 			if (IsBindingContextBinding(node))
 			{

--- a/src/Controls/src/Xaml/XamlServiceProvider.cs
+++ b/src/Controls/src/Xaml/XamlServiceProvider.cs
@@ -369,6 +369,7 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 
 			INode dataTypeNode = null;
 			ElementNode n = node as ElementNode;
+			var firstNode = n;
 
 			// Special handling for BindingContext={Binding ...}
 			// The order of checks is:
@@ -396,9 +397,20 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 			}
 			if (dataTypeNode is ValueNode valueNode)
 				this.dataType = valueNode.Value as string;
+			// Track whether x:DataType was found directly on the binding node, not inherited from
+			// an ancestor (e.g. a DataTemplate). This lets BindingExtension correctly skip the
+			// DataType for RelativeSource bindings whose DataType is only the DataTemplate item type.
+			IsDataTypeOnBindingNode = dataTypeNode != null && n == firstNode;
 		}
 		string dataType;
 		string IXamlDataTypeProvider.BindingDataType => dataType;
 		internal HydrationContext Context { get; }
+
+		/// <summary>
+		/// Gets whether the x:DataType was found directly on the binding node itself
+		/// (as opposed to being inherited from an ancestor element such as a DataTemplate).
+		/// </summary>
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		internal bool IsDataTypeOnBindingNode { get; }
 	}
 }

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui35564.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui35564.xaml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+    x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui35564"
+    x:DataType="local:Maui35564">
+    <VerticalStackLayout>
+        <!-- Scenario A: RelativeSource binding without x:DataType on the binding itself.
+             The DataTemplate's x:DataType (Maui35564Item) must NOT be applied to the
+             RelativeSource binding's resolved ancestor (Maui35564 page). -->
+        <CollectionView x:Name="TheCollectionView"
+            ItemsSource="{Binding Items}">
+            <CollectionView.ItemTemplate>
+                <DataTemplate x:DataType="local:Maui35564Item">
+                    <VerticalStackLayout>
+                        <VerticalStackLayout.GestureRecognizers>
+                            <TapGestureRecognizer
+                                Command="{Binding ItemTappedCommand, Source={RelativeSource AncestorType={x:Type local:Maui35564}}}"
+                                CommandParameter="{Binding}" />
+                        </VerticalStackLayout.GestureRecognizers>
+                        <Label Text="{Binding Name}" />
+                    </VerticalStackLayout>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+        <!-- Scenario B: RelativeSource binding WITH x:DataType directly on the binding.
+             This is the pattern used in real AOT apps — x:DataType describes the ancestor's
+             type so SourceGen can compile it to a TypedBinding (no reflection, AOT/trim safe). -->
+        <CollectionView x:Name="TheCollectionView2"
+            ItemsSource="{Binding Items}">
+            <CollectionView.ItemTemplate>
+                <DataTemplate x:DataType="local:Maui35564Item">
+                    <VerticalStackLayout>
+                        <VerticalStackLayout.GestureRecognizers>
+                            <TapGestureRecognizer
+                                Command="{Binding ItemTappedCommand, x:DataType=local:Maui35564, Source={RelativeSource AncestorType={x:Type local:Maui35564}}}"
+                                CommandParameter="{Binding}" />
+                        </VerticalStackLayout.GestureRecognizers>
+                        <Label Text="{Binding Name}" />
+                    </VerticalStackLayout>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui35564.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui35564.xaml
@@ -57,5 +57,19 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>
+        <!-- Scenario D: {RelativeSource Self} with x:DataType explicitly on the binding node.
+             Even with explicit x:DataType, Self bindings should stay uncompiled because the
+             source is the element itself and not inferred from a model type annotation. -->
+        <CollectionView x:Name="TheCollectionView4"
+            ItemsSource="{Binding Items}">
+            <CollectionView.ItemTemplate>
+                <DataTemplate x:DataType="local:Maui35564Item">
+                    <VerticalStackLayout>
+                        <Label AutomationId="scenario-d"
+                               Text="{Binding AutomationId, x:DataType=Label, Source={RelativeSource Self}}" />
+                    </VerticalStackLayout>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
     </VerticalStackLayout>
 </ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui35564.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui35564.xaml
@@ -41,5 +41,21 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>
+        <!-- Scenario C: {RelativeSource Self} inside a DataTemplate with inherited x:DataType.
+             The DataTemplate's x:DataType (Maui35564Item) must NOT be applied to Self bindings
+             — the item type is never the type of the View itself (Label).
+             Before the fix, the inherited type would fail the IsAssignableFrom check and null
+             out the source; after the fix DataType = null for Self bindings with inherited type. -->
+        <CollectionView x:Name="TheCollectionView3"
+            ItemsSource="{Binding Items}">
+            <CollectionView.ItemTemplate>
+                <DataTemplate x:DataType="local:Maui35564Item">
+                    <VerticalStackLayout>
+                        <Label AutomationId="scenario-c"
+                               Text="{Binding AutomationId, Source={RelativeSource Self}}" />
+                    </VerticalStackLayout>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
     </VerticalStackLayout>
 </ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui35564.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui35564.xaml.cs
@@ -22,6 +22,13 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests;
 ///   The binding has x:DataType=local:Maui35564 directly on it, alongside
 ///   Source={RelativeSource AncestorType=...}.  SourceGen must compile this to a
 ///   TypedBinding (no reflection) so the binding survives AOT/linker trimming.
+///
+/// Scenario C (Regression guard — RelativeSource Self with inherited x:DataType):
+///   A {RelativeSource Self} binding inside a DataTemplate that has x:DataType=
+///   "local:Maui35564Item". The inherited item type must NOT be applied to Self
+///   bindings — before the fix, Maui35564Item.IsAssignableFrom(Label) = false
+///   would null out the source; after the fix DataType = null for inherited-type
+///   RelativeSource bindings, so Self resolves to the Label correctly.
 /// </summary>
 public partial class Maui35564 : ContentPage
 {
@@ -124,6 +131,41 @@ public partial class Maui35564 : ContentPage
 					var binding = tapGesture.GetContext(TapGestureRecognizer.CommandProperty).Bindings.GetValue();
 					Assert.IsAssignableFrom<TypedBindingBase>(binding);
 				}
+			}
+			finally
+			{
+				AppContext.SetSwitch(FeatureSwitch, false);
+			}
+		}
+		/// <summary>
+		/// Scenario C: {RelativeSource Self} inside a DataTemplate that has x:DataType="Maui35564Item".
+		/// The inherited item type (Maui35564Item) must NOT be applied to the Self binding —
+		/// Self resolves to the Label itself, not to the DataTemplate item.
+		/// Before the fix: inherited DataType caused IsAssignableFrom(Label)=false → source=null.
+		/// After the fix: DataType=null for inherited-type RelativeSource bindings → Self resolves.
+		/// </summary>
+		[Theory]
+		[XamlInflatorData]
+		internal void RelativeSourceSelfInsideDataTemplateWithInheritedXDataType(XamlInflator inflator)
+		{
+			AppContext.SetSwitch(FeatureSwitch, true);
+			try
+			{
+				var page = new Maui35564(inflator);
+				page.BindingContext = page;
+
+				var itemLayout = page.TheCollectionView3.ItemTemplate.CreateContent() as VerticalStackLayout;
+				Assert.NotNull(itemLayout);
+
+				itemLayout.BindingContext = new Maui35564Item { Name = "Test" };
+
+				var label = itemLayout.Children[0] as Label;
+				Assert.NotNull(label);
+
+				// Label.Text must equal the Label's own AutomationId ("scenario-c"), bound via {RelativeSource Self}.
+				// If the inherited x:DataType were applied, the Self source would be nulled out
+				// and Text would be null or empty.
+				Assert.Equal("scenario-c", label.Text);
 			}
 			finally
 			{

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui35564.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui35564.xaml.cs
@@ -59,6 +59,8 @@ public partial class Maui35564 : ContentPage
 		/// Scenario A: RelativeSource binding without x:DataType directly on the binding node.
 		/// The DataTemplate's inherited x:DataType (Maui35564Item) must NOT be used to validate
 		/// the RelativeSource binding's resolved ancestor (the Maui35564 page).
+		/// For SourceGen, AncestorType should be resolved as the canonical source type and
+		/// compiled to TypedBinding even without x:DataType on the binding node.
 		/// </summary>
 		[Theory]
 		[XamlInflatorData]
@@ -84,6 +86,12 @@ public partial class Maui35564 : ContentPage
 
 				Assert.NotNull(tapGesture.Command);
 				Assert.Same(page.ItemTappedCommand, tapGesture.Command);
+
+				if (inflator == XamlInflator.SourceGen)
+				{
+					var binding = tapGesture.GetContext(TapGestureRecognizer.CommandProperty).Bindings.GetValue();
+					Assert.IsAssignableFrom<TypedBindingBase>(binding);
+				}
 			}
 			finally
 			{
@@ -166,6 +174,42 @@ public partial class Maui35564 : ContentPage
 				// If the inherited x:DataType were applied, the Self source would be nulled out
 				// and Text would be null or empty.
 				Assert.Equal("scenario-c", label.Text);
+			}
+			finally
+			{
+				AppContext.SetSwitch(FeatureSwitch, false);
+			}
+		}
+
+		/// <summary>
+		/// Scenario D: {RelativeSource Self} with x:DataType directly on the binding node.
+		/// Self bindings should not be compiled to TypedBinding, even with explicit x:DataType,
+		/// because the source is the view element itself.
+		/// </summary>
+		[Theory]
+		[XamlInflatorData]
+		internal void RelativeSourceSelfWithExplicitXDataTypeStaysUncompiled(XamlInflator inflator)
+		{
+			AppContext.SetSwitch(FeatureSwitch, true);
+			try
+			{
+				var page = new Maui35564(inflator);
+				page.BindingContext = page;
+
+				var itemLayout = page.TheCollectionView4.ItemTemplate.CreateContent() as VerticalStackLayout;
+				Assert.NotNull(itemLayout);
+
+				itemLayout.BindingContext = new Maui35564Item { Name = "Test" };
+
+				var label = itemLayout.Children[0] as Label;
+				Assert.NotNull(label);
+				Assert.Equal("scenario-d", label.Text);
+
+				if (inflator == XamlInflator.SourceGen)
+				{
+					var binding = label.GetContext(Label.TextProperty).Bindings.GetValue();
+					Assert.IsNotAssignableFrom<TypedBindingBase>(binding);
+				}
 			}
 			finally
 			{

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui35564.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui35564.xaml.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Windows.Input;
+using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Dispatching;
+using Microsoft.Maui.UnitTests;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+/// <summary>
+/// Regression test for https://github.com/dotnet/maui/issues/35564
+///
+/// Scenario A (Runtime inflator):
+///   A TapGestureRecognizer inside a CollectionView ItemTemplate binds its Command
+///   to the *page* using Source={RelativeSource AncestorType=...}, while the
+///   DataTemplate has x:DataType="local:Maui35564Item" (the item model type).
+///   When IsXamlCBindingWithSourceCompilationEnabled is true (AOT), BindingExtension
+///   must NOT propagate the DataTemplate's x:DataType to a RelativeSource binding.
+///
+/// Scenario B (SourceGen inflator):
+///   The binding has x:DataType=local:Maui35564 directly on it, alongside
+///   Source={RelativeSource AncestorType=...}.  SourceGen must compile this to a
+///   TypedBinding (no reflection) so the binding survives AOT/linker trimming.
+/// </summary>
+public partial class Maui35564 : ContentPage
+{
+	public ObservableCollection<Maui35564Item> Items { get; } = new()
+	{
+		new Maui35564Item { Name = "Item A" },
+		new Maui35564Item { Name = "Item B" },
+	};
+
+	public ICommand ItemTappedCommand { get; } = new Command<Maui35564Item>(_ => { });
+
+	public Maui35564()
+	{
+		InitializeComponent();
+		BindingContext = this;
+	}
+
+	[Collection("Issue")]
+	public class Tests : IDisposable
+	{
+		const string FeatureSwitch =
+			"Microsoft.Maui.RuntimeFeature.IsXamlCBindingWithSourceCompilationEnabled";
+
+		public Tests() => DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+		public void Dispose() => DispatcherProvider.SetCurrent(null);
+
+		/// <summary>
+		/// Scenario A: RelativeSource binding without x:DataType directly on the binding node.
+		/// The DataTemplate's inherited x:DataType (Maui35564Item) must NOT be used to validate
+		/// the RelativeSource binding's resolved ancestor (the Maui35564 page).
+		/// </summary>
+		[Theory]
+		[XamlInflatorData]
+		internal void RelativeSourceCommandBindsToAncestorWithXamlCCompilationEnabled(XamlInflator inflator)
+		{
+			AppContext.SetSwitch(FeatureSwitch, true);
+			try
+			{
+				var page = new Maui35564(inflator);
+				page.BindingContext = page;
+
+				var itemLayout = page.TheCollectionView.ItemTemplate.CreateContent() as VerticalStackLayout;
+				Assert.NotNull(itemLayout);
+
+				var container = new VerticalStackLayout();
+				container.Add(itemLayout);
+				page.Content = container;
+
+				itemLayout.BindingContext = new Maui35564Item { Name = "Test" };
+
+				var tapGesture = itemLayout.GestureRecognizers[0] as TapGestureRecognizer;
+				Assert.NotNull(tapGesture);
+
+				Assert.NotNull(tapGesture.Command);
+				Assert.Same(page.ItemTappedCommand, tapGesture.Command);
+			}
+			finally
+			{
+				AppContext.SetSwitch(FeatureSwitch, false);
+			}
+		}
+
+		/// <summary>
+		/// Scenario B: RelativeSource binding WITH x:DataType directly on the binding node.
+		/// This is the real-world pattern users write in AOT apps.  SourceGen must compile it
+		/// to a TypedBinding (no reflection) so the binding survives linker trimming.
+		/// For all inflators, the Command must resolve correctly.
+		/// For the SourceGen inflator specifically, the binding must be a TypedBinding.
+		/// </summary>
+		[Theory]
+		[XamlInflatorData]
+		internal void RelativeSourceCommandWithExplicitXDataTypeCompilesTypedBinding(XamlInflator inflator)
+		{
+			AppContext.SetSwitch(FeatureSwitch, true);
+			try
+			{
+				var page = new Maui35564(inflator);
+				page.BindingContext = page;
+
+				var itemLayout = page.TheCollectionView2.ItemTemplate.CreateContent() as VerticalStackLayout;
+				Assert.NotNull(itemLayout);
+
+				var container = new VerticalStackLayout();
+				container.Add(itemLayout);
+				page.Content = container;
+
+				itemLayout.BindingContext = new Maui35564Item { Name = "Test" };
+
+				var tapGesture = itemLayout.GestureRecognizers[0] as TapGestureRecognizer;
+				Assert.NotNull(tapGesture);
+
+				// Command must resolve to the page's command for ALL inflators.
+				Assert.NotNull(tapGesture.Command);
+				Assert.Same(page.ItemTappedCommand, tapGesture.Command);
+
+				// For the SourceGen inflator, the binding must be a TypedBinding — not a reflective
+				// Binding — so it survives AOT linker trimming.
+				if (inflator == XamlInflator.SourceGen)
+				{
+					var binding = tapGesture.GetContext(TapGestureRecognizer.CommandProperty).Bindings.GetValue();
+					Assert.IsAssignableFrom<TypedBindingBase>(binding);
+				}
+			}
+			finally
+			{
+				AppContext.SetSwitch(FeatureSwitch, false);
+			}
+		}
+	}
+}
+
+public class Maui35564Item
+{
+	public string Name { get; set; } = string.Empty;
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details:

When MauiXamlInflator=SourceGen + IsAotCompatible=true are set, a Command bound via {RelativeSource AncestorType} inside a CollectionView.ItemTemplate resolves to null at runtime on iOS Release (AOT) builds.
       
### Root Cause:

The issue occurs when MauiXamlInflator=SourceGen and IsAotCompatible=true are set together on an iOS Release build. When a Command is bound using {RelativeSource AncestorType} inside a CollectionView.ItemTemplate, the binding resolves to null at runtime.
 
The core problem is in the MAUI SourceGen (KnownMarkups.cs). When SourceGen processes a binding that has an explicit Source={RelativeSource AncestorType=...}, it sets hasExplicitSource=true. The existing guard if (!hasExplicitSource) then skips the TypedBinding code generation path entirely. This means SourceGen always falls back to generating a regular reflection-based Binding object for any RelativeSource binding — even when x:DataType is explicitly declared on the binding node, which would have given SourceGen all the type information it needs to generate a compiled TypedBinding.
 
A regular Binding resolves its property path at runtime using .NET reflection (PropertyInfo.GetValue). This works perfectly fine in Debug mode because reflection metadata is fully available. However, on iOS Release builds, the AOT linker performs static analysis to trim unused code and metadata. Since the linker only sees a string like "ViewModel.ItemTappedCommand" inside the Binding object — and cannot trace that it will be used reflectively at runtime — it trims the property metadata. When the binding tries to resolve at runtime, the metadata is gone and the binding returns null.
 
A secondary scenario exists for the Runtime inflator path: BindingExtension.ProvideValue was incorrectly propagating the inherited x:DataType from the parent DataTemplate (e.g., TestItem) onto the binding node itself. When IsXamlCBindingWithSourceCompilationEnabled=true, the runtime binding engine checks whether the source type (MainPage) is assignable from the DataType (TestItem) — which fails — so the source resolves to null and the Command becomes null.

### Description of Change:

The fix introduces a way to distinguish between an x:DataType that was explicitly declared on the binding node versus one that was inherited from the enclosing DataTemplate. A new interface IXamlDataTypeProviderWithBindingNodeInfo with an IsDataTypeOnBindingNode property was added to XamlServiceProvider.cs to carry this information through the XAML processing pipeline.
 
In KnownMarkups.cs, the SourceGen guard was updated from if (!hasExplicitSource) to if (!hasExplicitSource || xDataTypeOnBindingNode). This allows TypedBinding code generation to proceed for RelativeSource bindings when x:DataType is explicitly present on the binding node — giving SourceGen the type information it needs to emit a compiled lambda like static (m) => m.ViewModel.ItemTappedCommand instead of a reflective string lookup. This compiled lambda is a direct code reference that the AOT linker can see and preserve, making it safe on iOS Release AOT builds.
 
In BindingExtension.cs, the Runtime inflator was fixed to only propagate DataType when IsDataTypeOnBindingNode=true, preventing the inherited DataType from causing incorrect assignability checks during RelativeSource binding resolution. Similarly, SetPropertiesVisitor.cs was updated for the XamlC path to skip TypedBinding compilation when the DataType is only inherited and not explicitly declared on the binding node.

**Tested the behavior in the following platforms:**

- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Reference:

N/A

### Issues Fixed:

Fixes  #35564        

### Screenshots
| Before  | After  |
|---------|--------|
|   <Video src="https://github.com/user-attachments/assets/d3fb2c34-ad51-4053-91af-0cccd3dfca0b" Width="300" Height="600">   |    <Video src="https://github.com/user-attachments/assets/50b53482-b03e-4b52-997d-abae3b6e9a2a" Width="300" Height="600">  |