### PR TITLE
Fix Shell.Title binding in TitleView

### DIFF
--- a/src/Controls/src/Core/ShellToolbar.cs
+++ b/src/Controls/src/Core/ShellToolbar.cs
@@ -169,27 +169,44 @@ namespace Microsoft.Maui.Controls
 				Shell.TitleViewProperty,
 				Shell.GetTitleView(_shell));
 
+			var title = GetCurrentTitle();
+			if (!IsShellTitleSetByUser())
+				_shell.SetValueFromRenderer(Shell.TitleProperty, title);
+
 			if (TitleView != null)
 			{
 				Title = String.Empty;
 				return;
 			}
 
+			Title = title;
+		}
+
+		string GetCurrentTitle()
+		{
 			Page? currentPage = _shell.GetCurrentShellPage();
 			if (currentPage?.IsSet(Page.TitleProperty) == true)
 			{
-				Title = currentPage.Title ?? String.Empty;
+				return currentPage.Title ?? String.Empty;
 			}
 			// We only want to use the ShellContent as a title if no pages have been
 			// Pushed onto the stack
 			else if (_shell.Navigation?.NavigationStack?.Count <= 1)
 			{
-				Title = _shell.CurrentContent?.Title ?? String.Empty;
+				return _shell.CurrentContent?.Title ?? String.Empty;
 			}
-			else
-			{
-				Title = String.Empty;
-			}
+
+			return String.Empty;
+		}
+
+		bool IsShellTitleSetByUser()
+		{
+			var titleContext = _shell.GetContext(Shell.TitleProperty);
+			if (titleContext == null)
+				return false;
+
+			var specificity = titleContext.Values.GetSpecificity();
+			return specificity != SetterSpecificity.DefaultValue && specificity != SetterSpecificity.FromHandler;
 		}
 	}
 }

--- a/src/Controls/src/Core/ShellToolbar.cs
+++ b/src/Controls/src/Core/ShellToolbar.cs
@@ -205,6 +205,9 @@ namespace Microsoft.Maui.Controls
 			if (titleContext == null)
 				return false;
 
+			if (titleContext.Bindings.Count > 0)
+				return true;
+
 			var specificity = titleContext.Values.GetSpecificity();
 			return specificity != SetterSpecificity.DefaultValue && specificity != SetterSpecificity.FromHandler;
 		}

--- a/src/Controls/tests/Core.UnitTests/ShellToolbarTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellToolbarTests.cs
@@ -271,6 +271,38 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public void ShellTitleReflectsCurrentPageTitleForTitleViewBindings()
+		{
+			var contentPage = new ContentPage() { Title = "Test Title" };
+			var label = new Label();
+			var titleView = new VerticalStackLayout()
+			{
+				Children =
+				{
+					label
+				}
+			};
+
+			TestShell testShell = new TestShell(contentPage);
+			_ = new Window()
+			{
+				Page = testShell
+			};
+
+			label.SetBinding(Label.TextProperty, new Binding(nameof(Shell.Title), source: testShell));
+			Shell.SetTitleView(contentPage, titleView);
+
+			Assert.Empty(testShell.Toolbar.Title);
+			Assert.Equal("Test Title", testShell.Title);
+			Assert.Equal("Test Title", label.Text);
+
+			contentPage.Title = "Updated Test Title";
+
+			Assert.Equal("Updated Test Title", testShell.Title);
+			Assert.Equal("Updated Test Title", label.Text);
+		}
+
+		[Fact]
 		public void ContentPageColorsPropagateToShellToolbar()
 		{
 			var contentPage = new ContentPage() { Title = "Test Title" };

--- a/src/Controls/tests/Core.UnitTests/ShellToolbarTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellToolbarTests.cs
@@ -303,6 +303,32 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public void ShellTitleBindingIsNotOverwrittenByCurrentPageTitle()
+		{
+			var contentPage = new ContentPage() { Title = "Page Title" };
+			var titleView = new VerticalStackLayout();
+			var viewModel = new TestShellViewModel() { Text = "App Title" };
+
+			TestShell testShell = new TestShell(contentPage);
+			_ = new Window()
+			{
+				Page = testShell
+			};
+
+			testShell.SetBinding(Shell.TitleProperty, new Binding(nameof(TestShellViewModel.Text), BindingMode.TwoWay, source: viewModel));
+			Shell.SetTitleView(contentPage, titleView);
+
+			Assert.Empty(testShell.Toolbar.Title);
+			Assert.Equal("App Title", testShell.Title);
+			Assert.Equal("App Title", viewModel.Text);
+
+			contentPage.Title = "Updated Page Title";
+
+			Assert.Equal("App Title", testShell.Title);
+			Assert.Equal("App Title", viewModel.Text);
+		}
+
+		[Fact]
 		public void ContentPageColorsPropagateToShellToolbar()
 		{
 			var contentPage = new ContentPage() { Title = "Test Title" };


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

`Shell.TitleView` content can bind to the Shell instance, but `Shell.Title` was not updated from the active page title. This meant bindings such as `{Binding Title, Source={x:Reference Shell}}` resolved to `null` even when the current `ContentPage.Title` was set.

This change mirrors the effective current page or ShellContent title into `Shell.Title` when Shell does not already have a user-set title. The rendered toolbar title still remains empty while a custom TitleView is active, and explicit Shell titles continue to work for Window title fallback.

A core unit test covers the TitleView binding scenario and verifies updates when the current page title changes.

### Issues Fixed

Fixes #35761