### PR TITLE
[iOS] Fix Label Span formatting test failures on candidate branch

### DIFF
--- a/src/Controls/src/Core/Label/Label.Mapper.cs
+++ b/src/Controls/src/Core/Label/Label.Mapper.cs
@@ -144,11 +144,17 @@ namespace Microsoft.Maui.Controls
 
 		static void MapFont(ILabelHandler handler, Label label, Action<IElementHandler, IElement> baseMethod)
 		{
-			// if there is formatted text,
-			// then we re-apply the whole formatted text
-			if (label.HasFormattedTextSpans && !handler.IsConnectingHandler())
+			if (label.HasFormattedTextSpans)
 			{
-				handler.UpdateValue(nameof(FormattedText));
+				// if there is formatted text,
+				// then we re-apply the whole formatted text.
+				// During connection, MapText already set the correct AttributedText
+				// with font info embedded. We must not call baseMethod here as
+				// setting UILabel.Font replaces the AttributedText on iOS.
+				if (!handler.IsConnectingHandler())
+				{
+					handler.UpdateValue(nameof(FormattedText));
+				}
 			}
 			else if (label.TextType == TextType.Text || !IsDefaultFont(label))
 			{


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
PR #31159 ("Improve Label Mapping Performance") introduced a regression in three iOS Label snapshot tests:

- SpanShouldInheritStyleFromLabel
- VerifyLineHeightRendering
- VerifySpanInheritsLabelCharacterSpacing

As a result, Spans lose font attributes, line height, and character spacing inherited from the Label.

### Root Cause
In Label.Mapper.cs, MapFont was modified to include && !handler.IsConnectingHandler() in the HasFormattedTextSpans check. During handler connection, this causes execution to fall through to baseMethod, which ultimately calls UILabel.Font = .... On iOS, setting UILabel.Font after AttributedText has already been assigned recreates the attributed string, removing the span-level formatting (such as bold/italic styling, line height, and character spacing) that was previously applied by MapText.

### Test names:
- SpanShouldInheritStyleFromLabel
- VerifyLineHeightRendering
- VerifySpanInheritsLabelCharacterSpacing
 
### Description of Change
Restructured MapFont so that when HasFormattedTextSpans is true, execution never falls through to baseMethod.
During handler connection, the redundant UpdateValue(FormattedText) call is still skipped to preserve the performance optimization introduced in PR #31159. However, UpdateFont is no longer called, preventing the already-correct AttributedText from being overwritten and preserving all span-level formatting.

**Cause PR:** #31159

### Output
| Before Issue Fix | After Issue Fix |
|----------|----------|
| <img width="300" height="600"  src="https://github.com/user-attachments/assets/37d5099d-6cb8-436d-9907-55f290ff701a"> | <img width="300" height="600"  src="https://github.com/user-attachments/assets/8160de43-dd3c-4095-b0fe-dc90c6d9e615"> |

### Test result
| Before Issue Fix | After Issue Fix |
|----------|----------|
| <img width="400" height="200"  src="https://github.com/user-attachments/assets/e77db099-fed6-411a-a6fd-9fc61447cd52"> | <img width="300" height="200"  src="https://github.com/user-attachments/assets/fb69e7e0-7a9a-44f4-b6df-d5b6cc6bcd76"> |
| <img width="400" height="200"  src="https://github.com/user-attachments/assets/ca78f6e2-3b6d-4b75-8b77-a68b2941d4c5"> | <img width="300" height="200"  src="https://github.com/user-attachments/assets/cb94e0b3-e117-4a77-a81a-cdd4ac8b649b"> |
| <img width="400" height="200"  src="https://github.com/user-attachments/assets/e88bda5d-512b-48fc-b9af-906e67d62021"> | <img width="300" height="200"  src="https://github.com/user-attachments/assets/b9a47286-df33-40bd-a6dc-a3dec2937bf5"> |