### PR TITLE
[release/11.0.1xx-preview6] Bump dotnet/dotnet to preview.6.26325.125 (BAR 320350) and remove sdk#54779 workaround

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,12 +1,12 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.Sdk" Version="11.0.100-preview.6.26323.106">
+    <Dependency Name="Microsoft.NET.Sdk" Version="11.0.100-preview.6.26326.122">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a3bc9fe168e83785ed89c54c29aea18b80f3838b</Sha>
+      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-preview.6.26323.106">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-preview.6.26326.122">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a3bc9fe168e83785ed89c54c29aea18b80f3838b</Sha>
+      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Android.Sdk.Windows" Version="37.0.0-ci.main.51">
       <Uri>https://github.com/dotnet/android</Uri>
@@ -53,109 +53,109 @@
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="11.0.0-preview.6.26323.106">
+    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="11.0.0-preview.6.26326.122">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a3bc9fe168e83785ed89c54c29aea18b80f3838b</Sha>
+      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="11.0.0-preview.6.26323.106">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="11.0.0-preview.6.26326.122">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a3bc9fe168e83785ed89c54c29aea18b80f3838b</Sha>
+      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="11.0.0-preview.6.26323.106">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="11.0.0-preview.6.26326.122">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a3bc9fe168e83785ed89c54c29aea18b80f3838b</Sha>
+      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="11.0.0-preview.6.26323.106">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="11.0.0-preview.6.26326.122">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a3bc9fe168e83785ed89c54c29aea18b80f3838b</Sha>
+      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components" Version="11.0.0-preview.6.26323.106">
+    <Dependency Name="Microsoft.AspNetCore.Components" Version="11.0.0-preview.6.26326.122">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a3bc9fe168e83785ed89c54c29aea18b80f3838b</Sha>
+      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="11.0.0-preview.6.26323.106">
+    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="11.0.0-preview.6.26326.122">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a3bc9fe168e83785ed89c54c29aea18b80f3838b</Sha>
+      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="11.0.0-preview.6.26323.106">
+    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="11.0.0-preview.6.26326.122">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a3bc9fe168e83785ed89c54c29aea18b80f3838b</Sha>
+      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="11.0.0-preview.6.26323.106">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="11.0.0-preview.6.26326.122">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a3bc9fe168e83785ed89c54c29aea18b80f3838b</Sha>
+      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="11.0.0-preview.6.26323.106">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="11.0.0-preview.6.26326.122">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a3bc9fe168e83785ed89c54c29aea18b80f3838b</Sha>
+      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="11.0.0-preview.6.26323.106">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="11.0.0-preview.6.26326.122">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a3bc9fe168e83785ed89c54c29aea18b80f3838b</Sha>
+      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="11.0.0-preview.6.26323.106">
+    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="11.0.0-preview.6.26326.122">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a3bc9fe168e83785ed89c54c29aea18b80f3838b</Sha>
+      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="11.0.0-preview.6.26323.106">
+    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="11.0.0-preview.6.26326.122">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a3bc9fe168e83785ed89c54c29aea18b80f3838b</Sha>
+      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.JSInterop" Version="11.0.0-preview.6.26323.106">
+    <Dependency Name="Microsoft.JSInterop" Version="11.0.0-preview.6.26326.122">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a3bc9fe168e83785ed89c54c29aea18b80f3838b</Sha>
+      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
     </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-preview.2.22102.8">
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>3f4da9ced34942d83054e647f3b1d9d7dde281e8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration" Version="11.0.0-preview.6.26323.106">
+    <Dependency Name="Microsoft.Extensions.Configuration" Version="11.0.0-preview.6.26326.122">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a3bc9fe168e83785ed89c54c29aea18b80f3838b</Sha>
+      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="11.0.0-preview.6.26323.106">
+    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="11.0.0-preview.6.26326.122">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a3bc9fe168e83785ed89c54c29aea18b80f3838b</Sha>
+      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="11.0.0-preview.6.26323.106">
+    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="11.0.0-preview.6.26326.122">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a3bc9fe168e83785ed89c54c29aea18b80f3838b</Sha>
+      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="11.0.0-preview.6.26323.106">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="11.0.0-preview.6.26326.122">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a3bc9fe168e83785ed89c54c29aea18b80f3838b</Sha>
+      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="11.0.0-preview.6.26323.106">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="11.0.0-preview.6.26326.122">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a3bc9fe168e83785ed89c54c29aea18b80f3838b</Sha>
+      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="11.0.0-preview.6.26323.106">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="11.0.0-preview.6.26326.122">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a3bc9fe168e83785ed89c54c29aea18b80f3838b</Sha>
+      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="11.0.0-preview.6.26323.106">
+    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="11.0.0-preview.6.26326.122">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a3bc9fe168e83785ed89c54c29aea18b80f3838b</Sha>
+      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="11.0.0-preview.6.26323.106">
+    <Dependency Name="Microsoft.Extensions.Logging" Version="11.0.0-preview.6.26326.122">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a3bc9fe168e83785ed89c54c29aea18b80f3838b</Sha>
+      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="11.0.0-preview.6.26323.106">
+    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="11.0.0-preview.6.26326.122">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a3bc9fe168e83785ed89c54c29aea18b80f3838b</Sha>
+      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="11.0.0-preview.6.26323.106">
+    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="11.0.0-preview.6.26326.122">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a3bc9fe168e83785ed89c54c29aea18b80f3838b</Sha>
+      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Primitives" Version="11.0.0-preview.6.26323.106">
+    <Dependency Name="Microsoft.Extensions.Primitives" Version="11.0.0-preview.6.26326.122">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a3bc9fe168e83785ed89c54c29aea18b80f3838b</Sha>
+      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="11.0.0-preview.6.26323.106">
+    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="11.0.0-preview.6.26326.122">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a3bc9fe168e83785ed89c54c29aea18b80f3838b</Sha>
+      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="11.0.0-prerelease.26064.3">
       <Uri>https://github.com/dotnet/xharness</Uri>
@@ -175,37 +175,37 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="11.0.0-beta.26323.106">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="11.0.0-beta.26326.122">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a3bc9fe168e83785ed89c54c29aea18b80f3838b</Sha>
+      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26323.106">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26326.122">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a3bc9fe168e83785ed89c54c29aea18b80f3838b</Sha>
+      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="11.0.0-beta.26323.106">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="11.0.0-beta.26326.122">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a3bc9fe168e83785ed89c54c29aea18b80f3838b</Sha>
+      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="11.0.0-beta.26323.106">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="11.0.0-beta.26326.122">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a3bc9fe168e83785ed89c54c29aea18b80f3838b</Sha>
+      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26323.106">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26326.122">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a3bc9fe168e83785ed89c54c29aea18b80f3838b</Sha>
+      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="11.0.0-beta.26323.106">
+    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="11.0.0-beta.26326.122">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a3bc9fe168e83785ed89c54c29aea18b80f3838b</Sha>
+      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="11.0.0-beta.26323.106">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="11.0.0-beta.26326.122">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a3bc9fe168e83785ed89c54c29aea18b80f3838b</Sha>
+      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="11.0.0-beta.26323.106">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="11.0.0-beta.26326.122">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a3bc9fe168e83785ed89c54c29aea18b80f3838b</Sha>
+      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,12 +1,12 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.Sdk" Version="11.0.100-preview.6.26326.122">
+    <Dependency Name="Microsoft.NET.Sdk" Version="11.0.100-preview.6.26325.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-preview.6.26326.122">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-preview.6.26325.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Android.Sdk.Windows" Version="37.0.0-ci.main.51">
       <Uri>https://github.com/dotnet/android</Uri>
@@ -53,109 +53,109 @@
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="11.0.0-preview.6.26326.122">
+    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="11.0.0-preview.6.26325.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="11.0.0-preview.6.26326.122">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="11.0.0-preview.6.26325.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="11.0.0-preview.6.26326.122">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="11.0.0-preview.6.26325.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="11.0.0-preview.6.26326.122">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="11.0.0-preview.6.26325.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components" Version="11.0.0-preview.6.26326.122">
+    <Dependency Name="Microsoft.AspNetCore.Components" Version="11.0.0-preview.6.26325.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="11.0.0-preview.6.26326.122">
+    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="11.0.0-preview.6.26325.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="11.0.0-preview.6.26326.122">
+    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="11.0.0-preview.6.26325.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="11.0.0-preview.6.26326.122">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="11.0.0-preview.6.26325.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="11.0.0-preview.6.26326.122">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="11.0.0-preview.6.26325.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="11.0.0-preview.6.26326.122">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="11.0.0-preview.6.26325.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="11.0.0-preview.6.26326.122">
+    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="11.0.0-preview.6.26325.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="11.0.0-preview.6.26326.122">
+    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="11.0.0-preview.6.26325.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.JSInterop" Version="11.0.0-preview.6.26326.122">
+    <Dependency Name="Microsoft.JSInterop" Version="11.0.0-preview.6.26325.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-preview.2.22102.8">
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>3f4da9ced34942d83054e647f3b1d9d7dde281e8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration" Version="11.0.0-preview.6.26326.122">
+    <Dependency Name="Microsoft.Extensions.Configuration" Version="11.0.0-preview.6.26325.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="11.0.0-preview.6.26326.122">
+    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="11.0.0-preview.6.26325.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="11.0.0-preview.6.26326.122">
+    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="11.0.0-preview.6.26325.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="11.0.0-preview.6.26326.122">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="11.0.0-preview.6.26325.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="11.0.0-preview.6.26326.122">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="11.0.0-preview.6.26325.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="11.0.0-preview.6.26326.122">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="11.0.0-preview.6.26325.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="11.0.0-preview.6.26326.122">
+    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="11.0.0-preview.6.26325.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="11.0.0-preview.6.26326.122">
+    <Dependency Name="Microsoft.Extensions.Logging" Version="11.0.0-preview.6.26325.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="11.0.0-preview.6.26326.122">
+    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="11.0.0-preview.6.26325.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="11.0.0-preview.6.26326.122">
+    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="11.0.0-preview.6.26325.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Primitives" Version="11.0.0-preview.6.26326.122">
+    <Dependency Name="Microsoft.Extensions.Primitives" Version="11.0.0-preview.6.26325.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="11.0.0-preview.6.26326.122">
+    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="11.0.0-preview.6.26325.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="11.0.0-prerelease.26064.3">
       <Uri>https://github.com/dotnet/xharness</Uri>
@@ -175,37 +175,37 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="11.0.0-beta.26326.122">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="11.0.0-beta.26325.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26326.122">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26325.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="11.0.0-beta.26326.122">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="11.0.0-beta.26325.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="11.0.0-beta.26326.122">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="11.0.0-beta.26325.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26326.122">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26325.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="11.0.0-beta.26326.122">
+    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="11.0.0-beta.26325.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="11.0.0-beta.26326.122">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="11.0.0-beta.26325.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="11.0.0-beta.26326.122">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="11.0.0-beta.26325.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>1bff05b756db35ded2fbb17fb8f2934ac81e1b74</Sha>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -31,10 +31,10 @@
     <!-- Current previous .NET SDK major version's stable release of MAUI packages -->
     <MicrosoftMauiPreviousDotNetReleasedVersion>10.0.20</MicrosoftMauiPreviousDotNetReleasedVersion>
     <!-- dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>11.0.100-preview.6.26326.122</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>11.0.100-preview.6.26325.125</MicrosoftNETSdkPackageVersion>
     <MicrosoftDotnetSdkInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-preview.6.26326.122</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-preview.6.26325.125</MicrosoftNETCoreAppRefPackageVersion>
     <SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextJsonPackageVersion>
     <SystemTextEncodingsWebPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextEncodingsWebPackageVersion>
     <MicrosoftBclAsyncInterfacesPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftBclAsyncInterfacesPackageVersion>
@@ -42,18 +42,18 @@
     <optimizationandroidx64MIBCRuntimePackageVersion>1.0.0-prerelease.26317.1</optimizationandroidx64MIBCRuntimePackageVersion>
     <!-- Microsoft/Extensions -->
     <SystemCodeDomPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemCodeDomPackageVersion>
-    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.6.26326.122</MicrosoftExtensionsConfigurationVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsVersion>11.0.0-preview.6.26326.122</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationJsonVersion>11.0.0-preview.6.26326.122</MicrosoftExtensionsConfigurationJsonVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>11.0.0-preview.6.26326.122</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>11.0.0-preview.6.26326.122</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
-    <MicrosoftExtensionsFileProvidersAbstractionsVersion>11.0.0-preview.6.26326.122</MicrosoftExtensionsFileProvidersAbstractionsVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>11.0.0-preview.6.26326.122</MicrosoftExtensionsLoggingAbstractionsVersion>
-    <MicrosoftExtensionsLoggingVersion>11.0.0-preview.6.26326.122</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>11.0.0-preview.6.26326.122</MicrosoftExtensionsLoggingConsoleVersion>
-    <MicrosoftExtensionsLoggingDebugVersion>11.0.0-preview.6.26326.122</MicrosoftExtensionsLoggingDebugVersion>
-    <MicrosoftExtensionsPrimitivesVersion>11.0.0-preview.6.26326.122</MicrosoftExtensionsPrimitivesVersion>
-    <MicrosoftExtensionsHostingAbstractionsVersion>11.0.0-preview.6.26326.122</MicrosoftExtensionsHostingAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.6.26325.125</MicrosoftExtensionsConfigurationVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>11.0.0-preview.6.26325.125</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationJsonVersion>11.0.0-preview.6.26325.125</MicrosoftExtensionsConfigurationJsonVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>11.0.0-preview.6.26325.125</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>11.0.0-preview.6.26325.125</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
+    <MicrosoftExtensionsFileProvidersAbstractionsVersion>11.0.0-preview.6.26325.125</MicrosoftExtensionsFileProvidersAbstractionsVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>11.0.0-preview.6.26325.125</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingVersion>11.0.0-preview.6.26325.125</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>11.0.0-preview.6.26325.125</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingDebugVersion>11.0.0-preview.6.26325.125</MicrosoftExtensionsLoggingDebugVersion>
+    <MicrosoftExtensionsPrimitivesVersion>11.0.0-preview.6.26325.125</MicrosoftExtensionsPrimitivesVersion>
+    <MicrosoftExtensionsHostingAbstractionsVersion>11.0.0-preview.6.26325.125</MicrosoftExtensionsHostingAbstractionsVersion>
     <MicrosoftExtensionsAIVersion>10.3.0</MicrosoftExtensionsAIVersion>
     <MicrosoftExtensionsAIAbstractionsVersion>10.3.0</MicrosoftExtensionsAIAbstractionsVersion>
     <MicrosoftExtensionsHttpVersion>11.0.0-preview.2.26103.111</MicrosoftExtensionsHttpVersion>
@@ -84,19 +84,19 @@
     <MicrosoftGraphicsWin2DPackageVersion>1.3.2</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.3179.45</MicrosoftWindowsWebView2PackageVersion>
     <!-- Everything else -->
-    <MicrosoftAspNetCoreAuthorizationPackageVersion>11.0.0-preview.6.26326.122</MicrosoftAspNetCoreAuthorizationPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>11.0.0-preview.6.26326.122</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>11.0.0-preview.6.26326.122</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
-    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>11.0.0-preview.6.26326.122</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
-    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>11.0.0-preview.6.26326.122</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreComponentsFormsPackageVersion>11.0.0-preview.6.26326.122</MicrosoftAspNetCoreComponentsFormsPackageVersion>
-    <MicrosoftAspNetCoreComponentsPackageVersion>11.0.0-preview.6.26326.122</MicrosoftAspNetCoreComponentsPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebPackageVersion>11.0.0-preview.6.26326.122</MicrosoftAspNetCoreComponentsWebPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>11.0.0-preview.6.26326.122</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>11.0.0-preview.6.26326.122</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>11.0.0-preview.6.26326.122</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
-    <MicrosoftAspNetCoreMetadataPackageVersion>11.0.0-preview.6.26326.122</MicrosoftAspNetCoreMetadataPackageVersion>
-    <MicrosoftJSInteropPackageVersion>11.0.0-preview.6.26326.122</MicrosoftJSInteropPackageVersion>
+    <MicrosoftAspNetCoreAuthorizationPackageVersion>11.0.0-preview.6.26325.125</MicrosoftAspNetCoreAuthorizationPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>11.0.0-preview.6.26325.125</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>11.0.0-preview.6.26325.125</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
+    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>11.0.0-preview.6.26325.125</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
+    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>11.0.0-preview.6.26325.125</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreComponentsFormsPackageVersion>11.0.0-preview.6.26325.125</MicrosoftAspNetCoreComponentsFormsPackageVersion>
+    <MicrosoftAspNetCoreComponentsPackageVersion>11.0.0-preview.6.26325.125</MicrosoftAspNetCoreComponentsPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebPackageVersion>11.0.0-preview.6.26325.125</MicrosoftAspNetCoreComponentsWebPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>11.0.0-preview.6.26325.125</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>11.0.0-preview.6.26325.125</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>11.0.0-preview.6.26325.125</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
+    <MicrosoftAspNetCoreMetadataPackageVersion>11.0.0-preview.6.26325.125</MicrosoftAspNetCoreMetadataPackageVersion>
+    <MicrosoftJSInteropPackageVersion>11.0.0-preview.6.26325.125</MicrosoftJSInteropPackageVersion>
     <!-- Everything else (previous edition) -->
     <MicrosoftAspNetCorePackageVersion>10.0.2</MicrosoftAspNetCorePackageVersion>
     <MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>$(MicrosoftAspNetCorePackageVersion)</MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>
@@ -146,13 +146,13 @@
     <TizenUIExtensionsVersion>0.9.0</TizenUIExtensionsVersion>
     <ExCSSPackageVersion>4.2.3</ExCSSPackageVersion>
     <SystemDrawingCommonPackageVersion>9.0.0</SystemDrawingCommonPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>11.0.0-beta.26326.122</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetBuildTasksInstallersPackageVersion>11.0.0-beta.26326.122</MicrosoftDotNetBuildTasksInstallersPackageVersion>
-    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>11.0.0-beta.26326.122</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26326.122</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>11.0.0-beta.26325.125</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksInstallersPackageVersion>11.0.0-beta.26325.125</MicrosoftDotNetBuildTasksInstallersPackageVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>11.0.0-beta.26325.125</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26325.125</MicrosoftDotNetHelixSdkPackageVersion>
     <MicroBuildPluginsSwixBuildDotnetPackageVersion>1.1.87-gba258badda</MicroBuildPluginsSwixBuildDotnetPackageVersion>
-    <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.26326.122</MicrosoftDotNetRemoteExecutorPackageVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>11.0.0-beta.26326.122</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.26325.125</MicrosoftDotNetRemoteExecutorPackageVersion>
+    <MicrosoftDotNetXUnitExtensionsPackageVersion>11.0.0-beta.26325.125</MicrosoftDotNetXUnitExtensionsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftNETTestSdkPackageVersion>17.6.0</MicrosoftNETTestSdkPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -31,10 +31,10 @@
     <!-- Current previous .NET SDK major version's stable release of MAUI packages -->
     <MicrosoftMauiPreviousDotNetReleasedVersion>10.0.20</MicrosoftMauiPreviousDotNetReleasedVersion>
     <!-- dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>11.0.100-preview.6.26323.106</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>11.0.100-preview.6.26326.122</MicrosoftNETSdkPackageVersion>
     <MicrosoftDotnetSdkInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-preview.6.26323.106</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-preview.6.26326.122</MicrosoftNETCoreAppRefPackageVersion>
     <SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextJsonPackageVersion>
     <SystemTextEncodingsWebPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextEncodingsWebPackageVersion>
     <MicrosoftBclAsyncInterfacesPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftBclAsyncInterfacesPackageVersion>
@@ -42,18 +42,18 @@
     <optimizationandroidx64MIBCRuntimePackageVersion>1.0.0-prerelease.26317.1</optimizationandroidx64MIBCRuntimePackageVersion>
     <!-- Microsoft/Extensions -->
     <SystemCodeDomPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemCodeDomPackageVersion>
-    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.6.26323.106</MicrosoftExtensionsConfigurationVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsVersion>11.0.0-preview.6.26323.106</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationJsonVersion>11.0.0-preview.6.26323.106</MicrosoftExtensionsConfigurationJsonVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>11.0.0-preview.6.26323.106</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>11.0.0-preview.6.26323.106</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
-    <MicrosoftExtensionsFileProvidersAbstractionsVersion>11.0.0-preview.6.26323.106</MicrosoftExtensionsFileProvidersAbstractionsVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>11.0.0-preview.6.26323.106</MicrosoftExtensionsLoggingAbstractionsVersion>
-    <MicrosoftExtensionsLoggingVersion>11.0.0-preview.6.26323.106</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>11.0.0-preview.6.26323.106</MicrosoftExtensionsLoggingConsoleVersion>
-    <MicrosoftExtensionsLoggingDebugVersion>11.0.0-preview.6.26323.106</MicrosoftExtensionsLoggingDebugVersion>
-    <MicrosoftExtensionsPrimitivesVersion>11.0.0-preview.6.26323.106</MicrosoftExtensionsPrimitivesVersion>
-    <MicrosoftExtensionsHostingAbstractionsVersion>11.0.0-preview.6.26323.106</MicrosoftExtensionsHostingAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.6.26326.122</MicrosoftExtensionsConfigurationVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>11.0.0-preview.6.26326.122</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationJsonVersion>11.0.0-preview.6.26326.122</MicrosoftExtensionsConfigurationJsonVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>11.0.0-preview.6.26326.122</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>11.0.0-preview.6.26326.122</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
+    <MicrosoftExtensionsFileProvidersAbstractionsVersion>11.0.0-preview.6.26326.122</MicrosoftExtensionsFileProvidersAbstractionsVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>11.0.0-preview.6.26326.122</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingVersion>11.0.0-preview.6.26326.122</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>11.0.0-preview.6.26326.122</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingDebugVersion>11.0.0-preview.6.26326.122</MicrosoftExtensionsLoggingDebugVersion>
+    <MicrosoftExtensionsPrimitivesVersion>11.0.0-preview.6.26326.122</MicrosoftExtensionsPrimitivesVersion>
+    <MicrosoftExtensionsHostingAbstractionsVersion>11.0.0-preview.6.26326.122</MicrosoftExtensionsHostingAbstractionsVersion>
     <MicrosoftExtensionsAIVersion>10.3.0</MicrosoftExtensionsAIVersion>
     <MicrosoftExtensionsAIAbstractionsVersion>10.3.0</MicrosoftExtensionsAIAbstractionsVersion>
     <MicrosoftExtensionsHttpVersion>11.0.0-preview.2.26103.111</MicrosoftExtensionsHttpVersion>
@@ -84,19 +84,19 @@
     <MicrosoftGraphicsWin2DPackageVersion>1.3.2</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.3179.45</MicrosoftWindowsWebView2PackageVersion>
     <!-- Everything else -->
-    <MicrosoftAspNetCoreAuthorizationPackageVersion>11.0.0-preview.6.26323.106</MicrosoftAspNetCoreAuthorizationPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>11.0.0-preview.6.26323.106</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>11.0.0-preview.6.26323.106</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
-    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>11.0.0-preview.6.26323.106</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
-    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>11.0.0-preview.6.26323.106</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreComponentsFormsPackageVersion>11.0.0-preview.6.26323.106</MicrosoftAspNetCoreComponentsFormsPackageVersion>
-    <MicrosoftAspNetCoreComponentsPackageVersion>11.0.0-preview.6.26323.106</MicrosoftAspNetCoreComponentsPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebPackageVersion>11.0.0-preview.6.26323.106</MicrosoftAspNetCoreComponentsWebPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>11.0.0-preview.6.26323.106</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>11.0.0-preview.6.26323.106</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>11.0.0-preview.6.26323.106</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
-    <MicrosoftAspNetCoreMetadataPackageVersion>11.0.0-preview.6.26323.106</MicrosoftAspNetCoreMetadataPackageVersion>
-    <MicrosoftJSInteropPackageVersion>11.0.0-preview.6.26323.106</MicrosoftJSInteropPackageVersion>
+    <MicrosoftAspNetCoreAuthorizationPackageVersion>11.0.0-preview.6.26326.122</MicrosoftAspNetCoreAuthorizationPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>11.0.0-preview.6.26326.122</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>11.0.0-preview.6.26326.122</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
+    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>11.0.0-preview.6.26326.122</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
+    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>11.0.0-preview.6.26326.122</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreComponentsFormsPackageVersion>11.0.0-preview.6.26326.122</MicrosoftAspNetCoreComponentsFormsPackageVersion>
+    <MicrosoftAspNetCoreComponentsPackageVersion>11.0.0-preview.6.26326.122</MicrosoftAspNetCoreComponentsPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebPackageVersion>11.0.0-preview.6.26326.122</MicrosoftAspNetCoreComponentsWebPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>11.0.0-preview.6.26326.122</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>11.0.0-preview.6.26326.122</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>11.0.0-preview.6.26326.122</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
+    <MicrosoftAspNetCoreMetadataPackageVersion>11.0.0-preview.6.26326.122</MicrosoftAspNetCoreMetadataPackageVersion>
+    <MicrosoftJSInteropPackageVersion>11.0.0-preview.6.26326.122</MicrosoftJSInteropPackageVersion>
     <!-- Everything else (previous edition) -->
     <MicrosoftAspNetCorePackageVersion>10.0.2</MicrosoftAspNetCorePackageVersion>
     <MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>$(MicrosoftAspNetCorePackageVersion)</MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>
@@ -146,13 +146,13 @@
     <TizenUIExtensionsVersion>0.9.0</TizenUIExtensionsVersion>
     <ExCSSPackageVersion>4.2.3</ExCSSPackageVersion>
     <SystemDrawingCommonPackageVersion>9.0.0</SystemDrawingCommonPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>11.0.0-beta.26323.106</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetBuildTasksInstallersPackageVersion>11.0.0-beta.26323.106</MicrosoftDotNetBuildTasksInstallersPackageVersion>
-    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>11.0.0-beta.26323.106</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26323.106</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>11.0.0-beta.26326.122</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksInstallersPackageVersion>11.0.0-beta.26326.122</MicrosoftDotNetBuildTasksInstallersPackageVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>11.0.0-beta.26326.122</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26326.122</MicrosoftDotNetHelixSdkPackageVersion>
     <MicroBuildPluginsSwixBuildDotnetPackageVersion>1.1.87-gba258badda</MicroBuildPluginsSwixBuildDotnetPackageVersion>
-    <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.26323.106</MicrosoftDotNetRemoteExecutorPackageVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>11.0.0-beta.26323.106</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.26326.122</MicrosoftDotNetRemoteExecutorPackageVersion>
+    <MicrosoftDotNetXUnitExtensionsPackageVersion>11.0.0-beta.26326.122</MicrosoftDotNetXUnitExtensionsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftNETTestSdkPackageVersion>17.6.0</MicrosoftNETTestSdkPackageVersion>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "11.0.100-preview.6.26323.106"
+    "dotnet": "11.0.100-preview.6.26326.122"
   },
   "sdk": {
     "paths": [
@@ -11,7 +11,7 @@
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44",
     "Microsoft.Build.NoTargets": "3.7.0",
-    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26323.106",
-    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26323.106"
+    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26326.122",
+    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26326.122"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "11.0.100-preview.6.26326.122"
+    "dotnet": "11.0.100-preview.6.26325.125"
   },
   "sdk": {
     "paths": [
@@ -11,7 +11,7 @@
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44",
     "Microsoft.Build.NoTargets": "3.7.0",
-    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26326.122",
-    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26326.122"
+    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26325.125",
+    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26325.125"
   }
 }

--- a/src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj
+++ b/src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj
@@ -20,23 +20,6 @@
     <UseMaterial3>false</UseMaterial3>
   </PropertyGroup>
 
-  <!--
-    TEMPORARY WORKAROUND for https://github.com/dotnet/sdk/issues/54779
-    The .NET 11 preview.6 SDK regressed GenerateStaticWebAssetEndpointsManifest: it throws
-    "Sequence contains more than one element" when a MAUI Blazor Hybrid app references a Razor
-    class library together with the BlazorWebView package (exactly this gallery's shape). The
-    regression added a new 'jsmodules.publish.manifest.json' static web asset that collides with
-    the existing '_framework/blazor.modules.json' route, which the publish endpoints manifest
-    cannot disambiguate. Disabling JS module manifest generation removes the colliding asset and
-    unblocks the build while keeping StaticWebAssetsEnabled=true, so MAUI's BlazorWebView asset
-    pipeline (ConvertStaticWebAssetsToMauiAssets) still works. This only affects the gallery's
-    Blazor demo (a cosmetic "Hello from Razor Class Library" JS snippet); no test depends on it.
-    REMOVE this once the SDK fix flows in. Tracked for revert by the linked P/0 follow-up PR.
-  -->
-  <PropertyGroup>
-    <JSModulesEnabled>false</JSModulesEnabled>
-  </PropertyGroup>
-
   <PropertyGroup>
     <ApplicationTitle>.NET MAUI</ApplicationTitle>
     <ApplicationId>com.microsoft.maui.sample</ApplicationId>


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### What

Bump `release/11.0.1xx-preview6` to **dotnet/dotnet (VMR) build BAR 320350** — `11.0.100-preview.6.26325.125` (commit `a512c3ad`) — and **remove the temporary `dotnet/sdk#54779` workaround** in the gallery sample.

**BAR 320350 is the official .NET 11 Preview 6 release build** per releases.dot.net (ships 2026-07-14), so this pins the preview6 branch to the exact SDK that ships.

### Why

Build 320350 carries the aspnetcore fix (dotnet/aspnetcore#67375, backported via #67401) for the StaticWebAssets *"Sequence contains more than one element"* publish crash (dotnet/sdk#54779). With the fix in the SDK bits, the `JSModulesEnabled=false` workaround in `Maui.Controls.Sample.csproj` is no longer needed.

### Details

- All 35 `dotnet/dotnet` deps → `11.0.0-preview.6.26325.125` (SHA `a512c3ad`), via `darc update-dependencies --id 320350 --source-repo dotnet/dotnet`.
- `global.json` `tools.dotnet` → `11.0.100-preview.6.26325.125`; Arcade/Helix → `11.0.0-beta.26325.125`.
- This branch's own `dotnet/macios` pin (`26.5.11714-net11-p6`) is preserved.
- Gallery sample workaround block removed.

### Relationship to other PRs

- Companion to **#36186** (the equivalent change on `net11.0`, also pinned to BAR 320350), where the UI/device-test pipelines run.

Fixes #35953