### PR TITLE
[iOS] Fix MediaPicker FullPath for PHPicker results

### DIFF
--- a/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -18,8 +19,6 @@ namespace Microsoft.Maui.Media
 {
 	partial class MediaPickerImplementation : IMediaPicker
 	{
-		static UIViewController PickerRef;
-
 		public bool IsCaptureSupported
 			=> UIImagePickerController.IsSourceTypeAvailable(UIImagePickerControllerSourceType.Camera);
 
@@ -75,6 +74,9 @@ namespace Microsoft.Maui.Media
 
 			var vc = WindowStateManager.Default.GetCurrentUIViewController(true);
 			var tcs = new TaskCompletionSource<FileResult>();
+			UIViewController pickerRef = null;
+
+			PHPickerFileResult.CleanupTemporaryFiles();
 
 			if (pickExisting && OperatingSystem.IsIOSVersionAtLeast(14, 0))
 			{
@@ -85,16 +87,21 @@ namespace Microsoft.Maui.Media
 						: PHPickerFilter.VideosFilter
 				};
 
+				if (!photo)
+				{
+					config.PreferredAssetRepresentationMode = PHPickerConfigurationAssetRepresentationMode.Compatible;
+				}
+
 				var picker = new PHPickerViewController(config)
 				{
 					Delegate = new Media.PhotoPickerDelegate
 					{
 						CompletedHandler = res =>
-							tcs.TrySetResult(PickerResultsToMediaFile(res))
+							_ = CompletePickerResultAsync(res, options, tcs)
 					}
 				};
 
-				PickerRef = picker;
+				pickerRef = picker;
 			}
 			else
 			{
@@ -128,43 +135,41 @@ namespace Microsoft.Maui.Media
 					picker.CameraCaptureMode = UIImagePickerControllerCameraCaptureMode.Video;
 				}
 
-				PickerRef = picker;
+				pickerRef = picker;
 
 				picker.Delegate = new PhotoPickerDelegate
 				{
 					CompletedHandler = info =>
 					{
-						GetFileResult(info, tcs, options);
+						_ = CompleteUIImagePickerResultAsync(info, options, tcs);
 					}
 				};
 			}
 
 			if (!string.IsNullOrWhiteSpace(options?.Title))
 			{
-				PickerRef.Title = options.Title;
+				pickerRef.Title = options.Title;
 			}
 
 			if (DeviceInfo.Idiom == DeviceIdiom.Tablet)
 			{
-				PickerRef.ModalPresentationStyle = UIModalPresentationStyle.PageSheet;
+				pickerRef.ModalPresentationStyle = UIModalPresentationStyle.PageSheet;
 			}
 
-			if (PickerRef.PresentationController is not null)
+			pickerRef.PresentationController?.Delegate = new PhotoPickerPresentationControllerDelegate
 			{
-				PickerRef.PresentationController.Delegate = new PhotoPickerPresentationControllerDelegate
-				{
-					Handler = () => tcs.TrySetResult(null)
-				};
+				Handler = () => tcs.TrySetResult(null)
+			};
+
+			try
+			{
+				await vc.PresentViewControllerAsync(pickerRef, true);
+				return await tcs.Task;
 			}
-
-			await vc.PresentViewControllerAsync(PickerRef, true);
-
-			var result = await tcs.Task;
-
-			PickerRef?.Dispose();
-			PickerRef = null;
-
-			return result;
+			finally
+			{
+				pickerRef?.Dispose();
+			}
 		}
 
 		async Task<List<FileResult>> PhotosAsync(MediaPickerOptions options, bool photo, bool pickExisting)
@@ -194,6 +199,9 @@ namespace Microsoft.Maui.Media
 
 			var vc = WindowStateManager.Default.GetCurrentUIViewController(true);
 			var tcs = new TaskCompletionSource<List<FileResult>>();
+			UIViewController pickerRef = null;
+
+			PHPickerFileResult.CleanupTemporaryFiles();
 
 			if (pickExisting)
 			{
@@ -202,59 +210,76 @@ namespace Microsoft.Maui.Media
 					Filter = photo
 						? PHPickerFilter.ImagesFilter
 						: PHPickerFilter.VideosFilter,
-					SelectionLimit = options?.SelectionLimit ?? 1,
+					SelectionLimit = options?.SelectionLimit ?? 1
 				};
+
+				if (!photo)
+				{
+					config.PreferredAssetRepresentationMode = PHPickerConfigurationAssetRepresentationMode.Compatible;
+				}
 
 				var picker = new PHPickerViewController(config)
 				{
 					Delegate = new Media.PhotoPickerDelegate
 					{
-						CompletedHandler = async res =>
-						{
-							var result = await PickerResultsToMediaFiles(res, options);
-							tcs.TrySetResult(result);
-						}
+						CompletedHandler = res =>
+							_ = CompletePickerResultsAsync(res, options, tcs)
 					}
 				};
 
-				PickerRef = picker;
+				pickerRef = picker;
 			}
 
 			if (!string.IsNullOrWhiteSpace(options?.Title))
 			{
-				PickerRef.Title = options.Title;
+				pickerRef.Title = options.Title;
 			}
 
 			if (DeviceInfo.Idiom == DeviceIdiom.Tablet)
 			{
-				PickerRef.ModalPresentationStyle = UIModalPresentationStyle.PageSheet;
+				pickerRef.ModalPresentationStyle = UIModalPresentationStyle.PageSheet;
 			}
 
-			if (PickerRef.PresentationController is not null)
+			pickerRef.PresentationController?.Delegate = new PhotoPickerPresentationControllerDelegate
 			{
-				PickerRef.PresentationController.Delegate = new PhotoPickerPresentationControllerDelegate
-				{
-					Handler = () => tcs.TrySetResult([])
-				};
+				Handler = () => tcs.TrySetResult([])
+			};
+
+			try
+			{
+				await vc.PresentViewControllerAsync(pickerRef, true);
+				return await tcs.Task;
 			}
-
-			await vc.PresentViewControllerAsync(PickerRef, true);
-
-			var result = await tcs.Task;
-
-			PickerRef?.Dispose();
-			PickerRef = null;
-
-			return result;
+			finally
+			{
+				pickerRef?.Dispose();
+			}
 		}
 
-		static FileResult PickerResultsToMediaFile(PHPickerResult[] results)
+		static async Task CompletePickerResultAsync(PHPickerResult[] results, MediaPickerOptions options, TaskCompletionSource<FileResult> tcs)
 		{
-			var file = results?.FirstOrDefault();
+			try
+			{
+				var result = await PickerResultsToMediaFiles(results, options).ConfigureAwait(false);
+				tcs.TrySetResult(result.FirstOrDefault());
+			}
+			catch (Exception ex)
+			{
+				tcs.TrySetException(ex);
+			}
+		}
 
-			return file == null
-				? null
-				: new PHPickerFileResult(file.ItemProvider);
+		static async Task CompletePickerResultsAsync(PHPickerResult[] results, MediaPickerOptions options, TaskCompletionSource<List<FileResult>> tcs)
+		{
+			try
+			{
+				var result = await PickerResultsToMediaFiles(results, options).ConfigureAwait(false);
+				tcs.TrySetResult(result);
+			}
+			catch (Exception ex)
+			{
+				tcs.TrySetException(ex);
+			}
 		}
 
 		static async Task<List<FileResult>> PickerResultsToMediaFiles(PHPickerResult[] results, MediaPickerOptions options = null)
@@ -263,24 +288,42 @@ namespace Microsoft.Maui.Media
 			if (results == null || results.Length == 0)
 				return [];
 
-			var fileResults = results
-				.Select(file => (FileResult)new PHPickerFileResult(file.ItemProvider))
-				.ToList();
+			var fileResults = new List<FileResult>(results.Length);
+			try
+			{
+				foreach (var file in results)
+				{
+					var fileResult = new PHPickerFileResult(file.ItemProvider);
+					await fileResult.LoadFileRepresentationAsync().ConfigureAwait(false);
+					fileResults.Add(fileResult);
+				}
+			}
+			catch
+			{
+				DisposeFileResults(fileResults);
+				throw;
+			}
 
-			// Apply rotation if needed for images
-			if (ImageProcessor.IsRotationNeeded(options))
+			var processingNeeded = ImageProcessor.IsProcessingNeeded(options?.MaximumWidth, options?.MaximumHeight, options?.CompressionQuality ?? 100);
+
+			// Apply standalone rotation only when no later processing pass will do it from the original file.
+			if (ImageProcessor.IsRotationNeeded(options) && !processingNeeded)
 			{
 				var rotatedResults = new List<FileResult>();
 				foreach (var result in fileResults)
 				{
+					if (!IsImageFile(result.FileName))
+					{
+						rotatedResults.Add(result);
+						continue;
+					}
+
 					try
 					{
 						using var originalStream = await result.OpenReadAsync();
 						using var rotatedStream = await ImageProcessor.RotateImageAsync(originalStream, result.FileName);
 
-						// Create a temp file for the rotated image
-						var tempFileName = $"{Guid.NewGuid()}{Path.GetExtension(result.FileName)}";
-						var tempFilePath = Path.Combine(Path.GetTempPath(), tempFileName);
+						var tempFilePath = PHPickerFileResult.CreateTemporaryFilePath(Path.GetExtension(result.FileName));
 
 						using (var fileStream = File.Create(tempFilePath))
 						{
@@ -294,6 +337,7 @@ namespace Microsoft.Maui.Media
 							ContentType = result.ContentType
 						};
 						rotatedResults.Add(rotatedResult);
+						(result as IDisposable)?.Dispose();
 					}
 					catch
 					{
@@ -305,13 +349,32 @@ namespace Microsoft.Maui.Media
 			}
 
 			// Apply resizing and compression if specified and dealing with images
-			if (ImageProcessor.IsProcessingNeeded(options?.MaximumWidth, options?.MaximumHeight, options?.CompressionQuality ?? 100))
+			if (processingNeeded)
 			{
 				var compressedResults = new List<FileResult>();
-				foreach (var result in fileResults)
+				PHPickerProcessedFileResult compressedResult = null;
+				try
 				{
-					var compressedResult = new PHPickerProcessedFileResult(result, options?.MaximumWidth, options?.MaximumHeight, options?.CompressionQuality ?? 100, options?.RotateImage ?? false, options?.PreserveMetaData ?? true);
-					compressedResults.Add(compressedResult);
+					foreach (var result in fileResults)
+					{
+						if (!IsImageFile(result.FileName))
+						{
+							compressedResults.Add(result);
+							continue;
+						}
+
+						compressedResult = new PHPickerProcessedFileResult(result, options?.MaximumWidth, options?.MaximumHeight, options?.CompressionQuality ?? 100, options?.RotateImage ?? false, options?.PreserveMetaData ?? true);
+						await compressedResult.LoadProcessedFileAsync().ConfigureAwait(false);
+						compressedResults.Add(compressedResult);
+						compressedResult = null;
+					}
+				}
+				catch
+				{
+					compressedResult?.Dispose();
+					DisposeFileResults(compressedResults);
+					DisposeFileResults(fileResults);
+					throw;
 				}
 				return compressedResults;
 			}
@@ -319,11 +382,21 @@ namespace Microsoft.Maui.Media
 			return fileResults;
 		}
 
-		static void GetFileResult(NSDictionary info, TaskCompletionSource<FileResult> tcs, MediaPickerOptions options = null)
+		static void DisposeFileResults(IEnumerable<FileResult> fileResults)
+		{
+			foreach (var fileResult in fileResults)
+			{
+				PHPickerFileResult.TryDeleteTemporaryFile(fileResult.FullPath);
+				(fileResult as IDisposable)?.Dispose();
+			}
+		}
+
+		static async Task CompleteUIImagePickerResultAsync(NSDictionary info, MediaPickerOptions options, TaskCompletionSource<FileResult> tcs)
 		{
 			try
 			{
-				tcs.TrySetResult(DictionaryToMediaFile(info, options));
+				var result = await DictionaryToMediaFile(info, options).ConfigureAwait(false);
+				tcs.TrySetResult(result);
 			}
 			catch (Exception ex)
 			{
@@ -331,7 +404,7 @@ namespace Microsoft.Maui.Media
 			}
 		}
 
-		static FileResult DictionaryToMediaFile(NSDictionary info, MediaPickerOptions options = null)
+		static async Task<FileResult> DictionaryToMediaFile(NSDictionary info, MediaPickerOptions options = null)
 		{
 			// This method should only be called for iOS < 14
 			if (!OperatingSystem.IsIOSVersionAtLeast(14))
@@ -365,7 +438,7 @@ namespace Microsoft.Maui.Media
 						{
 							try
 							{
-								var rotatedResult = RotateImageFile(docResult).GetAwaiter().GetResult();
+								var rotatedResult = await RotateImageFile(docResult).ConfigureAwait(false);
 								if (rotatedResult != null)
 									return rotatedResult;
 							}
@@ -423,7 +496,7 @@ namespace Microsoft.Maui.Media
 			{
 				try
 				{
-					var rotatedResult = RotateImageFile(assetResult).GetAwaiter().GetResult();
+					var rotatedResult = await RotateImageFile(assetResult).ConfigureAwait(false);
 					if (rotatedResult != null)
 						return rotatedResult;
 				}
@@ -454,17 +527,15 @@ namespace Microsoft.Maui.Media
 
 			try
 			{
-				using var originalStream = await original.OpenReadAsync();
-				using var rotatedStream = await ImageProcessor.RotateImageAsync(originalStream, original.FileName);
+				using var originalStream = await original.OpenReadAsync().ConfigureAwait(false);
+				using var rotatedStream = await ImageProcessor.RotateImageAsync(originalStream, original.FileName).ConfigureAwait(false);
 
-				// Create a temp file for the rotated image
-				var tempFileName = $"{Guid.NewGuid()}{Path.GetExtension(original.FileName)}";
-				var tempFilePath = Path.Combine(Path.GetTempPath(), tempFileName);
+				var tempFilePath = PHPickerFileResult.CreateTemporaryFilePath(Path.GetExtension(original.FileName));
 
 				using (var fileStream = File.Create(tempFilePath))
 				{
 					rotatedStream.Position = 0;
-					await rotatedStream.CopyToAsync(fileStream);
+					await rotatedStream.CopyToAsync(fileStream).ConfigureAwait(false);
 				}
 
 				return new FileResult(tempFilePath, original.FileName);
@@ -480,12 +551,22 @@ namespace Microsoft.Maui.Media
 		{
 			public Action<NSDictionary> CompletedHandler { get; set; }
 			public override void FinishedPickingMedia(UIImagePickerController picker, NSDictionary info)
-            {
+			{
+				if (picker.PresentationController?.Delegate is PhotoPickerPresentationControllerDelegate pd)
+				{
+					pd.Handler = null;
+				}
+
 				picker.DismissViewController(true, () => CompletedHandler?.Invoke(info));
-            }
+			}
 
 			public override void Canceled(UIImagePickerController picker)
 			{
+				if (picker.PresentationController?.Delegate is PhotoPickerPresentationControllerDelegate pd)
+				{
+					pd.Handler = null;
+				}
+
 				picker.DismissViewController(true, () => CompletedHandler?.Invoke(null));
 			}
 		}
@@ -506,7 +587,7 @@ namespace Microsoft.Maui.Media
 			}
 
 			var captured = results?.Length > 0 ? results : [];
-            picker.DismissViewController(true, () => CompletedHandler?.Invoke(captured));
+			picker.DismissViewController(true, () => CompletedHandler?.Invoke(captured));
 		}
 	}
 
@@ -524,10 +605,22 @@ namespace Microsoft.Maui.Media
 		}
 	}
 
-	class PHPickerFileResult : FileResult
+	class PHPickerFileResult : FileResult, IDisposable
 	{
+		const string TemporaryDirectoryName = "maui-mediapicker";
+		static readonly TimeSpan TemporaryFileRetention = TimeSpan.FromDays(1);
+
 		readonly string _identifier;
 		readonly NSItemProvider _provider;
+		readonly object _loadLock = new();
+		Task _loadFileTask;
+		TaskCompletionSource<bool> _loadTcs;
+		NSProgress _loadProgress;
+		bool _isFileLoaded;
+		bool _disposed;
+
+		static string TemporaryDirectory =>
+			Path.Combine(Path.GetTempPath(), TemporaryDirectoryName);
 
 		internal PHPickerFileResult(NSItemProvider provider)
 		{
@@ -544,15 +637,346 @@ namespace Microsoft.Maui.Media
 				return;
 			}
 
-			FileName = FullPath
-				= $"{provider?.SuggestedName}.{GetTag(_identifier, UTType.TagClassFilenameExtension)}";
+			var extension = GetFileExtension(_identifier);
+			FileName = GetFileName(provider?.SuggestedName, extension);
+			FullPath = CreateTemporaryFilePath(Path.GetExtension(FileName));
 		}
 
 		internal override async Task<Stream> PlatformOpenReadAsync()
-			=> (await _provider?.LoadDataRepresentationAsync(_identifier))?.AsStream();
+		{
+			await LoadFileRepresentationAsync().ConfigureAwait(false);
+
+			return File.Open(FullPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+		}
+
+		internal Task LoadFileRepresentationAsync()
+		{
+			ValidateFileRepresentation();
+
+			TaskCompletionSource<bool> loadTcs = null;
+			Task loadTask;
+
+			lock (_loadLock)
+			{
+				ThrowIfDisposedNoLock();
+
+				if (_isFileLoaded)
+				{
+					return Task.CompletedTask;
+				}
+
+				if (_loadFileTask is null)
+				{
+					loadTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+					_loadTcs = loadTcs;
+					_loadFileTask = loadTcs.Task;
+				}
+
+				loadTask = _loadFileTask;
+			}
+
+			if (loadTcs is not null)
+			{
+				StartLoadFileRepresentation(loadTcs);
+			}
+
+			return AwaitLoadFileRepresentationAsync(loadTask);
+		}
+
+		internal static void CleanupTemporaryFiles()
+		{
+			var temporaryDirectory = TemporaryDirectory;
+
+			if (!Directory.Exists(temporaryDirectory))
+			{
+				return;
+			}
+
+			var cutoff = DateTime.UtcNow - TemporaryFileRetention;
+
+			try
+			{
+				foreach (var file in Directory.EnumerateFiles(temporaryDirectory))
+				{
+					DeleteTemporaryFileIfStale(file, cutoff);
+				}
+			}
+			catch (IOException ex)
+			{
+				Debug.WriteLine($"Unable to enumerate MediaPicker temporary files: {ex}");
+			}
+			catch (UnauthorizedAccessException ex)
+			{
+				Debug.WriteLine($"Unable to enumerate MediaPicker temporary files: {ex}");
+			}
+		}
+
+		async Task AwaitLoadFileRepresentationAsync(Task loadTask)
+		{
+			try
+			{
+				await loadTask.ConfigureAwait(false);
+			}
+			catch
+			{
+				lock (_loadLock)
+				{
+					if (ReferenceEquals(_loadFileTask, loadTask))
+					{
+						_loadFileTask = null;
+					}
+				}
+
+				throw;
+			}
+		}
+
+		void ValidateFileRepresentation()
+		{
+			if (_provider is null)
+			{
+				throw new InvalidOperationException("Item provider is null.");
+			}
+
+			if (string.IsNullOrWhiteSpace(_identifier))
+			{
+				throw new InvalidOperationException("Item provider does not contain a supported file representation.");
+			}
+
+			if (string.IsNullOrWhiteSpace(FullPath))
+			{
+				throw new InvalidOperationException("Destination file path is not set.");
+			}
+		}
+
+		void StartLoadFileRepresentation(TaskCompletionSource<bool> tcs)
+		{
+			var destinationPath = FullPath;
+
+			try
+			{
+				var progress = _provider.LoadFileRepresentation(_identifier, (url, error) =>
+				{
+					try
+					{
+						if (error is not null)
+						{
+							ClearLoadOperation(tcs);
+							tcs.TrySetException(new NSErrorException(error));
+							return;
+						}
+
+						if (string.IsNullOrWhiteSpace(url?.Path))
+						{
+							ClearLoadOperation(tcs);
+							tcs.TrySetException(new InvalidOperationException("Item provider did not return a file URL."));
+							return;
+						}
+
+						ThrowIfDisposed();
+						CopyTemporaryFile(url.Path, destinationPath);
+
+						lock (_loadLock)
+						{
+							ClearLoadOperationNoLock(tcs);
+
+							if (_disposed)
+							{
+								TryDeleteTemporaryFile(destinationPath);
+								tcs.TrySetException(new ObjectDisposedException(nameof(PHPickerFileResult)));
+								return;
+							}
+
+							_isFileLoaded = true;
+						}
+
+						tcs.TrySetResult(true);
+					}
+					catch (Exception ex)
+					{
+						ClearLoadOperation(tcs);
+						tcs.TrySetException(ex);
+					}
+				});
+
+				lock (_loadLock)
+				{
+					if (_disposed)
+					{
+						progress?.Cancel();
+					}
+					else if (!_isFileLoaded && ReferenceEquals(_loadTcs, tcs) && !tcs.Task.IsCompleted)
+					{
+						_loadProgress = progress;
+					}
+				}
+			}
+			catch (Exception ex)
+			{
+				ClearLoadOperation(tcs);
+				tcs.TrySetException(ex);
+			}
+		}
+
+		void ClearLoadOperation(TaskCompletionSource<bool> tcs)
+		{
+			lock (_loadLock)
+			{
+				ClearLoadOperationNoLock(tcs);
+			}
+		}
+
+		void ClearLoadOperationNoLock(TaskCompletionSource<bool> tcs)
+		{
+			if (ReferenceEquals(_loadTcs, tcs))
+			{
+				_loadTcs = null;
+				_loadProgress = null;
+			}
+		}
+
+		void ThrowIfDisposed()
+		{
+			lock (_loadLock)
+			{
+				ThrowIfDisposedNoLock();
+			}
+		}
+
+		void ThrowIfDisposedNoLock()
+		{
+			if (_disposed)
+			{
+				throw new ObjectDisposedException(nameof(PHPickerFileResult));
+			}
+		}
+
+		internal static string CreateTemporaryFilePath(string extension)
+		{
+			Directory.CreateDirectory(TemporaryDirectory);
+
+			return Path.Combine(TemporaryDirectory, $"{Guid.NewGuid():N}{NormalizeExtension(extension)}");
+		}
+
+		static void CopyTemporaryFile(string sourcePath, string destinationPath)
+		{
+			try
+			{
+				File.Copy(sourcePath, destinationPath, overwrite: true);
+				File.SetLastWriteTimeUtc(destinationPath, DateTime.UtcNow);
+			}
+			catch
+			{
+				TryDeleteTemporaryFile(destinationPath);
+				throw;
+			}
+		}
+
+		static void DeleteTemporaryFileIfStale(string path, DateTime cutoff)
+		{
+			try
+			{
+				if (File.GetLastWriteTimeUtc(path) < cutoff)
+				{
+					TryDeleteTemporaryFile(path);
+				}
+			}
+			catch (IOException ex)
+			{
+				Debug.WriteLine($"Unable to inspect MediaPicker temporary file '{path}': {ex}");
+			}
+			catch (UnauthorizedAccessException ex)
+			{
+				Debug.WriteLine($"Unable to inspect MediaPicker temporary file '{path}': {ex}");
+			}
+		}
+
+		internal static void TryDeleteTemporaryFile(string path)
+		{
+			if (string.IsNullOrWhiteSpace(path) || !IsTemporaryFile(path))
+			{
+				return;
+			}
+
+			try
+			{
+				if (File.Exists(path))
+				{
+					File.Delete(path);
+				}
+			}
+			catch (IOException ex)
+			{
+				Debug.WriteLine($"Unable to delete MediaPicker temporary file '{path}': {ex}");
+			}
+			catch (UnauthorizedAccessException ex)
+			{
+				Debug.WriteLine($"Unable to delete MediaPicker temporary file '{path}': {ex}");
+			}
+		}
+
+		static bool IsTemporaryFile(string path)
+		{
+			var fullDirectory = Path.GetFullPath(TemporaryDirectory + Path.DirectorySeparatorChar);
+			var fullPath = Path.GetFullPath(path);
+
+			return fullPath.StartsWith(fullDirectory, StringComparison.Ordinal);
+		}
+
+		static string NormalizeExtension(string extension)
+		{
+			return string.IsNullOrWhiteSpace(extension)
+				? string.Empty
+				: $".{extension.TrimStart('.')}";
+		}
+
+		static string GetFileExtension(string identifier)
+		{
+			var extension = GetTag(identifier, UTType.TagClassFilenameExtension);
+
+			return NormalizeExtension(extension);
+		}
+
+		static string GetFileName(string suggestedName, string extension)
+		{
+			var fileName = string.IsNullOrWhiteSpace(suggestedName)
+				? Guid.NewGuid().ToString("N")
+				: Path.GetFileName(suggestedName);
+
+			if (string.IsNullOrWhiteSpace(Path.GetExtension(fileName)) && !string.IsNullOrWhiteSpace(extension))
+			{
+				fileName += extension;
+			}
+
+			return fileName;
+		}
 
 		protected internal static string GetTag(string identifier, string tagClass)
 			   => UTType.CopyAllTags(identifier, tagClass)?.FirstOrDefault();
+
+		public void Dispose()
+		{
+			TaskCompletionSource<bool> loadTcs;
+			NSProgress loadProgress;
+
+			lock (_loadLock)
+			{
+				if (_disposed)
+				{
+					return;
+				}
+
+				_disposed = true;
+				loadTcs = _loadTcs;
+				_loadTcs = null;
+				loadProgress = _loadProgress;
+				_loadProgress = null;
+			}
+
+			loadProgress?.Cancel();
+			loadTcs?.TrySetException(new ObjectDisposedException(nameof(PHPickerFileResult)));
+			TryDeleteTemporaryFile(FullPath);
+		}
 	}
 
 	class CompressedUIImageFileResult : FileResult
@@ -735,10 +1159,6 @@ namespace Microsoft.Maui.Media
 		}
 	}
 
-	/// <summary>
-	/// Wrapper that applies compression lazily when the stream is opened.
-	/// This avoids iOS resource limits when processing multiple photos.
-	/// </summary>
 	class PHPickerProcessedFileResult : FileResult, IDisposable
 	{
 		readonly FileResult _originalResult;
@@ -747,9 +1167,10 @@ namespace Microsoft.Maui.Media
 		readonly int _compressionQuality;
 		readonly bool _rotateImage;
 		readonly bool _preserveMetaData;
-
-		// Cached result of the first call to PlatformOpenReadAsync to avoid re-processing
-		byte[] _cachedData;
+		readonly object _processLock = new();
+		Task _processFileTask;
+		bool _isProcessed;
+		bool _disposed;
 
 		internal PHPickerProcessedFileResult(FileResult originalResult, int? maximumWidth, int? maximumHeight, int compressionQuality, bool rotateImage, bool preserveMetaData)
 			: base()
@@ -761,45 +1182,60 @@ namespace Microsoft.Maui.Media
 			_rotateImage = rotateImage;
 			_preserveMetaData = preserveMetaData;
 
-			// Copy metadata from original, adjusting extension for compressed output
-			var originalFileName = originalResult.FileName;
-			var originalFullPath = originalResult.FullPath;
-			var originalContentType = originalResult.ContentType;
-
-			// Preserve the original format: PNG stays PNG, everything else compresses to JPEG.
-			// When no compression is applied (quality == 100), preserve the original extension as-is.
-			var originalWasPng = !string.IsNullOrEmpty(originalFileName) &&
-				Path.GetExtension(originalFileName).Equals(".png", StringComparison.OrdinalIgnoreCase);
-			string outputExtension;
-			if (compressionQuality == 100)
-				outputExtension = Path.GetExtension(originalFileName ?? string.Empty);
-			else if (originalWasPng)
-				outputExtension = ".png";
-			else
-				outputExtension = ".jpg";
-
-			FileName = !string.IsNullOrEmpty(originalFileName) && !string.IsNullOrEmpty(outputExtension)
-				? Path.ChangeExtension(originalFileName, outputExtension)
-				: originalFileName;
-
-			FullPath = !string.IsNullOrEmpty(originalFullPath) && !string.IsNullOrEmpty(outputExtension)
-				? Path.ChangeExtension(originalFullPath, outputExtension)
-				: originalFullPath;
-
-			ContentType = string.Equals(outputExtension, ".png", StringComparison.OrdinalIgnoreCase)
-				? "image/png"
-				: string.Equals(outputExtension, ".jpg", StringComparison.OrdinalIgnoreCase) || string.Equals(outputExtension, ".jpeg", StringComparison.OrdinalIgnoreCase)
-					? "image/jpeg"
-					: originalContentType;
+			FileName = originalResult.FileName;
+			FullPath = originalResult.FullPath;
+			ContentType = originalResult.ContentType;
 		}
 
 		internal override async Task<Stream> PlatformOpenReadAsync()
 		{
-			// Return cached result on subsequent calls to avoid re-processing
-			if (_cachedData is not null)
-				return new MemoryStream(_cachedData, writable: false);
+			await LoadProcessedFileAsync().ConfigureAwait(false);
 
-			// Load the original stream into memory once to avoid multiple expensive NSItemProvider loads.
+			return File.Open(FullPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+		}
+
+		internal Task LoadProcessedFileAsync()
+		{
+			Task processTask;
+
+			lock (_processLock)
+			{
+				ThrowIfDisposedNoLock();
+
+				if (_isProcessed)
+				{
+					return Task.CompletedTask;
+				}
+
+				_processFileTask ??= ProcessAndWriteFileAsync();
+				processTask = _processFileTask;
+			}
+
+			return AwaitProcessedFileAsync(processTask);
+		}
+
+		async Task AwaitProcessedFileAsync(Task processTask)
+		{
+			try
+			{
+				await processTask.ConfigureAwait(false);
+			}
+			catch
+			{
+				lock (_processLock)
+				{
+					if (ReferenceEquals(_processFileTask, processTask))
+					{
+						_processFileTask = null;
+					}
+				}
+
+				throw;
+			}
+		}
+
+		async Task ProcessAndWriteFileAsync()
+		{
 			byte[] originalData;
 			using (var originalStream = await _originalResult.OpenReadAsync())
 			using (var buffer = new MemoryStream())
@@ -823,34 +1259,103 @@ namespace Microsoft.Maui.Media
 					_rotateImage,
 					_preserveMetaData);
 			}
-			catch
+			catch (Exception ex)
 			{
-				// Swallow processing exceptions and fall back to the original data.
+				Debug.WriteLine($"Unable to process picked image '{_originalResult.FileName}': {ex}");
 				processedStream = null;
 			}
 
 			if (processedStream is null)
 			{
-				// Fall back to the original data if processing failed or returned null.
-				_cachedData = originalData;
-			}
-			else
-			{
-				using (processedStream)
-				using (var buffer = new MemoryStream())
+				lock (_processLock)
 				{
-					await processedStream.CopyToAsync(buffer);
-					_cachedData = buffer.ToArray();
+					ThrowIfDisposedNoLock();
+					_isProcessed = true;
 				}
+
+				return;
 			}
 
-			return new MemoryStream(_cachedData, writable: false);
+			using (processedStream)
+			{
+				var outputExtension = ImageProcessor.DetermineOutputExtension(processedStream, _compressionQuality, _originalResult.FileName);
+				var processedFileName = !string.IsNullOrEmpty(_originalResult.FileName) && !string.IsNullOrEmpty(outputExtension)
+					? Path.ChangeExtension(_originalResult.FileName, outputExtension)
+					: _originalResult.FileName;
+
+				var processedContentType = string.Equals(outputExtension, ".png", StringComparison.OrdinalIgnoreCase)
+					? "image/png"
+					: string.Equals(outputExtension, ".jpg", StringComparison.OrdinalIgnoreCase) || string.Equals(outputExtension, ".jpeg", StringComparison.OrdinalIgnoreCase)
+						? "image/jpeg"
+						: _originalResult.ContentType;
+
+				var processedPath = PHPickerFileResult.CreateTemporaryFilePath(outputExtension);
+
+				try
+				{
+					if (processedStream.CanSeek)
+					{
+						processedStream.Position = 0;
+					}
+
+					using (var fileStream = File.Create(processedPath))
+					{
+						await processedStream.CopyToAsync(fileStream);
+					}
+
+					File.SetLastWriteTimeUtc(processedPath, DateTime.UtcNow);
+
+					lock (_processLock)
+					{
+						if (_disposed)
+						{
+							PHPickerFileResult.TryDeleteTemporaryFile(processedPath);
+							throw new ObjectDisposedException(nameof(PHPickerProcessedFileResult));
+						}
+
+						FileName = processedFileName;
+						ContentType = processedContentType;
+						FullPath = processedPath;
+						_isProcessed = true;
+					}
+
+					PHPickerFileResult.TryDeleteTemporaryFile(_originalResult.FullPath);
+					(_originalResult as IDisposable)?.Dispose();
+				}
+				catch
+				{
+					PHPickerFileResult.TryDeleteTemporaryFile(processedPath);
+					throw;
+				}
+			}
 		}
 
 		public void Dispose()
 		{
+			string fullPath;
+
+			lock (_processLock)
+			{
+				if (_disposed)
+				{
+					return;
+				}
+
+				_disposed = true;
+				fullPath = FullPath;
+			}
+
+			PHPickerFileResult.TryDeleteTemporaryFile(fullPath);
+			PHPickerFileResult.TryDeleteTemporaryFile(_originalResult.FullPath);
 			(_originalResult as IDisposable)?.Dispose();
-			GC.SuppressFinalize(this);
+		}
+
+		void ThrowIfDisposedNoLock()
+		{
+			if (_disposed)
+			{
+				throw new ObjectDisposedException(nameof(PHPickerProcessedFileResult));
+			}
 		}
 	}
 }

--- a/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Media
 			=> PhotoAsync(options, true, true);
 
 		public Task<List<FileResult>> PickPhotosAsync(MediaPickerOptions options)
-			=> PhotosAsync(options, true, true);
+			=> PhotosAsync(options, true);
 
 		public Task<FileResult> CapturePhotoAsync(MediaPickerOptions options)
 		{
@@ -42,7 +42,7 @@ namespace Microsoft.Maui.Media
 			=> PhotoAsync(options, false, true);
 
 		public Task<List<FileResult>> PickVideosAsync(MediaPickerOptions options)
-			=> PhotosAsync(options, false, true);
+			=> PhotosAsync(options, false);
 
 		public Task<FileResult> CaptureVideoAsync(MediaPickerOptions options)
 		{
@@ -172,7 +172,7 @@ namespace Microsoft.Maui.Media
 			}
 		}
 
-		async Task<List<FileResult>> PhotosAsync(MediaPickerOptions options, bool photo, bool pickExisting)
+		async Task<List<FileResult>> PhotosAsync(MediaPickerOptions options, bool photo)
 		{
 			// iOS 14+ only supports multiple selection
 			// TODO throw exception?
@@ -181,54 +181,35 @@ namespace Microsoft.Maui.Media
 				return [];
 			}
 
-			if (!photo && !pickExisting)
-			{
-				await Permissions.EnsureGrantedAsync<Permissions.Microphone>();
-			}
-
-			// Check if picking existing or not and ensure permission accordingly as they can be set independently from each other
-			if (pickExisting && !OperatingSystem.IsIOSVersionAtLeast(11, 0))
-			{
-				await Permissions.EnsureGrantedAsync<Permissions.Photos>();
-			}
-
-			if (!pickExisting)
-			{
-				await Permissions.EnsureGrantedAsync<Permissions.Camera>();
-			}
-
 			var vc = WindowStateManager.Default.GetCurrentUIViewController(true);
 			var tcs = new TaskCompletionSource<List<FileResult>>();
 			UIViewController pickerRef = null;
 
 			PHPickerFileResult.CleanupTemporaryFiles();
 
-			if (pickExisting)
+			var config = new PHPickerConfiguration
 			{
-				var config = new PHPickerConfiguration
-				{
-					Filter = photo
-						? PHPickerFilter.ImagesFilter
-						: PHPickerFilter.VideosFilter,
-					SelectionLimit = options?.SelectionLimit ?? 1
-				};
+				Filter = photo
+					? PHPickerFilter.ImagesFilter
+					: PHPickerFilter.VideosFilter,
+				SelectionLimit = options?.SelectionLimit ?? 1
+			};
 
-				if (!photo)
-				{
-					config.PreferredAssetRepresentationMode = PHPickerConfigurationAssetRepresentationMode.Compatible;
-				}
-
-				var picker = new PHPickerViewController(config)
-				{
-					Delegate = new Media.PhotoPickerDelegate
-					{
-						CompletedHandler = res =>
-							_ = CompletePickerResultsAsync(res, options, tcs)
-					}
-				};
-
-				pickerRef = picker;
+			if (!photo)
+			{
+				config.PreferredAssetRepresentationMode = PHPickerConfigurationAssetRepresentationMode.Compatible;
 			}
+
+			var picker = new PHPickerViewController(config)
+			{
+				Delegate = new Media.PhotoPickerDelegate
+				{
+					CompletedHandler = res =>
+						_ = CompletePickerResultsAsync(res, options, tcs)
+				}
+			};
+
+			pickerRef = picker;
 
 			if (!string.IsNullOrWhiteSpace(options?.Title))
 			{
@@ -289,17 +270,20 @@ namespace Microsoft.Maui.Media
 				return [];
 
 			var fileResults = new List<FileResult>(results.Length);
+			PHPickerFileResult fileResult = null;
 			try
 			{
 				foreach (var file in results)
 				{
-					var fileResult = new PHPickerFileResult(file.ItemProvider);
+					fileResult = new PHPickerFileResult(file.ItemProvider);
 					await fileResult.LoadFileRepresentationAsync().ConfigureAwait(false);
 					fileResults.Add(fileResult);
+					fileResult = null;
 				}
 			}
 			catch
 			{
+				fileResult?.Dispose();
 				DisposeFileResults(fileResults);
 				throw;
 			}
@@ -538,6 +522,7 @@ namespace Microsoft.Maui.Media
 					await rotatedStream.CopyToAsync(fileStream).ConfigureAwait(false);
 				}
 
+				// Ownership transfers to the returned FileResult; stale files are swept from the MediaPicker temp folder.
 				return new FileResult(tempFilePath, original.FileName);
 			}
 			catch (Exception ex)
@@ -1300,7 +1285,7 @@ namespace Microsoft.Maui.Media
 
 					using (var fileStream = File.Create(processedPath))
 					{
-						await processedStream.CopyToAsync(fileStream);
+						await processedStream.CopyToAsync(fileStream).ConfigureAwait(false);
 					}
 
 					File.SetLastWriteTimeUtc(processedPath, DateTime.UtcNow);


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details

Fixes #32832

`MediaPicker` on iOS 14+ uses `PHPickerViewController`. The PHPicker-backed `FileResult` was returning a synthetic filename for `FullPath` instead of a real filesystem path, which regressed direct file access patterns such as `File.Copy(result.FullPath, ...)`. Video picking also lost the old compatible representation behavior.

### Description of Change

- Materializes PHPicker results into a MAUI-owned temporary folder before completing pick operations so `FileResult.FullPath` points to a readable file.
- Requests compatible asset representation for videos only.
- Keeps image rotation/resizing/compression on image files only, and ensures processed image results also expose real temp-backed `FullPath` values.
- Adds cleanup for stale MediaPicker temporary files and explicit cleanup on dispose/error paths.
- Removes the shared static picker reference to avoid overlapping picker lifecycle races.

### Testing

- `dotnet format src/Essentials/src/Essentials.csproj --no-restore --include src/Essentials/src/MediaPicker/MediaPicker.ios.cs --verbosity minimal`
- `dotnet build src/Essentials/src/Essentials.csproj -f net10.0-ios26.0 --no-restore /p:BuildIpa=false /p:EnableSourceLink=false /p:UseSharedCompilation=false`
- `dotnet build src/Essentials/src/Essentials.csproj -f net10.0-maccatalyst26.0 --no-restore /p:EnableSourceLink=false /p:UseSharedCompilation=false`

### Artifact Testing Request

@stefanottauma @BohdanRomaniuk @craftylogic @marcojak @msoftie @DennisWelu if you are able, could you please try the artifacts from this PR and confirm whether they restore your iOS MediaPicker scenarios for photos/videos and `FullPath` access?