### PR TITLE
Fix missing font and splash outputs after incremental builds

### DIFF
--- a/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
+++ b/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
@@ -75,8 +75,10 @@
         <_ResizetizerOutputsFile>$(_ResizetizerIntermediateOutputPath)mauiimage.outputs</_ResizetizerOutputsFile>
         <_ResizetizerStampFile>$(_ResizetizerIntermediateOutputPath)mauiimage.stamp</_ResizetizerStampFile>
         <_MauiFontInputsFile>$(_ResizetizerIntermediateOutputPath)mauifont.inputs</_MauiFontInputsFile>
+        <_MauiFontOutputsFile>$(_ResizetizerIntermediateOutputPath)mauifont.outputs</_MauiFontOutputsFile>
         <_MauiFontStampFile>$(_ResizetizerIntermediateOutputPath)mauifont.stamp</_MauiFontStampFile>
         <_MauiSplashInputsFile>$(_ResizetizerIntermediateOutputPath)mauisplash.inputs</_MauiSplashInputsFile>
+        <_MauiSplashOutputsFile>$(_ResizetizerIntermediateOutputPath)mauisplash.outputs</_MauiSplashOutputsFile>
         <_MauiSplashStampFile>$(_ResizetizerIntermediateOutputPath)mauisplash.stamp</_MauiSplashStampFile>
         <_MauiManifestStampFile>$(_ResizetizerIntermediateOutputPath)mauimanifest.stamp</_MauiManifestStampFile>
 
@@ -125,6 +127,7 @@
             ResizetizeCollectItems;
             ProcessMauiAssets;
             ProcessMauiSplashScreens;
+            _ReadMauiFontOutputs;
         </ProcessMauiFontsDependsOnTargets>
     </PropertyGroup>
 
@@ -399,7 +402,8 @@
     <Target Name="ProcessMauiSplashScreens"
         Condition="'$(EnableMauiSplashScreenProcessing)' == 'true'"
         Inputs="$(MSBuildThisFileFullPath);$(_ResizetizerTaskAssemblyName);$(_MauiSplashInputsFile);@(MauiSplashScreen)"
-        Outputs="$(_MauiSplashStampFile)">
+        Outputs="$(_MauiSplashStampFile);$(_MauiSplashOutputsFile);@(_MauiSplashOutputs)"
+        DependsOnTargets="_ReadMauiSplashOutputs">
 
         <PropertyGroup>
             <_MauiHasSplashScreens>false</_MauiHasSplashScreens>
@@ -508,18 +512,33 @@
         <!-- Stamp file for Outputs -->
         <MakeDir Directories="$(_ResizetizerIntermediateOutputPath)"/>
         <Touch Files="$(_MauiSplashStampFile)" AlwaysCreate="True" />
+        <WriteLinesToFile
+            File="$(_MauiSplashOutputsFile)"
+            Lines="@(_MauiSplashAssets->'%(FullPath)')"
+            Overwrite="true"
+            WriteOnlyWhenDifferent="true"
+        />
+        <Touch Files="@(_MauiSplashAssets)" Condition="'@(_MauiSplashAssets)' != ''" />
+        <Touch Files="$(_MauiSplashOutputsFile)" AlwaysCreate="True" />
 
         <ItemGroup>
             <FileWrites Include="@(_MauiSplashAssets)" />
+            <FileWrites Include="$(_MauiSplashOutputsFile)" />
             <FileWrites Include="$(_MauiSplashStampFile)" />
         </ItemGroup>
 
     </Target>
 
+    <Target Name="_ReadMauiSplashOutputs">
+        <ReadLinesFromFile File="$(_MauiSplashOutputsFile)" Condition="Exists ('$(_MauiSplashOutputsFile)')">
+            <Output TaskParameter="Lines" ItemName="_MauiSplashOutputs" />
+        </ReadLinesFromFile>
+    </Target>
+
     <Target Name="ProcessMauiFonts"
         Condition="'$(EnableMauiFontProcessing)' == 'true'"
         Inputs="$(MSBuildThisFileFullPath);$(_ResizetizerTaskAssemblyName);$(_MauiFontInputsFile);@(MauiFont)"
-        Outputs="$(_MauiFontStampFile)"
+        Outputs="$(_MauiFontStampFile);$(_MauiFontOutputsFile);@(_MauiFontOutputs)"
         AfterTargets="$(ProcessMauiFontsAfterTargets)"
         BeforeTargets="$(ProcessMauiFontsBeforeTargets)"
         DependsOnTargets="$(ProcessMauiFontsDependsOnTargets)">
@@ -595,14 +614,30 @@
             <TizenTpkUserIncludeFiles Include="@(_MauiFontCopied)"  Condition="'@(_MauiFontCopied)' != ''" TizenTpkSubDir="res\fonts\" />
         </ItemGroup>
 
+        <Touch Files="@(_MauiFontCopied)" Condition="'@(_MauiFontCopied)' != ''" />
+
         <!-- Touch/create our stamp file for outputs -->
         <Touch Files="$(_MauiFontStampFile)" AlwaysCreate="True" />
+        <WriteLinesToFile
+            File="$(_MauiFontOutputsFile)"
+            Lines="@(_MauiFontCopied->'%(FullPath)');@(_MauiFontPListFiles->'%(FullPath)')"
+            Overwrite="true"
+            WriteOnlyWhenDifferent="true"
+        />
+        <Touch Files="$(_MauiFontOutputsFile)" AlwaysCreate="True" />
 
         <!-- Include our fonts and stamp file as filewrites so they don't get rm'd -->
         <ItemGroup>
             <FileWrites Include="$(_MauiFontStampFile)" />
+            <FileWrites Include="$(_MauiFontOutputsFile)" />
             <FileWrites Include="@(_MauiFontCopied)" />
         </ItemGroup>
+    </Target>
+
+    <Target Name="_ReadMauiFontOutputs">
+        <ReadLinesFromFile File="$(_MauiFontOutputsFile)" Condition="Exists ('$(_MauiFontOutputsFile)')">
+            <Output TaskParameter="Lines" ItemName="_MauiFontOutputs" />
+        </ReadLinesFromFile>
     </Target>
 
     <Target Name="_ReadResizetizeImagesOutputs">

--- a/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
+++ b/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
@@ -516,7 +516,9 @@
             File="$(_MauiSplashOutputsFile)"
             Lines="@(_MauiSplashAssets->'%(FullPath)')"
             Overwrite="true"
+            WriteOnlyWhenDifferent="true"
         />
+        <Touch Files="$(_MauiSplashOutputsFile)" AlwaysCreate="True" />
         <Touch Files="@(_MauiSplashAssets)" Condition="'@(_MauiSplashAssets)' != ''" />
 
         <ItemGroup>
@@ -613,11 +615,14 @@
 
         <Touch Files="@(_MauiFontCopied)" Condition="'@(_MauiFontCopied)' != ''" />
 
+        <MakeDir Directories="$(_ResizetizerIntermediateOutputPath)"/>
         <WriteLinesToFile
             File="$(_MauiFontOutputsFile)"
             Lines="@(_MauiFontCopied->'%(FullPath)');@(_MauiFontPListFiles->'%(FullPath)')"
             Overwrite="true"
+            WriteOnlyWhenDifferent="true"
         />
+        <Touch Files="$(_MauiFontOutputsFile)" AlwaysCreate="True" />
 
         <!-- Include our fonts and output manifest as filewrites so they don't get rm'd -->
         <ItemGroup>

--- a/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
+++ b/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
@@ -516,10 +516,8 @@
             File="$(_MauiSplashOutputsFile)"
             Lines="@(_MauiSplashAssets->'%(FullPath)')"
             Overwrite="true"
-            WriteOnlyWhenDifferent="true"
         />
         <Touch Files="@(_MauiSplashAssets)" Condition="'@(_MauiSplashAssets)' != ''" />
-        <Touch Files="$(_MauiSplashOutputsFile)" AlwaysCreate="True" />
 
         <ItemGroup>
             <FileWrites Include="@(_MauiSplashAssets)" />
@@ -622,9 +620,7 @@
             File="$(_MauiFontOutputsFile)"
             Lines="@(_MauiFontCopied->'%(FullPath)');@(_MauiFontPListFiles->'%(FullPath)')"
             Overwrite="true"
-            WriteOnlyWhenDifferent="true"
         />
-        <Touch Files="$(_MauiFontOutputsFile)" AlwaysCreate="True" />
 
         <!-- Include our fonts and stamp file as filewrites so they don't get rm'd -->
         <ItemGroup>

--- a/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
+++ b/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
@@ -549,7 +549,7 @@
             SkipUnchangedFiles="true" />
 
         <ItemGroup>
-            <_MauiFontCopied Include="$(_MauiIntermediateFonts)*" />
+            <_MauiFontCopied Include="$(_MauiIntermediateFonts)*" Exclude="$(_MauiIntermediateFonts)MauiInfo.plist" />
         </ItemGroup>
 
         <!-- iOS -->

--- a/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
+++ b/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
@@ -76,10 +76,8 @@
         <_ResizetizerStampFile>$(_ResizetizerIntermediateOutputPath)mauiimage.stamp</_ResizetizerStampFile>
         <_MauiFontInputsFile>$(_ResizetizerIntermediateOutputPath)mauifont.inputs</_MauiFontInputsFile>
         <_MauiFontOutputsFile>$(_ResizetizerIntermediateOutputPath)mauifont.outputs</_MauiFontOutputsFile>
-        <_MauiFontStampFile>$(_ResizetizerIntermediateOutputPath)mauifont.stamp</_MauiFontStampFile>
         <_MauiSplashInputsFile>$(_ResizetizerIntermediateOutputPath)mauisplash.inputs</_MauiSplashInputsFile>
         <_MauiSplashOutputsFile>$(_ResizetizerIntermediateOutputPath)mauisplash.outputs</_MauiSplashOutputsFile>
-        <_MauiSplashStampFile>$(_ResizetizerIntermediateOutputPath)mauisplash.stamp</_MauiSplashStampFile>
         <_MauiManifestStampFile>$(_ResizetizerIntermediateOutputPath)mauimanifest.stamp</_MauiManifestStampFile>
 
         <_ResizetizerIntermediateOutputRoot>$(_ResizetizerIntermediateOutputPath)resizetizer\</_ResizetizerIntermediateOutputRoot>
@@ -122,6 +120,10 @@
             ProcessMauiSplashScreens;
             _ReadResizetizeImagesOutputs;
         </ResizetizeDependsOnTargets>
+        <ProcessMauiSplashScreensDependsOnTargets>
+            $(ProcessMauiSplashScreensDependsOnTargets);
+            _ReadMauiSplashOutputs;
+        </ProcessMauiSplashScreensDependsOnTargets>
         <ProcessMauiFontsDependsOnTargets>
             $(ProcessMauiFontsDependsOnTargets);
             ResizetizeCollectItems;
@@ -402,8 +404,8 @@
     <Target Name="ProcessMauiSplashScreens"
         Condition="'$(EnableMauiSplashScreenProcessing)' == 'true'"
         Inputs="$(MSBuildThisFileFullPath);$(_ResizetizerTaskAssemblyName);$(_MauiSplashInputsFile);@(MauiSplashScreen)"
-        Outputs="$(_MauiSplashStampFile);$(_MauiSplashOutputsFile);@(_MauiSplashOutputs)"
-        DependsOnTargets="_ReadMauiSplashOutputs">
+        Outputs="$(_MauiSplashOutputsFile);@(_MauiSplashOutputs)"
+        DependsOnTargets="$(ProcessMauiSplashScreensDependsOnTargets)">
 
         <PropertyGroup>
             <_MauiHasSplashScreens>false</_MauiHasSplashScreens>
@@ -509,9 +511,7 @@
             <TizenTpkUserIncludeFiles Include="@(_MauiSplashScreens)" TizenTpkSubDir="shared\res\splash" />
         </ItemGroup>
 
-        <!-- Stamp file for Outputs -->
         <MakeDir Directories="$(_ResizetizerIntermediateOutputPath)"/>
-        <Touch Files="$(_MauiSplashStampFile)" AlwaysCreate="True" />
         <WriteLinesToFile
             File="$(_MauiSplashOutputsFile)"
             Lines="@(_MauiSplashAssets->'%(FullPath)')"
@@ -522,7 +522,6 @@
         <ItemGroup>
             <FileWrites Include="@(_MauiSplashAssets)" />
             <FileWrites Include="$(_MauiSplashOutputsFile)" />
-            <FileWrites Include="$(_MauiSplashStampFile)" />
         </ItemGroup>
 
     </Target>
@@ -536,7 +535,7 @@
     <Target Name="ProcessMauiFonts"
         Condition="'$(EnableMauiFontProcessing)' == 'true'"
         Inputs="$(MSBuildThisFileFullPath);$(_ResizetizerTaskAssemblyName);$(_MauiFontInputsFile);@(MauiFont)"
-        Outputs="$(_MauiFontStampFile);$(_MauiFontOutputsFile);@(_MauiFontOutputs)"
+        Outputs="$(_MauiFontOutputsFile);@(_MauiFontOutputs)"
         AfterTargets="$(ProcessMauiFontsAfterTargets)"
         BeforeTargets="$(ProcessMauiFontsBeforeTargets)"
         DependsOnTargets="$(ProcessMauiFontsDependsOnTargets)">
@@ -614,17 +613,14 @@
 
         <Touch Files="@(_MauiFontCopied)" Condition="'@(_MauiFontCopied)' != ''" />
 
-        <!-- Touch/create our stamp file for outputs -->
-        <Touch Files="$(_MauiFontStampFile)" AlwaysCreate="True" />
         <WriteLinesToFile
             File="$(_MauiFontOutputsFile)"
             Lines="@(_MauiFontCopied->'%(FullPath)');@(_MauiFontPListFiles->'%(FullPath)')"
             Overwrite="true"
         />
 
-        <!-- Include our fonts and stamp file as filewrites so they don't get rm'd -->
+        <!-- Include our fonts and output manifest as filewrites so they don't get rm'd -->
         <ItemGroup>
-            <FileWrites Include="$(_MauiFontStampFile)" />
             <FileWrites Include="$(_MauiFontOutputsFile)" />
             <FileWrites Include="@(_MauiFontCopied)" />
         </ItemGroup>

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/ResizetizerTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/ResizetizerTests.cs
@@ -1,4 +1,3 @@
-using System.IO.Compression;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Logging.StructuredLogger;
 
@@ -105,72 +104,90 @@ public class ResizetizerTests : BaseBuildTest
 	}
 
 	[Fact]
-	public void AndroidPackageRegeneratesFontsAndSplashWhenIntermediateOutputsAreMissing()
+	public void BuildRegeneratesFontsAndSplashWhenIntermediateOutputsAreMissing()
 	{
-		SetTestIdentifier("AndroidMissingResizetizerOutputs");
+		SetTestIdentifier("MissingResizetizerOutputs");
 
 		var projectDir = TestDirectory;
 		var projectFile = Path.Combine(projectDir, $"{Path.GetFileName(projectDir)}.csproj");
-		var framework = $"{DotNetCurrent}-android";
 		const string config = "Debug";
 
 		Assert.True(DotnetInternal.New("maui", projectDir, DotNetCurrent, output: _output),
 			$"Unable to create template maui. Check test output for errors.");
 
-		StripNonAndroidTfms(projectFile, framework);
-
-		var buildProps = BuildProps;
-		buildProps.Add("AndroidPackageFormat=apk");
-
-		Assert.True(DotnetInternal.Build(projectFile, config, target: "SignAndroidPackage", framework: framework, properties: buildProps, output: _output),
+		Assert.True(DotnetInternal.Build(projectFile, config, properties: BuildProps, output: _output),
 			$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 
-		AssertAndroidPackageContainsFontsAndSplash(projectDir, config, framework);
+		var intermediateOutputRoots = GetResizetizerOutputRoots(projectDir, config);
+		AssertBuiltTargetPlatforms(intermediateOutputRoots);
+		AssertIntermediateOutputsExist(intermediateOutputRoots);
 
-		var intermediateOutputPath = Path.Combine(projectDir, "obj", config, framework);
-		DeleteDirectory(Path.Combine(intermediateOutputPath, "resizetizer", "f"));
-		DeleteDirectory(Path.Combine(intermediateOutputPath, "resizetizer", "sp"));
-		DeleteDirectory(Path.Combine(intermediateOutputPath, "android"));
-		DeleteDirectory(Path.Combine(intermediateOutputPath, "lp"));
-		DeleteDirectory(Path.Combine(intermediateOutputPath, "stamp"));
+		foreach (var intermediateOutputRoot in intermediateOutputRoots)
+		{
+			DeleteDirectory(Path.Combine(intermediateOutputRoot, "resizetizer", "f"));
+			DeleteDirectory(Path.Combine(intermediateOutputRoot, "resizetizer", "sp"));
+		}
 
-		foreach (var package in Directory.GetFiles(projectDir, "*.apk", SearchOption.AllDirectories))
-			File.Delete(package);
-
-		Assert.True(DotnetInternal.Build(projectFile, config, target: "SignAndroidPackage", framework: framework, properties: buildProps, output: _output),
+		Assert.True(DotnetInternal.Build(projectFile, config, properties: BuildProps, output: _output),
 			$"Project {Path.GetFileName(projectFile)} failed to rebuild. Check test output/attachments for errors.");
 
-		AssertAndroidPackageContainsFontsAndSplash(projectDir, config, framework);
+		AssertIntermediateOutputsExist(intermediateOutputRoots);
 
 		var noOpBinlogPath = Path.Combine(projectDir, "no-op.binlog");
-		Assert.True(DotnetInternal.Build(projectFile, config, target: "SignAndroidPackage", framework: framework, properties: buildProps, binlogPath: noOpBinlogPath, output: _output),
+		Assert.True(DotnetInternal.Build(projectFile, config, properties: BuildProps, binlogPath: noOpBinlogPath, output: _output),
 			$"Project {Path.GetFileName(projectFile)} failed to no-op rebuild. Check test output/attachments for errors.");
 
-		AssertTargetSkipped(noOpBinlogPath, "ProcessMauiFonts");
-		AssertTargetSkipped(noOpBinlogPath, "ProcessMauiSplashScreens");
-		AssertAndroidPackageContainsFontsAndSplash(projectDir, config, framework);
+		AssertTargetSkipped(noOpBinlogPath, "ProcessMauiFonts", intermediateOutputRoots.Count);
+		AssertTargetSkipped(noOpBinlogPath, "ProcessMauiSplashScreens", intermediateOutputRoots.Count);
+		AssertIntermediateOutputsExist(intermediateOutputRoots);
 	}
 
-	static void AssertAndroidPackageContainsFontsAndSplash(string projectDir, string config, string framework)
+	static IReadOnlyList<string> GetResizetizerOutputRoots(string projectDir, string config)
 	{
-		var apkSearchDir = Path.Combine(projectDir, "bin", config, framework);
-		var apkPath = Directory.GetFiles(apkSearchDir, "*-Signed.apk", SearchOption.AllDirectories)
-			.OrderByDescending(File.GetLastWriteTimeUtc)
-			.FirstOrDefault();
+		var intermediateOutputPath = Path.Combine(projectDir, "obj", config);
+		var outputRoots = Directory
+			.GetFiles(intermediateOutputPath, "mauifont.outputs", SearchOption.AllDirectories)
+			.Select(Path.GetDirectoryName)
+			.Where(root => root is not null && File.Exists(Path.Combine(root, "mauisplash.outputs")))
+			.Cast<string>()
+			.OrderBy(root => root, StringComparer.OrdinalIgnoreCase)
+			.ToArray();
 
-		Assert.True(apkPath is not null, $"No signed APK found in {apkSearchDir}");
+		Assert.NotEmpty(outputRoots);
+		return outputRoots;
+	}
 
-		using var apk = ZipFile.OpenRead(apkPath!);
-		var entries = apk.Entries
-			.Select(entry => entry.FullName)
-			.ToHashSet(StringComparer.Ordinal);
+	static void AssertBuiltTargetPlatforms(IReadOnlyList<string> intermediateOutputRoots)
+	{
+		Assert.Contains(intermediateOutputRoots, root => ContainsTargetFramework(root, $"{DotNetCurrent}-android"));
+		Assert.Contains(intermediateOutputRoots, root => ContainsTargetFramework(root, $"{DotNetCurrent}-ios"));
+		Assert.Contains(intermediateOutputRoots, root => ContainsTargetFramework(root, $"{DotNetCurrent}-maccatalyst"));
 
-		Assert.Contains("assets/OpenSans-Regular.ttf", entries);
-		Assert.Contains("assets/OpenSans-Semibold.ttf", entries);
-		Assert.True(
-			entries.Any(entry => entry.StartsWith("res/drawable-", StringComparison.Ordinal) &&
-				entry.EndsWith("/splash.png", StringComparison.Ordinal)),
-			$"APK {apkPath} does not contain generated splash screen raster assets.");
+		if (TestEnvironment.IsWindows)
+			Assert.Contains(intermediateOutputRoots, root => ContainsTargetFramework(root, $"{DotNetCurrent}-windows"));
+	}
+
+	static bool ContainsTargetFramework(string path, string targetFramework) =>
+		path.Contains(targetFramework, StringComparison.OrdinalIgnoreCase);
+
+	static void AssertIntermediateOutputsExist(IReadOnlyList<string> intermediateOutputRoots)
+	{
+		foreach (var intermediateOutputRoot in intermediateOutputRoots)
+		{
+			var fontsDir = Path.Combine(intermediateOutputRoot, "resizetizer", "f");
+			Assert.True(File.Exists(Path.Combine(fontsDir, "OpenSans-Regular.ttf")),
+				$"Missing OpenSans-Regular.ttf in {fontsDir}.");
+			Assert.True(File.Exists(Path.Combine(fontsDir, "OpenSans-Semibold.ttf")),
+				$"Missing OpenSans-Semibold.ttf in {fontsDir}.");
+
+			if (!ContainsTargetFramework(intermediateOutputRoot, $"{DotNetCurrent}-maccatalyst"))
+			{
+				var splashDir = Path.Combine(intermediateOutputRoot, "resizetizer", "sp");
+				Assert.True(
+					Directory.Exists(splashDir) && Directory.EnumerateFiles(splashDir, "*", SearchOption.AllDirectories).Any(),
+					$"Missing generated splash screen files in {splashDir}.");
+			}
+		}
 	}
 
 	static void DeleteDirectory(string path)
@@ -179,48 +196,15 @@ public class ResizetizerTests : BaseBuildTest
 			Directory.Delete(path, recursive: true);
 	}
 
-	static void StripNonAndroidTfms(string projectFile, string androidTfm)
+	static void AssertTargetSkipped(string binlogPath, string targetName, int minimumSkipCount)
 	{
-		var tempFile = Path.GetTempFileName();
-		try
-		{
-			using (var reader = File.OpenText(projectFile))
-			using (var writer = File.CreateText(tempFile))
-			{
-				string? line;
-				while ((line = reader.ReadLine()) is not null)
-				{
-					if (line.Contains("<TargetFrameworks ", StringComparison.Ordinal) &&
-						line.Contains(" Condition=", StringComparison.Ordinal))
-					{
-						continue;
-					}
-
-					if (line.Contains("<TargetFrameworks>", StringComparison.Ordinal))
-					{
-						var indentation = line[..line.IndexOf('<', StringComparison.Ordinal)];
-						line = $"{indentation}<TargetFrameworks>{androidTfm}</TargetFrameworks>";
-					}
-
-					writer.WriteLine(line);
-				}
-			}
-
-			File.Copy(tempFile, projectFile, overwrite: true);
-		}
-		finally
-		{
-			File.Delete(tempFile);
-		}
-	}
-
-	static void AssertTargetSkipped(string binlogPath, string targetName)
-	{
-		var skipped = new BinLogReader()
+		var skipCount = new BinLogReader()
 			.ReadRecords(binlogPath)
-			.Any(record => record.Args is BuildMessageEventArgs { Message: string message } &&
-				message.Contains($"Skipping target \"{targetName}\"", StringComparison.Ordinal));
+			.Count(record => record.Args is BuildMessageEventArgs { Message: string message } &&
+				message.Contains($"Skipping target \"{targetName}\"", StringComparison.Ordinal) &&
+				message.Contains("because all output files are up-to-date", StringComparison.OrdinalIgnoreCase));
 
-		Assert.True(skipped, $"Expected target '{targetName}' to be skipped. See binlog: {binlogPath}");
+		Assert.True(skipCount >= minimumSkipCount,
+			$"Expected target '{targetName}' to be skipped at least {minimumSkipCount} times, but found {skipCount}. See binlog: {binlogPath}");
 	}
 }

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/ResizetizerTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/ResizetizerTests.cs
@@ -1,5 +1,6 @@
 using System.IO.Compression;
-using System.Text.RegularExpressions;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Logging.StructuredLogger;
 
 namespace Microsoft.Maui.IntegrationTests;
 
@@ -140,6 +141,14 @@ public class ResizetizerTests : BaseBuildTest
 			$"Project {Path.GetFileName(projectFile)} failed to rebuild. Check test output/attachments for errors.");
 
 		AssertAndroidPackageContainsFontsAndSplash(projectDir, config, framework);
+
+		var noOpBinlogPath = Path.Combine(projectDir, "no-op.binlog");
+		Assert.True(DotnetInternal.Build(projectFile, config, target: "SignAndroidPackage", framework: framework, properties: buildProps, binlogPath: noOpBinlogPath, output: _output),
+			$"Project {Path.GetFileName(projectFile)} failed to no-op rebuild. Check test output/attachments for errors.");
+
+		AssertTargetSkipped(noOpBinlogPath, "ProcessMauiFonts");
+		AssertTargetSkipped(noOpBinlogPath, "ProcessMauiSplashScreens");
+		AssertAndroidPackageContainsFontsAndSplash(projectDir, config, framework);
 	}
 
 	static void AssertAndroidPackageContainsFontsAndSplash(string projectDir, string config, string framework)
@@ -172,13 +181,46 @@ public class ResizetizerTests : BaseBuildTest
 
 	static void StripNonAndroidTfms(string projectFile, string androidTfm)
 	{
-		var content = File.ReadAllText(projectFile);
-		content = Regex.Replace(content,
-			@"\s*<TargetFrameworks\s+Condition=""[^""]*"">[^<]*</TargetFrameworks>",
-			"");
-		content = Regex.Replace(content,
-			@"<TargetFrameworks>[^<]*</TargetFrameworks>",
-			$"<TargetFrameworks>{androidTfm}</TargetFrameworks>");
-		File.WriteAllText(projectFile, content);
+		var tempFile = Path.GetTempFileName();
+		try
+		{
+			using (var reader = File.OpenText(projectFile))
+			using (var writer = File.CreateText(tempFile))
+			{
+				string? line;
+				while ((line = reader.ReadLine()) is not null)
+				{
+					if (line.Contains("<TargetFrameworks ", StringComparison.Ordinal) &&
+						line.Contains(" Condition=", StringComparison.Ordinal))
+					{
+						continue;
+					}
+
+					if (line.Contains("<TargetFrameworks>", StringComparison.Ordinal))
+					{
+						var indentation = line[..line.IndexOf('<', StringComparison.Ordinal)];
+						line = $"{indentation}<TargetFrameworks>{androidTfm}</TargetFrameworks>";
+					}
+
+					writer.WriteLine(line);
+				}
+			}
+
+			File.Copy(tempFile, projectFile, overwrite: true);
+		}
+		finally
+		{
+			File.Delete(tempFile);
+		}
+	}
+
+	static void AssertTargetSkipped(string binlogPath, string targetName)
+	{
+		var skipped = new BinLogReader()
+			.ReadRecords(binlogPath)
+			.Any(record => record.Args is BuildMessageEventArgs { Message: string message } &&
+				message.Contains($"Skipping target \"{targetName}\"", StringComparison.Ordinal));
+
+		Assert.True(skipped, $"Expected target '{targetName}' to be skipped. See binlog: {binlogPath}");
 	}
 }

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/ResizetizerTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/ResizetizerTests.cs
@@ -1,3 +1,6 @@
+using System.IO.Compression;
+using System.Text.RegularExpressions;
+
 namespace Microsoft.Maui.IntegrationTests;
 
 [Trait("Category", "Build")]
@@ -98,5 +101,84 @@ public class ResizetizerTests : BaseBuildTest
 		if (TestEnvironment.IsWindows)
 			Assert.True(File.Exists(Path.Combine(appDir, $"obj\\Debug\\{DotNetCurrent}-windows10.0.19041.0\\win-x64\\resizetizer\\r\\the_image.scale-100.png")),
 				"Windows was missing the image file.");
+	}
+
+	[Fact]
+	public void AndroidPackageRegeneratesFontsAndSplashWhenIntermediateOutputsAreMissing()
+	{
+		SetTestIdentifier("AndroidMissingResizetizerOutputs");
+
+		var projectDir = TestDirectory;
+		var projectFile = Path.Combine(projectDir, $"{Path.GetFileName(projectDir)}.csproj");
+		var framework = $"{DotNetCurrent}-android";
+		const string config = "Debug";
+
+		Assert.True(DotnetInternal.New("maui", projectDir, DotNetCurrent, output: _output),
+			$"Unable to create template maui. Check test output for errors.");
+
+		StripNonAndroidTfms(projectFile, framework);
+
+		var buildProps = BuildProps;
+		buildProps.Add("AndroidPackageFormat=apk");
+
+		Assert.True(DotnetInternal.Build(projectFile, config, target: "SignAndroidPackage", framework: framework, properties: buildProps, output: _output),
+			$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
+
+		AssertAndroidPackageContainsFontsAndSplash(projectDir, config, framework);
+
+		var intermediateOutputPath = Path.Combine(projectDir, "obj", config, framework);
+		DeleteDirectory(Path.Combine(intermediateOutputPath, "resizetizer", "f"));
+		DeleteDirectory(Path.Combine(intermediateOutputPath, "resizetizer", "sp"));
+		DeleteDirectory(Path.Combine(intermediateOutputPath, "android"));
+		DeleteDirectory(Path.Combine(intermediateOutputPath, "lp"));
+		DeleteDirectory(Path.Combine(intermediateOutputPath, "stamp"));
+
+		foreach (var package in Directory.GetFiles(projectDir, "*.apk", SearchOption.AllDirectories))
+			File.Delete(package);
+
+		Assert.True(DotnetInternal.Build(projectFile, config, target: "SignAndroidPackage", framework: framework, properties: buildProps, output: _output),
+			$"Project {Path.GetFileName(projectFile)} failed to rebuild. Check test output/attachments for errors.");
+
+		AssertAndroidPackageContainsFontsAndSplash(projectDir, config, framework);
+	}
+
+	static void AssertAndroidPackageContainsFontsAndSplash(string projectDir, string config, string framework)
+	{
+		var apkSearchDir = Path.Combine(projectDir, "bin", config, framework);
+		var apkPath = Directory.GetFiles(apkSearchDir, "*-Signed.apk", SearchOption.AllDirectories)
+			.OrderByDescending(File.GetLastWriteTimeUtc)
+			.FirstOrDefault();
+
+		Assert.True(apkPath is not null, $"No signed APK found in {apkSearchDir}");
+
+		using var apk = ZipFile.OpenRead(apkPath!);
+		var entries = apk.Entries
+			.Select(entry => entry.FullName)
+			.ToHashSet(StringComparer.Ordinal);
+
+		Assert.Contains("assets/OpenSans-Regular.ttf", entries);
+		Assert.Contains("assets/OpenSans-Semibold.ttf", entries);
+		Assert.True(
+			entries.Any(entry => entry.StartsWith("res/drawable-", StringComparison.Ordinal) &&
+				entry.EndsWith("/splash.png", StringComparison.Ordinal)),
+			$"APK {apkPath} does not contain generated splash screen raster assets.");
+	}
+
+	static void DeleteDirectory(string path)
+	{
+		if (Directory.Exists(path))
+			Directory.Delete(path, recursive: true);
+	}
+
+	static void StripNonAndroidTfms(string projectFile, string androidTfm)
+	{
+		var content = File.ReadAllText(projectFile);
+		content = Regex.Replace(content,
+			@"\s*<TargetFrameworks\s+Condition=""[^""]*"">[^<]*</TargetFrameworks>",
+			"");
+		content = Regex.Replace(content,
+			@"<TargetFrameworks>[^<]*</TargetFrameworks>",
+			$"<TargetFrameworks>{androidTfm}</TargetFrameworks>");
+		File.WriteAllText(projectFile, content);
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Fixes an incremental Resizetizer invalidation gap where `ProcessMauiFonts` and `ProcessMauiSplashScreens` could be skipped even when their generated intermediate outputs were missing. This could produce Android packages without `MauiFont` assets and splash screen rasters after stale/incomplete incremental build state.

The fix tracks generated font and splash outputs in obj-scoped `.outputs` manifests, reads them before the MSBuild incremental check, and includes those generated files in target `Outputs`. If a generated font or splash file disappears after a previous successful build, only the relevant font/splash target reruns. Separate font/splash stamp files are no longer generated.

### Issues Fixed

Fixes #33092

### Related Issues / Scope

| Issue | Relationship |
| --- | --- |
| #25540 | Related Android evidence: intermittent fonts missing from APK/runtime after builds; also reports splash missing when fonts are missing. |
| #28502 | Recent discussion/testing thread. This PR may help only if the repro is actual packaged font/splash omission; it is not intended to fix Windows FontManager fallback/noisy missing-font logging. |
| #26889 | Related custom-font symptoms, but appears broader/naming/Windows/Blazor-specific; linked for awareness, not claimed fixed. |
| #24059 | EmbeddedResource/cache font warning path; distinct from `MauiFont` package omission and not claimed fixed. |
| #21771, #19804 | MAUI library/NuGet asset propagation issues; distinct from stale app Resizetizer intermediates and not claimed fixed. |
| #35584 | Artifact-testing blocker encountered by one tester, unrelated to this fix. |

### Artifact Testing

@danies8 @rokmeglicbit if your recent #28502/#33092 repro involves actual missing packaged fonts/splash resources rather than only Windows fallback logging, please try this PR's artifacts and let us know whether it resolves your issue. The validation here shows Android APK package contents are restored after the stale-incremental state described in #33092.

Requesting review from @jonathanpeppers.

### Validation

- Temporarily reverted this fix and reproduced the Android package omission 3/3 times by keeping the old pre-fix `mauifont.stamp`/`mauisplash.stamp` target outputs newer while deleting generated `obj\...\resizetizer\f` and `obj\...\resizetizer\sp` outputs, then rebuilding an Android APK.
- Reapplied the fix and verified the same stale-output Android rebuild passed 3/3 times.
- After review updates, validated the current target logic by deleting generated font/splash output folders after a successful build while preserving the new output manifests; the Android APK still contained fonts and splash rasters, and a following no-op build skipped both font/splash targets.
- Confirmed APK contents include:
  - `assets/OpenSans-Regular.ttf`
  - `assets/OpenSans-Semibold.ttf`
  - `res/drawable-*-v4/splash.png`
- Built `Microsoft.Maui.IntegrationTests.csproj` with the existing unrelated `CS9336` warning suppressed: `dotnet build .\src\TestUtils\src\Microsoft.Maui.IntegrationTests\Microsoft.Maui.IntegrationTests.csproj -v:minimal -p:NoWarn=CS9336`.