### PR TITLE
Fix Android nested gesture ownership

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
@@ -800,7 +800,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			public void RequestDisallowInterceptTouchEvent(bool disallowIntercept)
 			{
-				if (_gestureOwner == GestureOwner.Undecided)
+				if (_gestureOwner != GestureOwner.Parent)
 				{
 					_descendantDisallowedIntercept = disallowIntercept;
 				}
@@ -853,12 +853,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 					return false;
 				}
 
-				if (_descendantDisallowedIntercept)
-				{
-					_gestureOwner = GestureOwner.RecyclerView;
-					return false;
-				}
-
 				var target = FindParentScrollTarget(e, canScrollHorizontally);
 
 				if (target is null)
@@ -870,7 +864,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 				if (_descendantDisallowedIntercept)
 				{
-					_gestureOwner = GestureOwner.RecyclerView;
 					handled = recyclerViewHandled;
 					return true;
 				}

--- a/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
@@ -731,17 +731,21 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		class ParentScrollGestureDispatcher : IDisposable
 		{
 			readonly MauiRecyclerView<TItemsView, TAdapter, TItemsViewSource> _owner;
+			readonly DescendantDisallowInterceptListener _disallowInterceptListener;
 			readonly int[] _targetLocation = new int[2];
 			MotionEvent _downEvent;
 			AView _parentScrollTarget;
 			float _touchStartX;
 			float _touchStartY;
 			int? _scaledTouchSlop;
+			bool _descendantDisallowedIntercept;
 			GestureOwner _gestureOwner;
 
 			public ParentScrollGestureDispatcher(MauiRecyclerView<TItemsView, TAdapter, TItemsViewSource> owner)
 			{
 				_owner = owner;
+				_disallowInterceptListener = new DescendantDisallowInterceptListener(this);
+				_owner.AddOnItemTouchListener(_disallowInterceptListener);
 			}
 
 			public bool TryDispatchToParent(MotionEvent e, Func<MotionEvent, bool> dispatchToRecyclerView, out bool handled)
@@ -789,7 +793,17 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			public void Dispose()
 			{
+				_owner.RemoveOnItemTouchListener(_disallowInterceptListener);
+				_disallowInterceptListener.Dispose();
 				Reset();
+			}
+
+			public void RequestDisallowInterceptTouchEvent(bool disallowIntercept)
+			{
+				if (_gestureOwner == GestureOwner.Undecided)
+				{
+					_descendantDisallowedIntercept = disallowIntercept;
+				}
 			}
 
 			void TrackDown(MotionEvent e)
@@ -839,11 +853,26 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 					return false;
 				}
 
+				if (_descendantDisallowedIntercept)
+				{
+					_gestureOwner = GestureOwner.RecyclerView;
+					return false;
+				}
+
 				var target = FindParentScrollTarget(e, canScrollHorizontally);
 
 				if (target is null)
 				{
 					return false;
+				}
+
+				var recyclerViewHandled = dispatchToRecyclerView(e);
+
+				if (_descendantDisallowedIntercept)
+				{
+					_gestureOwner = GestureOwner.RecyclerView;
+					handled = recyclerViewHandled;
+					return true;
 				}
 
 				_parentScrollTarget = target;
@@ -934,6 +963,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			{
 				_owner.Parent?.RequestDisallowInterceptTouchEvent(false);
 				_parentScrollTarget = null;
+				_descendantDisallowedIntercept = false;
 				_gestureOwner = GestureOwner.Undecided;
 
 				if (_downEvent is not null)
@@ -953,6 +983,30 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				Undecided,
 				RecyclerView,
 				Parent
+			}
+
+			sealed class DescendantDisallowInterceptListener : Java.Lang.Object, RecyclerView.IOnItemTouchListener
+			{
+				readonly ParentScrollGestureDispatcher _dispatcher;
+
+				public DescendantDisallowInterceptListener(ParentScrollGestureDispatcher dispatcher)
+				{
+					_dispatcher = dispatcher;
+				}
+
+				public bool OnInterceptTouchEvent(RecyclerView rv, MotionEvent e)
+				{
+					return false;
+				}
+
+				public void OnTouchEvent(RecyclerView rv, MotionEvent e)
+				{
+				}
+
+				public void OnRequestDisallowInterceptTouchEvent(bool disallowIntercept)
+				{
+					_dispatcher.RequestDisallowInterceptTouchEvent(disallowIntercept);
+				}
 			}
 		}
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue7814.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue7814.cs
@@ -1,3 +1,8 @@
+#if ANDROID
+using Microsoft.Maui.Handlers;
+using AView = Android.Views.View;
+#endif
+
 namespace Maui.Controls.Sample.Issues;
 
 [Issue(IssueTracker.Github, 7814, "Vertical scrolling not working for CarouselView and CustomLayouts", PlatformAffected.Android)]
@@ -5,14 +10,20 @@ public class Issue7814 : TestContentPage
 {
 	const string VerticalOffsetPrefix = "VerticalScrollY";
 	const string HorizontalOffsetPrefix = "HorizontalScrollX";
+	const string TouchParentPositionPrefix = "TouchParentPosition";
+	const string TouchStatusPrefix = "TouchStatus";
 
 	Label _verticalOffsetLabel = null!;
 	Label _horizontalOffsetLabel = null!;
+	Label _touchParentPositionLabel = null!;
+	Label _touchStatusLabel = null!;
 
 	protected override void Init()
 	{
 		_verticalOffsetLabel = CreateOffsetLabel("Issue7814VerticalScrollYLabel", VerticalOffsetPrefix);
 		_horizontalOffsetLabel = CreateOffsetLabel("Issue7814HorizontalScrollXLabel", HorizontalOffsetPrefix);
+		_touchParentPositionLabel = CreateOffsetLabel("Issue7814TouchParentPositionLabel", TouchParentPositionPrefix);
+		_touchStatusLabel = CreateOffsetLabel("Issue7814TouchStatusLabel", TouchStatusPrefix);
 
 		Grid.SetColumn(_horizontalOffsetLabel, 1);
 
@@ -37,6 +48,11 @@ public class Issue7814 : TestContentPage
 				new Grid
 				{
 					Padding = new Thickness(12, 8),
+					RowDefinitions =
+					{
+						new RowDefinition(GridLength.Auto),
+						new RowDefinition(GridLength.Auto)
+					},
 					ColumnDefinitions =
 					{
 						new ColumnDefinition(GridLength.Star),
@@ -45,7 +61,9 @@ public class Issue7814 : TestContentPage
 					Children =
 					{
 						_verticalOffsetLabel,
-						_horizontalOffsetLabel
+						Column(_horizontalOffsetLabel, 1),
+						Row(_touchParentPositionLabel, 1),
+						Column(Row(_touchStatusLabel, 1), 1)
 					}
 				},
 				outerScrollView
@@ -115,6 +133,8 @@ public class Issue7814 : TestContentPage
 		};
 		horizontalScrollView.Scrolled += (_, e) => UpdateOffset(_horizontalOffsetLabel, HorizontalOffsetPrefix, e.ScrollX);
 
+		var touchClaimRegressionParent = CreateTouchClaimRegressionParent();
+
 		return new VerticalStackLayout
 		{
 			Spacing = 16,
@@ -134,6 +154,13 @@ public class Issue7814 : TestContentPage
 					Margin = new Thickness(12, 0)
 				},
 				horizontalScrollView,
+				new Label
+				{
+					Text = "Touch-claiming row in a vertical CollectionView inside a horizontal parent",
+					FontSize = 20,
+					Margin = new Thickness(12, 0)
+				},
+				touchClaimRegressionParent,
 				new BoxView
 				{
 					HeightRequest = 900,
@@ -141,6 +168,87 @@ public class Issue7814 : TestContentPage
 				}
 			}
 		};
+	}
+
+	View CreateTouchClaimRegressionParent()
+	{
+		var carouselView = new CarouselView
+		{
+			AutomationId = "Issue7814TouchClaimHorizontalParent",
+			HeightRequest = 380,
+			Loop = false,
+			ItemsLayout = new LinearItemsLayout(ItemsLayoutOrientation.Horizontal),
+			ItemsSource = Enumerable.Range(1, 3).ToList(),
+			ItemTemplate = new DataTemplate(CreateTouchClaimRegressionCarouselItem)
+		};
+		carouselView.PositionChanged += (_, e) => UpdateOffset(_touchParentPositionLabel, TouchParentPositionPrefix, e.CurrentPosition);
+
+		return carouselView;
+	}
+
+	View CreateTouchClaimRegressionCarouselItem()
+	{
+		var collectionView = new CollectionView
+		{
+			AutomationId = "Issue7814TouchClaimCollectionView",
+			WidthRequest = 360,
+			HeightRequest = 360,
+			ItemsLayout = new LinearItemsLayout(ItemsLayoutOrientation.Vertical),
+			ItemsSource = Enumerable.Range(1, 12).Select(index => $"Touch row {index}").ToList(),
+			ItemTemplate = new DataTemplate(CreateTouchClaimRow)
+		};
+
+		return new Grid
+		{
+			Children =
+			{
+				collectionView
+			}
+		};
+	}
+
+	View CreateTouchClaimRow()
+	{
+		var contentLabel = new Label
+		{
+			AutomationId = "Issue7814TouchClaimRowLabel",
+			FontSize = 18,
+			InputTransparent = true,
+			HorizontalOptions = LayoutOptions.Center,
+			VerticalOptions = LayoutOptions.Center
+		};
+		contentLabel.SetBinding(Label.TextProperty, ".");
+
+		var touchClaimView = new Issue7814TouchClaimView
+		{
+			AutomationId = "Issue7814TouchClaimView",
+			BackgroundColor = Colors.LightGreen,
+			TouchStateChanged = state => _touchStatusLabel.Text = state
+		};
+
+		return new Grid
+		{
+			HeightRequest = 84,
+			Margin = new Thickness(8, 4),
+			BackgroundColor = Colors.LightBlue,
+			Children =
+			{
+				touchClaimView,
+				contentLabel
+			}
+		};
+	}
+
+	static T Row<T>(T view, int row) where T : View
+	{
+		Grid.SetRow(view, row);
+		return view;
+	}
+
+	static T Column<T>(T view, int column) where T : View
+	{
+		Grid.SetColumn(view, column);
+		return view;
 	}
 
 	static Label CreateOffsetLabel(string automationId, string prefix)
@@ -160,3 +268,82 @@ public class Issue7814 : TestContentPage
 		label.Text = $"{prefix}: {(int)Math.Round(offset)}";
 	}
 }
+
+public class Issue7814TouchClaimView : View
+{
+	public Action<string> TouchStateChanged { get; set; }
+
+	internal void SendTouchState(string state)
+	{
+		TouchStateChanged?.Invoke(state);
+	}
+}
+
+#if ANDROID
+public class Issue7814TouchClaimViewHandler : ViewHandler<Issue7814TouchClaimView, AView>
+{
+	int _moveCount;
+
+	public Issue7814TouchClaimViewHandler() : base(ViewHandler.ViewMapper, ViewHandler.ViewCommandMapper)
+	{
+	}
+
+	protected override AView CreatePlatformView()
+	{
+		return new AView(Context)
+		{
+			Clickable = true
+		};
+	}
+
+	protected override void ConnectHandler(AView platformView)
+	{
+		base.ConnectHandler(platformView);
+		platformView.Touch += OnTouch;
+	}
+
+	protected override void DisconnectHandler(AView platformView)
+	{
+		platformView.Touch -= OnTouch;
+		base.DisconnectHandler(platformView);
+	}
+
+	void OnTouch(object sender, AView.TouchEventArgs e)
+	{
+		if (e.Event is null)
+		{
+			return;
+		}
+
+		switch (e.Event.ActionMasked)
+		{
+			case Android.Views.MotionEventActions.Down:
+				_moveCount = 0;
+				RequestTouchOwnership();
+				VirtualView.SendTouchState("TouchStatus: Down");
+				e.Handled = true;
+				break;
+			case Android.Views.MotionEventActions.Move:
+				_moveCount++;
+				RequestTouchOwnership();
+				VirtualView.SendTouchState($"TouchStatus: Move {_moveCount}");
+				e.Handled = true;
+				break;
+			case Android.Views.MotionEventActions.Up:
+				RequestTouchOwnership();
+				VirtualView.SendTouchState($"TouchStatus: Up {_moveCount}");
+				e.Handled = true;
+				break;
+			case Android.Views.MotionEventActions.Cancel:
+				VirtualView.SendTouchState($"TouchStatus: Cancel {_moveCount}");
+				e.Handled = true;
+				break;
+		}
+	}
+
+	void RequestTouchOwnership()
+	{
+		PlatformView?.Parent?.RequestDisallowInterceptTouchEvent(true);
+	}
+}
+#endif

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue7814.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue7814.cs
@@ -10,20 +10,28 @@ public class Issue7814 : TestContentPage
 {
 	const string VerticalOffsetPrefix = "VerticalScrollY";
 	const string HorizontalOffsetPrefix = "HorizontalScrollX";
+#if ANDROID
 	const string TouchParentPositionPrefix = "TouchParentPosition";
 	const string TouchStatusPrefix = "TouchStatus";
+	const string TouchClaimViewId = "Issue7814TouchClaimView";
+	const string TouchReleaseViewId = "Issue7814TouchReleaseView";
+#endif
 
 	Label _verticalOffsetLabel = null!;
 	Label _horizontalOffsetLabel = null!;
+#if ANDROID
 	Label _touchParentPositionLabel = null!;
 	Label _touchStatusLabel = null!;
+#endif
 
 	protected override void Init()
 	{
 		_verticalOffsetLabel = CreateOffsetLabel("Issue7814VerticalScrollYLabel", VerticalOffsetPrefix);
 		_horizontalOffsetLabel = CreateOffsetLabel("Issue7814HorizontalScrollXLabel", HorizontalOffsetPrefix);
+#if ANDROID
 		_touchParentPositionLabel = CreateOffsetLabel("Issue7814TouchParentPositionLabel", TouchParentPositionPrefix);
 		_touchStatusLabel = CreateOffsetLabel("Issue7814TouchStatusLabel", TouchStatusPrefix);
+#endif
 
 		Grid.SetColumn(_horizontalOffsetLabel, 1);
 
@@ -51,7 +59,9 @@ public class Issue7814 : TestContentPage
 					RowDefinitions =
 					{
 						new RowDefinition(GridLength.Auto),
+#if ANDROID
 						new RowDefinition(GridLength.Auto)
+#endif
 					},
 					ColumnDefinitions =
 					{
@@ -62,8 +72,10 @@ public class Issue7814 : TestContentPage
 					{
 						_verticalOffsetLabel,
 						Column(_horizontalOffsetLabel, 1),
+#if ANDROID
 						Row(_touchParentPositionLabel, 1),
 						Column(Row(_touchStatusLabel, 1), 1)
+#endif
 					}
 				},
 				outerScrollView
@@ -133,7 +145,9 @@ public class Issue7814 : TestContentPage
 		};
 		horizontalScrollView.Scrolled += (_, e) => UpdateOffset(_horizontalOffsetLabel, HorizontalOffsetPrefix, e.ScrollX);
 
+#if ANDROID
 		var touchClaimRegressionParent = CreateTouchClaimRegressionParent();
+#endif
 
 		return new VerticalStackLayout
 		{
@@ -154,6 +168,7 @@ public class Issue7814 : TestContentPage
 					Margin = new Thickness(12, 0)
 				},
 				horizontalScrollView,
+#if ANDROID
 				new Label
 				{
 					Text = "Touch-claiming row in a vertical CollectionView inside a horizontal parent",
@@ -161,6 +176,7 @@ public class Issue7814 : TestContentPage
 					Margin = new Thickness(12, 0)
 				},
 				touchClaimRegressionParent,
+#endif
 				new BoxView
 				{
 					HeightRequest = 900,
@@ -170,6 +186,7 @@ public class Issue7814 : TestContentPage
 		};
 	}
 
+#if ANDROID
 	View CreateTouchClaimRegressionParent()
 	{
 		var carouselView = new CarouselView
@@ -194,7 +211,7 @@ public class Issue7814 : TestContentPage
 			WidthRequest = 360,
 			HeightRequest = 360,
 			ItemsLayout = new LinearItemsLayout(ItemsLayoutOrientation.Vertical),
-			ItemsSource = Enumerable.Range(1, 12).Select(index => $"Touch row {index}").ToList(),
+			ItemsSource = CreateTouchClaimRows(),
 			ItemTemplate = new DataTemplate(CreateTouchClaimRow)
 		};
 
@@ -217,14 +234,15 @@ public class Issue7814 : TestContentPage
 			HorizontalOptions = LayoutOptions.Center,
 			VerticalOptions = LayoutOptions.Center
 		};
-		contentLabel.SetBinding(Label.TextProperty, ".");
+		contentLabel.SetBinding(Label.TextProperty, nameof(TouchClaimRow.Text));
 
 		var touchClaimView = new Issue7814TouchClaimView
 		{
-			AutomationId = "Issue7814TouchClaimView",
 			BackgroundColor = Colors.LightGreen,
 			TouchStateChanged = state => _touchStatusLabel.Text = state
 		};
+		touchClaimView.SetBinding(AutomationIdProperty, nameof(TouchClaimRow.AutomationId));
+		touchClaimView.SetBinding(Issue7814TouchClaimView.ReleaseTouchOwnershipOnMoveProperty, nameof(TouchClaimRow.ReleaseTouchOwnershipOnMove));
 
 		return new Grid
 		{
@@ -238,6 +256,20 @@ public class Issue7814 : TestContentPage
 			}
 		};
 	}
+
+	static List<TouchClaimRow> CreateTouchClaimRows()
+	{
+		var rows = new List<TouchClaimRow>
+		{
+			new("Touch row keeps ownership", TouchClaimViewId, false),
+			new("Touch row releases ownership", TouchReleaseViewId, true)
+		};
+
+		rows.AddRange(Enumerable.Range(3, 10).Select(index => new TouchClaimRow($"Touch row {index}", $"Issue7814TouchFillerView{index}", false)));
+
+		return rows;
+	}
+#endif
 
 	static T Row<T>(T view, int row) where T : View
 	{
@@ -269,9 +301,21 @@ public class Issue7814 : TestContentPage
 	}
 }
 
+#if ANDROID
+public record TouchClaimRow(string Text, string AutomationId, bool ReleaseTouchOwnershipOnMove);
+
 public class Issue7814TouchClaimView : View
 {
+	public static readonly BindableProperty ReleaseTouchOwnershipOnMoveProperty =
+		BindableProperty.Create(nameof(ReleaseTouchOwnershipOnMove), typeof(bool), typeof(Issue7814TouchClaimView), false);
+
 	public Action<string> TouchStateChanged { get; set; }
+
+	public bool ReleaseTouchOwnershipOnMove
+	{
+		get => (bool)GetValue(ReleaseTouchOwnershipOnMoveProperty);
+		set => SetValue(ReleaseTouchOwnershipOnMoveProperty, value);
+	}
 
 	internal void SendTouchState(string state)
 	{
@@ -279,7 +323,6 @@ public class Issue7814TouchClaimView : View
 	}
 }
 
-#if ANDROID
 public class Issue7814TouchClaimViewHandler : ViewHandler<Issue7814TouchClaimView, AView>
 {
 	int _moveCount;
@@ -325,12 +368,12 @@ public class Issue7814TouchClaimViewHandler : ViewHandler<Issue7814TouchClaimVie
 				break;
 			case Android.Views.MotionEventActions.Move:
 				_moveCount++;
-				RequestTouchOwnership();
+				RequestTouchOwnership(!VirtualView.ReleaseTouchOwnershipOnMove);
 				VirtualView.SendTouchState($"TouchStatus: Move {_moveCount}");
 				e.Handled = true;
 				break;
 			case Android.Views.MotionEventActions.Up:
-				RequestTouchOwnership();
+				RequestTouchOwnership(!VirtualView.ReleaseTouchOwnershipOnMove);
 				VirtualView.SendTouchState($"TouchStatus: Up {_moveCount}");
 				e.Handled = true;
 				break;
@@ -341,9 +384,9 @@ public class Issue7814TouchClaimViewHandler : ViewHandler<Issue7814TouchClaimVie
 		}
 	}
 
-	void RequestTouchOwnership()
+	void RequestTouchOwnership(bool disallowIntercept = true)
 	{
-		PlatformView?.Parent?.RequestDisallowInterceptTouchEvent(true);
+		PlatformView?.Parent?.RequestDisallowInterceptTouchEvent(disallowIntercept);
 	}
 }
 #endif

--- a/src/Controls/tests/TestCases.HostApp/MauiProgram.cs
+++ b/src/Controls/tests/TestCases.HostApp/MauiProgram.cs
@@ -68,6 +68,9 @@ namespace Maui.Controls.Sample
 #if IOS || MACCATALYST || ANDROID || WINDOWS
 				handlers.AddHandler(typeof(Issue34310NativeHostView), typeof(Issue34310NativeHostViewHandler));
 #endif
+#if ANDROID
+				handlers.AddHandler(typeof(Issue7814TouchClaimView), typeof(Issue7814TouchClaimViewHandler));
+#endif
 			});
 
 			appBuilder.Services.AddTransient<TransientPage>();

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue7814.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue7814.cs
@@ -13,6 +13,9 @@ public class Issue7814 : _IssuesUITest
 	const string OuterScrollViewId = "Issue7814OuterScrollView";
 	const string VerticalOffsetLabelId = "Issue7814VerticalScrollYLabel";
 	const string HorizontalOffsetLabelId = "Issue7814HorizontalScrollXLabel";
+	const string TouchParentPositionLabelId = "Issue7814TouchParentPositionLabel";
+	const string TouchStatusLabelId = "Issue7814TouchStatusLabel";
+	const string TouchClaimViewId = "Issue7814TouchClaimView";
 
 	public Issue7814(TestDevice testDevice) : base(testDevice)
 	{
@@ -59,6 +62,37 @@ public class Issue7814 : _IssuesUITest
 		});
 	}
 
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void TouchClaimingRowInsideVerticalCollectionViewNestedInHorizontalParentKeepsHorizontalGesture()
+	{
+		if (App is not AppiumAndroidApp)
+		{
+			Assert.Ignore("The Issue7814 touch-dispatch change is Android-specific.");
+		}
+
+		App.WaitForElement(OuterScrollViewId);
+		ScrollUntilVisible(TouchClaimViewId);
+
+		var parentPositionBeforeGesture = GetTouchParentPosition();
+		var touchViewRect = GetVisibleRect(TouchClaimViewId);
+
+		App.DragCoordinates(
+			touchViewRect.Right - 20,
+			touchViewRect.Top + (touchViewRect.Height / 2),
+			touchViewRect.Left + 20,
+			touchViewRect.Top + (touchViewRect.Height / 2));
+
+		var touchStatusAfterGesture = App.FindElement(TouchStatusLabelId).GetText();
+		var parentPositionAfterGesture = GetTouchParentPosition();
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(touchStatusAfterGesture, Does.Contain("Up"), "The row touch-claiming view should receive the whole drag.");
+			Assert.That(parentPositionAfterGesture, Is.EqualTo(parentPositionBeforeGesture), "The horizontal parent CarouselView should not steal the claimed row gesture.");
+		});
+	}
+
 	void DragWithinVisibleArea(string automationId, double fromXRatio, double fromYRatio, double toXRatio, double toYRatio)
 	{
 		var visibleRect = GetVisibleRect(automationId);
@@ -75,6 +109,21 @@ public class Issue7814 : _IssuesUITest
 		App.DragCoordinates(fromX, fromY, toX, toY);
 	}
 
+	void ScrollUntilVisible(string automationId)
+	{
+		for (var attempt = 0; attempt < 6; attempt++)
+		{
+			if (IsVisibleEnough(automationId))
+			{
+				return;
+			}
+
+			App.ScrollDown(OuterScrollViewId, ScrollStrategy.Gesture, swipePercentage: 0.75);
+		}
+
+		Assert.Fail($"{automationId} should become visible after scrolling {OuterScrollViewId}.");
+	}
+
 	Rectangle GetVisibleRect(string automationId)
 	{
 		var elementRect = App.WaitForElement(automationId).GetRect();
@@ -87,6 +136,22 @@ public class Issue7814 : _IssuesUITest
 		return visibleRect;
 	}
 
+	bool IsVisibleEnough(string automationId)
+	{
+		try
+		{
+			var elementRect = App.WaitForElement(automationId).GetRect();
+			var viewportRect = App.WaitForElement(OuterScrollViewId).GetRect();
+			var visibleRect = Rectangle.Intersect(elementRect, viewportRect);
+
+			return visibleRect.Width > 40 && visibleRect.Height > 40;
+		}
+		catch
+		{
+			return false;
+		}
+	}
+
 	static float GetCoordinate(int start, int length, double ratio)
 	{
 		return (float)(start + (length * ratio));
@@ -95,6 +160,8 @@ public class Issue7814 : _IssuesUITest
 	int GetVerticalOffset() => GetOffset(VerticalOffsetLabelId);
 
 	int GetHorizontalOffset() => GetOffset(HorizontalOffsetLabelId);
+
+	int GetTouchParentPosition() => GetOffset(TouchParentPositionLabelId);
 
 	int GetOffset(string automationId)
 	{

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue7814.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue7814.cs
@@ -16,6 +16,7 @@ public class Issue7814 : _IssuesUITest
 	const string TouchParentPositionLabelId = "Issue7814TouchParentPositionLabel";
 	const string TouchStatusLabelId = "Issue7814TouchStatusLabel";
 	const string TouchClaimViewId = "Issue7814TouchClaimView";
+	const string TouchReleaseViewId = "Issue7814TouchReleaseView";
 
 	public Issue7814(TestDevice testDevice) : base(testDevice)
 	{
@@ -90,6 +91,44 @@ public class Issue7814 : _IssuesUITest
 		{
 			Assert.That(touchStatusAfterGesture, Does.Contain("Up"), "The row touch-claiming view should receive the whole drag.");
 			Assert.That(parentPositionAfterGesture, Is.EqualTo(parentPositionBeforeGesture), "The horizontal parent CarouselView should not steal the claimed row gesture.");
+		});
+	}
+
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void TouchReleasingRowInsideVerticalCollectionViewNestedInHorizontalParentHandsHorizontalGestureToParent()
+	{
+		if (App is not AppiumAndroidApp)
+		{
+			Assert.Ignore("The Issue7814 touch-dispatch change is Android-specific.");
+		}
+
+		App.WaitForElement(OuterScrollViewId);
+		ScrollUntilVisible(TouchReleaseViewId);
+
+		var parentPositionBeforeGesture = GetTouchParentPosition();
+		var touchViewRect = GetVisibleRect(TouchReleaseViewId);
+
+		App.DragCoordinates(
+			touchViewRect.Right - 20,
+			touchViewRect.Top + (touchViewRect.Height / 2),
+			touchViewRect.Left + 20,
+			touchViewRect.Top + (touchViewRect.Height / 2));
+
+		App.RetryAssert(() =>
+		{
+			Assert.That(GetTouchParentPosition(), Is.GreaterThan(parentPositionBeforeGesture), "The horizontal parent CarouselView should take over after the row releases the gesture.");
+		});
+
+		App.RetryAssert(() =>
+		{
+			var touchStatusAfterGesture = App.FindElement(TouchStatusLabelId).GetText();
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(touchStatusAfterGesture, Does.Contain("Cancel"), "The row touch-claiming view should be cancelled after releasing the gesture.");
+				Assert.That(touchStatusAfterGesture, Does.Not.Contain("Up"), "The row touch-claiming view should not complete a released gesture.");
+			});
 		});
 	}
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue7814.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue7814.cs
@@ -84,13 +84,16 @@ public class Issue7814 : _IssuesUITest
 			touchViewRect.Left + 20,
 			touchViewRect.Top + (touchViewRect.Height / 2));
 
-		var touchStatusAfterGesture = App.FindElement(TouchStatusLabelId).GetText();
-		var parentPositionAfterGesture = GetTouchParentPosition();
-
-		Assert.Multiple(() =>
+		App.RetryAssert(() =>
 		{
-			Assert.That(touchStatusAfterGesture, Does.Contain("Up"), "The row touch-claiming view should receive the whole drag.");
-			Assert.That(parentPositionAfterGesture, Is.EqualTo(parentPositionBeforeGesture), "The horizontal parent CarouselView should not steal the claimed row gesture.");
+			var touchStatusAfterGesture = App.FindElement(TouchStatusLabelId).GetText();
+			var parentPositionAfterGesture = GetTouchParentPosition();
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(touchStatusAfterGesture, Does.Contain("Up"), "The row touch-claiming view should receive the whole drag.");
+				Assert.That(parentPositionAfterGesture, Is.EqualTo(parentPositionBeforeGesture), "The horizontal parent CarouselView should not steal the claimed row gesture.");
+			});
 		});
 	}
 


### PR DESCRIPTION
### Description of Change

This change fixes an Android gesture ownership regression introduced by the Issue7814 parent-scroll handoff behavior.

`MauiRecyclerView` now tracks when descendant content has requested touch ownership through Android’s `RequestDisallowInterceptTouchEvent(true)` contract. When a perpendicular gesture crosses touch slop, the recycler view still allows the Issue7814 parent handoff when no child has claimed the touch stream, but it no longer cancels the child path and forwards the gesture to the parent after descendant content has claimed ownership.

A regression test was added for a horizontal `CarouselView` containing a vertical `CollectionView` with a native-backed touch-claiming row. The test verifies that a horizontal drag across the claiming row completes with `Up` instead of `Cancel`, and that the parent `CarouselView` position does not change.

### Issues Fixed

Fixes #35862