### PR TITLE
Revert `environment:` gating on review-trigger.yml

### DIFF
--- a/.github/workflows/review-trigger.yml
+++ b/.github/workflows/review-trigger.yml
@@ -165,7 +165,6 @@ jobs:
     needs: match
     if: needs.match.outputs.matched == 'true' && needs.match.outputs.command == 'review'
     runs-on: ubuntu-latest
-    environment: gh-aw-agents
     concurrency:
       group: review-trigger-${{ github.event.issue.number || inputs.pr_number }}
       cancel-in-progress: false


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

Removes `environment: gh-aw-agents` from the `trigger-review` job in `review-trigger.yml`.

## Why

PR #35974 added `environment: gh-aw-agents` to `review-trigger.yml`, which changed the GitHub OIDC token subject from `repo:dotnet/maui:ref:refs/heads/main` to `repo:dotnet/maui:environment:gh-aw-agents`. The managed identity (`Testing-MI-gh2zdo`) behind `AZDO_TRIGGER_CLIENT_ID` has no federated credential for that environment subject, so every `/review` command fails with:

```
AADSTS700213: No matching federated identity record found for presented
assertion subject 'repo:dotnet/maui:environment:gh-aw-agents'
```

The `AZDO_TRIGGER_*` secrets have been re-added at the repo level. Once the federated credential is updated (requires Azure access to the managed identity), the environment gating can be re-added.

## What changed

- Removed `environment: gh-aw-agents` from the `trigger-review` job (1 line)
- All gh-aw workflows remain gated — only `review-trigger.yml` (regular GHA) is affected