### PR TITLE
[Windows] Throws ArgumentOutOfRangeException on WinUI when setting MaximumDate to null

### DIFF
--- a/src/Core/src/Platform/Windows/DatePickerExtensions.cs
+++ b/src/Core/src/Platform/Windows/DatePickerExtensions.cs
@@ -50,7 +50,17 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateMaximumDate(this CalendarDatePicker platformDatePicker, IDatePicker datePicker)
 		{
-			platformDatePicker.MaxDate = datePicker?.MaximumDate ?? DateTime.MaxValue;
+			if (datePicker?.MaximumDate is not null)
+			{
+				platformDatePicker.MaxDate = datePicker.MaximumDate.Value;
+			}
+			else
+			{
+				// DateTime.MaxValue cannot be safely converted to DateTimeOffset in negative UTC timezones
+				// (e.g. UTC-8) because the implicit conversion adds the local offset, causing an overflow.
+				// Mirror the MinDate pattern by jumping 100 years forward instead.
+				platformDatePicker.MaxDate = DateTime.Now.AddYears(100);
+			}
 		}
 
 		public static void UpdateCharacterSpacing(this CalendarDatePicker platformDatePicker, IDatePicker datePicker)


### PR DESCRIPTION

<!-- Please keep the note below for people who find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment whether this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
This pull request updates how the maximum date is set for the `CalendarDatePicker` on Windows to handle edge cases with time zone conversions. Instead of using `DateTime.MaxValue` when no maximum date is provided, it now sets the maximum date to 100 years from the current date to avoid overflow errors in negative UTC timezones.
### Description of Change

Previously, `UpdateMaximumDate` used `DateTime.MaxValue` as the fallback value. In negative UTC offset time zones, the control internally converts the value to UTC, which can exceed the supported `DateTime` range and result in an overflow exception.

To avoid this, the fallback maximum date is now set to 100 years from the current date instead of `DateTime.MaxValue`. This provides a practical upper bound while preventing overflow during time zone conversion.

<!-- Enter description of the fix in this section -->
### Why Tests not added : 

This scenario requires the operating system time zone to be configured with a negative UTC offset.

Since changing the system time zone is an OS-level operation and cannot be reliably automated within our test environment, a regression test was not added.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #35785 

### Tested the behavior in the following platforms

- [x] Windows
- [ ] Android
- [ ] iOS
- [ ] Mac

### ScreenShots : 
| Before Fix | After Fix |
|--------------------------|---------------------------|
| <img width="1486" height="987" alt="Screenshot 2026-06-07 224451" src="https://github.com/user-attachments/assets/63a47d34-1d38-4b70-b91d-1110c9ff9e7d" /> | <img width="1671" height="1023" alt="Screenshot 2026-06-08 041246" src="https://github.com/user-attachments/assets/29ad3526-f51e-424c-b516-ad720dfc9e28" />  |
<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
