### PR TITLE
Restore Color class semantics for derived type equality

### DIFF
--- a/src/Graphics/src/Graphics/Color.cs
+++ b/src/Graphics/src/Graphics/Color.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Graphics
 	[DebuggerDisplay("Red={Red}, Green={Green}, Blue={Blue}, Alpha={Alpha}")]
 	[TypeConverter(typeof(Converters.ColorTypeConverter))]
 	[ImmutableObject(true)]
-	public record class Color
+	public class Color
 	{
 		/// <summary>
 		/// The red component of the color, ranging from 0.0 to 1.0.
@@ -116,18 +116,12 @@ namespace Microsoft.Maui.Graphics
 
 		public override int GetHashCode() => ToInt();
 
-		/// <summary>
-		/// Determines whether the specified <see cref="Color"/> is equal to the current color using byte-precision comparison.
-		/// </summary>
-		public virtual bool Equals(Color? other)
+		public override bool Equals(object? obj)
 		{
-			if (other is null)
-				return false;
+			if (obj is Color other)
+				return ToInt() == other.ToInt();
 
-			if (EqualityContract != other.EqualityContract)
-				return false;
-
-			return ToInt() == other.ToInt();
+			return base.Equals(obj);
 		}
 
 		[Obsolete("Use ToArgbHex instead.")]

--- a/src/Graphics/src/Graphics/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,12 +1,5 @@
 #nullable enable
-Microsoft.Maui.Graphics.Color.Color(Microsoft.Maui.Graphics.Color! original) -> void
 override Microsoft.Maui.Graphics.Color.Equals(object? obj) -> bool
-static Microsoft.Maui.Graphics.Color.operator !=(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
-static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
-virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
-virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
-virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
-virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color? other) -> bool
 Microsoft.Maui.Graphics.Color.AddLuminosity(float delta) -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.ToArgbHex(bool includeAlpha = false) -> string!
 Microsoft.Maui.Graphics.Color.ToRgbaHex(bool includeAlpha = false) -> string!

--- a/src/Graphics/src/Graphics/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,12 +1,5 @@
 #nullable enable
-Microsoft.Maui.Graphics.Color.Color(Microsoft.Maui.Graphics.Color! original) -> void
 override Microsoft.Maui.Graphics.Color.Equals(object? obj) -> bool
-static Microsoft.Maui.Graphics.Color.operator !=(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
-static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
-virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
-virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
-virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color? other) -> bool
-virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
 Microsoft.Maui.Graphics.Color.AsPaint() -> Microsoft.Maui.Graphics.Paint!
 Microsoft.Maui.Graphics.Color.MultiplyAlpha(float multiplyBy) -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.WithAlpha(float alpha) -> Microsoft.Maui.Graphics.Color!

--- a/src/Graphics/src/Graphics/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,12 +1,5 @@
 #nullable enable
-Microsoft.Maui.Graphics.Color.Color(Microsoft.Maui.Graphics.Color! original) -> void
 override Microsoft.Maui.Graphics.Color.Equals(object? obj) -> bool
-static Microsoft.Maui.Graphics.Color.operator !=(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
-static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
-virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
-virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
-virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color? other) -> bool
-virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
 Microsoft.Maui.Graphics.Color.AsPaint() -> Microsoft.Maui.Graphics.Paint!
 Microsoft.Maui.Graphics.Color.MultiplyAlpha(float multiplyBy) -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.WithAlpha(float alpha) -> Microsoft.Maui.Graphics.Color!

--- a/src/Graphics/src/Graphics/PublicAPI/net-macos/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-macos/PublicAPI.Unshipped.txt
@@ -1,12 +1,5 @@
 #nullable enable
-Microsoft.Maui.Graphics.Color.Color(Microsoft.Maui.Graphics.Color! original) -> void
 override Microsoft.Maui.Graphics.Color.Equals(object? obj) -> bool
-static Microsoft.Maui.Graphics.Color.operator !=(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
-static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
-virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
-virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
-virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
-virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color? other) -> bool
 Microsoft.Maui.Graphics.Color.AddLuminosity(float delta) -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.GetComplementary() -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.ToArgbHex(bool includeAlpha = false) -> string!

--- a/src/Graphics/src/Graphics/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,12 +1,5 @@
 #nullable enable
-Microsoft.Maui.Graphics.Color.Color(Microsoft.Maui.Graphics.Color! original) -> void
 override Microsoft.Maui.Graphics.Color.Equals(object? obj) -> bool
-static Microsoft.Maui.Graphics.Color.operator !=(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
-static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
-virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
-virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
-virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
-virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color? other) -> bool
 Microsoft.Maui.Graphics.Color.AddLuminosity(float delta) -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.GetComplementary() -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.ToArgbHex(bool includeAlpha = false) -> string!

--- a/src/Graphics/src/Graphics/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,12 +1,5 @@
 #nullable enable
-Microsoft.Maui.Graphics.Color.Color(Microsoft.Maui.Graphics.Color! original) -> void
 override Microsoft.Maui.Graphics.Color.Equals(object? obj) -> bool
-static Microsoft.Maui.Graphics.Color.operator !=(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
-static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
-virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
-virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
-virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
-virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color? other) -> bool
 Microsoft.Maui.Graphics.Color.AddLuminosity(float delta) -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.GetComplementary() -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.ToArgbHex(bool includeAlpha = false) -> string!

--- a/src/Graphics/src/Graphics/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,12 +1,5 @@
 #nullable enable
-Microsoft.Maui.Graphics.Color.Color(Microsoft.Maui.Graphics.Color! original) -> void
 override Microsoft.Maui.Graphics.Color.Equals(object? obj) -> bool
-static Microsoft.Maui.Graphics.Color.operator !=(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
-static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
-virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
-virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
-virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color? other) -> bool
-virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
 Microsoft.Maui.Graphics.Color.AsPaint() -> Microsoft.Maui.Graphics.Paint!
 Microsoft.Maui.Graphics.Color.MultiplyAlpha(float multiplyBy) -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.WithAlpha(float alpha) -> Microsoft.Maui.Graphics.Color!

--- a/src/Graphics/src/Graphics/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,12 +1,5 @@
 #nullable enable
-Microsoft.Maui.Graphics.Color.Color(Microsoft.Maui.Graphics.Color! original) -> void
 override Microsoft.Maui.Graphics.Color.Equals(object? obj) -> bool
-static Microsoft.Maui.Graphics.Color.operator !=(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
-static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
-virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
-virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
-virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color? other) -> bool
-virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
 Microsoft.Maui.Graphics.Color.AsPaint() -> Microsoft.Maui.Graphics.Paint!
 Microsoft.Maui.Graphics.Color.MultiplyAlpha(float multiplyBy) -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.WithAlpha(float alpha) -> Microsoft.Maui.Graphics.Color!

--- a/src/Graphics/tests/Graphics.Tests/ColorUnitTests.cs
+++ b/src/Graphics/tests/Graphics.Tests/ColorUnitTests.cs
@@ -9,6 +9,14 @@ namespace Microsoft.Maui.Graphics.Tests
 {
 	public class ColorUnitTests
 	{
+		sealed class DerivedColor : Color
+		{
+			public DerivedColor(float red, float green, float blue, float alpha)
+				: base(red, green, blue, alpha)
+			{
+			}
+		}
+
 		[Fact]
 		public void TestHSLPostSetEquality()
 		{
@@ -136,6 +144,19 @@ namespace Microsoft.Maui.Graphics.Tests
 			var color2 = new Color(0.1f);
 
 			Assert.True(color1.GetHashCode() == color2.GetHashCode());
+		}
+
+		[Fact]
+		public void EqualsDerivedColorWithSameArgbValue()
+		{
+			Color baseColor = new Color(1f, 0f, 0f, 1f);
+			Color derivedColor = new DerivedColor(1f, 0f, 0f, 1f);
+
+			Assert.Equal(baseColor.ToInt(), derivedColor.ToInt());
+			Assert.True(baseColor.Equals(derivedColor));
+			Assert.True(derivedColor.Equals(baseColor));
+			Assert.True(EqualityComparer<Color>.Default.Equals(baseColor, derivedColor));
+			Assert.Equal(baseColor.GetHashCode(), derivedColor.GetHashCode());
 		}
 
 		[Fact]


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

Fixes #36034.

This intentionally reverts the `Color` type-kind change from #33824 / commit 797df249880f0b75a403207adc3617cc2d2be5d6 while keeping the useful `[ImmutableObject(true)]` metadata from that change.

The regression is caused by converting `Color` from a class to a `record class`: records add `EqualityContract` checks, so derived colors with the same ARGB value no longer compare equal. Keeping `Color` as a record and only changing equality would also leave existing class-based subclasses source-broken, because C# only allows records to inherit from records.

This restores `Color` to a normal class, removes the record-generated unshipped API entries, and adds regression coverage for base-vs-derived `Color` equality in both directions, `EqualityComparer<Color>.Default`, and matching hash codes.

cc @AdamEssenmacher, could you review this since you reported the issue?