### PR TITLE
Fix Windows Shell tests failure in June 8 Candidate

### DIFF
--- a/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Windows.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Maui.Controls.Handlers
 
 		StackNavigationManager? _navigationManager;
 		WeakReference? _lastShell;
+		List<ShellContent>? _subscribedItems;
 
 		public ShellSectionHandler() : base(Mapper, CommandMapper)
 		{
@@ -67,6 +68,7 @@ namespace Microsoft.Maui.Controls.Handlers
 					shell.RemoveAppearanceObserver(this);
 				}
 				_lastShell = null;
+				_subscribedItems?.Clear();
 			}
 
 			// If we've already connected to the navigation manager
@@ -88,12 +90,16 @@ namespace Microsoft.Maui.Controls.Handlers
 			_shellSection = (ShellSection)view;
 			if (_shellSection != null)
 			{
+				_subscribedItems ??= new HashSet<ShellContent>();
+				_subscribedItems.Clear();
+
 				((IShellSectionController)_shellSection).NavigationRequested += OnNavigationRequested;
 				((IShellSectionController)_shellSection).ItemsCollectionChanged += OnItemsCollectionChanged;
 
 				foreach (var item in ((IShellSectionController)_shellSection).GetItems())
 				{
 					item.PropertyChanged += OnShellContentPropertyChanged;
+					_subscribedItems.Add(item);
 				}
 
 				var shell = _shellSection.FindParentOfType<Shell>() as IShellController;
@@ -155,26 +161,51 @@ namespace Microsoft.Maui.Controls.Handlers
 
 		void OnItemsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
 		{
-			if (_shellSection is null)
-				return;
-
-			if (e.OldItems != null)
+			if (_shellSection is null || _subscribedItems is null)
 			{
-				foreach (ShellContent item in e.OldItems)
+				return;
+			}
+
+			// Handle Reset action - collection has been completely cleared and refilled
+			if (e.Action == NotifyCollectionChangedAction.Reset)
+			{
+				// Unsubscribe from all previously subscribed items
+				foreach (var item in _subscribedItems)
 				{
 					item.PropertyChanged -= OnShellContentPropertyChanged;
 				}
-			}
-				
+				_subscribedItems.Clear();
 
-			if (e.NewItems != null)
-			{
-				foreach (ShellContent item in e.NewItems)
+				// Subscribe to all items currently in the section
+				foreach (var item in ((IShellSectionController)_shellSection).GetItems())
 				{
 					item.PropertyChanged += OnShellContentPropertyChanged;
+					_subscribedItems.Add(item);
 				}
 			}
-				
+			else
+			{
+				// Handle Remove action
+				if (e.OldItems != null)
+				{
+					foreach (ShellContent item in e.OldItems)
+					{
+						item.PropertyChanged -= OnShellContentPropertyChanged;
+						_subscribedItems.Remove(item);
+					}
+				}
+
+				// Handle Add action
+				if (e.NewItems != null)
+				{
+					foreach (ShellContent item in e.NewItems)
+					{
+						item.PropertyChanged += OnShellContentPropertyChanged;
+						_subscribedItems.Add(item);
+					}
+				}
+			}
+
 			if (_shellSection.Parent is ShellItem shellItem && shellItem.Handler is ShellItemHandler shellItemHandler)
 			{
 				shellItemHandler.MapMenuItems();
@@ -234,6 +265,7 @@ namespace Microsoft.Maui.Controls.Handlers
 				{
 					item.PropertyChanged -= OnShellContentPropertyChanged;
 				}
+				_subscribedItems?.Clear();
 			}
 				
 			_navigationManager?.Disconnect(VirtualView, platformView);

--- a/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Windows.cs
@@ -58,9 +58,13 @@ namespace Microsoft.Maui.Controls.Handlers
 
 				((IShellSectionController)_shellSection).ItemsCollectionChanged -= OnItemsCollectionChanged;
 
-				foreach (var item in ((IShellSectionController)_shellSection).GetItems())
+				if (_subscribedItems != null)
 				{
-					item.PropertyChanged -= OnShellContentPropertyChanged;
+					foreach (var item in _subscribedItems)
+					{
+						item.PropertyChanged -= OnShellContentPropertyChanged;
+					}
+					_subscribedItems.Clear();
 				}
 
 				if (_lastShell?.Target is IShellController shell)
@@ -68,7 +72,6 @@ namespace Microsoft.Maui.Controls.Handlers
 					shell.RemoveAppearanceObserver(this);
 				}
 				_lastShell = null;
-				_subscribedItems?.Clear();
 			}
 
 			// If we've already connected to the navigation manager

--- a/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Windows.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Maui.Controls.Handlers
 			_shellSection = (ShellSection)view;
 			if (_shellSection != null)
 			{
-				_subscribedItems ??= new HashSet<ShellContent>();
+				_subscribedItems ??= new List<ShellContent>();
 				_subscribedItems.Clear();
 
 				((IShellSectionController)_shellSection).NavigationRequested += OnNavigationRequested;

--- a/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Windows.cs
@@ -53,10 +53,14 @@ namespace Microsoft.Maui.Controls.Handlers
 		{
 			if (_shellSection != null)
 			{
-				((IShellSectionController)_shellSection).RemoveDisplayedPageObserver(this);
 				((IShellSectionController)_shellSection).NavigationRequested -= OnNavigationRequested;
 
 				((IShellSectionController)_shellSection).ItemsCollectionChanged -= OnItemsCollectionChanged;
+
+				foreach (var item in ((IShellSectionController)_shellSection).GetItems())
+				{
+					item.PropertyChanged -= OnShellContentPropertyChanged;
+				}
 
 				if (_lastShell?.Target is IShellController shell)
 				{
@@ -87,39 +91,60 @@ namespace Microsoft.Maui.Controls.Handlers
 				((IShellSectionController)_shellSection).NavigationRequested += OnNavigationRequested;
 				((IShellSectionController)_shellSection).ItemsCollectionChanged += OnItemsCollectionChanged;
 
+				foreach (var item in ((IShellSectionController)_shellSection).GetItems())
+				{
+					item.PropertyChanged += OnShellContentPropertyChanged;
+				}
+
 				var shell = _shellSection.FindParentOfType<Shell>() as IShellController;
 				if (shell != null)
 				{
 					_lastShell = new WeakReference(shell);
 					shell.AddAppearanceObserver(this, _shellSection);
 				}
-
-				// AddDisplayedPageObserver immediately invokes the callback with the current page,
-				// but at that point PendingNavigationTask is already set from MapCurrentItem
-				// (which runs via base.SetVirtualView above), so it is safely skipped.
-				((IShellSectionController)_shellSection).AddDisplayedPageObserver(this, OnDisplayedPageChanged);
 			}
 		}
 
-		// Called when ShellSection.DisplayedPage changes — covers both content changes and
-		// navigation pushes. We only act on content changes (stack depth == 1, no pending nav).
-		void OnDisplayedPageChanged(Page page)
+		// Called when ShellContent.Content changes on a specific tab — forces Windows to
+		// rebuild the navigation stack so the new page becomes visible.
+		// Using PropertyChanged on each ShellContent (rather than AddDisplayedPageObserver)
+		// avoids false triggers during tab switches: OnCurrentItemChanged (the BindableProperty
+		// propertyChanged callback) fires BEFORE the handler's MapCurrentItem (which fires via
+		// the PropertyChanged event), so PendingNavigationTask is not yet set when
+		// DisplayedPage changes during a tab switch.
+		void OnShellContentPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
 		{
 			if (VirtualView is null)
+			{
 				return;
+			}
 
-			// Push/pop navigation is handled by OnNavigationRequested; skip those cases.
+			if (e.PropertyName != ShellContent.ContentProperty.PropertyName)
+			{
+				return;
+			}
+
+			if (sender is not ShellContent shellContent)
+			{
+				return;
+			}
+
+			// Only sync when the changed content belongs to the active tab at root level.
+			if (shellContent != VirtualView.CurrentItem)
+			{
+				return;
+			}
+
 			if (VirtualView.Stack.Count > 1)
+			{
 				return;
+			}
 
-			// Tab switches are handled by MapCurrentItem which sets PendingNavigationTask first
-			// (because the property mapper fires before the propertyChanged callback that calls
-			// UpdateDisplayedPage). Skip when another navigation is already in flight.
 			if (VirtualView.PendingNavigationTask != null)
+			{
 				return;
+			}
 
-			// ContentCache has been updated by OnContentChanged at this point, so
-			// SyncNavigationStack will correctly pick up the new page via GetOrCreateContent().
 			SyncNavigationStack(false, null);
 		}
 
@@ -133,6 +158,23 @@ namespace Microsoft.Maui.Controls.Handlers
 			if (_shellSection is null)
 				return;
 
+			if (e.OldItems != null)
+			{
+				foreach (ShellContent item in e.OldItems)
+				{
+					item.PropertyChanged -= OnShellContentPropertyChanged;
+				}
+			}
+				
+
+			if (e.NewItems != null)
+			{
+				foreach (ShellContent item in e.NewItems)
+				{
+					item.PropertyChanged += OnShellContentPropertyChanged;
+				}
+			}
+				
 			if (_shellSection.Parent is ShellItem shellItem && shellItem.Handler is ShellItemHandler shellItemHandler)
 			{
 				shellItemHandler.MapMenuItems();
@@ -187,8 +229,13 @@ namespace Microsoft.Maui.Controls.Handlers
 		protected override void DisconnectHandler(WFrame platformView)
 		{
 			if (_shellSection != null)
-				((IShellSectionController)_shellSection).RemoveDisplayedPageObserver(this);
-
+			{
+				foreach (var item in ((IShellSectionController)_shellSection).GetItems())
+				{
+					item.PropertyChanged -= OnShellContentPropertyChanged;
+				}
+			}
+				
 			_navigationManager?.Disconnect(VirtualView, platformView);
 			base.DisconnectHandler(platformView);
 		}


### PR DESCRIPTION
### Issue Details
Due to PR #34630, some shell tests are failed in the June 8 Candidate

### Description of changes
Replaced AddDisplayedPageObserver with per-ShellContent PropertyChanged subscription filtered to ShellContent.ContentProperty only (same pattern used on iOS). This fires only when the page content actually changes, never on tab switches. Event subscriptions are managed across SetVirtualView, OnItemsCollectionChanged, and DisconnectHandler to handle dynamic tab additions/removals.

### Failed test case
* ObservableCollectionChangeListView 
* NoDuplicateTitleViews[Shell]
* NoDuplicateTitleViews[TitleView]
* NavigatingBackAndForthDoesNotCrash
* NavigatingBackToAlreadySelectedTopTabDoesntCrash
* ShellNavigationFeatureTests - **All test cases except first 3**
* ShellItemItemsClearTests 
* ShellColorsResetOnNavigation 
* TabBarVisibilityShowsOnPage2UsingBinding 
* TabBarVisibilityHidesOnPage2UsingBindingn 
* NavBarUpdatesWhenSwitchingShellContent 
* HideActiveShellContent
* UpdateSearchHandlerMenuItemForTabNavigation 
