### PR TITLE
[Android] Fix FlyoutPage detail-swap fragment crash causing SwappingDetailPageWorksForSplitFlyoutBehavior device test failure on candidate branch

### DIFF
--- a/src/Core/src/Platform/Android/Navigation/NavigationRootManager.cs
+++ b/src/Core/src/Platform/Android/Navigation/NavigationRootManager.cs
@@ -153,7 +153,20 @@ namespace Microsoft.Maui.Platform
 			_pendingFragment?.Dispose();
 			_pendingFragment = null;
 			if (_rootView is ContainerView containerView)
+			{
+				// Clearing CurrentView below synchronously detaches the DrawerLayout that hosts
+				// navigationlayout_content. Flush pending fragment transactions first so a queued
+				// FlyoutView detail Replace doesn't run against a missing container and crash.
+				var fragmentManager = _mauiContext?.GetFragmentManager();
+				if (fragmentManager is not null &&
+					!fragmentManager.IsDestroyed(_mauiContext?.Context) &&
+					!fragmentManager.IsStateSaved)
+				{
+					fragmentManager.ExecutePendingTransactionsEx();
+				}
+
 				containerView.CurrentView = null;
+			}
 
 			DrawerLayout = null;
 			_rootView = null;


### PR DESCRIPTION
 <!-- Please let the below note in for people that find this PR -->
   > [!NOTE]
   > Are you waiting for the changes in this PR to be merged?
   > It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. 
  Thank you!
 
### Root Cause
A `FlyoutPage`'s `Detail` view is hosted inside a fragment container (`navigationlayout_content`) within the `FlyoutPage`'s `DrawerLayout`. Changing `Detail` swaps that view using an asynchronous fragment transaction (`Replace(...).Commit()`), which is queued to the main thread and not executed immediately.

PR #35372  added `containerView.CurrentView = null` to `NavigationRootManager.ClearPlatformParts()` — a teardown path. That line synchronously removes the `DrawerLayout`, along with `navigationlayout_content`.

The crash is caused by an ordering issue: if a detail `Replace` transaction is still queued when teardown runs, PR #35372 removes its container first; the queued transaction then executes, cannot find `navigationlayout_content`, and Android throws:

```text
java.lang.IllegalArgumentException: No view found for id 0x7f080156
(...:id/navigationlayout_content) for fragment ScopedFragment{...}
    at androidx.fragment.app.FragmentManager.execPendingActions(FragmentManager.java:2052)
```
This terminates the app process; in CI, the run appears hung with no per-test result.

In `SwappingDetailPageWorksForSplitFlyoutBehavior`, teardown is not triggered by setting `Detail`. Instead, it happens when the test harness disconnects the `Window` after `CreateHandlerAndAddToWindow(...)` completes its action block. The detail swap inside that block leaves a transaction queued; window teardown then removes the container before it executes.

Before PR #35372, teardown did not remove the `DrawerLayout`, so the queued transaction still found its container and no crash occurred.

### Description of Change
In `NavigationRootManager.ClearPlatformParts()` (Android), pending fragment transactions are drained before clearing the container’s `CurrentView`, while the container is still attached.

This ensures any in-flight detail replace completes against a valid container, so nothing remains queued when the `DrawerLayout` is detached.

PR #35372’s leak fix (clearing `CurrentView`) remains unchanged — this only hardens the ordering by adding the drain immediately before it.

The drain:

* Runs only when the window root is a `FlyoutPage`
* Safely no-ops when the fragment manager is unavailable
* Safely no-ops when the context is destroyed
* Safely no-ops when instance state has already been saved

### Regression Introduced By
PR #35372
 
### Issues Fixed
SwappingDetailPageWorksForSplitFlyoutBehavior
 
Tested the behaviour in the following platforms
- [x] Android
- [ ] Windows
- [ ] iOS
- [ ] Mac
