### PR TITLE
[Windows] Fix Modal page has a 32px title bar gap at the top in full-screen mode

### DIFF
--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Windows.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Maui.Graphics;
+using Microsoft.UI.Windowing;
 
 namespace Microsoft.Maui.Controls.Platform
 {
@@ -13,10 +14,18 @@ namespace Microsoft.Maui.Controls.Platform
 
 		bool _firstActivated;
 
+		// Tracks the AppWindow subscription used to update the top modal's title bar
+		// when the user enters or exits full-screen while a modal is visible.
+		AppWindow? _appWindowForPresenterChanges;
+
 		partial void InitializePlatform()
 		{
 			_window.Created += (_, _) => SyncModalStackWhenPlatformIsReady();
-			_window.Destroying += (_, _) => _firstActivated = false;
+			_window.Destroying += (_, _) =>
+			{
+				_firstActivated = false;
+				UnsubscribeFromPresenterChanges();
+			};
 			_window.Activated += OnWindowActivated;
 		}
 
@@ -123,14 +132,9 @@ namespace Microsoft.Maui.Controls.Platform
 						// mode there are no OS window controls to avoid, so suppress this reservation.
 						// This also clears the InputNonClientPointerSource passthrough regions, fixing
 						// the unclickable top area that would otherwise remain in full-screen mode.
-						var platformWindow = WindowMauiContext.GetPlatformWindow();
-						if (platformWindow is not null)
+						if (IsWindowFullScreen())
 						{
-							var presenter = platformWindow.GetAppWindow()?.Presenter;
-							if (presenter?.Kind == UI.Windowing.AppWindowPresenterKind.FullScreen)
-							{
-								windowManager.SetTitleBarVisibility(false);
-							}
+							windowManager.SetTitleBarVisibility(false);
 						}
 
 						// Set the titlebar on the new navigation root
@@ -145,11 +149,24 @@ namespace Microsoft.Maui.Controls.Platform
 						_waitingForIncomingPage = platform.OnLoaded(() => completedCallback?.Invoke());
 						windowManager.Connect(platform);
 						Container.AddPage(windowManager.RootView);
+
+						// Subscribe once (when first modal is pushed) so that full-screen
+						// entry/exit while the modal is shown updates the modal's title bar.
+						if (_platformModalPages.Count == 1)
+						{
+							SubscribeToPresenterChanges();
+						}
 					}
 				}
 				// popping modal
 				else
 				{
+					// Unsubscribe from presenter changes once the last modal is popped.
+					if (_platformModalPages.Count == 0)
+					{
+						UnsubscribeFromPresenterChanges();
+					}
+
 					var context = newPage.FindMauiContext();
 					var windowManager = context?.GetNavigationRootManager() ??
 						throw new InvalidOperationException("Previous Page Has Lost its MauiContext");
@@ -183,6 +200,71 @@ namespace Microsoft.Maui.Controls.Platform
 					"Changing the current page is only allowed if it's being called from the same UI thread." +
 					"Please ensure that the new page is in the same UI thread as the current page.", error);
 			}
+		}
+
+		// Returns true when the window is currently in full-screen presentation mode.
+		bool IsWindowFullScreen()
+		{
+			var platformWindow = WindowMauiContext?.GetPlatformWindow();
+			if (platformWindow is null)
+			{
+				return false;
+			}
+
+			return platformWindow.GetAppWindow()?.Presenter?.Kind == AppWindowPresenterKind.FullScreen;
+		}
+
+		// Subscribes to AppWindow.Changed (once) when the first modal is pushed so that
+		// entering or exiting full-screen while a modal is visible is handled correctly.
+		void SubscribeToPresenterChanges()
+		{
+			if (_appWindowForPresenterChanges is not null)
+			{
+				return;
+			}
+
+			var platformWindow = WindowMauiContext?.GetPlatformWindow();
+			if (platformWindow is null)
+			{
+				return;
+			}
+
+			var appWindow = platformWindow.GetAppWindow();
+			if (appWindow is null)
+			{
+				return;
+			}
+
+			_appWindowForPresenterChanges = appWindow;
+			_appWindowForPresenterChanges.Changed += OnAppWindowPresenterChanged;
+		}
+
+		// Removes the AppWindow.Changed subscription when the last modal is popped or
+		// the window is being destroyed.
+		void UnsubscribeFromPresenterChanges()
+		{
+			if (_appWindowForPresenterChanges is null)
+			{
+				return;
+			}
+
+			_appWindowForPresenterChanges.Changed -= OnAppWindowPresenterChanged;
+			_appWindowForPresenterChanges = null;
+		}
+
+		// Fires whenever the window's AppWindow.Presenter changes (e.g., windowed ↔ full-screen).
+		// Updates the top-most modal's NavigationRootManager so its title bar height and margins
+		// match the new presenter mode.
+		void OnAppWindowPresenterChanged(AppWindow sender, AppWindowChangedEventArgs args)
+		{
+			if (!args.DidPresenterChange || _platformModalPages.Count == 0)
+			{
+				return;
+			}
+
+			var topModal = _platformModalPages[_platformModalPages.Count - 1];
+			var rootManager = topModal.FindMauiContext()?.GetNavigationRootManager();
+			rootManager?.SetTitleBarVisibility(sender.Presenter?.Kind != AppWindowPresenterKind.FullScreen);
 		}
 	}
 }

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Windows.cs
@@ -171,12 +171,11 @@ namespace Microsoft.Maui.Controls.Platform
 					var windowManager = context?.GetNavigationRootManager() ??
 						throw new InvalidOperationException("Previous Page Has Lost its MauiContext");
 
-					// Toggle the titlebar visibility on the new page
-					var navRoot = context.GetNavigationRootManager();
-					if (navRoot.RootView is WindowRootView wrv && wrv.AppTitleBarContainer is not null)
-					{
-						wrv.SetTitleBarVisibility(UI.Xaml.Visibility.Visible);
-					}
+					// Toggle the titlebar visibility on the new page.
+					// Use NavigationRootManager.SetTitleBarVisibility(bool) so that height
+					// and margins are also reset — not just the container's visual visibility.
+					var navRoot = context?.GetNavigationRootManager();
+					navRoot?.SetTitleBarVisibility(!IsWindowFullScreen());
 
 					// Restore the titlebar
 					if (previousPage is not null &&

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Windows.cs
@@ -118,6 +118,21 @@ namespace Microsoft.Maui.Controls.Platform
 					var windowManager = modalContext.GetNavigationRootManager();
 					if (windowManager is not null)
 					{
+						// The NavigationRootManager constructor unconditionally reserves 32px for the
+						// title bar based on ExtendsContentIntoTitleBar (true by default). In full-screen
+						// mode there are no OS window controls to avoid, so suppress this reservation.
+						// This also clears the InputNonClientPointerSource passthrough regions, fixing
+						// the unclickable top area that would otherwise remain in full-screen mode.
+						var platformWindow = WindowMauiContext.GetPlatformWindow();
+						if (platformWindow is not null)
+						{
+							var presenter = platformWindow.GetAppWindow()?.Presenter;
+							if (presenter?.Kind == UI.Windowing.AppWindowPresenterKind.FullScreen)
+							{
+								windowManager.SetTitleBarVisibility(false);
+							}
+						}
+
 						// Set the titlebar on the new navigation root
 						if (previousPage is not null &&
 							previousPage.GetParentWindow() is Window window &&

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Windows.cs
@@ -171,11 +171,15 @@ namespace Microsoft.Maui.Controls.Platform
 					var windowManager = context?.GetNavigationRootManager() ??
 						throw new InvalidOperationException("Previous Page Has Lost its MauiContext");
 
-					// Toggle the titlebar visibility on the new page.
-					// Use NavigationRootManager.SetTitleBarVisibility(bool) so that height
-					// and margins are also reset — not just the container's visual visibility.
-					var navRoot = context?.GetNavigationRootManager();
-					navRoot?.SetTitleBarVisibility(!IsWindowFullScreen());
+					var navRoot = context.GetNavigationRootManager();
+					bool showTitleBar = !IsWindowFullScreen();
+
+					if (navRoot.RootView is WindowRootView wrv && wrv.AppTitleBarContainer is not null)
+					{
+						wrv.SetTitleBarVisibility(showTitleBar ? UI.Xaml.Visibility.Visible : UI.Xaml.Visibility.Collapsed);
+					}
+
+					navRoot?.SetTitleBarVisibility(showTitleBar);
 
 					// Restore the titlebar
 					if (previousPage is not null &&

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Windows.cs
@@ -27,6 +27,20 @@ namespace Microsoft.Maui.Controls.Platform
 				UnsubscribeFromPresenterChanges();
 			};
 			_window.Activated += OnWindowActivated;
+			_window.HandlerChanging += OnPlatformWindowHandlerChanging;
+		}
+
+		void OnPlatformWindowHandlerChanging(object? sender, HandlerChangingEventArgs e)
+		{
+			// When the WinUI window handler is recreated (e.g., activity recreation on Windows),
+			// the AppWindow instance may change. Clear the subscription to the old AppWindow so
+			// that SubscribeToPresenterChanges() can attach to the new one when the modal stack
+			// is resynced after the handler is reconnected.
+			if (e.OldHandler is not null)
+			{
+				_firstActivated = false;
+				UnsubscribeFromPresenterChanges();
+			}
 		}
 
 		void OnWindowActivated(object? sender, EventArgs e)

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Windows.cs
@@ -279,13 +279,27 @@ namespace Microsoft.Maui.Controls.Platform
 				return;
 			}
 
-			var topModal = _platformModalPages[_platformModalPages.Count - 1];
-			var rootManager = topModal.FindMauiContext()?.GetNavigationRootManager();
-			// AppWindow.Changed is not guaranteed to fire on the UI thread, so marshal the
-			// WinUI FrameworkElement mutation (min height, margins, visibility) onto the
-			// dispatcher — the same pattern used by MauiWinUIWindow.ViewSettingsColorValuesChanged.
-			bool showTitleBar = sender.Presenter?.Kind != AppWindowPresenterKind.FullScreen;
-			sender.DispatcherQueue?.TryEnqueue(() => rootManager?.SetTitleBarVisibility(showTitleBar));
+			// AppWindow.Changed is not guaranteed to fire on the UI thread, so marshal ALL
+			// MAUI/WinUI state reads (modal list, MauiContext, Presenter) onto the dispatcher.
+			// This avoids races with modal pop/disconnect and COM apartment violations.
+			// Re-check that a modal is still present at dispatch time before acting.
+			sender.DispatcherQueue?.TryEnqueue(() =>
+			{
+				if (_platformModalPages.Count == 0)
+				{
+					return;
+				}
+
+				var topModal = _platformModalPages[_platformModalPages.Count - 1];
+				var rootManager = topModal.FindMauiContext()?.GetNavigationRootManager();
+				if (rootManager is null)
+				{
+					return;
+				}
+
+				bool showTitleBar = sender.Presenter?.Kind != AppWindowPresenterKind.FullScreen;
+				rootManager.SetTitleBarVisibility(showTitleBar);
+			});
 		}
 	}
 }

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Windows.cs
@@ -274,7 +274,7 @@ namespace Microsoft.Maui.Controls.Platform
 		// match the new presenter mode.
 		void OnAppWindowPresenterChanged(AppWindow sender, AppWindowChangedEventArgs args)
 		{
-			if (!args.DidPresenterChange || _platformModalPages.Count == 0)
+			if (!args.DidPresenterChange)
 			{
 				return;
 			}

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Windows.cs
@@ -18,6 +18,12 @@ namespace Microsoft.Maui.Controls.Platform
 		// when the user enters or exits full-screen while a modal is visible.
 		AppWindow? _appWindowForPresenterChanges;
 
+		// Captured at subscription time from the WinUI Window (a DependencyObject with a
+		// guaranteed non-null DispatcherQueue). AppWindow.DispatcherQueue returns null because
+		// AppWindow does not implement IDispatcherQueueObject, so we cannot use sender.DispatcherQueue
+		// in the Changed event handler.
+		Microsoft.UI.Dispatching.DispatcherQueue? _windowDispatcherQueue;
+
 		partial void InitializePlatform()
 		{
 			_window.Created += (_, _) => SyncModalStackWhenPlatformIsReady();
@@ -258,6 +264,7 @@ namespace Microsoft.Maui.Controls.Platform
 				return;
 			}
 
+			_windowDispatcherQueue = platformWindow.DispatcherQueue;
 			_appWindowForPresenterChanges = appWindow;
 			_appWindowForPresenterChanges.Changed += OnAppWindowPresenterChanged;
 		}
@@ -273,6 +280,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 			_appWindowForPresenterChanges.Changed -= OnAppWindowPresenterChanged;
 			_appWindowForPresenterChanges = null;
+			_windowDispatcherQueue = null;
 		}
 
 		// Fires whenever the window's AppWindow.Presenter changes (e.g., windowed ↔ full-screen).
@@ -289,7 +297,10 @@ namespace Microsoft.Maui.Controls.Platform
 			// MAUI/WinUI state reads (modal list, MauiContext, Presenter) onto the dispatcher.
 			// This avoids races with modal pop/disconnect and COM apartment violations.
 			// Re-check that a modal is still present at dispatch time before acting.
-			sender.DispatcherQueue?.TryEnqueue(() =>
+			// NOTE: sender.DispatcherQueue is null for AppWindow (it does not implement
+			// IDispatcherQueueObject), so we use the window's DispatcherQueue captured at
+			// subscription time instead.
+			_windowDispatcherQueue?.TryEnqueue(() =>
 			{
 				if (_platformModalPages.Count == 0)
 				{

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Windows.cs
@@ -190,7 +190,13 @@ namespace Microsoft.Maui.Controls.Platform
 
 					if (navRoot.RootView is WindowRootView wrv && wrv.AppTitleBarContainer is not null)
 					{
-						wrv.SetTitleBarVisibility(showTitleBar ? UI.Xaml.Visibility.Visible : UI.Xaml.Visibility.Collapsed);
+						// Always restore the visual containers to Visible. The reserved height
+						// (WindowTitleBarContentControlMinHeight via navRoot.SetTitleBarVisibility below)
+						// will be 0 in full-screen, so no space is taken. Keeping the container Visible
+						// avoids a permanent collapse when the window later exits full-screen after
+						// the modal has already been dismissed. Height is restored by the
+						// WM_STYLECHANGING handler in MauiWinUIWindow when the window leaves full-screen.
+						wrv.SetTitleBarVisibility(UI.Xaml.Visibility.Visible);
 					}
 
 					navRoot?.SetTitleBarVisibility(showTitleBar);

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Windows.cs
@@ -281,7 +281,11 @@ namespace Microsoft.Maui.Controls.Platform
 
 			var topModal = _platformModalPages[_platformModalPages.Count - 1];
 			var rootManager = topModal.FindMauiContext()?.GetNavigationRootManager();
-			rootManager?.SetTitleBarVisibility(sender.Presenter?.Kind != AppWindowPresenterKind.FullScreen);
+			// AppWindow.Changed is not guaranteed to fire on the UI thread, so marshal the
+			// WinUI FrameworkElement mutation (min height, margins, visibility) onto the
+			// dispatcher — the same pattern used by MauiWinUIWindow.ViewSettingsColorValuesChanged.
+			bool showTitleBar = sender.Presenter?.Kind != AppWindowPresenterKind.FullScreen;
+			sender.DispatcherQueue?.TryEnqueue(() => rootManager?.SetTitleBarVisibility(showTitleBar));
 		}
 	}
 }

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Windows.cs
@@ -148,11 +148,14 @@ namespace Microsoft.Maui.Controls.Platform
 					if (windowManager is not null)
 					{
 						// The NavigationRootManager constructor unconditionally reserves 32px for the
-						// title bar based on ExtendsContentIntoTitleBar (true by default). In full-screen
-						// mode there are no OS window controls to avoid, so suppress this reservation.
+						// title bar based on ExtendsContentIntoTitleBar (true by default). Suppress
+						// this reservation when the app has hidden the title bar (IsVisible = false)
+						// or when running in full-screen mode (no OS window controls to avoid).
 						// This also clears the InputNonClientPointerSource passthrough regions, fixing
 						// the unclickable top area that would otherwise remain in full-screen mode.
-						if (IsWindowFullScreen())
+						// Use the same predicate as the pop/presenter-change paths so all paths agree.
+						bool showTitleBarOnPush = !IsWindowFullScreen() && ((_window.TitleBar as TitleBar)?.IsVisible ?? true);
+						if (!showTitleBarOnPush)
 						{
 							windowManager.SetTitleBarVisibility(false);
 						}

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Windows.cs
@@ -192,7 +192,11 @@ namespace Microsoft.Maui.Controls.Platform
 						throw new InvalidOperationException("Previous Page Has Lost its MauiContext");
 
 					var navRoot = context.GetNavigationRootManager();
-					bool showTitleBar = !IsWindowFullScreen();
+					// Combine presenter state with the app's explicit TitleBar.IsVisible setting.
+					// Casting to the concrete TitleBar type is safe — ModalNavigationManager is in the
+					// same assembly and TitleBar is the only platform implementation on Windows.
+					// Defaults to true (show title bar) when no custom TitleBar is set.
+					bool showTitleBar = !IsWindowFullScreen() && ((_window.TitleBar as TitleBar)?.IsVisible ?? true);
 
 					if (navRoot.RootView is WindowRootView wrv && wrv.AppTitleBarContainer is not null)
 					{
@@ -314,7 +318,11 @@ namespace Microsoft.Maui.Controls.Platform
 					return;
 				}
 
-				bool showTitleBar = sender.Presenter?.Kind != AppWindowPresenterKind.FullScreen;
+				bool isFullScreen = sender.Presenter?.Kind == AppWindowPresenterKind.FullScreen;
+				// Combine presenter state with the app's explicit TitleBar.IsVisible setting so that
+				// an app that intentionally hides its TitleBar does not have the reservation forced
+				// back on when leaving full-screen. Defaults to true when no TitleBar is set.
+				bool showTitleBar = !isFullScreen && ((_window.TitleBar as TitleBar)?.IsVisible ?? true);
 				rootManager.SetTitleBarVisibility(showTitleBar);
 			});
 		}

--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.Windows.cs
@@ -7,6 +7,7 @@ using Microsoft.Maui.Controls;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
+using Microsoft.UI.Windowing;
 using Xunit;
 using WPanel = Microsoft.UI.Xaml.Controls.Panel;
 
@@ -239,6 +240,86 @@ namespace Microsoft.Maui.DeviceTests
 
 					// The modal should be removed
 					Assert.DoesNotContain(modalRootView, container.CachedChildren);
+				});
+		}
+
+		// In full-screen mode, the NavigationRootManager constructor unconditionally reserves 32px
+		// for the title bar. ModalNavigationManager must suppress this for modal pages.
+		[Fact]
+		public async Task ModalPageInFullScreenModeHasNoTitleBarReservation()
+		{
+			SetupBuilder();
+
+			var navPage = new NavigationPage(new ContentPage());
+			var window = new Window(navPage);
+
+			await CreateHandlerAndAddToWindow<IWindowHandler>(window,
+				async (handler) =>
+				{
+					var platformWindow = handler.PlatformView;
+					var appWindow = platformWindow.GetAppWindow();
+
+					appWindow.SetPresenter(AppWindowPresenterKind.FullScreen);
+
+					try
+					{
+						var modalPage = new ContentPage { BackgroundColor = Colors.Red };
+						await navPage.CurrentPage.Navigation.PushModalAsync(modalPage);
+						await OnLoadedAsync(modalPage);
+
+						var modalWindowRootView = modalPage
+							.FindMauiContext()
+							.GetNavigationRootManager()
+							.RootView as WindowRootView;
+
+						Assert.NotNull(modalWindowRootView);
+
+						// In full-screen mode, the modal must NOT reserve any space for the title bar.
+						// Before the fix this was 32px, causing both a visual gap and an unclickable area.
+						Assert.Equal(0d, modalWindowRootView.WindowTitleBarContentControlMinHeight);
+
+						await navPage.CurrentPage.Navigation.PopModalAsync();
+						await OnUnloadedAsync(modalPage);
+					}
+					finally
+					{
+						// Restore windowed mode so subsequent tests are not affected.
+						appWindow.SetPresenter(AppWindowPresenterKind.Default);
+					}
+				});
+		}
+
+		// The full-screen fix must not suppress the title bar reservation in windowed mode.
+		[Fact]
+		public async Task ModalPageInWindowedModeRetainsTitleBarState()
+		{
+			SetupBuilder();
+
+			var navPage = new NavigationPage(new ContentPage());
+			var window = new Window(navPage);
+
+			await CreateHandlerAndAddToWindow<IWindowHandler>(window,
+				async (handler) =>
+				{
+					var modalPage = new ContentPage { BackgroundColor = Colors.Red };
+					await navPage.CurrentPage.Navigation.PushModalAsync(modalPage);
+					await OnLoadedAsync(modalPage);
+
+					var modalWindowRootView = modalPage
+						.FindMauiContext()
+						.GetNavigationRootManager()
+						.RootView as WindowRootView;
+
+					Assert.NotNull(modalWindowRootView);
+
+					// In windowed mode, the modal's title bar container must remain visible.
+					// The fix must not affect this path.
+					Assert.Equal(
+						UI.Xaml.Visibility.Visible,
+						modalWindowRootView.AppTitleBarContainer?.Visibility);
+
+					await navPage.CurrentPage.Navigation.PopModalAsync();
+					await OnUnloadedAsync(modalPage);
 				});
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.Windows.cs
@@ -9,6 +9,7 @@ using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using Microsoft.UI.Windowing;
 using Xunit;
+using static Microsoft.Maui.DeviceTests.AssertHelpers;
 using WPanel = Microsoft.UI.Xaml.Controls.Panel;
 
 namespace Microsoft.Maui.DeviceTests

--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.Windows.cs
@@ -323,6 +323,71 @@ namespace Microsoft.Maui.DeviceTests
 				});
 		}
 
+		// Verifies that the AppWindow.Changed subscription fires and updates the modal's
+		// title bar reservation when the presenter changes while a modal is already visible.
+		[Fact]
+		public async Task ModalTitleBarUpdatesWhenPresenterChangesWhileModalIsVisible()
+		{
+			SetupBuilder();
+
+			var navPage = new NavigationPage(new ContentPage());
+			var window = new Window(navPage);
+
+			await CreateHandlerAndAddToWindow<IWindowHandler>(window,
+				async (handler) =>
+				{
+					var platformWindow = handler.PlatformView;
+					var appWindow = platformWindow.GetAppWindow();
+
+					// Push a modal while the window is in windowed mode.
+					var modalPage = new ContentPage { BackgroundColor = Colors.Red };
+					await navPage.CurrentPage.Navigation.PushModalAsync(modalPage);
+					await OnLoadedAsync(modalPage);
+
+					var modalWindowRootView = modalPage
+						.FindMauiContext()
+						.GetNavigationRootManager()
+						.RootView as WindowRootView;
+
+					Assert.NotNull(modalWindowRootView);
+
+					// In windowed mode the modal must reserve space for the title bar.
+					Assert.True(
+						modalWindowRootView.WindowTitleBarContentControlMinHeight > 0,
+						"Modal should reserve title bar space in windowed mode");
+
+					try
+					{
+						// Switch to full-screen while the modal is already visible.
+						// This exercises the AppWindow.Changed subscription path added by the fix.
+						appWindow.SetPresenter(AppWindowPresenterKind.FullScreen);
+
+						// Allow the AppWindow.Changed event to propagate.
+						await Task.Delay(100);
+
+						// The presenter change must clear the title bar reservation on the modal.
+						Assert.Equal(0d, modalWindowRootView.WindowTitleBarContentControlMinHeight);
+
+						// Restore windowed mode while the modal is still open.
+						appWindow.SetPresenter(AppWindowPresenterKind.Default);
+
+						// Allow the AppWindow.Changed event to propagate.
+						await Task.Delay(100);
+
+						// The reservation must be restored when returning to windowed mode.
+						Assert.True(
+							modalWindowRootView.WindowTitleBarContentControlMinHeight > 0,
+							"Modal should restore title bar space when returning to windowed mode");
+					}
+					finally
+					{
+						appWindow.SetPresenter(AppWindowPresenterKind.Default);
+						await navPage.CurrentPage.Navigation.PopModalAsync();
+						await OnUnloadedAsync(modalPage);
+					}
+				});
+		}
+
 		[Fact]
 		public async Task NestedModalPagesMaintainHitTestVisibilityAndFocusTrap()
 		{

--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.Windows.cs
@@ -362,22 +362,22 @@ namespace Microsoft.Maui.DeviceTests
 						// This exercises the AppWindow.Changed subscription path added by the fix.
 						appWindow.SetPresenter(AppWindowPresenterKind.FullScreen);
 
-						// Allow the AppWindow.Changed event to propagate.
-						await Task.Delay(100);
-
-						// The presenter change must clear the title bar reservation on the modal.
-						Assert.Equal(0d, modalWindowRootView.WindowTitleBarContentControlMinHeight);
+						// Wait deterministically for the AppWindow.Changed event to propagate and
+						// the DispatcherQueue.TryEnqueue callback to update WindowTitleBarContentControlMinHeight.
+						await AssertEventually(
+							() => modalWindowRootView.WindowTitleBarContentControlMinHeight == 0d,
+							timeout: 2000,
+							message: "Modal should clear title bar space after switching to full-screen");
 
 						// Restore windowed mode while the modal is still open.
 						appWindow.SetPresenter(AppWindowPresenterKind.Default);
 
-						// Allow the AppWindow.Changed event to propagate.
-						await Task.Delay(100);
-
-						// The reservation must be restored when returning to windowed mode.
-						Assert.True(
-							modalWindowRootView.WindowTitleBarContentControlMinHeight > 0,
-							"Modal should restore title bar space when returning to windowed mode");
+						// Wait deterministically for the AppWindow.Changed event to propagate and
+						// the DispatcherQueue.TryEnqueue callback to restore WindowTitleBarContentControlMinHeight.
+						await AssertEventually(
+							() => modalWindowRootView.WindowTitleBarContentControlMinHeight > 0,
+							timeout: 2000,
+							message: "Modal should restore title bar space when returning to windowed mode");
 					}
 					finally
 					{


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
Two bugs when pushing a modal page while the app is in AppWindowPresenterKind.FullScreen:
* A 32px strip at the top of the modal page shows the page underneath (title bar height gap)
* The top ~32px of the modal page does not respond to mouse clicks

### Root Cause
NavigationRootManager's constructor always reserves 32px for the title bar (because ExtendsContentIntoTitleBar defaults to true). In full-screen mode there's no OS title bar — so this reservation is wrong for modal pages.

### Description of Change

<!-- Enter description of the fix in this section -->
In ModalNavigationManager.Windows.cs, when pushing a modal, check if the presenter is FullScreen and call windowManager.SetTitleBarVisibility(false) and also handled the runtime presented changes.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #36040 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

**Tested the behavior in the following platforms.**
- [ ] Android
- [x] Windows
- [ ] iOS
- [ ] Mac


| Before  | After  |
|---------|--------|
| **Windows**<br> <img src="https://github.com/user-attachments/assets/403ef318-205c-4bd7-a239-dbeef2c1bbcf" width="600" height="300"> | **Mac**<br> <img src="https://github.com/user-attachments/assets/ddd3c878-0141-40b1-b2c9-fbd23ecccb5f" width="600" height="300"> |
