### PR TITLE
Make Permissions API testable

### DIFF
--- a/src/Essentials/src/Permissions/Permissions.shared.cs
+++ b/src/Essentials/src/Permissions/Permissions.shared.cs
@@ -2,6 +2,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Maui.ApplicationModel
 {
+#nullable enable
 	/// <summary>
 	/// Provides an abstraction for checking and requesting runtime permissions.
 	/// </summary>
@@ -42,6 +43,7 @@ namespace Microsoft.Maui.ApplicationModel
 		bool ShouldShowRationale<TPermission>()
 			where TPermission : Permissions.BasePermission, new();
 	}
+#nullable restore
 
 	/// <summary>
 	/// The Permissions API provides the ability to check and request runtime permissions.
@@ -108,7 +110,8 @@ namespace Microsoft.Maui.ApplicationModel
 				throw new PermissionException($"{typeof(TPermission).Name} permission was not granted or restricted: {status}");
 		}
 
-		static IPermissions currentImplementation;
+#nullable enable
+		static IPermissions? currentImplementation;
 
 		/// <summary>
 		/// Provides the default implementation for static usage of this API.
@@ -116,8 +119,9 @@ namespace Microsoft.Maui.ApplicationModel
 		public static IPermissions Current =>
 			currentImplementation ??= new PermissionsImplementation();
 
-		internal static void SetCurrent(IPermissions implementation) =>
+		internal static void SetCurrent(IPermissions? implementation) =>
 			currentImplementation = implementation;
+#nullable restore
 
 		/// <summary>
 		/// Represents the abstract base class for all permissions. 

--- a/src/Essentials/src/Permissions/Permissions.shared.cs
+++ b/src/Essentials/src/Permissions/Permissions.shared.cs
@@ -3,6 +3,47 @@ using System.Threading.Tasks;
 namespace Microsoft.Maui.ApplicationModel
 {
 	/// <summary>
+	/// Provides an abstraction for checking and requesting runtime permissions.
+	/// </summary>
+	public interface IPermissions
+	{
+		/// <summary>
+		/// Retrieves the current status of the permission.
+		/// </summary>
+		/// <remarks>
+		/// Will throw <see cref="PermissionException"/> if a required entry was not found in the application manifest.
+		/// Not all permissions require a manifest entry.
+		/// </remarks>
+		/// <exception cref="PermissionException">Thrown if a required entry was not found in the application manifest.</exception>
+		/// <typeparam name="TPermission">The permission type to check.</typeparam>
+		/// <returns>A <see cref="PermissionStatus"/> value indicating the current status of the permission.</returns>
+		Task<PermissionStatus> CheckStatusAsync<TPermission>()
+			where TPermission : Permissions.BasePermission, new();
+
+		/// <summary>
+		/// Requests the permission from the user for this application.
+		/// </summary>
+		/// <remarks>
+		/// Will throw <see cref="PermissionException"/> if a required entry was not found in the application manifest.
+		/// Not all permissions require a manifest entry.
+		/// </remarks>
+		/// <exception cref="PermissionException">Thrown if a required entry was not found in the application manifest.</exception>
+		/// <typeparam name="TPermission">The permission type to request.</typeparam>
+		/// <returns>A <see cref="PermissionStatus"/> value indicating the result of this permission request.</returns>
+		Task<PermissionStatus> RequestAsync<TPermission>()
+			where TPermission : Permissions.BasePermission, new();
+
+		/// <summary>
+		/// Determines if an educational UI should be displayed explaining to the user how the permission will be used in the application.
+		/// </summary>
+		/// <remarks>Only used on Android, other platforms will always return <see langword="false"/>.</remarks>
+		/// <typeparam name="TPermission">The permission type to check.</typeparam>
+		/// <returns><see langword="true"/> if the user has denied or disabled the permission in the past, else <see langword="false"/>.</returns>
+		bool ShouldShowRationale<TPermission>()
+			where TPermission : Permissions.BasePermission, new();
+	}
+
+	/// <summary>
 	/// The Permissions API provides the ability to check and request runtime permissions.
 	/// </summary>
 	public static partial class Permissions
@@ -19,7 +60,7 @@ namespace Microsoft.Maui.ApplicationModel
 		/// <returns>A <see cref="PermissionStatus"/> value indicating the current status of the permission.</returns>
 		public static Task<PermissionStatus> CheckStatusAsync<TPermission>()
 			where TPermission : BasePermission, new() =>
-				new TPermission().CheckStatusAsync();
+				Current.CheckStatusAsync<TPermission>();
 
 		/// <summary>
 		/// Requests the permission from the user for this application.
@@ -33,7 +74,7 @@ namespace Microsoft.Maui.ApplicationModel
 		/// <returns>A <see cref="PermissionStatus"/> value indicating the result of this permission request.</returns>
 		public static Task<PermissionStatus> RequestAsync<TPermission>()
 			where TPermission : BasePermission, new() =>
-				new TPermission().RequestAsync();
+				Current.RequestAsync<TPermission>();
 
 		/// <summary>
 		/// Determines if an educational UI should be displayed explaining to the user how the permission will be used in the application.
@@ -43,7 +84,7 @@ namespace Microsoft.Maui.ApplicationModel
 		/// <returns><see langword="true"/> if the user has denied or disabled the permission in the past, else <see langword="false"/>.</returns>
 		public static bool ShouldShowRationale<TPermission>()
 			where TPermission : BasePermission, new() =>
-				new TPermission().ShouldShowRationale();
+				Current.ShouldShowRationale<TPermission>();
 
 		internal static void EnsureDeclared<TPermission>()
 			where TPermission : BasePermission, new() =>
@@ -66,6 +107,17 @@ namespace Microsoft.Maui.ApplicationModel
 			if (status != PermissionStatus.Granted && status != PermissionStatus.Restricted)
 				throw new PermissionException($"{typeof(TPermission).Name} permission was not granted or restricted: {status}");
 		}
+
+		static IPermissions currentImplementation;
+
+		/// <summary>
+		/// Provides the default implementation for static usage of this API.
+		/// </summary>
+		public static IPermissions Current =>
+			currentImplementation ??= new PermissionsImplementation();
+
+		internal static void SetCurrent(IPermissions implementation) =>
+			currentImplementation = implementation;
 
 		/// <summary>
 		/// Represents the abstract base class for all permissions. 
@@ -308,5 +360,20 @@ namespace Microsoft.Maui.ApplicationModel
 		public partial class Vibrate
 		{
 		}
+	}
+
+	class PermissionsImplementation : IPermissions
+	{
+		public Task<PermissionStatus> CheckStatusAsync<TPermission>()
+			where TPermission : Permissions.BasePermission, new() =>
+				new TPermission().CheckStatusAsync();
+
+		public Task<PermissionStatus> RequestAsync<TPermission>()
+			where TPermission : Permissions.BasePermission, new() =>
+				new TPermission().RequestAsync();
+
+		public bool ShouldShowRationale<TPermission>()
+			where TPermission : Permissions.BasePermission, new() =>
+				new TPermission().ShouldShowRationale();
 	}
 }

--- a/src/Essentials/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,9 +1,9 @@
 #nullable enable
 Microsoft.Maui.ApplicationModel.IPermissions
-~Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>
-~Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>
+~Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
+~Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
 ~Microsoft.Maui.ApplicationModel.IPermissions.ShouldShowRationale<TPermission>() -> bool
-~static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions
+~static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions!
 Microsoft.Maui.Media.RecoveredMediaPickerResult
 Microsoft.Maui.Media.RecoveredMediaPickerResult.Files.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Storage.FileResult!>!
 Microsoft.Maui.Media.RecoveredMediaPickerResult.Id.get -> string!

--- a/src/Essentials/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,4 +1,9 @@
 #nullable enable
+Microsoft.Maui.ApplicationModel.IPermissions
+~Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>
+~Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>
+~Microsoft.Maui.ApplicationModel.IPermissions.ShouldShowRationale<TPermission>() -> bool
+~static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions
 Microsoft.Maui.Media.RecoveredMediaPickerResult
 Microsoft.Maui.Media.RecoveredMediaPickerResult.Files.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Storage.FileResult!>!
 Microsoft.Maui.Media.RecoveredMediaPickerResult.Id.get -> string!

--- a/src/Essentials/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,9 +1,9 @@
 #nullable enable
 Microsoft.Maui.ApplicationModel.IPermissions
-~Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
-~Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
-~Microsoft.Maui.ApplicationModel.IPermissions.ShouldShowRationale<TPermission>() -> bool
-~static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions!
+Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
+Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
+Microsoft.Maui.ApplicationModel.IPermissions.ShouldShowRationale<TPermission>() -> bool
+static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions!
 Microsoft.Maui.Media.RecoveredMediaPickerResult
 Microsoft.Maui.Media.RecoveredMediaPickerResult.Files.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Storage.FileResult!>!
 Microsoft.Maui.Media.RecoveredMediaPickerResult.Id.get -> string!

--- a/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,9 +1,9 @@
 #nullable enable
 Microsoft.Maui.ApplicationModel.IPermissions
-~Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>
-~Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>
+~Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
+~Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
 ~Microsoft.Maui.ApplicationModel.IPermissions.ShouldShowRationale<TPermission>() -> bool
-~static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions
+~static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions!
 *REMOVED*Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 *REMOVED*static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 Microsoft.Maui.Devices.Sensors.GeolocationListeningRequest.MinimumDistance.get -> double

--- a/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,9 +1,9 @@
 #nullable enable
 Microsoft.Maui.ApplicationModel.IPermissions
-~Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
-~Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
-~Microsoft.Maui.ApplicationModel.IPermissions.ShouldShowRationale<TPermission>() -> bool
-~static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions!
+Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
+Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
+Microsoft.Maui.ApplicationModel.IPermissions.ShouldShowRationale<TPermission>() -> bool
+static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions!
 *REMOVED*Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 *REMOVED*static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 Microsoft.Maui.Devices.Sensors.GeolocationListeningRequest.MinimumDistance.get -> double

--- a/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,4 +1,9 @@
 #nullable enable
+Microsoft.Maui.ApplicationModel.IPermissions
+~Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>
+~Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>
+~Microsoft.Maui.ApplicationModel.IPermissions.ShouldShowRationale<TPermission>() -> bool
+~static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions
 *REMOVED*Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 *REMOVED*static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 Microsoft.Maui.Devices.Sensors.GeolocationListeningRequest.MinimumDistance.get -> double

--- a/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,9 +1,9 @@
 #nullable enable
 Microsoft.Maui.ApplicationModel.IPermissions
-~Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>
-~Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>
+~Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
+~Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
 ~Microsoft.Maui.ApplicationModel.IPermissions.ShouldShowRationale<TPermission>() -> bool
-~static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions
+~static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions!
 *REMOVED*Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 *REMOVED*static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 Microsoft.Maui.Devices.Sensors.GeolocationListeningRequest.MinimumDistance.get -> double

--- a/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,9 +1,9 @@
 #nullable enable
 Microsoft.Maui.ApplicationModel.IPermissions
-~Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
-~Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
-~Microsoft.Maui.ApplicationModel.IPermissions.ShouldShowRationale<TPermission>() -> bool
-~static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions!
+Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
+Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
+Microsoft.Maui.ApplicationModel.IPermissions.ShouldShowRationale<TPermission>() -> bool
+static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions!
 *REMOVED*Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 *REMOVED*static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 Microsoft.Maui.Devices.Sensors.GeolocationListeningRequest.MinimumDistance.get -> double

--- a/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,4 +1,9 @@
 #nullable enable
+Microsoft.Maui.ApplicationModel.IPermissions
+~Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>
+~Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>
+~Microsoft.Maui.ApplicationModel.IPermissions.ShouldShowRationale<TPermission>() -> bool
+~static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions
 *REMOVED*Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 *REMOVED*static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 Microsoft.Maui.Devices.Sensors.GeolocationListeningRequest.MinimumDistance.get -> double

--- a/src/Essentials/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,9 +1,9 @@
 #nullable enable
 Microsoft.Maui.ApplicationModel.IPermissions
-~Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>
-~Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>
+~Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
+~Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
 ~Microsoft.Maui.ApplicationModel.IPermissions.ShouldShowRationale<TPermission>() -> bool
-~static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions
+~static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions!
 *REMOVED*Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 *REMOVED*static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 Microsoft.Maui.Devices.Sensors.GeolocationListeningRequest.MinimumDistance.get -> double

--- a/src/Essentials/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,9 +1,9 @@
 #nullable enable
 Microsoft.Maui.ApplicationModel.IPermissions
-~Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
-~Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
-~Microsoft.Maui.ApplicationModel.IPermissions.ShouldShowRationale<TPermission>() -> bool
-~static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions!
+Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
+Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
+Microsoft.Maui.ApplicationModel.IPermissions.ShouldShowRationale<TPermission>() -> bool
+static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions!
 *REMOVED*Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 *REMOVED*static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 Microsoft.Maui.Devices.Sensors.GeolocationListeningRequest.MinimumDistance.get -> double

--- a/src/Essentials/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,4 +1,9 @@
 #nullable enable
+Microsoft.Maui.ApplicationModel.IPermissions
+~Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>
+~Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>
+~Microsoft.Maui.ApplicationModel.IPermissions.ShouldShowRationale<TPermission>() -> bool
+~static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions
 *REMOVED*Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 *REMOVED*static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 Microsoft.Maui.Devices.Sensors.GeolocationListeningRequest.MinimumDistance.get -> double

--- a/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,9 +1,9 @@
 #nullable enable
 Microsoft.Maui.ApplicationModel.IPermissions
-~Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>
-~Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>
+~Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
+~Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
 ~Microsoft.Maui.ApplicationModel.IPermissions.ShouldShowRationale<TPermission>() -> bool
-~static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions
+~static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions!
 *REMOVED*Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 *REMOVED*static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 Microsoft.Maui.Devices.Sensors.GeolocationListeningRequest.MinimumDistance.get -> double

--- a/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,9 +1,9 @@
 #nullable enable
 Microsoft.Maui.ApplicationModel.IPermissions
-~Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
-~Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
-~Microsoft.Maui.ApplicationModel.IPermissions.ShouldShowRationale<TPermission>() -> bool
-~static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions!
+Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
+Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
+Microsoft.Maui.ApplicationModel.IPermissions.ShouldShowRationale<TPermission>() -> bool
+static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions!
 *REMOVED*Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 *REMOVED*static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 Microsoft.Maui.Devices.Sensors.GeolocationListeningRequest.MinimumDistance.get -> double

--- a/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,4 +1,9 @@
 #nullable enable
+Microsoft.Maui.ApplicationModel.IPermissions
+~Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>
+~Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>
+~Microsoft.Maui.ApplicationModel.IPermissions.ShouldShowRationale<TPermission>() -> bool
+~static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions
 *REMOVED*Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 *REMOVED*static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 Microsoft.Maui.Devices.Sensors.GeolocationListeningRequest.MinimumDistance.get -> double

--- a/src/Essentials/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,9 +1,9 @@
 #nullable enable
 Microsoft.Maui.ApplicationModel.IPermissions
-~Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>
-~Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>
+~Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
+~Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
 ~Microsoft.Maui.ApplicationModel.IPermissions.ShouldShowRationale<TPermission>() -> bool
-~static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions
+~static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions!
 *REMOVED*Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 *REMOVED*static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 Microsoft.Maui.Devices.Sensors.GeolocationListeningRequest.MinimumDistance.get -> double

--- a/src/Essentials/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,9 +1,9 @@
 #nullable enable
 Microsoft.Maui.ApplicationModel.IPermissions
-~Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
-~Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
-~Microsoft.Maui.ApplicationModel.IPermissions.ShouldShowRationale<TPermission>() -> bool
-~static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions!
+Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
+Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
+Microsoft.Maui.ApplicationModel.IPermissions.ShouldShowRationale<TPermission>() -> bool
+static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions!
 *REMOVED*Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 *REMOVED*static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 Microsoft.Maui.Devices.Sensors.GeolocationListeningRequest.MinimumDistance.get -> double

--- a/src/Essentials/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,4 +1,9 @@
 #nullable enable
+Microsoft.Maui.ApplicationModel.IPermissions
+~Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>
+~Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>
+~Microsoft.Maui.ApplicationModel.IPermissions.ShouldShowRationale<TPermission>() -> bool
+~static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions
 *REMOVED*Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 *REMOVED*static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 Microsoft.Maui.Devices.Sensors.GeolocationListeningRequest.MinimumDistance.get -> double

--- a/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,9 +1,9 @@
 #nullable enable
 Microsoft.Maui.ApplicationModel.IPermissions
-~Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>
-~Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>
+~Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
+~Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
 ~Microsoft.Maui.ApplicationModel.IPermissions.ShouldShowRationale<TPermission>() -> bool
-~static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions
+~static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions!
 *REMOVED*Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 *REMOVED*static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 Microsoft.Maui.Devices.Sensors.GeolocationListeningRequest.MinimumDistance.get -> double

--- a/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,9 +1,9 @@
 #nullable enable
 Microsoft.Maui.ApplicationModel.IPermissions
-~Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
-~Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
-~Microsoft.Maui.ApplicationModel.IPermissions.ShouldShowRationale<TPermission>() -> bool
-~static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions!
+Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
+Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
+Microsoft.Maui.ApplicationModel.IPermissions.ShouldShowRationale<TPermission>() -> bool
+static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions!
 *REMOVED*Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 *REMOVED*static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 Microsoft.Maui.Devices.Sensors.GeolocationListeningRequest.MinimumDistance.get -> double

--- a/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,4 +1,9 @@
 #nullable enable
+Microsoft.Maui.ApplicationModel.IPermissions
+~Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>
+~Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>
+~Microsoft.Maui.ApplicationModel.IPermissions.ShouldShowRationale<TPermission>() -> bool
+~static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions
 *REMOVED*Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 *REMOVED*static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 Microsoft.Maui.Devices.Sensors.GeolocationListeningRequest.MinimumDistance.get -> double

--- a/src/Essentials/test/UnitTests/Permissions_Tests.cs
+++ b/src/Essentials/test/UnitTests/Permissions_Tests.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Threading.Tasks;
 using Microsoft.Maui.ApplicationModel;
@@ -50,8 +52,8 @@ namespace Tests
 
 		class TestPermissions : IPermissions
 		{
-			string lastCall;
-			Type lastPermissionType;
+			string? lastCall;
+			Type? lastPermissionType;
 
 			public Task<PermissionStatus> CheckStatusAsync<TPermission>()
 				where TPermission : Permissions.BasePermission, new()

--- a/src/Essentials/test/UnitTests/Permissions_Tests.cs
+++ b/src/Essentials/test/UnitTests/Permissions_Tests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Maui.ApplicationModel;
+using Xunit;
+
+namespace Tests
+{
+	public class Permissions_Tests
+	{
+		[Fact]
+		public async Task StaticMethodsUseCurrentImplementation()
+		{
+			var permissions = new TestPermissions();
+
+			Permissions.SetCurrent(permissions);
+
+			try
+			{
+				Assert.Same(permissions, Permissions.Current);
+
+				Assert.Equal(PermissionStatus.Denied, await Permissions.CheckStatusAsync<TestPermission>());
+				permissions.AssertLastCall(nameof(IPermissions.CheckStatusAsync));
+
+				Assert.Equal(PermissionStatus.Restricted, await Permissions.RequestAsync<TestPermission>());
+				permissions.AssertLastCall(nameof(IPermissions.RequestAsync));
+
+				Assert.True(Permissions.ShouldShowRationale<TestPermission>());
+				permissions.AssertLastCall(nameof(IPermissions.ShouldShowRationale));
+			}
+			finally
+			{
+				Permissions.SetCurrent(null);
+			}
+		}
+
+		class TestPermission : Permissions.BasePermission
+		{
+			public override Task<PermissionStatus> CheckStatusAsync() =>
+				throw new InvalidOperationException();
+
+			public override Task<PermissionStatus> RequestAsync() =>
+				throw new InvalidOperationException();
+
+			public override void EnsureDeclared() =>
+				throw new InvalidOperationException();
+
+			public override bool ShouldShowRationale() =>
+				throw new InvalidOperationException();
+		}
+
+		class TestPermissions : IPermissions
+		{
+			string lastCall;
+			Type lastPermissionType;
+
+			public Task<PermissionStatus> CheckStatusAsync<TPermission>()
+				where TPermission : Permissions.BasePermission, new()
+			{
+				CaptureCall<TPermission>(nameof(IPermissions.CheckStatusAsync));
+				return Task.FromResult(PermissionStatus.Denied);
+			}
+
+			public Task<PermissionStatus> RequestAsync<TPermission>()
+				where TPermission : Permissions.BasePermission, new()
+			{
+				CaptureCall<TPermission>(nameof(IPermissions.RequestAsync));
+				return Task.FromResult(PermissionStatus.Restricted);
+			}
+
+			public bool ShouldShowRationale<TPermission>()
+				where TPermission : Permissions.BasePermission, new()
+			{
+				CaptureCall<TPermission>(nameof(IPermissions.ShouldShowRationale));
+				return true;
+			}
+
+			public void AssertLastCall(string expectedCall)
+			{
+				Assert.Equal(expectedCall, lastCall);
+				Assert.Equal(typeof(TestPermission), lastPermissionType);
+			}
+
+			void CaptureCall<TPermission>(string call)
+				where TPermission : Permissions.BasePermission, new()
+			{
+				lastCall = call;
+				lastPermissionType = typeof(TPermission);
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description
Adds an `IPermissions` abstraction and `Permissions.Current` so the static permissions API can route through a replaceable implementation for testing.

### Changes
- Adds `IPermissions` for checking, requesting, and rationale checks.
- Delegates `Permissions` static methods through `Permissions.Current`.
- Adds PublicAPI entries for the new API surface.
- Adds unit coverage verifying the static methods use the current implementation.