### PR TITLE
[Android] Fix WebView.CanGoBack() returning true on first navigated page due to synthetic about:blank history entry

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue35788.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue35788.cs
@@ -1,0 +1,51 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 35788, "[Android] WebView CanGoBack returns true unexpectedly on first page due to spurious about:blank history entry", PlatformAffected.Android)]
+public class Issue35788 : ContentPage
+{
+	const string StatusLabelId = "Issue35788StatusLabel";
+	const string NavigateButtonId = "Issue35788NavigateButton";
+
+	readonly Label _statusLabel;
+	readonly WebView _webView;
+
+	public Issue35788()
+	{
+		_statusLabel = new Label
+		{
+			AutomationId = StatusLabelId,
+			Text = "Waiting"
+		};
+
+		_webView = new WebView
+		{
+			HeightRequest = 300
+		};
+
+		_webView.Navigated += OnWebViewNavigated;
+
+		var navigateButton = new Button
+		{
+			AutomationId = NavigateButtonId,
+			Text = "Load Page"
+		};
+
+		navigateButton.Clicked += (s, e) =>
+			_webView.Source = new HtmlWebViewSource { Html = "<html><body><h1>Hello</h1></body></html>" };
+
+		Content = new VerticalStackLayout
+		{
+			Padding = 20,
+			Spacing = 10,
+			Children = { navigateButton, _statusLabel, _webView }
+		};
+	}
+
+	void OnWebViewNavigated(object sender, WebNavigatedEventArgs e)
+	{
+		if (e.Result == WebNavigationResult.Success)
+			_statusLabel.Text = _webView.CanGoBack ? "CanGoBack=True" : "CanGoBack=False";
+		else
+			_statusLabel.Text = $"NavFailed:{e.Result}";
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35788.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35788.cs
@@ -1,0 +1,32 @@
+#if ANDROID
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue35788 : _IssuesUITest
+{
+	public Issue35788(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue => "[Android] WebView CanGoBack returns true unexpectedly on first page due to spurious about:blank history entry";
+
+	[Test]
+	[Category(UITestCategories.WebView)]
+	public void WebViewCanGoBackShouldBeFalseOnFirstPage()
+	{
+		App.WaitForElement("Issue35788NavigateButton");
+		App.Tap("Issue35788NavigateButton");
+
+		App.WaitForTextToBePresentInElement("Issue35788StatusLabel", "CanGoBack=");
+
+		var statusText = App.FindElement("Issue35788StatusLabel").GetText();
+
+		Assert.That(statusText, Is.EqualTo("CanGoBack=False"),
+			"WebView.CanGoBack should be false on the first navigated page. " +
+			"If true, the about:blank layout entry was not cleared from the native history stack.");
+	}
+}
+#endif

--- a/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
@@ -64,6 +64,12 @@ namespace Microsoft.Maui.Handlers
 					webChromeClient.Disconnect();
 			}
 
+			// Reset layout flag so a stale true value does not trigger ClearHistory()
+			// if this handler is re-connected (e.g., Shell tab switch). (#35788)
+			if (platformView is MauiWebView mauiWebView)
+				mauiWebView.IsLoadingForLayout = false;
+
+			platformView.SetWebViewClient(null!);
 			platformView.SetWebChromeClient(null);
 
 			platformView.StopLoading();

--- a/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
@@ -67,7 +67,9 @@ namespace Microsoft.Maui.Handlers
 			// Reset layout flag so a stale true value does not trigger ClearHistory()
 			// if this handler is re-connected (e.g., Shell tab switch). (#35788)
 			if (platformView is MauiWebView mauiWebView)
+			{
 				mauiWebView.IsLoadingForLayout = false;
+			}
 
 			platformView.SetWebViewClient(null!);
 			platformView.SetWebChromeClient(null);

--- a/src/Core/src/Platform/Android/MauiWebView.cs
+++ b/src/Core/src/Platform/Android/MauiWebView.cs
@@ -21,6 +21,11 @@ namespace Microsoft.Maui.Platform
 		// https://github.com/dotnet/maui/issues/35771
 		bool _isAutoSizing;
 
+		// Tracks whether about:blank was loaded synthetically for layout (null source).
+		// MauiWebViewClient clears this entry from the native back stack once the real URL loads,
+		// preventing CanGoBack() returning true unexpectedly. Fixes #35788.
+		internal bool IsLoadingForLayout { get; set; }
+
 		public MauiWebView(WebViewHandler handler, Context context) : base(context)
 		{
 			_handler = handler ?? throw new ArgumentNullException(nameof(handler));

--- a/src/Core/src/Platform/Android/MauiWebViewClient.cs
+++ b/src/Core/src/Platform/Android/MauiWebViewClient.cs
@@ -56,10 +56,15 @@ namespace Microsoft.Maui.Platform
 		public override void OnPageFinished(WebView? view, string? url)
 		{
 			if (!_handler.TryGetTarget(out var handler) || handler.VirtualView == null || string.IsNullOrWhiteSpace(url))
+			{
 				return;
+			}
 
 			bool navigate = _navigationResult != WebNavigationResult.Failure || !GetValidUrl(url).Equals(_lastUrlNavigatedCancel, StringComparison.OrdinalIgnoreCase);
 			_lastUrlNavigatedCancel = _navigationResult == WebNavigationResult.Cancel ? url : null;
+
+			var mauiWebView = view as MauiWebView;
+			bool isLayoutLoad = mauiWebView?.IsLoadingForLayout == true;
 
 			// Skip Navigated event for about:blank to prevent unwanted events when Source is null
 			if (navigate && !IsBlankNavigation(url))
@@ -67,21 +72,21 @@ namespace Microsoft.Maui.Platform
 				// Clear the synthetic about:blank entry (loaded for layout, see #32030) now that
 				// the real URL is current. ClearHistory() removes all entries except the current
 				// page, ensuring CanGoBack() is already false when Navigated fires (#35788).
-				if (view is MauiWebView mauiWebView && mauiWebView.IsLoadingForLayout)
+				if (isLayoutLoad)
 				{
-					view.ClearHistory();
-					mauiWebView.IsLoadingForLayout = false;
+					mauiWebView!.ClearHistory();
+					mauiWebView!.IsLoadingForLayout = false;
 					// Called BEFORE Navigated fires so user handlers observe CanGoBack=false immediately.
 					handler?.PlatformView?.UpdateCanGoBackForward(handler.VirtualView);
 				}
 
 				handler!.VirtualView.Navigated(handler.CurrentNavigationEvent, GetValidUrl(url), _navigationResult);
 			}
-			else if (view is MauiWebView mv && mv.IsLoadingForLayout && _navigationResult == WebNavigationResult.Failure)
+			else if (isLayoutLoad && _navigationResult == WebNavigationResult.Failure)
 			{
 				// Navigation failed — reset the layout flag so a subsequent successful load
 				// does not incorrectly trigger ClearHistory() (#35788).
-				mv.IsLoadingForLayout = false;
+				mauiWebView!.IsLoadingForLayout = false;
 			}
 
 			handler.SyncPlatformCookiesToVirtualView(url);

--- a/src/Core/src/Platform/Android/MauiWebViewClient.cs
+++ b/src/Core/src/Platform/Android/MauiWebViewClient.cs
@@ -64,12 +64,29 @@ namespace Microsoft.Maui.Platform
 			// Skip Navigated event for about:blank to prevent unwanted events when Source is null
 			if (navigate && !IsBlankNavigation(url))
 			{
-				handler.VirtualView.Navigated(handler.CurrentNavigationEvent, GetValidUrl(url), _navigationResult);
+				// Clear the synthetic about:blank entry (loaded for layout, see #32030) now that
+				// the real URL is current. ClearHistory() removes all entries except the current
+				// page, ensuring CanGoBack() is already false when Navigated fires (#35788).
+				if (view is MauiWebView mauiWebView && mauiWebView.IsLoadingForLayout)
+				{
+					view.ClearHistory();
+					mauiWebView.IsLoadingForLayout = false;
+					// Called BEFORE Navigated fires so user handlers observe CanGoBack=false immediately.
+					handler?.PlatformView?.UpdateCanGoBackForward(handler.VirtualView);
+				}
+
+				handler!.VirtualView.Navigated(handler.CurrentNavigationEvent, GetValidUrl(url), _navigationResult);
+			}
+			else if (view is MauiWebView mv && mv.IsLoadingForLayout && _navigationResult == WebNavigationResult.Failure)
+			{
+				// Navigation failed — reset the layout flag so a subsequent successful load
+				// does not incorrectly trigger ClearHistory() (#35788).
+				mv.IsLoadingForLayout = false;
 			}
 
 			handler.SyncPlatformCookiesToVirtualView(url);
 
-			handler?.PlatformView.UpdateCanGoBackForward(handler.VirtualView);
+			handler?.PlatformView?.UpdateCanGoBackForward(handler.VirtualView);
 
 			// Only inject the scroll-capture observer when the WebView is hosted inside
 			// a RefreshView – avoids unnecessary JS overhead for standalone WebViews.

--- a/src/Core/src/Platform/Android/MauiWebViewClient.cs
+++ b/src/Core/src/Platform/Android/MauiWebViewClient.cs
@@ -82,9 +82,9 @@ namespace Microsoft.Maui.Platform
 
 				handler!.VirtualView.Navigated(handler.CurrentNavigationEvent, GetValidUrl(url), _navigationResult);
 			}
-			else if (isLayoutLoad && _navigationResult == WebNavigationResult.Failure)
+			else if (isLayoutLoad && (_navigationResult == WebNavigationResult.Failure || _navigationResult == WebNavigationResult.Cancel))
 			{
-				// Navigation failed — reset the layout flag so a subsequent successful load
+				// Navigation failed or canceled — reset the layout flag so a subsequent successful load
 				// does not incorrectly trigger ClearHistory() (#35788).
 				mauiWebView!.IsLoadingForLayout = false;
 			}

--- a/src/Core/src/Platform/Android/WebViewExtensions.cs
+++ b/src/Core/src/Platform/Android/WebViewExtensions.cs
@@ -31,12 +31,12 @@ namespace Microsoft.Maui.Platform
 				// is null, preventing overflow in grid cells (#32030). Flag IsLoadingForLayout so
 				// MauiWebViewClient can remove this synthetic entry from the native back stack
 				// once the real URL loads, fixing CanGoBack() returning true unexpectedly (#35788).
-				if (platformWebView is MauiWebView mauiWebView)
+				// Guard: skip when real history exists so ClearHistory() does not destroy back entries.
+				if (platformWebView is MauiWebView mauiWebView && !platformWebView.CanGoBack() && !platformWebView.CanGoForward())
 				{
 					mauiWebView.IsLoadingForLayout = true;
+					platformWebView.LoadUrl("about:blank");
 				}
-
-				platformWebView.LoadUrl("about:blank");
 			}
 		}
 

--- a/src/Core/src/Platform/Android/WebViewExtensions.cs
+++ b/src/Core/src/Platform/Android/WebViewExtensions.cs
@@ -32,7 +32,9 @@ namespace Microsoft.Maui.Platform
 				// MauiWebViewClient can remove this synthetic entry from the native back stack
 				// once the real URL loads, fixing CanGoBack() returning true unexpectedly (#35788).
 				if (platformWebView is MauiWebView mauiWebView)
+				{
 					mauiWebView.IsLoadingForLayout = true;
+				}
 
 				platformWebView.LoadUrl("about:blank");
 			}

--- a/src/Core/src/Platform/Android/WebViewExtensions.cs
+++ b/src/Core/src/Platform/Android/WebViewExtensions.cs
@@ -27,7 +27,13 @@ namespace Microsoft.Maui.Platform
 			}
 			else
 			{
-				// Load about:blank when source is null to ensure proper layout bounds
+				// Load about:blank to constrain the WebView within its layout bounds when source
+				// is null, preventing overflow in grid cells (#32030). Flag IsLoadingForLayout so
+				// MauiWebViewClient can remove this synthetic entry from the native back stack
+				// once the real URL loads, fixing CanGoBack() returning true unexpectedly (#35788).
+				if (platformWebView is MauiWebView mauiWebView)
+					mauiWebView.IsLoadingForLayout = true;
+
 				platformWebView.LoadUrl("about:blank");
 			}
 		}


### PR DESCRIPTION
 <!-- Please let the below note in for people that find this PR -->
   > [!NOTE]
   > Are you waiting for the changes in this PR to be merged?
   > It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. 
  Thank you!
 
## Root Cause

PR #32145 introduced `LoadUrl("about:blank")` inside `WebViewExtensions.UpdateSource()` to fix the layout overflow issue when `WebView.Source` is `null` (#32030).

Although the `Navigated` event was suppressed for this synthetic load via `IsBlankNavigation()`, Android's native WebView unconditionally records every `LoadUrl()` call into its internal history stack. This caused the history on the first real page load to become:

```text
[0] about:blank
[1] real-url
```

As a result, `CanGoBack()` incorrectly returned `true` on the first real page load. Pressing back navigated to the synthetic blank page instead of a real previous page, leaving the user on an empty screen.

## Description of Change

The fix introduces an Android-only `IsLoadingForLayout` flag on `MauiWebView` to track synthetic `about:blank` loads and safely clear them from history after the first real navigation completes.

### MauiWebView.cs

Added internal `bool IsLoadingForLayout` property as a shared state bridge between `WebViewExtensions` and `MauiWebViewClient`.

### WebViewExtensions.cs

Sets `IsLoadingForLayout = true` before triggering `LoadUrl("about:blank")` in the null-source layout path, marking the load as synthetic.

### MauiWebViewClient.cs

In `OnPageFinished`, when a real URL completes while `IsLoadingForLayout` is `true`, calls `ClearHistory()` to remove the synthetic `about:blank` entry while preserving the current page.

The flag is then reset and `UpdateCanGoBackForward()` is invoked before `Navigated` fires, ensuring `CanGoBack = false` is already correct inside user handlers.

If the real navigation fails, the flag is reset immediately so stale state cannot incorrectly clear history on later navigations.

### WebViewHandler.Android.cs

Resets `IsLoadingForLayout = false` inside `DisconnectHandler` to prevent stale state from surviving handler disconnect and reconnect scenarios such as Shell tab switches.

## Regression Introduced By

PR #32145

### Issues Fixed
Fixes #35788 
 
Tested the behaviour in the following platforms
- [x] Android
- [ ] Windows
- [ ] iOS
- [ ] Mac

**Note**: This is an Android-only regression. Android's native WebView unconditionally records every LoadUrl() call into its history stack with no API to suppress individual entries. iOS uses WKWebView and Windows uses WebView2 — both manage history differently and are unaffected. The fix is scoped entirely to Android platform files.

### Screenshots
| Before Issue Fix | After Issue Fix |
|------------------|-----------------|
| <video width="350" alt="withoutfix" src="https://github.com/user-attachments/assets/255b4ab4-f933-4837-85c7-ffb1dbf61d3e" /> | <video width="350" alt="withfix" src="https://github.com/user-attachments/assets/a6f9adf7-91c8-4e9c-aade-ef6e39780b7e" /> |