### PR TITLE
[Testing] Fixed Build error on inflight/current 

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue7814.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue7814.cs
@@ -14,6 +14,8 @@ public class Issue7814 : TestContentPage
 		_verticalOffsetLabel = CreateOffsetLabel("Issue7814VerticalScrollYLabel", VerticalOffsetPrefix);
 		_horizontalOffsetLabel = CreateOffsetLabel("Issue7814HorizontalScrollXLabel", HorizontalOffsetPrefix);
 
+		Grid.SetColumn(_horizontalOffsetLabel, 1);
+
 		var outerScrollView = new ScrollView
 		{
 			AutomationId = "Issue7814OuterScrollView",
@@ -21,6 +23,7 @@ public class Issue7814 : TestContentPage
 			Content = CreateScrollableContent()
 		};
 		outerScrollView.Scrolled += (_, e) => UpdateOffset(_verticalOffsetLabel, VerticalOffsetPrefix, e.ScrollY);
+		Grid.SetRow(outerScrollView, 1);
 
 		Content = new Grid
 		{
@@ -42,10 +45,10 @@ public class Issue7814 : TestContentPage
 					Children =
 					{
 						_verticalOffsetLabel,
-						_horizontalOffsetLabel.Column(1)
+						_horizontalOffsetLabel
 					}
 				},
-				outerScrollView.Row(1)
+				outerScrollView
 			}
 		};
 	}


### PR DESCRIPTION
This pull request makes minor adjustments to the layout initialization in the `Issue7814` test case to improve clarity and consistency in how UI elements are positioned within the grid.

Layout and positioning improvements:

* Explicitly sets the column of `_horizontalOffsetLabel` to 1 using `Grid.SetColumn`, rather than relying on extension methods or implicit positioning.
* Explicitly sets the row of `outerScrollView` to 1 using `Grid.SetRow`, ensuring it appears in the intended grid row.
* Updates the `Children` collection and layout construction to remove the use of extension methods like `.Column(1)` and `.Row(1)`, instead relying on the explicit `Grid.SetColumn` and `Grid.SetRow` calls for clarity.