### PR TITLE
[SourceGen] Report correct location for expression parse errors

### DIFF
--- a/src/Controls/src/SourceGen/Visitors/ExpandMarkupsVisitor.cs
+++ b/src/Controls/src/SourceGen/Visitors/ExpandMarkupsVisitor.cs
@@ -234,31 +234,28 @@ class ExpandMarkupsVisitor(SourceGenContext context) : IXamlNodeVisitor
 
 	INode? ParseExpression(ref string expression, IXmlNamespaceResolver nsResolver, IXmlLineInfo xmlLineInfo, INode node, INode parentNode)
 	{
+		// Capture the original expression so diagnostics point at the full markup, even after `expression` is consumed below.
+		var originalExpression = expression;
+
 		if (expression.StartsWith("{}", StringComparison.Ordinal))
 			return new ValueNode(expression.Substring(2), null, xmlLineInfo?.LineNumber ?? -1, xmlLineInfo?.LinePosition ?? -1);
 
 		if (expression.Length == 0 || expression[expression.Length - 1] != '}')
 		{
-			//FIXME fix location
-			var location = Context.ProjectItem.RelativePath is not null ? Location.Create(Context.ProjectItem.RelativePath, new TextSpan(), new LinePositionSpan()) : null;
-			Context.ReportDiagnostic(Diagnostic.Create(Descriptors.ExpressionNotClosed, location));
+			Context.ReportDiagnostic(Diagnostic.Create(Descriptors.ExpressionNotClosed, CreateExpressionLocation(xmlLineInfo, originalExpression)));
 			return null;
 		}
 
 		if (!MarkupExpressionParser.MatchMarkup(out var match, expression, out var len))
 		{
-			//FIXME fix location
-			var location = Context.ProjectItem.RelativePath is not null ? Location.Create(Context.ProjectItem.RelativePath, new TextSpan(), new LinePositionSpan()) : null;
-			Context.ReportDiagnostic(Diagnostic.Create(Descriptors.XamlParserError, location));
+			Context.ReportDiagnostic(Diagnostic.Create(Descriptors.XamlParserError, CreateExpressionLocation(xmlLineInfo, originalExpression)));
 			return null;
 		}
 
 		expression = expression.Substring(len).TrimStart();
 		if (expression.Length == 0)
 		{
-			//FIXME fix location
-			var location = Context.ProjectItem.RelativePath is not null ? Location.Create(Context.ProjectItem.RelativePath, new TextSpan(), new LinePositionSpan()) : null;
-			Context.ReportDiagnostic(Diagnostic.Create(Descriptors.ExpressionNotClosed, location));
+			Context.ReportDiagnostic(Diagnostic.Create(Descriptors.ExpressionNotClosed, CreateExpressionLocation(xmlLineInfo, originalExpression)));
 			return null;
 		}
 		var serviceProvider = new XamlServiceProvider(node, Context);
@@ -268,6 +265,17 @@ class ExpandMarkupsVisitor(SourceGenContext context) : IXamlNodeVisitor
 			serviceProvider.Add(typeof(IXmlLineInfoProvider), new XmlLineInfoProvider(xmlLineInfo));
 
 		return new MarkupExpansionParser().Parse(match!, ref expression, serviceProvider);
+	}
+
+	// Builds a diagnostic location pointing at the offending expression using its line info,
+	// instead of defaulting to the file root (1,1).
+	Location? CreateExpressionLocation(IXmlLineInfo? xmlLineInfo, string text)
+	{
+		if (Context.ProjectItem.RelativePath is not string relativePath)
+			return null;
+		if (xmlLineInfo is null || !xmlLineInfo.HasLineInfo())
+			return Location.Create(relativePath, new TextSpan(), new LinePositionSpan());
+		return LocationHelpers.LocationCreate(relativePath, xmlLineInfo, text);
 	}
 
 

--- a/src/Controls/tests/SourceGen.UnitTests/Maui36158Tests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/Maui36158Tests.cs
@@ -1,0 +1,67 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.SourceGen.UnitTests;
+
+// https://github.com/dotnet/maui/issues/36158
+// When a markup / XAML C# Expression fails to parse, MAUIG1003 (and sibling parse errors)
+// must report the line/column of the offending expression, not the file root (1,1).
+public class Maui36158Tests : SourceGenXamlInitializeComponentTestBase
+{
+	[Fact]
+	public void UnclosedExpressionReportsExpressionLineNotFileRoot()
+	{
+		// The malformed expression (missing trailing '}') is on line 7 (1-indexed).
+		var xaml =
+"""
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	x:Class="Test.TestPage">
+	<Label Text="Hello" />
+	<Label Text="{IsActive ? 'Status: Active' : 'Status: Idle'" />
+</ContentPage>
+""";
+
+		var (result, _) = RunGenerator(xaml, string.Empty, assertNoCompilationErrors: false);
+
+		var diagnostic = Assert.Single(result.Diagnostics.Where(d => d.Id == "MAUIG1003"));
+
+		var location = diagnostic.Location.GetLineSpan();
+
+		// Line 7 (1-indexed) == line 6 (0-indexed). Before the fix this was the file root (line 0).
+		Assert.Equal(6, location.StartLinePosition.Line);
+		// And the column must point into the expression, not column 0.
+		Assert.NotEqual(0, location.StartLinePosition.Character);
+	}
+
+	[Fact]
+	public void UnclosedMarkupExtensionReportsExpressionLineNotFileRoot()
+	{
+		// An unclosed markup extension (missing trailing '}') on line 8 (1-indexed).
+		var xaml =
+"""
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	x:Class="Test.TestPage">
+	<Label Text="Hello" />
+	<Label Text="World" />
+	<Label Text="{StaticResource MissingBrace" />
+</ContentPage>
+""";
+
+		var (result, _) = RunGenerator(xaml, string.Empty, assertNoCompilationErrors: false);
+
+		var diagnostic = Assert.Single(result.Diagnostics.Where(d => d.Id == "MAUIG1003"));
+
+		var location = diagnostic.Location.GetLineSpan();
+
+		// Line 8 (1-indexed) == line 7 (0-indexed). Before the fix this was the file root (line 0).
+		Assert.Equal(7, location.StartLinePosition.Line);
+		Assert.NotEqual(0, location.StartLinePosition.Character);
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

Fixes #36158

## Summary

When a markup / XAML C# Expression fails to parse (e.g. a missing closing `}`), the source generator reported `MAUIG1003: Expression must end with '}'` (and the sibling `MAUIG1001` parse error) at the **file root `(1,1)`** instead of the actual line/column of the offending expression.

## Root cause

`ExpandMarkupsVisitor.ParseExpression` built the diagnostic `location` from an **empty** `TextSpan` / `LinePositionSpan` in three places (each marked `//FIXME fix location`), ignoring the `xmlLineInfo` parameter it already receives. `new LinePositionSpan()` defaults to line 0 / char 0, which renders as `(1,1)`.

## Fix

Derive the location from `xmlLineInfo` using the existing `LocationHelpers.LocationCreate` helper (the same helper already used throughout this file and the rest of the SourceGen), via a small `CreateExpressionLocation` method. It falls back gracefully to the previous behavior when line info or the relative path is unavailable.

The diagnostic now points at the expression's actual line, e.g. `MainPage.xaml(33,…)` instead of `MainPage.xaml(1,1)`.

## Tests

Added `Maui36158Tests` (in `Controls.SourceGen.UnitTests`) with two cases:
- The issue's exact repro — an unclosed XEPR ternary `{IsActive ? 'Status: Active' : 'Status: Idle'` — now reports `MAUIG1003` on the expression's line.
- An unclosed markup extension `{StaticResource MissingBrace` — likewise reports on the correct line.

Both tests **fail without the fix** (reported line `0`) and **pass with it**. The full `Controls.SourceGen.UnitTests` suite (218 tests) passes with no regressions.

## Notes

This addresses only the diagnostic-location bug. The related issues #36157 (stale `MAUIG1003` under `dotnet watch`), #36156 (rude-edit hot reload), and #36155 (XEPR nested-string / ternary parsing) are out of scope.
