### PR TITLE
[inflight/candidate] Revert Fix Android app bar inset background coloring

### DIFF
--- a/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
@@ -2,7 +2,6 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Runtime.CompilerServices;
 using Android.Content;
 using Android.Content.Res;
 using Android.Graphics;
@@ -31,7 +30,6 @@ namespace Microsoft.Maui.Controls.Platform
 	{
 		static ColorStateList? _defaultTitleTextColor;
 		static int? _defaultNavigationIconColor;
-		static readonly ConditionalWeakTable<AppBarLayout, AppBarBackgroundState> _defaultAppBarBackgrounds = new();
 		
 		// Track which ToolbarItem should currently be associated with each MenuItem ID to prevent race conditions
 		// This prevents stale async icon loading callbacks from updating the wrong toolbar items during navigation
@@ -197,99 +195,6 @@ namespace Microsoft.Maui.Controls.Platform
 				if (Brush.IsNullOrEmpty(barBackground))
 					nativeToolbar.BackgroundTintMode = null;
 			}
-
-			if (!nativeToolbar.TryUpdateAppBarBackground(toolbar))
-			{
-				nativeToolbar.Post(() => nativeToolbar.TryUpdateAppBarBackground(toolbar));
-			}
-		}
-
-		static bool TryUpdateAppBarBackground(this AToolbar nativeToolbar, Toolbar toolbar)
-		{
-			var appBarLayout = nativeToolbar.Parent?.GetParentOfType<AppBarLayout>();
-			if (appBarLayout is null)
-				return false;
-
-			var backgroundState = GetOrCreateDefaultAppBarBackgroundState(appBarLayout);
-			var barBackground = toolbar.BarBackground;
-
-			if (Brush.IsNullOrEmpty(barBackground))
-			{
-				RestoreDefaultAppBarBackground(appBarLayout, backgroundState);
-				return true;
-			}
-
-			if (barBackground is SolidColorBrush solidColor)
-			{
-				if (solidColor.Color is Color tintColor)
-				{
-					var platformColor = tintColor.ToPlatform();
-					appBarLayout.BackgroundTintMode = null;
-					appBarLayout.BackgroundTintList = null;
-					appBarLayout.Background = new ColorDrawable(platformColor);
-					appBarLayout.StatusBarForeground = new ColorDrawable(platformColor);
-				}
-				else
-				{
-					RestoreDefaultAppBarBackground(appBarLayout, backgroundState);
-				}
-
-				return true;
-			}
-
-			appBarLayout.BackgroundTintMode = null;
-			appBarLayout.BackgroundTintList = null;
-			appBarLayout.UpdateBackground(barBackground);
-			appBarLayout.StatusBarForeground = CloneDrawable(appBarLayout.Background);
-			return true;
-		}
-
-		static AppBarBackgroundState GetOrCreateDefaultAppBarBackgroundState(AppBarLayout appBarLayout)
-		{
-			if (_defaultAppBarBackgrounds.TryGetValue(appBarLayout, out var backgroundState))
-				return backgroundState;
-
-			backgroundState = new AppBarBackgroundState(
-				CloneDrawable(appBarLayout.Background),
-				CloneDrawable(appBarLayout.StatusBarForeground),
-				appBarLayout.BackgroundTintList,
-				appBarLayout.BackgroundTintMode);
-
-			_defaultAppBarBackgrounds.Add(appBarLayout, backgroundState);
-			return backgroundState;
-		}
-
-		static void RestoreDefaultAppBarBackground(AppBarLayout appBarLayout, AppBarBackgroundState backgroundState)
-		{
-			appBarLayout.Background = CloneDrawable(backgroundState.DefaultBackground);
-			appBarLayout.StatusBarForeground = CloneDrawable(backgroundState.DefaultStatusBarForeground);
-			appBarLayout.BackgroundTintMode = backgroundState.DefaultBackgroundTintMode;
-			appBarLayout.BackgroundTintList = backgroundState.DefaultBackgroundTintList;
-		}
-
-		static Drawable? CloneDrawable(Drawable? drawable)
-		{
-			if (drawable is null)
-				return null;
-
-			using var constantState = drawable.GetConstantState();
-			return constantState?.NewDrawable()?.Mutate();
-		}
-
-		sealed class AppBarBackgroundState
-		{
-			public AppBarBackgroundState(Drawable? defaultBackground, Drawable? defaultStatusBarForeground, ColorStateList? defaultBackgroundTintList, PorterDuff.Mode? defaultBackgroundTintMode)
-			{
-				DefaultBackground = defaultBackground;
-				DefaultStatusBarForeground = defaultStatusBarForeground;
-				DefaultBackgroundTintList = defaultBackgroundTintList;
-				DefaultBackgroundTintMode = defaultBackgroundTintMode;
-			}
-
-			public Drawable? DefaultBackground { get; }
-			public Drawable? DefaultStatusBarForeground { get; }
-			public ColorStateList? DefaultBackgroundTintList { get; }
-			public PorterDuff.Mode? DefaultBackgroundTintMode { get; }
 		}
 
 		public static void UpdateIconColor(this AToolbar nativeToolbar, Toolbar toolbar)

--- a/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.Android.cs
+++ b/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.Android.cs
@@ -159,16 +159,6 @@ namespace Microsoft.Maui.DeviceTests
 		protected string GetToolbarTitle(IElementHandler handler) =>
 			GetPlatformToolbar(handler).Title;
 
-		protected AppBarLayout GetPlatformAppBarLayout(IElementHandler handler)
-		{
-			var toolbar = GetPlatformToolbar(handler);
-
-			if (toolbar == null)
-				return null;
-
-			return toolbar.Parent.GetParentOfType<AppBarLayout>();
-		}
-
 		protected MaterialToolbar GetPlatformToolbar(IMauiContext mauiContext)
 		{
 			var navManager = mauiContext.GetNavigationRootManager();
@@ -220,31 +210,6 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			return GetPlatformToolbar(mauiContext)?
 					.LayoutParameters?.Height > 0;
-		}
-
-		protected async Task AssertAppBarTopInsetUsesColor(IElementHandler handler, Color expectedColor)
-		{
-			var toolbar = GetPlatformToolbar(handler);
-			Assert.NotNull(toolbar);
-
-			var appBar = GetPlatformAppBarLayout(handler);
-			Assert.NotNull(appBar);
-
-			var platformColor = expectedColor.ToPlatform();
-
-			await AssertHelpers.AssertEventually(() =>
-			{
-				var backgroundTintList = toolbar.BackgroundTintList;
-
-				return backgroundTintList != null &&
-					backgroundTintList.DefaultColor == platformColor.ToArgb() &&
-					appBar.PaddingTop > 0 &&
-					appBar.Width > 0 &&
-					appBar.Height > appBar.PaddingTop;
-			}, message: "Toolbar background or AppBarLayout top inset did not update.");
-
-			var bitmap = await appBar.ToBitmap(handler.MauiContext);
-			await bitmap.AssertContainsColor(platformColor, rect => new RectF(0, 0, rect.Width, appBar.PaddingTop));
 		}
 
 		protected static WindowInsetsCompat CreateTopCutoutInsets(int statusBarTopInset, int displayCutoutTopInset)

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Android.cs
@@ -10,7 +10,6 @@ using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers;
 using Microsoft.Maui.DeviceTests.Stubs;
-using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using Xunit;
@@ -111,30 +110,6 @@ namespace Microsoft.Maui.DeviceTests
 					fragmentContainerViewField.GetValue(tab2SnManager) == null &&
 					fragmentManagerField.GetValue(tab2SnManager) == null,
 					message: "StackNavigationManager fields were not cleared after Disconnect()");
-			});
-		}
-
-		[Fact(DisplayName = "NavigationPage bar background colors the edge-to-edge top inset area")]
-		public async Task BarBackgroundColorColorsEdgeToEdgeTopInsetArea()
-		{
-			SetupBuilder();
-
-			var expectedColor = Colors.OrangeRed;
-			var rootPage = new ContentPage
-			{
-				Title = "Page Title",
-				Content = new Label { Text = "NavigationPage content" }
-			};
-
-			var navPage = new NavigationPage(rootPage)
-			{
-				BarBackgroundColor = expectedColor
-			};
-
-			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), async (handler) =>
-			{
-				await OnLoadedAsync(rootPage);
-				await AssertAppBarTopInsetUsesColor(handler, expectedColor);
 			});
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Android.cs
@@ -16,7 +16,6 @@ using Microsoft.Maui.Controls.Handlers.Compatibility;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Controls.Platform.Compatibility;
 using Microsoft.Maui.DeviceTests.Stubs;
-using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using Xunit;
@@ -647,32 +646,6 @@ namespace Microsoft.Maui.DeviceTests
 
 				// Verify no exception was thrown - validates (_shellContext?.Shell as IShellController)?.RemoveAppearanceObserver(this);
 				Assert.Null(exception);
-			});
-		}
-
-		[Fact(DisplayName = "Shell background colors the edge-to-edge top inset area")]
-		public async Task ShellBackgroundColorsEdgeToEdgeTopInsetArea()
-		{
-			SetupBuilder();
-
-			var expectedColor = Colors.OrangeRed;
-			var page = new ContentPage
-			{
-				Title = "Page Title",
-				Content = new Label { Text = "Shell content" }
-			};
-
-			Shell.SetBackgroundColor(page, expectedColor);
-
-			var shell = new Shell
-			{
-				CurrentItem = page
-			};
-
-			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Controls.Window(shell), async (handler) =>
-			{
-				await OnLoadedAsync(page);
-				await AssertAppBarTopInsetUsesColor(handler, expectedColor);
 			});
 		}
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

 ### Issue Details
 
 The following Android UI tests fail due to changes introduced by #35601:
 
 - `TestIssue9419`
 - `ReusingNavigationPageDoesntBreakLayout`
 - `NavigationPageFeatureTests`
 
 These failures were observed in the candidate PR build and require further analysis.



 ### Reason
 
 PR #35601 introduces `AppBarLayout` background sync logic that interferes with existing navigation page layout behavior. Reverting to unblock the candidate branch while further investigation is conducted.
 
 A more comprehensive solution is being pursued in #35463 ("Make Android system chrome follow MAUI bar colors"), which takes a window-level approach rather than modifying `AppBarLayout` directly.
 
 ### Changes
 
 - Removed `AppBarLayout` background sync logic (`TryUpdateAppBarBackground`, `CloneDrawable`, `AppBarBackgroundState`) from `ToolbarExtensions.cs`
 - Removed `GetPlatformAppBarLayout` and `AssertAppBarTopInsetUsesColor` test helpers
 - Removed `BarBackgroundColorColorsEdgeToEdgeTopInsetArea` (NavigationPage) and `ShellBackgroundColorsEdgeToEdgeTopInsetArea` (Shell) tests