### PR TITLE
[iOS & Mac] Fix NullReferenceException in CollectionViewHandler2 after handler restore when property changes

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/CollectionViewHandler2.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items2/CollectionViewHandler2.iOS.cs
@@ -254,6 +254,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 			if (_subscribedItemsLayout is not null)
 			{
+				// Reinitialize the cache if it was cleared by DisconnectHandler
+				_layoutPropertyCache ??= new Dictionary<string, object>();
 				_subscribedItemsLayout.PropertyChanged += OnItemsLayoutPropertyChanged;
 			}
 		}

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
@@ -566,5 +566,154 @@ namespace Microsoft.Maui.DeviceTests
 			}
 			return null;
 		}
+
+		// Regression test for https://github.com/dotnet/maui/issues/36010
+		// CollectionViewHandler2 must not throw NullReferenceException when a
+		// GridItemsLayout property changes after the handler has been disconnected
+		// and then reconnected (the cached-workspace / native-host restore pattern).
+		[Theory(DisplayName = "CollectionViewHandler2 Does Not Crash After Disconnect-Restore-PropertyChange")]
+		[InlineData(nameof(GridItemsLayout.Span))]
+		[InlineData(nameof(GridItemsLayout.HorizontalItemSpacing))]
+		[InlineData(nameof(GridItemsLayout.VerticalItemSpacing))]
+		[InlineData(nameof(ItemsLayout.SnapPointsType))]
+		[InlineData(nameof(ItemsLayout.SnapPointsAlignment))]
+		[Category(TestCategory.CollectionView)]
+		public async Task CollectionViewHandler2DoesNotCrashAfterDisconnectRestorePropertyChange(string propertyName)
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler<CollectionView, CollectionViewHandler2>();
+					handlers.AddHandler<Label, LabelHandler>();
+				});
+			});
+
+			var itemsLayout = new GridItemsLayout(2, ItemsLayoutOrientation.Vertical)
+			{
+				HorizontalItemSpacing = 8,
+				VerticalItemSpacing = 8
+			};
+
+			var collectionView = new CollectionView
+			{
+				HeightRequest = 300,
+				WidthRequest = 300,
+				ItemsLayout = itemsLayout,
+				ItemsSource = Enumerable.Range(1, 12).Select(i => $"Item {i}").ToList(),
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var label = new Label();
+					label.SetBinding(Label.TextProperty, ".");
+					return label;
+				})
+			};
+
+			await CreateHandlerAndAddToWindow<CollectionViewHandler2>(collectionView, async handler =>
+			{
+				await Task.Delay(200);
+
+				// Step 1: Shelve — disconnect the handler (sets _layoutPropertyCache = null)
+				var mauiContext = handler.MauiContext;
+				((IElementHandler)handler).DisconnectHandler();
+
+				await Task.Delay(50);
+
+				// Step 2: Restore — re-attach the same handler instance
+				((IElementHandler)handler).SetMauiContext(mauiContext);
+				((IElementHandler)handler).SetVirtualView(collectionView);
+
+				await Task.Delay(50);
+
+				// Step 3: Change a GridItemsLayout property — must NOT throw NullReferenceException.
+				// Before the fix, _layoutPropertyCache was null here and TryGetValue crashed.
+				var exception = await Record.ExceptionAsync(async () =>
+				{
+					await InvokeOnMainThreadAsync(() =>
+					{
+						switch (propertyName)
+						{
+							case nameof(GridItemsLayout.Span):
+								itemsLayout.Span = 4;
+								break;
+							case nameof(GridItemsLayout.HorizontalItemSpacing):
+								itemsLayout.HorizontalItemSpacing = 16;
+								break;
+							case nameof(GridItemsLayout.VerticalItemSpacing):
+								itemsLayout.VerticalItemSpacing = 16;
+								break;
+							case nameof(ItemsLayout.SnapPointsType):
+								itemsLayout.SnapPointsType = SnapPointsType.MandatorySingle;
+								break;
+							case nameof(ItemsLayout.SnapPointsAlignment):
+								itemsLayout.SnapPointsAlignment = SnapPointsAlignment.Center;
+								break;
+						}
+					});
+				});
+
+				Assert.Null(exception);
+			});
+		}
+
+		// Regression test for https://github.com/dotnet/maui/issues/36010 (LinearItemsLayout path)
+		// ItemSpacing change on a LinearItemsLayout must also survive disconnect+restore.
+		[Fact(DisplayName = "CollectionViewHandler2 Does Not Crash After Disconnect-Restore-LinearItemSpacingChange")]
+		[Category(TestCategory.CollectionView)]
+		public async Task CollectionViewHandler2DoesNotCrashAfterDisconnectRestoreLinearItemSpacingChange()
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler<CollectionView, CollectionViewHandler2>();
+					handlers.AddHandler<Label, LabelHandler>();
+				});
+			});
+
+			var itemsLayout = new LinearItemsLayout(ItemsLayoutOrientation.Vertical)
+			{
+				ItemSpacing = 4
+			};
+
+			var collectionView = new CollectionView
+			{
+				HeightRequest = 300,
+				WidthRequest = 300,
+				ItemsLayout = itemsLayout,
+				ItemsSource = Enumerable.Range(1, 12).Select(i => $"Item {i}").ToList(),
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var label = new Label();
+					label.SetBinding(Label.TextProperty, ".");
+					return label;
+				})
+			};
+
+			await CreateHandlerAndAddToWindow<CollectionViewHandler2>(collectionView, async handler =>
+			{
+				await Task.Delay(200);
+
+				var mauiContext = handler.MauiContext;
+				((IElementHandler)handler).DisconnectHandler();
+
+				await Task.Delay(50);
+
+				((IElementHandler)handler).SetMauiContext(mauiContext);
+				((IElementHandler)handler).SetVirtualView(collectionView);
+
+				await Task.Delay(50);
+
+				var exception = await Record.ExceptionAsync(async () =>
+				{
+					await InvokeOnMainThreadAsync(() =>
+					{
+						itemsLayout.ItemSpacing = 20;
+					});
+				});
+
+				Assert.Null(exception);
+			});
+		}
 	}
 }


### PR DESCRIPTION
<!-- Please keep the note below for people who find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment whether this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

This pull request addresses a regression issue where `CollectionViewHandler2` could throw a `NullReferenceException` if a layout property changed after the handler was disconnected and then reconnected. The fix ensures the internal cache is properly reinitialized, and new tests are added to verify the handler's stability in these scenarios.

### Description of Change

**Bug fix:**
- Ensured `_layoutPropertyCache` is reinitialized when subscribing to a new items layout in `CollectionViewHandler2`, preventing `NullReferenceException` after handler disconnect/reconnect cycles.

**Testing improvements:**
- Added regression tests to confirm that changing properties on `GridItemsLayout` and `LinearItemsLayout` after a disconnect/restore cycle does not cause crashes in `CollectionViewHandler2`. These tests cover various property changes and validate the fix 

<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #36010 

### Tested the behavior in the following platforms

- [ ] Windows
- [ ] Android
- [x] iOS
- [x] Mac

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <img width="954" height="693" alt="BeforeFix36010" src="https://github.com/user-attachments/assets/fb32509b-ce7c-497c-9fa4-3170181e9475" /> |  <img width="947" height="689" alt="AfterFix36010" src="https://github.com/user-attachments/assets/188f6e3b-6b72-4ead-9af0-342d5d8d7c20" /> |

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
