### PR TITLE
[Windows] Shell: Apply TabBarDisabledColor to disabled tabs

### DIFF
--- a/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
@@ -265,12 +265,15 @@ namespace Microsoft.Maui.Controls.Handlers
 				void SetValues(BaseShellItem bsi, NavigationViewItemViewModel vm)
 				{
 					vm.Content = bsi.Title;
-					vm.IsEnabled = bsi.IsEnabled;
 
-					if (_shellAppearanceElement?.EffectiveTabBarDisabledColor is Color disabledColor)
-					{
-						vm.DisabledForeground = disabledColor.ToPlatform();
-					}
+						// Set DisabledForeground BEFORE IsEnabled so that when the IsEnabled setter
+						// calls UpdateForeground(), DisabledForeground is already available.
+						if (_shellAppearanceElement?.EffectiveTabBarDisabledColor is Color disabledColor)
+						{
+							vm.DisabledForeground = disabledColor.ToPlatform();
+						}
+
+						vm.IsEnabled = bsi.IsEnabled;
 
 					var iconSource = bsi.Icon?.ToIconSource(MauiContext!);
 

--- a/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
@@ -266,14 +266,10 @@ namespace Microsoft.Maui.Controls.Handlers
 				{
 					vm.Content = bsi.Title;
 
-						// Set DisabledForeground BEFORE IsEnabled so that when the IsEnabled setter
-						// calls UpdateForeground(), DisabledForeground is already available.
-						if (_shellAppearanceElement?.EffectiveTabBarDisabledColor is Color disabledColor)
-						{
-							vm.DisabledForeground = disabledColor.ToPlatform();
-						}
-
-						vm.IsEnabled = bsi.IsEnabled;
+					// Set DisabledForeground BEFORE IsEnabled so that when the IsEnabled setter
+					// calls UpdateForeground(), DisabledForeground is already available.
+					vm.DisabledForeground = _shellAppearanceElement?.EffectiveTabBarDisabledColor?.ToPlatform();
+					vm.IsEnabled = bsi.IsEnabled;
 
 					var iconSource = bsi.Icon?.ToIconSource(MauiContext!);
 

--- a/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using Microsoft.Maui.Controls.Platform;
+using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Platform;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -265,6 +266,12 @@ namespace Microsoft.Maui.Controls.Handlers
 				{
 					vm.Content = bsi.Title;
 					vm.IsEnabled = bsi.IsEnabled;
+
+					if (_shellAppearanceElement?.EffectiveTabBarDisabledColor is Color disabledColor)
+					{
+						vm.DisabledForeground = disabledColor.ToPlatform();
+					}
+
 					var iconSource = bsi.Icon?.ToIconSource(MauiContext!);
 
 					if (iconSource != null)
@@ -672,12 +679,14 @@ namespace Microsoft.Maui.Controls.Handlers
 			var foregroundColor = _shellAppearanceElement.EffectiveTabBarForegroundColor?.AsPaint();
 			var unselectedColor = _shellAppearanceElement.EffectiveTabBarUnselectedColor?.AsPaint();
 			var titleColor = _shellAppearanceElement.EffectiveTabBarTitleColor?.AsPaint();
+			var disabledColor = _shellAppearanceElement.EffectiveTabBarDisabledColor?.AsPaint();
 
 			mauiNavView.UpdateTopNavAreaBackground(backgroundColor);
 			mauiNavView.UpdateTopNavigationViewItemUnselectedColor(unselectedColor);
 			mauiNavView.UpdateTopNavigationViewItemTextSelectedColor(titleColor ?? foregroundColor);
 			mauiNavView.UpdateTopNavigationViewItemTextColor(unselectedColor);
 			mauiNavView.UpdateTopNavigationViewItemSelectedColor(foregroundColor ?? titleColor);
+			mauiNavView.UpdateTopNavigationViewItemDisabledColor(disabledColor);
 		}
 
 		void OnApplyTemplateFinished(object? sender, EventArgs e)

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue32995.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue32995.cs
@@ -3,6 +3,8 @@ namespace Maui.Controls.Sample.Issues;
 [Issue(IssueTracker.Github, 32995, "TabBarDisabledColor not applied to disabled tabs on iOS", PlatformAffected.iOS)]
 public class Issue32995 : Shell
 {
+	Tab _dynamicTab;
+
 	public Issue32995()
 	{
 		var tab2 = new Tab
@@ -57,12 +59,45 @@ public class Issue32995 : Shell
 									Text = "Disable Tab2",
 									AutomationId = "DisableButton",
 									Command = new Command(() => tab2.IsEnabled = false)
-								}
+								},
+								new Button
+								{
+									Text = "Add Disabled Tab",
+									AutomationId = "AddDisabledTabButton",
+									Command = new Command(() =>
+									{
+								if (_dynamicTab is not null)
+									return;
+
+								_dynamicTab = new Tab
+								{
+									Title = "Tab3",
+									Icon = "coffee.png",
+									AutomationId = "Tab3",
+									IsEnabled = false,
+									Items =
+									{
+										new ShellContent
+										{
+											Content = new ContentPage
+											{
+												Content = new Label
+												{
+													Text = "Tab3 Content",
+													HorizontalOptions = LayoutOptions.Center,
+													VerticalOptions = LayoutOptions.Center
+												}
+											}
+										}
+									}
+								};
+									Items.Add(_dynamicTab);
+								})
+	},                          }
 							}
 						}
 					}
 				}
-			}
 		};
 
 		Items.Add(tab1);

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32995.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32995.cs
@@ -1,4 +1,3 @@
-#if TEST_FAILS_ON_WINDOWS // Issue Link : https://github.com/dotnet/maui/issues/34738
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -23,4 +22,3 @@ public class Issue32995 : _IssuesUITest
 		VerifyScreenshot("EnabledTabWithNormalColor");
 	}
 }
-#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32995.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32995.cs
@@ -21,4 +21,27 @@ public class Issue32995 : _IssuesUITest
 		App.WaitForElement("Tab2");
 		VerifyScreenshot("EnabledTabWithNormalColor");
 	}
+
+	// Regression test for Windows: verifies that a tab added dynamically after appearance
+	// is already applied correctly inherits TabBarDisabledColor. Without the fix in
+	// ShellItemHandler.SetValues (setting DisabledForeground before IsEnabled), the new
+	// tab's NavigationViewItemViewModel.UpdateForeground() fires with DisabledForeground=null
+	// and falls back to the default unselected color instead of the custom disabled color.
+#if WINDOWS
+	[Test]
+	[Category(UITestCategories.Shell)]
+	public void DynamicallyAddedDisabledTabInheritsTabBarDisabledColor()
+	{
+		App.WaitForElement("AddDisabledTabButton");
+		App.Tap("AddDisabledTabButton");
+
+		// Wait for the new tab to appear in the navigation bar
+		App.WaitForElement("Tab3");
+
+		// The dynamically added Tab3 is disabled with TabBarDisabledColor = Green.
+		// Without the fix, DisabledForeground is null when IsEnabled.set fires
+		// UpdateForeground(), so Tab3 renders with the default unselected color instead of green.
+		VerifyScreenshot("DynamicallyAddedDisabledTabWithGreenColor");
+	}
+#endif
 }

--- a/src/Core/src/Platform/Windows/NavigationViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/NavigationViewExtensions.cs
@@ -141,6 +141,33 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
+		internal static void UpdateTopNavigationViewItemDisabledColor(this MauiNavigationView navigationView, Paint? paint)
+		{
+			var brush = paint?.ToPlatform();
+
+			if (navigationView.TopNavArea is not null)
+			{
+				if (brush is null)
+				{
+					navigationView.TopNavArea.Resources.Remove("TopNavigationViewItemForegroundDisabled");
+				}
+				else
+				{
+					navigationView.TopNavArea.Resources["TopNavigationViewItemForegroundDisabled"] = brush;
+				}
+
+				navigationView.TopNavArea.RefreshThemeResources();
+			}
+
+			if (navigationView.MenuItemsSource is IList<NavigationViewItemViewModel> items)
+			{
+				foreach (var item in items)
+				{
+					item.DisabledForeground = brush;
+				}
+			}
+		}
+
 		public static void UpdateTopNavigationViewItemBackgroundUnselectedColor(this MauiNavigationView navigationView, Paint? paint)
 		{
 			var brush = paint?.ToPlatform();

--- a/src/Core/src/Platform/Windows/NavigationViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/NavigationViewExtensions.cs
@@ -147,13 +147,21 @@ namespace Microsoft.Maui.Platform
 
 			if (navigationView.TopNavArea is not null)
 			{
-				if (brush is null)
+				if (brush is not null)
 				{
-					navigationView.TopNavArea.Resources.Remove("TopNavigationViewItemForegroundDisabled");
+					// Set both unselected-disabled and selected-disabled keys so the custom color
+					// applies regardless of whether the disabled tab is currently selected.
+					navigationView.TopNavArea.Resources["TopNavigationViewItemForegroundDisabled"] = brush;
+					navigationView.TopNavArea.Resources["TopNavigationViewItemForegroundSelectedDisabled"] = brush;
 				}
 				else
 				{
-					navigationView.TopNavArea.Resources["TopNavigationViewItemForegroundDisabled"] = brush;
+					// When no disabled color is configured, only clear the selected-disabled key
+					// (which we own). Do NOT remove TopNavigationViewItemForegroundDisabled —
+					// UpdateTopNavigationViewItemTextColor may have set it as a fallback and
+					// removing it would revert disabled tabs to the WinUI system default, which
+					// is a regression for apps using TabBarUnselectedColor without TabBarDisabledColor.
+					navigationView.TopNavArea.Resources.Remove("TopNavigationViewItemForegroundSelectedDisabled");
 				}
 
 				navigationView.TopNavArea.RefreshThemeResources();

--- a/src/Core/src/Platform/Windows/NavigationViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/NavigationViewExtensions.cs
@@ -164,6 +164,14 @@ namespace Microsoft.Maui.Platform
 				foreach (var item in items)
 				{
 					item.DisabledForeground = brush;
+
+					if (item.MenuItemsSource is { } subItems)
+					{
+						foreach (var subItem in subItems)
+						{
+							subItem.DisabledForeground = brush;
+						}
+					}
 				}
 			}
 		}

--- a/src/Core/src/Platform/Windows/NavigationViewItemViewModel.cs
+++ b/src/Core/src/Platform/Windows/NavigationViewItemViewModel.cs
@@ -104,7 +104,14 @@ namespace Microsoft.Maui.Platform
 		public WIconElement? Icon
 		{
 			get { return _icon; }
-			set { this.SetProperty(ref _icon, value, OnPropertyChanged); }
+			set
+			{
+				this.SetProperty(ref _icon, value, OnPropertyChanged);
+				// After the binding fires (and WinUI applies its initial visual-state transitions),
+				// re-apply the current Foreground to the new icon element so the custom disabled
+				// color isn't overridden by WinUI's default Disabled visual state.
+				UpdateForeground();
+			}
 		}
 
 		public WBrush? Foreground

--- a/src/Core/src/Platform/Windows/NavigationViewItemViewModel.cs
+++ b/src/Core/src/Platform/Windows/NavigationViewItemViewModel.cs
@@ -89,6 +89,7 @@ namespace Microsoft.Maui.Platform
 		WBrush? _selectedTitleColor;
 		WBrush? _unselectedTitleColor;
 		WBrush? _unselectedForeground;
+		WBrush? _disabledForeground;
 		WBrush? _iconColor;
 		ObservableCollection<NavigationViewItemViewModel>? _menuItemsSource;
 		WIconElement? _icon;
@@ -108,7 +109,7 @@ namespace Microsoft.Maui.Platform
 
 		public WBrush? Foreground
 		{
-			get => IconColor ?? (IsSelected ? SelectedForeground : UnselectedForeground);
+			get => IconColor ?? (!IsEnabled && DisabledForeground is not null ? DisabledForeground : (IsSelected ? SelectedForeground : UnselectedForeground));
 		}
 
 		public WBrush? Background
@@ -204,6 +205,16 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
+		public WBrush? DisabledForeground
+		{
+			get => _disabledForeground;
+			set
+			{
+				_disabledForeground = value;
+				UpdateForeground();
+			}
+		}
+
 		void UpdateForeground()
 		{
 			OnPropertyChanged(nameof(Foreground));
@@ -242,6 +253,7 @@ namespace Microsoft.Maui.Platform
 				{
 					_isEnabled = value;
 					OnPropertyChanged(nameof(IsEnabled));
+					UpdateForeground();
 				}
 			}
 		}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details:

- When a Tab is disabled (IsEnabled = false), the TabBarDisabledColor property is expected to change the icon and text color of the disabled Tab. On windows the TabBarDisabledColor is not applied, and the TabBar continues to use the default system disabled color.

- Additionally, on the initial load, only the tab text appeared disabled while the tab icon continued to display with the enabled color until a later update.


### Root Cause:
**Missing TabBarDisabledColor application**

- UpdateAppearance() never propagated EffectiveTabBarDisabledColor to the native WinUI controls, so the configured TabBarDisabledColor was ignored and the default system disabled color was used instead.

**Incorrect initial disabled icon color**

- During SetValues(), IsEnabled was assigned before the disabled foreground brush. As a result, UpdateForeground()executed before DisabledForeground was available, causing the icon to use the default foreground.
- In addition, WinUI applies its Disabled visual state immediately when IsEnabled changes, which could override the custom icon foreground during the initial load.

### Description of change:

- Added UpdateTopNavigationViewItemDisabledColor() to apply the disabled text color through the WinUI TopNavigationViewItemForegroundDisabled theme resource and propagate the disabled foreground brush to existing NavigationViewItemViewModel instances.
- Added a DisabledForeground property to NavigationViewItemViewModel and updated the foreground logic to use it whenever the item is disabled.
- Updated the icon setter to reapply the foreground after the icon element is created, ensuring the custom disabled color overrides WinUI's initial visual-state transition.
- Updated ShellItemHandler.Windows so UpdateAppearance() applies the disabled color, and reordered SetValues() to assign DisabledForeground before IsEnabled, ensuring the correct brush is available when the disabled state is applied.


### Validated the behavior in the following platforms
- [ ] Android
- [x] Windows
- [ ] iOS
- [ ] Mac

### Fixes
Fixes #34738 

### Screenshots
| Before  | After |
|---------|--------|
|  <img width="1250" height="907" src="https://github.com/user-attachments/assets/c8980378-7f4c-414d-ba68-d1760f24c8f6"> |   <img width="1250" height="907" src="https://github.com/user-attachments/assets/9a5a6a5f-2301-4d75-95f8-27306c97072e">  |