### PR TITLE
Update net11.0 merge-flow target to release/11.0.1xx-preview6

### DIFF
--- a/github-merge-flow-release-11.jsonc
+++ b/github-merge-flow-release-11.jsonc
@@ -2,7 +2,7 @@
 {
     "merge-flow-configurations": {
         "net11.0": {
-            "MergeToBranch": "release/11.0.1xx-preview4",
+            "MergeToBranch": "release/11.0.1xx-preview6",
             "ExtraSwitches": "-QuietComments",
             "ResetToTargetPaths": "global.json;NuGet.config;eng/Version.Details.xml;eng/Versions.props;eng/common/*"
         }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description

The inter-branch merge-flow configuration (`github-merge-flow-release-11.jsonc`), read by `merge-net11-to-release.yml`, still pointed at `release/11.0.1xx-preview4`. It was never bumped to preview5.

This updates `MergeToBranch` to **`release/11.0.1xx-preview6`** (the current latest release branch) so that `net11.0` merges down into the correct preview branch.

```diff
-            "MergeToBranch": "release/11.0.1xx-preview4",
+            "MergeToBranch": "release/11.0.1xx-preview6",
```

Verified `release/11.0.1xx-preview6` exists on origin.