### PR TITLE
[iOS/macCatalyst] Fix Entry cursor reset when typing with TextTransform

### DIFF
--- a/src/Core/src/Platform/iOS/TextFieldExtensions.cs
+++ b/src/Core/src/Platform/iOS/TextFieldExtensions.cs
@@ -88,9 +88,12 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateMaxLength(this UITextField textField, IEntry entry)
 		{
-			var newText = textField.AttributedText.TrimToMaxLength(entry.MaxLength);
-			if (newText != null && textField.AttributedText != newText)
+			var attributedText = textField.AttributedText;
+			var newText = attributedText.TrimToMaxLength(entry.MaxLength);
+			if (newText is not null && !ReferenceEquals(attributedText, newText))
+			{
 				textField.AttributedText = newText;
+			}
 		}
 
 		public static void UpdatePlaceholder(this UITextField textField, IEntry entry, Color? defaultPlaceholderColor = null)

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
@@ -672,6 +672,30 @@ namespace Microsoft.Maui.DeviceTests
 			await ScrollHelper(async () => await ScrollToNext(entry, editor), entry, editor);
 		}
 
+		[Fact]
+		public async Task CursorPositionPreservedDuringInsertTextWithTextTransformUppercase()
+		{
+			var entry = new EntryStub();
+
+			await AttachAndRun(entry, (handler) =>
+			{
+				var textField = GetNativeEntry(handler);
+
+				textField.BecomeFirstResponder();
+
+				foreach (var c in "hello")
+				{
+					textField.InsertText(c.ToString());
+				}
+
+				UpdateCursorStartPosition(handler, 2);
+				Assert.Equal(2, GetCursorStartPosition(handler));
+
+				textField.InsertText("x");
+				Assert.Equal(3, GetCursorStartPosition(handler));
+			});
+		}
+
 		async Task ScrollHelper(Func<Task> func, params StubBase[] views)
 		{
 			EnsureHandlerCreated(builder =>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
- When the cursor is at a mid-text position in an Entry with TextTransform set, typing a character resets the cursor to the end of the text instead of advancing it by one position.

### Root Cause
- On iOS/macCatalyst, each access to UITextField.AttributedText returns a new C# wrapper object around the same native ObjC instance, so the != guard in UpdateMaxLength was always true, causing an unconditional AttributedText assignment on every keystroke — which UIKit uses as a signal to reset the cursor to the end of the text.

### Description of Change
- Cache textField.AttributedText in a local variable and use ReferenceEquals as the guard, so the assignment is skipped when TrimToMaxLength returns the same instance (i.e., no trimming was needed), preserving the cursor position.

### Issues Fixed
Fixes #36018

### Validated the behaviour in the following platforms

- [ ] Windows
- [ ] Android
- [x] iOS
- [x] Mac


### Output
| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/fdeccb91-df21-4fd9-a0c3-2d331f00e056"> | <video src="https://github.com/user-attachments/assets/f927a51d-bfc3-4f48-bfab-45ab9aae93d8">