### PR TITLE
[iOS] Fix EditorScrollingWhenEnclosedInBorder test failure on candidate branch

### DIFF
--- a/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
@@ -55,11 +55,14 @@ namespace Microsoft.Maui.Handlers
 
 		public override Size GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
-			// When the height constraint is infinite, the handler substitutes a finite value.
-			// This flag tracks whether the substitute came from SizeThatFits (a content measurement,
-			// not a real bound). If so, the cap at the bottom must be skipped — the base already
-			// returns the correct size. When the substitute is Bounds.Height (a real frame bound),
-			// the flag stays false and the cap applies to preserve scrollability.
+			// Tracks whether the height constraint represents a content measurement rather
+			// than a real upper bound. When true, the cap at the bottom is skipped — either
+			// the base already returns the correct size (SizeThatFits substitution) or the
+			// caller provided a finite constraint and the standard MAUI measure contract
+			// applies (children may report DesiredSize larger than the constraint; the
+			// parent decides how to arrange). When false, the substitute came from
+			// Bounds.Height (a real frame bound) and the cap applies to preserve
+			// scrollability after rotation (#35114).
 			bool heightSubstitutedFromSizeThatFits = false;
 
 			if (double.IsInfinity(widthConstraint) || double.IsInfinity(heightConstraint))
@@ -94,6 +97,11 @@ namespace Microsoft.Maui.Handlers
 						heightSubstitutedFromSizeThatFits = true; // not a real bound — cap will be skipped
 					}
 				}
+			}
+			else
+			{
+				// Caller-provided finite constraint — not a substituted bound. Skip the cap.
+				heightSubstitutedFromSizeThatFits = true;
 			}
 
 			var result = base.GetDesiredSize(widthConstraint, heightConstraint);


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
After PR #35309, the iOS snapshot for EditorScrollingWhenEnclosedInBorder differs from the baseline by approximately 1 px vertically. The Border outline, visible text lines, and scroll thumb endpoints are all shifted by one pixel, causing the exact-match snapshot comparison to fail.

**Test name:** EditorScrollingWhenEnclosedInBorder
**Cause PR:** #35309
 
### Root Cause
PR #35309 added a final cap in EditorHandler.GetDesiredSize that clamps result.Height to heightConstraint. PR #35662 narrowed this behavior to skip the SizeThatFits substitution path, but the cap was still applied when the caller provided a finite heightConstraint (for example, when Border measures its child).
base.GetDesiredSize correctly returned the requested size, but the final cap reduced the calculated height to the Border's stroke-adjusted constraint, resulting in a 1 px vertical drift.
 
### Description of Change
Added an else branch to the double.IsInfinity(...) check in GetDesiredSize (iOS) to mark caller-provided finite constraints using heightSubstitutedFromSizeThatFits = true.
The final height cap now applies only when the height value was substituted internally, restoring the standard MAUI measure behavior for caller-provided constraints while preserving the existing behavior.

### Output
| Before Issue Fix | After Issue Fix |
|----------|----------|
| <img width="350" height="110"  src="https://github.com/user-attachments/assets/4f3d5b68-7931-4599-a869-b07c7e3bd521"> | <img width="350" height="110"  src="https://github.com/user-attachments/assets/b3c883a5-0c3d-41bd-8fc6-9d127def72b9"> |