### PR TITLE
[WIP][net11] Suppress IL2026/IL3050 for HybridWebView handler registration under NativeAOT

### DIFF
--- a/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
@@ -130,8 +130,14 @@ public static partial class AppHostBuilderExtensions
 		handlersCollection.AddHandler<WebView, WebViewHandler>();
 		if (RuntimeFeature.IsHybridWebViewSupported)
 		{
-			// NOTE: not registered under NativeAOT or TrimMode=Full scenarios
+			// NOTE: not registered under NativeAOT or TrimMode=Full scenarios.
+			// IL2026/IL3050 are suppressed because the RuntimeFeature.IsHybridWebViewSupported guard
+			// has [FeatureGuard(RequiresUnreferencedCodeAttribute)] and [FeatureGuard(RequiresDynamicCodeAttribute)]
+			// annotations that should suppress these warnings. The NativeAOT ILC does not always honor
+			// [FeatureGuard] for warning suppression, so we suppress explicitly.
+#pragma warning disable IL2026, IL3050
 			handlersCollection.AddHandler<HybridWebView, HybridWebViewHandler>();
+#pragma warning restore IL2026, IL3050
 		}
 
 		handlersCollection.AddHandler<Border, BorderHandler>();


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

- This pull request adds explicit suppression of IL2026 and IL3050 warnings when registering the `HybridWebViewHandler` in the handlers collection. This is necessary because the NativeAOT ILC does not always honor `[FeatureGuard]` attributes for warning suppression, even though the code is already guarded by `RuntimeFeature.IsHybridWebViewSupported`.

- **Warning Suppression for Handler Registration:**
  * - Explicitly suppresses IL2026 and IL3050 warnings around the `HybridWebViewHandler` registration in `AddControlsHandlers`, addressing the warnings raised under NativeAOT and TrimMode=Full builds where the `[FeatureGuard]` attributes on `RuntimeFeature.IsHybridWebViewSupported` are not always honored by the ILC.


### Issues Fixed
Fixes #35745



> [!IMPORTANT]
> Do not merge until CI confirms the `maui-pr` → `AOT macOS` leg is no longer failing.