### PR TITLE
Fix build error caused by duplicate property change registration in SwipeItem

### DIFF
--- a/src/Controls/src/Core/SwipeView/SwipeItem.cs
+++ b/src/Controls/src/Core/SwipeView/SwipeItem.cs
@@ -36,11 +36,6 @@ namespace Microsoft.Maui.Controls
 
 		public event EventHandler<EventArgs> Invoked;
 
-		static void OnIsVisibleChanged(BindableObject bindable, object oldValue, object newValue)
-		{
-			var swipeItem = (SwipeItem)bindable;
-			swipeItem.Handler?.UpdateValue(nameof(ISwipeItemMenuItem.Visibility));
-		}
 		Paint ISwipeItemMenuItem.Background => new SolidPaint(BackgroundColor);
 
 		Visibility ISwipeItemMenuItem.Visibility => this.IsVisible ? Visibility.Visible : Visibility.Collapsed;


### PR DESCRIPTION
<!-- Please keep the note below for people who find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment whether this change resolves your issue. Thank you!


### Description of Change :

- This change removes a duplicate property change registration that was causing build errors in the `SwipeItem` implementation.
- The property change handler was being added more than once, resulting in compilation/build issues. Removing the duplicate registration resolves the build failure without affecting existing functionality.

### Snapshots :

 | Before Fix | After Fix |
 |--------------------------|---------------------------|
 | <img width="945" height="421" alt="BeforeFix" src="https://github.com/user-attachments/assets/4c621c0e-3b0a-4b85-981d-e1ee2eb2e9ff" /> | <img width="963" height="397" alt="AfterFix" src="https://github.com/user-attachments/assets/bf8eb817-5d96-4622-b40b-775810a37510" /> |

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
