### PR TITLE
Fix s_currentTweener++ in AnimationExtensions is not thread-safe, producing duplicate animation IDs

### DIFF
--- a/src/Controls/src/Core/AnimationExtensions.cs
+++ b/src/Controls/src/Core/AnimationExtensions.cs
@@ -28,6 +28,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Threading;
 using Microsoft.Maui.Animations;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Dispatching;
@@ -64,7 +65,7 @@ namespace Microsoft.Maui.Controls
 
 		public static int Add(this IAnimationManager animationManager, Action<double> step)
 		{
-			var id = s_currentTweener++;
+			var id = Interlocked.Increment(ref s_currentTweener);
 			var animation = new Animation
 			{
 				Name = $"{id}",
@@ -84,7 +85,7 @@ namespace Microsoft.Maui.Controls
 
 		public static int Insert(this IAnimationManager animationManager, Func<long, bool> step)
 		{
-			var id = s_currentTweener++;
+			var id = Interlocked.Increment(ref s_currentTweener);
 			Animation animation = null;
 			animation = new TweenerAnimation(step)
 			{

--- a/src/Controls/tests/Core.UnitTests/AnimationExtensionsThreadSafetyTests.cs
+++ b/src/Controls/tests/Core.UnitTests/AnimationExtensionsThreadSafetyTests.cs
@@ -1,0 +1,88 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Maui.Animations;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	public class AnimationExtensionsThreadSafetyTests
+	{
+		[Fact]
+		public void Add_ConcurrentCalls_ProducesUniqueIds()
+		{
+			// Exercises the REAL AnimationExtensions.Add() from multiple threads.
+			// If the fix is reverted (s_currentTweener++ instead of Interlocked.Increment),
+			// this test will fail with duplicate IDs under contention.
+			var manager = new NoOpAnimationManager();
+			const int threadCount = 50;
+			const int callsPerThread = 200;
+			var ids = new ConcurrentBag<int>();
+
+			var tasks = new Task[threadCount];
+			for (int i = 0; i < threadCount; i++)
+			{
+				tasks[i] = Task.Run(() =>
+				{
+					for (int j = 0; j < callsPerThread; j++)
+					{
+						int id = manager.Add(_ => { });
+						ids.Add(id);
+					}
+				});
+			}
+
+			Task.WaitAll(tasks);
+
+			int expectedCount = threadCount * callsPerThread;
+			var uniqueIds = new HashSet<int>(ids);
+
+			Assert.Equal(expectedCount, ids.Count);
+			Assert.Equal(expectedCount, uniqueIds.Count);
+		}
+
+		[Fact]
+		public void Insert_ConcurrentCalls_ProducesUniqueIds()
+		{
+			// Same as above but exercises AnimationExtensions.Insert().
+			var manager = new NoOpAnimationManager();
+			const int threadCount = 50;
+			const int callsPerThread = 200;
+			var ids = new ConcurrentBag<int>();
+
+			var tasks = new Task[threadCount];
+			for (int i = 0; i < threadCount; i++)
+			{
+				tasks[i] = Task.Run(() =>
+				{
+					for (int j = 0; j < callsPerThread; j++)
+					{
+						int id = manager.Insert(_ => true);
+						ids.Add(id);
+					}
+				});
+			}
+
+			Task.WaitAll(tasks);
+
+			int expectedCount = threadCount * callsPerThread;
+			var uniqueIds = new HashSet<int>(ids);
+
+			Assert.Equal(expectedCount, ids.Count);
+			Assert.Equal(expectedCount, uniqueIds.Count);
+		}
+
+		/// <summary>
+		/// Minimal no-op IAnimationManager so AnimationExtensions.Add/Insert can run
+		/// without requiring a platform ticker (which would block or crash off-thread).
+		/// </summary>
+		sealed class NoOpAnimationManager : IAnimationManager
+		{
+			public ITicker Ticker => null!;
+			public double SpeedModifier { get; set; } = 1;
+			public bool AutoStartTicker { get; set; }
+			public void Add(Microsoft.Maui.Animations.Animation animation) { }
+			public void Remove(Microsoft.Maui.Animations.Animation animation) { }
+		}
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details

- s_currentTweener++ at lines 67 and 87 of src/Controls/src/Core/AnimationExtensions.cs is a non-atomic read-modify-write operation. When multiple threads call AnimationExtensions.Add() or Insert() concurrently (which happens via finalizer thread access as documented in the code comments), two threads can read the same value and produce duplicate IDs. These duplicates overwrite entries in s_tweeners (a ConcurrentDictionary), causing silently lost animations.


### Description of Change

**Thread safety improvements:**

* Replaced the use of `s_currentTweener++` with `Interlocked.Increment(ref s_currentTweener)` in both the `Add` and `Insert` methods of `AnimationExtensions` to ensure unique IDs are generated safely when accessed by multiple threads. 
* Added `using System.Threading;` to support atomic operations.

**Testing enhancements:**

* Introduced a new test suite `AnimationExtensionsThreadSafetyTests` that verifies `Add` and `Insert` produce unique IDs even under high concurrency, preventing regressions in thread safety. This includes a minimal `NoOpAnimationManager` implementation for testing purposes.

**Reference** - https://github.com/dotnet/maui/blob/main/src/Controls/src/Core/DataTemplate.cs#L22

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #35837

### Tested the behaviour in the following platforms

- [x] - Windows 
- [x] - Android
- [x] - iOS
- [x] - Mac

| Before | After |
|----------|----------|
| <img src="https://github.com/user-attachments/assets/2fe0fdc1-790a-4111-9905-5cb1656c857b"> | <img src="https://github.com/user-attachments/assets/3d6679ec-c89a-4010-aae5-9cec4e2595ac"> |



<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
