### PR TITLE
code-review: catch early-return-guard lifecycle regressions

### DIFF
--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -182,6 +182,7 @@ Classify based on the stdout row content (`pass`/`fail`/`skipping`/`pending`) **
 - What happens with null `Parent`, `Handler`, `BindingContext`, or `PlatformView`?
 - Can multiple subscriptions accumulate across handler lifecycle (missing unsubscribe)?
 - Does static state survive page disposal and get stale?
+- When a change adds an **early-return guard, idempotency flag, or one-way latch** *above* code that still propagates or has side effects (e.g. `CurrentPage?.SendX(args)`, event raises, cleanup), the early return skips **everything** below it — not just the duplicate call it targets. List every path that **sets** the latch and every path that **clears** it, then actively search for a sequence where the latch is set but a *legitimate* re-dispatch is still owed — e.g. a **container** whose visible child changes while the container itself never navigates away. Don't accept "all the scenarios are handled" without tracing that exact state transition.
 
 #### Confidence Calibration
 
@@ -198,6 +199,8 @@ Classify based on the stdout row content (`pass`/`fail`/`skipping`/`pending`) **
 | CI red or pending | Max **low** | Invoke `azdo-build-investigator` skill to classify failures. Per Rule #6, do not post `LGTM` unless failures are confirmed PR-unrelated. |
 | No relevant tests run (UITests skip PR builds) | Max **low** | Note the coverage gap in the CI Status section. |
 | Prior ❌ Error findings unresolved | n/a — overrides cap | Per Rule #5, verdict is **NEEDS_CHANGES** regardless of own assessment. |
+
+**Do not rationalize away a failure mode you surfaced.** If Failure-Mode Probing produces a concrete scenario where the change misbehaves and you cannot *disprove* it by tracing exact state transitions, you may not downgrade it to 💡 Info or post `LGTM`. An un-disproven failure mode caps confidence at **low** and the verdict at **NEEDS_DISCUSSION** (or **NEEDS_CHANGES** when the scenario is plausible). High confidence requires the *absence* of un-disproven failure modes — not a narrative explaining why the one you found is probably fine.
 
 #### Deliver Verdict
 

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -202,7 +202,7 @@ Classify based on the stdout row content (`pass`/`fail`/`skipping`/`pending`) **
 
 **Confidence is confidence in the safety recommendation, not confidence that an individual finding exists.** Apply the most restrictive applicable cap to the required `**Confidence:**` field. A reviewer can be certain that a failure mechanism exists while remaining low-confidence that the change is safe to merge.
 
-**Do not rationalize away a failure mode you surfaced.** If Failure-Mode Probing produces a concrete scenario where the change misbehaves and you cannot *disprove* it by tracing exact state transitions, you may not downgrade it to 💡 Info or post `LGTM`. An un-disproven failure mode is an unresolved risk: it caps the required `**Confidence:**` field at **low** and the verdict at **NEEDS_DISCUSSION** (or **NEEDS_CHANGES** when the scenario is plausible). High confidence requires the *absence* of un-disproven failure modes — not a narrative explaining why the one you found is probably fine.
+**Do not rationalize away a failure mode you surfaced.** If Failure-Mode Probing produces a concrete scenario where the change misbehaves and you cannot *disprove* it by tracing exact state transitions, you may not downgrade it to 💡 Info or post `LGTM`. An un-disproven failure mode is an unresolved risk: it caps the required `**Confidence:**` field at **low** and the verdict at **NEEDS_DISCUSSION**. Escalate to **NEEDS_CHANGES** only when exact state transitions verify a concrete ❌ Error finding; mere plausibility does not establish a defect. High confidence requires the *absence* of un-disproven failure modes — not a narrative explaining why the one you found is probably fine.
 
 #### Deliver Verdict
 

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -182,7 +182,7 @@ Classify based on the stdout row content (`pass`/`fail`/`skipping`/`pending`) **
 - What happens with null `Parent`, `Handler`, `BindingContext`, or `PlatformView`?
 - Can multiple subscriptions accumulate across handler lifecycle (missing unsubscribe)?
 - Does static state survive page disposal and get stale?
-- When a change adds an **early-return guard, idempotency flag, or one-way latch** *above* code that still propagates or has side effects (e.g. `CurrentPage?.SendX(args)`, event raises, cleanup), the early return skips **everything** below it — not just the duplicate call it targets. List every path that **sets** the latch and every path that **clears** it, then actively search for a sequence where the latch is set but a *legitimate* re-dispatch is still owed — e.g. a **container** whose visible child changes while the container itself never navigates away. Don't accept "all the scenarios are handled" without tracing that exact state transition.
+- When a change adds an **early-return guard, idempotency flag, or one-way latch** *above* propagation or other side effects, distinguish the local work the guard suppresses from every downstream effect it also bypasses. List every path that **sets** the latch and every path that **clears** it, then trace a subsequent call while the latch is set. Check whether the input, recipient, or downstream state can change while the latch remains set: completing local work once does not prove every recipient has observed the current state. Don't accept "all the scenarios are handled" without tracing that state transition.
 
 #### Confidence Calibration
 
@@ -200,7 +200,9 @@ Classify based on the stdout row content (`pass`/`fail`/`skipping`/`pending`) **
 | No relevant tests run (UITests skip PR builds) | Max **low** | Note the coverage gap in the CI Status section. |
 | Prior ❌ Error findings unresolved | n/a — overrides cap | Per Rule #5, verdict is **NEEDS_CHANGES** regardless of own assessment. |
 
-**Do not rationalize away a failure mode you surfaced.** If Failure-Mode Probing produces a concrete scenario where the change misbehaves and you cannot *disprove* it by tracing exact state transitions, you may not downgrade it to 💡 Info or post `LGTM`. An un-disproven failure mode caps confidence at **low** and the verdict at **NEEDS_DISCUSSION** (or **NEEDS_CHANGES** when the scenario is plausible). High confidence requires the *absence* of un-disproven failure modes — not a narrative explaining why the one you found is probably fine.
+**Confidence is confidence in the safety recommendation, not confidence that an individual finding exists.** Apply the most restrictive applicable cap to the required `**Confidence:**` field. A reviewer can be certain that a failure mechanism exists while remaining low-confidence that the change is safe to merge.
+
+**Do not rationalize away a failure mode you surfaced.** If Failure-Mode Probing produces a concrete scenario where the change misbehaves and you cannot *disprove* it by tracing exact state transitions, you may not downgrade it to 💡 Info or post `LGTM`. An un-disproven failure mode is an unresolved risk: it caps the required `**Confidence:**` field at **low** and the verdict at **NEEDS_DISCUSSION** (or **NEEDS_CHANGES** when the scenario is plausible). High confidence requires the *absence* of un-disproven failure modes — not a narrative explaining why the one you found is probably fine.
 
 #### Deliver Verdict
 

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -29,6 +29,7 @@ Standalone skill that evaluates PR code changes for correctness, safety, perform
 3. **Empirical grounding** — Reference specific code, line numbers, and call sites. No vague concerns
 4. **Severity calibration** — Distinguish errors from warnings from suggestions. Not everything is critical
 5. **Failure-mode probing** — Challenge your own conclusions with real failure scenarios, not softballs
+6. **Propagation-aware guards** — For an early return, idempotency flag, or latch above downstream side effects, trace every set/clear path and a repeat call after recipients or state change. If that trace exposes concrete misbehavior, do not dismiss it as rare or rationalize it into `LGTM`: use `NEEDS_DISCUSSION` while the failure remains unresolved, or `NEEDS_CHANGES` when the exact state transition verifies a ❌ Error.
 
 ## Inputs
 

--- a/.github/skills/code-review/tests/eval.vally.yaml
+++ b/.github/skills/code-review/tests/eval.vally.yaml
@@ -261,6 +261,124 @@ stimuli:
       expect_skills:
         - code-review
 
+  # ───────────────────────────────────────────────────────────────────────
+  # Scenario 3 — page lifecycle latch suppresses repeat OnNavigatedTo
+  # (PR #31931 → issue #35756)
+  #
+  # Regression PR:  dotnet/maui#31931
+  #   "[Android] Page: Fix OnNavigatedTo called twice when NavigationPage is
+  #    FlyoutPage Detail"
+  #   merge commit: af540589fc5a3b053cd8c08334d0ca5a0125451b
+  #   parent:       31257d81913000c0979d7075b492c2bc42311451
+  # Regression issue: dotnet/maui#35756
+  #   "Changing TabbedPage.CurrentPage from modal page no longer fires
+  #    OnNavigatedTo on PopModalAsync"
+  #   labels: i/regression · s/verified · regressed-in-10.0.70 ·
+  #           area-controls-tabbedpage · partner/syncfusion
+  #
+  # Smoking gun (verified in the live diff at
+  # src/Controls/src/Core/Page/Page.cs):
+  #   The PR prepended an early-return guard to SendNavigatedTo:
+  #       if (HasNavigatedTo) { return; }
+  #   to stop OnNavigatedTo firing twice. But that return short-circuits the
+  #   WHOLE method, including the trailing child propagation:
+  #       (this as IPageContainer<Page>)?.CurrentPage?.SendNavigatedTo(args);
+  #   HasNavigatedTo is cleared only in SendNavigatedFrom. A container page
+  #   (TabbedPage) whose CurrentPage changes while it stays navigated-to — a
+  #   modal is shown over it, the tab is switched, then the modal is popped —
+  #   keeps its latch set, so the guard suppresses re-dispatch to the now-
+  #   current tab. The asymmetry between "this page already fired its own
+  #   event" and "this page's subtree is fully navigated" IS the regression.
+  # User-visible failure: changing TabbedPage.CurrentPage from a modal and
+  #   then calling PopModalAsync no longer fires OnNavigatedTo on the newly
+  #   selected tab (Android + iOS, 10.0.70).
+  # ───────────────────────────────────────────────────────────────────────
+  - name: navigatedto-latch-suppresses-reentry
+    tags:
+      regression_pr: "31931"
+      regression_issue: "35756"
+      regression_file: src/Controls/src/Core/Page/Page.cs
+    prompt: >-
+      You are reviewing a single commit pre-merge. The repository is
+      already checked out as a worktree pinned to the commit under review.
+
+      Hypothesis to verify or refute: after this commit, a page still
+      receives its OnNavigatedTo lifecycle callback when it is navigated to
+      again without having first been fully navigated away from — for
+      example a container page (such as a tabbed or flyout page) whose
+      visible child changes while another page is displayed on top of it,
+      then becomes the foreground page again. The newly-current child should
+      still receive OnNavigatedTo.
+
+      Do not fetch any pull request, issue, or external page — use ONLY
+      the local worktree and `git diff HEAD^ HEAD` to inspect what
+      changed. Read full source files for changed paths, not just diff
+      hunks. Then deliver a code review using the skill's standard
+      output format (Independent Assessment → Findings → Failure-Mode
+      Probing → Verdict + Confidence). Mark each finding with a severity
+      emoji (❌ Error, ⚠️ Warning, or 💡 Info). End with a Verdict line:
+      NEEDS_CHANGES, NEEDS_DISCUSSION, or LGTM.
+    environment:
+      git:
+        type: worktree
+        ref: af540589fc5a3b053cd8c08334d0ca5a0125451b
+        source: .
+    graders:
+      # ── Structural floor (only one hard regex per scenario) ──────────
+      - type: output-matches
+        config:
+          pattern: '(❌|⚠️|🔴|NEEDS_CHANGES|NEEDS_DISCUSSION)'
+      - type: prompt
+        name: regression-judge
+        config:
+          scoring: scale_1_5
+          threshold: 0.6
+    rubric:
+      - >-
+        The agent inspects src/Controls/src/Core/Page/Page.cs in the
+        worktree's HEAD commit and identifies the new early-return guard
+        added at the top of SendNavigatedTo — `if (HasNavigatedTo) { return; }`
+        — by name, line reference, or near-equivalent quote of the code.
+      - >-
+        The agent recognizes that this guard short-circuits the ENTIRE
+        SendNavigatedTo body — not only the duplicate NavigatedTo /
+        OnNavigatedTo invocation but also the trailing propagation to the
+        current child, `(this as IPageContainer<Page>)?.CurrentPage?.SendNavigatedTo(args)`
+        — and that HasNavigatedTo is cleared only in SendNavigatedFrom.
+        Equivalent phrasings — "the latch is one-way until the page
+        navigates away", "the early return also skips forwarding NavigatedTo
+        to the current child", "a container that never navigates away stops
+        re-dispatching to its CurrentPage" — all count as correct
+        identification of the mechanism.
+      - >-
+        The agent connects this to a concrete failure: a container page
+        (TabbedPage / FlyoutPage) whose CurrentPage changes while it remains
+        navigated-to — e.g. a modal is dismissed over it — will not deliver
+        OnNavigatedTo to the newly-current child because the container's
+        latch is still set; more generally, any legitimate re-navigation to
+        an already-navigated page is suppressed. The agent flags this as a
+        regression risk (❌ Error or ⚠️ Warning). The verdict is
+        NEEDS_CHANGES or NEEDS_DISCUSSION, not LGTM.
+      - >-
+        The Failure-Mode Probing section actually traces what the second
+        SendNavigatedTo call does once HasNavigatedTo is already true,
+        per SKILL.md Step 6 ("What happens during handler disconnect/
+        reconnect (navigation, Shell tab switch)?"). The reviewer does NOT
+        softball with a rhetorical question — they follow the early return
+        through to the skipped child-propagation side effect.
+      - >-
+        The Blast Radius Assessment recognizes this as shared, cross-platform
+        navigation-lifecycle dispatch that runs for ALL pages — not opt-in
+        feature code. Confidence is calibrated to medium or lower; because
+        the change modifies shared lifecycle infrastructure affecting every
+        page, low is the most defensible cap per the Step 6 "shared
+        infrastructure" row. The structured `**Confidence:**` field is
+        present and consistent with that calibration.
+    constraints:
+      max_duration: 10m
+      expect_skills:
+        - code-review
+
 scoring:
   # Vally 0.10 supports scoring.weights, but this suite deliberately omits
   # them so a trial's score is the unweighted mean of its graders' [0,1]

--- a/.github/skills/code-review/tests/eval.vally.yaml
+++ b/.github/skills/code-review/tests/eval.vally.yaml
@@ -22,9 +22,10 @@
 #       never to fetch a PR from the API.
 #
 # Brittleness reduction:
-#   Each scenario has exactly ONE structural-floor regex
-#   ('(❌|⚠️|NEEDS_CHANGES|NEEDS_DISCUSSION)' — silent LGTM is the failure
-#   mode under test). All other semantics — confidence calibration, file/
+#   Each scenario has a narrow structural floor that tests the failure mode
+#   it is designed to catch. The lifecycle-latch scenario uses complementary
+#   verdict checks because surfacing a risk and then delivering LGTM is its
+#   exact regression. All other semantics — confidence calibration, file/
 #   symbol identification, mechanism description, blast-radius / failure-
 #   mode reasoning — are scored by an LLM-judge `prompt` grader against
 #   the rubric. No regex AND-gate of "confidence value + diff symbol +
@@ -316,18 +317,23 @@ stimuli:
       hunks. Then deliver a code review using the skill's standard
       output format (Independent Assessment → Findings → Failure-Mode
       Probing → Verdict + Confidence). Mark each finding with a severity
-      emoji (❌ Error, ⚠️ Warning, or 💡 Info). End with a Verdict line:
-      NEEDS_CHANGES, NEEDS_DISCUSSION, or LGTM.
+      emoji (❌ Error, ⚠️ Warning, or 💡 Info). End with a `### Verdict:`
+      line and a `**Confidence:**` rating.
     environment:
       git:
         type: worktree
         ref: af540589fc5a3b053cd8c08334d0ca5a0125451b
         source: .
     graders:
-      # ── Structural floor (only one hard regex per scenario) ──────────
+      # The failure under test is a reviewer that identifies the risk but
+      # still reaches LGTM. Require the standard non-LGTM verdict form
+      # before asking the judge to assess the reasoning behind it.
+      - type: output-not-contains
+        config:
+          substring: '### Verdict: LGTM'
       - type: output-matches
         config:
-          pattern: '(❌|⚠️|🔴|NEEDS_CHANGES|NEEDS_DISCUSSION)'
+          pattern: '### Verdict:\s*(NEEDS_CHANGES|NEEDS_DISCUSSION)'
       - type: prompt
         name: regression-judge
         config:
@@ -369,11 +375,11 @@ stimuli:
       - >-
         The Blast Radius Assessment recognizes this as shared, cross-platform
         navigation-lifecycle dispatch that runs for ALL pages — not opt-in
-        feature code. Confidence is calibrated to medium or lower; because
+        feature code. It distinguishes certainty in the identified failure
+        mechanism from confidence that the change is safe to merge. The
+        structured `**Confidence:**` field is explicitly **low**, because
         the change modifies shared lifecycle infrastructure affecting every
-        page, low is the most defensible cap per the Step 6 "shared
-        infrastructure" row. The structured `**Confidence:**` field is
-        present and consistent with that calibration.
+        page and the failure mode remains unresolved.
     constraints:
       max_duration: 10m
       expect_skills:
@@ -389,11 +395,15 @@ scoring:
   # normalized) — rubric criteria are not individually AND-gated, which is
   # exactly the de-brittling we want.
   #
-  # We keep exactly two graders per stimulus (one structural floor +
-  # one LLM judge) so the judge carries ~50% of every score. With
-  # threshold 0.6 and a scale_1_5 judge (normalized = (raw-1)/4):
-  #   - correct review:  (floor 1.0 + judge ~0.75) / 2 = ~0.875  -> PASS
-  #   - silent LGTM:     (floor 0.0 + judge ~0.25) / 2 = ~0.125  -> FAIL
-  # which is the falsifiability property (acceptance criterion #4) the
-  # corpus exists to guarantee.
+  # Most stimuli use one structural floor plus one LLM judge. The lifecycle
+  # latch stimulus adds a complementary "not LGTM" floor because a reviewer
+  # that finds the failure mechanism but still ships an LGTM is the exact
+  # false-pass it must reject. With threshold 0.6 and a scale_1_5 judge
+  # (normalized = (raw-1)/4), that stimulus scores approximately:
+  #   - correct review: (not-LGTM 1.0 + verdict 1.0 + judge ~0.75) / 3
+  #                     = ~0.92  -> PASS
+  #   - silent LGTM:    (not-LGTM 0.0 + verdict 0.0 + judge ~0.25) / 3
+  #                     = ~0.08  -> FAIL
+  # This preserves semantic grading while making the tested verdict
+  # inconsistency falsifiable.
   threshold: 0.6

--- a/.github/skills/code-review/tests/eval.vally.yaml
+++ b/.github/skills/code-review/tests/eval.vally.yaml
@@ -22,16 +22,17 @@
 #       never to fetch a PR from the API.
 #
 # Brittleness reduction:
-#   Each scenario has a deterministic manipulation check proving the
-#   code-review skill was invoked, plus a narrow structural floor that tests
-#   the failure mode it is designed to catch. The lifecycle-latch scenario
-#   checks its final verdict because surfacing a risk and then delivering
-#   LGTM is its exact regression. All other semantics — confidence
-#   calibration, file/symbol identification, mechanism description,
-#   blast-radius / failure-mode reasoning — are scored by an LLM-judge
-#   `prompt` grader against the rubric. No regex AND-gate of "confidence
-#   value + diff symbol + regression vocabulary + finding marker + section
-#   heading."
+#   Each scenario overlays the PR's current SKILL.md into the frozen worktree
+#   and has a deterministic manipulation check proving the agent read that
+#   exact policy. This avoids relying on live-PR skill routing, which is not
+#   applicable to a frozen commit fixture. A narrow structural floor then
+#   tests the failure mode each scenario is designed to catch. The lifecycle-
+#   latch scenario checks its final verdict because surfacing a risk and then
+#   delivering LGTM is its exact regression. All other semantics — confidence
+#   calibration, file/symbol identification, mechanism description, blast-
+#   radius / failure-mode reasoning — are scored by an LLM-judge `prompt`
+#   grader against the rubric. No regex AND-gate of "confidence value + diff
+#   symbol + regression vocabulary + finding marker + section heading."
 #
 # Run policy:
 #   runs: 5 on regression scenarios (these are high-variance — agent may
@@ -95,11 +96,10 @@ stimuli:
       regression_issue: "35280"
       regression_file: src/Core/src/Graphics/MauiDrawable.Android.cs
     prompt: >-
-      Use the skill tool to invoke the `code-review` skill, then follow its
-      instructions to review a single commit pre-merge. There is no live pull
-      request for this fixture: the repository is already checked out as a
-      worktree pinned to the commit under review, so use the local worktree
-      instead of PR APIs.
+      You are reviewing a single commit pre-merge. First use the view tool to
+      read `review-input/code-review-SKILL.md`; apply that policy throughout
+      the review. The repository is already checked out as a worktree pinned
+      to the commit under review.
 
       Hypothesis to verify or refute: the new gradient code paths in this
       commit preserve per-stop alpha when a developer uses a Transparent
@@ -119,13 +119,21 @@ stimuli:
         type: worktree
         ref: 48c7d8711d6d6befd0297336c6fb8958cfcfc3bd
         source: .
+      files:
+        - src: ../SKILL.md
+          dest: review-input/code-review-SKILL.md
     graders:
-      # Manipulation check: without this activation the run measures the base
-      # model, not the code-review skill this corpus claims to evaluate.
-      - type: skill-invocation
+      # Manipulation check: require a read of the exact SKILL.md overlaid from
+      # this PR, and reject network access that could reveal the known result.
+      - type: tool-calls
         config:
           required:
-            - code-review
+            - name: '^view$'
+              path: 'review-input/code-review-SKILL\.md$'
+          disallowed:
+            - name: '^(bash|powershell)$'
+              command: '\b(?:gh|curl|wget)\b'
+            - name: '^(web_fetch|web_search|github-mcp-server-.*)$'
       # ── Structural floor (only one hard regex per scenario) ──────────
       # Silent LGTM is the failure mode under test. Any of these tokens
       # proves the reviewer at least flagged SOMETHING; the rubric then
@@ -176,8 +184,6 @@ stimuli:
         and consistent with this calibration.
     constraints:
       max_duration: 10m
-      expect_skills:
-        - code-review
 
   # ───────────────────────────────────────────────────────────────────────
   # Scenario 2 — native iOS collection enumerated without null check
@@ -207,11 +213,10 @@ stimuli:
       regression_issue: "34910"
       regression_file: src/Core/maps/src/Platform/iOS/MauiMKMapView.cs
     prompt: >-
-      Use the skill tool to invoke the `code-review` skill, then follow its
-      instructions to review a single commit pre-merge. There is no live pull
-      request for this fixture: the repository is already checked out as a
-      worktree pinned to the commit under review, so use the local worktree
-      instead of PR APIs.
+      You are reviewing a single commit pre-merge. First use the view tool to
+      read `review-input/code-review-SKILL.md`; apply that policy throughout
+      the review. The repository is already checked out as a worktree pinned
+      to the commit under review.
 
       Hypothesis to verify or refute: tapping the Map control will not
       crash the app on iOS or Mac Catalyst after this commit lands when
@@ -230,13 +235,21 @@ stimuli:
         type: worktree
         ref: dcd44b30fb4a95319b1a33cce1ab1ffd7b3a16d9
         source: .
+      files:
+        - src: ../SKILL.md
+          dest: review-input/code-review-SKILL.md
     graders:
-      # Manipulation check: without this activation the run measures the base
-      # model, not the code-review skill this corpus claims to evaluate.
-      - type: skill-invocation
+      # Manipulation check: require a read of the exact SKILL.md overlaid from
+      # this PR, and reject network access that could reveal the known result.
+      - type: tool-calls
         config:
           required:
-            - code-review
+            - name: '^view$'
+              path: 'review-input/code-review-SKILL\.md$'
+          disallowed:
+            - name: '^(bash|powershell)$'
+              command: '\b(?:gh|curl|wget)\b'
+            - name: '^(web_fetch|web_search|github-mcp-server-.*)$'
       # ── Structural floor (only one hard regex per scenario) ──────────
       - type: output-matches
         config:
@@ -279,8 +292,6 @@ stimuli:
         present and consistent with the Step 6 Blast Radius table.
     constraints:
       max_duration: 10m
-      expect_skills:
-        - code-review
 
   # ───────────────────────────────────────────────────────────────────────
   # Scenario 3 — page lifecycle latch suppresses repeat OnNavigatedTo
@@ -289,8 +300,12 @@ stimuli:
   # Regression PR:  dotnet/maui#31931
   #   "[Android] Page: Fix OnNavigatedTo called twice when NavigationPage is
   #    FlyoutPage Detail"
-  #   merge commit: af540589fc5a3b053cd8c08334d0ca5a0125451b
-  #   parent:       31257d81913000c0979d7075b492c2bc42311451
+  #   original inflight merge: af540589fc5a3b053cd8c08334d0ca5a0125451b
+  #   flowed commit on main:    8ee24cfe4c38038cec62e09dacc182815310c97d
+  #   parent on main:           b8332a3a3c9d25b04bd47193b5429340416c699e
+  #   The two commits have byte-for-byte identical patches. Pin the flowed
+  #   commit because the original inflight merge is no longer reachable from
+  #   main and GitHub may reject direct-SHA fetches for that orphaned object.
   # Regression issue: dotnet/maui#35756
   #   "Changing TabbedPage.CurrentPage from modal page no longer fires
   #    OnNavigatedTo on PopModalAsync"
@@ -320,11 +335,10 @@ stimuli:
       regression_issue: "35756"
       regression_file: src/Controls/src/Core/Page/Page.cs
     prompt: >-
-      Use the skill tool to invoke the `code-review` skill, then follow its
-      instructions to review a single commit pre-merge. There is no live pull
-      request for this fixture: the repository is already checked out as a
-      worktree pinned to the commit under review, so use the local worktree
-      instead of PR APIs.
+      You are reviewing a single commit pre-merge. First use the view tool to
+      read `review-input/code-review-SKILL.md`; apply that policy throughout
+      the review. The repository is already checked out as a worktree pinned
+      to the commit under review.
 
       Hypothesis to verify or refute: after this commit, a page still
       receives its OnNavigatedTo lifecycle callback when it is navigated to
@@ -347,15 +361,23 @@ stimuli:
     environment:
       git:
         type: worktree
-        ref: af540589fc5a3b053cd8c08334d0ca5a0125451b
+        ref: 8ee24cfe4c38038cec62e09dacc182815310c97d
         source: .
+      files:
+        - src: ../SKILL.md
+          dest: review-input/code-review-SKILL.md
     graders:
-      # Manipulation check: without this activation the run measures the base
-      # model, not the code-review skill this corpus claims to evaluate.
-      - type: skill-invocation
+      # Manipulation check: require a read of the exact SKILL.md overlaid from
+      # this PR, and reject network access that could reveal the known result.
+      - type: tool-calls
         config:
           required:
-            - code-review
+            - name: '^view$'
+              path: 'review-input/code-review-SKILL\.md$'
+          disallowed:
+            - name: '^(bash|powershell)$'
+              command: '\b(?:gh|curl|wget)\b'
+            - name: '^(web_fetch|web_search|github-mcp-server-.*)$'
       # The failure under test is a reviewer that identifies the risk but
       # still delivers LGTM. The standard verdict section allows explanatory
       # prose, so the eval prompt adds a terminal, machine-readable marker
@@ -416,28 +438,26 @@ stimuli:
         page and the failure mode remains unresolved.
     constraints:
       max_duration: 10m
-      expect_skills:
-        - code-review
 
 scoring:
   # Vally 0.10 supports scoring.weights, but this suite deliberately omits
   # them so a trial's score is the unweighted mean of its graders' [0,1]
   # scores; the stimulus score is the mean across runs. The deterministic
-  # skill-invocation grader is the manipulation check: a trial that never
-  # activates code-review has not applied the treatment and fails regardless
-  # of how plausible its prose looks. The `prompt` grader contributes ONE
-  # holistic score (its rubric criteria are aggregated by the judge into a
-  # single overall_score, then normalized) — rubric criteria are not
-  # individually AND-gated, which is exactly the de-brittling we want.
+  # tool-calls grader is the manipulation check: a trial that never reads the
+  # overlaid current SKILL.md has not applied the treatment and fails
+  # regardless of how plausible its prose looks. The `prompt` grader
+  # contributes ONE holistic score (its rubric criteria are aggregated by the
+  # judge into a single overall_score, then normalized) — rubric criteria are
+  # not individually AND-gated, which is exactly the de-brittling we want.
   #
   # Each stimulus uses the manipulation check, one structural floor, and one
   # LLM judge. The lifecycle latch floor requires the terminal non-LGTM
   # marker; the judge verifies the regression conclusion without constraining
   # the prose in the standard Verdict section. With threshold 0.6 and a
   # scale_1_5 judge (normalized = (raw-1)/4), that stimulus scores roughly:
-  #   - correct review: (skill 1.0 + floor 1.0 + judge ~0.75) / 3
+  #   - correct review: (policy-read 1.0 + floor 1.0 + judge ~0.75) / 3
   #                     = ~0.917 -> PASS
-  #   - final LGTM:     (skill 1.0 + floor 0.0 + judge ~0.25) / 3
+  #   - final LGTM:     (policy-read 1.0 + floor 0.0 + judge ~0.25) / 3
   #                     = ~0.417 -> FAIL
   # This preserves semantic grading while making the tested verdict
   # inconsistency falsifiable and proving the skill was actually applied.

--- a/.github/skills/code-review/tests/eval.vally.yaml
+++ b/.github/skills/code-review/tests/eval.vally.yaml
@@ -22,14 +22,16 @@
 #       never to fetch a PR from the API.
 #
 # Brittleness reduction:
-#   Each scenario has a narrow structural floor that tests the failure mode
-#   it is designed to catch. The lifecycle-latch scenario checks its final
-#   verdict because surfacing a risk and then delivering LGTM is its exact
-#   regression. All other semantics — confidence calibration, file/
-#   symbol identification, mechanism description, blast-radius / failure-
-#   mode reasoning — are scored by an LLM-judge `prompt` grader against
-#   the rubric. No regex AND-gate of "confidence value + diff symbol +
-#   regression vocabulary + finding marker + section heading."
+#   Each scenario has a deterministic manipulation check proving the
+#   code-review skill was invoked, plus a narrow structural floor that tests
+#   the failure mode it is designed to catch. The lifecycle-latch scenario
+#   checks its final verdict because surfacing a risk and then delivering
+#   LGTM is its exact regression. All other semantics — confidence
+#   calibration, file/symbol identification, mechanism description,
+#   blast-radius / failure-mode reasoning — are scored by an LLM-judge
+#   `prompt` grader against the rubric. No regex AND-gate of "confidence
+#   value + diff symbol + regression vocabulary + finding marker + section
+#   heading."
 #
 # Run policy:
 #   runs: 5 on regression scenarios (these are high-variance — agent may
@@ -93,8 +95,11 @@ stimuli:
       regression_issue: "35280"
       regression_file: src/Core/src/Graphics/MauiDrawable.Android.cs
     prompt: >-
-      You are reviewing a single commit pre-merge. The repository is
-      already checked out as a worktree pinned to the commit under review.
+      Use the skill tool to invoke the `code-review` skill, then follow its
+      instructions to review a single commit pre-merge. There is no live pull
+      request for this fixture: the repository is already checked out as a
+      worktree pinned to the commit under review, so use the local worktree
+      instead of PR APIs.
 
       Hypothesis to verify or refute: the new gradient code paths in this
       commit preserve per-stop alpha when a developer uses a Transparent
@@ -115,6 +120,12 @@ stimuli:
         ref: 48c7d8711d6d6befd0297336c6fb8958cfcfc3bd
         source: .
     graders:
+      # Manipulation check: without this activation the run measures the base
+      # model, not the code-review skill this corpus claims to evaluate.
+      - type: skill-invocation
+        config:
+          required:
+            - code-review
       # ── Structural floor (only one hard regex per scenario) ──────────
       # Silent LGTM is the failure mode under test. Any of these tokens
       # proves the reviewer at least flagged SOMETHING; the rubric then
@@ -196,8 +207,11 @@ stimuli:
       regression_issue: "34910"
       regression_file: src/Core/maps/src/Platform/iOS/MauiMKMapView.cs
     prompt: >-
-      You are reviewing a single commit pre-merge. The repository is
-      already checked out as a worktree pinned to the commit under review.
+      Use the skill tool to invoke the `code-review` skill, then follow its
+      instructions to review a single commit pre-merge. There is no live pull
+      request for this fixture: the repository is already checked out as a
+      worktree pinned to the commit under review, so use the local worktree
+      instead of PR APIs.
 
       Hypothesis to verify or refute: tapping the Map control will not
       crash the app on iOS or Mac Catalyst after this commit lands when
@@ -217,6 +231,12 @@ stimuli:
         ref: dcd44b30fb4a95319b1a33cce1ab1ffd7b3a16d9
         source: .
     graders:
+      # Manipulation check: without this activation the run measures the base
+      # model, not the code-review skill this corpus claims to evaluate.
+      - type: skill-invocation
+        config:
+          required:
+            - code-review
       # ── Structural floor (only one hard regex per scenario) ──────────
       - type: output-matches
         config:
@@ -300,8 +320,11 @@ stimuli:
       regression_issue: "35756"
       regression_file: src/Controls/src/Core/Page/Page.cs
     prompt: >-
-      You are reviewing a single commit pre-merge. The repository is
-      already checked out as a worktree pinned to the commit under review.
+      Use the skill tool to invoke the `code-review` skill, then follow its
+      instructions to review a single commit pre-merge. There is no live pull
+      request for this fixture: the repository is already checked out as a
+      worktree pinned to the commit under review, so use the local worktree
+      instead of PR APIs.
 
       Hypothesis to verify or refute: after this commit, a page still
       receives its OnNavigatedTo lifecycle callback when it is navigated to
@@ -327,6 +350,12 @@ stimuli:
         ref: af540589fc5a3b053cd8c08334d0ca5a0125451b
         source: .
     graders:
+      # Manipulation check: without this activation the run measures the base
+      # model, not the code-review skill this corpus claims to evaluate.
+      - type: skill-invocation
+        config:
+          required:
+            - code-review
       # The failure under test is a reviewer that identifies the risk but
       # still delivers LGTM. The standard verdict section allows explanatory
       # prose, so the eval prompt adds a terminal, machine-readable marker
@@ -393,20 +422,23 @@ stimuli:
 scoring:
   # Vally 0.10 supports scoring.weights, but this suite deliberately omits
   # them so a trial's score is the unweighted mean of its graders' [0,1]
-  # scores; the stimulus
-  # score is the mean across runs; the skill passes when that mean >=
-  # threshold. The `prompt` grader contributes ONE holistic score (its rubric
-  # criteria are aggregated by the judge into a single overall_score, then
-  # normalized) — rubric criteria are not individually AND-gated, which is
-  # exactly the de-brittling we want.
+  # scores; the stimulus score is the mean across runs. The deterministic
+  # skill-invocation grader is the manipulation check: a trial that never
+  # activates code-review has not applied the treatment and fails regardless
+  # of how plausible its prose looks. The `prompt` grader contributes ONE
+  # holistic score (its rubric criteria are aggregated by the judge into a
+  # single overall_score, then normalized) — rubric criteria are not
+  # individually AND-gated, which is exactly the de-brittling we want.
   #
-  # Each stimulus uses one structural floor plus one LLM judge. The lifecycle
-  # latch floor requires the terminal non-LGTM marker; the judge verifies the
-  # required regression conclusion without constraining the prose in the
-  # standard Verdict section. With threshold 0.6 and a scale_1_5 judge
-  # (normalized = (raw-1)/4), that stimulus scores approximately:
-  #   - correct review: (floor 1.0 + judge ~0.75) / 2 = ~0.875  -> PASS
-  #   - final LGTM:     (floor 0.0 + judge ~0.25) / 2 = ~0.125  -> FAIL
+  # Each stimulus uses the manipulation check, one structural floor, and one
+  # LLM judge. The lifecycle latch floor requires the terminal non-LGTM
+  # marker; the judge verifies the regression conclusion without constraining
+  # the prose in the standard Verdict section. With threshold 0.6 and a
+  # scale_1_5 judge (normalized = (raw-1)/4), that stimulus scores roughly:
+  #   - correct review: (skill 1.0 + floor 1.0 + judge ~0.75) / 3
+  #                     = ~0.917 -> PASS
+  #   - final LGTM:     (skill 1.0 + floor 0.0 + judge ~0.25) / 3
+  #                     = ~0.417 -> FAIL
   # This preserves semantic grading while making the tested verdict
-  # inconsistency falsifiable.
+  # inconsistency falsifiable and proving the skill was actually applied.
   threshold: 0.6

--- a/.github/skills/code-review/tests/eval.vally.yaml
+++ b/.github/skills/code-review/tests/eval.vally.yaml
@@ -23,9 +23,9 @@
 #
 # Brittleness reduction:
 #   Each scenario has a narrow structural floor that tests the failure mode
-#   it is designed to catch. The lifecycle-latch scenario uses complementary
-#   verdict checks because surfacing a risk and then delivering LGTM is its
-#   exact regression. All other semantics — confidence calibration, file/
+#   it is designed to catch. The lifecycle-latch scenario checks its final
+#   verdict because surfacing a risk and then delivering LGTM is its exact
+#   regression. All other semantics — confidence calibration, file/
 #   symbol identification, mechanism description, blast-radius / failure-
 #   mode reasoning — are scored by an LLM-judge `prompt` grader against
 #   the rubric. No regex AND-gate of "confidence value + diff symbol +
@@ -326,14 +326,11 @@ stimuli:
         source: .
     graders:
       # The failure under test is a reviewer that identifies the risk but
-      # still reaches LGTM. Require the standard non-LGTM verdict form
-      # before asking the judge to assess the reasoning behind it.
-      - type: output-not-contains
-        config:
-          substring: '### Verdict: LGTM'
+      # still reaches LGTM. Match the required final verdict heading while
+      # accepting benign Markdown emphasis around the verdict token.
       - type: output-matches
         config:
-          pattern: '### Verdict:\s*(NEEDS_CHANGES|NEEDS_DISCUSSION)'
+          pattern: '### Verdict:[^A-Za-z]*(NEEDS_CHANGES|NEEDS_DISCUSSION)'
       - type: prompt
         name: regression-judge
         config:
@@ -395,15 +392,14 @@ scoring:
   # normalized) — rubric criteria are not individually AND-gated, which is
   # exactly the de-brittling we want.
   #
-  # Most stimuli use one structural floor plus one LLM judge. The lifecycle
-  # latch stimulus adds a complementary "not LGTM" floor because a reviewer
-  # that finds the failure mechanism but still ships an LGTM is the exact
-  # false-pass it must reject. With threshold 0.6 and a scale_1_5 judge
-  # (normalized = (raw-1)/4), that stimulus scores approximately:
-  #   - correct review: (not-LGTM 1.0 + verdict 1.0 + judge ~0.75) / 3
-  #                     = ~0.92  -> PASS
-  #   - silent LGTM:    (not-LGTM 0.0 + verdict 0.0 + judge ~0.25) / 3
-  #                     = ~0.08  -> FAIL
+  # Each stimulus uses one structural floor plus one LLM judge. The lifecycle
+  # latch floor is anchored to the final verdict heading, so it rejects a
+  # reviewer that finds the failure mechanism but still ships an LGTM while
+  # accepting benign Markdown emphasis around a non-LGTM verdict. With
+  # threshold 0.6 and a scale_1_5 judge (normalized = (raw-1)/4), that
+  # stimulus scores approximately:
+  #   - correct review: (verdict 1.0 + judge ~0.75) / 2 = ~0.875  -> PASS
+  #   - silent LGTM:    (verdict 0.0 + judge ~0.25) / 2 = ~0.125  -> FAIL
   # This preserves semantic grading while making the tested verdict
   # inconsistency falsifiable.
   threshold: 0.6

--- a/.github/skills/code-review/tests/eval.vally.yaml
+++ b/.github/skills/code-review/tests/eval.vally.yaml
@@ -318,7 +318,9 @@ stimuli:
       output format (Independent Assessment → Findings → Failure-Mode
       Probing → Verdict + Confidence). Mark each finding with a severity
       emoji (❌ Error, ⚠️ Warning, or 💡 Info). End with a `### Verdict:`
-      section and a `**Confidence:**` rating.
+      section and a `**Confidence:**` rating. After the review, make the
+      final non-empty line exactly one of `FINAL_VERDICT: NEEDS_CHANGES`,
+      `FINAL_VERDICT: NEEDS_DISCUSSION`, or `FINAL_VERDICT: LGTM`.
     environment:
       git:
         type: worktree
@@ -326,13 +328,12 @@ stimuli:
         source: .
     graders:
       # The failure under test is a reviewer that identifies the risk but
-      # still delivers an explicit LGTM. The skill's standard output format
-      # allows explanatory prose after the heading, so do not require a
-      # verdict token immediately after `### Verdict:`. The LLM judge below
-      # verifies that the prose still reaches the required non-LGTM result.
-      - type: output-not-contains
+      # still delivers LGTM. The standard verdict section allows explanatory
+      # prose, so the eval prompt adds a terminal, machine-readable marker
+      # instead of inferring the conclusion from free-form prose.
+      - type: output-matches
         config:
-          substring: 'Verdict: LGTM'
+          pattern: '(^|\n)FINAL_VERDICT: (NEEDS_CHANGES|NEEDS_DISCUSSION)\s*$'
       - type: prompt
         name: regression-judge
         config:
@@ -365,6 +366,11 @@ stimuli:
         regression risk (❌ Error or ⚠️ Warning). The verdict is
         NEEDS_CHANGES or NEEDS_DISCUSSION, not LGTM.
       - >-
+        The final non-empty line is exactly `FINAL_VERDICT: NEEDS_CHANGES`
+        or `FINAL_VERDICT: NEEDS_DISCUSSION`. This machine-readable marker
+        records the review conclusion without constraining the prose inside
+        the standard Verdict section.
+      - >-
         The Failure-Mode Probing section actually traces what the second
         SendNavigatedTo call does once HasNavigatedTo is already true,
         per SKILL.md Step 6 ("What happens during handler disconnect/
@@ -395,12 +401,12 @@ scoring:
   # exactly the de-brittling we want.
   #
   # Each stimulus uses one structural floor plus one LLM judge. The lifecycle
-  # latch floor rejects an explicit `Verdict: LGTM`; the judge verifies the
-  # required regression conclusion without assuming the verdict token is
-  # inline with the heading. With threshold 0.6 and a scale_1_5 judge
+  # latch floor requires the terminal non-LGTM marker; the judge verifies the
+  # required regression conclusion without constraining the prose in the
+  # standard Verdict section. With threshold 0.6 and a scale_1_5 judge
   # (normalized = (raw-1)/4), that stimulus scores approximately:
   #   - correct review: (floor 1.0 + judge ~0.75) / 2 = ~0.875  -> PASS
-  #   - explicit LGTM:  (floor 0.0 + judge ~0.25) / 2 = ~0.125  -> FAIL
+  #   - final LGTM:     (floor 0.0 + judge ~0.25) / 2 = ~0.125  -> FAIL
   # This preserves semantic grading while making the tested verdict
   # inconsistency falsifiable.
   threshold: 0.6

--- a/.github/skills/code-review/tests/eval.vally.yaml
+++ b/.github/skills/code-review/tests/eval.vally.yaml
@@ -318,7 +318,7 @@ stimuli:
       output format (Independent Assessment → Findings → Failure-Mode
       Probing → Verdict + Confidence). Mark each finding with a severity
       emoji (❌ Error, ⚠️ Warning, or 💡 Info). End with a `### Verdict:`
-      line and a `**Confidence:**` rating.
+      section and a `**Confidence:**` rating.
     environment:
       git:
         type: worktree
@@ -326,11 +326,13 @@ stimuli:
         source: .
     graders:
       # The failure under test is a reviewer that identifies the risk but
-      # still reaches LGTM. Match the required final verdict heading while
-      # accepting benign Markdown emphasis around the verdict token.
-      - type: output-matches
+      # still delivers an explicit LGTM. The skill's standard output format
+      # allows explanatory prose after the heading, so do not require a
+      # verdict token immediately after `### Verdict:`. The LLM judge below
+      # verifies that the prose still reaches the required non-LGTM result.
+      - type: output-not-contains
         config:
-          pattern: '### Verdict:[^A-Za-z]*(NEEDS_CHANGES|NEEDS_DISCUSSION)'
+          substring: 'Verdict: LGTM'
       - type: prompt
         name: regression-judge
         config:
@@ -393,13 +395,12 @@ scoring:
   # exactly the de-brittling we want.
   #
   # Each stimulus uses one structural floor plus one LLM judge. The lifecycle
-  # latch floor is anchored to the final verdict heading, so it rejects a
-  # reviewer that finds the failure mechanism but still ships an LGTM while
-  # accepting benign Markdown emphasis around a non-LGTM verdict. With
-  # threshold 0.6 and a scale_1_5 judge (normalized = (raw-1)/4), that
-  # stimulus scores approximately:
-  #   - correct review: (verdict 1.0 + judge ~0.75) / 2 = ~0.875  -> PASS
-  #   - silent LGTM:    (verdict 0.0 + judge ~0.25) / 2 = ~0.125  -> FAIL
+  # latch floor rejects an explicit `Verdict: LGTM`; the judge verifies the
+  # required regression conclusion without assuming the verdict token is
+  # inline with the heading. With threshold 0.6 and a scale_1_5 judge
+  # (normalized = (raw-1)/4), that stimulus scores approximately:
+  #   - correct review: (floor 1.0 + judge ~0.75) / 2 = ~0.875  -> PASS
+  #   - explicit LGTM:  (floor 0.0 + judge ~0.25) / 2 = ~0.125  -> FAIL
   # This preserves semantic grading while making the tested verdict
   # inconsistency falsifiable.
   threshold: 0.6


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### What this is

A worked, hermetic regression-corpus example for the `code-review` skill. It pairs a Vally stimulus based on a real lifecycle regression with reviewer guidance that targets the general failure mode.

### Regression captured

- **Introducing PR:** #31931
- **Regression:** #35756, fixed by #35803
- **Mechanism:** an early return added to `Page.SendNavigatedTo` suppressed not only duplicate local lifecycle work, but also propagation to the current child when the page's latch was already set.

### Rework

- Rebased onto current `main`.
- Generalized the guidance: reviewers must distinguish a guard's local duplicate suppression from downstream propagation or side effects, then trace a subsequent call while inputs, recipients, or downstream state may have changed.
- Clarified that `**Confidence:**` represents confidence in the safety recommendation, not certainty that an individual failure mechanism exists. An unresolved failure mode must report `**Confidence:** low`.
- Hardened the lifecycle eval against its original false pass: a review that identifies the risk but still returns `LGTM` fails the structural floor; semantic analysis remains LLM-judged.

### Validation

- `vally lint --eval-spec .github/skills/code-review/tests/eval.vally.yaml --strict` passes locally.
- The regression suite is configured for five trials; the CI model evaluation remains the authoritative measurement of the before/after effect.

### Related

- #35925 — regression-corpus scanner
- #36008 — before/after skill-evaluation reporting
