### PR TITLE
Fix CarouselView tests fail in June 8 Candidate

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		bool _initialized;
 		bool _isVisible;
 		bool _disposed;
+		bool? _lastLoopValue;
 		bool _isInternalPositionUpdate;
 
 		List<View> _oldViews;
@@ -90,6 +91,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		public override void SetUpNewElement(CarouselView newElement)
 		{
 			base.SetUpNewElement(newElement);
+			_lastLoopValue = null;
 
 			AddLayoutListener();
 			UpdateItemSpacing();
@@ -342,6 +344,17 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			{
 				return;
 			}
+
+			var loopValue = Carousel.Loop;
+
+			// Ignore startup mapper call and repeated same-value mapper calls.
+			if (!_initialized || (_lastLoopValue.HasValue && _lastLoopValue.Value == loopValue))
+			{
+				_lastLoopValue = loopValue;
+				return;
+			}
+
+			_lastLoopValue = loopValue;
 
 			// Preserve both the Position and the CurrentItem because UpdateAdapter() resets
 			// CarouselView.Position to 0 and CarouselView.CurrentItem to null on rebuild.

--- a/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
@@ -107,6 +107,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			if (ItemsView is not null)
 				ItemsView.Scrolled -= CarouselViewScrolled;
 
+			// Reset lifecycle state so the next element setup starts cleanly.
+			_initialized = false;
+			_lastLoopValue = null;
+
 			ClearLayoutListener();
 			UnsubscribeCollectionItemsSourceChanged(ItemsViewAdapter);
 			base.TearDownOldElement(oldElement);
@@ -346,15 +350,14 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			}
 
 			var loopValue = Carousel.Loop;
+			var previousLoopValue = _lastLoopValue;
+			_lastLoopValue = loopValue;
 
 			// Ignore startup mapper call and repeated same-value mapper calls.
-			if (!_initialized || (_lastLoopValue.HasValue && _lastLoopValue.Value == loopValue))
+			if (!_initialized || !previousLoopValue.HasValue || previousLoopValue.Value == loopValue)
 			{
-				_lastLoopValue = loopValue;
 				return;
 			}
-
-			_lastLoopValue = loopValue;
 
 			// Preserve both the Position and the CurrentItem because UpdateAdapter() resets
 			// CarouselView.Position to 0 and CarouselView.CurrentItem to null on rebuild.


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Issue Details
On Android, CarouselViewHandler.MapLoop can invoke MauiCarouselRecyclerView.UpdateLoop multiple times during handler setup/lifecycle even when Loop value has not changed.

This causes redundant adapter rebuild + position restoration + scroll operations during first render.

### Description of Change

<!-- Enter description of the fix in this section -->
Updated Android MauiCarouselRecyclerView.UpdateLoop to short-circuit redundant executions:
* Ignore startup mapper invocation before initialization.
* Ignore repeated calls when Loop value is unchanged using cached _lastLoopValue.
* Execute loop update logic only for real runtime Loop value changes.

### Failed test cases
* CarouselViewShouldRenderCorrectly
* VerifySpacingAffectsItemSize
* Issue29772ItemSpaceShouldApply