### PR TITLE
[Android] Fix ShellPages_NavBarVisibilityHide, VerifyNavBarStatusAtRuntime, and ToggleHasNavigationBar_HidesBar_Visual test failures 

### DIFF
--- a/src/Core/src/Platform/Android/MauiWindowInsetListener.cs
+++ b/src/Core/src/Platform/Android/MauiWindowInsetListener.cs
@@ -289,7 +289,7 @@ namespace Microsoft.Maui.Platform
 
 			// Cache the AppBar state on the listener so SafeAreaExtensions can read it
 			// without walking the view tree. Must be set before ApplySafeAreaInsets runs.
-			FindListenerForView(v)?.SetAppBarContentState(appBarHasContent);
+			FindRegisteredListener(v)?.SetAppBarContentState(appBarHasContent);
 
 			// Apply padding to AppBarLayout based on content and system insets
 			if (appBarLayout is not null)
@@ -390,8 +390,13 @@ namespace Microsoft.Maui.Platform
 		/// Whether the AppBarLayout sibling currently has visible content (toolbar shown).
 		/// Set at the start of every <see cref="ApplyDefaultWindowInsets"/> call so that
 		/// <see cref="SafeAreaExtensions"/> can read it without walking the view tree.
+		/// <para>
+		/// <c>null</c> = state unknown (e.g. after navigation, before the next root inset dispatch);
+		/// falls back to position-based logic in <see cref="SafeAreaExtensions"/>.
+		/// <c>true</c> = AppBar confirmed visible. <c>false</c> = AppBar confirmed hidden.
+		/// </para>
 		/// </summary>
-		internal bool AppBarHasContent { get; private set; }
+		internal bool? AppBarHasContent { get; private set; }
 
 		internal void SetAppBarContentState(bool hasContent)
 		{
@@ -421,6 +426,11 @@ namespace Microsoft.Maui.Platform
 			{
 				ResetView(view);
 			}
+
+			// Reset AppBar state so that child-view inset dispatches triggered during navigation
+			// (before the next root ApplyDefaultWindowInsets runs) fall back to position-based
+			// logic rather than reading a stale cached value from the previous page.
+			AppBarHasContent = null;
 		}
 
 		/// <summary>

--- a/src/Core/src/Platform/Android/MauiWindowInsetListener.cs
+++ b/src/Core/src/Platform/Android/MauiWindowInsetListener.cs
@@ -287,6 +287,10 @@ namespace Microsoft.Maui.Platform
 			// leaving a blank gap on cutout devices.
 			bool appBarHasContent = HasVisibleAppBarContent(appBarLayout);
 
+			// Cache the AppBar state on the listener so SafeAreaExtensions can read it
+			// without walking the view tree. Must be set before ApplySafeAreaInsets runs.
+			FindListenerForView(v)?.SetAppBarContentState(appBarHasContent);
+
 			// Apply padding to AppBarLayout based on content and system insets
 			if (appBarLayout is not null)
 			{
@@ -382,10 +386,23 @@ namespace Microsoft.Maui.Platform
 
 		public bool HasTrackedView => _trackedViews.Count > 0;
 
-        public bool IsViewTracked(AView view)
+		/// <summary>
+		/// Whether the AppBarLayout sibling currently has visible content (toolbar shown).
+		/// Set at the start of every <see cref="ApplyDefaultWindowInsets"/> call so that
+		/// <see cref="SafeAreaExtensions"/> can read it without walking the view tree.
+		/// </summary>
+		internal bool AppBarHasContent { get; private set; }
+
+		internal void SetAppBarContentState(bool hasContent)
+		{
+			AppBarHasContent = hasContent;
+		}
+
+		public bool IsViewTracked(AView view)
         {
             return _trackedViews.Contains(view);
         }
+
 		public void ResetView(AView view)
 		{
 			if (view is IHandleWindowInsets customHandler)

--- a/src/Core/src/Platform/Android/SafeAreaExtensions.cs
+++ b/src/Core/src/Platform/Android/SafeAreaExtensions.cs
@@ -169,16 +169,44 @@ internal static class SafeAreaExtensions
 
 					if (top > 0 && viewTop < top && viewTop >= 0)
 					{
-						// Calculate the actual overlap amount
-						top = Math.Min(top - viewTop, top);
+						// If the AppBar is confirmed visible it handles the status-bar inset.
+						// Zero top so the content view does not double-pad itself alongside the
+						// AppBar. This also covers the stale-position case on NavBar SHOW:
+						// the immediate dispatch fires before layout, so viewTop is still 0
+						// (the old hide-state position), but AppBarHasContent already reflects
+						// the new visible state. Zeroing here ensures a correct first frame.
+						if (globalWindowInsetsListener?.AppBarHasContent == true)
+						{
+							top = 0;
+						}
+						else
+						{
+							// Calculate the actual overlap amount
+							top = Math.Min(top - viewTop, top);
+						}
 					}
 					else if (top > 0 && viewIsAnimatingVertically)
 					{
 						// View is animating - positioned beyond status bar but extends off-screen
 						// Apply full top inset since view will settle at Y=0
 					}
+					else if (top > 0 && viewTop >= top && viewTop >= 0)
+					{
+						// viewTop >= top: view is at or below the safe area.
+						// Don't zero top when the AppBar is confirmed hidden — the content view
+						// must own the full top inset because the AppBar is no longer claiming it.
+						// AppBarHasContent is set at the start of every inset dispatch (before this
+						// runs), so it accurately reflects the current AppBar state even when
+						// view positions are stale (pre-layout).
+						if (globalWindowInsetsListener?.AppBarHasContent != false && (viewHeight > 0 || hasTrackedViews))
+						{
+							top = 0;
+						}
+					}
 					else
 					{
+						// viewTop < 0: view is panned off the top of the screen (or top == 0).
+						// Per the comment above, don't apply the top inset in this case.
 						if (viewHeight > 0 || hasTrackedViews)
 						{
 							top = 0;


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause
-  PR #35555 calls ViewCompat.RequestApplyInsets() synchronously in ToolbarExtensions.UpdateIsVisible — before the layout pass runs. At that moment, GetLocationOnScreen returns the content view's stale pre-collapse position, which makes SafeAreaExtensions think the view is already safely below the status bar and zeros the top inset. When layout then runs and the AppBar collapses, the content moves to y=0 with paddingTop=0 — rendering behind the status bar.

### Description of Change
- Instead of relying on the content view's on-screen position (which is stale at dispatch time), the fix caches the AppBar's current visibility state as AppBarHasContent on MauiWindowInsetListener — set at the start of every inset dispatch before SafeAreaExtensions runs. SafeAreaExtensions then uses this cached state in both inset branches: when AppBar is confirmed hidden, the top inset is preserved on the content view regardless of stale position; when AppBar is confirmed visible, the top inset is zeroed so the content doesn't double-pad alongside the AppBar. This ensures correct padding is applied in the same layout frame as the AppBar visibility change — with no flicker and no timing dependency.

### Issues Fixed
**Resolved test failures:**
 - ShellPages_NavBarVisibilityHide
 - VerifyNavBarStatusAtRuntime
 - ToggleHasNavigationBar_HidesBar_Visual
 
 ### Output
 
| Before | After |
|----------|----------|
| <img src="https://github.com/user-attachments/assets/aa9fba3a-2deb-4216-9d53-a2a986f27688"> | <img src="https://github.com/user-attachments/assets/9012667c-631a-4219-98da-0eccee151c9a"> |