### PR TITLE
Fix /review tests trigger and output

### DIFF
--- a/.github/scripts/Review-Tests.ps1
+++ b/.github/scripts/Review-Tests.ps1
@@ -218,7 +218,7 @@ function New-TestFailureReviewBody {
         [string]$ContextJsonPath
     )
 
-    $marker = "<!-- Test Failure Review -->"
+    $marker = "<!-- Test Failure Review (local) -->"
     $ReportContent = Collapse-OpenDetails $ReportContent
     if ($ReportContent.Contains($marker)) {
         return $ReportContent
@@ -237,6 +237,7 @@ function New-TestFailureReviewBody {
     $prAuthor = $pr.author.login
 
     $verdict = Get-ReportVerdict -Content $ReportContent
+    $safeVerdict = Escape-Html $verdict
     $verdictColor = Get-VerdictColor -Verdict $verdict
     $verdictIcon = Get-VerdictIcon -Verdict $verdict
 
@@ -281,7 +282,7 @@ function New-TestFailureReviewBody {
 $marker
 
 <details>
-<summary>$verdictIcon <strong>Test Failure Review:</strong> $verdict — <a href="$commitUrl"><code>$commitSha7</code></a> · <strong>$prTitle</strong></summary>
+<summary>$verdictIcon <strong>Test Failure Review:</strong> $safeVerdict — <a href="$commitUrl"><code>$commitSha7</code></a> · <strong>$prTitle</strong></summary>
 <br/>
 
 $authorPing
@@ -327,7 +328,7 @@ function Publish-TestFailureReviewComment {
         [string]$CommentBody
     )
 
-    $marker = "<!-- Test Failure Review -->"
+    $marker = "<!-- Test Failure Review (local) -->"
     $commentsRaw = & gh api "repos/$Repository/issues/$PRNumber/comments" --paginate 2>$null
     $existing = $null
     if ($LASTEXITCODE -eq 0 -and $commentsRaw) {

--- a/.github/scripts/Review-Tests.ps1
+++ b/.github/scripts/Review-Tests.ps1
@@ -307,14 +307,18 @@ function Publish-TestFailureReview {
 
     Set-Content -Path $ReviewBodyPath -Value $ReviewBody -Encoding UTF8
     $payloadPath = [System.IO.Path]::GetTempFileName()
+    $stderrPath = [System.IO.Path]::GetTempFileName()
     @{ body = $ReviewBody; event = "COMMENT" } | ConvertTo-Json -Depth 4 | Set-Content -Path $payloadPath -Encoding UTF8
-    $postOutput = & gh api --method POST "repos/$Repository/pulls/$PRNumber/reviews" --input $payloadPath --jq .html_url 2>&1
+    $postOutput = & gh api --method POST "repos/$Repository/pulls/$PRNumber/reviews" --input $payloadPath --jq .html_url 2>$stderrPath
+    $postExitCode = $LASTEXITCODE
+    $postError = Get-Content -Path $stderrPath -Raw -Encoding UTF8 -ErrorAction SilentlyContinue
     Remove-Item -Path $payloadPath -Force -ErrorAction SilentlyContinue
-    if ($LASTEXITCODE -ne 0) {
-        throw "Failed to post PR review: $postOutput"
+    Remove-Item -Path $stderrPath -Force -ErrorAction SilentlyContinue
+    if ($postExitCode -ne 0) {
+        throw "Failed to post PR review: $postOutput $postError"
     }
 
-    return ($postOutput | Select-Object -Last 1)
+    return ($postOutput | Where-Object { $_ -is [string] -and $_ -match '^https?://' } | Select-Object -Last 1)
 }
 
 Write-Host "Running local /review tests for PR #$PRNumber"

--- a/.github/scripts/Review-Tests.ps1
+++ b/.github/scripts/Review-Tests.ps1
@@ -25,7 +25,7 @@
     Root output directory. A PR-number subdirectory is created below it.
 
 .PARAMETER PostComment
-    Post the generated report as a non-blocking PR review. By default, the
+    Post the generated report as a PR conversation comment. By default, the
     script only writes local artifacts.
 
 .PARAMETER DryRun
@@ -297,28 +297,56 @@ $ReportContent
 "@
 }
 
-function Publish-TestFailureReview {
+function Invoke-GhApiWithJsonPayload {
+    param(
+        [string[]]$Arguments,
+        [hashtable]$Payload,
+        [string]$FailureMessage
+    )
+
+    $payloadPath = [System.IO.Path]::GetTempFileName()
+    $stderrPath = [System.IO.Path]::GetTempFileName()
+    $Payload | ConvertTo-Json -Depth 4 | Set-Content -Path $payloadPath -Encoding UTF8
+    $output = & gh api @Arguments --input $payloadPath --jq .html_url 2>$stderrPath
+    $exitCode = $LASTEXITCODE
+    $errorOutput = Get-Content -Path $stderrPath -Raw -Encoding UTF8 -ErrorAction SilentlyContinue
+    Remove-Item -Path $payloadPath -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path $stderrPath -Force -ErrorAction SilentlyContinue
+    if ($exitCode -ne 0) {
+        throw "${FailureMessage}: $output $errorOutput"
+    }
+
+    return ($output | Where-Object { $_ -is [string] -and $_ -match '^https?://' } | Select-Object -Last 1)
+}
+
+function Publish-TestFailureReviewComment {
     param(
         [int]$PRNumber,
         [string]$Repository,
-        [string]$ReviewBodyPath,
-        [string]$ReviewBody
+        [string]$CommentPath,
+        [string]$CommentBody
     )
 
-    Set-Content -Path $ReviewBodyPath -Value $ReviewBody -Encoding UTF8
-    $payloadPath = [System.IO.Path]::GetTempFileName()
-    $stderrPath = [System.IO.Path]::GetTempFileName()
-    @{ body = $ReviewBody; event = "COMMENT" } | ConvertTo-Json -Depth 4 | Set-Content -Path $payloadPath -Encoding UTF8
-    $postOutput = & gh api --method POST "repos/$Repository/pulls/$PRNumber/reviews" --input $payloadPath --jq .html_url 2>$stderrPath
-    $postExitCode = $LASTEXITCODE
-    $postError = Get-Content -Path $stderrPath -Raw -Encoding UTF8 -ErrorAction SilentlyContinue
-    Remove-Item -Path $payloadPath -Force -ErrorAction SilentlyContinue
-    Remove-Item -Path $stderrPath -Force -ErrorAction SilentlyContinue
-    if ($postExitCode -ne 0) {
-        throw "Failed to post PR review: $postOutput $postError"
+    $marker = "<!-- Test Failure Review -->"
+    $commentsRaw = & gh api "repos/$Repository/issues/$PRNumber/comments" --paginate 2>$null
+    $existing = $null
+    if ($LASTEXITCODE -eq 0 -and $commentsRaw) {
+        $comments = $commentsRaw | ConvertFrom-Json
+        $existing = @($comments | Where-Object { $_.body -and $_.body.Contains($marker) }) | Select-Object -Last 1
     }
 
-    return ($postOutput | Where-Object { $_ -is [string] -and $_ -match '^https?://' } | Select-Object -Last 1)
+    Set-Content -Path $CommentPath -Value $CommentBody -Encoding UTF8
+    if ($existing -and $existing.id) {
+        return Invoke-GhApiWithJsonPayload `
+            -Arguments @("--method", "PATCH", "repos/$Repository/issues/comments/$($existing.id)") `
+            -Payload @{ body = $CommentBody } `
+            -FailureMessage "Failed to update PR comment"
+    }
+
+    return Invoke-GhApiWithJsonPayload `
+        -Arguments @("--method", "POST", "repos/$Repository/issues/$PRNumber/comments") `
+        -Payload @{ body = $CommentBody } `
+        -FailureMessage "Failed to post PR comment"
 }
 
 Write-Host "Running local /review tests for PR #$PRNumber"
@@ -445,15 +473,15 @@ Set-Content -Path $CommentPath -Value $reviewBody -Encoding UTF8
 Write-Host "Review body: $CommentPath"
 
 if ($PostComment -and -not $DryRun) {
-    Write-Host "Posting report as PR review on #$PRNumber..."
-    $reviewUrl = Publish-TestFailureReview -PRNumber $PRNumber -Repository $Repository -ReviewBodyPath $CommentPath -ReviewBody $reviewBody
-    if ($reviewUrl) {
-        Write-Host "Posted PR review to #${PRNumber}: $reviewUrl"
+    Write-Host "Posting report as PR comment on #$PRNumber..."
+    $commentUrl = Publish-TestFailureReviewComment -PRNumber $PRNumber -Repository $Repository -CommentPath $CommentPath -CommentBody $reviewBody
+    if ($commentUrl) {
+        Write-Host "Posted PR comment to #${PRNumber}: $commentUrl"
     }
     else {
-        Write-Host "Posted PR review to #$PRNumber."
+        Write-Host "Posted PR comment to #$PRNumber."
     }
 }
 else {
-    Write-Host "Not posting. Use -PostComment to publish the generated PR review."
+    Write-Host "Not posting. Use -PostComment to publish the generated PR comment."
 }

--- a/.github/scripts/Review-Tests.ps1
+++ b/.github/scripts/Review-Tests.ps1
@@ -25,8 +25,8 @@
     Root output directory. A PR-number subdirectory is created below it.
 
 .PARAMETER PostComment
-    Post the generated report to the PR. By default, the script only writes
-    local artifacts.
+    Post the generated report as a non-blocking PR review. By default, the
+    script only writes local artifacts.
 
 .PARAMETER DryRun
     Never post, even if PostComment is also supplied.
@@ -210,7 +210,7 @@ function Collapse-OpenDetails {
         [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
 }
 
-function New-TestFailureReviewComment {
+function New-TestFailureReviewBody {
     param(
         [int]$PRNumber,
         [string]$Repository,
@@ -221,7 +221,7 @@ function New-TestFailureReviewComment {
     $marker = "<!-- Test Failure Review -->"
     $ReportContent = Collapse-OpenDetails $ReportContent
     if ($ReportContent.Contains($marker)) {
-        return [regex]::Replace($ReportContent, '(?m)^##\s+.*Test Failure Review.*$', '## Test Failure Review', 1)
+        return $ReportContent
     }
 
     $prJson = & gh pr view $PRNumber --repo $Repository --json title,author,headRefOid,url 2>&1
@@ -235,7 +235,6 @@ function New-TestFailureReviewComment {
     $commitUrl = if ($commitFull) { "https://github.com/$Repository/commit/$commitFull" } else { "#" }
     $prTitle = Escape-Html $pr.title
     $prAuthor = $pr.author.login
-    $timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-dd HH:mm UTC")
 
     $verdict = Get-ReportVerdict -Content $ReportContent
     $verdictColor = Get-VerdictColor -Verdict $verdict
@@ -269,13 +268,11 @@ function New-TestFailureReviewComment {
         $badgeLines += New-Badge -Label "Platform" -Message $platform -Color "0969da" -Alt "Platform $platform"
     }
 
-    $sessionMarkerStart = "<!-- SESSION:$commitSha7 START -->"
-    $sessionMarkerEnd = "<!-- SESSION:$commitSha7 END -->"
     $authorPing = if ($prAuthor) {
-        "> @$prAuthor — new test-failure review results are available based on this last commit: <a href=""$commitUrl""><code>$commitSha7</code></a>."
+        "> @$prAuthor — test-failure review results are available based on commit <a href=""$commitUrl""><code>$commitSha7</code></a>."
     }
     else {
-        "> New test-failure review results are available based on this last commit: <a href=""$commitUrl""><code>$commitSha7</code></a>."
+        "> Test-failure review results are available based on commit <a href=""$commitUrl""><code>$commitSha7</code></a>."
     }
 
     $badges = $badgeLines -join "`n"
@@ -283,7 +280,9 @@ function New-TestFailureReviewComment {
     return @"
 $marker
 
-## Test Failure Review
+<details>
+<summary>$verdictIcon <strong>Test Failure Review:</strong> $verdict — <a href="$commitUrl"><code>$commitSha7</code></a> · <strong>$prTitle</strong></summary>
+<br/>
 
 $authorPing
 > To request a fresh review after new comments, commits, or CI runs, comment `/review tests`.
@@ -292,98 +291,30 @@ $authorPing
 $badges
 </p>
 
-$sessionMarkerStart
-<details>
-<summary>$verdictIcon <strong>Test Failure Review</strong> — <a href="$commitUrl"><code>$commitSha7</code></a> · <strong>$prTitle</strong> · <em>$timestamp</em></summary>
-<br/>
-
 $ReportContent
 
 </details>
-$sessionMarkerEnd
 "@
 }
 
-function Merge-TestFailureReviewSessions {
-    param(
-        [string]$ExistingBody,
-        [string]$NewBody
-    )
-
-    $marker = "<!-- Test Failure Review -->"
-    $sessionPattern = '(?s)<!-- SESSION:([a-f0-9]+|unknown) START -->.*?<!-- SESSION:\1 END -->'
-    $newSession = [regex]::Match($NewBody, $sessionPattern)
-    if (-not $newSession.Success) {
-        return $NewBody
-    }
-
-    $newSha = $newSession.Groups[1].Value
-    $sessions = [ordered]@{}
-    foreach ($match in [regex]::Matches($ExistingBody, $sessionPattern)) {
-        $sessions[$match.Groups[1].Value] = $match.Value
-    }
-    $sessions[$newSha] = $newSession.Value
-
-    $orderedKeys = @($newSha) + @($sessions.Keys | Where-Object { $_ -ne $newSha })
-    $sessionBlocks = @()
-    foreach ($sha in $orderedKeys) {
-        $block = $sessions[$sha]
-        $block = Collapse-OpenDetails $block
-        $sessionBlocks += $block
-    }
-
-    $prefix = [regex]::Replace($NewBody, $sessionPattern, '', 1).TrimEnd()
-    return "$prefix`n`n$($sessionBlocks -join "`n`n---`n`n")"
-}
-
-function Publish-TestFailureReviewComment {
+function Publish-TestFailureReview {
     param(
         [int]$PRNumber,
         [string]$Repository,
-        [string]$CommentPath,
-        [string]$CommentBody
+        [string]$ReviewBodyPath,
+        [string]$ReviewBody
     )
 
-    $marker = "<!-- Test Failure Review -->"
-    $commentsRaw = & gh api "repos/$Repository/issues/$PRNumber/comments" --paginate 2>$null
-    $existing = $null
-    if ($LASTEXITCODE -eq 0 -and $commentsRaw) {
-        $comments = $commentsRaw | ConvertFrom-Json
-        $existing = @($comments | Where-Object {
-            $_.body -and ($_.body.Contains($marker) -or $_.body.TrimStart().StartsWith("## Test Failure Review"))
-        }) | Select-Object -Last 1
-
-        if ($existing -and $existing.body.Contains($marker) -and -not ([regex]::IsMatch($existing.body, '(?s)<!-- SESSION:([a-f0-9]+|unknown) START -->.*?<!-- SESSION:\1 END -->'))) {
-            Write-Host "Existing Test Failure Review comment has no session block; creating a fresh comment instead of overwriting legacy content." -ForegroundColor Yellow
-            $existing = $null
-        }
-    }
-
-    if ($existing -and $existing.id) {
-        $bodyToPost = if ($existing.body.Contains($marker)) {
-            Merge-TestFailureReviewSessions -ExistingBody $existing.body -NewBody $CommentBody
-        }
-        else {
-            $CommentBody
-        }
-        Set-Content -Path $CommentPath -Value $bodyToPost -Encoding UTF8
-        $payloadPath = [System.IO.Path]::GetTempFileName()
-        @{ body = $bodyToPost } | ConvertTo-Json -Depth 4 | Set-Content -Path $payloadPath -Encoding UTF8
-        $patchOutput = & gh api --method PATCH "repos/$Repository/issues/comments/$($existing.id)" --input $payloadPath 2>&1
-        Remove-Item -Path $payloadPath -Force -ErrorAction SilentlyContinue
-        if ($LASTEXITCODE -ne 0) {
-            throw "Failed to update PR comment: $patchOutput"
-        }
-        return $existing.html_url
-    }
-
-    Set-Content -Path $CommentPath -Value $CommentBody -Encoding UTF8
-    $postOutput = & gh pr comment $PRNumber --repo $Repository --body-file $CommentPath 2>&1
+    Set-Content -Path $ReviewBodyPath -Value $ReviewBody -Encoding UTF8
+    $payloadPath = [System.IO.Path]::GetTempFileName()
+    @{ body = $ReviewBody; event = "COMMENT" } | ConvertTo-Json -Depth 4 | Set-Content -Path $payloadPath -Encoding UTF8
+    $postOutput = & gh api --method POST "repos/$Repository/pulls/$PRNumber/reviews" --input $payloadPath --jq .html_url 2>&1
+    Remove-Item -Path $payloadPath -Force -ErrorAction SilentlyContinue
     if ($LASTEXITCODE -ne 0) {
-        throw "Failed to post PR comment: $postOutput"
+        throw "Failed to post PR review: $postOutput"
     }
 
-    return $null
+    return ($postOutput | Select-Object -Last 1)
 }
 
 Write-Host "Running local /review tests for PR #$PRNumber"
@@ -505,20 +436,20 @@ if (-not (Test-Path $ReportPath)) {
 
 Write-Host "Report: $ReportPath"
 $reportContent = Get-Content -Path $ReportPath -Raw -Encoding UTF8
-$commentBody = New-TestFailureReviewComment -PRNumber $PRNumber -Repository $Repository -ReportContent $reportContent -ContextJsonPath $ContextJsonPath
-Set-Content -Path $CommentPath -Value $commentBody -Encoding UTF8
-Write-Host "Comment: $CommentPath"
+$reviewBody = New-TestFailureReviewBody -PRNumber $PRNumber -Repository $Repository -ReportContent $reportContent -ContextJsonPath $ContextJsonPath
+Set-Content -Path $CommentPath -Value $reviewBody -Encoding UTF8
+Write-Host "Review body: $CommentPath"
 
 if ($PostComment -and -not $DryRun) {
-    Write-Host "Posting report to PR #$PRNumber..."
-    $commentUrl = Publish-TestFailureReviewComment -PRNumber $PRNumber -Repository $Repository -CommentPath $CommentPath -CommentBody $commentBody
-    if ($commentUrl) {
-        Write-Host "Posted report to PR #${PRNumber}: $commentUrl"
+    Write-Host "Posting report as PR review on #$PRNumber..."
+    $reviewUrl = Publish-TestFailureReview -PRNumber $PRNumber -Repository $Repository -ReviewBodyPath $CommentPath -ReviewBody $reviewBody
+    if ($reviewUrl) {
+        Write-Host "Posted PR review to #${PRNumber}: $reviewUrl"
     }
     else {
-        Write-Host "Posted report to PR #$PRNumber."
+        Write-Host "Posted PR review to #$PRNumber."
     }
 }
 else {
-    Write-Host "Not posting. Use -PostComment to publish the generated report."
+    Write-Host "Not posting. Use -PostComment to publish the generated PR review."
 }

--- a/.github/skills/review-test-failures/SKILL.md
+++ b/.github/skills/review-test-failures/SKILL.md
@@ -146,4 +146,5 @@ Rules:
 - Use badge colors: `d1242f` for `Likely PR-caused`, `1a7f37` for `Likely unrelated`, `bf8700` for `Needs human investigation`, and `6e7781` for `Insufficient data`.
 - Use `Data-Partial` when any limitations are present; otherwise use `Data-Complete`.
 - Do not use `<details open>` anywhere. Every collapsible section must be collapsed by default.
+- Repeated `/review tests` runs append separate non-blocking PR reviews; this workflow does not edit, hide, or supersede earlier review entries.
 - If there are no failing or inconclusive checks, report that no failing test evidence was found and use the noop path in gh-aw.

--- a/.github/skills/review-test-failures/SKILL.md
+++ b/.github/skills/review-test-failures/SKILL.md
@@ -97,7 +97,7 @@ Platform mismatch is supporting evidence, not proof by itself. For example, an i
 
 ## Output format
 
-Use a collapsed pull request review body. Start with a stable marker and put the review content inside one top-level `<details>` block so the PR timeline stays compact:
+Use a collapsed PR conversation comment body. Start with a stable marker and put the review content inside one top-level `<details>` block so the PR timeline stays compact:
 
 ```markdown
 <!-- Test Failure Review -->
@@ -146,5 +146,5 @@ Rules:
 - Use badge colors: `d1242f` for `Likely PR-caused`, `1a7f37` for `Likely unrelated`, `bf8700` for `Needs human investigation`, and `6e7781` for `Insufficient data`.
 - Use `Data-Partial` when any limitations are present; otherwise use `Data-Complete`.
 - Do not use `<details open>` anywhere. Every collapsible section must be collapsed by default.
-- Repeated `/review tests` runs append separate non-blocking PR reviews; this workflow does not edit, hide, or supersede earlier review entries.
+- Repeated `/review tests` runs post a new PR conversation comment and hide older comments from the same workflow.
 - If there are no failing or inconclusive checks, report that no failing test evidence was found and use the noop path in gh-aw.

--- a/.github/skills/review-test-failures/SKILL.md
+++ b/.github/skills/review-test-failures/SKILL.md
@@ -97,14 +97,16 @@ Platform mismatch is supporting evidence, not proof by itself. For example, an i
 
 ## Output format
 
-Use an AI-summary-style comment format. Start with a stable marker, a short status header, badges, and one expandable review session:
+Use a collapsed pull request review body. Start with a stable marker and put the review content inside one top-level `<details>` block so the PR timeline stays compact:
 
 ```markdown
 <!-- Test Failure Review -->
 
-## Test Failure Review
+<details>
+<summary>[icon] <strong>Test Failure Review:</strong> [verdict] — <a href="[commit URL]"><code>[sha7]</code></a> · <strong>[PR title]</strong></summary>
+<br/>
 
-> @[PR author] — new test-failure review results are available based on this last commit: <a href="[commit URL]"><code>[sha7]</code></a>.
+> @[PR author] — test-failure review results are available based on commit <a href="[commit URL]"><code>[sha7]</code></a>.
 > To request a fresh review after new comments, commits, or CI runs, comment `/review tests`.
 
 <p align="left">
@@ -113,11 +115,6 @@ Use an AI-summary-style comment format. Start with a stable marker, a short stat
   <img alt="Data [Complete|Partial]" src="https://img.shields.io/badge/Data-[Complete|Partial]-[color]?labelColor=30363d&style=flat-square">
   <img alt="Platform [platform]" src="https://img.shields.io/badge/Platform-[platform]-0969da?labelColor=30363d&style=flat-square">
 </p>
-
-<!-- SESSION:[sha7] START -->
-<details>
-<summary>[icon] <strong>Test Failure Review</strong> — <a href="[commit URL]"><code>[sha7]</code></a> · <strong>[PR title]</strong> · <em>[UTC timestamp]</em></summary>
-<br/>
 
 **Overall verdict:** [Likely PR-caused | Likely unrelated | Needs human investigation | Insufficient data]
 
@@ -139,7 +136,6 @@ Use an AI-summary-style comment format. Start with a stable marker, a short stat
 </details>
 
 </details>
-<!-- SESSION:[sha7] END -->
 ```
 
 Rules:

--- a/.github/workflows/copilot-review-tests.lock.yml
+++ b/.github/workflows/copilot-review-tests.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"40fc16bb0370d195914648af599670ec2792a1744c98a7c19b555b6a99517ba5","body_hash":"4a82a161bccd0dae5eb0f206c450c9dccae275f24225a3c4b5f0fdc222a66fb6","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot","agent_model":"claude-sonnet-4.6"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"22da6f0c0daae73ce341c1a6756e07b4f993f0304ea9ed41567d12fcf7e7ab94","body_hash":"4a82a161bccd0dae5eb0f206c450c9dccae275f24225a3c4b5f0fdc222a66fb6","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot","agent_model":"claude-sonnet-4.6"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -57,6 +57,19 @@ on:
   # - admin # Roles processed as role check in pre-activation job
   # - maintain # Roles processed as role check in pre-activation job
   # - write # Roles processed as role check in pre-activation job
+  # skip-author-associations: # Skip-author-associations compiled into pre-activation job if condition
+    # issue_comment:
+    # - contributor
+    # - first_time_contributor
+    # - first_timer
+    # - mannequin
+    # - none
+    # pull_request_review_comment:
+    # - contributor
+    # - first_time_contributor
+    # - first_timer
+    # - mannequin
+    # - none
   # steps: # Steps injected into pre-activation job
   # - env:
       # COMMENT_BODY: ${{ github.event.comment.body }}
@@ -66,16 +79,15 @@ on:
     # name: Confirm exact /review tests command
     # run: |
       # if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-        # echo "should_run=true" >> "$GITHUB_OUTPUT"
         # exit 0
       # fi
-      # echo "should_run=false" >> "$GITHUB_OUTPUT"
       # if [ "$EVENT_NAME" != "issue_comment" ] || [ -z "${ISSUE_PULL_REQUEST_URL:-}" ]; then
-        # exit 0
+        # exit 1
       # fi
       # if [[ "$COMMENT_BODY" =~ ^[[:space:]]*/review[[:space:]]+tests[[:space:]]*$ ]]; then
-        # echo "should_run=true" >> "$GITHUB_OUTPUT"
+        # exit 0
       # fi
+      # exit 1
   workflow_dispatch:
     inputs:
       aw_context:
@@ -113,7 +125,7 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      needs.pre_activation.outputs.activated == 'true' && (github.event_name == 'workflow_dispatch' || needs.pre_activation.outputs.exact_command_should_run == 'true')
+      needs.pre_activation.outputs.activated == 'true' && (github.event_name == 'workflow_dispatch' || needs.pre_activation.outputs.exact_command_result == 'success')
     runs-on: ubuntu-slim
     permissions:
       actions: read
@@ -256,20 +268,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_5628afd3aa8a9acf_EOF'
+          cat << 'GH_AW_PROMPT_57f6a05746909f5b_EOF'
           <system>
-          GH_AW_PROMPT_5628afd3aa8a9acf_EOF
+          GH_AW_PROMPT_57f6a05746909f5b_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_5628afd3aa8a9acf_EOF'
+          cat << 'GH_AW_PROMPT_57f6a05746909f5b_EOF'
           <safe-output-tools>
           Tools: submit_pull_request_review, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_5628afd3aa8a9acf_EOF
+          GH_AW_PROMPT_57f6a05746909f5b_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_5628afd3aa8a9acf_EOF'
+          cat << 'GH_AW_PROMPT_57f6a05746909f5b_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -298,15 +310,15 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_5628afd3aa8a9acf_EOF
+          GH_AW_PROMPT_57f6a05746909f5b_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_5628afd3aa8a9acf_EOF'
+          cat << 'GH_AW_PROMPT_57f6a05746909f5b_EOF'
           </system>
           {{#runtime-import .github/workflows/copilot-review-tests.md}}
-          GH_AW_PROMPT_5628afd3aa8a9acf_EOF
+          GH_AW_PROMPT_57f6a05746909f5b_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -565,9 +577,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_060763b3de37da18_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_98b24060547eb92a_EOF'
           {"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{},"submit_pull_request_review":{"allowed_events":["COMMENT"],"footer":"none","max":1,"target":"*"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_060763b3de37da18_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_98b24060547eb92a_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -757,7 +769,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_f7bd9d4d72421535_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_e891f50e9bda761b_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -798,7 +810,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_f7bd9d4d72421535_EOF
+          GH_AW_MCP_CONFIG_e891f50e9bda761b_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1410,11 +1422,13 @@ jobs:
             }
 
   pre_activation:
+    if: >
+      (!(github.event_name == 'issue_comment') || !contains(fromJSON('["CONTRIBUTOR","FIRST_TIME_CONTRIBUTOR","FIRST_TIMER","MANNEQUIN","NONE"]'), github.event.comment.author_association)) &&
+      (!(github.event_name == 'pull_request_review_comment') || !contains(fromJSON('["CONTRIBUTOR","FIRST_TIME_CONTRIBUTOR","FIRST_TIMER","MANNEQUIN","NONE"]'), github.event.comment.author_association))
     runs-on: ubuntu-slim
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' && steps.check_command_position.outputs.command_position_ok == 'true' }}
       exact_command_result: ${{ steps.exact_command.outcome }}
-      exact_command_should_run: ${{ steps.exact_command.outputs.should_run }}
       matched_command: ${{ steps.check_command_position.outputs.matched_command }}
       setup-parent-span-id: ${{ steps.setup.outputs.parent-span-id || steps.setup.outputs.span-id }}
       setup-span-id: ${{ steps.setup.outputs.span-id }}
@@ -1459,16 +1473,15 @@ jobs:
         id: exact_command
         run: |
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            echo "should_run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          echo "should_run=false" >> "$GITHUB_OUTPUT"
           if [ "$EVENT_NAME" != "issue_comment" ] || [ -z "${ISSUE_PULL_REQUEST_URL:-}" ]; then
-            exit 0
+            exit 1
           fi
           if [[ "$COMMENT_BODY" =~ ^[[:space:]]*/review[[:space:]]+tests[[:space:]]*$ ]]; then
-            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          exit 1
         env:
           COMMENT_BODY: ${{ github.event.comment.body }}
           EVENT_NAME: ${{ github.event_name }}

--- a/.github/workflows/copilot-review-tests.lock.yml
+++ b/.github/workflows/copilot-review-tests.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"98b044654dd0b6b4fccf586c48097c7c3bd0a6bc0057a11041a5d98232f59ae1","body_hash":"5fade2f7e6856f1122d467fb26fa357c30dfa6042100971cabc6efa20c053ca3","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot","agent_model":"claude-sonnet-4.6"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"40fc16bb0370d195914648af599670ec2792a1744c98a7c19b555b6a99517ba5","body_hash":"4a82a161bccd0dae5eb0f206c450c9dccae275f24225a3c4b5f0fdc222a66fb6","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot","agent_model":"claude-sonnet-4.6"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -57,6 +57,25 @@ on:
   # - admin # Roles processed as role check in pre-activation job
   # - maintain # Roles processed as role check in pre-activation job
   # - write # Roles processed as role check in pre-activation job
+  # steps: # Steps injected into pre-activation job
+  # - env:
+      # COMMENT_BODY: ${{ github.event.comment.body }}
+      # EVENT_NAME: ${{ github.event_name }}
+      # ISSUE_PULL_REQUEST_URL: ${{ github.event.issue.pull_request.url }}
+    # id: exact_command
+    # name: Confirm exact /review tests command
+    # run: |
+      # if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+        # echo "should_run=true" >> "$GITHUB_OUTPUT"
+        # exit 0
+      # fi
+      # echo "should_run=false" >> "$GITHUB_OUTPUT"
+      # if [ "$EVENT_NAME" != "issue_comment" ] || [ -z "${ISSUE_PULL_REQUEST_URL:-}" ]; then
+        # exit 0
+      # fi
+      # if [[ "$COMMENT_BODY" =~ ^[[:space:]]*/review[[:space:]]+tests[[:space:]]*$ ]]; then
+        # echo "should_run=true" >> "$GITHUB_OUTPUT"
+      # fi
   workflow_dispatch:
     inputs:
       aw_context:
@@ -93,18 +112,16 @@ run-name: "Review PR Test Failures"
 jobs:
   activation:
     needs: pre_activation
-    if: needs.pre_activation.outputs.activated == 'true'
+    if: >
+      needs.pre_activation.outputs.activated == 'true' && (github.event_name == 'workflow_dispatch' || needs.pre_activation.outputs.exact_command_should_run == 'true')
     runs-on: ubuntu-slim
     permissions:
       actions: read
       contents: read
-      issues: write
-      pull-requests: write
     outputs:
       body: ${{ steps.sanitized.outputs.body }}
-      comment_id: ${{ steps.add-comment.outputs.comment-id }}
-      comment_repo: ${{ steps.add-comment.outputs.comment-repo }}
-      comment_url: ${{ steps.add-comment.outputs.comment-url }}
+      comment_id: ""
+      comment_repo: ""
       engine_id: ${{ steps.generate_aw_info.outputs.engine_id }}
       lockdown_check_failed: ${{ steps.generate_aw_info.outputs.lockdown_check_failed == 'true' }}
       model: ${{ steps.generate_aw_info.outputs.model }}
@@ -144,7 +161,7 @@ jobs:
           GH_AW_INFO_EXPERIMENTAL: "false"
           GH_AW_INFO_SUPPORTS_TOOLS_ALLOWLIST: "true"
           GH_AW_INFO_STAGED: "false"
-          GH_AW_INFO_ALLOWED_DOMAINS: '["defaults","dotnet","github","dev.azure.com","*.visualstudio.com","helix.dot.net","*.blob.core.windows.net"]'
+          GH_AW_INFO_ALLOWED_DOMAINS: '["defaults","dotnet","github","dev.azure.com","*.visualstudio.com","helix.dot.net","*.blob.core.windows.net","img.shields.io"]'
           GH_AW_INFO_FIREWALL_ENABLED: "true"
           GH_AW_INFO_AWF_VERSION: "v0.25.58"
           GH_AW_INFO_AWMG_VERSION: ""
@@ -157,19 +174,6 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/generate_aw_info.cjs');
             await main(core, context);
-      - name: Add eyes reaction for immediate feedback
-        id: react
-        if: github.event_name == 'issues' || github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment' || github.event_name == 'discussion' || github.event_name == 'discussion_comment' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.id == github.repository_id
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          GH_AW_REACTION: "eyes"
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io, getOctokit);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/add_reaction.cjs');
-            await main();
       - name: Validate COPILOT_GITHUB_TOKEN secret
         id: validate-secret
         run: bash "${RUNNER_TEMP}/gh-aw/actions/validate_multi_secret.sh" COPILOT_GITHUB_TOKEN 'GitHub Copilot CLI' https://github.github.com/gh-aw/reference/engines/#github-copilot-default
@@ -223,25 +227,12 @@ jobs:
         id: sanitized
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          GH_AW_ALLOWED_DOMAINS: "*.blob.core.windows.net,*.githubusercontent.com,*.visualstudio.com,*.vsblob.vsassets.io,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.nuget.org,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,azuresearch-usnc.nuget.org,azuresearch-ussc.nuget.org,builds.dotnet.microsoft.com,ci.dot.net,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,dc.services.visualstudio.com,dev.azure.com,dist.nuget.org,docs.github.com,dot.net,dotnet.microsoft.com,dotnetcli.blob.core.windows.net,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,helix.dot.net,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,nuget.org,nuget.pkg.github.com,nugetregistryv2prod.blob.core.windows.net,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,oneocsp.microsoft.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,patch-diff.githubusercontent.com,pkgs.dev.azure.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com,www.microsoft.com"
+          GH_AW_ALLOWED_DOMAINS: "*.blob.core.windows.net,*.githubusercontent.com,*.visualstudio.com,*.vsblob.vsassets.io,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.nuget.org,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,azuresearch-usnc.nuget.org,azuresearch-ussc.nuget.org,builds.dotnet.microsoft.com,ci.dot.net,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,dc.services.visualstudio.com,dev.azure.com,dist.nuget.org,docs.github.com,dot.net,dotnet.microsoft.com,dotnetcli.blob.core.windows.net,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,helix.dot.net,host.docker.internal,img.shields.io,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,nuget.org,nuget.pkg.github.com,nugetregistryv2prod.blob.core.windows.net,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,oneocsp.microsoft.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,patch-diff.githubusercontent.com,pkgs.dev.azure.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com,www.microsoft.com"
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/compute_text.cjs');
-            await main();
-      - name: Add comment with workflow run link
-        id: add-comment
-        if: github.event_name == 'issues' || github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment' || github.event_name == 'discussion' || github.event_name == 'discussion_comment' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.id == github.repository_id
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          GH_AW_WORKFLOW_NAME: "Review PR Test Failures"
-          GH_AW_SAFE_OUTPUT_MESSAGES: "{\"footer\":\"\\u003e Test-failure review by [{workflow_name}]({run_url})\",\"runStarted\":\"Reviewing test failures on this PR... [{workflow_name}]({run_url})\",\"runSuccess\":\"Test-failure review complete. [{workflow_name}]({run_url})\",\"runFailure\":\"Test-failure review failed. [{workflow_name}]({run_url}) {status}\"}"
-        with:
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io, getOctokit);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/add_workflow_run_comment.cjs');
             await main();
       - name: Create prompt with built-in context
         env:
@@ -265,20 +256,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_23edeb1ed6cb541e_EOF'
+          cat << 'GH_AW_PROMPT_5628afd3aa8a9acf_EOF'
           <system>
-          GH_AW_PROMPT_23edeb1ed6cb541e_EOF
+          GH_AW_PROMPT_5628afd3aa8a9acf_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_23edeb1ed6cb541e_EOF'
+          cat << 'GH_AW_PROMPT_5628afd3aa8a9acf_EOF'
           <safe-output-tools>
-          Tools: add_comment, missing_tool, missing_data, noop
+          Tools: submit_pull_request_review, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_23edeb1ed6cb541e_EOF
+          GH_AW_PROMPT_5628afd3aa8a9acf_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_23edeb1ed6cb541e_EOF'
+          cat << 'GH_AW_PROMPT_5628afd3aa8a9acf_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -307,15 +298,15 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_23edeb1ed6cb541e_EOF
+          GH_AW_PROMPT_5628afd3aa8a9acf_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_23edeb1ed6cb541e_EOF'
+          cat << 'GH_AW_PROMPT_5628afd3aa8a9acf_EOF'
           </system>
           {{#runtime-import .github/workflows/copilot-review-tests.md}}
-          GH_AW_PROMPT_23edeb1ed6cb541e_EOF
+          GH_AW_PROMPT_5628afd3aa8a9acf_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -415,14 +406,7 @@ jobs:
           retention-days: 1
 
   agent:
-    needs:
-      - activation
-      - command-filter
-    if: >
-      github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request &&
-      contains(github.event.comment.body, 'tests') &&
-      needs.command-filter.outputs.should-run == 'true')
+    needs: activation
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -581,43 +565,21 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_82df3c75129b7fb3_EOF'
-          {"add_comment":{"hide_older_comments":true,"max":1,"target":"*"},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_82df3c75129b7fb3_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_060763b3de37da18_EOF'
+          {"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{},"submit_pull_request_review":{"allowed_events":["COMMENT"],"footer":"none","max":1,"target":"*"}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_060763b3de37da18_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added. Target: *. Supports reply_to_id for discussion threading."
+                "submit_pull_request_review": " CONSTRAINTS: Maximum 1 review(s) can be submitted."
               },
               "repo_params": {},
               "dynamic_tools": []
             }
           GH_AW_VALIDATION_JSON: |
             {
-              "add_comment": {
-                "defaultMax": 1,
-                "fields": {
-                  "body": {
-                    "required": true,
-                    "type": "string",
-                    "sanitize": true,
-                    "maxLength": 65000
-                  },
-                  "item_number": {
-                    "issueOrPRNumber": true
-                  },
-                  "reply_to_id": {
-                    "type": "string",
-                    "maxLength": 256
-                  },
-                  "repo": {
-                    "type": "string",
-                    "maxLength": 256
-                  }
-                }
-              },
               "missing_data": {
                 "defaultMax": 20,
                 "fields": {
@@ -688,6 +650,24 @@ jobs:
                     "type": "string",
                     "sanitize": true,
                     "maxLength": 1024
+                  }
+                }
+              },
+              "submit_pull_request_review": {
+                "defaultMax": 1,
+                "fields": {
+                  "body": {
+                    "type": "string",
+                    "sanitize": true,
+                    "maxLength": 65000
+                  },
+                  "event": {
+                    "type": "string",
+                    "enum": [
+                      "APPROVE",
+                      "REQUEST_CHANGES",
+                      "COMMENT"
+                    ]
                   }
                 }
               }
@@ -777,7 +757,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_80374fc2d380feea_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_f7bd9d4d72421535_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -818,7 +798,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_80374fc2d380feea_EOF
+          GH_AW_MCP_CONFIG_f7bd9d4d72421535_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -852,7 +832,7 @@ jobs:
           export GH_AW_NODE_BIN
           export COPILOT_API_KEY="$COPILOT_DUMMY_BYOK"
           (umask 177 && touch /tmp/gh-aw/agent-stdio.log)
-          printf '%s\n' '{"$schema":"https://github.com/github/gh-aw-firewall/releases/download/v0.25.58/awf-config.schema.json","network":{"allowDomains":["*.blob.core.windows.net","*.githubusercontent.com","*.visualstudio.com","*.vsblob.vsassets.io","api.business.githubcopilot.com","api.enterprise.githubcopilot.com","api.github.com","api.githubcopilot.com","api.individual.githubcopilot.com","api.nuget.org","api.snapcraft.io","archive.ubuntu.com","azure.archive.ubuntu.com","azuresearch-usnc.nuget.org","azuresearch-ussc.nuget.org","builds.dotnet.microsoft.com","ci.dot.net","codeload.github.com","crl.geotrust.com","crl.globalsign.com","crl.identrust.com","crl.sectigo.com","crl.thawte.com","crl.usertrust.com","crl.verisign.com","crl3.digicert.com","crl4.digicert.com","crls.ssl.com","dc.services.visualstudio.com","dev.azure.com","dist.nuget.org","docs.github.com","dot.net","dotnet.microsoft.com","dotnetcli.blob.core.windows.net","github-cloud.githubusercontent.com","github-cloud.s3.amazonaws.com","github.blog","github.com","github.githubassets.com","helix.dot.net","host.docker.internal","json-schema.org","json.schemastore.org","keyserver.ubuntu.com","lfs.github.com","nuget.org","nuget.pkg.github.com","nugetregistryv2prod.blob.core.windows.net","objects.githubusercontent.com","ocsp.digicert.com","ocsp.geotrust.com","ocsp.globalsign.com","ocsp.identrust.com","ocsp.sectigo.com","ocsp.ssl.com","ocsp.thawte.com","ocsp.usertrust.com","ocsp.verisign.com","oneocsp.microsoft.com","packagecloud.io","packages.cloud.google.com","packages.microsoft.com","patch-diff.githubusercontent.com","pkgs.dev.azure.com","ppa.launchpad.net","raw.githubusercontent.com","registry.npmjs.org","s.symcb.com","s.symcd.com","security.ubuntu.com","telemetry.enterprise.githubcopilot.com","ts-crl.ws.symantec.com","ts-ocsp.ws.symantec.com","www.googleapis.com","www.microsoft.com"]},"apiProxy":{"enabled":true,"enableTokenSteering":true,"maxRuns":500,"maxEffectiveTokens":25000000,"models":{"agent":["sonnet-6x","gpt-5.4","gpt-5.3","gemini-pro","any"],"antigravity":["copilot/antigravity*","google/antigravity*","gemini/antigravity*"],"any":["copilot/*","anthropic/*","openai/*","google/*","gemini/*"],"claude":["agent"],"codex":["agent"],"coding":["copilot/gpt-5*codex*","openai/gpt-5*codex*","gpt-5-codex"],"computer-use":["copilot/*computer-use*","google/*computer-use*","gemini/*computer-use*","openai/*computer-use*"],"copilot":["agent"],"deep-research":["copilot/deep-research*","copilot/o3-deep-research*","copilot/o4-mini-deep-research*","google/deep-research*","gemini/deep-research*","openai/o3-deep-research*","openai/o4-mini-deep-research*"],"gemini":["agent"],"gemini-3-flash":["copilot/gemini-3*flash*","google/gemini-3*flash*","gemini/gemini-3*flash*"],"gemini-3-pro":["copilot/gemini-3*pro*","google/gemini-3*pro*","gemini/gemini-3*pro*"],"gemini-3.1-flash":["copilot/gemini-3.1*flash*","google/gemini-3.1*flash*","gemini/gemini-3.1*flash*"],"gemini-3.1-pro":["copilot/gemini-3.1*pro*","google/gemini-3.1*pro*","gemini/gemini-3.1*pro*"],"gemini-3.5-flash":["copilot/gemini-3.5*flash*","google/gemini-3.5*flash*","gemini/gemini-3.5*flash*"],"gemini-flash":["copilot/gemini-*flash*","google/gemini-*flash*","gemini/gemini-*flash*"],"gemini-flash-lite":["copilot/gemini-*flash*lite*","google/gemini-*flash*lite*","gemini/gemini-*flash*lite*"],"gemini-pro":["copilot/gemini-*pro*","google/gemini-*pro*","gemini/gemini-*pro*"],"gemma":["copilot/gemma*","google/gemma*","gemini/gemma*"],"gpt-5":["copilot/gpt-5*","openai/gpt-5*"],"gpt-5-codex":["copilot/gpt-5*codex*","openai/gpt-5*codex*"],"gpt-5-mini":["copilot/gpt-5*mini*","openai/gpt-5*mini*"],"gpt-5-nano":["copilot/gpt-5*nano*","openai/gpt-5*nano*"],"gpt-5-pro":["copilot/gpt-5*pro*","openai/gpt-5*pro*"],"gpt-5.2":["copilot/gpt-5.2*","openai/gpt-5.2*"],"gpt-5.3":["copilot/gpt-5.3*","openai/gpt-5.3*"],"gpt-5.4":["copilot/gpt-5.4*","openai/gpt-5.4*"],"gpt-5.5":["copilot/gpt-5.5*","openai/gpt-5.5*"],"haiku":["copilot/*haiku*","anthropic/*haiku*"],"large":["sonnet","gpt-5-pro","gpt-5","gemini-pro"],"mini":["haiku","gpt-5-mini","gpt-5-nano","gemini-flash-lite"],"opus":["copilot/*opus*","anthropic/*opus*"],"opusplan":["opus?effort=high"],"reasoning":["copilot/o1*","copilot/o3*","copilot/o4*","openai/o1*","openai/o3*","openai/o4*"],"robotics":["copilot/*robotics*","google/*robotics*","gemini/*robotics*"],"small":["mini"],"sonnet":["copilot/*sonnet*","anthropic/*sonnet*"],"sonnet-6x":["copilot/*sonnet-4-5-*","anthropic/*sonnet-4-5-*","copilot/*sonnet-4-6*","anthropic/*sonnet-4-6*"],"summarization":["haiku","gpt-5-mini","gemini-flash-lite","mini"],"vision":["copilot/gemini-*image*","gemini/gemini-*image*","copilot/gemini-*flash*","gemini/gemini-*flash*"]}},"container":{"imageTag":"0.25.58"}}' > "${RUNNER_TEMP}/gh-aw/awf-config.json"
+          printf '%s\n' '{"$schema":"https://github.com/github/gh-aw-firewall/releases/download/v0.25.58/awf-config.schema.json","network":{"allowDomains":["*.blob.core.windows.net","*.githubusercontent.com","*.visualstudio.com","*.vsblob.vsassets.io","api.business.githubcopilot.com","api.enterprise.githubcopilot.com","api.github.com","api.githubcopilot.com","api.individual.githubcopilot.com","api.nuget.org","api.snapcraft.io","archive.ubuntu.com","azure.archive.ubuntu.com","azuresearch-usnc.nuget.org","azuresearch-ussc.nuget.org","builds.dotnet.microsoft.com","ci.dot.net","codeload.github.com","crl.geotrust.com","crl.globalsign.com","crl.identrust.com","crl.sectigo.com","crl.thawte.com","crl.usertrust.com","crl.verisign.com","crl3.digicert.com","crl4.digicert.com","crls.ssl.com","dc.services.visualstudio.com","dev.azure.com","dist.nuget.org","docs.github.com","dot.net","dotnet.microsoft.com","dotnetcli.blob.core.windows.net","github-cloud.githubusercontent.com","github-cloud.s3.amazonaws.com","github.blog","github.com","github.githubassets.com","helix.dot.net","host.docker.internal","img.shields.io","json-schema.org","json.schemastore.org","keyserver.ubuntu.com","lfs.github.com","nuget.org","nuget.pkg.github.com","nugetregistryv2prod.blob.core.windows.net","objects.githubusercontent.com","ocsp.digicert.com","ocsp.geotrust.com","ocsp.globalsign.com","ocsp.identrust.com","ocsp.sectigo.com","ocsp.ssl.com","ocsp.thawte.com","ocsp.usertrust.com","ocsp.verisign.com","oneocsp.microsoft.com","packagecloud.io","packages.cloud.google.com","packages.microsoft.com","patch-diff.githubusercontent.com","pkgs.dev.azure.com","ppa.launchpad.net","raw.githubusercontent.com","registry.npmjs.org","s.symcb.com","s.symcd.com","security.ubuntu.com","telemetry.enterprise.githubcopilot.com","ts-crl.ws.symantec.com","ts-ocsp.ws.symantec.com","www.googleapis.com","www.microsoft.com"]},"apiProxy":{"enabled":true,"enableTokenSteering":true,"maxRuns":500,"maxEffectiveTokens":25000000,"models":{"agent":["sonnet-6x","gpt-5.4","gpt-5.3","gemini-pro","any"],"antigravity":["copilot/antigravity*","google/antigravity*","gemini/antigravity*"],"any":["copilot/*","anthropic/*","openai/*","google/*","gemini/*"],"claude":["agent"],"codex":["agent"],"coding":["copilot/gpt-5*codex*","openai/gpt-5*codex*","gpt-5-codex"],"computer-use":["copilot/*computer-use*","google/*computer-use*","gemini/*computer-use*","openai/*computer-use*"],"copilot":["agent"],"deep-research":["copilot/deep-research*","copilot/o3-deep-research*","copilot/o4-mini-deep-research*","google/deep-research*","gemini/deep-research*","openai/o3-deep-research*","openai/o4-mini-deep-research*"],"gemini":["agent"],"gemini-3-flash":["copilot/gemini-3*flash*","google/gemini-3*flash*","gemini/gemini-3*flash*"],"gemini-3-pro":["copilot/gemini-3*pro*","google/gemini-3*pro*","gemini/gemini-3*pro*"],"gemini-3.1-flash":["copilot/gemini-3.1*flash*","google/gemini-3.1*flash*","gemini/gemini-3.1*flash*"],"gemini-3.1-pro":["copilot/gemini-3.1*pro*","google/gemini-3.1*pro*","gemini/gemini-3.1*pro*"],"gemini-3.5-flash":["copilot/gemini-3.5*flash*","google/gemini-3.5*flash*","gemini/gemini-3.5*flash*"],"gemini-flash":["copilot/gemini-*flash*","google/gemini-*flash*","gemini/gemini-*flash*"],"gemini-flash-lite":["copilot/gemini-*flash*lite*","google/gemini-*flash*lite*","gemini/gemini-*flash*lite*"],"gemini-pro":["copilot/gemini-*pro*","google/gemini-*pro*","gemini/gemini-*pro*"],"gemma":["copilot/gemma*","google/gemma*","gemini/gemma*"],"gpt-5":["copilot/gpt-5*","openai/gpt-5*"],"gpt-5-codex":["copilot/gpt-5*codex*","openai/gpt-5*codex*"],"gpt-5-mini":["copilot/gpt-5*mini*","openai/gpt-5*mini*"],"gpt-5-nano":["copilot/gpt-5*nano*","openai/gpt-5*nano*"],"gpt-5-pro":["copilot/gpt-5*pro*","openai/gpt-5*pro*"],"gpt-5.2":["copilot/gpt-5.2*","openai/gpt-5.2*"],"gpt-5.3":["copilot/gpt-5.3*","openai/gpt-5.3*"],"gpt-5.4":["copilot/gpt-5.4*","openai/gpt-5.4*"],"gpt-5.5":["copilot/gpt-5.5*","openai/gpt-5.5*"],"haiku":["copilot/*haiku*","anthropic/*haiku*"],"large":["sonnet","gpt-5-pro","gpt-5","gemini-pro"],"mini":["haiku","gpt-5-mini","gpt-5-nano","gemini-flash-lite"],"opus":["copilot/*opus*","anthropic/*opus*"],"opusplan":["opus?effort=high"],"reasoning":["copilot/o1*","copilot/o3*","copilot/o4*","openai/o1*","openai/o3*","openai/o4*"],"robotics":["copilot/*robotics*","google/*robotics*","gemini/*robotics*"],"small":["mini"],"sonnet":["copilot/*sonnet*","anthropic/*sonnet*"],"sonnet-6x":["copilot/*sonnet-4-5-*","anthropic/*sonnet-4-5-*","copilot/*sonnet-4-6*","anthropic/*sonnet-4-6*"],"summarization":["haiku","gpt-5-mini","gemini-flash-lite","mini"],"vision":["copilot/gemini-*image*","gemini/gemini-*image*","copilot/gemini-*flash*","gemini/gemini-*flash*"]}},"container":{"imageTag":"0.25.58"}}' > "${RUNNER_TEMP}/gh-aw/awf-config.json"
           GH_AW_MODEL_MULTIPLIERS_PATH="/tmp/gh-aw/model_multipliers.json" node "${RUNNER_TEMP}/gh-aw/actions/merge_awf_model_multipliers.cjs"
           cp "${RUNNER_TEMP}/gh-aw/awf-config.json" /tmp/gh-aw/awf-config.json
           GH_AW_DOCKER_HOST_PATH_PREFIX_ARGS=""
@@ -959,7 +939,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_SAFE_OUTPUTS: ${{ steps.set-runtime-paths.outputs.GH_AW_SAFE_OUTPUTS }}
-          GH_AW_ALLOWED_DOMAINS: "*.blob.core.windows.net,*.githubusercontent.com,*.visualstudio.com,*.vsblob.vsassets.io,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.nuget.org,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,azuresearch-usnc.nuget.org,azuresearch-ussc.nuget.org,builds.dotnet.microsoft.com,ci.dot.net,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,dc.services.visualstudio.com,dev.azure.com,dist.nuget.org,docs.github.com,dot.net,dotnet.microsoft.com,dotnetcli.blob.core.windows.net,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,helix.dot.net,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,nuget.org,nuget.pkg.github.com,nugetregistryv2prod.blob.core.windows.net,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,oneocsp.microsoft.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,patch-diff.githubusercontent.com,pkgs.dev.azure.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com,www.microsoft.com"
+          GH_AW_ALLOWED_DOMAINS: "*.blob.core.windows.net,*.githubusercontent.com,*.visualstudio.com,*.vsblob.vsassets.io,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.nuget.org,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,azuresearch-usnc.nuget.org,azuresearch-ussc.nuget.org,builds.dotnet.microsoft.com,ci.dot.net,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,dc.services.visualstudio.com,dev.azure.com,dist.nuget.org,docs.github.com,dot.net,dotnet.microsoft.com,dotnetcli.blob.core.windows.net,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,helix.dot.net,host.docker.internal,img.shields.io,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,nuget.org,nuget.pkg.github.com,nugetregistryv2prod.blob.core.windows.net,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,oneocsp.microsoft.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,patch-diff.githubusercontent.com,pkgs.dev.azure.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com,www.microsoft.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
           GH_AW_COMMANDS: "[\"review\"]"
@@ -1057,51 +1037,10 @@ jobs:
             /tmp/gh-aw/sandbox/firewall/awf-reflect.json
           if-no-files-found: ignore
 
-  command-filter:
-    needs: activation
-    if: >
-      github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request &&
-      contains(github.event.comment.body, 'tests'))
-    runs-on: ubuntu-slim
-    outputs:
-      should-run: ${{ steps.check.outputs.should-run }}
-    steps:
-      - name: Configure GH_HOST for enterprise compatibility
-        id: ghes-host-config
-        shell: bash
-        run: |
-          # Derive GH_HOST from GITHUB_SERVER_URL so the gh CLI targets the correct
-          # GitHub instance (GHES/GHEC). On github.com this is a harmless no-op.
-          GH_HOST="${GITHUB_SERVER_URL#https://}"
-          GH_HOST="${GH_HOST#http://}"
-          echo "GH_HOST=${GH_HOST}" >> "$GITHUB_ENV"
-      - name: Confirm /review tests subcommand
-        id: check
-        run: |
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            echo "should-run=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "should-run=false" >> "$GITHUB_OUTPUT"
-          if [ "$EVENT_NAME" != "issue_comment" ] || [ -z "${ISSUE_PULL_REQUEST_URL:-}" ]; then
-            exit 0
-          fi
-
-          if [[ "$COMMENT_BODY" =~ ^[[:space:]]*/review[[:space:]]+tests([[:space:]]|$) ]]; then
-            echo "should-run=true" >> "$GITHUB_OUTPUT"
-          fi
-        env:
-          COMMENT_BODY: ${{ github.event.comment.body }}
-          EVENT_NAME: ${{ github.event_name }}
-          ISSUE_PULL_REQUEST_URL: ${{ github.event.issue.pull_request.url }}
-
   conclusion:
     needs:
       - activation
       - agent
-      - command-filter
       - detection
       - safe_outputs
     if: >
@@ -1110,7 +1049,6 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: read
-      issues: write
       pull-requests: write
     concurrency:
       group: "gh-aw-conclusion-copilot-review-tests"
@@ -1241,7 +1179,6 @@ jobs:
           GH_AW_ENGINE_API_HOSTS: "api.enterprise.githubcopilot.com,api.githubcopilot.com,api.business.githubcopilot.com,api.individual.githubcopilot.com"
           GH_AW_LOCKDOWN_CHECK_FAILED: ${{ needs.activation.outputs.lockdown_check_failed }}
           GH_AW_STALE_LOCK_FILE_FAILED: ${{ needs.activation.outputs.stale_lock_file_failed }}
-          GH_AW_SAFE_OUTPUT_MESSAGES: "{\"footer\":\"\\u003e Test-failure review by [{workflow_name}]({run_url})\",\"runStarted\":\"Reviewing test failures on this PR... [{workflow_name}]({run_url})\",\"runSuccess\":\"Test-failure review complete. [{workflow_name}]({run_url})\",\"runFailure\":\"Test-failure review failed. [{workflow_name}]({run_url}) {status}\"}"
           GH_AW_GROUP_REPORTS: "false"
           GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_MISSING_TOOL_REPORT_AS_FAILURE: "true"
@@ -1254,27 +1191,6 @@ jobs:
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/handle_agent_failure.cjs');
-            await main();
-      - name: Update reaction comment with completion status
-        id: conclusion
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
-          GH_AW_COMMENT_ID: ${{ needs.activation.outputs.comment_id }}
-          GH_AW_COMMENT_REPO: ${{ needs.activation.outputs.comment_repo }}
-          GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          GH_AW_WORKFLOW_NAME: "Review PR Test Failures"
-          GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
-          GH_AW_SAFE_OUTPUTS_RESULT: ${{ needs.safe_outputs.result }}
-          GH_AW_DETECTION_CONCLUSION: ${{ needs.detection.outputs.detection_conclusion }}
-          GH_AW_DETECTION_REASON: ${{ needs.detection.outputs.detection_reason }}
-          GH_AW_SAFE_OUTPUT_MESSAGES: "{\"footer\":\"\\u003e Test-failure review by [{workflow_name}]({run_url})\",\"runStarted\":\"Reviewing test failures on this PR... [{workflow_name}]({run_url})\",\"runSuccess\":\"Test-failure review complete. [{workflow_name}]({run_url})\",\"runFailure\":\"Test-failure review failed. [{workflow_name}]({run_url}) {status}\"}"
-        with:
-          github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io, getOctokit);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/notify_comment_error.cjs');
             await main();
 
   detection:
@@ -1494,11 +1410,11 @@ jobs:
             }
 
   pre_activation:
-    if: >
-      github.event_name != 'issue_comment' && github.event_name != 'pull_request_review_comment' || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-slim
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' && steps.check_command_position.outputs.command_position_ok == 'true' }}
+      exact_command_result: ${{ steps.exact_command.outcome }}
+      exact_command_should_run: ${{ steps.exact_command.outputs.should_run }}
       matched_command: ${{ steps.check_command_position.outputs.matched_command }}
       setup-parent-span-id: ${{ steps.setup.outputs.parent-span-id || steps.setup.outputs.span-id }}
       setup-span-id: ${{ steps.setup.outputs.span-id }}
@@ -1539,6 +1455,24 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_command_position.cjs');
             await main();
+      - name: Confirm exact /review tests command
+        id: exact_command
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "should_run=false" >> "$GITHUB_OUTPUT"
+          if [ "$EVENT_NAME" != "issue_comment" ] || [ -z "${ISSUE_PULL_REQUEST_URL:-}" ]; then
+            exit 0
+          fi
+          if [[ "$COMMENT_BODY" =~ ^[[:space:]]*/review[[:space:]]+tests[[:space:]]*$ ]]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          EVENT_NAME: ${{ github.event_name }}
+          ISSUE_PULL_REQUEST_URL: ${{ github.event.issue.pull_request.url }}
 
   safe_outputs:
     needs:
@@ -1549,7 +1483,6 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: read
-      issues: write
       pull-requests: write
     timeout-minutes: 15
     env:
@@ -1561,15 +1494,12 @@ jobs:
       GH_AW_ENGINE_ID: "copilot"
       GH_AW_ENGINE_MODEL: "claude-sonnet-4.6"
       GH_AW_ENGINE_VERSION: "1.0.55"
-      GH_AW_SAFE_OUTPUT_MESSAGES: "{\"footer\":\"\\u003e Test-failure review by [{workflow_name}]({run_url})\",\"runStarted\":\"Reviewing test failures on this PR... [{workflow_name}]({run_url})\",\"runSuccess\":\"Test-failure review complete. [{workflow_name}]({run_url})\",\"runFailure\":\"Test-failure review failed. [{workflow_name}]({run_url}) {status}\"}"
       GH_AW_WORKFLOW_ID: "copilot-review-tests"
       GH_AW_WORKFLOW_NAME: "Review PR Test Failures"
       GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/copilot-review-tests.md"
     outputs:
       code_push_failure_count: ${{ steps.process_safe_outputs.outputs.code_push_failure_count }}
       code_push_failure_errors: ${{ steps.process_safe_outputs.outputs.code_push_failure_errors }}
-      comment_id: ${{ steps.process_safe_outputs.outputs.comment_id }}
-      comment_url: ${{ steps.process_safe_outputs.outputs.comment_url }}
       create_discussion_error_count: ${{ steps.process_safe_outputs.outputs.create_discussion_error_count }}
       create_discussion_errors: ${{ steps.process_safe_outputs.outputs.create_discussion_errors }}
       process_safe_outputs_processed_count: ${{ steps.process_safe_outputs.outputs.processed_count }}
@@ -1618,10 +1548,10 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_COMMENT_ID: ${{ needs.activation.outputs.comment_id }}
-          GH_AW_ALLOWED_DOMAINS: "*.blob.core.windows.net,*.githubusercontent.com,*.visualstudio.com,*.vsblob.vsassets.io,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.nuget.org,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,azuresearch-usnc.nuget.org,azuresearch-ussc.nuget.org,builds.dotnet.microsoft.com,ci.dot.net,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,dc.services.visualstudio.com,dev.azure.com,dist.nuget.org,docs.github.com,dot.net,dotnet.microsoft.com,dotnetcli.blob.core.windows.net,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,helix.dot.net,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,nuget.org,nuget.pkg.github.com,nugetregistryv2prod.blob.core.windows.net,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,oneocsp.microsoft.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,patch-diff.githubusercontent.com,pkgs.dev.azure.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com,www.microsoft.com"
+          GH_AW_ALLOWED_DOMAINS: "*.blob.core.windows.net,*.githubusercontent.com,*.visualstudio.com,*.vsblob.vsassets.io,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.nuget.org,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,azuresearch-usnc.nuget.org,azuresearch-ussc.nuget.org,builds.dotnet.microsoft.com,ci.dot.net,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,dc.services.visualstudio.com,dev.azure.com,dist.nuget.org,docs.github.com,dot.net,dotnet.microsoft.com,dotnetcli.blob.core.windows.net,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,helix.dot.net,host.docker.internal,img.shields.io,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,nuget.org,nuget.pkg.github.com,nugetregistryv2prod.blob.core.windows.net,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,oneocsp.microsoft.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,patch-diff.githubusercontent.com,pkgs.dev.azure.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com,www.microsoft.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":1,\"target\":\"*\"},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"report_incomplete\":{},\"submit_pull_request_review\":{\"allowed_events\":[\"COMMENT\"],\"footer\":\"none\",\"max\":1,\"target\":\"*\"}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/copilot-review-tests.lock.yml
+++ b/.github/workflows/copilot-review-tests.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"637b0c0b4edeaf07126aa15390c8a535135d22bf22019996cc1e57dcffa52c0c","body_hash":"9f6ec4ed379a8e593b8231a3319903247d8a4f413bd4634ad27ff66037b5395d","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot","agent_model":"claude-sonnet-4.6"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"53de81b2269a74e2ed986e4b5dde3d9548eb6501470a563a38241db242b0fe66","body_hash":"9f6ec4ed379a8e593b8231a3319903247d8a4f413bd4634ad27ff66037b5395d","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot","agent_model":"claude-sonnet-4.6"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -79,15 +79,16 @@ on:
     # name: Confirm exact /review tests command
     # run: |
       # if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-        # exit 0
+        # echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
       # fi
       # if [ "$EVENT_NAME" != "issue_comment" ] || [ -z "${ISSUE_PULL_REQUEST_URL:-}" ]; then
-        # exit 1
+        # echo "should_run=false" >> "$GITHUB_OUTPUT"; exit 0
       # fi
       # if [[ "$COMMENT_BODY" =~ ^[[:space:]]*/review[[:space:]]+tests[[:space:]]*$ ]]; then
-        # exit 0
+        # echo "should_run=true" >> "$GITHUB_OUTPUT"
+      # else
+        # echo "should_run=false" >> "$GITHUB_OUTPUT"
       # fi
-      # exit 1
   workflow_dispatch:
     inputs:
       aw_context:
@@ -125,7 +126,7 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      needs.pre_activation.outputs.activated == 'true' && (github.event_name == 'workflow_dispatch' || needs.pre_activation.outputs.exact_command_result == 'success')
+      needs.pre_activation.outputs.activated == 'true' && (github.event_name == 'workflow_dispatch' || needs.pre_activation.outputs.exact_command_should_run == 'true')
     runs-on: ubuntu-slim
     permissions:
       actions: read
@@ -268,20 +269,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_18fcfdba4f2a66e5_EOF'
+          cat << 'GH_AW_PROMPT_9223401ff282ccea_EOF'
           <system>
-          GH_AW_PROMPT_18fcfdba4f2a66e5_EOF
+          GH_AW_PROMPT_9223401ff282ccea_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_18fcfdba4f2a66e5_EOF'
+          cat << 'GH_AW_PROMPT_9223401ff282ccea_EOF'
           <safe-output-tools>
           Tools: add_comment, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_18fcfdba4f2a66e5_EOF
+          GH_AW_PROMPT_9223401ff282ccea_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_18fcfdba4f2a66e5_EOF'
+          cat << 'GH_AW_PROMPT_9223401ff282ccea_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -310,15 +311,15 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_18fcfdba4f2a66e5_EOF
+          GH_AW_PROMPT_9223401ff282ccea_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_18fcfdba4f2a66e5_EOF'
+          cat << 'GH_AW_PROMPT_9223401ff282ccea_EOF'
           </system>
           {{#runtime-import .github/workflows/copilot-review-tests.md}}
-          GH_AW_PROMPT_18fcfdba4f2a66e5_EOF
+          GH_AW_PROMPT_9223401ff282ccea_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -577,9 +578,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_a3fbd95abd39770f_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_c89f701ef87a38cc_EOF'
           {"add_comment":{"footer":false,"hide_older_comments":true,"max":1,"target":"*"},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_a3fbd95abd39770f_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_c89f701ef87a38cc_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -773,7 +774,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_a86145f3e3991b1f_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_050fb0338b54f25f_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -814,7 +815,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_a86145f3e3991b1f_EOF
+          GH_AW_MCP_CONFIG_050fb0338b54f25f_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1434,6 +1435,7 @@ jobs:
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' && steps.check_command_position.outputs.command_position_ok == 'true' }}
       exact_command_result: ${{ steps.exact_command.outcome }}
+      exact_command_should_run: ${{ steps.exact_command.outputs.should_run }}
       matched_command: ${{ steps.check_command_position.outputs.matched_command }}
       setup-parent-span-id: ${{ steps.setup.outputs.parent-span-id || steps.setup.outputs.span-id }}
       setup-span-id: ${{ steps.setup.outputs.span-id }}
@@ -1478,15 +1480,16 @@ jobs:
         id: exact_command
         run: |
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            exit 0
+            echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
           fi
           if [ "$EVENT_NAME" != "issue_comment" ] || [ -z "${ISSUE_PULL_REQUEST_URL:-}" ]; then
-            exit 1
+            echo "should_run=false" >> "$GITHUB_OUTPUT"; exit 0
           fi
           if [[ "$COMMENT_BODY" =~ ^[[:space:]]*/review[[:space:]]+tests[[:space:]]*$ ]]; then
-            exit 0
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
           fi
-          exit 1
         env:
           COMMENT_BODY: ${{ github.event.comment.body }}
           EVENT_NAME: ${{ github.event_name }}

--- a/.github/workflows/copilot-review-tests.lock.yml
+++ b/.github/workflows/copilot-review-tests.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"22da6f0c0daae73ce341c1a6756e07b4f993f0304ea9ed41567d12fcf7e7ab94","body_hash":"4a82a161bccd0dae5eb0f206c450c9dccae275f24225a3c4b5f0fdc222a66fb6","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot","agent_model":"claude-sonnet-4.6"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"637b0c0b4edeaf07126aa15390c8a535135d22bf22019996cc1e57dcffa52c0c","body_hash":"9f6ec4ed379a8e593b8231a3319903247d8a4f413bd4634ad27ff66037b5395d","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot","agent_model":"claude-sonnet-4.6"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -268,20 +268,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_57f6a05746909f5b_EOF'
+          cat << 'GH_AW_PROMPT_18fcfdba4f2a66e5_EOF'
           <system>
-          GH_AW_PROMPT_57f6a05746909f5b_EOF
+          GH_AW_PROMPT_18fcfdba4f2a66e5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_57f6a05746909f5b_EOF'
+          cat << 'GH_AW_PROMPT_18fcfdba4f2a66e5_EOF'
           <safe-output-tools>
-          Tools: submit_pull_request_review, missing_tool, missing_data, noop
+          Tools: add_comment, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_57f6a05746909f5b_EOF
+          GH_AW_PROMPT_18fcfdba4f2a66e5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_57f6a05746909f5b_EOF'
+          cat << 'GH_AW_PROMPT_18fcfdba4f2a66e5_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -310,15 +310,15 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_57f6a05746909f5b_EOF
+          GH_AW_PROMPT_18fcfdba4f2a66e5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_57f6a05746909f5b_EOF'
+          cat << 'GH_AW_PROMPT_18fcfdba4f2a66e5_EOF'
           </system>
           {{#runtime-import .github/workflows/copilot-review-tests.md}}
-          GH_AW_PROMPT_57f6a05746909f5b_EOF
+          GH_AW_PROMPT_18fcfdba4f2a66e5_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -577,21 +577,43 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_98b24060547eb92a_EOF'
-          {"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{},"submit_pull_request_review":{"allowed_events":["COMMENT"],"footer":"none","max":1,"target":"*"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_98b24060547eb92a_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_a3fbd95abd39770f_EOF'
+          {"add_comment":{"footer":false,"hide_older_comments":true,"max":1,"target":"*"},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_a3fbd95abd39770f_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "submit_pull_request_review": " CONSTRAINTS: Maximum 1 review(s) can be submitted."
+                "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added. Target: *. Supports reply_to_id for discussion threading."
               },
               "repo_params": {},
               "dynamic_tools": []
             }
           GH_AW_VALIDATION_JSON: |
             {
+              "add_comment": {
+                "defaultMax": 1,
+                "fields": {
+                  "body": {
+                    "required": true,
+                    "type": "string",
+                    "sanitize": true,
+                    "maxLength": 65000
+                  },
+                  "item_number": {
+                    "issueOrPRNumber": true
+                  },
+                  "reply_to_id": {
+                    "type": "string",
+                    "maxLength": 256
+                  },
+                  "repo": {
+                    "type": "string",
+                    "maxLength": 256
+                  }
+                }
+              },
               "missing_data": {
                 "defaultMax": 20,
                 "fields": {
@@ -662,24 +684,6 @@ jobs:
                     "type": "string",
                     "sanitize": true,
                     "maxLength": 1024
-                  }
-                }
-              },
-              "submit_pull_request_review": {
-                "defaultMax": 1,
-                "fields": {
-                  "body": {
-                    "type": "string",
-                    "sanitize": true,
-                    "maxLength": 65000
-                  },
-                  "event": {
-                    "type": "string",
-                    "enum": [
-                      "APPROVE",
-                      "REQUEST_CHANGES",
-                      "COMMENT"
-                    ]
                   }
                 }
               }
@@ -769,7 +773,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_e891f50e9bda761b_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_a86145f3e3991b1f_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -810,7 +814,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_e891f50e9bda761b_EOF
+          GH_AW_MCP_CONFIG_a86145f3e3991b1f_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1061,6 +1065,7 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: read
+      issues: write
       pull-requests: write
     concurrency:
       group: "gh-aw-conclusion-copilot-review-tests"
@@ -1496,6 +1501,7 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: read
+      issues: write
       pull-requests: write
     timeout-minutes: 15
     env:
@@ -1513,6 +1519,8 @@ jobs:
     outputs:
       code_push_failure_count: ${{ steps.process_safe_outputs.outputs.code_push_failure_count }}
       code_push_failure_errors: ${{ steps.process_safe_outputs.outputs.code_push_failure_errors }}
+      comment_id: ${{ steps.process_safe_outputs.outputs.comment_id }}
+      comment_url: ${{ steps.process_safe_outputs.outputs.comment_url }}
       create_discussion_error_count: ${{ steps.process_safe_outputs.outputs.create_discussion_error_count }}
       create_discussion_errors: ${{ steps.process_safe_outputs.outputs.create_discussion_errors }}
       process_safe_outputs_processed_count: ${{ steps.process_safe_outputs.outputs.processed_count }}
@@ -1564,7 +1572,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.blob.core.windows.net,*.githubusercontent.com,*.visualstudio.com,*.vsblob.vsassets.io,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.nuget.org,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,azuresearch-usnc.nuget.org,azuresearch-ussc.nuget.org,builds.dotnet.microsoft.com,ci.dot.net,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,dc.services.visualstudio.com,dev.azure.com,dist.nuget.org,docs.github.com,dot.net,dotnet.microsoft.com,dotnetcli.blob.core.windows.net,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,helix.dot.net,host.docker.internal,img.shields.io,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,nuget.org,nuget.pkg.github.com,nugetregistryv2prod.blob.core.windows.net,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,oneocsp.microsoft.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,patch-diff.githubusercontent.com,pkgs.dev.azure.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com,www.microsoft.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"report_incomplete\":{},\"submit_pull_request_review\":{\"allowed_events\":[\"COMMENT\"],\"footer\":\"none\",\"max\":1,\"target\":\"*\"}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"footer\":false,\"hide_older_comments\":true,\"max\":1,\"target\":\"*\"},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"report_incomplete\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/copilot-review-tests.md
+++ b/.github/workflows/copilot-review-tests.md
@@ -18,15 +18,16 @@ on:
         ISSUE_PULL_REQUEST_URL: ${{ github.event.issue.pull_request.url }}
       run: |
         if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-          exit 0
+          echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
         fi
         if [ "$EVENT_NAME" != "issue_comment" ] || [ -z "${ISSUE_PULL_REQUEST_URL:-}" ]; then
-          exit 1
+          echo "should_run=false" >> "$GITHUB_OUTPUT"; exit 0
         fi
         if [[ "$COMMENT_BODY" =~ ^[[:space:]]*/review[[:space:]]+tests[[:space:]]*$ ]]; then
-          exit 0
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "should_run=false" >> "$GITHUB_OUTPUT"
         fi
-        exit 1
   workflow_dispatch:
     inputs:
       pr_number:
@@ -55,7 +56,12 @@ labels: ["pr-review", "testing"]
 # exactly `/review tests`. workflow_dispatch is always allowed.
 if: >-
   github.event_name == 'workflow_dispatch' ||
-  needs.pre_activation.outputs.exact_command_result == 'success'
+  needs.pre_activation.outputs.exact_command_should_run == 'true'
+
+jobs:
+  pre-activation:
+    outputs:
+      exact_command_should_run: ${{ steps.exact_command.outputs.should_run }}
 
 permissions:
   contents: read

--- a/.github/workflows/copilot-review-tests.md
+++ b/.github/workflows/copilot-review-tests.md
@@ -69,11 +69,12 @@ engine:
   model: claude-sonnet-4.6
 
 safe-outputs:
-  submit-pull-request-review:
-    allowed-events: [COMMENT]
+  add-comment:
     max: 1
     target: "*"
-    footer: "none"
+    hide-older-comments: true
+    discussions: false
+    footer: false
   noop:
     report-as-issue: false
   missing-tool:
@@ -178,14 +179,14 @@ test -f CustomAgentLogsTmp/TestFailureReview/${{ github.event.issue.number || in
 test -f CustomAgentLogsTmp/TestFailureReview/${{ github.event.issue.number || inputs.pr_number }}/context.md
 ```
 
-If required files are missing, post a short failure report with `submit_pull_request_review` unless dry-run mode is active.
+If required files are missing, post a short failure report with `add_comment` unless dry-run mode is active.
 
 ## Dry-run mode
 
 When triggered via `workflow_dispatch`, `${{ inputs.suppress_output }}` controls output:
 
-- If `true`, perform the review and log the final report in your response, but do not call `submit_pull_request_review`.
-- If `false` or empty, post the report as a non-blocking PR review comment.
+- If `true`, perform the review and log the final report in your response, but do not call `add_comment`.
+- If `false` or empty, post the report as a PR conversation comment.
 
 ## When no action is needed
 
@@ -199,7 +200,7 @@ Example:
 
 ## Posting results
 
-If dry-run mode is not active, call `submit_pull_request_review` exactly once with `pull_request_number` set to the target PR number, `event` set to `COMMENT`, and `body` set to this collapsed top-level shape:
+If dry-run mode is not active, call `add_comment` exactly once with `item_number` set to the target PR number and `body` set to this collapsed top-level shape:
 
 ```markdown
 <!-- Test Failure Review -->

--- a/.github/workflows/copilot-review-tests.md
+++ b/.github/workflows/copilot-review-tests.md
@@ -4,6 +4,27 @@ on:
   slash_command:
     name: review
     events: [pull_request_comment]
+  reaction: none
+  status-comment: false
+  steps:
+    - name: Confirm exact /review tests command
+      id: exact_command
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        COMMENT_BODY: ${{ github.event.comment.body }}
+        ISSUE_PULL_REQUEST_URL: ${{ github.event.issue.pull_request.url }}
+      run: |
+        if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        echo "should_run=false" >> "$GITHUB_OUTPUT"
+        if [ "$EVENT_NAME" != "issue_comment" ] || [ -z "${ISSUE_PULL_REQUEST_URL:-}" ]; then
+          exit 0
+        fi
+        if [[ "$COMMENT_BODY" =~ ^[[:space:]]*/review[[:space:]]+tests[[:space:]]*$ ]]; then
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
+        fi
   workflow_dispatch:
     inputs:
       pr_number:
@@ -28,14 +49,11 @@ on:
 labels: ["pr-review", "testing"]
 
 # gh-aw slash commands match the first token only, so this workflow listens for
-# `/review` and then a deterministic filter job skips unless the comment uses
-# the canonical `/review tests` subcommand. workflow_dispatch is always allowed.
+# `/review` and then a pre-activation step skips unless the whole comment is
+# exactly `/review tests`. workflow_dispatch is always allowed.
 if: >-
   github.event_name == 'workflow_dispatch' ||
-  (github.event_name == 'issue_comment' &&
-   github.event.issue.pull_request &&
-   contains(github.event.comment.body, 'tests') &&
-   needs.command-filter.outputs.should-run == 'true')
+  needs.pre_activation.outputs.exact_command_should_run == 'true'
 
 permissions:
   contents: read
@@ -49,11 +67,11 @@ engine:
   model: claude-sonnet-4.6
 
 safe-outputs:
-  add-comment:
+  submit-pull-request-review:
+    allowed-events: [COMMENT]
     max: 1
     target: "*"
-    hide-older-comments: true
-    discussions: false
+    footer: "none"
   noop:
     report-as-issue: false
   missing-tool:
@@ -61,43 +79,11 @@ safe-outputs:
   report-incomplete:
     create-issue: false
   report-failure-as-issue: false
-  messages:
-    footer: "> Test-failure review by [{workflow_name}]({run_url})"
-    run-started: "Reviewing test failures on this PR... [{workflow_name}]({run_url})"
-    run-success: "Test-failure review complete. [{workflow_name}]({run_url})"
-    run-failure: "Test-failure review failed. [{workflow_name}]({run_url}) {status}"
 
 jobs:
-  command-filter:
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
-       contains(github.event.comment.body, 'tests'))
-    runs-on: ubuntu-slim
+  pre-activation:
     outputs:
-      should-run: ${{ steps.check.outputs.should-run }}
-    steps:
-      - name: Confirm /review tests subcommand
-        id: check
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          COMMENT_BODY: ${{ github.event.comment.body }}
-          ISSUE_PULL_REQUEST_URL: ${{ github.event.issue.pull_request.url }}
-        run: |
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            echo "should-run=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "should-run=false" >> "$GITHUB_OUTPUT"
-          if [ "$EVENT_NAME" != "issue_comment" ] || [ -z "${ISSUE_PULL_REQUEST_URL:-}" ]; then
-            exit 0
-          fi
-
-          if [[ "$COMMENT_BODY" =~ ^[[:space:]]*/review[[:space:]]+tests([[:space:]]|$) ]]; then
-            echo "should-run=true" >> "$GITHUB_OUTPUT"
-          fi
+      exact_command_should_run: ${{ steps.exact_command.outputs.should_run }}
 
 tools:
   github:
@@ -112,6 +98,7 @@ network:
     - "*.visualstudio.com"
     - helix.dot.net
     - "*.blob.core.windows.net"
+    - img.shields.io
 
 concurrency:
   group: "review-tests-${{ github.event.issue.number || inputs.pr_number || github.run_id }}"
@@ -194,14 +181,14 @@ test -f CustomAgentLogsTmp/TestFailureReview/${{ github.event.issue.number || in
 test -f CustomAgentLogsTmp/TestFailureReview/${{ github.event.issue.number || inputs.pr_number }}/context.md
 ```
 
-If required files are missing, post a short failure report with `add_comment` unless dry-run mode is active.
+If required files are missing, post a short failure report with `submit_pull_request_review` unless dry-run mode is active.
 
 ## Dry-run mode
 
 When triggered via `workflow_dispatch`, `${{ inputs.suppress_output }}` controls output:
 
-- If `true`, perform the review and log the final report in your response, but do not call `add_comment`.
-- If `false` or empty, post the report as a PR comment.
+- If `true`, perform the review and log the final report in your response, but do not call `submit_pull_request_review`.
+- If `false` or empty, post the report as a non-blocking PR review comment.
 
 ## When no action is needed
 
@@ -215,14 +202,16 @@ Example:
 
 ## Posting results
 
-If dry-run mode is not active, call `add_comment` exactly once with `item_number` set to the target PR number. Use this AI-summary-style top-level shape:
+If dry-run mode is not active, call `submit_pull_request_review` exactly once with `pull_request_number` set to the target PR number, `event` set to `COMMENT`, and `body` set to this collapsed top-level shape:
 
 ```markdown
 <!-- Test Failure Review -->
 
-## Test Failure Review
+<details>
+<summary>[icon] <strong>Test Failure Review:</strong> [verdict] — <a href="[commit URL]"><code>[sha7]</code></a> · <strong>[PR title]</strong></summary>
+<br/>
 
-> @[PR author] — new test-failure review results are available based on this last commit: <a href="[commit URL]"><code>[sha7]</code></a>.
+> @[PR author] — test-failure review results are available based on commit <a href="[commit URL]"><code>[sha7]</code></a>.
 > To request a fresh review after new comments, commits, or CI runs, comment `/review tests`.
 
 <p align="left">
@@ -231,11 +220,6 @@ If dry-run mode is not active, call `add_comment` exactly once with `item_number
   <img alt="Data [Complete|Partial]" src="https://img.shields.io/badge/Data-[Complete|Partial]-[color]?labelColor=30363d&style=flat-square">
   <img alt="Platform [platform]" src="https://img.shields.io/badge/Platform-[platform]-0969da?labelColor=30363d&style=flat-square">
 </p>
-
-<!-- SESSION:[sha7] START -->
-<details>
-<summary>[icon] <strong>Test Failure Review</strong> — <a href="[commit URL]"><code>[sha7]</code></a> · <strong>[PR title]</strong> · <em>[UTC timestamp]</em></summary>
-<br/>
 
 **Overall verdict:** [Likely PR-caused | Likely unrelated | Needs human investigation | Insufficient data]
 
@@ -257,7 +241,6 @@ If dry-run mode is not active, call `add_comment` exactly once with `item_number
 </details>
 
 </details>
-<!-- SESSION:[sha7] END -->
 ```
 
 Do not apply labels, trigger reruns, approve the PR, request changes, or modify code.

--- a/.github/workflows/copilot-review-tests.md
+++ b/.github/workflows/copilot-review-tests.md
@@ -4,6 +4,9 @@ on:
   slash_command:
     name: review
     events: [pull_request_comment]
+  skip-author-associations:
+    issue_comment: [contributor, first_time_contributor, first_timer, mannequin, none]
+    pull_request_review_comment: [contributor, first_time_contributor, first_timer, mannequin, none]
   reaction: none
   status-comment: false
   steps:
@@ -15,16 +18,15 @@ on:
         ISSUE_PULL_REQUEST_URL: ${{ github.event.issue.pull_request.url }}
       run: |
         if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-          echo "should_run=true" >> "$GITHUB_OUTPUT"
           exit 0
         fi
-        echo "should_run=false" >> "$GITHUB_OUTPUT"
         if [ "$EVENT_NAME" != "issue_comment" ] || [ -z "${ISSUE_PULL_REQUEST_URL:-}" ]; then
-          exit 0
+          exit 1
         fi
         if [[ "$COMMENT_BODY" =~ ^[[:space:]]*/review[[:space:]]+tests[[:space:]]*$ ]]; then
-          echo "should_run=true" >> "$GITHUB_OUTPUT"
+          exit 0
         fi
+        exit 1
   workflow_dispatch:
     inputs:
       pr_number:
@@ -53,7 +55,7 @@ labels: ["pr-review", "testing"]
 # exactly `/review tests`. workflow_dispatch is always allowed.
 if: >-
   github.event_name == 'workflow_dispatch' ||
-  needs.pre_activation.outputs.exact_command_should_run == 'true'
+  needs.pre_activation.outputs.exact_command_result == 'success'
 
 permissions:
   contents: read
@@ -79,11 +81,6 @@ safe-outputs:
   report-incomplete:
     create-issue: false
   report-failure-as-issue: false
-
-jobs:
-  pre-activation:
-    outputs:
-      exact_command_should_run: ${{ steps.exact_command.outputs.should_run }}
 
 tools:
   github:


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Refines the `/review tests` gh-aw workflow so it only activates for the exact `/review tests` command, not other `/review` subcommands such as `/review rerun`.

Also removes the noisy gh-aw status/reaction comments and changes the final test-failure report to post as a non-blocking PR review with a single collapsed `<details>` block.

### Validation

- `gh aw compile copilot-review-tests --validate`
- PowerShell parse check for `.github/scripts/Review-Tests.ps1`
- `git diff --check`
