### PR TITLE
Revert - Fix Entry clear button appearing dimmed compared to TextColor #35541

### DIFF
--- a/src/Core/src/Platform/iOS/TextFieldExtensions.cs
+++ b/src/Core/src/Platform/iOS/TextFieldExtensions.cs
@@ -229,29 +229,59 @@ namespace Microsoft.Maui.Platform
 			{
 				if (entry.TextColor is null)
 				{
-					// Release any custom image so UIKit restores its own system clear button appearance.
-					// Setting TintColor to null alone is not enough — the template image persists.
+					// Setting TintColor to null allows the system to automatically apply the appropriate color based on the current theme (light or dark mode)
+					clearButton.TintColor = null;
+					// SetImage(null) releases the custom tinted bitmap so UIKit restores its system default.
+					// The color path (else branch) reads ImageForState(.Highlighted) to get that original
+					// image as the source for tinting. Without these calls, TintColor=null has no visual effect.
 					clearButton.SetImage(null, UIControlState.Normal);
 					clearButton.SetImage(null, UIControlState.Highlighted);
-					clearButton.TintColor = null;
 				}
 				else
 				{
-					// Use AlwaysTemplate rendering so UIKit fills the icon at full opacity with TintColor,
-					// bypassing the semi-transparent pixels baked into the system clear button icon.
-					UIImage? sourceImage = clearButton.ImageForState(UIControlState.Normal)
-						?? clearButton.ImageForState(UIControlState.Highlighted);
-
-					if (sourceImage is not null)
-					{
-						UIImage templateImage = sourceImage.ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);
-						clearButton.SetImage(templateImage, UIControlState.Normal);
-						clearButton.SetImage(templateImage, UIControlState.Highlighted);
-					}
-
+					// On a null→color transition, UIKit restores the system image after SetImage(null),
+					// so ImageForState(Highlighted) returns the system clear button image as the tinting source.
+					UIImage? defaultClearImage = clearButton.ImageForState(UIControlState.Highlighted);
 					clearButton.TintColor = entry.TextColor.ToPlatform();
+
+					var tintedClearImage = GetClearButtonTintImage(defaultClearImage, entry.TextColor.ToPlatform());
+					if (tintedClearImage is not null)
+					{
+						clearButton.SetImage(tintedClearImage, UIControlState.Normal);
+						clearButton.SetImage(tintedClearImage, UIControlState.Highlighted);
+					}
 				}
 			}
+		}
+
+		internal static UIImage? GetClearButtonTintImage(UIImage? image, UIColor color)
+		{
+			if (image is null)
+			{
+				return null;
+			}
+
+			var size = image.Size;
+
+			var renderer = new UIGraphicsImageRenderer(size, new UIGraphicsImageRendererFormat()
+			{
+				Opaque = false,
+				Scale = UIScreen.MainScreen.Scale,
+			});
+
+			if (renderer is null)
+			{
+				return null;
+			}
+
+			return renderer.CreateImage((context) =>
+			{
+				image.Draw(CGPoint.Empty, CGBlendMode.Normal, 1.0f);
+				color.ColorWithAlpha(1.0f).SetFill();
+
+				var rect = new CGRect(CGPoint.Empty.X, CGPoint.Empty.Y, image.Size.Width, image.Size.Height);
+				context?.FillRect(rect, CGBlendMode.SourceIn);
+			});
 		}
 
 		internal static void AddMauiDoneAccessoryView(this UITextField textField, IViewHandler handler)

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Maui.DeviceTests
 
 				var tintedImage = clearButton.ImageForState(UIControlState.Normal);
 				Assert.NotNull(tintedImage);
-				Assert.Equal(UIImageRenderingMode.AlwaysTemplate, tintedImage.RenderingMode);
+				Assert.Equal(UIImageRenderingMode.Automatic, tintedImage.RenderingMode);
 
 				entry.TextColor = null;
 				handler.UpdateValue(nameof(IEntry.TextColor));
@@ -139,7 +139,7 @@ namespace Microsoft.Maui.DeviceTests
 				// Confirms ImageForState(.Highlighted) returns the original after SetImage(null)
 				var retintedImage = clearButton.ImageForState(UIControlState.Normal);
 				Assert.NotNull(retintedImage);
-				Assert.Equal(UIImageRenderingMode.AlwaysTemplate, retintedImage.RenderingMode);
+				Assert.Equal(UIImageRenderingMode.Automatic, retintedImage.RenderingMode);
 			});
 		}
 
@@ -807,42 +807,6 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			var entry = GetNativeEntry(entryHandler);
 			return entry.AttributedText.GetCharacterSpacing();
-		}
-
-		[Fact(DisplayName = "Entry ClearButton uses template rendering tinted to TextColor")]
-		public async Task EntryClearButtonUsesTemplateRenderingTintedToTextColor()
-		{
-			var entry = new EntryStub
-			{
-				Text = "hello",
-				TextColor = Colors.Blue,
-				ClearButtonVisibility = ClearButtonVisibility.WhileEditing,
-			};
-
-			await InvokeOnMainThreadAsync(async () =>
-			{
-				var handler = CreateHandler<EntryHandler>(entry);
-				var textField = GetNativeEntry(handler);
-
-				await textField.AttachAndRun(async () =>
-				{
-					textField.BecomeFirstResponder();
-
-					UIButton clearButton = null;
-					await AssertEventually(() =>
-					{
-						clearButton = textField.ValueForKey(new NSString("clearButton")) as UIButton;
-						return clearButton?.ImageForState(UIControlState.Normal) is not null;
-					}, timeout: 2000);
-
-					Assert.NotNull(clearButton);
-					Assert.Equal(Colors.Blue.ToPlatform(), clearButton.TintColor);
-
-					var image = clearButton.ImageForState(UIControlState.Normal);
-					Assert.NotNull(image);
-					Assert.Equal(UIImageRenderingMode.AlwaysTemplate, image.RenderingMode);
-				});
-			});
 		}
 
 		static UITextField GetNativeEntry(EntryHandler entryHandler) =>


### PR DESCRIPTION
On macOS, some of the Entry feature test cases are failing in the candidate PR https://github.com/dotnet/maui/pull/35716 in CI due to changes to the clear button. These failures are caused by PR https://github.com/dotnet/maui/pull/35541, so its changes were reverted from the candidate PR.

<img width="617" height="328" alt="image" src="https://github.com/user-attachments/assets/c115f31a-cde8-4689-81d5-8d251741c47c" />
