### PR TITLE
Shorten BindingSourceGen hint names

### DIFF
--- a/src/Controls/src/BindingSourceGen/BindingSourceGenerator.cs
+++ b/src/Controls/src/BindingSourceGen/BindingSourceGenerator.cs
@@ -47,8 +47,7 @@ public class BindingSourceGenerator : IIncrementalGenerator
 				throw new InvalidOperationException("Location cannot be null");
 			}
 
-			var fileName = $"{location.FilePath}-GeneratedBindingInterceptors-{location.Line}-{location.Column}.g.cs";
-			var sanitizedFileName = fileName.Replace('/', '-').Replace('\\', '-').Replace(':', '-');
+			var hintName = CreateHintName(location);
 			var methodNamePrefix = binding.MethodType switch
 			{
 				InterceptedMethodType.SetBinding => "SetBinding",
@@ -58,8 +57,31 @@ public class BindingSourceGenerator : IIncrementalGenerator
 			var uniqueId = (uint)Math.Abs(location.GetHashCode());
 
 			var code = BindingCodeWriter.GenerateBinding(binding, $"{methodNamePrefix}{uniqueId}");
-			spc.AddSource(sanitizedFileName, code);
+			spc.AddSource(hintName, code);
 		});
+	}
+
+	private static string CreateHintName(SimpleLocation location)
+	{
+		return $"BindingSourceGen-{ComputeStableHash(location.FilePath)}-{location.Line}-{location.Column}.g.cs";
+	}
+
+	private static string ComputeStableHash(string text)
+	{
+		const ulong offsetBasis = 14695981039346656037;
+		const ulong prime = 1099511628211;
+
+		unchecked
+		{
+			var hash = offsetBasis;
+			foreach (var character in text)
+			{
+				hash ^= character;
+				hash *= prime;
+			}
+
+			return hash.ToString("x16");
+		}
 	}
 
 	private static bool IsSetBindingMethod(SyntaxNode node)

--- a/src/Controls/src/BindingSourceGen/BindingSourceGenerator.cs
+++ b/src/Controls/src/BindingSourceGen/BindingSourceGenerator.cs
@@ -47,23 +47,28 @@ public class BindingSourceGenerator : IIncrementalGenerator
 				throw new InvalidOperationException("Location cannot be null");
 			}
 
-			var hintName = CreateHintName(location);
+			var stableLocationId = CreateStableLocationId(location);
+			var hintName = CreateHintName(stableLocationId, location);
 			var methodNamePrefix = binding.MethodType switch
 			{
 				InterceptedMethodType.SetBinding => "SetBinding",
 				InterceptedMethodType.Create => "Create",
 				_ => throw new NotSupportedException()
 			};
-			var uniqueId = (uint)Math.Abs(location.GetHashCode());
 
-			var code = BindingCodeWriter.GenerateBinding(binding, $"{methodNamePrefix}{uniqueId}");
+			var code = BindingCodeWriter.GenerateBinding(binding, $"{methodNamePrefix}{stableLocationId}");
 			spc.AddSource(hintName, code);
 		});
 	}
 
-	private static string CreateHintName(SimpleLocation location)
+	private static string CreateHintName(string stableLocationId, SimpleLocation location)
 	{
-		return $"BindingSourceGen-{ComputeStableHash(location.FilePath)}-{location.Line}-{location.Column}.g.cs";
+		return $"BindingSourceGen-{stableLocationId}-{location.Line}-{location.Column}.g.cs";
+	}
+
+	private static string CreateStableLocationId(SimpleLocation location)
+	{
+		return ComputeStableHash($"{location.FilePath}|{location.Line}|{location.Column}");
 	}
 
 	private static string ComputeStableHash(string text)

--- a/src/Controls/tests/BindingSourceGen.UnitTests/IntegrationTests.cs
+++ b/src/Controls/tests/BindingSourceGen.UnitTests/IntegrationTests.cs
@@ -111,7 +111,28 @@ public class IntegrationTests
                 }
             }
             """,
-			result.GeneratedFiles["Path-To-Program.cs-GeneratedBindingInterceptors-3-7.g.cs"]);
+			SourceGenHelpers.GetGeneratedBindingSource(result));
+	}
+
+	[Fact]
+	public void GeneratedHintNameDoesNotIncludeSourceFilePath()
+	{
+		var source = """
+        using Microsoft.Maui.Controls;
+        var label = new Label();
+        label.SetBinding(Label.RotationProperty, static (string s) => s.Length);
+        """;
+		var filePath = @"E:\GitHub\Esri\arcgis-toolkit-dotnet\src\Toolkit\Toolkit.Maui\Toolkit\UI\Controls\OfflineMapAreas\OfflineMapAreasView.Maui.cs";
+
+		var result = SourceGenHelpers.Run(new Dictionary<string, string> { { filePath, source } });
+		var generatedFile = SourceGenHelpers.GetGeneratedBindingFile(result);
+
+		AssertExtensions.AssertNoDiagnostics(result);
+		Assert.StartsWith(SourceGenHelpers.BindingGeneratedSourceHintNamePrefix, generatedFile.Key, StringComparison.Ordinal);
+		Assert.EndsWith("-3-7.g.cs", generatedFile.Key, StringComparison.Ordinal);
+		Assert.DoesNotContain("OfflineMapAreasView", generatedFile.Key, StringComparison.Ordinal);
+		Assert.DoesNotContain("GitHub", generatedFile.Key, StringComparison.Ordinal);
+		Assert.True(generatedFile.Key.Length < 80);
 	}
 
 	[Fact]
@@ -213,7 +234,7 @@ public class IntegrationTests
                 }
             }
             """,
-			result.GeneratedFiles["Path-To-Program.cs-GeneratedBindingInterceptors-2-27.g.cs"]);
+			SourceGenHelpers.GetGeneratedBindingSource(result));
 	}
 
 	[Fact]
@@ -397,7 +418,7 @@ public class IntegrationTests
                 }
             }
             """,
-			result.GeneratedFiles["Path-To-Program.cs-GeneratedBindingInterceptors-6-7.g.cs"]);
+			SourceGenHelpers.GetGeneratedBindingSource(result));
 	}
 
 	[Fact]
@@ -525,7 +546,7 @@ public class IntegrationTests
                 }
             }
             """,
-			result.GeneratedFiles["Path-To-Program.cs-GeneratedBindingInterceptors-7-7.g.cs"]);
+							SourceGenHelpers.GetGeneratedBindingSource(result));
 	}
 
 	public static IEnumerable<object[]> GenerateSimpleBindingWhenNullableDisabledAndPropertyNullableData =>
@@ -753,7 +774,7 @@ public class IntegrationTests
                 }
             }
             """,
-			result.GeneratedFiles["Path-To-Program.cs-GeneratedBindingInterceptors-7-7.g.cs"]);
+							SourceGenHelpers.GetGeneratedBindingSource(result));
 	}
 
 	[Fact]
@@ -893,7 +914,7 @@ public class IntegrationTests
                 }
             }
             """,
-			result.GeneratedFiles["Path-To-Program.cs-GeneratedBindingInterceptors-7-7.g.cs"]);
+							SourceGenHelpers.GetGeneratedBindingSource(result));
 	}
 
 	[Theory]
@@ -1040,7 +1061,7 @@ public class IntegrationTests
                 }
             }
             """,
-			result.GeneratedFiles["Path-To-Program.cs-GeneratedBindingInterceptors-4-7.g.cs"]);
+			SourceGenHelpers.GetGeneratedBindingSource(result));
 	}
 
 	[Fact]
@@ -1181,7 +1202,7 @@ public class IntegrationTests
                 }
             }
             """,
-			result.GeneratedFiles["Path-To-Program.cs-GeneratedBindingInterceptors-4-7.g.cs"]);
+			SourceGenHelpers.GetGeneratedBindingSource(result));
 	}
 
 	[Fact]
@@ -1308,7 +1329,7 @@ public class IntegrationTests
                 }
             }
             """,
-			result.GeneratedFiles["Path-To-Program.cs-GeneratedBindingInterceptors-3-7.g.cs"]);
+			SourceGenHelpers.GetGeneratedBindingSource(result));
 	}
 
 	[Fact]
@@ -1449,7 +1470,7 @@ public class IntegrationTests
                 }
             }
             """,
-			result.GeneratedFiles["Path-To-Program.cs-GeneratedBindingInterceptors-6-7.g.cs"]);
+			SourceGenHelpers.GetGeneratedBindingSource(result));
 	}
 
 	[Fact]
@@ -1575,7 +1596,7 @@ public class IntegrationTests
                 }
             }
             """,
-	result.GeneratedFiles["Path-To-Program.cs-GeneratedBindingInterceptors-17-23.g.cs"]);
+	SourceGenHelpers.GetGeneratedBindingSource(result));
 	}
 
 	[Fact]
@@ -1700,7 +1721,7 @@ public class IntegrationTests
                 }
             }
             """,
-			result.GeneratedFiles["Path-To-Program.cs-GeneratedBindingInterceptors-17-23.g.cs"]);
+			SourceGenHelpers.GetGeneratedBindingSource(result));
 	}
 
 	[Fact]
@@ -1824,7 +1845,7 @@ public class IntegrationTests
                 }
             }
             """,
-	result.GeneratedFiles["Path-To-Program.cs-GeneratedBindingInterceptors-17-23.g.cs"]);
+	SourceGenHelpers.GetGeneratedBindingSource(result));
 	}
 
 	[Fact]
@@ -1949,7 +1970,7 @@ public class IntegrationTests
                 }
             }
             """,
-	result.GeneratedFiles["Path-To-Program.cs-GeneratedBindingInterceptors-17-23.g.cs"]);
+	SourceGenHelpers.GetGeneratedBindingSource(result));
 	}
 
 	[Fact]
@@ -1973,7 +1994,7 @@ public class IntegrationTests
 		""";
 
 		var result = SourceGenHelpers.Run(source);
-		var actual = result.GeneratedFiles["Path-To-Program.cs-GeneratedBindingInterceptors-5-7.g.cs"];
+		var actual = SourceGenHelpers.GetGeneratedBindingSource(result);
 		AssertExtensions.AssertNoDiagnostics(result);
 
 		var id = Math.Abs(result.Binding!.SimpleLocation!.GetHashCode());
@@ -2182,7 +2203,7 @@ public class IntegrationTests
 				}
 			}
 			""",
-			result.GeneratedFiles["Path-To-Program.cs-GeneratedBindingInterceptors-13-13.g.cs"]);
+			SourceGenHelpers.GetGeneratedBindingSource(result));
 	}
 
 	[Fact]
@@ -2301,7 +2322,7 @@ public class IntegrationTests
 				}
 			}
 			""",
-			result.GeneratedFiles["Path-To-Program.cs-GeneratedBindingInterceptors-14-11.g.cs"]);
+			SourceGenHelpers.GetGeneratedBindingSource(result));
 	}
 
 	[Theory]
@@ -2337,10 +2358,9 @@ public class IntegrationTests
 
 		var result = SourceGenHelpers.Run(source);
 		AssertExtensions.AssertNoDiagnostics(result);
-		
-		// Find the interceptor file (not the common helper file)
-		var generatedCode = result.GeneratedFiles.First(kvp => kvp.Key.Contains("Path-To-Program", StringComparison.Ordinal)).Value;
-		
+
+		var generatedCode = SourceGenHelpers.GetGeneratedBindingSource(result);
+
 		if (shouldUseUnsafeAccessor)
 		{
 			// Verify that UnsafeAccessor is generated for the setter and is called correctly
@@ -2468,7 +2488,7 @@ public class IntegrationTests
 			    }
 			}
 			""",
-			result.GeneratedFiles["Path-To-Program.cs-GeneratedBindingInterceptors-3-7.g.cs"]);
+			SourceGenHelpers.GetGeneratedBindingSource(result));
 	}
 
 	[Fact]

--- a/src/Controls/tests/BindingSourceGen.UnitTests/IntegrationTests.cs
+++ b/src/Controls/tests/BindingSourceGen.UnitTests/IntegrationTests.cs
@@ -20,7 +20,7 @@ public class IntegrationTests
 		var result = SourceGenHelpers.Run(source);
 		Assert.NotNull(result.Binding);
 
-		var id = Math.Abs(result.Binding.SimpleLocation!.GetHashCode());
+		var id = SourceGenHelpers.GetStableBindingId(result.Binding);
 
 		AssertExtensions.AssertNoDiagnostics(result);
 		AssertExtensions.CodeIsEqual(
@@ -126,13 +126,31 @@ public class IntegrationTests
 
 		var result = SourceGenHelpers.Run(new Dictionary<string, string> { { filePath, source } });
 		var generatedFile = SourceGenHelpers.GetGeneratedBindingFile(result);
+		var stableLocationId = SourceGenHelpers.GetStableBindingId(result.Binding);
 
 		AssertExtensions.AssertNoDiagnostics(result);
 		Assert.StartsWith(SourceGenHelpers.BindingGeneratedSourceHintNamePrefix, generatedFile.Key, StringComparison.Ordinal);
+		Assert.Contains(stableLocationId, generatedFile.Key, StringComparison.Ordinal);
 		Assert.EndsWith("-3-7.g.cs", generatedFile.Key, StringComparison.Ordinal);
 		Assert.DoesNotContain("OfflineMapAreasView", generatedFile.Key, StringComparison.Ordinal);
 		Assert.DoesNotContain("GitHub", generatedFile.Key, StringComparison.Ordinal);
 		Assert.True(generatedFile.Key.Length < 80);
+	}
+
+	[Fact]
+	public void GeneratedMethodNameUsesStableLocationId()
+	{
+		var source = """
+        using Microsoft.Maui.Controls;
+        var label = new Label();
+        label.SetBinding(Label.RotationProperty, static (string s) => s.Length);
+        """;
+
+		var result = SourceGenHelpers.Run(source);
+		var stableLocationId = SourceGenHelpers.GetStableBindingId(result.Binding);
+
+		AssertExtensions.AssertNoDiagnostics(result);
+		Assert.Contains($"public static void SetBinding{stableLocationId}(", SourceGenHelpers.GetGeneratedBindingSource(result), StringComparison.Ordinal);
 	}
 
 	[Fact]
@@ -147,7 +165,7 @@ public class IntegrationTests
 		AssertExtensions.AssertNoDiagnostics(result);
 		Assert.NotNull(result.Binding);
 
-		var id = Math.Abs(result.Binding.SimpleLocation!.GetHashCode());
+		var id = SourceGenHelpers.GetStableBindingId(result.Binding);
 
 		AssertExtensions.CodeIsEqual(
 			$$"""
@@ -323,7 +341,8 @@ public class IntegrationTests
         """;
 
 		var result = SourceGenHelpers.Run(source);
-		var id = Math.Abs(result.Binding!.SimpleLocation!.GetHashCode());
+		Assert.NotNull(result.Binding);
+		var id = SourceGenHelpers.GetStableBindingId(result.Binding);
 		AssertExtensions.AssertNoDiagnostics(result);
 		AssertExtensions.CodeIsEqual(
 			$$"""
@@ -448,7 +467,8 @@ public class IntegrationTests
         """;
 
 		var result = SourceGenHelpers.Run(source);
-		var id = Math.Abs(result.Binding!.SimpleLocation!.GetHashCode());
+		Assert.NotNull(result.Binding);
+		var id = SourceGenHelpers.GetStableBindingId(result.Binding);
 		AssertExtensions.AssertNoDiagnostics(result);
 		AssertExtensions.CodeIsEqual(
 			$$"""
@@ -679,7 +699,8 @@ public class IntegrationTests
 	public void GenerateSimpleBindingWhenNullableDisabledAndPropertyNullable(string source)
 	{
 		var result = SourceGenHelpers.Run(source);
-		var id = Math.Abs(result.Binding!.SimpleLocation!.GetHashCode());
+		Assert.NotNull(result.Binding);
+		var id = SourceGenHelpers.GetStableBindingId(result.Binding);
 		AssertExtensions.AssertNoDiagnostics(result);
 		AssertExtensions.CodeIsEqual(
 			$$"""
@@ -818,7 +839,8 @@ public class IntegrationTests
         """;
 
 		var result = SourceGenHelpers.Run(source);
-		var id = Math.Abs(result.Binding!.SimpleLocation!.GetHashCode());
+		Assert.NotNull(result.Binding);
+		var id = SourceGenHelpers.GetStableBindingId(result.Binding);
 		AssertExtensions.AssertNoDiagnostics(result);
 		AssertExtensions.CodeIsEqual(
 			$$"""
@@ -957,7 +979,8 @@ public class IntegrationTests
             """;
 
 		var result = SourceGenHelpers.Run(source);
-		var id = Math.Abs(result.Binding!.SimpleLocation!.GetHashCode());
+		Assert.NotNull(result.Binding);
+		var id = SourceGenHelpers.GetStableBindingId(result.Binding);
 
 		AssertExtensions.AssertNoDiagnostics(result);
 		AssertExtensions.CodeIsEqual(
@@ -1102,7 +1125,8 @@ public class IntegrationTests
             """;
 
 		var result = SourceGenHelpers.Run(source);
-		var id = Math.Abs(result.Binding!.SimpleLocation!.GetHashCode());
+		Assert.NotNull(result.Binding);
+		var id = SourceGenHelpers.GetStableBindingId(result.Binding);
 
 		AssertExtensions.AssertNoDiagnostics(result);
 		AssertExtensions.CodeIsEqual(
@@ -1234,7 +1258,8 @@ public class IntegrationTests
             """;
 
 		var result = SourceGenHelpers.Run(source);
-		var id = Math.Abs(result.Binding!.SimpleLocation!.GetHashCode());
+		Assert.NotNull(result.Binding);
+		var id = SourceGenHelpers.GetStableBindingId(result.Binding);
 
 		AssertExtensions.AssertNoDiagnostics(result);
 		AssertExtensions.CodeIsEqual(
@@ -1365,7 +1390,8 @@ public class IntegrationTests
             """;
 
 		var result = SourceGenHelpers.Run(source);
-		var id = Math.Abs(result.Binding!.SimpleLocation!.GetHashCode());
+		Assert.NotNull(result.Binding);
+		var id = SourceGenHelpers.GetStableBindingId(result.Binding);
 
 		AssertExtensions.AssertNoDiagnostics(result);
 		AssertExtensions.CodeIsEqual(
@@ -1500,7 +1526,8 @@ public class IntegrationTests
         """;
 
 		var result = SourceGenHelpers.Run(source);
-		var id = Math.Abs(result.Binding!.SimpleLocation!.GetHashCode());
+		Assert.NotNull(result.Binding);
+		var id = SourceGenHelpers.GetStableBindingId(result.Binding);
 		AssertExtensions.AssertNoDiagnostics(result);
 		AssertExtensions.CodeIsEqual(
 			$$"""
@@ -1626,7 +1653,8 @@ public class IntegrationTests
         """;
 
 		var result = SourceGenHelpers.Run(source);
-		var id = Math.Abs(result.Binding!.SimpleLocation!.GetHashCode());
+		Assert.NotNull(result.Binding);
+		var id = SourceGenHelpers.GetStableBindingId(result.Binding);
 		AssertExtensions.AssertNoDiagnostics(result);
 		AssertExtensions.CodeIsEqual(
 			$$"""
@@ -1751,7 +1779,8 @@ public class IntegrationTests
         """;
 
 		var result = SourceGenHelpers.Run(source);
-		var id = Math.Abs(result.Binding!.SimpleLocation!.GetHashCode());
+		Assert.NotNull(result.Binding);
+		var id = SourceGenHelpers.GetStableBindingId(result.Binding);
 		AssertExtensions.AssertNoDiagnostics(result);
 		AssertExtensions.CodeIsEqual(
 			$$"""
@@ -1875,7 +1904,8 @@ public class IntegrationTests
         """;
 
 		var result = SourceGenHelpers.Run(source);
-		var id = Math.Abs(result.Binding!.SimpleLocation!.GetHashCode());
+		Assert.NotNull(result.Binding);
+		var id = SourceGenHelpers.GetStableBindingId(result.Binding);
 		AssertExtensions.AssertNoDiagnostics(result);
 		AssertExtensions.CodeIsEqual(
 			$$"""
@@ -1997,7 +2027,8 @@ public class IntegrationTests
 		var actual = SourceGenHelpers.GetGeneratedBindingSource(result);
 		AssertExtensions.AssertNoDiagnostics(result);
 
-		var id = Math.Abs(result.Binding!.SimpleLocation!.GetHashCode());
+		Assert.NotNull(result.Binding);
+		var id = SourceGenHelpers.GetStableBindingId(result.Binding);
 
 		AssertExtensions.CodeIsEqual(
 			$$"""
@@ -2113,7 +2144,8 @@ public class IntegrationTests
 		""";
 
 		var result = SourceGenHelpers.Run(source, [new BindingSourceGenerator(), new IncrementalGeneratorSlider()]);
-		var id = Math.Abs(result.Binding!.SimpleLocation!.GetHashCode());
+		Assert.NotNull(result.Binding);
+		var id = SourceGenHelpers.GetStableBindingId(result.Binding);
 		AssertExtensions.AssertNoDiagnostics(result.SourceGeneratorDiagnostics, "Source generator");
 		AssertExtensions.AssertNoDiagnostics(result.GeneratedCodeCompilationDiagnostics, "Generated code compilation");
 
@@ -2230,7 +2262,8 @@ public class IntegrationTests
 		""";
 
 		var result = SourceGenHelpers.Run(source, [new BindingSourceGenerator(), new IncrementalGeneratorSlider()]);
-		var id = Math.Abs(result.Binding!.SimpleLocation!.GetHashCode());
+		Assert.NotNull(result.Binding);
+		var id = SourceGenHelpers.GetStableBindingId(result.Binding);
 		AssertExtensions.AssertNoDiagnostics(result.SourceGeneratorDiagnostics, "Source generator");
 		AssertExtensions.AssertNoDiagnostics(result.GeneratedCodeCompilationDiagnostics, "Generated code compilation");
 
@@ -2397,7 +2430,7 @@ public class IntegrationTests
 		var result = SourceGenHelpers.Run(source);
 		Assert.NotNull(result.Binding);
 
-		var id = Math.Abs(result.Binding.SimpleLocation!.GetHashCode());
+		var id = SourceGenHelpers.GetStableBindingId(result.Binding);
 
 		// The key assertion: no CS8603 errors should be present
 		AssertExtensions.AssertNoDiagnostics(result);

--- a/src/Controls/tests/BindingSourceGen.UnitTests/SourceGenHelpers.cs
+++ b/src/Controls/tests/BindingSourceGen.UnitTests/SourceGenHelpers.cs
@@ -51,6 +51,32 @@ internal static class SourceGenHelpers
 		return result.GeneratedFiles.Single(source => source.Key.StartsWith(BindingGeneratedSourceHintNamePrefix, StringComparison.Ordinal));
 	}
 
+	internal static string GetStableBindingId(BindingInvocationDescription? binding)
+	{
+		Assert.NotNull(binding);
+		Assert.NotNull(binding.SimpleLocation);
+
+		return ComputeStableHash($"{binding.SimpleLocation.FilePath}|{binding.SimpleLocation.Line}|{binding.SimpleLocation.Column}");
+	}
+
+	private static string ComputeStableHash(string text)
+	{
+		const ulong offsetBasis = 14695981039346656037;
+		const ulong prime = 1099511628211;
+
+		unchecked
+		{
+			var hash = offsetBasis;
+			foreach (var character in text)
+			{
+				hash ^= character;
+				hash *= prime;
+			}
+
+			return hash.ToString("x16");
+		}
+	}
+
 	internal static CodeGeneratorResult Run(string source, IEnumerable<IIncrementalGenerator> generators)
 	{
 		// Function assumes the first generator in a list is BindingSourceGenerator

--- a/src/Controls/tests/BindingSourceGen.UnitTests/SourceGenHelpers.cs
+++ b/src/Controls/tests/BindingSourceGen.UnitTests/SourceGenHelpers.cs
@@ -16,6 +16,8 @@ internal record CodeGeneratorResult(
 
 internal static class SourceGenHelpers
 {
+	internal const string BindingGeneratedSourceHintNamePrefix = "BindingSourceGen-";
+
 	private static readonly CSharpParseOptions ParseOptions = new CSharpParseOptions(LanguageVersion.Preview).WithFeatures(
 				[new KeyValuePair<string, string>("InterceptorsNamespaces", "Microsoft.Maui.Controls.Generated")]);
 
@@ -34,13 +36,32 @@ internal static class SourceGenHelpers
 		return Run(source, new[] { new BindingSourceGenerator() });
 	}
 
+	internal static CodeGeneratorResult Run(Dictionary<string, string> sources)
+	{
+		return Run(CreateCompilation(sources), new[] { new BindingSourceGenerator() });
+	}
+
+	internal static string GetGeneratedBindingSource(CodeGeneratorResult result)
+	{
+		return GetGeneratedBindingFile(result).Value;
+	}
+
+	internal static KeyValuePair<string, string> GetGeneratedBindingFile(CodeGeneratorResult result)
+	{
+		return result.GeneratedFiles.Single(source => source.Key.StartsWith(BindingGeneratedSourceHintNamePrefix, StringComparison.Ordinal));
+	}
+
 	internal static CodeGeneratorResult Run(string source, IEnumerable<IIncrementalGenerator> generators)
 	{
 		// Function assumes the first generator in a list is BindingSourceGenerator
 		Assert.NotEmpty(generators);
 		Assert.IsType<BindingSourceGenerator>(generators.First());
 
-		var inputCompilation = CreateCompilation(source);
+		return Run(CreateCompilation(source), generators);
+	}
+
+	private static CodeGeneratorResult Run(Compilation inputCompilation, IEnumerable<IIncrementalGenerator> generators)
+	{
 		var driver = CreateDriver(generators.Select(g => g.AsSourceGenerator()));
 
 		var result = driver.RunGeneratorsAndUpdateCompilation(inputCompilation, out Compilation compilation, out _).GetRunResult().Results.FirstOrDefault();


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

Fixes #35857

Reviewer: @stephanedelcroix

## Description

The BindingSourceGen source generator used the full source file path as part of its generated source hint name. When `EmitCompilerGeneratedFiles` is enabled, Roslyn mirrors that hint name into the generated file path, which can exceed Windows `MAX_PATH` for projects in deeper directory structures.

This changes the generated binding source hint name to use a compact stable hash of the source file path plus the binding line and column, avoiding long absolute paths while preserving deterministic uniqueness.

## Testing

- `dotnet test src\Controls\tests\BindingSourceGen.UnitTests\Controls.BindingSourceGen.UnitTests.csproj --no-restore --verbosity minimal`