### PR TITLE
Fix BindableObject.GetLocalValueEnumerator() removed by #33584 breaks VS Live Property Explorer

### DIFF
--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -173,6 +173,7 @@ namespace Microsoft.Maui.Controls
 			return context == null ? property.DefaultValue : context.Values.GetValue();
 		}
 
+		// Used by Visual Studio Live Property Explorer via reflection; do not remove without coordinating with VS.
 		internal LocalValueEnumerator GetLocalValueEnumerator() => new LocalValueEnumerator(this);
 
 		internal sealed class LocalValueEnumerator : IEnumerator<LocalValueEntry>

--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -173,6 +173,50 @@ namespace Microsoft.Maui.Controls
 			return context == null ? property.DefaultValue : context.Values.GetValue();
 		}
 
+		internal LocalValueEnumerator GetLocalValueEnumerator() => new LocalValueEnumerator(this);
+
+		internal sealed class LocalValueEnumerator : IEnumerator<LocalValueEntry>
+		{
+			Dictionary<int, BindablePropertyContext>.ValueCollection.Enumerator _propertiesEnumerator;
+			internal LocalValueEnumerator(BindableObject bindableObject) => _propertiesEnumerator = bindableObject._properties.Values.GetEnumerator();
+
+			object IEnumerator.Current => Current;
+			public LocalValueEntry Current { get; private set; }
+
+			public bool MoveNext()
+			{
+				if (_propertiesEnumerator.MoveNext())
+				{
+					var context = _propertiesEnumerator.Current;
+					Current = new LocalValueEntry(context.Property, context.Values.GetValue(), context.Attributes);
+					return true;
+				}
+				return false;
+			}
+
+			public void Dispose() => _propertiesEnumerator.Dispose();
+
+			void IEnumerator.Reset()
+			{
+				((IEnumerator)_propertiesEnumerator).Reset();
+				Current = null;
+			}
+		}
+
+		internal sealed class LocalValueEntry
+		{
+			internal LocalValueEntry(BindableProperty property, object value, BindableContextAttributes attributes)
+			{
+				Property = property;
+				Value = value;
+				Attributes = attributes;
+			}
+
+			public BindableProperty Property { get; }
+			public object Value { get; }
+			public BindableContextAttributes Attributes { get; }
+		}
+
 		internal (bool IsSet, T Value)[] GetValues<T>(BindableProperty[] propArray)
 		{
 			var properties = _properties;


### PR DESCRIPTION
### Issue details:
After PR #33584 (BindableObject property access micro-optimizations), Visual Studio's Live Property Explorer stops showing any property values for MAUI controls. The feature becomes completely blank.
 
### Description of changes:
PR #33584 removed GetLocalValueEnumerator(), LocalValueEnumerator, and LocalValueEntry from BindableObject as "unused dead code" — a grep of the MAUI codebase confirmed zero internal callers. However, Visual Studio's Live Property Explorer calls GetLocalValueEnumerator() via reflection at runtime to enumerate locally-set bindable property values on live objects. With these types removed, the reflection call fails silently and the panel shows nothing.
 
This changes restores all three types, adapted to the new Dictionary<int, BindablePropertyContext> storage introduced by #33584 — the enumerator now iterates .Values (the BindablePropertyContext objects directly) and reads context.Property to expose the BindableProperty, since the dictionary key is now an int rather than the property itself.

**Tested the behavior in the following platforms.**
- [ ] Android
- [x] Windows
- [ ] iOS
- [ ] Mac

| Before  | After  |
|---------|--------|
| **Windows**<br> <video src="https://github.com/user-attachments/assets/df3a3448-c79c-4457-8901-f2a075087df4" width="300" height="600"> | **Windows**<br> <video src="https://github.com/user-attachments/assets/2dcbdb35-2336-44bd-9c8b-baf1f9b64b4a" width="300" height="600"> |








