### PR TITLE
Revert Android CollectionView handler cleanup and scrolling performance fixes (#34534, #35379, #35536)

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/Adapters/ItemsViewAdapter.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/Adapters/ItemsViewAdapter.cs
@@ -1,6 +1,5 @@
 ﻿#nullable disable
 using System;
-using System.Collections.Generic;
 using Android.Content;
 using Android.Widget;
 using AndroidX.RecyclerView.Widget;
@@ -20,7 +19,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		bool _disposed;
 		bool _usingItemTemplate = false;
 		DataTemplateSelector _itemTemplateSelector = null;
-		readonly List<WeakReference<TemplatedItemViewHolder>> _templatedViewHolders = new();
 
 		protected internal ItemsViewAdapter(TItemsView itemsView, Func<View, Context, ItemContentView> createItemContentView = null)
 		{
@@ -92,15 +90,15 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			// See if our cached templates have a match
 			if (_viewTypeDataTemplates.TryGetValue(viewType, out var dataTemplate))
 			{
-				return TrackTemplatedViewHolder(new TemplatedItemViewHolder(itemContentView, dataTemplate, IsSelectionEnabled(parent, viewType)));
+				return new TemplatedItemViewHolder(itemContentView, dataTemplate, IsSelectionEnabled(parent, viewType));
 			}
 
-			return TrackTemplatedViewHolder(new TemplatedItemViewHolder(itemContentView, ItemsView.ItemTemplate, IsSelectionEnabled(parent, viewType)));
+			return new TemplatedItemViewHolder(itemContentView, ItemsView.ItemTemplate, IsSelectionEnabled(parent, viewType));
 		}
 
 		public override int ItemCount => ItemsSource.Count;
 
-		Dictionary<int, DataTemplate> _viewTypeDataTemplates = new();
+		System.Collections.Generic.Dictionary<int, DataTemplate> _viewTypeDataTemplates = new();
 
 		public override int GetItemViewType(int position)
 		{
@@ -129,7 +127,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			{
 				if (disposing)
 				{
-					DisconnectTemplatedViewHolders();
 					ItemsSource?.Dispose();
 					ItemsView.PropertyChanged -= ItemsViewPropertyChanged;
 				}
@@ -159,33 +156,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			_usingItemTemplate = ItemsView.ItemTemplate != null;
 			_itemTemplateSelector = ItemsView.ItemTemplate as DataTemplateSelector;
-		}
-
-		TemplatedItemViewHolder TrackTemplatedViewHolder(TemplatedItemViewHolder holder)
-		{
-			for (int index = _templatedViewHolders.Count - 1; index >= 0; index--)
-			{
-				if (!_templatedViewHolders[index].TryGetTarget(out _))
-				{
-					_templatedViewHolders.RemoveAt(index);
-				}
-			}
-
-			_templatedViewHolders.Add(new WeakReference<TemplatedItemViewHolder>(holder));
-			return holder;
-		}
-
-		void DisconnectTemplatedViewHolders()
-		{
-			for (int index = _templatedViewHolders.Count - 1; index >= 0; index--)
-			{
-				if (_templatedViewHolders[index].TryGetTarget(out var holder))
-				{
-					holder.DisconnectAndRecycle(ItemsView);
-				}
-			}
-
-			_templatedViewHolders.Clear();
 		}
 	}
 }

--- a/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
@@ -61,9 +61,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			var platformView = PlatformView;
 
-			if (this.IsAlive() &&
-				platformView.IsAlive() &&
-				platformView.Parent == this)
+			if (platformView != null)
 			{
 				RemoveView(platformView);
 			}

--- a/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
@@ -68,10 +68,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				RemoveView(platformView);
 			}
 
-			// Capture the current platform view before disconnecting handlers, because
-			// DisconnectHandlers() may null out the handler's PlatformView/ContainerView.
-			View?.DisconnectHandlers();
-
 			Content = null;
 			_pixelSize = null;
 			_reportMeasure = null;

--- a/src/Controls/src/Core/Handlers/Items/Android/TemplatedItemViewHolder.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/TemplatedItemViewHolder.cs
@@ -42,22 +42,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			itemsView.RemoveLogicalChild(View);
 		}
 
-		internal void DisconnectAndRecycle(ItemsView itemsView)
-		{
-			if (View != null)
-			{
-				itemsView.RemoveLogicalChild(View);
-			}
-
-			// Disconnect and clear the handler via ItemContentView.Recycle(), which calls
-			// DisconnectHandlers() before releasing Content. Reset _selectedTemplate so the
-			// next Bind() call always goes through the templateChanging path and recreates
-			// the handler (since we just disconnected it).
-			_itemContentView.Recycle();
-			View = null; // clear reference to the disconnected view
-			_selectedTemplate = null; // force templateChanging=true on next Bind() to recreate the view
-		}
-
 		public void Bind(object itemBindingContext, ItemsView itemsView,
 			Action<Size> reportMeasure = null, Size? size = null)
 		{

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32243.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32243.cs
@@ -1,3 +1,4 @@
+#if !ANDROID
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -31,3 +32,4 @@ public class Issue32243 : _IssuesUITest
 			"CollectionView should disconnect handlers from views belonging to the old DataTemplate after navigating back.");
 	}
 }
+#endif


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment whether this change resolves your issue. Thank you!

###  Description of Change

  Reverts the Android changes from the following PRs on the candidate branch, matching what was already reverted in SR7:

   - Reverts Android fix from #34534 (already reverted via #35461 in SR7)
   - Reverts Android scrolling performance fix from #35379 
   - Reverts CI fix from #35536 (continuation of #35379)

  **Changes**

  Revert of #35461 / #34534 (Android handler cleanup on recycle):

   - Removed `View?.DisconnectHandlers()` call from ItemContentView.Recycle()
   - Added #if !ANDROID guard to Issue32243 test to exclude it from Android runs

  Revert of #35379 (CollectionView scrolling performance refactor):

   - Removed `DisconnectAndRecycle()` method from TemplatedItemViewHolder
   - Removed `_templatedViewHolders` tracking list and TrackTemplatedViewHolder() / `DisconnectTemplatedViewHolders()` methods from ItemsViewAdapter
   - Removed `DisconnectTemplatedViewHolders()` call from ItemsViewAdapter.Dispose()

  Revert of #35536 (CI fix continuation of #35379):

   - Reverted IsAlive() guard check back to simple if (platformView != null) in ItemContentView.Recycle()