### PR TITLE
Add Binding converter culture support

### DIFF
--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -384,6 +384,12 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 
 							if (bindingExtensionType.Value.Item3 == "BindingExtension")
 							{
+								// extension.TypedBinding.ConverterCulture = extension.ConverterCulture;
+								yield return Create(Ldloc, vardefref.VariableDefinition);
+								yield return Create(Callvirt, module.ImportPropertyGetterReference(context.Cache, bindingExtensionType.Value, propertyName: "TypedBinding"));
+								yield return Create(Ldloc, vardefref.VariableDefinition);
+								yield return Create(Callvirt, module.ImportPropertyGetterReference(context.Cache, bindingExtensionType.Value, propertyName: "ConverterCulture"));
+								yield return Create(Callvirt, module.ImportPropertySetterReference(context.Cache, ("Microsoft.Maui.Controls", "Microsoft.Maui.Controls.Internals", "TypedBindingBase"), propertyName: "ConverterCulture"));
 								// // extension.TypedBinding.Source = extension.Source;
 								yield return Create(Ldloc, vardefref.VariableDefinition);
 								yield return Create(Callvirt, module.ImportPropertyGetterReference(context.Cache, bindingExtensionType.Value, propertyName: "TypedBinding"));

--- a/src/Controls/src/Core/Binding.cs
+++ b/src/Controls/src/Core/Binding.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Maui.Controls
 		public const string SelfPath = ".";
 		IValueConverter _converter;
 		object _converterParameter;
+		CultureInfo _converterCulture;
 
 		BindingExpression _expression;
 		string _path;
@@ -78,6 +79,21 @@ namespace Microsoft.Maui.Controls
 				ThrowIfApplied();
 
 				_converterParameter = value;
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the culture information used by the converter.
+		/// </summary>
+		[TypeConverter(typeof(CultureInfoConverter))]
+		public CultureInfo ConverterCulture
+		{
+			get { return _converterCulture ?? CultureInfo.CurrentUICulture; }
+			set
+			{
+				ThrowIfApplied();
+
+				_converterCulture = value;
 			}
 		}
 
@@ -195,6 +211,7 @@ namespace Microsoft.Maui.Controls
 			{
 				Converter = Converter,
 				ConverterParameter = ConverterParameter,
+				ConverterCulture = _converterCulture,
 				StringFormat = StringFormat,
 				Source = Source,
 				UpdateSourceEventName = UpdateSourceEventName,
@@ -211,7 +228,7 @@ namespace Microsoft.Maui.Controls
 		internal override object GetSourceValue(object value, Type targetPropertyType)
 		{
 			if (Converter != null)
-				value = Converter.Convert(value, targetPropertyType, ConverterParameter, CultureInfo.CurrentUICulture);
+				value = Converter.Convert(value, targetPropertyType, ConverterParameter, ConverterCulture);
 
 			return base.GetSourceValue(value, targetPropertyType);
 		}
@@ -219,7 +236,7 @@ namespace Microsoft.Maui.Controls
 		internal override object GetTargetValue(object value, Type sourcePropertyType)
 		{
 			if (Converter != null)
-				value = Converter.ConvertBack(value, sourcePropertyType, ConverterParameter, CultureInfo.CurrentUICulture);
+				value = Converter.ConvertBack(value, sourcePropertyType, ConverterParameter, ConverterCulture);
 
 			return base.GetTargetValue(value, sourcePropertyType);
 		}

--- a/src/Controls/src/Core/MultiBinding.cs
+++ b/src/Controls/src/Core/MultiBinding.cs
@@ -1,6 +1,7 @@
 #nullable disable
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Globalization;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Xaml.Diagnostics;
@@ -14,6 +15,7 @@ namespace Microsoft.Maui.Controls
 	public sealed class MultiBinding : BindingBase
 	{
 		IMultiValueConverter _converter;
+		CultureInfo _converterCulture;
 		object _converterParameter;
 		IList<BindingBase> _bindings;
 		BindableProperty _targetProperty;
@@ -32,6 +34,20 @@ namespace Microsoft.Maui.Controls
 			{
 				ThrowIfApplied();
 				_converter = value;
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the culture in which to evaluate the <see cref="Converter"/>.
+		/// </summary>
+		[TypeConverter(typeof(CultureInfoConverter))]
+		public CultureInfo ConverterCulture
+		{
+			get { return _converterCulture ?? CultureInfo.CurrentUICulture; }
+			set
+			{
+				ThrowIfApplied();
+				_converterCulture = value;
 			}
 		}
 
@@ -70,6 +86,7 @@ namespace Microsoft.Maui.Controls
 			var clone = new MultiBinding()
 			{
 				Converter = Converter,
+				ConverterCulture = _converterCulture,
 				ConverterParameter = ConverterParameter,
 				Bindings = bindingsclone,
 				FallbackValue = FallbackValue,
@@ -208,7 +225,7 @@ namespace Microsoft.Maui.Controls
 		{
 			var valuearray = value as object[];
 			if (valuearray != null && Converter != null)
-				value = Converter.Convert(valuearray, targetPropertyType, ConverterParameter, CultureInfo.CurrentUICulture);
+				value = Converter.Convert(valuearray, targetPropertyType, ConverterParameter, ConverterCulture);
 
 			if (valuearray != null && Converter == null && StringFormat != null && BindingBase.TryFormat(StringFormat, valuearray, out var formatted))
 				return formatted;
@@ -227,7 +244,7 @@ namespace Microsoft.Maui.Controls
 				var types = new Type[_bpProxies.Length];
 				for (var i = 0; i < _bpProxies.Length; i++)
 					types[i] = values[i]?.GetType() ?? typeof(object);
-				return Converter.ConvertBack(value, types, ConverterParameter, CultureInfo.CurrentUICulture);
+				return Converter.ConvertBack(value, types, ConverterParameter, ConverterCulture);
 			}
 
 			return base.GetTargetValue(value, sourcePropertyType);

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,4 +1,8 @@
 #nullable enable
+~Microsoft.Maui.Controls.Binding.ConverterCulture.get -> System.Globalization.CultureInfo
+~Microsoft.Maui.Controls.Binding.ConverterCulture.set -> void
+~Microsoft.Maui.Controls.Internals.TypedBindingBase.ConverterCulture.get -> System.Globalization.CultureInfo
+~Microsoft.Maui.Controls.Internals.TypedBindingBase.ConverterCulture.set -> void
 *REMOVED*~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> System.Collections.Generic.IList<Microsoft.Maui.Controls.VisualStateGroup>
 Microsoft.Maui.Controls.HybridWebView.Invoker.get -> Microsoft.Maui.HybridWebViewInvoker!
 Microsoft.Maui.Controls.HybridWebView.Invoker.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,6 +1,8 @@
 #nullable enable
 ~Microsoft.Maui.Controls.Binding.ConverterCulture.get -> System.Globalization.CultureInfo
 ~Microsoft.Maui.Controls.Binding.ConverterCulture.set -> void
+~Microsoft.Maui.Controls.MultiBinding.ConverterCulture.get -> System.Globalization.CultureInfo
+~Microsoft.Maui.Controls.MultiBinding.ConverterCulture.set -> void
 ~Microsoft.Maui.Controls.Internals.TypedBindingBase.ConverterCulture.get -> System.Globalization.CultureInfo
 ~Microsoft.Maui.Controls.Internals.TypedBindingBase.ConverterCulture.set -> void
 *REMOVED*~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> System.Collections.Generic.IList<Microsoft.Maui.Controls.VisualStateGroup>

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,6 +1,10 @@
 ﻿#nullable enable
 *REMOVED*~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
 *REMOVED*~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> System.Collections.Generic.IList<Microsoft.Maui.Controls.VisualStateGroup>
+~Microsoft.Maui.Controls.Binding.ConverterCulture.get -> System.Globalization.CultureInfo
+~Microsoft.Maui.Controls.Binding.ConverterCulture.set -> void
+~Microsoft.Maui.Controls.Internals.TypedBindingBase.ConverterCulture.get -> System.Globalization.CultureInfo
+~Microsoft.Maui.Controls.Internals.TypedBindingBase.ConverterCulture.set -> void
 Microsoft.Maui.Controls.AppThemeBinding
 Microsoft.Maui.Controls.AppThemeBinding.AppThemeBinding() -> void
 Microsoft.Maui.Controls.BoxView.~BoxView() -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -3,6 +3,8 @@
 *REMOVED*~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> System.Collections.Generic.IList<Microsoft.Maui.Controls.VisualStateGroup>
 ~Microsoft.Maui.Controls.Binding.ConverterCulture.get -> System.Globalization.CultureInfo
 ~Microsoft.Maui.Controls.Binding.ConverterCulture.set -> void
+~Microsoft.Maui.Controls.MultiBinding.ConverterCulture.get -> System.Globalization.CultureInfo
+~Microsoft.Maui.Controls.MultiBinding.ConverterCulture.set -> void
 ~Microsoft.Maui.Controls.Internals.TypedBindingBase.ConverterCulture.get -> System.Globalization.CultureInfo
 ~Microsoft.Maui.Controls.Internals.TypedBindingBase.ConverterCulture.set -> void
 Microsoft.Maui.Controls.AppThemeBinding

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,6 +1,10 @@
 ﻿#nullable enable
 *REMOVED*~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
 *REMOVED*~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> System.Collections.Generic.IList<Microsoft.Maui.Controls.VisualStateGroup>
+~Microsoft.Maui.Controls.Binding.ConverterCulture.get -> System.Globalization.CultureInfo
+~Microsoft.Maui.Controls.Binding.ConverterCulture.set -> void
+~Microsoft.Maui.Controls.Internals.TypedBindingBase.ConverterCulture.get -> System.Globalization.CultureInfo
+~Microsoft.Maui.Controls.Internals.TypedBindingBase.ConverterCulture.set -> void
 Microsoft.Maui.Controls.AppThemeBinding
 Microsoft.Maui.Controls.AppThemeBinding.AppThemeBinding() -> void
 Microsoft.Maui.Controls.BoxView.~BoxView() -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -3,6 +3,8 @@
 *REMOVED*~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> System.Collections.Generic.IList<Microsoft.Maui.Controls.VisualStateGroup>
 ~Microsoft.Maui.Controls.Binding.ConverterCulture.get -> System.Globalization.CultureInfo
 ~Microsoft.Maui.Controls.Binding.ConverterCulture.set -> void
+~Microsoft.Maui.Controls.MultiBinding.ConverterCulture.get -> System.Globalization.CultureInfo
+~Microsoft.Maui.Controls.MultiBinding.ConverterCulture.set -> void
 ~Microsoft.Maui.Controls.Internals.TypedBindingBase.ConverterCulture.get -> System.Globalization.CultureInfo
 ~Microsoft.Maui.Controls.Internals.TypedBindingBase.ConverterCulture.set -> void
 Microsoft.Maui.Controls.AppThemeBinding

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -2,6 +2,10 @@
 Microsoft.Maui.Controls.HybridWebView.Invoker.get -> Microsoft.Maui.HybridWebViewInvoker!
 Microsoft.Maui.Controls.HybridWebView.Invoker.set -> void
 Microsoft.Maui.Controls.HybridWebView.SetInvokeJavaScriptTarget<T>(T! target, System.Text.Json.Serialization.JsonSerializerContext! jsonSerializerContext) -> void
+~Microsoft.Maui.Controls.Binding.ConverterCulture.get -> System.Globalization.CultureInfo
+~Microsoft.Maui.Controls.Binding.ConverterCulture.set -> void
+~Microsoft.Maui.Controls.Internals.TypedBindingBase.ConverterCulture.get -> System.Globalization.CultureInfo
+~Microsoft.Maui.Controls.Internals.TypedBindingBase.ConverterCulture.set -> void
 *REMOVED*~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> System.Collections.Generic.IList<Microsoft.Maui.Controls.VisualStateGroup>
 Microsoft.Maui.Controls.AppThemeBinding
 Microsoft.Maui.Controls.AppThemeBinding.AppThemeBinding() -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -4,6 +4,8 @@ Microsoft.Maui.Controls.HybridWebView.Invoker.set -> void
 Microsoft.Maui.Controls.HybridWebView.SetInvokeJavaScriptTarget<T>(T! target, System.Text.Json.Serialization.JsonSerializerContext! jsonSerializerContext) -> void
 ~Microsoft.Maui.Controls.Binding.ConverterCulture.get -> System.Globalization.CultureInfo
 ~Microsoft.Maui.Controls.Binding.ConverterCulture.set -> void
+~Microsoft.Maui.Controls.MultiBinding.ConverterCulture.get -> System.Globalization.CultureInfo
+~Microsoft.Maui.Controls.MultiBinding.ConverterCulture.set -> void
 ~Microsoft.Maui.Controls.Internals.TypedBindingBase.ConverterCulture.get -> System.Globalization.CultureInfo
 ~Microsoft.Maui.Controls.Internals.TypedBindingBase.ConverterCulture.set -> void
 *REMOVED*~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> System.Collections.Generic.IList<Microsoft.Maui.Controls.VisualStateGroup>

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -2,6 +2,10 @@
 Microsoft.Maui.Controls.HybridWebView.Invoker.get -> Microsoft.Maui.HybridWebViewInvoker!
 Microsoft.Maui.Controls.HybridWebView.Invoker.set -> void
 Microsoft.Maui.Controls.HybridWebView.SetInvokeJavaScriptTarget<T>(T! target, System.Text.Json.Serialization.JsonSerializerContext! jsonSerializerContext) -> void
+~Microsoft.Maui.Controls.Binding.ConverterCulture.get -> System.Globalization.CultureInfo
+~Microsoft.Maui.Controls.Binding.ConverterCulture.set -> void
+~Microsoft.Maui.Controls.Internals.TypedBindingBase.ConverterCulture.get -> System.Globalization.CultureInfo
+~Microsoft.Maui.Controls.Internals.TypedBindingBase.ConverterCulture.set -> void
 *REMOVED*~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> System.Collections.Generic.IList<Microsoft.Maui.Controls.VisualStateGroup>
 Microsoft.Maui.Controls.AppThemeBinding
 Microsoft.Maui.Controls.AppThemeBinding.AppThemeBinding() -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -4,6 +4,8 @@ Microsoft.Maui.Controls.HybridWebView.Invoker.set -> void
 Microsoft.Maui.Controls.HybridWebView.SetInvokeJavaScriptTarget<T>(T! target, System.Text.Json.Serialization.JsonSerializerContext! jsonSerializerContext) -> void
 ~Microsoft.Maui.Controls.Binding.ConverterCulture.get -> System.Globalization.CultureInfo
 ~Microsoft.Maui.Controls.Binding.ConverterCulture.set -> void
+~Microsoft.Maui.Controls.MultiBinding.ConverterCulture.get -> System.Globalization.CultureInfo
+~Microsoft.Maui.Controls.MultiBinding.ConverterCulture.set -> void
 ~Microsoft.Maui.Controls.Internals.TypedBindingBase.ConverterCulture.get -> System.Globalization.CultureInfo
 ~Microsoft.Maui.Controls.Internals.TypedBindingBase.ConverterCulture.set -> void
 *REMOVED*~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> System.Collections.Generic.IList<Microsoft.Maui.Controls.VisualStateGroup>

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,5 +1,9 @@
 #nullable enable
 *REMOVED*~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> System.Collections.Generic.IList<Microsoft.Maui.Controls.VisualStateGroup>
+~Microsoft.Maui.Controls.Binding.ConverterCulture.get -> System.Globalization.CultureInfo
+~Microsoft.Maui.Controls.Binding.ConverterCulture.set -> void
+~Microsoft.Maui.Controls.Internals.TypedBindingBase.ConverterCulture.get -> System.Globalization.CultureInfo
+~Microsoft.Maui.Controls.Internals.TypedBindingBase.ConverterCulture.set -> void
 Microsoft.Maui.Controls.AppThemeBinding
 Microsoft.Maui.Controls.AppThemeBinding.AppThemeBinding() -> void
 Microsoft.Maui.Controls.BoxView.~BoxView() -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -2,6 +2,8 @@
 *REMOVED*~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> System.Collections.Generic.IList<Microsoft.Maui.Controls.VisualStateGroup>
 ~Microsoft.Maui.Controls.Binding.ConverterCulture.get -> System.Globalization.CultureInfo
 ~Microsoft.Maui.Controls.Binding.ConverterCulture.set -> void
+~Microsoft.Maui.Controls.MultiBinding.ConverterCulture.get -> System.Globalization.CultureInfo
+~Microsoft.Maui.Controls.MultiBinding.ConverterCulture.set -> void
 ~Microsoft.Maui.Controls.Internals.TypedBindingBase.ConverterCulture.get -> System.Globalization.CultureInfo
 ~Microsoft.Maui.Controls.Internals.TypedBindingBase.ConverterCulture.set -> void
 Microsoft.Maui.Controls.AppThemeBinding

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -2,6 +2,8 @@
 *REMOVED*~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> System.Collections.Generic.IList<Microsoft.Maui.Controls.VisualStateGroup>
 ~Microsoft.Maui.Controls.Binding.ConverterCulture.get -> System.Globalization.CultureInfo
 ~Microsoft.Maui.Controls.Binding.ConverterCulture.set -> void
+~Microsoft.Maui.Controls.MultiBinding.ConverterCulture.get -> System.Globalization.CultureInfo
+~Microsoft.Maui.Controls.MultiBinding.ConverterCulture.set -> void
 ~Microsoft.Maui.Controls.Internals.TypedBindingBase.ConverterCulture.get -> System.Globalization.CultureInfo
 ~Microsoft.Maui.Controls.Internals.TypedBindingBase.ConverterCulture.set -> void
 ~Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.get -> string

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,5 +1,19 @@
 #nullable enable
 *REMOVED*~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> System.Collections.Generic.IList<Microsoft.Maui.Controls.VisualStateGroup>
+~Microsoft.Maui.Controls.Binding.ConverterCulture.get -> System.Globalization.CultureInfo
+~Microsoft.Maui.Controls.Binding.ConverterCulture.set -> void
+~Microsoft.Maui.Controls.Internals.TypedBindingBase.ConverterCulture.get -> System.Globalization.CultureInfo
+~Microsoft.Maui.Controls.Internals.TypedBindingBase.ConverterCulture.set -> void
+~Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.get -> string
+~Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.set -> void
+~Microsoft.Maui.Controls.BaseShellItem.BadgeColor.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.BaseShellItem.BadgeColor.set -> void
+~Microsoft.Maui.Controls.BaseShellItem.BadgeText.get -> string
+~Microsoft.Maui.Controls.BaseShellItem.BadgeText.set -> void
+~Microsoft.Maui.Controls.BaseShellItem.BadgeTextColor.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.BaseShellItem.BadgeTextColor.set -> void
+~Microsoft.Maui.Controls.BoxView.Fill.get -> Microsoft.Maui.Controls.Brush
+~Microsoft.Maui.Controls.BoxView.Fill.set -> void
 Microsoft.Maui.Controls.BoxView.~BoxView() -> void
 Microsoft.Maui.Controls.HybridWebView.Invoker.get -> Microsoft.Maui.HybridWebViewInvoker!
 Microsoft.Maui.Controls.HybridWebView.Invoker.set -> void
@@ -50,16 +64,6 @@ static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.NumberOfTouch
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.StateProperty -> Microsoft.Maui.Controls.BindableProperty!
 virtual Microsoft.Maui.Controls.LongPressedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
-~Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.get -> string
-~Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.set -> void
-~Microsoft.Maui.Controls.BaseShellItem.BadgeColor.get -> Microsoft.Maui.Graphics.Color
-~Microsoft.Maui.Controls.BaseShellItem.BadgeColor.set -> void
-~Microsoft.Maui.Controls.BaseShellItem.BadgeText.get -> string
-~Microsoft.Maui.Controls.BaseShellItem.BadgeText.set -> void
-~Microsoft.Maui.Controls.BaseShellItem.BadgeTextColor.get -> Microsoft.Maui.Graphics.Color
-~Microsoft.Maui.Controls.BaseShellItem.BadgeTextColor.set -> void
-~Microsoft.Maui.Controls.BoxView.Fill.get -> Microsoft.Maui.Controls.Brush
-~Microsoft.Maui.Controls.BoxView.Fill.set -> void
 ~Microsoft.Maui.Controls.Editor.ReturnCommand.get -> System.Windows.Input.ICommand
 ~Microsoft.Maui.Controls.Editor.ReturnCommand.set -> void
 ~Microsoft.Maui.Controls.Editor.ReturnCommandParameter.get -> object

--- a/src/Controls/src/Core/TypedBinding.cs
+++ b/src/Controls/src/Core/TypedBinding.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Maui.Controls.Internals
 	{
 		IValueConverter _converter;
 		object _converterParameter;
+		CultureInfo _converterCulture;
 		object _source;
 		string _updateSourceEventName;
 
@@ -41,6 +42,20 @@ namespace Microsoft.Maui.Controls.Internals
 				_converterParameter = value;
 			}
 		}
+
+		/// <summary>Gets or sets the culture information used by the converter.</summary>
+		[TypeConverter(typeof(CultureInfoConverter))]
+		public CultureInfo ConverterCulture
+		{
+			get { return _converterCulture ?? CultureInfo.CurrentUICulture; }
+			set
+			{
+				ThrowIfApplied();
+				_converterCulture = value;
+			}
+		}
+
+		internal CultureInfo ConverterCultureValue => _converterCulture;
 
 		/// <summary>Gets or sets the source object for the binding.</summary>
 		public object Source
@@ -237,6 +252,7 @@ namespace Microsoft.Maui.Controls.Internals
 				Mode = Mode,
 				Converter = Converter,
 				ConverterParameter = ConverterParameter,
+				ConverterCulture = ConverterCultureValue,
 				StringFormat = StringFormat,
 				Source = Source,
 				UpdateSourceEventName = UpdateSourceEventName,
@@ -263,7 +279,7 @@ namespace Microsoft.Maui.Controls.Internals
 		internal override object GetSourceValue(object value, Type targetPropertyType)
 		{
 			if (Converter != null)
-				value = Converter.Convert(value, targetPropertyType, ConverterParameter, CultureInfo.CurrentUICulture);
+				value = Converter.Convert(value, targetPropertyType, ConverterParameter, ConverterCulture);
 
 			return base.GetSourceValue(value, targetPropertyType);
 		}
@@ -271,7 +287,7 @@ namespace Microsoft.Maui.Controls.Internals
 		internal override object GetTargetValue(object value, Type sourcePropertyType)
 		{
 			if (Converter != null)
-				value = Converter.ConvertBack(value, sourcePropertyType, ConverterParameter, CultureInfo.CurrentUICulture);
+				value = Converter.ConvertBack(value, sourcePropertyType, ConverterParameter, ConverterCulture);
 
 			//return base.GetTargetValue(value, sourcePropertyType);
 			return value;

--- a/src/Controls/src/SourceGen/CompiledBindingMarkup.cs
+++ b/src/Controls/src/SourceGen/CompiledBindingMarkup.cs
@@ -92,6 +92,7 @@ internal struct CompiledBindingMarkup
 			propertyFlags |= BindingPropertyFlags.FallbackValue;
 		if (_node.HasProperty("TargetNullValue"))
 			propertyFlags |= BindingPropertyFlags.TargetNullValue;
+		var hasConverterCulture = !isTemplateBinding && _node.HasProperty("ConverterCulture");
 
 		//Generate the complete inline binding creation method
 		using var stringWriter = new StringWriter();
@@ -191,7 +192,7 @@ internal struct CompiledBindingMarkup
 		code.Indent--;
 
 		// Object initializer if any properties are set
-		if (propertyFlags != BindingPropertyFlags.None)
+		if (propertyFlags != BindingPropertyFlags.None || hasConverterCulture)
 		{
 			code.WriteLine();
 			code.WriteLine("{");
@@ -203,6 +204,8 @@ internal struct CompiledBindingMarkup
 				code.WriteLine("Converter = extension.Converter,");
 			if (propertyFlags.HasFlag(BindingPropertyFlags.ConverterParameter))
 				code.WriteLine("ConverterParameter = extension.ConverterParameter,");
+			if (hasConverterCulture)
+				code.WriteLine("ConverterCulture = extension.ConverterCulture,");
 			if (propertyFlags.HasFlag(BindingPropertyFlags.StringFormat))
 				code.WriteLine("StringFormat = extension.StringFormat,");
 			if (propertyFlags.HasFlag(BindingPropertyFlags.Source))

--- a/src/Controls/src/SourceGen/KnownMarkups.cs
+++ b/src/Controls/src/SourceGen/KnownMarkups.cs
@@ -451,7 +451,7 @@ internal class KnownMarkups
 				{
 					if (converterCultureNode is ValueNode { Value: string converterCulture })
 					{
-						expression += $"ConverterCulture = (global::System.Globalization.CultureInfo)new global::System.ComponentModel.CultureInfoConverter().ConvertFromInvariantString({SymbolDisplay.FormatLiteral(converterCulture, true)})!, ";
+						expression += $"ConverterCulture = global::System.Globalization.CultureInfo.GetCultureInfo({SymbolDisplay.FormatLiteral(converterCulture, true)}), ";
 					}
 					else
 					{

--- a/src/Controls/src/SourceGen/KnownMarkups.cs
+++ b/src/Controls/src/SourceGen/KnownMarkups.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Xml;
 
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Maui.Controls.Xaml;
 
 using static System.String;
@@ -404,10 +405,15 @@ internal class KnownMarkups
 			}
 			else
 			{
-				value = expression +
-					$"{{ UpdateSourceEventName = {extVariable.ValueAccessor}.UpdateSourceEventName, " +
-					$"FallbackValue = {extVariable.ValueAccessor}.FallbackValue, " +
-					$"TargetNullValue = {extVariable.ValueAccessor}.TargetNullValue }}";
+				var objectInitializer = new StringBuilder()
+					.Append($"{{ UpdateSourceEventName = {extVariable.ValueAccessor}.UpdateSourceEventName, ");
+				if (markupNode.HasProperty("ConverterCulture"))
+					objectInitializer.Append($"ConverterCulture = {extVariable.ValueAccessor}.ConverterCulture, ");
+				objectInitializer
+					.Append($"FallbackValue = {extVariable.ValueAccessor}.FallbackValue, ")
+					.Append($"TargetNullValue = {extVariable.ValueAccessor}.TargetNullValue }}");
+
+				value = expression + objectInitializer;
 				return true;
 			}
 		}
@@ -441,6 +447,17 @@ internal class KnownMarkups
 				expression += ") {";
 				if (markupNode.Properties.TryGetValue(new XmlName(null, "UpdateSourceEventName"), out var updateSourceEventNameNode))
 					expression += $"UpdateSourceEventName = {getNodeValue(updateSourceEventNameNode, context.Compilation.GetTypeByMetadataName("System.String")!).ValueAccessor}, ";
+				if (markupNode.Properties.TryGetValue(new XmlName(null, "ConverterCulture"), out var converterCultureNode))
+				{
+					if (converterCultureNode is ValueNode { Value: string converterCulture })
+					{
+						expression += $"ConverterCulture = (global::System.Globalization.CultureInfo)new global::System.ComponentModel.CultureInfoConverter().ConvertFromInvariantString({SymbolDisplay.FormatLiteral(converterCulture, true)})!, ";
+					}
+					else
+					{
+						expression += $"ConverterCulture = {getNodeValue(converterCultureNode, context.Compilation.GetTypeByMetadataName("System.Globalization.CultureInfo")!).ValueAccessor}, ";
+					}
+				}
 				if (markupNode.Properties.TryGetValue(new XmlName(null, "FallbackValue"), out var fallbackValueNode))
 					expression += $"FallbackValue = {getNodeValue(fallbackValueNode, context.Compilation.GetTypeByMetadataName("System.Object")!).ValueAccessor}, ";
 				if (markupNode.Properties.TryGetValue(new XmlName(null, "TargetNullValue"), out var targetNullValueNode))

--- a/src/Controls/src/Xaml/MarkupExtensions/BindingExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/BindingExtension.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using Microsoft.Maui.Controls.Internals;
 
 namespace Microsoft.Maui.Controls.Xaml
@@ -31,6 +32,12 @@ namespace Microsoft.Maui.Controls.Xaml
 		/// Gets or sets a parameter to pass to the converter.
 		/// </summary>
 		public object ConverterParameter { get; set; }
+
+		/// <summary>
+		/// Gets or sets the culture information used by the converter.
+		/// </summary>
+		[TypeConverter(typeof(CultureInfoConverter))]
+		public CultureInfo ConverterCulture { get; set; }
 
 		/// <summary>
 		/// Gets or sets a format string to use when converting the bound value to a string.
@@ -70,6 +77,7 @@ namespace Microsoft.Maui.Controls.Xaml
 			TypedBinding.Mode = Mode;
 			TypedBinding.Converter = Converter;
 			TypedBinding.ConverterParameter = ConverterParameter;
+			TypedBinding.ConverterCulture = ConverterCulture;
 			TypedBinding.StringFormat = StringFormat;
 			TypedBinding.Source = Source;
 			TypedBinding.UpdateSourceEventName = UpdateSourceEventName;
@@ -92,6 +100,7 @@ namespace Microsoft.Maui.Controls.Xaml
 				}
 				return new Binding(Path, Mode, Converter, ConverterParameter, StringFormat, Source)
 				{
+					ConverterCulture = ConverterCulture,
 					UpdateSourceEventName = UpdateSourceEventName,
 					FallbackValue = FallbackValue,
 					TargetNullValue = TargetNullValue,

--- a/src/Controls/src/Xaml/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Xaml/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+~Microsoft.Maui.Controls.Xaml.BindingExtension.ConverterCulture.get -> System.Globalization.CultureInfo
+~Microsoft.Maui.Controls.Xaml.BindingExtension.ConverterCulture.set -> void

--- a/src/Controls/src/Xaml/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Xaml/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+~Microsoft.Maui.Controls.Xaml.BindingExtension.ConverterCulture.get -> System.Globalization.CultureInfo
+~Microsoft.Maui.Controls.Xaml.BindingExtension.ConverterCulture.set -> void

--- a/src/Controls/src/Xaml/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Xaml/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+~Microsoft.Maui.Controls.Xaml.BindingExtension.ConverterCulture.get -> System.Globalization.CultureInfo
+~Microsoft.Maui.Controls.Xaml.BindingExtension.ConverterCulture.set -> void

--- a/src/Controls/src/Xaml/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Xaml/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+~Microsoft.Maui.Controls.Xaml.BindingExtension.ConverterCulture.get -> System.Globalization.CultureInfo
+~Microsoft.Maui.Controls.Xaml.BindingExtension.ConverterCulture.set -> void

--- a/src/Controls/src/Xaml/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Xaml/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+~Microsoft.Maui.Controls.Xaml.BindingExtension.ConverterCulture.get -> System.Globalization.CultureInfo
+~Microsoft.Maui.Controls.Xaml.BindingExtension.ConverterCulture.set -> void

--- a/src/Controls/src/Xaml/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Xaml/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+~Microsoft.Maui.Controls.Xaml.BindingExtension.ConverterCulture.get -> System.Globalization.CultureInfo
+~Microsoft.Maui.Controls.Xaml.BindingExtension.ConverterCulture.set -> void

--- a/src/Controls/src/Xaml/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Xaml/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+~Microsoft.Maui.Controls.Xaml.BindingExtension.ConverterCulture.get -> System.Globalization.CultureInfo
+~Microsoft.Maui.Controls.Xaml.BindingExtension.ConverterCulture.set -> void

--- a/src/Controls/tests/Core.UnitTests/BindingConverterCultureTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindingConverterCultureTests.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Globalization;
+using System.Threading;
+using Microsoft.Maui.Controls.Internals;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	public class BindingConverterCultureTests : BaseTestFixture
+	{
+		[Fact]
+		public void BindingConverterCultureOverridesCurrentUICulture()
+		{
+			var originalCulture = Thread.CurrentThread.CurrentUICulture;
+
+			try
+			{
+				Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-US");
+
+				var vm = new MockViewModel { Text = "Text" };
+				var bindable = new MockBindable { BindingContext = vm };
+				bindable.SetBinding(MockBindable.TextProperty, new Binding("Text", converter: new CultureNameConverter())
+				{
+					ConverterCulture = new CultureInfo("nl-NL")
+				});
+
+				Assert.Equal("nl-NL", bindable.Text);
+
+				bindable.SetValueFromRenderer(MockBindable.TextProperty, "Updated");
+
+				Assert.Equal("nl-NL", vm.Text);
+			}
+			finally
+			{
+				Thread.CurrentThread.CurrentUICulture = originalCulture;
+			}
+		}
+
+		[Fact]
+		public void TypedBindingConverterCultureOverridesCurrentUICulture()
+		{
+			var originalCulture = Thread.CurrentThread.CurrentUICulture;
+
+			try
+			{
+				Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-US");
+
+				var vm = new MockViewModel { Text = "Text" };
+				var bindable = new MockBindable { BindingContext = vm };
+				bindable.SetBinding(MockBindable.TextProperty, CreateTypedBinding(new CultureInfo("nl-NL")));
+
+				Assert.Equal("nl-NL", bindable.Text);
+
+				bindable.SetValueFromRenderer(MockBindable.TextProperty, "Updated");
+
+				Assert.Equal("nl-NL", vm.Text);
+			}
+			finally
+			{
+				Thread.CurrentThread.CurrentUICulture = originalCulture;
+			}
+		}
+
+		[Fact]
+		public void ClonesPreserveExplicitConverterCulture()
+		{
+			var culture = new CultureInfo("nl-NL");
+
+			var bindingClone = (Binding)new Binding(".", converter: new CultureNameConverter())
+			{
+				ConverterCulture = culture
+			}.Clone();
+
+			var typedBindingClone = (TypedBinding<MockViewModel, string>)CreateTypedBinding(culture).Clone();
+
+			Assert.Same(culture, bindingClone.ConverterCulture);
+			Assert.Same(culture, typedBindingClone.ConverterCulture);
+		}
+
+		[Fact]
+		public void ClonesKeepUnsetConverterCultureDynamic()
+		{
+			var originalCulture = Thread.CurrentThread.CurrentUICulture;
+
+			try
+			{
+				Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-US");
+
+				var bindingClone = (Binding)new Binding(".", converter: new CultureNameConverter()).Clone();
+				var typedBindingClone = (TypedBinding<MockViewModel, string>)CreateTypedBinding().Clone();
+
+				Thread.CurrentThread.CurrentUICulture = new CultureInfo("nl-NL");
+
+				Assert.Equal("nl-NL", bindingClone.ConverterCulture.Name);
+				Assert.Equal("nl-NL", typedBindingClone.ConverterCulture.Name);
+			}
+			finally
+			{
+				Thread.CurrentThread.CurrentUICulture = originalCulture;
+			}
+		}
+
+		static TypedBinding<MockViewModel, string> CreateTypedBinding(CultureInfo culture = null)
+		{
+			var binding = new TypedBinding<MockViewModel, string>(
+				getter: vm => (vm.Text, true),
+				setter: (vm, value) => vm.Text = value,
+				handlers: new[]
+				{
+					new Tuple<Func<MockViewModel, object>, string>(vm => vm, nameof(MockViewModel.Text))
+				})
+			{
+				Converter = new CultureNameConverter()
+			};
+
+			if (culture is not null)
+				binding.ConverterCulture = culture;
+
+			return binding;
+		}
+
+		class CultureNameConverter : IValueConverter
+		{
+			public object Convert(object value, Type targetType, object parameter, CultureInfo culture) => culture.Name;
+
+			public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => culture.Name;
+		}
+	}
+}

--- a/src/Controls/tests/Core.UnitTests/MultiBindingTests.cs
+++ b/src/Controls/tests/Core.UnitTests/MultiBindingTests.cs
@@ -541,6 +541,109 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal("Hello FOO 042 BAZ", bindable.GetValue(property));
 		}
 
+		[Fact]
+		public void ConverterCulturePassedToConvert()
+		{
+			var property = BindableProperty.Create("foo", typeof(string), typeof(MockBindable), null);
+			var bindable = new MockBindable
+			{
+				BindingContext = new { foo = "FOO", bar = "BAR" }
+			};
+			var converter = new CultureReportingMultiConverter();
+			var culture = CultureInfo.GetCultureInfo("nl-NL");
+
+			bindable.SetBinding(property, new MultiBinding
+			{
+				Bindings =
+				{
+					new Binding("foo"),
+					new Binding("bar"),
+				},
+				Converter = converter,
+				ConverterCulture = culture,
+			});
+
+			Assert.Equal("nl-NL", bindable.GetValue(property));
+			Assert.Same(culture, converter.ConvertCulture);
+		}
+
+		[Fact]
+		public void ConverterCulturePassedToConvertBack()
+		{
+			var viewModel = new PersonViewModel
+			{
+				FirstName = "Jane",
+				MiddleName = "A.",
+				LastName = "Doe",
+			};
+			var label = new Label
+			{
+				BindingContext = viewModel
+			};
+			var converter = new CultureReportingMultiConverter();
+			var culture = CultureInfo.GetCultureInfo("nl-NL");
+
+			label.SetBinding(Label.TextProperty, new MultiBinding
+			{
+				Bindings =
+				{
+					new Binding(nameof(PersonViewModel.FirstName)),
+					new Binding(nameof(PersonViewModel.MiddleName)),
+					new Binding(nameof(PersonViewModel.LastName)),
+				},
+				Converter = converter,
+				ConverterCulture = culture,
+				Mode = BindingMode.TwoWay,
+			});
+
+			label.SetValueCore(Label.TextProperty, "John Q. Public", Internals.SetValueFlags.None, BindableObject.SetValuePrivateFlags.Default, SetterSpecificity.ManualValueSetter);
+
+			Assert.Same(culture, converter.ConvertBackCulture);
+			Assert.Equal("John", viewModel.FirstName);
+			Assert.Equal("Q.", viewModel.MiddleName);
+			Assert.Equal("Public", viewModel.LastName);
+		}
+
+		[Fact]
+		public void ClonePreservesExplicitConverterCulture()
+		{
+			var culture = CultureInfo.GetCultureInfo("nl-NL");
+			var binding = new MultiBinding
+			{
+				Bindings = { new Binding("foo") },
+				Converter = new CultureReportingMultiConverter(),
+				ConverterCulture = culture,
+			};
+
+			var clone = (MultiBinding)binding.Clone();
+
+			Assert.Same(culture, clone.ConverterCulture);
+		}
+
+		[Fact]
+		public void ClonePreservesDynamicDefaultConverterCulture()
+		{
+			var binding = new MultiBinding
+			{
+				Bindings = { new Binding("foo") },
+				Converter = new CultureReportingMultiConverter(),
+			};
+
+			var oldCulture = CultureInfo.CurrentUICulture;
+			try
+			{
+				CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
+				var clone = (MultiBinding)binding.Clone();
+				CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("nl-NL");
+
+				Assert.Equal(CultureInfo.GetCultureInfo("nl-NL"), clone.ConverterCulture);
+			}
+			finally
+			{
+				CultureInfo.CurrentUICulture = oldCulture;
+			}
+		}
+
 		private Label GenerateNameLabel(string person, BindingMode mode)
 		{
 			var label = new Label();
@@ -701,6 +804,25 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 						array[i] = Binding.DoNothing;
 				}
 				return array;
+			}
+		}
+
+		public class CultureReportingMultiConverter : IMultiValueConverter
+		{
+			public CultureInfo ConvertCulture { get; private set; }
+
+			public CultureInfo ConvertBackCulture { get; private set; }
+
+			public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+			{
+				ConvertCulture = culture;
+				return culture.Name;
+			}
+
+			public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+			{
+				ConvertBackCulture = culture;
+				return (value as string)?.Split(' ').Cast<object>().ToArray();
 			}
 		}
 

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui5696.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui5696.xaml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+	x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui5696">
+	<ContentPage.Resources>
+		<local:Maui5696Converter x:Key="CultureConverter" />
+	</ContentPage.Resources>
+	<VerticalStackLayout x:DataType="local:Maui5696ViewModel">
+		<Label
+			x:Name="label"
+			Text="{Binding Text, Converter={StaticResource CultureConverter}, ConverterCulture='nl-NL'}" />
+	</VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui5696.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui5696.xaml.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Globalization;
+using System.Threading;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui5696 : ContentPage
+{
+	public Maui5696()
+	{
+		InitializeComponent();
+	}
+
+	[Collection("Issue")]
+	public class Tests
+	{
+		[Theory]
+		[XamlInflatorData]
+		internal void BindingConverterCultureOverridesCurrentUICulture(XamlInflator inflator)
+		{
+			var originalCulture = Thread.CurrentThread.CurrentUICulture;
+
+			try
+			{
+				Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-US");
+
+				var page = new Maui5696(inflator)
+				{
+					BindingContext = new Maui5696ViewModel { Text = "Text" }
+				};
+
+				Assert.Equal("nl-NL", page.label.Text);
+			}
+			finally
+			{
+				Thread.CurrentThread.CurrentUICulture = originalCulture;
+			}
+		}
+	}
+}
+
+public class Maui5696ViewModel
+{
+	public string Text { get; set; } = string.Empty;
+}
+
+public class Maui5696Converter : IValueConverter
+{
+	public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		=> culture.Name;
+
+	public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		=> culture.Name;
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description

Adds `Binding.ConverterCulture` support for #5696 so bindings can pass an explicit `CultureInfo` to `IValueConverter.Convert` and `ConvertBack` instead of always using `CultureInfo.CurrentUICulture`.

The implementation preserves existing `Binding` constructor signatures and wires the property through runtime bindings, typed bindings, runtime XAML, XamlC, and source-generated XAML.

This intentionally does not add new `ConverterCulture` APIs to `MultiBinding` or `TemplateBinding`. `MultiBinding` parity can be considered separately, and `TemplateBinding` has no `ConverterCulture` property to propagate.

### Issues Fixed

Fixes #5696

### Testing

- `git diff --check`
- `dotnet build src/Controls/src/Build.Tasks/Controls.Build.Tasks.csproj --no-restore`
- `dotnet build src/Controls/src/SourceGen/Controls.SourceGen.csproj --no-restore`
- `dotnet test src/Controls/tests/BindingSourceGen.UnitTests/Controls.BindingSourceGen.UnitTests.csproj --no-restore`
- `dotnet test src/Controls/tests/SourceGen.UnitTests/SourceGen.UnitTests.csproj --no-restore`
- `LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 dotnet test src/Controls/tests/Core.UnitTests/Controls.Core.UnitTests.csproj --no-restore`
- `LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 dotnet test src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj --no-restore -p:WarningsNotAsErrors=XC0618%3BXC0619%3BXC0022%3BXC0023%3BXC0025%3BXC0045%3BXC0067%3BMAUIG2045%3BMAUID1000%3BMAUIX2005%3BMAUIX2015%3BMAUIX2017`