### PR TITLE
Fix /review rerun for MauiBot summaries

### DIFF
--- a/.github/scripts/Resolve-RerunEligibility.Tests.ps1
+++ b/.github/scripts/Resolve-RerunEligibility.Tests.ps1
@@ -270,7 +270,7 @@ Describe 'Resolve-RerunEligibility' {
         $result.Reason | Should -Be 'no-ai-summary'
     }
 
-    It 'recognizes AI Summary comments from the legacy MauiBot account' {
+    It 'recognizes AI Summary comments from the MauiBot account' {
         $comments = @(
             New-TestComment -Id 4239128463 -Body (New-AISummaryBody -Sha '6e9af5b') -CreatedAt '2026-04-13T19:37:50Z' -Login 'MauiBot' -Type 'User'
             New-TestComment -Id 4658057491 -Body '@kubaflo , Addressed AI concerns.' -CreatedAt '2026-06-09T08:50:38Z'

--- a/.github/scripts/Resolve-RerunEligibility.Tests.ps1
+++ b/.github/scripts/Resolve-RerunEligibility.Tests.ps1
@@ -269,6 +269,19 @@ Describe 'Resolve-RerunEligibility' {
         $result.Eligible | Should -BeTrue
     }
 
+    It 'recognizes AI Summary comments from the legacy MauiBot account' {
+        $comments = @(
+            New-TestComment -Id 4239128463 -Body (New-AISummaryBody -Sha '6e9af5b') -CreatedAt '2026-04-13T19:37:50Z' -Login 'MauiBot' -Type 'User'
+            New-TestComment -Id 4658057491 -Body '@kubaflo , Addressed AI concerns.' -CreatedAt '2026-06-09T08:50:38Z'
+            New-TestComment -Id 4659999999 -Body '/review rerun' -CreatedAt '2026-06-09T09:00:00Z'
+        )
+
+        $result = Resolve-RerunEligibility -Comments $comments -Commits @() -CurrentCommentId 4659999999 -CurrentHeadSha '6e9af5bc8b5d0023400d653500951fb46df44170'
+
+        $result.Eligible | Should -BeTrue
+        $result.Reason | Should -Be 'new-comment-after-ai-summary'
+    }
+
     It 'uses the first session marker from an AI Summary' {
         $body = @"
 <!-- AI Summary -->

--- a/.github/scripts/Resolve-RerunEligibility.Tests.ps1
+++ b/.github/scripts/Resolve-RerunEligibility.Tests.ps1
@@ -183,7 +183,7 @@ Describe 'Resolve-RerunEligibility' {
 
     It 'rejects a rerun command when there are no new comments or commits' {
         $comments = @(
-            New-TestComment -Id 1 -Body (New-AISummaryBody) -CreatedAt '2026-05-31T09:00:00Z' -UpdatedAt '2026-05-31T09:30:00Z' -Login 'maui-bot' -Type 'Bot'
+            New-TestComment -Id 1 -Body (New-AISummaryBody) -CreatedAt '2026-05-31T09:00:00Z' -UpdatedAt '2026-05-31T09:30:00Z' -Login 'MauiBot' -Type 'User'
             New-TestComment -Id 10 -Body '/review rerun' -CreatedAt '2026-05-31T10:00:00Z'
         )
 
@@ -195,7 +195,7 @@ Describe 'Resolve-RerunEligibility' {
 
     It 'accepts a non-command comment after the latest AI Summary' {
         $comments = @(
-            New-TestComment -Id 1 -Body (New-AISummaryBody) -CreatedAt '2026-05-31T09:00:00Z' -UpdatedAt '2026-05-31T09:30:00Z' -Login 'maui-bot' -Type 'Bot'
+            New-TestComment -Id 1 -Body (New-AISummaryBody) -CreatedAt '2026-05-31T09:00:00Z' -UpdatedAt '2026-05-31T09:30:00Z' -Login 'MauiBot' -Type 'User'
             New-TestComment -Id 2 -Body 'I pushed the requested update.' -CreatedAt '2026-05-31T09:45:00Z'
             New-TestComment -Id 10 -Body '/review rerun' -CreatedAt '2026-05-31T10:00:00Z'
         )
@@ -208,7 +208,7 @@ Describe 'Resolve-RerunEligibility' {
 
     It 'uses AI Summary creation time as the activity checkpoint when the summary was edited later' {
         $comments = @(
-            New-TestComment -Id 1 -Body (New-AISummaryBody) -CreatedAt '2026-05-31T09:00:00Z' -UpdatedAt '2026-05-31T10:30:00Z' -Login 'maui-bot' -Type 'Bot'
+            New-TestComment -Id 1 -Body (New-AISummaryBody) -CreatedAt '2026-05-31T09:00:00Z' -UpdatedAt '2026-05-31T10:30:00Z' -Login 'MauiBot' -Type 'User'
             New-TestComment -Id 2 -Body 'I pushed the requested update before the summary edit.' -CreatedAt '2026-05-31T09:45:00Z'
             New-TestComment -Id 10 -Body '/review rerun' -CreatedAt '2026-05-31T10:00:00Z'
         )
@@ -221,8 +221,8 @@ Describe 'Resolve-RerunEligibility' {
 
     It 'selects the newest AI Summary by creation time instead of edit time' {
         $comments = @(
-            New-TestComment -Id 1 -Body (New-AISummaryBody -Sha '1111111') -CreatedAt '2026-05-31T09:00:00Z' -UpdatedAt '2026-05-31T11:00:00Z' -Login 'maui-bot' -Type 'Bot'
-            New-TestComment -Id 2 -Body (New-AISummaryBody -Sha '2222222') -CreatedAt '2026-05-31T10:00:00Z' -UpdatedAt '2026-05-31T10:00:00Z' -Login 'maui-bot' -Type 'Bot'
+            New-TestComment -Id 1 -Body (New-AISummaryBody -Sha '1111111') -CreatedAt '2026-05-31T09:00:00Z' -UpdatedAt '2026-05-31T11:00:00Z' -Login 'MauiBot' -Type 'User'
+            New-TestComment -Id 2 -Body (New-AISummaryBody -Sha '2222222') -CreatedAt '2026-05-31T10:00:00Z' -UpdatedAt '2026-05-31T10:00:00Z' -Login 'MauiBot' -Type 'User'
             New-TestComment -Id 3 -Body 'Follow-up after the latest summary.' -CreatedAt '2026-05-31T10:15:00Z'
             New-TestComment -Id 10 -Body '/review rerun' -CreatedAt '2026-05-31T10:30:00Z'
         )
@@ -257,7 +257,7 @@ Describe 'Resolve-RerunEligibility' {
         $result.Reason | Should -Be 'no-ai-summary'
     }
 
-    It 'still recognizes AI Summary comments from github-actions[bot]' {
+    It 'ignores AI Summary comments from github-actions[bot]' {
         $comments = @(
             New-TestComment -Id 1 -Body (New-AISummaryBody -Sha 'abcdef1') -CreatedAt '2026-05-31T09:00:00Z' -UpdatedAt '2026-05-31T09:30:00Z' -Login 'github-actions[bot]' -Type 'Bot'
             New-TestComment -Id 2 -Body 'A meaningful follow-up after the summary.' -CreatedAt '2026-05-31T09:45:00Z'
@@ -266,7 +266,8 @@ Describe 'Resolve-RerunEligibility' {
 
         $result = Resolve-RerunEligibility -Comments $comments -Commits @() -CurrentCommentId 10 -CurrentHeadSha 'abcdef123'
 
-        $result.Eligible | Should -BeTrue
+        $result.Eligible | Should -BeFalse
+        $result.Reason | Should -Be 'no-ai-summary'
     }
 
     It 'recognizes AI Summary comments from the legacy MauiBot account' {
@@ -296,7 +297,7 @@ new
 
     It 'does not count repeated rerun commands as evidence' {
         $comments = @(
-            New-TestComment -Id 1 -Body (New-AISummaryBody) -CreatedAt '2026-05-31T09:00:00Z' -UpdatedAt '2026-05-31T09:30:00Z' -Login 'maui-bot' -Type 'Bot'
+            New-TestComment -Id 1 -Body (New-AISummaryBody) -CreatedAt '2026-05-31T09:00:00Z' -UpdatedAt '2026-05-31T09:30:00Z' -Login 'MauiBot' -Type 'User'
             New-TestComment -Id 9 -Body '/review rerun' -CreatedAt '2026-05-31T09:45:00Z'
             New-TestComment -Id 10 -Body '/review rerun' -CreatedAt '2026-05-31T10:00:00Z'
         )
@@ -309,7 +310,7 @@ new
 
     It 'accepts a non-command comment after the previous rerun command' {
         $comments = @(
-            New-TestComment -Id 1 -Body (New-AISummaryBody) -CreatedAt '2026-05-31T09:00:00Z' -UpdatedAt '2026-05-31T09:30:00Z' -Login 'maui-bot' -Type 'Bot'
+            New-TestComment -Id 1 -Body (New-AISummaryBody) -CreatedAt '2026-05-31T09:00:00Z' -UpdatedAt '2026-05-31T09:30:00Z' -Login 'MauiBot' -Type 'User'
             New-TestComment -Id 8 -Body '/review rerun' -CreatedAt '2026-05-31T09:45:00Z'
             New-TestComment -Id 9 -Body 'Follow-up detail after rerun request.' -CreatedAt '2026-05-31T09:50:00Z'
             New-TestComment -Id 10 -Body '/review rerun' -CreatedAt '2026-05-31T10:00:00Z'
@@ -323,7 +324,7 @@ new
 
     It 'does not reuse old activity from before a previous rerun command' {
         $comments = @(
-            New-TestComment -Id 1 -Body (New-AISummaryBody) -CreatedAt '2026-05-31T09:00:00Z' -UpdatedAt '2026-05-31T09:30:00Z' -Login 'maui-bot' -Type 'Bot'
+            New-TestComment -Id 1 -Body (New-AISummaryBody) -CreatedAt '2026-05-31T09:00:00Z' -UpdatedAt '2026-05-31T09:30:00Z' -Login 'MauiBot' -Type 'User'
             New-TestComment -Id 7 -Body 'Old follow-up before the first rerun.' -CreatedAt '2026-05-31T09:40:00Z'
             New-TestComment -Id 8 -Body '/review rerun' -CreatedAt '2026-05-31T09:45:00Z'
             New-TestComment -Id 10 -Body '/review rerun' -CreatedAt '2026-05-31T10:00:00Z'
@@ -337,7 +338,7 @@ new
 
     It 'finds AI Summary content posted as a PR review' {
         $comments = @(
-            New-TestComment -Id 1 -Body (New-AISummaryBody) -CreatedAt '2026-05-31T09:00:00Z' -UpdatedAt '2026-05-31T09:30:00Z' -Login 'maui-bot' -Type 'Bot' -Kind 'review'
+            New-TestComment -Id 1 -Body (New-AISummaryBody) -CreatedAt '2026-05-31T09:00:00Z' -UpdatedAt '2026-05-31T09:30:00Z' -Login 'MauiBot' -Type 'User' -Kind 'review'
             New-TestComment -Id 2 -Body 'Follow-up after the review.' -CreatedAt '2026-05-31T09:45:00Z'
             New-TestComment -Id 10 -Body '/review rerun' -CreatedAt '2026-05-31T10:00:00Z'
         )
@@ -350,7 +351,7 @@ new
 
     It 'accepts a current head SHA that differs from the latest reviewed session' {
         $comments = @(
-            New-TestComment -Id 1 -Body (New-AISummaryBody -Sha 'abcdef1') -CreatedAt '2026-05-31T09:00:00Z' -UpdatedAt '2026-05-31T09:30:00Z' -Login 'maui-bot' -Type 'Bot'
+            New-TestComment -Id 1 -Body (New-AISummaryBody -Sha 'abcdef1') -CreatedAt '2026-05-31T09:00:00Z' -UpdatedAt '2026-05-31T09:30:00Z' -Login 'MauiBot' -Type 'User'
             New-TestComment -Id 10 -Body '/review rerun' -CreatedAt '2026-05-31T10:00:00Z'
         )
 
@@ -362,7 +363,7 @@ new
 
     It 'accepts a commit after the previous rerun command' {
         $comments = @(
-            New-TestComment -Id 1 -Body (New-AISummaryBody) -CreatedAt '2026-05-31T09:00:00Z' -UpdatedAt '2026-05-31T09:30:00Z' -Login 'maui-bot' -Type 'Bot'
+            New-TestComment -Id 1 -Body (New-AISummaryBody) -CreatedAt '2026-05-31T09:00:00Z' -UpdatedAt '2026-05-31T09:30:00Z' -Login 'MauiBot' -Type 'User'
             New-TestComment -Id 8 -Body '/review rerun' -CreatedAt '2026-05-31T09:45:00Z'
             New-TestComment -Id 10 -Body '/review rerun' -CreatedAt '2026-05-31T10:00:00Z'
         )
@@ -378,8 +379,8 @@ new
 
     It 'rejects bot rerun comments' {
         $comments = @(
-            New-TestComment -Id 1 -Body (New-AISummaryBody) -CreatedAt '2026-05-31T09:00:00Z' -UpdatedAt '2026-05-31T09:30:00Z' -Login 'maui-bot' -Type 'Bot'
-            New-TestComment -Id 10 -Body '/review rerun' -CreatedAt '2026-05-31T10:00:00Z' -Login 'maui-bot' -Type 'Bot'
+            New-TestComment -Id 1 -Body (New-AISummaryBody) -CreatedAt '2026-05-31T09:00:00Z' -UpdatedAt '2026-05-31T09:30:00Z' -Login 'MauiBot' -Type 'User'
+            New-TestComment -Id 10 -Body '/review rerun' -CreatedAt '2026-05-31T10:00:00Z' -Login 'MauiBot' -Type 'User'
         )
 
         $result = Resolve-RerunEligibility -Comments $comments -Commits @() -CurrentCommentId 10 -CurrentHeadSha 'abcdef123'
@@ -390,7 +391,7 @@ new
 
     It 'is idempotent when ready-for-rerun label already exists' {
         $comments = @(
-            New-TestComment -Id 1 -Body (New-AISummaryBody) -CreatedAt '2026-05-31T09:00:00Z' -UpdatedAt '2026-05-31T09:30:00Z' -Login 'maui-bot' -Type 'Bot'
+            New-TestComment -Id 1 -Body (New-AISummaryBody) -CreatedAt '2026-05-31T09:00:00Z' -UpdatedAt '2026-05-31T09:30:00Z' -Login 'MauiBot' -Type 'User'
             New-TestComment -Id 10 -Body '/review rerun' -CreatedAt '2026-05-31T10:00:00Z'
         )
 
@@ -402,7 +403,7 @@ new
 
     It 'rejects rerun commands while a review is already in progress' {
         $comments = @(
-            New-TestComment -Id 1 -Body (New-AISummaryBody) -CreatedAt '2026-05-31T09:00:00Z' -UpdatedAt '2026-05-31T09:30:00Z' -Login 'maui-bot' -Type 'Bot'
+            New-TestComment -Id 1 -Body (New-AISummaryBody) -CreatedAt '2026-05-31T09:00:00Z' -UpdatedAt '2026-05-31T09:30:00Z' -Login 'MauiBot' -Type 'User'
             New-TestComment -Id 2 -Body 'Please look at the latest push.' -CreatedAt '2026-05-31T09:45:00Z'
             New-TestComment -Id 10 -Body '/review rerun' -CreatedAt '2026-05-31T10:00:00Z'
         )
@@ -415,7 +416,7 @@ new
 
     It 'builds deterministic rerun context with new comments and commits' {
         $comments = @(
-            New-TestComment -Id 1 -Body (New-AISummaryBody) -CreatedAt '2026-05-31T09:00:00Z' -UpdatedAt '2026-05-31T09:30:00Z' -Login 'maui-bot' -Type 'Bot'
+            New-TestComment -Id 1 -Body (New-AISummaryBody) -CreatedAt '2026-05-31T09:00:00Z' -UpdatedAt '2026-05-31T09:30:00Z' -Login 'MauiBot' -Type 'User'
             New-TestComment -Id 2 -Body 'New author context.' -CreatedAt '2026-05-31T09:45:00Z'
             New-TestComment -Id 3 -Body '/review rerun' -CreatedAt '2026-05-31T09:50:00Z'
         )

--- a/.github/scripts/Resolve-RerunEligibility.ps1
+++ b/.github/scripts/Resolve-RerunEligibility.ps1
@@ -29,6 +29,13 @@ $ReadyForRerunLabel = 's/agent-ready-for-rerun'
 $ReviewInProgressLabel = 's/agent-review-in-progress'
 $ReadyForRerunLabelDescription = 'AI review has new PR activity and is ready for rerun'
 $ReadyForRerunLabelColor = '5319E7'
+$AISummaryAuthorLogins = @(
+    'MauiBot',
+    'maui-bot',
+    'maui-bot[bot]',
+    'github-actions',
+    'github-actions[bot]'
+)
 
 function ConvertTo-DateTimeOffset {
     param([Parameter(Mandatory = $true)]$Value)
@@ -46,6 +53,17 @@ function Test-RerunCommand {
     param([string]$Body)
 
     return ([string]$Body).Trim() -match '(?i)^/review\s+rerun\s*$'
+}
+
+function Test-AISummaryCommentAuthor {
+    param([object]$Comment)
+
+    $login = if ($Comment.user) { [string]$Comment.user.login } else { '' }
+    if ([string]::IsNullOrWhiteSpace($login)) {
+        return $false
+    }
+
+    return @($AISummaryAuthorLogins | Where-Object { $_ -ieq $login }).Count -gt 0
 }
 
 function Normalize-ReviewPipelineRef {
@@ -210,7 +228,7 @@ function Get-LatestAISummaryComment {
         Where-Object {
             $_.body -and
             ([string]$_.body).Contains($AISummaryMarker) -and
-            ($_.user -and $_.user.login -match '(?i)^(maui-bot|github-actions)(\[bot\])?$')
+            (Test-AISummaryCommentAuthor $_)
         } |
         Sort-Object @{ Expression = { Get-ObjectDate $_ 'created_at' }; Descending = $true }, @{ Expression = { [Int64]$_.id }; Descending = $true } |
         Select-Object -First 1)
@@ -517,7 +535,7 @@ function Resolve-RerunEligibility {
         return [pscustomobject]@{ Eligible = $false; Reason = 'not-rerun-command'; Label = $ReadyForRerunLabel }
     }
 
-    if ($current.user -and ($current.user.type -eq 'Bot' -or $current.user.login -match '(?i)^(maui-bot|github-actions)(\[bot\])?$')) {
+    if ($current.user -and ($current.user.type -eq 'Bot' -or (Test-AISummaryCommentAuthor $current))) {
         return [pscustomobject]@{ Eligible = $false; Reason = 'bot-comment'; Label = $ReadyForRerunLabel }
     }
 

--- a/.github/scripts/Resolve-RerunEligibility.ps1
+++ b/.github/scripts/Resolve-RerunEligibility.ps1
@@ -30,11 +30,7 @@ $ReviewInProgressLabel = 's/agent-review-in-progress'
 $ReadyForRerunLabelDescription = 'AI review has new PR activity and is ready for rerun'
 $ReadyForRerunLabelColor = '5319E7'
 $AISummaryAuthorLogins = @(
-    'MauiBot',
-    'maui-bot',
-    'maui-bot[bot]',
-    'github-actions',
-    'github-actions[bot]'
+    'MauiBot'
 )
 
 function ConvertTo-DateTimeOffset {
@@ -295,7 +291,7 @@ function Test-CommentIsEvidence {
     if ($Comment.user -and $Comment.user.type -eq 'Bot') {
         return $false
     }
-    if ($Comment.user -and $Comment.user.login -match '(?i)^(maui-bot|github-actions)(\[bot\])?$') {
+    if (Test-AISummaryCommentAuthor $Comment) {
         return $false
     }
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

- Recognizes the `MauiBot` account as the AI Summary author for `/review rerun` eligibility.
- Replaces duplicated author regex checks with one allowlist helper used by AI Summary detection and bot-comment rejection.
- Adds regression coverage based on dotnet/maui#34426 comments 4239128463 and 4658057491.

## Validation

- `Invoke-Pester .github/scripts/Resolve-RerunEligibility.Tests.ps1,.github/scripts/Invoke-RerunReviewTrigger.Tests.ps1 -CI`
- `Resolve-RerunEligibility.ps1 -PRNumber 34426 -CurrentCommentId 4658995396` returned `Rerun eligibility: True (new-head-commit)`
- Verified the patched helper selects AI Summary comment `4239128463` authored by `MauiBot`.

## Fixes

- Follow-up to #35685
