### PR TITLE
Fix iOS Shell badge color bleed

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellItemRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellItemRenderer.cs
@@ -355,7 +355,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				var renderer = RendererForShellContent(shellSection);
 				if (renderer is not null)
 				{
-					UpdateTabBarItemBadge(renderer.ViewController?.TabBarItem, shellSection, TabBar);
+					UpdateTabBarItemBadge(renderer.ViewController?.TabBarItem, shellSection);
 				}
 			}
 		}
@@ -397,12 +397,12 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				for (int tabIndex = 0; tabIndex < items.Count; tabIndex++)
 				{
 					TabBar.Items[tabIndex].Enabled = items[tabIndex].IsEnabled;
-					UpdateTabBarItemBadge(TabBar.Items[tabIndex], items[tabIndex], TabBar);
+					UpdateTabBarItemBadge(TabBar.Items[tabIndex], items[tabIndex]);
 				}
 			}
 		}
 
-		internal static void UpdateTabBarItemBadge(UITabBarItem tabBarItem, ShellSection shellSection, UITabBar tabBar = null)
+		internal static void UpdateTabBarItemBadge(UITabBarItem tabBarItem, ShellSection shellSection)
 		{
 			if (tabBarItem is null)
 				return;
@@ -426,89 +426,17 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			{
 				var attrs = new UIStringAttributes { ForegroundColor = badgeTextColor.ToPlatform() };
 				tabBarItem.SetBadgeTextAttributes(attrs, UIControlState.Normal);
+				tabBarItem.SetBadgeTextAttributes(attrs, UIControlState.Selected);
+				tabBarItem.SetBadgeTextAttributes(attrs, UIControlState.Disabled);
+				tabBarItem.SetBadgeTextAttributes(attrs, UIControlState.Focused);
 			}
 			else
 			{
 				tabBarItem.SetBadgeTextAttributes(null, UIControlState.Normal);
+				tabBarItem.SetBadgeTextAttributes(null, UIControlState.Selected);
+				tabBarItem.SetBadgeTextAttributes(null, UIControlState.Disabled);
+				tabBarItem.SetBadgeTextAttributes(null, UIControlState.Focused);
 			}
-
-			if (OperatingSystem.IsIOSVersionAtLeast(15) || OperatingSystem.IsMacCatalystVersionAtLeast(15))
-				UpdateTabBarItemBadgeAppearance(tabBarItem, tabBar, badgeColor, badgeTextColor);
-		}
-
-		[System.Runtime.Versioning.SupportedOSPlatform("ios15.0")]
-		[System.Runtime.Versioning.SupportedOSPlatform("maccatalyst15.0")]
-		static void UpdateTabBarItemBadgeAppearance(UITabBarItem tabBarItem, UITabBar tabBar, Color badgeColor, Color badgeTextColor)
-		{
-			if (badgeColor is null && badgeTextColor is null)
-			{
-				tabBarItem.StandardAppearance = null;
-				tabBarItem.ScrollEdgeAppearance = null;
-				return;
-			}
-
-			var standardAppearance = CreateTabBarBadgeAppearance(tabBarItem.StandardAppearance, tabBar?.StandardAppearance);
-			UpdateTabBarItemBadgeAppearance(standardAppearance, badgeColor, badgeTextColor);
-			tabBarItem.StandardAppearance = standardAppearance;
-
-			var scrollEdgeAppearance = CreateTabBarBadgeAppearance(tabBarItem.ScrollEdgeAppearance, tabBar?.ScrollEdgeAppearance ?? tabBar?.StandardAppearance);
-			UpdateTabBarItemBadgeAppearance(scrollEdgeAppearance, badgeColor, badgeTextColor);
-			tabBarItem.ScrollEdgeAppearance = scrollEdgeAppearance;
-		}
-
-		[System.Runtime.Versioning.SupportedOSPlatform("ios15.0")]
-		[System.Runtime.Versioning.SupportedOSPlatform("maccatalyst15.0")]
-		static UITabBarAppearance CreateTabBarBadgeAppearance(UITabBarAppearance itemAppearance, UITabBarAppearance tabBarAppearance)
-		{
-			if (itemAppearance is not null)
-				return new UITabBarAppearance(itemAppearance);
-
-			if (tabBarAppearance is not null)
-				return new UITabBarAppearance(tabBarAppearance);
-
-			var appearance = new UITabBarAppearance();
-			appearance.ConfigureWithDefaultBackground();
-			return appearance;
-		}
-
-		[System.Runtime.Versioning.SupportedOSPlatform("ios15.0")]
-		[System.Runtime.Versioning.SupportedOSPlatform("maccatalyst15.0")]
-		static void UpdateTabBarItemBadgeAppearance(UITabBarAppearance appearance, Color badgeColor, Color badgeTextColor)
-		{
-			UpdateTabBarItemBadgeAppearance(appearance.StackedLayoutAppearance, badgeColor, badgeTextColor);
-			UpdateTabBarItemBadgeAppearance(appearance.InlineLayoutAppearance, badgeColor, badgeTextColor);
-			UpdateTabBarItemBadgeAppearance(appearance.CompactInlineLayoutAppearance, badgeColor, badgeTextColor);
-		}
-
-		[System.Runtime.Versioning.SupportedOSPlatform("ios15.0")]
-		[System.Runtime.Versioning.SupportedOSPlatform("maccatalyst15.0")]
-		static void UpdateTabBarItemBadgeAppearance(UITabBarItemAppearance appearance, Color badgeColor, Color badgeTextColor)
-		{
-			UpdateTabBarItemBadgeAppearance(appearance.Normal, badgeColor, badgeTextColor);
-			UpdateTabBarItemBadgeAppearance(appearance.Selected, badgeColor, badgeTextColor);
-			UpdateTabBarItemBadgeAppearance(appearance.Disabled, badgeColor, badgeTextColor);
-			UpdateTabBarItemBadgeAppearance(appearance.Focused, badgeColor, badgeTextColor);
-		}
-
-		[System.Runtime.Versioning.SupportedOSPlatform("ios15.0")]
-		[System.Runtime.Versioning.SupportedOSPlatform("maccatalyst15.0")]
-		static void UpdateTabBarItemBadgeAppearance(UITabBarItemStateAppearance appearance, Color badgeColor, Color badgeTextColor)
-		{
-			appearance.BadgeBackgroundColor = badgeColor?.ToPlatform();
-
-			if (badgeTextColor is not null)
-			{
-				appearance.WeakBadgeTextAttributes = new UIStringAttributes { ForegroundColor = badgeTextColor.ToPlatform() }.Dictionary;
-				return;
-			}
-
-			var badgeTextAttributes = appearance.WeakBadgeTextAttributes;
-			if (badgeTextAttributes?[UIStringAttributeKey.ForegroundColor] is null)
-				return;
-
-			var mutableBadgeTextAttributes = new NSMutableDictionary(badgeTextAttributes);
-			mutableBadgeTextAttributes.Remove(UIStringAttributeKey.ForegroundColor);
-			appearance.WeakBadgeTextAttributes = mutableBadgeTextAttributes;
 		}
 
 		void UpdateIsInMoreTabForRenderers()

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRenderer.cs
@@ -604,7 +604,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				var image = TabbedViewExtensions.AutoResizeTabBarImage(TraitCollection, icon?.Value);
 				TabBarItem = new UITabBarItem(ShellSection.Title, image, null);
 				TabBarItem.AccessibilityIdentifier = ShellSection.AutomationId ?? ShellSection.Title;
-				ShellItemRenderer.UpdateTabBarItemBadge(TabBarItem, ShellSection, TabBarController?.TabBar);
+				ShellItemRenderer.UpdateTabBarItemBadge(TabBarItem, ShellSection);
 			});
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellBadgeTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellBadgeTests.iOS.cs
@@ -27,6 +27,10 @@ namespace Microsoft.Maui.DeviceTests
 
 			var shell = await CreateShellAsync(shell =>
 			{
+				Shell.SetTabBarBackgroundColor(shell, Colors.White);
+				Shell.SetTabBarForegroundColor(shell, Colors.Black);
+				Shell.SetTabBarTitleColor(shell, Colors.Black);
+
 				shell.Items.Add(new TabBar()
 				{
 					Items =
@@ -139,7 +143,47 @@ namespace Microsoft.Maui.DeviceTests
 
 				await AssertEventually(() =>
 					NativeTabBarItemHasBadgeColors(tab, badgeColor, null) &&
-					!NativeTabBarItemHasBadgeAppearanceTextColor(tab, badgeTextColor), timeout: 2000);
+					!NativeTabBarItemHasAnyBadgeTextColor(tab, badgeTextColor), timeout: 2000);
+			});
+		}
+
+		[Fact(DisplayName = "Shell Tab Badge Colors Stay Independent Across Selected Tabs")]
+		public async Task ShellTabBadgeColorsStayIndependentAcrossSelectedTabs()
+		{
+			SetupBuilder();
+
+			var tab1BadgeColor = Colors.Blue;
+			var tab2BadgeColor = Colors.Red;
+			var tab1 = CreateBadgeTab("Tab1", "white_tab.png", tab1BadgeColor, Colors.White);
+			var tab2 = CreateBadgeTab("Tab2", "white_tab.png", tab2BadgeColor, Colors.White);
+
+			var shell = await CreateShellAsync(shell =>
+			{
+				shell.Items.Add(new TabBar()
+				{
+					Items =
+					{
+						tab1,
+						tab2
+					}
+				});
+			});
+
+			await CreateHandlerAndAddToWindow<ShellRenderer>(shell, async (handler) =>
+			{
+				await OnLoadedAsync(shell.CurrentPage);
+				await AssertEventually(() =>
+					NativeTabBarItemHasBadgeColors(tab1, tab1BadgeColor, Colors.White) &&
+					NativeTabBarItemHasBadgeColors(tab2, tab2BadgeColor, Colors.White) &&
+					!NativeTabBarItemHasBadgeAppearanceColors(tab1) &&
+					!NativeTabBarItemHasBadgeAppearanceColors(tab2), timeout: 2000);
+
+				await InvokeOnMainThreadAsync(() => shell.CurrentItem.CurrentItem = tab2);
+				await AssertEventually(() =>
+					NativeTabBarItemHasBadgeColors(tab1, tab1BadgeColor, Colors.White) &&
+					NativeTabBarItemHasBadgeColors(tab2, tab2BadgeColor, Colors.White) &&
+					!NativeTabBarItemHasBadgeAppearanceColors(tab1) &&
+					!NativeTabBarItemHasBadgeAppearanceColors(tab2), timeout: 2000);
 			});
 		}
 
@@ -198,90 +242,69 @@ namespace Microsoft.Maui.DeviceTests
 			if (tabBarItem is null || tabBarItem.BadgeValue != item.BadgeText)
 				return false;
 
-			var badgeAttributes = tabBarItem.GetBadgeTextAttributes(UIControlState.Normal);
-
 			if (!ColorComparison.ARGBEquivalent(tabBarItem.BadgeColor, badgeColor.ToPlatform()))
 				return false;
 
-			if (badgeTextColor is not null && !ColorComparison.ARGBEquivalent(badgeAttributes?.ForegroundColor, badgeTextColor.ToPlatform()))
+			if (badgeTextColor is not null && !NativeTabBarItemHasBadgeTextColor(item, badgeTextColor))
 			{
 				return false;
 			}
 
-			return NativeTabBarItemHasBadgeAppearance(tabBarItem, badgeColor, badgeTextColor);
+			return true;
 		}
 
-		bool NativeTabBarItemHasBadgeAppearance(UITabBarItem tabBarItem, Color badgeColor, Color badgeTextColor)
+		bool NativeTabBarItemHasAnyBadgeTextColor(ShellSection item, Color badgeTextColor)
 		{
-			if (!OperatingSystem.IsIOSVersionAtLeast(15) && !OperatingSystem.IsMacCatalystVersionAtLeast(15))
-				return true;
+			var tabBarItem = GetRendererTabBarItem(item);
+			if (tabBarItem is null)
+				return false;
 
-			return TabBarAppearanceHasBadgeColors(tabBarItem.StandardAppearance, badgeColor, badgeTextColor) &&
-				TabBarAppearanceHasBadgeColors(tabBarItem.ScrollEdgeAppearance, badgeColor, badgeTextColor);
+			return BadgeTextAttributesHaveColor(tabBarItem, UIControlState.Normal, badgeTextColor) ||
+				BadgeTextAttributesHaveColor(tabBarItem, UIControlState.Selected, badgeTextColor) ||
+				BadgeTextAttributesHaveColor(tabBarItem, UIControlState.Disabled, badgeTextColor) ||
+				BadgeTextAttributesHaveColor(tabBarItem, UIControlState.Focused, badgeTextColor);
 		}
 
-		bool NativeTabBarItemHasBadgeAppearanceTextColor(ShellSection item, Color badgeTextColor)
+		bool NativeTabBarItemHasBadgeTextColor(ShellSection item, Color badgeTextColor)
+		{
+			var tabBarItem = GetRendererTabBarItem(item);
+			if (tabBarItem is null)
+				return false;
+
+			return BadgeTextAttributesHaveColor(tabBarItem, UIControlState.Normal, badgeTextColor) &&
+				BadgeTextAttributesHaveColor(tabBarItem, UIControlState.Selected, badgeTextColor) &&
+				BadgeTextAttributesHaveColor(tabBarItem, UIControlState.Disabled, badgeTextColor) &&
+				BadgeTextAttributesHaveColor(tabBarItem, UIControlState.Focused, badgeTextColor);
+		}
+
+		bool BadgeTextAttributesHaveColor(UITabBarItem tabBarItem, UIControlState state, Color badgeTextColor) =>
+			ColorComparison.ARGBEquivalent(tabBarItem.GetBadgeTextAttributes(state)?.ForegroundColor, badgeTextColor.ToPlatform());
+
+		bool NativeTabBarItemHasBadgeAppearanceColors(ShellSection item)
 		{
 			if (!OperatingSystem.IsIOSVersionAtLeast(15) && !OperatingSystem.IsMacCatalystVersionAtLeast(15))
 				return false;
 
 			var tabBarItem = GetRendererTabBarItem(item);
 			return tabBarItem is not null &&
-				(TabBarAppearanceHasBadgeTextColor(tabBarItem.StandardAppearance, badgeTextColor) ||
-				TabBarAppearanceHasBadgeTextColor(tabBarItem.ScrollEdgeAppearance, badgeTextColor));
+				(TabBarAppearanceHasBadgeColors(tabBarItem.StandardAppearance) ||
+				TabBarAppearanceHasBadgeColors(tabBarItem.ScrollEdgeAppearance));
 		}
 
-		bool TabBarAppearanceHasBadgeColors(UITabBarAppearance appearance, Color badgeColor, Color badgeTextColor)
-		{
-			if (appearance is null)
-				return false;
+		bool TabBarAppearanceHasBadgeColors(UITabBarAppearance appearance) =>
+			appearance is not null &&
+			(TabBarItemAppearanceHasBadgeColors(appearance.StackedLayoutAppearance) ||
+			TabBarItemAppearanceHasBadgeColors(appearance.InlineLayoutAppearance) ||
+			TabBarItemAppearanceHasBadgeColors(appearance.CompactInlineLayoutAppearance));
 
-			return TabBarItemAppearanceHasBadgeColors(appearance.StackedLayoutAppearance, badgeColor, badgeTextColor) &&
-				TabBarItemAppearanceHasBadgeColors(appearance.InlineLayoutAppearance, badgeColor, badgeTextColor) &&
-				TabBarItemAppearanceHasBadgeColors(appearance.CompactInlineLayoutAppearance, badgeColor, badgeTextColor);
-		}
+		bool TabBarItemAppearanceHasBadgeColors(UITabBarItemAppearance appearance) =>
+			TabBarItemStateAppearanceHasBadgeColors(appearance.Normal) ||
+			TabBarItemStateAppearanceHasBadgeColors(appearance.Selected) ||
+			TabBarItemStateAppearanceHasBadgeColors(appearance.Disabled) ||
+			TabBarItemStateAppearanceHasBadgeColors(appearance.Focused);
 
-		bool TabBarItemAppearanceHasBadgeColors(UITabBarItemAppearance appearance, Color badgeColor, Color badgeTextColor)
-		{
-			return TabBarItemStateAppearanceHasBadgeColors(appearance.Normal, badgeColor, badgeTextColor) &&
-				TabBarItemStateAppearanceHasBadgeColors(appearance.Selected, badgeColor, badgeTextColor) &&
-				TabBarItemStateAppearanceHasBadgeColors(appearance.Disabled, badgeColor, badgeTextColor) &&
-				TabBarItemStateAppearanceHasBadgeColors(appearance.Focused, badgeColor, badgeTextColor);
-		}
-
-		bool TabBarAppearanceHasBadgeTextColor(UITabBarAppearance appearance, Color badgeTextColor)
-		{
-			return appearance is not null &&
-				(TabBarItemAppearanceHasBadgeTextColor(appearance.StackedLayoutAppearance, badgeTextColor) ||
-				TabBarItemAppearanceHasBadgeTextColor(appearance.InlineLayoutAppearance, badgeTextColor) ||
-				TabBarItemAppearanceHasBadgeTextColor(appearance.CompactInlineLayoutAppearance, badgeTextColor));
-		}
-
-		bool TabBarItemAppearanceHasBadgeTextColor(UITabBarItemAppearance appearance, Color badgeTextColor)
-		{
-			return TabBarItemStateAppearanceHasBadgeTextColor(appearance.Normal, badgeTextColor) ||
-				TabBarItemStateAppearanceHasBadgeTextColor(appearance.Selected, badgeTextColor) ||
-				TabBarItemStateAppearanceHasBadgeTextColor(appearance.Disabled, badgeTextColor) ||
-				TabBarItemStateAppearanceHasBadgeTextColor(appearance.Focused, badgeTextColor);
-		}
-
-		bool TabBarItemStateAppearanceHasBadgeColors(UITabBarItemStateAppearance appearance, Color badgeColor, Color badgeTextColor)
-		{
-			if (!ColorComparison.ARGBEquivalent(appearance.BadgeBackgroundColor, badgeColor.ToPlatform()))
-				return false;
-
-			var foregroundColor = appearance.WeakBadgeTextAttributes?[UIStringAttributeKey.ForegroundColor] as UIColor;
-
-			if (badgeTextColor is null)
-				return true;
-
-			return ColorComparison.ARGBEquivalent(foregroundColor, badgeTextColor.ToPlatform());
-		}
-
-		bool TabBarItemStateAppearanceHasBadgeTextColor(UITabBarItemStateAppearance appearance, Color badgeTextColor)
-		{
-			var foregroundColor = appearance.WeakBadgeTextAttributes?[UIStringAttributeKey.ForegroundColor] as UIColor;
-			return ColorComparison.ARGBEquivalent(foregroundColor, badgeTextColor.ToPlatform());
-		}
+		bool TabBarItemStateAppearanceHasBadgeColors(UITabBarItemStateAppearance appearance) =>
+			appearance.BadgeBackgroundColor is not null ||
+			appearance.WeakBadgeTextAttributes?[UIStringAttributeKey.ForegroundColor] is not null;
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Fixes #35948 by avoiding per-item `UITabBarAppearance` badge color updates for iOS/MacCatalyst Shell tab badges. UIKit can render badge appearance state from the selected tab across other visible tabs, causing badge colors to bleed between Shell tabs. Badge colors now stay on the native `UITabBarItem` path, and badge text attributes are applied for normal, selected, disabled, and focused states.

## Testing

- `dotnet build src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj -c Release -f net11.0-ios -r iossimulator-arm64 /p:TreatWarningsAsErrors=false /p:CodesignRequireProvisioningProfile=false /p:ValidateXcodeVersion=false`
- `dotnet xharness apple test --app artifacts/bin/Controls.DeviceTests/Release/net11.0-ios/iossimulator-arm64/Microsoft.Maui.Controls.DeviceTests.app --target ios-simulator-64_26.4 --device ABC02C6A-A076-4C9F-B651-610FDA4BA06A -o artifacts/log/shell-ios-net11-final4 --timeout 01:00:00 -v --set-env=TestFilter=Category=Shell` — 209 passed, 0 failed