### PR TITLE
[Inflight/Candidate][iOS] Fix for ShouldIgnoreBottomContentInsetForCollectionViewItems - Editor cells becoming invisible in CollectionView (CV1)

### DIFF
--- a/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
@@ -12,6 +12,18 @@ namespace Microsoft.Maui.Handlers
 	{
 		readonly MauiTextViewEventProxy _proxy = new();
 
+		// Height from MAUI's last PlatformArrange call. Native layout containers can assign
+		// a transient placeholder height directly to a view's Bounds via UIKit, bypassing
+		// MAUI's arrange pipeline. This field is zero until MAUI explicitly arranges the view,
+		// making it a reliable guard for the scrollability cap in GetDesiredSize.
+		double _lastArrangedHeight;
+
+		public override void PlatformArrange(Rect rect)
+		{
+			_lastArrangedHeight = rect.Height;
+			base.PlatformArrange(rect);
+		}
+
 		protected override MauiTextView CreatePlatformView()
 		{
 			var platformEditor = new MauiTextView();
@@ -80,16 +92,18 @@ namespace Microsoft.Maui.Handlers
 
 				if (double.IsInfinity(heightConstraint))
 				{
-					var currentHeight = (double)PlatformView.Bounds.Height;
+					// Prefer _lastArrangedHeight over PlatformView.Bounds.Height. Native containers
+					// can set Bounds directly via UIKit outside MAUI's pipeline, making Bounds.Height
+					// unreliable. _lastArrangedHeight is zero until MAUI explicitly arranges the view,
+					// so the cap is skipped for transient placeholder frames and applied only once
+					// MAUI has given the view a real frame.
+					var currentHeight = _lastArrangedHeight;
 
-					// When content overflows the current frame and auto-growth is disabled,
-					// use Bounds.Height as the constraint to preserve scrollability after rotation.
-					// Editors with AutoSize=TextChanges (AllowAutoGrowth=true) are exempt.
 					if (!PlatformView.AllowAutoGrowth
 						&& currentHeight > 0
 						&& PlatformView.ContentSize.Height > currentHeight)
 					{
-						heightConstraint = currentHeight; // real bound — cap will apply
+						heightConstraint = currentHeight; // real MAUI-arranged bound — cap will apply
 					}
 					else
 					{

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -15,3 +15,4 @@ static Microsoft.Maui.Handlers.RadioButtonHandler.MapBackground(Microsoft.Maui.H
 static Microsoft.Maui.Handlers.EditorHandler.MapBackground(Microsoft.Maui.Handlers.IEditorHandler! handler, Microsoft.Maui.IEditor! editor) -> void
 static Microsoft.Maui.Handlers.EntryHandler.MapBackground(Microsoft.Maui.Handlers.IEntryHandler! handler, Microsoft.Maui.IEntry! entry) -> void
 static Microsoft.Maui.Handlers.DatePickerHandler.MapFlowDirection(Microsoft.Maui.Handlers.IDatePickerHandler! handler, Microsoft.Maui.IDatePicker! datePicker) -> void
+override Microsoft.Maui.Handlers.EditorHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect rect) -> void

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -15,3 +15,4 @@ static Microsoft.Maui.Handlers.EntryHandler.MapBackground(Microsoft.Maui.Handler
 static Microsoft.Maui.Handlers.DatePickerHandler.MapFlowDirection(Microsoft.Maui.Handlers.IDatePickerHandler! handler, Microsoft.Maui.IDatePicker! datePicker) -> void
 override Microsoft.Maui.Platform.MauiTextField.LayoutSubviews() -> void
 override Microsoft.Maui.Platform.NoCaretField.LayoutSubviews() -> void
+override Microsoft.Maui.Handlers.EditorHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect rect) -> void


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue details

When using an Editor inside a CollectionView with the legacy handler (CV1) on iOS, the Editor cells collapse and become invisible after the user taps on them to begin typing.


### Root Cause of the Regression

The issue occurs because of the scrollability cap introduced in EditorHandler.GetDesiredSize by PR [#35309](https://github.com/dotnet/maui/pull/35309). This cap was added to prevent Editors from growing unboundedly when AllowAutoGrowth = false. However, the native layout container assigns a transient placeholder height of 1pt directly to MauiTextView.Bounds via UIKit, completely bypassing MAUI's PlatformArrange pipeline. When the keyboard appears and the layout invalidates, GetDesiredSize is called and the cap reads Bounds.Height = 1 > 0 and ContentSize.Height = 36 > 1, both true, so it fires incorrectly, capping every Editor cell to 1pt and making them invisible.

### Description of Change

The fix involves overriding PlatformArrange in EditorHandler to track the last MAUI-arranged height in a _lastArrangedHeight field, and using that value instead of PlatformView.Bounds.Height inside the scrollability cap condition. Since the native layout container assigns the placeholder height directly via UIKit without going through PlatformArrange, _lastArrangedHeight remains 0 until MAUI explicitly arranges the view. 

The cap condition currentHeight > 0 therefore evaluates to false for placeholder frames, skipping the cap automatically. Once MAUI arranges the view with a real height, _lastArrangedHeight is updated and the cap applies correctly for all subsequent measure passes, Editors outside a CollectionView are completely unaffected.

**Regression PR:** https://github.com/dotnet/maui/pull/35309
 
### Issues Fixed

**iOS UI Test:** CV1: ShouldIgnoreBottomContentInsetForCollectionViewItems