### PR TITLE
[release/11.0.1xx-preview6] Bump dotnet/macios to 26.5.11714-net11-p6

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -8,7 +8,7 @@
     <!--  Begin: Package sources from dotnet-android -->
     <!--  End: Package sources from dotnet-android -->
     <!--  Begin: Package sources from dotnet-macios -->
-    <add key="darc-pub-dotnet-macios-90e2eb7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-90e2eb7a/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-macios-ce56202" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-ce562026/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-macios -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <!--  Begin: Package sources from dotnet-dotnet -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -17,21 +17,21 @@
       <Uri>https://github.com/dotnet/android</Uri>
       <Sha>d549e1dc4e2a083b08b4f24cb5495e81b99d79b5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net11.0_26.5" Version="26.5.11711-net11-p6">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net11.0_26.5" Version="26.5.11714-net11-p6">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>6f668023025549b851dbdb7ee5d9db48a84c1e51</Sha>
+      <Sha>b3b48f57fe0122ef927468071519a1f8c9c91f16</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net11.0_26.5" Version="26.5.11711-net11-p6">
+    <Dependency Name="Microsoft.macOS.Sdk.net11.0_26.5" Version="26.5.11714-net11-p6">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>6f668023025549b851dbdb7ee5d9db48a84c1e51</Sha>
+      <Sha>b3b48f57fe0122ef927468071519a1f8c9c91f16</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net11.0_26.5" Version="26.5.11711-net11-p6">
+    <Dependency Name="Microsoft.iOS.Sdk.net11.0_26.5" Version="26.5.11714-net11-p6">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>6f668023025549b851dbdb7ee5d9db48a84c1e51</Sha>
+      <Sha>b3b48f57fe0122ef927468071519a1f8c9c91f16</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net11.0_26.5" Version="26.5.11711-net11-p6">
+    <Dependency Name="Microsoft.tvOS.Sdk.net11.0_26.5" Version="26.5.11714-net11-p6">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>6f668023025549b851dbdb7ee5d9db48a84c1e51</Sha>
+      <Sha>b3b48f57fe0122ef927468071519a1f8c9c91f16</Sha>
     </Dependency>
     <!-- Previous .NET iOS version(s) -->
     <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_26.5" Version="26.5.10298" CoherentParentDependency="Microsoft.MacCatalyst.Sdk.net11.0_26.5">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -34,21 +34,21 @@
       <Sha>b3b48f57fe0122ef927468071519a1f8c9c91f16</Sha>
     </Dependency>
     <!-- Previous .NET iOS version(s) -->
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_26.5" Version="26.5.10298" CoherentParentDependency="Microsoft.MacCatalyst.Sdk.net11.0_26.5">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_26.5" Version="26.5.10299" CoherentParentDependency="Microsoft.MacCatalyst.Sdk.net11.0_26.5">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>90e2eb7a981084044380d3b34c4d33694bc1a401</Sha>
+      <Sha>ce562026607fbe214874862de1f333064a0d2ff9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net10.0_26.5" Version="26.5.10298" CoherentParentDependency="Microsoft.macOS.Sdk.net11.0_26.5">
+    <Dependency Name="Microsoft.macOS.Sdk.net10.0_26.5" Version="26.5.10299" CoherentParentDependency="Microsoft.macOS.Sdk.net11.0_26.5">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>90e2eb7a981084044380d3b34c4d33694bc1a401</Sha>
+      <Sha>ce562026607fbe214874862de1f333064a0d2ff9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net10.0_26.5" Version="26.5.10298" CoherentParentDependency="Microsoft.iOS.Sdk.net11.0_26.5">
+    <Dependency Name="Microsoft.iOS.Sdk.net10.0_26.5" Version="26.5.10299" CoherentParentDependency="Microsoft.iOS.Sdk.net11.0_26.5">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>90e2eb7a981084044380d3b34c4d33694bc1a401</Sha>
+      <Sha>ce562026607fbe214874862de1f333064a0d2ff9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_26.5" Version="26.5.10298" CoherentParentDependency="Microsoft.tvOS.Sdk.net11.0_26.5">
+    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_26.5" Version="26.5.10299" CoherentParentDependency="Microsoft.tvOS.Sdk.net11.0_26.5">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>90e2eb7a981084044380d3b34c4d33694bc1a401</Sha>
+      <Sha>ce562026607fbe214874862de1f333064a0d2ff9</Sha>
     </Dependency>
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -67,10 +67,10 @@
     <MicrosoftNETSdkAndroidManifest100100PackageVersion>36.1.69</MicrosoftNETSdkAndroidManifest100100PackageVersion>
     <AndroidNetPreviousVersion>$(MicrosoftNetSdkAndroidManifest100100PackageVersion)</AndroidNetPreviousVersion>
     <!-- dotnet/macios -->
-    <MicrosoftMacCatalystSdknet110_265PackageVersion>26.5.11711-net11-p6</MicrosoftMacCatalystSdknet110_265PackageVersion>
-    <MicrosoftmacOSSdknet110_265PackageVersion>26.5.11711-net11-p6</MicrosoftmacOSSdknet110_265PackageVersion>
-    <MicrosoftiOSSdknet110_265PackageVersion>26.5.11711-net11-p6</MicrosoftiOSSdknet110_265PackageVersion>
-    <MicrosofttvOSSdknet110_265PackageVersion>26.5.11711-net11-p6</MicrosofttvOSSdknet110_265PackageVersion>
+    <MicrosoftMacCatalystSdknet110_265PackageVersion>26.5.11714-net11-p6</MicrosoftMacCatalystSdknet110_265PackageVersion>
+    <MicrosoftmacOSSdknet110_265PackageVersion>26.5.11714-net11-p6</MicrosoftmacOSSdknet110_265PackageVersion>
+    <MicrosoftiOSSdknet110_265PackageVersion>26.5.11714-net11-p6</MicrosoftiOSSdknet110_265PackageVersion>
+    <MicrosofttvOSSdknet110_265PackageVersion>26.5.11714-net11-p6</MicrosofttvOSSdknet110_265PackageVersion>
     <!-- This is a subscription of the .NET 10 latest stable versions of our packages -->
     <MicrosoftMacCatalystSdknet100_265PackageVersion>26.5.10298</MicrosoftMacCatalystSdknet100_265PackageVersion>
     <MicrosoftmacOSSdknet100_265PackageVersion>26.5.10298</MicrosoftmacOSSdknet100_265PackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -72,10 +72,10 @@
     <MicrosoftiOSSdknet110_265PackageVersion>26.5.11714-net11-p6</MicrosoftiOSSdknet110_265PackageVersion>
     <MicrosofttvOSSdknet110_265PackageVersion>26.5.11714-net11-p6</MicrosofttvOSSdknet110_265PackageVersion>
     <!-- This is a subscription of the .NET 10 latest stable versions of our packages -->
-    <MicrosoftMacCatalystSdknet100_265PackageVersion>26.5.10298</MicrosoftMacCatalystSdknet100_265PackageVersion>
-    <MicrosoftmacOSSdknet100_265PackageVersion>26.5.10298</MicrosoftmacOSSdknet100_265PackageVersion>
-    <MicrosoftiOSSdknet100_265PackageVersion>26.5.10298</MicrosoftiOSSdknet100_265PackageVersion>
-    <MicrosofttvOSSdknet100_265PackageVersion>26.5.10298</MicrosofttvOSSdknet100_265PackageVersion>
+    <MicrosoftMacCatalystSdknet100_265PackageVersion>26.5.10299</MicrosoftMacCatalystSdknet100_265PackageVersion>
+    <MicrosoftmacOSSdknet100_265PackageVersion>26.5.10299</MicrosoftmacOSSdknet100_265PackageVersion>
+    <MicrosoftiOSSdknet100_265PackageVersion>26.5.10299</MicrosoftiOSSdknet100_265PackageVersion>
+    <MicrosofttvOSSdknet100_265PackageVersion>26.5.10299</MicrosofttvOSSdknet100_265PackageVersion>
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>8.0.148</SamsungTizenSdkPackageVersion>
     <!-- wasdk -->


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description

Bumps the net11.0 **dotnet/macios** SDKs from `26.5.11711-net11-p6` to **`26.5.11714-net11-p6`** on the `release/11.0.1xx-preview6` branch.

- **macios commit:** `b3b48f57fe0122ef927468071519a1f8c9c91f16`
- Updated dependencies (net11.0 / `_26.5`): `Microsoft.iOS.Sdk`, `Microsoft.MacCatalyst.Sdk`, `Microsoft.macOS.Sdk`, `Microsoft.tvOS.Sdk`

### Files changed

- `eng/Version.Details.xml` — version + `<Sha>` for the 4 net11.0 macios dependencies
- `eng/Versions.props` — the 4 `Microsoft*Sdknet110_265PackageVersion` properties

The net10.0 macios entries (`26.5.10298`) are intentionally left unchanged.