### PR TITLE
Surface p/0 PRs as Preview blockers; drop stale below-watermark SR branches from the tracker matrix

### DIFF
--- a/.github/skills/release-readiness/scripts/Find-ReleaseReadinessTrackers.ps1
+++ b/.github/skills/release-readiness/scripts/Find-ReleaseReadinessTrackers.ps1
@@ -283,6 +283,38 @@ function Test-IsBranchInFlight {
     return -not $ShippedPatches.Contains($BranchPatch)
 }
 
+function Test-IsStaleSrBranch {
+    <#
+    .SYNOPSIS
+        True when a tag-absent SR branch should be treated as a stale/abandoned
+        hotfix leftover rather than a live in-flight SR.
+    .DESCRIPTION
+        Secondary disambiguator applied ONLY after Test-IsBranchInFlight has
+        already returned true (the branch's stable `<major>.0.<patch>` tag does
+        not exist). Tag-existence stays the PRIMARY in-flight signal; this guard
+        narrows the false-positive where an old hotfix branch sits below the
+        shipped watermark with its tag never published.
+
+        A branch is stale when BOTH:
+          - its patch is strictly below the highest shipped patch
+            (e.g. SR2 patch 21 / SR3 patch 33 long after SR7 patch 71 shipped), and
+          - it has had no commits within the activity window (idle).
+
+        The idle requirement preserves the out-of-order / hotfix scenario that
+        tag-existence protects: a real security-hotfix branch that resets
+        PatchVersion below the watermark has recent commits
+        (RecentActivityCount > 0) and is therefore NOT considered stale. A
+        freshly-cut live SR sits at-or-above the watermark, so it is never
+        stale regardless of activity.
+    #>
+    param(
+        [Parameter(Mandatory)][int]$BranchPatch,
+        [Parameter(Mandatory)][int]$HighestShippedPatch,
+        [Parameter(Mandatory)][int]$RecentActivityCount
+    )
+    return ($RecentActivityCount -le 0 -and $BranchPatch -lt $HighestShippedPatch)
+}
+
 function Test-IsPreviewBranchInFlight {
     <#
     .SYNOPSIS
@@ -674,6 +706,19 @@ function Invoke-DetectionForMajor {
 
         if (Test-IsBranchInFlight -BranchPatch $branchPatch -ShippedPatches $shippedPatches) {
             $recent = Get-RecentCommitCount -Ref $branch -Days $ActivityWindowDays
+
+            # Staleness guard: a tag-absent branch below the shipped watermark
+            # with no recent activity is a stale/abandoned hotfix leftover
+            # (e.g. SR2 patch 21 / SR3 patch 33 long after SR7 patch 71 shipped),
+            # not a live in-flight SR. Dropping it here keeps it out of the
+            # workflow matrix entirely (no no-op per-tracker job). Tag-existence
+            # stays the primary signal; the idle requirement preserves the
+            # out-of-order/hotfix case (a real reset branch has recent commits).
+            if (Test-IsStaleSrBranch -BranchPatch $branchPatch -HighestShippedPatch $highestShippedPatch -RecentActivityCount $recent) {
+                Write-Host "  -> skipping stale SR$sr branch '$branch' (patch=$branchPatch < highest shipped $highestShippedPatch, no tag $expectedTag, no commits in ${ActivityWindowDays}d)" -ForegroundColor DarkGray
+                continue
+            }
+
             $tracker = New-Tracker -Major $Major -SrNumber $sr -Mode 'in-flight' `
                 -BranchName $branch -SurveyRef $branch -PriorSrBranch $null `
                 -PriorShippedPatch $highestShippedPatch -PriorShippedTag $highestShippedTag `

--- a/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
+++ b/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
@@ -690,6 +690,24 @@ function Get-PRAction {
     return [PSCustomObject]@{ Status = "WATCH"; Action = "Needs review or triage."; Age = $ageDays }
 }
 
+function Test-IsP0Pr {
+    <#
+    .SYNOPSIS
+        True when a PR object carries the release-blocking 'p/0' label.
+    .DESCRIPTION
+        Mirrors the issue-side p/0 detection so a p/0-labelled PR targeting the
+        release branch is surfaced as a blocker (not buried in the generic PR
+        WATCH count). StrictMode-safe: a PR with a missing or null `labels`
+        property yields an empty array (-> $false) instead of throwing.
+    #>
+    param($PR)
+
+    if (-not $PR) { return $false }
+    $labels = if ($PR.PSObject.Properties['labels']) { $PR.labels } else { $null }
+    if (-not $labels) { return $false }
+    return (@($labels | ForEach-Object { $_.name }) -contains 'p/0')
+}
+
 function New-Check {
     param(
         [string]$Area,
@@ -872,6 +890,11 @@ function Add-CiScanTable {
 # MAIN — gather checks
 # ===================================================================
 
+# Guard: skip the main driver when dot-sourced so tests can load the helper
+# functions (e.g. Test-IsP0Pr) without invoking the full report flow, which
+# requires git + gh + network. Mirrors Find-ReleaseReadinessTrackers.ps1.
+if ($MyInvocation.InvocationName -eq '.' -or $MyInvocation.Line -match '^\.\s') { return }
+
 $checks = @()
 
 # --- Target branch existence ---
@@ -999,6 +1022,16 @@ $mergeUpPRs = @($targetHumanPRsRaw | Where-Object {
 $mergeUpPrNumbers = @($mergeUpPRs | ForEach-Object { $_.number })
 $targetHumanPRs = @($targetHumanPRsRaw | Where-Object { $mergeUpPrNumbers -notcontains $_.number })
 
+# Carve out P/0-labelled release-branch PRs so they are surfaced as blockers in
+# the hoisted "🔴 High-priority items" section (alongside P/0 issues) instead of
+# being buried in the generic "Release branch PRs" WATCH count. A PR whose base
+# IS the survey ref is release-relevant by definition, so — unlike issues — no
+# title/milestone relevance filter is needed. Labels are already fetched by
+# Get-OpenPullRequests, so this needs no extra API call.
+$p0Prs = @($targetHumanPRs | Where-Object { Test-IsP0Pr $_ })
+$p0PrNumbers = @($p0Prs | ForEach-Object { $_.number })
+$targetHumanPRs = @($targetHumanPRs | Where-Object { $p0PrNumbers -notcontains $_.number })
+
 if ($maestroPRs.Count -eq 0) {
     $checks += New-Check -Area "Maestro PRs" -Status "READY" -Details "No open Maestro PRs target ``$SurveyRef`` or ``$mainBranch``." -NextAction "Continue monitoring for new dependency-flow PRs."
 } elseif (@($maestroPRs | Where-Object { (Get-PRAction -PR $_).Status -eq "BLOCKED" }).Count -gt 0) {
@@ -1016,7 +1049,15 @@ if ($targetHumanPRs.Count -eq 0) {
     # noise: the captain decides per-PR if any specific one MUST merge.
     $blockedCount = @($targetHumanPRs | Where-Object { (Get-PRAction -PR $_).Status -eq "BLOCKED" }).Count
     $blockedNote = if ($blockedCount -gt 0) { " ($blockedCount with merge conflicts / do-not-merge label)" } else { "" }
-    $checks += New-Check -Area "Release branch PRs" -Status "WATCH" -Details "$($targetHumanPRs.Count) non-Maestro PR(s) target ``$SurveyRef``$blockedNote. Not auto-blocking — only P/0 issues block shipment." -NextAction "Confirm which PRs (if any) must merge for the release; the rest can ride normal queue cadence."
+    $checks += New-Check -Area "Release branch PRs" -Status "WATCH" -Details "$($targetHumanPRs.Count) non-Maestro PR(s) target ``$SurveyRef``$blockedNote. Not auto-blocking — only P/0 issues and P/0-labelled PRs block shipment." -NextAction "Confirm which PRs (if any) must merge for the release; the rest can ride normal queue cadence."
+}
+
+# P/0-labelled PRs targeting the release branch are blockers (parallel to P/0
+# issues). They are itemized in the hoisted "🔴 High-priority items" section.
+if ($p0Prs.Count -gt 0) {
+    $checks += New-Check -Area "P/0 release-branch PRs" -Status "BLOCKED" -Details "$($p0Prs.Count) open P/0-labelled PR(s) target ``$SurveyRef``. See 🔴 High-priority items at top." -NextAction "Land or de-prioritize each P/0 PR before shipping."
+} else {
+    $checks += New-Check -Area "P/0 release-branch PRs" -Status "READY" -Details "No open P/0-labelled PRs target ``$SurveyRef``." -NextAction "No action required."
 }
 
 # Inflight watch only matters when survey != inflight (otherwise it
@@ -1215,11 +1256,14 @@ if ($Mode -eq 'candidate') {
 [void]$md.AppendLine("")
 
 # === HIGH-PRIORITY ITEMS (hoisted to the very top) ===
-# Three categories the release captain must see BEFORE anything else:
+# Four categories the release captain must see BEFORE anything else:
 #   1. P/0 priority blockers — open issues labeled p/0 (release-blocking severity).
-#   2. Maestro dependency-flow PRs — open Maestro PRs against the survey ref.
+#   2. P/0 release-branch PRs — open PRs labeled p/0 targeting the survey ref.
+#      A p/0 PR is an explicitly release-blocking change that must land (or be
+#      de-prioritized) before shipping.
+#   3. Maestro dependency-flow PRs — open Maestro PRs against the survey ref.
 #      A stuck Maestro PR blocks all upstream dependency flow into this branch.
-#   3. Merge-up PRs (main → survey ref) — daily-flow sync PRs whose head ref
+#   4. Merge-up PRs (main → survey ref) — daily-flow sync PRs whose head ref
 #      matches `merge/...-to-...` or title starts with "[automated] Merge branch".
 #      A stuck merge-up PR accumulates conflicts and starves the release branch
 #      of new fixes from main.
@@ -1233,6 +1277,16 @@ foreach ($iss in $p0Issues) {
         title = $iss.title
         actor = if ($iss.milestone -and $iss.milestone.title) { $iss.milestone.title } else { '' }
         nextAction = 'Resolve or downgrade before shipping.'
+    })
+}
+foreach ($pr in $p0Prs) {
+    $action = Get-PRAction -PR $pr
+    [void]$highPriorityRows.Add(@{
+        kind = '🔥 P/0 PR'
+        link = "[#$($pr.number)]($($pr.url))"
+        title = $pr.title
+        actor = "base ``$($pr.baseRefName)``, $($action.Age)d old"
+        nextAction = $action.Action
     })
 }
 foreach ($pr in $maestroPRs) {
@@ -1259,7 +1313,7 @@ foreach ($pr in $mergeUpPRs) {
 if ($highPriorityRows.Count -gt 0) {
     [void]$md.AppendLine("## 🔴 High-priority items — $($highPriorityRows.Count) item(s)")
     [void]$md.AppendLine("")
-    [void]$md.AppendLine("_P/0 issues, Maestro PRs, and ``main`` → ``$SurveyRef`` merge-up PRs. Resolve these before treating the release as ready._")
+    [void]$md.AppendLine("_P/0 issues, P/0 PRs, Maestro PRs, and ``main`` → ``$SurveyRef`` merge-up PRs. Resolve these before treating the release as ready._")
     [void]$md.AppendLine("")
     [void]$md.AppendLine("| Kind | Item | Title | Context | Next action |")
     [void]$md.AppendLine("|------|------|-------|---------|-------------|")
@@ -1271,10 +1325,11 @@ if ($highPriorityRows.Count -gt 0) {
 
 # === BLOCKING SUMMARY (hoisted to top) ===
 # Surface aggregate BLOCKED checks (e.g. CI red, versions.props not bumped).
-# The three high-priority categories above already enumerate individual items,
+# The high-priority categories above already enumerate individual items,
 # so exclude them here to avoid duplicate rows under two separate headings.
 $highPriorityCheckAreas = @(
     'P/0 priority blockers',
+    'P/0 release-branch PRs',
     "Merge-up PRs (main → $SurveyRef)"
 )
 $blockingChecks = @($checks | Where-Object {

--- a/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
+++ b/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
@@ -698,12 +698,21 @@ function Test-IsP0Pr {
         Mirrors the issue-side p/0 detection so a p/0-labelled PR targeting the
         release branch is surfaced as a blocker (not buried in the generic PR
         WATCH count). StrictMode-safe: a PR with a missing or null `labels`
-        property yields an empty array (-> $false) instead of throwing.
+        property yields an empty array (-> $false) instead of throwing. Accepts
+        both PSCustomObject (the production `gh ... --json` shape) and
+        IDictionary/hashtable (the shape test mocks commonly use), mirroring the
+        dual-shape handling in Get-ReleaseReadiness.ps1.
     #>
     param($PR)
 
     if (-not $PR) { return $false }
-    $labels = if ($PR.PSObject.Properties['labels']) { $PR.labels } else { $null }
+    $labels = if ($PR -is [System.Collections.IDictionary]) {
+        if ($PR.Contains('labels')) { $PR['labels'] } else { $null }
+    } elseif ($PR.PSObject.Properties['labels']) {
+        $PR.labels
+    } else {
+        $null
+    }
     if (-not $labels) { return $false }
     return (@($labels | ForEach-Object { $_.name }) -contains 'p/0')
 }
@@ -1237,6 +1246,7 @@ $report = [PSCustomObject]@{
     MaestroPullRequests   = $maestroPRs
     ReleasePullRequests   = $targetHumanPRs
     P0PullRequests        = $p0Prs
+    MergeUpPullRequests   = $mergeUpPRs
     InflightPullRequests  = $inflightHumanPRs
     PriorityIssues        = $priorityIssues
     KnownBuildErrorIssues = $kbeIssues
@@ -1328,9 +1338,12 @@ if ($highPriorityRows.Count -gt 0) {
 # Surface aggregate BLOCKED checks (e.g. CI red, versions.props not bumped).
 # The high-priority categories above already enumerate individual items,
 # so exclude them here to avoid duplicate rows under two separate headings.
+# Every Area whose items are hoisted into 🔴 High-priority items must be listed
+# here (Maestro PRs are hoisted as '📦 Maestro PR' rows, so they belong too).
 $highPriorityCheckAreas = @(
     'P/0 priority blockers',
     'P/0 release-branch PRs',
+    'Maestro PRs',
     "Merge-up PRs (main → $SurveyRef)"
 )
 $blockingChecks = @($checks | Where-Object {

--- a/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
+++ b/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
@@ -1015,8 +1015,25 @@ if ($SurveyRef -ne $mainBranch -and $inflightExists) {
 }
 
 $allReleasePRs = @($targetPRs) + @($inflightPRs)
-$maestroPRs = @($allReleasePRs | Where-Object { $_.author -and $_.author.login -match "dotnet-maestro" })
-$targetHumanPRsRaw = @($targetPRs | Where-Object { -not ($_.author -and $_.author.login -match "dotnet-maestro") })
+
+# Carve out P/0-labelled release-branch PRs FIRST, from the full set of PRs whose
+# base IS the survey ref (release-relevant by definition). P/0 is the strongest
+# release signal and takes precedence over author-type (Maestro) / merge-up
+# categorization: a p/0-labelled Maestro or merge-up PR must still trip the
+# dedicated "P/0 release-branch PRs" BLOCKED check and be itemized once as a
+# 🔥 P/0 PR row — never silently downgraded to a 📦 Maestro / merge-up row just
+# because it also happens to be automated. Unlike issues, no title/milestone
+# relevance filter is needed (base == survey ref ⇒ release-relevant). Inflight
+# (net<major>.0) PRs are intentionally excluded — only survey-ref PRs block.
+# Labels are already fetched by Get-OpenPullRequests, so this needs no extra API call.
+$p0Prs = @($targetPRs | Where-Object { Test-IsP0Pr $_ })
+$p0PrNumbers = @($p0Prs | ForEach-Object { $_.number })
+
+# Split the remaining (non-P/0) PRs into Maestro (dependency-flow) vs human.
+# P/0 PRs are excluded from BOTH buckets so an escalated p/0 PR is surfaced once
+# under the P/0 category, never double-counted in the Maestro or generic buckets.
+$maestroPRs = @($allReleasePRs | Where-Object { $_.author -and $_.author.login -match "dotnet-maestro" -and ($p0PrNumbers -notcontains $_.number) })
+$targetHumanPRsRaw = @($targetPRs | Where-Object { -not ($_.author -and $_.author.login -match "dotnet-maestro") -and ($p0PrNumbers -notcontains $_.number) })
 $inflightHumanPRs = @($inflightPRs | Where-Object { -not ($_.author -and $_.author.login -match "dotnet-maestro") })
 
 # Carve out main → $SurveyRef merge-up PRs from the human-PR set so they're
@@ -1024,22 +1041,14 @@ $inflightHumanPRs = @($inflightPRs | Where-Object { -not ($_.author -and $_.auth
 # instead of double-counted as generic "Release branch PRs". MAUI convention:
 #   - head ref like `merge/main-to-net11.0` or `merge/preview4-to-net11.0`
 #   - title like "[automated] Merge branch 'main' => 'net11.0'"
+# (P/0 PRs were already removed above, so a p/0-labelled merge-up PR escalates
+# to the P/0 category rather than being bucketed here.)
 $mergeUpPRs = @($targetHumanPRsRaw | Where-Object {
     ($_.headRefName -and $_.headRefName -match '^merge/.+-to-') -or
     ($_.title -and $_.title -match '^\[automated\] Merge branch')
 })
 $mergeUpPrNumbers = @($mergeUpPRs | ForEach-Object { $_.number })
 $targetHumanPRs = @($targetHumanPRsRaw | Where-Object { $mergeUpPrNumbers -notcontains $_.number })
-
-# Carve out P/0-labelled release-branch PRs so they are surfaced as blockers in
-# the hoisted "🔴 High-priority items" section (alongside P/0 issues) instead of
-# being buried in the generic "Release branch PRs" WATCH count. A PR whose base
-# IS the survey ref is release-relevant by definition, so — unlike issues — no
-# title/milestone relevance filter is needed. Labels are already fetched by
-# Get-OpenPullRequests, so this needs no extra API call.
-$p0Prs = @($targetHumanPRs | Where-Object { Test-IsP0Pr $_ })
-$p0PrNumbers = @($p0Prs | ForEach-Object { $_.number })
-$targetHumanPRs = @($targetHumanPRs | Where-Object { $p0PrNumbers -notcontains $_.number })
 
 if ($maestroPRs.Count -eq 0) {
     $checks += New-Check -Area "Maestro PRs" -Status "READY" -Details "No open Maestro PRs target ``$SurveyRef`` or ``$mainBranch``." -NextAction "Continue monitoring for new dependency-flow PRs."

--- a/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
+++ b/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
@@ -745,9 +745,13 @@ function Get-CategorizedPullRequests {
         to P/0 (only survey-ref PRs block), matching the engine's release scope:
         $p0PrNumbers is computed from $TargetPRs only, and PR numbers are globally
         unique, so excluding them from the target+inflight Maestro set cannot drop
-        an inflight PR. StrictMode-safe: every property accessed is guaranteed
-        present by Get-OpenPullRequests' --json projection, and the `-and`
-        short-circuits keep a null author from dereferencing `.login`.
+        an inflight PR. StrictMode-safe on two fronts: (1) inputs are normalized to
+        drop $null elements up front, so an AutomationNull list (what
+        Get-OpenPullRequests returns for a zero-PR branch) can't seed a `@($null)`
+        whose null element would throw "property 'author' cannot be found"; and
+        (2) for genuine PR objects every property accessed is guaranteed present by
+        Get-OpenPullRequests' --json projection, with `-and` short-circuits keeping
+        a null author from dereferencing `.login`.
     .OUTPUTS
         PSCustomObject with arrays: P0Prs, MaestroPRs, MergeUpPRs, TargetHumanPRs,
         InflightHumanPRs.
@@ -756,6 +760,20 @@ function Get-CategorizedPullRequests {
         [array]$TargetPRs = @(),
         [array]$InflightPRs = @()
     )
+
+    # Normalize inputs: the driver assigns these from Get-OpenPullRequests, which
+    # returns AutomationNull for a branch with zero open PRs (an empty `gh pr list`
+    # result collapses through `return @()`). When AutomationNull is bound to an
+    # [array] parameter the parameter becomes $null (NOT the `= @()` default — the
+    # default only applies when the argument is omitted), and `@($null)` then yields
+    # a single-element array whose lone element is $null. Iterating that under
+    # `Set-StrictMode -Version Latest` and dereferencing `$_.author` throws
+    # "The property 'author' cannot be found on this object". Stripping nulls here
+    # makes the function robust to null / AutomationNull / @($null) inputs — the
+    # realistic trigger is an in-flight run against a freshly-cut release branch
+    # that exists but has no PRs yet while the inflight (net<major>.0) branch does.
+    $TargetPRs   = @($TargetPRs   | Where-Object { $null -ne $_ })
+    $InflightPRs = @($InflightPRs | Where-Object { $null -ne $_ })
 
     $allReleasePRs = @($TargetPRs) + @($InflightPRs)
 

--- a/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
+++ b/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
@@ -717,6 +717,80 @@ function Test-IsP0Pr {
     return (@($labels | ForEach-Object { $_.name }) -contains 'p/0')
 }
 
+function Get-CategorizedPullRequests {
+    <#
+    .SYNOPSIS
+        Splits the open release/inflight PRs into mutually-exclusive buckets:
+        P/0, Maestro (dependency-flow), merge-up, generic-human (target), and
+        inflight-human.
+    .DESCRIPTION
+        Single source of truth for PR categorization precedence, shared by the
+        engine driver and its unit tests so the tests exercise the REAL filter
+        expressions (not a re-implementation). Precedence, highest first:
+
+          1. P/0  — any survey-ref PR carrying the 'p/0' label, REGARDLESS of
+                    author or merge-up status. P/0 is the strongest release
+                    signal: a p/0-labelled Maestro or merge-up PR escalates to
+                    the P/0 blocker category (trips its dedicated BLOCKED check +
+                    renders once as a 🔥 P/0 PR row) and is never silently
+                    downgraded to a 📦 Maestro / merge-up row.
+          2. Maestro  — non-P/0 PRs authored by dotnet-maestro (target OR inflight).
+          3. Merge-up — non-P/0, non-Maestro target PRs that are automated
+                    main → survey-ref merges (head `merge/<x>-to-<y>` or title
+                    "[automated] Merge branch ...").
+          4. Generic-human (target) — the remaining survey-ref PRs.
+          5. Inflight-human — non-Maestro PRs on the inflight (net<major>.0) branch.
+
+        Buckets are mutually exclusive by PR number. Inflight PRs never escalate
+        to P/0 (only survey-ref PRs block), matching the engine's release scope:
+        $p0PrNumbers is computed from $TargetPRs only, and PR numbers are globally
+        unique, so excluding them from the target+inflight Maestro set cannot drop
+        an inflight PR. StrictMode-safe: every property accessed is guaranteed
+        present by Get-OpenPullRequests' --json projection, and the `-and`
+        short-circuits keep a null author from dereferencing `.login`.
+    .OUTPUTS
+        PSCustomObject with arrays: P0Prs, MaestroPRs, MergeUpPRs, TargetHumanPRs,
+        InflightHumanPRs.
+    #>
+    param(
+        [array]$TargetPRs = @(),
+        [array]$InflightPRs = @()
+    )
+
+    $allReleasePRs = @($TargetPRs) + @($InflightPRs)
+
+    # 1. P/0 first (highest precedence), from survey-ref PRs only.
+    $p0Prs = @($TargetPRs | Where-Object { Test-IsP0Pr $_ })
+    $p0PrNumbers = @($p0Prs | ForEach-Object { $_.number })
+
+    # 2. Maestro (non-P/0), across target + inflight.
+    $maestroPRs = @($allReleasePRs | Where-Object { $_.author -and $_.author.login -match "dotnet-maestro" -and ($p0PrNumbers -notcontains $_.number) })
+
+    # Non-P/0, non-Maestro humans, split by scope.
+    $targetHumanPRsRaw = @($TargetPRs | Where-Object { -not ($_.author -and $_.author.login -match "dotnet-maestro") -and ($p0PrNumbers -notcontains $_.number) })
+    $inflightHumanPRs = @($InflightPRs | Where-Object { -not ($_.author -and $_.author.login -match "dotnet-maestro") })
+
+    # 3. Merge-up: non-P/0, non-Maestro target PRs. MAUI convention:
+    #   - head ref like `merge/main-to-net11.0` or `merge/preview4-to-net11.0`
+    #   - title like "[automated] Merge branch 'main' => 'net11.0'"
+    $mergeUpPRs = @($targetHumanPRsRaw | Where-Object {
+        ($_.headRefName -and $_.headRefName -match '^merge/.+-to-') -or
+        ($_.title -and $_.title -match '^\[automated\] Merge branch')
+    })
+    $mergeUpPrNumbers = @($mergeUpPRs | ForEach-Object { $_.number })
+
+    # 4. Generic-human (target) = the remainder, counted/listed once.
+    $targetHumanPRs = @($targetHumanPRsRaw | Where-Object { $mergeUpPrNumbers -notcontains $_.number })
+
+    return [PSCustomObject]@{
+        P0Prs            = $p0Prs
+        MaestroPRs       = $maestroPRs
+        MergeUpPRs       = $mergeUpPRs
+        TargetHumanPRs   = $targetHumanPRs
+        InflightHumanPRs = $inflightHumanPRs
+    }
+}
+
 function New-Check {
     param(
         [string]$Area,
@@ -1014,41 +1088,17 @@ if ($SurveyRef -ne $mainBranch -and $inflightExists) {
     $inflightPRs = Get-OpenPullRequests -BaseBranch $mainBranch
 }
 
-$allReleasePRs = @($targetPRs) + @($inflightPRs)
-
-# Carve out P/0-labelled release-branch PRs FIRST, from the full set of PRs whose
-# base IS the survey ref (release-relevant by definition). P/0 is the strongest
-# release signal and takes precedence over author-type (Maestro) / merge-up
-# categorization: a p/0-labelled Maestro or merge-up PR must still trip the
-# dedicated "P/0 release-branch PRs" BLOCKED check and be itemized once as a
-# 🔥 P/0 PR row — never silently downgraded to a 📦 Maestro / merge-up row just
-# because it also happens to be automated. Unlike issues, no title/milestone
-# relevance filter is needed (base == survey ref ⇒ release-relevant). Inflight
-# (net<major>.0) PRs are intentionally excluded — only survey-ref PRs block.
-# Labels are already fetched by Get-OpenPullRequests, so this needs no extra API call.
-$p0Prs = @($targetPRs | Where-Object { Test-IsP0Pr $_ })
-$p0PrNumbers = @($p0Prs | ForEach-Object { $_.number })
-
-# Split the remaining (non-P/0) PRs into Maestro (dependency-flow) vs human.
-# P/0 PRs are excluded from BOTH buckets so an escalated p/0 PR is surfaced once
-# under the P/0 category, never double-counted in the Maestro or generic buckets.
-$maestroPRs = @($allReleasePRs | Where-Object { $_.author -and $_.author.login -match "dotnet-maestro" -and ($p0PrNumbers -notcontains $_.number) })
-$targetHumanPRsRaw = @($targetPRs | Where-Object { -not ($_.author -and $_.author.login -match "dotnet-maestro") -and ($p0PrNumbers -notcontains $_.number) })
-$inflightHumanPRs = @($inflightPRs | Where-Object { -not ($_.author -and $_.author.login -match "dotnet-maestro") })
-
-# Carve out main → $SurveyRef merge-up PRs from the human-PR set so they're
-# only counted/listed once (in the hoisted "🔴 High-priority items" section)
-# instead of double-counted as generic "Release branch PRs". MAUI convention:
-#   - head ref like `merge/main-to-net11.0` or `merge/preview4-to-net11.0`
-#   - title like "[automated] Merge branch 'main' => 'net11.0'"
-# (P/0 PRs were already removed above, so a p/0-labelled merge-up PR escalates
-# to the P/0 category rather than being bucketed here.)
-$mergeUpPRs = @($targetHumanPRsRaw | Where-Object {
-    ($_.headRefName -and $_.headRefName -match '^merge/.+-to-') -or
-    ($_.title -and $_.title -match '^\[automated\] Merge branch')
-})
-$mergeUpPrNumbers = @($mergeUpPRs | ForEach-Object { $_.number })
-$targetHumanPRs = @($targetHumanPRsRaw | Where-Object { $mergeUpPrNumbers -notcontains $_.number })
+# Categorize PRs into mutually-exclusive blocker buckets with P/0 as the highest
+# precedence (a p/0-labelled Maestro or merge-up PR escalates to the P/0 category
+# rather than being downgraded to a 📦 Maestro / merge-up row). The carve-out
+# precedence logic lives in Get-CategorizedPullRequests so the unit tests drive
+# the same code the engine runs (see Test-ReleaseReadiness.ps1 precedence block).
+$prBuckets        = Get-CategorizedPullRequests -TargetPRs $targetPRs -InflightPRs $inflightPRs
+$p0Prs            = $prBuckets.P0Prs
+$maestroPRs       = $prBuckets.MaestroPRs
+$mergeUpPRs       = $prBuckets.MergeUpPRs
+$targetHumanPRs   = $prBuckets.TargetHumanPRs
+$inflightHumanPRs = $prBuckets.InflightHumanPRs
 
 if ($maestroPRs.Count -eq 0) {
     $checks += New-Check -Area "Maestro PRs" -Status "READY" -Details "No open Maestro PRs target ``$SurveyRef`` or ``$mainBranch``." -NextAction "Continue monitoring for new dependency-flow PRs."

--- a/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
+++ b/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
@@ -1236,6 +1236,7 @@ $report = [PSCustomObject]@{
     XcodeRequirements     = $xcodeRequirements
     MaestroPullRequests   = $maestroPRs
     ReleasePullRequests   = $targetHumanPRs
+    P0PullRequests        = $p0Prs
     InflightPullRequests  = $inflightHumanPRs
     PriorityIssues        = $priorityIssues
     KnownBuildErrorIssues = $kbeIssues

--- a/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
+++ b/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
@@ -1140,6 +1140,12 @@ if ($targetHumanPRs.Count -eq 0) {
 
 # P/0-labelled PRs targeting the release branch are blockers (parallel to P/0
 # issues). They are itemized in the hoisted "🔴 High-priority items" section.
+# By design this is label-only and does NOT filter drafts: a `p/0` label
+# deliberately placed on a release-targeting PR is an explicit "must ship"
+# signal regardless of draft state, so a draft p/0 PR intentionally trips
+# BLOCKED here. Surfacing "a release-critical change isn't ready yet" is the
+# useful behavior; the per-row 🔥 entry still shows "Draft PR; wait until
+# ready" via Get-PRAction, so the draft state is not lost.
 if ($p0Prs.Count -gt 0) {
     $checks += New-Check -Area "P/0 release-branch PRs" -Status "BLOCKED" -Details "$($p0Prs.Count) open P/0-labelled PR(s) target ``$SurveyRef``. See 🔴 High-priority items at top." -NextAction "Land or de-prioritize each P/0 PR before shipping."
 } else {

--- a/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
+++ b/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
@@ -2703,6 +2703,45 @@ Assert-Eq -Label "carve-out: p/0 subset contains #44444"      -Expected $true -A
 Assert-Eq -Label "carve-out: generic bucket excludes p/0 PRs" -Expected 2     -Actual $generic.Count
 Assert-Eq -Label "carve-out: generic bucket keeps #99999"     -Expected $true -Actual (@($generic | ForEach-Object { $_.number }) -contains 99999)
 
+# Precedence: P/0 takes priority over author-type (Maestro) AND merge-up
+# categorization. A p/0-labelled Maestro or merge-up PR must be carved into the
+# P/0 blocker set FIRST (so it trips the dedicated BLOCKED check + 🔥 P/0 PR row)
+# and excluded from the Maestro / merge-up / generic buckets — never silently
+# downgraded to a 📦 Maestro / merge-up row. Mirrors the engine's exact carve-out
+# sequence in Get-PreviewReadiness.ps1 (p/0 first, then maestro/human, then merge-up).
+$maestroLogin = [PSCustomObject]@{ login = 'dotnet-maestro[bot]' }
+$humanLogin   = [PSCustomObject]@{ login = 'someDev' }
+$p0Lbl        = @([PSCustomObject]@{ name = 'p/0' })
+$plainLbl     = @([PSCustomObject]@{ name = 'area-xaml' })
+
+$prHumanP0   = [PSCustomObject]@{ number = 1; author = $humanLogin;   labels = $p0Lbl;    headRefName = 'fix/x';                  title = 'Fix X' }
+$prMaestroP0 = [PSCustomObject]@{ number = 2; author = $maestroLogin; labels = $p0Lbl;    headRefName = 'darc-net11.0-abc';       title = 'Update dependencies' }
+$prMergeP0   = [PSCustomObject]@{ number = 3; author = $humanLogin;   labels = $p0Lbl;    headRefName = 'merge/main-to-net11.0';  title = "[automated] Merge branch 'main' => 'net11.0'" }
+$prMaestro   = [PSCustomObject]@{ number = 4; author = $maestroLogin; labels = $plainLbl; headRefName = 'darc-net11.0-def';       title = 'Update dependencies' }
+$prHuman     = [PSCustomObject]@{ number = 5; author = $humanLogin;   labels = $plainLbl; headRefName = 'fix/y';                  title = 'Fix Y' }
+$prMergeUp   = [PSCustomObject]@{ number = 6; author = $humanLogin;   labels = $plainLbl; headRefName = 'merge/main-to-net11.0';  title = "[automated] Merge branch 'main' => 'net11.0'" }
+
+$targetSet = @($prHumanP0, $prMaestroP0, $prMergeP0, $prMaestro, $prHuman, $prMergeUp)
+
+# Replicates the engine ordering exactly.
+$pre_p0       = @($targetSet | Where-Object { Test-IsP0Pr $_ })
+$pre_p0N      = @($pre_p0 | ForEach-Object { $_.number })
+$pre_maestro  = @($targetSet | Where-Object { $_.author -and $_.author.login -match 'dotnet-maestro' -and ($pre_p0N -notcontains $_.number) })
+$pre_humanRaw = @($targetSet | Where-Object { -not ($_.author -and $_.author.login -match 'dotnet-maestro') -and ($pre_p0N -notcontains $_.number) })
+$pre_mergeUp  = @($pre_humanRaw | Where-Object { ($_.headRefName -match '^merge/.+-to-') -or ($_.title -match '^\[automated\] Merge branch') })
+$pre_mergeUpN = @($pre_mergeUp | ForEach-Object { $_.number })
+$pre_generic  = @($pre_humanRaw | Where-Object { $pre_mergeUpN -notcontains $_.number })
+
+Assert-Eq -Label "precedence: 3 p/0 PRs carved (human+maestro+merge-up)"   -Expected 3     -Actual $pre_p0.Count
+Assert-Eq -Label "precedence: p/0 set includes the Maestro p/0 (#2)"       -Expected $true -Actual ($pre_p0N -contains 2)
+Assert-Eq -Label "precedence: p/0 set includes the merge-up p/0 (#3)"      -Expected $true -Actual ($pre_p0N -contains 3)
+Assert-Eq -Label "precedence: Maestro bucket excludes the p/0 Maestro (#2)" -Expected $false -Actual (@($pre_maestro | ForEach-Object { $_.number }) -contains 2)
+Assert-Eq -Label "precedence: Maestro bucket = only the plain Maestro (#4)" -Expected 1     -Actual $pre_maestro.Count
+Assert-Eq -Label "precedence: merge-up bucket excludes the p/0 merge-up (#3)" -Expected $false -Actual (@($pre_mergeUp | ForEach-Object { $_.number }) -contains 3)
+Assert-Eq -Label "precedence: merge-up bucket = only the plain merge-up (#6)" -Expected 1   -Actual $pre_mergeUp.Count
+Assert-Eq -Label "precedence: generic human = only the plain human (#5)"   -Expected 1     -Actual $pre_generic.Count
+Assert-Eq -Label "precedence: generic human keeps #5"                      -Expected $true -Actual (@($pre_generic | ForEach-Object { $_.number }) -contains 5)
+
 Write-Host "`n────────────────────────────────────────" -ForegroundColor Cyan
 Write-Host "Passed: $script:passed   Failed: $script:failed" -ForegroundColor $(if ($script:failed -eq 0) { 'Green' } else { 'Red' })
 exit $(if ($script:failed -eq 0) { 0 } else { 1 })

--- a/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
+++ b/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
@@ -2759,6 +2759,43 @@ Assert-Eq -Label "precedence: empty input → 0 merge-up" -Expected 0 -Actual $e
 Assert-Eq -Label "precedence: empty input → 0 human"    -Expected 0 -Actual $emptyBuckets.TargetHumanPRs.Count
 Assert-Eq -Label "precedence: empty input → 0 inflight" -Expected 0 -Actual $emptyBuckets.InflightHumanPRs.Count
 
+# AutomationNull-input safety (regression for the zero-PR-branch crash).
+# The driver assigns $targetPRs/$inflightPRs from Get-OpenPullRequests, which
+# returns AutomationNull (NOT a literal @()) for a branch with no open PRs — an
+# empty `gh pr list` result collapses through `return @()`. AutomationNull bound
+# to an [array] param becomes $null, and @($null) seeds a single null element
+# whose `$_.author` dereference throws under StrictMode. Reproduce that EXACT
+# value via ConvertFrom-JsonOrEmptyArray '[]' (the real collapse path), not a
+# literal @() — the literal does not reproduce the bug.
+$nullFromGh    = ConvertFrom-JsonOrEmptyArray '[]'   # AutomationNull, exactly like Get-OpenPullRequests on a 0-PR branch
+$maestroPrMock = [PSCustomObject]@{ number = 9001; title = 'Bump deps'; author = [PSCustomObject]@{ login = 'dotnet-maestro' }; headRefName = 'darc-x'; labels = @(); url = 'u'; isDraft = $false }
+
+# (a) The reachable in-flight shape: AutomationNull target (existing branch, 0 PRs)
+#     + non-empty inflight Maestro list. Must not throw; Maestro PR still counted.
+$nullTargetThrew = $false
+$nullTargetBuckets = $null
+try { $nullTargetBuckets = Get-CategorizedPullRequests -TargetPRs $nullFromGh -InflightPRs @($maestroPrMock) }
+catch { $nullTargetThrew = $true }
+Assert-Eq -Label "AutomationNull target + inflight Maestro → no throw" -Expected $false -Actual $nullTargetThrew
+Assert-Eq -Label "AutomationNull target → 0 target-human"             -Expected 0     -Actual $nullTargetBuckets.TargetHumanPRs.Count
+Assert-Eq -Label "AutomationNull target → inflight Maestro counted"   -Expected 1     -Actual $nullTargetBuckets.MaestroPRs.Count
+
+# (b) Both inputs AutomationNull → five empty buckets, no throw.
+$bothNullThrew = $false
+$bothNullBuckets = $null
+try { $bothNullBuckets = Get-CategorizedPullRequests -TargetPRs (ConvertFrom-JsonOrEmptyArray '[]') -InflightPRs (ConvertFrom-JsonOrEmptyArray '[]') }
+catch { $bothNullThrew = $true }
+Assert-Eq -Label "AutomationNull both → no throw"      -Expected $false -Actual $bothNullThrew
+Assert-Eq -Label "AutomationNull both → 0 p/0"         -Expected 0      -Actual $bothNullBuckets.P0Prs.Count
+Assert-Eq -Label "AutomationNull both → 0 Maestro"     -Expected 0      -Actual $bothNullBuckets.MaestroPRs.Count
+Assert-Eq -Label "AutomationNull both → 0 inflight"    -Expected 0      -Actual $bothNullBuckets.InflightHumanPRs.Count
+
+# (c) Explicit $null and an array carrying a $null element are both normalized.
+$explicitNullThrew = $false
+try { $null = Get-CategorizedPullRequests -TargetPRs $null -InflightPRs @($null, $maestroPrMock) }
+catch { $explicitNullThrew = $true }
+Assert-Eq -Label "explicit null target + @(null, maestro) inflight → no throw" -Expected $false -Actual $explicitNullThrew
+
 Write-Host "`n────────────────────────────────────────" -ForegroundColor Cyan
 Write-Host "Passed: $script:passed   Failed: $script:failed" -ForegroundColor $(if ($script:failed -eq 0) { 'Green' } else { 'Red' })
 exit $(if ($script:failed -eq 0) { 0 } else { 1 })

--- a/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
+++ b/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
@@ -573,25 +573,16 @@ if (-not $SkipE2E) {
 
             # SR2 (tag-absent but STALE — Lane 1 staleness guard drops it so the
             # workflow matrix never spins up a no-op job for it).
-            if ($bySr.ContainsKey(2)) {
-                Write-Host "  ❌ SR2 tracker should be dropped (patch=21 < watermark 71, idle — stale)" -ForegroundColor Red; $script:failed++
-            } else {
-                Assert-Eq -Label "SR2 tracker absent (stale: patch 21 < 71, no recent activity)" -Expected $true -Actual $true
-            }
+            Assert-Eq -Label "SR2 tracker absent (stale: patch 21 < 71, no recent activity)" `
+                      -Expected $false -Actual ($bySr.ContainsKey(2))
 
             # SR3 (tag-absent but STALE — dropped by the staleness guard)
-            if ($bySr.ContainsKey(3)) {
-                Write-Host "  ❌ SR3 tracker should be dropped (patch=33 < watermark 71, idle — stale)" -ForegroundColor Red; $script:failed++
-            } else {
-                Assert-Eq -Label "SR3 tracker absent (stale: patch 33 < 71, no recent activity)" -Expected $true -Actual $true
-            }
+            Assert-Eq -Label "SR3 tracker absent (stale: patch 33 < 71, no recent activity)" `
+                      -Expected $false -Actual ($bySr.ContainsKey(3))
 
             # SR7 (shipped 2026-06-05 as 10.0.71 — Lane 1 should NOT emit a tracker)
-            if ($bySr.ContainsKey(7)) {
-                Write-Host "  ❌ SR7 tracker should NOT be present (tag 10.0.71 shipped 2026-06-05)" -ForegroundColor Red; $script:failed++
-            } else {
-                Assert-Eq -Label "SR7 tracker absent (shipped)" -Expected $true -Actual $true
-            }
+            Assert-Eq -Label "SR7 tracker absent (shipped)" `
+                      -Expected $false -Actual ($bySr.ContainsKey(7))
 
             # SR8 (in-flight, ACTIVE)
             if ($bySr.ContainsKey(8)) {

--- a/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
+++ b/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
@@ -2636,6 +2636,49 @@ $t19 = Get-ExpectedShipDate -ReferenceDate ([DateTime]'2026-06-11') -PatchVersio
 Assert-Eq -Label "T19: patch=81 + MainBumpDate → asap-hotfix"     -Expected 'asap-hotfix'     -Actual $t19.Cadence
 Assert-Eq -Label "T19: missedWindow = false for hotfix"           -Expected $false            -Actual $t19.MissedWindow
 
+# =========================================================================
+# Test-IsP0Pr — preview engine p/0 PR blocker classification
+# =========================================================================
+# Regression guard for the gap where p/0-labelled PRs targeting a preview
+# release branch were NOT surfaced as blockers (only p/0 *issues* were).
+# gh issue list --label p/0 never returns PRs, so p/0 PRs (e.g. #34758,
+# #35626 against net11.0) rendered as generic "Needs review or triage"
+# WATCH rows. Test-IsP0Pr is the predicate that carves them out for hoisting.
+Write-Host "`n[Unit] Test-IsP0Pr — p/0 PR blocker classification" -ForegroundColor Cyan
+
+# Dot-source the preview engine to access its helpers without running the
+# main driver (the InvocationName guard returns on dot-source). A valid
+# -Branch is required to satisfy the mandatory parameter + branch parse.
+$prevScript = Join-Path $PSScriptRoot '..' 'scripts' 'Get-PreviewReadiness.ps1'
+. $prevScript -Branch 'release/11.0.1xx-preview6'
+
+$p0Pr        = [PSCustomObject]@{ number = 34758; labels = @([PSCustomObject]@{ name = 'p/0' }, [PSCustomObject]@{ name = 'area-xaml' }) }
+$nonP0Pr     = [PSCustomObject]@{ number = 99999; labels = @([PSCustomObject]@{ name = 'area-xaml' }, [PSCustomObject]@{ name = 'p/1' }) }
+$missingLbls = [PSCustomObject]@{ number = 12345 }            # no labels property at all
+$nullLbls    = [PSCustomObject]@{ number = 22222; labels = $null }
+$emptyLbls   = [PSCustomObject]@{ number = 33333; labels = @() }
+$hashLbls    = [PSCustomObject]@{ number = 44444; labels = @(@{ name = 'p/0' }) }   # hashtable-shaped labels
+
+Assert-Eq -Label "p/0-labelled PR → blocker"                  -Expected $true  -Actual (Test-IsP0Pr $p0Pr)
+Assert-Eq -Label "non-p/0 PR (has p/1) → not a blocker"       -Expected $false -Actual (Test-IsP0Pr $nonP0Pr)
+Assert-Eq -Label "PR missing labels property → false (StrictMode-safe)" -Expected $false -Actual (Test-IsP0Pr $missingLbls)
+Assert-Eq -Label "PR with null labels → false"                -Expected $false -Actual (Test-IsP0Pr $nullLbls)
+Assert-Eq -Label "PR with empty labels → false"               -Expected $false -Actual (Test-IsP0Pr $emptyLbls)
+Assert-Eq -Label "hashtable-shaped labels still matched"      -Expected $true  -Actual (Test-IsP0Pr $hashLbls)
+Assert-Eq -Label "null PR → false (no throw)"                 -Expected $false -Actual (Test-IsP0Pr $null)
+
+# Carve-out semantics: the p/0 subset is selected, and the generic (WATCH)
+# bucket has them removed — exactly what the engine does before hoisting.
+$mixedPrs = @($p0Pr, $nonP0Pr, $hashLbls, $emptyLbls)
+$p0Subset = @($mixedPrs | Where-Object { Test-IsP0Pr $_ })
+$p0Nums   = @($p0Subset | ForEach-Object { $_.number })
+$generic  = @($mixedPrs | Where-Object { $p0Nums -notcontains $_.number })
+Assert-Eq -Label "carve-out: 2 of 4 PRs are p/0"              -Expected 2     -Actual $p0Subset.Count
+Assert-Eq -Label "carve-out: p/0 subset contains #34758"      -Expected $true -Actual ($p0Nums -contains 34758)
+Assert-Eq -Label "carve-out: p/0 subset contains #44444"      -Expected $true -Actual ($p0Nums -contains 44444)
+Assert-Eq -Label "carve-out: generic bucket excludes p/0 PRs" -Expected 2     -Actual $generic.Count
+Assert-Eq -Label "carve-out: generic bucket keeps #99999"     -Expected $true -Actual (@($generic | ForEach-Object { $_.number }) -contains 99999)
+
 Write-Host "`n────────────────────────────────────────" -ForegroundColor Cyan
 Write-Host "Passed: $script:passed   Failed: $script:failed" -ForegroundColor $(if ($script:failed -eq 0) { 'Green' } else { 'Red' })
 exit $(if ($script:failed -eq 0) { 0 } else { 1 })

--- a/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
+++ b/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
@@ -2707,8 +2707,9 @@ Assert-Eq -Label "carve-out: generic bucket keeps #99999"     -Expected $true -A
 # categorization. A p/0-labelled Maestro or merge-up PR must be carved into the
 # P/0 blocker set FIRST (so it trips the dedicated BLOCKED check + 🔥 P/0 PR row)
 # and excluded from the Maestro / merge-up / generic buckets — never silently
-# downgraded to a 📦 Maestro / merge-up row. Mirrors the engine's exact carve-out
-# sequence in Get-PreviewReadiness.ps1 (p/0 first, then maestro/human, then merge-up).
+# downgraded to a 📦 Maestro / merge-up row. This drives the REAL engine carve-out
+# (Get-CategorizedPullRequests) rather than a re-implementation, so a regression
+# in the engine's own filter expressions is caught here.
 $maestroLogin = [PSCustomObject]@{ login = 'dotnet-maestro[bot]' }
 $humanLogin   = [PSCustomObject]@{ login = 'someDev' }
 $p0Lbl        = @([PSCustomObject]@{ name = 'p/0' })
@@ -2720,27 +2721,43 @@ $prMergeP0   = [PSCustomObject]@{ number = 3; author = $humanLogin;   labels = $
 $prMaestro   = [PSCustomObject]@{ number = 4; author = $maestroLogin; labels = $plainLbl; headRefName = 'darc-net11.0-def';       title = 'Update dependencies' }
 $prHuman     = [PSCustomObject]@{ number = 5; author = $humanLogin;   labels = $plainLbl; headRefName = 'fix/y';                  title = 'Fix Y' }
 $prMergeUp   = [PSCustomObject]@{ number = 6; author = $humanLogin;   labels = $plainLbl; headRefName = 'merge/main-to-net11.0';  title = "[automated] Merge branch 'main' => 'net11.0'" }
+# Inflight (net<major>.0) PRs: a Maestro one (must still bucket as Maestro) and a
+# p/0-labelled one (must NOT escalate — only survey-ref PRs block).
+$prInflightMaestro = [PSCustomObject]@{ number = 7; author = $maestroLogin; labels = $plainLbl; headRefName = 'darc-main-xyz'; title = 'Update dependencies' }
+$prInflightP0      = [PSCustomObject]@{ number = 8; author = $humanLogin;   labels = $p0Lbl;    headRefName = 'fix/z';          title = 'Fix Z' }
 
-$targetSet = @($prHumanP0, $prMaestroP0, $prMergeP0, $prMaestro, $prHuman, $prMergeUp)
+$targetSet   = @($prHumanP0, $prMaestroP0, $prMergeP0, $prMaestro, $prHuman, $prMergeUp)
+$inflightSet = @($prInflightMaestro, $prInflightP0)
 
-# Replicates the engine ordering exactly.
-$pre_p0       = @($targetSet | Where-Object { Test-IsP0Pr $_ })
-$pre_p0N      = @($pre_p0 | ForEach-Object { $_.number })
-$pre_maestro  = @($targetSet | Where-Object { $_.author -and $_.author.login -match 'dotnet-maestro' -and ($pre_p0N -notcontains $_.number) })
-$pre_humanRaw = @($targetSet | Where-Object { -not ($_.author -and $_.author.login -match 'dotnet-maestro') -and ($pre_p0N -notcontains $_.number) })
-$pre_mergeUp  = @($pre_humanRaw | Where-Object { ($_.headRefName -match '^merge/.+-to-') -or ($_.title -match '^\[automated\] Merge branch') })
-$pre_mergeUpN = @($pre_mergeUp | ForEach-Object { $_.number })
-$pre_generic  = @($pre_humanRaw | Where-Object { $pre_mergeUpN -notcontains $_.number })
+$buckets = Get-CategorizedPullRequests -TargetPRs $targetSet -InflightPRs $inflightSet
+$bP0      = @($buckets.P0Prs            | ForEach-Object { $_.number })
+$bMaestro = @($buckets.MaestroPRs       | ForEach-Object { $_.number })
+$bMergeUp = @($buckets.MergeUpPRs       | ForEach-Object { $_.number })
+$bHuman   = @($buckets.TargetHumanPRs   | ForEach-Object { $_.number })
+$bInflight = @($buckets.InflightHumanPRs | ForEach-Object { $_.number })
 
-Assert-Eq -Label "precedence: 3 p/0 PRs carved (human+maestro+merge-up)"   -Expected 3     -Actual $pre_p0.Count
-Assert-Eq -Label "precedence: p/0 set includes the Maestro p/0 (#2)"       -Expected $true -Actual ($pre_p0N -contains 2)
-Assert-Eq -Label "precedence: p/0 set includes the merge-up p/0 (#3)"      -Expected $true -Actual ($pre_p0N -contains 3)
-Assert-Eq -Label "precedence: Maestro bucket excludes the p/0 Maestro (#2)" -Expected $false -Actual (@($pre_maestro | ForEach-Object { $_.number }) -contains 2)
-Assert-Eq -Label "precedence: Maestro bucket = only the plain Maestro (#4)" -Expected 1     -Actual $pre_maestro.Count
-Assert-Eq -Label "precedence: merge-up bucket excludes the p/0 merge-up (#3)" -Expected $false -Actual (@($pre_mergeUp | ForEach-Object { $_.number }) -contains 3)
-Assert-Eq -Label "precedence: merge-up bucket = only the plain merge-up (#6)" -Expected 1   -Actual $pre_mergeUp.Count
-Assert-Eq -Label "precedence: generic human = only the plain human (#5)"   -Expected 1     -Actual $pre_generic.Count
-Assert-Eq -Label "precedence: generic human keeps #5"                      -Expected $true -Actual (@($pre_generic | ForEach-Object { $_.number }) -contains 5)
+Assert-Eq -Label "precedence: 3 p/0 PRs carved (human+maestro+merge-up)"   -Expected 3     -Actual $buckets.P0Prs.Count
+Assert-Eq -Label "precedence: p/0 set includes the Maestro p/0 (#2)"       -Expected $true -Actual ($bP0 -contains 2)
+Assert-Eq -Label "precedence: p/0 set includes the merge-up p/0 (#3)"      -Expected $true -Actual ($bP0 -contains 3)
+Assert-Eq -Label "precedence: p/0 set EXCLUDES inflight p/0 (#8 never blocks)" -Expected $false -Actual ($bP0 -contains 8)
+Assert-Eq -Label "precedence: Maestro bucket excludes the p/0 Maestro (#2)" -Expected $false -Actual ($bMaestro -contains 2)
+Assert-Eq -Label "precedence: Maestro bucket = plain target + inflight Maestro" -Expected 2  -Actual $buckets.MaestroPRs.Count
+Assert-Eq -Label "precedence: Maestro bucket keeps the plain target Maestro (#4)" -Expected $true -Actual ($bMaestro -contains 4)
+Assert-Eq -Label "precedence: Maestro bucket keeps the inflight Maestro (#7)" -Expected $true -Actual ($bMaestro -contains 7)
+Assert-Eq -Label "precedence: merge-up bucket excludes the p/0 merge-up (#3)" -Expected $false -Actual ($bMergeUp -contains 3)
+Assert-Eq -Label "precedence: merge-up bucket = only the plain merge-up (#6)" -Expected 1   -Actual $buckets.MergeUpPRs.Count
+Assert-Eq -Label "precedence: generic human = only the plain human (#5)"   -Expected 1     -Actual $buckets.TargetHumanPRs.Count
+Assert-Eq -Label "precedence: generic human keeps #5"                      -Expected $true -Actual ($bHuman -contains 5)
+Assert-Eq -Label "precedence: inflight-human = the inflight p/0 human (#8)" -Expected $true -Actual ($bInflight -contains 8)
+Assert-Eq -Label "precedence: inflight-human excludes inflight Maestro (#7)" -Expected $false -Actual ($bInflight -contains 7)
+
+# Empty-input safety: no PRs at all yields five empty buckets, no throw.
+$emptyBuckets = Get-CategorizedPullRequests -TargetPRs @() -InflightPRs @()
+Assert-Eq -Label "precedence: empty input → 0 p/0"      -Expected 0 -Actual $emptyBuckets.P0Prs.Count
+Assert-Eq -Label "precedence: empty input → 0 Maestro"  -Expected 0 -Actual $emptyBuckets.MaestroPRs.Count
+Assert-Eq -Label "precedence: empty input → 0 merge-up" -Expected 0 -Actual $emptyBuckets.MergeUpPRs.Count
+Assert-Eq -Label "precedence: empty input → 0 human"    -Expected 0 -Actual $emptyBuckets.TargetHumanPRs.Count
+Assert-Eq -Label "precedence: empty input → 0 inflight" -Expected 0 -Actual $emptyBuckets.InflightHumanPRs.Count
 
 Write-Host "`n────────────────────────────────────────" -ForegroundColor Cyan
 Write-Host "Passed: $script:passed   Failed: $script:failed" -ForegroundColor $(if ($script:failed -eq 0) { 'Green' } else { 'Red' })

--- a/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
+++ b/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
@@ -2674,6 +2674,9 @@ $missingLbls = [PSCustomObject]@{ number = 12345 }            # no labels proper
 $nullLbls    = [PSCustomObject]@{ number = 22222; labels = $null }
 $emptyLbls   = [PSCustomObject]@{ number = 33333; labels = @() }
 $hashLbls    = [PSCustomObject]@{ number = 44444; labels = @(@{ name = 'p/0' }) }   # hashtable-shaped labels
+$hashPrP0    = @{ number = 55555; labels = @(@{ name = 'p/0' }, @{ name = 'area-xaml' }) }  # whole PR is a hashtable (test-mock shape)
+$hashPrNonP0 = @{ number = 66666; labels = @(@{ name = 'p/1' }) }                            # hashtable PR, no p/0
+$hashPrNoLbl = @{ number = 77777 }                                                          # hashtable PR, no labels key
 
 Assert-Eq -Label "p/0-labelled PR → blocker"                  -Expected $true  -Actual (Test-IsP0Pr $p0Pr)
 Assert-Eq -Label "non-p/0 PR (has p/1) → not a blocker"       -Expected $false -Actual (Test-IsP0Pr $nonP0Pr)
@@ -2682,6 +2685,11 @@ Assert-Eq -Label "PR with null labels → false"                -Expected $false
 Assert-Eq -Label "PR with empty labels → false"               -Expected $false -Actual (Test-IsP0Pr $emptyLbls)
 Assert-Eq -Label "hashtable-shaped labels still matched"      -Expected $true  -Actual (Test-IsP0Pr $hashLbls)
 Assert-Eq -Label "null PR → false (no throw)"                 -Expected $false -Actual (Test-IsP0Pr $null)
+# Whole-PR-as-hashtable (IDictionary) shape: common in test mocks; must not
+# silently return $false (a hashtable's PSObject.Properties has no 'labels').
+Assert-Eq -Label "hashtable PR with p/0 → blocker (IDictionary path)"  -Expected $true  -Actual (Test-IsP0Pr $hashPrP0)
+Assert-Eq -Label "hashtable PR without p/0 → not a blocker"            -Expected $false -Actual (Test-IsP0Pr $hashPrNonP0)
+Assert-Eq -Label "hashtable PR missing labels key → false (no throw)"  -Expected $false -Actual (Test-IsP0Pr $hashPrNoLbl)
 
 # Carve-out semantics: the p/0 subset is selected, and the generic (WATCH)
 # bucket has them removed — exactly what the engine does before hoisting.

--- a/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
+++ b/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
@@ -398,6 +398,37 @@ if (-not (Test-Path $detectScriptPath)) {
     Assert-Eq -Label "no shipped tags yet: patch 0 (GA) in-flight"  -Expected $true -Actual (Test-IsBranchInFlight -BranchPatch 0  -ShippedPatches $emptySet)
     Assert-Eq -Label "no shipped tags yet: patch 11 in-flight"      -Expected $true -Actual (Test-IsBranchInFlight -BranchPatch 11 -ShippedPatches $emptySet)
 
+    # ─────────── Test-IsStaleSrBranch (Lane 1 staleness guard) ───────────
+    # Secondary disambiguator that runs AFTER Test-IsBranchInFlight returns true.
+    # Drops tag-absent SR branches that sit below the shipped watermark AND are
+    # idle — e.g. SR2 (patch 21) / SR3 (patch 33) lingering long after SR7
+    # (patch 71) shipped — so they don't spin up no-op workflow matrix jobs.
+    Write-Host "`n[Unit] Test-IsStaleSrBranch (Lane 1 staleness guard)" -ForegroundColor Cyan
+
+    # The reported case: stale below-watermark branches with no recent commits.
+    Assert-Eq -Label "SR2 patch 21 < 71, idle -> stale (skip)" `
+              -Expected $true  -Actual (Test-IsStaleSrBranch -BranchPatch 21 -HighestShippedPatch 71 -RecentActivityCount 0)
+    Assert-Eq -Label "SR3 patch 33 < 71, idle -> stale (skip)" `
+              -Expected $true  -Actual (Test-IsStaleSrBranch -BranchPatch 33 -HighestShippedPatch 71 -RecentActivityCount 0)
+
+    # A freshly-cut live SR sits at/above the watermark — never stale, even idle.
+    Assert-Eq -Label "SR8 patch 80 > 71, idle -> NOT stale (above watermark)" `
+              -Expected $false -Actual (Test-IsStaleSrBranch -BranchPatch 80 -HighestShippedPatch 71 -RecentActivityCount 0)
+    Assert-Eq -Label "patch 71 == 71, idle -> NOT stale (equal, not strictly below)" `
+              -Expected $false -Actual (Test-IsStaleSrBranch -BranchPatch 71 -HighestShippedPatch 71 -RecentActivityCount 0)
+
+    # The hotfix scenario tag-existence protects: a reset branch BELOW the
+    # watermark but with recent commits is genuinely in-flight, NOT stale.
+    Assert-Eq -Label "security-hotfix patch 22 < 71 but active -> NOT stale" `
+              -Expected $false -Actual (Test-IsStaleSrBranch -BranchPatch 22 -HighestShippedPatch 71 -RecentActivityCount 3)
+    Assert-Eq -Label "below-watermark patch 21 with 1 recent commit -> NOT stale" `
+              -Expected $false -Actual (Test-IsStaleSrBranch -BranchPatch 21 -HighestShippedPatch 71 -RecentActivityCount 1)
+
+    # No shipped tags yet (highest = 0): nothing is below the watermark, so the
+    # guard never fires — every in-flight branch is preserved.
+    Assert-Eq -Label "no shipped tags (highest 0): patch 11 idle -> NOT stale" `
+              -Expected $false -Actual (Test-IsStaleSrBranch -BranchPatch 11 -HighestShippedPatch 0 -RecentActivityCount 0)
+
     # ─────────── Preview-tag regex contract ───────────
     Write-Host "`n[Unit] Preview tag regex (<major>.0.0-preview.<N>.<date>[.<build>])" -ForegroundColor Cyan
     $previewTagCases = @(
@@ -506,11 +537,12 @@ if (-not (Test-Path $detectScriptPath)) {
 
 if (-not $SkipE2E) {
     Write-Host "`n[E2E] Detection against live repo" -ForegroundColor Cyan
-    Write-Host "  Under the tag-existence rule we expect FOUR trackers:" -ForegroundColor DarkGray
-    Write-Host "    - SR2 (patch=21, no tag 10.0.21)        - in-flight but inactive (workflow will skip — no recent commits)" -ForegroundColor DarkGray
-    Write-Host "    - SR3 (patch=33, no tag 10.0.33)        - in-flight but inactive (workflow will skip — no recent commits)" -ForegroundColor DarkGray
+    Write-Host "  Under the tag-existence rule + Lane 1 staleness guard we expect TWO trackers:" -ForegroundColor DarkGray
     Write-Host "    - SR8 (patch=80, no tag 10.0.80)        - in-flight, active" -ForegroundColor DarkGray
     Write-Host "    - SR9 (candidate off main)              - active" -ForegroundColor DarkGray
+    Write-Host "    DROPPED by the staleness guard (idle + below the shipped watermark 71):" -ForegroundColor DarkGray
+    Write-Host "    - SR2 (patch=21, no tag 10.0.21)        - tag-absent but stale -> no matrix job" -ForegroundColor DarkGray
+    Write-Host "    - SR3 (patch=33, no tag 10.0.33)        - tag-absent but stale -> no matrix job" -ForegroundColor DarkGray
     Write-Host "    NOTE: SR7 shipped 2026-06-05 (tag 10.0.71); no longer produces a tracker." -ForegroundColor DarkGray
 
     $detectOut = Join-Path ([System.IO.Path]::GetTempPath()) "rr-detect-$(Get-Date -Format 'HHmmss').json"
@@ -527,8 +559,8 @@ if (-not $SkipE2E) {
             Assert-Eq -Label "highestShippedTag is '10.0.71'"  -Expected '10.0.71' -Actual $detected.highestShippedTag
             Assert-Eq -Label "highestShippedPreviewTag carries net10's last preview" `
                       -Expected '10.0.0-preview.7.25406.3' -Actual $detected.highestShippedPreviewTag
-            Assert-Eq -Label "tracker count is 4 (SR2+SR3+SR8+SR9 — SR7 shipped)" `
-                      -Expected 4 -Actual $detected.trackers.Count
+            Assert-Eq -Label "tracker count is 2 (SR8+SR9 — SR7 shipped; SR2/SR3 dropped as stale)" `
+                      -Expected 2 -Actual $detected.trackers.Count
             # All trackers in single-major net10 mode must be SR-flavored. (Net10's
             # previews 1–7 all shipped + no in-flight preview branch -> no preview tracker.)
             foreach ($t in $detected.trackers) {
@@ -539,27 +571,19 @@ if (-not $SkipE2E) {
             $bySr = @{}
             foreach ($t in $detected.trackers) { $bySr[[int]$t.srNumber] = $t }
 
-            # SR2 (in-flight, INACTIVE — workflow's activity gate prevents new issue)
+            # SR2 (tag-absent but STALE — Lane 1 staleness guard drops it so the
+            # workflow matrix never spins up a no-op job for it).
             if ($bySr.ContainsKey(2)) {
-                $sr2 = $bySr[2]
-                Assert-Eq -Label "SR2 mode = in-flight (tag 10.0.21 absent)" `
-                          -Expected 'in-flight' -Actual $sr2.mode
-                Assert-Eq -Label "SR2 expectedTag = 10.0.21"     -Expected '10.0.21' -Actual $sr2.expectedTag
-                Assert-Eq -Label "SR2 hasRecentActivity = false (workflow will skip new issue)" `
-                          -Expected $false -Actual $sr2.hasRecentActivity
+                Write-Host "  ❌ SR2 tracker should be dropped (patch=21 < watermark 71, idle — stale)" -ForegroundColor Red; $script:failed++
             } else {
-                Write-Host "  ❌ SR2 tracker missing (tag rule should pick it up — patch=21, no tag)" -ForegroundColor Red; $script:failed++
+                Assert-Eq -Label "SR2 tracker absent (stale: patch 21 < 71, no recent activity)" -Expected $true -Actual $true
             }
 
-            # SR3 (in-flight, INACTIVE)
+            # SR3 (tag-absent but STALE — dropped by the staleness guard)
             if ($bySr.ContainsKey(3)) {
-                $sr3 = $bySr[3]
-                Assert-Eq -Label "SR3 mode = in-flight (tag 10.0.33 absent)" `
-                          -Expected 'in-flight' -Actual $sr3.mode
-                Assert-Eq -Label "SR3 expectedTag = 10.0.33"     -Expected '10.0.33' -Actual $sr3.expectedTag
-                Assert-Eq -Label "SR3 hasRecentActivity = false" -Expected $false -Actual $sr3.hasRecentActivity
+                Write-Host "  ❌ SR3 tracker should be dropped (patch=33 < watermark 71, idle — stale)" -ForegroundColor Red; $script:failed++
             } else {
-                Write-Host "  ❌ SR3 tracker missing (tag rule should pick it up — patch=33, no tag)" -ForegroundColor Red; $script:failed++
+                Assert-Eq -Label "SR3 tracker absent (stale: patch 33 < 71, no recent activity)" -Expected $true -Actual $true
             }
 
             # SR7 (shipped 2026-06-05 as 10.0.71 — Lane 1 should NOT emit a tracker)
@@ -622,14 +646,15 @@ if (-not $SkipE2E) {
     # ──────────── E2E: -AllActiveMajors multi-major envelope ────────────
     # In the unified post-consolidation shape, one invocation must surface every
     # active major (main's + any net<N>.0 ≥ main). Expected current state:
-    #   - net10 -> 4 SR trackers (SR2, SR3, SR8, SR9), no preview tracker
-    #     (SR7 shipped 2026-06-05; every net10 preview branch already shipped + net10.0 isn't in preview cycle)
+    #   - net10 -> 2 SR trackers (SR8, SR9), no preview tracker
+    #     (SR7 shipped 2026-06-05; SR2/SR3 dropped by the Lane 1 staleness guard;
+    #      every net10 preview branch already shipped + net10.0 isn't in preview cycle)
     #   - net11 -> 0 SR trackers (pre-GA: no `11.0.0` tag), 1 preview tracker
     #     (preview6 candidate from net11.0)
     Write-Host "`n[E2E] Detection with -AllActiveMajors" -ForegroundColor Cyan
     Write-Host "  Expected:" -ForegroundColor DarkGray
     Write-Host "    - majors[].length = 2 (net10 + net11)" -ForegroundColor DarkGray
-    Write-Host "    - net10 trackers: 4 SR (sr2/sr3/sr8/sr9), 0 preview (SR7 shipped 2026-06-05)" -ForegroundColor DarkGray
+    Write-Host "    - net10 trackers: 2 SR (sr8/sr9), 0 preview (SR7 shipped 2026-06-05; SR2/SR3 stale-dropped)" -ForegroundColor DarkGray
     Write-Host "    - net11 trackers: 0 SR (pre-GA), 1 preview (preview6 candidate from net11.0)" -ForegroundColor DarkGray
 
     $multiOut = Join-Path ([System.IO.Path]::GetTempPath()) "rr-detect-allmajors-$(Get-Date -Format 'HHmmss').json"
@@ -654,10 +679,10 @@ if (-not $SkipE2E) {
                 $net10 = $byMajor[10]
                 Assert-Eq -Label "net10 mainBranch is 'main'"               -Expected 'main' -Actual $net10.mainBranch
                 Assert-Eq -Label "net10 highestShippedTag is '10.0.71'"      -Expected '10.0.71' -Actual $net10.highestShippedTag
-                Assert-Eq -Label "net10 tracker count is 4 (no preview lane, SR7 shipped)" -Expected 4 -Actual $net10.trackers.Count
+                Assert-Eq -Label "net10 tracker count is 2 (no preview lane, SR7 shipped, SR2/SR3 stale-dropped)" -Expected 2 -Actual $net10.trackers.Count
                 $srCount = @($net10.trackers | Where-Object branchType -eq 'sr').Count
                 $previewCount = @($net10.trackers | Where-Object branchType -eq 'preview').Count
-                Assert-Eq -Label "net10 has 4 SR trackers"      -Expected 4 -Actual $srCount
+                Assert-Eq -Label "net10 has 2 SR trackers"      -Expected 2 -Actual $srCount
                 Assert-Eq -Label "net10 has 0 preview trackers" -Expected 0 -Actual $previewCount
             } else {
                 Write-Host "  ❌ majors[] missing net10 entry" -ForegroundColor Red; $script:failed++


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

Follow-up to #35807. Two independent release-readiness fixes.

---

## Fix 1 — Surface p/0-labelled PRs as Preview release blockers

### Summary

The Preview readiness engine (`Get-PreviewReadiness.ps1`) only treated **p/0 issues** as release blockers. **p/0-labelled PRs** targeting a preview/candidate branch were silently bucketed into the generic "Release branch PRs" WATCH count and rendered as "Needs review or triage" rows — never hoisted, never blocking.

The root cause is structural: the p/0 blocker path used `gh issue list --label p/0`, which **by design never returns PRs**. So p/0 PRs were invisible to the blocker logic.

This was observed live on the **net11.0 preview6** tracker (#35866), where #34758, #35626, and #34600 (all `p/0`, base `net11.0`) appeared only as generic WATCH rows instead of blockers.

### What changed

Carves p/0-labelled PRs out of the generic human-PR bucket — the label data is **already fetched** by `Get-OpenPullRequests`, so no extra API call — and:

- adds a **BLOCKED `P/0 release-branch PRs`** check (parallel to the p/0-issues check) so the overall verdict turns red when one is open;
- itemizes each p/0 PR as a **`🔥 P/0 PR`** row in the hoisted **🔴 High-priority items** section (with base ref + age + per-PR next action);
- **excludes** the new check from the **🔴 Blocking** summary (its PRs are already enumerated in the hoist) — exactly matching the p/0-issues treatment;
- updates the WATCH note + hoist header/intro text from 3 → 4 high-priority categories.

A PR whose base **is** the survey ref is release-relevant by definition, so — unlike issues — no title/milestone relevance filter is applied.

### Testability

Adds a small **StrictMode-safe `Test-IsP0Pr`** helper plus a **dot-source guard** on the engine (mirroring `Find-ReleaseReadinessTrackers.ps1`) so the predicate can be unit-tested without invoking the full git/gh-backed report flow.

---

## Fix 2 — Drop stale below-watermark SR branches from the tracker matrix

### Summary

The Lane 1 in-flight detector (`Find-ReleaseReadinessTrackers.ps1`) treated **tag-absence** as the sole in-flight signal. Abandoned hotfix leftovers like **SR2** (patch 21) and **SR3** (patch 33) — which never published their stable tags and sit far below the shipped watermark (**SR7** patch 71) — were still emitted as trackers. The workflow then spun up a **no-op matrix job** per branch: the per-job activity gate skipped issue creation, but the job still ran.

### What changed

Adds a secondary **`Test-IsStaleSrBranch`** disambiguator applied **only after** `Test-IsBranchInFlight` returns true. A branch is stale when **both**:

- its patch is **strictly below** the highest shipped patch, **and**
- it has had **no commits** within the activity window (idle).

Tag-existence stays the **primary** signal; the idle requirement preserves the out-of-order / security-hotfix case — a real reset branch below the watermark has recent commits and is therefore **not** dropped. Freshly-cut live SRs sit at/above the watermark and are never affected.

Dropping these at the detector removes them from the workflow matrix **entirely**. Verified safe: SR2/SR3 have no open tracker issues, so nothing is stranded (only SR8/SR9/preview6 have open trackers).

---

### Tests

`Test-ReleaseReadiness.ps1`:
- **12** new unit assertions for `Test-IsP0Pr` (predicate: p/0 present/absent, missing/null/empty labels, hashtable-shaped labels, null PR; carve-out semantics: p/0 subset selected, generic bucket excludes them).
- **7** new unit assertions for `Test-IsStaleSrBranch` (below-watermark idle → stale; above/equal watermark → not stale; below-watermark but active → not stale; no shipped tags → never fires).
- Live-repo E2E expectations updated: net10 now surfaces **2** SR trackers (SR8 + SR9) instead of 4.

```
Passed: 517   Failed: 0
```