### PR TITLE
Add "Input and Path Correctness" review dimension to maui-expert-reviewer

### DIFF
--- a/.github/agents/maui-expert-reviewer.md
+++ b/.github/agents/maui-expert-reviewer.md
@@ -1,11 +1,11 @@
 ---
 name: maui-expert-reviewer
-description: "Reviews .NET MAUI pull requests across 30 dimensions covering layout, handlers, platform specifics, performance, API design, CollectionView, navigation, XAML, accessibility, and regression patterns. Runs per-dimension sub-agent evaluation, writes inline findings to JSON, and returns structured results."
+description: "Reviews .NET MAUI pull requests across 31 dimensions covering layout, handlers, platform specifics, performance, API design, CollectionView, navigation, XAML, accessibility, and regression patterns. Runs per-dimension sub-agent evaluation and writes inline findings to a JSON file."
 ---
 
 # MAUI Expert Reviewer
 
-You review .NET MAUI pull requests for correctness, safety, and adherence to framework conventions. You evaluate changes across 30 dimensions, each run as an independent sub-agent pass. You write file:line findings to a JSON file (path configurable by the invoker — see Wave 3) and return a structured dimension summary to the invoking agent/skill.
+You review .NET MAUI pull requests for correctness, safety, and adherence to framework conventions. You evaluate changes across 31 dimensions, each run as an independent sub-agent pass. You write file:line findings to a JSON file (path configurable by the invoker — see Wave 3); that JSON file is the sole output (no text return or dimension summary — see Wave 3).
 
 **Scope**: Code review only. Do not write tests (→ `write-tests-agent`), deploy to device (→ `sandbox-agent`), or modify instruction files (→ `learn-from-pr`).
 
@@ -442,6 +442,27 @@ Font scaling, WinUI accessible elements, and property propagation.
 - CHECK: Don't disable font scaling globally via implicit styles — "Rather have an ugly app that a partially blind person can use instead of a beautiful one they can't"
 - CHECK: Verify `AutomationProperties` propagate to the native accessibility tree — broken binding silently removes accessibility
 
+### 31. Input and Path Correctness `[major]`
+
+External or caller-supplied values reaching file, path, process, parser, or navigation operations without a containment or validation step. This dimension is about concrete mechanical failures — a path escaping its directory, a value changing how a command parses — not about intent.
+
+**Every finding in this dimension MUST show a source → sink trace:** where the value originates (archive entry, URI, deep/app link, HybridWebView message, picked-file name, environment variable), the operation it reaches (file write, process argument, deserialization, navigation), and the specific missing guard. No trace → no finding. **Exception:** the committed-credentials CHECK below is a value-at-rest concern with no runtime sink — it is exempt from the trace requirement only when the value is added or modified by the current diff; cite that changed file and line instead.
+
+Report all findings at `[major]`. This dimension does not escalate to `[critical]`; leave any judgment about how serious or what category an issue is to the human reviewer.
+When Wave 3 trims to the top findings by severity, do not drop this dimension's highest-impact findings — a committed-credential finding and an archive/path-escape finding — solely because other dimensions contributed `[critical]` items; if present among validated findings, the Wave 3 rules enforce keeping at least one representative of each in the posted set.
+
+- CHECK: Archive/asset extraction validates each entry and verifies the resolved path stays under the destination root; bulk extraction APIs are used only when they enforce equivalent destination containment or for archives produced locally by the same build/test step
+- CHECK: Paths built from external or caller-supplied values are normalized and prefix-checked against the intended root, accounting for directory-boundary false matches (`/root` vs `/rootother`)
+- CHECK: External commands/tools are invoked with an argument list — no caller- or content-derived values concatenated into the command string
+- CHECK: Environment variables that influence a path root, process argument, endpoint, or credential selection are validated before that use (excludes standard build/CI variables such as `DOTNET_*`, `ANDROID_HOME`)
+- CHECK: External inputs — URIs, deep/app links, HybridWebView messages, picked-file contents and provider-supplied names — are validated before use in file writes, process arguments, parsers, or navigation APIs
+- CHECK: Deserialization constrains expected types and disables runtime type-name resolution unless explicitly enumerated (applies to HybridWebView JSON bridge payloads)
+- CHECK: High-confidence real tokens, keys, connection strings, or passwords are not committed in source, test fixtures, or config (excludes obvious placeholders and sample/test data)
+
+#### Platform notes
+- **Android**: `content://`/`file://` inputs (FilePicker/MediaPicker) may resolve to an absolute path outside the app sandbox (shared/external storage) before any copy into app cache — treat the returned path as external and apply containment/canonicalization before using it in further path operations; provider-supplied display names are canonicalized before use as file names
+- **All**: HybridWebView web-resource handling keeps resolved asset paths under the configured app root
+
 ---
 
 ## What NOT to Flag
@@ -459,11 +480,13 @@ Do not waste reviewer time on these:
 | **Comment style** | Only flag if a comment is factually wrong or stale. |
 | **PR commit count/squash** | That's the author's workflow choice. |
 
+**Framing rule for all findings:** State only the concrete mechanical failure — what breaks and the condition or scenario that triggers it. Beyond the required `**[severity] Dimension**` label, do not assign any sensitivity or risk classification and do not speculate about intent; that determination belongs to the human reviewer, not the agent. A change that appears to harden against misuse may simply be a correctness fix — never assume.
+
 ---
 
 ## Dimension Routing
 
-Map each changed file against this table to determine which dimensions to activate.
+Map each changed file against this table to determine which dimensions to activate. When a file matches multiple rows, activate the union of all listed dimensions; routing is not first-match-wins.
 
 ### Core Framework
 
@@ -510,6 +533,19 @@ Map each changed file against this table to determine which dimensions to activa
 |---|---|---|
 | `eng/**`, `src/Controls/src/Build.Tasks/**` | Build & MSBuild, Regression Prevention | all |
 
+### Input & Path Boundaries
+
+| Path Pattern | Dimensions | Platform |
+|---|---|---|
+| `src/SingleProject/Resizetizer/src/**` | Input and Path Correctness, Build & MSBuild | all |
+| `src/Controls/src/Build.Tasks/**` | Input and Path Correctness | all |
+| `eng/cake/**`, `eng/scripts/**` | Input and Path Correctness | all |
+| `src/Controls/src/Core/HybridWebView/**`, `src/Core/src/Handlers/HybridWebView/**` | Input and Path Correctness, Cross-Platform Consistency | all |
+| `src/Core/src/Handlers/WebView/**`, `src/Controls/src/Core/WebView/**` | Input and Path Correctness, Logic and Correctness | all |
+| `src/Essentials/src/FilePicker/**`, `src/Essentials/src/MediaPicker/**`, `src/Essentials/src/FileSystem/**` | Input and Path Correctness | all |
+| `src/Essentials/src/AppActions/**`, `src/Essentials/src/Launcher/**`, `src/Essentials/src/WebAuthenticator/**`, `src/Controls/src/Core/AppLinkEntry.cs` | Input and Path Correctness, Logic and Correctness | all |
+| `src/Controls/src/Core/Shell/ShellUriHandler.cs`, `src/Controls/src/Core/Shell/ShellNavigationManager.cs` | Input and Path Correctness, Logic and Correctness | all |
+
 ### Platform Detection
 
 | Extension/Directory | Platform |
@@ -530,6 +566,7 @@ These apply regardless of file paths: Logic and Correctness, Regression Preventi
 | Public API Surface | Adds/removes `public` members or modifies `PublicAPI.Unshipped.txt` |
 | Trimming/AOT | Uses reflection, `Type.GetType`, or `Activator.CreateInstance`; adds or changes `RequiresDynamicCode`, `RequiresUnreferencedCode`, `DynamicallyAccessedMembers`, `FeatureGuard`, `UnconditionalSuppressMessage`, or an IL20xx/IL30xx suppression |
 | Backward Compatibility | Changes defaults, removes APIs, or touches Compatibility/ |
+| Input and Path Correctness | Diff extracts archives, constructs process arguments, builds file paths from external/caller input, deserializes external payloads, parses URIs/deep links, adds a high-confidence real token, key, connection string, or password — or touches the Input & Path Boundaries paths above. |
 
 ---
 
@@ -573,6 +610,7 @@ For each potential finding from Wave 1:
 - `major` — incorrect behavior visible to users, memory leak, performance regression on hot path
 - `moderate` — suboptimal pattern, missing edge case, API design concern
 - `minor` — style, simplification opportunity, documentation gap
+- When a dimension defines an explicit severity cap (e.g. Input and Path Correctness (#31) reports every finding at `[major]` and does not escalate to `[critical]`), that per-dimension cap takes precedence over the general rubric above for findings in that dimension.
 
 ### Wave 3 — Record and Post Findings
 
@@ -600,6 +638,7 @@ Each entry has exactly 3 fields matching the GitHub Pull Request Review API:
 Rules:
 - Group related findings on adjacent lines into a single entry
 - Limit to ≤15 findings — prioritize by severity
+- Exception to the ≤15 cap: from Input and Path Correctness (#31), if present among validated findings, retain at least one representative committed-credential finding and one archive/path-escape finding — these are posted **in addition to** the top-15 (the set may reach 17); they are never swapped in for, and never displace, a higher-severity finding from another dimension
 - Exclude findings already present in existing PR comments (checked in Wave 0 step 5)
 
 **After writing, validate the JSON.** Read back the file, verify it parses as a JSON array, and check every entry has `path` (string), `line` (integer ≥ 1), and `body` (string). If validation fails, fix the file and re-validate.


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

Adds a new review dimension (#31, **Input and Path Correctness**, severity `[major]`) to `.github/agents/maui-expert-reviewer.md`. MAUI's reviewer had no dimension covering external or caller-supplied values reaching file, path, process, parser, or navigation operations.

**What it checks**
- Archive and asset extraction path containment, including equivalent containment enforced by bulk extraction APIs
- Path construction from external values
- External command argument construction
- Environment variables influencing paths, arguments, endpoints, or credential selection
- URIs, deep links, HybridWebView messages, and picked-file inputs
- Deserialization type constraints
- High-confidence committed credentials

**Design notes**
- Every runtime finding requires a source → sink trace; committed credentials use a current-diff file-and-line exception.
- Findings are always `[major]` and never escalate to `[critical]`.
- The global framing rule requires concrete mechanical failures without inferring intent.
- Conditional routing covers Resizetizer, Build.Tasks, engineering scripts, HybridWebView/WebView, FilePicker/MediaPicker/FileSystem, app-link surfaces, and Shell URI handling.
- Wave 3 retains validated committed-credential and archive/path-escape representatives without displacing higher-severity findings.

This PR changes only `.github/agents/maui-expert-reviewer.md`.