### PR TITLE
[SourceGen] Don't emit INPC handlers for static type references in C# XAML expressions

### DIFF
--- a/src/Controls/src/SourceGen/ExpressionAnalyzer.cs
+++ b/src/Controls/src/SourceGen/ExpressionAnalyzer.cs
@@ -326,18 +326,34 @@ internal static class ExpressionAnalyzer
 		var handlers = ExtractHandlers(transformedExpression, sourceParameterName);
 
 		// Filter handlers to only include:
-		// 1. Top-level handlers (parent == __source) where property exists on DataType
-		// 2. Nested handlers (parent != __source) - always keep since they're on intermediate objects
-		// This excludes things like ToString() and __capture_X at the root level
-		// Also exclude handlers whose parent is a capture variable (__capture_*) - those are local, not bindings
+		// 1. Top-level handlers (parent == __source) where property exists on DataType.
+		// 2. Nested handlers (parent != __source) whose chain root identifier is a member of DataType.
+		//    Chains rooted at a static type (e.g. Colors.Goldenrod, DateTime.Now, Math.Max(...))
+		//    or at a local capture (__capture_*) must NOT produce INPC subscriptions — those names
+		//    do not exist on the DataType and would emit invalid getter lambdas like
+		//    `static __source => __source.Colors`.
 		if (dataType != null)
 		{
-			handlers = handlers.Where(h => 
-				h.PropertyName == "." || 
-				(h.ParentExpression != sourceParameterName &&  // Keep nested handlers...
-				 !h.ParentExpression.Contains("__capture_")) ||  // ...unless parent is a capture variable
-				HasProperty(dataType, h.PropertyName)  // Top-level must exist on DataType
-			).ToList();
+			var sourcePrefix = sourceParameterName + ".";
+			handlers = handlers.Where(h =>
+			{
+				if (h.PropertyName == ".")
+					return true;
+
+				if (h.ParentExpression == sourceParameterName)
+					return HasProperty(dataType, h.PropertyName);
+
+				if (h.ParentExpression.Contains("__capture_"))
+					return false;
+
+				if (!h.ParentExpression.StartsWith(sourcePrefix, StringComparison.Ordinal))
+					return true;
+
+				var afterSource = h.ParentExpression.Substring(sourcePrefix.Length);
+				var dotIdx = afterSource.IndexOf('.');
+				var rootIdent = dotIdx >= 0 ? afterSource.Substring(0, dotIdx) : afterSource;
+				return HasProperty(dataType, rootIdent);
+			}).ToList();
 		}
 
 		// Transform the expression to prefix root identifiers that are on DataType with __source.

--- a/src/Controls/tests/SourceGen.UnitTests/CSharpExpressionDiagnosticsTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/CSharpExpressionDiagnosticsTests.cs
@@ -809,4 +809,65 @@ public partial class OperatorAliasPage : ContentPage
 		Assert.Contains(" <= ", output, StringComparison.Ordinal);
 		Assert.Contains(" >= ", output, StringComparison.Ordinal);
 	}
+
+	// https://github.com/dotnet/maui/issues/35900
+	[Theory]
+	[InlineData("<Label TextColor=\"{IsVip ? Colors.Goldenrod : Colors.Gray}\" />")]
+	[InlineData("<Label Text=\"{$'Now: {DateTime.Now:t}'}\" />")]
+	[InlineData("<Label Text=\"{$'Max = {Math.Max(Price, Quantity):F2}'}\" />")]
+	[InlineData("<Label Text=\"{$'{Name} - {DateTime.Now:d}'}\" />")]
+	public void StaticTypeReferenceInExpression_DoesNotGenerateInvalidHandlers(string labelXaml)
+	{
+		var xaml =
+$"""
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:TestApp"
+             x:Class="TestApp.StaticRefPage"
+             x:DataType="local:StaticRefViewModel">
+    {labelXaml}
+</ContentPage>
+""";
+
+		var codeBehind =
+"""
+global using System;
+global using Microsoft.Maui.Graphics;
+using System.ComponentModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace TestApp;
+
+public class StaticRefViewModel : INotifyPropertyChanged
+{
+	public bool IsVip { get; set; }
+	public string Name { get; set; } = string.Empty;
+	public double Price { get; set; }
+	public double Quantity { get; set; }
+	public event PropertyChangedEventHandler? PropertyChanged;
+}
+
+[XamlProcessing(XamlInflator.SourceGen)]
+public partial class StaticRefPage : ContentPage
+{
+	public StaticRefPage() => InitializeComponent();
+}
+""";
+
+		var (result, output) = RunGenerator(xaml, codeBehind);
+
+		// The generated code must not contain handler tuples rooted at static type
+		// names (Colors, DateTime, Math), which previously produced
+		// `static __source => __source.Colors` / `__source.DateTime` / `__source.Math`
+		// and broke compilation with CS1061.
+		Assert.NotNull(output);
+		Assert.DoesNotContain("__source.Colors", output!, StringComparison.Ordinal);
+		Assert.DoesNotContain("__source.DateTime", output!, StringComparison.Ordinal);
+		Assert.DoesNotContain("__source.Math", output!, StringComparison.Ordinal);
+
+		// And the compilation must succeed (no compiler errors leaked through).
+		Assert.DoesNotContain(result.Diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Fixes #35900.

The XAML C# expression source generator was emitting INPC subscription handlers for *every* `MemberAccess` chain in an expression, including chains rooted at a **static type** reachable via `global using` such as `Colors.Goldenrod`, `DateTime.Now`, or `Math.Max(...)`.

The existing filter in `ExpressionAnalyzer.Analyze` correctly dropped the *top-level* handler when the root identifier (`Colors`, `DateTime`, `Math`) was not a member of the `x:DataType`, but it **always kept the nested handlers** for the same chain. That produced invalid getter lambdas like:

```csharp
new(static __source => __source.Colors, "Goldenrod")
new(static __source => __source.DateTime, "Now")
new(static __source => __source.Math,     "Max")
```

…which then failed compilation with `CS1061: 'MainViewModel' does not contain a definition for 'Colors'` (and similar for `DateTime`/`Math`). This is step 4 of the [XamlCSharpExpressions](https://github.com/dotnet/maui/blob/main/docs/specs/XamlCSharpExpressions.md) name-resolution spec: an identifier that doesn't resolve as a `BindingContext` member, code-behind member, or lambda parameter must fall through to a static type reference — it must never produce an INPC subscription against a non-existent member of the DataType.

The fix tightens the handler filter so a nested handler is kept only when the root identifier of its parent expression (after the `__source.` prefix) is an actual member of the DataType. The getter-body rewriter (`TransformRootIdentifiers`) already handled the static-type case correctly, so the lambda body — e.g. `__source => (__source.IsVip ? Colors.Goldenrod : Colors.Gray, true)` — compiles unchanged once the handler array is clean.

### Issues Fixed

Fixes #35900

### Tests

Added a parameterized test in `CSharpExpressionDiagnosticsTests` that exercises all four scenarios from the issue report:

- `TextColor="{IsVip ? Colors.Goldenrod : Colors.Gray}"`
- `Text="{$'Now: {DateTime.Now:t}'}"`
- `Text="{$'Max = {Math.Max(Price, Quantity):F2}'}"`
- `Text="{$'{Name} - {DateTime.Now:d}'}"`

The test asserts the generated `.xsg.cs` contains no `__source.Colors`/`__source.DateTime`/`__source.Math` handler subscriptions and that the resulting compilation has no errors. All 205 existing `SourceGen.UnitTests` continue to pass.
