### PR TITLE
Surface p/0-labelled PRs targeting SR branches as release blockers (SR lane parity with Preview)

### DIFF
--- a/.github/skills/release-readiness/scripts/Get-ReleaseReadiness.ps1
+++ b/.github/skills/release-readiness/scripts/Get-ReleaseReadiness.ps1
@@ -2261,6 +2261,67 @@ function Get-OpenSrPrs {
     return @($raw | ConvertFrom-Json -ErrorAction SilentlyContinue)
 }
 
+function Test-IsP0Pr {
+    <#
+    .SYNOPSIS
+        True when a PR object carries the release-blocking 'p/0' label.
+    .DESCRIPTION
+        Ported verbatim from Get-PreviewReadiness.ps1 so the SR lane honors
+        p/0-labelled PRs as blockers exactly like the Preview lane. A p/0 label
+        deliberately placed on a release-targeting PR is an explicit "must ship"
+        signal, so it must surface as a blocker instead of being buried in the
+        generic open-PR list. StrictMode-safe: a PR with a missing or null
+        `labels` property yields an empty array (-> $false) instead of throwing.
+        Accepts both PSCustomObject (the production `gh ... --json` shape) and
+        IDictionary/hashtable (the shape test mocks commonly use).
+    #>
+    param($PR)
+
+    if (-not $PR) { return $false }
+    $labels = if ($PR -is [System.Collections.IDictionary]) {
+        if ($PR.Contains('labels')) { $PR['labels'] } else { $null }
+    } elseif ($PR.PSObject.Properties['labels']) {
+        $PR.labels
+    } else {
+        $null
+    }
+    if (-not $labels) { return $false }
+    return (@($labels | ForEach-Object { $_.name }) -contains 'p/0')
+}
+
+function Get-P0PrChecks {
+    <#
+    .SYNOPSIS
+        Builds a single readiness-check record reporting whether any open PR
+        targeting the SR branch carries the release-blocking 'p/0' label.
+    .DESCRIPTION
+        Mirrors the Preview lane's p/0 PR check. A BLOCKED result is auto-hoisted
+        into the top-of-issue "🔴 Blocking" table and escalates the verdict to
+        Tier 1 (Not Ready) via the shared ship-check machinery — no verdict or
+        renderer changes are needed. StrictMode-safe: guards null/empty input.
+    .OUTPUTS
+        Array with exactly one check record (see New-ReadinessCheck).
+    #>
+    param($OpenSrPrs, [string]$SrBranch)
+
+    $prs = @($OpenSrPrs)
+    $p0 = @($prs | Where-Object { Test-IsP0Pr $_ })
+
+    if ($p0.Count -gt 0) {
+        $nums = ($p0 | ForEach-Object { "#$($_.number)" }) -join ', '
+        return @(New-ReadinessCheck `
+            -Area 'P/0 release-branch PRs' `
+            -Status 'BLOCKED' `
+            -Details "$($p0.Count) open P/0-labelled PR(s) target ``$SrBranch``: $nums." `
+            -NextAction 'Land or de-prioritize each P/0 PR before shipping.')
+    }
+    return @(New-ReadinessCheck `
+        -Area 'P/0 release-branch PRs' `
+        -Status 'READY' `
+        -Details 'No open P/0-labelled PRs target this SR branch.' `
+        -NextAction 'Continue monitoring.')
+}
+
 function Get-OpenIssuesByLabel {
     <#
     .SYNOPSIS
@@ -3458,6 +3519,20 @@ function Invoke-Main {
     # questions as blocking items at the top of the report.
     if ($Phase -in 'all', 'commits', 'regressions', 'open-prs') {
         $data['shipChecks'] = Get-ReleaseShipChecks -Ctx $ctx
+    }
+
+    # P/0-labelled open PRs targeting the SR branch are release blockers (SR-lane
+    # parity with the Preview lane). Reuse the already-fetched open-PR list — only
+    # the 'all'/'open-prs' phases populate it — so we avoid an extra `gh` call. A
+    # BLOCKED result is auto-hoisted into the "🔴 Blocking" summary and escalates
+    # the verdict to Not Ready via the shared ship-check machinery.
+    if ($Phase -in 'all', 'commits', 'regressions', 'open-prs') {
+        if ($data.ContainsKey('openSrPrs')) {
+            if (-not $data.ContainsKey('shipChecks') -or -not $data['shipChecks']) {
+                $data['shipChecks'] = @()
+            }
+            $data['shipChecks'] = @($data['shipChecks']) + @(Get-P0PrChecks -OpenSrPrs $data['openSrPrs'] -SrBranch $ctx.srBranch)
+        }
     }
 
     # CI scanner + KBE issue signals — merged into shipChecks so they appear in the

--- a/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
+++ b/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
@@ -2768,6 +2768,65 @@ Assert-Eq -Label "T19: patch=81 + MainBumpDate → asap-hotfix"     -Expected 'a
 Assert-Eq -Label "T19: missedWindow = false for hotfix"           -Expected $false            -Actual $t19.MissedWindow
 
 # =========================================================================
+# SR lane — Test-IsP0Pr + Get-P0PrChecks (p/0 PR blocker parity)
+# =========================================================================
+# Regression guard for the gap where p/0-labelled PRs targeting an SR branch
+# were NOT surfaced as blockers (the SR lane derived blocking only from
+# ship-checks and Tier-1 regression ISSUES; open PRs were informational).
+# These deterministic, synthetic-fixture tests exercise the SR script's OWN
+# Test-IsP0Pr + Get-P0PrChecks. Re-dot-source the SR engine so the functions
+# under test are unambiguously the SR-lane copies regardless of any prior
+# preview dot-source.
+Write-Host "`n[Unit] SR lane — Test-IsP0Pr + Get-P0PrChecks (p/0 PR parity)" -ForegroundColor Cyan
+
+$env:GET_RELEASE_READINESS_TEST_MODE = '1'
+try {
+    $srScriptForP0 = Join-Path $PSScriptRoot '..' 'scripts' 'Get-ReleaseReadiness.ps1'
+    . $srScriptForP0 -SrBranch 'release/10.0.1xx-sr8'
+} finally {
+    Remove-Item -Path Env:GET_RELEASE_READINESS_TEST_MODE -ErrorAction SilentlyContinue
+}
+
+# --- Test-IsP0Pr: PSCustomObject (production gh --json) shape ---
+$srP0Pr        = [PSCustomObject]@{ number = 35970; labels = @([PSCustomObject]@{ name = 'p/0' }, [PSCustomObject]@{ name = 'area-controls' }) }
+$srNonP0Pr     = [PSCustomObject]@{ number = 99999; labels = @([PSCustomObject]@{ name = 'p/1' }) }
+$srMissingLbls = [PSCustomObject]@{ number = 12345 }                 # no labels property
+$srNullLbls    = [PSCustomObject]@{ number = 22222; labels = $null }
+Assert-Eq -Label "SR: p/0-labelled PR → true"                      -Expected $true  -Actual (Test-IsP0Pr $srP0Pr)
+Assert-Eq -Label "SR: non-p/0 PR → false"                          -Expected $false -Actual (Test-IsP0Pr $srNonP0Pr)
+Assert-Eq -Label "SR: PR missing labels → false (StrictMode-safe)" -Expected $false -Actual (Test-IsP0Pr $srMissingLbls)
+Assert-Eq -Label "SR: PR null labels → false"                      -Expected $false -Actual (Test-IsP0Pr $srNullLbls)
+Assert-Eq -Label "SR: null PR → false (no throw)"                  -Expected $false -Actual (Test-IsP0Pr $null)
+
+# --- Test-IsP0Pr: hashtable / IDictionary (test-mock) shape ---
+$srHashP0    = @{ number = 35970; labels = @(@{ name = 'p/0' }) }
+$srHashNonP0 = @{ number = 66666; labels = @(@{ name = 'p/1' }) }
+$srHashNoLbl = @{ number = 77777 }                                  # no labels key
+Assert-Eq -Label "SR: hashtable PR with p/0 → true (IDictionary path)"   -Expected $true  -Actual (Test-IsP0Pr $srHashP0)
+Assert-Eq -Label "SR: hashtable PR without p/0 → false"                  -Expected $false -Actual (Test-IsP0Pr $srHashNonP0)
+Assert-Eq -Label "SR: hashtable PR missing labels key → false (no throw)" -Expected $false -Actual (Test-IsP0Pr $srHashNoLbl)
+
+# --- Get-P0PrChecks: emits exactly one BLOCKED/READY ship-check ---
+$srP0Checks = @(Get-P0PrChecks -OpenSrPrs @($srP0Pr, $srNonP0Pr) -SrBranch 'release/10.0.1xx-sr8')
+Assert-Eq -Label "Get-P0PrChecks: one record when p/0 present" -Expected 1 -Actual $srP0Checks.Count
+Assert-Eq -Label "Get-P0PrChecks: Area is 'P/0 release-branch PRs'" -Expected 'P/0 release-branch PRs' -Actual $srP0Checks[0].Area
+Assert-Eq -Label "Get-P0PrChecks: Status BLOCKED when p/0 present" -Expected 'BLOCKED' -Actual $srP0Checks[0].Status
+Assert-Eq -Label "Get-P0PrChecks: Details names #35970" -Expected $true -Actual ($srP0Checks[0].Details -like '*35970*')
+
+$srNoP0Checks = @(Get-P0PrChecks -OpenSrPrs @($srNonP0Pr) -SrBranch 'release/10.0.1xx-sr8')
+Assert-Eq -Label "Get-P0PrChecks: one record when no p/0" -Expected 1 -Actual $srNoP0Checks.Count
+Assert-Eq -Label "Get-P0PrChecks: Status READY when no p/0" -Expected 'READY' -Actual $srNoP0Checks[0].Status
+
+$srNullThrew = $false
+$srNullChecks = $null
+try { $srNullChecks = @(Get-P0PrChecks -OpenSrPrs $null -SrBranch 'release/10.0.1xx-sr8') } catch { $srNullThrew = $true }
+Assert-Eq -Label "Get-P0PrChecks: null input → no throw" -Expected $false -Actual $srNullThrew
+Assert-Eq -Label "Get-P0PrChecks: null input → READY" -Expected 'READY' -Actual $srNullChecks[0].Status
+
+$srEmptyChecks = @(Get-P0PrChecks -OpenSrPrs @() -SrBranch 'release/10.0.1xx-sr8')
+Assert-Eq -Label "Get-P0PrChecks: empty input → READY" -Expected 'READY' -Actual $srEmptyChecks[0].Status
+
+# =========================================================================
 # Test-IsP0Pr — preview engine p/0 PR blocker classification
 # =========================================================================
 # Regression guard for the gap where p/0-labelled PRs targeting a preview

--- a/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
+++ b/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
@@ -2813,6 +2813,14 @@ Assert-Eq -Label "Get-P0PrChecks: Area is 'P/0 release-branch PRs'" -Expected 'P
 Assert-Eq -Label "Get-P0PrChecks: Status BLOCKED when p/0 present" -Expected 'BLOCKED' -Actual $srP0Checks[0].Status
 Assert-Eq -Label "Get-P0PrChecks: Details names #35970" -Expected $true -Actual ($srP0Checks[0].Details -like '*35970*')
 
+# Multiple p/0 PRs: the count and the comma-joined "#a, #b" naming the release
+# captain sees must both be exercised (single-PR fixture above never hits the join).
+$srP0Pr2       = [PSCustomObject]@{ number = 35971; labels = @([PSCustomObject]@{ name = 'p/0' }) }
+$srMultiChecks = @(Get-P0PrChecks -OpenSrPrs @($srP0Pr, $srP0Pr2, $srNonP0Pr) -SrBranch 'release/10.0.1xx-sr8')
+Assert-Eq -Label "Get-P0PrChecks: BLOCKED with 2 p/0 PRs" -Expected 'BLOCKED' -Actual $srMultiChecks[0].Status
+Assert-Eq -Label "Get-P0PrChecks: Details counts 2 p/0 PRs" -Expected $true -Actual ($srMultiChecks[0].Details -like '*2 open P/0-labelled PR(s)*')
+Assert-Eq -Label "Get-P0PrChecks: Details comma-joins #35970, #35971" -Expected $true -Actual ($srMultiChecks[0].Details -like '*#35970, #35971*')
+
 $srNoP0Checks = @(Get-P0PrChecks -OpenSrPrs @($srNonP0Pr) -SrBranch 'release/10.0.1xx-sr8')
 Assert-Eq -Label "Get-P0PrChecks: one record when no p/0" -Expected 1 -Actual $srNoP0Checks.Count
 Assert-Eq -Label "Get-P0PrChecks: Status READY when no p/0" -Expected 'READY' -Actual $srNoP0Checks[0].Status


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### The gap

The release-readiness skill has two report generators. The **Preview lane** (`Get-PreviewReadiness.ps1`) already surfaces open PRs carrying the `p/0` label as release **blockers**. The **SR lane** (`Get-ReleaseReadiness.ps1`) did **not**: it derived blocking only from ship-checks (`BLOCKED`) and Tier-1 `regressed-in-*` **issue** classifications. Open PRs were listed purely informationally.

Consequence: a `p/0`-labelled PR targeting an SR branch was never flagged as blocking on the SR tracker issue. Concretely, PR #35970 (`Revert PR #33584…`, base `release/10.0.1xx-sr8`, label `p/0`) did **not** show as blocking on the SR8 tracker issue #35876.

### What changed

- **Ported `Test-IsP0Pr`** from the Preview lane into `Get-ReleaseReadiness.ps1`. It is StrictMode-safe and accepts both the production `gh --json` PSCustomObject shape and the IDictionary/hashtable shape used by test mocks.
- **Added `Get-P0PrChecks`**, which emits a single `P/0 release-branch PRs` ship-check — `BLOCKED` (naming each offending PR, e.g. `#35970`) when any open `p/0` PR targets the SR branch, `READY` otherwise.
- **Merged the check into `shipChecks`** in the main flow, reusing the already-fetched open-PR list so there is **no extra `gh` call**. Because it's a standard `BLOCKED` ship-check, it is automatically hoisted into the top-of-issue `🔴 Blocking` summary and escalates the verdict to **Not Ready** — no verdict or renderer changes were needed.
- **Added deterministic synthetic-fixture unit tests** for both functions (no network, no wall-clock dependence).

### Notes

- This is a PowerShell-only `.github/skills/**` change; the framework `maui-pr` pipeline intentionally skips for skills-only PRs.
- Discovered while working on the separate deflake PR #36004.