### PR TITLE
Resolve SR sub-patch milestones from the earliest containing tag

### DIFF
--- a/.github/scripts/Fix-MilestoneDrift.Tests.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.Tests.ps1
@@ -3,8 +3,11 @@
 <#
 .SYNOPSIS
     Pester tests for Fix-MilestoneDrift.ps1.
-    Tests the pure functions (milestone mapping, matching, linked-issue extraction)
-    without hitting GitHub or Git.
+    Most tests cover the pure functions (milestone mapping, matching, linked-issue
+    extraction) and never touch GitHub or Git. One block — 'Get-RefinedReleaseMilestone
+    — git integration (unmocked)' — builds a disposable LOCAL git repo in a temp dir to
+    exercise the real `git tag -l` / `git merge-base --is-ancestor` plumbing end-to-end;
+    it still never touches GitHub (no `gh`, no network) and is skipped if git is absent.
 
 .EXAMPLE
     Invoke-Pester ./Fix-MilestoneDrift.Tests.ps1
@@ -1383,5 +1386,95 @@ Describe 'Get-OnBranchShaFromLog — grep fallback subject precision' {
 
     It 'returns null for empty input' {
         Get-OnBranchShaFromLog @() 42 | Should -BeNullOrEmpty
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Git-backed integration block (no mocks, no GitHub).
+#
+# Everything above mocks Get-AllTags / Test-CommitInTag so the resolution logic
+# can be tested in isolation. This block instead builds a throwaway LOCAL git
+# repo in a temp dir and calls the REAL, unmocked helpers, so the actual
+# `git tag -l` and `git merge-base --is-ancestor` plumbing is exercised
+# end-to-end. It never touches GitHub (no `gh`, no network) and never mutates
+# the checkout it runs from — every git command is scoped with `git -C $tmp`.
+# Skipped cleanly when git is not on PATH.
+# ---------------------------------------------------------------------------
+Describe 'Get-RefinedReleaseMilestone — git integration (unmocked)' -Skip:(-not (Get-Command git -ErrorAction SilentlyContinue)) {
+
+    BeforeAll {
+        $script:tmp = Join-Path ([IO.Path]::GetTempPath()) "miletest-$(New-Guid)"
+        New-Item -ItemType Directory -Path $script:tmp -Force | Out-Null
+
+        # Disposable repo with a deterministic identity; nothing global is touched.
+        git -C $script:tmp init -q
+        git -C $script:tmp config user.email 'milestone-test@example.invalid'
+        git -C $script:tmp config user.name  'Milestone Test'
+        git -C $script:tmp config commit.gpgsign false
+
+        # Build a linear history of empty commits and tag the SR-family drops:
+        #   c0 -> 10.0.70 (SR7 base)
+        #   c1 -> 10.0.71 (SR7.1)   <-- the commit under test
+        #   c2 -> 10.0.72 (SR7.2)
+        #   c3 -> (untagged, ships in the NEXT drop)
+        git -C $script:tmp commit -q --allow-empty -m 'SR7 base drop'
+        $script:shaBase = (git -C $script:tmp rev-parse HEAD).Trim()
+        git -C $script:tmp tag '10.0.70'
+
+        git -C $script:tmp commit -q --allow-empty -m 'fix shipped in SR7.1 (#35694)'
+        $script:shaFix = (git -C $script:tmp rev-parse HEAD).Trim()
+        git -C $script:tmp tag '10.0.71'
+
+        git -C $script:tmp commit -q --allow-empty -m 'SR7.2 drop'
+        git -C $script:tmp tag '10.0.72'
+
+        git -C $script:tmp commit -q --allow-empty -m 'not yet tagged'
+        $script:shaUntagged = (git -C $script:tmp rev-parse HEAD).Trim()
+    }
+
+    AfterAll {
+        if ($script:tmp -and (Test-Path $script:tmp)) {
+            Remove-Item -Recurse -Force $script:tmp -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'resolves a commit to the EARLIEST family tag that contains it (SR7.1, not SR7.2)' {
+        # shaFix is contained in 10.0.71 AND 10.0.72, but the earliest wins.
+        Get-RefinedReleaseMilestone '.NET 10 SR7' $script:shaFix $script:tmp |
+            Should -Be '.NET 10 SR7.1'
+    }
+
+    It 'resolves a commit that only shipped in the base drop to the base SR (SR7)' {
+        # shaBase is the commit tagged 10.0.70 — earliest containing family tag.
+        Get-RefinedReleaseMilestone '.NET 10 SR7' $script:shaBase $script:tmp |
+            Should -Be '.NET 10 SR7'
+    }
+
+    It 'predicts the next sub-patch for a commit not yet in any family tag (SR7.3)' {
+        # shaUntagged sits after 10.0.72; base SR already shipped, so it lands in
+        # the next drop: latest family tag .72 -> predict .73 -> SR7.3.
+        Get-RefinedReleaseMilestone '.NET 10 SR7' $script:shaUntagged $script:tmp |
+            Should -Be '.NET 10 SR7.3'
+    }
+
+    It 'leaves a non-SR milestone untouched even when family tags exist' {
+        Get-RefinedReleaseMilestone '.NET 10 Preview 3' $script:shaFix $script:tmp |
+            Should -Be '.NET 10 Preview 3'
+    }
+
+    It 'Test-CommitInTag returns $true when the commit IS contained in the tag' {
+        Test-CommitInTag $script:shaFix '10.0.71' $script:tmp | Should -BeTrue
+    }
+
+    It 'Test-CommitInTag returns $false when the commit is NOT contained (exit 1)' {
+        # shaFix shipped in .71 — it is not an ancestor of the earlier .70 tag.
+        Test-CommitInTag $script:shaFix '10.0.70' $script:tmp | Should -BeFalse
+    }
+
+    It 'Test-CommitInTag THROWS on a git error (bad object, exit > 1)' {
+        # A well-formed but non-existent 40-hex SHA makes git fatal (exit 128),
+        # which must surface as an exception rather than a silent "not contained".
+        $bogus = 'deadbeef' * 5   # 40 hex chars, resolves to nothing
+        { Test-CommitInTag $bogus '10.0.70' $script:tmp } | Should -Throw
     }
 }

--- a/.github/scripts/Fix-MilestoneDrift.Tests.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.Tests.ps1
@@ -1244,3 +1244,74 @@ Describe 'Get-PrsInTag — unary-comma preserves HashSet on cache hit' {
         Assert-MockCalled Get-PrNumbersReachableFromTag -Times 1 -Exactly
     }
 }
+
+Describe 'Get-RefinedReleaseMilestone — SR sub-patch precision' {
+    # The bug: a commit that lands on an SR release branch AFTER the base SR
+    # shipped actually goes out in a later sub-patch (10.0.71 = SR7.1), but the
+    # branch name alone (release/10.0.1xx-sr7) only yields the base SR (SR7).
+    # Get-RefinedReleaseMilestone fixes this by resolving the EARLIEST SR-family
+    # tag that contains the commit. These tests mock the tag list and the
+    # commit-in-tag ancestry check so no real git repo / tags are required.
+
+    It 'refines to the earliest sub-patch tag that contains the commit (SR7 → SR7.1)' {
+        # Family tags 10.0.70/71/72 all exist; commit shipped in .71 (and is
+        # therefore also in .72), but NOT in the base .70. Earliest containing = .71.
+        Mock Get-AllTags { return @('10.0.60', '10.0.70', '10.0.71', '10.0.72', '11.0.0') }
+        Mock Test-CommitInTag { return ($Tag -in @('10.0.71', '10.0.72')) }
+        Get-RefinedReleaseMilestone '.NET 10 SR7' 'abc123' '.' | Should -Be '.NET 10 SR7.1'
+    }
+
+    It 'keeps the base SR when the commit shipped in the base drop (SR7 stays SR7)' {
+        # Commit is contained in the base .70 tag → earliest containing is .70 → SR7.
+        Mock Get-AllTags { return @('10.0.70', '10.0.71') }
+        Mock Test-CommitInTag { return $true }  # contained in everything, incl. base
+        Get-RefinedReleaseMilestone '.NET 10 SR7' 'abc123' '.' | Should -Be '.NET 10 SR7'
+    }
+
+    It 'uses the next sub-patch after the latest shipped tag when not yet tagged (SR7 → SR7.2)' {
+        # .70 and .71 already shipped but none contains this (untagged) commit, so
+        # it goes out in the next drop after the latest shipped family tag → .72.
+        Mock Get-AllTags { return @('10.0.70', '10.0.71') }
+        Mock Test-CommitInTag { return $false }
+        Get-RefinedReleaseMilestone '.NET 10 SR7' 'abc123' '.' | Should -Be '.NET 10 SR7.2'
+    }
+
+    It 'never crosses the family boundary: SR7 exhausted at .79 falls back to base SR (not SR8)' {
+        # Degenerate state — all 10 SR7 drops (.70..79) shipped and none contains the
+        # commit. The next patch (.80) belongs to SR8, which the SR7 branch never
+        # ships, so the refiner must NOT predict SR8; it falls back to the base SR7.
+        Mock Get-AllTags { return @('10.0.70', '10.0.71', '10.0.72', '10.0.73', '10.0.74', '10.0.75', '10.0.76', '10.0.77', '10.0.78', '10.0.79') }
+        Mock Test-CommitInTag { return $false }
+        Get-RefinedReleaseMilestone '.NET 10 SR7' 'abc123' '.' | Should -Be '.NET 10 SR7'
+    }
+
+    It 'returns the base SR unchanged when no family tags have shipped yet' {
+        # Branch exists but no 10.0.7x tag yet → base SR is the best we can say.
+        Mock Get-AllTags { return @('10.0.60', '10.0.61') }
+        Mock Test-CommitInTag { return $false }
+        Get-RefinedReleaseMilestone '.NET 10 SR7' 'abc123' '.' | Should -Be '.NET 10 SR7'
+    }
+
+    It 'does not let an adjacent SR family leak in (SR1 vs SR10 boundary)' {
+        # SR10 family is 10.0.100..10.0.109; the SR1-era 10.0.10 tag must be ignored.
+        Mock Get-AllTags { return @('10.0.10', '10.0.100', '10.0.101') }
+        Mock Test-CommitInTag { return ($Tag -in @('10.0.101')) }
+        Get-RefinedReleaseMilestone '.NET 10 SR10' 'abc123' '.' | Should -Be '.NET 10 SR10.1'
+    }
+
+    It 'returns non-SR milestones unchanged without touching tags' -ForEach @(
+        @{ Milestone = '.NET 11.0-preview3' }
+        @{ Milestone = '.NET 11.0-rc1' }
+        @{ Milestone = '.NET 11.0 GA' }
+    ) {
+        Mock Get-AllTags { throw 'should not be called for non-SR milestones' }
+        Mock Test-CommitInTag { throw 'should not be called for non-SR milestones' }
+        Get-RefinedReleaseMilestone $Milestone 'abc123' '.' | Should -Be $Milestone
+    }
+
+    It 'returns the input unchanged for empty milestone or empty commit' {
+        Mock Get-AllTags { throw 'should not be called' }
+        Get-RefinedReleaseMilestone '' 'abc123' '.' | Should -Be ''
+        Get-RefinedReleaseMilestone '.NET 10 SR7' '' '.' | Should -Be '.NET 10 SR7'
+    }
+}

--- a/.github/scripts/Fix-MilestoneDrift.Tests.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.Tests.ps1
@@ -1314,4 +1314,74 @@ Describe 'Get-RefinedReleaseMilestone — SR sub-patch precision' {
         Get-RefinedReleaseMilestone '' 'abc123' '.' | Should -Be ''
         Get-RefinedReleaseMilestone '.NET 10 SR7' '' '.' | Should -Be '.NET 10 SR7'
     }
+
+    It 'falls back to the base SR when the ancestry check hits a real git error' {
+        # Test-CommitInTag throws on a git failure (exit >1), distinct from a clean
+        # "not an ancestor". The refiner must NOT turn that into a speculative
+        # sub-patch (e.g. SR7.2) — it catches the error and returns the base SR so a
+        # transient failure can only ever lose precision, never assign a wrong drop.
+        Mock Get-AllTags { return @('10.0.70', '10.0.71') }
+        Mock Test-CommitInTag { throw 'git merge-base --is-ancestor failed (exit 128)' }
+        Get-RefinedReleaseMilestone '.NET 10 SR7' 'abc123' '.' | Should -Be '.NET 10 SR7'
+    }
+}
+
+Describe 'Get-OnBranchShaFromLog — grep fallback subject precision' {
+    # The grep fallback feeds this `git log --format='%H%x1f%s'` output (full SHA,
+    # 0x1f Unit Separator, subject). Only a subject that ENDS with the squash token
+    # "(#PrNum)" is a genuine squash-merge / cherry-pick of that PR; body-only
+    # mentions and quoted reverts must be rejected so the milestone is refined from
+    # the right commit. Input is oldest-first (git --reverse).
+    BeforeAll {
+        $script:US   = [char]0x1f
+        $script:Sha1 = '1111111111111111111111111111111111111111'
+        $script:Sha2 = '2222222222222222222222222222222222222222'
+    }
+
+    It 'returns the SHA of a genuine squash-merge subject (trailing token)' {
+        $lines = @("$Sha1$US" + 'Fix crash on startup (#35694)')
+        Get-OnBranchShaFromLog $lines 35694 | Should -Be $Sha1
+    }
+
+    It 'ignores a PR number that appears only in the commit body, not the subject' {
+        # --grep matched on the body, but the emitted subject has no trailing token.
+        $lines = @("$Sha1$US" + 'Unrelated change with no PR token in the subject')
+        Get-OnBranchShaFromLog $lines 35694 | Should -BeNullOrEmpty
+    }
+
+    It 'ignores a revert that merely quotes the original PR number mid-subject' {
+        # Searching for #100: the revert subject ends with (#200), not (#100).
+        $lines = @("$Sha1$US" + 'Revert "Fix X (#100)" (#200)')
+        Get-OnBranchShaFromLog $lines 100 | Should -BeNullOrEmpty
+    }
+
+    It 'matches the revert itself when searching for the revert PR number' {
+        $lines = @("$Sha1$US" + 'Revert "Fix X (#100)" (#200)')
+        Get-OnBranchShaFromLog $lines 200 | Should -Be $Sha1
+    }
+
+    It 'returns the FIRST genuine match (oldest-first input wins)' {
+        # Two real squash subjects for the same PR (introduce, then re-apply). The
+        # --reverse ordering means the original introduction is selected.
+        $lines = @(
+            "$Sha1$US" + 'Original fix (#42)',
+            "$Sha2$US" + 'Re-apply fix (#42)'
+        )
+        Get-OnBranchShaFromLog $lines 42 | Should -Be $Sha1
+    }
+
+    It 'tolerates trailing whitespace after the token' {
+        $lines = @("$Sha1$US" + 'Fix thing (#42)   ')
+        Get-OnBranchShaFromLog $lines 42 | Should -Be $Sha1
+    }
+
+    It 'does not partial-match a longer PR number that shares the prefix' {
+        # Searching #42 must not match (#420).
+        $lines = @("$Sha1$US" + 'Some fix (#420)')
+        Get-OnBranchShaFromLog $lines 42 | Should -BeNullOrEmpty
+    }
+
+    It 'returns null for empty input' {
+        Get-OnBranchShaFromLog @() 42 | Should -BeNullOrEmpty
+    }
 }

--- a/.github/scripts/Fix-MilestoneDrift.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.ps1
@@ -166,6 +166,13 @@ function Get-AllTags([string]$Repo) {
     return ($output -split "`n" | Where-Object { $_ })
 }
 
+function Test-CommitInTag([string]$CommitSha, [string]$Tag, [string]$Repo) {
+    <# Returns $true if $CommitSha is an ancestor of (i.e. contained in) $Tag.
+       Extracted into its own function so it can be mocked in unit tests. #>
+    $null = git -C $Repo merge-base --is-ancestor $CommitSha $Tag 2>&1
+    return ($LASTEXITCODE -eq 0)
+}
+
 function Get-PrNumbersBetweenTags([string]$TagFrom, [string]$TagTo, [string]$Repo) {
     $output = git -C $Repo --no-pager log --oneline "$TagFrom..$TagTo" 2>&1
     if ($LASTEXITCODE -ne 0) { throw "git log failed: $output" }
@@ -217,11 +224,72 @@ function Find-TagContainingPr([int]$PrNum, [string]$Repo, [int]$Major) {
     return $null
 }
 
+function Get-RefinedReleaseMilestone([string]$BranchMilestone, [string]$CommitSha, [string]$Repo) {
+    <# Refines an SR branch milestone (e.g. ".NET 10 SR7") to the sub-patch the
+       commit actually shipped in (e.g. ".NET 10 SR7.1").
+
+       Why: an SR release branch (release/X.0.Yxx-srN) produces MULTIPLE servicing
+       drops over its lifetime — 10.0.70 (SR7), 10.0.71 (SR7.1), 10.0.72 (SR7.2), …
+       ConvertBranchToMilestone only knows the branch name, so it always returns the
+       BASE SR. A revert/hotfix that lands after the base SR shipped actually goes
+       out in a later sub-patch, and milestoning it as the base SR is wrong (it can
+       even DOWNGRADE an already-correct SR7.1 issue back to SR7).
+
+       Rule (earliest release wins): a commit on the SR branch ships in the EARLIEST
+       SR-family tag (X.0.{sr}{sub}) that contains it. If no family tag contains it
+       yet (the drop hasn't been tagged), the base SR (and any earlier sub-patches)
+       are already shipped, so the commit goes out in the NEXT sub-patch after the
+       latest shipped family tag — provided that next sub-patch is still within THIS
+       SR family (the SR7 branch only ever ships 10.0.70..10.0.79).
+
+       Non-SR milestones (preview/rc/GA) have no sub-patches and are returned as-is.
+       The major version is taken from the milestone string itself (authoritative). #>
+    if ([string]::IsNullOrWhiteSpace($BranchMilestone)) { return $BranchMilestone }
+    if ([string]::IsNullOrWhiteSpace($CommitSha)) { return $BranchMilestone }
+    if ($BranchMilestone -notmatch '^\.NET (\d+) SR(\d+)$') { return $BranchMilestone }
+    $msMajor = [int]$Matches[1]
+    $sr = [int]$Matches[2]
+
+    # SR-family tags: X.0.{sr*10 .. sr*10+9} (e.g. SR7 → 10.0.70..10.0.79), ascending.
+    $low = $sr * 10
+    $high = $low + 9
+    $familyTags = @(Get-AllTags $Repo | Where-Object {
+        ($_ -match "^$msMajor\.0\.(\d+)$") -and ([int]$Matches[1] -ge $low) -and ([int]$Matches[1] -le $high)
+    } | Sort-Object { Get-TagSortKey $_ })
+
+    # Earliest family tag that contains the commit = the drop it shipped in.
+    foreach ($tag in $familyTags) {
+        if (Test-CommitInTag $CommitSha $tag $Repo) {
+            $refined = ConvertTo-Milestone $tag
+            if ($refined) { return $refined }
+        }
+    }
+
+    # Not in any shipped family tag yet. If earlier drops already shipped, this
+    # commit goes out in the next sub-patch after the latest one — but only while
+    # that next sub-patch still belongs to THIS SR family (patch <= $high). Once the
+    # family is exhausted (latest is X.0.{sr}9) the next patch would roll into the
+    # NEXT SR, which this branch never ships, so fall back to the base SR rather than
+    # silently crossing the family boundary (e.g. SR7 → SR8).
+    if ($familyTags.Count -gt 0 -and $familyTags[-1] -match "^$msMajor\.0\.(\d+)$") {
+        $nextPatch = [int]$Matches[1] + 1
+        if ($nextPatch -le $high) {
+            $refined = ConvertTo-Milestone "$msMajor.0.$nextPatch"
+            if ($refined) { return $refined }
+        }
+    }
+
+    # No (further) family tags apply — still the base SR.
+    return $BranchMilestone
+}
+
 function Find-ReleaseBranchForCommit([string]$CommitSha, [string]$Repo, [int]$Major, [int]$PrNum = 0) {
     <# Finds the earliest release branch containing a PR.
        First checks git ancestry (commit SHA). If that fails (rebase/cherry-pick
        changed the SHA), falls back to searching commit messages for the PR number.
        Checks in chronological order: previews → RCs → GA → SRs.
+       The matched branch's milestone is refined to the sub-patch the commit shipped
+       in (see Get-RefinedReleaseMilestone).
        Returns @{ Branch; Milestone } or $null. #>
 
     # Fetch all release branches for this major version
@@ -254,16 +322,25 @@ function Find-ReleaseBranchForCommit([string]$CommitSha, [string]$Repo, [int]$Ma
         if ($LASTEXITCODE -eq 0) {
             $milestone = ConvertBranchToMilestone $branch
             if ($milestone) {
+                $milestone = Get-RefinedReleaseMilestone $milestone $CommitSha $Repo
                 return @{ Branch = $branch; Milestone = $milestone }
             }
         }
 
-        # Fall back to commit message search (handles rebase/cherry-pick)
+        # Fall back to commit message search (handles rebase/cherry-pick).
+        # Capture the on-branch SHA (%H) so the milestone can still be refined to
+        # the correct sub-patch even though the squash SHA differs from $CommitSha.
+        # --reverse puts the OLDEST matching commit first (the original introduction),
+        # so a later revert/re-mention that quotes "(#$PrNum)" in its subject can't
+        # hijack the refinement to a later sub-patch. stderr is discarded and only a
+        # full 40-hex SHA is accepted, so a git warning can never be read as the SHA.
         if ($PrNum -gt 0) {
-            $grepResult = git -C $Repo --no-pager log "origin/$branch" --oneline --grep="(#$PrNum)" -1 2>&1
-            if ($LASTEXITCODE -eq 0 -and $grepResult) {
+            $grepResult = git -C $Repo --no-pager log "origin/$branch" --format='%H' --grep="(#$PrNum)" --reverse 2>$null
+            $branchSha = @($grepResult | Where-Object { $_ -match '^[0-9a-f]{40}$' }) | Select-Object -First 1
+            if ($branchSha) {
                 $milestone = ConvertBranchToMilestone $branch
                 if ($milestone) {
+                    $milestone = Get-RefinedReleaseMilestone $milestone $branchSha $Repo
                     Write-Verbose "  PR #$PrNum found via commit message on $branch (rebased/cherry-picked)"
                     return @{ Branch = $branch; Milestone = $milestone }
                 }

--- a/.github/scripts/Fix-MilestoneDrift.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.ps1
@@ -168,9 +168,42 @@ function Get-AllTags([string]$Repo) {
 
 function Test-CommitInTag([string]$CommitSha, [string]$Tag, [string]$Repo) {
     <# Returns $true if $CommitSha is an ancestor of (i.e. contained in) $Tag.
+       git merge-base --is-ancestor exits 0 (ancestor), 1 (NOT ancestor), or >1
+       for a real failure (bad/unknown object, shallow clone missing the object,
+       tag not fetched). Only 0 and 1 are valid answers; a higher exit code is a
+       git error, NOT proof of non-containment, so we throw rather than silently
+       reporting $false — otherwise a transient failure on the earliest containing
+       tag would skip it and mislabel the milestone. Callers that prefer precision
+       over hard-failing catch this and fall back to the coarser branch milestone.
        Extracted into its own function so it can be mocked in unit tests. #>
-    $null = git -C $Repo merge-base --is-ancestor $CommitSha $Tag 2>&1
+    $output = git -C $Repo merge-base --is-ancestor $CommitSha $Tag 2>&1
+    if ($LASTEXITCODE -gt 1) {
+        throw "git merge-base --is-ancestor failed (exit $LASTEXITCODE) for '$CommitSha' in '$Tag': $output"
+    }
     return ($LASTEXITCODE -eq 0)
+}
+
+function Get-OnBranchShaFromLog([string[]]$LogLines, [int]$PrNum) {
+    <# Selects the on-branch commit SHA for a squash-merged/cherry-picked PR from
+       `git log --format='%H%x1f%s'` output (full SHA, US 0x1f separator, subject).
+
+       Only a commit whose SUBJECT ENDS with the squash-merge token "(#$PrNum)" is
+       accepted. This is the crux of the fallback's correctness: GitHub squash and
+       cherry-pick subjects place the PR token at the END ("Some title (#$PrNum)"),
+       so matching the trailing token rejects two whole classes of false positives
+       that a raw --grep over the full message would let through:
+         * body-only mentions  — "Workaround until (#$PrNum) lands" (token in body,
+           not the subject)  → subject doesn't end with the token → ignored.
+         * quoted reverts      — 'Revert "Fix X (#$PrNum)" (#OTHER)' when searching
+           for #$PrNum         → trailing token is (#OTHER), not (#$PrNum) → ignored.
+       Input is expected oldest-first (git --reverse), so the FIRST genuine match is
+       the original introduction, not a later re-mention. #>
+    foreach ($line in $LogLines) {
+        if ($line -match "^([0-9a-f]{40})\x1f.*\(#$PrNum\)\s*$") {
+            return $Matches[1]
+        }
+    }
+    return $null
 }
 
 function Get-PrNumbersBetweenTags([string]$TagFrom, [string]$TagTo, [string]$Repo) {
@@ -251,32 +284,41 @@ function Get-RefinedReleaseMilestone([string]$BranchMilestone, [string]$CommitSh
     $sr = [int]$Matches[2]
 
     # SR-family tags: X.0.{sr*10 .. sr*10+9} (e.g. SR7 → 10.0.70..10.0.79), ascending.
-    $low = $sr * 10
-    $high = $low + 9
-    $familyTags = @(Get-AllTags $Repo | Where-Object {
-        ($_ -match "^$msMajor\.0\.(\d+)$") -and ([int]$Matches[1] -ge $low) -and ([int]$Matches[1] -le $high)
-    } | Sort-Object { Get-TagSortKey $_ })
+    # The whole tag scan is guarded: Test-CommitInTag throws on a real git error
+    # (vs a clean "not an ancestor"), and rather than risk an incorrect sub-patch we
+    # fall back to the coarser base SR milestone — never wrong, just less precise.
+    try {
+        $low = $sr * 10
+        $high = $low + 9
+        $familyTags = @(Get-AllTags $Repo | Where-Object {
+            ($_ -match "^$msMajor\.0\.(\d+)$") -and ([int]$Matches[1] -ge $low) -and ([int]$Matches[1] -le $high)
+        } | Sort-Object { Get-TagSortKey $_ })
 
-    # Earliest family tag that contains the commit = the drop it shipped in.
-    foreach ($tag in $familyTags) {
-        if (Test-CommitInTag $CommitSha $tag $Repo) {
-            $refined = ConvertTo-Milestone $tag
-            if ($refined) { return $refined }
+        # Earliest family tag that contains the commit = the drop it shipped in.
+        foreach ($tag in $familyTags) {
+            if (Test-CommitInTag $CommitSha $tag $Repo) {
+                $refined = ConvertTo-Milestone $tag
+                if ($refined) { return $refined }
+            }
+        }
+
+        # Not in any shipped family tag yet. If earlier drops already shipped, this
+        # commit goes out in the next sub-patch after the latest one — but only while
+        # that next sub-patch still belongs to THIS SR family (patch <= $high). Once the
+        # family is exhausted (latest is X.0.{sr}9) the next patch would roll into the
+        # NEXT SR, which this branch never ships, so fall back to the base SR rather than
+        # silently crossing the family boundary (e.g. SR7 → SR8).
+        if ($familyTags.Count -gt 0 -and $familyTags[-1] -match "^$msMajor\.0\.(\d+)$") {
+            $nextPatch = [int]$Matches[1] + 1
+            if ($nextPatch -le $high) {
+                $refined = ConvertTo-Milestone "$msMajor.0.$nextPatch"
+                if ($refined) { return $refined }
+            }
         }
     }
-
-    # Not in any shipped family tag yet. If earlier drops already shipped, this
-    # commit goes out in the next sub-patch after the latest one — but only while
-    # that next sub-patch still belongs to THIS SR family (patch <= $high). Once the
-    # family is exhausted (latest is X.0.{sr}9) the next patch would roll into the
-    # NEXT SR, which this branch never ships, so fall back to the base SR rather than
-    # silently crossing the family boundary (e.g. SR7 → SR8).
-    if ($familyTags.Count -gt 0 -and $familyTags[-1] -match "^$msMajor\.0\.(\d+)$") {
-        $nextPatch = [int]$Matches[1] + 1
-        if ($nextPatch -le $high) {
-            $refined = ConvertTo-Milestone "$msMajor.0.$nextPatch"
-            if ($refined) { return $refined }
-        }
+    catch {
+        Write-Warning "Get-RefinedReleaseMilestone: git error refining '$BranchMilestone' for '$CommitSha' — falling back to base milestone. $_"
+        return $BranchMilestone
     }
 
     # No (further) family tags apply — still the base SR.
@@ -328,15 +370,17 @@ function Find-ReleaseBranchForCommit([string]$CommitSha, [string]$Repo, [int]$Ma
         }
 
         # Fall back to commit message search (handles rebase/cherry-pick).
-        # Capture the on-branch SHA (%H) so the milestone can still be refined to
-        # the correct sub-patch even though the squash SHA differs from $CommitSha.
-        # --reverse puts the OLDEST matching commit first (the original introduction),
-        # so a later revert/re-mention that quotes "(#$PrNum)" in its subject can't
-        # hijack the refinement to a later sub-patch. stderr is discarded and only a
-        # full 40-hex SHA is accepted, so a git warning can never be read as the SHA.
+        # Emit "%H<US>%s" (SHA, 0x1f separator, subject) and accept ONLY commits whose
+        # SUBJECT ends with the squash token "(#$PrNum)" — see Get-OnBranchShaFromLog.
+        # --grep is a coarse pre-filter over the whole message; the trailing-subject
+        # check is what makes this precise, rejecting body-only mentions and quoted
+        # reverts that would otherwise refine to the wrong sub-patch. --reverse yields
+        # oldest-first so the original introduction wins, not a later re-mention.
+        # stderr is discarded and only a 40-hex SHA is returned, so a git warning can
+        # never be misread as the SHA.
         if ($PrNum -gt 0) {
-            $grepResult = git -C $Repo --no-pager log "origin/$branch" --format='%H' --grep="(#$PrNum)" --reverse 2>$null
-            $branchSha = @($grepResult | Where-Object { $_ -match '^[0-9a-f]{40}$' }) | Select-Object -First 1
+            $grepResult = git -C $Repo --no-pager log "origin/$branch" --format='%H%x1f%s' --grep="(#$PrNum)" --reverse 2>$null
+            $branchSha = Get-OnBranchShaFromLog @($grepResult) $PrNum
             if ($branchSha) {
                 $milestone = ConvertBranchToMilestone $branch
                 if ($milestone) {


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Problem

The milestone-drift automation (`Fix-MilestoneDrift.ps1`) maps a commit found on an SR release branch to a milestone using **only the branch name** — `release/10.0.1xx-sr7` → `.NET 10 SR7`. But a single SR release branch ships **many servicing drops** over its lifetime (`10.0.70` = SR7, `10.0.71` = SR7.1, `10.0.72` = SR7.2, …), so the base SR is too coarse.

A revert/hotfix that lands **after** the base SR shipped actually goes out in a later sub-patch. Milestoning it as the base SR is wrong — and can even **downgrade** an already-correct SR7.1 issue back to SR7.

### Concrete case that motivated this

- PR #35694 is a backport to `release/10.0.1xx-sr7`; its commit is contained only in tag `10.0.71` → it ships in **SR7.1**.
- It directly links the issue via `Fixes #35584`.
- Before this change the script resolved #35694 → **SR7** (branch name), which would *downgrade* issue #35584 from SR7.1 → SR7.

## Root cause

`Find-ReleaseBranchForCommit` resolved the milestone via `ConvertBranchToMilestone` (branch-name only), which has no notion of sub-patches.

## Fix (general — no special-casing)

Add `Get-RefinedReleaseMilestone`: for a commit found on an **SR** branch, resolve the milestone from the **earliest SR-family tag** (`X.0.{sr}{sub}`) that actually contains the commit (git ancestry). Rules:

- **Earliest release wins** — return the earliest family tag that contains the commit.
- If no family tag contains it yet (the drop isn't tagged), use the **next sub-patch** after the latest shipped family tag — **clamped to the SR family** so it never crosses into the next SR (an exhausted SR7 at `.79` falls back to base SR7, never predicts SR8).
- **Non-SR** milestones (preview/rc/GA) are returned unchanged.

It's wired into both match paths of `Find-ReleaseBranchForCommit`. The PR-number grep fallback now captures the **oldest** on-branch SHA (`--reverse`, so a later revert that re-mentions `(#NNN)` can't hijack the result) and is hardened against stderr noise (`2>$null` + strict 40-hex SHA filter).

Result: #35694 → **SR7.1**, so its existing `Fixes #35584` link marks the issue **SR7.1**. The existing earliest-release-wins guard reconciles the issue regardless of merge order.

Note: PR #35625 (the same revert on `inflight/current`) intentionally stays **SR9** — a PR's milestone tracks the physical branch it merged into; the *issue* converges to the earliest customer-facing release (SR7.1).

## Verification

- ✅ Dry-run #35694 → `.NET 10 SR7.1` (was SR7); issue #35584 already-correct (no downgrade).
- ✅ Regression dry-runs unchanged: #34620 → SR6, #35016 → SR6, #30132 → preview3.
- ✅ Pester suite: **162 passed, 0 failed** (9 new unit tests for the helper, incl. the family-boundary clamp).

## Review

Reviewed with three independent models (GPT-5.5, Gemini 3.1 Pro, Claude Opus 4.8). Consensus on correctness and contained blast radius (refinement only ever moves *within* one SR family). Their concrete findings — boundary clamp, stderr hardening, oldest-match grep, and a dead parameter — were all addressed in this PR.