### PR TITLE
Update net11.0 merge-flow target to release/11.0.1xx-preview6

### DIFF
--- a/github-merge-flow-release-11.jsonc
+++ b/github-merge-flow-release-11.jsonc
@@ -2,7 +2,7 @@
 {
     "merge-flow-configurations": {
         "net11.0": {
-            "MergeToBranch": "release/11.0.1xx-preview4",
+            "MergeToBranch": "release/11.0.1xx-preview6",
             "ExtraSwitches": "-QuietComments",
             "ResetToTargetPaths": "global.json;NuGet.config;eng/Version.Details.xml;eng/Versions.props;eng/common/*"
         }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description

Fixes the broken `net11.0` → release down-merge automation. The `Merge net11.0 to next release` workflow (`.github/workflows/merge-net11-to-release.yml`) delegates to the shared arcade `inter-branch-merge-base.yml`, which reads its merge-flow configuration from the **default branch (`main`)** — the `configuration_file_branch` input [defaults to `'main'`](https://github.com/dotnet/arcade/blob/main/.github/workflows/inter-branch-merge-base.yml).

On `main`, `github-merge-flow-release-11.jsonc` still pointed at the stale `release/11.0.1xx-preview4`. The bump to `preview6` (#36110) was applied only to the copy on the `net11.0` branch, which the workflow never reads. As a result the workflow targeted `preview4`, tried to update the leftover stale `merge/net11.0-to-release/11.0.1xx-preview4` branch, hit a non-fast-forward push rejection, and exited 1 on every `push`-from-`net11.0` run — so no `preview6` down-merge PR was ever created.

This one-line change updates the **main** copy to `release/11.0.1xx-preview6` so the automation targets the current preview release branch.

### Evidence

- Run [`28241084988`](https://github.com/dotnet/maui/actions/runs/28241084988) Merge step: `read-configuration.ps1 -ConfigurationFileBranch main … github-merge-flow-release-11.jsonc` → `[MergeToBranch, release/11.0.1xx-preview4]`, then non-fast-forward push rejection → `WARNING: Failed to update existing PR` → exit code 1.
- `git show origin/main:github-merge-flow-release-11.jsonc` → `preview4`; `git show origin/net11.0:…` → `preview6` (unread by the workflow).
- `release/11.0.1xx-preview6` exists on origin, so this was a stale-config issue, not a missing-branch issue.

### Follow-up (not in this PR)

Stale leftover branches `merge/net11.0-to-release/11.0.1xx-preview4` and `…preview3` (and stale PR #34875) can be cleaned up separately. The misleading comments in `merge-net11-to-release.yml` (claiming the config is read from `net11.0`, and that the daily schedule works from `net11.0`) are also worth revisiting, since scheduled workflows and config reads both happen from the default branch.