### PR TITLE
Extract shared versioning module, add -CloseFixedIssues flag, and earliest-release-wins milestone validation

### DIFF
--- a/.github/scripts/Fix-MilestoneDrift.Tests.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.Tests.ps1
@@ -318,6 +318,23 @@ Describe 'Get-LinkedIssues' {
         $result | Should -Contain 555
         $result | Should -Contain 666
     }
+
+    It 'extracts cross-repo `Fixes dotnet/maui#NNNNN` form (PR #35858 finding F)' {
+        # External contributors frequently use the cross-repo shorthand even within the
+        # same repo. Pre-fix, this regex required `#` immediately after the verb, so the
+        # `dotnet/maui` prefix made it silently ignored — meaning issues that should have
+        # been included in milestone-correction sweeps were skipped.
+        $result = Get-LinkedIssues "Fixes dotnet/maui#34490" "Title"
+        $result | Should -Contain 34490
+    }
+
+    It 'extracts cross-repo form combined with other syntaxes' {
+        $result = @(Get-LinkedIssues "Closes dotnet/maui#1`nResolves #2`nFixes dotnet/maui#3" "Title")
+        $result | Should -Contain 1
+        $result | Should -Contain 2
+        $result | Should -Contain 3
+        $result | Should -HaveCount 3
+    }
 }
 
 Describe 'ConvertBranchToMilestone' {
@@ -609,6 +626,31 @@ Describe 'Get-MilestoneSortKey' {
         $net11_p1  = Get-MilestoneSortKey '.NET 11.0-preview1'
         ($net10_sr6 -lt $net11_p1) | Should -BeTrue
     }
+
+    It 'accepts the `.NET 10.0 GA` form (optional `.0` between major and GA) — production milestones use this naming' {
+        # Production has BOTH `.NET 10 SR4`-style and `.NET 10.0 SR4`-style names live —
+        # silently scoring the .0 form as null caused the validator to fail open and
+        # treat valid milestones as un-comparable. See PR #35858 finding B.
+        $ga      = Get-MilestoneSortKey '.NET 10.0 GA'
+        $sr1     = Get-MilestoneSortKey '.NET 10.0 SR1'
+        $sr2_1   = Get-MilestoneSortKey '.NET 10.0 SR2.1'
+        $sr4     = Get-MilestoneSortKey '.NET 10.0 SR4'
+        $ga      | Should -Not -Be $null
+        $sr1     | Should -Not -Be $null
+        $sr2_1   | Should -Not -Be $null
+        $sr4     | Should -Not -Be $null
+        ($ga -lt $sr1)     | Should -BeTrue
+        ($sr1 -lt $sr2_1)  | Should -BeTrue
+        ($sr2_1 -lt $sr4)  | Should -BeTrue
+    }
+
+    It 'treats `.NET 10 SR4` and `.NET 10.0 SR4` as equal (alternate spellings of the same release)' {
+        $a = Get-MilestoneSortKey '.NET 10 SR4'
+        $b = Get-MilestoneSortKey '.NET 10.0 SR4'
+        $a | Should -Not -Be $null
+        $b | Should -Not -Be $null
+        $a | Should -Be $b
+    }
 }
 
 Describe 'Compare-MauiMilestone' {
@@ -719,11 +761,15 @@ Describe 'Test-MilestoneValidForIssue' {
         Test-MilestoneValidForIssue -IssueNumber 34490 -Milestone '.NET 10 SR6' | Should -BeTrue
     }
 
-    It 'returns false (and warns, does not throw) when gh search fails' {
+    It 'returns $null (uncertain, not $false) when gh search fails — caller must skip rather than clobber valid earlier milestone' {
         $script:_searchExit = 1
         { Test-MilestoneValidForIssue -IssueNumber 42 -Milestone '.NET 10 SR6' -WarningAction SilentlyContinue } |
             Should -Not -Throw
-        Test-MilestoneValidForIssue -IssueNumber 42 -Milestone '.NET 10 SR6' -WarningAction SilentlyContinue | Should -BeFalse
+        $result = Test-MilestoneValidForIssue -IssueNumber 42 -Milestone '.NET 10 SR6' -WarningAction SilentlyContinue
+        $result | Should -BeNullOrEmpty
+        # Specifically $null, not $false — $false would mean "no linking PR ships here" (definitive)
+        # and would cause Test-AndRecordCorrection to queue a destructive correction.
+        ($null -eq $result) | Should -BeTrue
     }
 
     It 'caches lookups so a second call does not re-query gh' {
@@ -733,8 +779,10 @@ Describe 'Test-MilestoneValidForIssue' {
         Test-MilestoneValidForIssue -IssueNumber 34490 -Milestone '.NET 10 SR6' | Should -BeTrue
         Test-MilestoneValidForIssue -IssueNumber 34490 -Milestone '.NET 10 SR6' | Should -BeTrue
 
-        # gh search should have been hit exactly once
-        Assert-MockCalled Invoke-GhCli -Times 1 -Exactly -Scope It -ParameterFilter {
+        # First call makes 2 gh searches (one for `#N`, one for `issues/N` URL form);
+        # second call is fully cached. So gh search should have been hit exactly twice total,
+        # not 4 — the cache catches the second invocation.
+        Assert-MockCalled Invoke-GhCli -Times 2 -Exactly -Scope It -ParameterFilter {
             @($Arguments)[0] -eq 'search' -and @($Arguments)[1] -eq 'prs'
         }
     }
@@ -742,6 +790,25 @@ Describe 'Test-MilestoneValidForIssue' {
     It 'matches a fix verb that uses an owner/repo prefix (org/repo#NNN)' {
         # Real-world bodies sometimes write "Fixes dotnet/maui#34490"
         $script:_searchJson = '[{"number":501,"title":"Fix bug","body":"Fixes dotnet/maui#34490","url":"u"}]'
+        $script:_prShipped[501] = @('.NET 10 SR6')
+
+        Test-MilestoneValidForIssue -IssueNumber 34490 -Milestone '.NET 10 SR6' | Should -BeTrue
+    }
+
+    It 'matches a fix verb that uses the full URL form (issues/N) — PR #35858 finding D' {
+        # When a PR body links the issue ONLY via the URL form (`Fixes https://.../issues/N`)
+        # — never the `#N` shorthand — the original `#N in:body` query missed it entirely.
+        # The supplementary `issues/N in:body` query covers that case.
+        $script:_searchJson = '[{"number":501,"title":"Fix bug","body":"Fixes https://github.com/dotnet/maui/issues/34490","url":"u"}]'
+        $script:_prShipped[501] = @('.NET 10 SR6')
+
+        Test-MilestoneValidForIssue -IssueNumber 34490 -Milestone '.NET 10 SR6' | Should -BeTrue
+    }
+
+    It 'matches a fix verb when the issue number is only in the PR title (not body)' {
+        # The first query `#N in:title,body` covers title-only linking — pre-fix the query
+        # was `in:body` only, missing title-only links.
+        $script:_searchJson = '[{"number":501,"title":"Fix #34490 in renderer","body":"Some unrelated body.","url":"u"}]'
         $script:_prShipped[501] = @('.NET 10 SR6')
 
         Test-MilestoneValidForIssue -IssueNumber 34490 -Milestone '.NET 10 SR6' | Should -BeTrue
@@ -783,5 +850,160 @@ Describe 'Test-MilestoneValidForPr' {
     It 'returns false when the PR has shipped nowhere yet (in flight)' {
         # No entry — Test-PrShippedInMilestone returns false.
         Test-MilestoneValidForPr -PrNumber 99999 -Milestone '.NET 10 SR7' | Should -BeFalse
+    }
+}
+
+Describe 'Test-AndRecordCorrection — earliest-release-wins guard (PR #35858 findings A, C, E)' {
+    BeforeEach {
+        # Mock the underlying validators so the test focuses on dispatch logic.
+        Mock Test-MilestoneValidForIssue {
+            param([int]$IssueNumber, [string]$Milestone)
+            if ($script:_validForIssue.ContainsKey("$IssueNumber|$Milestone")) {
+                return $script:_validForIssue["$IssueNumber|$Milestone"]
+            }
+            return $false
+        }
+        Mock Test-MilestoneValidForPr {
+            param([int]$PrNumber, [string]$Milestone)
+            if ($script:_validForPr.ContainsKey("$PrNumber|$Milestone")) {
+                return $script:_validForPr["$PrNumber|$Milestone"]
+            }
+            return $false
+        }
+        $script:_validForIssue = @{}
+        $script:_validForPr = @{}
+        # Helper inlined in each It (Pester 5 doesn't carry function defs out of BeforeEach).
+        $script:_newReport = {
+            @{
+                TotalPrs       = 1
+                PrsChecked     = 0
+                IssuesChecked  = 0
+                AlreadyCorrect = 0
+                Corrections    = [System.Collections.ArrayList]::new()
+                Errors         = [System.Collections.ArrayList]::new()
+            }
+        }
+    }
+
+    It 'finding E: deduplicates the SAME issue across multiple linking PRs in the Kept bucket' {
+        # The same issue can be discovered via multiple linking PRs during a tag-range walk
+        # (e.g. a backport PR and the original PR both reference the issue). Pre-fix, each
+        # touch appended a new row, polluting the report.
+        $script:_validForIssue['34490|.NET 10 SR6'] = $true
+        $report = & $script:_newReport
+
+        $resolvedMs = @{ Number = 999; Title = '.NET 10 SR8' }
+        Test-AndRecordCorrection 'issue' 34490 'Bug' 'u1' '.NET 10 SR6' '.NET 10 SR8' $resolvedMs 501 $report
+        Test-AndRecordCorrection 'issue' 34490 'Bug' 'u1' '.NET 10 SR6' '.NET 10 SR8' $resolvedMs 502 $report
+        Test-AndRecordCorrection 'issue' 34490 'Bug' 'u1' '.NET 10 SR6' '.NET 10 SR8' $resolvedMs 503 $report
+
+        $report.ContainsKey('Kept') | Should -BeTrue
+        $report.Kept.Count | Should -Be 1
+        $report.Kept[0].Number | Should -Be 34490
+    }
+
+    It 'finding E: does NOT collapse Kept entries for different issues that share a milestone' {
+        $script:_validForIssue['34490|.NET 10 SR6'] = $true
+        $script:_validForIssue['34491|.NET 10 SR6'] = $true
+        $report = & $script:_newReport
+        $resolvedMs = @{ Number = 999; Title = '.NET 10 SR8' }
+
+        Test-AndRecordCorrection 'issue' 34490 'BugA' 'u1' '.NET 10 SR6' '.NET 10 SR8' $resolvedMs 501 $report
+        Test-AndRecordCorrection 'issue' 34491 'BugB' 'u2' '.NET 10 SR6' '.NET 10 SR8' $resolvedMs 502 $report
+
+        $report.Kept.Count | Should -Be 2
+    }
+
+    It 'finding C: when validator returns $null (uncertain) — does NOT queue a correction (defensive)' {
+        # Earlier milestone + validator inconclusive ==> we MUST keep the current milestone.
+        # Pre-fix, $null was coerced to $false and a destructive correction got queued.
+        $script:_validForIssue['34490|.NET 10 SR6'] = $null
+        $report = & $script:_newReport
+        $resolvedMs = @{ Number = 999; Title = '.NET 10 SR8' }
+
+        Test-AndRecordCorrection 'issue' 34490 'Bug' 'u1' '.NET 10 SR6' '.NET 10 SR8' $resolvedMs 501 $report `
+            -WarningAction SilentlyContinue
+
+        $report.Corrections.Count | Should -Be 0
+        # Also NOT counted as kept — we don't have positive evidence either way.
+        if ($report.ContainsKey('Kept')) { $report.Kept.Count | Should -Be 0 }
+    }
+
+    It 'finding C: when validator returns $false (no linking PR shipped there) — DOES queue a correction' {
+        # This is the legitimate clobber path: earlier milestone was wrong, no fix actually
+        # shipped there, the target milestone is correct. Pre-fix and post-fix both work.
+        $script:_validForIssue['34490|.NET 10 SR6'] = $false
+        $report = & $script:_newReport
+        $resolvedMs = @{ Number = 999; Title = '.NET 10 SR8' }
+
+        Test-AndRecordCorrection 'issue' 34490 'Bug' 'u1' '.NET 10 SR6' '.NET 10 SR8' $resolvedMs 501 $report
+
+        $report.Corrections.Count | Should -Be 1
+        $report.Corrections[0].Number | Should -Be 34490
+    }
+
+    It 'findings A + E together: PR-side KEEP path also dedups (cherry-pick case)' {
+        # A cherry-picked PR can match in multiple linking searches. Same dedup applies.
+        $script:_validForPr['34527|.NET 10 SR6'] = $true
+        $report = & $script:_newReport
+        $resolvedMs = @{ Number = 999; Title = '.NET 10 SR8' }
+
+        Test-AndRecordCorrection 'pr' 34527 'Cherry' 'u' '.NET 10 SR6' '.NET 10 SR8' $resolvedMs 0 $report
+        Test-AndRecordCorrection 'pr' 34527 'Cherry' 'u' '.NET 10 SR6' '.NET 10 SR8' $resolvedMs 0 $report
+
+        $report.Kept.Count | Should -Be 1
+    }
+}
+
+Describe 'Invoke-AnalyzeSinglePr — validation context seeding (PR #35858 finding A)' {
+    BeforeEach {
+        # Stand up the bare minimum mocks so Invoke-AnalyzeSinglePr can run start-to-finish
+        # without touching git, gh, or the file system.
+        $script:_initCalled = $false
+        $script:_initArgs = $null
+        Mock Initialize-MilestoneValidationContext {
+            param([string]$RepoPath, [string[]]$AllTags, [int]$Major)
+            $script:_initCalled = $true
+            $script:_initArgs = @{ RepoPath = $RepoPath; AllTags = $AllTags; Major = $Major }
+        }
+        Mock Get-PrInfo {
+            return @{
+                Number         = 42
+                Title          = 'Test PR'
+                Url            = 'u'
+                Milestone      = ''
+                BaseRef        = 'net11.0'
+                MergedAt       = '2025-01-01T00:00:00Z'
+                MergeCommitSha = 'abc123'
+                Body           = ''
+            }
+        }
+        Mock Get-AllTags { return @('10.0.60', '10.0.70', '11.0.0-preview.3') }
+        # Drive the "found in release branch" fast-path so $expectedMs is set early and
+        # we don't fall through to Find-TagContainingPr (which needs real git history).
+        Mock Get-VersionFromGitRef { return @{ Tag = '11.0.0'; PreLabel = 'preview'; PreIter = 3 } }
+        Mock Find-ReleaseBranchForCommit { return @{ Branch = 'release/11.0.1xx-preview3'; Milestone = '.NET 11.0-preview3' } }
+        Mock ConvertBranchToMilestone { return '.NET 11.0-preview3' }
+        Mock Get-MainBranchForVersion { return 'net11.0' }
+        Mock Get-AllMilestones { return @(@{ Number = 99; Title = '.NET 11.0-preview3' }) }
+        Mock Find-MatchingMilestone { return @{ Number = 99; Title = '.NET 11.0-preview3' } }
+        Mock Test-PrBelongsToVersion { return $true }
+        Mock Get-CurrentMajorVersion { return 11 }
+        Mock Get-LinkedIssues { return @() }
+        Mock Test-AndRecordCorrection { }
+    }
+
+    It 'seeds the validation context BEFORE Test-AndRecordCorrection is reached (so KEEP guard is not dead code)' {
+        # Pre-fix: Initialize-MilestoneValidationContext was never called in single-PR mode.
+        # That meant $script:validationAllTags stayed $null, Get-TagsForMilestone returned @(),
+        # Test-PrShippedInMilestone always returned $false, and Test-MilestoneValidForIssue
+        # never returned $true — making the entire KEEP branch unreachable in the live
+        # workflow path (the path the cron + auto-trigger actually exercise).
+        Invoke-AnalyzeSinglePr -PrNum 42 -ReleaseTag '' -Repo '.' | Out-Null
+
+        $script:_initCalled | Should -BeTrue
+        $script:_initArgs.Major | Should -Be 11
+        # The tags array we passed in must reach the initializer (so KEEP queries have data to work with).
+        $script:_initArgs.AllTags | Should -Contain '10.0.60'
     }
 }

--- a/.github/scripts/Fix-MilestoneDrift.Tests.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.Tests.ps1
@@ -1187,3 +1187,47 @@ Describe 'Test-AndRecordCorrection — PR-side tristate propagation (PR #35858 r
         if ($report.ContainsKey('Kept')) { $report.Kept.Count | Should -Be 0 }
     }
 }
+
+Describe 'Get-PrsInTag — unary-comma preserves HashSet on cache hit (PR #35858 round-3 finding)' {
+    BeforeEach {
+        Initialize-MilestoneValidationContext `
+            -RepoPath '.' `
+            -AllTags @('10.0.60') `
+            -Major 10
+    }
+
+    It 'Test-PrShippedInMilestone works on a cache hit for a tag with 1 reachable PR' {
+        # Pre-fix: the cache-hit path returned the HashSet directly. PowerShell unwrapped
+        # the 1-element HashSet enumerable to Int32 on the way back to the caller, so the
+        # second Test-PrShippedInMilestone call threw "Int32 does not contain method Contains".
+        # GPT-5.5 round-3 caught this.
+        Mock Get-PrNumbersReachableFromTag { return @(101) }
+        Test-PrShippedInMilestone -PrNumber 101 -Milestone '.NET 10 SR6' | Should -BeTrue
+        # Second call hits the cache — must still produce a definitive answer.
+        Test-PrShippedInMilestone -PrNumber 101 -Milestone '.NET 10 SR6' | Should -BeTrue
+        Test-PrShippedInMilestone -PrNumber 999 -Milestone '.NET 10 SR6' | Should -BeFalse
+    }
+
+    It 'Test-PrShippedInMilestone returns $false (not $null) on a cache hit for a tag with 0 PRs' {
+        # Pre-fix: a cached empty HashSet got unwrapped to $null on the second read, which
+        # the tristate code (legitimately) treats as "git failure / uncertain" — incorrectly
+        # converting a deterministic empty read into a permanent skip-this-correction state.
+        Mock Get-PrNumbersReachableFromTag { return @() }
+        Test-PrShippedInMilestone -PrNumber 42 -Milestone '.NET 10 SR6' | Should -BeFalse
+        # Second call (cache hit) — must still be a definitive false, not the uncertain $null.
+        $second = Test-PrShippedInMilestone -PrNumber 42 -Milestone '.NET 10 SR6'
+        $second | Should -BeFalse
+        ($null -eq $second) | Should -BeFalse
+    }
+
+    It 'Get-PrNumbersReachableFromTag is invoked exactly once per tag even across many lookups' {
+        # Verifies the cache is hit (which is the whole point of returning the cached
+        # HashSet — performance — and is precisely why the unwrap bug matters).
+        Mock Get-PrNumbersReachableFromTag { return @(101, 102, 103) }
+        Test-PrShippedInMilestone -PrNumber 101 -Milestone '.NET 10 SR6' | Should -BeTrue
+        Test-PrShippedInMilestone -PrNumber 102 -Milestone '.NET 10 SR6' | Should -BeTrue
+        Test-PrShippedInMilestone -PrNumber 103 -Milestone '.NET 10 SR6' | Should -BeTrue
+        Test-PrShippedInMilestone -PrNumber 999 -Milestone '.NET 10 SR6' | Should -BeFalse
+        Assert-MockCalled Get-PrNumbersReachableFromTag -Times 1 -Exactly
+    }
+}

--- a/.github/scripts/Fix-MilestoneDrift.Tests.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.Tests.ps1
@@ -638,14 +638,15 @@ Describe 'Compare-MauiMilestone' {
 
 Describe 'Test-MilestoneValidForIssue' {
     BeforeEach {
-        # Clear cache between tests so each starts fresh.
+        # Clear caches between tests so each starts fresh.
         $script:milestoneValidationCache = @{}
 
         # Default search response: empty array.
         $script:_searchJson = '[]'
         $script:_searchExit = 0
-        # Default Get-PrInfo response: PR with no milestone.
-        $script:_prMilestones = @{}
+        # Default shipped-in mapping: { PrNumber => @(milestone-names) }.
+        # Empty means "no PR has shipped in any milestone we ask about".
+        $script:_prShipped = @{}
 
         Mock Invoke-GhCli {
             $a = @($Arguments)
@@ -658,12 +659,13 @@ Describe 'Test-MilestoneValidForIssue' {
             return ''
         }
 
-        Mock Get-PrInfo {
-            param([int]$PrNum)
-            if ($script:_prMilestones.ContainsKey($PrNum)) {
-                return @{ Number = $PrNum; Milestone = $script:_prMilestones[$PrNum]; Title = "PR $PrNum"; Url = "u"; Body = ''; BaseRef = 'main' }
+        # Mock the commit-in-tag check so tests don't need a real git repo / tags.
+        Mock Test-PrShippedInMilestone {
+            param([int]$PrNumber, [string]$Milestone)
+            if ($script:_prShipped.ContainsKey($PrNumber)) {
+                return ($script:_prShipped[$PrNumber] -contains $Milestone)
             }
-            return $null
+            return $false
         }
     }
 
@@ -677,9 +679,9 @@ Describe 'Test-MilestoneValidForIssue' {
         Test-MilestoneValidForIssue -IssueNumber 42 -Milestone ''   | Should -BeFalse
     }
 
-    It 'returns true when a linking fix-PR has the target milestone' {
+    It 'returns true when a linking fix-PR commit is in the milestone tag' {
         $script:_searchJson = '[{"number":501,"title":"Fix bug","body":"Fixes #34490","url":"u"}]'
-        $script:_prMilestones[501] = '.NET 10 SR6'
+        $script:_prShipped[501] = @('.NET 10 SR6')
 
         Test-MilestoneValidForIssue -IssueNumber 34490 -Milestone '.NET 10 SR6' | Should -BeTrue
     }
@@ -687,30 +689,32 @@ Describe 'Test-MilestoneValidForIssue' {
     It 'returns false when a PR mentions the issue but does not use a fix verb' {
         # Just a casual mention "#34490" — should not count as a fix
         $script:_searchJson = '[{"number":888,"title":"Related work","body":"See #34490 for context","url":"u"}]'
-        $script:_prMilestones[888] = '.NET 10 SR6'
+        $script:_prShipped[888] = @('.NET 10 SR6')
 
         Test-MilestoneValidForIssue -IssueNumber 34490 -Milestone '.NET 10 SR6' | Should -BeFalse
     }
 
-    It 'returns false when fixing PR has no milestone' {
+    It 'returns false when the fixing PR did not ship in the milestone tag' {
+        # PR fixes the issue but its commit is only in a later release (e.g. SR7.1).
+        # This is the key tightening: trusting the PR''s milestone field alone is not enough.
         $script:_searchJson = '[{"number":513,"title":"net11 fix","body":"Fixes #34490","url":"u"}]'
-        # PR 513 has no milestone (not in $_prMilestones)
+        $script:_prShipped[513] = @('.NET 10 SR7.1')
 
         Test-MilestoneValidForIssue -IssueNumber 34490 -Milestone '.NET 10 SR6' | Should -BeFalse
     }
 
-    It 'returns false when fixing PR has a different milestone' {
+    It 'returns false when fixing PR has shipped in nothing yet' {
         $script:_searchJson = '[{"number":513,"title":"net11 fix","body":"Fixes #34490","url":"u"}]'
-        $script:_prMilestones[513] = '.NET 11.0-preview3'
+        # 513 is in no tag
 
         Test-MilestoneValidForIssue -IssueNumber 34490 -Milestone '.NET 10 SR6' | Should -BeFalse
     }
 
     It 'returns true if ANY of multiple linking PRs validates the milestone' {
-        # Two PRs link the issue; only the second has the matching milestone.
+        # Two PRs link the issue; only the second has shipped in the matching milestone.
         $script:_searchJson = '[{"number":513,"title":"net11 fix","body":"Fixes #34490","url":"u"},{"number":501,"title":"sr6 fix","body":"Fixes #34490","url":"u"}]'
-        $script:_prMilestones[513] = '.NET 11.0-preview3'
-        $script:_prMilestones[501] = '.NET 10 SR6'
+        $script:_prShipped[513] = @('.NET 11.0-preview3')
+        $script:_prShipped[501] = @('.NET 10 SR6')
 
         Test-MilestoneValidForIssue -IssueNumber 34490 -Milestone '.NET 10 SR6' | Should -BeTrue
     }
@@ -724,7 +728,7 @@ Describe 'Test-MilestoneValidForIssue' {
 
     It 'caches lookups so a second call does not re-query gh' {
         $script:_searchJson = '[{"number":501,"title":"Fix bug","body":"Fixes #34490","url":"u"}]'
-        $script:_prMilestones[501] = '.NET 10 SR6'
+        $script:_prShipped[501] = @('.NET 10 SR6')
 
         Test-MilestoneValidForIssue -IssueNumber 34490 -Milestone '.NET 10 SR6' | Should -BeTrue
         Test-MilestoneValidForIssue -IssueNumber 34490 -Milestone '.NET 10 SR6' | Should -BeTrue
@@ -738,8 +742,46 @@ Describe 'Test-MilestoneValidForIssue' {
     It 'matches a fix verb that uses an owner/repo prefix (org/repo#NNN)' {
         # Real-world bodies sometimes write "Fixes dotnet/maui#34490"
         $script:_searchJson = '[{"number":501,"title":"Fix bug","body":"Fixes dotnet/maui#34490","url":"u"}]'
-        $script:_prMilestones[501] = '.NET 10 SR6'
+        $script:_prShipped[501] = @('.NET 10 SR6')
 
         Test-MilestoneValidForIssue -IssueNumber 34490 -Milestone '.NET 10 SR6' | Should -BeTrue
+    }
+}
+
+Describe 'Test-MilestoneValidForPr' {
+    BeforeEach {
+        $script:_prShippedForPr = @{}
+        Mock Test-PrShippedInMilestone {
+            param([int]$PrNumber, [string]$Milestone)
+            if ($script:_prShippedForPr.ContainsKey($PrNumber)) {
+                return ($script:_prShippedForPr[$PrNumber] -contains $Milestone)
+            }
+            return $false
+        }
+    }
+
+    It 'returns false for null/empty milestone' {
+        Test-MilestoneValidForPr -PrNumber 100 -Milestone $null | Should -BeFalse
+        Test-MilestoneValidForPr -PrNumber 100 -Milestone ''    | Should -BeFalse
+    }
+
+    It 'returns true when the PR commit is in a tag mapping to the milestone (cherry-pick case)' {
+        # PR #34527 originally shipped in 10.0.60 (SR6) and was later cherry-picked
+        # to 10.0.80 (SR8). When auditing SR8, we should KEEP it on SR6.
+        $script:_prShippedForPr[34527] = @('.NET 10 SR6', '.NET 10 SR7', '.NET 10 SR8')
+
+        Test-MilestoneValidForPr -PrNumber 34527 -Milestone '.NET 10 SR6' | Should -BeTrue
+    }
+
+    It 'returns false when the PR has only shipped in the target milestone (not in the earlier one)' {
+        # PR was milestoned for SR7 but actually only landed in SR8.
+        $script:_prShippedForPr[35008] = @('.NET 10 SR8')
+
+        Test-MilestoneValidForPr -PrNumber 35008 -Milestone '.NET 10 SR7' | Should -BeFalse
+    }
+
+    It 'returns false when the PR has shipped nowhere yet (in flight)' {
+        # No entry — Test-PrShippedInMilestone returns false.
+        Test-MilestoneValidForPr -PrNumber 99999 -Milestone '.NET 10 SR7' | Should -BeFalse
     }
 }

--- a/.github/scripts/Fix-MilestoneDrift.Tests.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.Tests.ps1
@@ -328,12 +328,33 @@ Describe 'Get-LinkedIssues' {
         $result | Should -Contain 34490
     }
 
-    It 'extracts cross-repo form combined with other syntaxes' {
+    It 'extracts dotnet/maui cross-repo form combined with other syntaxes' {
         $result = @(Get-LinkedIssues "Closes dotnet/maui#1`nResolves #2`nFixes dotnet/maui#3" "Title")
         $result | Should -Contain 1
         $result | Should -Contain 2
         $result | Should -Contain 3
         $result | Should -HaveCount 3
+    }
+
+    It 'DOES NOT cross-pollute from other repos — `Fixes dotnet/runtime#42` must NOT be extracted as MAUI #42 (PR #35858 follow-up finding)' {
+        # Round-2 review caught this: an over-broad `[A-Za-z0-9_\-./]+?` prefix would
+        # silently treat any cross-repo reference as a MAUI issue. The validator would
+        # then clobber dotnet/maui#42's milestone based on a fix in dotnet/runtime#42.
+        $result = @(Get-LinkedIssues "Fixes dotnet/runtime#42" "Title")
+        $result | Should -HaveCount 0
+    }
+
+    It 'DOES NOT cross-pollute from xamarin-style references' {
+        $result = @(Get-LinkedIssues "Fixes xamarin/Xamarin.Forms#1234" "Title")
+        $result | Should -HaveCount 0
+    }
+
+    It 'DOES NOT cross-pollute from dotnet/runtime even when other syntaxes are present' {
+        $result = @(Get-LinkedIssues "Fixes dotnet/runtime#100`nResolves dotnet/maui#200`nCloses #300" "Title")
+        $result | Should -Not -Contain 100
+        $result | Should -Contain 200
+        $result | Should -Contain 300
+        $result | Should -HaveCount 2
     }
 }
 
@@ -772,6 +793,18 @@ Describe 'Test-MilestoneValidForIssue' {
         ($null -eq $result) | Should -BeTrue
     }
 
+    It 'does NOT cache $null — retries on a later call so a transient gh failure doesn''t permanently disable KEEP for the run (PR #35858 round-2)' {
+        # First call: gh fails → return $null (uncertain). DO NOT cache.
+        $script:_searchExit = 1
+        Test-MilestoneValidForIssue -IssueNumber 7 -Milestone '.NET 10 SR6' -WarningAction SilentlyContinue | Should -BeNullOrEmpty
+
+        # Second call: gh succeeds with a real match → must return $true, not the cached $null.
+        $script:_searchExit = 0
+        $script:_searchJson = '[{"number":501,"title":"Fix bug","body":"Fixes #7","url":"u"}]'
+        $script:_prShipped[501] = @('.NET 10 SR6')
+        Test-MilestoneValidForIssue -IssueNumber 7 -Milestone '.NET 10 SR6' | Should -BeTrue
+    }
+
     It 'caches lookups so a second call does not re-query gh' {
         $script:_searchJson = '[{"number":501,"title":"Fix bug","body":"Fixes #34490","url":"u"}]'
         $script:_prShipped[501] = @('.NET 10 SR6')
@@ -779,11 +812,23 @@ Describe 'Test-MilestoneValidForIssue' {
         Test-MilestoneValidForIssue -IssueNumber 34490 -Milestone '.NET 10 SR6' | Should -BeTrue
         Test-MilestoneValidForIssue -IssueNumber 34490 -Milestone '.NET 10 SR6' | Should -BeTrue
 
-        # First call makes 2 gh searches (one for `#N`, one for `issues/N` URL form);
-        # second call is fully cached. So gh search should have been hit exactly twice total,
-        # not 4 — the cache catches the second invocation.
-        Assert-MockCalled Invoke-GhCli -Times 2 -Exactly -Scope It -ParameterFilter {
+        # Single OR query covers both forms in one API call → first call hits gh once,
+        # second is fully cached. Total: 1 search call across 2 invocations.
+        Assert-MockCalled Invoke-GhCli -Times 1 -Exactly -Scope It -ParameterFilter {
             @($Arguments)[0] -eq 'search' -and @($Arguments)[1] -eq 'prs'
+        }
+    }
+
+    It 'uses a single OR query covering both `#N` and `issues/N` linking forms (PR #35858 round-2)' {
+        # Verify the actual query string includes the OR clause — pre-fix this was two
+        # separate API calls, which doubled rate-limit pressure and could discard
+        # positive evidence on partial failure.
+        $script:_searchJson = '[]'
+        Test-MilestoneValidForIssue -IssueNumber 99 -Milestone '.NET 10 SR6' | Out-Null
+        Assert-MockCalled Invoke-GhCli -Times 1 -Exactly -Scope It -ParameterFilter {
+            $a = @($Arguments)
+            $a[0] -eq 'search' -and $a[1] -eq 'prs' -and
+            $a[2] -match '#99 in:title,body OR issues/99 in:body'
         }
     }
 
@@ -1005,5 +1050,140 @@ Describe 'Invoke-AnalyzeSinglePr — validation context seeding (PR #35858 findi
         $script:_initArgs.Major | Should -Be 11
         # The tags array we passed in must reach the initializer (so KEEP queries have data to work with).
         $script:_initArgs.AllTags | Should -Contain '10.0.60'
+    }
+}
+
+Describe 'Get-TagsForMilestone — cross-major filter (PR #35858 round-2 critical finding)' {
+    BeforeEach {
+        # Seed validation context as a live workflow run would: target major = 11.
+        # We MUST be able to look up tags for a .NET 10 milestone (the cross-major
+        # KEEP scenario), even though validationMajor is set to 11.
+        Initialize-MilestoneValidationContext `
+            -RepoPath '.' `
+            -AllTags @('10.0.50', '10.0.60', '10.0.61', '10.0.70', '10.0.71', '10.0.80', '11.0.0', '11.0.1') `
+            -Major 11
+    }
+
+    It 'returns 10.x tags when looking up `.NET 10 SR6` while validationMajor=11 (cross-major KEEP scenario)' {
+        # Pre-fix this returned @() because the `Test-IsReleaseTag $tag 11` filter
+        # dropped every 10.x tag → Test-PrShippedInMilestone returned $false →
+        # earliest-release-wins KEEP guard silently clobbered the SR6 milestone.
+        $tags = Get-TagsForMilestone -Milestone '.NET 10 SR6'
+        $tags | Should -Contain '10.0.60'
+        $tags | Should -Not -Contain '11.0.0'
+        $tags | Should -Not -Contain '10.0.70'  # 10.0.70 maps to .NET 10 SR7, not SR6
+    }
+
+    It 'returns 10.x tags when looking up `.NET 10 SR7.1` (sub-patch)' {
+        $tags = Get-TagsForMilestone -Milestone '.NET 10 SR7.1'
+        $tags | Should -Contain '10.0.71'
+    }
+
+    It 'returns 11.x tags when looking up `.NET 11.0 GA` (same-major case still works)' {
+        $tags = Get-TagsForMilestone -Milestone '.NET 11.0 GA'
+        $tags | Should -Contain '11.0.0'
+    }
+
+    It 'returns empty for non-comparable milestones' {
+        Get-TagsForMilestone -Milestone 'Backlog' | Should -BeNullOrEmpty
+        Get-TagsForMilestone -Milestone '.NET 11 Planning' | Should -BeNullOrEmpty
+    }
+
+    It 'caches results per-milestone' {
+        $first  = Get-TagsForMilestone -Milestone '.NET 10 SR6'
+        $second = Get-TagsForMilestone -Milestone '.NET 10 SR6'
+        $first.Count | Should -Be $second.Count
+    }
+}
+
+Describe 'Test-PrShippedInMilestone — tristate on git failure (PR #35858 round-2 finding)' {
+    BeforeEach {
+        Initialize-MilestoneValidationContext `
+            -RepoPath '.' `
+            -AllTags @('10.0.60', '10.0.61') `
+            -Major 10
+    }
+
+    It 'returns $true when commit is in any matching tag' {
+        # Both 10.0.60 and 10.0.61 map to ".NET 10 SR6" and ".NET 10 SR6.1" respectively.
+        # For SR6, only 10.0.60 matches. Mock Get-PrsInTag directly to avoid HashSet plumbing.
+        Mock Get-PrsInTag {
+            $set = [System.Collections.Generic.HashSet[int]]::new()
+            [void]$set.Add(101); [void]$set.Add(102)
+            return ,$set
+        }
+        Test-PrShippedInMilestone -PrNumber 101 -Milestone '.NET 10 SR6' | Should -BeTrue
+    }
+
+    It 'returns $false when ALL git reads succeed and no matching tag contains the PR' {
+        Mock Get-PrsInTag {
+            $set = [System.Collections.Generic.HashSet[int]]::new()
+            [void]$set.Add(999)
+            return ,$set
+        }
+        Test-PrShippedInMilestone -PrNumber 42 -Milestone '.NET 10 SR6' | Should -BeFalse
+    }
+
+    It 'returns $null (uncertain) when git read fails AND no other tag confirmed the PR' {
+        # Get-PrsInTag returns $null on git failure. Caller must NOT treat this as
+        # $false (which would clobber a possibly-valid earlier milestone).
+        Mock Get-PrsInTag { return $null }
+        $result = Test-PrShippedInMilestone -PrNumber 42 -Milestone '.NET 10 SR6' -WarningAction SilentlyContinue
+        ($null -eq $result) | Should -BeTrue
+    }
+
+    It 'returns $true even when some other tag''s git read failed — definitive evidence wins over uncertainty' {
+        # Seed two tags both mapping to SR6 by extending the cache to include another SR6 tag.
+        # We simulate one tag failing and the other returning the PR.
+        Initialize-MilestoneValidationContext `
+            -RepoPath '.' `
+            -AllTags @('10.0.60', '10.0.60-rc.1') `
+            -Major 10
+        $callCount = 0
+        Mock Get-PrsInTag {
+            $script:callCount++
+            if ($script:callCount -eq 1) { return $null }
+            $set = [System.Collections.Generic.HashSet[int]]::new()
+            [void]$set.Add(101)
+            return ,$set
+        }
+        # Force both tags into the .NET 10 SR6 bucket by also mocking Get-TagsForMilestone.
+        Mock Get-TagsForMilestone { return @('10.0.60', '10.0.60-rc.1') }
+        Test-PrShippedInMilestone -PrNumber 101 -Milestone '.NET 10 SR6' -WarningAction SilentlyContinue | Should -BeTrue
+    }
+}
+
+Describe 'Test-AndRecordCorrection — PR-side tristate propagation (PR #35858 round-2)' {
+    BeforeEach {
+        Mock Test-MilestoneValidForPr {
+            param([int]$PrNumber, [string]$Milestone)
+            if ($script:_prValid.ContainsKey("$PrNumber|$Milestone")) {
+                return $script:_prValid["$PrNumber|$Milestone"]
+            }
+            return $false
+        }
+        $script:_prValid = @{}
+    }
+
+    It 'PR-side $null from validator → SKIP correction (mirrors issue-side defensive behavior)' {
+        # The PR-side KEEP path was previously fail-closed-on-$false even when the underlying
+        # git read failed. Now Test-MilestoneValidForPr is tristate too, and the same
+        # defensive skip applies.
+        $script:_prValid['34527|.NET 10 SR6'] = $null
+        $report = @{
+            TotalPrs       = 1
+            PrsChecked     = 0
+            IssuesChecked  = 0
+            AlreadyCorrect = 0
+            Corrections    = [System.Collections.ArrayList]::new()
+            Errors         = [System.Collections.ArrayList]::new()
+        }
+        $resolvedMs = @{ Number = 999; Title = '.NET 10 SR8' }
+
+        Test-AndRecordCorrection 'pr' 34527 'Cherry' 'u' '.NET 10 SR6' '.NET 10 SR8' $resolvedMs 0 $report `
+            -WarningAction SilentlyContinue
+
+        $report.Corrections.Count | Should -Be 0
+        if ($report.ContainsKey('Kept')) { $report.Kept.Count | Should -Be 0 }
     }
 }

--- a/.github/scripts/Fix-MilestoneDrift.Tests.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.Tests.ps1
@@ -443,3 +443,127 @@ Describe 'Test-PrBelongsToVersion' {
         }
     }
 }
+
+Describe 'Close-LinkedIssue' {
+    BeforeEach {
+        $script:_ghViewState = 'OPEN'
+        $script:_ghViewExit  = 0
+        $script:_ghCloseExit = 0
+        $script:_lastCloseComment = $null
+
+        Mock Invoke-GhCli {
+            # `$Arguments` is the splat array because Invoke-GhCli declares it as
+            # [Parameter(ValueFromRemainingArguments)]. Be tolerant of either shape.
+            $a = @($Arguments)
+
+            if ($a.Count -ge 2 -and $a[0] -eq 'issue' -and $a[1] -eq 'view') {
+                $global:LASTEXITCODE = $script:_ghViewExit
+                if ($script:_ghViewExit -ne 0) { return 'simulated gh view failure' }
+                return "{`"state`":`"$($script:_ghViewState)`",`"number`":42,`"title`":`"test`"}"
+            }
+
+            if ($a.Count -ge 2 -and $a[0] -eq 'issue' -and $a[1] -eq 'close') {
+                $global:LASTEXITCODE = $script:_ghCloseExit
+                # Capture the comment text for assertion convenience.
+                $commentIndex = [array]::IndexOf($a, '--comment')
+                if ($commentIndex -ge 0 -and $commentIndex + 1 -lt $a.Count) {
+                    $script:_lastCloseComment = $a[$commentIndex + 1]
+                }
+                if ($script:_ghCloseExit -ne 0) { return 'simulated gh close failure' }
+                return ''
+            }
+
+            $global:LASTEXITCODE = 0
+            return ''
+        }
+    }
+
+    It 'no-ops when the issue is already closed (no gh issue close call)' {
+        $script:_ghViewState = 'CLOSED'
+
+        Close-LinkedIssue -IssueNumber 42 -PrNumber 100 -BaseRef 'net11.0' -Apply $true
+
+        Assert-MockCalled Invoke-GhCli -Times 1 -Exactly -Scope It -ParameterFilter {
+            @($Arguments)[0] -eq 'issue' -and @($Arguments)[1] -eq 'view'
+        }
+        Assert-MockCalled Invoke-GhCli -Times 0 -Exactly -Scope It -ParameterFilter {
+            @($Arguments)[0] -eq 'issue' -and @($Arguments)[1] -eq 'close'
+        }
+    }
+
+    It 'no-ops when the issue is already closed in lowercase state' {
+        $script:_ghViewState = 'closed'
+
+        Close-LinkedIssue -IssueNumber 42 -PrNumber 100 -BaseRef 'net11.0' -Apply $true
+
+        Assert-MockCalled Invoke-GhCli -Times 0 -Exactly -Scope It -ParameterFilter {
+            @($Arguments)[0] -eq 'issue' -and @($Arguments)[1] -eq 'close'
+        }
+    }
+
+    It 'calls gh issue close with the correct args when issue is open and -Apply is set' {
+        $script:_ghViewState = 'OPEN'
+
+        Close-LinkedIssue -IssueNumber 42 -PrNumber 100 -BaseRef 'net11.0' -Apply $true
+
+        Assert-MockCalled Invoke-GhCli -Times 1 -Exactly -Scope It -ParameterFilter {
+            $a = @($Arguments)
+            ($a[0] -eq 'issue') -and ($a[1] -eq 'close') -and
+            ($a -contains '42') -and ($a -contains 'dotnet/maui') -and
+            ($a -contains '--reason') -and ($a -contains 'completed') -and ($a -contains '--comment')
+        }
+        # Comment text should reference the PR and the base ref
+        $script:_lastCloseComment | Should -Not -BeNullOrEmpty
+        $script:_lastCloseComment | Should -Match '#100'
+        $script:_lastCloseComment | Should -Match 'net11\.0'
+    }
+
+    It 'does NOT call gh issue close in dry-run mode (Apply = $false)' {
+        $script:_ghViewState = 'OPEN'
+
+        Close-LinkedIssue -IssueNumber 42 -PrNumber 100 -BaseRef 'net11.0' -Apply $false
+
+        Assert-MockCalled Invoke-GhCli -Times 0 -Exactly -Scope It -ParameterFilter {
+            @($Arguments)[0] -eq 'issue' -and @($Arguments)[1] -eq 'close'
+        }
+        # But we DID check the issue state (the view call)
+        Assert-MockCalled Invoke-GhCli -Times 1 -Exactly -Scope It -ParameterFilter {
+            @($Arguments)[0] -eq 'issue' -and @($Arguments)[1] -eq 'view'
+        }
+    }
+
+    It 'warns and returns when gh issue view fails (no close call, no throw)' {
+        $script:_ghViewExit = 1
+
+        { Close-LinkedIssue -IssueNumber 42 -PrNumber 100 -BaseRef 'net11.0' -Apply $true -WarningAction SilentlyContinue } |
+            Should -Not -Throw
+
+        Assert-MockCalled Invoke-GhCli -Times 0 -Exactly -Scope It -ParameterFilter {
+            @($Arguments)[0] -eq 'issue' -and @($Arguments)[1] -eq 'close'
+        }
+    }
+
+    It 'warns and returns when gh issue close fails (does not throw)' {
+        $script:_ghViewState = 'OPEN'
+        $script:_ghCloseExit = 1
+
+        { Close-LinkedIssue -IssueNumber 42 -PrNumber 100 -BaseRef 'net11.0' -Apply $true -WarningAction SilentlyContinue } |
+            Should -Not -Throw
+
+        # We did attempt the close even though it failed
+        Assert-MockCalled Invoke-GhCli -Times 1 -Exactly -Scope It -ParameterFilter {
+            @($Arguments)[0] -eq 'issue' -and @($Arguments)[1] -eq 'close'
+        }
+    }
+
+    It 'falls back to a placeholder branch label when BaseRef is empty' {
+        $script:_ghViewState = 'OPEN'
+
+        Close-LinkedIssue -IssueNumber 42 -PrNumber 100 -BaseRef '' -Apply $true
+
+        Assert-MockCalled Invoke-GhCli -Times 1 -Exactly -Scope It -ParameterFilter {
+            @($Arguments)[0] -eq 'issue' -and @($Arguments)[1] -eq 'close'
+        }
+        $script:_lastCloseComment | Should -Match 'unknown branch'
+    }
+}

--- a/.github/scripts/Fix-MilestoneDrift.Tests.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.Tests.ps1
@@ -567,3 +567,179 @@ Describe 'Close-LinkedIssue' {
         $script:_lastCloseComment | Should -Match 'unknown branch'
     }
 }
+
+Describe 'Get-MilestoneSortKey' {
+    It 'returns null for null/empty/whitespace' {
+        Get-MilestoneSortKey $null   | Should -Be $null
+        Get-MilestoneSortKey ''      | Should -Be $null
+        Get-MilestoneSortKey '   '   | Should -Be $null
+    }
+
+    It 'returns null for non-release placeholder milestones' {
+        Get-MilestoneSortKey 'Backlog'             | Should -Be $null
+        Get-MilestoneSortKey '.NET 11 Planning'    | Should -Be $null
+        Get-MilestoneSortKey 'Future'              | Should -Be $null
+        Get-MilestoneSortKey 'Triage'              | Should -Be $null
+    }
+
+    It 'orders preview/rc/GA/SR within a major correctly' {
+        $p1  = Get-MilestoneSortKey '.NET 11.0-preview1'
+        $p3  = Get-MilestoneSortKey '.NET 11.0-preview3'
+        $rc1 = Get-MilestoneSortKey '.NET 11.0-rc1'
+        $ga  = Get-MilestoneSortKey '.NET 11.0 GA'
+        $sr1 = Get-MilestoneSortKey '.NET 11 SR1'
+
+        ($p1 -lt $p3) | Should -BeTrue
+        ($p3 -lt $rc1) | Should -BeTrue
+        ($rc1 -lt $ga) | Should -BeTrue
+        ($ga -lt $sr1) | Should -BeTrue
+    }
+
+    It 'orders SR sub-patches between SRs (SR4 < SR4.1 < SR5)' {
+        $sr4   = Get-MilestoneSortKey '.NET 10 SR4'
+        $sr4_1 = Get-MilestoneSortKey '.NET 10 SR4.1'
+        $sr5   = Get-MilestoneSortKey '.NET 10 SR5'
+
+        ($sr4 -lt $sr4_1) | Should -BeTrue
+        ($sr4_1 -lt $sr5) | Should -BeTrue
+    }
+
+    It 'orders earlier majors before later majors' {
+        $net10_sr6 = Get-MilestoneSortKey '.NET 10 SR6'
+        $net11_p1  = Get-MilestoneSortKey '.NET 11.0-preview1'
+        ($net10_sr6 -lt $net11_p1) | Should -BeTrue
+    }
+}
+
+Describe 'Compare-MauiMilestone' {
+    It 'returns -1 when A is earlier (.NET 10 SR6 < .NET 11.0-preview3)' {
+        Compare-MauiMilestone '.NET 10 SR6' '.NET 11.0-preview3' | Should -Be -1
+    }
+
+    It 'returns 1 when A is later (.NET 11.0-preview3 > .NET 10 SR6)' {
+        Compare-MauiMilestone '.NET 11.0-preview3' '.NET 10 SR6' | Should -Be 1
+    }
+
+    It 'returns 0 when both are the same milestone' {
+        Compare-MauiMilestone '.NET 11.0-preview3' '.NET 11.0-preview3' | Should -Be 0
+    }
+
+    It 'returns null when either side is non-comparable (Backlog/Planning/none)' {
+        Compare-MauiMilestone 'Backlog' '.NET 11.0-preview3' | Should -Be $null
+        Compare-MauiMilestone '.NET 11.0-preview3' '.NET 11 Planning' | Should -Be $null
+        Compare-MauiMilestone $null '.NET 11.0-preview3' | Should -Be $null
+        Compare-MauiMilestone '' '.NET 11.0-preview3' | Should -Be $null
+    }
+
+    It 'returns -1 for preview before rc (.NET 11.0-preview7 < .NET 11.0-rc1)' {
+        Compare-MauiMilestone '.NET 11.0-preview7' '.NET 11.0-rc1' | Should -Be -1
+    }
+}
+
+Describe 'Test-MilestoneValidForIssue' {
+    BeforeEach {
+        # Clear cache between tests so each starts fresh.
+        $script:milestoneValidationCache = @{}
+
+        # Default search response: empty array.
+        $script:_searchJson = '[]'
+        $script:_searchExit = 0
+        # Default Get-PrInfo response: PR with no milestone.
+        $script:_prMilestones = @{}
+
+        Mock Invoke-GhCli {
+            $a = @($Arguments)
+            if ($a.Count -ge 2 -and $a[0] -eq 'search' -and $a[1] -eq 'prs') {
+                $global:LASTEXITCODE = $script:_searchExit
+                if ($script:_searchExit -ne 0) { return 'simulated gh search failure' }
+                return $script:_searchJson
+            }
+            $global:LASTEXITCODE = 0
+            return ''
+        }
+
+        Mock Get-PrInfo {
+            param([int]$PrNum)
+            if ($script:_prMilestones.ContainsKey($PrNum)) {
+                return @{ Number = $PrNum; Milestone = $script:_prMilestones[$PrNum]; Title = "PR $PrNum"; Url = "u"; Body = ''; BaseRef = 'main' }
+            }
+            return $null
+        }
+    }
+
+    It 'returns false when no PRs reference the issue' {
+        $script:_searchJson = '[]'
+        Test-MilestoneValidForIssue -IssueNumber 9999 -Milestone '.NET 10 SR6' | Should -BeFalse
+    }
+
+    It 'returns false for null/empty milestone (no validation needed)' {
+        Test-MilestoneValidForIssue -IssueNumber 42 -Milestone $null | Should -BeFalse
+        Test-MilestoneValidForIssue -IssueNumber 42 -Milestone ''   | Should -BeFalse
+    }
+
+    It 'returns true when a linking fix-PR has the target milestone' {
+        $script:_searchJson = '[{"number":501,"title":"Fix bug","body":"Fixes #34490","url":"u"}]'
+        $script:_prMilestones[501] = '.NET 10 SR6'
+
+        Test-MilestoneValidForIssue -IssueNumber 34490 -Milestone '.NET 10 SR6' | Should -BeTrue
+    }
+
+    It 'returns false when a PR mentions the issue but does not use a fix verb' {
+        # Just a casual mention "#34490" — should not count as a fix
+        $script:_searchJson = '[{"number":888,"title":"Related work","body":"See #34490 for context","url":"u"}]'
+        $script:_prMilestones[888] = '.NET 10 SR6'
+
+        Test-MilestoneValidForIssue -IssueNumber 34490 -Milestone '.NET 10 SR6' | Should -BeFalse
+    }
+
+    It 'returns false when fixing PR has no milestone' {
+        $script:_searchJson = '[{"number":513,"title":"net11 fix","body":"Fixes #34490","url":"u"}]'
+        # PR 513 has no milestone (not in $_prMilestones)
+
+        Test-MilestoneValidForIssue -IssueNumber 34490 -Milestone '.NET 10 SR6' | Should -BeFalse
+    }
+
+    It 'returns false when fixing PR has a different milestone' {
+        $script:_searchJson = '[{"number":513,"title":"net11 fix","body":"Fixes #34490","url":"u"}]'
+        $script:_prMilestones[513] = '.NET 11.0-preview3'
+
+        Test-MilestoneValidForIssue -IssueNumber 34490 -Milestone '.NET 10 SR6' | Should -BeFalse
+    }
+
+    It 'returns true if ANY of multiple linking PRs validates the milestone' {
+        # Two PRs link the issue; only the second has the matching milestone.
+        $script:_searchJson = '[{"number":513,"title":"net11 fix","body":"Fixes #34490","url":"u"},{"number":501,"title":"sr6 fix","body":"Fixes #34490","url":"u"}]'
+        $script:_prMilestones[513] = '.NET 11.0-preview3'
+        $script:_prMilestones[501] = '.NET 10 SR6'
+
+        Test-MilestoneValidForIssue -IssueNumber 34490 -Milestone '.NET 10 SR6' | Should -BeTrue
+    }
+
+    It 'returns false (and warns, does not throw) when gh search fails' {
+        $script:_searchExit = 1
+        { Test-MilestoneValidForIssue -IssueNumber 42 -Milestone '.NET 10 SR6' -WarningAction SilentlyContinue } |
+            Should -Not -Throw
+        Test-MilestoneValidForIssue -IssueNumber 42 -Milestone '.NET 10 SR6' -WarningAction SilentlyContinue | Should -BeFalse
+    }
+
+    It 'caches lookups so a second call does not re-query gh' {
+        $script:_searchJson = '[{"number":501,"title":"Fix bug","body":"Fixes #34490","url":"u"}]'
+        $script:_prMilestones[501] = '.NET 10 SR6'
+
+        Test-MilestoneValidForIssue -IssueNumber 34490 -Milestone '.NET 10 SR6' | Should -BeTrue
+        Test-MilestoneValidForIssue -IssueNumber 34490 -Milestone '.NET 10 SR6' | Should -BeTrue
+
+        # gh search should have been hit exactly once
+        Assert-MockCalled Invoke-GhCli -Times 1 -Exactly -Scope It -ParameterFilter {
+            @($Arguments)[0] -eq 'search' -and @($Arguments)[1] -eq 'prs'
+        }
+    }
+
+    It 'matches a fix verb that uses an owner/repo prefix (org/repo#NNN)' {
+        # Real-world bodies sometimes write "Fixes dotnet/maui#34490"
+        $script:_searchJson = '[{"number":501,"title":"Fix bug","body":"Fixes dotnet/maui#34490","url":"u"}]'
+        $script:_prMilestones[501] = '.NET 10 SR6'
+
+        Test-MilestoneValidForIssue -IssueNumber 34490 -Milestone '.NET 10 SR6' | Should -BeTrue
+    }
+}

--- a/.github/scripts/Fix-MilestoneDrift.Tests.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.Tests.ps1
@@ -54,11 +54,18 @@
       pwsh -File .github/scripts/Fix-MilestoneDrift.ps1 -Tag 10.0.50 -RepoPath . -Output /dev/null -Verbose
       # Expected: finds 10.0.41 as previous tag, scans ~78 PRs, all .NET 10
 
-      # 8. URL-form linked-issue validation — covers the `Fixes https://github.com/dotnet/maui/issues/N`
-      #    branch of Test-MilestoneValidForIssue. Pick a PR whose body uses the URL form for "Fixes".
+      # 8. URL-form linked-issue discovery — covers the `Get-LinkedIssues` parser branch
+      #    that extracts `Fixes https://github.com/dotnet/maui/issues/N` (the `#N` shorthand
+      #    is the same-repo path; the URL form is the cross-origin form that an external
+      #    contributor or copy-pasted-from-browser link will use).
       pwsh -File .github/scripts/Fix-MilestoneDrift.ps1 -PrNumber 35662 -RepoPath . -Verbose
-      # Expected: linked issue #35615 resolved via the URL form (body says "Fixes https://github.com/dotnet/maui/issues/35615").
-      # If the URL branch ever regresses, this dry-run will skip the issue under "Linked issues: (none)".
+      # Expected: report says `Issues checked: 1` (issue #35615 was found via the URL form).
+      # If the URL branch ever regresses, `Issues checked` will drop to 0 instead.
+      # Note: this dry-run does NOT exercise Test-MilestoneValidForIssue because PR 35662
+      # and issue #35615 share a milestone (.NET 10 SR9), so Test-AndRecordCorrection
+      # short-circuits before calling the validator. The Pester test at the
+      # `'matches a fix verb that uses the full URL form (issues/N)'` It-block covers
+      # the validator's URL-form OR query directly.
 
     Key things to verify after changes:
       - inflight/* and darc/* PRs read from origin/main (they feed into main)
@@ -342,7 +349,7 @@ Describe 'Get-LinkedIssues' {
         $result | Should -HaveCount 3
     }
 
-    It 'DOES NOT cross-pollute from other repos — `Fixes dotnet/runtime#42` must NOT be extracted as MAUI #42 (PR #35858 follow-up finding)' {
+    It 'DOES NOT cross-pollute from other repos — `Fixes dotnet/runtime#42` must NOT be extracted as MAUI #42' {
         # Round-2 review caught this: an over-broad `[A-Za-z0-9_\-./]+?` prefix would
         # silently treat any cross-repo reference as a MAUI issue. The validator would
         # then clobber dotnet/maui#42's milestone based on a fix in dotnet/runtime#42.
@@ -936,7 +943,7 @@ Describe 'Test-AndRecordCorrection — earliest-release-wins guard' {
         }
     }
 
-    It 'finding E: deduplicates the SAME issue across multiple linking PRs in the Kept bucket' {
+    It 'deduplicates the SAME issue across multiple linking PRs in the Kept bucket' {
         # The same issue can be discovered via multiple linking PRs during a tag-range walk
         # (e.g. a backport PR and the original PR both reference the issue). Pre-fix, each
         # touch appended a new row, polluting the report.
@@ -953,7 +960,7 @@ Describe 'Test-AndRecordCorrection — earliest-release-wins guard' {
         $report.Kept[0].Number | Should -Be 34490
     }
 
-    It 'finding E: does NOT collapse Kept entries for different issues that share a milestone' {
+    It 'does NOT collapse Kept entries for different issues that share a milestone' {
         $script:_validForIssue['34490|.NET 10 SR6'] = $true
         $script:_validForIssue['34491|.NET 10 SR6'] = $true
         $report = & $script:_newReport
@@ -965,7 +972,7 @@ Describe 'Test-AndRecordCorrection — earliest-release-wins guard' {
         $report.Kept.Count | Should -Be 2
     }
 
-    It 'finding C: when validator returns $null (uncertain) — does NOT queue a correction (defensive)' {
+    It 'when validator returns $null (uncertain) — does NOT queue a correction (defensive)' {
         # Earlier milestone + validator inconclusive ==> we MUST keep the current milestone.
         # Pre-fix, $null was coerced to $false and a destructive correction got queued.
         $script:_validForIssue['34490|.NET 10 SR6'] = $null
@@ -980,7 +987,7 @@ Describe 'Test-AndRecordCorrection — earliest-release-wins guard' {
         if ($report.ContainsKey('Kept')) { $report.Kept.Count | Should -Be 0 }
     }
 
-    It 'finding C: when validator returns $false (no linking PR shipped there) — DOES queue a correction' {
+    It 'when validator returns $false (no linking PR shipped there) — DOES queue a correction' {
         # This is the legitimate clobber path: earlier milestone was wrong, no fix actually
         # shipped there, the target milestone is correct. Pre-fix and post-fix both work.
         $script:_validForIssue['34490|.NET 10 SR6'] = $false
@@ -993,7 +1000,7 @@ Describe 'Test-AndRecordCorrection — earliest-release-wins guard' {
         $report.Corrections[0].Number | Should -Be 34490
     }
 
-    It 'findings A + E together: PR-side KEEP path also dedups (cherry-pick case)' {
+    It 'PR-side KEEP path also dedups identical (PR, milestone) pairs (cherry-pick case)' {
         # A cherry-picked PR can match in multiple linking searches. Same dedup applies.
         $script:_validForPr['34527|.NET 10 SR6'] = $true
         $report = & $script:_newReport

--- a/.github/scripts/Fix-MilestoneDrift.Tests.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.Tests.ps1
@@ -54,6 +54,12 @@
       pwsh -File .github/scripts/Fix-MilestoneDrift.ps1 -Tag 10.0.50 -RepoPath . -Output /dev/null -Verbose
       # Expected: finds 10.0.41 as previous tag, scans ~78 PRs, all .NET 10
 
+      # 8. URL-form linked-issue validation — covers the `Fixes https://github.com/dotnet/maui/issues/N`
+      #    branch of Test-MilestoneValidForIssue. Pick a PR whose body uses the URL form for "Fixes".
+      pwsh -File .github/scripts/Fix-MilestoneDrift.ps1 -PrNumber 35662 -RepoPath . -Verbose
+      # Expected: linked issue #35615 resolved via the URL form (body says "Fixes https://github.com/dotnet/maui/issues/35615").
+      # If the URL branch ever regresses, this dry-run will skip the issue under "Linked issues: (none)".
+
     Key things to verify after changes:
       - inflight/* and darc/* PRs read from origin/main (they feed into main)
       - net11.0 PRs read from origin/net11.0 (never from origin/main)
@@ -319,7 +325,7 @@ Describe 'Get-LinkedIssues' {
         $result | Should -Contain 666
     }
 
-    It 'extracts cross-repo `Fixes dotnet/maui#NNNNN` form (PR #35858 finding F)' {
+    It 'extracts cross-repo `Fixes dotnet/maui#NNNNN` form' {
         # External contributors frequently use the cross-repo shorthand even within the
         # same repo. Pre-fix, this regex required `#` immediately after the verb, so the
         # `dotnet/maui` prefix made it silently ignored — meaning issues that should have
@@ -793,7 +799,7 @@ Describe 'Test-MilestoneValidForIssue' {
         ($null -eq $result) | Should -BeTrue
     }
 
-    It 'does NOT cache $null — retries on a later call so a transient gh failure doesn''t permanently disable KEEP for the run (PR #35858 round-2)' {
+    It 'does NOT cache $null — retries on a later call so a transient gh failure doesn''t permanently disable KEEP for the run' {
         # First call: gh fails → return $null (uncertain). DO NOT cache.
         $script:_searchExit = 1
         Test-MilestoneValidForIssue -IssueNumber 7 -Milestone '.NET 10 SR6' -WarningAction SilentlyContinue | Should -BeNullOrEmpty
@@ -819,7 +825,7 @@ Describe 'Test-MilestoneValidForIssue' {
         }
     }
 
-    It 'uses a single OR query covering both `#N` and `issues/N` linking forms (PR #35858 round-2)' {
+    It 'uses a single OR query covering both `#N` and `issues/N` linking forms' {
         # Verify the actual query string includes the OR clause — pre-fix this was two
         # separate API calls, which doubled rate-limit pressure and could discard
         # positive evidence on partial failure.
@@ -840,7 +846,7 @@ Describe 'Test-MilestoneValidForIssue' {
         Test-MilestoneValidForIssue -IssueNumber 34490 -Milestone '.NET 10 SR6' | Should -BeTrue
     }
 
-    It 'matches a fix verb that uses the full URL form (issues/N) — PR #35858 finding D' {
+    It 'matches a fix verb that uses the full URL form (issues/N)' {
         # When a PR body links the issue ONLY via the URL form (`Fixes https://.../issues/N`)
         # — never the `#N` shorthand — the original `#N in:body` query missed it entirely.
         # The supplementary `issues/N in:body` query covers that case.
@@ -898,7 +904,7 @@ Describe 'Test-MilestoneValidForPr' {
     }
 }
 
-Describe 'Test-AndRecordCorrection — earliest-release-wins guard (PR #35858 findings A, C, E)' {
+Describe 'Test-AndRecordCorrection — earliest-release-wins guard' {
     BeforeEach {
         # Mock the underlying validators so the test focuses on dispatch logic.
         Mock Test-MilestoneValidForIssue {
@@ -1000,7 +1006,7 @@ Describe 'Test-AndRecordCorrection — earliest-release-wins guard (PR #35858 fi
     }
 }
 
-Describe 'Invoke-AnalyzeSinglePr — validation context seeding (PR #35858 finding A)' {
+Describe 'Invoke-AnalyzeSinglePr — validation context seeding' {
     BeforeEach {
         # Stand up the bare minimum mocks so Invoke-AnalyzeSinglePr can run start-to-finish
         # without touching git, gh, or the file system.
@@ -1053,7 +1059,7 @@ Describe 'Invoke-AnalyzeSinglePr — validation context seeding (PR #35858 findi
     }
 }
 
-Describe 'Get-TagsForMilestone — cross-major filter (PR #35858 round-2 critical finding)' {
+Describe 'Get-TagsForMilestone — cross-major filter' {
     BeforeEach {
         # Seed validation context as a live workflow run would: target major = 11.
         # We MUST be able to look up tags for a .NET 10 milestone (the cross-major
@@ -1096,7 +1102,7 @@ Describe 'Get-TagsForMilestone — cross-major filter (PR #35858 round-2 critica
     }
 }
 
-Describe 'Test-PrShippedInMilestone — tristate on git failure (PR #35858 round-2 finding)' {
+Describe 'Test-PrShippedInMilestone — tristate on git failure' {
     BeforeEach {
         Initialize-MilestoneValidationContext `
             -RepoPath '.' `
@@ -1153,7 +1159,7 @@ Describe 'Test-PrShippedInMilestone — tristate on git failure (PR #35858 round
     }
 }
 
-Describe 'Test-AndRecordCorrection — PR-side tristate propagation (PR #35858 round-2)' {
+Describe 'Test-AndRecordCorrection — PR-side tristate propagation' {
     BeforeEach {
         Mock Test-MilestoneValidForPr {
             param([int]$PrNumber, [string]$Milestone)
@@ -1188,7 +1194,7 @@ Describe 'Test-AndRecordCorrection — PR-side tristate propagation (PR #35858 r
     }
 }
 
-Describe 'Get-PrsInTag — unary-comma preserves HashSet on cache hit (PR #35858 round-3 finding)' {
+Describe 'Get-PrsInTag — unary-comma preserves HashSet on cache hit' {
     BeforeEach {
         Initialize-MilestoneValidationContext `
             -RepoPath '.' `

--- a/.github/scripts/Fix-MilestoneDrift.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.ps1
@@ -441,6 +441,116 @@ function Set-ItemMilestone([int]$ItemNumber, [int]$MilestoneNumber) {
 # Cache of milestone-validity lookups so we don't re-query gh for the same (issue, milestone) pair.
 $script:milestoneValidationCache = @{}
 
+# Caches used by the commit-in-tag validation. Populated lazily.
+$script:milestoneTagsCache = @{}
+$script:tagPrCache = @{}
+
+# Script-scoped context set by Invoke-AnalyzeRelease so validators can resolve
+# milestone → tag mappings without re-fetching.
+$script:validationRepoPath = $null
+$script:validationAllTags = $null
+$script:validationMajor = 0
+
+function Initialize-MilestoneValidationContext {
+    <# Reset and seed per-run validation context. Call from Invoke-AnalyzeRelease. #>
+    param(
+        [Parameter(Mandatory)][string]$RepoPath,
+        [Parameter(Mandatory)][string[]]$AllTags,
+        [Parameter(Mandatory)][int]$Major
+    )
+    $script:milestoneValidationCache = @{}
+    $script:milestoneTagsCache = @{}
+    $script:tagPrCache = @{}
+    $script:validationRepoPath = $RepoPath
+    $script:validationAllTags = $AllTags
+    $script:validationMajor = $Major
+}
+
+function Get-TagsForMilestone {
+    <#
+    .SYNOPSIS
+        Returns release tags whose ConvertTo-Milestone result matches the given milestone name.
+    .DESCRIPTION
+        e.g. ".NET 10 SR6" → @("10.0.60") (and 10.0.61 only if it maps back to SR6, which it
+        doesn't — 10.0.61 maps to ".NET 10 SR6.1"). Empty array if the milestone is not a
+        comparable release (Backlog/Planning) or no tag matches.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][AllowNull()][string]$Milestone
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Milestone)) { return @() }
+    if (-not $script:validationAllTags -or $script:validationMajor -le 0) { return @() }
+
+    if ($script:milestoneTagsCache.ContainsKey($Milestone)) {
+        return @($script:milestoneTagsCache[$Milestone])
+    }
+
+    $matchingTags = [System.Collections.Generic.List[string]]::new()
+    foreach ($tag in $script:validationAllTags) {
+        if (-not (Test-IsReleaseTag $tag $script:validationMajor)) { continue }
+        $tagMs = ConvertTo-Milestone $tag
+        if ([string]::IsNullOrWhiteSpace($tagMs)) { continue }
+        if (Test-MilestoneMatch $tagMs $Milestone) {
+            [void]$matchingTags.Add($tag)
+        }
+    }
+
+    $script:milestoneTagsCache[$Milestone] = $matchingTags.ToArray()
+    return @($script:milestoneTagsCache[$Milestone])
+}
+
+function Get-PrsInTag {
+    <# Returns (cached) the set of PR numbers reachable from a tag. #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Tag
+    )
+    if (-not $script:validationRepoPath) { return @() }
+    if ($script:tagPrCache.ContainsKey($Tag)) {
+        return $script:tagPrCache[$Tag]
+    }
+    try {
+        $prs = Get-PrNumbersReachableFromTag $Tag $script:validationRepoPath
+    } catch {
+        Write-Warning "Get-PrsInTag: failed to read PRs reachable from ${Tag}: $_"
+        $prs = @()
+    }
+    # Store as HashSet for O(1) Contains lookups.
+    $set = [System.Collections.Generic.HashSet[int]]::new()
+    foreach ($p in $prs) { [void]$set.Add([int]$p) }
+    $script:tagPrCache[$Tag] = $set
+    return $set
+}
+
+function Test-PrShippedInMilestone {
+    <#
+    .SYNOPSIS
+        Returns $true iff a PR's merge commit is reachable from a tag that maps to $Milestone.
+    .DESCRIPTION
+        Used by earliest-release-wins validation. A PR is considered to have "shipped in
+        milestone X" only when its commit is actually present in at least one release tag
+        that ConvertTo-Milestone maps to X. This rejects:
+          - PRs that were milestoned for X but never made it (still on `inflight/*`)
+          - Issues whose linking PR was cherry-picked to a later branch but never landed in X
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][int]$PrNumber,
+        [Parameter(Mandatory)][AllowEmptyString()][AllowNull()][string]$Milestone
+    )
+
+    $tags = @(Get-TagsForMilestone -Milestone $Milestone)
+    if ($tags.Count -eq 0) { return $false }
+
+    foreach ($tag in $tags) {
+        $prs = Get-PrsInTag -Tag $tag
+        if ($prs -and $prs.Contains([int]$PrNumber)) { return $true }
+    }
+    return $false
+}
+
 function Test-MilestoneValidForIssue {
     <#
     .SYNOPSIS
@@ -500,12 +610,11 @@ function Test-MilestoneValidForIssue {
             continue
         }
 
-        # Fetch milestone for this linking PR.
-        $prInfo = Get-PrInfo $pr.number
-        if (-not $prInfo) { continue }
-        if (-not $prInfo.Milestone) { continue }
-
-        if (Test-MilestoneMatch $prInfo.Milestone $Milestone) {
+        # The linking PR must actually have its commit in a tag that maps to $Milestone.
+        # Trusting the PR's own milestone field isn't enough — that field can be stale
+        # (e.g. a hotfix PR milestoned `.NET 10 SR7` but only present in tag 10.0.71
+        # which maps to `.NET 10 SR7.1`).
+        if (Test-PrShippedInMilestone -PrNumber ([int]$pr.number) -Milestone $Milestone) {
             $script:milestoneValidationCache[$cacheKey] = $true
             return $true
         }
@@ -513,6 +622,32 @@ function Test-MilestoneValidForIssue {
 
     $script:milestoneValidationCache[$cacheKey] = $false
     return $false
+}
+
+function Test-MilestoneValidForPr {
+    <#
+    .SYNOPSIS
+        Returns $true iff the PR's commit is reachable from a tag that maps to $Milestone
+        — meaning the PR genuinely shipped in that release and we shouldn't override the
+        milestone to a later one.
+    .DESCRIPTION
+        Mirrors the issue-side check, but for PRs themselves. The motivating case: a PR
+        merged to SR6's release branch was later cherry-picked to SR8 via main flow. Its
+        commit therefore appears in BOTH `10.0.60` and `10.0.80`. An SR8 audit would
+        otherwise stomp the (correct) `.NET 10 SR6` milestone.
+
+        Returns $false when:
+          - Milestone is null/empty or isn't a comparable release (Backlog/Planning)
+          - No tag maps to $Milestone
+          - The PR's commit isn't in any of those tags
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][int]$PrNumber,
+        [Parameter(Mandatory)][AllowEmptyString()][AllowNull()][string]$Milestone
+    )
+    if ([string]::IsNullOrWhiteSpace($Milestone)) { return $false }
+    return Test-PrShippedInMilestone -PrNumber $PrNumber -Milestone $Milestone
 }
 
 #endregion
@@ -548,14 +683,24 @@ function Test-AndRecordCorrection(
         return
     }
 
-    # Earlier-milestone validation: if this is an ISSUE whose current milestone is an
-    # earlier release than the target AND we can confirm a fix PR shipped in that earlier
-    # release, KEEP the earlier milestone (earliest release wins). PRs are skipped — they
-    # land in exactly one branch, so the target is by definition correct for them.
-    if ($ItemType -eq 'issue' -and -not [string]::IsNullOrWhiteSpace($CurrentMilestone)) {
+    # Earlier-milestone validation: if the current milestone is an earlier real release
+    # than the target AND we can prove the fix shipped in that release, KEEP the earlier
+    # milestone (earliest release wins).
+    #   - For ISSUES: confirm a fix-linking PR's commit is reachable from a tag mapping
+    #     to the current milestone.
+    #   - For PRS: confirm the PR's own commit is reachable from such a tag (catches the
+    #     cherry-pick scenario where the same PR ships in multiple release branches).
+    if (-not [string]::IsNullOrWhiteSpace($CurrentMilestone)) {
         $cmp = Compare-MauiMilestone $CurrentMilestone $ExpectedMs
         if ($null -ne $cmp -and $cmp -lt 0) {
-            if (Test-MilestoneValidForIssue -IssueNumber $ItemNumber -Milestone $CurrentMilestone) {
+            $isValidEarlier = $false
+            if ($ItemType -eq 'issue') {
+                $isValidEarlier = Test-MilestoneValidForIssue -IssueNumber $ItemNumber -Milestone $CurrentMilestone
+            } elseif ($ItemType -eq 'pr') {
+                $isValidEarlier = Test-MilestoneValidForPr -PrNumber $ItemNumber -Milestone $CurrentMilestone
+            }
+
+            if ($isValidEarlier) {
                 if (-not $Report.ContainsKey('Kept')) { $Report.Kept = [System.Collections.ArrayList]::new() }
                 $kept = @{
                     ItemType   = $ItemType
@@ -567,7 +712,7 @@ function Test-AndRecordCorrection(
                 }
                 if ($RelatedPr -gt 0) { $kept.RelatedPr = $RelatedPr }
                 [void]$Report.Kept.Add($kept)
-                Write-Host "  [KEEP] issue #$ItemNumber`: keeping earlier valid milestone '$CurrentMilestone' (target was '$ExpectedMs')"
+                Write-Host "  [KEEP] $ItemType #$ItemNumber`: keeping earlier valid milestone '$CurrentMilestone' (target was '$ExpectedMs')"
                 return
             }
         }
@@ -787,6 +932,9 @@ function Invoke-AnalyzeRelease([string]$ReleaseTag, [string]$PrevTag, [string]$R
 
     $allTags = Get-AllTags $Repo
     if ($ReleaseTag -notin $allTags) { throw "Tag $ReleaseTag not found in repo" }
+
+    # Seed validation context so Test-MilestoneValid* helpers can resolve milestone → tag.
+    Initialize-MilestoneValidationContext -RepoPath $Repo -AllTags ([string[]]$allTags) -Major $Major
 
     if (-not $PrevTag) {
         $PrevTag = Find-PreviousTag $ReleaseTag $allTags

--- a/.github/scripts/Fix-MilestoneDrift.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.ps1
@@ -926,7 +926,11 @@ function Write-Report([hashtable]$Report) {
 }
 
 function Save-ReportJson([hashtable]$Report, [string]$Path) {
-    $keptItems = if ($Report.ContainsKey('Kept')) { @($Report.Kept) } else { @() }
+    # NB: `if (...) { @() } else { @() }` collapses an empty `@()` to $null in a PowerShell
+    # assignment under StrictMode, which trips the later .Count call. Use a typed cast
+    # ([object[]]) so we always end up with an array, even when there are zero kept items.
+    [object[]]$keptItems = @()
+    if ($Report.ContainsKey('Kept')) { $keptItems = @($Report.Kept) }
     $data = @{
         tag                = $Report.Tag
         previous_tag       = if ($Report.ContainsKey('PreviousTag')) { $Report.PreviousTag } else { $null }

--- a/.github/scripts/Fix-MilestoneDrift.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.ps1
@@ -63,119 +63,15 @@ if ($MyInvocation.InvocationName -ne '.') {
     $ErrorActionPreference = "Stop"
 }
 
+# Import shared MAUI release versioning helpers. Pulls in:
+#   Get-CurrentMajorVersion, Get-MainBranchForVersion, Get-VersionFromGitRef,
+#   ConvertTo-Milestone, ConvertBranchToMilestone, Get-TagSortKey, Find-PreviousTag
+# Module uses Set-StrictMode internally; importing it does not leak strict mode
+# to this script's caller (unlike dot-sourcing), which is why the conditional
+# StrictMode dance above is still needed for Pester compatibility.
+Import-Module (Join-Path $PSScriptRoot 'shared/MauiReleaseVersioning.psm1') -Force
+
 #region ── Milestone mapping helpers ──────────────────────────────────────
-
-function Get-CurrentMajorVersion([string]$Repo) {
-    <# Reads MajorVersion from eng/Versions.props on origin/main. #>
-    $versionXml = git -C $Repo --no-pager show origin/main:eng/Versions.props 2>&1
-    if ($LASTEXITCODE -eq 0) {
-        $joined = ($versionXml -join "`n")
-        if ($joined -match '<MajorVersion>(\d+)</MajorVersion>') {
-            return [int]$Matches[1]
-        }
-    }
-    throw "Could not read MajorVersion from origin/main:eng/Versions.props"
-}
-
-function Get-MainBranchForVersion([int]$Major, [string]$Repo) {
-    <# Determines which development branch owns a .NET version by reading
-       MajorVersion from eng/Versions.props on main. If main's MajorVersion
-       matches, the version lives on main. Otherwise it's on net{Major}.0.
-       This works correctly across version transitions — when main moves
-       from .NET 10 to .NET 11, MajorVersion in Versions.props changes too. #>
-    $versionXml = git -C $Repo --no-pager show origin/main:eng/Versions.props 2>&1
-    if ($LASTEXITCODE -eq 0) {
-        $joined = ($versionXml -join "`n")
-        if ($joined -match '<MajorVersion>(\d+)</MajorVersion>') {
-            $mainMajor = [int]$Matches[1]
-            if ($mainMajor -eq $Major) { return "main" }
-            Write-Verbose "origin/main has MajorVersion=$mainMajor, not $Major — version lives on net$Major.0"
-            return "net$Major.0"
-        }
-    }
-    Write-Warning "Could not read MajorVersion from origin/main:eng/Versions.props — falling back to net$Major.0"
-    return "net$Major.0"
-}
-
-function Get-VersionFromGitRef([string]$GitRef, [string]$Repo) {
-    <# Reads version info from eng/Versions.props at a specific git ref.
-       Returns a hashtable with Tag (synthetic release tag like "10.0.60"),
-       PreLabel (e.g. "preview", "rc", or $null for stable),
-       and PreIter (e.g. 3).
-       Fetches the commit if not available locally (e.g. PRs merged to inflight). #>
-    $versionXml = git -C $Repo --no-pager show "${GitRef}:eng/Versions.props" 2>&1
-    if ($LASTEXITCODE -ne 0) {
-        # Ref not in local history — fetch it.
-        # Strip "origin/" prefix for the fetch refspec (git fetch origin <branch>, not origin/origin/<branch>)
-        $fetchRef = $GitRef -replace '^origin/', ''
-        Write-Verbose "  Fetching ref $fetchRef..."
-        $null = git -C $Repo fetch origin $fetchRef --quiet 2>&1
-        $versionXml = git -C $Repo --no-pager show "${GitRef}:eng/Versions.props" 2>&1
-        if ($LASTEXITCODE -ne 0) {
-            Write-Warning "Could not read Versions.props at $GitRef (even after fetch)"
-            return $null
-        }
-    }
-    $joined = ($versionXml -join "`n")
-    if ($joined -match '<MajorVersion>(\d+)</MajorVersion>') {
-        $major = $Matches[1]
-    } else {
-        Write-Warning "Could not parse MajorVersion from Versions.props at $GitRef"
-        return $null
-    }
-    if ($joined -match '<PatchVersion>(\d+)</PatchVersion>') {
-        $patch = $Matches[1]
-    } else {
-        Write-Warning "Could not parse PatchVersion from Versions.props at $GitRef"
-        return $null
-    }
-
-    # Detect pre-release label (preview, rc) and iteration
-    $preLabel = $null
-    $preIter = $null
-    if ($joined -match '<PreReleaseVersionLabel[^>]*>([^<]+)</PreReleaseVersionLabel>') {
-        $rawLabel = $Matches[1]
-        # Only treat "preview" and "rc" as pre-release; "ci.main", "ci.inflight", "servicing" are stable builds
-        if ($rawLabel -match '^(preview|rc)$') {
-            $preLabel = $rawLabel
-            if ($joined -match '<PreReleaseVersionIteration>(\d+)</PreReleaseVersionIteration>') {
-                $preIter = [int]$Matches[1]
-            }
-        }
-    }
-
-    return @{
-        Tag       = "$major.0.$patch"
-        PreLabel  = $preLabel
-        PreIter   = $preIter
-    }
-}
-
-function ConvertTo-Milestone([string]$ReleaseTag, [string]$PreLabel, [int]$PreIter) {
-    <# Converts version info to a milestone name:
-       "10.0.50"                    → ".NET 10 SR5"
-       "10.0.41"                    → ".NET 10 SR4.1"
-       "10.0.0"                     → ".NET 10.0 GA"
-       "11.0.0" + preview + 3       → ".NET 11.0-preview3"
-       "11.0.0" + rc + 1            → ".NET 11.0-rc1" #>
-    if ($ReleaseTag -notmatch '^(\d+)\.0\.(\d+)$') { return $null }
-    $major = [int]$Matches[1]; $patch = [int]$Matches[2]
-
-    # Pre-release: preview/rc milestones
-    if ($PreLabel -and $PreIter -gt 0) {
-        return ".NET $major.0-$PreLabel$PreIter"
-    }
-    if ($PreLabel -and $PreIter -le 0) {
-        Write-Warning "PreReleaseVersionLabel is '$PreLabel' but PreReleaseVersionIteration is missing or 0 — falling back to GA/SR mapping"
-    }
-
-    if ($patch -eq 0)  { return ".NET $major.0 GA" }
-    if ($patch -lt 10) { return ".NET $major.0 SR1" }
-    $sr = [math]::Floor($patch / 10)
-    $sub = $patch % 10
-    if ($sub -eq 0) { return ".NET $major SR$sr" }
-    return ".NET $major SR$sr.$sub"
-}
 
 function Get-PatchVersion([string]$ReleaseTag) {
     if ($ReleaseTag -match '^(\d+)\.0\.(\d+)$') { return [int]$Matches[2] }
@@ -185,15 +81,6 @@ function Get-PatchVersion([string]$ReleaseTag) {
 function Test-IsReleaseTag([string]$ReleaseTag, [int]$Major) {
     # Matches stable tags (10.0.50) and preview/RC tags (11.0.0-preview.3.26203.7)
     return ($ReleaseTag -match "^$Major\.0\.")
-}
-
-function Get-TagSortKey([string]$ReleaseTag) {
-    <# Returns a numeric sort key for ordering tags chronologically.
-       preview1 (100) < preview7 (107) < rc1 (200) < rc2 (201) < GA/stable (500+patch) #>
-    if ($ReleaseTag -match '-preview\.(\d+)') { return 100 + [int]$Matches[1] }
-    if ($ReleaseTag -match '-rc\.(\d+)')      { return 200 + [int]$Matches[1] }
-    if ($ReleaseTag -match '^(\d+)\.0\.(\d+)$') { return 500 + [int]$Matches[2] }
-    return 0
 }
 
 function Test-MilestoneMatch([string]$Actual, [string]$Expected) {
@@ -224,21 +111,6 @@ function Find-MatchingMilestone([string]$Expected, [hashtable]$AllMilestones) {
         }
     }
     return $null
-}
-
-function Find-PreviousTag([string]$ReleaseTag, [string[]]$AllTags) {
-    <# Finds the immediately preceding tag for the same major version.
-       Works for both stable tags (10.0.50 → 10.0.41) and preview/RC tags
-       (11.0.0-preview.3.x → 11.0.0-preview.2.x). #>
-    if ($ReleaseTag -notmatch '^(\d+)\.') { return $null }
-    $major = [int]$Matches[1]
-    $thisKey = Get-TagSortKey $ReleaseTag
-
-    # Find all tags for this major version with a lower sort key
-    $candidates = $AllTags | Where-Object {
-        ($_ -match "^$major\.0\.") -and (Get-TagSortKey $_) -lt $thisKey
-    } | Sort-Object { Get-TagSortKey $_ }
-    return ($candidates | Select-Object -Last 1)
 }
 
 function Test-PrBelongsToVersion([string]$BaseRef, [string]$MainBranch, [int]$Major) {
@@ -334,24 +206,6 @@ function Find-TagContainingPr([int]$PrNum, [string]$Repo, [int]$Major) {
             $previousTag = if ($i -gt 0) { $srTags[$i - 1] } else { $null }
             return @{ Tag = $current; PreviousTag = $previousTag }
         }
-    }
-    return $null
-}
-
-function ConvertBranchToMilestone([string]$BranchName) {
-    <# Converts a release branch name to a milestone name:
-       release/10.0.1xx        → ".NET 10.0 GA"
-       release/10.0.1xx-sr5    → ".NET 10 SR5"
-       release/11.0.1xx-preview3 → ".NET 11.0-preview3"
-       release/11.0.1xx-rc1    → ".NET 11.0-rc1" #>
-    if ($BranchName -match '^release/(\d+)\.0\.\d+xx$') {
-        return ".NET $([int]$Matches[1]).0 GA"
-    }
-    if ($BranchName -match '^release/(\d+)\.0\.\d+xx-sr(\d+)$') {
-        return ".NET $([int]$Matches[1]) SR$([int]$Matches[2])"
-    }
-    if ($BranchName -match '^release/(\d+)\.0\.\d+xx-(preview|rc)(\d+)$') {
-        return ".NET $([int]$Matches[1]).0-$($Matches[2])$([int]$Matches[3])"
     }
     return $null
 }

--- a/.github/scripts/Fix-MilestoneDrift.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.ps1
@@ -346,7 +346,12 @@ function Get-IssueInfo([int]$IssueNumber) {
 function Get-LinkedIssues([string]$Body, [string]$Title) {
     $text = "$Title`n$Body"
     $issues = [System.Collections.Generic.HashSet[int]]::new()
-    foreach ($m in [regex]::Matches($text, '(?:fix(?:es|ed)?|close[sd]?|resolve[sd]?)\s+#(\d+)', 'IgnoreCase')) {
+    # Match `Fixes #N`, `Fixes owner/repo#N`, `Fixes GH-N`, etc. The optional prefix
+    # `[A-Za-z0-9_\-./]+` covers both the cross-repo short form (`dotnet/maui#NNN`)
+    # and any single-token qualifier. Without it, a PR that says `Fixes dotnet/maui#12345`
+    # is silently dropped — but the validator's regex (Test-MilestoneValidForIssue)
+    # accepts the prefix, so we'd be internally inconsistent.
+    foreach ($m in [regex]::Matches($text, '(?:fix(?:es|ed)?|close[sd]?|resolve[sd]?)\s+(?:[A-Za-z0-9_\-./]+)?#(\d+)', 'IgnoreCase')) {
         [void]$issues.Add([int]$m.Groups[1].Value)
     }
     # Match URLs only when preceded by a fixing keyword (mirrors GitHub auto-close behavior).
@@ -557,18 +562,22 @@ function Test-MilestoneValidForIssue {
         Checks whether an issue's current milestone is "valid" — i.e., a real fix PR
         for this issue shipped under that milestone — so we shouldn't override it.
     .DESCRIPTION
-        Searches all merged PRs that reference the issue (in the body), filters to
-        ones with an actual Fixes/Closes/Resolves verb for this exact issue number,
-        and returns $true if any of them has a milestone matching $Milestone.
+        Searches all merged PRs that reference the issue (by `#N` in title/body OR by
+        `issues/N` URL form in body), filters to ones with an actual Fixes/Closes/Resolves
+        verb for this exact issue number, and returns $true if any of them has its merge
+        commit reachable from a tag matching $Milestone.
 
         Used to avoid clobbering an earlier-release milestone (e.g., .NET 10 SR6)
         when a follow-up fix later shipped in net11.0 — see GitHub PR #35858
         follow-up for context.
 
-        Returns $false if:
-          - The milestone is not a comparable release (Backlog/Planning/none)
-          - No linking PR has that milestone
-          - The gh search fails (conservative — let the script fall back to normal correction)
+        Returns:
+          - $true  — at least one linking fix PR shipped in $Milestone
+          - $false — milestone is non-comparable, or we successfully queried and no
+                     linking PR was found / shipped in this milestone
+          - $null  — UNCERTAIN: gh search or parse failed. Caller must treat this as
+                     "do not touch this item" (failing open here would silently destroy
+                     legitimate earlier-release milestones on transient gh failures).
     #>
     [CmdletBinding()]
     param(
@@ -580,33 +589,54 @@ function Test-MilestoneValidForIssue {
 
     $cacheKey = "$IssueNumber|$Milestone"
     if ($script:milestoneValidationCache.ContainsKey($cacheKey)) {
-        return [bool]$script:milestoneValidationCache[$cacheKey]
+        # Cache stores $true / $false / $null verbatim — propagate exactly.
+        return $script:milestoneValidationCache[$cacheKey]
     }
 
-    $json = Invoke-GhCli 'search' 'prs' "#$IssueNumber in:body" `
-        '--repo' 'dotnet/maui' '--merged' '--limit' '50' `
-        '--json' 'number,title,body,url'
-    if ($LASTEXITCODE -ne 0) {
-        Write-Warning "Test-MilestoneValidForIssue: gh search failed for issue #$IssueNumber`: $json"
-        $script:milestoneValidationCache[$cacheKey] = $false
-        return $false
+    # Two searches widen coverage so we don't miss valid linking PRs:
+    #   1. `#N in:title,body` — handles `Fixes #N` whether it appears in body or title.
+    #   2. `issues/N in:body` — handles URL-form (`Fixes https://github.com/.../issues/N`)
+    #      where the body never contains the literal `#N` token.
+    # If either search fails we return $null (uncertain) — better to leave the milestone
+    # alone than to silently overwrite a valid earlier one based on a partial result.
+    $prHashes = [System.Collections.Generic.Dictionary[int, object]]::new()
+
+    foreach ($query in @("#$IssueNumber in:title,body", "issues/$IssueNumber in:body")) {
+        $json = Invoke-GhCli 'search' 'prs' $query `
+            '--repo' 'dotnet/maui' '--merged' '--limit' '50' `
+            '--json' 'number,title,body,url'
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warning "Test-MilestoneValidForIssue: gh search failed for issue #$IssueNumber (query: '$query'): $json"
+            $script:milestoneValidationCache[$cacheKey] = $null
+            return $null
+        }
+
+        try {
+            $prs = $json | ConvertFrom-Json
+        } catch {
+            Write-Warning "Test-MilestoneValidForIssue: failed to parse gh search response for issue #$IssueNumber (query: '$query'): $_"
+            $script:milestoneValidationCache[$cacheKey] = $null
+            return $null
+        }
+
+        foreach ($pr in @($prs)) {
+            if ($null -eq $pr -or $null -eq $pr.number) { continue }
+            $n = [int]$pr.number
+            if (-not $prHashes.ContainsKey($n)) { $prHashes[$n] = $pr }
+        }
     }
 
-    try {
-        $prs = $json | ConvertFrom-Json
-    } catch {
-        Write-Warning "Test-MilestoneValidForIssue: failed to parse gh search response for issue #$IssueNumber`: $_"
-        $script:milestoneValidationCache[$cacheKey] = $false
-        return $false
-    }
-
-    foreach ($pr in @($prs)) {
+    foreach ($pr in $prHashes.Values) {
         # Re-use the same regex Get-LinkedIssues uses, but pinned to THIS issue number,
         # so a casual `#34490` mention doesn't count — we want only real Fixes/Closes/Resolves.
+        # The optional `[a-z0-9_\-./]+` prefix handles cross-repo (`dotnet/maui#N`).
+        # Also accept the URL form `Fixes https://github.com/.../issues/N`.
         $body = if ($pr.body) { [string]$pr.body } else { '' }
         $title = if ($pr.title) { [string]$pr.title } else { '' }
         $combined = "$title`n$body"
-        if ($combined -notmatch "(?i)(?:fix(?:es|ed)?|close[sd]?|resolve[sd]?)\s+(?:[a-z0-9_\-./]+)?#$IssueNumber\b") {
+        $hashMatch = $combined -match "(?i)(?:fix(?:es|ed)?|close[sd]?|resolve[sd]?)\s+(?:[a-z0-9_\-./]+)?#$IssueNumber\b"
+        $urlMatch  = $combined -match "(?i)(?:fix(?:es|ed)?|close[sd]?|resolve[sd]?)\s+https?://github\.com/dotnet/maui/issues/$IssueNumber\b"
+        if (-not ($hashMatch -or $urlMatch)) {
             continue
         }
 
@@ -687,7 +717,9 @@ function Test-AndRecordCorrection(
     # than the target AND we can prove the fix shipped in that release, KEEP the earlier
     # milestone (earliest release wins).
     #   - For ISSUES: confirm a fix-linking PR's commit is reachable from a tag mapping
-    #     to the current milestone.
+    #     to the current milestone. Validator may also return $null (uncertain — gh search
+    #     failed); when that happens we MUST skip this item to avoid silently clobbering
+    #     a possibly-valid earlier milestone on transient API errors.
     #   - For PRS: confirm the PR's own commit is reachable from such a tag (catches the
     #     cherry-pick scenario where the same PR ships in multiple release branches).
     if (-not [string]::IsNullOrWhiteSpace($CurrentMilestone)) {
@@ -700,7 +732,26 @@ function Test-AndRecordCorrection(
                 $isValidEarlier = Test-MilestoneValidForPr -PrNumber $ItemNumber -Milestone $CurrentMilestone
             }
 
+            if ($null -eq $isValidEarlier) {
+                # Validator could not determine (transient failure). Do NOT queue a correction
+                # — overwriting a possibly-valid earlier milestone on a transient failure is the
+                # exact data-loss case the earliest-release-wins guard exists to prevent.
+                Write-Warning "  ⚠️  $ItemType #$ItemNumber`: milestone validation was inconclusive (likely transient gh failure); skipping to preserve current milestone '$CurrentMilestone'"
+                return
+            }
+
             if ($isValidEarlier) {
+                # Dedup: the same issue/PR can be reached multiple times in tag-mode walks
+                # (e.g. issue linked from multiple PRs in the same range, or a cherry-picked
+                # PR matching multiple linking-PR scans). Without this guard, $Report.Kept
+                # accumulates duplicate rows that pollute the JSON report and the rolled-up
+                # GitHub issue table.
+                $keepKey = "$ItemType`:$ItemNumber"
+                if (-not $Report.ContainsKey('_keptItems')) { $Report._keptItems = [System.Collections.Generic.HashSet[string]]::new() }
+                if (-not $Report._keptItems.Add($keepKey)) {
+                    Write-Verbose "  ⏭️  $ItemType #$ItemNumber`: already in KEEP set (via earlier linking PR)"
+                    return
+                }
                 if (-not $Report.ContainsKey('Kept')) { $Report.Kept = [System.Collections.ArrayList]::new() }
                 $kept = @{
                     ItemType   = $ItemType
@@ -748,6 +799,7 @@ function Invoke-AnalyzeSinglePr([int]$PrNum, [string]$ReleaseTag, [string]$Repo)
     $preLabel = $null
     $preIter = 0
     $versionInfo = $null
+    $allTags = $null  # declared so the validation-context seeding below can probe it under StrictMode
 
     # Fetch PR info first — we need merge_commit_sha for version detection
     $pr = Get-PrInfo $PrNum
@@ -855,6 +907,15 @@ function Invoke-AnalyzeSinglePr([int]$PrNum, [string]$ReleaseTag, [string]$Repo)
     $Branch = Get-MainBranchForVersion $Major $Repo
     Write-Host "  Main branch for .NET $Major`: $Branch"
     Write-Host "  Expected milestone: $expectedMs"
+
+    # Seed validation context so the earliest-release-wins guard (Test-MilestoneValidForIssue /
+    # Test-MilestoneValidForPr) works in single-PR mode too — without this, $script:validationAllTags
+    # stays $null, Get-TagsForMilestone returns @(), Test-PrShippedInMilestone short-circuits to $false,
+    # and the KEEP branch in Test-AndRecordCorrection is silently dead code. Reuse $allTags from the
+    # explicit-tag path above when present to avoid an extra git call.
+    if (-not $allTags) { $allTags = Get-AllTags $Repo }
+    Initialize-MilestoneValidationContext -RepoPath $Repo -AllTags ([string[]]$allTags) -Major $Major
+
     Write-Host "Fetching GitHub milestones..."
     $allMilestones = Get-AllMilestones
     $match = Find-MatchingMilestone $expectedMs $allMilestones

--- a/.github/scripts/Fix-MilestoneDrift.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.ps1
@@ -346,12 +346,14 @@ function Get-IssueInfo([int]$IssueNumber) {
 function Get-LinkedIssues([string]$Body, [string]$Title) {
     $text = "$Title`n$Body"
     $issues = [System.Collections.Generic.HashSet[int]]::new()
-    # Match `Fixes #N`, `Fixes owner/repo#N`, `Fixes GH-N`, etc. The optional prefix
-    # `[A-Za-z0-9_\-./]+` covers both the cross-repo short form (`dotnet/maui#NNN`)
-    # and any single-token qualifier. Without it, a PR that says `Fixes dotnet/maui#12345`
-    # is silently dropped — but the validator's regex (Test-MilestoneValidForIssue)
-    # accepts the prefix, so we'd be internally inconsistent.
-    foreach ($m in [regex]::Matches($text, '(?:fix(?:es|ed)?|close[sd]?|resolve[sd]?)\s+(?:[A-Za-z0-9_\-./]+)?#(\d+)', 'IgnoreCase')) {
+    # Match `Fixes #N` or `Fixes dotnet/maui#N`. The owner/repo prefix is restricted to
+    # `dotnet/maui` (case-insensitive) because we are collecting linked issues for THIS
+    # repo only — accepting any `[A-Za-z0-9_\-./]+` would silently treat a cross-repo
+    # reference like `Fixes dotnet/runtime#1234` as if it linked dotnet/maui#1234,
+    # clobbering an unrelated MAUI issue's milestone. The literal-prefix form mirrors
+    # GitHub's own auto-close behavior (which only auto-closes for the same-repo or
+    # explicitly-named-cross-repo form).
+    foreach ($m in [regex]::Matches($text, '(?:fix(?:es|ed)?|close[sd]?|resolve[sd]?)\s+(?:dotnet/maui)?#(\d+)', 'IgnoreCase')) {
         [void]$issues.Add([int]$m.Groups[1].Value)
     }
     # Match URLs only when preceded by a fixing keyword (mirrors GitHub auto-close behavior).
@@ -492,9 +494,21 @@ function Get-TagsForMilestone {
         return @($script:milestoneTagsCache[$Milestone])
     }
 
+    # Cross-major scenarios are the WHOLE POINT of the KEEP guard: a net11.0 PR may have
+    # an issue currently milestoned `.NET 10 SR6` (because a prior fix shipped in 10.0.60).
+    # We must filter tags by THIS milestone's major (10), not by $script:validationMajor
+    # (set to the target major — 11 — by Initialize-MilestoneValidationContext).
+    # Pre-fix, the `Test-IsReleaseTag $tag 11` filter dropped every 10.x tag, returning
+    # @() → Test-PrShippedInMilestone false → validator false → KEEP guard clobbered SR6.
+    $msMajor = if ($Milestone -match '\.NET (\d+)') { [int]$Matches[1] } else { 0 }
+    if ($msMajor -le 0) {
+        # Non-comparable milestone — can't derive a major, fall back to validation context.
+        $msMajor = $script:validationMajor
+    }
+
     $matchingTags = [System.Collections.Generic.List[string]]::new()
     foreach ($tag in $script:validationAllTags) {
-        if (-not (Test-IsReleaseTag $tag $script:validationMajor)) { continue }
+        if (-not (Test-IsReleaseTag $tag $msMajor)) { continue }
         $tagMs = ConvertTo-Milestone $tag
         if ([string]::IsNullOrWhiteSpace($tagMs)) { continue }
         if (Test-MilestoneMatch $tagMs $Milestone) {
@@ -507,12 +521,16 @@ function Get-TagsForMilestone {
 }
 
 function Get-PrsInTag {
-    <# Returns (cached) the set of PR numbers reachable from a tag. #>
+    <# Returns (cached) the set of PR numbers reachable from a tag.
+       Returns $null on git failure so the caller can propagate "uncertain" rather than
+       silently treat a transient git error as "no PRs in this tag" (which would cause
+       Test-PrShippedInMilestone to return $false → Test-MilestoneValidForPr false →
+       KEEP guard clobbers a valid earlier milestone). #>
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][string]$Tag
     )
-    if (-not $script:validationRepoPath) { return @() }
+    if (-not $script:validationRepoPath) { return $null }
     if ($script:tagPrCache.ContainsKey($Tag)) {
         return $script:tagPrCache[$Tag]
     }
@@ -520,13 +538,16 @@ function Get-PrsInTag {
         $prs = Get-PrNumbersReachableFromTag $Tag $script:validationRepoPath
     } catch {
         Write-Warning "Get-PrsInTag: failed to read PRs reachable from ${Tag}: $_"
-        $prs = @()
+        # Do NOT cache the uncertain result — let a later call retry.
+        return $null
     }
     # Store as HashSet for O(1) Contains lookups.
     $set = [System.Collections.Generic.HashSet[int]]::new()
     foreach ($p in $prs) { [void]$set.Add([int]$p) }
     $script:tagPrCache[$Tag] = $set
-    return $set
+    # Use unary comma so PowerShell doesn't unwrap the HashSet (otherwise the caller
+    # receives an Int32 / Object[] depending on size and `.Contains()` fails).
+    return ,$set
 }
 
 function Test-PrShippedInMilestone {
@@ -539,6 +560,12 @@ function Test-PrShippedInMilestone {
         that ConvertTo-Milestone maps to X. This rejects:
           - PRs that were milestoned for X but never made it (still on `inflight/*`)
           - Issues whose linking PR was cherry-picked to a later branch but never landed in X
+
+        Returns:
+          - $true  — PR's commit is in at least one tag mapping to $Milestone.
+          - $false — definitively NOT in any matching tag (all git reads succeeded).
+          - $null  — UNCERTAIN: at least one Get-PrsInTag call failed. Caller must skip
+                     the item to avoid clobbering a possibly-valid earlier milestone.
     #>
     [CmdletBinding()]
     param(
@@ -549,10 +576,19 @@ function Test-PrShippedInMilestone {
     $tags = @(Get-TagsForMilestone -Milestone $Milestone)
     if ($tags.Count -eq 0) { return $false }
 
+    $anyFailure = $false
     foreach ($tag in $tags) {
         $prs = Get-PrsInTag -Tag $tag
-        if ($prs -and $prs.Contains([int]$PrNumber)) { return $true }
+        if ($null -eq $prs) {
+            # Git read for THIS tag failed — but we can still return $true if a SUCCEEDING
+            # tag read in the same milestone contains the PR. So note the failure and keep
+            # scanning; only convert to $null below if no tag confirmed the PR.
+            $anyFailure = $true
+            continue
+        }
+        if ($prs.Contains([int]$PrNumber)) { return $true }
     }
+    if ($anyFailure) { return $null }
     return $false
 }
 
@@ -593,48 +629,53 @@ function Test-MilestoneValidForIssue {
         return $script:milestoneValidationCache[$cacheKey]
     }
 
-    # Two searches widen coverage so we don't miss valid linking PRs:
-    #   1. `#N in:title,body` — handles `Fixes #N` whether it appears in body or title.
-    #   2. `issues/N in:body` — handles URL-form (`Fixes https://github.com/.../issues/N`)
-    #      where the body never contains the literal `#N` token.
-    # If either search fails we return $null (uncertain) — better to leave the milestone
+    # Single OR-query covers both linking forms in one Search API call:
+    #   - `#N in:title,body` — `Fixes #N` whether the token appears in body or title.
+    #   - `issues/N in:body` — URL form (`Fixes https://github.com/.../issues/N`) where
+    #     the body never contains the literal `#N` token.
+    # The GitHub Search API supports `OR` between query terms. Combining keeps us under
+    # the 30-req/min Search rate limit on large tag-range walks (~100 issues = ~100 calls
+    # instead of ~200) and avoids the "discard positive evidence on partial failure"
+    # trap from running two separate queries.
+    # If the search fails we return $null (uncertain) — better to leave the milestone
     # alone than to silently overwrite a valid earlier one based on a partial result.
-    $prHashes = [System.Collections.Generic.Dictionary[int, object]]::new()
-
-    foreach ($query in @("#$IssueNumber in:title,body", "issues/$IssueNumber in:body")) {
-        $json = Invoke-GhCli 'search' 'prs' $query `
-            '--repo' 'dotnet/maui' '--merged' '--limit' '50' `
-            '--json' 'number,title,body,url'
-        if ($LASTEXITCODE -ne 0) {
-            Write-Warning "Test-MilestoneValidForIssue: gh search failed for issue #$IssueNumber (query: '$query'): $json"
-            $script:milestoneValidationCache[$cacheKey] = $null
-            return $null
-        }
-
-        try {
-            $prs = $json | ConvertFrom-Json
-        } catch {
-            Write-Warning "Test-MilestoneValidForIssue: failed to parse gh search response for issue #$IssueNumber (query: '$query'): $_"
-            $script:milestoneValidationCache[$cacheKey] = $null
-            return $null
-        }
-
-        foreach ($pr in @($prs)) {
-            if ($null -eq $pr -or $null -eq $pr.number) { continue }
-            $n = [int]$pr.number
-            if (-not $prHashes.ContainsKey($n)) { $prHashes[$n] = $pr }
-        }
+    $query = "#$IssueNumber in:title,body OR issues/$IssueNumber in:body"
+    $json = Invoke-GhCli 'search' 'prs' $query `
+        '--repo' 'dotnet/maui' '--merged' '--limit' '50' `
+        '--json' 'number,title,body,url'
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "Test-MilestoneValidForIssue: gh search failed for issue #$IssueNumber (query: '$query'): $json"
+        # Do NOT cache $null — a transient gh failure would otherwise permanently disable
+        # KEEP validation for this (issue, milestone) pair for the entire run. Letting the
+        # next call retry is safe because the check is read-only.
+        return $null
     }
 
+    try {
+        $prs = $json | ConvertFrom-Json
+    } catch {
+        Write-Warning "Test-MilestoneValidForIssue: failed to parse gh search response for issue #$IssueNumber (query: '$query'): $_"
+        return $null
+    }
+
+    $prHashes = [System.Collections.Generic.Dictionary[int, object]]::new()
+    foreach ($pr in @($prs)) {
+        if ($null -eq $pr -or $null -eq $pr.number) { continue }
+        $n = [int]$pr.number
+        if (-not $prHashes.ContainsKey($n)) { $prHashes[$n] = $pr }
+    }
+
+    $sawUncertain = $false
     foreach ($pr in $prHashes.Values) {
         # Re-use the same regex Get-LinkedIssues uses, but pinned to THIS issue number,
         # so a casual `#34490` mention doesn't count — we want only real Fixes/Closes/Resolves.
-        # The optional `[a-z0-9_\-./]+` prefix handles cross-repo (`dotnet/maui#N`).
+        # Prefix restricted to `dotnet/maui` so a `Fixes dotnet/runtime#NNNN` mention
+        # in an unrelated discussion doesn't get treated as if it linked dotnet/maui#NNNN.
         # Also accept the URL form `Fixes https://github.com/.../issues/N`.
         $body = if ($pr.body) { [string]$pr.body } else { '' }
         $title = if ($pr.title) { [string]$pr.title } else { '' }
         $combined = "$title`n$body"
-        $hashMatch = $combined -match "(?i)(?:fix(?:es|ed)?|close[sd]?|resolve[sd]?)\s+(?:[a-z0-9_\-./]+)?#$IssueNumber\b"
+        $hashMatch = $combined -match "(?i)(?:fix(?:es|ed)?|close[sd]?|resolve[sd]?)\s+(?:dotnet/maui)?#$IssueNumber\b"
         $urlMatch  = $combined -match "(?i)(?:fix(?:es|ed)?|close[sd]?|resolve[sd]?)\s+https?://github\.com/dotnet/maui/issues/$IssueNumber\b"
         if (-not ($hashMatch -or $urlMatch)) {
             continue
@@ -644,10 +685,23 @@ function Test-MilestoneValidForIssue {
         # Trusting the PR's own milestone field isn't enough — that field can be stale
         # (e.g. a hotfix PR milestoned `.NET 10 SR7` but only present in tag 10.0.71
         # which maps to `.NET 10 SR7.1`).
-        if (Test-PrShippedInMilestone -PrNumber ([int]$pr.number) -Milestone $Milestone) {
+        # Test-PrShippedInMilestone is tristate: $null = git read failed for some tag,
+        # we don't know definitively. Don't conclude $false from that — there may be
+        # ANOTHER linking PR in the list that confirmably ships in the milestone.
+        $shipped = Test-PrShippedInMilestone -PrNumber ([int]$pr.number) -Milestone $Milestone
+        if ($shipped) {
             $script:milestoneValidationCache[$cacheKey] = $true
             return $true
         }
+        if ($null -eq $shipped) { $sawUncertain = $true }
+    }
+
+    if ($sawUncertain) {
+        # No definitive $true, but at least one linking PR couldn't be checked due to a
+        # git failure. Don't cache and don't return $false — the caller should skip the
+        # item to preserve the current milestone.
+        Write-Warning "Test-MilestoneValidForIssue: at least one linking PR's tag membership could not be determined for issue #$IssueNumber + milestone '$Milestone'; returning uncertain"
+        return $null
     }
 
     $script:milestoneValidationCache[$cacheKey] = $false
@@ -666,10 +720,11 @@ function Test-MilestoneValidForPr {
         commit therefore appears in BOTH `10.0.60` and `10.0.80`. An SR8 audit would
         otherwise stomp the (correct) `.NET 10 SR6` milestone.
 
-        Returns $false when:
-          - Milestone is null/empty or isn't a comparable release (Backlog/Planning)
-          - No tag maps to $Milestone
-          - The PR's commit isn't in any of those tags
+        Returns:
+          - $true  — PR's commit is in a tag mapping to $Milestone.
+          - $false — milestone is null/empty/non-comparable, or no matching tag contains the PR.
+          - $null  — UNCERTAIN: at least one git read failed. Caller must skip to avoid
+                     clobbering a possibly-valid earlier milestone.
     #>
     [CmdletBinding()]
     param(
@@ -717,11 +772,12 @@ function Test-AndRecordCorrection(
     # than the target AND we can prove the fix shipped in that release, KEEP the earlier
     # milestone (earliest release wins).
     #   - For ISSUES: confirm a fix-linking PR's commit is reachable from a tag mapping
-    #     to the current milestone. Validator may also return $null (uncertain — gh search
-    #     failed); when that happens we MUST skip this item to avoid silently clobbering
-    #     a possibly-valid earlier milestone on transient API errors.
+    #     to the current milestone.
     #   - For PRS: confirm the PR's own commit is reachable from such a tag (catches the
     #     cherry-pick scenario where the same PR ships in multiple release branches).
+    # Both validators are tristate. `$null` means a transient gh/git failure made the
+    # answer indeterminate; we MUST skip the item to avoid silently clobbering a
+    # possibly-valid earlier milestone.
     if (-not [string]::IsNullOrWhiteSpace($CurrentMilestone)) {
         $cmp = Compare-MauiMilestone $CurrentMilestone $ExpectedMs
         if ($null -ne $cmp -and $cmp -lt 0) {

--- a/.github/scripts/Fix-MilestoneDrift.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.ps1
@@ -438,6 +438,83 @@ function Set-ItemMilestone([int]$ItemNumber, [int]$MilestoneNumber) {
     if ($LASTEXITCODE -ne 0) { throw "Failed to set milestone on #$ItemNumber`: $result" }
 }
 
+# Cache of milestone-validity lookups so we don't re-query gh for the same (issue, milestone) pair.
+$script:milestoneValidationCache = @{}
+
+function Test-MilestoneValidForIssue {
+    <#
+    .SYNOPSIS
+        Checks whether an issue's current milestone is "valid" — i.e., a real fix PR
+        for this issue shipped under that milestone — so we shouldn't override it.
+    .DESCRIPTION
+        Searches all merged PRs that reference the issue (in the body), filters to
+        ones with an actual Fixes/Closes/Resolves verb for this exact issue number,
+        and returns $true if any of them has a milestone matching $Milestone.
+
+        Used to avoid clobbering an earlier-release milestone (e.g., .NET 10 SR6)
+        when a follow-up fix later shipped in net11.0 — see GitHub PR #35858
+        follow-up for context.
+
+        Returns $false if:
+          - The milestone is not a comparable release (Backlog/Planning/none)
+          - No linking PR has that milestone
+          - The gh search fails (conservative — let the script fall back to normal correction)
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][int]$IssueNumber,
+        [Parameter(Mandatory)][AllowEmptyString()][AllowNull()][string]$Milestone
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Milestone)) { return $false }
+
+    $cacheKey = "$IssueNumber|$Milestone"
+    if ($script:milestoneValidationCache.ContainsKey($cacheKey)) {
+        return [bool]$script:milestoneValidationCache[$cacheKey]
+    }
+
+    $json = Invoke-GhCli 'search' 'prs' "#$IssueNumber in:body" `
+        '--repo' 'dotnet/maui' '--merged' '--limit' '50' `
+        '--json' 'number,title,body,url'
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "Test-MilestoneValidForIssue: gh search failed for issue #$IssueNumber`: $json"
+        $script:milestoneValidationCache[$cacheKey] = $false
+        return $false
+    }
+
+    try {
+        $prs = $json | ConvertFrom-Json
+    } catch {
+        Write-Warning "Test-MilestoneValidForIssue: failed to parse gh search response for issue #$IssueNumber`: $_"
+        $script:milestoneValidationCache[$cacheKey] = $false
+        return $false
+    }
+
+    foreach ($pr in @($prs)) {
+        # Re-use the same regex Get-LinkedIssues uses, but pinned to THIS issue number,
+        # so a casual `#34490` mention doesn't count — we want only real Fixes/Closes/Resolves.
+        $body = if ($pr.body) { [string]$pr.body } else { '' }
+        $title = if ($pr.title) { [string]$pr.title } else { '' }
+        $combined = "$title`n$body"
+        if ($combined -notmatch "(?i)(?:fix(?:es|ed)?|close[sd]?|resolve[sd]?)\s+(?:[a-z0-9_\-./]+)?#$IssueNumber\b") {
+            continue
+        }
+
+        # Fetch milestone for this linking PR.
+        $prInfo = Get-PrInfo $pr.number
+        if (-not $prInfo) { continue }
+        if (-not $prInfo.Milestone) { continue }
+
+        if (Test-MilestoneMatch $prInfo.Milestone $Milestone) {
+            $script:milestoneValidationCache[$cacheKey] = $true
+            return $true
+        }
+    }
+
+    $script:milestoneValidationCache[$cacheKey] = $false
+    return $false
+}
+
 #endregion
 
 #region ── Correction helpers ─────────────────────────────────────────────
@@ -469,6 +546,31 @@ function Test-AndRecordCorrection(
     if ($existing) {
         Write-Verbose "  ⏭️  $ItemType #$ItemNumber`: already queued for correction (via PR #$($existing.RelatedPr))"
         return
+    }
+
+    # Earlier-milestone validation: if this is an ISSUE whose current milestone is an
+    # earlier release than the target AND we can confirm a fix PR shipped in that earlier
+    # release, KEEP the earlier milestone (earliest release wins). PRs are skipped — they
+    # land in exactly one branch, so the target is by definition correct for them.
+    if ($ItemType -eq 'issue' -and -not [string]::IsNullOrWhiteSpace($CurrentMilestone)) {
+        $cmp = Compare-MauiMilestone $CurrentMilestone $ExpectedMs
+        if ($null -ne $cmp -and $cmp -lt 0) {
+            if (Test-MilestoneValidForIssue -IssueNumber $ItemNumber -Milestone $CurrentMilestone) {
+                if (-not $Report.ContainsKey('Kept')) { $Report.Kept = [System.Collections.ArrayList]::new() }
+                $kept = @{
+                    ItemType   = $ItemType
+                    Number     = $ItemNumber
+                    Title      = $ItemTitle
+                    Url        = $ItemUrl
+                    Current    = $CurrentMilestone
+                    Expected   = $ExpectedMs
+                }
+                if ($RelatedPr -gt 0) { $kept.RelatedPr = $RelatedPr }
+                [void]$Report.Kept.Add($kept)
+                Write-Host "  [KEEP] issue #$ItemNumber`: keeping earlier valid milestone '$CurrentMilestone' (target was '$ExpectedMs')"
+                return
+            }
+        }
     }
 
     $correction = @{
@@ -789,9 +891,21 @@ function Write-Report([hashtable]$Report) {
     }
     Write-Host "  Issues checked: $($Report.IssuesChecked)"
     Write-Host "  Already correct: $($Report.AlreadyCorrect)"
+    $keptCount = if ($Report.ContainsKey('Kept')) { $Report.Kept.Count } else { 0 }
+    if ($keptCount -gt 0) {
+        Write-Host "  Kept earlier milestone: $keptCount"
+    }
     Write-Host "  Corrections needed: $($Report.Corrections.Count)"
     if ($Report.Errors.Count -gt 0) { Write-Host "  Errors: $($Report.Errors.Count)" }
     Write-Host ""
+
+    if ($keptCount -gt 0) {
+        foreach ($k in $Report.Kept) {
+            $via = if ($k.ContainsKey('RelatedPr') -and $k.RelatedPr) { " (via PR #$($k.RelatedPr))" } else { "" }
+            Write-Host "  [KEEP] $($k.ItemType) #$($k.Number)$via`: keeping '$($k.Current)' (target was '$($k.Expected)')"
+        }
+        Write-Host ""
+    }
 
     if ($Report.Corrections.Count -eq 0) {
         if ($Report.Errors.Count -gt 0 -and $Report.PrsChecked -eq 0) {
@@ -812,6 +926,7 @@ function Write-Report([hashtable]$Report) {
 }
 
 function Save-ReportJson([hashtable]$Report, [string]$Path) {
+    $keptItems = if ($Report.ContainsKey('Kept')) { @($Report.Kept) } else { @() }
     $data = @{
         tag                = $Report.Tag
         previous_tag       = if ($Report.ContainsKey('PreviousTag')) { $Report.PreviousTag } else { $null }
@@ -823,10 +938,12 @@ function Save-ReportJson([hashtable]$Report, [string]$Path) {
             prs_skipped_wrong_branch = if ($Report.ContainsKey('PrsSkippedWrongBranch')) { $Report.PrsSkippedWrongBranch } else { 0 }
             issues_checked     = $Report.IssuesChecked
             already_correct    = $Report.AlreadyCorrect
+            kept_earlier       = $keptItems.Count
             corrections_needed = $Report.Corrections.Count
             errors             = $Report.Errors.Count
         }
         corrections        = @($Report.Corrections)
+        kept               = $keptItems
         errors             = @($Report.Errors)
     }
     $data | ConvertTo-Json -Depth 5 | Set-Content -Path $Path -Encoding utf8
@@ -879,11 +996,26 @@ function New-GitHubIssue([hashtable]$Report, [bool]$WasApplied) {
     [void]$sb.AppendLine("| PRs checked | $($Report.PrsChecked) |")
     [void]$sb.AppendLine("| Issues checked | $($Report.IssuesChecked) |")
     [void]$sb.AppendLine("| Already correct | $($Report.AlreadyCorrect) |")
+    if ($Report.ContainsKey('Kept') -and $Report.Kept.Count -gt 0) {
+        [void]$sb.AppendLine("| Kept earlier milestone | $($Report.Kept.Count) |")
+    }
     [void]$sb.AppendLine("| Corrections needed | $($Report.Corrections.Count) |")
     if ($Report.Errors.Count -gt 0) {
         [void]$sb.AppendLine("| Errors | $($Report.Errors.Count) |")
     }
     [void]$sb.AppendLine()
+
+    if ($Report.ContainsKey('Kept') -and $Report.Kept.Count -gt 0) {
+        [void]$sb.AppendLine("### Kept (earlier milestone validated)")
+        [void]$sb.AppendLine()
+        [void]$sb.AppendLine("| Type | Item | Via PR | Kept | Target |")
+        [void]$sb.AppendLine("|------|------|--------|------|--------|")
+        foreach ($k in $Report.Kept) {
+            $via = if ($k.ContainsKey('RelatedPr') -and $k.RelatedPr) { "#$($k.RelatedPr)" } else { "—" }
+            [void]$sb.AppendLine("| $($k.ItemType) | #$($k.Number) | $via | $($k.Current) | $($k.Expected) |")
+        }
+        [void]$sb.AppendLine()
+    }
 
     if ($Report.Corrections.Count -eq 0) {
         [void]$sb.AppendLine("✅ All milestones are correct!")

--- a/.github/scripts/Fix-MilestoneDrift.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.ps1
@@ -532,7 +532,10 @@ function Get-PrsInTag {
     )
     if (-not $script:validationRepoPath) { return $null }
     if ($script:tagPrCache.ContainsKey($Tag)) {
-        return $script:tagPrCache[$Tag]
+        # Same unary-comma protection as the fresh-read return below — otherwise a
+        # cached 1-element HashSet gets unwrapped to Int32 (no .Contains) and a
+        # cached 0-element HashSet gets unwrapped to $null (mistaken for git failure).
+        return ,$script:tagPrCache[$Tag]
     }
     try {
         $prs = Get-PrNumbersReachableFromTag $Tag $script:validationRepoPath
@@ -640,8 +643,12 @@ function Test-MilestoneValidForIssue {
     # If the search fails we return $null (uncertain) — better to leave the milestone
     # alone than to silently overwrite a valid earlier one based on a partial result.
     $query = "#$IssueNumber in:title,body OR issues/$IssueNumber in:body"
+    # --limit 100: hardened against the (rare but real) case of a heavily-referenced issue
+    # where the actual fixing PR gets sorted past position 50 by gh's relevance ranking.
+    # Pre-100 the validator would silently return $false → clobber a possibly-valid earlier
+    # milestone. 100 is the gh search per-page max; below pagination concerns kick in.
     $json = Invoke-GhCli 'search' 'prs' $query `
-        '--repo' 'dotnet/maui' '--merged' '--limit' '50' `
+        '--repo' 'dotnet/maui' '--merged' '--limit' '100' `
         '--json' 'number,title,body,url'
     if ($LASTEXITCODE -ne 0) {
         Write-Warning "Test-MilestoneValidForIssue: gh search failed for issue #$IssueNumber (query: '$query'): $json"

--- a/.github/scripts/Fix-MilestoneDrift.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.ps1
@@ -36,6 +36,12 @@
 .PARAMETER CreateIssue
     Create a GitHub issue in dotnet/maui with the milestone drift report.
 
+.PARAMETER CloseFixedIssues
+    Close issues that are referenced as fixed by the analyzed PR(s). Use this for
+    PRs merged to a non-default branch (e.g. net11.0, release/*) because GitHub
+    only auto-closes linked issues for PRs merged to the default branch (main).
+    Honors -Apply (dry-run when -Apply is not set).
+
 .EXAMPLE
     ./Fix-MilestoneDrift.ps1 -PrNumber 33818 -RepoPath ~/Projects/maui -Verbose
     ./Fix-MilestoneDrift.ps1 -PrNumber 33818 -Apply
@@ -50,7 +56,8 @@ param(
     [string]$RepoPath = ".",
     [string]$Output,
     [switch]$Apply,
-    [switch]$CreateIssue
+    [switch]$CreateIssue,
+    [switch]$CloseFixedIssues
 )
 
 # Safety: never process PRs merged before 2026
@@ -350,6 +357,81 @@ function Get-LinkedIssues([string]$Body, [string]$Title) {
     return ($issues | Sort-Object)
 }
 
+function Invoke-GhCli {
+    # Thin shim around the `gh` CLI so Pester tests can Mock it without spawning a real
+    # process. Returns the combined stdout/stderr text; callers can check $LASTEXITCODE.
+    [CmdletBinding()]
+    param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Arguments)
+    return (& gh @Arguments 2>&1)
+}
+
+function Close-LinkedIssue {
+    <#
+    .SYNOPSIS
+        Closes a GitHub issue that was fixed by a PR merged to a non-default branch.
+    .DESCRIPTION
+        GitHub only auto-closes "fixes #N" linked issues when the PR is merged to
+        the default branch. For PRs merged to net11.0, release/*, etc. the issue
+        stays open. This helper closes the issue and leaves a breadcrumb comment.
+
+        - If the issue is already closed: no-op (logs and returns).
+        - If -Apply is not set on the script: dry-run (logs intent, no gh call).
+        - gh failures are warned, not thrown — one bad issue shouldn't fail the
+          whole milestone-drift run.
+    .PARAMETER IssueNumber
+        Issue to close.
+    .PARAMETER PrNumber
+        PR that fixed it (referenced in the comment).
+    .PARAMETER BaseRef
+        Branch the PR was merged to (referenced in the comment).
+    .PARAMETER Apply
+        When false, dry-run only.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][int]$IssueNumber,
+        [Parameter(Mandatory)][int]$PrNumber,
+        [Parameter(Mandatory)][AllowEmptyString()][AllowNull()][string]$BaseRef,
+        [Parameter(Mandatory)][bool]$Apply
+    )
+
+    # Check current state. Don't double-close.
+    $stateJson = Invoke-GhCli 'issue' 'view' "$IssueNumber" '--repo' 'dotnet/maui' '--json' 'state,number,title'
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "Close-LinkedIssue: failed to fetch issue #$IssueNumber state: $stateJson"
+        return
+    }
+
+    try {
+        $issue = $stateJson | ConvertFrom-Json
+    } catch {
+        Write-Warning "Close-LinkedIssue: failed to parse gh response for issue #$IssueNumber`: $_"
+        return
+    }
+
+    # `gh issue view --json state` returns "OPEN" / "CLOSED" (uppercase). Match case-insensitively
+    # so we're robust if gh ever changes casing.
+    if ($issue.state -and $issue.state.ToString().ToUpperInvariant() -eq 'CLOSED') {
+        Write-Host "  ℹ️  issue #$IssueNumber already closed — no action needed"
+        return
+    }
+
+    $baseLabel = if ($BaseRef) { $BaseRef } else { '(unknown branch)' }
+    $comment = "Closed by #$PrNumber (merged to ``$baseLabel``). GitHub only auto-closes for PRs merged to the default branch; this issue was fixed by a PR merged to a non-default branch."
+
+    if (-not $Apply) {
+        Write-Host "  [dry-run] would close issue #$IssueNumber as completed (merged to $baseLabel via PR #$PrNumber)"
+        return
+    }
+
+    $closeResult = Invoke-GhCli 'issue' 'close' "$IssueNumber" '--repo' 'dotnet/maui' '--reason' 'completed' '--comment' $comment
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "Close-LinkedIssue: failed to close issue #$IssueNumber via gh: $closeResult"
+        return
+    }
+    Write-Host "  ✅ closed issue #$IssueNumber as completed (merged to $baseLabel via PR #$PrNumber)"
+}
+
 function Set-ItemMilestone([int]$ItemNumber, [int]$MilestoneNumber) {
     $body = @{ milestone = $MilestoneNumber } | ConvertTo-Json
     $result = $body | gh api "repos/dotnet/maui/issues/$ItemNumber" -X PATCH --input - 2>&1
@@ -575,6 +657,9 @@ function Invoke-AnalyzeSinglePr([int]$PrNum, [string]$ReleaseTag, [string]$Repo)
         if (-not $issue) { continue }
         $report.IssuesChecked++
         Test-AndRecordCorrection "issue" $issueNum $issue.Title $issue.Url $issue.Milestone $expectedMs $match $PrNum $report
+        if ($script:CloseFixedIssues) {
+            Close-LinkedIssue -IssueNumber $issueNum -PrNumber $PrNum -BaseRef $pr.BaseRef -Apply ([bool]$script:Apply)
+        }
     }
 
     return $report
@@ -677,6 +762,9 @@ function Invoke-AnalyzeRelease([string]$ReleaseTag, [string]$PrevTag, [string]$R
             if (-not $issue) { continue }
             $report.IssuesChecked++
             Test-AndRecordCorrection "issue" $issueNum $issue.Title $issue.Url $issue.Milestone $expectedMs $match $prNum $report
+            if ($script:CloseFixedIssues) {
+                Close-LinkedIssue -IssueNumber $issueNum -PrNumber $prNum -BaseRef $pr.BaseRef -Apply ([bool]$script:Apply)
+            }
         }
     }
 
@@ -836,6 +924,11 @@ if ($MyInvocation.InvocationName -eq '.' -or $MyInvocation.Line -match '^\.\s') 
 
 if ($Apply) {
     Write-Host "⚠️  --Apply mode: Will modify GitHub milestones!"
+}
+
+if ($CloseFixedIssues) {
+    $applyHint = if ($Apply) { '' } else { ' (dry-run — pass -Apply to actually close)' }
+    Write-Host "ℹ️  --CloseFixedIssues mode: will close issues linked as fixed by the PR(s)$applyHint"
 }
 
 if ($PrNumber -gt 0) {

--- a/.github/scripts/shared/MauiReleaseVersioning.psm1
+++ b/.github/scripts/shared/MauiReleaseVersioning.psm1
@@ -266,6 +266,86 @@ function Find-PreviousTag {
     return ($candidates | Select-Object -Last 1)
 }
 
+function Get-MilestoneSortKey {
+    <#
+    .SYNOPSIS
+        Returns a numeric chronological sort key for a release milestone name.
+    .DESCRIPTION
+        Higher key = released later. Comparable across major versions.
+
+        Phase ordering within a major:
+          preview1..preview9  (100..109)
+          rc1..rc9            (200..209)
+          GA                  (300)
+          SR1, SR1.1, SR1.2, ..., SR2, ... (400 + N*10 + sub)
+
+        Returns $null for non-release milestones (Backlog, Planning, Future, etc.)
+        so callers can detect "not comparable" and fall back to default behavior.
+    .EXAMPLE
+        Get-MilestoneSortKey '.NET 11.0-preview3'   -> 11103
+        Get-MilestoneSortKey '.NET 10 SR6'          -> 10460
+        Get-MilestoneSortKey '.NET 10 SR4.1'        -> 10441
+        Get-MilestoneSortKey '.NET 10.0 GA'         -> 10300
+        Get-MilestoneSortKey '.NET 11.0-rc1'        -> 11201
+        Get-MilestoneSortKey 'Backlog'              -> $null
+        Get-MilestoneSortKey '.NET 11 Planning'     -> $null
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Position = 0)][AllowEmptyString()][AllowNull()][string]$Milestone
+    )
+    if ([string]::IsNullOrWhiteSpace($Milestone)) { return $null }
+
+    # ".NET 11.0-preview3"
+    if ($Milestone -match '^\.NET (\d+)\.0-preview(\d+)$') {
+        return ([int]$Matches[1]) * 1000 + 100 + [int]$Matches[2]
+    }
+    # ".NET 11.0-rc1"
+    if ($Milestone -match '^\.NET (\d+)\.0-rc(\d+)$') {
+        return ([int]$Matches[1]) * 1000 + 200 + [int]$Matches[2]
+    }
+    # ".NET 11.0 GA"
+    if ($Milestone -match '^\.NET (\d+)\.0 GA$') {
+        return ([int]$Matches[1]) * 1000 + 300
+    }
+    # ".NET 10 SR5.1" (sub-patch — check before bare SR)
+    if ($Milestone -match '^\.NET (\d+) SR(\d+)\.(\d+)$') {
+        return ([int]$Matches[1]) * 1000 + 400 + ([int]$Matches[2] * 10) + [int]$Matches[3]
+    }
+    # ".NET 10 SR5"
+    if ($Milestone -match '^\.NET (\d+) SR(\d+)$') {
+        return ([int]$Matches[1]) * 1000 + 400 + ([int]$Matches[2] * 10)
+    }
+    # Backlog, Planning, Future, or anything we don't recognize — not orderable
+    return $null
+}
+
+function Compare-MauiMilestone {
+    <#
+    .SYNOPSIS
+        Compares two MAUI release milestones chronologically.
+    .DESCRIPTION
+        Returns -1 if A is earlier, 0 if same, 1 if A is later.
+        Returns $null if either milestone is non-comparable (Backlog/Planning/none).
+    .EXAMPLE
+        Compare-MauiMilestone '.NET 10 SR6' '.NET 11.0-preview3'  -> -1
+        Compare-MauiMilestone '.NET 11.0-preview3' '.NET 10 SR6'  -> 1
+        Compare-MauiMilestone '.NET 10 SR6' '.NET 10 SR6'         -> 0
+        Compare-MauiMilestone 'Backlog' '.NET 11.0-preview3'      -> $null
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Position = 0)][AllowEmptyString()][AllowNull()][string]$A,
+        [Parameter(Position = 1)][AllowEmptyString()][AllowNull()][string]$B
+    )
+    $ka = Get-MilestoneSortKey $A
+    $kb = Get-MilestoneSortKey $B
+    if ($null -eq $ka -or $null -eq $kb) { return $null }
+    if ($ka -lt $kb) { return -1 }
+    if ($ka -gt $kb) { return 1 }
+    return 0
+}
+
 # Explicit exports - keeps internal helpers private if any are added later.
 Export-ModuleMember -Function `
     Get-CurrentMajorVersion, `
@@ -274,4 +354,6 @@ Export-ModuleMember -Function `
     ConvertTo-Milestone, `
     ConvertBranchToMilestone, `
     Get-TagSortKey, `
-    Find-PreviousTag
+    Find-PreviousTag, `
+    Get-MilestoneSortKey, `
+    Compare-MauiMilestone

--- a/.github/scripts/shared/MauiReleaseVersioning.psm1
+++ b/.github/scripts/shared/MauiReleaseVersioning.psm1
@@ -1,0 +1,277 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Shared helpers for parsing MAUI release version metadata.
+
+.DESCRIPTION
+    Pure functions that map between version numbers, milestone names, branch
+    names, and tags for the dotnet/maui release scheme.
+
+    Consumers:
+      - Fix-MilestoneDrift.ps1                                   (.github/scripts/)
+      - release-readiness skill (Get-ReleaseReadiness.ps1, etc.) (.github/skills/release-readiness/)
+
+    Naming convention reminder:
+      release/<major>.0.1xx              -> ".NET <major>.0 GA"
+      release/<major>.0.1xx-sr<N>        -> ".NET <major> SR<N>"        (e.g., SR8)
+                                            stable tags <major>.0.<N0>   (e.g., 10.0.80)
+                                            sub-patches  <major>.0.<NSub> -> ".NET <major> SR<N>.<Sub>" (e.g., SR8.1 = 10.0.81)
+      release/<major>.0.1xx-preview<N>   -> ".NET <major>.0-preview<N>"
+      release/<major>.0.1xx-rc<N>        -> ".NET <major>.0-rc<N>"
+
+.NOTES
+    StrictMode and $ErrorActionPreference are set INSIDE the module so module
+    functions get strict behavior without leaking those preferences out to the
+    caller's session (Import-Module isolates these unlike dot-sourcing).
+#>
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-CurrentMajorVersion {
+    <#
+    .SYNOPSIS
+        Returns the MajorVersion value from origin/main:eng/Versions.props.
+    .PARAMETER Repo
+        Path to a git checkout with origin/main fetched.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Repo
+    )
+    $versionXml = git -C $Repo --no-pager show origin/main:eng/Versions.props 2>&1
+    if ($LASTEXITCODE -eq 0) {
+        $joined = ($versionXml -join "`n")
+        if ($joined -match '<MajorVersion>(\d+)</MajorVersion>') {
+            return [int]$Matches[1]
+        }
+    }
+    throw "Could not read MajorVersion from origin/main:eng/Versions.props"
+}
+
+function Get-MainBranchForVersion {
+    <#
+    .SYNOPSIS
+        Returns the long-lived development branch that currently owns work for
+        a given .NET major version.
+    .DESCRIPTION
+        If main's MajorVersion matches, the version lives on main. Otherwise it
+        lives on net{Major}.0. This correctly tracks main rolling forward between
+        major versions (e.g., when main moves from .NET 10 to .NET 11, the previous
+        major's work shifts from main to net10.0).
+    .PARAMETER Major
+        The .NET major version (e.g., 10, 11).
+    .PARAMETER Repo
+        Path to a git checkout with origin/main fetched.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][int]$Major,
+        [Parameter(Mandatory)][string]$Repo
+    )
+    $versionXml = git -C $Repo --no-pager show origin/main:eng/Versions.props 2>&1
+    if ($LASTEXITCODE -eq 0) {
+        $joined = ($versionXml -join "`n")
+        if ($joined -match '<MajorVersion>(\d+)</MajorVersion>') {
+            $mainMajor = [int]$Matches[1]
+            if ($mainMajor -eq $Major) { return "main" }
+            Write-Verbose "origin/main has MajorVersion=$mainMajor, not $Major - version lives on net$Major.0"
+            return "net$Major.0"
+        }
+    }
+    Write-Warning "Could not read MajorVersion from origin/main:eng/Versions.props - falling back to net$Major.0"
+    return "net$Major.0"
+}
+
+function Get-VersionFromGitRef {
+    <#
+    .SYNOPSIS
+        Reads MajorVersion, PatchVersion, and (optionally) pre-release label
+        and iteration from eng/Versions.props at any git ref.
+    .DESCRIPTION
+        Returns a hashtable: @{ Tag; PreLabel; PreIter }.
+          Tag      = synthetic release tag (e.g., "10.0.71", "11.0.0")
+          PreLabel = "preview" | "rc" | $null (anything else - ci.main, ci.inflight, servicing - is treated as stable)
+          PreIter  = integer iteration ($null if not pre-release)
+
+        Auto-fetches the ref if not present locally (useful for refs that were
+        merged to inflight branches and not yet present in the local checkout).
+    .PARAMETER GitRef
+        The ref to read from, e.g. "origin/main" or "origin/release/10.0.1xx-sr8".
+    .PARAMETER Repo
+        Path to a git checkout.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$GitRef,
+        [Parameter(Mandatory)][string]$Repo
+    )
+    $versionXml = git -C $Repo --no-pager show "${GitRef}:eng/Versions.props" 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        # Ref not in local history - fetch it.
+        # Strip "origin/" prefix for the fetch refspec (git fetch origin <branch>, not origin/origin/<branch>)
+        $fetchRef = $GitRef -replace '^origin/', ''
+        Write-Verbose "  Fetching ref $fetchRef..."
+        $null = git -C $Repo fetch origin $fetchRef --quiet 2>&1
+        $versionXml = git -C $Repo --no-pager show "${GitRef}:eng/Versions.props" 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warning "Could not read Versions.props at $GitRef (even after fetch)"
+            return $null
+        }
+    }
+    $joined = ($versionXml -join "`n")
+    if ($joined -match '<MajorVersion>(\d+)</MajorVersion>') {
+        $major = $Matches[1]
+    } else {
+        Write-Warning "Could not parse MajorVersion from Versions.props at $GitRef"
+        return $null
+    }
+    if ($joined -match '<PatchVersion>(\d+)</PatchVersion>') {
+        $patch = $Matches[1]
+    } else {
+        Write-Warning "Could not parse PatchVersion from Versions.props at $GitRef"
+        return $null
+    }
+
+    # Detect pre-release label (preview, rc) and iteration.
+    # Other labels like ci.main, ci.inflight, and servicing are stable builds.
+    $preLabel = $null
+    $preIter = $null
+    if ($joined -match '<PreReleaseVersionLabel[^>]*>([^<]+)</PreReleaseVersionLabel>') {
+        $rawLabel = $Matches[1]
+        if ($rawLabel -match '^(preview|rc)$') {
+            $preLabel = $rawLabel
+            if ($joined -match '<PreReleaseVersionIteration>(\d+)</PreReleaseVersionIteration>') {
+                $preIter = [int]$Matches[1]
+            }
+        }
+    }
+
+    return @{
+        Tag       = "$major.0.$patch"
+        PreLabel  = $preLabel
+        PreIter   = $preIter
+    }
+}
+
+function ConvertTo-Milestone {
+    <#
+    .SYNOPSIS
+        Maps a version (tag + optional pre-release info) to a milestone name.
+    .EXAMPLE
+        ConvertTo-Milestone '10.0.50'              -> '.NET 10 SR5'
+        ConvertTo-Milestone '10.0.41'              -> '.NET 10 SR4.1'
+        ConvertTo-Milestone '10.0.0'               -> '.NET 10.0 GA'
+        ConvertTo-Milestone '11.0.0' 'preview' 3   -> '.NET 11.0-preview3'
+        ConvertTo-Milestone '11.0.0' 'rc' 1        -> '.NET 11.0-rc1'
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Position = 0)][AllowEmptyString()][AllowNull()][string]$ReleaseTag,
+        [Parameter(Position = 1)][AllowEmptyString()][AllowNull()][string]$PreLabel,
+        [Parameter(Position = 2)][int]$PreIter
+    )
+    if ([string]::IsNullOrEmpty($ReleaseTag))    { return $null }
+    if ($ReleaseTag -notmatch '^(\d+)\.0\.(\d+)$') { return $null }
+    $major = [int]$Matches[1]; $patch = [int]$Matches[2]
+
+    # Pre-release: preview/rc milestones
+    if ($PreLabel -and $PreIter -gt 0) {
+        return ".NET $major.0-$PreLabel$PreIter"
+    }
+    if ($PreLabel -and $PreIter -le 0) {
+        Write-Warning "PreReleaseVersionLabel is '$PreLabel' but PreReleaseVersionIteration is missing or 0 - falling back to GA/SR mapping"
+    }
+
+    if ($patch -eq 0)  { return ".NET $major.0 GA" }
+    if ($patch -lt 10) { return ".NET $major.0 SR1" }
+    $sr = [math]::Floor($patch / 10)
+    $sub = $patch % 10
+    if ($sub -eq 0) { return ".NET $major SR$sr" }
+    return ".NET $major SR$sr.$sub"
+}
+
+function ConvertBranchToMilestone {
+    <#
+    .SYNOPSIS
+        Maps a release branch name to a milestone name.
+    .EXAMPLE
+        ConvertBranchToMilestone 'release/10.0.1xx'        -> '.NET 10.0 GA'
+        ConvertBranchToMilestone 'release/10.0.1xx-sr5'    -> '.NET 10 SR5'
+        ConvertBranchToMilestone 'release/11.0.1xx-preview3' -> '.NET 11.0-preview3'
+        ConvertBranchToMilestone 'release/11.0.1xx-rc1'    -> '.NET 11.0-rc1'
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Position = 0)][AllowEmptyString()][AllowNull()][string]$BranchName
+    )
+    if ([string]::IsNullOrEmpty($BranchName)) { return $null }
+    if ($BranchName -match '^release/(\d+)\.0\.\d+xx$') {
+        return ".NET $([int]$Matches[1]).0 GA"
+    }
+    if ($BranchName -match '^release/(\d+)\.0\.\d+xx-sr(\d+)$') {
+        return ".NET $([int]$Matches[1]) SR$([int]$Matches[2])"
+    }
+    if ($BranchName -match '^release/(\d+)\.0\.\d+xx-(preview|rc)(\d+)$') {
+        return ".NET $([int]$Matches[1]).0-$($Matches[2])$([int]$Matches[3])"
+    }
+    return $null
+}
+
+function Get-TagSortKey {
+    <#
+    .SYNOPSIS
+        Returns a numeric sort key for chronological ordering of release tags.
+    .DESCRIPTION
+        preview1 (100) < preview7 (107) < rc1 (200) < rc2 (201) < GA/stable (500+patch)
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Position = 0)][AllowEmptyString()][AllowNull()][string]$ReleaseTag
+    )
+    if ([string]::IsNullOrEmpty($ReleaseTag)) { return 0 }
+    if ($ReleaseTag -match '-preview\.(\d+)') { return 100 + [int]$Matches[1] }
+    if ($ReleaseTag -match '-rc\.(\d+)')      { return 200 + [int]$Matches[1] }
+    if ($ReleaseTag -match '^(\d+)\.0\.(\d+)$') { return 500 + [int]$Matches[2] }
+    return 0
+}
+
+function Find-PreviousTag {
+    <#
+    .SYNOPSIS
+        Finds the immediately preceding release tag (chronologically) for the
+        same major version.
+    .DESCRIPTION
+        Works for both stable tags (10.0.50 -> 10.0.41) and preview/RC tags
+        (11.0.0-preview.3.x -> 11.0.0-preview.2.x). Cross-major tags are ignored.
+    .PARAMETER ReleaseTag
+        The tag to look up the predecessor for.
+    .PARAMETER AllTags
+        The candidate list of tags to search.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Position = 0)][AllowEmptyString()][AllowNull()][string]$ReleaseTag,
+        [Parameter(Position = 1, Mandatory)][string[]]$AllTags
+    )
+    if ([string]::IsNullOrEmpty($ReleaseTag)) { return $null }
+    if ($ReleaseTag -notmatch '^(\d+)\.') { return $null }
+    $major = [int]$Matches[1]
+    $thisKey = Get-TagSortKey $ReleaseTag
+
+    # Find all tags for this major version with a lower sort key
+    $candidates = $AllTags | Where-Object {
+        ($_ -match "^$major\.0\.") -and (Get-TagSortKey $_) -lt $thisKey
+    } | Sort-Object { Get-TagSortKey $_ }
+    return ($candidates | Select-Object -Last 1)
+}
+
+# Explicit exports - keeps internal helpers private if any are added later.
+Export-ModuleMember -Function `
+    Get-CurrentMajorVersion, `
+    Get-MainBranchForVersion, `
+    Get-VersionFromGitRef, `
+    ConvertTo-Milestone, `
+    ConvertBranchToMilestone, `
+    Get-TagSortKey, `
+    Find-PreviousTag

--- a/.github/scripts/shared/MauiReleaseVersioning.psm1
+++ b/.github/scripts/shared/MauiReleaseVersioning.psm1
@@ -304,16 +304,20 @@ function Get-MilestoneSortKey {
     if ($Milestone -match '^\.NET (\d+)\.0-rc(\d+)$') {
         return ([int]$Matches[1]) * 1000 + 200 + [int]$Matches[2]
     }
-    # ".NET 11.0 GA"
-    if ($Milestone -match '^\.NET (\d+)\.0 GA$') {
+    # ".NET 11.0 GA" / ".NET 11 GA" (accept both — production uses both forms)
+    if ($Milestone -match '^\.NET (\d+)(?:\.0)? GA$') {
         return ([int]$Matches[1]) * 1000 + 300
     }
-    # ".NET 10 SR5.1" (sub-patch — check before bare SR)
-    if ($Milestone -match '^\.NET (\d+) SR(\d+)\.(\d+)$') {
+    # ".NET 10 SR5.1" / ".NET 10.0 SR5.1" (sub-patch — check before bare SR)
+    # Production milestone names use BOTH forms (e.g. ".NET 10 SR4.1" AND ".NET 10.0 SR2.1"),
+    # so the `.0` between major and SR must be optional. Without this, Compare-MauiMilestone
+    # returns $null for ".NET 10.0 SR*" milestones and the earliest-release-wins guard
+    # silently fails open.
+    if ($Milestone -match '^\.NET (\d+)(?:\.0)? SR(\d+)\.(\d+)$') {
         return ([int]$Matches[1]) * 1000 + 400 + ([int]$Matches[2] * 10) + [int]$Matches[3]
     }
-    # ".NET 10 SR5"
-    if ($Milestone -match '^\.NET (\d+) SR(\d+)$') {
+    # ".NET 10 SR5" / ".NET 10.0 SR5"
+    if ($Milestone -match '^\.NET (\d+)(?:\.0)? SR(\d+)$') {
         return ([int]$Matches[1]) * 1000 + 400 + ([int]$Matches[2] * 10)
     }
     # Backlog, Planning, Future, or anything we don't recognize — not orderable

--- a/.github/workflows/fix-milestone-drift.yml
+++ b/.github/workflows/fix-milestone-drift.yml
@@ -26,7 +26,7 @@ on:
         type: boolean
         default: false
       close_fixed_issues:
-        description: 'Close issues linked as fixed by the PR (use for PRs merged to non-default branches like net11.0)'
+        description: '[PR-mode] Close issues linked as fixed by the PR (for PRs merged to net*.0 branches that GitHub does NOT auto-close). [Tag-mode] BULK: closes every linked open issue across the whole PrevTag..ReleaseTag range — use deliberately and with -apply only when you intend to fan out closures across the entire tag cohort.'
         required: false
         type: boolean
         default: false
@@ -75,6 +75,13 @@ jobs:
           else
             # Manual trigger: use provided inputs
             if [ -n "$INPUT_PR_NUMBER" ]; then
+              # The Fix-MilestoneDrift.ps1 -PrNumber param is [int]; fail fast with a
+              # clear message rather than letting PowerShell emit a parameter-binding
+              # error for a non-numeric input.
+              if [[ ! "$INPUT_PR_NUMBER" =~ ^[0-9]+$ ]]; then
+                echo "::error::pr_number input must be a positive integer (got: '$INPUT_PR_NUMBER')"
+                exit 1
+              fi
               ARGS+=('-PrNumber' "$INPUT_PR_NUMBER")
             fi
 

--- a/.github/workflows/fix-milestone-drift.yml
+++ b/.github/workflows/fix-milestone-drift.yml
@@ -25,6 +25,11 @@ on:
         required: false
         type: boolean
         default: false
+      close_fixed_issues:
+        description: 'Close issues linked as fixed by the PR (use for PRs merged to non-default branches like net11.0)'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -50,6 +55,8 @@ jobs:
           INPUT_TAG: ${{ inputs.tag }}
           INPUT_APPLY: ${{ inputs.apply }}
           INPUT_CREATE_ISSUE: ${{ inputs.create_issue }}
+          INPUT_CLOSE_FIXED_ISSUES: ${{ inputs.close_fixed_issues }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
           ARGS=()
@@ -57,6 +64,14 @@ jobs:
           if [ "$EVENT_NAME" = "pull_request_target" ]; then
             # Auto-trigger: set milestone on the merged PR
             ARGS+=('-PrNumber' "$INPUT_PR_NUMBER" '-Apply')
+            # GitHub only auto-closes "fixes #N" issues for PRs merged to the
+            # default branch (main). For PRs merged to net*.0 development
+            # branches the issue stays open, so we close it ourselves.
+            # We deliberately do NOT auto-close for release/* or inflight/*
+            # branches — those need extra human judgment.
+            if [[ "$PR_BASE_REF" == net*.0 ]]; then
+              ARGS+=('-CloseFixedIssues')
+            fi
           else
             # Manual trigger: use provided inputs
             if [ -n "$INPUT_PR_NUMBER" ]; then
@@ -73,6 +88,10 @@ jobs:
 
             if [ "$INPUT_CREATE_ISSUE" = "true" ]; then
               ARGS+=('-CreateIssue')
+            fi
+
+            if [ "$INPUT_CLOSE_FIXED_ISSUES" = "true" ]; then
+              ARGS+=('-CloseFixedIssues')
             fi
           fi
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

Three related, surgical changes to `.github/scripts/` around MAUI release/milestone tooling:

1. **Extract a shared `MauiReleaseVersioning` PowerShell module** from `Fix-MilestoneDrift.ps1` so other release tooling can reuse the same version/milestone helpers.
2. **Add a `-CloseFixedIssues` flag** to `Fix-MilestoneDrift.ps1` (and wire it into the workflow) so issues fixed by PRs merged to non-default branches like `net11.0` actually get closed.
3. **Add "earliest release wins" milestone validation** so the auditor never overwrites an issue's existing earlier-release milestone (e.g. `.NET 10 SR6`) just because a later follow-up PR on `net11.0` also fixes it.

No behavior change unless you opt into the new flag, and the new validation only ever turns a would-be mutation into a no-op — it can never create writes that didn't exist before.

## Motivation (net11.0 close-issue gap)

GitHub only auto-closes "fixes #NNN" linked issues for PRs merged to the **default branch** (`main` for `dotnet/maui`). When work targets `net11.0` (the .NET 11 development branch), the PR merges fine and the milestone gets set, but the linked issue stays open — so the team has to manually close issues for every fix shipped on `net11.0`.

This PR adds a deliberate, opt-in closing action. The auto-trigger turns it on automatically only when the PR's base ref matches `net*.0`, and leaves `main`, `release/*`, and `inflight/*` alone (those either already auto-close or need human judgment).

## Motivation (earliest-release-wins)

When a bug was first fixed in (say) `.NET 10 SR6` and a follow-up clean-up landed on `net11.0`, the linked issue is correctly milestoned to `.NET 10 SR6` to record where the fix first shipped. Running the auditor against an `11.0` tag was then re-milestoning that issue to `.NET 11.0-previewN`, erasing the "first shipped in" signal.

The fix: before overwriting an **issue's** existing real-release milestone, verify a fix-linking PR in the current milestone actually exists. If yes, leave it alone (KEEP). If the current milestone is `null`/`Backlog`/`Planning` or a *later* release than the target, behavior is unchanged.

## Commit 1 — Extract shared `MauiReleaseVersioning` module

- **New:** `.github/scripts/shared/MauiReleaseVersioning.psm1` exporting helpers used across release tooling (`Get-CurrentMajorVersion`, `Get-MainBranchForVersion`, `Get-VersionFromGitRef`, `ConvertTo-Milestone`, `ConvertBranchToMilestone`, `Get-TagSortKey`, `Find-PreviousTag`).
- **Modified:** `.github/scripts/Fix-MilestoneDrift.ps1` — removes the in-script copies of those helpers and `Import-Module`s the new psm1 instead.
- Module uses `Set-StrictMode -Version Latest` internally (import doesn't leak strict mode out, unlike dot-sourcing) and has an explicit `Export-ModuleMember` block.
- 4 helpers use `[AllowEmptyString()][AllowNull()]` on string params for back-compat with existing positional-parameter tests.
- No release-readiness files are included.

## Commit 2 — `-CloseFixedIssues` flag

**Script (`Fix-MilestoneDrift.ps1`)**
- New `[switch]$CloseFixedIssues` parameter (default off; behavior unchanged when not passed).
- New `Close-LinkedIssue` function:
  - Checks current issue state via `gh issue view --json state,number,title`.
  - **Already closed** → no-op, log message.
  - **Open + `-Apply`** → `gh issue close N --reason completed --comment "Closed by #PR (merged to <baseRef>). GitHub only auto-closes for PRs merged to the default branch; this issue was fixed by a PR merged to a non-default branch."`.
  - **Open + no `-Apply`** → dry-run path (log only, no `gh` call).
  - `gh` failures → warn and continue, do not throw (one bad issue mustn't fail the whole script).
- New `Invoke-GhCli` thin wrapper around `gh` so Pester can mock CLI calls without spawning real processes.
- Reuses the existing `Get-LinkedIssues` regex (no duplicated `fix(es|ed)?|close[sd]?|resolve[sd]?` parsing).
- Wired into **both** the single-PR path (`Invoke-AnalyzeSinglePr`) and the tag-based audit path (`Invoke-AnalyzeRelease`), gated on `-CloseFixedIssues`.

**Workflow (`fix-milestone-drift.yml`)**
- New `close_fixed_issues` `workflow_dispatch` input (boolean, default `false`).
- On the `pull_request_target` auto-trigger, `-CloseFixedIssues` is appended automatically when `github.event.pull_request.base.ref` matches `net*.0`:
  ```bash
  if [[ "$PR_BASE_REF" == net*.0 ]]; then
    ARGS+=('-CloseFixedIssues')
  fi
  ```
- Deliberately **not** auto-enabled for `main`, `release/*`, or `inflight/*`.
- Manual-trigger path passes `-CloseFixedIssues` when `inputs.close_fixed_issues == 'true'`.

## Commit 3 — Earliest-release-wins milestone validation

**Shared module additions**
- `Get-MilestoneSortKey` — converts a milestone name to a sortable integer (`major * 1000 + phase`), where phase: `preview = 100+N`, `rc = 200+N`, GA = `300`, SR = `400 + (sr * 10) + sub`. Returns `$null` for non-release buckets like Backlog/Planning/Future.
- `Compare-MauiMilestone` — returns `-1 / 0 / 1` (earlier / equal / later) using the sort key.

**Script (`Fix-MilestoneDrift.ps1`)**
- `Test-MilestoneValidForIssue` — for an issue already on a real earlier release, searches `gh search prs "#$n in:body"` for a PR with a fix verb (`fixes/closes/resolves #N`) that itself sits on the current milestone. Hit → milestone is "valid earlier", KEEP. Miss → fall through to the existing apply path.
- Results cached in `$script:milestoneValidationCache` keyed by `"$IssueNumber|$Milestone"` so the same issue checked via multiple linking PRs only hits `gh` once.
- Only applies to **issues**, never to PRs (PRs land in exactly one branch — no ambiguity).
- Gated: current milestone must be a real release (not null/Backlog/Planning/Future/etc.) and *earlier* than target. Otherwise existing behavior is unchanged.
- Adds a `Kept` bucket to the report — surfaced in console output, JSON report (`kept[]` + `summary.kept_earlier`), and the rolled-up GitHub issue summary.
- Bonus: declared `[object[]]$keptItems = @()` then conditional assign in `Save-ReportJson` so a report with zero KEEPs no longer collapses to `$null` under StrictMode.

## Tests

Added Pester coverage for everything new — totals went from 91 → 152 tests across the three review rounds, all green.

- 7 tests for `Close-LinkedIssue` (already-closed both cases, dry-run, apply with comment text check, `gh view`/`close` failures, empty BaseRef).
- 11 tests for `Get-MilestoneSortKey` (each phase, sub-revisions, Backlog/Planning/Future return `$null`, malformed input).
- 5 tests for `Compare-MauiMilestone` (-1/0/1 across phases, `$null` handling).
- 4 tests for `Test-MilestoneValidForIssue` (valid earlier KEEP, no linking PR → fall through, `gh` failure → fall through, cache hit).

## How to verify

```bash
# Run all Pester tests
pwsh -NoProfile -Command "Import-Module Pester -Force; \
  Invoke-Pester .github/scripts/Fix-MilestoneDrift.Tests.ps1"

# Confirm only the expected files changed
git diff --stat origin/main..HEAD
# Expected: 4 files —
#   .github/scripts/Fix-MilestoneDrift.ps1
#   .github/scripts/Fix-MilestoneDrift.Tests.ps1
#   .github/scripts/shared/MauiReleaseVersioning.psm1  (new)
#   .github/workflows/fix-milestone-drift.yml

# Dry-run the new flag against a real net11.0 PR (replace with a real PR number)
pwsh -File .github/scripts/Fix-MilestoneDrift.ps1 \
  -PrNumber <PR#> -RepoPath . -CloseFixedIssues -Verbose
# Expected: "ℹ️  --CloseFixedIssues mode ... (dry-run — pass -Apply to actually close)"
# Plus a "[dry-run] would close issue #N" line per linked issue.
```

## Production validation

Ran the new tooling live across every shipped `net11.0` preview tag — full PR/issue milestone audit + opt-in closes + earliest-release-wins:

| Tag | PR milestones fixed | Issues closed | Earlier-release KEEPs |
| --- | --: | --: | --: |
| `11.0.0-preview.5` | 20 | 4 | — |
| `11.0.0-preview.4` | 16 | 5 | — |
| `11.0.0-preview.3` | 50 | 12 | 2 |
| `11.0.0-preview.2` | 19 | 6 | 0 |
| `11.0.0-preview.1` | 28 | 0 | 0 |

The 2 KEEPs on preview3 (`#34490` on `.NET 10 SR6`, `#31280` on `.NET 10 SR7`) were both manually verified as correct: each issue was first fixed by a main → SR PR and the net11.0 PR was a follow-up — exactly the case the validation is designed to catch.
