### PR TITLE
Fix /review trigger lock label permissions

### DIFF
--- a/.github/scripts/shared/Update-AgentLabels.ps1
+++ b/.github/scripts/shared/Update-AgentLabels.ps1
@@ -140,8 +140,7 @@ function Add-Label {
             return $true
         }
 
-        $message = ($output | ForEach-Object { [string]$_ }) -join "`n"
-        $message = $message.Trim()
+        $message = ($output | Out-String).Trim()
         if ([string]::IsNullOrWhiteSpace($message)) {
             $message = "gh api exited with code $exitCode."
         } elseif ($message.Length -gt 1000) {

--- a/.github/scripts/shared/Update-AgentLabels.ps1
+++ b/.github/scripts/shared/Update-AgentLabels.ps1
@@ -132,10 +132,24 @@ function Add-Label {
     try {
         $tmp = New-TemporaryFile
         @{ labels = @($LabelName) } | ConvertTo-Json -Compress | Set-Content -LiteralPath $tmp -Encoding utf8 -NoNewline
-        & gh api "repos/$Owner/$Repo/issues/$PRNumber/labels" `
+        $output = & gh api "repos/$Owner/$Repo/issues/$PRNumber/labels" `
             --method POST `
-            --input $tmp 1>$null 2>$null
-        return $LASTEXITCODE -eq 0
+            --input $tmp 2>&1
+        $exitCode = $LASTEXITCODE
+        if ($exitCode -eq 0) {
+            return $true
+        }
+
+        $message = ($output | ForEach-Object { [string]$_ }) -join "`n"
+        $message = $message.Trim()
+        if ([string]::IsNullOrWhiteSpace($message)) {
+            $message = "gh api exited with code $exitCode."
+        } elseif ($message.Length -gt 1000) {
+            $message = $message.Substring(0, 1000) + '...'
+        }
+
+        Write-Host "  ⚠️  Failed to add label '$LabelName' to PR #$PRNumber (gh api exit code $exitCode): $message" -ForegroundColor Yellow
+        return $false
     } finally {
         if ($tmp) {
             Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue

--- a/.github/workflows/review-trigger.yml
+++ b/.github/workflows/review-trigger.yml
@@ -151,7 +151,7 @@ jobs:
       id-token: write
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Check actor permission
         if: github.event_name == 'issue_comment'


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

- Gives the normal `/review` trigger job `pull-requests: write`, matching the rerun job, so it can apply the `s/agent-review-in-progress` lock label before dispatching the AzDO pipeline.
- Logs the actual `gh api` response when adding a label fails, instead of suppressing stderr and returning only a generic failure.

## Why this broke

`/review -b feature/enhanced-reviewer` was still parsed correctly; the failure was introduced by a default-branch workflow change. The last successful trigger on PR #33365 ran on workflow SHA `c389325e`, before the `Set review in-progress lock` step existed. After `main` moved to `dd5b6d2`, the normal `/review` path started applying `s/agent-review-in-progress` before dispatching AzDO, but that job still only requested `pull-requests: read`.

The rerun path already requested `pull-requests: write` and could apply labels successfully. This PR aligns the normal `/review` path with that permission so the lock label can be applied and the AzDO pipeline dispatch can proceed.

## Validation

- `git diff --check`
- Parsed `.github/workflows/review-trigger.yml` with Ruby YAML
- Fake `gh` success/failure checks for `Add-Label`
- `Invoke-Pester .github/scripts -CI`
- `Invoke-Pester .github/skills -CI`

## Fixes

- Fixes `/review -b feature/enhanced-reviewer` failing before AzDO dispatch at `Set review in-progress lock`.

