### PR TITLE
Fix Skill Validation results comment: define missing agentCount + harden comment posting

### DIFF
--- a/.github/workflows/skill-validation.yml
+++ b/.github/workflows/skill-validation.yml
@@ -230,6 +230,7 @@ jobs:
           ref: ${{ needs.pr-gate.outputs.head_sha || needs.slash-gate.outputs.head_sha || github.sha }}
           sparse-checkout: |
             .github/skills
+            .github/agents
             .github/plugin.json
           persist-credentials: false
 

--- a/.github/workflows/skill-validation.yml
+++ b/.github/workflows/skill-validation.yml
@@ -295,6 +295,8 @@ jobs:
           mkdir -p sv-results
           skill_count=$(find .github/skills -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')
           echo "$skill_count" > sv-results/skill-count.txt
+          agent_count=$(find .github/agents -mindepth 1 -maxdepth 1 -name '*.md' -type f 2>/dev/null | wc -l | tr -d ' ')
+          echo "$agent_count" > sv-results/agent-count.txt
           echo "${{ steps.check.outputs.spec_count }}" > sv-results/spec-count.txt
           echo "${{ steps.check.outputs.exit_code }}" > sv-results/exit-code.txt
           if [ -f sv-output.txt ]; then
@@ -893,6 +895,10 @@ jobs:
               try { return fs.readFileSync('static-results/skill-count.txt', 'utf8').trim(); }
               catch { return '?'; }
             })();
+            const agentCount = (() => {
+              try { return fs.readFileSync('static-results/agent-count.txt', 'utf8').trim(); }
+              catch { return '?'; }
+            })();
             const specCount = (() => {
               try { return fs.readFileSync('static-results/spec-count.txt', 'utf8').trim(); }
               catch { return '?'; }
@@ -1159,39 +1165,64 @@ jobs:
                 ? 'Passed'
                 : 'Needs attention';
             const overallIcon = overallStatus === 'Passed' ? '✅' : overallStatus === 'Failed' ? '❌' : '⚠️';
-            const badges = [
-              badge('Overall', overallStatus, colorFor(overallStatus)),
-              badge('Static', staticStatus, colorFor(staticStatus)),
-              badge('LLM', evalStatus, colorFor(evalStatus)),
-              badge('Skills', String(skillCount), '8250df'),
-              badge('Agents', String(agentCount), '0969da'),
-            ].join('\n');
-            const authorLine = prAuthor
-              ? `> @${prAuthor} — new skill validation results are available based on this last commit: <a href="${commitUrl}"><code>${headSha7}</code></a>.`
-              : `> New skill validation results are available based on this last commit: <a href="${commitUrl}"><code>${headSha7}</code></a>.`;
-            const content = lines.join('\n');
-            let body = [
-              marker,
-              '',
-              '## Skill Validation Results',
-              '',
-              authorLine,
-              '> To request a fresh validation after new comments or commits, comment `/evaluate-skills`.',
-              '',
-              '<p align="left">',
-              badges,
-              '</p>',
-              '',
-              `<!-- SESSION:${headSha7} START -->`,
-              '<details>',
-              `<summary>${overallIcon} <strong>Skill Validation Results</strong> — <a href="${commitUrl}"><code>${headSha7}</code></a> · <strong>${prTitle}</strong> · <em>${timestamp}</em></summary>`,
-              '<br/>',
-              '',
-              content,
-              '',
-              '</details>',
-              `<!-- SESSION:${headSha7} END -->`,
-            ].join('\n').replace(/<details\s+open>/g, '<details>');
+            // Wrap badge + body construction so a future undefined variable or formatting
+            // error can never sink the whole job: on failure we log loudly and fall back to a
+            // minimal plain-text body so the results comment ALWAYS posts.
+            let body;
+            try {
+              const badges = [
+                badge('Overall', overallStatus, colorFor(overallStatus)),
+                badge('Static', staticStatus, colorFor(staticStatus)),
+                badge('LLM', evalStatus, colorFor(evalStatus)),
+                badge('Skills', String(skillCount), '8250df'),
+                badge('Agents', String(agentCount), '0969da'),
+              ].join('\n');
+              const authorLine = prAuthor
+                ? `> @${prAuthor} — new skill validation results are available based on this last commit: <a href="${commitUrl}"><code>${headSha7}</code></a>.`
+                : `> New skill validation results are available based on this last commit: <a href="${commitUrl}"><code>${headSha7}</code></a>.`;
+              const content = lines.join('\n');
+              body = [
+                marker,
+                '',
+                '## Skill Validation Results',
+                '',
+                authorLine,
+                '> To request a fresh validation after new comments or commits, comment `/evaluate-skills`.',
+                '',
+                '<p align="left">',
+                badges,
+                '</p>',
+                '',
+                `<!-- SESSION:${headSha7} START -->`,
+                '<details>',
+                `<summary>${overallIcon} <strong>Skill Validation Results</strong> — <a href="${commitUrl}"><code>${headSha7}</code></a> · <strong>${prTitle}</strong> · <em>${timestamp}</em></summary>`,
+                '<br/>',
+                '',
+                content,
+                '',
+                '</details>',
+                `<!-- SESSION:${headSha7} END -->`,
+              ].join('\n').replace(/<details\s+open>/g, '<details>');
+            } catch (err) {
+              const detail = err && err.stack ? err.stack : String(err);
+              console.error(`Failed to build formatted Skill Validation comment body: ${detail}`);
+              core.warning(`Skill Validation comment formatting failed; posting plain-text fallback instead: ${err && err.message ? err.message : detail}`);
+              // Keep the marker so the upsert logic still finds/updates this comment, and use
+              // only the already-computed status values (no badge formatting that could rethrow).
+              body = [
+                marker,
+                '',
+                '## Skill Validation Results',
+                '',
+                `Overall: ${overallStatus} · Static: ${staticStatus} · LLM: ${evalStatus}`,
+                '',
+                `Commit: \`${headSha7}\``,
+                '',
+                `[🔍 Full results and investigation steps](${runUrl})`,
+                '',
+                '> _Result badges could not be rendered due to an internal formatting error; see the workflow run logs for details._',
+              ].join('\n');
+            }
 
             // ── Write step summary with investigation prompt ──────
             const summaryPath = process.env.GITHUB_STEP_SUMMARY;


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### The bug

The **Skill Validation** workflow's `Post results comment` job was failing on its `Post comment` step with:

```
ReferenceError: agentCount is not defined
    at eval (... actions/github-script/v7 ...)
##[error]Unhandled error: ReferenceError: agentCount is not defined
```

The `github-script` step builds a badge array that references `agentCount`:

```js
badge('Skills', String(skillCount), '8250df'),
badge('Agents', String(agentCount), '0969da'),   // ❌ agentCount never defined/produced
```

…but `agentCount` was **never defined** in the script and **never produced** as an artifact, whereas `skillCount` is defined (reads `static-results/skill-count.txt`). The script threw while constructing the comment body — *before* any API call — so the results comment was **never posted**.

This was introduced on 2026-06-16 in commit `1c0c0eb200` (#35713, "Style skill validation results comment") and has silently broken the results comment on **every** Skill Validation run since.

It is a real, deterministic workflow bug — not a permissions issue (the job already has `pull-requests: write` + `issues: write`) and not a merge/close race (the failure is a JS `ReferenceError`, not a 403).

### The fix

Self-contained to `.github/workflows/skill-validation.yml`:

1. **Producer** — In the existing `Save results artifact` step (the one that writes `skill-count.txt`/`spec-count.txt`), add an agent count written to `agent-count.txt` in the same `sv-results/` dir, flowing through the same `static-check-results` upload/download wiring:
   ```bash
   agent_count=$(find .github/agents -mindepth 1 -maxdepth 1 -name '*.md' -type f 2>/dev/null | wc -l | tr -d ' ')
   echo "$agent_count" > sv-results/agent-count.txt
   ```
2. **Definition** — In the `Post comment` github-script step, define `agentCount` mirroring `skillCount`/`specCount` exactly (read `static-results/agent-count.txt` inside a try/catch that falls back to `'?'`), placed alongside the existing definitions so it's in scope before the badge array.
3. **Hardening** — Wrap the badge + body construction in a `try/catch`. On any failure it logs via `console.error` and `core.warning` (no silent swallowing) and posts a minimal **plain-text fallback** body (keeping the `<!-- skill-validation-results -->` marker so the upsert still finds/updates the comment). The results comment now **always** posts even if the badge formatting breaks.

### Validation

- YAML parses (`yaml.safe_load`).
- `agentCount` is defined (script line ~898) before its only use in the badge array (line ~1178).
- The embedded github-script JS passes `node --check` (balanced braces / valid scope) when wrapped in an async function (it uses top-level `await`, which github-script permits).

The embedded JS can't be executed locally (depends on the `github`/`context`/`core` runtime), so dynamic behavior wasn't run; logic was reviewed by hand.