### PR TITLE
Sanitize upstream titles in release-readiness tracker tables (embedded newlines + unescaped pipes)

### DIFF
--- a/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
+++ b/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
@@ -854,12 +854,16 @@ function Format-MarkdownCell {
     # Collapse embedded newlines first: a malformed upstream title can contain a
     # literal CR/LF (observed: ci-scan issue #35957), which would otherwise split
     # the markdown table row across physical lines and break the rendered table.
-    # Double pre-existing backslashes BEFORE escaping pipes: a title may legally
-    # contain a literal `\|`, and escaping only the pipe would yield `\\|` — which
-    # GFM renders as a literal `\` plus an ACTIVE column delimiter (table breakout).
-    # Doubling backslashes first makes `\|` -> `\\\|`, a literal `\|`. No-backslash
-    # titles are unaffected (`a | b` -> `a \| b`).
-    return (((($Value -replace "[\r\n]+", " ") -replace "\\", "\\") -replace "\|", "\|") -replace "<", "&lt;" -replace ">", "&gt;").Trim()
+    # Escape each pipe AND double only the backslash run immediately preceding it:
+    # a title may legally contain a literal `\|`, and escaping only the pipe would
+    # yield `\\|` — which GFM renders as a literal `\` plus an ACTIVE column delimiter
+    # (table breakout). Doubling the pipe-adjacent run makes `\|` -> `\\\|`, a literal
+    # `\|`. Scoping the doubling to `(\\*)\|` (rather than every backslash) preserves a
+    # title's other backslash escapes (e.g. `\[link\](url)` is not de-escaped into an
+    # active link). No-pipe-adjacent-backslash titles are unaffected (`a | b` -> `a \| b`).
+    $v = $Value -replace "[\r\n]+", " "
+    $v = [regex]::Replace($v, '(\\*)\|', { param($m) ($m.Groups[1].Value * 2) + '\|' })
+    return ($v -replace "<", "&lt;" -replace ">", "&gt;").Trim()
 }
 
 function Format-GitHubHandle {

--- a/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
+++ b/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
@@ -851,7 +851,10 @@ function Format-MarkdownCell {
     # `List<T>` that GitHub markdown would otherwise swallow as an HTML tag. The
     # engine's own markers are emitted via AppendLine, not through this formatter,
     # so escaping cells never disturbs them.
-    return (($Value -replace "\|", "\|") -replace "<", "&lt;" -replace ">", "&gt;").Trim()
+    # Collapse embedded newlines first: a malformed upstream title can contain a
+    # literal CR/LF (observed: ci-scan issue #35957), which would otherwise split
+    # the markdown table row across physical lines and break the rendered table.
+    return ((($Value -replace "[\r\n]+", " ") -replace "\|", "\|") -replace "<", "&lt;" -replace ">", "&gt;").Trim()
 }
 
 function Format-GitHubHandle {

--- a/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
+++ b/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
@@ -854,7 +854,12 @@ function Format-MarkdownCell {
     # Collapse embedded newlines first: a malformed upstream title can contain a
     # literal CR/LF (observed: ci-scan issue #35957), which would otherwise split
     # the markdown table row across physical lines and break the rendered table.
-    return ((($Value -replace "[\r\n]+", " ") -replace "\|", "\|") -replace "<", "&lt;" -replace ">", "&gt;").Trim()
+    # Double pre-existing backslashes BEFORE escaping pipes: a title may legally
+    # contain a literal `\|`, and escaping only the pipe would yield `\\|` — which
+    # GFM renders as a literal `\` plus an ACTIVE column delimiter (table breakout).
+    # Doubling backslashes first makes `\|` -> `\\\|`, a literal `\|`. No-backslash
+    # titles are unaffected (`a | b` -> `a \| b`).
+    return (((($Value -replace "[\r\n]+", " ") -replace "\\", "\\") -replace "\|", "\|") -replace "<", "&lt;" -replace ">", "&gt;").Trim()
 }
 
 function Format-GitHubHandle {

--- a/.github/skills/release-readiness/scripts/Get-ReleaseReadiness.ps1
+++ b/.github/skills/release-readiness/scripts/Get-ReleaseReadiness.ps1
@@ -2842,7 +2842,10 @@ function Format-CiScanIssueRows {
             }
         }
         $issLink = "[#$($iss.number)]($RepoUrl/issues/$($iss.number))"
-        $title = ($iss.title -replace '\|', '\|').Trim()
+        # Collapse embedded newlines first: a malformed upstream ci-scan title can
+        # contain a literal CR/LF (observed: #35957), which would otherwise split this
+        # markdown table row across physical lines and break the rendered table.
+        $title = ($iss.title -replace '[\r\n]+', ' ' -replace '\|', '\|').Trim()
         [void]$sb.AppendLine("| $marker$issLink | $title | $ageDisplay |")
     }
     if ($Issues.Count -gt $MaxRows) {

--- a/.github/skills/release-readiness/scripts/Get-ReleaseReadiness.ps1
+++ b/.github/skills/release-readiness/scripts/Get-ReleaseReadiness.ps1
@@ -2814,6 +2814,30 @@ function ConvertTo-LinkedPr {
     return "[#$PrNumber]($RepoUrl/pull/$PrNumber)"
 }
 
+function Format-MarkdownTableCell {
+    <#
+    .SYNOPSIS
+        Sanitize an arbitrary (often upstream-controlled) string for safe use inside a
+        single Markdown table cell.
+    .DESCRIPTION
+        Two hazards are neutralized so a hostile/malformed issue or PR title cannot
+        corrupt the rendered table:
+          1. Embedded CR/LF runs are collapsed to a single space, so the value cannot
+             split the row across physical lines (observed live: ci-scan issue #35957,
+             whose title contained a literal newline).
+          2. Literal `|` is escaped to `\|`, so a pipe in a title cannot open a new
+             column (common in PR/issue titles such as `[Android] A | B`).
+        Mirrors the newline+pipe contract of Get-PreviewReadiness.ps1's
+        Format-MarkdownCell. The SR engine deliberately omits `<`/`>` escaping: it emits
+        its own semantic hash at the TOP of the body, so — unlike the hash-less Preview
+        engine — it is not exposed to the HTML-comment hash-freeze vector that makes
+        angle-bracket escaping load-bearing there.
+    #>
+    param([string]$Value)
+    if ([string]::IsNullOrEmpty($Value)) { return '' }
+    return (($Value -replace '[\r\n]+', ' ') -replace '\|', '\|').Trim()
+}
+
 function Format-CiScanIssueRows {
     <#
     .SYNOPSIS
@@ -2842,10 +2866,10 @@ function Format-CiScanIssueRows {
             }
         }
         $issLink = "[#$($iss.number)]($RepoUrl/issues/$($iss.number))"
-        # Collapse embedded newlines first: a malformed upstream ci-scan title can
-        # contain a literal CR/LF (observed: #35957), which would otherwise split this
-        # markdown table row across physical lines and break the rendered table.
-        $title = ($iss.title -replace '[\r\n]+', ' ' -replace '\|', '\|').Trim()
+        # Sanitize the upstream ci-scan title for a single Markdown table cell:
+        # collapse embedded CR/LF (observed: #35957) and escape pipes. See
+        # Format-MarkdownTableCell for the full rationale (and why SR omits `<>`).
+        $title = Format-MarkdownTableCell $iss.title
         [void]$sb.AppendLine("| $marker$issLink | $title | $ageDisplay |")
     }
     if ($Issues.Count -gt $MaxRows) {
@@ -3384,6 +3408,7 @@ function Format-MarkdownReport {
             [void]$sb.AppendLine('|---|---|---|---|---|---|')
             foreach ($pr in $Data['openSrPrs']) {
                 $title = if ($pr.title.Length -gt 60) { $pr.title.Substring(0, 60) + '...' } else { $pr.title }
+                $title = Format-MarkdownTableCell $title
                 $draft = if ($pr.isDraft) { '✏️' } else { '' }
                 $rev = if ($pr.reviewDecision) { $pr.reviewDecision } else { '—' }
                 $prLink = ConvertTo-LinkedPr -PrNumber $pr.number -RepoUrl $RepoUrl
@@ -3437,6 +3462,7 @@ function Format-MarkdownReport {
                 # Stable sort: by issue number ascending
                 foreach ($it in ($items | Sort-Object issue)) {
                     $title = if ($it.title.Length -gt 50) { $it.title.Substring(0, 50) + '...' } else { $it.title }
+                    $title = Format-MarkdownTableCell $title
                     $prList = @($it.candidateFixPrs | ForEach-Object { ConvertTo-LinkedPr -PrNumber $_.number -RepoUrl $RepoUrl }) -join ', '
                     if (-not $prList) { $prList = '—' }
                     $issueLink = if ($RepoUrl) { "[#$($it.issue)]($RepoUrl/issues/$($it.issue))" } else { "#$($it.issue)" }

--- a/.github/skills/release-readiness/scripts/Get-ReleaseReadiness.ps1
+++ b/.github/skills/release-readiness/scripts/Get-ReleaseReadiness.ps1
@@ -2821,22 +2821,25 @@ function Format-MarkdownTableCell {
         single Markdown table cell. Also used for the candidate-PR bulleted list, where
         the newline collapse matters and `\|` renders as `|`.
     .DESCRIPTION
-        Four hazards are neutralized so a hostile/malformed issue or PR title cannot
+        Three hazards are neutralized so a hostile/malformed issue or PR title cannot
         corrupt the rendered body:
           1. Embedded CR/LF runs are collapsed to a single space, so the value cannot
              split the row across physical lines (observed live: ci-scan issue #35957,
              whose title contained a literal newline).
-          2. Pre-existing backslashes are doubled (`\` -> `\\`) BEFORE the pipe escape.
-             This ordering is load-bearing: GitHub-issue/PR titles may legally contain a
-             literal `\|` (backslash immediately followed by a pipe). Escaping only the
-             pipe would turn that into `\\|`, which GFM renders as a literal `\` followed
-             by an ACTIVE column delimiter `|` (the classic "escape-the-escaper" table
-             breakout). Doubling backslashes first makes `\|` -> `\\\|`, which renders as a
-             literal `\|` and cannot open a new column. Titles with no backslash (the
-             common case) are unaffected: `a | b` still yields `a \| b`.
-          3. Literal `|` is escaped to `\|`, so a pipe in a title cannot open a new
-             column (common in PR/issue titles such as `[Android] A | B`).
-          4. `<` / `>` are escaped to `&lt;` / `&gt;`, so a title cannot inject raw HTML
+          2. Each pipe is escaped to `\|`, AND any run of backslashes immediately
+             preceding that pipe is doubled FIRST. This ordering is load-bearing:
+             GitHub-issue/PR titles may legally contain a literal `\|` (backslash
+             immediately followed by a pipe). Escaping only the pipe would turn that
+             into `\\|`, which GFM renders as a literal `\` followed by an ACTIVE
+             column delimiter `|` (the classic "escape-the-escaper" table breakout).
+             Doubling the preceding backslash run first makes `\|` -> `\\\|`, which
+             renders as a literal `\|` and cannot open a new column. The doubling is
+             SCOPED to pipe-adjacent backslash runs (via the `(\\*)\|` match) rather
+             than every backslash in the string, so a title's OTHER backslash escapes
+             are preserved verbatim — e.g. an author-escaped `\[link\](url)` or `\*not
+             emphasis\*` is NOT de-escaped into active Markdown. Titles with no pipe-
+             adjacent backslash (the common case) are unaffected: `a | b` -> `a \| b`.
+          3. `<` / `>` are escaped to `&lt;` / `&gt;`, so a title cannot inject raw HTML
              (e.g. an `<!-- ... -->` comment) into the body. This matches the Preview
              engine's Format-MarkdownCell, has zero visual cost (`&lt;T&gt;` renders as
              `<T>`, preserving titles like `List<T>`), and is defense-in-depth: even
@@ -2852,7 +2855,12 @@ function Format-MarkdownTableCell {
     #>
     param([string]$Value)
     if ([string]::IsNullOrEmpty($Value)) { return '' }
-    return (((($Value -replace '[\r\n]+', ' ') -replace '\\', '\\') -replace '\|', '\|') -replace '<', '&lt;' -replace '>', '&gt;').Trim()
+    $v = $Value -replace '[\r\n]+', ' '
+    # Escape each pipe AND double only the backslash run immediately before it, so a
+    # pre-existing `\|` cannot survive as `\\|` (literal `\` + active delimiter). Non-
+    # pipe backslash escapes elsewhere in the title are left intact.
+    $v = [regex]::Replace($v, '(\\*)\|', { param($m) ($m.Groups[1].Value * 2) + '\|' })
+    return ($v -replace '<', '&lt;' -replace '>', '&gt;').Trim()
 }
 
 function Format-CiScanIssueRows {

--- a/.github/skills/release-readiness/scripts/Get-ReleaseReadiness.ps1
+++ b/.github/skills/release-readiness/scripts/Get-ReleaseReadiness.ps1
@@ -2818,20 +2818,33 @@ function Format-MarkdownTableCell {
     <#
     .SYNOPSIS
         Sanitize an arbitrary (often upstream-controlled) string for safe use inside a
-        single Markdown table cell.
+        single Markdown table cell. Also used for the candidate-PR bulleted list, where
+        the newline collapse matters and `\|` renders as `|`.
     .DESCRIPTION
         Two hazards are neutralized so a hostile/malformed issue or PR title cannot
-        corrupt the rendered table:
+        corrupt the rendered body:
           1. Embedded CR/LF runs are collapsed to a single space, so the value cannot
              split the row across physical lines (observed live: ci-scan issue #35957,
              whose title contained a literal newline).
           2. Literal `|` is escaped to `\|`, so a pipe in a title cannot open a new
              column (common in PR/issue titles such as `[Android] A | B`).
-        Mirrors the newline+pipe contract of Get-PreviewReadiness.ps1's
-        Format-MarkdownCell. The SR engine deliberately omits `<`/`>` escaping: it emits
-        its own semantic hash at the TOP of the body, so — unlike the hash-less Preview
-        engine — it is not exposed to the HTML-comment hash-freeze vector that makes
-        angle-bracket escaping load-bearing there.
+        Every SR markdown cell that embeds upstream-controlled text routes through this
+        single helper: the ci-scan rows, the Open-PRs / regression / Blocking / Cleanup /
+        ship-readiness-checks / Open-Fix-PRs tables, and the candidate-PR list.
+
+        The SR engine deliberately omits `<`/`>` escaping (unlike Get-PreviewReadiness.ps1's
+        Format-MarkdownCell, whose newline+pipe contract this otherwise mirrors), preserving
+        title fidelity like `List<T>`. That omission is safe because:
+          * Hash-freeze: SR emits its own semantic hash at the TOP of the body, so an
+            injected `<!-- ...hash... -->` lower in the body can never win the workflow's
+            `head -n1` extraction — it is structurally immune (the Preview engine, being
+            hash-less, is not, which is why `<>` escaping is load-bearing there).
+          * Human-notes forgery: the workflow matches the `<!-- release-readiness:human-notes:
+            begin/end -->` preservation markers with FULL-LINE-ANCHORED regex (`^\s*<!-- ... -->\s*$`).
+            An injected marker can therefore only fire if it lands ALONE on a physical line,
+            which requires an embedded newline to break out of its surrounding row/list text.
+            The newline collapse in (1) removes that capability, so a raw `<>` in a title
+            cannot forge an anchored marker and wipe Release Captain Notes.
     #>
     param([string]$Value)
     if ([string]::IsNullOrEmpty($Value)) { return '' }
@@ -3132,9 +3145,9 @@ function Format-MarkdownReport {
         [void]$sb.AppendLine('| Area | Details | Next action |')
         [void]$sb.AppendLine('|---|---|---|')
         foreach ($b in $blockingItems) {
-            $area = ($b.area -replace '\|', '\|').Trim()
-            $details = ($b.details -replace '\|', '\|').Trim()
-            $action = ($b.action -replace '\|', '\|').Trim()
+            $area = Format-MarkdownTableCell $b.area
+            $details = Format-MarkdownTableCell $b.details
+            $action = Format-MarkdownTableCell $b.action
             [void]$sb.AppendLine("| $area | $details | $action |")
         }
         [void]$sb.AppendLine()
@@ -3169,9 +3182,9 @@ function Format-MarkdownReport {
         [void]$sb.AppendLine('| Area | Details | Next action |')
         [void]$sb.AppendLine('|---|---|---|')
         foreach ($c in $cleanupItems) {
-            $area = ($c.area -replace '\|', '\|').Trim()
-            $details = ($c.details -replace '\|', '\|').Trim()
-            $action = ($c.action -replace '\|', '\|').Trim()
+            $area = Format-MarkdownTableCell $c.area
+            $details = Format-MarkdownTableCell $c.details
+            $action = Format-MarkdownTableCell $c.action
             [void]$sb.AppendLine("| $area | $details | $action |")
         }
         [void]$sb.AppendLine()
@@ -3272,11 +3285,11 @@ function Format-MarkdownReport {
             [void]$sb.AppendLine('| Fix PR | Base | Regression issue | Status | Next action |')
             [void]$sb.AppendLine('|---|---|---|---|---|')
             foreach ($row in $openFixRows) {
-                $prCell    = ($row.prCell     -replace '\|', '\|').Trim()
-                $baseCell  = ($row.baseCell   -replace '\|', '\|').Trim()
-                $issCell   = ($row.issCell    -replace '\|', '\|').Trim()
-                $statCell  = ($row.statusCell -replace '\|', '\|').Trim()
-                $actCell   = ($row.actionCell -replace '\|', '\|').Trim()
+                $prCell    = Format-MarkdownTableCell $row.prCell
+                $baseCell  = Format-MarkdownTableCell $row.baseCell
+                $issCell   = Format-MarkdownTableCell $row.issCell
+                $statCell  = Format-MarkdownTableCell $row.statusCell
+                $actCell   = Format-MarkdownTableCell $row.actionCell
                 [void]$sb.AppendLine("| $prCell | $baseCell | $issCell | $statCell | $actCell |")
             }
             [void]$sb.AppendLine()
@@ -3297,9 +3310,9 @@ function Format-MarkdownReport {
                 'CLEANUP' { '🧹 CLEANUP' }
                 default   { "⚪ $($sc.Status)" }
             }
-            $area = ($sc.Area -replace '\|', '\|').Trim()
-            $details = ($sc.Details -replace '\|', '\|').Trim()
-            $action = ($sc.NextAction -replace '\|', '\|').Trim()
+            $area = Format-MarkdownTableCell $sc.Area
+            $details = Format-MarkdownTableCell $sc.Details
+            $action = Format-MarkdownTableCell $sc.NextAction
             [void]$sb.AppendLine("| $area | $statusEmoji | $details | $action |")
         }
         [void]$sb.AppendLine()
@@ -3395,6 +3408,12 @@ function Format-MarkdownReport {
                 foreach ($cp in $candidatePrs) {
                     $cpLink = ConvertTo-LinkedPr -PrNumber $cp.number -RepoUrl $RepoUrl
                     $cpTitle = if ($cp.title.Length -gt 80) { $cp.title.Substring(0, 80) + '...' } else { $cp.title }
+                    # Collapse newlines (and escape pipes) even though this is a list, not a
+                    # table: an upstream title with an embedded newline could otherwise push
+                    # injected content (e.g. a forged `<!-- release-readiness:human-notes -->`
+                    # marker) onto its own physical line. Markdown renders `\|` as `|` in a
+                    # list, so escaping is harmless here.
+                    $cpTitle = Format-MarkdownTableCell $cpTitle
                     [void]$sb.AppendLine("- $cpLink — $cpTitle (by $(Format-GitHubHandle $cp.author.login), updated $($cp.updatedAt))")
                 }
                 [void]$sb.AppendLine()

--- a/.github/skills/release-readiness/scripts/Get-ReleaseReadiness.ps1
+++ b/.github/skills/release-readiness/scripts/Get-ReleaseReadiness.ps1
@@ -2821,34 +2821,38 @@ function Format-MarkdownTableCell {
         single Markdown table cell. Also used for the candidate-PR bulleted list, where
         the newline collapse matters and `\|` renders as `|`.
     .DESCRIPTION
-        Two hazards are neutralized so a hostile/malformed issue or PR title cannot
+        Four hazards are neutralized so a hostile/malformed issue or PR title cannot
         corrupt the rendered body:
           1. Embedded CR/LF runs are collapsed to a single space, so the value cannot
              split the row across physical lines (observed live: ci-scan issue #35957,
              whose title contained a literal newline).
-          2. Literal `|` is escaped to `\|`, so a pipe in a title cannot open a new
+          2. Pre-existing backslashes are doubled (`\` -> `\\`) BEFORE the pipe escape.
+             This ordering is load-bearing: GitHub-issue/PR titles may legally contain a
+             literal `\|` (backslash immediately followed by a pipe). Escaping only the
+             pipe would turn that into `\\|`, which GFM renders as a literal `\` followed
+             by an ACTIVE column delimiter `|` (the classic "escape-the-escaper" table
+             breakout). Doubling backslashes first makes `\|` -> `\\\|`, which renders as a
+             literal `\|` and cannot open a new column. Titles with no backslash (the
+             common case) are unaffected: `a | b` still yields `a \| b`.
+          3. Literal `|` is escaped to `\|`, so a pipe in a title cannot open a new
              column (common in PR/issue titles such as `[Android] A | B`).
+          4. `<` / `>` are escaped to `&lt;` / `&gt;`, so a title cannot inject raw HTML
+             (e.g. an `<!-- ... -->` comment) into the body. This matches the Preview
+             engine's Format-MarkdownCell, has zero visual cost (`&lt;T&gt;` renders as
+             `<T>`, preserving titles like `List<T>`), and is defense-in-depth: even
+             though SR is structurally hash-freeze-immune (it emits its own semantic hash
+             at the TOP of the body, so an injected lower `<!-- ...hash... -->` can never
+             win the workflow's `head -n1` extraction) and its human-notes markers are
+             matched FULL-LINE-ANCHORED (a forged marker only fires if it lands alone on a
+             physical line, which hazard 1 already prevents), escaping `<>` keeps SR and
+             Preview consistent and removes any reliance on those backend invariants.
         Every SR markdown cell that embeds upstream-controlled text routes through this
         single helper: the ci-scan rows, the Open-PRs / regression / Blocking / Cleanup /
         ship-readiness-checks / Open-Fix-PRs tables, and the candidate-PR list.
-
-        The SR engine deliberately omits `<`/`>` escaping (unlike Get-PreviewReadiness.ps1's
-        Format-MarkdownCell, whose newline+pipe contract this otherwise mirrors), preserving
-        title fidelity like `List<T>`. That omission is safe because:
-          * Hash-freeze: SR emits its own semantic hash at the TOP of the body, so an
-            injected `<!-- ...hash... -->` lower in the body can never win the workflow's
-            `head -n1` extraction — it is structurally immune (the Preview engine, being
-            hash-less, is not, which is why `<>` escaping is load-bearing there).
-          * Human-notes forgery: the workflow matches the `<!-- release-readiness:human-notes:
-            begin/end -->` preservation markers with FULL-LINE-ANCHORED regex (`^\s*<!-- ... -->\s*$`).
-            An injected marker can therefore only fire if it lands ALONE on a physical line,
-            which requires an embedded newline to break out of its surrounding row/list text.
-            The newline collapse in (1) removes that capability, so a raw `<>` in a title
-            cannot forge an anchored marker and wipe Release Captain Notes.
     #>
     param([string]$Value)
     if ([string]::IsNullOrEmpty($Value)) { return '' }
-    return (($Value -replace '[\r\n]+', ' ') -replace '\|', '\|').Trim()
+    return (((($Value -replace '[\r\n]+', ' ') -replace '\\', '\\') -replace '\|', '\|') -replace '<', '&lt;' -replace '>', '&gt;').Trim()
 }
 
 function Format-CiScanIssueRows {

--- a/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
+++ b/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
@@ -2451,7 +2451,8 @@ Assert-Eq -Label "Format-MarkdownTableCell: angle brackets escaped to entities (
 # already contains a literal `\|` must NOT collapse to `\\|` (literal `\` + ACTIVE pipe).
 # Pre-fix (pipe-only escape) returns 'A \\| B' and these go red.
 Assert-Eq -Label "Format-MarkdownTableCell: literal backslash-pipe does NOT break out (doubled backslash)" -Expected 'A \\\| B' -Actual (Format-MarkdownTableCell 'A \| B')
-Assert-Eq -Label "Format-MarkdownTableCell: pre-existing backslash doubled"   -Expected 'C:\\dir' -Actual (Format-MarkdownTableCell 'C:\dir')
+Assert-Eq -Label "Format-MarkdownTableCell: pre-existing NON-pipe backslash preserved (doubling is scoped to pipe-adjacent runs)" -Expected 'C:\dir' -Actual (Format-MarkdownTableCell 'C:\dir')
+Assert-Eq -Label "Format-MarkdownTableCell: author-escaped non-pipe Markdown NOT de-escaped" -Expected '\[link\](url)' -Actual (Format-MarkdownTableCell '\[link\](url)')
 # Injected HTML comment opener is rendered inert (cannot start an `<!-- ... -->` region).
 Assert-Eq -Label "Format-MarkdownTableCell: HTML-comment opener neutralized"  -Expected 'Crash &lt;!--' -Actual (Format-MarkdownTableCell 'Crash <!--')
 
@@ -3383,7 +3384,8 @@ Assert-Eq -Label "Format-MarkdownCell: angle brackets still escaped"        -Exp
 # Backslash-first ordering: a literal `\|` in a title must not collapse to `\\|`
 # (literal `\` + ACTIVE pipe = table breakout). Pre-fix returns 'A \\| B' → red.
 Assert-Eq -Label "Format-MarkdownCell: literal backslash-pipe does NOT break out (doubled backslash)" -Expected 'A \\\| B' -Actual (Format-MarkdownCell 'A \| B')
-Assert-Eq -Label "Format-MarkdownCell: pre-existing backslash doubled"      -Expected 'C:\\dir'       -Actual (Format-MarkdownCell 'C:\dir')
+Assert-Eq -Label "Format-MarkdownCell: pre-existing NON-pipe backslash preserved (doubling is scoped to pipe-adjacent runs)" -Expected 'C:\dir'       -Actual (Format-MarkdownCell 'C:\dir')
+Assert-Eq -Label "Format-MarkdownCell: author-escaped non-pipe Markdown NOT de-escaped" -Expected '\[link\](url)' -Actual (Format-MarkdownCell '\[link\](url)')
 
 Write-Host "`n────────────────────────────────────────" -ForegroundColor Cyan
 Write-Host "Passed: $script:passed   Failed: $script:failed" -ForegroundColor $(if ($script:failed -eq 0) { 'Green' } else { 'Red' })

--- a/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
+++ b/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
@@ -2263,6 +2263,21 @@ Assert-Eq -Label "Age column shows 'Nd ago' for older issues" -Expected $true `
 Assert-Eq -Label "Format-CiScanIssueRows returns null for empty input" -Expected $true `
     -Actual ($null -eq (Format-CiScanIssueRows -Issues @() -RepoUrl 'https://github.com/dotnet/maui'))
 
+# Regression: a malformed upstream ci-scan title containing a literal newline
+# (observed live: #35957) must NOT split the markdown table row across physical
+# lines. The title cell is collapsed to a single line so the rendered table stays
+# intact. On the pre-fix code the embedded LF pushed the title tail + age cell onto
+# a second line that no longer contained the issue link.
+$nlIssue = @([PSCustomObject]@{ number = 35957; url = 'https://github.com/dotnet/maui/issues/35957';
+    title = "Recurring long title (maui-pr-uitest`n[Content truncated due to length]";
+    createdAt = $nowUtc.AddDays(-3).ToString('o') })
+$nlRows = Format-CiScanIssueRows -Issues $nlIssue -RepoUrl 'https://github.com/dotnet/maui'
+$nlRowLines = @($nlRows -split "`r?`n" | Where-Object { $_ -match '#35957' })
+Assert-Eq -Label "Newline ci-scan title: issue row is a single physical line" -Expected 1 `
+    -Actual $nlRowLines.Count
+Assert-Eq -Label "Newline ci-scan title: title tail + age stay on that row" -Expected $true `
+    -Actual ($nlRowLines.Count -eq 1 -and $nlRowLines[0] -match 'truncated due to length.*ago \|')
+
 # Truncation behavior: > MaxRows
 $manyIssues = 1..20 | ForEach-Object {
     [PSCustomObject]@{ number = 40000 + $_; url = "https://github.com/dotnet/maui/issues/$(40000+$_)";
@@ -3177,6 +3192,17 @@ $explicitNullThrew = $false
 try { $null = Get-CategorizedPullRequests -TargetPRs $null -InflightPRs @($null, $maestroPrMock) }
 catch { $explicitNullThrew = $true }
 Assert-Eq -Label "explicit null target + @(null, maestro) inflight → no throw" -Expected $false -Actual $explicitNullThrew
+
+Write-Host "`n[Unit] Format-MarkdownCell collapses embedded newlines (table-row safety)" -ForegroundColor Cyan
+# A malformed upstream title with a literal CR/LF (observed live: ci-scan issue
+# #35957) must be collapsed to a single line so it cannot split the markdown table
+# row in the rendered Preview tracker body. The existing pipe / angle-bracket
+# escaping contract must remain intact.
+Assert-Eq -Label "Format-MarkdownCell: LF collapsed to single space"        -Expected 'a b'           -Actual (Format-MarkdownCell "a`nb")
+Assert-Eq -Label "Format-MarkdownCell: CRLF run collapsed to single space"  -Expected 'a b'           -Actual (Format-MarkdownCell "a`r`n`r`nb")
+Assert-Eq -Label "Format-MarkdownCell: no CR/LF survives in the cell"       -Expected $false          -Actual ((Format-MarkdownCell "x`ny") -match "`r|`n")
+Assert-Eq -Label "Format-MarkdownCell: pipe still escaped"                  -Expected 'a \| b'        -Actual (Format-MarkdownCell 'a | b')
+Assert-Eq -Label "Format-MarkdownCell: angle brackets still escaped"        -Expected 'List&lt;T&gt;' -Actual (Format-MarkdownCell 'List<T>')
 
 Write-Host "`n────────────────────────────────────────" -ForegroundColor Cyan
 Write-Host "Passed: $script:passed   Failed: $script:failed" -ForegroundColor $(if ($script:failed -eq 0) { 'Green' } else { 'Red' })

--- a/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
+++ b/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
@@ -1793,9 +1793,11 @@ Assert-Eq -Label "Regression table: pipe escaped AND trailing action column inta
 # (^\s*<!-- release-readiness:human-notes:begin -->\s*$). A hostile title containing
 # `...\n<!-- ...:begin -->\n...` would, pre-fix, isolate that marker on its own physical
 # line and forge a second notes region — letting an attacker's PR/issue title corrupt the
-# notes-preservation step. Collapsing newlines defeats this WITHOUT escaping `<>` (so
-# legitimate `List<T>` titles stay intact). We assert exactly ONE anchored begin-marker
-# survives (the real one the renderer emits) even when an upstream title embeds the marker.
+# notes-preservation step. Collapsing newlines defeats this (the marker can no longer land
+# alone on a line), and escaping `<>` to entities is belt-and-suspenders (the injected
+# `<!--` renders as `&lt;!--`, so it never matches the anchored marker regex at all). We
+# assert exactly ONE anchored begin-marker survives (the real one the renderer emits) even
+# when an upstream title embeds the marker.
 Write-Host "`n[Unit] Blocking/Open-Fix cells sanitized + human-notes marker-forgery defense" -ForegroundColor Cyan
 
 # (3) Blocking summary table (Tier-1 regression: no-fix-yet + OPEN renders here AND in the tier table).
@@ -1960,8 +1962,8 @@ Assert-Eq -Label "BLOCKED ship check: blocking summary header reflects count" -E
     -Actual ($mdBlocked -match '🔴 Blocking — \d+ item')
 Assert-Eq -Label "BLOCKED ship check: blocking summary mentions versions.props area" -Expected $true `
     -Actual ($mdBlocked -match '🛠️ versions.props PatchVersion')
-Assert-Eq -Label "BLOCKED ship check: blocking summary contains the next-action text" -Expected $true `
-    -Actual ($mdBlocked -match 'Bump <PatchVersion>')
+Assert-Eq -Label "BLOCKED ship check: blocking summary contains the next-action text (angle brackets entity-escaped so GitHub actually displays them)" -Expected $true `
+    -Actual ($mdBlocked -match 'Bump &lt;PatchVersion&gt;')
 Assert-Eq -Label "BLOCKED ship check: full Ship-readiness checks table emitted" -Expected $true `
     -Actual ($mdBlocked -match 'Ship-readiness checks')
 Assert-Eq -Label "BLOCKED ship check: table shows READY entry for bug template (transparency)" -Expected $true `
@@ -2444,7 +2446,14 @@ Assert-Eq -Label "Format-MarkdownTableCell: no CR/LF survives"        -Expected 
 Assert-Eq -Label "Format-MarkdownTableCell: null → empty string"      -Expected ''        -Actual (Format-MarkdownTableCell $null)
 Assert-Eq -Label "Format-MarkdownTableCell: empty → empty string"     -Expected ''        -Actual (Format-MarkdownTableCell '')
 Assert-Eq -Label "Format-MarkdownTableCell: surrounding whitespace trimmed" -Expected 'a b' -Actual (Format-MarkdownTableCell "  a`nb  ")
-Assert-Eq -Label "Format-MarkdownTableCell: angle brackets deliberately NOT escaped (SR parity)" -Expected 'List<T>' -Actual (Format-MarkdownTableCell 'List<T>')
+Assert-Eq -Label "Format-MarkdownTableCell: angle brackets escaped to entities (SR↔Preview parity)" -Expected 'List&lt;T&gt;' -Actual (Format-MarkdownTableCell 'List<T>')
+# Backslash-first ordering closes the "escape-the-escaper" table breakout: a title that
+# already contains a literal `\|` must NOT collapse to `\\|` (literal `\` + ACTIVE pipe).
+# Pre-fix (pipe-only escape) returns 'A \\| B' and these go red.
+Assert-Eq -Label "Format-MarkdownTableCell: literal backslash-pipe does NOT break out (doubled backslash)" -Expected 'A \\\| B' -Actual (Format-MarkdownTableCell 'A \| B')
+Assert-Eq -Label "Format-MarkdownTableCell: pre-existing backslash doubled"   -Expected 'C:\\dir' -Actual (Format-MarkdownTableCell 'C:\dir')
+# Injected HTML comment opener is rendered inert (cannot start an `<!-- ... -->` region).
+Assert-Eq -Label "Format-MarkdownTableCell: HTML-comment opener neutralized"  -Expected 'Crash &lt;!--' -Actual (Format-MarkdownTableCell 'Crash <!--')
 
 # Truncation behavior: > MaxRows
 $manyIssues = 1..20 | ForEach-Object {
@@ -3371,6 +3380,10 @@ Assert-Eq -Label "Format-MarkdownCell: CRLF run collapsed to single space"  -Exp
 Assert-Eq -Label "Format-MarkdownCell: no CR/LF survives in the cell"       -Expected $false          -Actual ((Format-MarkdownCell "x`ny") -match "`r|`n")
 Assert-Eq -Label "Format-MarkdownCell: pipe still escaped"                  -Expected 'a \| b'        -Actual (Format-MarkdownCell 'a | b')
 Assert-Eq -Label "Format-MarkdownCell: angle brackets still escaped"        -Expected 'List&lt;T&gt;' -Actual (Format-MarkdownCell 'List<T>')
+# Backslash-first ordering: a literal `\|` in a title must not collapse to `\\|`
+# (literal `\` + ACTIVE pipe = table breakout). Pre-fix returns 'A \\| B' → red.
+Assert-Eq -Label "Format-MarkdownCell: literal backslash-pipe does NOT break out (doubled backslash)" -Expected 'A \\\| B' -Actual (Format-MarkdownCell 'A \| B')
+Assert-Eq -Label "Format-MarkdownCell: pre-existing backslash doubled"      -Expected 'C:\\dir'       -Actual (Format-MarkdownCell 'C:\dir')
 
 Write-Host "`n────────────────────────────────────────" -ForegroundColor Cyan
 Write-Host "Passed: $script:passed   Failed: $script:failed" -ForegroundColor $(if ($script:failed -eq 0) { 'Green' } else { 'Red' })

--- a/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
+++ b/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
@@ -2268,14 +2268,22 @@ Assert-Eq -Label "Format-CiScanIssueRows returns null for empty input" -Expected
 # lines. The title cell is collapsed to a single line so the rendered table stays
 # intact. On the pre-fix code the embedded LF pushed the title tail + age cell onto
 # a second line that no longer contained the issue link.
+#
+# Discrimination note: the FIRST assertion below ("issue row is a single physical
+# line") is a coarse sanity check and is NON-discriminating — it also passes on the
+# pre-fix code, because the split row still leaves '#35957' on exactly one physical
+# line (the title tail + age spill onto a SEPARATE line with no issue link). The
+# SECOND assertion ("title tail + age stay on that row") is the real regression
+# guard: it fails pre-fix and passes post-fix. Do not weaken or remove it assuming
+# the first assertion already covers row integrity.
 $nlIssue = @([PSCustomObject]@{ number = 35957; url = 'https://github.com/dotnet/maui/issues/35957';
     title = "Recurring long title (maui-pr-uitest`n[Content truncated due to length]";
     createdAt = $nowUtc.AddDays(-3).ToString('o') })
 $nlRows = Format-CiScanIssueRows -Issues $nlIssue -RepoUrl 'https://github.com/dotnet/maui'
 $nlRowLines = @($nlRows -split "`r?`n" | Where-Object { $_ -match '#35957' })
-Assert-Eq -Label "Newline ci-scan title: issue row is a single physical line" -Expected 1 `
+Assert-Eq -Label "Newline ci-scan title: issue row is a single physical line (coarse sanity; non-discriminating)" -Expected 1 `
     -Actual $nlRowLines.Count
-Assert-Eq -Label "Newline ci-scan title: title tail + age stay on that row" -Expected $true `
+Assert-Eq -Label "Newline ci-scan title: title tail + age stay on that row (discriminating regression guard)" -Expected $true `
     -Actual ($nlRowLines.Count -eq 1 -and $nlRowLines[0] -match 'truncated due to length.*ago \|')
 
 # Truncation behavior: > MaxRows

--- a/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
+++ b/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
@@ -1780,6 +1780,88 @@ Assert-Eq -Label "Regression table: piped/newline issue title stays on one physi
 Assert-Eq -Label "Regression table: pipe escaped AND trailing action column intact on the row" -Expected $true `
     -Actual ($issRowLines.Count -eq 1 -and $issRowLines[0] -match 'Crash \\\| NRE' -and $issRowLines[0] -match 'Investigate')
 
+# ───── Blocking summary + Open-Fix-PRs cells sanitized; human-notes marker-forgery defense ─────
+# The remaining SR tables that embed upstream titles — the 🔴 Blocking summary
+# (Tier-1 regressions + BLOCKED ship-checks) and the 📥 Open Fix PRs Inbound table —
+# plus the candidate-PR bulleted list now route every upstream cell through
+# Format-MarkdownTableCell. Each assertion below is DISCRIMINATING on pre-fix code:
+# an embedded newline splits the row (orphaning the title tail onto its own line),
+# and the escaped-pipe match fails when the pipe is left raw.
+#
+# The marker-forgery assertions are the security centerpiece: the production workflow
+# preserves Release-Captain notes by splicing on FULL-LINE-ANCHORED markers
+# (^\s*<!-- release-readiness:human-notes:begin -->\s*$). A hostile title containing
+# `...\n<!-- ...:begin -->\n...` would, pre-fix, isolate that marker on its own physical
+# line and forge a second notes region — letting an attacker's PR/issue title corrupt the
+# notes-preservation step. Collapsing newlines defeats this WITHOUT escaping `<>` (so
+# legitimate `List<T>` titles stay intact). We assert exactly ONE anchored begin-marker
+# survives (the real one the renderer emits) even when an upstream title embeds the marker.
+Write-Host "`n[Unit] Blocking/Open-Fix cells sanitized + human-notes marker-forgery defense" -ForegroundColor Cyan
+
+# (3) Blocking summary table (Tier-1 regression: no-fix-yet + OPEN renders here AND in the tier table).
+$mdDataBlock = @{} + $mdData
+$mdDataBlock['regressions'] = @(
+    @{ issue = 96003; title = "Hang | freeze`nat startup"; state = 'OPEN'; classification = 'no-fix-yet';
+       candidateFixPrs = @(); recommendedAction = 'Fix before ship' }
+)
+$mdDataBlock['summary'] = @{ 'no-fix-yet' = 1 }
+$mdBlock = Format-MarkdownReport -Data $mdDataBlock -RepoUrl 'https://github.com/dotnet/maui' `
+                                 -TrackerKey 'net10-sr7' -MaxBodyBytes 60000
+$blockOrphans = @($mdBlock -split "`r?`n" | Where-Object { $_ -match '^\s*at startup' })
+Assert-Eq -Label "Blocking table: embedded newline does NOT orphan the title tail onto its own line" -Expected 0 `
+    -Actual $blockOrphans.Count
+Assert-Eq -Label "Blocking table: title rendered glued + pipe-escaped on one row" -Expected $true `
+    -Actual ($mdBlock -match 'Hang \\\| freeze at startup')
+
+# (4) Open Fix PRs Inbound table (open-on-main regression with an OPEN candidate fix PR).
+$mdDataOpenFix = @{} + $mdData
+$mdDataOpenFix['regressions'] = @(
+    @{ issue = 96004; title = "Glitch | bug`nhere"; state = 'OPEN'; classification = 'open-on-main';
+       candidateFixPrs = @( @{ number = 96104; state = 'OPEN'; baseRef = 'main' } ); recommendedAction = 'Watch' }
+)
+$mdDataOpenFix['summary'] = @{ 'open-on-main' = 1 }
+$mdOpenFix = Format-MarkdownReport -Data $mdDataOpenFix -RepoUrl 'https://github.com/dotnet/maui' `
+                                   -TrackerKey 'net10-sr7' -MaxBodyBytes 60000
+$ofOrphans = @($mdOpenFix -split "`r?`n" | Where-Object { $_ -match '^\s*here' })
+Assert-Eq -Label "Open-Fix-PRs table: embedded newline does NOT orphan the title tail onto its own line" -Expected 0 `
+    -Actual $ofOrphans.Count
+$ofRow = @($mdOpenFix -split "`r?`n" | Where-Object { $_ -match '🔵 OPEN — awaiting main merge' })
+Assert-Eq -Label "Open-Fix-PRs table: regression-issue cell glued + pipe-escaped, status column intact" -Expected $true `
+    -Actual ($ofRow.Count -eq 1 -and $ofRow[0] -match 'Glitch \\\| bug here')
+
+# (5) Marker-forgery via a TABLE cell: a Tier-1 title embedding the begin-marker between
+#     newlines must NOT forge a second anchored marker line.
+$mdDataForgeTbl = @{} + $mdData
+$mdDataForgeTbl['regressions'] = @(
+    @{ issue = 96006; title = "Spoof`n<!-- release-readiness:human-notes:begin -->`ntail"; state = 'OPEN';
+       classification = 'no-fix-yet'; candidateFixPrs = @(); recommendedAction = 'Investigate' }
+)
+$mdDataForgeTbl['summary'] = @{ 'no-fix-yet' = 1 }
+$mdForgeTbl = Format-MarkdownReport -Data $mdDataForgeTbl -RepoUrl 'https://github.com/dotnet/maui' `
+                                    -TrackerKey 'net10-sr7' -MaxBodyBytes 60000
+$forgeTblMarkers = @($mdForgeTbl -split "`r?`n" | Where-Object { $_ -match '^\s*<!-- release-readiness:human-notes:begin -->\s*$' })
+Assert-Eq -Label "Marker-forgery (table cell): exactly ONE anchored begin-marker survives (the legit one)" -Expected 1 `
+    -Actual $forgeTblMarkers.Count
+
+# (6) Marker-forgery via the candidate-PR LIST (the bulleted site, not a table). The title
+#     must match \bcandidate\b to be selected, and embeds the marker between newlines.
+$mdDataForgeList = @{} + $mdData
+$mdDataForgeList['metadata'] = @{} + $mdData.metadata
+$mdDataForgeList['metadata']['mode'] = 'candidate'
+$mdDataForgeList['metadata']['priorSrBranch'] = 'release/10.0.1xx-sr7'
+$mdDataForgeList['metadata']['srBranch'] = 'main'
+$mdDataForgeList['openSrPrs'] = @(
+    @{ number = 96005; title = "Candidate`n<!-- release-readiness:human-notes:begin -->`ntail";
+       author = @{ login = 'mallory' }; isDraft = $false; reviewDecision = 'APPROVED'; updatedAt = '2026-06-01T00:00:00Z' }
+)
+$mdForgeList = Format-MarkdownReport -Data $mdDataForgeList -RepoUrl 'https://github.com/dotnet/maui' `
+                                     -TrackerKey 'net10-sr8' -MaxBodyBytes 60000
+$forgeListMarkers = @($mdForgeList -split "`r?`n" | Where-Object { $_ -match '^\s*<!-- release-readiness:human-notes:begin -->\s*$' })
+Assert-Eq -Label "Marker-forgery (candidate list): exactly ONE anchored begin-marker survives (the legit one)" -Expected 1 `
+    -Actual $forgeListMarkers.Count
+Assert-Eq -Label "Candidate list: hostile title collapsed onto the bullet line (no isolated tail)" -Expected 0 `
+    -Actual (@($mdForgeList -split "`r?`n" | Where-Object { $_ -match '^\s*tail\b' }).Count)
+
 # ───── Candidate-mode open-PR collapse: avoid noisy main-PR dump ─────
 Write-Host "`n[Unit] Candidate-mode open-PR collapse (link to candidate PR only)" -ForegroundColor Cyan
 
@@ -1903,6 +1985,27 @@ $mdReady = Format-MarkdownReport -Data $mdDataReady -RepoUrl 'https://github.com
                                  -TrackerKey 'net10-sr7' -MaxBodyBytes 60000
 Assert-Eq -Label "All ship checks READY (no Tier 1 regressions): '🟢 No blocking items'" -Expected $true `
     -Actual ($mdReady -match '🟢 No blocking items')
+
+# Ship-readiness checks TABLE: a WATCH check (renders only in the table, not the blocking
+# summary) whose Details carry a literal pipe + embedded newline must stay on one row,
+# pipe-escaped — proving the table's Details/NextAction cells route through the sanitizer.
+$mdDataWatchCell = @{} + $mdData
+$mdDataWatchCell['shipChecks'] = @(
+    [PSCustomObject]@{
+        Area       = 'Maestro channel'
+        Status     = 'WATCH'
+        Details    = "Default channel A | B`nnot yet mapped"
+        NextAction = 'Verify mapping'
+    }
+)
+$mdWatchCell = Format-MarkdownReport -Data $mdDataWatchCell -RepoUrl 'https://github.com/dotnet/maui' `
+                                     -TrackerKey 'net10-sr7' -MaxBodyBytes 60000
+$watchOrphans = @($mdWatchCell -split "`r?`n" | Where-Object { $_ -match '^\s*not yet mapped' })
+Assert-Eq -Label "Ship-checks table: embedded newline in Details does NOT orphan a line" -Expected 0 `
+    -Actual $watchOrphans.Count
+$watchRow = @($mdWatchCell -split "`r?`n" | Where-Object { $_ -match '🟡 WATCH' })
+Assert-Eq -Label "Ship-checks table: Details glued + pipe-escaped, NextAction column intact" -Expected $true `
+    -Actual ($watchRow.Count -eq 1 -and $watchRow[0] -match 'Default channel A \\\| B not yet mapped' -and $watchRow[0] -match 'Verify mapping')
 
 # Hash includes shipChecks state (changing a ship check status flips the hash)
 $h1 = if ($mdReady -match '<!-- release-readiness-hash: sha=([0-9a-f]{64}) -->') { $Matches[1] } else { $null }

--- a/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
+++ b/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
@@ -1740,6 +1740,46 @@ Assert-Eq -Label "Hostile PR title: @another/user defanged to `another/user`" -E
 Assert-Eq -Label "Author column also defanged (no bare @jfversluis)" -Expected $true `
     -Actual ($mdWithAt -match '`jfversluis`')
 
+# ───── Sibling SR title cells must be sanitized too (Format-MarkdownTableCell) ─────
+# Beyond the ci-scan rows, two other SR tables embed upstream titles into pipe-delimited
+# rows: the "Open PRs Targeting <srBranch>" table and the regression classification
+# table. A literal '|' (common in titles) or an embedded newline in those titles must NOT
+# corrupt the row. Each integration test below is DISCRIMINATING on the pre-fix code:
+# the trailing-column match fails when an embedded newline splits the row, and the
+# escaped-pipe match fails when the pipe is left raw.
+Write-Host "`n[Unit] Sibling SR table cells sanitized (Open-PRs + regression tables)" -ForegroundColor Cyan
+
+# (1) Open PRs Targeting <srBranch> table (shipped mode renders the full table).
+$mdDataPipePr = @{} + $mdData
+$mdDataPipePr['metadata'] = @{} + $mdData.metadata
+$mdDataPipePr['metadata']['mode'] = 'shipped'
+$mdDataPipePr['openSrPrs'] = @(
+    @{ number = 96001; title = "Fix A | B`nand C"; author = @{ login = 'alice' };
+       isDraft = $false; reviewDecision = 'APPROVED'; updatedAt = '2026-06-01T00:00:00Z' }
+)
+$mdPipePr = Format-MarkdownReport -Data $mdDataPipePr -RepoUrl 'https://github.com/dotnet/maui' `
+                                  -TrackerKey 'net10-sr7' -MaxBodyBytes 60000
+$prRowLines = @($mdPipePr -split "`r?`n" | Where-Object { $_ -match '#96001' })
+Assert-Eq -Label "Open-PRs table: piped/newline PR title stays on one physical row" -Expected 1 `
+    -Actual $prRowLines.Count
+Assert-Eq -Label "Open-PRs table: pipe escaped AND trailing columns intact on the row" -Expected $true `
+    -Actual ($prRowLines.Count -eq 1 -and $prRowLines[0] -match 'Fix A \\\| B' -and $prRowLines[0] -match 'APPROVED')
+
+# (2) Regression classification table (needs-human-review is a Tier-2 class that renders).
+$mdDataPipeIss = @{} + $mdData
+$mdDataPipeIss['regressions'] = @(
+    @{ issue = 96002; title = "Crash | NRE`nin layout"; state = 'OPEN'; classification = 'needs-human-review';
+       candidateFixPrs = @(); recommendedAction = 'Investigate' }
+)
+$mdDataPipeIss['summary'] = @{ 'needs-human-review' = 1 }
+$mdPipeIss = Format-MarkdownReport -Data $mdDataPipeIss -RepoUrl 'https://github.com/dotnet/maui' `
+                                   -TrackerKey 'net10-sr7' -MaxBodyBytes 60000
+$issRowLines = @($mdPipeIss -split "`r?`n" | Where-Object { $_ -match '#96002' })
+Assert-Eq -Label "Regression table: piped/newline issue title stays on one physical row" -Expected 1 `
+    -Actual $issRowLines.Count
+Assert-Eq -Label "Regression table: pipe escaped AND trailing action column intact on the row" -Expected $true `
+    -Actual ($issRowLines.Count -eq 1 -and $issRowLines[0] -match 'Crash \\\| NRE' -and $issRowLines[0] -match 'Investigate')
+
 # ───── Candidate-mode open-PR collapse: avoid noisy main-PR dump ─────
 Write-Host "`n[Unit] Candidate-mode open-PR collapse (link to candidate PR only)" -ForegroundColor Cyan
 
@@ -2285,6 +2325,23 @@ Assert-Eq -Label "Newline ci-scan title: issue row is a single physical line (co
     -Actual $nlRowLines.Count
 Assert-Eq -Label "Newline ci-scan title: title tail + age stay on that row (discriminating regression guard)" -Expected $true `
     -Actual ($nlRowLines.Count -eq 1 -and $nlRowLines[0] -match 'truncated due to length.*ago \|')
+
+# ───── Format-MarkdownTableCell: shared SR table-cell sanitizer ─────
+# This helper backs every SR title cell (ci-scan rows, Open-PRs table, regression
+# classification table). It must collapse CR/LF (row-split safety) AND escape pipes
+# (column-injection safety), null-safely, while deliberately NOT escaping `<`/`>`
+# (the SR engine emits its own hash at the top of the body, so it has no Preview-style
+# HTML-comment hash-freeze vector — escaping `<>` here would only reduce fidelity).
+Write-Host "`n[Unit] Format-MarkdownTableCell (shared SR table-cell sanitizer)" -ForegroundColor Cyan
+Assert-Eq -Label "Format-MarkdownTableCell: pipe escaped"             -Expected 'a \| b'  -Actual (Format-MarkdownTableCell 'a | b')
+Assert-Eq -Label "Format-MarkdownTableCell: LF collapsed to space"    -Expected 'a b'     -Actual (Format-MarkdownTableCell "a`nb")
+Assert-Eq -Label "Format-MarkdownTableCell: CRLF run collapsed"       -Expected 'a b'     -Actual (Format-MarkdownTableCell "a`r`n`r`nb")
+Assert-Eq -Label "Format-MarkdownTableCell: newline + pipe together"  -Expected 'a \| b'  -Actual (Format-MarkdownTableCell "a`n| b")
+Assert-Eq -Label "Format-MarkdownTableCell: no CR/LF survives"        -Expected $false    -Actual ((Format-MarkdownTableCell "x`ny") -match "`r|`n")
+Assert-Eq -Label "Format-MarkdownTableCell: null → empty string"      -Expected ''        -Actual (Format-MarkdownTableCell $null)
+Assert-Eq -Label "Format-MarkdownTableCell: empty → empty string"     -Expected ''        -Actual (Format-MarkdownTableCell '')
+Assert-Eq -Label "Format-MarkdownTableCell: surrounding whitespace trimmed" -Expected 'a b' -Actual (Format-MarkdownTableCell "  a`nb  ")
+Assert-Eq -Label "Format-MarkdownTableCell: angle brackets deliberately NOT escaped (SR parity)" -Expected 'List<T>' -Actual (Format-MarkdownTableCell 'List<T>')
 
 # Truncation behavior: > MaxRows
 $manyIssues = 1..20 | ForEach-Object {


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Problem

The `[Release Readiness]` tracker issues render markdown tables built from upstream-controlled content — issue/PR **titles** dropped into pipe-delimited rows (`| #link | <title> | <…> |`). Several kinds of malformed (or hostile) title corrupt those rows:

1. **Embedded newlines.** Some `ci-scan` issues have a title containing a **literal newline** — observed live on issue #35957, whose real GitHub title spans two physical lines and ends with `(maui-pr-uitest\n[Content truncated due to length]`. An embedded `\r\n` splits the row across two physical lines, so the title tail + trailing cells land on a line that no longer contains the issue link. This was visible on the live trackers: **net10-sr9 #35867** (2 broken rows) and **net11-preview6 #35866** (3 broken rows).
2. **Unescaped pipes.** A literal `|` in a title (common — e.g. `Fix A | B`) injects an extra column. The preview engine already escaped pipes everywhere via its shared `Format-MarkdownCell`, but on the **SR** side cells were escaped ad-hoc — several embedded titles with **no newline collapse at all**.
3. **Escape-the-escaper pipe breakout.** A title may legally contain a literal `\|` (backslash immediately followed by a pipe). Escaping only the pipe turns that into `\\|`, which GitHub-flavored Markdown renders as a literal `\` followed by an **active** column delimiter — so the row still breaks out. Both engines had this latent bug.
4. **Raw `<`/`>` (HTML injection / display loss) on the SR side.** SR dropped titles in raw, so a title like `Crash <!--` could inject an HTML-comment opener, and a legitimate `List<T>` (or engine-authored placeholder text like `Bump <PatchVersion> …`) was silently swallowed by GitHub as an unknown HTML tag and never displayed.

The ultimate root cause of (1) is upstream (the CI Failure Scanner producing a multi-line title), but a readiness engine should defensively sanitize any external content it embeds into its own tables.

### Fix

- **`Get-ReleaseReadiness.ps1`** — introduce a single null-safe **`Format-MarkdownTableCell`** helper and route **every** SR site that embeds upstream-controlled text through it. This covers the ci-scan rows, the **Open PRs Targeting `<srBranch>`**, **regression classification**, **🔴 Blocking summary**, **🧹 Cleanup**, **📥 Open Fix PRs Inbound**, and **Ship-readiness checks** tables, **plus the candidate-PR bulleted list**. The helper:
  - collapses `[\r\n]+` → space (hazard 1),
  - escapes each `|` → `\|` and **doubles only the backslash run immediately preceding that pipe** (via a single `(\\*)\|` regex pass), so a pre-existing `\|` becomes `\\\|` (renders a literal `\|`, no breakout — hazards 2 & 3). The doubling is **scoped to pipe-adjacent runs** rather than every backslash, so a title's other backslash escapes (`\[link\](url)`, `\*not emphasis\*`) are preserved verbatim and not de-escaped into active Markdown. No-pipe-adjacent-backslash titles are unchanged (`a | b` → `a \| b`).
  - escapes `<`/`>` → `&lt;`/`&gt;` (hazard 4), **matching the preview engine** for SR↔Preview parity.
- **`Get-PreviewReadiness.ps1` (`Format-MarkdownCell`)** — the newline collapse plus the same **pipe-adjacent** backslash handling so the preview engine is immune to the `\|` breakout too.

**On `<`/`>` escaping (now consistent across both engines):** escaping angle brackets to entities has **zero visual cost** — `&lt;T&gt;` renders as `<T>` — so `List<T>` fidelity is preserved while raw HTML injection is neutralized (`<!--` → `&lt;!--`). It also fixes a latent display bug: engine-authored `NextAction` text such as `Bump <PatchVersion> in eng/Versions.props` was previously rendered raw and **swallowed by GitHub as an unknown HTML tag**, so the Release Captain saw `Bump  in eng/Versions.props`; it now displays correctly. SR is additionally hash-freeze-immune (it emits its own hash at the **top** of the body, extracted with `head -n1`) and its human-notes markers are matched **full-line-anchored**, so escaping `<>` is defense-in-depth layered on top of those backend invariants rather than the sole protection. (`.Trim()` only touches leading/trailing whitespace.)

### Tests

Deterministic, offline assertions:

- **`Format-MarkdownTableCell` / `Format-MarkdownCell` unit tests** — pipe escaping, LF/CRLF-run collapse, newline+pipe together, null/empty → empty string, whitespace trim; **angle brackets escaped to `&lt;`/`&gt;` (both engines, parity)**; **literal `\|` does NOT break out** (→ `A \\\| B`); **non-pipe backslash preserved** (`C:\dir` unchanged) and **author-escaped non-pipe Markdown not de-escaped** (`\[link\](url)` unchanged) for both engines; **`<!--` opener neutralized** to `&lt;!--`.
- **SR ci-scan row** — an embedded-newline title renders as a **single** physical row with its tail + age intact.
- **SR tables (end-to-end `Format-MarkdownReport`)** — a piped+newline title in the **Open PRs Targeting**, **regression classification**, **🔴 Blocking summary**, **📥 Open Fix PRs Inbound**, and **Ship-readiness checks** tables each stays on one physical row, pipe escaped, trailing column intact; the BLOCKED ship-check next-action with `<PatchVersion>` renders entity-escaped (so GitHub actually displays it).
- **Human-notes marker-forgery regressions (security)** — a title embedding `…\n<!-- …:human-notes:begin -->\n…` in a **table cell** and in the **candidate-PR list** must leave **exactly one** anchored begin-marker in the rendered body (the legitimate one), proving a hostile title cannot forge a second notes region.
- **Preview engine** — `Format-MarkdownCell` collapses LF/CRLF runs and preserves the existing pipe / angle-bracket escaping contract.

The discriminating assertions were verified **red on the pre-fix scripts** and **green after** (and the surgical-scoping assertions were verified red against the earlier global-doubling commit). Offline suite: **566 passed / 0 failed**; full E2E: **632 / 0**.

### Scope / follow-ups (intentionally out of this PR)

- Backtick (inline-code) is intentionally **not** escaped: doing so would degrade the very common legitimate case of code-quoted titles like `` `CollectionView` ``, and an unescaped backtick is a cosmetic-only, non-structural concern (it cannot create a new column, inject HTML, or forge a human-notes marker, all of which require `|`/`<`, which **are** escaped).
- Null-safety of `.title.Length` under `Set-StrictMode -Version Latest` is **pre-existing** (titles are non-null by GitHub API contract) and intentionally deferred to a focused follow-up rather than mixed into this rendering PR.
- The SR "Reverts" table's "Reverts commit" column shows `?` for every row (the `This reverts commit <sha>` body-regex never resolves). Pre-existing and unrelated; noted for a future pass.
- Filing an upstream issue against the CI Failure Scanner for the malformed (multi-line) titles is worth doing separately so the trackers receive clean input at the source.