### PR TITLE
Revert - Fix Android stale ContainerView root leak #35372

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.cs
@@ -175,56 +175,6 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-#if ANDROID
-		[Fact(DisplayName = "Replaced FlyoutPage Root Clears Old ContainerView")]
-		public async Task ReplacedFlyoutPageRootClearsOldContainerView()
-		{
-			SetupBuilder();
-
-			var rootPage = CreateFlyoutRoot();
-			var window = new Window(rootPage);
-
-			await CreateHandlerAndAddToWindow<WindowHandlerStub>(window, async handler =>
-			{
-				var rootManager = handler.MauiContext.GetNavigationRootManager();
-				var oldRootView = Assert.IsType<ContainerView>(rootManager.RootView);
-
-				Assert.Same(rootPage, oldRootView.CurrentView);
-				Assert.NotNull(oldRootView.MainView);
-
-				var replacementPage = new ContentPage
-				{
-					Content = new Label { Text = "Replacement page" }
-				};
-
-				window.Page = replacementPage;
-				await OnLoadedAsync(replacementPage);
-
-				Assert.Null(oldRootView.CurrentView);
-				Assert.Null(oldRootView.MainView);
-				Assert.NotSame(oldRootView, rootManager.RootView);
-			});
-		}
-
-		static FlyoutPage CreateFlyoutRoot()
-		{
-			var flyoutPage = new ContentPage { Title = "Flyout" };
-			var detailPage = new ContentPage
-			{
-				Title = "Detail",
-				Content = new Label { Text = "Detail page" }
-			};
-			var detailNavigationPage = new NavigationPage(detailPage) { Title = "Detail" };
-			var rootPage = new FlyoutPage
-			{
-				Flyout = flyoutPage,
-				Detail = detailNavigationPage
-			};
-
-			return rootPage;
-		}
-#endif
-
 #if !IOS && !MACCATALYST
 		// Automated Shell tests are currently broken via xharness
 		[Fact(DisplayName = "Toolbar Items Update when swapping out Main Page on Handler")]

--- a/src/Core/src/Platform/Android/Navigation/NavigationRootManager.cs
+++ b/src/Core/src/Platform/Android/Navigation/NavigationRootManager.cs
@@ -152,9 +152,6 @@ namespace Microsoft.Maui.Platform
 		{
 			_pendingFragment?.Dispose();
 			_pendingFragment = null;
-			if (_rootView is ContainerView containerView)
-				containerView.CurrentView = null;
-
 			DrawerLayout = null;
 			_rootView = null;
 			_toolbarElement = null;


### PR DESCRIPTION
On Android, control device test cases are failing in the candidate PR https://github.com/dotnet/maui/pull/35716 in CI, but it is not showing which tests are failing. When checking locally, the SwappingDetailPageWorksForSplitFlyoutBehavior test crashed. After reverting PR https://github.com/dotnet/maui/pull/35372, the SwappingDetailPageWorksForSplitFlyoutBehavior test no longer crashed. To confirm this, the changes from PR https://github.com/dotnet/maui/pull/35372 were reverted to identify the cause of the failures.

**Note: Do not merge this PR**