### PR TITLE
release-readiness: refresh the most-recently-shipped SR tracker until manually closed

### DIFF
--- a/.github/skills/release-readiness/SKILL.md
+++ b/.github/skills/release-readiness/SKILL.md
@@ -34,7 +34,7 @@ This skill has **three** PowerShell entry points and one workflow:
 | Script | Branch type | Purpose |
 |--------|-------------|---------|
 | [`Find-ReleaseReadinessTrackers.ps1`](scripts/Find-ReleaseReadinessTrackers.ps1) | both | Detects active in-flight & candidate trackers (SR and Preview) across all active majors using a four-lane algorithm and the **tag-existence rule** ("a release is in flight unless its tag already exists"). Emits a single tracker JSON consumed by the workflow. |
-| [`Get-ReleaseReadiness.ps1`](scripts/Get-ReleaseReadiness.ps1) | SR | Full readiness report for a single SR branch (in-flight or `-Candidate`). |
+| [`Get-ReleaseReadiness.ps1`](scripts/Get-ReleaseReadiness.ps1) | SR | Full readiness report for a single SR branch (in-flight, `-Candidate`, or `-Shipped`). `-Shipped` is a display-only relabel — it surveys the SR branch exactly like in-flight but renders the header as `mode=shipped` for the post-ship tracker. |
 | [`Get-PreviewReadiness.ps1`](scripts/Get-PreviewReadiness.ps1) | Preview | Full readiness report for a single Preview branch (in-flight or candidate via `-Mode candidate -SurveyRef net<major>.0`). |
 | [`release-readiness.yml`](../../workflows/release-readiness.yml) | both | Daily cron + manual dispatch + PR validation. Runs `Find-Trackers -AllActiveMajors`, fans out a matrix job per tracker, and writes idempotent `[Release Readiness]` issues per branch. |
 
@@ -42,8 +42,10 @@ This skill has **three** PowerShell entry points and one workflow:
 
 The trackers detector is grounded in **tag existence as the source of truth for "shipped vs in-flight"**. A release is in-flight if and only if its expected tag has NOT been published — branch existence, commit recency, and milestone state are all secondary signals.
 
-- SR shipped tag pattern: `<major>.0.<patch>` (e.g. `10.0.71` shipped → SR7 no longer produces a tracker)
+- SR shipped tag pattern: `<major>.0.<patch>` (e.g. `10.0.71` shipped → SR7 retired, no longer produces a tracker)
 - Preview shipped tag pattern: `<major>.0.0-preview.<N>.<date>[.<build>]` (e.g. `11.0.0-preview.5.26304.4` shipped → preview5 no longer produces a tracker)
+
+**Post-ship lifecycle (`shipped` mode).** Most shipped SRs are retired the moment their tag exists. The **one exception** is the *most-recently-shipped* SR (highest shipped patch), which keeps emitting as `mode='shipped'` so its tracker issue stays useful through post-ship follow-up — adding the new build to the GitHub issue version dropdown, publishing release notes, closing out the milestone. The workflow treats `shipped` as **refresh-only**: it updates the tracker issue while it stays open, but **never (re)creates it**. Once a human closes the tracker, it stays closed and is not resurrected on the next scheduled run. This implements "keep updating until closed manually" without spamming a fresh issue after sign-off. Older shipped SRs are still retired.
 
 ## Quick Start
 
@@ -59,7 +61,7 @@ pwsh .github/skills/release-readiness/scripts/Find-ReleaseReadinessTrackers.ps1 
 #   branchType:    'sr' | 'preview'
 #   branchName:    canonical proposed branch slug (always populated)
 #   branchExists:  true if the branch is on origin, false for candidates
-#   mode:          'in-flight' | 'candidate'
+#   mode:          'in-flight' | 'candidate' | 'shipped'  (shipped = most-recently-shipped SR, refresh-only)
 #   surveyRef:     ref to actually survey (branch itself, or net<major>.0 for candidates)
 #   canonicalKey:  stable join key (e.g. net10-sr8, net11-preview6)
 #   issueTitle:    title for the daily tracker issue

--- a/.github/skills/release-readiness/scripts/Find-ReleaseReadinessTrackers.ps1
+++ b/.github/skills/release-readiness/scripts/Find-ReleaseReadinessTrackers.ps1
@@ -18,7 +18,14 @@
         does NOT exist on origin, the branch is in-flight — the release
         notes for that exact patch haven't been published yet, so it hasn't
         shipped. If the tag exists, the branch has already shipped that
-        patch and is skipped.
+        patch. Shipped SRs are normally retired, EXCEPT the most-recently-
+        shipped one (highest shipped patch), which is emitted as
+        mode='shipped' so its tracker keeps refreshing through post-ship
+        follow-up (adding the new build to the GitHub issue version dropdown,
+        release notes, milestone close-out). The workflow treats 'shipped'
+        as REFRESH-ONLY: it updates the tracker issue while it stays open but
+        never re-creates it, so once a human closes it, it stays closed.
+        Older shipped SRs are skipped.
 
       Lane 2 — next SR off main
         Identifies the highest SR (across in-flight branches AND shipped tags)
@@ -538,7 +545,7 @@ function New-Tracker {
     param(
         [int]$Major,
         [int]$SrNumber,
-        [string]$Mode,                 # 'in-flight' or 'candidate'
+        [string]$Mode,                 # 'in-flight', 'candidate', or 'shipped'
         [string]$BranchName,            # nullable for candidate without branch
         [string]$SurveyRef,             # branch or development ref to survey
         [string]$PriorSrBranch,         # nullable; used as -SrBranch for -Candidate mode
@@ -560,6 +567,9 @@ function New-Tracker {
     $title = "[Release Readiness] .NET $Major SR$SrNumber — $branchDisplay"
     if ($Mode -eq 'candidate') {
         $title = "[Release Readiness] .NET $Major SR$SrNumber — candidate from $SurveyRef"
+    }
+    elseif ($Mode -eq 'shipped') {
+        $title = "[Release Readiness] .NET $Major SR$SrNumber — shipped ($branchDisplay)"
     }
     return [pscustomobject]@{
         branchType           = 'sr'
@@ -728,7 +738,28 @@ function Invoke-DetectionForMajor {
             $inflightBranchesBySr[$sr] = $branch
             Write-Host "  -> in-flight SR tracker: SR$sr (patch=$branchPatch, no tag $expectedTag yet, recent=$recent)" -ForegroundColor Green
         } else {
-            Write-Host "  -> SR$sr branch '$branch' patch=$branchPatch already shipped (tag $expectedTag exists)" -ForegroundColor DarkGray
+            # Already shipped (the stable tag exists). We normally retire the
+            # tracker here, BUT the most-recently-shipped SR still has post-ship
+            # follow-up the tracker should keep surfacing until a human signs off
+            # (e.g. adding the new build to the GitHub issue version dropdown,
+            # release notes, closing out the milestone). So keep emitting the
+            # HIGHEST shipped SR as mode='shipped'. The workflow consumes this as
+            # REFRESH-ONLY: it refreshes the tracker issue while it stays open and
+            # never re-creates it once a human closes it — implementing
+            # "update until closed manually" without resurrecting a closed tracker.
+            # Lower (older) shipped SRs stay retired.
+            if ($branchPatch -eq $highestShippedPatch) {
+                $recent = Get-RecentCommitCount -Ref $branch -Days $ActivityWindowDays
+                $tracker = New-Tracker -Major $Major -SrNumber $sr -Mode 'shipped' `
+                    -BranchName $branch -SurveyRef $branch -PriorSrBranch $null `
+                    -PriorShippedPatch $highestShippedPatch -PriorShippedTag $highestShippedTag `
+                    -ExpectedPatch $branchPatch -ExpectedTag $expectedTag `
+                    -HasRecentActivityCount $recent
+                $trackers.Add($tracker)
+                Write-Host "  -> shipped SR tracker (refresh-until-closed): SR$sr (patch=$branchPatch, tag $expectedTag exists, recent=$recent)" -ForegroundColor Yellow
+            } else {
+                Write-Host "  -> SR$sr branch '$branch' patch=$branchPatch already shipped (tag $expectedTag exists)" -ForegroundColor DarkGray
+            }
         }
     }
 

--- a/.github/skills/release-readiness/scripts/Get-ReleaseReadiness.ps1
+++ b/.github/skills/release-readiness/scripts/Get-ReleaseReadiness.ps1
@@ -133,6 +133,14 @@ param(
     # from main today. Requires -SrBranch to be the prior SR (used as the
     # exclude baseline). Treats origin/main as the "SR-to-be".
     [switch]$Candidate,
+    # Display-only: mark the survey as a SHIPPED SR (its stable tag already
+    # exists). Behaves exactly like in-flight for all survey/verdict logic
+    # (surveys the SR branch directly) — it ONLY relabels the rendered report
+    # header `mode=shipped` so a post-ship tracker doesn't misreport as
+    # in-flight. Set by the workflow for the most-recently-shipped SR, whose
+    # tracker keeps refreshing until a human closes it. Mutually exclusive with
+    # -Candidate.
+    [switch]$Shipped,
     # When set in -Candidate mode, model the dotnet/maui workflow where, after
     # cutting SRn+1 from main, the prior SR (-SrBranch) is merged in. The
     # candidate's "what's shipping" set = main-since-priorSR ∪ priorSR-only commits.
@@ -1280,10 +1288,14 @@ function Get-CandidatePrChecks {
 function Resolve-Context {
     param([string]$SrBranch, [string]$Repo, [string]$MainBranch,
           [string[]]$ExcludeBranches, [switch]$NoFetch, [switch]$Candidate,
-          [switch]$InheritFromPriorSr)
+          [switch]$InheritFromPriorSr, [switch]$Shipped)
 
     if ($InheritFromPriorSr -and -not $Candidate) {
         throw "-InheritFromPriorSr is only valid with -Candidate (it models the SR cut-then-merge workflow)."
+    }
+
+    if ($Shipped -and $Candidate) {
+        throw "-Shipped and -Candidate are mutually exclusive: -Shipped surveys an existing (already-tagged) SR branch; -Candidate pre-flights main as the next SR."
     }
 
     # HARD VALIDATION — refuse inflight/staging refs as SR sources.
@@ -1332,6 +1344,13 @@ function Resolve-Context {
         # Exclude prior SR from main, so we see only "new since last SR" commits
         $effectiveExcludes = @($priorSrRef)
         Write-Host "Candidate mode: surveying $effectiveSrRef vs prior SR $priorSrRef" -ForegroundColor Cyan
+    }
+    elseif ($Shipped) {
+        # Display-only relabel. The survey is identical to in-flight (the SR
+        # branch surveyed directly); only the rendered header reads 'shipped'
+        # so the post-ship tracker doesn't misreport as in-flight.
+        $mode = 'shipped'
+        Write-Host "Shipped mode: surveying already-tagged SR branch $effectiveSrRef (display-only relabel)" -ForegroundColor Cyan
     }
 
     if ($Candidate -and $InheritFromPriorSr) {
@@ -3860,7 +3879,7 @@ function Invoke-Main {
     $excludes = $ExcludeBranches -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ }
     $ctx = Resolve-Context -SrBranch $SrBranch -Repo $Repo -MainBranch $MainBranch `
                            -ExcludeBranches $excludes -NoFetch:$NoFetch -Candidate:$Candidate `
-                           -InheritFromPriorSr:$InheritFromPriorSr
+                           -InheritFromPriorSr:$InheritFromPriorSr -Shipped:$Shipped
 
     # Resolve regression labels
     $labelMode = 'explicit'

--- a/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
+++ b/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
@@ -429,6 +429,42 @@ if (-not (Test-Path $detectScriptPath)) {
     Assert-Eq -Label "no shipped tags (highest 0): patch 11 idle -> NOT stale" `
               -Expected $false -Actual (Test-IsStaleSrBranch -BranchPatch 11 -HighestShippedPatch 0 -RecentActivityCount 0)
 
+    # ─────────── New-Tracker title + mode contract ───────────
+    # The issue title encodes the tracker's lifecycle mode. Marker matching is by
+    # canonicalKey (not title), so title text is safe to vary, but downstream the
+    # 'shipped' title signals the refresh-until-closed lifecycle. Pin all three.
+    Write-Host "`n[Unit] New-Tracker title + mode" -ForegroundColor Cyan
+    $tkInflight = New-Tracker -Major 10 -SrNumber 8 -Mode 'in-flight' `
+        -BranchName 'release/10.0.1xx-sr8' -SurveyRef 'release/10.0.1xx-sr8' -PriorSrBranch $null `
+        -PriorShippedPatch 71 -PriorShippedTag '10.0.71' -ExpectedPatch 80 -ExpectedTag '10.0.80' `
+        -HasRecentActivityCount 3
+    Assert-Eq -Label "in-flight mode preserved" -Expected 'in-flight' -Actual $tkInflight.mode
+    Assert-Eq -Label "in-flight title = branch form" `
+              -Expected '[Release Readiness] .NET 10 SR8 — release/10.0.1xx-sr8' -Actual $tkInflight.issueTitle
+
+    $tkCandidate = New-Tracker -Major 10 -SrNumber 9 -Mode 'candidate' `
+        -BranchName $null -SurveyRef 'main' -PriorSrBranch 'release/10.0.1xx-sr8' `
+        -PriorShippedPatch 80 -PriorShippedTag '10.0.80' -ExpectedPatch 90 -ExpectedTag '10.0.90' `
+        -HasRecentActivityCount 12
+    Assert-Eq -Label "candidate mode preserved" -Expected 'candidate' -Actual $tkCandidate.mode
+    Assert-Eq -Label "candidate title = candidate-from form" `
+              -Expected '[Release Readiness] .NET 10 SR9 — candidate from main' -Actual $tkCandidate.issueTitle
+    Assert-Eq -Label "candidate canonicalKey is title-independent" -Expected 'net10-sr9' -Actual $tkCandidate.canonicalKey
+
+    $tkShipped = New-Tracker -Major 10 -SrNumber 8 -Mode 'shipped' `
+        -BranchName 'release/10.0.1xx-sr8' -SurveyRef 'release/10.0.1xx-sr8' -PriorSrBranch $null `
+        -PriorShippedPatch 80 -PriorShippedTag '10.0.80' -ExpectedPatch 80 -ExpectedTag '10.0.80' `
+        -HasRecentActivityCount 1
+    Assert-Eq -Label "shipped mode preserved" -Expected 'shipped' -Actual $tkShipped.mode
+    Assert-Eq -Label "shipped title = shipped form (signals refresh-until-closed)" `
+              -Expected '[Release Readiness] .NET 10 SR8 — shipped (release/10.0.1xx-sr8)' -Actual $tkShipped.issueTitle
+    Assert-Eq -Label "shipped surveys its own branch (not a candidate ref)" `
+              -Expected 'release/10.0.1xx-sr8' -Actual $tkShipped.surveyRef
+    Assert-Eq -Label "shipped canonicalKey matches in-flight (stable join key across lifecycle)" `
+              -Expected 'net10-sr8' -Actual $tkShipped.canonicalKey
+    Assert-Eq -Label "shipped branchExists = true (the SR branch is real)" `
+              -Expected $true -Actual $tkShipped.branchExists
+
     # ─────────── Preview-tag regex contract ───────────
     Write-Host "`n[Unit] Preview tag regex (<major>.0.0-preview.<N>.<date>[.<build>])" -ForegroundColor Cyan
     $previewTagCases = @(
@@ -624,12 +660,13 @@ if (-not (Test-Path $detectScriptPath)) {
 if (-not $SkipE2E) {
     Write-Host "`n[E2E] Detection against live repo" -ForegroundColor Cyan
     Write-Host "  Under the tag-existence rule + Lane 1 staleness guard we expect TWO trackers:" -ForegroundColor DarkGray
-    Write-Host "    - SR8 (patch=80, no tag 10.0.80)        - in-flight, active" -ForegroundColor DarkGray
+    Write-Host "    - SR8 (patch=80, tag 10.0.80 exists)    - shipped, refresh-until-closed (highest shipped SR)" -ForegroundColor DarkGray
     Write-Host "    - SR9 (candidate off main)              - active" -ForegroundColor DarkGray
-    Write-Host "    DROPPED by the staleness guard (idle + below the shipped watermark 71):" -ForegroundColor DarkGray
+    Write-Host "    DROPPED by the staleness guard (idle + below the shipped watermark 80):" -ForegroundColor DarkGray
     Write-Host "    - SR2 (patch=21, no tag 10.0.21)        - tag-absent but stale -> no matrix job" -ForegroundColor DarkGray
     Write-Host "    - SR3 (patch=33, no tag 10.0.33)        - tag-absent but stale -> no matrix job" -ForegroundColor DarkGray
-    Write-Host "    NOTE: SR7 shipped 2026-06-05 (tag 10.0.71); no longer produces a tracker." -ForegroundColor DarkGray
+    Write-Host "    NOTE: SR7 shipped 2026-06-05 (tag 10.0.71); NOT the highest shipped SR -> retired (no tracker)." -ForegroundColor DarkGray
+    Write-Host "    NOTE: SR8 shipped 2026-06-22 (tag 10.0.80); as the HIGHEST shipped SR it emits a 'shipped' tracker that refreshes until a human closes it." -ForegroundColor DarkGray
 
     $detectOut = Join-Path ([System.IO.Path]::GetTempPath()) "rr-detect-$(Get-Date -Format 'HHmmss').json"
     try {
@@ -642,10 +679,10 @@ if (-not $SkipE2E) {
 
             Assert-Eq -Label "majorVersion is 10"             -Expected 10 -Actual $detected.majorVersion
             Assert-Eq -Label "mainBranch is 'main'"            -Expected 'main' -Actual $detected.mainBranch
-            Assert-Eq -Label "highestShippedTag is '10.0.71'"  -Expected '10.0.71' -Actual $detected.highestShippedTag
+            Assert-Eq -Label "highestShippedTag is '10.0.80'"  -Expected '10.0.80' -Actual $detected.highestShippedTag
             Assert-Eq -Label "highestShippedPreviewTag carries net10's last preview" `
                       -Expected '10.0.0-preview.7.25406.3' -Actual $detected.highestShippedPreviewTag
-            Assert-Eq -Label "tracker count is 2 (SR8+SR9 — SR7 shipped; SR2/SR3 dropped as stale)" `
+            Assert-Eq -Label "tracker count is 2 (SR8 shipped+refresh, SR9 candidate; SR7 retired; SR2/SR3 stale-dropped)" `
                       -Expected 2 -Actual $detected.trackers.Count
             # All trackers in single-major net10 mode must be SR-flavored. (Net10's
             # previews 1–7 all shipped + no in-flight preview branch -> no preview tracker.)
@@ -670,13 +707,19 @@ if (-not $SkipE2E) {
             Assert-Eq -Label "SR7 tracker absent (shipped)" `
                       -Expected $false -Actual ($bySr.ContainsKey(7))
 
-            # SR8 (in-flight, ACTIVE)
+            # SR8 (SHIPPED — highest shipped SR (tag 10.0.80) -> emits a
+            # 'shipped' tracker that refreshes until a human closes it).
             if ($bySr.ContainsKey(8)) {
                 $sr8 = $bySr[8]
-                Assert-Eq -Label "SR8 mode = in-flight"         -Expected 'in-flight' -Actual $sr8.mode
+                Assert-Eq -Label "SR8 mode = shipped"           -Expected 'shipped' -Actual $sr8.mode
                 Assert-Eq -Label "SR8 canonicalKey"             -Expected 'net10-sr8' -Actual $sr8.canonicalKey
                 Assert-Eq -Label "SR8 branchName"               -Expected 'release/10.0.1xx-sr8' -Actual $sr8.branchName
                 Assert-Eq -Label "SR8 branchExists = true"      -Expected $true -Actual $sr8.branchExists
+                Assert-Eq -Label "SR8 surveyRef = its own branch (shipped surveys the SR branch)" `
+                          -Expected 'release/10.0.1xx-sr8' -Actual $sr8.surveyRef
+                Assert-Eq -Label "SR8 issue title = shipped format" `
+                          -Expected '[Release Readiness] .NET 10 SR8 — shipped (release/10.0.1xx-sr8)' `
+                          -Actual $sr8.issueTitle
                 Assert-Eq -Label "SR8 expectedTag = 10.0.80"    -Expected '10.0.80' -Actual $sr8.expectedTag
                 # hasRecentActivity is a 7-day-window signal (git log --since=7.days
                 # against the live branch), so its VALUE is wall-clock dependent and
@@ -722,8 +765,9 @@ if (-not $SkipE2E) {
             # for "active": an active SR can legitimately sit idle for >7 days near
             # the tail of a cycle and report hasRecentActivity=$false. So assert the
             # flag is a real [bool] — never a hardcoded, date-dependent $true. SR7
-            # shipped 2026-06-05 and is no longer in the tracker set; only SR8 + SR9
-            # are active.
+            # shipped 2026-06-05 and (no longer the highest shipped SR) is retired;
+            # SR8 (shipped, highest -> refresh-until-closed) + SR9 (candidate) are
+            # the tracked set.
             foreach ($srNum in @(8, 9)) {
                 if ($bySr.ContainsKey($srNum)) {
                     Assert-Eq -Label "SR$srNum hasRecentActivity is a [bool] (active SR; value date-dependent)" `
@@ -744,16 +788,18 @@ if (-not $SkipE2E) {
     # ──────────── E2E: -AllActiveMajors multi-major envelope ────────────
     # In the unified post-consolidation shape, one invocation must surface every
     # active major (main's + any net<N>.0 ≥ main). Expected current state:
-    #   - net10 -> 2 SR trackers (SR8, SR9), no preview tracker
-    #     (SR7 shipped 2026-06-05; SR2/SR3 dropped by the Lane 1 staleness guard;
+    #   - net10 -> 2 SR trackers (SR8 shipped+refresh, SR9 candidate), no preview tracker
+    #     (SR7 shipped 2026-06-05 and is no longer the highest shipped SR -> retired;
+    #      SR8 shipped 2026-06-22 as the HIGHEST shipped SR -> 'shipped' tracker that
+    #      refreshes until closed; SR2/SR3 dropped by the Lane 1 staleness guard;
     #      every net10 preview branch already shipped + net10.0 isn't in preview cycle)
     #   - net11 -> 0 SR trackers (pre-GA: no `11.0.0` tag), 1 preview tracker
-    #     (preview6 candidate from net11.0)
+    #     (preview6 in-flight: release/11.0.1xx-preview6 was cut, tag not yet published)
     Write-Host "`n[E2E] Detection with -AllActiveMajors" -ForegroundColor Cyan
     Write-Host "  Expected:" -ForegroundColor DarkGray
     Write-Host "    - majors[].length = 2 (net10 + net11)" -ForegroundColor DarkGray
-    Write-Host "    - net10 trackers: 2 SR (sr8/sr9), 0 preview (SR7 shipped 2026-06-05; SR2/SR3 stale-dropped)" -ForegroundColor DarkGray
-    Write-Host "    - net11 trackers: 0 SR (pre-GA), 1 preview (preview6 candidate from net11.0)" -ForegroundColor DarkGray
+    Write-Host "    - net10 trackers: 2 SR (sr8 shipped/sr9 candidate), 0 preview (SR7 retired; SR2/SR3 stale-dropped)" -ForegroundColor DarkGray
+    Write-Host "    - net11 trackers: 0 SR (pre-GA), 1 preview (preview6 in-flight from release/11.0.1xx-preview6)" -ForegroundColor DarkGray
 
     $multiOut = Join-Path ([System.IO.Path]::GetTempPath()) "rr-detect-allmajors-$(Get-Date -Format 'HHmmss').json"
     try {
@@ -776,8 +822,8 @@ if (-not $SkipE2E) {
             if ($byMajor.ContainsKey(10)) {
                 $net10 = $byMajor[10]
                 Assert-Eq -Label "net10 mainBranch is 'main'"               -Expected 'main' -Actual $net10.mainBranch
-                Assert-Eq -Label "net10 highestShippedTag is '10.0.71'"      -Expected '10.0.71' -Actual $net10.highestShippedTag
-                Assert-Eq -Label "net10 tracker count is 2 (no preview lane, SR7 shipped, SR2/SR3 stale-dropped)" -Expected 2 -Actual $net10.trackers.Count
+                Assert-Eq -Label "net10 highestShippedTag is '10.0.80'"      -Expected '10.0.80' -Actual $net10.highestShippedTag
+                Assert-Eq -Label "net10 tracker count is 2 (no preview lane; SR8 shipped+refresh, SR9 candidate; SR7 retired, SR2/SR3 stale-dropped)" -Expected 2 -Actual $net10.trackers.Count
                 $srCount = @($net10.trackers | Where-Object branchType -eq 'sr').Count
                 $previewCount = @($net10.trackers | Where-Object branchType -eq 'preview').Count
                 Assert-Eq -Label "net10 has 2 SR trackers"      -Expected 2 -Actual $srCount
@@ -801,18 +847,18 @@ if (-not $SkipE2E) {
 
                 $preview6 = $previewTrackers[0]
                 Assert-Eq -Label "preview6 canonicalKey"              -Expected 'net11-preview6'       -Actual $preview6.canonicalKey
-                Assert-Eq -Label "preview6 mode = candidate"          -Expected 'candidate'           -Actual $preview6.mode
-                Assert-Eq -Label "preview6 surveyRef = net11.0"       -Expected 'net11.0'             -Actual $preview6.surveyRef
+                Assert-Eq -Label "preview6 mode = in-flight (branch cut, tag not yet published)" -Expected 'in-flight' -Actual $preview6.mode
+                Assert-Eq -Label "preview6 surveyRef = its own branch" -Expected 'release/11.0.1xx-preview6' -Actual $preview6.surveyRef
                 Assert-Eq -Label "preview6 expectedTagPrefix"         -Expected '11.0.0-preview.6.'   -Actual $preview6.expectedTagPrefix
                 Assert-Eq -Label "preview6 previewNumber = 6"         -Expected 6                      -Actual $preview6.previewNumber
                 Assert-Eq -Label "preview6 milestone name"            -Expected '.NET 11.0-preview6'  -Actual $preview6.milestoneName
                 Assert-Eq -Label "preview6 issue title format"        `
-                          -Expected '[Release Readiness] .NET 11.0 preview6 — candidate from net11.0' `
+                          -Expected '[Release Readiness] .NET 11.0 preview6 — release/11.0.1xx-preview6' `
                           -Actual $preview6.issueTitle
-                Assert-Eq -Label "preview6 branchName = canonical proposed slug" `
+                Assert-Eq -Label "preview6 branchName = canonical slug" `
                           -Expected 'release/11.0.1xx-preview6' -Actual $preview6.branchName
-                Assert-Eq -Label "preview6 branchExists = false (no branch yet)" `
-                          -Expected $false -Actual $preview6.branchExists
+                Assert-Eq -Label "preview6 branchExists = true (branch cut)" `
+                          -Expected $true -Actual $preview6.branchExists
                 # hasRecentActivity is a 7-day-window signal, not a marker of an
                 # "active preview cycle" — net11.0 can idle >7 days and report $false.
                 # Assert the flag's TYPE, not its date-dependent value.
@@ -1817,6 +1863,36 @@ Assert-Eq -Label "Without -TrackerKey: no visible Tracker line" -Expected $false
 # Hash marker still present (it's not gated by TrackerKey)
 Assert-Eq -Label "Without -TrackerKey: hash marker still present" -Expected $true `
     -Actual ($mdNoTracker -match '<!-- release-readiness-hash:')
+
+# ───── Body header `mode=` label: in-flight (default) / shipped / candidate ─────
+# The rendered Tracker line and H1 must reflect metadata.mode so a post-ship
+# tracker reads `mode=shipped` instead of misreporting as in-flight. Clone the
+# metadata hashtable (shallow .Clone() shares it) so we don't pollute later tests.
+Assert-Eq -Label 'Default render: Tracker line reads mode=in-flight' -Expected $true `
+    -Actual ($md -match '\*\*Tracker:\*\* `net10-sr7` · mode=`in-flight`')
+Assert-Eq -Label 'Default render: H1 is plain (not CANDIDATE)' -Expected $true `
+    -Actual ($md -match '# Release Readiness — release/10\.0\.1xx-sr7')
+
+$mdDataShipped = $mdData.Clone()
+$mdDataShipped.metadata = $mdData.metadata.Clone()
+$mdDataShipped.metadata.mode = 'shipped'
+$mdShipped = Format-MarkdownReport -Data $mdDataShipped -RepoUrl 'https://github.com/dotnet/maui' `
+                                   -TrackerKey 'net10-sr7' -MaxBodyBytes 60000
+Assert-Eq -Label 'Shipped render: Tracker line reads mode=shipped' -Expected $true `
+    -Actual ($mdShipped -match '\*\*Tracker:\*\* `net10-sr7` · mode=`shipped`')
+Assert-Eq -Label 'Shipped render: H1 stays plain branch survey (not CANDIDATE)' -Expected $true `
+    -Actual ($mdShipped -match '# Release Readiness — release/10\.0\.1xx-sr7' -and $mdShipped -notmatch '# Release Readiness — CANDIDATE')
+
+$mdDataCand = $mdData.Clone()
+$mdDataCand.metadata = $mdData.metadata.Clone()
+$mdDataCand.metadata.mode = 'candidate'
+$mdDataCand.metadata.priorSrBranch = 'release/10.0.1xx-sr6'
+$mdCand = Format-MarkdownReport -Data $mdDataCand -RepoUrl 'https://github.com/dotnet/maui' `
+                                -TrackerKey 'net10-sr7' -MaxBodyBytes 60000
+Assert-Eq -Label 'Candidate render: H1 shows CANDIDATE pre-flight' -Expected $true `
+    -Actual ($mdCand -match '# Release Readiness — CANDIDATE for next SR')
+Assert-Eq -Label 'Candidate render: Tracker line reads mode=candidate' -Expected $true `
+    -Actual ($mdCand -match 'mode=`candidate`')
 
 # Body cap: with very low cap, must truncate
 $mdCapped = Format-MarkdownReport -Data $mdData -RepoUrl 'https://github.com/dotnet/maui' `

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -184,6 +184,12 @@ jobs:
               fi
               SR_ARG="$PRIOR_SR"
               CANDIDATE_ARG=(-Candidate)
+            elif [ "$MODE" = "shipped" ]; then
+              # Already-tagged SR: survey the branch directly (same as in-flight),
+              # but pass -Shipped so the rendered header reads mode=shipped rather
+              # than misreporting the post-ship tracker as in-flight.
+              SR_ARG="$BRANCH_NAME"
+              CANDIDATE_ARG=(-Shipped)
             else
               SR_ARG="$BRANCH_NAME"
             fi
@@ -242,6 +248,7 @@ jobs:
           MILESTONE_NAME:     ${{ matrix.milestoneName }}
           BODY_FILE:          ${{ steps.report.outputs.body-file }}
           RECENT_COMMIT_COUNT: ${{ matrix.recentCommitCount }}
+          MODE:               ${{ matrix.mode }}
         shell: bash
         run: |
           set -euo pipefail
@@ -257,6 +264,17 @@ jobs:
             --json number,title,createdAt \
             --limit 50 \
             --jq '. // [] | sort_by(.createdAt) | .[].number')
+
+          # Shipped trackers are REFRESH-ONLY. The most-recently-shipped SR keeps
+          # surfacing post-ship follow-up (adding the build to the GitHub issue
+          # version dropdown, release notes, milestone close-out) while its tracker
+          # issue stays OPEN, but we never (re)create it. Once a human closes the
+          # tracker, it stays closed — "update until closed manually" without
+          # resurrecting a closed issue on the next scheduled run.
+          if [ "$MODE" = "shipped" ] && [ -z "$EXISTING" ]; then
+            echo "Shipped tracker ${TRACKER_KEY}: no open issue (closed or never created) — refresh-only, nothing to do."
+            exit 0
+          fi
 
           # Activity gate: when there is no recent activity AND no open tracker issue,
           # skip new-issue creation. (If an existing issue is open, we still refresh it.)


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Stacked on #36111

This PR is **stacked on top of #36111** (`closed-fix-unlinked` classifier). Its base is `pureween/rr-closed-fix-unlinked`, so the diff below shows **only** the shipped-tracker work. Please merge #36111 first; this PR's branch already contains both commits so the release-readiness workflow dispatches coherently from it. _(Happy to fold this into #36111 instead if you'd prefer a single PR.)_

### What & why

After an SR ships (its stable tag exists), its `[Release Readiness]` tracker issue still has **post-ship follow-up** worth surfacing — adding the new build to the GitHub issue version dropdown, publishing release notes, and closing out the milestone. Previously the detector hard-retired every shipped SR the moment its tag appeared, so the *just-shipped* tracker stopped refreshing immediately. The SR8 tag (`10.0.80`) was just published, which is exactly what triggered this.

This adds a **`shipped`** tracker mode for the single **most-recently-shipped** SR (highest shipped patch). Older shipped SRs stay retired as before.

### Changes

- **`Find-ReleaseReadinessTrackers.ps1`** — Lane 1 emits `mode='shipped'` for the highest shipped SR (guarded by `$branchPatch -eq $highestShippedPatch`); older shipped SRs still drop. `New-Tracker` gains a `shipped` title variant (`… SR8 — shipped (release/10.0.1xx-sr8)`).
- **`release-readiness.yml`** — the report step passes `-Shipped` for shipped trackers; the issue step treats `shipped` as **refresh-only**: it updates an open tracker but **never (re)creates** one, so once a human closes it, it stays closed (no resurrection on the next cron).
- **`Get-ReleaseReadiness.ps1`** — new **display-only** `-Shipped` switch. It surveys the SR branch identically to in-flight (`mode` only ever gates `candidate` logic) and solely relabels the rendered header `mode=shipped`, mutually exclusive with `-Candidate`. Without it, a post-ship tracker would misreport as `mode=in-flight`.
- **`Test-ReleaseReadiness.ps1`** — +6 render assertions (in-flight / shipped / candidate header + H1) and the detector E2E updated for the SR8 ship and the preview6 branch-cut drift. **Full suite 738/0.**
- **`SKILL.md`** — documents the post-ship `shipped` refresh-only lifecycle.

### Verification

- Detector (live clone): `net10-sr8 → mode=shipped` (refresh-until-closed), `net10-sr9 → candidate`, `net11-preview6 → in-flight`. Older shipped SRs retired.
- `Get-ReleaseReadiness -Shipped` (offline): `mode=shipped`, mutual-exclusion with `-Candidate` enforced, default still `in-flight`.
- Render: shipped body prints `mode=`shipped`` with the plain branch H1 (not the CANDIDATE pre-flight header).
- Full test suite: **738 passed / 0 failed** (run from repo root).

> [!IMPORTANT]
> Not for merge by an agent — human approval only. Do not merge before #36111.
