### PR TITLE
Fix for PathGeometry.Figures.Clear() leaks when clearing shared PathFigure instances

### DIFF
--- a/src/Controls/src/Core/Shapes/PathGeometry.cs
+++ b/src/Controls/src/Core/Shapes/PathGeometry.cs
@@ -14,6 +14,11 @@ namespace Microsoft.Maui.Controls.Shapes
 	[ContentProperty("Figures")]
 	public sealed class PathGeometry : Geometry
 	{
+		// Tracks figures whose PropertyChanged and InvalidatePathSegmentRequested events are
+		// subscribed so we can unsubscribe them even when the collection is cleared (Reset
+		// action does not populate OldItems).
+		readonly List<PathFigure> _subscribedFigures = new List<PathFigure>();
+
 		/// <summary>
 		/// Initializes a new instance of the <see cref="PathGeometry"/> class.
 		/// </summary>
@@ -198,17 +203,36 @@ namespace Microsoft.Maui.Controls.Shapes
 			}
 		}
 
+		void SubscribeFigure(PathFigure figure)
+		{
+			figure.PropertyChanged += OnPathFigurePropertyChanged;
+			figure.InvalidatePathSegmentRequested += OnInvalidatePathSegmentRequested;
+			_subscribedFigures.Add(figure);
+		}
+
+		void UnsubscribeFigure(PathFigure figure)
+		{
+			figure.PropertyChanged -= OnPathFigurePropertyChanged;
+			figure.InvalidatePathSegmentRequested -= OnInvalidatePathSegmentRequested;
+			_subscribedFigures.Remove(figure);
+		}
+
+		void UnsubscribeAllFigures()
+		{
+			foreach (var figure in _subscribedFigures)
+			{
+				figure.PropertyChanged -= OnPathFigurePropertyChanged;
+				figure.InvalidatePathSegmentRequested -= OnInvalidatePathSegmentRequested;
+			}
+			_subscribedFigures.Clear();
+		}
+
 		void UpdatePathFigureCollection(PathFigureCollection oldCollection, PathFigureCollection newCollection)
 		{
 			if (oldCollection != null)
 			{
 				oldCollection.CollectionChanged -= OnPathFigureCollectionChanged;
-
-				foreach (var oldPathFigure in oldCollection)
-				{
-					oldPathFigure.PropertyChanged -= OnPathFigurePropertyChanged;
-					oldPathFigure.InvalidatePathSegmentRequested -= OnInvalidatePathSegmentRequested;
-				}
+				UnsubscribeAllFigures();
 			}
 
 			if (newCollection == null)
@@ -217,35 +241,32 @@ namespace Microsoft.Maui.Controls.Shapes
 			newCollection.CollectionChanged += OnPathFigureCollectionChanged;
 
 			foreach (var newPathFigure in newCollection)
-			{
-				newPathFigure.PropertyChanged += OnPathFigurePropertyChanged;
-				newPathFigure.InvalidatePathSegmentRequested += OnInvalidatePathSegmentRequested;
-			}
+				SubscribeFigure(newPathFigure);
 		}
 
 		void OnPathFigureCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
-			if (e.OldItems != null)
+			if (e.OldItems != null && e.Action != NotifyCollectionChangedAction.Move)
 			{
 				foreach (var oldItem in e.OldItems)
 				{
-					if (!(oldItem is PathFigure oldPathFigure))
-						continue;
-
-					oldPathFigure.PropertyChanged -= OnPathFigurePropertyChanged;
-					oldPathFigure.InvalidatePathSegmentRequested -= OnInvalidatePathSegmentRequested;
+					if (oldItem is PathFigure oldPathFigure)
+						UnsubscribeFigure(oldPathFigure);
 				}
 			}
+			if (e.Action == NotifyCollectionChangedAction.Reset)
+			{
+				// Clear() raises Reset with OldItems = null; unsubscribe all tracked figures
+				// to prevent the cleared figures from retaining this PathGeometry alive.
+				UnsubscribeAllFigures();
+			}
 
-			if (e.NewItems != null)
+			if (e.NewItems != null && e.Action != NotifyCollectionChangedAction.Move)
 			{
 				foreach (var newItem in e.NewItems)
 				{
-					if (!(newItem is PathFigure newPathFigure))
-						continue;
-
-					newPathFigure.PropertyChanged += OnPathFigurePropertyChanged;
-					newPathFigure.InvalidatePathSegmentRequested += OnInvalidatePathSegmentRequested;
+					if (newItem is PathFigure newPathFigure)
+						SubscribeFigure(newPathFigure);
 				}
 			}
 

--- a/src/Controls/src/Core/Shapes/PathGeometry.cs
+++ b/src/Controls/src/Core/Shapes/PathGeometry.cs
@@ -241,7 +241,9 @@ namespace Microsoft.Maui.Controls.Shapes
 			newCollection.CollectionChanged += OnPathFigureCollectionChanged;
 
 			foreach (var newPathFigure in newCollection)
+			{
 				SubscribeFigure(newPathFigure);
+			}
 		}
 
 		void OnPathFigureCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
@@ -251,7 +253,9 @@ namespace Microsoft.Maui.Controls.Shapes
 				foreach (var oldItem in e.OldItems)
 				{
 					if (oldItem is PathFigure oldPathFigure)
+					{
 						UnsubscribeFigure(oldPathFigure);
+					}
 				}
 			}
 			if (e.Action == NotifyCollectionChangedAction.Reset)
@@ -266,7 +270,9 @@ namespace Microsoft.Maui.Controls.Shapes
 				foreach (var newItem in e.NewItems)
 				{
 					if (newItem is PathFigure newPathFigure)
+					{
 						SubscribeFigure(newPathFigure);
+					}
 				}
 			}
 

--- a/src/Controls/tests/Core.UnitTests/Shapes/PathGeometryTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Shapes/PathGeometryTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Runtime.CompilerServices;
+using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Graphics;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests.Shapes;
+
+public class PathGeometryTests : BaseTestFixture
+{
+	/// <summary>
+	/// Figures.Clear() must unsubscribe the cleared PathFigure from the PathGeometry,
+	/// otherwise the figure retains the geometry alive via its PropertyChanged delegate.
+	/// </summary>
+	[Fact]
+	public void FiguresClear_UnsubscribesFigurePropertyChangedHandler()
+	{
+		var geometry = new PathGeometry();
+		var sharedFigure = new PathFigure { StartPoint = new Point(0, 0) };
+		geometry.Figures.Add(sharedFigure);
+
+		int invalidateCount = 0;
+		geometry.InvalidatePathGeometryRequested += (s, e) => invalidateCount++;
+
+		// Sanity-check: mutating the figure before Clear should trigger invalidation.
+		sharedFigure.StartPoint = new Point(10, 10);
+		Assert.Equal(1, invalidateCount);
+
+		// Act - Clear() fires CollectionChanged (Reset), which itself calls Invalidate() once.
+		geometry.Figures.Clear();
+		int countAfterClear = invalidateCount;
+
+		// After Clear, mutating the figure must NOT trigger any further invalidation on the geometry.
+		sharedFigure.StartPoint = new Point(20, 20);
+		Assert.Equal(countAfterClear, invalidateCount);
+	}
+
+	/// <summary>
+	/// Figures.Clear() must unsubscribe the cleared PathFigure's segment-invalidation event
+	/// from the PathGeometry.
+	/// </summary>
+	[Fact]
+	public void FiguresClear_UnsubscribesFigureSegmentInvalidateHandler()
+	{
+		var geometry = new PathGeometry();
+		var sharedFigure = new PathFigure { StartPoint = new Point(0, 0) };
+		geometry.Figures.Add(sharedFigure);
+
+		int invalidateCount = 0;
+		geometry.InvalidatePathGeometryRequested += (s, e) => invalidateCount++;
+
+		// Sanity-check: adding a segment before Clear should trigger invalidation.
+		sharedFigure.Segments.Add(new LineSegment { Point = new Point(100, 100) });
+		Assert.Equal(1, invalidateCount);
+
+		// Act - Clear() fires CollectionChanged (Reset), which itself calls Invalidate() once.
+		geometry.Figures.Clear();
+		int countAfterClear = invalidateCount;
+
+		// After Clear, adding segments to the cleared figure must NOT trigger any further invalidation.
+		sharedFigure.Segments.Add(new LineSegment { Point = new Point(200, 200) });
+		Assert.Equal(countAfterClear, invalidateCount);
+	}
+
+	/// <summary>
+	/// After Figures.Clear(), the PathGeometry must be eligible for garbage collection
+	/// even when the cleared PathFigure is still alive (shared/rooted elsewhere).
+	/// </summary>
+	[Fact]
+	public void FiguresClear_AllowsPathGeometryToBeGarbageCollected()
+	{
+		var sharedFigure = new PathFigure { StartPoint = new Point(0, 0) };
+		var weakRef = CreateGeometryAndClear(sharedFigure);
+
+		GC.Collect();
+		GC.WaitForPendingFinalizers();
+		GC.Collect();
+
+		// If the bug is present, sharedFigure still holds the geometry alive via
+		// its PropertyChanged delegate chain, so TryGetTarget would return true.
+		Assert.False(weakRef.TryGetTarget(out _),
+			"PathGeometry was retained by the cleared PathFigure (event-handler leak in Figures.Clear()).");
+	}
+
+	// Factored out so the JIT cannot inline the PathGeometry local onto the caller's frame.
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static WeakReference<PathGeometry> CreateGeometryAndClear(PathFigure figure)
+	{
+		var geometry = new PathGeometry();
+		geometry.Figures.Add(figure);
+		geometry.Figures.Clear();
+		return new WeakReference<PathGeometry>(geometry);
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Root cause of the issue

The issue occurs because PathGeometry subscribes to the PropertyChanged and InvalidatePathSegmentRequested events of each PathFigure in its Figures collection. These event subscriptions are removed only when the collection change notification provides an OldItems list, such as during Remove or RemoveAt operations.

However, when Figures.Clear() is called, the underlying ObservableCollection<T> raises a Reset collection change notification, where OldItems is null. As a result, the existing unsubscription logic is skipped, leaving previously added PathFigureinstances subscribed to the PathGeometry.
 
This creates a memory leak scenario where shared or retained PathFigure objects continue to hold references to the PathGeometry. Consequently, the associated Path control, page, and its BindingContext cannot be garbage collected even after navigation away from the page.

### Description of Change

The fix introduces a private _subscribedFigures collection within PathGeometry to explicitly track all PathFigure instances whose events are currently subscribed. To centralize subscription management, three helper methods were added:

- SubscribeFigure – subscribes to a figure's events and records it in the tracking collection.
- UnsubscribeFigure – removes event subscriptions for a specific figure and removes it from the tracking collection.
- UnsubscribeAllFigures – unsubscribes all tracked figures and clears the tracking collection.

The CollectionChanged handler has been updated to handle the Reset action raised by Figures.Clear(). When a reset occurs, UnsubscribeAllFigures() is invoked to ensure that all previously subscribed figures are properly detached, regardless of whether OldItems is available. The else if condition guarding the Reset branch has been changed to an independent if statement, ensuring the Reset handler always executes even if OldItems happens to be non-null, preventing silent subscription divergence in custom collection scenarios.

Additionally, the CollectionChanged handler now skips the unsubscribe and resubscribe cycle when the action is Move. Since OldItems and NewItems contain the same figure instance on a Move, both blocks are guarded with e.Action != NotifyCollectionChangedAction.Move to eliminate the unnecessary round-trip while keeping the figure correctly subscribed and Invalidate() still firing as expected.

These changes guarantee that event subscriptions are always cleaned up correctly, preventing retained references and eliminating the memory leak without modifying the public API or altering existing collection behavior.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes https://github.com/dotnet/maui/issues/35809

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

**Tested the behavior in the following platforms.**
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

| Before fix | After fix |
|---------|--------|
| **Android**<br> <video src="https://github.com/user-attachments/assets/323b81a5-fb4a-4814-9263-eb6d6fb73a06" width="300" height="600"> | **Android**<br> <video src="https://github.com/user-attachments/assets/6892cfc1-a1f1-42b8-a711-0470e0e34808" width="300" height="600"> |
