### PR TITLE
Fix Path.Data and Path.RenderTransform visual tree leaks with shared resources

### DIFF
--- a/src/Controls/src/Core/Internals/WeakEventProxy.cs
+++ b/src/Controls/src/Core/Internals/WeakEventProxy.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using Microsoft.Maui.Controls.Shapes;
 
 // NOTE: warning disabled for netstandard projects
 #pragma warning disable 0436
@@ -147,6 +148,64 @@ namespace Microsoft.Maui.Controls
 			if (TryGetSource(out var s))
 			{
 				s.PropertyChanged -= OnPropertyChanged;
+			}
+
+			base.Unsubscribe();
+		}
+	}
+
+	/// <summary>
+	/// A "proxy" class for subscribing Geometry and PathGeometry invalidation via WeakReference.
+	/// General usage is to store this in a member variable and call Subscribe()/Unsubscribe() appropriately.
+	/// Your class should have a finalizer that calls Unsubscribe() to prevent WeakGeometryChangedProxy objects from leaking.
+	/// </summary>
+	class WeakGeometryChangedProxy : WeakEventProxy<Geometry, EventHandler>
+	{
+		public WeakGeometryChangedProxy() { }
+
+		public WeakGeometryChangedProxy(Geometry source, EventHandler handler)
+		{
+			Subscribe(source, handler);
+		}
+
+		void OnGeometryChanged(object? sender, EventArgs e)
+		{
+			if (TryGetHandler(out var handler))
+			{
+				handler(sender, e);
+			}
+			else
+			{
+				Unsubscribe();
+			}
+		}
+
+		public override void Subscribe(Geometry source, EventHandler handler)
+		{
+			if (TryGetSource(out var s))
+			{
+				s.PropertyChanged -= OnGeometryChanged;
+
+				if (s is PathGeometry oldPathGeometry)
+					oldPathGeometry.InvalidatePathGeometryRequested -= OnGeometryChanged;
+			}
+
+			source.PropertyChanged += OnGeometryChanged;
+
+			if (source is PathGeometry pathGeometry)
+				pathGeometry.InvalidatePathGeometryRequested += OnGeometryChanged;
+
+			base.Subscribe(source, handler);
+		}
+
+		public override void Unsubscribe()
+		{
+			if (TryGetSource(out var s))
+			{
+				s.PropertyChanged -= OnGeometryChanged;
+
+				if (s is PathGeometry pathGeometry)
+					pathGeometry.InvalidatePathGeometryRequested -= OnGeometryChanged;
 			}
 
 			base.Unsubscribe();

--- a/src/Controls/src/Core/Shapes/Path.cs
+++ b/src/Controls/src/Core/Shapes/Path.cs
@@ -11,11 +11,22 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// </summary>
 	public sealed partial class Path : Shape, IShape
 	{
+		WeakGeometryChangedProxy _dataProxy;
+		EventHandler _dataChanged;
+		WeakNotifyPropertyChangedProxy _transformProxy;
+		PropertyChangedEventHandler _transformChanged;
+
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Path"/> class.
 		/// </summary>
 		public Path() : base()
 		{
+		}
+
+		~Path()
+		{
+			_dataProxy?.Unsubscribe();
+			_transformProxy?.Unsubscribe();
 		}
 
 		public Path(Geometry data) : this()
@@ -26,12 +37,30 @@ namespace Microsoft.Maui.Controls.Shapes
 		/// <summary>Bindable property for <see cref="Data"/>.</summary>
 		public static readonly BindableProperty DataProperty =
 			 BindableProperty.Create(nameof(Data), typeof(Geometry), typeof(Path), null,
-				 propertyChanged: OnGeometryPropertyChanged);
+				 propertyChanging: (bindable, oldValue, newValue) =>
+				 {
+					 if (oldValue != null)
+						 (bindable as Path)?.StopNotifyingDataChanges();
+				 },
+				 propertyChanged: (bindable, oldValue, newValue) =>
+				 {
+					 if (newValue != null)
+						 (bindable as Path)?.NotifyDataChanges();
+				 });
 
 		/// <summary>Bindable property for <see cref="RenderTransform"/>.</summary>
 		public static readonly BindableProperty RenderTransformProperty =
 			BindableProperty.Create(nameof(RenderTransform), typeof(Transform), typeof(Path), null,
-				propertyChanged: OnTransformPropertyChanged);
+				propertyChanging: (bindable, oldValue, newValue) =>
+				{
+					if (oldValue != null)
+						(bindable as Path)?.StopNotifyingTransformChanges();
+				},
+				propertyChanged: (bindable, oldValue, newValue) =>
+				{
+					if (newValue != null)
+						(bindable as Path)?.NotifyTransformChanges();
+				});
 
 		/// <summary>
 		/// Gets or sets the <see cref="Geometry"/> that specifies the shape to be drawn. This is a bindable property.
@@ -52,46 +81,38 @@ namespace Microsoft.Maui.Controls.Shapes
 			get { return (Transform)GetValue(RenderTransformProperty); }
 		}
 
-		static void OnGeometryPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		void NotifyDataChanges()
 		{
-			if (oldValue != null)
+			var data = Data;
+
+			if (data != null)
 			{
-				(oldValue as Geometry).PropertyChanged -= (bindable as Path).OnGeometryPropertyChanged;
-
-				if (oldValue is PathGeometry pathGeometry)
-					pathGeometry.InvalidatePathGeometryRequested -= (bindable as Path).OnInvalidatePathGeometryRequested;
-			}
-
-			if (newValue != null)
-			{
-				(newValue as Geometry).PropertyChanged += (bindable as Path).OnGeometryPropertyChanged;
-
-				if (newValue is PathGeometry pathGeometry)
-					pathGeometry.InvalidatePathGeometryRequested += (bindable as Path).OnInvalidatePathGeometryRequested;
+				_dataChanged ??= (sender, e) => OnPropertyChanged(nameof(Data));
+				_dataProxy ??= new WeakGeometryChangedProxy();
+				_dataProxy.Subscribe(data, _dataChanged);
 			}
 		}
 
-		static void OnTransformPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		void StopNotifyingDataChanges()
 		{
-			if (oldValue != null)
-			{
-				(oldValue as Transform).PropertyChanged -= (bindable as Path).OnTransformPropertyChanged;
-			}
+			_dataProxy?.Unsubscribe();
+		}
 
-			if (newValue != null)
+		void NotifyTransformChanges()
+		{
+			var renderTransform = RenderTransform;
+
+			if (renderTransform != null)
 			{
-				(newValue as Transform).PropertyChanged += (bindable as Path).OnTransformPropertyChanged;
+				_transformChanged ??= OnTransformPropertyChanged;
+				_transformProxy ??= new WeakNotifyPropertyChangedProxy();
+				_transformProxy.Subscribe(renderTransform, _transformChanged);
 			}
 		}
 
-		void OnGeometryPropertyChanged(object sender, PropertyChangedEventArgs args)
+		void StopNotifyingTransformChanges()
 		{
-			OnPropertyChanged(nameof(Data));
-		}
-
-		void OnInvalidatePathGeometryRequested(object sender, EventArgs e)
-		{
-			OnPropertyChanged(nameof(Data));
+			_transformProxy?.Unsubscribe();
 		}
 
 		void OnTransformPropertyChanged(object sender, PropertyChangedEventArgs args)

--- a/src/Controls/tests/Core.UnitTests/Shapes/PathSharedResourcesMemoryLeakTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Shapes/PathSharedResourcesMemoryLeakTests.cs
@@ -1,0 +1,115 @@
+using System;
+using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Graphics;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests.Shapes;
+
+public class PathSharedResourcesMemoryLeakTests : BaseTestFixture
+{
+	// NOTE: Path creation MUST be in a separate method.
+	// If created inline in the test method, the JIT keeps local variables alive for the
+	// entire method scope in debug mode — making the path uncollectable regardless of the fix.
+	// This is the standard .NET pattern for writing reliable GC/leak unit tests.
+
+	static WeakReference CreatePathWithGeometry(PathGeometry geometry)
+	{
+		var path = new Path { Data = geometry };
+		return new WeakReference(path);
+	}
+
+	static WeakReference CreatePathWithTransform(ScaleTransform transform)
+	{
+		var path = new Path { RenderTransform = transform };
+		return new WeakReference(path);
+	}
+
+	static WeakReference CreatePathWithBoth(PathGeometry geometry, ScaleTransform transform)
+	{
+		var path = new Path { Data = geometry, RenderTransform = transform };
+		return new WeakReference(path);
+	}
+
+	[Fact]
+	public void SharedPathGeometry_DoesNotKeepPathAlive()
+	{
+		var sharedGeometry = new PathGeometry
+		{
+			Figures = new PathFigureCollection
+			{
+				new PathFigure
+				{
+					StartPoint = new Point(0, 0),
+					Segments = new PathSegmentCollection
+					{
+						new LineSegment { Point = new Point(100, 100) }
+					}
+				}
+			}
+		};
+
+		var pathRef = CreatePathWithGeometry(sharedGeometry);
+
+		GC.Collect();
+		GC.WaitForPendingFinalizers();
+		GC.Collect();
+
+		Assert.False(pathRef.IsAlive,
+			"Path was not collected. The shared PathGeometry is holding a strong reference to " +
+			"Path via its PropertyChanged event handler. Use WeakGeometryChangedProxy to fix.");
+
+		// Ensures sharedGeometry is a live GC root during the Collect calls above.
+		GC.KeepAlive(sharedGeometry);
+	}
+
+	[Fact]
+	public void SharedRenderTransform_DoesNotKeepPathAlive()
+	{
+		var sharedTransform = new ScaleTransform(1.5, 1.5) { CenterX = 50, CenterY = 50 };
+
+		var pathRef = CreatePathWithTransform(sharedTransform);
+
+		GC.Collect();
+		GC.WaitForPendingFinalizers();
+		GC.Collect();
+
+		Assert.False(pathRef.IsAlive,
+			"Path was not collected. The shared ScaleTransform is holding a strong reference to " +
+			"Path via its PropertyChanged event handler. Use WeakNotifyPropertyChangedProxy to fix.");
+
+		GC.KeepAlive(sharedTransform);
+	}
+
+	[Fact]
+	public void SharedGeometryAndTransform_DoNotKeepPathAlive()
+	{
+		var sharedGeometry = new PathGeometry
+		{
+			Figures = new PathFigureCollection
+			{
+				new PathFigure
+				{
+					StartPoint = new Point(0, 0),
+					Segments = new PathSegmentCollection
+					{
+						new LineSegment { Point = new Point(50, 50) }
+					}
+				}
+			}
+		};
+		var sharedTransform = new ScaleTransform(2.0, 2.0) { CenterX = 25, CenterY = 25 };
+
+		var pathRef = CreatePathWithBoth(sharedGeometry, sharedTransform);
+
+		GC.Collect();
+		GC.WaitForPendingFinalizers();
+		GC.Collect();
+
+		Assert.False(pathRef.IsAlive,
+			"Path was not collected. Shared PathGeometry and/or ScaleTransform are holding " +
+			"strong references to Path via event subscriptions. Use weak proxies to fix.");
+
+		GC.KeepAlive(sharedGeometry);
+		GC.KeepAlive(sharedTransform);
+	}
+}


### PR DESCRIPTION
<!-- Please keep the note below for people who find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment whether this change resolves your issue. Thank you!<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Issue Details
Path.Data and Path.RenderTransform can cause memory leaks when they use shared long-lived resources (PathGeometry / ScaleTransform).
The shared resource stays alive for app lifetime, and its event subscriptions can keep old Path controls alive after a page is popped.
Because those Path controls stay alive, related page objects and binding context data may also be retained.This is reproducible across platforms.

### Description of Change

<!-- Enter description of the fix in this section -->
Added weak-event subscription handling so Path no longer holds strong references through shared geometry/transform change events.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #35860 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

**Tested the behavior in the following platforms.**
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

| Before  | After  |
|---------|--------|
| **iOS**<br> <video src="https://github.com/user-attachments/assets/5bbfab0e-1978-46f9-91e2-a93b5b037ced" width="300" height="600"> | **iOS**<br> <video src="https://github.com/user-attachments/assets/98c362a0-a10e-411b-91b6-d612105958a2" width="300" height="600"> |

