### PR TITLE
[Android] Fix  crash in Label FormattedText span position recalculation with MaxLines/TailTruncation

### DIFF
--- a/src/Controls/src/Core/Platform/Android/Extensions/FormattedStringExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/FormattedStringExtensions.cs
@@ -126,7 +126,8 @@ namespace Microsoft.Maui.Controls.Platform
 			if (layout == null)
 				return;
 
-			// Pre-compute the last visible offset so out-of-range spans are skipped.
+			// Fix for https://github.com/dotnet/maui/issues/35755: skip spans in the
+			// ellipsized tail to avoid IndexOutOfBoundsException.
 			var lastLayoutLine = layout.LineCount - 1;
 			if (lastLayoutLine < 0)
 				return;
@@ -172,11 +173,12 @@ namespace Microsoft.Maui.Controls.Platform
 				var spanStartLine = layout.GetLineForOffset(spanStartOffset);
 				var spanEndLine = layout.GetLineForOffset(spanEndOffset);
 
-				// Skip spans that start beyond the visible layout range.
+				// Safe for TailTruncation only: both offsets share the same string prefix.
 				if (spanStartOffset >= layoutEndOffset)
 					continue;
 
-				// Clamp spanEndLine so the inner loop never walks past the last laid-out line.
+				// OEM guard: some Layout subclasses don't cap GetLineForOffset at lineCount-1.
+				// Not dead code — see https://github.com/dotnet/maui/issues/35755
 				spanEndLine = System.Math.Min(spanEndLine, lastLayoutLine);
 
 				// Go through all lines that are affected by the span and calculate a rectangle for each

--- a/src/Controls/src/Core/Platform/Android/Extensions/FormattedStringExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/FormattedStringExtensions.cs
@@ -126,6 +126,15 @@ namespace Microsoft.Maui.Controls.Platform
 			if (layout == null)
 				return;
 
+			// When MaxLines truncates the text, the Layout only covers a subset of the
+			// SpannableString's characters. Pre-compute the last addressable offset so we
+			// can skip spans that fall entirely beyond the laid-out range and avoid
+			// IndexOutOfBoundsException in GetPrimaryHorizontal (see GitHub #35755).
+			var lastLayoutLine = layout.LineCount - 1;
+			if (lastLayoutLine < 0)
+				return;
+			var layoutEndOffset = layout.GetLineEnd(lastLayoutLine);
+
 			int next = 0;
 			int count = 0;
 
@@ -165,6 +174,14 @@ namespace Microsoft.Maui.Controls.Platform
 
 				var spanStartLine = layout.GetLineForOffset(spanStartOffset);
 				var spanEndLine = layout.GetLineForOffset(spanEndOffset);
+
+				// If MaxLines is active, spanStartOffset may exceed the laid-out character
+				// range. GetPrimaryHorizontal would throw in that case, so skip the span.
+				if (spanStartOffset >= layoutEndOffset)
+					continue;
+
+				// Clamp spanEndLine so the inner loop never walks past the last laid-out line.
+				spanEndLine = System.Math.Min(spanEndLine, lastLayoutLine);
 
 				// Go through all lines that are affected by the span and calculate a rectangle for each
 				List<Graphics.Rect> spanRectangles = new List<Graphics.Rect>();

--- a/src/Controls/src/Core/Platform/Android/Extensions/FormattedStringExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/FormattedStringExtensions.cs
@@ -170,12 +170,12 @@ namespace Microsoft.Maui.Controls.Platform
 				var spanStartOffset = spannableString.GetSpanStart(startSpan);
 				var spanEndOffset = spannableString.GetSpanEnd(endSpan);
 
-				var spanStartLine = layout.GetLineForOffset(spanStartOffset);
-				var spanEndLine = layout.GetLineForOffset(spanEndOffset);
-
 				// Safe for TailTruncation only: both offsets share the same string prefix.
 				if (spanStartOffset >= layoutEndOffset)
 					continue;
+
+				var spanStartLine = layout.GetLineForOffset(spanStartOffset);
+				var spanEndLine = layout.GetLineForOffset(System.Math.Min(spanEndOffset, layoutEndOffset - 1));
 
 				// OEM guard: some Layout subclasses don't cap GetLineForOffset at lineCount-1.
 				// Not dead code — see https://github.com/dotnet/maui/issues/35755

--- a/src/Controls/src/Core/Platform/Android/Extensions/FormattedStringExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/FormattedStringExtensions.cs
@@ -126,10 +126,7 @@ namespace Microsoft.Maui.Controls.Platform
 			if (layout == null)
 				return;
 
-			// When MaxLines truncates the text, the Layout only covers a subset of the
-			// SpannableString's characters. Pre-compute the last addressable offset so we
-			// can skip spans that fall entirely beyond the laid-out range and avoid
-			// IndexOutOfBoundsException in GetPrimaryHorizontal (see GitHub #35755).
+			// Pre-compute the last visible offset so out-of-range spans are skipped.
 			var lastLayoutLine = layout.LineCount - 1;
 			if (lastLayoutLine < 0)
 				return;
@@ -175,8 +172,7 @@ namespace Microsoft.Maui.Controls.Platform
 				var spanStartLine = layout.GetLineForOffset(spanStartOffset);
 				var spanEndLine = layout.GetLineForOffset(spanEndOffset);
 
-				// If MaxLines is active, spanStartOffset may exceed the laid-out character
-				// range. GetPrimaryHorizontal would throw in that case, so skip the span.
+				// Skip spans that start beyond the visible layout range.
 				if (spanStartOffset >= layoutEndOffset)
 					continue;
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue35755.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue35755.cs
@@ -1,6 +1,6 @@
 namespace Maui.Controls.Sample.Issues;
 
-[Issue(IssueTracker.Github, 35755, "[Android] IndexOutOfBoundsException in RecalculateSpanPositions when Label uses FormattedText + MaxLines + TailTruncation", PlatformAffected.Android)]
+[Issue(IssueTracker.Github, 35755, "IndexOutOfBoundsException in RecalculateSpanPositions when a Label uses FormattedText, MaxLines, and TailTruncation", PlatformAffected.Android)]
 public class Issue35755 : ContentPage
 {
 	readonly string _paragraphA = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum eleifend, augue nec aliquam interdum, massa nisl viverra orci, non interdum risus arcu id lorem. Curabitur accumsan, urna eu tempor tincidunt, purus neque feugiat tortor, sed tristique nibh nunc et augue.";
@@ -33,12 +33,7 @@ public class Issue35755 : ContentPage
 
 		triggerButton.Clicked += (s, e) =>
 		{
-			// Reassign FormattedText multiple times to increase crash frequency
-			for (var i = 0; i < 3; i++)
-			{
-				_crashTargetLabel.FormattedText = BuildFormattedText(i);
-			}
-
+			_crashTargetLabel.FormattedText = BuildFormattedText();
 			resultLabel.Text = "Success";
 		};
 
@@ -58,12 +53,12 @@ public class Issue35755 : ContentPage
 		};
 	}
 
-	FormattedString BuildFormattedText(int iteration)
+	FormattedString BuildFormattedText()
 	{
 		var fs = new FormattedString();
 		fs.Spans.Add(new Span
 		{
-			Text = $"Run {iteration + 1}: ",
+			Text = "Content: ",
 			FontAttributes = FontAttributes.Bold,
 			TextColor = Colors.DarkRed
 		});

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue35755.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue35755.cs
@@ -1,0 +1,75 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 35755, "[Android] IndexOutOfBoundsException in RecalculateSpanPositions when Label uses FormattedText + MaxLines + TailTruncation", PlatformAffected.Android)]
+public class Issue35755 : ContentPage
+{
+	readonly string _paragraphA = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum eleifend, augue nec aliquam interdum, massa nisl viverra orci, non interdum risus arcu id lorem. Curabitur accumsan, urna eu tempor tincidunt, purus neque feugiat tortor, sed tristique nibh nunc et augue.";
+	readonly string _paragraphB = "Aliquam erat volutpat. Quisque a mi lacus. Integer vitae malesuada sem. Nunc id dui nec lacus feugiat volutpat. Morbi et sollicitudin erat. Sed varius felis id dignissim facilisis. Vivamus vulputate, augue sed finibus laoreet, enim neque tristique odio, id rhoncus elit purus a turpis.";
+	readonly string _paragraphC = "Praesent in lectus non mauris mattis ultrices. Donec non justo ac nunc porta pellentesque. Integer euismod, velit in posuere iaculis, lorem nunc commodo libero, nec interdum lorem nibh ut turpis. Phasellus gravida tristique tortor, id posuere turpis sodales in.";
+
+	Label _crashTargetLabel;
+
+	public Issue35755()
+	{
+		_crashTargetLabel = new Label
+		{
+			AutomationId = "CrashTargetLabel",
+			MaxLines = 4,
+			LineBreakMode = LineBreakMode.TailTruncation,
+			FontSize = 14
+		};
+
+		var resultLabel = new Label
+		{
+			AutomationId = "ResultLabel",
+			Text = "Waiting for trigger..."
+		};
+
+		var triggerButton = new Button
+		{
+			AutomationId = "TriggerButton",
+			Text = "Trigger FormattedText"
+		};
+
+		triggerButton.Clicked += (s, e) =>
+		{
+			// Reassign FormattedText multiple times to increase crash frequency
+			for (var i = 0; i < 3; i++)
+			{
+				_crashTargetLabel.FormattedText = BuildFormattedText(i);
+			}
+
+			resultLabel.Text = "Success";
+		};
+
+		Content = new ScrollView
+		{
+			Content = new VerticalStackLayout
+			{
+				Padding = new Thickness(24),
+				Spacing = 16,
+				Children =
+				{
+					triggerButton,
+					resultLabel,
+					_crashTargetLabel
+				}
+			}
+		};
+	}
+
+	FormattedString BuildFormattedText(int iteration)
+	{
+		var fs = new FormattedString();
+		fs.Spans.Add(new Span
+		{
+			Text = $"Run {iteration + 1}: ",
+			FontAttributes = FontAttributes.Bold,
+			TextColor = Colors.DarkRed
+		});
+		fs.Spans.Add(new Span { Text = _paragraphA + "\n\n", TextColor = Colors.Black });
+		fs.Spans.Add(new Span { Text = _paragraphB + "\n\n", TextColor = Colors.DarkBlue });
+		fs.Spans.Add(new Span { Text = _paragraphC, TextColor = Colors.DarkGreen });
+		return fs;
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35755.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35755.cs
@@ -1,0 +1,35 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue35755 : _IssuesUITest
+{
+	public Issue35755(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue => "[Android] IndexOutOfBoundsException in RecalculateSpanPositions when Label uses FormattedText + MaxLines + TailTruncation";
+
+	[Test]
+	[Category(UITestCategories.Label)]
+	public void FormattedTextWithMaxLinesAndTailTruncationShouldNotCrash()
+	{
+		// Wait for the page to load
+		App.WaitForElement("TriggerButton");
+
+		// Tap button — this assigns a multi-span FormattedString to a Label with
+		// MaxLines=4 and TailTruncation three times in a row, which previously
+		// caused a fatal IndexOutOfBoundsException on Android.
+		App.Tap("TriggerButton");
+
+		// If the app didn't crash, the result label will show "Success"
+		App.WaitForElement("ResultLabel");
+		var resultText = App.FindElement("ResultLabel").GetText();
+		Assert.That(resultText, Is.EqualTo("Success"), "Label should display truncated FormattedText without crashing.");
+
+		// Verify the label is visible and rendered
+		App.WaitForElement("CrashTargetLabel");
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35755.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35755.cs
@@ -10,26 +10,18 @@ public class Issue35755 : _IssuesUITest
 	{
 	}
 
-	public override string Issue => "[Android] IndexOutOfBoundsException in RecalculateSpanPositions when Label uses FormattedText + MaxLines + TailTruncation";
+	public override string Issue => "IndexOutOfBoundsException in RecalculateSpanPositions when a Label uses FormattedText, MaxLines, and TailTruncation";
 
 	[Test]
 	[Category(UITestCategories.Label)]
 	public void FormattedTextWithMaxLinesAndTailTruncationShouldNotCrash()
 	{
-		// Wait for the page to load
 		App.WaitForElement("TriggerButton");
-
-		// Tap button — this assigns a multi-span FormattedString to a Label with
-		// MaxLines=4 and TailTruncation three times in a row, which previously
-		// caused a fatal IndexOutOfBoundsException on Android.
 		App.Tap("TriggerButton");
 
-		// If the app didn't crash, the result label will show "Success"
 		App.WaitForElement("ResultLabel");
 		var resultText = App.FindElement("ResultLabel").GetText();
 		Assert.That(resultText, Is.EqualTo("Success"), "Label should display truncated FormattedText without crashing.");
-
-		// Verify the label is visible and rendered
 		App.WaitForElement("CrashTargetLabel");
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->


### Issue Details
Android app crashes when a Label uses FormattedText + MaxLines + TailTruncation with long text.

### Root Cause
MaxLines shows only part of the text, but old code still reads positions from the full text.So Android gets an invalid text position and throws IndexOutOfBoundsException.

### Description of Change
Added a safety check to use only valid visible text positions. If a span is outside visible range, it is skipped/clamped, so no crash.

Validated the behavior in the following platforms
 
- [x] Android
- [ ] Windows
- [ ] iOS
- [ ] Mac
 
### Issues Fixed
  
Fixes #35755

### Output  ScreenShot

|Before|After|
|--|--|
| <video src="https://github.com/user-attachments/assets/ff85b136-8472-47c6-8ade-d4cbf185065c" >| <video src="https://github.com/user-attachments/assets/9a971d43-4b8c-4f73-8641-f0fd1cc897da">|