### PR TITLE
[iOS/MacCatalyst] Fix SkiaSharp views becoming non-interactive after parent IsEnabled toggle

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.cs
+++ b/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.cs
@@ -28,7 +28,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			[Controls.ItemsView.EmptyViewTemplateProperty.PropertyName] = MapEmptyViewTemplate,
 			[Controls.ItemsView.FlowDirectionProperty.PropertyName] = MapFlowDirection,
 			[Controls.ItemsView.IsVisibleProperty.PropertyName] = MapIsVisible,
-			[Controls.ItemsView.ItemsUpdatingScrollModeProperty.PropertyName] = MapItemsUpdatingScrollMode
+			[Controls.ItemsView.ItemsUpdatingScrollModeProperty.PropertyName] = MapItemsUpdatingScrollMode,
+#if IOS || MACCATALYST
+			[Controls.VisualElement.IsEnabledProperty.PropertyName] = MapIsEnabled,
+#endif
 		};
 	}
 }

--- a/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.iOS.cs
@@ -91,6 +91,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			handler._layout.ItemsUpdatingScrollMode = itemsView.ItemsUpdatingScrollMode;
 		}
 
+		internal static void MapIsEnabled(ItemsViewHandler<TItemsView> handler, ItemsView itemsView)
+		{
+			handler.Controller?.CollectionView?.UpdateIsEnabled(itemsView);
+		}
+
 		protected virtual void UpdateLayout()
 		{
 			_layout = SelectLayout();

--- a/src/Controls/src/Core/Handlers/Items2/ItemsViewHandler2.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items2/ItemsViewHandler2.iOS.cs
@@ -33,7 +33,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			[Controls.ItemsView.EmptyViewTemplateProperty.PropertyName] = MapEmptyViewTemplate,
 			[Controls.ItemsView.FlowDirectionProperty.PropertyName] = MapFlowDirection,
 			[Controls.ItemsView.IsVisibleProperty.PropertyName] = MapIsVisible,
-			[Controls.ItemsView.ItemsUpdatingScrollModeProperty.PropertyName] = MapItemsUpdatingScrollMode
+			[Controls.ItemsView.ItemsUpdatingScrollModeProperty.PropertyName] = MapItemsUpdatingScrollMode,
+			[Controls.VisualElement.IsEnabledProperty.PropertyName] = MapIsEnabled
 		};
 
 		UICollectionViewLayout _layout;
@@ -127,6 +128,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			{
 				itemsLayout.ItemsUpdatingScrollMode = itemsView.ItemsUpdatingScrollMode;
 			}
+		}
+
+		internal static void MapIsEnabled(ItemsViewHandler2<TItemsView> handler, ItemsView itemsView)
+		{
+			handler.Controller?.CollectionView?.UpdateIsEnabled(itemsView);
 		}
 
 		//TODO: this is being called 2 times on startup, one from OnCreatePlatformView and otehr from the mapper for the layout

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -17,16 +17,12 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateIsEnabled(this UIView platformView, IView view)
 		{
-			if (platformView is UIControl uiControl)
+			if (platformView is not UIControl uiControl)
 			{
-				// UIControl has native Enabled property with visual feedback
-				uiControl.Enabled = view.IsEnabled;
+				return;
 			}
-			else
-			{
-				// Non-UIControl views (like UICollectionView) only get interaction disable
-				platformView.UserInteractionEnabled = view.IsEnabled;
-			}
+
+			uiControl.Enabled = view.IsEnabled;
 		}
 
 		public static void Focus(this UIView platformView, FocusRequest request)


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
- On iOS, after upgrading to .NET MAUI 10.0.60, toggling a parent Grid’s IsEnabled causes SkiaSharp SKCanvasView/SKGLView to become non-interactive (taps/clicks stop working), which is a regression from 10.0.51.

### Root Cause
- PR #31403 added else { platformView.UserInteractionEnabled = view.IsEnabled; } to ViewExtensions.UpdateIsEnabled, which runs for all non-UIControl native views, including SkiaSharp SKCanvasView/SKGLView. As a result, UserInteractionEnabled is set to false when a parent’s IsEnabled is toggled off, and SkiaSharp interaction can freeze even after IsEnabled is toggled back on and the value is restored.

### Description of Change
- Revert ViewExtensions.UpdateIsEnabled to its pre-PR #31403 form (UIControl-only) and instead add a dedicated MapIsEnabled to ItemsViewHandler (iOS/MacCatalyst) that calls handler.Controller?.CollectionView?.UpdateIsEnabled(itemsView) directly — routing the IsEnabled change to the actual UICollectionView via the already-existing CollectionViewExtensions.UpdateIsEnabled, without touching any other non-UIControl native views.

**Test Coverage / Validation :**
- No new test was added in this PR because the issue is reproduced via a SkiaSharp-based runtime repro, and this change is a targeted rollback plus CollectionView-specific remap; CollectionView behavior is already covered by the existing PR #31403 test path.

### Issues Fixed
Fixes #36059

### Validated the behaviour in the following platforms

- [ ] Windows
- [ ] Android
- [x] iOS
- [x] Mac


### Output
| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/5aa8eb1d-9965-4013-9694-4ead35bf0ee0"> | <video src="https://github.com/user-attachments/assets/570899c3-9538-490f-aa6c-c5f0b6252a29"> |