### PR TITLE
[Android] Fix CollectionView KeepScrollOffset regressed after PR #29255

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
@@ -1060,8 +1060,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			if (RecyclerViewScrollListener == null)
 				return;
 
+			RemoveOnScrollListener(RecyclerViewScrollListener);
 			RecyclerViewScrollListener.Dispose();
-			ClearOnScrollListeners();
 			RecyclerViewScrollListener = null;
 		}
 	}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue35806.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue35806.cs
@@ -1,0 +1,92 @@
+using System.Collections.ObjectModel;
+using Maui.Controls.Sample.Issues;
+
+namespace Controls.TestCases.HostApp.Issues;
+
+[Issue(IssueTracker.Github, 35806, "Android CollectionView KeepScrollOffset stops working after replacing ItemsSource", PlatformAffected.Android)]
+public class Issue35806 : TestContentPage
+{
+	ObservableCollection<string> items;
+	CollectionView collectionView;
+	int sourceVersion = 1;
+
+	protected override void Init()
+	{
+		items = CreateItemsSource(sourceVersion);
+
+		collectionView = new CollectionView
+		{
+			AutomationId = "CollectionView35806",
+			ItemsSource = items,
+			ItemsUpdatingScrollMode = ItemsUpdatingScrollMode.KeepScrollOffset,
+			ItemTemplate = new DataTemplate(() =>
+			{
+				var label = new Label();
+				label.SetBinding(Label.TextProperty, ".");
+				return new Border
+				{
+					Content = label,
+					Padding = 10,
+					Margin = new Thickness(5),
+					BackgroundColor = Colors.LightGray,
+				};
+			})
+		};
+
+		var replaceSourceButton = new Button
+		{
+			Text = "Replace ItemsSource",
+			AutomationId = "ReplaceSourceButton",
+			Command = new Command(() =>
+			{
+				sourceVersion++;
+				items = CreateItemsSource(sourceVersion);
+				collectionView.ItemsSource = items;
+			})
+		};
+
+		var scrollToTopButton = new Button
+		{
+			Text = "Scroll To Top",
+			AutomationId = "ScrollToTopButton",
+			Command = new Command(() =>
+			{
+				collectionView.ScrollTo(0, position: ScrollToPosition.Start, animate: false);
+			})
+		};
+
+		var insertAtTopButton = new Button
+		{
+			Text = "Insert At Top",
+			AutomationId = "InsertAtTopButton",
+			Command = new Command(() =>
+			{
+				items.Insert(0, $"Inserted-{items.Count + 1}");
+			})
+		};
+
+		var grid = new Grid
+		{
+			RowDefinitions =
+			{
+				new RowDefinition { Height = GridLength.Auto },
+				new RowDefinition { Height = GridLength.Auto },
+				new RowDefinition { Height = GridLength.Auto },
+				new RowDefinition { Height = GridLength.Star }
+			},
+			RowSpacing = 5
+		};
+		grid.Add(replaceSourceButton, 0, 0);
+		grid.Add(scrollToTopButton, 0, 1);
+		grid.Add(insertAtTopButton, 0, 2);
+		grid.Add(collectionView, 0, 3);
+
+		Content = grid;
+	}
+
+	static ObservableCollection<string> CreateItemsSource(int version)
+	{
+		return new ObservableCollection<string>(
+			Enumerable.Range(1, 30).Select(i => $"v{version}-Item {i}"));
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35806.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35806.cs
@@ -1,0 +1,43 @@
+#if ANDROID // This regression is Android-only: https://github.com/dotnet/maui/pull/29255
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue35806 : _IssuesUITest
+{
+	public Issue35806(TestDevice device) : base(device) { }
+
+	public override string Issue => "Android CollectionView KeepScrollOffset stops working after replacing ItemsSource";
+
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void KeepScrollOffsetWorksAfterReplacingItemsSource()
+	{
+		App.WaitForElement("CollectionView35806");
+
+		// Verify initial source loaded
+		App.WaitForElement("v1-Item 1");
+
+		// Replace source, scroll to top, insert at top — KeepScrollOffset should keep position
+		App.Click("ReplaceSourceButton");
+		App.WaitForElement("v2-Item 1");
+		App.Click("ScrollToTopButton");
+		App.Click("InsertAtTopButton");
+
+		// With KeepScrollOffset at position 0, the inserted item should be visible at the top.
+		// Without the fix, "Inserted-31" is hidden above the viewport (broken KeepItemsInView behavior).
+		App.WaitForElement("Inserted-31");
+
+		// Replace source again to verify it still works on subsequent replacements
+		App.Click("ReplaceSourceButton");
+		App.WaitForElement("v3-Item 1");
+		App.Click("ScrollToTopButton");
+		App.Click("InsertAtTopButton");
+
+		// After second replacement (30 items in new source), inserted item text is "Inserted-31"
+		App.WaitForElement("Inserted-31");
+	}
+}
+#endif


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details

- Android CollectionView.ItemsUpdatingScrollMode = KeepScrollOffset stops working after ItemsSource is replaced.
- After the reassignment, inserting a new item at index 0 leaves the previous top item anchored on screen and hides the new item above the viewport — effectively KeepItemsInView semantics instead of KeepScrollOffset.
- Only Android is affected. iOS behaves correctly.


### Root Cause of the issue
- MauiRecyclerView.RemoveScrollListener() calls ClearOnScrollListeners(), which removes all scroll listeners registered on the RecyclerView — including the one ScrollHelper self-registered.
- ScrollHelper._maintainingScrollOffsets flag is never reset, so it goes stale (true while the listener is actually detached).
- Subsequent ScrollHelper.AddScrollListener() calls short-circuit on the stale flag, so ScrollHelper is never re-attached.
- With no scroll callbacks reaching ScrollHelper, TrackOffsets() never runs and the ScrollBy(-delta) correction that drives KeepScrollOffset is silently skipped.
### Before PR #29255
- ScrollHelper attached its listener lazily, inside UndoNextScrollAdjustment(), only when an insert actually needed it.
- The stale-flag desync caused by ClearOnScrollListeners() was a latent bug, but the lazy re-register path inside UndoNextScrollAdjustment() masked it for the typical user — the listener got attached the next time it was needed, so most KeepScrollOffset scenarios still worked.
### After PR #29255
- Listener registration was moved out of UndoNextScrollAdjustment() and into an explicit ScrollHelper.AddScrollListener() method, called eagerly from MauiRecyclerView.UpdateItemsUpdatingScrollMode().
- Both AddScrollListener() and the old lazy block use the same _maintainingScrollOffsets guard, but the lazy self-heal block in UndoNextScrollAdjustment() was deleted.
- Now, when ClearOnScrollListeners() detaches ScrollHelper's listener, the flag stays true, the eager AddScrollListener() no-ops, the lazy safety net is gone, and KeepScrollOffset is permanently broken after the first ItemsSource reassignment.
### Description of Change

<!-- Enter description of the fix in this section -->
**Bug fix:**

* Fixed the scroll listener removal logic in `RemoveScrollListener()` by removing only the specific listener instead of clearing all listeners, which resolves the `KeepScrollOffset` issue when replacing the `ItemsSource` in `CollectionView` on Android. (`src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs`)

**Test coverage:**

* Added a new test case page that reproduces the issue and provides buttons to replace the `ItemsSource`, scroll to the top, and insert items at the top, making it easier to manually verify the fix. (`src/Controls/tests/TestCases.HostApp/Issues/Issue35806.cs`)
* Introduced an automated UI test (Android only) that verifies the `KeepScrollOffset` behavior after replacing the `ItemsSource`, ensuring the regression is caught in the future. (`src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35806.cs`)

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #35806 

### Tested the behavior in the following platforms
 
- [ ] Windows
- [x] Android
- [ ] iOS
- [ ] Mac
 
### Output
 
| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/0b73f9e5-83e1-4e82-a382-47b22e56c797"> | <video src="https://github.com/user-attachments/assets/fc2c4648-4d77-4b55-a988-0a87c2c17e8a"> |







<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
