### PR TITLE
 [Windows] Fix AspectFit image fills container regression causing UI test failures on candidate branch

### DIFF
--- a/src/Core/src/Handlers/Image/ImageHandler.Windows.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.Windows.cs
@@ -71,8 +71,13 @@ namespace Microsoft.Maui.Handlers
 			// unconstrained here and rely on layout constraints.
 			if (VirtualView.Aspect == Aspect.AspectFit)
 			{
-				// Use cached size to avoid timing-dependent behavior from BitmapSource properties
-				var imageSize = _cachedImageSize;
+				// Read the live decoded size first: WinUI sets PixelWidth/PixelHeight synchronously
+				// once decoding completes, before firing ImageOpened. Reading live here closes the
+				// race window where the cache is still Zero but the bitmap is already decoded (#32393).
+				// Fall back to cache only when the live size is not yet available.
+				var imageSize = GetImageSize();
+				if (imageSize.Width <= 0 || imageSize.Height <= 0)
+					imageSize = _cachedImageSize;
 				double w = possibleSize.Width;
 				double h = possibleSize.Height;
 
@@ -280,7 +285,7 @@ namespace Microsoft.Maui.Handlers
 
 		private Graphics.Size GetImageSize()
 		{
-			if (PlatformView.Source is BitmapSource bitmap)
+			if (PlatformView?.Source is BitmapSource bitmap)
 			{
 				// BitmapSource may not have PixelWidth/PixelHeight set until image is loaded
 				if (bitmap.PixelWidth > 0 && bitmap.PixelHeight > 0)


### PR DESCRIPTION
 <!-- Please let the below note in for people that find this PR -->
   > [!NOTE]
   > Are you waiting for the changes in this PR to be merged?
   > It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. 
  Thank you!

## Root Cause

PR #34699 introduced `_cachedImageSize` to eliminate timing-dependent behavior in `GetDesiredSize()`. As part of that change, `MapSourceAsync()` resets the cache to `Zero` whenever a new image source is assigned.

However, `GetDesiredSize()` was updated to rely exclusively on `_cachedImageSize` and no longer considered the live decoded size available on `BitmapSource`. This created a timing gap where WinUI had already completed image decoding and populated `BitmapSource.PixelWidth`/`PixelHeight`, but the asynchronous `ImageOpened` event had not yet fired to update the cache.

If a layout pass occurred during this window, `GetDesiredSize()` observed a zero-sized cache, skipped the natural-size constraint, and allowed the image to expand to the available container size instead of respecting its decoded pixel dimensions.

## Description of Change

Two minimal updates were made in `ImageHandler.Windows.cs`:

`GetDesiredSize()
`
* Reads the live decoded size from `BitmapSource` first.
* Falls back to `_cachedImageSize` only when the live size is not yet available.
* Aligns with the existing live-first, cache-fallback pattern already used in `UpdatePlatformMaxConstraints()`.

`GetImageSize()
`
* Added a null-conditional guard for `PlatformView` to prevent a potential null-reference exception when `GetDesiredSize()` is called after handler disconnection.

## Regression Introduced By
PR #34699 
 
### Issues Fixed
Fixes the following candidate branch regressions:
In `Issue30403SmallImages.cs` file:
`ConstrainedContainers_ShouldHandleSmallImages` 
`SmallImageEndAlignment_ShouldRespectAlignment`
`SmallImageInLargeContainer_ShouldNotExceedIntrinsicSize`
`SmallImageStartAlignment_ShouldRespectAlignment`
`SizeComparison_ShouldShowDifferentSizes`
`TinyImage_ShouldRemainTiny` 
 
Tested the behaviour in the following platforms
- [ ] Android
- [x] Windows
- [ ] iOS
- [ ] Mac