### PR TITLE
Shapes: Fix TransformGroup child subscription leaks

### DIFF
--- a/src/Controls/src/Core/Shapes/TransformGroup.cs
+++ b/src/Controls/src/Core/Shapes/TransformGroup.cs
@@ -74,24 +74,23 @@ namespace Microsoft.Maui.Controls.Shapes
 						SubscribeToTransformPropertyChanged(item);
 					}
 				}
-
-				UpdateTransformMatrix();
-				return;
 			}
-
-			if (args.OldItems is not null)
+			else
 			{
-				foreach (INotifyPropertyChanged item in args.OldItems)
+				if (args.OldItems is not null)
 				{
-					UnsubscribeFromTransformPropertyChanged(item);
+					foreach (INotifyPropertyChanged item in args.OldItems)
+					{
+						UnsubscribeFromTransformPropertyChanged(item);
+					}
 				}
-			}
 
-			if (args.NewItems is not null)
-			{
-				foreach (INotifyPropertyChanged item in args.NewItems)
+				if (args.NewItems is not null)
 				{
-					SubscribeToTransformPropertyChanged(item);
+					foreach (INotifyPropertyChanged item in args.NewItems)
+					{
+						SubscribeToTransformPropertyChanged(item);
+					}
 				}
 			}
 

--- a/src/Controls/src/Core/Shapes/TransformGroup.cs
+++ b/src/Controls/src/Core/Shapes/TransformGroup.cs
@@ -1,4 +1,5 @@
 #nullable disable
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
 
@@ -10,6 +11,8 @@ namespace Microsoft.Maui.Controls.Shapes
 	[ContentProperty("Children")]
 	public sealed class TransformGroup : Transform
 	{
+		readonly Dictionary<INotifyPropertyChanged, int> _subscribedTransforms = new();
+
 		/// <summary>Bindable property for <see cref="Children"/>.</summary>
 		public static readonly BindableProperty ChildrenProperty =
 			BindableProperty.Create(nameof(Children), typeof(TransformCollection), typeof(TransformGroup), null,
@@ -40,12 +43,9 @@ namespace Microsoft.Maui.Controls.Shapes
 			{
 				var oldCollection = (TransformCollection)oldValue;
 				oldCollection.CollectionChanged -= transformGroup.OnChildrenCollectionChanged;
-
-				foreach (INotifyPropertyChanged item in oldCollection)
-				{
-					item.PropertyChanged -= transformGroup.OnTransformPropertyChanged;
-				}
 			}
+
+			transformGroup.UnsubscribeFromAllTransformPropertyChanged();
 
 			if (newValue != null)
 			{
@@ -54,7 +54,7 @@ namespace Microsoft.Maui.Controls.Shapes
 
 				foreach (INotifyPropertyChanged item in newCollection)
 				{
-					item.PropertyChanged += transformGroup.OnTransformPropertyChanged;
+					transformGroup.SubscribeToTransformPropertyChanged(item);
 				}
 			}
 
@@ -63,19 +63,78 @@ namespace Microsoft.Maui.Controls.Shapes
 
 		void OnChildrenCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)
 		{
-			if (args.NewItems != null)
-				foreach (INotifyPropertyChanged item in args.NewItems)
+			if (args.Action == NotifyCollectionChangedAction.Reset)
+			{
+				UnsubscribeFromAllTransformPropertyChanged();
+
+				if (sender is TransformCollection collection)
 				{
-					item.PropertyChanged += OnTransformPropertyChanged;
+					foreach (INotifyPropertyChanged item in collection)
+					{
+						SubscribeToTransformPropertyChanged(item);
+					}
 				}
 
-			if (args.OldItems != null)
+				UpdateTransformMatrix();
+				return;
+			}
+
+			if (args.OldItems is not null)
+			{
 				foreach (INotifyPropertyChanged item in args.OldItems)
 				{
-					item.PropertyChanged -= OnTransformPropertyChanged;
+					UnsubscribeFromTransformPropertyChanged(item);
 				}
+			}
+
+			if (args.NewItems is not null)
+			{
+				foreach (INotifyPropertyChanged item in args.NewItems)
+				{
+					SubscribeToTransformPropertyChanged(item);
+				}
+			}
 
 			UpdateTransformMatrix();
+		}
+
+		void SubscribeToTransformPropertyChanged(INotifyPropertyChanged item)
+		{
+			if (_subscribedTransforms.TryGetValue(item, out int count))
+			{
+				_subscribedTransforms[item] = count + 1;
+				return;
+			}
+
+			item.PropertyChanged += OnTransformPropertyChanged;
+			_subscribedTransforms[item] = 1;
+		}
+
+		void UnsubscribeFromTransformPropertyChanged(INotifyPropertyChanged item)
+		{
+			if (!_subscribedTransforms.TryGetValue(item, out int count))
+			{
+				return;
+			}
+
+			if (count > 1)
+			{
+				_subscribedTransforms[item] = count - 1;
+				return;
+			}
+
+			item.PropertyChanged -= OnTransformPropertyChanged;
+			_subscribedTransforms.Remove(item);
+		}
+
+		void UnsubscribeFromAllTransformPropertyChanged()
+		{
+			foreach (var item in _subscribedTransforms)
+			{
+				item.Key.PropertyChanged -= OnTransformPropertyChanged;
+			}
+
+			_subscribedTransforms.Clear();
 		}
 
 		void OnTransformPropertyChanged(object sender, PropertyChangedEventArgs args)

--- a/src/Controls/src/Core/Shapes/TransformGroup.cs
+++ b/src/Controls/src/Core/Shapes/TransformGroup.cs
@@ -34,17 +34,31 @@ namespace Microsoft.Maui.Controls.Shapes
 
 		static void OnTransformGroupChanged(BindableObject bindable, object oldValue, object newValue)
 		{
+			var transformGroup = (TransformGroup)bindable;
+
 			if (oldValue != null)
 			{
-				(oldValue as TransformCollection).CollectionChanged -= (bindable as TransformGroup).OnChildrenCollectionChanged;
+				var oldCollection = (TransformCollection)oldValue;
+				oldCollection.CollectionChanged -= transformGroup.OnChildrenCollectionChanged;
+
+				foreach (INotifyPropertyChanged item in oldCollection)
+				{
+					item.PropertyChanged -= transformGroup.OnTransformPropertyChanged;
+				}
 			}
 
 			if (newValue != null)
 			{
-				(newValue as TransformCollection).CollectionChanged += (bindable as TransformGroup).OnChildrenCollectionChanged;
+				var newCollection = (TransformCollection)newValue;
+				newCollection.CollectionChanged += transformGroup.OnChildrenCollectionChanged;
+
+				foreach (INotifyPropertyChanged item in newCollection)
+				{
+					item.PropertyChanged += transformGroup.OnTransformPropertyChanged;
+				}
 			}
 
-			(bindable as TransformGroup).UpdateTransformMatrix();
+			transformGroup.UpdateTransformMatrix();
 		}
 
 		void OnChildrenCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)

--- a/src/Controls/src/Core/Shapes/TransformGroup.cs
+++ b/src/Controls/src/Core/Shapes/TransformGroup.cs
@@ -15,8 +15,7 @@ namespace Microsoft.Maui.Controls.Shapes
 
 		/// <summary>Bindable property for <see cref="Children"/>.</summary>
 		public static readonly BindableProperty ChildrenProperty =
-			BindableProperty.Create(nameof(Children), typeof(TransformCollection), typeof(TransformGroup), null,
-				propertyChanged: OnTransformGroupChanged);
+			BindableProperty.Create(nameof(Children), typeof(TransformCollection), typeof(TransformGroup), null, propertyChanged: OnChildrenChanged);
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="TransformGroup"/> class.
@@ -35,37 +34,54 @@ namespace Microsoft.Maui.Controls.Shapes
 			get { return (TransformCollection)GetValue(ChildrenProperty); }
 		}
 
-		static void OnTransformGroupChanged(BindableObject bindable, object oldValue, object newValue)
+		static void OnChildrenChanged(BindableObject bindable, object oldValue, object newValue)
 		{
 			var transformGroup = (TransformGroup)bindable;
+			transformGroup.UpdateChildren(
+			 oldValue as TransformCollection,
+			 newValue as TransformCollection);
+		}
 
-			if (oldValue != null)
+		void UpdateChildren(TransformCollection oldCollection, TransformCollection newCollection)
+		{
+			DetachCollection(oldCollection);
+			AttachCollection(newCollection);
+
+			UpdateTransformMatrix();
+		}
+
+		void AttachCollection(TransformCollection collection)
+		{
+			if (collection is null)
 			{
-				var oldCollection = (TransformCollection)oldValue;
-				oldCollection.CollectionChanged -= transformGroup.OnChildrenCollectionChanged;
+				return;
 			}
 
-			transformGroup.UnsubscribeFromAllTransformPropertyChanged();
+			collection.CollectionChanged += OnChildrenCollectionChanged;
 
-			if (newValue != null)
+			foreach (var transform in collection)
 			{
-				var newCollection = (TransformCollection)newValue;
-				newCollection.CollectionChanged += transformGroup.OnChildrenCollectionChanged;
+				SubscribeToTransformPropertyChanged(transform);
+			}
+		}
 
-				foreach (INotifyPropertyChanged item in newCollection)
-				{
-					transformGroup.SubscribeToTransformPropertyChanged(item);
-				}
+		void DetachCollection(TransformCollection collection)
+		{
+			if (collection is null)
+			{
+				return;
 			}
 
-			transformGroup.UpdateTransformMatrix();
+			collection.CollectionChanged -= OnChildrenCollectionChanged;
+
+			ClearAllTransformSubscriptions();
 		}
 
 		void OnChildrenCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)
 		{
 			if (args.Action == NotifyCollectionChangedAction.Reset)
 			{
-				UnsubscribeFromAllTransformPropertyChanged();
+				ClearAllTransformSubscriptions();
 
 				if (sender is TransformCollection collection)
 				{
@@ -126,7 +142,8 @@ namespace Microsoft.Maui.Controls.Shapes
 			_subscribedTransforms.Remove(item);
 		}
 
-		void UnsubscribeFromAllTransformPropertyChanged()
+		// Unsubscribes all tracked transforms from PropertyChanged and clears the dictionary.
+		void ClearAllTransformSubscriptions()
 		{
 			foreach (var item in _subscribedTransforms)
 			{

--- a/src/Controls/tests/Core.UnitTests/Shapes/TransformGroupTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Shapes/TransformGroupTests.cs
@@ -65,5 +65,23 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Shapes
 					$"TransformGroup #{i} should be collected. Shared transform is retaining it.");
 			}
 		}
+
+		[Fact]
+		public async Task ClearingChildrenUnsubscribesAllTransforms()
+		{
+			var sharedTransform = new ScaleTransform { ScaleX = 1.0, ScaleY = 1.0 };
+			WeakReference weakGroup;
+
+			{
+				var group = new TransformGroup();
+				group.Children.Add(sharedTransform);
+				group.Children.Clear();
+				weakGroup = new WeakReference(group);
+			}
+
+			Assert.False(await weakGroup.WaitForCollect(),
+				"TransformGroup should be collected after Children.Clear(). " +
+				"Shared child transform is keeping it alive via stale PropertyChanged subscription.");
+		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/Shapes/TransformGroupTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Shapes/TransformGroupTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls.Shapes;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests.Shapes
+{
+	public class TransformGroupTests : BaseTestFixture
+	{
+		[Fact]
+		public async Task ReplacingChildrenUnsubscribesFromOldChildPropertyChanged()
+		{
+			var sharedTransform = new ScaleTransform { ScaleX = 1.0, ScaleY = 1.0 };
+			WeakReference weakGroup;
+
+			{
+				var group = new TransformGroup();
+				group.Children.Add(sharedTransform);
+				group.Children = new TransformCollection();
+				weakGroup = new WeakReference(group);
+			}
+
+			Assert.False(await weakGroup.WaitForCollect(),
+				"TransformGroup should be collected after Children replacement. " +
+				"Shared child transform is keeping it alive via stale PropertyChanged subscription.");
+		}
+
+		[Fact]
+		public void ReplacingChildrenSubscribesToNewChildPropertyChanged()
+		{
+			var group = new TransformGroup();
+			var newCollection = new TransformCollection();
+			var childTransform = new ScaleTransform { ScaleX = 1.0, ScaleY = 1.0 };
+			newCollection.Add(childTransform);
+
+			group.Children = newCollection;
+
+			var matrixBefore = group.Value;
+			childTransform.ScaleX = 2.0;
+			var matrixAfter = group.Value;
+
+			Assert.NotEqual(matrixBefore, matrixAfter);
+		}
+
+		[Fact]
+		public void ReplacingChildrenDoesNotUpdateMatrixOnOldChildChange()
+		{
+			var group = new TransformGroup();
+			var childTransform = new ScaleTransform { ScaleX = 1.0, ScaleY = 1.0 };
+			group.Children.Add(childTransform);
+
+			group.Children = new TransformCollection();
+			var matrixAfterReplacement = group.Value;
+
+			childTransform.ScaleX = 5.0;
+
+			Assert.Equal(matrixAfterReplacement, group.Value);
+		}
+
+		[Fact]
+		public async Task SharedTransformDoesNotRetainMultipleGroups()
+		{
+			var sharedTransform = new ScaleTransform { ScaleX = 1.0, ScaleY = 1.0 };
+			var weakRefs = new WeakReference[10];
+
+			{
+				for (int i = 0; i < 10; i++)
+				{
+					var group = new TransformGroup();
+					group.Children.Add(sharedTransform);
+					group.Children = new TransformCollection();
+					weakRefs[i] = new WeakReference(group);
+				}
+			}
+
+			for (int i = 0; i < weakRefs.Length; i++)
+			{
+				Assert.False(await weakRefs[i].WaitForCollect(),
+					$"TransformGroup #{i} should be collected. Shared transform is retaining it.");
+			}
+		}
+	}
+}

--- a/src/Controls/tests/Core.UnitTests/Shapes/TransformGroupTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Shapes/TransformGroupTests.cs
@@ -44,21 +44,6 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Shapes
 		}
 
 		[Fact]
-		public void ReplacingChildrenDoesNotUpdateMatrixOnOldChildChange()
-		{
-			var group = new TransformGroup();
-			var childTransform = new ScaleTransform { ScaleX = 1.0, ScaleY = 1.0 };
-			group.Children.Add(childTransform);
-
-			group.Children = new TransformCollection();
-			var matrixAfterReplacement = group.Value;
-
-			childTransform.ScaleX = 5.0;
-
-			Assert.Equal(matrixAfterReplacement, group.Value);
-		}
-
-		[Fact]
 		public async Task SharedTransformDoesNotRetainMultipleGroups()
 		{
 			var sharedTransform = new ScaleTransform { ScaleX = 1.0, ScaleY = 1.0 };


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details

- `TransformGroup.Children` replacement and `Clear()` can leak child transform `PropertyChanged` subscriptions.

### Root Cause of the issue

`TransformGroup` subscribes to each child transform's `PropertyChanged` event when the child is added to the `Children` collection through the collection change handler.

There are two leak scenarios:

1. **Collection Replacement** (`Children = new TransformCollection()`)

   The previous `Children` change callback only:
   - Unsubscribed from the old collection's `CollectionChanged` event
   - Subscribed to the new collection's `CollectionChanged` event

   It did not:
   - Iterate old collection items to unsubscribe their `PropertyChanged` handlers
   - Iterate new collection items to subscribe their `PropertyChanged` handlers

2. **Collection Clear** (`Children.Clear()`)

   `ObservableCollection` raises `CollectionChanged` with `Action = Reset` and `OldItems = null`. The previous handler only checked `OldItems` and `NewItems`, so it skipped child `PropertyChanged` unsubscription on `Clear()`.

In both cases, old child transforms can keep a delegate reference to `TransformGroup.OnTransformPropertyChanged`. If the child transform is long-lived, shared, cached, or static, it can retain the `TransformGroup`, associated `Path`, and the `Path` binding context.

### Description of Change

- Added reference-counted child transform subscriptions with `Dictionary<INotifyPropertyChanged, int>` so a transform that appears multiple times in the same collection has one event subscription that remains attached until the last occurrence is removed.
- Added `AttachCollection` and `DetachCollection` helpers so `Children` replacement unsubscribes child transforms from the old collection and subscribes child transforms from the new collection.
- Added explicit `NotifyCollectionChangedAction.Reset` handling in `OnChildrenCollectionChanged` so `Children.Clear()` clears tracked subscriptions and rebuilt collections keep current child subscriptions.

### Testing Enhancements

Added `TransformGroupTests` covering:

- Replacing `Children` unsubscribes old child transform `PropertyChanged` handlers
- Replacing `Children` subscribes child transforms already present in the new collection
- Shared transforms do not retain multiple detached `TransformGroup` instances
- Clearing `Children` unsubscribes all tracked child transforms

### Issues Fixed

Fixes #36033

### Tested the behaviour in the following platforms

- [x] Windows
- [x] Android
- [x] iOS
- [x] Mac

| Before | After |
|----------|----------|
| <img src="https://github.com/user-attachments/assets/34fa60ce-1981-4c2c-9f1d-5e0e65941a87"> | <img src="https://github.com/user-attachments/assets/aa6b92ee-487d-4718-8ed0-bd76a329076d"> |




<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
