### PR TITLE
Fix memory leak when clearing shared PathSegments from PathFigure

### DIFF
--- a/src/Controls/src/Core/Shapes/PathFigure.cs
+++ b/src/Controls/src/Core/Shapes/PathFigure.cs
@@ -13,25 +13,14 @@ namespace Microsoft.Maui.Controls.Shapes
 	[ContentProperty("Segments")]
 	public sealed class PathFigure : BindableObject, IAnimatable
 	{
-		readonly NotifyCollectionChangedEventHandler _pathSegmentCollectionChangedHandler;
-		readonly PropertyChangedEventHandler _pathSegmentPropertyChangedHandler;
-		readonly WeakNotifyCollectionChangedProxy _segmentCollectionChangedProxy = new();
-		readonly Dictionary<PathSegment, WeakNotifyPropertyChangedProxy> _segmentPropertyChangedProxies = new();
+		readonly List<PathSegment> _subscribedSegments = new();
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="PathFigure"/> class.
 		/// </summary>
 		public PathFigure()
 		{
-			_pathSegmentCollectionChangedHandler = OnPathSegmentCollectionChanged;
-			_pathSegmentPropertyChangedHandler = OnPathSegmentPropertyChanged;
 			Segments = new PathSegmentCollection();
-		}
-
-		~PathFigure()
-		{
-			_segmentCollectionChangedProxy.Unsubscribe();
-			UnsubscribeFromAllPathSegmentPropertyChanged();
 		}
 
 		/// <summary>Bindable property for <see cref="Segments"/>.</summary>
@@ -108,13 +97,14 @@ namespace Microsoft.Maui.Controls.Shapes
 
 		void UpdatePathSegmentCollection(PathSegmentCollection oldCollection, PathSegmentCollection newCollection)
 		{
-			_segmentCollectionChangedProxy.Unsubscribe();
+			oldCollection?.CollectionChanged -= OnPathSegmentCollectionChanged;
+
 			UnsubscribeFromAllPathSegmentPropertyChanged();
 
 			if (newCollection == null)
 				return;
 
-			_segmentCollectionChangedProxy.Subscribe(newCollection, _pathSegmentCollectionChangedHandler);
+			newCollection.CollectionChanged += OnPathSegmentCollectionChanged;
 
 			foreach (var newPathSegment in newCollection)
 			{
@@ -126,7 +116,10 @@ namespace Microsoft.Maui.Controls.Shapes
 		{
 			if (e.Action == NotifyCollectionChangedAction.Reset)
 			{
-				UnsubscribeFromAllPathSegmentPropertyChanged();
+				for (int i = _subscribedSegments.Count - 1; i >= 0; i--)
+				{
+					UnsubscribeFromPathSegmentPropertyChanged(_subscribedSegments[i]);
+				}
 
 				if (sender is PathSegmentCollection pathSegmentCollection)
 				{
@@ -165,37 +158,39 @@ namespace Microsoft.Maui.Controls.Shapes
 			Invalidate();
 		}
 
-		void OnPathSegmentPropertyChanged(object sender, PropertyChangedEventArgs e)
-		{
-			Invalidate();
-		}
-
 		void SubscribeToPathSegmentPropertyChanged(PathSegment pathSegment)
 		{
-			if (_segmentPropertyChangedProxies.ContainsKey(pathSegment))
+			if (_subscribedSegments.Contains(pathSegment))
+			{
 				return;
+			}
 
-			var weakProxy = new WeakNotifyPropertyChangedProxy(pathSegment, _pathSegmentPropertyChangedHandler);
-			_segmentPropertyChangedProxies[pathSegment] = weakProxy;
+			pathSegment.PropertyChanged += OnPathSegmentPropertyChanged;
+			_subscribedSegments.Add(pathSegment);
 		}
 
 		void UnsubscribeFromPathSegmentPropertyChanged(PathSegment pathSegment)
 		{
-			if (!_segmentPropertyChangedProxies.TryGetValue(pathSegment, out var weakProxy))
+			if (!_subscribedSegments.Contains(pathSegment))
+			{
 				return;
+			}
 
-			weakProxy.Unsubscribe();
-			_segmentPropertyChangedProxies.Remove(pathSegment);
+			pathSegment.PropertyChanged -= OnPathSegmentPropertyChanged;
+			_subscribedSegments.Remove(pathSegment);
 		}
 
 		void UnsubscribeFromAllPathSegmentPropertyChanged()
 		{
-			foreach (var weakProxy in _segmentPropertyChangedProxies.Values)
+			for (int i = _subscribedSegments.Count - 1; i >= 0; i--)
 			{
-				weakProxy.Unsubscribe();
+				UnsubscribeFromPathSegmentPropertyChanged(_subscribedSegments[i]);
 			}
+		}
 
-			_segmentPropertyChangedProxies.Clear();
+		void OnPathSegmentPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			Invalidate();
 		}
 
 		void Invalidate()

--- a/src/Controls/src/Core/Shapes/PathFigure.cs
+++ b/src/Controls/src/Core/Shapes/PathFigure.cs
@@ -1,6 +1,7 @@
 #nullable disable
 using System;
 using System.Collections.Specialized;
+using System.Collections.Generic;
 using System.ComponentModel;
 using Microsoft.Maui.Graphics;
 
@@ -12,6 +13,9 @@ namespace Microsoft.Maui.Controls.Shapes
 	[ContentProperty("Segments")]
 	public sealed class PathFigure : BindableObject, IAnimatable
 	{
+		readonly WeakNotifyCollectionChangedProxy _segmentCollectionChangedProxy = new();
+		readonly Dictionary<PathSegment, WeakNotifyPropertyChangedProxy> _segmentPropertyChangedProxies = new();
+
 		/// <summary>
 		/// Initializes a new instance of the <see cref="PathFigure"/> class.
 		/// </summary>
@@ -94,29 +98,38 @@ namespace Microsoft.Maui.Controls.Shapes
 
 		void UpdatePathSegmentCollection(PathSegmentCollection oldCollection, PathSegmentCollection newCollection)
 		{
-			if (oldCollection != null)
-			{
-				oldCollection.CollectionChanged -= OnPathSegmentCollectionChanged;
-
-				foreach (var oldPathSegment in oldCollection)
-				{
-					oldPathSegment.PropertyChanged -= OnPathSegmentPropertyChanged;
-				}
-			}
+			_segmentCollectionChangedProxy.Unsubscribe();
+			UnsubscribeFromAllPathSegmentPropertyChanged();
 
 			if (newCollection == null)
 				return;
 
-			newCollection.CollectionChanged += OnPathSegmentCollectionChanged;
+			_segmentCollectionChangedProxy.Subscribe(newCollection, OnPathSegmentCollectionChanged);
 
 			foreach (var newPathSegment in newCollection)
 			{
-				newPathSegment.PropertyChanged += OnPathSegmentPropertyChanged;
+				SubscribeToPathSegmentPropertyChanged(newPathSegment);
 			}
 		}
 
 		void OnPathSegmentCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
+			if (e.Action == NotifyCollectionChangedAction.Reset)
+			{
+				UnsubscribeFromAllPathSegmentPropertyChanged();
+
+				if (sender is PathSegmentCollection pathSegmentCollection)
+				{
+					foreach (var pathSegment in pathSegmentCollection)
+					{
+						SubscribeToPathSegmentPropertyChanged(pathSegment);
+					}
+				}
+
+				Invalidate();
+				return;
+			}
+
 			if (e.OldItems != null)
 			{
 				foreach (var oldItem in e.OldItems)
@@ -124,7 +137,7 @@ namespace Microsoft.Maui.Controls.Shapes
 					if (!(oldItem is PathSegment oldPathSegment))
 						continue;
 
-					oldPathSegment.PropertyChanged -= OnPathSegmentPropertyChanged;
+					UnsubscribeFromPathSegmentPropertyChanged(oldPathSegment);
 				}
 			}
 
@@ -135,7 +148,7 @@ namespace Microsoft.Maui.Controls.Shapes
 					if (!(newItem is PathSegment newPathSegment))
 						continue;
 
-					newPathSegment.PropertyChanged += OnPathSegmentPropertyChanged;
+					SubscribeToPathSegmentPropertyChanged(newPathSegment);
 				}
 			}
 
@@ -145,6 +158,34 @@ namespace Microsoft.Maui.Controls.Shapes
 		void OnPathSegmentPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			Invalidate();
+		}
+
+		void SubscribeToPathSegmentPropertyChanged(PathSegment pathSegment)
+		{
+			if (_segmentPropertyChangedProxies.ContainsKey(pathSegment))
+				return;
+
+			var weakProxy = new WeakNotifyPropertyChangedProxy(pathSegment, OnPathSegmentPropertyChanged);
+			_segmentPropertyChangedProxies[pathSegment] = weakProxy;
+		}
+
+		void UnsubscribeFromPathSegmentPropertyChanged(PathSegment pathSegment)
+		{
+			if (!_segmentPropertyChangedProxies.TryGetValue(pathSegment, out var weakProxy))
+				return;
+
+			weakProxy.Unsubscribe();
+			_segmentPropertyChangedProxies.Remove(pathSegment);
+		}
+
+		void UnsubscribeFromAllPathSegmentPropertyChanged()
+		{
+			foreach (var weakProxy in _segmentPropertyChangedProxies.Values)
+			{
+				weakProxy.Unsubscribe();
+			}
+
+			_segmentPropertyChangedProxies.Clear();
 		}
 
 		void Invalidate()

--- a/src/Controls/src/Core/Shapes/PathFigure.cs
+++ b/src/Controls/src/Core/Shapes/PathFigure.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Maui.Controls.Shapes
 	[ContentProperty("Segments")]
 	public sealed class PathFigure : BindableObject, IAnimatable
 	{
+		readonly NotifyCollectionChangedEventHandler _pathSegmentCollectionChangedHandler;
+		readonly PropertyChangedEventHandler _pathSegmentPropertyChangedHandler;
 		readonly WeakNotifyCollectionChangedProxy _segmentCollectionChangedProxy = new();
 		readonly Dictionary<PathSegment, WeakNotifyPropertyChangedProxy> _segmentPropertyChangedProxies = new();
 
@@ -21,7 +23,15 @@ namespace Microsoft.Maui.Controls.Shapes
 		/// </summary>
 		public PathFigure()
 		{
+			_pathSegmentCollectionChangedHandler = OnPathSegmentCollectionChanged;
+			_pathSegmentPropertyChangedHandler = OnPathSegmentPropertyChanged;
 			Segments = new PathSegmentCollection();
+		}
+
+		~PathFigure()
+		{
+			_segmentCollectionChangedProxy.Unsubscribe();
+			UnsubscribeFromAllPathSegmentPropertyChanged();
 		}
 
 		/// <summary>Bindable property for <see cref="Segments"/>.</summary>
@@ -104,7 +114,7 @@ namespace Microsoft.Maui.Controls.Shapes
 			if (newCollection == null)
 				return;
 
-			_segmentCollectionChangedProxy.Subscribe(newCollection, OnPathSegmentCollectionChanged);
+			_segmentCollectionChangedProxy.Subscribe(newCollection, _pathSegmentCollectionChangedHandler);
 
 			foreach (var newPathSegment in newCollection)
 			{
@@ -165,7 +175,7 @@ namespace Microsoft.Maui.Controls.Shapes
 			if (_segmentPropertyChangedProxies.ContainsKey(pathSegment))
 				return;
 
-			var weakProxy = new WeakNotifyPropertyChangedProxy(pathSegment, OnPathSegmentPropertyChanged);
+			var weakProxy = new WeakNotifyPropertyChangedProxy(pathSegment, _pathSegmentPropertyChangedHandler);
 			_segmentPropertyChangedProxies[pathSegment] = weakProxy;
 		}
 

--- a/src/Controls/tests/Core.UnitTests/PathSegmentTests.cs
+++ b/src/Controls/tests/Core.UnitTests/PathSegmentTests.cs
@@ -128,5 +128,23 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal(100, quadraticBezierSegment2.Point2.X);
 			Assert.Equal(100, quadraticBezierSegment2.Point2.Y);
 		}
+
+		[Fact]
+		public void ClearingSegmentsDetachesPropertyChangedFromRemovedSegments()
+		{
+			var pathFigure = new PathFigure();
+			var sharedSegment = new LineSegment();
+			var invalidationCount = 0;
+
+			pathFigure.InvalidatePathSegmentRequested += (_, __) => invalidationCount++;
+			pathFigure.Segments.Add(sharedSegment);
+
+			pathFigure.Segments.Clear();
+			var invalidationCountAfterClear = invalidationCount;
+
+			sharedSegment.Point = new Point(10, 10);
+
+			Assert.Equal(invalidationCountAfterClear, invalidationCount);
+		}
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Issue Details
Memory leak in PathFigure.Segments.Clear() when PathSegment objects are shared. The clear operation raises a reset change, and old segment handlers were not fully unsubscribed, so shared segments could keep old PathFigure instances alive and retain the related Path visual tree and page/viewmodel objects.

### Description of Change

<!-- Enter description of the fix in this section -->
Added segment subscription tracking using a _subscribedSegments list to prevent memory leaks. The code now properly unsubscribes from segments when .Clear() is called by handling the Reset collection action. Subscription logic was extracted into reusable methods: SubscribeToPathSegmentPropertyChanged(), UnsubscribeFromPathSegmentPropertyChanged(), and UnsubscribeFromAllPathSegmentPropertyChanged(). This prevents cleared segments from triggering invalidation after removal.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #35796 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

**Tested the behavior in the following platforms.**
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

| Before  | After  |
|---------|--------|
| **iOS**<br> <video src="https://github.com/user-attachments/assets/9e3fad2a-aeb9-4159-86f8-27dbb9d4d0fb" width="300" height="600"> | **iOS**<br> <video src="https://github.com/user-attachments/assets/5dfcf942-fa2b-49b5-9e45-590850af84d0" width="300" height="600"> |
