### PR TITLE
Fix Color equality for derived types

### DIFF
--- a/src/Graphics/src/Graphics/Color.cs
+++ b/src/Graphics/src/Graphics/Color.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Maui.Graphics
 	/// </summary>
 	[DebuggerDisplay("Red={Red}, Green={Green}, Blue={Blue}, Alpha={Alpha}")]
 	[TypeConverter(typeof(Converters.ColorTypeConverter))]
+	[ImmutableObject(true)]
 	public class Color
 	{
 		/// <summary>
@@ -112,17 +113,7 @@ namespace Microsoft.Maui.Graphics
 			return $"[Color: Red={r}, Green={g}, Blue={b}, Alpha={a}]";
 		}
 
-		public override int GetHashCode()
-		{
-			unchecked
-			{
-				int hashcode = Red.GetHashCode();
-				hashcode = (hashcode * 397) ^ Green.GetHashCode();
-				hashcode = (hashcode * 397) ^ Blue.GetHashCode();
-				hashcode = (hashcode * 397) ^ Alpha.GetHashCode();
-				return hashcode;
-			}
-		}
+		public override int GetHashCode() => ToInt();
 
 		public override bool Equals(object obj)
 		{

--- a/src/Graphics/tests/Graphics.Tests/ColorUnitTests.cs
+++ b/src/Graphics/tests/Graphics.Tests/ColorUnitTests.cs
@@ -9,6 +9,14 @@ namespace Microsoft.Maui.Graphics.Tests
 {
 	public class ColorUnitTests
 	{
+		sealed class DerivedColor : Color
+		{
+			public DerivedColor(float red, float green, float blue, float alpha)
+				: base(red, green, blue, alpha)
+			{
+			}
+		}
+
 		[Fact]
 		public void TestHSLPostSetEquality()
 		{
@@ -136,6 +144,19 @@ namespace Microsoft.Maui.Graphics.Tests
 			var color2 = new Color(0.1f);
 
 			Assert.True(color1.GetHashCode() == color2.GetHashCode());
+		}
+
+		[Fact]
+		public void EqualsDerivedColorWithSameArgbValue()
+		{
+			Color baseColor = new Color(1f, 0f, 0f, 1f);
+			Color derivedColor = new DerivedColor(1f, 0f, 0f, 1f);
+
+			Assert.Equal(baseColor.ToInt(), derivedColor.ToInt());
+			Assert.True(baseColor.Equals(derivedColor));
+			Assert.True(derivedColor.Equals(baseColor));
+			Assert.True(EqualityComparer<Color>.Default.Equals(baseColor, derivedColor));
+			Assert.Equal(baseColor.GetHashCode(), derivedColor.GetHashCode());
 		}
 
 		[Fact]


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

Fixes #36034.

This restores the pre-.NET 11 Preview 3 behavior where a `Color` subclass with the same ARGB value compares equal to a base `Color` instance. The regression was introduced by #33824 / commit 797df249880f0b75a403207adc3617cc2d2be5d6 when `Color` was converted to a `record class`, which added record `EqualityContract` checks for derived types.

The fix keeps `Color` as a normal class, preserves the `[ImmutableObject(true)]` metadata intended by #33824, and aligns `GetHashCode()` with the existing byte-precision equality contract.

Added regression coverage for base-vs-derived `Color` equality in both directions, `EqualityComparer<Color>.Default`, and matching hash codes.

cc @AdamEssenmacher, could you review this since you reported the issue?