### PR TITLE
[Windows] Make Layout AutomationPeer internal + opt-in for screen reader tree

### DIFF
--- a/src/Controls/src/Core/Element/Element.Windows.cs
+++ b/src/Controls/src/Core/Element/Element.Windows.cs
@@ -2,6 +2,9 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation.Peers;
+using NativeAutomationProperties = Microsoft.UI.Xaml.Automation.AutomationProperties;
 
 namespace Microsoft.Maui.Controls
 {
@@ -12,8 +15,28 @@ namespace Microsoft.Maui.Controls
 			if (handler.IsConnectingHandler() && element.GetValue(AutomationProperties.IsInAccessibleTreeProperty) is null)
 				return;
 
-			Platform.AccessibilityExtensions.SetAutomationPropertiesAccessibilityView(
-				handler.PlatformView as Microsoft.UI.Xaml.FrameworkElement, element);
+			if (handler.PlatformView is not FrameworkElement platformView)
+				return;
+
+			var isInAccessibleTree = (bool?)element.GetValue(AutomationProperties.IsInAccessibleTreeProperty);
+			if (isInAccessibleTree == true)
+			{
+				platformView.SetValue(NativeAutomationProperties.AccessibilityViewProperty, AccessibilityView.Content);
+			}
+			else if (isInAccessibleTree == false)
+			{
+				platformView.SetValue(NativeAutomationProperties.AccessibilityViewProperty, AccessibilityView.Raw);
+			}
+			else
+			{
+				// Only clear if this mapper itself previously set the value (Content or Raw).
+				// Preserve any AccessibilityView set externally by platform code or a custom handler.
+				var current = platformView.ReadLocalValue(NativeAutomationProperties.AccessibilityViewProperty);
+				if (current is AccessibilityView.Content or AccessibilityView.Raw)
+				{
+					platformView.ClearValue(NativeAutomationProperties.AccessibilityViewProperty);
+				}
+			}
 		}
 
 		public static void MapAutomationPropertiesLabeledBy(IElementHandler handler, Element element)

--- a/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.Windows.cs
@@ -28,7 +28,6 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.Equal(view.InputTransparent, !handler.PlatformView.IsHitTestVisible);
 			}
 		}
-
 		void SetupLayoutBuilder()
 		{
 			EnsureHandlerCreated(builder =>
@@ -59,8 +58,8 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Fact(DisplayName = "LayoutPanel AutomationPeer control type is Pane")]
-		public async Task LayoutPanelAutomationPeerControlTypeIsPane()
+		[Fact(DisplayName = "LayoutPanel AutomationPeer default control type is Custom with lowercase class name as localized type")]
+		public async Task LayoutPanelAutomationPeerDefaultControlTypeIsCustom()
 		{
 			SetupLayoutBuilder();
 
@@ -69,7 +68,10 @@ namespace Microsoft.Maui.DeviceTests
 			await AttachAndRun(grid, (LayoutHandler handler) =>
 			{
 				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(handler.PlatformView);
-				Assert.Equal(AutomationControlType.Pane, peer.GetAutomationControlType());
+				Assert.Equal(AutomationControlType.Custom, peer.GetAutomationControlType());
+				// UIA spec requires Custom elements to have a non-empty LocalizedControlType.
+				// For anonymous layouts, we return the lowercase cross-platform type name.
+				Assert.Equal("grid", peer.GetLocalizedControlType());
 			});
 		}
 
@@ -104,10 +106,10 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Theory(DisplayName = "LayoutPanel with AutomationId is exposed in automation tree")]
+		[Theory(DisplayName = "LayoutPanel AutomationId is exposed via the automation peer")]
 		[InlineData(true)]
 		[InlineData(false)]
-		public async Task LayoutPanelWithAutomationIdIsExposedInTree(bool hasAutomationId)
+		public async Task LayoutPanelAutomationIdIsExposedViaPeer(bool hasAutomationId)
 		{
 			SetupLayoutBuilder();
 
@@ -118,7 +120,8 @@ namespace Microsoft.Maui.DeviceTests
 			await AttachAndRun(grid, (LayoutHandler handler) =>
 			{
 				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(handler.PlatformView);
-				Assert.Equal(hasAutomationId, peer.IsContentElement());
+				var expected = hasAutomationId ? "TestGrid" : string.Empty;
+				Assert.Equal(expected, peer.GetAutomationId());
 			});
 		}
 
@@ -136,7 +139,139 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Fact(DisplayName = "LayoutPanel IsControlElement and IsContentElement update when AutomationId is set at runtime")]
+		[Fact(DisplayName = "LayoutPanel without automation signals is excluded from Control and Content views")]
+		public async Task LayoutPanelWithoutAutomationSignalsIsExcludedFromControlAndContentViews()
+		{
+			SetupLayoutBuilder();
+
+			var grid = new Grid();
+
+			await AttachAndRun(grid, (LayoutHandler handler) =>
+			{
+				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(handler.PlatformView);
+				Assert.False(peer.IsControlElement());
+				Assert.False(peer.IsContentElement());
+			});
+		}
+
+		[Fact(DisplayName = "LayoutPanel with AutomationId is included in Control view only")]
+		public async Task LayoutPanelWithAutomationIdIsIncludedInControlViewOnly()
+		{
+			SetupLayoutBuilder();
+
+			var grid = new Grid { AutomationId = "TestGrid" };
+
+			await AttachAndRun(grid, (LayoutHandler handler) =>
+			{
+				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(handler.PlatformView);
+
+				Assert.Equal("TestGrid", peer.GetAutomationId());
+				Assert.True(peer.IsControlElement());
+				Assert.False(peer.IsContentElement());
+				Assert.Equal(AutomationControlType.Custom, peer.GetAutomationControlType());
+				// UIA spec requires Custom elements to have a non-empty LocalizedControlType.
+				Assert.Equal("grid", peer.GetLocalizedControlType());
+			});
+		}
+
+		[Fact(DisplayName = "LayoutPanel opts into Control view when AutomationProperties.IsInAccessibleTree is true")]
+		public async Task LayoutPanelOptsIntoControlViewViaIsInAccessibleTree()
+		{
+			SetupLayoutBuilder();
+
+			var grid = new Grid();
+			AutomationProperties.SetIsInAccessibleTree(grid, true);
+
+			await AttachAndRun(grid, (LayoutHandler handler) =>
+			{
+				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(handler.PlatformView);
+				Assert.True(peer.IsControlElement());
+				Assert.True(peer.IsContentElement());
+				Assert.Equal(AutomationControlType.Pane, peer.GetAutomationControlType());
+			});
+		}
+
+		[Fact(DisplayName = "LayoutPanel opts into Control view when SemanticProperties.Description is set")]
+		public async Task LayoutPanelOptsIntoControlViewWhenDescriptionIsSet()
+		{
+			SetupLayoutBuilder();
+
+			var grid = new Grid();
+			SemanticProperties.SetDescription(grid, "Welcome card");
+
+			await AttachAndRun(grid, (LayoutHandler handler) =>
+			{
+				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(handler.PlatformView);
+				Assert.True(peer.IsControlElement());
+				Assert.Equal(AutomationControlType.Pane, peer.GetAutomationControlType());
+			});
+		}
+
+		[Fact(DisplayName = "LayoutPanel opts into Control view when SemanticProperties.Hint is set")]
+		public async Task LayoutPanelOptsIntoControlViewWhenHintIsSet()
+		{
+			SetupLayoutBuilder();
+
+			var grid = new Grid();
+			SemanticProperties.SetHint(grid, "Contains welcome card actions");
+
+			await AttachAndRun(grid, (LayoutHandler handler) =>
+			{
+				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(handler.PlatformView);
+				Assert.True(peer.IsControlElement());
+				Assert.Equal(AutomationControlType.Pane, peer.GetAutomationControlType());
+			});
+		}
+
+		[Fact(DisplayName = "LayoutPanel explicit accessible-tree opt out overrides AutomationId and SemanticProperties.Description")]
+		public async Task LayoutPanelAccessibleTreeOptOutOverridesAutomationIdAndDescription()
+		{
+			SetupLayoutBuilder();
+
+			var grid = new Grid { AutomationId = "TestGrid" };
+			SemanticProperties.SetDescription(grid, "Welcome card");
+			AutomationProperties.SetIsInAccessibleTree(grid, false);
+
+			await AttachAndRun(grid, (LayoutHandler handler) =>
+			{
+				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(handler.PlatformView);
+				Assert.Equal("TestGrid", peer.GetAutomationId());
+				Assert.False(peer.IsControlElement());
+				Assert.False(peer.IsContentElement());
+			});
+		}
+
+		[Fact(DisplayName = "LayoutPanel ignores whitespace-only SemanticProperties.Description")]
+		public async Task LayoutPanelDoesNotOptIntoControlViewWhenDescriptionIsWhitespace()
+		{
+			SetupLayoutBuilder();
+
+			var grid = new Grid();
+			SemanticProperties.SetDescription(grid, "   ");
+
+			await AttachAndRun(grid, (LayoutHandler handler) =>
+			{
+				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(handler.PlatformView);
+				Assert.False(peer.IsControlElement());
+			});
+		}
+
+		[Fact(DisplayName = "LayoutPanel ignores whitespace-only SemanticProperties.Hint")]
+		public async Task LayoutPanelDoesNotOptIntoControlViewWhenHintIsWhitespace()
+		{
+			SetupLayoutBuilder();
+
+			var grid = new Grid();
+			SemanticProperties.SetHint(grid, "   ");
+
+			await AttachAndRun(grid, (LayoutHandler handler) =>
+			{
+				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(handler.PlatformView);
+				Assert.False(peer.IsControlElement());
+			});
+		}
+
+		[Fact(DisplayName = "LayoutPanel AutomationId is exposed via the peer when set at runtime")]
 		public async Task LayoutPanelAutomationPeerUpdatesWhenAutomationIdChangesAtRuntime()
 		{
 			SetupLayoutBuilder();
@@ -147,17 +282,15 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(handler.PlatformView);
 
-				// Initially no AutomationId — should NOT be exposed
-				Assert.False(peer.IsContentElement());
+				// Initially no AutomationId.
+				Assert.Equal(string.Empty, peer.GetAutomationId());
 
-				// Set AutomationId at runtime — should now be exposed.
+				// Set AutomationId at runtime -- peer should reflect the new value.
 				// Note: MAUI AutomationId is write-once (Element.cs enforces this),
-				// so we can only test the transition from unset → set, not set → cleared.
+				// so we can only test the transition from unset -> set, not set -> cleared.
 				grid.AutomationId = "DynamicGrid";
-				Assert.True(peer.IsContentElement());
+				Assert.Equal("DynamicGrid", peer.GetAutomationId());
 			});
 		}
 	}
 }
-
-

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue4715.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue4715.cs
@@ -5,6 +5,114 @@ public class Issue4715 : ContentPage
 {
 	public Issue4715()
 	{
+		// Grid with AutomationId only. This verifies UI tests can find layout containers
+		// by AutomationId without needing explicit accessible-tree opt-in.
+		var testGrid = new Grid
+		{
+			AutomationId = "TestGrid",
+			BackgroundColor = Colors.LightBlue,
+			HeightRequest = 60,
+			Children =
+			{
+				new Label { Text = "Grid", VerticalOptions = LayoutOptions.Center, HorizontalOptions = LayoutOptions.Center }
+			}
+		};
+
+		// VerticalStackLayout with AutomationId and explicit accessible-tree opt-in.
+		var testVerticalStackLayout = new VerticalStackLayout
+		{
+			AutomationId = "TestVerticalStackLayout",
+			BackgroundColor = Colors.LightGreen,
+			Children =
+			{
+				new Label { Text = "VerticalStackLayout", Padding = new Thickness(8) }
+			}
+		};
+		SemanticProperties.SetDescription(testVerticalStackLayout, "Test vertical stack layout");
+		AutomationProperties.SetIsInAccessibleTree(testVerticalStackLayout, true);
+
+		// HorizontalStackLayout with AutomationId and explicit accessible-tree opt-in.
+		var testHorizontalStackLayout = new HorizontalStackLayout
+		{
+			AutomationId = "TestHorizontalStackLayout",
+			BackgroundColor = Colors.LightYellow,
+			Children =
+			{
+				new Label { Text = "HorizontalStackLayout", Padding = new Thickness(8) }
+			}
+		};
+		SemanticProperties.SetDescription(testHorizontalStackLayout, "Test horizontal stack layout");
+		AutomationProperties.SetIsInAccessibleTree(testHorizontalStackLayout, true);
+
+		// FlexLayout with AutomationId and explicit accessible-tree opt-in.
+		var testFlexLayout = new FlexLayout
+		{
+			AutomationId = "TestFlexLayout",
+			BackgroundColor = Colors.LightPink,
+			HeightRequest = 60,
+			Children =
+			{
+				new Label { Text = "FlexLayout", Margin = new Thickness(8) }
+			}
+		};
+		SemanticProperties.SetDescription(testFlexLayout, "Test flex layout");
+		AutomationProperties.SetIsInAccessibleTree(testFlexLayout, true);
+
+		// AbsoluteLayout with AutomationId and explicit accessible-tree opt-in.
+		var testAbsoluteLayout = new AbsoluteLayout
+		{
+			AutomationId = "TestAbsoluteLayout",
+			BackgroundColor = Colors.LightSteelBlue,
+			HeightRequest = 60,
+			Children =
+			{
+				new Label
+				{
+					Text = "AbsoluteLayout",
+					Margin = new Thickness(8)
+				}
+			}
+		};
+		SemanticProperties.SetDescription(testAbsoluteLayout, "Test absolute layout");
+		AutomationProperties.SetIsInAccessibleTree(testAbsoluteLayout, true);
+
+		// Nested layout — outer has AutomationId and explicit accessible-tree opt-in, inner is anonymous.
+		var testNestedOuterGrid = new Grid
+		{
+			AutomationId = "TestNestedOuterGrid",
+			BackgroundColor = Colors.Lavender,
+			HeightRequest = 80,
+			Children =
+			{
+				new VerticalStackLayout
+				{
+					// No AutomationId — anonymous inner layout
+					Children =
+					{
+						new Label { Text = "Nested: Outer Grid (named)", HorizontalOptions = LayoutOptions.Center },
+						new Label { Text = "Inner VerticalStackLayout (anonymous)", HorizontalOptions = LayoutOptions.Center, FontSize = 11 }
+					}
+				}
+			}
+		};
+		SemanticProperties.SetDescription(testNestedOuterGrid, "Test nested outer grid layout");
+		AutomationProperties.SetIsInAccessibleTree(testNestedOuterGrid, true);
+
+		// Layout with an AutomationId but an explicit accessible-tree opt-out (IsInAccessibleTree="False").
+		// The Raw opt-out removes it from the UIA Control view, so Appium must NOT be able to find it by
+		// its AutomationId — proving the explicit opt-out takes precedence over the AutomationId test hook.
+		var testOptedOutGrid = new Grid
+		{
+			AutomationId = "OptedOutGrid",
+			BackgroundColor = Colors.LightGray,
+			HeightRequest = 60,
+			Children =
+			{
+				new Label { Text = "Opted-out Grid (IsInAccessibleTree=False)", VerticalOptions = LayoutOptions.Center, HorizontalOptions = LayoutOptions.Center }
+			}
+		};
+		AutomationProperties.SetIsInAccessibleTree(testOptedOutGrid, false);
+
 		var scrollView = new ScrollView
 		{
 			Content = new VerticalStackLayout
@@ -20,99 +128,13 @@ public class Issue4715 : ContentPage
 						FontAttributes = FontAttributes.Bold,
 						AutomationId = "PageTitle"
 					},
-
-					// Grid with AutomationId
-					new Grid
-					{
-						AutomationId = "TestGrid",
-						BackgroundColor = Colors.LightBlue,
-						HeightRequest = 60,
-						Children =
-						{
-							new Label { Text = "Grid", VerticalOptions = LayoutOptions.Center, HorizontalOptions = LayoutOptions.Center }
-						}
-					},
-
-					// VerticalStackLayout with AutomationId
-					new VerticalStackLayout
-					{
-						AutomationId = "TestVerticalStackLayout",
-						BackgroundColor = Colors.LightGreen,
-						Children =
-						{
-							new Label { Text = "VerticalStackLayout", Padding = new Thickness(8) }
-						}
-					},
-
-					// HorizontalStackLayout with AutomationId
-					new HorizontalStackLayout
-					{
-						AutomationId = "TestHorizontalStackLayout",
-						BackgroundColor = Colors.LightYellow,
-						Children =
-						{
-							new Label { Text = "HorizontalStackLayout", Padding = new Thickness(8) }
-						}
-					},
-
-					// FlexLayout with AutomationId
-					new FlexLayout
-					{
-						AutomationId = "TestFlexLayout",
-						BackgroundColor = Colors.LightPink,
-						HeightRequest = 60,
-						Children =
-						{
-							new Label { Text = "FlexLayout", Margin = new Thickness(8) }
-						}
-					},
-
-					// AbsoluteLayout with AutomationId
-					new AbsoluteLayout
-					{
-						AutomationId = "TestAbsoluteLayout",
-						BackgroundColor = Colors.LightSteelBlue,
-						HeightRequest = 60,
-						Children =
-						{
-							new Label
-							{
-								Text = "AbsoluteLayout",
-								Margin = new Thickness(8)
-							}
-						}
-					},
-
-					// Nested layout — outer has AutomationId, inner is anonymous
-					new Grid
-					{
-						AutomationId = "TestNestedOuterGrid",
-						BackgroundColor = Colors.Lavender,
-						HeightRequest = 80,
-						Children =
-						{
-							new VerticalStackLayout
-							{
-								// No AutomationId — anonymous inner layout
-								Children =
-								{
-									new Label { Text = "Nested: Outer Grid (named)", HorizontalOptions = LayoutOptions.Center },
-									new Label { Text = "Inner VerticalStackLayout (anonymous)", HorizontalOptions = LayoutOptions.Center, FontSize = 11 }
-								}
-							}
-						}
-					},
-
-					// Anonymous layout — no AutomationId, should NOT be found by Appium
-					new Grid
-					{
-						BackgroundColor = Colors.LightGray,
-						HeightRequest = 60,
-						Children =
-						{
-							new Label { Text = "Anonymous Grid (no AutomationId)", VerticalOptions = LayoutOptions.Center, HorizontalOptions = LayoutOptions.Center }
-						}
-					},
+					testGrid,
+					testVerticalStackLayout,
+					testHorizontalStackLayout,
+					testFlexLayout,
+					testAbsoluteLayout,
+					testNestedOuterGrid,
+					testOptedOutGrid,
 
 					// Sentinel label to confirm page has loaded
 					new Label

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue4715.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue4715.cs
@@ -11,72 +11,85 @@ public class Issue4715 : _IssuesUITest
 	public override string Issue => "[Windows] Layout containers not visible to UI automation";
 
 	[Test]
-	[Category(UITestCategories.Layout)]
-	public void GridWithAutomationIdIsFoundByAppium()
+	[Category(UITestCategories.Accessibility)]
+	public void GridWithAutomationIdOnlyIsFoundByAppium()
 	{
 		App.WaitForElement("WaitForStubControl");
 
-		// Grid with AutomationId must be visible in the UIA tree
+		// AutomationId-only layouts must remain visible to Windows UI tests.
 		App.WaitForElement("TestGrid");
 	}
 
 	[Test]
-	[Category(UITestCategories.Layout)]
-	public void VerticalStackLayoutWithAutomationIdIsFoundByAppium()
+	[Category(UITestCategories.Accessibility)]
+	public void VerticalStackLayoutWithAccessibleTreeOptInIsFoundByAppium()
 	{
 		App.WaitForElement("WaitForStubControl");
 
-		// VerticalStackLayout with AutomationId must be visible in the UIA tree
+		// VerticalStackLayout with explicit accessible-tree opt-in must be visible in the UIA tree.
 		App.WaitForElement("TestVerticalStackLayout");
 	}
 
 	[Test]
-	[Category(UITestCategories.Layout)]
-	public void HorizontalStackLayoutWithAutomationIdIsFoundByAppium()
+	[Category(UITestCategories.Accessibility)]
+	public void HorizontalStackLayoutWithAccessibleTreeOptInIsFoundByAppium()
 	{
 		App.WaitForElement("WaitForStubControl");
 
-		// HorizontalStackLayout with AutomationId must be visible in the UIA tree
+		// HorizontalStackLayout with explicit accessible-tree opt-in must be visible in the UIA tree.
 		App.WaitForElement("TestHorizontalStackLayout");
 	}
 
 	[Test]
-	[Category(UITestCategories.Layout)]
-	public void FlexLayoutWithAutomationIdIsFoundByAppium()
+	[Category(UITestCategories.Accessibility)]
+	public void FlexLayoutWithAccessibleTreeOptInIsFoundByAppium()
 	{
 		App.WaitForElement("WaitForStubControl");
 
-		// FlexLayout with AutomationId must be visible in the UIA tree
+		// FlexLayout with explicit accessible-tree opt-in must be visible in the UIA tree.
 		App.WaitForElement("TestFlexLayout");
 	}
 
 	[Test]
-	[Category(UITestCategories.Layout)]
-	public void AbsoluteLayoutWithAutomationIdIsFoundByAppium()
+	[Category(UITestCategories.Accessibility)]
+	public void AbsoluteLayoutWithAccessibleTreeOptInIsFoundByAppium()
 	{
 		App.WaitForElement("WaitForStubControl");
 
-		// AbsoluteLayout with AutomationId must be visible in the UIA tree
+		// AbsoluteLayout with explicit accessible-tree opt-in must be visible in the UIA tree.
 		App.WaitForElement("TestAbsoluteLayout");
 	}
 
 	[Test]
-	[Category(UITestCategories.Layout)]
-	public void NestedOuterLayoutWithAutomationIdIsFoundByAppium()
+	[Category(UITestCategories.Accessibility)]
+	public void NestedOuterLayoutWithAccessibleTreeOptInIsFoundByAppium()
 	{
 		App.WaitForElement("WaitForStubControl");
 
-		// Outer nested Grid with AutomationId must be visible
+		// Outer nested Grid with explicit accessible-tree opt-in must be visible.
 		App.WaitForElement("TestNestedOuterGrid");
 	}
 
 	[Test]
-	[Category(UITestCategories.Layout)]
-	public void AnonymousLayoutWithoutAutomationIdIsNotFoundByAppium()
+	[Category(UITestCategories.Accessibility)]
+	public void LayoutWithAccessibleTreeOptOutIsNotFoundByAppium()
 	{
+		// Removing an AutomationId-bearing element from the accessibility tree via
+		// IsInAccessibleTree="False" hides it from the Windows UIA Control view, so Appium can no
+		// longer find it. This is Windows-specific behavior: on other platforms an element keeps its
+		// AutomationId/AccessibilityIdentifier and stays discoverable by Appium regardless of the
+		// accessible-tree opt-out, so this assertion only holds on Windows.
+		if (Device != TestDevice.Windows)
+		{
+			Assert.Ignore("Accessible-tree opt-out from the UIA Control view is Windows-specific behavior.");
+		}
+
 		App.WaitForElement("WaitForStubControl");
 
-		// Anonymous Grid (no AutomationId) must NOT be found in the UIA tree
-		App.WaitForNoElement("Anonymous Grid");
+		// A layout with an AutomationId but an explicit IsInAccessibleTree="False" opts out of the
+		// UIA Control view. Appium must NOT find it by its AutomationId, proving the Raw opt-out takes
+		// precedence over the AutomationId discoverability hook. Anonymous (no-AutomationId) layout
+		// exclusion is covered authoritatively by the LayoutPanel device tests.
+		App.WaitForNoElement("OptedOutGrid");
 	}
 }

--- a/src/Core/src/Platform/Windows/LayoutPanel.cs
+++ b/src/Core/src/Platform/Windows/LayoutPanel.cs
@@ -13,6 +13,9 @@ namespace Microsoft.Maui.Platform
 		Canvas? _backgroundLayer;
 		public bool ClipsToBounds { get; set; }
 
+		// Creates a MauiLayoutAutomationPeer so a Layout's AutomationId is visible to UI Automation
+		// clients while keeping anonymous layouts out of the screen-reader tree. On net10/main the peer
+		// is internal; the net11 version (https://github.com/dotnet/maui/pull/35597) makes it public.
 		protected override AutomationPeer OnCreateAutomationPeer()
 		{
 			return new MauiLayoutAutomationPeer(this);

--- a/src/Core/src/Platform/Windows/MauiLayoutAutomationPeer.cs
+++ b/src/Core/src/Platform/Windows/MauiLayoutAutomationPeer.cs
@@ -5,7 +5,11 @@ using Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.Maui.Platform
 {
-	// TODO: Make this class public in .NET11.0
+	// NOTE: This type is intentionally `internal` on net10/main, because the `main` branch does not
+	// accept new public API. The net11 counterpart of this change —
+	// https://github.com/dotnet/maui/pull/35597 — makes MauiLayoutAutomationPeer public (class +
+	// constructor + the protected overrides) and adds the matching net-windows PublicAPI entries.
+	// When this flows forward to net11, promote this type and its constructor to public to match #35597.
 	internal partial class MauiLayoutAutomationPeer : FrameworkElementAutomationPeer
 	{
 		internal MauiLayoutAutomationPeer(LayoutPanel owner) : base(owner) { }
@@ -23,31 +27,131 @@ namespace Microsoft.Maui.Platform
 			return nameof(Panel);
 		}
 
-		// Layouts are structural containers — AutomationControlType.Pane signals to screen readers
-		// that this is a grouping/container element, not an interactive control.
+		// Layouts with accessibility semantics use Pane to signal a grouping/container element.
+		// AutomationId-only layouts remain discoverable to Windows UI automation, but report as
+		// Custom so screen readers do not announce them as meaningful groups.
 		protected override AutomationControlType GetAutomationControlTypeCore()
 		{
-			return AutomationControlType.Pane;
+			return HasAccessibilitySemantics()
+				? AutomationControlType.Pane
+				: AutomationControlType.Custom;
+		}
+
+		protected override string GetLocalizedControlTypeCore()
+		{
+			if (HasAccessibilitySemantics())
+			{
+				return base.GetLocalizedControlTypeCore() ?? string.Empty;
+			}
+
+			// AutomationId-only layouts report as Custom control type. The UIA spec requires
+			// that Custom elements provide a non-empty LocalizedControlType string representing
+			// the role of the element. Return the cross-platform layout type name in lowercase
+			// (e.g. "grid", "verticallayout") to satisfy the spec while keeping screen-reader
+			// behavior unchanged — Narrator only announces the Name (Description), not this string.
+			return GetClassNameCore().ToLowerInvariant();
 		}
 
 		// Layouts are never keyboard-focusable — they are structural containers, not interactive elements.
 		protected override bool IsKeyboardFocusableCore() => false;
 
-		// Always expose in the Control View so that Narrator can read SemanticProperties.Description
-		// even when no AutomationId is set.
-		protected override bool IsControlElementCore() => true;
-
-		// Expose in the Content View only when an AutomationId is explicitly set by the developer.
-		protected override bool IsContentElementCore() => HasAutomationId();
-
-		bool HasAutomationId()
+		// Layouts/panels are structural containers. By default we exclude anonymous layouts from
+		// the UIA Control view so screen readers (Narrator, NVDA) don't stop on every nested Grid /
+		// StackLayout while a user is navigating a page.
+		//
+		// We DO opt in to the Control view when the developer signals that this panel should
+		// be discoverable through UI Automation:
+		//   * AutomationId on the cross-platform view, so Windows Appium/WinAppDriver can find
+		//     layout containers by their test hook. This is a deliberate trade-off: Windows UI
+		//     test automation does not see these peers unless they participate in Control view,
+		//     so named layout containers become visible to screen readers too.
+		//   * AutomationProperties.IsInAccessibleTree="True" on the cross-platform view
+		//     (mapped to AccessibilityView = Content on the platform view; Control can still be
+		//     set directly by platform code), or
+		//   * SemanticProperties.Description / Hint (mapped to AutomationProperties.Name /
+		//     HelpText on the platform view) -- if the developer wrote a description, they
+		//     want screen readers to announce it.
+		protected override bool IsControlElementCore()
 		{
 			if (Owner is not Panel panel)
 			{
 				return false;
 			}
 
-			return !string.IsNullOrEmpty(AutomationProperties.GetAutomationId(panel));
+			// Use GetValue for Raw opt-out to honor AccessibilityView=Raw from ANY source
+			// (local, WinUI Style, or template) — ensures styled opt-outs are respected.
+			var effectiveView = (AccessibilityView)panel.GetValue(AutomationProperties.AccessibilityViewProperty);
+			if (effectiveView == AccessibilityView.Raw)
+			{
+				return false;
+			}
+
+			// Use ReadLocalValue for opt-in — only a locally-set Content/Control value
+			// (set by MAUI's mapper) should opt the layout in; Style-applied Content is not
+			// an intentional MAUI opt-in signal.
+			var accessibilityView = panel.ReadLocalValue(AutomationProperties.AccessibilityViewProperty);
+			if (accessibilityView is AccessibilityView.Control or AccessibilityView.Content)
+			{
+				return true;
+			}
+
+			if (!string.IsNullOrWhiteSpace(AutomationProperties.GetAutomationId(panel)))
+			{
+				return true;
+			}
+
+			if (!string.IsNullOrWhiteSpace(AutomationProperties.GetName(panel)))
+			{
+				return true;
+			}
+
+			if (!string.IsNullOrWhiteSpace(AutomationProperties.GetHelpText(panel)))
+			{
+				return true;
+			}
+
+			return false;
+		}
+
+		// Expose in the Content View only when the developer explicitly opted into Content via
+		// AutomationProperties.IsInAccessibleTree="True" (mapped to AccessibilityView = Content).
+		// AutomationId keeps the panel discoverable to Windows UI test automation through the
+		// Control view, but does NOT pull the panel into the Content view.
+		protected override bool IsContentElementCore()
+		{
+			if (Owner is not Panel panel)
+			{
+				return false;
+			}
+
+			var accessibilityView = panel.ReadLocalValue(AutomationProperties.AccessibilityViewProperty);
+			return accessibilityView is AccessibilityView.Content;
+		}
+
+		bool HasAccessibilitySemantics()
+		{
+			if (Owner is not Panel panel)
+			{
+				return false;
+			}
+
+			// Use GetValue for Raw opt-out to honor Style/template-applied values.
+			var effectiveView = (AccessibilityView)panel.GetValue(AutomationProperties.AccessibilityViewProperty);
+			if (effectiveView == AccessibilityView.Raw)
+			{
+				return false;
+			}
+
+			// Use ReadLocalValue for opt-in — only locally-set Content/Control (by MAUI's mapper)
+			// signals intentional accessibility semantics.
+			var accessibilityView = panel.ReadLocalValue(AutomationProperties.AccessibilityViewProperty);
+			if (accessibilityView is AccessibilityView.Control or AccessibilityView.Content)
+			{
+				return true;
+			}
+
+			return !string.IsNullOrWhiteSpace(AutomationProperties.GetName(panel)) ||
+				!string.IsNullOrWhiteSpace(AutomationProperties.GetHelpText(panel));
 		}
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

This is the `main` (net10) counterpart of #35597. It adds `MauiLayoutAutomationPeer` so an `AutomationId` set on a `Layout` is visible to UI Automation clients (Appium / WinAppDriver, etc.), fixing #4715, while keeping anonymous layouts out of the UIA **Control view** that screen readers (Narrator, NVDA) walk.

Because `main` cannot take new public API, `MauiLayoutAutomationPeer` is **internal** here (class + constructor). The net11 version (#35597) makes it **public** and adds the matching `net-windows` PublicAPI entries. The only public-API addition in this PR is the `LayoutPanel.OnCreateAutomationPeer()` override, which is unavoidable and acceptable.

**Behavior after this PR:**

| Set on a Layout / ContentView | UIA raw view (UI tests) | UIA Control view (screen readers) | UIA Content view |
|---|---|---|---|
| Nothing | excluded | excluded | excluded |
| `AutomationId="..."` only | **included** | **included** as `Custom` (lowercase layout type name as localized control type) | excluded |
| `AutomationProperties.IsInAccessibleTree="True"` | included | **included** | **included** |
| `SemanticProperties.Description="..."` (or `Hint`) | included | **included** | excluded |

So:
- **Pure test hook:** `AutomationId` alone keeps Windows UI tests working. It enters the Control view for Appium / WinAppDriver discoverability, but reports `Custom` with the lowercase cross-platform layout type name (e.g. `grid`) as its localized control type instead of a grouping `Pane`.
- **Accessibility landmark:** `AutomationProperties.IsInAccessibleTree="True"` opts the panel into the accessibility tree. Screen readers see it.
- **Accessibility content:** `SemanticProperties.Description` / `Hint` is treated as an implicit opt-in.
- **Explicit opt-out wins:** `IsInAccessibleTree="False"` (Raw) always wins over any opt-in, and is honored even when applied via a WinUI `Style` / template.

`GetClassNameCore` reports the cross-platform layout type name. `GetAutomationControlTypeCore` reports `Custom` for anonymous / AutomationId-only layouts and `Pane` only for explicit accessibility semantics. `IsKeyboardFocusableCore` is `false`.

### Relationship to #35597

This PR mirrors #35597 but targets `main`:
- `MauiLayoutAutomationPeer` is `internal` (vs `public` in #35597); **no** peer entries are added to `PublicAPI.Unshipped.txt`.
- Only `override Microsoft.Maui.Platform.LayoutPanel.OnCreateAutomationPeer()` is added to the `net-windows` PublicAPI.
- Code comments in `MauiLayoutAutomationPeer.cs` and `LayoutPanel.cs` reference #35597 and note that the type should be promoted to `public` when this flows forward to net11.

### Tests

`LayoutTests.Windows.cs` verifies `AutomationId` through the peer, keeps AutomationId-only layouts out of the Content view (quieter `Custom` role with a lowercase localized control type), and covers the opt-in paths (`IsInAccessibleTree`, `Description`, `Hint`), explicit `Raw` opt-out precedence, and whitespace-only semantic text. UI test coverage added in `Issue4715`.

### Validation

This change is Windows-only. Windows CI must confirm the PublicAPI analyzer results (RS0016/RS0017), since `net-windows` cannot be built locally on macOS.

### Issues Fixed

Fixes #4715. Net10 counterpart of #35597.
