### PR TITLE
Use MVVM Toolkit partial properties in templates

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -167,10 +167,10 @@
     <!-- Additional packages for cgmanifest.json -->
     <SyncfusionMauiToolkitPackageVersion>1.0.4</SyncfusionMauiToolkitPackageVersion>
     <MicrosoftDataSqliteCorePackageVersion>8.0.8</MicrosoftDataSqliteCorePackageVersion>
-    <SQLitePCLRawBundleGreenPackageVersion>2.1.10</SQLitePCLRawBundleGreenPackageVersion>
+    <SQLitePCLRawBundleESqlite3PackageVersion>3.0.3</SQLitePCLRawBundleESqlite3PackageVersion>
     <CommunityToolkitMauiPackageVersion>11.1.1</CommunityToolkitMauiPackageVersion>
     <CommunityToolkitMauiPreviousPackageVersion>9.1.0</CommunityToolkitMauiPreviousPackageVersion>
-    <CommunityToolkitMvvmPackageVersion>8.3.2</CommunityToolkitMvvmPackageVersion>
+    <CommunityToolkitMvvmPackageVersion>8.4.2</CommunityToolkitMvvmPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Appium -->

--- a/eng/scripts/update-cgmanifest.ps1
+++ b/eng/scripts/update-cgmanifest.ps1
@@ -57,7 +57,7 @@ $packageVersionMappings = @{
     # Additional packages specified by the user
     'Syncfusion.Maui.Toolkit' = 'SyncfusionMauiToolkitPackageVersion'
     'Microsoft.Data.Sqlite.Core' = 'MicrosoftDataSqliteCorePackageVersion'
-    'SQLitePCLRaw.bundle_green' = 'SQLitePCLRawBundleGreenPackageVersion'
+    'SQLitePCLRaw.bundle_e_sqlite3' = 'SQLitePCLRawBundleESqlite3PackageVersion'
     'CommunityToolkit.Mvvm' = 'CommunityToolkitMvvmPackageVersion'
 }
 

--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -87,10 +87,10 @@
 
 <!--#if (IncludeSampleContent) -->
 	<ItemGroup>
-		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
+		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
 		<PackageReference Include="CommunityToolkit.Maui" Version="12.3.0" />
 		<PackageReference Include="Microsoft.Data.Sqlite.Core" Version="8.0.8" />
-		<PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.10" />
+		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
 		<PackageReference Include="Syncfusion.Maui.Toolkit" Version="1.0.9" />
 	</ItemGroup>
 	

--- a/src/Templates/src/templates/maui-mobile/PageModels/MainPageModel.cs
+++ b/src/Templates/src/templates/maui-mobile/PageModels/MainPageModel.cs
@@ -15,31 +15,31 @@ public partial class MainPageModel : ObservableObject, IProjectTaskPageModel
 	private readonly SeedDataService _seedDataService;
 
 	[ObservableProperty]
-	private List<CategoryChartData> _todoCategoryData = [];
+	public partial List<CategoryChartData> TodoCategoryData { get; set; } = [];
 
 	[ObservableProperty]
-	private List<Brush> _todoCategoryColors = [];
+	public partial List<Brush> TodoCategoryColors { get; set; } = [];
 
 	[ObservableProperty]
-	private List<ProjectTask> _tasks = [];
+	public partial List<ProjectTask> Tasks { get; set; } = [];
 
 	[ObservableProperty]
-	private List<Project> _projects = [];
+	public partial List<Project> Projects { get; set; } = [];
 
 	[ObservableProperty]
-	bool _isBusy;
+	public partial bool IsBusy { get; set; }
 
 	[ObservableProperty]
-	bool _isRefreshing;
+	public partial bool IsRefreshing { get; set; }
 
 	[ObservableProperty]
-	private string _today = DateTime.Now.ToString("dddd, MMM d");
+	public partial string Today { get; set; } = DateTime.Now.ToString("dddd, MMM d");
 
 	[ObservableProperty]
-	private Project? selectedProject;
+	public partial Project? SelectedProject { get; set; }
 
 	[ObservableProperty]
-	private ProjectTask? selectedTask;
+	public partial ProjectTask? SelectedTask { get; set; }
 
 	public bool HasCompletedTasks
 		=> Tasks?.Any(t => t.IsCompleted) ?? false;

--- a/src/Templates/src/templates/maui-mobile/PageModels/ManageMetaPageModel.cs
+++ b/src/Templates/src/templates/maui-mobile/PageModels/ManageMetaPageModel.cs
@@ -14,10 +14,10 @@ public partial class ManageMetaPageModel : ObservableObject
     private readonly SeedDataService _seedDataService;
 
 	[ObservableProperty]
-	private ObservableCollection<Category> _categories = [];
+	public partial ObservableCollection<Category> Categories { get; set; } = [];
 
 	[ObservableProperty]
-	private ObservableCollection<Tag> _tags = [];
+	public partial ObservableCollection<Tag> Tags { get; set; } = [];
 
 	public ManageMetaPageModel(CategoryRepository categoryRepository, TagRepository tagRepository, SeedDataService seedDataService)
 	{

--- a/src/Templates/src/templates/maui-mobile/PageModels/ProjectDetailPageModel.cs
+++ b/src/Templates/src/templates/maui-mobile/PageModels/ProjectDetailPageModel.cs
@@ -16,39 +16,39 @@ public partial class ProjectDetailPageModel : ObservableObject, IQueryAttributab
 	private readonly ModalErrorHandler _errorHandler;
 
 	[ObservableProperty]
-	private string _name = string.Empty;
+	public partial string Name { get; set; } = string.Empty;
 
 	[ObservableProperty]
-	private string _description = string.Empty;
+	public partial string Description { get; set; } = string.Empty;
 
 	[ObservableProperty]
-	private List<ProjectTask> _tasks = [];
+	public partial List<ProjectTask> Tasks { get; set; } = [];
 
 	[ObservableProperty]
-	private List<Category> _categories = [];
+	public partial List<Category> Categories { get; set; } = [];
 
 	[ObservableProperty]
-	private Category? _category;
+	public partial Category? Category { get; set; }
 
 	[ObservableProperty]
-	private int _categoryIndex = -1;
+	public partial int CategoryIndex { get; set; } = -1;
 
 	[ObservableProperty]
-	private List<Tag> _allTags = [];
+	public partial List<Tag> AllTags { get; set; } = [];
 
 	public IList<object> SelectedTags { get; set; } = new List<object>();
 
 	[ObservableProperty]
-	private IconData _icon;
+	public partial IconData Icon { get; set; } = null!;
 
 	[ObservableProperty]
-	bool _isBusy;
+	public partial bool IsBusy { get; set; }
 
 	[ObservableProperty]
-	private bool _isCategoryPickerExpanded;
+	public partial bool IsCategoryPickerExpanded { get; set; }
 
 	[ObservableProperty]
-	private List<IconData> _icons =	new List<IconData>
+	public partial List<IconData> Icons { get; set; } = new List<IconData>
 	{
 		new IconData { Icon = FluentUI.ribbon_24_regular, Description = "Ribbon Icon" },
 		new IconData { Icon = FluentUI.ribbon_star_24_regular, Description = "Ribbon Star Icon" },
@@ -60,19 +60,11 @@ public partial class ProjectDetailPageModel : ObservableObject, IQueryAttributab
 	};
 
 	[ObservableProperty]
-	private ProjectTask? selectedTask;
+	public partial ProjectTask? SelectedTask { get; set; }
 
-	private bool _canDelete;
-
-	public bool CanDelete
-	{
-		get => _canDelete;
-		set
-		{
-			_canDelete = value;
-			DeleteCommand.NotifyCanExecuteChanged();
-        }
-    }
+	[ObservableProperty]
+	[NotifyCanExecuteChangedFor(nameof(DeleteCommand))]
+	public partial bool CanDelete { get; set; }
 
     public bool HasCompletedTasks
 		=> _project?.Tasks.Any(t => t.IsCompleted) ?? false;
@@ -84,7 +76,7 @@ public partial class ProjectDetailPageModel : ObservableObject, IQueryAttributab
 		_categoryRepository = categoryRepository;
 		_tagRepository = tagRepository;
 		_errorHandler = errorHandler;
-		_icon = _icons.First();
+		Icon = Icons.First();
 		Tasks = [];
 	}
 

--- a/src/Templates/src/templates/maui-mobile/PageModels/ProjectListPageModel.cs
+++ b/src/Templates/src/templates/maui-mobile/PageModels/ProjectListPageModel.cs
@@ -11,10 +11,10 @@ public partial class ProjectListPageModel : ObservableObject
 	private readonly ProjectRepository _projectRepository;
 
 	[ObservableProperty]
-	private List<Project> _projects = [];
+	public partial List<Project> Projects { get; set; } = [];
 
 	[ObservableProperty]
-	private Project? selectedProject;
+	public partial Project? SelectedProject { get; set; }
 
 	public ProjectListPageModel(ProjectRepository projectRepository)
 	{

--- a/src/Templates/src/templates/maui-mobile/PageModels/TaskDetailPageModel.cs
+++ b/src/Templates/src/templates/maui-mobile/PageModels/TaskDetailPageModel.cs
@@ -10,32 +10,35 @@ public partial class TaskDetailPageModel : ObservableObject, IQueryAttributable
 {
 	public const string ProjectQueryKey = "project";
 	private ProjectTask? _task;
-	private bool _canDelete;
 	private readonly ProjectRepository _projectRepository;
 	private readonly TaskRepository _taskRepository;
 	private readonly ModalErrorHandler _errorHandler;
 
 	[ObservableProperty]
-	private string _title = string.Empty;
+	public partial string Title { get; set; } = string.Empty;
 
 	[ObservableProperty]
-	private bool _isCompleted;
+	public partial bool IsCompleted { get; set; }
 
 	[ObservableProperty]
-	private List<Project> _projects = [];
+	public partial List<Project> Projects { get; set; } = [];
 
 	[ObservableProperty]
-	private Project? _project;
+	public partial Project? Project { get; set; }
 
 	[ObservableProperty]
-	private int _selectedProjectIndex = -1;
+	public partial int SelectedProjectIndex { get; set; } = -1;
 
 
 	[ObservableProperty]
-	private bool _isExistingProject;
+	public partial bool IsExistingProject { get; set; }
 
 	[ObservableProperty]
-	private bool _isProjectPickerExpanded;
+	public partial bool IsProjectPickerExpanded { get; set; }
+
+	[ObservableProperty]
+	[NotifyCanExecuteChangedFor(nameof(DeleteCommand))]
+	public partial bool CanDelete { get; set; }
 
 	public TaskDetailPageModel(ProjectRepository projectRepository, TaskRepository taskRepository, ModalErrorHandler errorHandler)
 	{
@@ -108,16 +111,6 @@ public partial class TaskDetailPageModel : ObservableObject, IQueryAttributable
 			{
 				ProjectID = Project?.ID ?? 0
 			};
-		}
-	}
-
-	public bool CanDelete
-	{
-		get => _canDelete;
-		set
-		{
-			_canDelete = value;
-			DeleteCommand.NotifyCanExecuteChanged();
 		}
 	}
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary
- Updates the sample-content MAUI template to use `CommunityToolkit.Mvvm` 8.4.2.
- Converts template page models from field-backed `[ObservableProperty]` members to partial observable properties without enabling preview language features.
- Switches the sample-content SQLitePCLRaw dependency from `bundle_green` to `bundle_e_sqlite3` 3.0.3 and updates cgmanifest version mapping so generated projects avoid default NuGet audit warnings.

## Validation
- `dotnet build .\src\Templates\src\Microsoft.Maui.Templates.csproj -p:UpdateCgManifestBeforeBuild=false -p:GenerateCgManifest=false`
- Packed templates and generated a `dotnet new maui --sample-content true` app from an isolated template hive.
- `dotnet build <generated app> -f net10.0-windows10.0.19041.0 -p:RestoreIgnoreFailedSources=true` completed with 0 warnings and 0 errors, with no generated `LangVersion` or `EnablePreviewFeatures` entries.