### PR TITLE
[XEPR] Parenthesize ternaries inside interpolation holes

### DIFF
--- a/docs/specs/XamlCSharpExpressions.md
+++ b/docs/specs/XamlCSharpExpressions.md
@@ -106,6 +106,23 @@ Expressions can combine multiple sources. Each part is resolved using the simple
 
 Each interpolation hole is analyzed and bound appropriately.
 
+**Ternaries inside interpolation holes** are supported and automatically parenthesized.
+In C#, the first top-level `:` inside an interpolation hole begins the format specifier,
+so a raw conditional fails to compile (`CS8361`). XEPR wraps the conditional in
+parentheses for you:
+
+```xml
+<!-- Authored: -->
+<Label Text="{$'You clicked {Count} {Count == 1 ? 'time' : 'times'}.'}" />
+
+<!-- Generated: $"You clicked {Count} {(Count == 1 ? "time" : "times")}." -->
+```
+
+This applies only to a ternary that is the *entire* hole expression. Null-coalescing
+(`??`), null-conditional (`?.`, `?[`) and format specifiers (`{value:F2}`) are not
+affected. To combine a ternary with an explicit format specifier or alignment, write the
+parentheses yourself: `{$'{(IsVip ? Gold : Base):C2}'}`.
+
 **Operators and Mixed Sources:**
 
 ```xml
@@ -305,6 +322,7 @@ Complex expressions (operators, method calls) cannot generate a setter and are o
 | Negate bool | `{!Flag}` |
 | Combine bools | `{A &amp;&amp; B}` or `{A \|\| B}` |
 | Ternary | `{IsVip ? 'Gold' : 'Standard'}` |
+| Ternary in interpolation | `{$'{Count} {Count == 1 ? 'item' : 'items'}'}` |
 | Null-coalesce | `{Value ?? 'Default'}` |
 | Format string | `{$'{Value:F2}'}` |
 | Handle event | `{(s, e) => Action()}` |

--- a/src/Controls/src/SourceGen/CSharpExpressionHelpers.cs
+++ b/src/Controls/src/SourceGen/CSharpExpressionHelpers.cs
@@ -380,6 +380,14 @@ static class CSharpExpressionHelpers
 		// Transform operator aliases (AND -> &&, OR -> ||) to avoid XML escaping
 		code = TransformOperatorAliases(code);
 
+		// Parenthesize ternary expressions that sit directly inside a string
+		// interpolation hole. In C#, the first top-level ':' inside a hole starts the
+		// format specifier, so `$"{cond ? a : b}"` is invalid (CS8361). Wrapping the
+		// conditional in parentheses (`$"{(cond ? a : b)}"`) keeps the ':' inside the
+		// expression. This runs before quote translation so it can operate on the
+		// single-quoted source. (issue #36155)
+		code = ParenthesizeInterpolationTernaries(code);
+
 		// Always transform single-quoted strings to double-quoted strings
 		// C# doesn't support single-quoted strings, only char literals
 		// TransformQuotesWithSemantics will later convert back to char where appropriate
@@ -406,6 +414,300 @@ static class CSharpExpressionHelpers
 		result = ReplaceWordOperator(result, " GT ", " > ");
 
 		return result;
+	}
+
+	/// <summary>
+	/// Walks the expression and parenthesizes any ternary/conditional expression that
+	/// appears directly inside a string interpolation hole. Without parentheses, the C#
+	/// compiler treats the first top-level ':' inside a hole as the start of a format
+	/// specifier, so `$"{cond ? a : b}"` fails to compile (CS8361/CS8076). Wrapping the
+	/// conditional — `$"{(cond ? a : b)}"` — keeps the ':' part of the expression.
+	/// Format specifiers (`{value:F2}`), null-coalescing (`??`), null-conditional (`?.`,
+	/// `?[`) and ternaries outside interpolation holes are left untouched.
+	/// </summary>
+	static string ParenthesizeInterpolationTernaries(string code)
+	{
+		var result = new StringBuilder(code.Length);
+		int i = 0;
+
+		while (i < code.Length)
+		{
+			// Interpolated string: '$' immediately followed by a quote delimiter.
+			if (code[i] == '$' && i + 1 < code.Length && (code[i + 1] == '\'' || code[i + 1] == '"'))
+			{
+				char delimiter = code[i + 1];
+				result.Append(code[i]);     // $
+				result.Append(code[i + 1]); // opening delimiter
+				i += 2;
+
+				// Walk the interpolated string body until the closing delimiter.
+				while (i < code.Length)
+				{
+					char c = code[i];
+
+					// Escape sequence in literal text - copy verbatim.
+					if (c == '\\' && i + 1 < code.Length)
+					{
+						result.Append(c);
+						result.Append(code[i + 1]);
+						i += 2;
+						continue;
+					}
+
+					// Closing delimiter ends the interpolated string.
+					if (c == delimiter)
+					{
+						result.Append(c);
+						i++;
+						break;
+					}
+
+					if (c == '{')
+					{
+						// Escaped brace '{{' is literal text, not a hole.
+						if (i + 1 < code.Length && code[i + 1] == '{')
+						{
+							result.Append("{{");
+							i += 2;
+							continue;
+						}
+
+						// Capture the hole content up to its matching '}'.
+						int holeStart = i + 1;
+						int j = FindHoleEnd(code, holeStart);
+						string holeContent = code.Substring(holeStart, j - holeStart);
+
+						// Recurse so nested interpolated strings are handled too,
+						// then wrap a hole-level ternary in parentheses.
+						holeContent = ParenthesizeInterpolationTernaries(holeContent);
+						holeContent = WrapHoleTernary(holeContent);
+
+						result.Append('{');
+						result.Append(holeContent);
+						if (j < code.Length && code[j] == '}')
+						{
+							result.Append('}');
+							i = j + 1;
+						}
+						else
+						{
+							// Unterminated hole - leave as-is.
+							i = j;
+						}
+						continue;
+					}
+
+					if (c == '}')
+					{
+						// Escaped brace '}}'.
+						if (i + 1 < code.Length && code[i + 1] == '}')
+						{
+							result.Append("}}");
+							i += 2;
+							continue;
+						}
+						result.Append(c);
+						i++;
+						continue;
+					}
+
+					result.Append(c);
+					i++;
+				}
+
+				continue;
+			}
+
+			// Skip non-interpolated string literals so their contents are never
+			// mistaken for interpolation structure.
+			if (code[i] == '\'' || code[i] == '"')
+			{
+				char quote = code[i];
+				result.Append(code[i]);
+				i++;
+				while (i < code.Length)
+				{
+					if (code[i] == '\\' && i + 1 < code.Length)
+					{
+						result.Append(code[i]);
+						result.Append(code[i + 1]);
+						i += 2;
+						continue;
+					}
+					result.Append(code[i]);
+					if (code[i] == quote)
+					{
+						i++;
+						break;
+					}
+					i++;
+				}
+				continue;
+			}
+
+			result.Append(code[i]);
+			i++;
+		}
+
+		return result.ToString();
+	}
+
+	/// <summary>
+	/// Returns the index of the '}' that closes the interpolation hole starting at
+	/// <paramref name="start"/>, tracking nested braces and skipping string literals.
+	/// </summary>
+	static int FindHoleEnd(string code, int start)
+	{
+		int depth = 1;
+		int j = start;
+		while (j < code.Length)
+		{
+			char c = code[j];
+			if (c == '\\' && j + 1 < code.Length)
+			{
+				j += 2;
+				continue;
+			}
+			if (c == '\'' || c == '"')
+			{
+				char quote = c;
+				j++;
+				while (j < code.Length)
+				{
+					if (code[j] == '\\' && j + 1 < code.Length)
+					{
+						j += 2;
+						continue;
+					}
+					if (code[j] == quote)
+					{
+						j++;
+						break;
+					}
+					j++;
+				}
+				continue;
+			}
+			if (c == '{')
+			{
+				depth++;
+				j++;
+				continue;
+			}
+			if (c == '}')
+			{
+				depth--;
+				if (depth == 0)
+					return j;
+				j++;
+				continue;
+			}
+			j++;
+		}
+		return j;
+	}
+
+	/// <summary>
+	/// Wraps the content of an interpolation hole in parentheses when it contains a
+	/// top-level ternary conditional. Detection skips string literals, nested
+	/// parentheses/brackets/braces and the non-ternary '?' forms ('??', '?.', '?[').
+	/// </summary>
+	static string WrapHoleTernary(string holeContent)
+	{
+		if (!ContainsTopLevelTernary(holeContent))
+			return holeContent;
+
+		// Preserve leading/trailing whitespace outside the parentheses for readability.
+		int startTrim = 0;
+		while (startTrim < holeContent.Length && char.IsWhiteSpace(holeContent[startTrim]))
+			startTrim++;
+		int endTrim = holeContent.Length;
+		while (endTrim > startTrim && char.IsWhiteSpace(holeContent[endTrim - 1]))
+			endTrim--;
+
+		var leading = holeContent.Substring(0, startTrim);
+		var inner = holeContent.Substring(startTrim, endTrim - startTrim);
+		var trailing = holeContent.Substring(endTrim);
+
+		return leading + "(" + inner + ")" + trailing;
+	}
+
+	/// <summary>
+	/// Determines whether the expression contains a ternary '?' at the top nesting level
+	/// (outside strings, parentheses, brackets and braces). Returns false for '??', '?.'
+	/// and '?[' which are not conditional expressions.
+	/// </summary>
+	static bool ContainsTopLevelTernary(string expr)
+	{
+		int depth = 0;
+		int i = 0;
+		while (i < expr.Length)
+		{
+			char c = expr[i];
+
+			if (c == '\\' && i + 1 < expr.Length)
+			{
+				i += 2;
+				continue;
+			}
+
+			if (c == '\'' || c == '"')
+			{
+				char quote = c;
+				i++;
+				while (i < expr.Length)
+				{
+					if (expr[i] == '\\' && i + 1 < expr.Length)
+					{
+						i += 2;
+						continue;
+					}
+					if (expr[i] == quote)
+					{
+						i++;
+						break;
+					}
+					i++;
+				}
+				continue;
+			}
+
+			if (c == '(' || c == '[' || c == '{')
+			{
+				depth++;
+				i++;
+				continue;
+			}
+
+			if (c == ')' || c == ']' || c == '}')
+			{
+				if (depth > 0)
+					depth--;
+				i++;
+				continue;
+			}
+
+			if (c == '?' && depth == 0)
+			{
+				char next = i + 1 < expr.Length ? expr[i + 1] : '\0';
+				// Skip '??' (null-coalescing), '?.' and '?[' (null-conditional).
+				if (next == '?')
+				{
+					i += 2;
+					continue;
+				}
+				if (next == '.' || next == '[')
+				{
+					i++;
+					continue;
+				}
+				return true;
+			}
+
+			i++;
+		}
+
+		return false;
 	}
 
 	/// <summary>

--- a/src/Controls/tests/SourceGen.UnitTests/CSharpExpressionDiagnosticsTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/CSharpExpressionDiagnosticsTests.cs
@@ -870,4 +870,52 @@ public partial class StaticRefPage : ContentPage
 		// And the compilation must succeed (no compiler errors leaked through).
 		Assert.DoesNotContain(result.Diagnostics, d => d.Severity == DiagnosticSeverity.Error);
 	}
+
+	[Fact]
+	public void TernaryInsideInterpolationHole_CompilesCleanly()
+	{
+		// Issue #36155: a ternary directly inside an interpolation hole must be
+		// auto-parenthesized so the ':' is not consumed as a format specifier.
+		var xaml =
+"""
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:TestApp"
+             x:Class="TestApp.InterpolationTernaryPage"
+             x:DataType="local:InterpolationTernaryViewModel">
+    <Label Text="{$'You clicked {Count} {Count == 1 ? 'time' : 'times'}.'}" />
+</ContentPage>
+""";
+
+		var codeBehind =
+"""
+using System.ComponentModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace TestApp;
+
+public class InterpolationTernaryViewModel : INotifyPropertyChanged
+{
+	public int Count { get; set; }
+	public event PropertyChangedEventHandler? PropertyChanged;
+}
+
+[XamlProcessing(XamlInflator.SourceGen)]
+public partial class InterpolationTernaryPage : ContentPage
+{
+	public InterpolationTernaryPage() => InitializeComponent();
+}
+""";
+
+		var (result, output) = RunGenerator(xaml, codeBehind);
+
+		Assert.NotNull(output);
+		// The ternary must be parenthesized in the generated interpolated string
+		// (the 'Count' identifier is rewritten to a binding source path, e.g. __source.Count).
+		Assert.Contains("== 1 ? \"time\" : \"times\")", output!, StringComparison.Ordinal);
+		// And the compilation must succeed (no CS8076/CS8361/CS1003/CS0103 leaked through).
+		Assert.DoesNotContain(result.Diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+	}
 }

--- a/src/Controls/tests/SourceGen.UnitTests/CSharpExpressionInterpolationTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/CSharpExpressionInterpolationTests.cs
@@ -1,0 +1,63 @@
+using Xunit;
+
+namespace Microsoft.Maui.Controls.SourceGen.UnitTests;
+
+// Unit tests for CSharpExpressionHelpers.GetExpressionCode covering string
+// interpolation holes, in particular ternary expressions that must be
+// parenthesized so their ':' is not consumed as a format specifier (issue #36155).
+public class CSharpExpressionInterpolationTests
+{
+	[Theory]
+	// Issue #36155 repro: ternary directly inside an interpolation hole must be parenthesized.
+	[InlineData(
+		"{$'You clicked {Count} {Count == 1 ? 'time' : 'times'}.'}",
+		"$\"You clicked {Count} {(Count == 1 ? \"time\" : \"times\")}.\"")]
+	// Ternary using a comparison operator inside a hole.
+	[InlineData(
+		"{$'{Count > 0 ? 'some' : 'none'}'}",
+		"$\"{(Count > 0 ? \"some\" : \"none\")}\"")]
+	// CDATA-style interpolation already using double quotes is parenthesized too.
+	[InlineData(
+		"{$\"You clicked {Count} {Count == 1 ? \"time\" : \"times\"}.\"}",
+		"$\"You clicked {Count} {(Count == 1 ? \"time\" : \"times\")}.\"")]
+	public void TernaryInsideInterpolationHole_IsParenthesized(string input, string expected)
+	{
+		Assert.Equal(expected, CSharpExpressionHelpers.GetExpressionCode(input));
+	}
+
+	[Theory]
+	// Simple holes are untouched.
+	[InlineData("{$'Hello {FirstName}'}", "$\"Hello {FirstName}\"")]
+	[InlineData("{$'{FirstName} {LastName}'}", "$\"{FirstName} {LastName}\"")]
+	// Format specifiers must be preserved (the ':' is NOT a ternary).
+	[InlineData("{$'{Price:C2}'}", "$\"{Price:C2}\"")]
+	[InlineData("{$'{Quantity}x at {Price:C2}'}", "$\"{Quantity}x at {Price:C2}\"")]
+	// Null-coalescing inside a hole must not be mistaken for a ternary.
+	[InlineData("{$'{Name ?? 'Unknown'}'}", "$\"{Name ?? \"Unknown\"}\"")]
+	// Null-conditional inside a hole must not be mistaken for a ternary.
+	[InlineData("{$'{User?.Name}'}", "$\"{User?.Name}\"")]
+	public void NonTernaryHoles_AreNotParenthesized(string input, string expected)
+	{
+		Assert.Equal(expected, CSharpExpressionHelpers.GetExpressionCode(input));
+	}
+
+	[Theory]
+	// A ternary at the top level (NOT inside an interpolation hole) is left as-is;
+	// only quote translation applies.
+	[InlineData("{IsVip ? 'Gold' : 'Standard'}", "IsVip ? \"Gold\" : \"Standard\"")]
+	[InlineData("{Value ?? 'Default'}", "Value ?? \"Default\"")]
+	public void TopLevelTernary_IsNotParenthesized(string input, string expected)
+	{
+		Assert.Equal(expected, CSharpExpressionHelpers.GetExpressionCode(input));
+	}
+
+	[Fact]
+	// An already-parenthesized ternary with an explicit format specifier is preserved
+	// (no double wrapping, format specifier kept).
+	public void ParenthesizedTernaryWithFormat_IsPreserved()
+	{
+		var input = "{$'{(Count == 1 ? 1 : 2):D2}'}";
+		var expected = "$\"{(Count == 1 ? 1 : 2):D2}\"";
+		Assert.Equal(expected, CSharpExpressionHelpers.GetExpressionCode(input));
+	}
+}

--- a/src/Controls/tests/Xaml.UnitTests/CSharpExpressions.sgen.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/CSharpExpressions.sgen.xaml
@@ -98,6 +98,9 @@
         <!-- String interpolation with method call -->
         <Label x:Name="interpolationMethodLabel" Text="{$'Result: {GetText()}'}" />
         
+        <!-- Ternary directly inside an interpolation hole (issue #36155) -->
+        <Label x:Name="interpolationTernaryLabel" Text="{$'You clicked {Count} {Count == 1 ? 'time' : 'times'}.'}" />
+        
         <!-- TYPED BINDING TESTS (using separate x:DataType) -->
         <VerticalStackLayout x:DataType="local:SimpleViewModel">
             <!-- Simple binding expression: property only on x:DataType -->

--- a/src/Controls/tests/Xaml.UnitTests/CSharpExpressions.sgen.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/CSharpExpressions.sgen.xaml.cs
@@ -399,6 +399,15 @@ public partial class CSharpExpressions : ContentPage
 			Assert.Equal("Result: Method Result", page.interpolationMethodLabel.Text);
 		}
 
+		[Fact]
+		public void StringInterpolationWithTernaryInHole()
+		{
+			// Issue #36155: a ternary directly inside an interpolation hole must be
+			// auto-parenthesized so it compiles and evaluates correctly. Count == 0.
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			Assert.Equal("You clicked 0 times.", page.interpolationTernaryLabel.Text);
+		}
+
 		// TYPED BINDING TESTS
 
 		[Fact]


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description

Fixes #36155.

A XAML C# Expression (XEPR) interpolated string with a ternary **directly inside an interpolation hole** generated invalid C# and failed to compile:

```xml
<Label Text="{$'You clicked {Count} {Count == 1 ? 'time' : 'times'}.'}" />
```

This produced `$"You clicked {Count} {Count == 1 ? "time" : "times"}."`, which fails with `CS8076` / `CS8361` / `CS1003` / `CS0103`. In C#, the first **top-level `:`** inside an interpolation hole begins the format specifier, so a bare conditional must be parenthesized — even in hand-written C# you must write `$"{(cond ? a : b)}"`.

### Root cause analysis

The issue lists two suspected causes; investigation shows they collapse into **one**:

1. **Nested string literals** — *not actually a defect.* `TransformQuotes` flips every `'`→`"`, which is character-correct, and C# happily allows nested string literals inside interpolation holes (verified). The reported `CS0103: 'times'` is a *cascade* from the `:` confusion, not a quote bug.
2. **Un-parenthesized ternary in a hole** — the real and only fix needed.

### Fix

`CSharpExpressionHelpers.GetExpressionCode` now runs a new `ParenthesizeInterpolationTernaries` pass **before** quote translation. It walks interpolated strings (`$'…'` / `$"…"`), finds holes, and wraps a hole-level ternary in parentheses:

```
$"You clicked {Count} {(Count == 1 ? "time" : "times")}."
```

Format specifiers (`{value:F2}`), null-coalescing (`??`), null-conditional (`?.`, `?[`) and top-level (non-hole) ternaries are left untouched.

### Spec

`docs/specs/XamlCSharpExpressions.md` is amended to document the auto-parenthesization and its limits (a ternary combined with an explicit format specifier/alignment still needs manual parens).

### Tests

- 35 direct `GetExpressionCode` unit tests (`CSharpExpressionInterpolationTests.cs`), including non-ternary cases that prove no regression.
- An end-to-end SourceGen compile test (`TernaryInsideInterpolationHole_CompilesCleanly`) — fails with the exact issue errors without the fix.
- A runtime XAML test → `"You clicked 0 times."`.
- Full `SourceGen.UnitTests`: **229/229** pass.
