### PR TITLE
[iOS/Mac][CV2] Fix CarouselView2 freezes with infinite loop when IsScrollAnimated=False

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
@@ -334,7 +334,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 				return;
 			}
 
-			//_gotoPosition = -1;
+			_gotoPosition = -1;
 
 			// We need to update the position while modifying the collection.
 			targetPosition = GetTargetPosition();
@@ -473,7 +473,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 				return;
 			}
 
-			if (goToPosition != carouselPosition || forceScroll)
+			if (_gotoPosition == -1 && (goToPosition != carouselPosition || forceScroll))
 			{
 				UICollectionViewScrollPosition uICollectionViewScrollPosition = IsHorizontal ? UICollectionViewScrollPosition.CenteredHorizontally : UICollectionViewScrollPosition.CenteredVertically;
 				var goToIndexPath = GetScrollToIndexPath(goToPosition);
@@ -565,6 +565,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			if (currentItemIndex.Row < 0)
 			{
 				return;
+			}
+
+			if (currentItemIndex.Row == _gotoPosition)
+			{
+				_gotoPosition = -1;
 			}
 
 			ScrollToPosition(currentItemIndex.Row, carousel.Position, carousel.AnimateCurrentItemChanges);

--- a/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		bool _isInternalCollectionUpdate = false;
 		int _section = 0;
 		bool _wasDetachedFromWindow = false;
+		int _gotoPosition = -1;
 		CarouselViewLoopManager _carouselViewLoopManager;
 		CancellationTokenSource _scrollDebounce;
 
@@ -482,6 +483,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 					return;
 				}
 
+				_gotoPosition = goToPosition;
 				CollectionView.ScrollToItem(goToIndexPath, uICollectionViewScrollPosition, animate);
 			}
 		}
@@ -507,6 +509,19 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			if (!InitialPositionSet || position == -1)
 			{
 				return;
+			}
+
+			if (_gotoPosition != -1)
+			{
+				if (position == _gotoPosition)
+				{
+					_gotoPosition = -1;
+				}
+				else
+				{
+					// Suppress intermediate positions while scrolling to target
+					return;
+				}
 			}
 
 			ItemsView.SetValueFromRenderer(CarouselView.PositionProperty, position);

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue35675.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue35675.cs
@@ -1,0 +1,59 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 35675, "[iOS] CarouselView freezes with infinite loop when IsScrollAnimated=False", PlatformAffected.iOS)]
+public class Issue35675 : ContentPage
+{
+	readonly string[] _initialItems = ["Item 0", "Item 1", "Item 2"];
+	readonly string[] _updatedItems = ["Item 0b", "Item 1b", "Item 2b"];
+
+	public Issue35675()
+	{
+		Label instructionLabel = new Label
+		{
+			AutomationId = "InstructionLabel",
+			Text = "The test passes if the CarouselView is not frozen after the button click and the current item is updated properly.",
+			HorizontalOptions = LayoutOptions.Center,
+			HorizontalTextAlignment = TextAlignment.Center,
+			FontSize = 18
+		};
+
+		CarouselView carouselView = new CarouselView
+		{
+			AutomationId = "CarouselView",
+			HeightRequest = 300,
+			IsScrollAnimated = false,
+			BackgroundColor = Colors.LightGray,
+			HorizontalScrollBarVisibility = ScrollBarVisibility.Never,
+			ItemsSource = _initialItems,
+			ItemTemplate = new DataTemplate(() =>
+			{
+				Label label = new Label
+				{
+					FontSize = 24
+				};
+				label.SetBinding(Label.TextProperty, ".");
+				label.SetBinding(Label.AutomationIdProperty, ".");
+				return label;
+			})
+		};
+
+		Button scrollButton = new Button
+		{
+			Text = "Change Items And Scroll",
+			AutomationId = "ScrollButton"
+		};
+
+		scrollButton.Clicked += (s, e) =>
+		{
+			carouselView.ItemsSource = _updatedItems;
+			carouselView.CurrentItem = "Item 2b";
+		};
+
+		Content = new VerticalStackLayout
+		{
+			Padding = 20,
+			Spacing = 15,
+			Children = { instructionLabel, carouselView, scrollButton }
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35675.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35675.cs
@@ -1,0 +1,27 @@
+#if TEST_FAILS_ON_ANDROID && TEST_FAILS_ON_WINDOWS // Android Issue: https://github.com/dotnet/maui/issues/35643, Windows PR: https://github.com/dotnet/maui/pull/35398
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue35675 : _IssuesUITest
+{
+	public Issue35675(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue => "[iOS] CarouselView freezes with infinite loop when IsScrollAnimated=False";
+
+	[Test]
+	[Category(UITestCategories.CarouselView)]
+	public void CV2DoesNotFreezeWhenSettingCurrentItemWithIsScrollAnimatedFalse()
+	{
+		App.WaitForElement("ScrollButton");
+		App.WaitForElement("Item 0");
+		App.Tap("ScrollButton");
+
+		App.WaitForElement("Item 2b");
+	}
+}
+#endif


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
- CarouselView2 (CV2) on iOS freezes with an infinite loop when ItemsSource is swapped and CurrentItem is set programmatically with IsScrollAnimated=False — the app becomes completely unresponsive.

### Root Cause
- When IsScrollAnimated=False, UICollectionView.ScrollToItem(animated:false) fires scroll callbacks synchronously, causing the scroll logic to re-enter itself indefinitely and making the app completely unresponsive.

### Description of Change
- Added a _gotoPosition field to CarouselViewController2 to track the intended scroll target and suppress intermediate position updates during scrolls, preventing infinite loops when IsScrollAnimated is false.

- **Reference** => [SetPosition](https://github.com/dotnet/maui/blob/dd5b6d2ee7832952d1b65ba683ba22f8c6220b17/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs#L516-L534) (CarouselViewController)
-  Additionally added the missing _gotoPosition cleanup paths:

   - Clear _gotoPosition in CollectionViewUpdated when the collection changes.
   - Guard ScrollToPosition to skip if a scroll is already in-flight.
   - Clear _gotoPosition in UpdateFromCurrentItem when the animated scroll lands at the intended position.


### Issues Fixed
Fixes #35675

### Validated the behaviour in the following platforms

- [ ] Windows
- [ ] Android
- [x] iOS
- [x] Mac

### Output
| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/00a9844d-354f-4b95-b0e2-47243e1e0cc6"> | <video src="https://github.com/user-attachments/assets/b9c9bca2-79a0-43e6-9a34-b625c0f175c3"> |