### PR TITLE
[Implementation] Android system color should follow Maui bar colors

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellBottomNavViewAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellBottomNavViewAppearanceTracker.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			bottomView.ItemIconTintList = GetDefaultTabColorList(_shellContext.AndroidContext);
 			bottomView.ItemTextColor = GetDefaultTabColorList(_shellContext.AndroidContext);
 			SetBackgroundColor(bottomView, null);
+			AndroidSystemChrome.UpdateBottomChrome(bottomView, null);
 		}
 
 		public virtual void SetAppearance(BottomNavigationView bottomView, IShellAppearanceElement appearance)
@@ -68,6 +69,10 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			bottomView.ItemIconTintList = _itemIconTint;
 
 			SetBackgroundColor(bottomView, backgroundColor);
+			AndroidSystemChrome.UpdateBottomChrome(
+				bottomView,
+				backgroundColor is null ? null : new SolidColorBrush(backgroundColor),
+				titleColor ?? foregroundColor);
 		}
 
 		protected virtual void SetBackgroundColor(BottomNavigationView bottomView, Color color)

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellTabLayoutAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellTabLayoutAppearanceTracker.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				ShellRenderer.DefaultBackgroundColor,
 				ShellRenderer.DefaultTitleColor,
 				ShellRenderer.DefaultUnselectedColor);
+			AndroidSystemChrome.UpdateTopChrome(tabLayout, null, ShellRenderer.DefaultTitleColor);
 		}
 
 		public virtual void SetAppearance(TabLayout tabLayout, ShellAppearance appearance)
@@ -42,6 +43,10 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			tabLayout.SetTabTextColors(unselectedArgb, titleArgb);
 			tabLayout.SetBackground(new ColorDrawable(background.ToPlatform(ShellRenderer.DefaultBackgroundColor)));
 			tabLayout.SetSelectedTabIndicatorColor(foreground.ToPlatform(ShellRenderer.DefaultForegroundColor));
+			AndroidSystemChrome.UpdateTopChrome(
+				tabLayout,
+				background is null ? null : new SolidColorBrush(background),
+				title ?? foreground);
 		}
 
 		#region IDisposable

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarAppearanceTracker.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		public virtual void ResetAppearance(AToolbar toolbar, IShellToolbarTracker toolbarTracker)
 		{
 			SetColors(toolbar, toolbarTracker, ShellRenderer.DefaultForegroundColor, ShellRenderer.DefaultBackgroundColor, ShellRenderer.DefaultTitleColor);
+			AndroidSystemChrome.UpdateTopChrome(toolbar, null, ShellRenderer.DefaultTitleColor);
 		}
 
 		protected virtual void SetColors(AToolbar toolbar, IShellToolbarTracker toolbarTracker, Color foreground, Color background, Color title)
@@ -45,6 +46,10 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			shellToolbar.BarTextColor = title ?? ShellRenderer.DefaultTitleColor;
 			shellToolbar.BarBackground = new SolidColorBrush(background ?? ShellRenderer.DefaultBackgroundColor);
 			shellToolbar.IconColor = foreground ?? ShellRenderer.DefaultForegroundColor;
+			AndroidSystemChrome.UpdateTopChrome(
+				toolbar,
+				background is null ? null : shellToolbar.BarBackground,
+				title ?? foreground);
 		}
 
 		#region IDisposable

--- a/src/Controls/src/Core/Platform/Android/AndroidSystemChrome.cs
+++ b/src/Controls/src/Core/Platform/Android/AndroidSystemChrome.cs
@@ -135,7 +135,16 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				ViewCompat.SetBackgroundTintMode(appBarLayout, null);
 				ViewCompat.SetBackgroundTintList(appBarLayout, null);
-				appBarLayout.Background = originalBackground.CreateDrawable();
+
+				// Restore the original drawable only if it can still be recreated. The cached
+				// constant state can become disposed across navigation/handler teardown; in that
+				// case keep the current background rather than clearing it (and crashing).
+				var restored = originalBackground.CreateDrawable();
+				if (restored is not null)
+				{
+					appBarLayout.Background = restored;
+				}
+
 				return;
 			}
 
@@ -143,7 +152,11 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				if (appBarLayout.Background is null)
 				{
-					appBarLayout.Background = originalBackground.CreateDrawable();
+					var restored = originalBackground.CreateDrawable();
+					if (restored is not null)
+					{
+						appBarLayout.Background = restored;
+					}
 				}
 
 				ViewCompat.SetBackgroundTintMode(appBarLayout, AGraphics.PorterDuff.Mode.Src);
@@ -337,7 +350,17 @@ namespace Microsoft.Maui.Controls.Platform
 
 			public Drawable? CreateDrawable()
 			{
-				return _backgroundConstantState?.NewDrawable()?.Mutate();
+				try
+				{
+					return _backgroundConstantState?.NewDrawable()?.Mutate();
+				}
+				catch (ObjectDisposedException)
+				{
+					// The cached constant state's underlying Java peer was disposed (e.g. the
+					// original AppBar drawable was torn down across navigation). We can't recreate
+					// it, so return null and let the caller keep the current background.
+					return null;
+				}
 			}
 		}
 	}

--- a/src/Controls/src/Core/Platform/Android/AndroidSystemChrome.cs
+++ b/src/Controls/src/Core/Platform/Android/AndroidSystemChrome.cs
@@ -1,0 +1,344 @@
+﻿#nullable enable
+using System;
+using System.Runtime.CompilerServices;
+using Android.App;
+using Android.Content;
+using Android.Content.Res;
+using Android.Graphics.Drawables;
+using AndroidX.Core.View;
+using Google.Android.Material.AppBar;
+using Microsoft.Maui;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Platform;
+using AGraphics = Android.Graphics;
+using AView = Android.Views.View;
+using AWindow = Android.Views.Window;
+
+namespace Microsoft.Maui.Controls.Platform
+{
+	internal static class AndroidSystemChrome
+	{
+		static readonly ConditionalWeakTable<AppBarLayout, OriginalAppBarBackground> s_originalAppBarBackgrounds = new();
+
+		internal static void UpdateTopChrome(AView? chromeView, Brush? background, Color? foreground = null)
+		{
+			if (chromeView is null)
+			{
+				return;
+			}
+
+			var appBarLayout = chromeView.GetParentOfType<AppBarLayout>();
+			UpdateAppBarBackground(appBarLayout, background);
+			UpdateSystemBarAppearance(
+				chromeView.Context,
+				window: null,
+				updateStatusBar: true,
+				updateNavigationBar: false,
+				statusBarBackgroundColor: GetChromeColor(background, ChromeEdge.Top),
+				statusBarForegroundColor: foreground);
+		}
+
+		internal static void UpdateBottomChrome(AView? chromeView, Brush? background, Color? foreground = null)
+		{
+			if (chromeView is null)
+			{
+				return;
+			}
+
+			UpdateSystemBarAppearance(
+				chromeView.Context,
+				window: null,
+				updateStatusBar: false,
+				updateNavigationBar: true,
+				navigationBarBackgroundColor: GetChromeColor(background, ChromeEdge.Bottom),
+				navigationBarForegroundColor: foreground);
+		}
+
+		internal static void UpdateWindowChrome(
+			Context? context,
+			AWindow? window,
+			bool updateStatusBar,
+			bool updateNavigationBar,
+			Paint? background = null,
+			Color? foreground = null)
+		{
+			UpdateSystemBarAppearance(
+				context,
+				window,
+				updateStatusBar,
+				updateNavigationBar,
+				statusBarBackgroundColor: GetChromeColor(background, ChromeEdge.Top),
+				statusBarForegroundColor: foreground,
+				navigationBarBackgroundColor: GetChromeColor(background, ChromeEdge.Bottom),
+				navigationBarForegroundColor: foreground);
+		}
+
+		internal static void UpdateWindowChrome(
+			Context? context,
+			AWindow? window,
+			bool updateStatusBar,
+			bool updateNavigationBar,
+			Brush? statusBarBackground,
+			Color? statusBarForeground = null,
+			Paint? navigationBarBackground = null,
+			Color? navigationBarForeground = null)
+		{
+			UpdateSystemBarAppearance(
+				context,
+				window,
+				updateStatusBar,
+				updateNavigationBar,
+				statusBarBackgroundColor: GetChromeColor(statusBarBackground, ChromeEdge.Top),
+				statusBarForegroundColor: statusBarForeground,
+				navigationBarBackgroundColor: GetChromeColor(navigationBarBackground, ChromeEdge.Bottom),
+				navigationBarForegroundColor: navigationBarForeground);
+		}
+
+		static void UpdateSystemBarAppearance(
+			Context? context,
+			AWindow? window,
+			bool updateStatusBar,
+			bool updateNavigationBar,
+			Color? statusBarBackgroundColor = null,
+			Color? statusBarForegroundColor = null,
+			Color? navigationBarBackgroundColor = null,
+			Color? navigationBarForegroundColor = null)
+		{
+			var activity = context?.GetActivity();
+			if (window is null)
+			{
+				window = activity?.Window;
+			}
+
+			window.UpdateSystemBarAppearance(
+				activity,
+				updateStatusBar,
+				updateNavigationBar,
+				statusBarBackgroundColor,
+				statusBarForegroundColor,
+				navigationBarBackgroundColor,
+				navigationBarForegroundColor);
+		}
+
+		static void UpdateAppBarBackground(AppBarLayout? appBarLayout, Brush? background)
+		{
+			if (appBarLayout is null)
+			{
+				return;
+			}
+
+			var originalBackground = s_originalAppBarBackgrounds.GetValue(
+				appBarLayout,
+				static appBar => new OriginalAppBarBackground(appBar.Background?.GetConstantState()));
+
+			if (Brush.IsNullOrEmpty(background))
+			{
+				ViewCompat.SetBackgroundTintMode(appBarLayout, null);
+				ViewCompat.SetBackgroundTintList(appBarLayout, null);
+				appBarLayout.Background = originalBackground.CreateDrawable();
+				return;
+			}
+
+			if (background is SolidColorBrush { Color: not null } solidColorBrush)
+			{
+				if (appBarLayout.Background is null)
+				{
+					appBarLayout.Background = originalBackground.CreateDrawable();
+				}
+
+				ViewCompat.SetBackgroundTintMode(appBarLayout, AGraphics.PorterDuff.Mode.Src);
+				ViewCompat.SetBackgroundTintList(appBarLayout, ColorStateList.ValueOf(solidColorBrush.Color.ToPlatform()));
+				return;
+			}
+
+			ViewCompat.SetBackgroundTintMode(appBarLayout, null);
+			ViewCompat.SetBackgroundTintList(appBarLayout, null);
+			appBarLayout.UpdateBackground(background);
+		}
+
+		static Color? GetChromeColor(Brush? background, ChromeEdge edge)
+		{
+			return background switch
+			{
+				SolidColorBrush { Color: { Alpha: > 0 } color } => color,
+				LinearGradientBrush linearGradientBrush => GetGradientColorAt(
+					linearGradientBrush.GradientStops,
+					GetLinearGradientOffset(linearGradientBrush.StartPoint, linearGradientBrush.EndPoint, edge)),
+				RadialGradientBrush radialGradientBrush => GetGradientColorAt(
+					radialGradientBrush.GradientStops,
+					GetRadialGradientOffset(radialGradientBrush.Center, radialGradientBrush.Radius, edge)),
+				_ => null
+			};
+		}
+
+		static Color? GetChromeColor(Paint? background, ChromeEdge edge)
+		{
+			return background switch
+			{
+				SolidPaint { Color: { Alpha: > 0 } color } => color,
+				LinearGradientPaint linearGradientPaint => GetGradientColorAt(
+					linearGradientPaint.GradientStops,
+					GetLinearGradientOffset(linearGradientPaint.StartPoint, linearGradientPaint.EndPoint, edge)),
+				RadialGradientPaint radialGradientPaint => GetGradientColorAt(
+					radialGradientPaint.GradientStops,
+					GetRadialGradientOffset(radialGradientPaint.Center, radialGradientPaint.Radius, edge)),
+				_ => null
+			};
+		}
+
+		static Color? GetGradientColorAt(GradientStopCollection? gradientStops, float offset)
+		{
+			if (gradientStops is null || gradientStops.Count == 0)
+			{
+				return null;
+			}
+
+			GradientStop? before = null;
+			GradientStop? after = null;
+
+			foreach (var gradientStop in gradientStops)
+			{
+				if (gradientStop is null || gradientStop.Color is null)
+				{
+					continue;
+				}
+
+				if (gradientStop.Offset <= offset && (before is null || gradientStop.Offset >= before.Offset))
+				{
+					before = gradientStop;
+				}
+
+				if (gradientStop.Offset >= offset && (after is null || gradientStop.Offset <= after.Offset))
+				{
+					after = gradientStop;
+				}
+			}
+
+			return GetGradientColorAt(before?.Offset, before?.Color, after?.Offset, after?.Color, offset);
+		}
+
+		static Color? GetGradientColorAt(PaintGradientStop[]? gradientStops, float offset)
+		{
+			if (gradientStops is null || gradientStops.Length == 0)
+			{
+				return null;
+			}
+
+			PaintGradientStop? before = null;
+			PaintGradientStop? after = null;
+
+			foreach (var gradientStop in gradientStops)
+			{
+				if (gradientStop is null || gradientStop.Color is null)
+				{
+					continue;
+				}
+
+				if (gradientStop.Offset <= offset && (before is null || gradientStop.Offset >= before.Offset))
+				{
+					before = gradientStop;
+				}
+
+				if (gradientStop.Offset >= offset && (after is null || gradientStop.Offset <= after.Offset))
+				{
+					after = gradientStop;
+				}
+			}
+
+			return GetGradientColorAt(before?.Offset, before?.Color, after?.Offset, after?.Color, offset);
+		}
+
+		static Color? GetGradientColorAt(float? beforeOffset, Color? beforeColor, float? afterOffset, Color? afterColor, float offset)
+		{
+			Color? color = null;
+
+			if (beforeOffset.HasValue && beforeColor is not null && afterOffset.HasValue && afterColor is not null)
+			{
+				color = beforeOffset == afterOffset
+					? beforeColor
+					: BlendColors(beforeColor, afterColor, (offset - beforeOffset.Value) / (afterOffset.Value - beforeOffset.Value));
+			}
+			else if (beforeColor is not null)
+			{
+				color = beforeColor;
+			}
+			else if (afterColor is not null)
+			{
+				color = afterColor;
+			}
+
+			return color is { Alpha: > 0 } ? color : null;
+		}
+
+		static Color BlendColors(Color startColor, Color endColor, float factor)
+		{
+			factor = Math.Clamp(factor, 0f, 1f);
+
+			return new Color(
+				startColor.Red + ((endColor.Red - startColor.Red) * factor),
+				startColor.Green + ((endColor.Green - startColor.Green) * factor),
+				startColor.Blue + ((endColor.Blue - startColor.Blue) * factor),
+				startColor.Alpha + ((endColor.Alpha - startColor.Alpha) * factor));
+		}
+
+		static float GetLinearGradientOffset(Point startPoint, Point endPoint, ChromeEdge edge)
+		{
+			var samplePoint = GetEdgeSamplePoint(edge);
+			var x = endPoint.X - startPoint.X;
+			var y = endPoint.Y - startPoint.Y;
+			var lengthSquared = (x * x) + (y * y);
+
+			if (lengthSquared == 0)
+			{
+				return 0;
+			}
+
+			return (float)Math.Clamp(
+				(((samplePoint.X - startPoint.X) * x) + ((samplePoint.Y - startPoint.Y) * y)) / lengthSquared,
+				0,
+				1);
+		}
+
+		static float GetRadialGradientOffset(Point center, double radius, ChromeEdge edge)
+		{
+			if (radius <= 0)
+			{
+				return 0;
+			}
+
+			var samplePoint = GetEdgeSamplePoint(edge);
+			var x = samplePoint.X - center.X;
+			var y = samplePoint.Y - center.Y;
+
+			return (float)Math.Clamp(Math.Sqrt((x * x) + (y * y)) / radius, 0, 1);
+		}
+
+		static Point GetEdgeSamplePoint(ChromeEdge edge)
+		{
+			return edge == ChromeEdge.Top
+				? new Point(0.5, 0)
+				: new Point(0.5, 1);
+		}
+
+		enum ChromeEdge
+		{
+			Top,
+			Bottom
+		}
+
+		sealed class OriginalAppBarBackground
+		{
+			readonly Drawable.ConstantState? _backgroundConstantState;
+
+			public OriginalAppBarBackground(Drawable.ConstantState? backgroundConstantState)
+			{
+				_backgroundConstantState = backgroundConstantState;
+			}
+
+			public Drawable? CreateDrawable()
+			{
+				return _backgroundConstantState?.NewDrawable()?.Mutate();
+			}
+		}
+	}
+}

--- a/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
@@ -176,13 +176,18 @@ namespace Microsoft.Maui.Controls.Platform
 				if (Brush.IsNullOrEmpty(barBackground))
 					nativeToolbar.BackgroundTintMode = null;
 			}
+
+			nativeToolbar.UpdateSystemChrome(toolbar);
 		}
 
 		public static void UpdateIconColor(this AToolbar nativeToolbar, Toolbar toolbar)
 		{
 			var navIconColor = toolbar.IconColor;
 			if (navIconColor is null)
+			{
+				nativeToolbar.UpdateSystemChrome(toolbar);
 				return;
+			}
 
 			var platformColor = navIconColor.ToPlatform();
 			if (nativeToolbar.NavigationIcon is Drawable navigationIcon)
@@ -197,6 +202,8 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				overflowIcon.SetColorFilter(platformColor, FilterMode.SrcAtop);
 			}
+
+			nativeToolbar.UpdateSystemChrome(toolbar);
 		}
 
 		public static void UpdateBarTextColor(this AToolbar nativeToolbar, Toolbar toolbar)
@@ -233,6 +240,13 @@ namespace Microsoft.Maui.Controls.Platform
 					icon.Color = _defaultNavigationIconColor.Value;
 				}
 			}
+
+			nativeToolbar.UpdateSystemChrome(toolbar);
+		}
+
+		static void UpdateSystemChrome(this AToolbar nativeToolbar, Toolbar toolbar)
+		{
+			AndroidSystemChrome.UpdateTopChrome(nativeToolbar, toolbar.BarBackground, toolbar.BarTextColor ?? toolbar.IconColor);
 		}
 
 		class ToolbarTitleIconImageView : AppCompatImageView

--- a/src/Controls/src/Core/Platform/Android/TabbedPageManager.cs
+++ b/src/Controls/src/Core/Platform/Android/TabbedPageManager.cs
@@ -297,11 +297,21 @@ public class TabbedPageManager
 
 						_tabplacementId = id;
 
-						fm
+						var transaction = fm
 							.BeginTransactionEx()
 							.ReplaceEx(id, _tabLayoutFragment)
-							.SetReorderingAllowed(true)
-							.Commit();
+							.SetReorderingAllowed(true);
+
+						// Re-apply top chrome after the fragment transaction completes so that
+						// UpdateTopChrome runs with the TabLayout already parented under the
+						// AppBarLayout. RunOnCommit fires after OnCreateView returns and the
+						// view is attached to its container — no race window.
+						if (!IsBottomTabPlacement)
+						{
+							transaction.RunOnCommit(new Java.Lang.Runnable(UpdateSystemChrome));
+						}
+
+						transaction.Commit();
 					});
 		}
 	}
@@ -586,6 +596,8 @@ public class TabbedPageManager
 				_tabLayout.BackgroundTintList = ColorStateList.ValueOf(tintColor.ToPlatform());
 			}
 		}
+
+		UpdateSystemChrome();
 	}
 
 	public virtual void UpdateBarBackground()
@@ -629,6 +641,38 @@ public class TabbedPageManager
 			_bottomNavigationView.UpdateBackground(_currentBarBackground);
 		else
 			_tabLayout.UpdateBackground(_currentBarBackground);
+
+		UpdateSystemChrome();
+	}
+
+	void UpdateSystemChrome()
+	{
+		if (Element is null)
+		{
+			return;
+		}
+
+		var background = GetEffectiveBarBackground();
+		var foreground = Element.BarTextColor ?? BarSelectedItemColor ?? BarItemColor;
+
+		if (IsBottomTabPlacement)
+		{
+			AndroidSystemChrome.UpdateBottomChrome(_bottomNavigationView, background, foreground);
+		}
+		else
+		{
+			AndroidSystemChrome.UpdateTopChrome(_tabLayout, background, foreground);
+		}
+	}
+
+	Brush GetEffectiveBarBackground()
+	{
+		if (Element.BarBackground is not null)
+		{
+			return Element.BarBackground;
+		}
+
+		return Element.BarBackgroundColor is null ? null : new SolidColorBrush(Element.BarBackgroundColor);
 	}
 
 	protected virtual ColorStateList GetItemTextColorStates()
@@ -881,6 +925,8 @@ public class TabbedPageManager
 			_bottomNavigationView.ItemTextColor = _currentBarTextColorStateList;
 		else
 			_tabLayout.TabTextColors = _currentBarTextColorStateList;
+
+		UpdateSystemChrome();
 	}
 
 	void SetIconColorFilter(Page page, TabLayout.Tab tab)

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
@@ -14,6 +14,7 @@ using Microsoft.Maui.LifecycleEvents;
 using AAnimation = Android.Views.Animations.Animation;
 using AColor = Android.Graphics.Color;
 using AView = Android.Views.View;
+using AWindow = Android.Views.Window;
 
 namespace Microsoft.Maui.Controls.Platform
 {
@@ -277,6 +278,7 @@ namespace Microsoft.Maui.Controls.Platform
 #pragma warning restore CA1422
 				}
 
+				UpdateModalWindowChrome(dialog.Window, Context);
 
 				return dialog;
 			}
@@ -305,7 +307,8 @@ namespace Microsoft.Maui.Controls.Platform
 				}
 
 
-				if (e.IsOneOf(Page.BackgroundColorProperty, Page.BackgroundProperty))
+				if (e.IsOneOf(Page.BackgroundColorProperty, Page.BackgroundProperty) ||
+					IsNavigationPageBarProperty(e.PropertyName))
 				{
 					UpdateBackgroundColor();
 				}
@@ -323,9 +326,53 @@ namespace Microsoft.Maui.Controls.Platform
 				if (pageView is null)
 					return;
 
-				var modalBkgndColor = view.Background;
-				if (modalBkgndColor is null)
+				var modalBackground = view.Background;
+				if (modalBackground is null)
 					pageView.SetWindowBackground();
+
+				UpdateModalWindowChrome(Dialog?.Window, pageView.Context);
+			}
+
+			void UpdateModalWindowChrome(AWindow? window, Context? context)
+			{
+				var modalBackground = (_modal as IView)?.Background;
+
+				if (_modal is NavigationPage navigationPage)
+				{
+					AndroidSystemChrome.UpdateWindowChrome(
+						context ?? Context,
+						window,
+						updateStatusBar: true,
+						updateNavigationBar: true,
+						statusBarBackground: GetNavigationPageBarBackground(navigationPage),
+						statusBarForeground: navigationPage.BarTextColor,
+						navigationBarBackground: modalBackground);
+					return;
+				}
+
+				AndroidSystemChrome.UpdateWindowChrome(
+					context ?? Context,
+					window,
+					updateStatusBar: true,
+					updateNavigationBar: true,
+					background: modalBackground);
+			}
+
+			static bool IsNavigationPageBarProperty(string? propertyName)
+			{
+				return propertyName == NavigationPage.BarBackgroundColorProperty.PropertyName ||
+					propertyName == NavigationPage.BarBackgroundProperty.PropertyName ||
+					propertyName == NavigationPage.BarTextColorProperty.PropertyName;
+			}
+
+			static Brush? GetNavigationPageBarBackground(NavigationPage navigationPage)
+			{
+				if (navigationPage.BarBackground is not null)
+				{
+					return navigationPage.BarBackground;
+				}
+
+				return navigationPage.BarBackgroundColor is null ? null : new SolidColorBrush(navigationPage.BarBackgroundColor);
 			}
 
 			public override AView OnCreateView(LayoutInflater inflater, ViewGroup? container, Bundle? savedInstanceState)

--- a/src/Controls/src/Core/Toolbar/Toolbar.Android.cs
+++ b/src/Controls/src/Core/Toolbar/Toolbar.Android.cs
@@ -31,8 +31,7 @@ namespace Microsoft.Maui.Controls
 		{
 			if (newHandler == null)
 			{
-				if (_platformTitleView != null)
-					_platformTitleView.Child = null;
+				_platformTitleView?.Child = null;
 
 				Controls.Platform.ToolbarExtensions.DisposeMenuItems(
 					oldHandler?.PlatformView as AToolbar,
@@ -149,6 +148,11 @@ namespace Microsoft.Maui.Controls
 			if (Handler?.PlatformView is MaterialToolbar materialToolbar)
 			{
 				materialToolbar.UpdateBarBackground(this);
+
+				if (this is NavigationPageToolbar { Parent: Window })
+				{
+					AndroidSystemChrome.UpdateBottomChrome(materialToolbar, _currentBarBackground);
+				}
 			}
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Android.cs
@@ -172,7 +172,19 @@ namespace Microsoft.Maui.DeviceTests
 
 		static int GetAppBarBackgroundColor(AppBarLayout appBar)
 		{
-			return Assert.IsType<ColorDrawable>(appBar.Background).Color.ToArgb();
+			// The bar background is applied as a background tint over the AppBar's default
+			// MaterialShapeDrawable (preserving Material elevation/shape), so read the tint color
+			// rather than expecting the background to be replaced with a flat ColorDrawable.
+			var tintList = AndroidX.Core.View.ViewCompat.GetBackgroundTintList(appBar);
+			if (tintList is not null)
+			{
+				return tintList.DefaultColor;
+			}
+
+			// The bar color hasn't been applied yet (the AppBar still has its default
+			// MaterialShapeDrawable). Return transparent so polling callers (AssertEventually)
+			// keep waiting for the async chrome update to settle instead of throwing.
+			return Colors.Transparent.ToPlatform().ToArgb();
 		}
 
 		static void AssertAppBarBackgroundColor(AppBarLayout appBar, Color expectedColor)

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Android.cs
@@ -4,11 +4,13 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using Android.Graphics.Drawables;
 using Google.Android.Material.AppBar;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers;
 using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using Xunit;
@@ -109,6 +111,73 @@ namespace Microsoft.Maui.DeviceTests
 					fragmentManagerField.GetValue(tab2SnManager) == null,
 					message: "StackNavigationManager fields were not cleared after Disconnect()");
 			});
+		}
+
+		[Fact(DisplayName = "NavigationPage BarBackgroundColor colors AppBar status bar area")]
+		public async Task BarBackgroundColorUpdatesAppBarStatusBarArea()
+		{
+			SetupBuilder();
+
+			var firstColor = Colors.Orange;
+			var secondColor = Colors.Blue;
+			var navPage = new NavigationPage(new ContentPage { Title = "Page Title" })
+			{
+				BarBackgroundColor = firstColor,
+				BarTextColor = Colors.Black
+			};
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), async handler =>
+			{
+				await OnLoadedAsync(navPage.CurrentPage);
+
+				var platformToolbar = GetPlatformToolbar(handler.MauiContext);
+				var appBar = platformToolbar.Parent.GetParentOfType<AppBarLayout>();
+				Assert.NotNull(appBar);
+
+				AssertAppBarBackgroundColor(appBar, firstColor);
+
+				navPage.BarBackgroundColor = secondColor;
+				await AssertEventually(() => GetAppBarBackgroundColor(appBar) == secondColor.ToPlatform().ToArgb());
+			});
+		}
+
+		[Fact(DisplayName = "NavigationPage BarBackgroundColor colors Android navigation bar on initial load")]
+		public async Task BarBackgroundColorUpdatesAndroidNavigationBarOnInitialLoad()
+		{
+			SetupBuilder();
+
+			var firstColor = Colors.Orange;
+			var secondColor = Colors.Blue;
+			var navPage = new NavigationPage(new ContentPage { Title = "Page Title" })
+			{
+				BarBackgroundColor = firstColor,
+				BarTextColor = Colors.Black
+			};
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), async handler =>
+			{
+				await OnLoadedAsync(navPage.CurrentPage);
+
+				var platformWindow = handler.PlatformView.Window;
+				Assert.NotNull(platformWindow);
+
+#pragma warning disable CA1422 // System bar color APIs still apply to older Android versions and are harmless on newer versions.
+				await AssertEventually(() => platformWindow.NavigationBarColor == firstColor.ToPlatform().ToArgb());
+
+				navPage.BarBackgroundColor = secondColor;
+				await AssertEventually(() => platformWindow.NavigationBarColor == secondColor.ToPlatform().ToArgb());
+#pragma warning restore CA1422
+			});
+		}
+
+		static int GetAppBarBackgroundColor(AppBarLayout appBar)
+		{
+			return Assert.IsType<ColorDrawable>(appBar.Background).Color.ToArgb();
+		}
+
+		static void AssertAppBarBackgroundColor(AppBarLayout appBar, Color expectedColor)
+		{
+			Assert.Equal(expectedColor.ToPlatform().ToArgb(), GetAppBarBackgroundColor(appBar));
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Android.cs
@@ -5,12 +5,14 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Android.Content;
+using Android.Graphics.Drawables;
 using Android.OS;
 using AndroidX.CoordinatorLayout.Widget;
 using AndroidX.Fragment.App;
 using AndroidX.RecyclerView.Widget;
 using AndroidX.ViewPager2.Adapter;
 using AndroidX.ViewPager2.Widget;
+using Google.Android.Material.AppBar;
 using Google.Android.Material.BottomNavigation;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.DeviceTests.Stubs;
@@ -25,6 +27,27 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class TabbedPageTests : ControlsHandlerTestBase
 	{
+		[Fact]
+		[Description("TabbedPage BarBackgroundColor should be applied to AppBar immediately after handler creation, before the fragment transaction completes")]
+		public async Task TopTabbedPageBarBackgroundColorAppliedOnInitialLoad()
+		{
+			SetupBuilder();
+
+			// Set BarBackgroundColor before the handler is created to exercise the path where
+			// UpdateTopChrome is called during initialization (async fragment transaction).
+			var tabbedPage = CreateBasicTabbedPage();
+			tabbedPage.BarBackgroundColor = Colors.LightGreen;
+
+			await CreateHandlerAndAddToWindow<TabbedViewHandler>(tabbedPage, async handler =>
+			{
+				var appBar = GetAppBarLayout(handler);
+				Assert.NotNull(appBar);
+
+				// The AppBar background must be applied even on initial load (timing race fix).
+				await AssertEventually(() => GetAppBarBackgroundColor(appBar) == Colors.LightGreen.ToPlatform().ToArgb());
+			});
+		}
+
 		[Fact(DisplayName = "Using SelectedTab Color doesnt crash")]
 		public async Task SelectedTabColorNoDoesntCrash()
 		{
@@ -211,6 +234,30 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact]
+		[Description("Top TabbedPage BarBackgroundColor should color the AppBar status bar area")]
+		public async Task TopTabbedPageBarBackgroundColorColorsAppBarStatusBarArea()
+		{
+			SetupBuilder();
+
+			var firstColor = Colors.Orange;
+			var secondColor = Colors.Blue;
+			var tabbedPage = CreateBasicTabbedPage();
+			tabbedPage.BarBackgroundColor = firstColor;
+			tabbedPage.BarTextColor = Colors.Black;
+
+			await CreateHandlerAndAddToWindow<TabbedViewHandler>(tabbedPage, async handler =>
+			{
+				var appBar = GetAppBarLayout(handler);
+				Assert.NotNull(appBar);
+
+				await AssertEventually(() => GetAppBarBackgroundColor(appBar) == firstColor.ToPlatform().ToArgb());
+
+				tabbedPage.BarBackgroundColor = secondColor;
+				await AssertEventually(() => GetAppBarBackgroundColor(appBar) == secondColor.ToPlatform().ToArgb());
+			});
+		}
+
+		[Fact]
 		[Description("BottomNavigationView should extend to screen bottom in Edge-to-Edge mode (Issue 33344)")]
 		public async Task BottomNavigationViewExtendsToScreenBottom()
 		{
@@ -258,6 +305,19 @@ namespace Microsoft.Maui.DeviceTests
 				as CoordinatorLayout;
 
 			return layout.GetFirstChildOfType<BottomNavigationView>();
+		}
+
+		AppBarLayout GetAppBarLayout(IPlatformViewHandler tabViewHandler)
+		{
+			var layout = tabViewHandler.PlatformView.FindParent((view) => view is CoordinatorLayout)
+				as CoordinatorLayout;
+
+			return layout.GetFirstChildOfType<AppBarLayout>();
+		}
+
+		static int GetAppBarBackgroundColor(AppBarLayout appBar)
+		{
+			return Assert.IsType<ColorDrawable>(appBar.Background).Color.ToArgb();
 		}
 
 		async Task ValidateTabBarIconColor(

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Android.cs
@@ -317,7 +317,19 @@ namespace Microsoft.Maui.DeviceTests
 
 		static int GetAppBarBackgroundColor(AppBarLayout appBar)
 		{
-			return Assert.IsType<ColorDrawable>(appBar.Background).Color.ToArgb();
+			// The bar background is applied as a background tint over the AppBar's default
+			// MaterialShapeDrawable (preserving Material elevation/shape), so read the tint color
+			// rather than expecting the background to be replaced with a flat ColorDrawable.
+			var tintList = AndroidX.Core.View.ViewCompat.GetBackgroundTintList(appBar);
+			if (tintList is not null)
+			{
+				return tintList.DefaultColor;
+			}
+
+			// The bar color hasn't been applied yet (the AppBar still has its default
+			// MaterialShapeDrawable). Return transparent so polling callers (AssertEventually)
+			// keep waiting for the async chrome update to settle instead of throwing.
+			return Colors.Transparent.ToPlatform().ToArgb();
 		}
 
 		async Task ValidateTabBarIconColor(

--- a/src/Core/src/Platform/Android/WindowExtensions.cs
+++ b/src/Core/src/Platform/Android/WindowExtensions.cs
@@ -1,15 +1,21 @@
-﻿using Android.App;
+﻿using System.Runtime.CompilerServices;
+using Android.App;
 using Android.Content;
 using Android.Content.Res;
+using Android.Util;
 using Android.Views;
 using AndroidX.Core.View;
 using Microsoft.Maui.Devices;
+using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Platform;
+using AColor = Android.Graphics.Color;
 
 namespace Microsoft.Maui
 {
 	public static partial class WindowExtensions
 	{
+		static readonly ConditionalWeakTable<Window, OriginalSystemBarColors> s_originalSystemBarColors = new();
+
 		internal static void UpdateTitle(this Activity platformWindow, IWindow window)
 		{
 			if (string.IsNullOrEmpty(window.Title))
@@ -45,22 +51,159 @@ namespace Microsoft.Maui
 		//TODO : Make it public in NET 11.
 		internal static void ConfigureTranslucentSystemBars(this Window? window, Activity activity)
 		{
+			window.UpdateSystemBarAppearance(activity, updateStatusBar: true, updateNavigationBar: true);
+		}
+
+		internal static void UpdateSystemBarAppearance(
+			this Window? window,
+			Activity? activity,
+			bool updateStatusBar,
+			bool updateNavigationBar,
+			Color? statusBarBackgroundColor = null,
+			Color? statusBarForegroundColor = null,
+			Color? navigationBarBackgroundColor = null,
+			Color? navigationBarForegroundColor = null)
+		{
 			if (window is null)
 			{
 				return;
 			}
 
-			// Set appropriate system bar appearance for readability using API 30+ methods
+			UpdateSystemBarBackgrounds(
+				window,
+				updateStatusBar,
+				updateNavigationBar,
+				statusBarBackgroundColor,
+				navigationBarBackgroundColor);
+
+			// Set appropriate system bar appearance for readability using AndroidX compat APIs.
 			var windowInsetsController = WindowCompat.GetInsetsController(window, window.DecorView);
 			if (windowInsetsController is not null)
 			{
-				// Automatically adjust icon/text colors based on app theme
-				var configuration = activity.Resources?.Configuration;
+				// Automatically adjust icon/text colors based on explicit chrome colors when available,
+				// falling back to the app theme when MAUI doesn't know the system bar background.
+				var configuration = activity?.Resources?.Configuration;
 				var isLightTheme = configuration is null ||
 					(configuration.UiMode & UiMode.NightMask) != UiMode.NightYes;
 
-				windowInsetsController.AppearanceLightStatusBars = isLightTheme;
-				windowInsetsController.AppearanceLightNavigationBars = isLightTheme;
+				if (updateStatusBar)
+				{
+					windowInsetsController.AppearanceLightStatusBars =
+						GetLightSystemBarAppearance(statusBarBackgroundColor, statusBarForegroundColor) ?? isLightTheme;
+				}
+
+				if (updateNavigationBar)
+				{
+					windowInsetsController.AppearanceLightNavigationBars =
+						GetLightSystemBarAppearance(navigationBarBackgroundColor, navigationBarForegroundColor) ?? isLightTheme;
+				}
+			}
+		}
+
+		static void UpdateSystemBarBackgrounds(
+			Window window,
+			bool updateStatusBar,
+			bool updateNavigationBar,
+			Color? statusBarBackgroundColor,
+			Color? navigationBarBackgroundColor)
+		{
+			var originalSystemBarColors = s_originalSystemBarColors.GetValue(
+				window,
+				static window => new OriginalSystemBarColors(window));
+
+#pragma warning disable CA1422 // System bar color APIs still apply to older Android versions and are harmless on newer versions.
+			if (updateStatusBar)
+			{
+				if (statusBarBackgroundColor?.Alpha > 0)
+				{
+					window.SetStatusBarColor(statusBarBackgroundColor.ToPlatform());
+				}
+				else
+				{
+					originalSystemBarColors.RestoreStatusBarColor(window);
+				}
+			}
+
+			if (updateNavigationBar)
+			{
+				if (navigationBarBackgroundColor?.Alpha > 0)
+				{
+					window.SetNavigationBarColor(navigationBarBackgroundColor.ToPlatform());
+				}
+				else
+				{
+					originalSystemBarColors.RestoreNavigationBarColor(window);
+				}
+			}
+#pragma warning restore CA1422
+		}
+
+		static bool? GetLightSystemBarAppearance(Color? backgroundColor, Color? foregroundColor)
+		{
+			if (backgroundColor?.Alpha > 0)
+			{
+				// HSL luminosity misclassifies perceptually-bright hues (yellow, cyan, lime) as dark
+				// because it averages max/min channel values and lands at exactly 0.5 for these colours.
+				// Use ITU-R BT.601 perceptual luminance with a gamma-2.0 approximation instead:
+				//   L = 0.299R² + 0.587G² + 0.114B²  (squaring approximates linear-light encoding)
+				// Threshold 0.25 ≈ 50% perceived brightness.
+				return IsPerceptuallyLight(backgroundColor);
+			}
+
+			if (foregroundColor?.Alpha > 0)
+			{
+				return foregroundColor.GetLuminosity() <= 0.5;
+			}
+
+			return null;
+		}
+
+		// ITU-R BT.601 perceptual luminance with gamma-2.0 approximation.
+		// Returns true when the colour is bright enough to need dark (black) system bar icons.
+		static bool IsPerceptuallyLight(Color color)
+		{
+			float r = color.Red * color.Red;
+			float g = color.Green * color.Green;
+			float b = color.Blue * color.Blue;
+			return 0.299f * r + 0.587f * g + 0.114f * b > 0.25f;
+		}
+
+		sealed class OriginalSystemBarColors
+		{
+			readonly int _statusBarColor;
+			readonly int _navigationBarColor;
+
+			public OriginalSystemBarColors(Window window)
+			{
+#pragma warning disable CA1422
+				_statusBarColor = window.StatusBarColor;
+				_navigationBarColor = window.NavigationBarColor;
+#pragma warning restore CA1422
+			}
+
+			public void RestoreStatusBarColor(Window window)
+			{
+				window.SetStatusBarColor(new AColor(_statusBarColor));
+			}
+
+			public void RestoreNavigationBarColor(Window window)
+			{
+				var restoreColor = new AColor(_navigationBarColor);
+
+				// Only substitute the transparent edge-to-edge default navigation bar color.
+				// Preserve any explicit captured native value (including opaque black 0xFF000000)
+				// so temporary MAUI overrides can be restored exactly.
+				if (_navigationBarColor == 0 && window.Context?.Theme is { } theme)
+				{
+					var typedValue = new TypedValue();
+					if (theme.ResolveAttribute(global::Android.Resource.Attribute.ColorBackground, typedValue, true)
+						&& typedValue.Data != 0)
+					{
+						restoreColor = new AColor(typedValue.Data);
+					}
+				}
+
+				window.SetNavigationBarColor(restoreColor);
 			}
 		}
 	}

--- a/src/Core/src/Platform/Android/WindowExtensions.cs
+++ b/src/Core/src/Platform/Android/WindowExtensions.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Maui
 	{
 		static readonly ConditionalWeakTable<Window, OriginalSystemBarColors> s_originalSystemBarColors = new();
 
+		static readonly ConditionalWeakTable<Window, SystemBarIconAppearanceState> s_systemBarIconAppearance = new();
+
 		internal static void UpdateTitle(this Activity platformWindow, IWindow window)
 		{
 			if (string.IsNullOrEmpty(window.Title))
@@ -86,16 +88,34 @@ namespace Microsoft.Maui
 				var isLightTheme = configuration is null ||
 					(configuration.UiMode & UiMode.NightMask) != UiMode.NightYes;
 
+				// MAUI only "owns" the icon-appearance flag while its current value still matches the
+				// value MAUI last wrote. If a developer changed it out-of-band (e.g. directly through
+				// WindowInsetsControllerCompat), the current value diverges from MAUI's last write and
+				// we preserve the developer's explicit choice instead of overwriting it.
+				var appearanceState = s_systemBarIconAppearance.GetValue(window, static _ => new SystemBarIconAppearanceState());
+
 				if (updateStatusBar)
 				{
-					windowInsetsController.AppearanceLightStatusBars =
-						GetLightSystemBarAppearance(statusBarBackgroundColor, statusBarForegroundColor) ?? isLightTheme;
+					var desired = GetLightSystemBarAppearance(statusBarBackgroundColor, statusBarForegroundColor) ?? isLightTheme;
+
+					if (appearanceState.LastStatusBarAppearance is not bool lastStatusBar
+						|| windowInsetsController.AppearanceLightStatusBars == lastStatusBar)
+					{
+						windowInsetsController.AppearanceLightStatusBars = desired;
+						appearanceState.LastStatusBarAppearance = desired;
+					}
 				}
 
 				if (updateNavigationBar)
 				{
-					windowInsetsController.AppearanceLightNavigationBars =
-						GetLightSystemBarAppearance(navigationBarBackgroundColor, navigationBarForegroundColor) ?? isLightTheme;
+					var desired = GetLightSystemBarAppearance(navigationBarBackgroundColor, navigationBarForegroundColor) ?? isLightTheme;
+
+					if (appearanceState.LastNavigationBarAppearance is not bool lastNavigationBar
+						|| windowInsetsController.AppearanceLightNavigationBars == lastNavigationBar)
+					{
+						windowInsetsController.AppearanceLightNavigationBars = desired;
+						appearanceState.LastNavigationBarAppearance = desired;
+					}
 				}
 			}
 		}
@@ -166,6 +186,20 @@ namespace Microsoft.Maui
 			float g = color.Green * color.Green;
 			float b = color.Blue * color.Blue;
 			return 0.299f * r + 0.587f * g + 0.114f * b > 0.25f;
+		}
+
+		// Forgets MAUI's tracked system bar icon-appearance ownership for a window so the next
+		// chrome update re-establishes ownership. Intended for tests.
+		internal static void ResetSystemBarIconAppearanceTracking(this Window window) =>
+			s_systemBarIconAppearance.Remove(window);
+
+		// Tracks the system bar icon-appearance values MAUI last wrote so it can detect (and respect)
+		// out-of-band developer overrides on subsequent chrome updates.
+		sealed class SystemBarIconAppearanceState
+		{
+			public bool? LastStatusBarAppearance { get; set; }
+
+			public bool? LastNavigationBarAppearance { get; set; }
 		}
 
 		sealed class OriginalSystemBarColors

--- a/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Android.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact]
-		public async Task SystemBarAppearanceDoesNotOverwriteDeveloperAppearance()
+		public async Task SystemBarIconAppearanceFollowsBarColorButRespectsDeveloperOverride()
 		{
 			await InvokeOnMainThreadAsync(() =>
 			{
@@ -82,17 +82,33 @@ namespace Microsoft.Maui.DeviceTests
 
 				Assert.NotNull(windowInsetsController);
 
-				windowInsetsController.AppearanceLightStatusBars = false;
-				windowInsetsController.AppearanceLightNavigationBars = false;
+				// Start from a clean ownership state so the assertions are deterministic.
+				platformWindow.ResetSystemBarIconAppearanceTracking();
 
+				// 1) The developer hasn't touched the icon-appearance flags, so MAUI derives a readable
+				//    icon style from the bar background. A light bar background needs dark icons, which
+				//    maps to AppearanceLight*Bars == true.
 				platformWindow.UpdateSystemBarAppearance(
 					activity,
 					updateStatusBar: true,
 					updateNavigationBar: true,
 					statusBarBackgroundColor: Colors.LightGreen,
-					statusBarForegroundColor: Colors.Black,
-					navigationBarBackgroundColor: Colors.LightGreen,
-					navigationBarForegroundColor: Colors.Black);
+					navigationBarBackgroundColor: Colors.LightGreen);
+
+				Assert.True(windowInsetsController.AppearanceLightStatusBars);
+				Assert.True(windowInsetsController.AppearanceLightNavigationBars);
+
+				// 2) The developer now explicitly overrides the flags out-of-band...
+				windowInsetsController.AppearanceLightStatusBars = false;
+				windowInsetsController.AppearanceLightNavigationBars = false;
+
+				// ...a subsequent MAUI chrome update must preserve the developer's explicit choice.
+				platformWindow.UpdateSystemBarAppearance(
+					activity,
+					updateStatusBar: true,
+					updateNavigationBar: true,
+					statusBarBackgroundColor: Colors.LightGreen,
+					navigationBarBackgroundColor: Colors.LightGreen);
 
 				Assert.False(windowInsetsController.AppearanceLightStatusBars);
 				Assert.False(windowInsetsController.AppearanceLightNavigationBars);

--- a/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Android.cs
@@ -2,9 +2,11 @@
 using System.Threading.Tasks;
 using Android.App;
 using AndroidX.AppCompat.App;
+using AndroidX.Core.View;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Hosting;
 using Xunit;
 
@@ -66,6 +68,34 @@ namespace Microsoft.Maui.DeviceTests
 
 				WindowExtensions.UpdateTitle(activity, testWindow);
 				Assert.Equal(activity.Title, ApplicationModel.AppInfo.Current.Name);
+			});
+		}
+
+		[Fact]
+		public async Task SystemBarAppearanceDoesNotOverwriteDeveloperAppearance()
+		{
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var activity = (Activity)MauiProgramDefaults.DefaultContext;
+				var platformWindow = activity.Window;
+				var windowInsetsController = WindowCompat.GetInsetsController(platformWindow, platformWindow.DecorView);
+
+				Assert.NotNull(windowInsetsController);
+
+				windowInsetsController.AppearanceLightStatusBars = false;
+				windowInsetsController.AppearanceLightNavigationBars = false;
+
+				platformWindow.UpdateSystemBarAppearance(
+					activity,
+					updateStatusBar: true,
+					updateNavigationBar: true,
+					statusBarBackgroundColor: Colors.LightGreen,
+					statusBarForegroundColor: Colors.Black,
+					navigationBarBackgroundColor: Colors.LightGreen,
+					navigationBarForegroundColor: Colors.Black);
+
+				Assert.False(windowInsetsController.AppearanceLightStatusBars);
+				Assert.False(windowInsetsController.AppearanceLightNavigationBars);
 			});
 		}
 	}


### PR DESCRIPTION
This PR is an improved version of #35463

In PR #35463, the original automatic icon contrast logic was removed after review because it could overwrite developer-defined values for AppearanceLightStatusBars and AppearanceLightNavigationBars. While this preserved explicit developer settings, it also introduced a usability regression: Android defaults to light-colored system bar icons, so applying a light system bar background could result in white icons on a light background, reducing readability.
 
PR #35869 addresses both problems by restoring automatic icon appearance handling through per-window ownership tracking. MAUI now derives an appropriate icon appearance from the effective bar color when it owns the value, while preserving any explicit developer or theme overrides. The implementation tracks the last value written by MAUI and only updates the system bar icon flags if they have not been modified externally.
 
**Additional improvements include:**
 

- Perceptual luminance (BT.601 with gamma approximation) for more accurate light/dark background detection, correctly classifying bright colors such as yellow, lime, and cyan.
- Restoration of original system bar colors when MAUI no longer controls the chrome.
- Consistent routing of all Shell, NavigationPage, TabbedPage, toolbar, and modal updates through the shared AndroidSystemChrome helper.
- Comprehensive device and unit tests covering automatic icon appearance, developer override preservation, and ownership tracking.

 
**Android platform limitation**: navigation bar icon color cannot be controlled on API 25 and earlier because Android only introduced dark navigation bar icon support in API 26. Consequently, MAUI updates the navigation bar background on these versions but cannot change the icon appearance. This is documented as an Android platform limitation rather than a framework bug.

## References
- Android View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR documentation: https://developer.android.com/reference/android/view/View#SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
- Dark theme implementation: [Implement dark theme | Views | Android Developers](https://developer.android.com/develop/ui/views/theming/darktheme)
- Android windowLightNavigationBar documentation: https://developer.android.com/reference/android/R.attr#windowLightNavigationBar
- Community discussion: https://stackoverflow.com/questions/36480262/light-navigation-bar


### Screenshots
|API | Before  | After |
|--|---------|--------|
|30 |  <img height="600" width="300" src="https://github.com/user-attachments/assets/49bdda73-94bc-48d2-a70b-4d3da6ff3b6c"> |   <img height="600" width="300" src="https://github.com/user-attachments/assets/e7677686-3b54-4a4c-9161-7bc770d283b2">  |
|34 |  <img height="600" width="300" src="https://github.com/user-attachments/assets/8d48bcf2-07f3-4300-80c7-959b8b8e43a1"> |   <img height="600" width="300" src="https://github.com/user-attachments/assets/1a4f62a5-019e-4a55-b49c-680bc17ca310">  |
|36 |  <img height="600" width="300" src="https://github.com/user-attachments/assets/26b094e8-4ab4-4ffc-9ffb-03e448b71a84"> |   <img height="600" width="300" src="https://github.com/user-attachments/assets/ae77aabc-cc30-4672-8e51-2c316152286d">  |

### Light and Dark Navigation Bar and Status Bar Icons
 
| Dark  | Light |
|---------|--------|
|  <img height="600" width="300" src="https://github.com/user-attachments/assets/9382afa5-c3b7-41fd-8c0d-0784c7c3e28a"> |   <img height="600" width="300" src="https://github.com/user-attachments/assets/c1d5db60-e871-47f8-9bc8-0ce5be101956"> |