### PR TITLE
[Android] Fix ActivityStateManager leaking lifecycle callbacks on Activity recreation

### DIFF
--- a/src/Essentials/src/Platform/ActivityStateManager.android.cs
+++ b/src/Essentials/src/Platform/ActivityStateManager.android.cs
@@ -73,6 +73,9 @@ namespace Microsoft.Maui.ApplicationModel
 
 		public void Init(Application application)
 		{
+			if (lifecycleListener is not null)
+				return;
+
 			lifecycleListener = new ActivityLifecycleContextListener(OnActivityStateChanged);
 			application.RegisterActivityLifecycleCallbacks(lifecycleListener);
 		}

--- a/src/Essentials/src/Platform/ActivityStateManager.android.cs
+++ b/src/Essentials/src/Platform/ActivityStateManager.android.cs
@@ -74,7 +74,9 @@ namespace Microsoft.Maui.ApplicationModel
 		public void Init(Application application)
 		{
 			if (lifecycleListener is not null)
+			{
 				return;
+			}
 
 			lifecycleListener = new ActivityLifecycleContextListener(OnActivityStateChanged);
 			application.RegisterActivityLifecycleCallbacks(lifecycleListener);

--- a/src/Essentials/test/DeviceTests/Tests/ActivityStateManager_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/ActivityStateManager_Tests.cs
@@ -1,0 +1,104 @@
+// Device tests for GitHub issue #36035:
+// ActivityStateManager listener leak — Init(Application) was called on every
+// Activity recreation without a guard, registering a new listener each time.
+// Android's RegisterActivityLifecycleCallbacks is additive, so all old listeners
+// accumulated and every ActivityStateChanged event fired N+1 times after N recreations.
+
+#if __ANDROID__
+using System.Linq;
+using System.Threading;
+using Microsoft.Maui.ApplicationModel;
+using Xunit;
+
+namespace Microsoft.Maui.Essentials.DeviceTests
+{
+	using MauiPlatform = Microsoft.Maui.ApplicationModel.Platform;
+
+	[Category("ActivityStateManager")]
+	public class ActivityStateManager_Tests
+	{
+		/// <summary>
+		/// Verifies the fix for issue #36035: calling Init(Application) multiple times
+		/// (which happens on every Activity recreation) must keep the SAME listener
+		/// and NOT register additional ones.
+		/// Before the fix: each call created a new listener → N calls = N listeners.
+		/// After the fix: the guard `if (lifecycleListener is not null) return;` ensures
+		/// only the first call registers a listener.
+		/// </summary>
+		[Fact]
+		public void Init_CalledMultipleTimes_SameListenerIsKept()
+		{
+			var app = (global::Android.App.Application)global::Android.App.Application.Context;
+			var manager = new ActivityStateManagerImplementation();
+
+			manager.Init(app);
+			var listenerAfterFirst = GetListener(manager);
+
+			manager.Init(app);
+			var listenerAfterSecond = GetListener(manager);
+
+			manager.Init(app);
+			var listenerAfterThird = GetListener(manager);
+
+			Assert.NotNull(listenerAfterFirst);
+			Assert.Same(listenerAfterFirst, listenerAfterSecond);
+			Assert.Same(listenerAfterFirst, listenerAfterThird);
+		}
+
+		/// <summary>
+		/// Verifies that ActivityStateChanged fires exactly once per lifecycle event
+		/// even after Init(Application) is called multiple times.
+		/// Before the fix: N calls = N listeners → event fired N times per real event.
+		/// After the fix: always exactly 1 listener → event fires exactly once.
+		///
+		/// IMPORTANT: we capture each listener BEFORE the next Init call because
+		/// the bug overwrites the internal field each time. We then fire on ALL captured
+		/// listeners (simulating Android dispatching to every registered callback).
+		/// With the fix all three are the same object → fires once.
+		/// With the bug all three are different objects → fires three times.
+		/// </summary>
+		[Fact]
+		public void Init_CalledMultipleTimes_ActivityStateChangedFiresOnce()
+		{
+			var app = (global::Android.App.Application)global::Android.App.Application.Context;
+			var activity = MauiPlatform.CurrentActivity;
+
+			var manager = new ActivityStateManagerImplementation();
+
+			int invocations = 0;
+			manager.ActivityStateChanged += (_, _) => Interlocked.Increment(ref invocations);
+
+			// Capture the listener after EACH Init call, before the next one overwrites it.
+			manager.Init(app);
+			var l1 = GetListener(manager) as global::Android.App.Application.IActivityLifecycleCallbacks;
+
+			manager.Init(app);
+			var l2 = GetListener(manager) as global::Android.App.Application.IActivityLifecycleCallbacks;
+
+			manager.Init(app);
+			var l3 = GetListener(manager) as global::Android.App.Application.IActivityLifecycleCallbacks;
+
+			// Simulate Android dispatching a Resumed event to every distinct registered listener.
+			// With fix:  l1 == l2 == l3 (same object) → 1 unique listener → 1 invocation ✅
+			// With bug:  l1 != l2 != l3 (different)   → 3 unique listeners → 3 invocations ❌
+			foreach (var l in new[] { l1, l2, l3 }.Distinct())
+				l?.OnActivityResumed(activity);
+
+			Assert.Equal(1, invocations);
+		}
+
+		// Reads the private 'lifecycleListener' field from ActivityStateManagerImplementation
+		// via reflection. InternalsVisibleTo in AssemblyInfo.shared.cs grants access to
+		// internal types; reflection is needed only for the private field itself.
+		static ActivityLifecycleContextListener GetListener(ActivityStateManagerImplementation manager)
+		{
+			var field = typeof(ActivityStateManagerImplementation)
+				.GetField("lifecycleListener",
+					System.Reflection.BindingFlags.NonPublic |
+					System.Reflection.BindingFlags.Instance);
+
+			return field?.GetValue(manager) as ActivityLifecycleContextListener;
+		}
+	}
+}
+#endif


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->


### Issue Details
Every time an Android Activity is programmatically recreated (via Activity.Recreate()), Platform.ActivityStateChanged fires more times than expected. After 120 recreations, the event fires 61× more than it should, causing serious performance problems.

### Root Cause
ActivityStateManager.Init(Application) was called on every Activity recreation, and each call registered a new listener with Android without removing the old one. Android keeps all registered listeners, so after N recreations, N+1 listeners exist and every event fires N+1 times.

### Description of Change
Added a 2-line early-return guard in Init(Application):
 
if (lifecycleListener is not null)
     return;
 
This ensures the listener is registered only once on the first call. All subsequent calls (from Activity recreations) are safely skipped.

Validated the behavior in the following platforms
 
- [x] Android
- [ ] Windows
- [ ] iOS
- [ ] Mac
 
### Issues Fixed
  
Fixes #36035 

### Output  ScreenShot

|Before|After|
|--|--|
| <img width="367" height="741" alt="image" src="https://github.com/user-attachments/assets/5d8d5679-8285-4a7c-9bf2-5185e6f781b8" />| <img width="367" height="741" alt="image" src="https://github.com/user-attachments/assets/15a01574-e0c2-4e2b-bcc3-e5e7d0d9ccd5" /> |