### PR TITLE
[Controls] Fix BindableObject DefaultValueCreator re-entrancy regression

### DIFF
--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -6,7 +6,6 @@ using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using Microsoft.Extensions.Logging;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Dispatching;
@@ -721,20 +720,19 @@ namespace Microsoft.Maui.Controls
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		BindablePropertyContext GetOrCreateContext(BindableProperty property)
 		{
-#if NETSTANDARD
 			var context = GetContext(property);
 			if (context is null)
 			{
+				// Create the context before adding it to _properties. CreateContext can invoke a
+				// DefaultValueCreator that re-entrantly sets other properties, which may resize
+				// _properties and reallocate its backing storage. Holding a ref into the dictionary
+				// across that call (e.g. via CollectionsMarshal.GetValueRefOrAddDefault) would leave
+				// the ref pointing at the discarded array, so the created context would never be
+				// stored. See https://github.com/dotnet/maui/pull/35970.
 				context = CreateContext(property);
 				_properties.Add(property.InternalId, context);
 			}
-#else
-			ref var context = ref CollectionsMarshal.GetValueRefOrAddDefault(_properties, property.InternalId, out var exists);
-			if (!exists)
-			{
-				context = CreateContext(property);
-			}
-#endif
+
 			return context;
 		}
 

--- a/src/Controls/tests/Core.UnitTests/BindableObjectUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindableObjectUnitTests.cs
@@ -1564,6 +1564,65 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal(5, values[2]);
 		}
 
+		[Fact]
+		public void GetValuesReturnsSetStateAndValue()
+		{
+			var prop = BindableProperty.Create("Foo", typeof(int), typeof(MockBindable), 0);
+			var prop1 = BindableProperty.Create("Foo1", typeof(int), typeof(MockBindable), 1);
+			var prop2 = BindableProperty.Create("Foo2", typeof(int), typeof(MockBindable), 2);
+			var bindable = new MockBindable();
+
+			bindable.SetValue(prop, 3);
+			bindable.SetValue(prop2, 5);
+
+			var values = bindable.GetValues<int>(new[] { prop, prop1, prop2 });
+
+			Assert.Equal(3, values.Length);
+			Assert.True(values[0].IsSet);
+			Assert.Equal(3, values[0].Value);
+			Assert.False(values[1].IsSet);
+			Assert.Equal(0, values[1].Value);
+			Assert.True(values[2].IsSet);
+			Assert.Equal(5, values[2].Value);
+		}
+
+		[Fact]
+		public void DefaultValueCreatorCachesValueWhenReentrantPropertyAddsResizeStore()
+		{
+			var reentrantProperties = new BindableProperty[8];
+			for (var i = 0; i < reentrantProperties.Length; i++)
+			{
+				reentrantProperties[i] = BindableProperty.Create($"Reentrant{i}", typeof(int), typeof(MockBindable), 0);
+			}
+
+			var defaultValueCreatorInvocations = 0;
+			var propertyWithCreator = BindableProperty.Create(
+				"ReentrantDefault",
+				typeof(int),
+				typeof(MockBindable),
+				0,
+				defaultValueCreator: b =>
+				{
+					defaultValueCreatorInvocations++;
+					for (var i = 0; i < reentrantProperties.Length; i++)
+					{
+						b.SetValue(reentrantProperties[i], i + 1);
+					}
+
+					return 42;
+				});
+
+			var bindable = new MockBindable();
+
+			var first = (int)bindable.GetValue(propertyWithCreator);
+			var second = (int)bindable.GetValue(propertyWithCreator);
+
+			Assert.Equal(42, first);
+			Assert.Equal(42, second);
+			Assert.Equal(1, defaultValueCreatorInvocations);
+			Assert.True(bindable.IsSet(propertyWithCreator));
+		}
+
 		class BindingContextConverter
 			: IValueConverter
 		{


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

Fixes a regression introduced by #33584 in which a `BindableProperty` whose value comes from a `DefaultValueCreator` could permanently return its raw `DefaultValue` (and report `IsSet == false`) when that creator re-entrantly sets other properties.

This is the **`main` counterpart** to the servicing-branch revert #35970. On `release/10.0.1xx-sr8` the safest action was to fully revert #33584. On `main` we instead **fix the bug directly**, because #33584 also introduced internal APIs that other code now depends on (see below) — a straight revert would remove them.

## Root cause

`#33584` rewrote `GetOrCreateContext` (non-`NETSTANDARD` path) to use `CollectionsMarshal.GetValueRefOrAddDefault`:

```csharp
ref var context = ref CollectionsMarshal.GetValueRefOrAddDefault(_properties, property.InternalId, out var exists);
if (!exists)
    context = CreateContext(property);   // <-- runs the DefaultValueCreator
```

`GetValueRefOrAddDefault` returns a `ref` **into the dictionary's backing array**. `CreateContext` then invokes the property's `DefaultValueCreator`, which can re-entrantly `SetValue` other properties. Those additions can grow `_properties` past its capacity, **reallocating the backing array**. The held `ref` now points at the *old, discarded* array, so `context = CreateContext(...)` writes there and the live dictionary slot for the property stays `null`.

Net effect:
- 1st `GetValue` returns the creator's value (the freshly created context is returned directly).
- 2nd `GetValue` finds the `null` slot and falls back to `property.DefaultValue`.
- `IsSet` returns `false`.

## The fix

Create the context **before** inserting it, holding no `ref` across `CreateContext` — exactly the shape the `#if NETSTANDARD` branch already used:

```csharp
var context = GetContext(property);
if (context is null)
{
    context = CreateContext(property);
    _properties.Add(property.InternalId, context);
}
return context;
```

The two TFM branches are unified and the now-unused `using System.Runtime.InteropServices;` is removed. The hot path (`GetContext`, already-exists case) is unchanged.

## Why fix instead of revert on `main`

Reverting #33584 here would remove internal API that is in use:

- `BindableProperty.InternalId` and the `Dictionary<int, BindablePropertyContext>` keying model.
- `BindableObject.GetValues<T>(BindableProperty[])`, consumed internally by `ShellAppearance` (and useful to tooling).

This PR preserves all of those — only `GetOrCreateContext` changes.

## Tests

- `DefaultValueCreatorCachesValueWhenReentrantPropertyAddsResizeStore` — regression test that forces a dictionary resize *during* default-value creation and asserts both reads return the created value, the creator runs once, and `IsSet` is `true`.
- `GetValuesReturnsSetStateAndValue` — first direct unit coverage for the internal `GetValues<T>` API (the existing `GetValues` test never actually called it).

The `LocalValueEnumerator`-based test from #35970 is intentionally omitted here — that API only exists on the reverted servicing branch, not on `main`.

### Verified locally (net10.0)

| Code | Regression test |
|------|-----------------|
| `main` as-is (#33584 optimization) | ❌ FAIL — `Assert.Equal() Expected: 42, Actual: 0` |
| `main` + this fix | ✅ PASS (both new tests) |

## Related

- #33584 — original micro-optimization that introduced the regression.
- #35970 — servicing-branch revert on `release/10.0.1xx-sr8`.
