### PR TITLE
[Net 11]Fix SwipeItemView command leak

### DIFF
--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -117,3 +117,4 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
 ~virtual Microsoft.Maui.Controls.Platform.Compatibility.ShellItemRenderer.UpdateShellSectionBadge(Microsoft.Maui.Controls.ShellSection shellSection, int index) -> void
+override Microsoft.Maui.Controls.SwipeItemView.IsEnabledCore.get -> bool

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 *REMOVED*~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
 *REMOVED*~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> System.Collections.Generic.IList<Microsoft.Maui.Controls.VisualStateGroup>
 Microsoft.Maui.Controls.AppThemeBinding
@@ -109,3 +109,4 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
+override Microsoft.Maui.Controls.SwipeItemView.IsEnabledCore.get -> bool

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 *REMOVED*~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
 *REMOVED*~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> System.Collections.Generic.IList<Microsoft.Maui.Controls.VisualStateGroup>
 Microsoft.Maui.Controls.AppThemeBinding
@@ -109,3 +109,4 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
+override Microsoft.Maui.Controls.SwipeItemView.IsEnabledCore.get -> bool

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -27,6 +27,7 @@ Microsoft.Maui.Controls.LongPressingEventArgs.LongPressingEventArgs(Microsoft.Ma
 Microsoft.Maui.Controls.LongPressingEventArgs.Status.get -> Microsoft.Maui.GestureStatus
 Microsoft.Maui.Controls.Span.InvalidateStyle() -> void
 Microsoft.Maui.Controls.StyleableElement.InvalidateStyle() -> void
+override Microsoft.Maui.Controls.SwipeItemView.IsEnabledCore.get -> bool
 override Microsoft.Maui.Controls.GraphicsView.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void
 override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -99,3 +99,4 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
+override Microsoft.Maui.Controls.SwipeItemView.IsEnabledCore.get -> bool

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -90,3 +90,4 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
+override Microsoft.Maui.Controls.SwipeItemView.IsEnabledCore.get -> bool

--- a/src/Controls/src/Core/SwipeView/SwipeItemView.cs
+++ b/src/Controls/src/Core/SwipeView/SwipeItemView.cs
@@ -2,6 +2,7 @@
 using System;
 using System.ComponentModel;
 using System.Windows.Input;
+using Microsoft.Maui.Controls.Internals;
 
 namespace Microsoft.Maui.Controls
 {
@@ -9,16 +10,21 @@ namespace Microsoft.Maui.Controls
 	/// Represents a swipe item that displays custom content in a <see cref="SwipeView"/>.
 	/// </summary>
 	[ContentProperty(nameof(Content))]
-	public partial class SwipeItemView : ContentView, Controls.ISwipeItem, Maui.ISwipeItemView
+	public partial class SwipeItemView : ContentView, Controls.ISwipeItem, Maui.ISwipeItemView, ICommandElement
 	{
 		/// <summary>Bindable property for <see cref="Command"/>.</summary>
 		public static readonly BindableProperty CommandProperty = BindableProperty.Create(nameof(Command), typeof(ICommand), typeof(SwipeItemView), null,
-			propertyChanging: (bo, o, n) => ((SwipeItemView)bo).OnCommandChanging(),
-			propertyChanged: (bo, o, n) => ((SwipeItemView)bo).OnCommandChanged());
+			propertyChanging: CommandElement.OnCommandChanging,
+			propertyChanged: CommandElement.OnCommandChanged);
 
 		/// <summary>Bindable property for <see cref="CommandParameter"/>.</summary>
 		public static readonly BindableProperty CommandParameterProperty = BindableProperty.Create(nameof(CommandParameter), typeof(object), typeof(SwipeItemView), null,
-			propertyChanged: (bo, o, n) => ((SwipeItemView)bo).OnCommandParameterChanged());
+			propertyChanged: CommandElement.OnCommandParameterChanged);
+
+		static SwipeItemView()
+		{
+			CommandProperty.DependsOn(CommandParameterProperty);
+		}
 
 		/// <summary>
 		/// Gets or sets the command invoked when this swipe item is activated. This is a bindable property.
@@ -52,35 +58,12 @@ namespace Microsoft.Maui.Controls
 			Invoked?.Invoke(this, EventArgs.Empty);
 		}
 
-		void OnCommandChanged()
-		{
-			IsEnabled = Command?.CanExecute(CommandParameter) ?? true;
+		protected override bool IsEnabledCore =>
+			base.IsEnabledCore && CommandElement.GetCanExecute(this, CommandProperty);
 
-			if (Command == null)
-				return;
+		void ICommandElement.CanExecuteChanged(object sender, EventArgs e) =>
+			RefreshIsEnabledProperty();
 
-			Command.CanExecuteChanged += OnCommandCanExecuteChanged;
-		}
-
-		void OnCommandChanging()
-		{
-			if (Command == null)
-				return;
-
-			Command.CanExecuteChanged -= OnCommandCanExecuteChanged;
-		}
-
-		void OnCommandParameterChanged()
-		{
-			if (Command == null)
-				return;
-
-			IsEnabled = Command.CanExecute(CommandParameter);
-		}
-
-		void OnCommandCanExecuteChanged(object sender, EventArgs eventArgs)
-		{
-			IsEnabled = Command.CanExecute(CommandParameter);
-		}
+		WeakCommandSubscription ICommandElement.CleanupTracker { get; set; }
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/CommandTests.cs
+++ b/src/Controls/tests/Core.UnitTests/CommandTests.cs
@@ -271,6 +271,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[InlineData(typeof(SearchBar), false)]
 		[InlineData(typeof(SearchHandler), true)]
 		[InlineData(typeof(SearchHandler), false)]
+		[InlineData(typeof(SwipeItemView), true)]
+		[InlineData(typeof(SwipeItemView), false)]
 		public async Task CommandsSubscribedToCanExecuteCollect(Type controlType, bool useWeakEventHandler)
 		{
 			// Create a view model with a Command
@@ -309,6 +311,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 					case SearchHandler sh:
 						sh.Command = command;
 						sh.ClearPlaceholderCommand = command;
+						break;
+					case SwipeItemView siv:
+						siv.Command = command;
 						break;
 				}
 

--- a/src/Controls/tests/Core.UnitTests/SwipeViewTests.cs
+++ b/src/Controls/tests/Core.UnitTests/SwipeViewTests.cs
@@ -415,6 +415,41 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public void SwipeItemViewCommandCanExecuteUpdatesIsEnabled()
+		{
+			var expectedParameter = new object();
+			var canExecute = false;
+			var command = new Command(
+				_ => { },
+				parameter => canExecute && ReferenceEquals(parameter, expectedParameter));
+			var swipeItemView = new SwipeItemView
+			{
+				CommandParameter = expectedParameter,
+				Command = command
+			};
+
+			Assert.False(swipeItemView.IsEnabled);
+
+			canExecute = true;
+			command.ChangeCanExecute();
+
+			Assert.True(swipeItemView.IsEnabled);
+
+			swipeItemView.CommandParameter = new object();
+
+			Assert.False(swipeItemView.IsEnabled);
+
+			swipeItemView.CommandParameter = expectedParameter;
+
+			Assert.True(swipeItemView.IsEnabled);
+
+			swipeItemView.IsEnabled = false;
+			command.ChangeCanExecute();
+
+			Assert.False(swipeItemView.IsEnabled);
+		}
+
+		[Fact]
 		public void SwipeItemsRemainInLogicalTreeWhenContentIsSet()
 		{
 			var swipeView = new SwipeView();


### PR DESCRIPTION
Fixes a memory leak in `SwipeItemView.Command` where assigning a long-lived `ICommand` caused each `SwipeItemView` to be retained through a direct `CanExecuteChanged` subscription.

The retained graph could keep row content, command parameters, binding contexts, and row view models alive after the containing page was closed.

This changes `SwipeItemView` to use the existing `ICommandElement` / `WeakCommandSubscription` infrastructure used by other command-backed controls. It also moves command enablement into `IsEnabledCore`, so explicit `IsEnabled=false`, parent disabled state, and `Command.CanExecute` are composed consistently.

Fixes #35498

## Testing

- `dotnet test src/Controls/tests/Core.UnitTests/Controls.Core.UnitTests.csproj --filter "FullyQualifiedName~CommandTests|FullyQualifiedName~SwipeViewTests"`
- `dotnet build Microsoft.Maui.BuildTasks.slnf`
- Verified the #35498 iOS repro after forced rebuild:
  - `SwipeItemViewCommand`: `commandSubscribers=0`, `aliveRows=0`, `retainedPayloadBytes=0`
- Verified the #35498 Android repro after forced rebuild:
  - `SwipeItemViewCommand` no longer retains all 1,000 rows / 125 MiB and drops to the Android platform baseline