### PR TITLE
release-readiness: preview readiness — blessed-build source + subscription-wiring & feed-drift checks (evolve #36268)

### DIFF
--- a/.github/skills/dependency-flow/SKILL.md
+++ b/.github/skills/dependency-flow/SKILL.md
@@ -571,6 +571,8 @@ Interpretation:
 
 All three anchors are byte-identical to `net11.0` HEAD → **clean cut, component pins coherent** ✅. The android `-ci.main.51` moniker is **not** a preview6 anomaly — `net11.0` carries the same pin, so it's the net11 android train's current state, not a mis-wire. (For contrast, `main` is a different band entirely — android `36.1.2`, runtime `10.0.0`.)
 
+> **Anchor note:** the automated 🏷️ pins table in the generated tracker issue anchors the VMR on **`Microsoft.NET.Sdk`** (SDK band, e.g. `11.0.100-preview.6.*`), whereas this manual check reads **`Microsoft.NETCore.App.Ref`** (runtime band, e.g. `11.0.0-preview.6.*`). Same repo, same commit — different package, so the version *strings* differ by design. Compare coherence by **SHA**, not by the version string, when reconciling the two views.
+
 ## Quick reference: lifecycle commands by phase
 
 | Phase | Action | Command sketch |

--- a/.github/skills/dependency-flow/SKILL.md
+++ b/.github/skills/dependency-flow/SKILL.md
@@ -381,6 +381,196 @@ Exemplar: [PR 61033](https://dev.azure.com/dnceng/internal/_git/maestro-configur
 
 When standing up a new preview, **confirm the new preview's subs are in place before removing the old preview's** to avoid a flow gap.
 
+## Preview release readiness (authoritative source + access tiers)
+
+Use this when asked things like *"is .NET MAUI Preview N release-ready?"*, *"which
+build is the official Preview N?"*, or *"are we good to ship Preview N?"* **while
+assessing a preview** (not GA or servicing).
+
+**Why a special source:** the build that releases.dot.net has *blessed* as the
+official preview is designated in an internal **.NET Release Tracker** plugin.
+Public BAR/Maestro data can enumerate candidate builds but **cannot, on its own,
+tell you which staged build is the blessed one**. This is exactly the trap from
+[PR #35364](https://github.com/dotnet/maui/pull/35364) / the Preview 6 cycle: two
+same-band VMR builds (e.g. `…26325.125` vs `…26326.122`) look interchangeable
+until you know which BAR id the release designates.
+
+The plugin lives in a **private** marketplace repo and is **double-gated** — you
+need (1) GitHub read access to that repo to load it, and (2) an authorized Azure
+AD identity for it to return data. So referencing it from this public repo is
+safe: a user without access simply can't load it or pull embargoed data.
+
+### Step 1 — classify access (deterministic)
+
+```bash
+pwsh ./.github/skills/dependency-flow/scripts/Get-PreviewReleaseReadiness.ps1
+# -> RELEASE_TRACKER_STATUS=NO_ACCESS | ACCESS_ON_INACTIVE_ACCOUNT | AVAILABLE_NOT_ENABLED | AVAILABLE_ENABLED
+```
+
+The script only *classifies* the environment (GitHub read access + whether the
+plugin is locally enabled). It fetches **no** release data and always exits 0.
+
+### Step 2 — branch on the status token
+
+| `RELEASE_TRACKER_STATUS` | What it means | What to do |
+|--------------------------|---------------|------------|
+| `AVAILABLE_ENABLED` | Caller has access **and** the `dotnet-release-tracker` plugin is enabled | **Invoke the `dotnet-release-tracker` skill** — it is a Copilot **skill/plugin, NOT an MCP server tool**, so do **not** search the MCP tool list for a `release-tracker` tool and conclude it's unavailable. Run it the normal skill way (it self-documents a PowerShell script — e.g. `pwsh scripts/Get-DotNetReleaseStatus.ps1`) for the authoritative SDK/runtime + BAR id, then cross-reference with BAR/Maestro for asset/feed details. If the gate says `AVAILABLE_ENABLED` but the skill isn't loaded in this session yet, **reload extensions / restart the session and retry** — enabled-but-not-yet-loaded is **not** a `NO_ACCESS` condition. |
+| `AVAILABLE_NOT_ENABLED` | Caller has access but the plugin is **not** enabled locally | Tell the user they have access and offer the **user-scope opt-in** below. After they opt in and reload, re-run Step 1 → `AVAILABLE_ENABLED`. |
+| `ACCESS_ON_INACTIVE_ACCOUNT` | The **active** `gh` identity can't read the repo, but a logged-in but **inactive** `gh` account (named in `reason`/`inactiveAccount`) can — the plugin loads under the *active* identity, so it still can't be used as-is | Tell the user access exists under `<account>` and to run `gh auth switch --user <account>`, then re-run Step 1. **Do not** invoke the plugin or claim availability under the current identity. (Only appears when access is confirmed on some account, so it never leaks to a true no-access user.) |
+| `NO_ACCESS` | Access can't be confirmed on **any** logged-in account (no access, or `gh` missing/unauthenticated) | Fall back to PUBLIC data only. For the official-build line, report the **latest build promoted to the public `.NET 11.0.1xx SDK Preview N` channel** (public BAR/Maestro) as the *best-available candidate*, and **label it**: "source: public preview feed — may not be the final official (blessed) build." **Do not** name or hint at the private plugin/tracker tool, and don't imply the user is missing a tool — see privacy guardrail. |
+
+> **Source labels (avoid the per-component over-claim):** the tracker is
+> **SDK/runtime-level only**. When you present a blessed build, label each field
+> with where it came from: **SDK / runtime version → .NET Release Tracker**;
+> **per-component `dotnet/android` / `dotnet/macios` / `dotnet/dotnet` (VMR) builds
+> → BAR/Maestro** (the blessed channel's promoted builds — the tracker has **no**
+> android/macios build field). Never imply the tracker "blessed" a specific
+> android/macios build; that number is a BAR/Maestro fact, not a tracker one.
+
+### User-scope opt-in (Tier B) — do NOT commit this
+
+Add to the user's **personal** `~/.copilot/settings.json` (merge with existing
+keys; this is intentionally *not* committed to the repo so forks and no-access
+users are unaffected):
+
+```jsonc
+{
+  "extraKnownMarketplaces": {
+    "dotnet-release": { "source": { "source": "github", "repo": "dotnet/release" } }
+  },
+  "enabledPlugins": {
+    "dotnet-release-tracker@dotnet-release": true
+  }
+}
+```
+
+Then reload extensions (or restart the session) so the plugin loads.
+
+### 🛡️ Guardrails
+
+- **Privacy default:** when the status is `NO_ACCESS`, never reveal, hint at, or
+  apologize for the private plugin/tracker **tool**, and never surface embargoed
+  data (unreleased blessed BAR ids, internal coordinates). This guardrail protects
+  the *tool and its private data* — it does **not** forbid the honest, publicly-true
+  statement that the public feed's newest build may not be the final official
+  build (see *Honest limitation* below). So: answer from public data, label your
+  source, and caveat its limits — but don't say "there's a gated tracker I can't
+  reach." The gate script enforces the tier by treating *any* unconfirmed-access
+  case as `NO_ACCESS`.
+- **Never** copy internal coordinates (Azure AD resource IDs / `api://…`
+  audiences, backend service hostnames, internal endpoint paths) from the plugin
+  into this public repo. The only sanctioned reference is the *marketplace
+  pointer* (repo name + plugin name) used above.
+- **No fetch-and-exec.** Do not download and run remote scripts to obtain release
+  data; use the installed plugin through normal skill invocation.
+- **Comment-only on GitHub.** As everywhere in this skill, never approve, merge, or
+  request changes on PRs — only post comments.
+- **Honest limitation (public-feed fallback):** on the public fallback path,
+  report the **latest build promoted to the public `.NET 11.0.1xx SDK Preview N`
+  channel** as the best-available *candidate* official build — but present it
+  **explicitly labeled** as feed-sourced, e.g. "🔎 Candidate from the **public
+  Preview N feed** (BAR #NNNNNN @ `<sha>`) — this is the newest build promoted to
+  the public channel, **not** a confirmed official (blessed) build; the final
+  official build is designated at release time and may differ." Give the concrete
+  candidate + caveat rather than either silently omitting the line or guessing a
+  single blessed build.
+
+### Wiring checks: is Preview N actually plumbed? (subscriptions + feed drift + component pins)
+
+The blessed-build lookup above answers *"which build is official?"*. These three
+mechanical checks answer *"is the preview branch actually receiving flow, is its
+promoted feed current, and are the component builds it bundles coherent?"* — a preview
+can have a blessed build yet still be mis-plumbed (branch cut, build exists, but nothing
+flows in; the feed lags the branch; or its android/macios pins diverged from the inflight
+branch). All three run off **public** BAR/Maestro + git, so they work regardless of the
+release-tracker access tier.
+
+#### Check A — are the subscriptions wired for `release/11.0.1xx-previewN`?
+
+Three prerequisites must **all** hold for the preview to receive dependency flow:
+
+1. **Branch exists:** `git ls-remote origin refs/heads/release/11.0.1xx-previewN` returns a sha.
+2. **Default-channel mapping exists:** MCP `maestro_default_channels(repository="https://github.com/dotnet/maui")` (or `darc get-default-channels --repo https://github.com/dotnet/maui`) has a row `release/11.0.1xx-previewN → .NET 11.0.1xx SDK Preview N`.
+3. **Subscriptions exist:** MCP `maestro_subscriptions(targetRepository="https://github.com/dotnet/maui", targetBranch="release/11.0.1xx-previewN")` returns the baseline **three** rows — android + macios (`everyDay`, batchable) and dotnet (`none`, batchable), all on channel `.NET 11.0.1xx SDK Preview N` (see the baseline table above).
+
+Interpretation:
+
+| Observed | Meaning | Report |
+|----------|---------|--------|
+| Branch + default-channel + 3 subs | Fully wired | ✅ OK |
+| Branch + default-channel present, **0 subs** (or missing android/macios/dotnet) | Start-of-preview gap: branch cut (possibly with a promoted build already) but the prior preview's subs were never rolled forward — no upstream flow into the branch | ℹ️ **FYI note** (not a ship blocker) — name the missing source repos |
+| Sub on wrong channel/band/stage/frequency | The [PR #35364](https://github.com/dotnet/maui/pull/35364) mis-wire class (see "Channel-name casing gotcha") | ⚠️ Flag the specific sub |
+
+**Remediation (only when the user asks to fix it):** stand the missing subs up with **the combined-PR pattern** above — copy it verbatim, swapping `preview5`→`previewN` and `Preview 5`→`Preview N` throughout; do **not** invent new commands, and honor its explicit-confirmation + draft-PR review gate. If the default-channel mapping is also missing, add it first (lifecycle table, row 1). Subs are **inert until the `maestro-configuration` config PR merges to `production`**.
+
+**Worked example (net11 Preview 6, live 2026-07-07):** branch `release/11.0.1xx-preview6` cut, default-channel mapping present, build #321033 already promoted to `.NET 11.0.1xx SDK Preview 6` — **yet `maestro_subscriptions(targetBranch="release/11.0.1xx-preview6")` returns zero rows.** Preview 5 has the full android/macios/dotnet set; Preview 6's were never authored → **FYI**: nothing flows into preview6 yet (Preview 5's subs weren't rolled forward) — worth noting, not a ship blocker.
+
+#### Check B — does the promoted feed match the branch? (feed-vs-branch drift)
+
+"Latest version on the Preview N feed" = the newest MAUI build promoted to the
+`.NET 11.0.1xx SDK Preview N` channel; "what's in .NET MAUI" = the current HEAD of
+`release/11.0.1xx-previewN`.
+
+```bash
+# feed side (BAR) — the latest build promoted to the preview channel:
+#   MCP maestro_latest_build(repository="https://github.com/dotnet/maui",
+#                            channelName=".NET 11.0.1xx SDK Preview N")  -> .commit
+# branch side (git):
+git rev-parse origin/release/11.0.1xx-previewN
+```
+
+Compare the feed build's commit to the branch HEAD:
+
+| Comparison | Meaning | Report |
+|------------|---------|--------|
+| Equal | The promoted build **is** the branch HEAD — feed current | ✅ OK |
+| Feed commit is an ancestor of the branch HEAD (`git merge-base --is-ancestor <feedCommit> origin/release/11.0.1xx-previewN` → exit 0, and they differ) | Branch has moved **ahead** of the last promoted build — feed stale | ⚠️ Flag; report how many commits ahead (`git rev-list --count <feedCommit>..origin/release/11.0.1xx-previewN`) |
+| Feed commit not on the branch | Build promoted from a different ref — investigate, don't guess | ⚠️ Flag |
+
+**Version cross-check (optional, human-readable):** the branch produces
+`11.0.0-preview.N.<date>.<rev>` (from `eng/Versions.props`: `MajorVersion.MinorVersion.PatchVersion` + `preview` + `PreReleaseVersionIteration=N`); the feed's latest build should carry the same `preview.N` stamp. A band/stage mismatch (feed shows `preview.5` on a `-preview6` branch) is the same mis-wire signal as Check A.
+
+**Worked example (net11 Preview 6, live 2026-07-07):** `maestro_latest_build(".NET 11.0.1xx SDK Preview 6")` → build #321033 @ `6e35dc58d0…`; `git rev-parse origin/release/11.0.1xx-preview6` → `6e35dc58d0…` — **equal, feed current** (produced version `11.0.0-preview.6.*`).
+
+#### Check C — are the upstream component pins coherent? (android / macios / dotnet)
+
+MAUI bundles specific **dotnet/android**, **dotnet/macios**, and **dotnet/dotnet** (VMR runtime/SDK) builds, pinned in `eng/Version.Details.xml`. A natural question for a preview is *"which android/macios builds is MAUI shipping — are they the right ones?"*
+
+> **Why not the .NET Release Tracker for this?** The `dotnet-release-tracker` plugin exposes **only SDK/runtime-level** release data (`RuntimeVersion`, `SdkVersion`, `Stage`, …) — it has **no per-component (android/macios) build field**. So there is **no tracker-"blessed" android/macios build** to look up. This check therefore runs entirely off **public** git + BAR/Maestro.
+
+> **Why not "is it behind the latest component build?"** For a **cut** preview branch the component pins are deliberately **frozen** at what the inflight branch (`netN.0`) carried at cut time; the component repos have already moved on to the *next* preview band (e.g. `dotnet/android` is publishing `preview.7`-band builds while `preview6` is out). "Behind latest" is therefore the **expected, correct** state for a cut branch — chasing latest would be wrong. The meaningful signal is **coherence with the inflight branch it was cut from**, plus a band-stamp sanity check.
+
+Read the three anchor dependencies from both the preview branch **and** the inflight branch it was cut from, then diff version+SHA:
+
+```bash
+# dotnet/dotnet (VMR runtime/SDK)  -> Microsoft.NETCore.App.Ref   (11.0.0-preview.N.<date>.<rev>)
+# dotnet/android                   -> Microsoft.Android.Sdk.Windows (android's own scheme, e.g. 37.0.0-ci.main.NN on net11)
+# dotnet/macios                    -> Microsoft.iOS.Sdk.net11.0_26.5 (+ MacCatalyst/macOS/tvOS; 26.5.<build>-net11-pN)
+for ref in release/11.0.1xx-previewN netN.0; do
+  git show origin/$ref:eng/Version.Details.xml
+done
+# extract <Version> + <Sha> for the three anchors and compare the preview branch to the inflight branch
+```
+
+Interpretation:
+
+| Observed | Meaning | Report |
+|----------|---------|--------|
+| previewN pins **==** `netN.0` pins (version **and** SHA) for all three | Clean cut — the preview inherited the inflight component state with no divergence | ✅ OK |
+| previewN pin **diverges** from `netN.0` for a component | Preview was cut around a bump, or was patched/forward-ported after cut — decide which side is newer; a preview *behind* inflight may be missing a component fix, a preview *ahead* is an out-of-band bump | ⚠️ Flag the component + both version/SHA pairs |
+| macios/dotnet pin **missing** the `-net11-pN` / `preview.N` stamp | Off-band pin (e.g. a `preview.5` macios build on a `-preview6` branch) — same mis-wire class as Check A/B | ⚠️ Flag |
+| android on `-ci.main.NN` | **Normal** for the net11 android train — android versions its net11 flow as CI-off-main, *not* with a `-pN` moniker. Validate by matching `netN.0`; do **not** alarm on the `ci.main` scheme itself | ✅ if it matches inflight |
+
+**Worked example (net11 Preview 6, live 2026-07-07):**
+
+| Component | Anchor dependency | preview6 pin | SHA | vs `net11.0` |
+|-----------|-------------------|--------------|-----|--------------|
+| dotnet/dotnet (VMR) | `Microsoft.NETCore.App.Ref` | `11.0.0-preview.6.26325.125` (✅ `preview.6`) | `a512c3ad` | **identical** |
+| dotnet/macios | `Microsoft.iOS.Sdk.net11.0_26.5` | `26.5.11717-net11-p6` (✅ `-net11-p6`) | `5bf7d00b` | **identical** |
+| dotnet/android | `Microsoft.Android.Sdk.Windows` | `37.0.0-ci.main.51` (android net11 CI-main scheme) | `7ab8bac5` | **identical** |
+
+All three anchors are byte-identical to `net11.0` HEAD → **clean cut, component pins coherent** ✅. The android `-ci.main.51` moniker is **not** a preview6 anomaly — `net11.0` carries the same pin, so it's the net11 android train's current state, not a mis-wire. (For contrast, `main` is a different band entirely — android `36.1.2`, runtime `10.0.0`.)
+
 ## Quick reference: lifecycle commands by phase
 
 | Phase | Action | Command sketch |
@@ -391,79 +581,3 @@ When standing up a new preview, **confirm the new preview's subs are in place be
 | Mid-cycle | Verify a sub exists | `darc get-subscriptions --ids "<guid>"` or MCP `maestro_subscription(subscriptionId=...)` |
 | Mid-cycle | Trigger a single sub | `darc trigger-subscriptions --id "<guid>"` (config PR must be merged first) |
 | Preview-ship | Cleanup prior preview | One PR removing per-preview subscription file, per-preview default-channel file, and the 24 lines for that preview in `dotnet-maui.yml`. Reference [PR 61033](https://dev.azure.com/dnceng/internal/_git/maestro-configuration/pullrequest/61033). |
-
-## Preview release readiness
-
-When a contributor asks a "is this preview ready to ship?" style question about a
-`release/X.0.Yxx-previewN` branch, the best available answer depends on whether
-that contributor has access to an authoritative, sometimes-embargoed release
-source. This section defines a tiered workflow that lets contributors **with
-access** benefit automatically while contributors **without access** fall back
-safely to public BAR/Maestro data — and never learn that a private source exists.
-
-### Privacy & security guardrails (read first)
-
-- **Never echo private coordinates.** Do not print or repeat private endpoints,
-  hostnames, AAD/tenant/identity GUIDs, or secrets. None appear in this skill and
-  none should be introduced.
-- **The private source is invisible to no-access users.** In the `NO_ACCESS`
-  tier you must NOT mention that any private plugin or embargoed data source
-  exists. Answer purely from public data.
-- **No fetch-and-exec.** The gate below runs only a local `gh api` read probe and
-  prints a status token. It never downloads or executes remote code.
-- **Comment-only on GitHub.** As everywhere in this skill, never approve, merge,
-  or request changes on PRs.
-
-### Step 1 — run the access gate
-
-Run the deterministic gate script. It performs a cheap local GitHub read probe
-and prints **exactly one** status line — and **no private data** — to stdout:
-
-```bash
-pwsh .github/skills/dependency-flow/scripts/Get-PreviewReleaseReadiness.ps1
-```
-
-It always exits `0` (it can never fail its caller) and emits one of:
-
-| Token | Meaning |
-|-------|---------|
-| `RELEASE_TRACKER_STATUS=NO_ACCESS` | The local `gh` CLI is missing, unauthenticated, or cannot read the private release repo. |
-| `RELEASE_TRACKER_STATUS=AVAILABLE_ENABLED` | The user can read the private release repo AND the authoritative plugin is already enabled in their personal `~/.copilot/settings.json`. |
-| `RELEASE_TRACKER_STATUS=AVAILABLE_NOT_ENABLED` | The user can read the private release repo but has not enabled the authoritative plugin. |
-
-### Step 2 — branch on the token (A/B/C tiers)
-
-**Tier A — `AVAILABLE_ENABLED`:** Use the `dotnet-release-tracker` skill/plugin as
-the **authoritative source** for preview-release-readiness (including which staged
-build is blessed as the official preview). Prefer it over BAR/Maestro when they
-disagree, and present its answer directly.
-
-**Tier B — `AVAILABLE_NOT_ENABLED`:** The user appears to have access but hasn't
-enabled the authoritative plugin. Tell them so and offer an **opt-in** snippet for
-their **personal** `~/.copilot/settings.json`. Do **not** commit plugin enablement
-to the repo, and do not enable it on their behalf:
-
-```jsonc
-// ~/.copilot/settings.json
-"extraKnownMarketplaces": { "dotnet-release": { "source": { "source": "github", "repo": "dotnet/release" } } },
-"enabledPlugins": { "dotnet-release-tracker@dotnet-release": true }
-```
-
-After they enable it and restart, re-running the gate should report
-`AVAILABLE_ENABLED`. Until then, answer from public data (Tier C workflow) but you
-may note that a more authoritative source is available to them.
-
-**Tier C — `NO_ACCESS`:** Silently fall back to the public workflow already
-documented in this skill. Use BAR/Maestro (MCP tools or `mstro`/`darc`) plus
-public `dotnet/core` release metadata to report what public data can show —
-build/channel state, subscription health, and coherency. **Do not** reference any
-private plugin or embargoed source in this tier.
-
-### Honest limitation of the public fallback
-
-Public data (BAR/Maestro + `dotnet/core` release metadata) can surface a lot:
-which builds exist, what channels they're on, subscription health, and coherency
-state. But it **cannot identify which staged build is "blessed"** as the official
-preview — that determination lives in the authoritative source. In the `NO_ACCESS`
-and un-enabled Tier-B cases, be explicit that you can describe build/channel
-readiness but cannot confirm the official/blessed build.

--- a/.github/skills/dependency-flow/scripts/Get-PreviewReleaseReadiness.ps1
+++ b/.github/skills/dependency-flow/scripts/Get-PreviewReleaseReadiness.ps1
@@ -174,6 +174,8 @@ function Test-PluginEnabled {
     # Match an enabled entry, tolerant of a marketplace suffix being present or
     # absent. Anchored to the start of a line (after optional whitespace) so a
     # commented-out entry such as `// "dotnet-release-tracker@x": true` is ignored.
+    # Block comments (/* ... */) are stripped separately below before matching, so
+    # a block-commented entry is likewise not read as enabled.
     # Examples that match: "dotnet-release-tracker": true
     #                      "dotnet-release-tracker@dotnet-release": true
     $pattern = '(?m)^\s*"' + [regex]::Escape($Plugin) + '(@[^"]+)?"\s*:\s*true'
@@ -182,7 +184,13 @@ function Test-PluginEnabled {
             try {
                 $text = Get-Content -LiteralPath $path -Raw -ErrorAction Stop
             } catch { continue }
-            if ($text -match $pattern) {
+            # Strip /* ... */ block comments before matching so an entry that has
+            # been block-commented out isn't misread as enabled. The (?m)^-anchor
+            # already excludes // line comments, but a block comment can wrap a
+            # line that still starts with the quoted key. JSON string values never
+            # contain the '/*' sequence, so this cannot eat a real setting.
+            $scrubbed = [regex]::Replace($text, '/\*[\s\S]*?\*/', '')
+            if ($scrubbed -match $pattern) {
                 return [pscustomobject]@{ Enabled = $true; Source = $path }
             }
         }
@@ -240,8 +248,22 @@ try {
 catch {
     # Unreachable in normal operation, but the always-exit-0 / always-emit-a-line
     # contract must hold even if an unexpected terminating error occurs. Fall back
-    # to the safe privacy default and never leak the error detail.
-    Write-Output 'RELEASE_TRACKER_STATUS=NO_ACCESS'
+    # to the safe privacy default and never leak the error detail. Honor -Json so a
+    # structured consumer still gets parseable output on this path.
+    if ($Json) {
+        [pscustomobject]@{
+            status          = 'NO_ACCESS'
+            access          = $false
+            enabled         = $false
+            reason          = 'unexpected-error'
+            repo            = $ReleaseRepo
+            plugin          = $PluginId
+            inactiveAccount = $null
+        } | ConvertTo-Json -Compress
+    } else {
+        Write-Output 'RELEASE_TRACKER_STATUS=NO_ACCESS'
+        Write-Output '# access=false enabled=false reason=unexpected-error'
+    }
 }
 
 exit 0

--- a/.github/skills/dependency-flow/scripts/Get-PreviewReleaseReadiness.ps1
+++ b/.github/skills/dependency-flow/scripts/Get-PreviewReleaseReadiness.ps1
@@ -156,6 +156,26 @@ function Test-MarketplaceAccess {
     return [pscustomobject]@{ Access = $false; Reason = "no-read-access-to-$Repo"; InactiveAccount = $null }
 }
 
+function Remove-JsoncComments {
+    <#
+    .SYNOPSIS
+        Strip // line and /* */ block comments from JSONC text, STRING-AWARE.
+    .DESCRIPTION
+        `/*`, `*/` and `//` all occur legitimately inside JSON string values (path
+        globs, URLs). A naive comment strip is content-blind and can DELETE a real
+        setting that sits between two such values. This alternates a full
+        double-quoted string (honoring \ escapes) against the two comment forms and
+        keeps only the strings — comments are dropped, string contents (including
+        any stray `/*` / `//`) are preserved verbatim. Pure/side-effect-free.
+    #>
+    param([string]$Text)
+    if ([string]::IsNullOrEmpty($Text)) { return $Text }
+    return [regex]::Replace(
+        $Text,
+        '"(?:\\.|[^"\\])*"|/\*[\s\S]*?\*/|//[^\r\n]*',
+        { param($m) if ($m.Value.StartsWith('"')) { $m.Value } else { '' } })
+}
+
 function Test-PluginEnabled {
     param([string]$Plugin)
 
@@ -174,8 +194,8 @@ function Test-PluginEnabled {
     # Match an enabled entry, tolerant of a marketplace suffix being present or
     # absent. Anchored to the start of a line (after optional whitespace) so a
     # commented-out entry such as `// "dotnet-release-tracker@x": true` is ignored.
-    # Block comments (/* ... */) are stripped separately below before matching, so
-    # a block-commented entry is likewise not read as enabled.
+    # A string-aware JSONC comment scrub below also removes block-commented and
+    # inline-commented entries before matching, so neither is read as enabled.
     # Examples that match: "dotnet-release-tracker": true
     #                      "dotnet-release-tracker@dotnet-release": true
     $pattern = '(?m)^\s*"' + [regex]::Escape($Plugin) + '(@[^"]+)?"\s*:\s*true'
@@ -184,12 +204,11 @@ function Test-PluginEnabled {
             try {
                 $text = Get-Content -LiteralPath $path -Raw -ErrorAction Stop
             } catch { continue }
-            # Strip /* ... */ block comments before matching so an entry that has
-            # been block-commented out isn't misread as enabled. The (?m)^-anchor
-            # already excludes // line comments, but a block comment can wrap a
-            # line that still starts with the quoted key. JSON string values never
-            # contain the '/*' sequence, so this cannot eat a real setting.
-            $scrubbed = [regex]::Replace($text, '/\*[\s\S]*?\*/', '')
+            # Strip JSONC comments before matching so a commented-out entry (either
+            # `// ...` or `/* ... */`) isn't misread as enabled. Remove-JsoncComments
+            # is string-aware, so a stray `/*`/`//` inside a real string value can't
+            # cause a genuinely-enabled entry to be deleted.
+            $scrubbed = Remove-JsoncComments $text
             if ($scrubbed -match $pattern) {
                 return [pscustomobject]@{ Enabled = $true; Source = $path }
             }
@@ -197,6 +216,11 @@ function Test-PluginEnabled {
     }
     return [pscustomobject]@{ Enabled = $false; Source = $null }
 }
+
+# Guard: skip the access-gate body (and the trailing `exit 0`) when dot-sourced so
+# tests can load the helper functions without running the gate. Mirrors the guard in
+# Get-PreviewReadiness.ps1.
+if ($MyInvocation.InvocationName -eq '.' -or $MyInvocation.Line -match '^\.\s') { return }
 
 try {
     $access = Test-MarketplaceAccess -Repo $ReleaseRepo

--- a/.github/skills/dependency-flow/scripts/Get-PreviewReleaseReadiness.ps1
+++ b/.github/skills/dependency-flow/scripts/Get-PreviewReleaseReadiness.ps1
@@ -219,8 +219,13 @@ function Test-PluginEnabled {
 
 # Guard: skip the access-gate body (and the trailing `exit 0`) when dot-sourced so
 # tests can load the helper functions without running the gate. Mirrors the guard in
-# Get-PreviewReadiness.ps1.
-if ($MyInvocation.InvocationName -eq '.' -or $MyInvocation.Line -match '^\.\s') { return }
+# Get-PreviewReadiness.ps1. `InvocationName -eq '.'` is the canonical dot-source
+# discriminator and holds for every dot-source form (literal, $var, parenthesized,
+# absolute path); we deliberately do NOT also match `$MyInvocation.Line` against a
+# leading dot, because that whole-command-line text can begin with an earlier
+# dot-source statement and would then wrongly skip a later `&`/`-File` invocation
+# on the same command line.
+if ($MyInvocation.InvocationName -eq '.') { return }
 
 try {
     $access = Test-MarketplaceAccess -Repo $ReleaseRepo

--- a/.github/skills/dependency-flow/scripts/Get-PreviewReleaseReadiness.ps1
+++ b/.github/skills/dependency-flow/scripts/Get-PreviewReleaseReadiness.ps1
@@ -1,117 +1,247 @@
 #!/usr/bin/env pwsh
-#Requires -Version 7.0
+#requires -Version 7.0
 <#
 .SYNOPSIS
-    Deterministic access gate for the private "preview release readiness" data source.
+    Deterministic access gate for preview release-readiness data sources.
 
 .DESCRIPTION
-    Some .NET MAUI contributors have access to an authoritative (and sometimes
-    embargoed) preview-release-readiness data source that is delivered as a
-    PRIVATE Copilot plugin. Access is double-gated:
-        1. GitHub read access to the private repository dotnet/release, AND
-        2. an authorized AAD identity (handled by the plugin itself, not here).
+    When someone asks "is .NET MAUI preview N release-ready?", the *authoritative*
+    answer to "which staged build is blessed as the official preview" comes from
+    an internal '.NET Release Tracker' Copilot plugin that lives in a private
+    marketplace repo. Public BAR/Maestro data can list candidate builds but cannot
+    by itself identify the blessed one.
 
-    This script performs ONLY the cheap, local GitHub read probe and reports one
-    of three states so a skill can branch its behavior. It emits NO private data:
-    the ONLY thing written to stdout is a single status token. It never prints
-    the repository response, error detail, endpoints, or identity information.
+    This script does NOT fetch any release data. It only classifies the caller's
+    environment so the agent can pick the right data source and the right tone:
 
-    States (written to stdout as exactly one line):
-        RELEASE_TRACKER_STATUS=NO_ACCESS
-            The local gh CLI is missing, unauthenticated, or cannot read
-            dotnet/release. Callers must fall back to public data (BAR/Maestro)
-            and must NOT reveal that a private source exists.
+        AVAILABLE_ENABLED      caller can read the marketplace repo AND the plugin
+                               is already enabled locally  -> use the plugin.
+        AVAILABLE_NOT_ENABLED  caller can read the marketplace repo but the plugin
+                               is NOT enabled locally       -> offer an opt-in.
+        ACCESS_ON_INACTIVE_ACCOUNT
+                               the ACTIVE gh identity cannot read the marketplace
+                               repo, but a logged-in but *inactive* gh account CAN.
+                               The plugin loads under the active identity, so this is
+                               NOT reported as AVAILABLE (that would be a false
+                               positive the plugin can't honor). Instead the caller is
+                               advised to run 'gh auth switch --user <account>' and
+                               re-run. This only fires when access is CONFIRMED on some
+                               account, so a genuine no-access caller never sees it.
+        NO_ACCESS              caller cannot confirm read access on ANY logged-in
+                               account (no access, gh missing, or gh unauthenticated)
+                               -> fall back to PUBLIC data only, and say NOTHING about
+                               the private plugin (privacy default).
 
-        RELEASE_TRACKER_STATUS=AVAILABLE_ENABLED
-            The user can read dotnet/release AND the dotnet-release-tracker
-            plugin is already enabled in their personal ~/.copilot/settings.json.
-            Callers should use that plugin as the authoritative source.
+    The result is printed as a single token line:
 
-        RELEASE_TRACKER_STATUS=AVAILABLE_NOT_ENABLED
-            The user can read dotnet/release but has not enabled the plugin.
-            Callers may offer a personal, opt-in enablement snippet.
+        RELEASE_TRACKER_STATUS=<token>
 
-    The script ALWAYS exits 0 so it can never fail its caller. Any error while
-    probing access or reading settings is treated as the safe default
-    (NO_ACCESS for the probe, not-enabled for the plugin check).
+    followed by a '# ...' diagnostic line. The script ALWAYS exits 0 — it is a
+    classifier, not a build gate.
 
-    Cross-platform: pure PowerShell 7+, no bashisms, no external shell.
+.NOTES
+    PUBLIC-SAFE CONTRACT (this file ships in the public dotnet/maui repo):
+      * Contains NO embargoed/unshipped release data.
+      * Contains NO Azure AD resource identifiers (GUIDs / api://... audiences).
+      * Contains NO backend service hostnames or internal endpoint paths.
+      * Performs NO fetch-and-exec of remote code.
+    It only references the *marketplace pointer* (a repo name + a plugin name),
+    which is the sanctioned reference. Actual data access is independently gated
+    by the plugin's own Azure AD authentication, so a no-access caller cannot
+    obtain embargoed data even if they read this script.
+
+.PARAMETER ReleaseRepo
+    The private marketplace repo that hosts the release-tracker plugin, in
+    'owner/name' form. Default: dotnet/release.
+
+.PARAMETER PluginId
+    The plugin name as declared in its plugin.json. Default: dotnet-release-tracker.
+
+.PARAMETER Json
+    Emit a JSON object instead of the token line.
+
+.EXAMPLE
+    pwsh ./Get-PreviewReleaseReadiness.ps1
+    RELEASE_TRACKER_STATUS=NO_ACCESS
+    # access=false enabled=false reason=no-read-access-to-dotnet/release
 #>
-
 [CmdletBinding()]
-param()
+param(
+    [string]$ReleaseRepo = 'dotnet/release',
+    [string]$PluginId = 'dotnet-release-tracker',
+    [switch]$Json
+)
 
 Set-StrictMode -Version Latest
-$ErrorActionPreference = 'SilentlyContinue'
-# A non-zero exit from a native command must never throw; we inspect the exit
-# code ourselves to decide access.
+$ErrorActionPreference = 'Stop'
+# A non-zero exit from a native command (e.g. `gh api` on a private/404 repo) must
+# NEVER throw — we inspect $LASTEXITCODE ourselves. This defends against hosts or
+# $PROFILEs that flip the PowerShell 7.4+ default of this preference to $true, which
+# would otherwise turn the common NO_ACCESS probe into a terminating error.
 $PSNativeCommandUseErrorActionPreference = $false
 
-function Test-ReleaseRepoAccess {
-    # Returns $true only when the local gh CLI can read the private repo.
-    # Treats a missing gh, an unauthenticated CLI, or any non-zero exit as
-    # "no access". Never surfaces the response or error text.
-    if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
-        return $false
+function Get-GhLoggedInAccounts {
+    # Best-effort list of DISTINCT account logins known to `gh auth status`
+    # (covers both keyring accounts and a GH_TOKEN-provided one). Parsing the
+    # human-readable status text is intentional: `gh auth status` has no --json
+    # form, and this is only ever used on the already-slow no-active-access path.
+    $gh = Get-Command gh -ErrorAction SilentlyContinue
+    if (-not $gh) { return @() }
+    $raw = & gh auth status 2>&1
+    $logins = @()
+    foreach ($line in $raw) {
+        $m = [regex]::Match([string]$line, 'account\s+(\S+)')
+        if ($m.Success) { $logins += $m.Groups[1].Value }
     }
-
-    try {
-        # --silent suppresses the response body; the pipe to Out-Null is a
-        # second safety net; stderr is discarded so nothing private can leak.
-        & gh api 'repos/dotnet/release' --silent 2>$null | Out-Null
-        return ($LASTEXITCODE -eq 0)
-    }
-    catch {
-        return $false
-    }
+    return @($logins | Select-Object -Unique)
 }
 
-function Test-ReleaseTrackerEnabled {
-    # Returns $true when the personal settings file enables a
-    # dotnet-release-tracker plugin under any marketplace suffix
-    # (e.g. dotnet-release-tracker@dotnet-release) with a truthy value.
-    $settingsPath = Join-Path -Path $HOME -ChildPath '.copilot/settings.json'
-    if (-not (Test-Path -LiteralPath $settingsPath)) {
-        return $false
+function Test-MarketplaceAccess {
+    param([string]$Repo)
+
+    $gh = Get-Command gh -ErrorAction SilentlyContinue
+    if (-not $gh) {
+        return [pscustomobject]@{ Access = $false; Reason = 'gh-cli-not-installed'; InactiveAccount = $null }
     }
 
-    try {
-        $raw = Get-Content -LiteralPath $settingsPath -Raw -ErrorAction Stop
-        $settings = $raw | ConvertFrom-Json -ErrorAction Stop
-    }
-    catch {
-        return $false
-    }
-
-    if ($null -eq $settings -or
-        -not ($settings.PSObject.Properties.Name -contains 'enabledPlugins')) {
-        return $false
+    # 1. Probe the ACTIVE identity (honors $GH_TOKEN or the active keyring account).
+    #    --silent suppresses the repo JSON body; we only care about the exit code.
+    #    A 404 (no access) or auth failure both yield a non-zero exit -> no access.
+    & gh api "repos/$Repo" --silent 2>$null | Out-Null
+    if ($LASTEXITCODE -eq 0) {
+        return [pscustomobject]@{ Access = $true; Reason = "read-access-to-$Repo"; InactiveAccount = $null }
     }
 
-    $enabled = $settings.enabledPlugins
-    if ($null -eq $enabled) {
-        return $false
-    }
+    # 2. The active identity can't read the repo. Before concluding NO_ACCESS, check
+    #    whether the user has ANOTHER logged-in gh account that CAN — a common
+    #    multi-account footgun (e.g. a corp account is active but a personal account
+    #    holds the access). We surface this ONLY when access is confirmed on some
+    #    account, so a genuine no-access user still gets a silent NO_ACCESS (the
+    #    privacy default is preserved). We do NOT report AVAILABLE for an inactive
+    #    account: the plugin loads under the ACTIVE identity, so the fix is a switch.
+    $activeLogin = $null
+    try { $activeLogin = (& gh api user --jq '.login' 2>$null) } catch { $activeLogin = $null }
 
-    foreach ($prop in $enabled.PSObject.Properties) {
-        # Match the plugin name with or without a marketplace suffix.
-        if ($prop.Name -match '^dotnet-release-tracker(@.*)?$' -and $prop.Value) {
-            return $true
+    # Collect candidate (login, token) pairs under the ORIGINAL environment first,
+    # so fetching one account's token isn't perturbed by a GH_TOKEN we set to probe.
+    $candidates = @()
+    foreach ($login in (Get-GhLoggedInAccounts)) {
+        if ($activeLogin -and $login -eq $activeLogin) { continue }
+        $tok = & gh auth token --user $login 2>$null
+        if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace([string]$tok)) {
+            $candidates += [pscustomobject]@{ Login = $login; Token = ([string]$tok).Trim() }
         }
     }
 
-    return $false
+    $savedToken = $env:GH_TOKEN
+    try {
+        foreach ($c in $candidates) {
+            $env:GH_TOKEN = $c.Token
+            & gh api "repos/$Repo" --silent 2>$null | Out-Null
+            if ($LASTEXITCODE -eq 0) {
+                return [pscustomobject]@{
+                    Access          = $false
+                    Reason          = "access-on-inactive-account=$($c.Login)"
+                    InactiveAccount = $c.Login
+                }
+            }
+        }
+    }
+    finally {
+        # Always restore the caller's original GH_TOKEN (or remove it if it was unset).
+        if ($null -eq $savedToken) { Remove-Item Env:GH_TOKEN -ErrorAction SilentlyContinue }
+        else { $env:GH_TOKEN = $savedToken }
+    }
+
+    return [pscustomobject]@{ Access = $false; Reason = "no-read-access-to-$Repo"; InactiveAccount = $null }
 }
 
-$status = 'NO_ACCESS'
-if (Test-ReleaseRepoAccess) {
-    if (Test-ReleaseTrackerEnabled) {
-        $status = 'AVAILABLE_ENABLED'
+function Test-PluginEnabled {
+    param([string]$Plugin)
+
+    # Scan the well-known Copilot settings locations. We use a tolerant regex
+    # (settings files are JSONC and may contain // and /* */ comments) rather
+    # than a strict JSON parse. An enabled entry looks like:
+    #   "dotnet-release-tracker@<marketplace>": true
+    $candidates = @()
+    if ($env:HOME) { $candidates += (Join-Path $env:HOME '.copilot/settings.json') }
+    if ($env:USERPROFILE) { $candidates += (Join-Path $env:USERPROFILE '.copilot/settings.json') }
+    # User-scope only, by design: the private-plugin opt-in must live in the
+    # user's personal settings and must NOT be enable-able from a committable
+    # project file (e.g. .github/copilot/settings.json), so forks and no-access
+    # users are never silently opted in. (Matches the hardening shipped in #36268.)
+
+    # Match an enabled entry, tolerant of a marketplace suffix being present or
+    # absent. Anchored to the start of a line (after optional whitespace) so a
+    # commented-out entry such as `// "dotnet-release-tracker@x": true` is ignored.
+    # Examples that match: "dotnet-release-tracker": true
+    #                      "dotnet-release-tracker@dotnet-release": true
+    $pattern = '(?m)^\s*"' + [regex]::Escape($Plugin) + '(@[^"]+)?"\s*:\s*true'
+    foreach ($path in ($candidates | Select-Object -Unique)) {
+        if (Test-Path -LiteralPath $path) {
+            try {
+                $text = Get-Content -LiteralPath $path -Raw -ErrorAction Stop
+            } catch { continue }
+            if ($text -match $pattern) {
+                return [pscustomobject]@{ Enabled = $true; Source = $path }
+            }
+        }
     }
-    else {
-        $status = 'AVAILABLE_NOT_ENABLED'
-    }
+    return [pscustomobject]@{ Enabled = $false; Source = $null }
 }
 
-Write-Output "RELEASE_TRACKER_STATUS=$status"
+try {
+    $access = Test-MarketplaceAccess -Repo $ReleaseRepo
+
+    if (-not $access.Access) {
+        if ($access.InactiveAccount) {
+            # Access is confirmed, but only under a logged-in *inactive* gh account.
+            # The plugin loads under the ACTIVE identity, so reporting AVAILABLE would
+            # be a false positive. Advise the account switch instead.
+            $status = 'ACCESS_ON_INACTIVE_ACCOUNT'
+            $enabled = $false
+            $reason = "$($access.Reason); run 'gh auth switch --user $($access.InactiveAccount)' then re-run"
+        } else {
+            # Privacy default: anything other than confirmed access -> NO_ACCESS.
+            $status = 'NO_ACCESS'
+            $enabled = $false
+            $reason = $access.Reason
+        }
+    } else {
+        $pluginState = Test-PluginEnabled -Plugin $PluginId
+        $enabled = $pluginState.Enabled
+        if ($enabled) {
+            $status = 'AVAILABLE_ENABLED'
+            # $pluginState.Source is a user-scope settings path (see Test-PluginEnabled) —
+            # emit a fixed scope label, never the raw path, so the printed reason line
+            # (and the JSON reason field) can't leak the caller's $HOME/username.
+            $reason = "enabled-via=user-settings"
+        } else {
+            $status = 'AVAILABLE_NOT_ENABLED'
+            $reason = 'access-ok-plugin-not-enabled'
+        }
+    }
+
+    if ($Json) {
+        [pscustomobject]@{
+            status          = $status
+            access          = [bool]$access.Access
+            enabled         = [bool]$enabled
+            reason          = $reason
+            repo            = $ReleaseRepo
+            plugin          = $PluginId
+            inactiveAccount = $access.InactiveAccount
+        } | ConvertTo-Json -Compress
+    } else {
+        Write-Output "RELEASE_TRACKER_STATUS=$status"
+        Write-Output "# access=$($access.Access.ToString().ToLower()) enabled=$($enabled.ToString().ToLower()) reason=$reason"
+    }
+}
+catch {
+    # Unreachable in normal operation, but the always-exit-0 / always-emit-a-line
+    # contract must hold even if an unexpected terminating error occurs. Fall back
+    # to the safe privacy default and never leak the error detail.
+    Write-Output 'RELEASE_TRACKER_STATUS=NO_ACCESS'
+}
+
 exit 0

--- a/.github/skills/release-readiness/SKILL.md
+++ b/.github/skills/release-readiness/SKILL.md
@@ -106,6 +106,46 @@ pwsh .github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1 \
   -OutputDir CustomAgentLogsTmp/release-readiness/preview6-candidate
 ```
 
+### Preview: authoritative blessed-build source (.NET Release Tracker)
+
+For **Previews**, this skill's public survey (CI health + regression classification on `net<major>.0` or the preview branch) tells you whether the code is *ready*, but it **cannot on its own name which staged build is the official, blessed preview** — that designation lives in the private **.NET Release Tracker** plugin. So when answering *"run release readiness … is net11 preview6 ready?"* / *"which build is the official preview6?"*, consult that authoritative source **in addition to** running `Get-PreviewReadiness.ps1`:
+
+1. **Classify access first (deterministic gate — fetches no release data, always exits 0):**
+
+   ```bash
+   pwsh ./.github/skills/dependency-flow/scripts/Get-PreviewReleaseReadiness.ps1
+   # -> RELEASE_TRACKER_STATUS=NO_ACCESS | ACCESS_ON_INACTIVE_ACCOUNT | AVAILABLE_NOT_ENABLED | AVAILABLE_ENABLED
+   ```
+
+2. **Branch on the token:**
+   - `AVAILABLE_ENABLED` → invoke the **`dotnet-release-tracker`** skill for the blessed SDK/runtime + BAR id + stage, and present it as the authoritative official preview build. It is a **skill/plugin, not an MCP tool** — don't look for a `release-tracker` entry in the tool list and give up; run the skill (reload/restart the session if it's enabled but hasn't loaded yet). Combine it with this skill's CI/regression verdict for the full picture.
+   - `AVAILABLE_NOT_ENABLED` → the caller has access but the plugin isn't enabled locally; offer the one-time user-scope opt-in, then re-run the gate.
+   - `ACCESS_ON_INACTIVE_ACCOUNT` → access exists, but only under a logged-in **inactive** `gh` account (named in the gate's `inactiveAccount`); the plugin loads under the active identity, so advise `gh auth switch --user <account>` and re-run the gate — do **not** invoke the plugin or claim availability under the current identity.
+   - `NO_ACCESS` → report from public data only. For the official-build line, fall back to the **latest build on the public `.NET 11.0.1xx SDK Preview N` channel** (public BAR/Maestro) and present it **labeled** as a public-feed candidate — "source: public preview feed; may not be the final official (blessed) build; the official build is designated at release time and may differ." Don't name or hint at the private tracker tool (see dependency-flow's privacy guardrail), but do be honest that this is the public feed and not a confirmed official build.
+
+The full tier table, the user-scope opt-in snippet, and the privacy guardrails live in dependency-flow's **"Preview release readiness (authoritative source + access tiers)"** section ([`../dependency-flow/SKILL.md`](../dependency-flow/SKILL.md)) — cross-reference it rather than duplicating it here.
+
+> **Blessed ≠ green.** The release tracker names the *official* build; it does **not** substitute for the ship-readiness judgment. A build can be blessed while this skill still reports open `regressed-in-*` blockers — surface both.
+
+### Preview: is the branch actually plumbed? (subscription wiring + feed drift)
+
+A preview can pass CI and even have a blessed build yet still not be *ship-wired* —
+the branch is cut but nothing flows into it, or its promoted feed lags the branch.
+A complete *"is preview N ready?"* answer runs three more **public** (BAR/Maestro + git)
+checks alongside the survey and the blessed-build lookup:
+
+- **Subscriptions wired?** Confirm the `release/11.0.1xx-previewN` branch has its default-channel mapping **and** the baseline three subscriptions (android + macios + dotnet on `.NET 11.0.1xx SDK Preview N`). Branch cut + default-channel present but **zero subs** = a start-of-preview flow gap → surface as an **FYI note** (not a ship blocker), naming the missing source repos.
+- **Feed matches the branch?** Compare the latest build promoted to the `.NET 11.0.1xx SDK Preview N` channel (`maestro_latest_build`) against `origin/release/11.0.1xx-previewN` HEAD. Branch ahead of the promoted build = stale feed → flag it.
+- **Component pins coherent?** Report which `dotnet/android`, `dotnet/macios`, and `dotnet/dotnet` (VMR) builds MAUI bundles (version + SHA from `eng/Version.Details.xml`) and confirm they **match the inflight `netN.0` branch the preview was cut from**. Match = clean cut ✅; divergence or an off-band pin (macios/dotnet missing the `-net11-pN`/`preview.N` stamp) → flag. The tracker has **no** per-component build, so there is no "blessed" android/macios to look up — this is git+BAR only, and "behind the latest component build" is *expected* for a cut branch (don't flag it). Android's `-ci.main.NN` scheme is normal for net11 — validate against `netN.0`, don't alarm on the moniker.
+
+All three checks — the exact MCP/`darc`/git commands, the interpretation tables, the
+remediation (combined-PR pattern), and live worked examples — live in dependency-flow's
+**"Wiring checks: is Preview N actually plumbed?"** subsection (Checks A/B/C)
+([`../dependency-flow/SKILL.md`](../dependency-flow/SKILL.md)); run them from there and
+fold the results into the preview report (missing subs ⇒ an FYI note; stale feed ⇒ a
+flagged concern; component pins ⇒ coherent ✅ or a flagged divergence) rather than
+duplicating the mechanics here.
+
 ## Parameters
 
 ### `Find-ReleaseReadinessTrackers.ps1`
@@ -285,6 +325,7 @@ Determinism / idempotency: the engine captures **one** `UtcNow` per run (`$Data[
 
 - **Custom agent**: `.github/agents/release-readiness-agent.agent.md` wraps this skill — handles regression-label confirmation, runs the script, then uses WorkIQ to add context for `rejected-from-sr` PRs.
 - **WorkIQ**: NOT called from the PowerShell scripts (PowerShell can't invoke MCP tools). The agent enriches the script's JSON output with WorkIQ context where needed.
+- **.NET Release Tracker (Preview blessed build)**: for Previews, the *authoritative* official build is designated in the private `dotnet-release-tracker` plugin, reached through dependency-flow's deterministic access gate (`Get-PreviewReleaseReadiness.ps1`). See [Preview: authoritative blessed-build source](#preview-authoritative-blessed-build-source-net-release-tracker) above; the tier table + opt-in live in `../dependency-flow/SKILL.md`.
 
 ## Anti-Patterns
 

--- a/.github/skills/release-readiness/SKILL.md
+++ b/.github/skills/release-readiness/SKILL.md
@@ -127,10 +127,19 @@ The full tier table, the user-scope opt-in snippet, and the privacy guardrails l
 
 > **Blessed ≠ green.** The release tracker names the *official* build; it does **not** substitute for the ship-readiness judgment. A build can be blessed while this skill still reports open `regressed-in-*` blockers — surface both.
 
+**Don't maintain a standing "🏷️ Official (blessed) preview build" table in the tracker.** The deterministic CI body already owns the public blessed-build handling: its **"🏷️ Preview N component build — branch pins + inferred sub health"** section states the pins are explicitly *not* the blessed build, carries the drift-proof "verify locally" prompt, and infers subscription health from the public PR trail. Because the blessed build number is embargoed (withheld from the public issue), a standing public table just renders "🔒 withheld" and duplicates that callout. So a local run with tracker access should **report the blessed SDK/runtime build in its conversational answer**, and only add a line to _Release Captain Notes_ when there's a **decision or exception worth persisting** — e.g. the blessed build differs from the branch pin, a promoted build was rejected, or a subscription is confirmed broken. Don't re-create the section the CI body already renders.
+
 ### Preview: is the branch actually plumbed? (subscription wiring + feed drift)
 
 A preview can pass CI and even have a blessed build yet still not be *ship-wired* —
 the branch is cut but nothing flows into it, or its promoted feed lags the branch.
+The deterministic CI body already gives a **best-effort inferred** read of the
+wiring from the public PR trail — the **Flow signal** column in its
+**"🏷️ Preview N component build — branch pins + inferred sub health"** section
+(🔄 open dep-flow PR / ✅ fresh merge ≤14d / ⚠️ stale >14d / ❌ none seen). The
+checks below are the **authoritative** confirmation a local run adds on top of that
+inference (`darc`/BAR can see the subscription itself; CI can only see its PR
+exhaust). Run them when the inferred signal is ⚠️/❌, or to confirm a ✅ before ship.
 A complete *"is preview N ready?"* answer runs three more **public** (BAR/Maestro + git)
 checks alongside the survey and the blessed-build lookup:
 
@@ -144,7 +153,11 @@ remediation (combined-PR pattern), and live worked examples — live in dependen
 ([`../dependency-flow/SKILL.md`](../dependency-flow/SKILL.md)); run them from there and
 fold the results into the preview report (missing subs ⇒ an FYI note; stale feed ⇒ a
 flagged concern; component pins ⇒ coherent ✅ or a flagged divergence) rather than
-duplicating the mechanics here.
+duplicating the mechanics here. Persist a line in _Release Captain Notes_ **only when
+the authoritative check diverges from or refines the CI-inferred Flow signal** — e.g.
+inferred ✅ but the sub points at the wrong channel, or inferred ⚠️/❌ confirmed as a
+real gap with the missing source repos named. When the local check simply agrees with
+the inferred signal, report it conversationally and leave the tracker to the CI body.
 
 ## Parameters
 

--- a/.github/skills/release-readiness/scripts/Find-ReleaseReadinessTrackers.ps1
+++ b/.github/skills/release-readiness/scripts/Find-ReleaseReadinessTrackers.ps1
@@ -916,7 +916,10 @@ function Invoke-DetectionForMajor {
 
 # Guard: skip the driver when dot-sourced (tests dot-source to access helpers
 # like New-RegressionLabelList and the strict regex constants).
-if ($MyInvocation.InvocationName -eq '.' -or $MyInvocation.Line -match '^\.\s') { return }
+# `InvocationName -eq '.'` alone reliably detects dot-sourcing across every form;
+# matching `$MyInvocation.Line` against a leading dot is avoided because that text
+# can be the whole command line and would wrongly skip a later `&`/`-File` call.
+if ($MyInvocation.InvocationName -eq '.') { return }
 
 if (-not (Test-Path (Join-Path $Repo '.git'))) {
     throw "Fail-closed: $Repo is not a git repository. Pass -Repo <checkout>."

--- a/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
+++ b/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
@@ -1640,7 +1640,10 @@ function Add-CiScanTable {
 # Guard: skip the main driver when dot-sourced so tests can load the helper
 # functions (e.g. Test-IsP0Pr) without invoking the full report flow, which
 # requires git + gh + network. Mirrors Find-ReleaseReadinessTrackers.ps1.
-if ($MyInvocation.InvocationName -eq '.' -or $MyInvocation.Line -match '^\.\s') { return }
+# `InvocationName -eq '.'` alone reliably detects dot-sourcing; matching
+# `$MyInvocation.Line` against a leading dot is avoided because that text can be
+# the whole command line and would wrongly skip a later `&`/`-File` call.
+if ($MyInvocation.InvocationName -eq '.') { return }
 
 $checks = @()
 

--- a/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
+++ b/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
@@ -1166,6 +1166,38 @@ function Get-ComponentFlowSignal {
     }
 }
 
+function Format-FlowSignalCell {
+    <#
+    .SYNOPSIS
+        Render the Flow-signal table cell for one component from a
+        Get-ComponentFlowSignal result. Pure/string-only so it is unit-testable.
+    .DESCRIPTION
+        The 'missing' status normally renders as "❌ none seen — sub may be
+        missing" (we looked at the public PR trail and found nothing → the sub may
+        never have been wired). But when the merged-PR history could NOT be fetched
+        (transient gh failure caught upstream), 'missing' is NOT a trustworthy
+        "none seen" — we simply couldn't look. In that case -HistoryUnavailable
+        renders an honest "couldn't check" cell instead of a false absence claim.
+    #>
+    param(
+        [Parameter(Mandatory)] $Flow,
+        [switch]$HistoryUnavailable
+    )
+    $ageTxt = ''
+    if ($null -ne $Flow.AgeDays) {
+        $ageTxt = if ($Flow.AgeDays -le 0) { 'today' } elseif ($Flow.AgeDays -eq 1) { '1 day ago' } else { "$($Flow.AgeDays) days ago" }
+    }
+    switch ($Flow.Status) {
+        'open'  { "🔄 [#$($Flow.Number)]($($Flow.Url)) open — flowing" }
+        'fresh' { "✅ [#$($Flow.Number)]($($Flow.Url)) merged $ageTxt" }
+        'stale' { "⚠️ stale — newest [#$($Flow.Number)]($($Flow.Url)) merged $ageTxt" }
+        default {
+            if ($HistoryUnavailable) { "— _merged-PR history unavailable (transient); re-run to confirm sub health_" }
+            else { "❌ none seen — sub may be missing" }
+        }
+    }
+}
+
 function Get-UpstreamDriftSignal {
     <#
     .SYNOPSIS
@@ -1265,7 +1297,9 @@ function Get-UpstreamDriftSignal {
         return $result
     }
 
-    if ($null -eq $cmp -or -not $cmp.PSObject.Properties['ahead_by'] -or -not $cmp.PSObject.Properties['behind_by']) {
+    if ($null -eq $cmp -or
+        -not $cmp.PSObject.Properties['ahead_by'] -or $null -eq $cmp.ahead_by -or
+        -not $cmp.PSObject.Properties['behind_by'] -or $null -eq $cmp.behind_by) {
         $result.Reason = 'compare returned no counts'
         return $result
     }
@@ -2176,9 +2210,11 @@ if ($componentPins) {
     # signal to open-PR-only inference, NEVER abort the whole readiness report
     # (every other data section in this driver degrades rather than throws).
     $mergedPRsForFlow = @()
+    $mergedHistoryUnavailable = $false
     try {
         $mergedPRsForFlow = @(Get-MergedPullRequests -BaseBranch $SurveyRef)
     } catch {
+        $mergedHistoryUnavailable = $true
         Write-Warning "Flow-signal merged-PR fetch failed (non-fatal): $($_.Exception.Message)" -WarningAction Continue
     }
     $allPRsForFlow   = @($targetPRs) + @($mergedPRsForFlow)
@@ -2205,16 +2241,7 @@ if ($componentPins) {
     )
     foreach ($r in $pinRows) {
         $flow = Get-ComponentFlowSignal -Repo $r.Repo -DepFlowPRs $depFlowPRs -Now $flowNow -StaleDays $flowStaleDays
-        $ageTxt = ''
-        if ($null -ne $flow.AgeDays) {
-            $ageTxt = if ($flow.AgeDays -le 0) { 'today' } elseif ($flow.AgeDays -eq 1) { '1 day ago' } else { "$($flow.AgeDays) days ago" }
-        }
-        $flowCell = switch ($flow.Status) {
-            'open'  { "🔄 [#$($flow.Number)]($($flow.Url)) open — flowing" }
-            'fresh' { "✅ [#$($flow.Number)]($($flow.Url)) merged $ageTxt" }
-            'stale' { "⚠️ stale — newest [#$($flow.Number)]($($flow.Url)) merged $ageTxt" }
-            default { "❌ none seen — sub may be missing" }
-        }
+        $flowCell = Format-FlowSignalCell -Flow $flow -HistoryUnavailable:$mergedHistoryUnavailable
         $pin = $r.Pin
         if (-not $pin) {
             [void]$md.AppendLine("| $(Format-MarkdownCell $r.Label) | _not pinned_ | — | $flowCell | — |")

--- a/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
+++ b/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
@@ -542,6 +542,41 @@ function Get-OpenPullRequests {
     return ConvertFrom-JsonOrEmptyArray $json
 }
 
+function Get-MergedPullRequests {
+    <#
+    .SYNOPSIS
+        Fetches recently MERGED PRs into $BaseBranch (for dependency-flow /
+        subscription-health inference). Public data — readable in CI with the
+        repo-scoped GITHUB_TOKEN.
+    .NOTES
+        `mergedAt` is requested so callers can date each merge; an open PR (from
+        Get-OpenPullRequests) has no `mergedAt`, which is how Get-ComponentFlowSignal
+        tells "open (flowing now)" from "merged N days ago". Newest-first by default.
+    #>
+    param([string]$BaseBranch)
+
+    if (-not (Test-BranchExists -BranchName $BaseBranch)) {
+        return @()
+    }
+
+    $json = Invoke-GitHubWithRetry -Arguments @(
+        "pr",
+        "list",
+        "--repo",
+        $Repository,
+        "--state",
+        "merged",
+        "--base",
+        $BaseBranch,
+        "--limit",
+        "100",
+        "--json",
+        "number,title,author,url,createdAt,updatedAt,mergedAt,labels,headRefName,baseRefName"
+    ) -Description "list merged PRs for $BaseBranch"
+
+    return ConvertFrom-JsonOrEmptyArray $json
+}
+
 function Get-IssuesByLabel {
     param(
         [string]$Label,
@@ -1038,6 +1073,97 @@ function Test-IsSdkBumpPr {
     } else { $null }
 
     return [bool]($title -and $title -match '(?i)\bBump\b.*dotnet/(dotnet|sdk)\b')
+}
+
+function Get-ComponentFlowSignal {
+    <#
+    .SYNOPSIS
+        Best-effort inference of one component's dependency-flow (subscription)
+        health from PUBLIC PR history — no Maestro/darc access required.
+    .DESCRIPTION
+        The GitHub Action cannot read Maestro subscription config (that lives in
+        the AzDO-internal maestro-configuration repo). But every *working*
+        subscription leaves a public trail: dependency-flow PRs into the branch
+        — darc "Update dependencies from dotnet/<repo> …" or human "Bump
+        dotnet/<repo> …". This scans that trail (open + merged dep-flow PRs) for
+        a single source repo and classifies:
+          * open    — an unmerged dep-flow PR for this repo is open right now
+                      (flow is actively happening) → healthy
+          * fresh   — newest dep-flow PR merged within $StaleDays → healthy
+          * stale   — newest dep-flow PR merged, but older than $StaleDays. This
+                      is the silent-decay case: the subscription exists but has
+                      stopped producing PRs ("it's been a while… 🤨") → suspicious
+          * missing — NO dep-flow PR for this repo into this branch at all: the
+                      subscription may never have been wired (or the branch is
+                      brand new) → suspicious
+        This is an INFERENCE from public signal, NOT the subscription itself; the
+        authoritative wiring is confirmed locally (darc get-subscriptions).
+    .NOTES
+        Feed ONLY open + merged dep-flow PRs (never closed-unmerged): a fed PR
+        with no `mergedAt` is treated as open. Repo match uses a trailing
+        negative lookahead so 'dotnet/dotnet' does not collide with
+        'dotnet/dotnet-optimization'. StrictMode-safe, dual-shape.
+    #>
+    param(
+        [string]$Repo,
+        [array]$DepFlowPRs,
+        [datetime]$Now = ([DateTime]::UtcNow),
+        [int]$StaleDays = 14
+    )
+
+    $none = [PSCustomObject]@{ Repo = $Repo; Status = 'missing'; Number = $null; Url = $null; AgeDays = $null }
+
+    if (-not $DepFlowPRs -or $DepFlowPRs.Count -eq 0) { return $none }
+
+    # dual-shape field reader (StrictMode-safe)
+    $field = {
+        param($obj, $name)
+        if ($null -eq $obj) { return $null }
+        if ($obj -is [System.Collections.IDictionary]) {
+            if ($obj.Contains($name)) { return $obj[$name] } else { return $null }
+        } elseif ($obj.PSObject.Properties[$name]) { return $obj.$name } else { return $null }
+    }
+
+    $pattern = "(?i)$([regex]::Escape($Repo))(?![\w-])"
+
+    $hits = @()
+    foreach ($pr in $DepFlowPRs) {
+        if (-not $pr) { continue }
+        $title = & $field $pr 'title'
+        if ($title -and ($title -match $pattern)) { $hits += $pr }
+    }
+    if ($hits.Count -eq 0) { return $none }
+
+    # Prefer an OPEN dep-flow PR (flow is happening right now) — no mergedAt.
+    $openHits = @($hits | Where-Object { -not (& $field $_ 'mergedAt') })
+    if ($openHits.Count -gt 0) {
+        $pick = $openHits |
+            Sort-Object -Descending { ConvertTo-UtcDateTime (& $field $_ 'createdAt') } |
+            Select-Object -First 1
+        return [PSCustomObject]@{
+            Repo    = $Repo
+            Status  = 'open'
+            Number  = (& $field $pick 'number')
+            Url     = (& $field $pick 'url')
+            AgeDays = $null
+        }
+    }
+
+    # Otherwise the newest MERGED dep-flow PR decides fresh vs stale.
+    $pick = $hits |
+        Sort-Object -Descending { ConvertTo-UtcDateTime (& $field $_ 'mergedAt') } |
+        Select-Object -First 1
+    $mergedUtc = ConvertTo-UtcDateTime (& $field $pick 'mergedAt')
+    $ageDays = if ($mergedUtc) { [Math]::Round(($Now - $mergedUtc).TotalDays) } else { $null }
+    $status = if ($null -ne $ageDays -and $ageDays -gt $StaleDays) { 'stale' } else { 'fresh' }
+
+    return [PSCustomObject]@{
+        Repo    = $Repo
+        Status  = $status
+        Number  = (& $field $pick 'number')
+        Url     = (& $field $pick 'url')
+        AgeDays = $ageDays
+    }
 }
 
 function Get-CategorizedPullRequests {
@@ -1916,17 +2042,28 @@ $notesBlockText = $notesSb.ToString()
 # self-refreshes on every automated re-run.
 $componentPins = Get-BranchComponentPins -Ref $SurveyRef -Major $majorVersion
 if ($componentPins) {
-    [void]$md.AppendLine("## 🏷️ Preview $previewNumber component build — branch pins (blessed build: verify locally)")
+    # --- Inferred subscription health (public PR trail) ---
+    # We can't read Maestro subscription config from CI, but a *working* sub
+    # leaves a public trail of dependency-flow PRs into the branch. Gather that
+    # trail (open $targetPRs + recently merged) so each component row can show
+    # whether flow is alive, silently stalled, or apparently never wired.
+    $flowStaleDays   = 14
+    $flowNow         = [DateTime]::UtcNow
+    $mergedPRsForFlow = Get-MergedPullRequests -BaseBranch $SurveyRef
+    $allPRsForFlow   = @($targetPRs) + @($mergedPRsForFlow)
+    $depFlowPRs      = @($allPRsForFlow | Where-Object { Test-IsDependencyFlowPr $_ })
+
+    [void]$md.AppendLine("## 🏷️ Preview $previewNumber component build — branch pins + inferred sub health")
     [void]$md.AppendLine("")
     [void]$md.AppendLine("> [!IMPORTANT]")
-    [void]$md.AppendLine("> The versions below are the component builds **currently bundled** on ``$SurveyRef`` (read from ``eng/Version.Details.xml`` — public git). **This is NOT the confirmed official/blessed build.** The blessed designation lives in the internal **.NET Release Tracker**, and the android/macios/dotnet preview **subscription** wiring lives in **Maestro** — this Action can reach *neither* (it runs with ``contents:read`` + ``GITHUB_TOKEN`` only). **A maintainer must confirm both locally** and paste the result into _Release Captain Notes_ above. Run the release-readiness skill locally with a prompt like:")
+    [void]$md.AppendLine("> **Branch pins** below are the component builds **currently bundled** on ``$SurveyRef`` (``eng/Version.Details.xml`` — public git). **This is NOT the confirmed official/blessed build** — that designation lives in the internal **.NET Release Tracker**, which this Action can't reach (``contents:read`` + ``GITHUB_TOKEN`` only). The **Flow signal** column *infers* each component's subscription health from the **public dependency-flow PR trail** (the Action can't read Maestro subscription config directly). It surfaces both a **never-wired** sub (❌ none seen) and a **silently stalled** one (⚠️ stale — the `"we stopped getting Maestro PRs a month ago`" decay case). The blessed build AND the authoritative subscription wiring are both confirmed **locally** — run the release-readiness skill:")
     [void]$md.AppendLine(">")
     [void]$md.AppendLine("> ``````")
     [void]$md.AppendLine("> Run release readiness for ${Branch}: report the blessed/official preview build (SDK + runtime) from the .NET Release Tracker, and verify the dotnet/android + dotnet/macios preview subscriptions are wired to the .NET $majorVersion.0.1xx SDK Preview $previewNumber channel.")
     [void]$md.AppendLine("> ``````")
     [void]$md.AppendLine("")
-    [void]$md.AppendLine("| Component | Branch pin (bundled) | Commit |")
-    [void]$md.AppendLine("|-----------|----------------------|--------|")
+    [void]$md.AppendLine("| Component | Branch pin (bundled) | Commit | Flow signal (inferred sub health) |")
+    [void]$md.AppendLine("|-----------|----------------------|--------|-----------------------------------|")
 
     $pinRows = @(
         @{ Label = 'dotnet/dotnet (VMR / SDK)'; Repo = 'dotnet/dotnet'; Pin = $componentPins.Vmr }
@@ -1934,9 +2071,20 @@ if ($componentPins) {
         @{ Label = 'dotnet/macios';             Repo = 'dotnet/macios';  Pin = $componentPins.Macios }
     )
     foreach ($r in $pinRows) {
+        $flow = Get-ComponentFlowSignal -Repo $r.Repo -DepFlowPRs $depFlowPRs -Now $flowNow -StaleDays $flowStaleDays
+        $ageTxt = ''
+        if ($null -ne $flow.AgeDays) {
+            $ageTxt = if ($flow.AgeDays -le 0) { 'today' } elseif ($flow.AgeDays -eq 1) { '1 day ago' } else { "$($flow.AgeDays) days ago" }
+        }
+        $flowCell = switch ($flow.Status) {
+            'open'  { "🔄 [#$($flow.Number)]($($flow.Url)) open — flowing" }
+            'fresh' { "✅ [#$($flow.Number)]($($flow.Url)) merged $ageTxt" }
+            'stale' { "⚠️ stale — newest [#$($flow.Number)]($($flow.Url)) merged $ageTxt" }
+            default { "❌ none seen — sub may be missing" }
+        }
         $pin = $r.Pin
         if (-not $pin) {
-            [void]$md.AppendLine("| $(Format-MarkdownCell $r.Label) | _not pinned_ | — |")
+            [void]$md.AppendLine("| $(Format-MarkdownCell $r.Label) | _not pinned_ | — | $flowCell |")
             continue
         }
         $commitCell = '—'
@@ -1944,8 +2092,10 @@ if ($componentPins) {
             $shortSha = $pin.Sha.Substring(0, [Math]::Min(7, $pin.Sha.Length))
             $commitCell = "[``$shortSha``](https://github.com/$($r.Repo)/commit/$($pin.Sha))"
         }
-        [void]$md.AppendLine("| $(Format-MarkdownCell $r.Label) | ``$($pin.Version)`` | $commitCell |")
+        [void]$md.AppendLine("| $(Format-MarkdownCell $r.Label) | ``$($pin.Version)`` | $commitCell | $flowCell |")
     }
+    [void]$md.AppendLine("")
+    [void]$md.AppendLine("_Flow-signal legend: 🔄 open dep-flow PR (flowing now) · ✅ merged ≤ $flowStaleDays d · ⚠️ newest merge > $flowStaleDays d (sub may have stalled) · ❌ no dep-flow PR into ``$SurveyRef`` seen (sub may be missing — or the branch is brand new). Inferred from the **public** PR trail; confirm authoritative wiring locally with ``darc get-subscriptions --target-repo https://github.com/dotnet/maui --target-branch $SurveyRef``. dotnet/dotnet (VMR) typically flows on manual trigger, so a quiet VMR is less alarming than a quiet android/macios._")
     [void]$md.AppendLine("")
 
     # If a manual/darc component-bump PR is open against the branch, it names the

--- a/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
+++ b/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
@@ -1013,6 +1013,33 @@ function Test-IsDependencyFlowPr {
     return $false
 }
 
+function Test-IsSdkBumpPr {
+    <#
+    .SYNOPSIS
+        True when a PR bumps the .NET SDK/VMR (dotnet/dotnet or dotnet/sdk).
+    .DESCRIPTION
+        A narrow subset of Test-IsDependencyFlowPr: specifically the VMR/SDK bump,
+        whose landed pin advances the branch's SDK version. That new pin is only a
+        *candidate* until the blessed build is confirmed locally (the Action can't
+        reach the .NET Release Tracker), so callers add a "verify blessed locally"
+        emphasis for these. Matches on TITLE only ("Bump dotnet/dotnet …" /
+        "Bump dotnet/sdk …"); android / macios / runtime bumps are intentionally
+        NOT flagged as SDK bumps. StrictMode-safe, dual-shape (PSCustomObject /
+        IDictionary), mirroring Test-IsDependencyFlowPr.
+    #>
+    param($PR)
+
+    if (-not $PR) { return $false }
+
+    $title = if ($PR -is [System.Collections.IDictionary]) {
+        if ($PR.Contains('title')) { $PR['title'] } else { $null }
+    } elseif ($PR.PSObject.Properties['title']) {
+        $PR.title
+    } else { $null }
+
+    return [bool]($title -and $title -match '(?i)\bBump\b.*dotnet/(dotnet|sdk)\b')
+}
+
 function Get-CategorizedPullRequests {
     <#
     .SYNOPSIS
@@ -1804,12 +1831,18 @@ foreach ($pr in $p0Prs) {
 }
 foreach ($pr in $maestroPRs) {
     $action = Get-PRAction -PR $pr
+    # A dependency-flow PR that bumps the VMR/SDK (dotnet/dotnet or dotnet/sdk)
+    # advances the branch's SDK pin — but the landed pin is only a *candidate*
+    # until the blessed build is confirmed locally (the Action can't reach the
+    # .NET Release Tracker). Flag it so the captain runs the local check.
+    $isSdkBump = Test-IsSdkBumpPr $pr
+    $paNote = if ($isSdkBump) { " ⚠️ bumps the SDK/VMR — confirm the blessed build locally (see 🏷️ component build) before treating the new pin as final." } else { "" }
     [void]$highPriorityRows.Add(@{
         kind = '📦 Dependency-flow PR'
         link = "[#$($pr.number)]($($pr.url))"
         title = $pr.title
         actor = "base ``$($pr.baseRefName)``, $($action.Age)d old"
-        nextAction = $action.Action
+        nextAction = "$($action.Action)$paNote"
     })
 }
 foreach ($pr in $mergeUpPRs) {
@@ -1869,24 +1902,31 @@ $notesBlockText = $notesSb.ToString()
 [void]$md.Append($notesBlockText)
 [void]$md.AppendLine("")
 
-# === Action-owned best-effort component build (git-pin sourced) ===
-# The authoritative "blessed" preview build comes from the internal .NET Release
-# Tracker (private dotnet/release), which the GitHub Action's repo-scoped
-# GITHUB_TOKEN CANNOT reach. So the Action always emits this best-effort fallback
-# from the branch's own eng/Version.Details.xml — a PUBLIC git source reachable
-# with GITHUB_TOKEN — reporting the components CURRENTLY BUNDLED on the branch.
-# This is explicitly NOT a confirmed blessed build; a maintainer running the
-# release-readiness skill locally fills the authoritative blessed set into the
-# Release Captain Notes block above (which has private tracker access). Rendered
-# OUTSIDE the human-notes markers so it self-refreshes on every automated re-run.
+# === Action-owned component build (git-pin sourced) — blessed & subs are LOCAL-only ===
+# The GitHub Action runs with only contents:read + GITHUB_TOKEN. It CANNOT reach:
+#   * the internal .NET Release Tracker (which names the authoritative "blessed"
+#     preview build), nor
+#   * Maestro/BAR or the AzDO-internal maestro-configuration repo (which hold the
+#     android/macios/dotnet preview *subscription* wiring).
+# So the Action reports only what PUBLIC git can prove: the component builds
+# CURRENTLY BUNDLED on the branch (eng/Version.Details.xml). These are branch pins,
+# NOT a confirmed blessed build. Confirming the blessed build AND verifying the
+# preview subscriptions are both LOCAL tasks — the callout below points the captain
+# at the exact local prompt to run. Rendered OUTSIDE the human-notes markers so it
+# self-refreshes on every automated re-run.
 $componentPins = Get-BranchComponentPins -Ref $SurveyRef -Major $majorVersion
 if ($componentPins) {
-    [void]$md.AppendLine("## 🏷️ Preview $previewNumber component build — branch pins (best-effort)")
+    [void]$md.AppendLine("## 🏷️ Preview $previewNumber component build — branch pins (blessed build: verify locally)")
     [void]$md.AppendLine("")
-    [void]$md.AppendLine("_Source: ``eng/Version.Details.xml`` on ``$SurveyRef`` (public git, always readable in CI). These are the component builds **currently bundled on the branch** — **not** a confirmed *blessed* build. The authoritative blessed designation comes from the internal .NET Release Tracker (private ``dotnet/release``), which this GitHub Action cannot reach; a maintainer running the release-readiness skill locally fills the confirmed blessed build into **Release Captain Notes** above._")
+    [void]$md.AppendLine("> [!IMPORTANT]")
+    [void]$md.AppendLine("> The versions below are the component builds **currently bundled** on ``$SurveyRef`` (read from ``eng/Version.Details.xml`` — public git). **This is NOT the confirmed official/blessed build.** The blessed designation lives in the internal **.NET Release Tracker**, and the android/macios/dotnet preview **subscription** wiring lives in **Maestro** — this Action can reach *neither* (it runs with ``contents:read`` + ``GITHUB_TOKEN`` only). **A maintainer must confirm both locally** and paste the result into _Release Captain Notes_ above. Run the release-readiness skill locally with a prompt like:")
+    [void]$md.AppendLine(">")
+    [void]$md.AppendLine("> ``````")
+    [void]$md.AppendLine("> Run release readiness for ${Branch}: report the blessed/official preview build (SDK + runtime) from the .NET Release Tracker, and verify the dotnet/android + dotnet/macios preview subscriptions are wired to the .NET $majorVersion.0.1xx SDK Preview $previewNumber channel.")
+    [void]$md.AppendLine("> ``````")
     [void]$md.AppendLine("")
-    [void]$md.AppendLine("| Component | Version | Commit | Source repo |")
-    [void]$md.AppendLine("|-----------|---------|--------|-------------|")
+    [void]$md.AppendLine("| Component | Branch pin (bundled) | Commit |")
+    [void]$md.AppendLine("|-----------|----------------------|--------|")
 
     $pinRows = @(
         @{ Label = 'dotnet/dotnet (VMR / SDK)'; Repo = 'dotnet/dotnet'; Pin = $componentPins.Vmr }
@@ -1896,7 +1936,7 @@ if ($componentPins) {
     foreach ($r in $pinRows) {
         $pin = $r.Pin
         if (-not $pin) {
-            [void]$md.AppendLine("| $(Format-MarkdownCell $r.Label) | _not pinned_ | — | ``$($r.Repo)`` |")
+            [void]$md.AppendLine("| $(Format-MarkdownCell $r.Label) | _not pinned_ | — |")
             continue
         }
         $commitCell = '—'
@@ -1904,7 +1944,7 @@ if ($componentPins) {
             $shortSha = $pin.Sha.Substring(0, [Math]::Min(7, $pin.Sha.Length))
             $commitCell = "[``$shortSha``](https://github.com/$($r.Repo)/commit/$($pin.Sha))"
         }
-        [void]$md.AppendLine("| $(Format-MarkdownCell $r.Label) | ``$($pin.Version)`` | $commitCell | ``$($r.Repo)`` |")
+        [void]$md.AppendLine("| $(Format-MarkdownCell $r.Label) | ``$($pin.Version)`` | $commitCell |")
     }
     [void]$md.AppendLine("")
 
@@ -2022,6 +2062,15 @@ Add-CheckTable -Builder $md -Checks $checks
 
 [void]$md.AppendLine("## Maestro / dependency-flow PRs")
 [void]$md.AppendLine("")
+# Highlight any open SDK/VMR bump: its landed pin is only a candidate until the
+# blessed build is confirmed locally (the Action can't reach the .NET Release Tracker).
+$sdkBumpPrs = @($maestroPRs | Where-Object { Test-IsSdkBumpPr $_ })
+if ($sdkBumpPrs.Count -gt 0) {
+    $sdkBumpLinks = ($sdkBumpPrs | ForEach-Object { "[#$($_.number)]($($_.url))" }) -join ', '
+    [void]$md.AppendLine("> [!WARNING]")
+    [void]$md.AppendLine("> $($sdkBumpPrs.Count) open PR(s) bump the **SDK/VMR** ($sdkBumpLinks). The new SDK pin they land is only a **candidate** — the official/blessed build is designated in the internal .NET Release Tracker, which this Action can't reach. **Confirm the blessed SDK build locally** (see 🏷️ Preview $previewNumber component build above) before treating the bumped pin as final.")
+    [void]$md.AppendLine("")
+}
 Add-PRTable -Builder $md -PRs $maestroPRs
 
 [void]$md.AppendLine("## Release branch PRs")

--- a/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
+++ b/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
@@ -351,6 +351,89 @@ function Get-XcodeRequirements {
     }
 }
 
+function Get-BranchComponentPins {
+    <#
+    .SYNOPSIS
+        Reads the dotnet/dotnet (VMR), dotnet/android and dotnet/macios anchor
+        pins (version + commit SHA) from eng/Version.Details.xml at $Ref.
+    .DESCRIPTION
+        Public git source — reachable with the repo-scoped GITHUB_TOKEN the
+        GitHub Action runs under (no Maestro/BAR access required). These are the
+        components CURRENTLY BUNDLED on the branch, NOT a confirmed "blessed"
+        build. The authoritative blessed designation comes from the internal
+        .NET Release Tracker (private dotnet/release), which CI cannot reach.
+
+        Returns a PSCustomObject with Vmr/Android/Macios members (each with
+        Name/Version/Sha), or $null if the file can't be read or parsed.
+    .NOTES
+        eng/Version.Details.xml `<Dependency>` elements carry Name/Version as
+        XML *attributes* and Uri/Sha as child *elements*. On an XmlElement,
+        `$dep.Name` resolves to the element tag ("Dependency") — NOT the Name
+        attribute — so attributes are read with GetAttribute() and children via
+        the `$dep['Uri']` indexer.
+    #>
+    param(
+        [string]$Ref,
+        [int]$Major
+    )
+
+    $xmlText = $null
+    try {
+        $xmlText = Get-ContentFromRepo -Path "eng/Version.Details.xml" -Ref $Ref
+    } catch {
+        Write-Warning "Could not read eng/Version.Details.xml at ${Ref}: $($_.Exception.Message)"
+        return $null
+    }
+
+    $xml = $null
+    try {
+        $xml = [xml]$xmlText
+    } catch {
+        Write-Warning "Could not parse eng/Version.Details.xml at ${Ref}: $($_.Exception.Message)"
+        return $null
+    }
+
+    $deps = @($xml.SelectNodes("//Dependency"))
+    if ($deps.Count -eq 0) { return $null }
+
+    # Pick the anchor dependency for a repo: match by <Uri>, then prefer the
+    # most representative Name (falling back to the first dep for that repo).
+    $selectPin = {
+        param($UriMatch, $PreferredNamePatterns)
+        $cands = @($deps | Where-Object {
+            $u = ''
+            if ($_['Uri']) { $u = "$($_['Uri'].InnerText)".Trim().TrimEnd('/') }
+            $u -match $UriMatch
+        })
+        if ($cands.Count -eq 0) { return $null }
+        $pick = $null
+        foreach ($pat in $PreferredNamePatterns) {
+            $pick = $cands | Where-Object { "$($_.GetAttribute('Name'))" -match $pat } | Select-Object -First 1
+            if ($pick) { break }
+        }
+        if (-not $pick) { $pick = $cands[0] }
+        $sha = ''
+        if ($pick['Sha']) { $sha = "$($pick['Sha'].InnerText)".Trim() }
+        [PSCustomObject]@{
+            Name    = $pick.GetAttribute('Name')
+            Version = $pick.GetAttribute('Version')
+            Sha     = $sha
+        }
+    }
+
+    $vmr     = & $selectPin 'github\.com/dotnet/dotnet'  @('^Microsoft\.NET\.Sdk$')
+    $android = & $selectPin 'github\.com/dotnet/android' @('^Microsoft\.Android\.Sdk\.Windows$', '^Microsoft\.Android\.Sdk')
+    $macios  = & $selectPin 'github\.com/dotnet/macios'  @("^Microsoft\.macOS\.Sdk\.net$Major\.0", '^Microsoft\.macOS\.Sdk', '^Microsoft\.iOS\.Sdk')
+
+    if (-not ($vmr -or $android -or $macios)) { return $null }
+
+    return [PSCustomObject]@{
+        Vmr     = $vmr
+        Android = $android
+        Macios  = $macios
+    }
+}
+
 function Get-BugTemplateVersions {
     <#
     .SYNOPSIS
@@ -863,6 +946,73 @@ function Test-IsP0Pr {
     return (@($labels | ForEach-Object { $_.name }) -contains 'p/0')
 }
 
+function Test-IsDependencyFlowPr {
+    <#
+    .SYNOPSIS
+        True when a PR is a dependency-flow / component-bump PR — either an
+        automated darc PR (author dotnet-maestro) OR a human-authored component
+        bump that rolls upstream builds into a branch.
+    .DESCRIPTION
+        The dependency-flow bucket was originally author-only (`dotnet-maestro`).
+        But release owners also open MANUAL component-bump PRs — e.g.
+        "[release/11.0.1xx-preview6] Bump dotnet/dotnet (BAR 321614), dotnet/android
+        (BAR 321622) and dotnet/macios (BAR 321780)" (head `update-321614`, authored
+        by a human) — which land the blessed component set into the release branch
+        and are just as release-critical as a darc PR. Author-only detection buried
+        those in the generic "Release branch PRs" list instead of surfacing them in
+        the hoisted 🔴 High-priority items. Detect them by title / head-ref too.
+
+        Signals (ANY one is sufficient):
+          - author login matches `dotnet-maestro` (the automated darc flow);
+          - title has the word "Bump" plus a dotnet dependency repo
+            (dotnet/dotnet|android|macios|runtime|sdk|emsdk|wasm) or a "BAR <id>";
+          - head ref matches `update-<digits>` (the manual bump-PR branch scheme,
+            e.g. `update-321614`).
+
+        Deliberately NARROW so it doesn't swallow unrelated human PRs: a generic
+        "Fix Y" or a "[automated] Merge branch" merge-up PR matches none of the
+        signals. StrictMode-safe: tolerates a missing author/title/headRefName.
+        Accepts both PSCustomObject (the gh --json shape) and IDictionary
+        (the shape test mocks commonly use), mirroring Test-IsP0Pr.
+    #>
+    param($PR)
+
+    if (-not $PR) { return $false }
+
+    # --- author login (dual-shape, StrictMode-safe) ---
+    $author = if ($PR -is [System.Collections.IDictionary]) {
+        if ($PR.Contains('author')) { $PR['author'] } else { $null }
+    } elseif ($PR.PSObject.Properties['author']) {
+        $PR.author
+    } else { $null }
+    if ($author) {
+        $login = if ($author -is [System.Collections.IDictionary]) {
+            if ($author.Contains('login')) { $author['login'] } else { $null }
+        } elseif ($author.PSObject.Properties['login']) {
+            $author.login
+        } else { $null }
+        if ($login -and $login -match 'dotnet-maestro') { return $true }
+    }
+
+    # --- title (component / BAR bump) ---
+    $title = if ($PR -is [System.Collections.IDictionary]) {
+        if ($PR.Contains('title')) { $PR['title'] } else { $null }
+    } elseif ($PR.PSObject.Properties['title']) {
+        $PR.title
+    } else { $null }
+    if ($title -and $title -match '(?i)\bBump\b.*(dotnet/(dotnet|android|macios|runtime|sdk|emsdk|wasm)|\bBAR\s*\d+)') { return $true }
+
+    # --- head ref (manual bump-branch scheme `update-<barId>`) ---
+    $head = if ($PR -is [System.Collections.IDictionary]) {
+        if ($PR.Contains('headRefName')) { $PR['headRefName'] } else { $null }
+    } elseif ($PR.PSObject.Properties['headRefName']) {
+        $PR.headRefName
+    } else { $null }
+    if ($head -and $head -match '(?i)^update-\d+$') { return $true }
+
+    return $false
+}
+
 function Get-CategorizedPullRequests {
     <#
     .SYNOPSIS
@@ -880,7 +1030,10 @@ function Get-CategorizedPullRequests {
                     the P/0 blocker category (trips its dedicated BLOCKED check +
                     renders once as a 🔥 P/0 PR row) and is never silently
                     downgraded to a 📦 Maestro / merge-up row.
-          2. Maestro  — non-P/0 PRs authored by dotnet-maestro (target OR inflight).
+          2. Maestro  — non-P/0 PRs authored by dotnet-maestro on the TARGET
+                    branch only (the survey ref). net<major>.0 (inflight) Maestro
+                    bumps are intentionally NOT reported by a branched preview
+                    tracker — they belong to the inflight branch's own readiness.
           3. Merge-up — non-P/0, non-Maestro target PRs that are automated
                     main → survey-ref merges (head `merge/<x>-to-<y>` or title
                     "[automated] Merge branch ...").
@@ -888,11 +1041,14 @@ function Get-CategorizedPullRequests {
           5. Inflight-human — non-Maestro PRs on the inflight (net<major>.0) branch.
 
         Buckets are mutually exclusive by PR number. Inflight PRs never escalate
-        to P/0 (only survey-ref PRs block), matching the engine's release scope:
-        $p0PrNumbers is computed from $TargetPRs only, and PR numbers are globally
-        unique, so excluding them from the target+inflight Maestro set cannot drop
-        an inflight PR. StrictMode-safe on two fronts: (1) inputs are normalized to
-        drop $null elements up front, so an AutomationNull list (what
+        to P/0 (only survey-ref PRs block), and Maestro is scoped to $TargetPRs
+        only — a branched preview reports dependency-flow bumps against its own
+        branch, so net<major>.0 (inflight) Maestro PRs are intentionally dropped
+        from this tracker (only non-Maestro inflight PRs surface, in the
+        Inflight-human bucket). $p0PrNumbers is computed from $TargetPRs only, and
+        PR numbers are globally unique. StrictMode-safe on two fronts: (1) inputs
+        are normalized to drop $null elements up front, so an AutomationNull list
+        (what
         Get-OpenPullRequests returns for a zero-PR branch) can't seed a `@($null)`
         whose null element would throw "property 'author' cannot be found"; and
         (2) for genuine PR objects every property accessed is guaranteed present by
@@ -921,18 +1077,29 @@ function Get-CategorizedPullRequests {
     $TargetPRs   = @($TargetPRs   | Where-Object { $null -ne $_ })
     $InflightPRs = @($InflightPRs | Where-Object { $null -ne $_ })
 
-    $allReleasePRs = @($TargetPRs) + @($InflightPRs)
-
     # 1. P/0 first (highest precedence), from survey-ref PRs only.
     $p0Prs = @($TargetPRs | Where-Object { Test-IsP0Pr $_ })
     $p0PrNumbers = @($p0Prs | ForEach-Object { $_.number })
 
-    # 2. Maestro (non-P/0), across target + inflight.
-    $maestroPRs = @($allReleasePRs | Where-Object { $_.author -and $_.author.login -match "dotnet-maestro" -and ($p0PrNumbers -notcontains $_.number) })
+    # 2. Dependency-flow (non-P/0), TARGET branch only. Once a preview is branched,
+    #    this tracker must only surface dependency-flow bumps against its OWN branch
+    #    (the survey ref). Detection is NOT author-only: it covers both automated
+    #    darc PRs (author dotnet-maestro) AND human-authored component-bump PRs
+    #    (e.g. a "[release/...] Bump dotnet/dotnet (BAR ...)" PR on head `update-<id>`
+    #    that lands the blessed component set) via Test-IsDependencyFlowPr. Bumps
+    #    targeting net<major>.0 (the inflight branch) belong to the inflight branch's
+    #    own readiness, not this preview tracker — so they are intentionally NOT
+    #    reported here. (In candidate mode the survey ref IS net<major>.0 and
+    #    $InflightPRs is empty, so target-only is correct there too.)
+    $maestroPRs = @($TargetPRs | Where-Object { (Test-IsDependencyFlowPr $_) -and ($p0PrNumbers -notcontains $_.number) })
 
-    # Non-P/0, non-Maestro humans, split by scope.
-    $targetHumanPRsRaw   = @($TargetPRs   | Where-Object { -not ($_.author -and $_.author.login -match "dotnet-maestro") -and ($p0PrNumbers -notcontains $_.number) })
-    $inflightHumanPRsRaw = @($InflightPRs | Where-Object { -not ($_.author -and $_.author.login -match "dotnet-maestro") })
+    # Non-P/0, non-dependency-flow humans, split by scope. Both slots keep a
+    #    Raw stage so the two-hop merge-up filter below can strip hoisted merge-up
+    #    PRs from target AND inflight. Detection uses Test-IsDependencyFlowPr so
+    #    human-authored component bumps (not just author dotnet-maestro) are
+    #    excluded from the human buckets and routed to the dependency-flow bucket.
+    $targetHumanPRsRaw   = @($TargetPRs   | Where-Object { -not (Test-IsDependencyFlowPr $_) -and ($p0PrNumbers -notcontains $_.number) })
+    $inflightHumanPRsRaw = @($InflightPRs | Where-Object { -not (Test-IsDependencyFlowPr $_) })
 
     # 3. Merge-up: non-P/0, non-Maestro PRs from BOTH hops of the daily-flow chain
     #    that feeds the survey ref. The preview lane chains main → net<N>.0 →
@@ -1321,11 +1488,20 @@ $targetHumanPRs   = $prBuckets.TargetHumanPRs
 $inflightHumanPRs = $prBuckets.InflightHumanPRs
 
 if ($maestroPRs.Count -eq 0) {
-    $checks += New-Check -Area "Maestro PRs" -Status "READY" -Details "No open Maestro PRs target ``$SurveyRef`` or ``$mainBranch``." -NextAction "Continue monitoring for new dependency-flow PRs."
+    # Maestro is scoped to the survey ref (target) only. When the preview is
+    # branched ($SurveyRef differs from the inflight $mainBranch), don't claim
+    # anything about net<major>.0 Maestro PRs — they exist but are intentionally
+    # tracked by the inflight branch's own readiness, not this preview tracker.
+    $maestroReadyDetails = if ($SurveyRef -ne $mainBranch) {
+        "No open Maestro PRs target ``$SurveyRef``. (Dependency-flow PRs targeting the inflight ``$mainBranch`` branch are tracked by ``$mainBranch``'s own readiness, not this branched preview.)"
+    } else {
+        "No open Maestro PRs target ``$SurveyRef``."
+    }
+    $checks += New-Check -Area "Maestro PRs" -Status "READY" -Details $maestroReadyDetails -NextAction "Continue monitoring for new dependency-flow PRs."
 } elseif (@($maestroPRs | Where-Object { (Get-PRAction -PR $_).Status -eq "BLOCKED" }).Count -gt 0) {
-    $checks += New-Check -Area "Maestro PRs" -Status "BLOCKED" -Details "$($maestroPRs.Count) open Maestro PR(s), including blocked/conflicted PRs." -NextAction "Resolve blocked Maestro PRs before release."
+    $checks += New-Check -Area "Maestro PRs" -Status "BLOCKED" -Details "$($maestroPRs.Count) open dependency-flow PR(s) (darc + manual component bumps), including blocked/conflicted PRs." -NextAction "Resolve blocked dependency-flow PRs before release."
 } else {
-    $checks += New-Check -Area "Maestro PRs" -Status "WATCH" -Details "$($maestroPRs.Count) open Maestro PR(s) need review/merge triage." -NextAction "Review dependency PRs and merge expected updates."
+    $checks += New-Check -Area "Maestro PRs" -Status "WATCH" -Details "$($maestroPRs.Count) open dependency-flow PR(s) (darc + manual component bumps) need review/merge triage." -NextAction "Review dependency PRs and merge expected updates."
 }
 
 if ($targetHumanPRs.Count -eq 0) {
@@ -1629,7 +1805,7 @@ foreach ($pr in $p0Prs) {
 foreach ($pr in $maestroPRs) {
     $action = Get-PRAction -PR $pr
     [void]$highPriorityRows.Add(@{
-        kind = '📦 Maestro PR'
+        kind = '📦 Dependency-flow PR'
         link = "[#$($pr.number)]($($pr.url))"
         title = $pr.title
         actor = "base ``$($pr.baseRefName)``, $($action.Age)d old"
@@ -1661,7 +1837,7 @@ foreach ($pr in $mergeUpPRs) {
 if ($highPriorityRows.Count -gt 0) {
     [void]$md.AppendLine("## 🔴 High-priority items — $($highPriorityRows.Count) item(s)")
     [void]$md.AppendLine("")
-    [void]$md.AppendLine("_P/0 issues, P/0 PRs, Maestro PRs, and merge-up PRs in the ``$mergeUpChainLabel`` daily-flow chain. Resolve these before treating the release as ready._")
+    [void]$md.AppendLine("_P/0 issues, P/0 PRs, dependency-flow PRs (darc + manual component bumps), and merge-up PRs in the ``$mergeUpChainLabel`` daily-flow chain. Resolve these before treating the release as ready._")
     [void]$md.AppendLine("")
     [void]$md.AppendLine("| Kind | Item | Title | Context | Next action |")
     [void]$md.AppendLine("|------|------|-------|---------|-------------|")
@@ -1671,12 +1847,86 @@ if ($highPriorityRows.Count -gt 0) {
     [void]$md.AppendLine("")
 }
 
+# Human-editable section, preserved across re-runs by workflow body merge.
+# Positioned directly under the "🔴 High-priority items" section so the
+# agent-orchestrated, release-critical content that gets spliced in here (the
+# official/blessed build, subscription wiring, component-pin coherence) renders
+# near the TOP of the tracker — right below the blockers — while still living
+# inside the preserved human-notes markers so it survives automated re-runs.
+#
+# Built as a reusable block (like the SR engine) so the body-size cap below can
+# strip it, truncate the remaining content, then re-append it — guaranteeing the
+# begin/end markers always survive truncation regardless of section order. The
+# "🔴 High-priority items" section above is itemized and uncapped, so a naive
+# byte-prefix cut could otherwise drop these markers.
+$notesSb = [System.Text.StringBuilder]::new()
+[void]$notesSb.AppendLine("<!-- release-readiness:human-notes:begin -->")
+[void]$notesSb.AppendLine("## Release Captain Notes")
+[void]$notesSb.AppendLine("")
+[void]$notesSb.AppendLine("_Add manual notes here. Anything between these begin/end markers is preserved across automated re-runs._")
+[void]$notesSb.AppendLine("<!-- release-readiness:human-notes:end -->")
+$notesBlockText = $notesSb.ToString()
+[void]$md.Append($notesBlockText)
+[void]$md.AppendLine("")
+
+# === Action-owned best-effort component build (git-pin sourced) ===
+# The authoritative "blessed" preview build comes from the internal .NET Release
+# Tracker (private dotnet/release), which the GitHub Action's repo-scoped
+# GITHUB_TOKEN CANNOT reach. So the Action always emits this best-effort fallback
+# from the branch's own eng/Version.Details.xml — a PUBLIC git source reachable
+# with GITHUB_TOKEN — reporting the components CURRENTLY BUNDLED on the branch.
+# This is explicitly NOT a confirmed blessed build; a maintainer running the
+# release-readiness skill locally fills the authoritative blessed set into the
+# Release Captain Notes block above (which has private tracker access). Rendered
+# OUTSIDE the human-notes markers so it self-refreshes on every automated re-run.
+$componentPins = Get-BranchComponentPins -Ref $SurveyRef -Major $majorVersion
+if ($componentPins) {
+    [void]$md.AppendLine("## 🏷️ Preview $previewNumber component build — branch pins (best-effort)")
+    [void]$md.AppendLine("")
+    [void]$md.AppendLine("_Source: ``eng/Version.Details.xml`` on ``$SurveyRef`` (public git, always readable in CI). These are the component builds **currently bundled on the branch** — **not** a confirmed *blessed* build. The authoritative blessed designation comes from the internal .NET Release Tracker (private ``dotnet/release``), which this GitHub Action cannot reach; a maintainer running the release-readiness skill locally fills the confirmed blessed build into **Release Captain Notes** above._")
+    [void]$md.AppendLine("")
+    [void]$md.AppendLine("| Component | Version | Commit | Source repo |")
+    [void]$md.AppendLine("|-----------|---------|--------|-------------|")
+
+    $pinRows = @(
+        @{ Label = 'dotnet/dotnet (VMR / SDK)'; Repo = 'dotnet/dotnet'; Pin = $componentPins.Vmr }
+        @{ Label = 'dotnet/android';            Repo = 'dotnet/android'; Pin = $componentPins.Android }
+        @{ Label = 'dotnet/macios';             Repo = 'dotnet/macios';  Pin = $componentPins.Macios }
+    )
+    foreach ($r in $pinRows) {
+        $pin = $r.Pin
+        if (-not $pin) {
+            [void]$md.AppendLine("| $(Format-MarkdownCell $r.Label) | _not pinned_ | — | ``$($r.Repo)`` |")
+            continue
+        }
+        $commitCell = '—'
+        if (-not [string]::IsNullOrWhiteSpace($pin.Sha)) {
+            $shortSha = $pin.Sha.Substring(0, [Math]::Min(7, $pin.Sha.Length))
+            $commitCell = "[``$shortSha``](https://github.com/$($r.Repo)/commit/$($pin.Sha))"
+        }
+        [void]$md.AppendLine("| $(Format-MarkdownCell $r.Label) | ``$($pin.Version)`` | $commitCell | ``$($r.Repo)`` |")
+    }
+    [void]$md.AppendLine("")
+
+    # If a manual/darc component-bump PR is open against the branch, it names the
+    # pending target BAR builds in its title — surface it so readers see the pins
+    # above will advance once it merges. Reuses the already-computed dependency-flow set.
+    $bumpPr = @($maestroPRs | Where-Object { $_.title -match 'Bump\s+dotnet/dotnet' }) | Select-Object -First 1
+    if ($bumpPr) {
+        $bars = @([regex]::Matches($bumpPr.title, 'BAR\s+(\d+)') | ForEach-Object { $_.Groups[1].Value } | Select-Object -Unique)
+        $barText = if ($bars.Count -gt 0) { " (target BAR $([string]::Join('/', $bars)))" } else { "" }
+        [void]$md.AppendLine("⏳ **Pending component bump:** [#$($bumpPr.number)]($($bumpPr.url))$barText will advance these branch pins — see 🔴 High-priority items above.")
+        [void]$md.AppendLine("")
+    }
+}
+
+
 # === BLOCKING SUMMARY (hoisted to top) ===
 # Surface aggregate BLOCKED checks (e.g. CI red, versions.props not bumped).
 # The high-priority categories above already enumerate individual items,
 # so exclude them here to avoid duplicate rows under two separate headings.
 # Every Area whose items are hoisted into 🔴 High-priority items must be listed
-# here (Maestro PRs are hoisted as '📦 Maestro PR' rows, so they belong too).
+# here (dependency-flow PRs are hoisted as '📦 Dependency-flow PR' rows, so they belong too).
 $highPriorityCheckAreas = @(
     'P/0 priority blockers',
     'P/0 release-branch PRs',
@@ -1764,22 +2014,6 @@ if ($Mode -eq 'candidate') {
 [void]$md.AppendLine("| Expected SDK channel | ``.NET $majorVersion.0.1xx SDK Preview $previewNumber`` |")
 [void]$md.AppendLine("| Workload release channel | ``.NET $majorVersion Workload Release`` |")
 [void]$md.AppendLine("| Expected PreReleaseVersionIteration | ``$previewNumber`` |")
-[void]$md.AppendLine("")
-
-# Human-editable section, preserved across re-runs by workflow body merge.
-# Built as a reusable block (like the SR engine) so the body-size cap below can
-# strip it, truncate the remaining content, then re-append it — guaranteeing the
-# begin/end markers always survive truncation regardless of section order. The
-# "🔴 High-priority items" table above this block is itemized and uncapped, so a
-# naive byte-prefix cut could otherwise drop these markers.
-$notesSb = [System.Text.StringBuilder]::new()
-[void]$notesSb.AppendLine("<!-- release-readiness:human-notes:begin -->")
-[void]$notesSb.AppendLine("## Release Captain Notes")
-[void]$notesSb.AppendLine("")
-[void]$notesSb.AppendLine("_Add manual notes here. Anything between these begin/end markers is preserved across automated re-runs._")
-[void]$notesSb.AppendLine("<!-- release-readiness:human-notes:end -->")
-$notesBlockText = $notesSb.ToString()
-[void]$md.Append($notesBlockText)
 [void]$md.AppendLine("")
 
 [void]$md.AppendLine("## Readiness checklist")

--- a/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
+++ b/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
@@ -1166,6 +1166,127 @@ function Get-ComponentFlowSignal {
     }
 }
 
+function Get-UpstreamDriftSignal {
+    <#
+    .SYNOPSIS
+        Best-effort detection of whether an upstream component repo's same-named
+        branch has advanced past the commit maui currently pins — a public,
+        CI-reachable "the source moved, you may want to pull it in" FYI.
+    .DESCRIPTION
+        maui pins a specific SHA of each component (dotnet/dotnet, dotnet/android,
+        dotnet/macios) in eng/Version.Details.xml. Those repos are PUBLIC, so the
+        GitHub Action can — with only GITHUB_TOKEN — ask GitHub's *compare* API
+        whether that repo's branch has newer commits than our pin. This is a hard
+        git fact, complementary to Get-ComponentFlowSignal (which infers whether a
+        subscription is *producing PRs into maui*): a sub can be healthy and quiet
+        while upstream just landed a fix we haven't pulled — only THIS check sees it.
+
+        Branch is DERIVED, never hardcoded: we look up $BranchName (the survey ref,
+        e.g. release/11.0.1xx-preview6) on the component repo via git/matching-refs.
+        All three components mirror maui's branch naming today; if a future one
+        doesn't, we degrade to 'unknown' rather than false-alarm.
+
+        Compares base=our pin, head=branch tip. GitHub returns ahead_by (commits the
+        branch has beyond our pin) and behind_by (commits our pin has the branch
+        lacks). Classifies:
+          * current   — ahead_by 0 & behind_by 0: our pin IS the branch tip.
+          * ahead     — ahead_by N & behind_by 0: N newer upstream commits we don't
+                        bundle yet. FYI only — maui pins BLESSED builds deliberately,
+                        so these may be post-preview churn or not-yet-blessed work.
+          * diverged  — behind_by > 0: our pin isn't a clean ancestor of the branch
+                        tip (build tag / different line) — can't cleanly count "ahead".
+          * unknown   — no pin SHA, no same-named upstream branch, or an API error.
+    .NOTES
+        Soft-fail: any lookup/parse failure returns 'unknown' with a Reason and
+        never throws (must not break report generation). ~2 gh calls per component.
+        dotnet/dotnet (VMR) moves constantly and flows on manual trigger, so a large
+        ahead_by there is expected churn, rarely actionable — the caller labels it.
+    #>
+    param(
+        [string]$Repo,        # e.g. 'dotnet/macios'
+        [string]$Sha,         # our pinned SHA (base of the compare)
+        [string]$BranchName,  # survey ref, e.g. 'release/11.0.1xx-preview6'
+        [scriptblock]$Fetcher # optional seam: (ApiPath) -> parsed JSON. Defaults to live gh.
+    )
+
+    # Default fetcher hits the public GitHub REST API via the retrying gh wrapper
+    # and returns parsed JSON. Tests inject a mock that returns fixtures instead.
+    if (-not $Fetcher) {
+        $Fetcher = {
+            param($ApiPath)
+            $json = Invoke-GitHubWithRetry -Arguments @("api", $ApiPath) -Description "gh api $ApiPath" -MaxRetries 2
+            if ([string]::IsNullOrWhiteSpace($json)) { return $null }
+            return ($json | ConvertFrom-Json)
+        }
+    }
+
+    $result = [PSCustomObject]@{
+        Repo     = $Repo
+        Status   = 'unknown'
+        AheadBy  = $null
+        BehindBy = $null
+        Branch   = $BranchName
+        Url      = $null
+        Reason   = $null
+    }
+
+    if ([string]::IsNullOrWhiteSpace($Sha)) {
+        $result.Reason = 'no pin SHA'
+        return $result
+    }
+    if ([string]::IsNullOrWhiteSpace($BranchName)) {
+        $result.Reason = 'no branch to compare'
+        return $result
+    }
+
+    # 1) Confirm the component repo actually has a branch of this name (derive,
+    #    don't assume). matching-refs is an exact-PREFIX match, so require an exact
+    #    full-ref hit — otherwise 'release/11.0.1xx-preview6' would also match a
+    #    hypothetical 'release/11.0.1xx-preview60'.
+    try {
+        $refs = & $Fetcher "repos/$Repo/git/matching-refs/heads/$BranchName"
+        $branchFound = @($refs | Where-Object { $_.ref -eq "refs/heads/$BranchName" }).Count -gt 0
+    } catch {
+        $result.Reason = 'branch lookup failed'
+        return $result
+    }
+    if (-not $branchFound) {
+        $result.Reason = 'no same-named upstream branch'
+        return $result
+    }
+
+    # 2) Compare our pin (base) against the branch tip (head). The '/' in the
+    #    branch name is passed through literally — GitHub's compare endpoint
+    #    accepts slashed branch names as the head ref.
+    try {
+        $cmp = & $Fetcher "repos/$Repo/compare/$Sha...$BranchName"
+    } catch {
+        $result.Reason = 'compare failed'
+        return $result
+    }
+
+    if ($null -eq $cmp -or -not $cmp.PSObject.Properties['ahead_by']) {
+        $result.Reason = 'compare returned no counts'
+        return $result
+    }
+
+    $aheadBy  = [int]$cmp.ahead_by
+    $behindBy = [int]$cmp.behind_by
+    $result.AheadBy  = $aheadBy
+    $result.BehindBy = $behindBy
+    $result.Url      = "https://github.com/$Repo/compare/$Sha...$BranchName"
+
+    if ($behindBy -gt 0) {
+        $result.Status = 'diverged'
+    } elseif ($aheadBy -gt 0) {
+        $result.Status = 'ahead'
+    } else {
+        $result.Status = 'current'
+    }
+    $result.Reason = $null
+    return $result
+}
+
 function Get-CategorizedPullRequests {
     <#
     .SYNOPSIS
@@ -2058,17 +2179,19 @@ if ($componentPins) {
     [void]$md.AppendLine("> [!IMPORTANT]")
     [void]$md.AppendLine("> **Branch pins** below are the component builds **currently bundled** on ``$SurveyRef`` (``eng/Version.Details.xml`` — public git). **This is NOT the confirmed official/blessed build** — that designation lives in the internal **.NET Release Tracker**, which this Action can't reach (``contents:read`` + ``GITHUB_TOKEN`` only). The **Flow signal** column *infers* each component's subscription health from the **public dependency-flow PR trail** (the Action can't read Maestro subscription config directly). It surfaces both a **never-wired** sub (❌ none seen) and a **silently stalled** one (⚠️ stale — the `"we stopped getting Maestro PRs a month ago`" decay case). The blessed build AND the authoritative subscription wiring are both confirmed **locally** — run the release-readiness skill:")
     [void]$md.AppendLine(">")
+    [void]$md.AppendLine("> The **Upstream** column is a hard git fact (not an inference): it compares our pinned SHA against the tip of each component's same-named branch (``$SurveyRef`` — derived, never hardcoded) via the public compare API. ⬆️ *N ahead* means the source moved past what we bundle — an FYI you *may* want to pull in, **not** a required bump (maui pins blessed builds deliberately, so those commits may be post-preview churn or not yet blessed).")
+    [void]$md.AppendLine(">")
     [void]$md.AppendLine("> ``````")
     [void]$md.AppendLine("> Run release readiness for ${Branch}: report the blessed/official preview build (SDK + runtime) from the .NET Release Tracker, and verify the dotnet/android + dotnet/macios preview subscriptions are wired to the .NET $majorVersion.0.1xx SDK Preview $previewNumber channel.")
     [void]$md.AppendLine("> ``````")
     [void]$md.AppendLine("")
-    [void]$md.AppendLine("| Component | Branch pin (bundled) | Commit | Flow signal (inferred sub health) |")
-    [void]$md.AppendLine("|-----------|----------------------|--------|-----------------------------------|")
+    [void]$md.AppendLine("| Component | Branch pin (bundled) | Commit | Flow signal (inferred sub health) | Upstream (vs our pin) |")
+    [void]$md.AppendLine("|-----------|----------------------|--------|-----------------------------------|-----------------------|")
 
     $pinRows = @(
-        @{ Label = 'dotnet/dotnet (VMR / SDK)'; Repo = 'dotnet/dotnet'; Pin = $componentPins.Vmr }
-        @{ Label = 'dotnet/android';            Repo = 'dotnet/android'; Pin = $componentPins.Android }
-        @{ Label = 'dotnet/macios';             Repo = 'dotnet/macios';  Pin = $componentPins.Macios }
+        @{ Label = 'dotnet/dotnet (VMR / SDK)'; Repo = 'dotnet/dotnet'; Pin = $componentPins.Vmr;     Noisy = $true  }
+        @{ Label = 'dotnet/android';            Repo = 'dotnet/android'; Pin = $componentPins.Android; Noisy = $false }
+        @{ Label = 'dotnet/macios';             Repo = 'dotnet/macios';  Pin = $componentPins.Macios;  Noisy = $false }
     )
     foreach ($r in $pinRows) {
         $flow = Get-ComponentFlowSignal -Repo $r.Repo -DepFlowPRs $depFlowPRs -Now $flowNow -StaleDays $flowStaleDays
@@ -2084,19 +2207,39 @@ if ($componentPins) {
         }
         $pin = $r.Pin
         if (-not $pin) {
-            [void]$md.AppendLine("| $(Format-MarkdownCell $r.Label) | _not pinned_ | — | $flowCell |")
+            [void]$md.AppendLine("| $(Format-MarkdownCell $r.Label) | _not pinned_ | — | $flowCell | — |")
             continue
         }
+
+        # Upstream drift (public compare API) — has the component's same-named
+        # branch advanced past the SHA we pin? Needs the pin SHA; soft-fails to '—'.
+        $driftCell = '—'
+        if (-not [string]::IsNullOrWhiteSpace($pin.Sha)) {
+            $drift = Get-UpstreamDriftSignal -Repo $r.Repo -Sha $pin.Sha -BranchName $SurveyRef
+            $driftCell = switch ($drift.Status) {
+                'current'  { '✅ current' }
+                'ahead'    {
+                    $n = $drift.AheadBy
+                    $unit = if ($n -eq 1) { 'commit' } else { 'commits' }
+                    if ($r.Noisy) { "⬆️ [$n $unit ahead]($($drift.Url)) — VMR churn (expected)" }
+                    else          { "⬆️ [$n $unit ahead]($($drift.Url)) — FYI" }
+                }
+                'diverged' { "⚠️ [diverged]($($drift.Url)) — compare manually" }
+                default    { if ($drift.Reason) { "— _$($drift.Reason)_" } else { '—' } }
+            }
+        }
+
         $commitCell = '—'
         if (-not [string]::IsNullOrWhiteSpace($pin.Sha)) {
             $shortSha = $pin.Sha.Substring(0, [Math]::Min(7, $pin.Sha.Length))
             $commitCell = "[``$shortSha``](https://github.com/$($r.Repo)/commit/$($pin.Sha))"
         }
-        [void]$md.AppendLine("| $(Format-MarkdownCell $r.Label) | ``$($pin.Version)`` | $commitCell | $flowCell |")
+        [void]$md.AppendLine("| $(Format-MarkdownCell $r.Label) | ``$($pin.Version)`` | $commitCell | $flowCell | $driftCell |")
     }
     [void]$md.AppendLine("")
     [void]$md.AppendLine("_Flow-signal legend: 🔄 open dep-flow PR (flowing now) · ✅ merged ≤ $flowStaleDays d · ⚠️ newest merge > $flowStaleDays d (sub may have stalled) · ❌ no dep-flow PR into ``$SurveyRef`` seen (sub may be missing — or the branch is brand new). Inferred from the **public** PR trail; confirm authoritative wiring locally with ``darc get-subscriptions --target-repo https://github.com/dotnet/maui --target-branch $SurveyRef``. dotnet/dotnet (VMR) typically flows on manual trigger, so a quiet VMR is less alarming than a quiet android/macios._")
     [void]$md.AppendLine("")
+    [void]$md.AppendLine("_Upstream legend: ✅ current = our pin **is** the tip of the component's ``$SurveyRef`` branch · ⬆️ N ahead = that branch has N newer commit(s) than we bundle (**FYI** — may be post-preview churn or not-yet-blessed work; not necessarily a bump you need) · ⚠️ diverged = our pin isn't a clean ancestor of the branch tip (build tag / different line) — compare manually · — = couldn't determine (no same-named upstream branch, or the compare API was unavailable). Branch is **derived** from the survey ref, never hardcoded. dotnet/dotnet (VMR) advances constantly on manual trigger, so 'N ahead' there is expected churn and rarely actionable._")
 
     # If a manual/darc component-bump PR is open against the branch, it names the
     # pending target BAR builds in its title — surface it so readers see the pins

--- a/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
+++ b/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
@@ -421,9 +421,9 @@ function Get-BranchComponentPins {
         }
     }
 
-    $vmr     = & $selectPin 'github\.com/dotnet/dotnet'  @('^Microsoft\.NET\.Sdk$')
-    $android = & $selectPin 'github\.com/dotnet/android' @('^Microsoft\.Android\.Sdk\.Windows$', '^Microsoft\.Android\.Sdk')
-    $macios  = & $selectPin 'github\.com/dotnet/macios'  @("^Microsoft\.macOS\.Sdk\.net$Major\.0", '^Microsoft\.macOS\.Sdk', '^Microsoft\.iOS\.Sdk')
+    $vmr     = & $selectPin 'github\.com/dotnet/dotnet(?![\w-])'  @('^Microsoft\.NET\.Sdk$')
+    $android = & $selectPin 'github\.com/dotnet/android(?![\w-])' @('^Microsoft\.Android\.Sdk\.Windows$', '^Microsoft\.Android\.Sdk')
+    $macios  = & $selectPin 'github\.com/dotnet/macios(?![\w-])'  @("^Microsoft\.macOS\.Sdk\.net$Major\.0", '^Microsoft\.macOS\.Sdk', '^Microsoft\.iOS\.Sdk')
 
     if (-not ($vmr -or $android -or $macios)) { return $null }
 
@@ -1265,7 +1265,7 @@ function Get-UpstreamDriftSignal {
         return $result
     }
 
-    if ($null -eq $cmp -or -not $cmp.PSObject.Properties['ahead_by']) {
+    if ($null -eq $cmp -or -not $cmp.PSObject.Properties['ahead_by'] -or -not $cmp.PSObject.Properties['behind_by']) {
         $result.Reason = 'compare returned no counts'
         return $result
     }
@@ -2170,7 +2170,17 @@ if ($componentPins) {
     # whether flow is alive, silently stalled, or apparently never wired.
     $flowStaleDays   = 14
     $flowNow         = [DateTime]::UtcNow
-    $mergedPRsForFlow = Get-MergedPullRequests -BaseBranch $SurveyRef
+    # Best-effort: the flow signal is inferred from the public dep-flow PR trail.
+    # Get-MergedPullRequests re-throws non-retryable gh failures (e.g. a 403
+    # secondary-rate-limit or a 500), so a transient outage here must degrade the
+    # signal to open-PR-only inference, NEVER abort the whole readiness report
+    # (every other data section in this driver degrades rather than throws).
+    $mergedPRsForFlow = @()
+    try {
+        $mergedPRsForFlow = @(Get-MergedPullRequests -BaseBranch $SurveyRef)
+    } catch {
+        Write-Warning "Flow-signal merged-PR fetch failed (non-fatal): $($_.Exception.Message)" -WarningAction Continue
+    }
     $allPRsForFlow   = @($targetPRs) + @($mergedPRsForFlow)
     $depFlowPRs      = @($allPRsForFlow | Where-Object { Test-IsDependencyFlowPr $_ })
 

--- a/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
+++ b/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
@@ -4248,6 +4248,21 @@ Assert-Eq -Label "dep-flow helper: plain human 'Fix Y' → false"              -
 Assert-Eq -Label "dep-flow helper: merge-up PR → false"                      -Expected $false -Actual (Test-IsDependencyFlowPr $dfMergeUp)
 Assert-Eq -Label "dep-flow helper: null PR → false"                          -Expected $false -Actual (Test-IsDependencyFlowPr $null)
 
+# --- Test-IsSdkBumpPr helper: the VMR/SDK-bump subset (dotnet/dotnet or dotnet/sdk) ---
+# Only VMR/SDK bumps earn the "confirm blessed locally" emphasis; android/macios/
+# runtime bumps do NOT (their pins aren't the SDK). Dual-shape + StrictMode-safe.
+$sbVmr  = [PSCustomObject]@{ title = 'Bump dotnet/dotnet from 11.0.0-preview.6.26325.125 to 11.0.0-preview.6.26356.105 (BAR 321614)' }
+$sbSdk  = [PSCustomObject]@{ title = 'Bump dotnet/sdk to 11.0.100-preview.6.26356.105' }
+$sbDict = @{ title = 'Bump dotnet/dotnet (BAR 322000)' }   # IDictionary shape (mock)
+Assert-Eq -Label "sdk-bump: dotnet/dotnet bump → true"             -Expected $true  -Actual (Test-IsSdkBumpPr $sbVmr)
+Assert-Eq -Label "sdk-bump: combined bump w/ dotnet/dotnet → true" -Expected $true  -Actual (Test-IsSdkBumpPr $dfHumanBump)
+Assert-Eq -Label "sdk-bump: dotnet/sdk bump → true"                -Expected $true  -Actual (Test-IsSdkBumpPr $sbSdk)
+Assert-Eq -Label "sdk-bump: IDictionary shape → true"              -Expected $true  -Actual (Test-IsSdkBumpPr $sbDict)
+Assert-Eq -Label "sdk-bump: dotnet/android bump → false (not SDK)"  -Expected $false -Actual (Test-IsSdkBumpPr $dfTitleOnly)
+Assert-Eq -Label "sdk-bump: merge-up PR → false"                   -Expected $false -Actual (Test-IsSdkBumpPr $dfMergeUp)
+Assert-Eq -Label "sdk-bump: plain human PR → false"                -Expected $false -Actual (Test-IsSdkBumpPr $dfPlain)
+Assert-Eq -Label "sdk-bump: null PR → false"                       -Expected $false -Actual (Test-IsSdkBumpPr $null)
+
 # --- Get-BranchComponentPins: git-pin fallback for the Action-owned best-effort
 #     component-build section. Parses eng/Version.Details.xml (public git, always
 #     readable in CI) to report the dotnet/dotnet, dotnet/android and dotnet/macios

--- a/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
+++ b/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
@@ -4294,6 +4294,23 @@ $sigDict = Get-ComponentFlowSignal -Repo 'dotnet/android' -DepFlowPRs @($fDictFr
 Assert-Eq -Label "flow: IDictionary-shaped PR → fresh"                     -Expected 'fresh'  -Actual $sigDict.Status
 Assert-Eq -Label "flow: IDictionary-shaped PR number"                      -Expected 110      -Actual $sigDict.Number
 
+# --- Format-FlowSignalCell: render a flow-signal result to a table cell ---
+# The 'missing' status must render differently when merged-PR history could NOT be
+# fetched (transient gh failure) — an honest "couldn't check" instead of a false
+# "none seen — sub may be missing" absence claim.
+$cellOpen  = Format-FlowSignalCell -Flow ([pscustomobject]@{ Status='open';  Number=1; Url='u'; AgeDays=$null })
+$cellFresh = Format-FlowSignalCell -Flow ([pscustomobject]@{ Status='fresh'; Number=2; Url='u'; AgeDays=1 })
+$cellStale = Format-FlowSignalCell -Flow ([pscustomobject]@{ Status='stale'; Number=3; Url='u'; AgeDays=40 })
+$cellMiss  = Format-FlowSignalCell -Flow ([pscustomobject]@{ Status='missing'; Number=$null; Url=$null; AgeDays=$null })
+$cellMissHU= Format-FlowSignalCell -Flow ([pscustomobject]@{ Status='missing'; Number=$null; Url=$null; AgeDays=$null }) -HistoryUnavailable
+Assert-Eq -Label "flowcell: open → flowing"                 -Expected $true -Actual ([bool]($cellOpen  -match '🔄' -and $cellOpen  -match 'flowing'))
+Assert-Eq -Label "flowcell: fresh → merged 1 day ago"       -Expected $true -Actual ([bool]($cellFresh -match '✅' -and $cellFresh -match '1 day ago'))
+Assert-Eq -Label "flowcell: stale → stale + 40 days ago"    -Expected $true -Actual ([bool]($cellStale -match '⚠️' -and $cellStale -match '40 days ago'))
+Assert-Eq -Label "flowcell: missing (history ok) → none seen absence claim" -Expected $true -Actual ([bool]($cellMiss -match 'none seen'))
+# The crux: on a merged-history-fetch failure the cell must NOT assert absence.
+Assert-Eq -Label "flowcell: missing + HistoryUnavailable → no false 'none seen'" -Expected $true -Actual ([bool]($cellMissHU -notmatch 'none seen'))
+Assert-Eq -Label "flowcell: missing + HistoryUnavailable → honest 'unavailable'" -Expected $true -Actual ([bool]($cellMissHU -match 'unavailable'))
+
 # --- Get-UpstreamDriftSignal: has the component's same-named branch advanced past our pin? ---
 # Complementary to the Flow signal: a hard git fact (public compare API), not an inference.
 # Tested via the injectable -Fetcher seam (same idiom as Get-NightlyFeedFreshness) so no
@@ -4350,6 +4367,14 @@ $drNoBehind = Get-UpstreamDriftSignal -Repo 'dotnet/macios' -Sha $drSha -BranchN
 Assert-Eq -Label "drift: compare missing behind_by → unknown (no throw)" -Expected 'unknown' -Actual $drNoBehind.Status
 Assert-Eq -Label "drift: missing-behind reason"                         -Expected 'compare returned no counts' -Actual $drNoBehind.Reason
 
+# (c4) present-but-null counts — a compare payload where ahead_by/behind_by exist
+# but are null must ALSO degrade to unknown (not misclassify as 'current', which
+# would be falsely reassuring). Guards against [int]$null → 0 → current.
+$fNullCounts = New-DriftFetcher -RefName "refs/heads/$drBranch" -Compare ([pscustomobject]@{ ahead_by = $null; behind_by = $null })
+$drNull = Get-UpstreamDriftSignal -Repo 'dotnet/macios' -Sha $drSha -BranchName $drBranch -Fetcher $fNullCounts
+Assert-Eq -Label "drift: null counts → unknown (not falsely 'current')" -Expected 'unknown' -Actual $drNull.Status
+Assert-Eq -Label "drift: null-counts reason"                           -Expected 'compare returned no counts' -Actual $drNull.Reason
+
 # (d) unknown — no pin SHA (soft-fail, never calls the fetcher).
 $drNoSha = Get-UpstreamDriftSignal -Repo 'dotnet/macios' -Sha '' -BranchName $drBranch -Fetcher $fCurrent
 Assert-Eq -Label "drift: empty SHA → unknown"                -Expected 'unknown'  -Actual $drNoSha.Status
@@ -4383,6 +4408,42 @@ $fNoCounts = New-DriftFetcher -RefName "refs/heads/$drBranch" -Compare ([pscusto
 $drNC = Get-UpstreamDriftSignal -Repo 'dotnet/macios' -Sha $drSha -BranchName $drBranch -Fetcher $fNoCounts
 Assert-Eq -Label "drift: compare missing ahead_by → unknown"     -Expected 'unknown' -Actual $drNC.Status
 Assert-Eq -Label "drift: no-counts reason"                       -Expected 'compare returned no counts' -Actual $drNC.Reason
+
+# --- Remove-JsoncComments (dependency-flow access gate): STRING-AWARE JSONC comment
+#     strip. Must remove real // and /* */ comments but must NOT delete a genuinely-
+#     enabled plugin entry whose neighbouring string VALUES contain stray /* */ // .
+$gateScript = Join-Path $PSScriptRoot '..' '..' 'dependency-flow' 'scripts' 'Get-PreviewReleaseReadiness.ps1'
+Write-Host "`n[Unit] Remove-JsoncComments (string-aware JSONC scrub)" -ForegroundColor Cyan
+if (-not (Test-Path -LiteralPath $gateScript)) {
+    Assert-Eq -Label "jsonc: access-gate script exists" -Expected $true -Actual $false
+} else {
+    . $gateScript   # dot-source guard skips the gate body + exit; only loads helpers
+    $pluginPat = '(?m)^\s*"dotnet-release-tracker(@[^"]+)?"\s*:\s*true'
+
+    # 1. Regression case: live entry straddled by /* and */ inside string VALUES.
+    $jLive = "{`n  `"before`": `"https://ex.com/api/*`",`n  `"dotnet-release-tracker`": true,`n  `"after`": `"glob*/tail`"`n}"
+    $sLive = Remove-JsoncComments $jLive
+    Assert-Eq -Label "jsonc: straddling /* */ in string values keeps live entry" -Expected $true -Actual ([bool]($sLive -match $pluginPat))
+
+    # 2. Genuinely block-commented entry → stripped → not enabled.
+    $jBlock = "{`n  /* `"dotnet-release-tracker`": true */`n  `"other`": 1`n}"
+    Assert-Eq -Label "jsonc: block-commented entry stripped → not enabled" -Expected $false -Actual ([bool]((Remove-JsoncComments $jBlock) -match $pluginPat))
+
+    # 3. // line-commented entry → stripped → not enabled.
+    $jLine = "{`n  // `"dotnet-release-tracker`": true`n  `"other`": 1`n}"
+    Assert-Eq -Label "jsonc: // line-commented entry stripped → not enabled" -Expected $false -Actual ([bool]((Remove-JsoncComments $jLine) -match $pluginPat))
+
+    # 4. Real entry with a trailing inline // comment → still enabled.
+    $jInline = "{`n  `"dotnet-release-tracker`": true // opted in`n}"
+    Assert-Eq -Label "jsonc: inline // after real entry keeps it enabled" -Expected $true -Actual ([bool]((Remove-JsoncComments $jInline) -match $pluginPat))
+
+    # 5. // inside a URL string value must NOT be treated as a comment.
+    $jUrl = "{`n  `"docs`": `"https://example.com/a`",`n  `"dotnet-release-tracker`": true`n}"
+    Assert-Eq -Label "jsonc: // inside a URL string value preserved (entry enabled)" -Expected $true -Actual ([bool]((Remove-JsoncComments $jUrl) -match $pluginPat))
+
+    # 6. Empty/null input is returned as-is (no throw).
+    Assert-Eq -Label "jsonc: empty input returned unchanged" -Expected '' -Actual (Remove-JsoncComments '')
+}
 
 # --- Get-BranchComponentPins: git-pin fallback for the Action-owned best-effort
 #     component-build section. Parses eng/Version.Details.xml (public git, always

--- a/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
+++ b/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
@@ -4294,6 +4294,82 @@ $sigDict = Get-ComponentFlowSignal -Repo 'dotnet/android' -DepFlowPRs @($fDictFr
 Assert-Eq -Label "flow: IDictionary-shaped PR → fresh"                     -Expected 'fresh'  -Actual $sigDict.Status
 Assert-Eq -Label "flow: IDictionary-shaped PR number"                      -Expected 110      -Actual $sigDict.Number
 
+# --- Get-UpstreamDriftSignal: has the component's same-named branch advanced past our pin? ---
+# Complementary to the Flow signal: a hard git fact (public compare API), not an inference.
+# Tested via the injectable -Fetcher seam (same idiom as Get-NightlyFeedFreshness) so no
+# live network. Mock distinguishes the matching-refs probe from the compare call by path.
+$drBranch = 'release/11.0.1xx-preview6'
+$drSha    = 'abc1234def5678'
+
+# Fetcher factory: branch-exists (exact ref) + a compare shape (ahead/behind counts).
+function New-DriftFetcher {
+    param([string]$RefName, [object]$Compare, [string]$ThrowOn)
+    return {
+        param($ApiPath)
+        if ($ThrowOn -eq 'refs'    -and $ApiPath -match '/git/matching-refs/heads/') { throw 'boom-refs' }
+        if ($ThrowOn -eq 'compare' -and $ApiPath -match '/compare/')                 { throw 'boom-compare' }
+        if ($ApiPath -match '/git/matching-refs/heads/') {
+            if ($null -eq $RefName) { return @() }
+            return @([pscustomobject]@{ ref = $RefName })
+        }
+        if ($ApiPath -match '/compare/') { return $Compare }
+        throw "unexpected api path $ApiPath"
+    }.GetNewClosure()
+}
+
+# (a) current — our pin IS the branch tip (ahead 0, behind 0).
+$fCurrent = New-DriftFetcher -RefName "refs/heads/$drBranch" -Compare ([pscustomobject]@{ ahead_by = 0; behind_by = 0 })
+$drCur = Get-UpstreamDriftSignal -Repo 'dotnet/macios' -Sha $drSha -BranchName $drBranch -Fetcher $fCurrent
+Assert-Eq -Label "drift: pin == branch tip → current"        -Expected 'current' -Actual $drCur.Status
+Assert-Eq -Label "drift: current has ahead_by 0"             -Expected 0         -Actual $drCur.AheadBy
+Assert-Eq -Label "drift: url points at compare base...head"  -Expected "https://github.com/dotnet/macios/compare/$drSha...$drBranch" -Actual $drCur.Url
+
+# (b) ahead — branch has newer commits than our pin (ahead N, behind 0).
+$fAhead = New-DriftFetcher -RefName "refs/heads/$drBranch" -Compare ([pscustomobject]@{ ahead_by = 3; behind_by = 0 })
+$drAhead = Get-UpstreamDriftSignal -Repo 'dotnet/android' -Sha $drSha -BranchName $drBranch -Fetcher $fAhead
+Assert-Eq -Label "drift: branch moved ahead → ahead"         -Expected 'ahead' -Actual $drAhead.Status
+Assert-Eq -Label "drift: ahead surfaces the count"           -Expected 3       -Actual $drAhead.AheadBy
+
+# (c) diverged — our pin isn't a clean ancestor of the branch tip (behind > 0).
+$fDiverged = New-DriftFetcher -RefName "refs/heads/$drBranch" -Compare ([pscustomobject]@{ ahead_by = 5; behind_by = 2 })
+$drDiv = Get-UpstreamDriftSignal -Repo 'dotnet/macios' -Sha $drSha -BranchName $drBranch -Fetcher $fDiverged
+Assert-Eq -Label "drift: behind_by > 0 → diverged (not ahead)" -Expected 'diverged' -Actual $drDiv.Status
+Assert-Eq -Label "drift: diverged surfaces behind_by"          -Expected 2          -Actual $drDiv.BehindBy
+
+# (d) unknown — no pin SHA (soft-fail, never calls the fetcher).
+$drNoSha = Get-UpstreamDriftSignal -Repo 'dotnet/macios' -Sha '' -BranchName $drBranch -Fetcher $fCurrent
+Assert-Eq -Label "drift: empty SHA → unknown"                -Expected 'unknown'  -Actual $drNoSha.Status
+Assert-Eq -Label "drift: empty SHA reason"                   -Expected 'no pin SHA' -Actual $drNoSha.Reason
+
+# (e) unknown — component has no same-named branch (matching-refs empty).
+$fNoBranch = New-DriftFetcher -RefName $null -Compare $null
+$drNoBr = Get-UpstreamDriftSignal -Repo 'dotnet/macios' -Sha $drSha -BranchName $drBranch -Fetcher $fNoBranch
+Assert-Eq -Label "drift: no upstream branch → unknown"       -Expected 'unknown' -Actual $drNoBr.Status
+Assert-Eq -Label "drift: no-branch reason"                   -Expected 'no same-named upstream branch' -Actual $drNoBr.Reason
+
+# (f) exact-ref discipline — a longer-named branch (preview60) must NOT satisfy preview6.
+$fPrefix = New-DriftFetcher -RefName "refs/heads/${drBranch}0" -Compare ([pscustomobject]@{ ahead_by = 9; behind_by = 0 })
+$drPfx = Get-UpstreamDriftSignal -Repo 'dotnet/macios' -Sha $drSha -BranchName $drBranch -Fetcher $fPrefix
+Assert-Eq -Label "drift: prefix-only ref (preview60) rejected → unknown" -Expected 'unknown' -Actual $drPfx.Status
+
+# (g) unknown — branch lookup throws (soft-fail, never bubbles).
+$fRefsThrow = New-DriftFetcher -RefName "refs/heads/$drBranch" -Compare $null -ThrowOn 'refs'
+$drRT = Get-UpstreamDriftSignal -Repo 'dotnet/macios' -Sha $drSha -BranchName $drBranch -Fetcher $fRefsThrow
+Assert-Eq -Label "drift: refs lookup throws → unknown (soft-fail)" -Expected 'unknown' -Actual $drRT.Status
+Assert-Eq -Label "drift: refs-throw reason"                        -Expected 'branch lookup failed' -Actual $drRT.Reason
+
+# (h) unknown — compare throws (soft-fail).
+$fCmpThrow = New-DriftFetcher -RefName "refs/heads/$drBranch" -Compare $null -ThrowOn 'compare'
+$drCT = Get-UpstreamDriftSignal -Repo 'dotnet/macios' -Sha $drSha -BranchName $drBranch -Fetcher $fCmpThrow
+Assert-Eq -Label "drift: compare throws → unknown (soft-fail)"    -Expected 'unknown' -Actual $drCT.Status
+Assert-Eq -Label "drift: compare-throw reason"                    -Expected 'compare failed' -Actual $drCT.Reason
+
+# (i) unknown — compare returns a shape with no counts.
+$fNoCounts = New-DriftFetcher -RefName "refs/heads/$drBranch" -Compare ([pscustomobject]@{ status = 'identical' })
+$drNC = Get-UpstreamDriftSignal -Repo 'dotnet/macios' -Sha $drSha -BranchName $drBranch -Fetcher $fNoCounts
+Assert-Eq -Label "drift: compare missing ahead_by → unknown"     -Expected 'unknown' -Actual $drNC.Status
+Assert-Eq -Label "drift: no-counts reason"                       -Expected 'compare returned no counts' -Actual $drNC.Reason
+
 # --- Get-BranchComponentPins: git-pin fallback for the Action-owned best-effort
 #     component-build section. Parses eng/Version.Details.xml (public git, always
 #     readable in CI) to report the dotnet/dotnet, dotnet/android and dotnet/macios

--- a/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
+++ b/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
@@ -4336,6 +4336,20 @@ $drDiv = Get-UpstreamDriftSignal -Repo 'dotnet/macios' -Sha $drSha -BranchName $
 Assert-Eq -Label "drift: behind_by > 0 → diverged (not ahead)" -Expected 'diverged' -Actual $drDiv.Status
 Assert-Eq -Label "drift: diverged surfaces behind_by"          -Expected 2          -Actual $drDiv.BehindBy
 
+# (c2) pure-behind — behind_by > 0 AND ahead_by == 0 must still classify diverged,
+# locking the classifier's check order (behind is tested before ahead).
+$fBehindOnly = New-DriftFetcher -RefName "refs/heads/$drBranch" -Compare ([pscustomobject]@{ ahead_by = 0; behind_by = 4 })
+$drBehind = Get-UpstreamDriftSignal -Repo 'dotnet/macios' -Sha $drSha -BranchName $drBranch -Fetcher $fBehindOnly
+Assert-Eq -Label "drift: pure-behind (ahead 0, behind 4) → diverged" -Expected 'diverged' -Actual $drBehind.Status
+Assert-Eq -Label "drift: pure-behind surfaces behind_by"            -Expected 4          -Actual $drBehind.BehindBy
+
+# (c3) symmetric guard — a compare payload with ahead_by but MISSING behind_by must
+# degrade to unknown, never throw under StrictMode (guards the behind_by dereference).
+$fNoBehind = New-DriftFetcher -RefName "refs/heads/$drBranch" -Compare ([pscustomobject]@{ ahead_by = 1 })
+$drNoBehind = Get-UpstreamDriftSignal -Repo 'dotnet/macios' -Sha $drSha -BranchName $drBranch -Fetcher $fNoBehind
+Assert-Eq -Label "drift: compare missing behind_by → unknown (no throw)" -Expected 'unknown' -Actual $drNoBehind.Status
+Assert-Eq -Label "drift: missing-behind reason"                         -Expected 'compare returned no counts' -Actual $drNoBehind.Reason
+
 # (d) unknown — no pin SHA (soft-fail, never calls the fetcher).
 $drNoSha = Get-UpstreamDriftSignal -Repo 'dotnet/macios' -Sha '' -BranchName $drBranch -Fetcher $fCurrent
 Assert-Eq -Label "drift: empty SHA → unknown"                -Expected 'unknown'  -Actual $drNoSha.Status

--- a/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
+++ b/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
@@ -4263,6 +4263,37 @@ Assert-Eq -Label "sdk-bump: merge-up PR → false"                   -Expected $
 Assert-Eq -Label "sdk-bump: plain human PR → false"                -Expected $false -Actual (Test-IsSdkBumpPr $dfPlain)
 Assert-Eq -Label "sdk-bump: null PR → false"                       -Expected $false -Actual (Test-IsSdkBumpPr $null)
 
+# --- Get-ComponentFlowSignal: infer subscription health from the public PR trail ---
+# A working sub leaves a public trail of dep-flow PRs; classify open/fresh/stale/missing.
+$flowNow = [datetime]::new(2026, 7, 8, 0, 0, 0, [System.DateTimeKind]::Utc)
+$fOpenAndroid  = [PSCustomObject]@{ number = 101; title = '[release/11.0.1xx-preview6] Update dependencies from dotnet/android'; url = 'u101'; createdAt = '2026-07-06T00:00:00Z'; mergedAt = $null }
+$fStaleAndroid = [PSCustomObject]@{ number = 100; title = 'Bump dotnet/android to old (BAR 0)'; url = 'u100'; createdAt = '2026-05-01T00:00:00Z'; mergedAt = '2026-05-01T00:00:00Z' }
+$fFreshMacios  = [PSCustomObject]@{ number = 102; title = 'Bump dotnet/macios to 26.5 (BAR 1)'; url = 'u102'; createdAt = '2026-07-05T00:00:00Z'; mergedAt = '2026-07-05T00:00:00Z' }
+$fStaleVmr     = [PSCustomObject]@{ number = 103; title = 'Bump dotnet/dotnet (VMR) to preview.6 (BAR 2)'; url = 'u103'; createdAt = '2026-06-01T00:00:00Z'; mergedAt = '2026-06-01T00:00:00Z' }
+$fVmrOptColl   = [PSCustomObject]@{ number = 104; title = 'Bump dotnet/dotnet-optimization to 1.2 (BAR 3)'; url = 'u104'; createdAt = '2026-07-07T00:00:00Z'; mergedAt = '2026-07-07T00:00:00Z' }
+$fBatched      = [PSCustomObject]@{ number = 105; title = 'Update dependencies from dotnet/android, dotnet/macios'; url = 'u105'; createdAt = '2026-07-04T00:00:00Z'; mergedAt = '2026-07-04T00:00:00Z' }
+$fDictFresh    = @{ number = 110; title = 'Bump dotnet/android (BAR 9)'; url = 'u110'; createdAt = '2026-07-06T00:00:00Z'; mergedAt = '2026-07-06T00:00:00Z' }  # IDictionary shape
+
+$sigOpen  = Get-ComponentFlowSignal -Repo 'dotnet/android' -DepFlowPRs @($fStaleAndroid, $fOpenAndroid, $fFreshMacios) -Now $flowNow
+Assert-Eq -Label "flow: open dep-flow PR preferred over stale merge → open" -Expected 'open'   -Actual $sigOpen.Status
+Assert-Eq -Label "flow: open picks the open PR number"                      -Expected 101      -Actual $sigOpen.Number
+$sigFresh = Get-ComponentFlowSignal -Repo 'dotnet/macios' -DepFlowPRs @($fFreshMacios) -Now $flowNow
+Assert-Eq -Label "flow: recent merge → fresh"                              -Expected 'fresh'  -Actual $sigFresh.Status
+Assert-Eq -Label "flow: fresh age computed (3 days)"                        -Expected 3        -Actual $sigFresh.AgeDays
+$sigStale = Get-ComponentFlowSignal -Repo 'dotnet/dotnet' -DepFlowPRs @($fStaleVmr) -Now $flowNow
+Assert-Eq -Label "flow: old-only merge → stale"                           -Expected 'stale'  -Actual $sigStale.Status
+$sigMissing = Get-ComponentFlowSignal -Repo 'dotnet/android' -DepFlowPRs @() -Now $flowNow
+Assert-Eq -Label "flow: no PRs → missing"                                 -Expected 'missing' -Actual $sigMissing.Status
+$sigColl = Get-ComponentFlowSignal -Repo 'dotnet/dotnet' -DepFlowPRs @($fVmrOptColl) -Now $flowNow
+Assert-Eq -Label "flow: dotnet/dotnet does NOT collide w/ dotnet-optimization → missing" -Expected 'missing' -Actual $sigColl.Status
+$sigBatchA = Get-ComponentFlowSignal -Repo 'dotnet/android' -DepFlowPRs @($fBatched) -Now $flowNow
+$sigBatchM = Get-ComponentFlowSignal -Repo 'dotnet/macios' -DepFlowPRs @($fBatched) -Now $flowNow
+Assert-Eq -Label "flow: batched PR counts for android"                     -Expected 'fresh'  -Actual $sigBatchA.Status
+Assert-Eq -Label "flow: batched PR counts for macios"                      -Expected 'fresh'  -Actual $sigBatchM.Status
+$sigDict = Get-ComponentFlowSignal -Repo 'dotnet/android' -DepFlowPRs @($fDictFresh) -Now $flowNow
+Assert-Eq -Label "flow: IDictionary-shaped PR → fresh"                     -Expected 'fresh'  -Actual $sigDict.Status
+Assert-Eq -Label "flow: IDictionary-shaped PR number"                      -Expected 110      -Actual $sigDict.Number
+
 # --- Get-BranchComponentPins: git-pin fallback for the Action-owned best-effort
 #     component-build section. Parses eng/Version.Details.xml (public git, always
 #     readable in CI) to report the dotnet/dotnet, dotnet/android and dotnet/macios

--- a/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
+++ b/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
@@ -673,14 +673,12 @@ function Get-ExpectedHighestShippedTag {
 
 if (-not $SkipE2E) {
     Write-Host "`n[E2E] Detection against live repo" -ForegroundColor Cyan
-    Write-Host "  Under the tag-existence rule + Lane 1 staleness guard we expect TWO trackers:" -ForegroundColor DarkGray
-    Write-Host "    - SR8 (patch=80, tag 10.0.80 exists)    - shipped, refresh-until-closed (highest shipped SR)" -ForegroundColor DarkGray
-    Write-Host "    - SR9 (candidate off main)              - active" -ForegroundColor DarkGray
-    Write-Host "    DROPPED by the staleness guard (idle + below the shipped watermark 80):" -ForegroundColor DarkGray
-    Write-Host "    - SR2 (patch=21, no tag 10.0.21)        - tag-absent but stale -> no matrix job" -ForegroundColor DarkGray
-    Write-Host "    - SR3 (patch=33, no tag 10.0.33)        - tag-absent but stale -> no matrix job" -ForegroundColor DarkGray
-    Write-Host "    NOTE: SR7 shipped 2026-06-05 (tag 10.0.71); NOT the highest shipped SR -> retired (no tracker)." -ForegroundColor DarkGray
-    Write-Host "    NOTE: SR8 shipped 2026-06-22 (tag 10.0.80); as the HIGHEST shipped SR it emits a 'shipped' tracker that refreshes until a human closes it." -ForegroundColor DarkGray
+    Write-Host "  Under the tag-existence rule + Lane 1 staleness guard, the SR set is asserted" -ForegroundColor DarkGray
+    Write-Host "  STRUCTURALLY (drift-proof), not pinned: the highest shipped SR emits a 'shipped'" -ForegroundColor DarkGray
+    Write-Host "  refresh tracker, plus >=0 in-flight SRs (branch cut, unshipped) and exactly one" -ForegroundColor DarkGray
+    Write-Host "  candidate SR (the next SR off main). Today: SR8 shipped, SR9 in-flight, SR10 candidate." -ForegroundColor DarkGray
+    Write-Host "    DROPPED by the staleness guard (idle + below the shipped watermark): e.g. SR2, SR3." -ForegroundColor DarkGray
+    Write-Host "    RETIRED (shipped, below the highest shipped SR): e.g. SR7 (10.0.71)." -ForegroundColor DarkGray
 
     $detectOut = Join-Path ([System.IO.Path]::GetTempPath()) "rr-detect-$(Get-Date -Format 'HHmmss').json"
     try {
@@ -698,8 +696,21 @@ if (-not $SkipE2E) {
                       -Expected $expectedHighestShipped -Actual $detected.highestShippedTag
             Assert-Eq -Label "highestShippedPreviewTag carries net10's last preview" `
                       -Expected '10.0.0-preview.7.25406.3' -Actual $detected.highestShippedPreviewTag
-            Assert-Eq -Label "tracker count is 2 (SR8 shipped+refresh, SR9 candidate; SR7 retired; SR2/SR3 stale-dropped)" `
-                      -Expected 2 -Actual $detected.trackers.Count
+            # Tracker COUNT is not pinned — it advances every time an SR ships or is
+            # cut. Assert the invariant SHAPE instead: >=1 SR tracker, exactly one
+            # candidate (the next SR off main), at most one 'shipped' refresh tracker
+            # (the highest shipped SR), and a clean shipped+in-flight+candidate
+            # partition. Today that's SR8 shipped + SR9 in-flight + SR10 candidate;
+            # when SR9 ships this stays green (SR9 shipped + SR10 in-flight + SR11
+            # candidate) with no per-cut edit.
+            $srTrackers   = @($detected.trackers | Where-Object branchType -eq 'sr')
+            $shippedSrs   = @($srTrackers | Where-Object mode -eq 'shipped')
+            $inflightSrs  = @($srTrackers | Where-Object mode -eq 'in-flight' | Sort-Object { [int]$_.srNumber })
+            $candidateSrs = @($srTrackers | Where-Object mode -eq 'candidate')
+            Assert-Eq -Label "at least one SR tracker detected"                    -Expected $true -Actual ($srTrackers.Count -ge 1)
+            Assert-Eq -Label "exactly one candidate SR (the next SR off main)"     -Expected 1     -Actual $candidateSrs.Count
+            Assert-Eq -Label "at most one shipped refresh SR (the highest shipped SR)" -Expected $true -Actual ($shippedSrs.Count -le 1)
+            Assert-Eq -Label "SR trackers partition into shipped + in-flight + candidate" -Expected $srTrackers.Count -Actual ($shippedSrs.Count + $inflightSrs.Count + $candidateSrs.Count)
             # All trackers in single-major net10 mode must be SR-flavored. (Net10's
             # previews 1–7 all shipped + no in-flight preview branch -> no preview tracker.)
             foreach ($t in $detected.trackers) {
@@ -723,78 +734,76 @@ if (-not $SkipE2E) {
             Assert-Eq -Label "SR7 tracker absent (shipped as 10.0.71)" `
                       -Expected $false -Actual ($bySr.ContainsKey(7))
 
-            # SR8 (SHIPPED — highest shipped SR (tag 10.0.80) -> emits a
-            # 'shipped' tracker that refreshes until a human closes it).
-            if ($bySr.ContainsKey(8)) {
-                $sr8 = $bySr[8]
-                Assert-Eq -Label "SR8 mode = shipped"           -Expected 'shipped' -Actual $sr8.mode
-                Assert-Eq -Label "SR8 canonicalKey"             -Expected 'net10-sr8' -Actual $sr8.canonicalKey
-                Assert-Eq -Label "SR8 branchName"               -Expected 'release/10.0.1xx-sr8' -Actual $sr8.branchName
-                Assert-Eq -Label "SR8 branchExists = true"      -Expected $true -Actual $sr8.branchExists
-                Assert-Eq -Label "SR8 surveyRef = its own branch (shipped surveys the SR branch)" `
-                          -Expected 'release/10.0.1xx-sr8' -Actual $sr8.surveyRef
-                Assert-Eq -Label "SR8 issue title = shipped format" `
-                          -Expected '[Release Readiness] .NET 10 SR8 — shipped (release/10.0.1xx-sr8)' `
-                          -Actual $sr8.issueTitle
-                Assert-Eq -Label "SR8 expectedTag = 10.0.80"    -Expected '10.0.80' -Actual $sr8.expectedTag
-                # hasRecentActivity is a 7-day-window signal (git log --since=7.days
-                # against the live branch), so its VALUE is wall-clock dependent and
-                # MUST NOT be pinned here — SR8 idling >7 days at the tail of a cycle
-                # is a NORMAL state that would (correctly) report $false. Assert only
-                # that the detector emits it as a real [bool]. The window math itself
-                # is covered deterministically by the synthetic-fixture unit test
-                # ([Unit] Get-RecentCommitCount recency window).
-                Assert-Eq -Label "SR8 hasRecentActivity is a [bool] (value is date-dependent)" `
-                          -Expected $true -Actual ($sr8.hasRecentActivity -is [bool])
-                Assert-Eq -Label "SR8 regression labels"        `
-                          -Expected 'regressed-in-10.0.70,regressed-in-10.0.80' `
-                          -Actual ($sr8.regressionLabels -join ',')
-            } else {
-                Write-Host "  ❌ SR8 tracker missing" -ForegroundColor Red; $script:failed++
+            # SR8 (shipped 2026-07-03 as 10.0.80) is the HIGHEST shipped SR, so under
+            # main's model it does NOT retire — it emits a 'shipped' refresh tracker
+            # (refresh-until-closed) while SR9's branch is in-flight and SR10 is the
+            # candidate off main. Assert this structurally from the detector's own
+            # shipped set so it survives the next ship (SR9 shipped, SR10 in-flight, ...).
+            foreach ($sh in $shippedSrs) {
+                Assert-Eq -Label "shipped SR$($sh.srNumber) mode = shipped"                     -Expected 'shipped'      -Actual $sh.mode
+                Assert-Eq -Label "shipped SR$($sh.srNumber) branchExists = true"                -Expected $true          -Actual $sh.branchExists
+                Assert-Eq -Label "shipped SR$($sh.srNumber) surveys its own branch"             -Expected $sh.branchName -Actual $sh.surveyRef
+                Assert-Eq -Label "shipped SR$($sh.srNumber) ship tag $($sh.expectedTag) EXISTS"  -Expected $true         -Actual ([bool](& git -C $detected.repo tag --list $sh.expectedTag))
             }
 
-            # SR9 (candidate from main, ACTIVE)
-            if ($bySr.ContainsKey(9)) {
-                $sr9 = $bySr[9]
-                Assert-Eq -Label "SR9 mode = candidate"         -Expected 'candidate' -Actual $sr9.mode
-                Assert-Eq -Label "SR9 canonicalKey"             -Expected 'net10-sr9' -Actual $sr9.canonicalKey
-                Assert-Eq -Label "SR9 branchName = canonical proposed slug" `
-                          -Expected 'release/10.0.1xx-sr9' -Actual $sr9.branchName
-                Assert-Eq -Label "SR9 branchExists = false (not cut yet)" `
-                          -Expected $false -Actual $sr9.branchExists
-                Assert-Eq -Label "SR9 surveyRef = main"         -Expected 'main' -Actual $sr9.surveyRef
-                Assert-Eq -Label "SR9 priorSrBranch = SR8 branch" `
-                          -Expected 'release/10.0.1xx-sr8' -Actual $sr9.priorSrBranch
-                Assert-Eq -Label "SR9 expectedPatch = 90"       -Expected 90 -Actual $sr9.expectedPatch
-                # Same 7-day-window caveat as SR8: don't pin the value, assert the type.
-                Assert-Eq -Label "SR9 hasRecentActivity is a [bool] (value is date-dependent)" `
-                          -Expected $true -Actual ($sr9.hasRecentActivity -is [bool])
-                Assert-Eq -Label "SR9 regression labels"        `
-                          -Expected 'regressed-in-10.0.80,regressed-in-10.0.90' `
-                          -Actual ($sr9.regressionLabels -join ',')
-            } else {
-                Write-Host "  ❌ SR9 tracker missing" -ForegroundColor Red; $script:failed++
+            # Drift-proof invariant: every in-flight/candidate SR does NOT yet have its
+            # ship tag in git (only the 'shipped' refresh tracker carries an existing
+            # ship tag). Uses each tracker's own expectedTag so the non-uniform patch
+            # convention (SR7 shipped as 10.0.71, SR8 as 10.0.80) is honored.
+            foreach ($active in @($inflightSrs + $candidateSrs)) {
+                Assert-Eq -Label "active SR$($active.srNumber) has no ship tag $($active.expectedTag) yet [unshipped invariant]" `
+                          -Expected $false `
+                          -Actual ([bool](& git -C $detected.repo tag --list $active.expectedTag))
             }
 
-            # Every active SR tracker must EXPOSE a hasRecentActivity flag, but that
-            # flag is a 7-day-window signal (git log --since=7.days), NOT a synonym
-            # for "active": an active SR can legitimately sit idle for >7 days near
-            # the tail of a cycle and report hasRecentActivity=$false. So assert the
-            # flag is a real [bool] — never a hardcoded, date-dependent $true. SR7
-            # shipped 2026-06-05 and (no longer the highest shipped SR) is retired;
-            # SR8 (shipped, highest -> refresh-until-closed) + SR9 (candidate) are
-            # the tracked set.
-            foreach ($srNum in @(8, 9)) {
-                if ($bySr.ContainsKey($srNum)) {
-                    Assert-Eq -Label "SR$srNum hasRecentActivity is a [bool] (active SR; value date-dependent)" `
-                              -Expected $true -Actual ($bySr[$srNum].hasRecentActivity -is [bool])
-                    # Pin the detector's count->flag WIRING (hasRecentActivity = recentCommitCount > 0)
-                    # without pinning the date-dependent value: both fields come off the SAME tracker
-                    # computed at the SAME instant, so this invariant holds no matter how active the
-                    # branch is, yet still catches an inverted/hardcoded mapping.
-                    Assert-Eq -Label "SR$srNum hasRecentActivity == (recentCommitCount > 0) [mapping invariant]" `
-                              -Expected $true -Actual ($bySr[$srNum].hasRecentActivity -eq ([int]$bySr[$srNum].recentCommitCount -gt 0))
-                }
+            # --- In-flight SRs: branch cut, survey their OWN branch, no priorSrBranch. ---
+            #     (Derived from the detector's output, so this survives future SR cuts
+            #     instead of pinning "SR9". Real bugs still caught: mode<->branchExists
+            #     wiring, surveyRef routing, canonical slug, and priorSrBranch emptiness.)
+            foreach ($fl in $inflightSrs) {
+                Assert-Eq -Label "in-flight SR$($fl.srNumber) mode = in-flight"           -Expected 'in-flight' -Actual $fl.mode
+                Assert-Eq -Label "in-flight SR$($fl.srNumber) branchExists = true"         -Expected $true       -Actual $fl.branchExists
+                Assert-Eq -Label "in-flight SR$($fl.srNumber) surveys its own branch"      -Expected $fl.branchName -Actual $fl.surveyRef
+                Assert-Eq -Label "in-flight SR$($fl.srNumber) canonicalKey"                -Expected "net10-sr$($fl.srNumber)" -Actual $fl.canonicalKey
+                Assert-Eq -Label "in-flight SR$($fl.srNumber) branchName = canonical slug" -Expected "release/10.0.1xx-sr$($fl.srNumber)" -Actual $fl.branchName
+                Assert-Eq -Label "in-flight SR$($fl.srNumber) has no priorSrBranch"        -Expected $true       -Actual ([string]::IsNullOrEmpty($fl.priorSrBranch))
+            }
+
+            # --- Candidate SR: off main, branch NOT cut, numbered one past the highest
+            #     in-flight SR, with priorSrBranch = that highest in-flight branch. ---
+            $cand = $candidateSrs[0]
+            $highestInflight = if ($inflightSrs.Count -gt 0) { $inflightSrs[-1] } else { $null }
+            Assert-Eq -Label "candidate SR mode = candidate"                    -Expected 'candidate' -Actual $cand.mode
+            Assert-Eq -Label "candidate SR surveyRef = main"                    -Expected 'main'      -Actual $cand.surveyRef
+            Assert-Eq -Label "candidate SR branchExists = false (not cut yet)"  -Expected $false      -Actual $cand.branchExists
+            Assert-Eq -Label "candidate SR canonicalKey"                        -Expected "net10-sr$($cand.srNumber)" -Actual $cand.canonicalKey
+            Assert-Eq -Label "candidate SR branchName = canonical proposed slug" -Expected "release/10.0.1xx-sr$($cand.srNumber)" -Actual $cand.branchName
+            if ($highestInflight) {
+                Assert-Eq -Label "candidate SR number = highest in-flight SR + 1" `
+                          -Expected ([int]$highestInflight.srNumber + 1) -Actual ([int]$cand.srNumber)
+                Assert-Eq -Label "candidate SR priorSrBranch = highest in-flight branch" `
+                          -Expected $highestInflight.branchName -Actual $cand.priorSrBranch
+            } else {
+                Write-Host "  ❌ no in-flight SR to anchor candidate numbering" -ForegroundColor Red; $script:failed++
+            }
+
+            # --- Per-SR invariants for BOTH modes (drift-proof). The regression-label
+            #     pair mirrors New-RegressionLabelList exactly ({prior, own} at N*10, or
+            #     the GA label when prior is 0); expectedTag is the detector's own
+            #     "10.0.<expectedPatch>" construction; hasRecentActivity is a real [bool]
+            #     wired to recentCommitCount (never a hardcoded, date-dependent $true). ---
+            foreach ($t in $srTrackers) {
+                $priorSr = [int]$t.srNumber - 1
+                $priorLabel = if ($priorSr -le 0) { 'regressed-in-10.0.0' } else { "regressed-in-10.0.$($priorSr * 10)" }
+                $expectedLabels = "$priorLabel,regressed-in-10.0.$([int]$t.srNumber * 10)"
+                Assert-Eq -Label "SR$($t.srNumber) regression labels = prior + own patch" `
+                          -Expected $expectedLabels -Actual ($t.regressionLabels -join ',')
+                Assert-Eq -Label "SR$($t.srNumber) expectedTag = 10.0.<expectedPatch>" `
+                          -Expected "10.0.$([int]$t.expectedPatch)" -Actual $t.expectedTag
+                Assert-Eq -Label "SR$($t.srNumber) hasRecentActivity is a [bool] (value date-dependent)" `
+                          -Expected $true -Actual ($t.hasRecentActivity -is [bool])
+                Assert-Eq -Label "SR$($t.srNumber) hasRecentActivity == (recentCommitCount > 0) [mapping invariant]" `
+                          -Expected $true -Actual ($t.hasRecentActivity -eq ([int]$t.recentCommitCount -gt 0))
             }
         }
     } finally {
@@ -803,12 +812,12 @@ if (-not $SkipE2E) {
 
     # ──────────── E2E: -AllActiveMajors multi-major envelope ────────────
     # In the unified post-consolidation shape, one invocation must surface every
-    # active major (main's + any net<N>.0 ≥ main). Expected current state:
-    #   - net10 -> 2 SR trackers (SR8 shipped+refresh, SR9 candidate), no preview tracker
-    #     (SR7 shipped 2026-06-05 and is no longer the highest shipped SR -> retired;
-    #      SR8 shipped 2026-06-22 as the HIGHEST shipped SR -> 'shipped' tracker that
-    #      refreshes until closed; SR2/SR3 dropped by the Lane 1 staleness guard;
-    #      every net10 preview branch already shipped + net10.0 isn't in preview cycle)
+    # active major (main's + any net<N>.0 ≥ main). Expected current state (asserted
+    # structurally so it survives SR cuts/ships and preview transitions):
+    #   - net10 -> ≥1 SR tracker + exactly one candidate SR, no preview lane
+    #     (SR2/SR3 dropped by the Lane 1 staleness guard; shipped SRs dropped by
+    #      shipped-exclusion; every net10 preview branch already shipped + net10.0
+    #      isn't in a preview cycle). Today: SR9 in-flight + SR10 candidate.
     #   - net11 -> 0 SR trackers (pre-GA: no `11.0.0` tag), 2 preview trackers
     #     (preview6 in-flight: release/11.0.1xx-preview6 was cut, tag not yet published;
     #      preview7 candidate: net11.0 bumped to PreReleaseVersionIteration=7, so the
@@ -818,8 +827,8 @@ if (-not $SkipE2E) {
     Write-Host "`n[E2E] Detection with -AllActiveMajors" -ForegroundColor Cyan
     Write-Host "  Expected:" -ForegroundColor DarkGray
     Write-Host "    - majors[].length = 2 (net10 + net11)" -ForegroundColor DarkGray
-    Write-Host "    - net10 trackers: 2 SR (sr8 shipped/sr9 candidate), 0 preview (SR7 retired; SR2/SR3 stale-dropped)" -ForegroundColor DarkGray
-    Write-Host "    - net11 trackers: 0 SR (pre-GA), 2 preview (preview6 in-flight + preview7 candidate from net11.0)" -ForegroundColor DarkGray
+    Write-Host "    - net10 trackers: >=1 SR + exactly 1 candidate, 0 preview (today SR9 in-flight + SR10 candidate)" -ForegroundColor DarkGray
+    Write-Host "    - net11 trackers: 0 SR (pre-GA), 2 preview (preview6 in-flight, preview7 candidate)" -ForegroundColor DarkGray
 
     $multiOut = Join-Path ([System.IO.Path]::GetTempPath()) "rr-detect-allmajors-$(Get-Date -Format 'HHmmss').json"
     try {
@@ -845,11 +854,17 @@ if (-not $SkipE2E) {
                 $expectedNet10Highest = Get-ExpectedHighestShippedTag -RepoPath $multi.repo -Major 10
                 Assert-Eq -Label "net10 highestShippedTag matches highest stable 10.0.M tag (derived)" `
                           -Expected $expectedNet10Highest -Actual $net10.highestShippedTag
-                Assert-Eq -Label "net10 tracker count is 2 (no preview lane; SR8 shipped+refresh, SR9 candidate; SR7 retired, SR2/SR3 stale-dropped)" -Expected 2 -Actual $net10.trackers.Count
-                $srCount = @($net10.trackers | Where-Object branchType -eq 'sr').Count
-                $previewCount = @($net10.trackers | Where-Object branchType -eq 'preview').Count
-                Assert-Eq -Label "net10 has 2 SR trackers"      -Expected 2 -Actual $srCount
-                Assert-Eq -Label "net10 has 0 preview trackers" -Expected 0 -Actual $previewCount
+                $net10Sr        = @($net10.trackers | Where-Object branchType -eq 'sr')
+                $net10Preview   = @($net10.trackers | Where-Object branchType -eq 'preview')
+                $net10Candidate = @($net10Sr | Where-Object mode -eq 'candidate')
+                # Count is not pinned (advances every SR cut/ship). Assert the shape:
+                # ≥1 SR tracker, exactly one candidate SR, no preview lane (every net10
+                # preview shipped + net10.0 isn't in a preview cycle), and a clean SR-only
+                # partition. Today: SR9 in-flight + SR10 candidate.
+                Assert-Eq -Label "net10 has at least one SR tracker"      -Expected $true -Actual ($net10Sr.Count -ge 1)
+                Assert-Eq -Label "net10 has exactly one candidate SR"     -Expected 1     -Actual $net10Candidate.Count
+                Assert-Eq -Label "net10 has 0 preview trackers"          -Expected 0     -Actual $net10Preview.Count
+                Assert-Eq -Label "net10 trackers are all SR (partition)"  -Expected $net10.trackers.Count -Actual $net10Sr.Count
             } else {
                 Write-Host "  ❌ majors[] missing net10 entry" -ForegroundColor Red; $script:failed++
             }
@@ -4173,12 +4188,19 @@ $prMergeP0   = [PSCustomObject]@{ number = 3; author = $humanLogin;   labels = $
 $prMaestro   = [PSCustomObject]@{ number = 4; author = $maestroLogin; labels = $plainLbl; headRefName = 'darc-net11.0-def';       title = 'Update dependencies' }
 $prHuman     = [PSCustomObject]@{ number = 5; author = $humanLogin;   labels = $plainLbl; headRefName = 'fix/y';                  title = 'Fix Y' }
 $prMergeUp   = [PSCustomObject]@{ number = 6; author = $humanLogin;   labels = $plainLbl; headRefName = 'merge/main-to-net11.0';  title = "[automated] Merge branch 'main' => 'net11.0'" }
-# Inflight (net<major>.0) PRs: a Maestro one (must still bucket as Maestro) and a
+# Human-authored component-bump PR targeting the survey ref (models #36433: rmarinho
+# "[release/11.0.1xx-preview6] Bump dotnet/dotnet (BAR ...)", head `update-<id>`).
+# Author is NOT dotnet-maestro, so author-only detection missed it; it must now
+# bucket as a dependency-flow PR (and hoist to 🔴 High-priority items), NOT as a
+# generic human release-branch PR.
+$prHumanBump = [PSCustomObject]@{ number = 9; author = $humanLogin;   labels = $plainLbl; headRefName = 'update-321614';           title = '[release/11.0.1xx-preview6] Bump dotnet/dotnet (BAR 321614), dotnet/android (BAR 321622) and dotnet/macios (BAR 321780)' }
+# Inflight (net<major>.0) PRs: a Maestro one (must NOT bucket as Maestro — a
+# branched preview only reports dependency bumps against its own branch) and a
 # p/0-labelled one (must NOT escalate — only survey-ref PRs block).
 $prInflightMaestro = [PSCustomObject]@{ number = 7; author = $maestroLogin; labels = $plainLbl; headRefName = 'darc-main-xyz'; title = 'Update dependencies' }
 $prInflightP0      = [PSCustomObject]@{ number = 8; author = $humanLogin;   labels = $p0Lbl;    headRefName = 'fix/z';          title = 'Fix Z' }
 
-$targetSet   = @($prHumanP0, $prMaestroP0, $prMergeP0, $prMaestro, $prHuman, $prMergeUp)
+$targetSet   = @($prHumanP0, $prMaestroP0, $prMergeP0, $prMaestro, $prHuman, $prMergeUp, $prHumanBump)
 $inflightSet = @($prInflightMaestro, $prInflightP0)
 
 $buckets = Get-CategorizedPullRequests -TargetPRs $targetSet -InflightPRs $inflightSet
@@ -4193,15 +4215,101 @@ Assert-Eq -Label "precedence: p/0 set includes the Maestro p/0 (#2)"       -Expe
 Assert-Eq -Label "precedence: p/0 set includes the merge-up p/0 (#3)"      -Expected $true -Actual ($bP0 -contains 3)
 Assert-Eq -Label "precedence: p/0 set EXCLUDES inflight p/0 (#8 never blocks)" -Expected $false -Actual ($bP0 -contains 8)
 Assert-Eq -Label "precedence: Maestro bucket excludes the p/0 Maestro (#2)" -Expected $false -Actual ($bMaestro -contains 2)
-Assert-Eq -Label "precedence: Maestro bucket = plain target + inflight Maestro" -Expected 2  -Actual $buckets.MaestroPRs.Count
-Assert-Eq -Label "precedence: Maestro bucket keeps the plain target Maestro (#4)" -Expected $true -Actual ($bMaestro -contains 4)
-Assert-Eq -Label "precedence: Maestro bucket keeps the inflight Maestro (#7)" -Expected $true -Actual ($bMaestro -contains 7)
+Assert-Eq -Label "precedence: dependency-flow bucket = target darc (#4) + human bump (#9)" -Expected 2  -Actual $buckets.MaestroPRs.Count
+Assert-Eq -Label "precedence: dependency-flow bucket keeps the plain target Maestro (#4)" -Expected $true -Actual ($bMaestro -contains 4)
+Assert-Eq -Label "precedence: dependency-flow bucket keeps the human component bump (#9)" -Expected $true -Actual ($bMaestro -contains 9)
+Assert-Eq -Label "precedence: human bump (#9) is NOT downgraded to generic release-branch PRs" -Expected $false -Actual ($bHuman -contains 9)
+Assert-Eq -Label "precedence: Maestro bucket EXCLUDES inflight Maestro (#7) — net<major>.0 bumps not reported" -Expected $false -Actual ($bMaestro -contains 7)
 Assert-Eq -Label "precedence: merge-up bucket excludes the p/0 merge-up (#3)" -Expected $false -Actual ($bMergeUp -contains 3)
 Assert-Eq -Label "precedence: merge-up bucket = only the plain merge-up (#6)" -Expected 1   -Actual $buckets.MergeUpPRs.Count
 Assert-Eq -Label "precedence: generic human = only the plain human (#5)"   -Expected 1     -Actual $buckets.TargetHumanPRs.Count
 Assert-Eq -Label "precedence: generic human keeps #5"                      -Expected $true -Actual ($bHuman -contains 5)
 Assert-Eq -Label "precedence: inflight-human = the inflight p/0 human (#8)" -Expected $true -Actual ($bInflight -contains 8)
 Assert-Eq -Label "precedence: inflight-human excludes inflight Maestro (#7)" -Expected $false -Actual ($bInflight -contains 7)
+# #7 (net<major>.0 Maestro) is now dropped from EVERY rendered bucket — a branched
+# preview reports only dependency bumps against its own branch.
+$bAll7 = @($bP0 + $bMaestro + $bMergeUp + $bHuman + $bInflight)
+Assert-Eq -Label "precedence: inflight Maestro (#7) appears in NO bucket" -Expected $false -Actual ($bAll7 -contains 7)
+
+# --- Test-IsDependencyFlowPr helper: dual-signal detection (author OR title/head) ---
+# A branched preview must surface human-authored component-bump PRs (like #36433)
+# alongside automated darc PRs, but must NOT swallow unrelated human PRs.
+$dfMaestro   = [PSCustomObject]@{ author = [PSCustomObject]@{ login = 'dotnet-maestro[bot]' }; title = 'Update dependencies'; headRefName = 'darc-net11.0-abc' }
+$dfHumanBump = [PSCustomObject]@{ author = [PSCustomObject]@{ login = 'rmarinho' }; title = '[release/11.0.1xx-preview6] Bump dotnet/dotnet (BAR 321614), dotnet/android (BAR 321622) and dotnet/macios (BAR 321780)'; headRefName = 'update-321614' }
+$dfHeadOnly  = [PSCustomObject]@{ author = [PSCustomObject]@{ login = 'rmarinho' }; title = 'Roll components forward'; headRefName = 'update-999' }
+$dfTitleOnly = [PSCustomObject]@{ author = [PSCustomObject]@{ login = 'rmarinho' }; title = 'Bump dotnet/android to latest BAR 321622'; headRefName = 'fix/roll' }
+$dfPlain     = [PSCustomObject]@{ author = [PSCustomObject]@{ login = 'someDev' }; title = 'Fix Y'; headRefName = 'fix/y' }
+$dfMergeUp   = [PSCustomObject]@{ author = [PSCustomObject]@{ login = 'someDev' }; title = "[automated] Merge branch 'main' => 'net11.0'"; headRefName = 'merge/main-to-net11.0' }
+Assert-Eq -Label "dep-flow helper: darc author → true"                       -Expected $true  -Actual (Test-IsDependencyFlowPr $dfMaestro)
+Assert-Eq -Label "dep-flow helper: human component bump (#36433 shape) → true" -Expected $true -Actual (Test-IsDependencyFlowPr $dfHumanBump)
+Assert-Eq -Label "dep-flow helper: head-ref update-<id> alone → true"         -Expected $true  -Actual (Test-IsDependencyFlowPr $dfHeadOnly)
+Assert-Eq -Label "dep-flow helper: title 'Bump dotnet/... BAR' alone → true"  -Expected $true  -Actual (Test-IsDependencyFlowPr $dfTitleOnly)
+Assert-Eq -Label "dep-flow helper: plain human 'Fix Y' → false"              -Expected $false -Actual (Test-IsDependencyFlowPr $dfPlain)
+Assert-Eq -Label "dep-flow helper: merge-up PR → false"                      -Expected $false -Actual (Test-IsDependencyFlowPr $dfMergeUp)
+Assert-Eq -Label "dep-flow helper: null PR → false"                          -Expected $false -Actual (Test-IsDependencyFlowPr $null)
+
+# --- Get-BranchComponentPins: git-pin fallback for the Action-owned best-effort
+#     component-build section. Parses eng/Version.Details.xml (public git, always
+#     readable in CI) to report the dotnet/dotnet, dotnet/android and dotnet/macios
+#     builds CURRENTLY BUNDLED on the branch. Covers the [xml] attribute-vs-child
+#     gotcha (Name/Version are attributes; Uri/Sha are child elements), the
+#     name-preference + Uri-fallback selection, and the unreadable-file → $null path.
+$fixtureVd = @'
+<?xml version="1.0" encoding="utf-8"?>
+<Dependencies>
+  <ProductDependencies>
+    <Dependency Name="Microsoft.NET.Sdk" Version="11.0.100-preview.6.26325.125">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26325.125">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="37.0.0-ci.main.51">
+      <Uri>https://github.com/dotnet/android</Uri>
+      <Sha>7ab8bac563839df778de1b91409cf4099cc76940</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.macOS.Sdk.net11.0_26.5" Version="26.5.11717-net11-p6">
+      <Uri>https://github.com/dotnet/macios</Uri>
+      <Sha>5bf7d00bec4a09ba623398bea41429ab1be795a1</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.iOS.Sdk.net11.0_26.5" Version="26.5.11717-net11-p6">
+      <Uri>https://github.com/dotnet/macios</Uri>
+      <Sha>5bf7d00bec4a09ba623398bea41429ab1be795a1</Sha>
+    </Dependency>
+  </ProductDependencies>
+</Dependencies>
+'@
+
+$script:_origGetContent = Get-Command Get-ContentFromRepo -CommandType Function -ErrorAction SilentlyContinue
+$script:_mockVdText = $fixtureVd
+function global:Get-ContentFromRepo {
+    param([string]$Path, [string]$Ref)
+    if ($Path -eq 'eng/Version.Details.xml') {
+        if ($script:_mockVdText -eq '__THROW__') { throw "boom" }
+        return $script:_mockVdText
+    }
+    return $null
+}
+try {
+    $pins = Get-BranchComponentPins -Ref 'release/11.0.1xx-preview6' -Major 11
+    Assert-Eq -Label "component-pins: object returned"          -Expected $true -Actual ($null -ne $pins)
+    Assert-Eq -Label "component-pins: VMR name = Microsoft.NET.Sdk (not Arcade)" -Expected 'Microsoft.NET.Sdk' -Actual $pins.Vmr.Name
+    Assert-Eq -Label "component-pins: VMR version"              -Expected '11.0.100-preview.6.26325.125' -Actual $pins.Vmr.Version
+    Assert-Eq -Label "component-pins: VMR sha"                  -Expected 'a512c3ad43185e96fc2c2769a4f02af689e3fb99' -Actual $pins.Vmr.Sha
+    Assert-Eq -Label "component-pins: Android version"         -Expected '37.0.0-ci.main.51' -Actual $pins.Android.Version
+    Assert-Eq -Label "component-pins: Android sha"             -Expected '7ab8bac563839df778de1b91409cf4099cc76940' -Actual $pins.Android.Sha
+    Assert-Eq -Label "component-pins: macios prefers net11.0 SDK" -Expected 'Microsoft.macOS.Sdk.net11.0_26.5' -Actual $pins.Macios.Name
+    Assert-Eq -Label "component-pins: macios version exact"    -Expected '26.5.11717-net11-p6' -Actual $pins.Macios.Version
+
+    # Unreadable Version.Details.xml (gh api throws) → $null, no crash.
+    $script:_mockVdText = '__THROW__'
+    $nullPins = Get-BranchComponentPins -Ref 'release/11.0.1xx-preview6' -Major 11
+    Assert-Eq -Label "component-pins: unreadable file → \$null (no throw)" -Expected $true -Actual ($null -eq $nullPins)
+} finally {
+    Remove-Item function:global:Get-ContentFromRepo -ErrorAction SilentlyContinue
+}
 
 # Inflight merge-up hoist (#36085 scenario): a main → net<N>.0 automated merge PR
 # (base = inflight branch) must be carved into the merge-up bucket — hoisted to
@@ -4238,14 +4346,26 @@ $nullFromGh    = ConvertFrom-JsonOrEmptyArray '[]'   # AutomationNull, exactly l
 $maestroPrMock = [PSCustomObject]@{ number = 9001; title = 'Bump deps'; author = [PSCustomObject]@{ login = 'dotnet-maestro' }; headRefName = 'darc-x'; labels = @(); url = 'u'; isDraft = $false }
 
 # (a) The reachable in-flight shape: AutomationNull target (existing branch, 0 PRs)
-#     + non-empty inflight Maestro list. Must not throw; Maestro PR still counted.
+#     + non-empty inflight Maestro list. Must not throw. A branched preview reports
+#     ONLY its own-branch dependency bumps, so the inflight (net<major>.0) Maestro
+#     PR is DROPPED from every bucket — it belongs to net<major>.0's own readiness.
 $nullTargetThrew = $false
 $nullTargetBuckets = $null
 try { $nullTargetBuckets = Get-CategorizedPullRequests -TargetPRs $nullFromGh -InflightPRs @($maestroPrMock) }
 catch { $nullTargetThrew = $true }
 Assert-Eq -Label "AutomationNull target + inflight Maestro → no throw" -Expected $false -Actual $nullTargetThrew
 Assert-Eq -Label "AutomationNull target → 0 target-human"             -Expected 0     -Actual $nullTargetBuckets.TargetHumanPRs.Count
-Assert-Eq -Label "AutomationNull target → inflight Maestro counted"   -Expected 1     -Actual $nullTargetBuckets.MaestroPRs.Count
+Assert-Eq -Label "AutomationNull target → inflight Maestro DROPPED (target-only)" -Expected 0 -Actual $nullTargetBuckets.MaestroPRs.Count
+
+# (a2) Positive iteration path: a non-null TARGET Maestro PR still buckets as Maestro
+#      even when the inflight slot collapses to AutomationNull (proves the null-safety
+#      guard doesn't suppress real bucketing on the surviving list).
+$nullInflightThrew = $false
+$nullInflightBuckets = $null
+try { $nullInflightBuckets = Get-CategorizedPullRequests -TargetPRs @($maestroPrMock) -InflightPRs $nullFromGh }
+catch { $nullInflightThrew = $true }
+Assert-Eq -Label "AutomationNull inflight + target Maestro → no throw" -Expected $false -Actual $nullInflightThrew
+Assert-Eq -Label "AutomationNull inflight → target Maestro counted"    -Expected 1     -Actual $nullInflightBuckets.MaestroPRs.Count
 
 # (b) Both inputs AutomationNull → five empty buckets, no throw.
 $bothNullThrew = $false

--- a/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
+++ b/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
@@ -4445,6 +4445,27 @@ if (-not (Test-Path -LiteralPath $gateScript)) {
     Assert-Eq -Label "jsonc: empty input returned unchanged" -Expected '' -Actual (Remove-JsoncComments '')
 }
 
+# --- Access-gate dot-source guard: must skip the gate body (no RELEASE_TRACKER_STATUS,
+#     no exit) ONLY when dot-sourced, and must NOT wrongly skip a real `&` invocation
+#     that follows a dot-source on the same command line. Regression guard for the
+#     fragile `$MyInvocation.Line -match '^\.\s'` fallback (would suppress the second
+#     call because the whole command-line text starts with the earlier dot-source).
+Write-Host "`n[Unit] Access-gate dot-source guard (line-match false-skip regression)" -ForegroundColor Cyan
+if (-not (Test-Path -LiteralPath $gateScript)) {
+    Assert-Eq -Label "guard: access-gate script exists" -Expected $true -Actual $false
+} else {
+    # Pure dot-source: the gate body must NOT run (no status line emitted).
+    $dotOnly = & pwsh -NoProfile -Command ". '$gateScript'; 'DOT-DONE'" 2>$null
+    Assert-Eq -Label "guard: pure dot-source does not run the gate (no status line)" `
+        -Expected $false -Actual ([bool](($dotOnly -join "`n") -match 'RELEASE_TRACKER_STATUS='))
+
+    # Dot-source THEN a real `&` invocation on the SAME command line: the `&` call
+    # MUST run the gate and emit a status line. The old fallback wrongly skipped it.
+    $dotThenCall = & pwsh -NoProfile -Command ". '$gateScript'; & '$gateScript'" 2>$null
+    Assert-Eq -Label "guard: `& call after dot-source still runs the gate (emits status)" `
+        -Expected $true -Actual ([bool](($dotThenCall -join "`n") -match 'RELEASE_TRACKER_STATUS='))
+}
+
 # --- Get-BranchComponentPins: git-pin fallback for the Action-owned best-effort
 #     component-build section. Parses eng/Version.Details.xml (public git, always
 #     readable in CI) to report the dotnet/dotnet, dotnet/android and dotnet/macios

--- a/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
+++ b/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
@@ -4445,25 +4445,47 @@ if (-not (Test-Path -LiteralPath $gateScript)) {
     Assert-Eq -Label "jsonc: empty input returned unchanged" -Expected '' -Actual (Remove-JsoncComments '')
 }
 
-# --- Access-gate dot-source guard: must skip the gate body (no RELEASE_TRACKER_STATUS,
-#     no exit) ONLY when dot-sourced, and must NOT wrongly skip a real `&` invocation
-#     that follows a dot-source on the same command line. Regression guard for the
-#     fragile `$MyInvocation.Line -match '^\.\s'` fallback (would suppress the second
-#     call because the whole command-line text starts with the earlier dot-source).
+# --- Access-gate dot-source guard: must skip the driver body (return before any
+#     side effect / exit) ONLY when dot-sourced, and must NOT wrongly skip a real
+#     `&`/`-File` invocation that follows a dot-source on the same command line.
+#     Regression guard for the fragile `$MyInvocation.Line -match '^\.\s'` fallback
+#     (would suppress the second call because the whole command-line text starts
+#     with the earlier dot-source).
+#     Hermetic: builds a throwaway fixture from the REAL guard line (read out of the
+#     gate script, so this test cannot drift from it) plus a sentinel, then exercises
+#     the exact guard semantics with NO `gh`/network dependency. The fixture path is
+#     passed through an env var (not string-interpolated) so paths with spaces or
+#     apostrophes are safe.
 Write-Host "`n[Unit] Access-gate dot-source guard (line-match false-skip regression)" -ForegroundColor Cyan
 if (-not (Test-Path -LiteralPath $gateScript)) {
     Assert-Eq -Label "guard: access-gate script exists" -Expected $true -Actual $false
 } else {
-    # Pure dot-source: the gate body must NOT run (no status line emitted).
-    $dotOnly = & pwsh -NoProfile -Command ". '$gateScript'; 'DOT-DONE'" 2>$null
-    Assert-Eq -Label "guard: pure dot-source does not run the gate (no status line)" `
-        -Expected $false -Actual ([bool](($dotOnly -join "`n") -match 'RELEASE_TRACKER_STATUS='))
+    $guardLine = @(Get-Content -LiteralPath $gateScript |
+        Where-Object { $_ -match "^\s*if \(\`$MyInvocation\.InvocationName -eq '\.'" }) |
+        Select-Object -First 1
+    if (-not $guardLine) {
+        Assert-Eq -Label "guard: real dot-source guard line located in gate script" -Expected $true -Actual $false
+    } else {
+        $guardFixture = Join-Path ([System.IO.Path]::GetTempPath()) ('rr_guard_{0}.ps1' -f [guid]::NewGuid().ToString('N'))
+        Set-Content -LiteralPath $guardFixture -Value ($guardLine + "`n'GUARD_SENTINEL_RAN'")
+        $env:RR_GUARD_FIXTURE = $guardFixture
+        try {
+            # (a) Pure dot-source: the guard returns before the sentinel → sentinel absent.
+            $dotOnly = & pwsh -NoProfile -Command '. $env:RR_GUARD_FIXTURE; "DONE"' 2>$null
+            Assert-Eq -Label "guard: pure dot-source skips the body (no sentinel)" `
+                -Expected $false -Actual ([bool](($dotOnly -join "`n") -match 'GUARD_SENTINEL_RAN'))
 
-    # Dot-source THEN a real `&` invocation on the SAME command line: the `&` call
-    # MUST run the gate and emit a status line. The old fallback wrongly skipped it.
-    $dotThenCall = & pwsh -NoProfile -Command ". '$gateScript'; & '$gateScript'" 2>$null
-    Assert-Eq -Label "guard: `& call after dot-source still runs the gate (emits status)" `
-        -Expected $true -Actual ([bool](($dotThenCall -join "`n") -match 'RELEASE_TRACKER_STATUS='))
+            # (b) Dot-source THEN a real `&` call on the SAME command line: the `&` call
+            #     must run the body → sentinel present. The old fallback wrongly skipped it
+            #     (verified: restoring the `-or ... -match '^\.\s'` form flips this to absent).
+            $dotThenCall = & pwsh -NoProfile -Command '. $env:RR_GUARD_FIXTURE; & $env:RR_GUARD_FIXTURE' 2>$null
+            Assert-Eq -Label "guard: `& call after dot-source still runs the body (sentinel present)" `
+                -Expected $true -Actual ([bool](($dotThenCall -join "`n") -match 'GUARD_SENTINEL_RAN'))
+        } finally {
+            Remove-Item -LiteralPath $guardFixture -Force -ErrorAction SilentlyContinue
+            Remove-Item Env:\RR_GUARD_FIXTURE -ErrorAction SilentlyContinue
+        }
+    }
 }
 
 # --- Get-BranchComponentPins: git-pin fallback for the Action-owned best-effort


### PR DESCRIPTION
&lt;!-- Please let the below note in for people that find this PR --&gt;
&gt; [!NOTE]
&gt; Are you waiting for the changes in this PR to be merged?
&gt; It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### What

Makes the local ask **"run release readiness skill to see if net11 preview6 is ready"** consult the *authoritative* official-preview build **and** verify the preview branch is actually ship-wired — not just public CI/regression health. Three files:

**1. `release-readiness/SKILL.md` — net-new bridge (the star of this PR).**
A new **Preview: authoritative blessed-build source** subsection so the `release-readiness` skill, after its public survey, runs the access gate and — when the caller has access **and** the plugin is enabled — invokes the private **`dotnet-release-tracker`** plugin for the blessed build / BAR id + stage, then combines that with the CI/regression verdict. It branches on the gate token (`AVAILABLE_ENABLED` → use the plugin; `AVAILABLE_NOT_ENABLED` → offer the opt-in; `ACCESS_ON_INACTIVE_ACCOUNT` → advise an account switch; `NO_ACCESS` → **public-feed fallback**: report the latest build on the public Preview N channel as a *labeled candidate* that may not be the official/blessed build, without naming the private tool) and adds a **"Blessed ≠ green"** caveat so the blessed build never masks open `regressed-in-*` blockers. DRY — it cross-references dependency-flow's tier table / opt-in / guardrails rather than duplicating them.

**2. `dependency-flow/` gate — evolves the version already merged in #36268.**
The deterministic classifier `scripts/Get-PreviewReleaseReadiness.ps1` emits:

```
RELEASE_TRACKER_STATUS = NO_ACCESS | ACCESS_ON_INACTIVE_ACCOUNT | AVAILABLE_NOT_ENABLED | AVAILABLE_ENABLED
```

It checks (1) GitHub read access to the private marketplace repo that hosts the internal **.NET Release Tracker** plugin and (2) whether that plugin is enabled locally. It fetches **no** release data and always exits `0`. This PR carries improvements over the version on `main`:

- **JSONC-tolerant** enabled-plugin parser — the strict `ConvertFrom-Json` on `main` chokes on the `//`-commented opt-in snippet the skill itself documents;
- `$USERPROFILE` support (Windows user scope) alongside `$HOME`;
- **multi-account advisory** — when the active `gh` identity can't read the repo but a logged-in *inactive* account can, the gate emits `ACCESS_ON_INACTIVE_ACCOUNT` and advises `gh auth switch --user <account>` instead of a false-positive `AVAILABLE` (the plugin loads under the *active* identity). Only fires when access is confirmed on some account, so a true no-access caller still gets a silent `NO_ACCESS`;
- `-ReleaseRepo` / `-PluginId` / `-Json` parameters and a public-safe `.NOTES` contract;
- try/catch hardening so an unexpected terminating error still emits the safe `NO_ACCESS` default;
- the *"why a special source"* / Preview 6 (#35364) trap prose in `SKILL.md`.

&gt; **Relationship to #36268.** #36268 ("public-safe preview release readiness gate") already merged the first version of this gate. This PR is a **forward-evolution** of those two files, **plus** the net-new release-readiness bridge — it does **not** revert any shipped behavior. In particular the plugin opt-in stays **user-scope only** (`~/.copilot/settings.json`); there is no committable project-scope enablement, so forks and no-access users are never silently opted in. The "comment-only on GitHub" guardrail is retained.

**3. Preview wiring checks — subscriptions + feed drift + component pins (net-new).**
A preview can pass CI and even have a blessed build yet still not be *ship-wired*. Three **public** (BAR/Maestro + git) checks close that gap:

- **Check A — subscriptions wired?** Confirm `release/11.0.1xx-previewN` has its default-channel mapping **and** the baseline three subs (android + macios + dotnet on `.NET 11.0.1xx SDK Preview N`). Branch cut + default-channel present but **zero subs** = a start-of-preview flow gap → surfaced as an **FYI note** (not a ship blocker); the skill still knows how to remediate via the existing **combined-PR pattern** (DRY, honoring its confirm/draft-PR gate).
- **Check B — feed matches the branch?** Compare the latest build promoted to the `.NET 11.0.1xx SDK Preview N` channel (`maestro_latest_build`) against `origin/release/11.0.1xx-previewN` HEAD. Branch ahead of the promoted build = stale feed → flag.
- **Check C — component pins coherent?** Report which `dotnet/android`, `dotnet/macios`, and `dotnet/dotnet` (VMR) builds MAUI bundles (version + SHA from `eng/Version.Details.xml`) and confirm they **match the inflight `netN.0` branch the preview was cut from**. Match = clean cut ✅; divergence or an off-band pin (macios/dotnet missing the `-net11-pN`/`preview.N` stamp) → flag. The `.NET Release Tracker` exposes **only** SDK/runtime-level data, so there is **no** "blessed" per-component android/macios build to look up — this is git+BAR only. "Behind the latest component build" is *expected* for a cut branch (don't flag it); android's `-ci.main.NN` scheme is normal for net11 and validated against inflight rather than alarmed on.

Mechanics (exact MCP/`darc`/git commands, interpretation tables, remediation, and **live net11 Preview 6 worked examples**) live in a new **"Wiring checks: is Preview N actually plumbed?"** subsection (Checks A/B/C) in `dependency-flow/SKILL.md` (its Maestro/subscription domain); `release-readiness/SKILL.md` gets a short orchestration hook that cross-references it and folds the results into the preview report.

**4. Preview generator — scope Maestro PRs to the target branch (net-new bug fix).**
`scripts/Get-PreviewReadiness.ps1` (the deterministic generator the GitHub Action runs to author the `[Release Readiness]` preview tracker, e.g. #35866) was listing Maestro / dependency-flow PRs that target `netN.0` (the **inflight** branch) inside the preview tracker's own "Maestro / dependency-flow PRs" section. Once a preview is **branched**, those `netN.0` bumps belong to the inflight branch's own readiness, not the preview tracker. `Get-CategorizedPullRequests` now computes the Maestro bucket from `$TargetPRs` (the survey ref) **only** instead of target + inflight, so `netN.0` (inflight) Maestro PRs land in no rendered bucket and are intentionally dropped from a branched preview tracker. Non-Maestro inflight PRs still surface unchanged in the Inflight-human bucket. In **candidate** mode the survey ref *is* `netN.0` and the inflight list is empty, so target-only is correct there too. Unit tests (`tests/Test-ReleaseReadiness.ps1`, precedence + AutomationNull null-safety) updated to assert target-only scoping, including a new assertion that an inflight Maestro PR appears in no bucket.

**5. Surface human-authored dependency-bump PRs in High-priority items + drift-proof SR E2E tests (net-new).**
Two follow-ups in `scripts/Get-PreviewReadiness.ps1`:

- **Dependency-bump detection was author-only.** The component-bump PR that *is* the release (e.g. #36433 — `rmarinho`, "Bump dotnet/dotnet (BAR 321614), dotnet/android (BAR 321622) and dotnet/macios (BAR 321780)", head `update-321614`, no labels) was authored by a human, so the old `-match "dotnet-maestro"` author filters missed it and it fell into the generic release-branch bucket instead of **High-priority items**. A new `Test-IsDependencyFlowPr` helper now flags a PR as dependency-flow if it matches *any* of: `dotnet-maestro` author **OR** a `Bump dotnet/(dotnet|android|macios|runtime|sdk|…) … (BAR NNN)` title **OR** an `update-<id>` head ref. The three maestro bucket filters were rewired to use it, and the high-priority row kind was renamed `📦 Maestro PR` → `📦 Dependency-flow PR`. Merge-up PRs (`[automated] Merge branch …`, head `merge/…`) are intentionally *not* matched.
- **Human-notes block repositioned.** The blessed-build / wiring / component-pin notes now render directly under **High-priority items** (previously below the Target section), so the authoritative-build context sits next to the items it qualifies.
- **Drift-proof SR E2E tests.** The end-to-end tests in `tests/Test-ReleaseReadiness.ps1` run the *real* detector against the live repo and had pinned a specific SR as the not-yet-cut candidate; when that SR shipped/cut the fixtures rotted (7 stale failures). They now **derive** the in-flight/candidate split structurally from the detector output (≥1 SR, exactly one candidate numbered one past the highest in-flight SR, clean partition, regression-label formula mirrored from `New-RegressionLabelList`), so they survive every future SR cut/ship without a per-cut edit.

**6. Action-owned best-effort component-build section (net-new).**
The authoritative *blessed* build lives in the private **.NET Release Tracker** (`dotnet/release`), which the GitHub Action's repo-scoped `GITHUB_TOKEN` **cannot** reach — so on an automated run that row can only come from a maintainer's local notes (spliced into the preserved human-notes block). To give the Action *something* to say on its own, `scripts/Get-PreviewReadiness.ps1` now emits a **best-effort** component-build section sourced from the branch's own `eng/Version.Details.xml` (a **public** git source always readable in CI). A new `Get-BranchComponentPins` reads the `dotnet/dotnet` (VMR/SDK), `dotnet/android` and `dotnet/macios` anchor pins (version + commit SHA) and renders a `🏷️ Preview N component build — branch pins (best-effort)` table. It is **explicitly labeled NOT a confirmed blessed build** — it reports what's *currently bundled on the branch* and points maintainers to the **Release Captain Notes** block (filled locally with tracker access) for the authoritative designation. The section renders **outside** the human-notes markers so it **self-refreshes** on every automated re-run (verified: after #36433 merged, the pins advanced to the post-bump build automatically), and it surfaces an open component-bump PR (e.g. #36433) as a *pending advance* when one is still open. `Get-BranchComponentPins` handles the `[xml]` attribute-vs-child gotcha (`Name`/`Version` are attributes; `Uri`/`Sha` are child elements), prefers the most representative dependency name per repo with a `Uri`-based fallback, and returns `$null` (no throw) when the file can't be read/parsed. Adds 9 unit assertions. Full suite: **794 passed / 0 failed**.

### Why

During the Preview 6 cycle (see #35364), two same-band VMR builds (e.g. `…26325.125` vs `…26326.122`) looked interchangeable. Public BAR/Maestro data can enumerate candidate builds but **cannot, on its own, identify which staged build releases.dot.net has *blessed* as the official preview**. That authoritative signal lives in the internal release tracker. This change lets developers *with access* get the authoritative answer automatically from the `release-readiness` skill, while developers *without access* fall back to the **public preview-feed candidate** — the latest build promoted to the public Preview N channel, explicitly labeled as possibly-not-the-official build — with the private *tool* never named or implied. The wiring checks add the complementary *"is the branch even receiving flow, and is its feed current?"* signal — validated live: net11 Preview 6 is branched with a promoted build **but has no subscriptions authored yet** (Preview 5's set was never rolled forward), exactly the gap Check A surfaces (as an FYI).

### Privacy / safety

The plugin is **double-gated** (GitHub read access to load it + an authorized Azure AD identity to pull data), so referencing it from this public repo is safe. The change deliberately:

- contains **no** Azure AD resource ids / `api://…` audiences, backend hostnames, or internal endpoint paths — only the sanctioned *marketplace pointer* (repo name + plugin name);
- performs **no** fetch-and-exec of remote code;
- defaults to `NO_ACCESS` for any unconfirmed-access case, so the agent **never** reveals the private plugin *tool* to users who can't use it — the NO_ACCESS path now emits an honest, public-source-labeled preview-feed candidate (public data), which reveals nothing about the gated tooling — the multi-account advisory only fires when access is *confirmed* on some logged-in account, and never prints a token;
- keeps the opt-in **user-scope** (personal `~/.copilot/settings.json`), so forks and no-access users are unaffected;
- the wiring checks read only **public** BAR/Maestro + git data and never mutate config — remediation is opt-in and routes through the documented confirm/draft-PR gate.

### Testing

`scripts/Get-PreviewReleaseReadiness.ps1` was exercised across all states locally with `pwsh` (token **and** `-Json` forms):

| Scenario | Result |
|----------|--------|
| Real access probe (`dotnet/release`), plugin enabled in `~/.copilot/settings.json` (JSONC w/ comments) | `AVAILABLE_ENABLED`, exit 0 |
| Real access probe, plugin not enabled | `AVAILABLE_NOT_ENABLED`, exit 0 |
| Active identity lacks access, but a logged-in inactive account has it | `ACCESS_ON_INACTIVE_ACCOUNT` + `gh auth switch --user &lt;account&gt;` advice, exit 0 (and `GH_TOKEN` restored after probing) |
| Same user settings with `: false` | `AVAILABLE_NOT_ENABLED` (correctly not matched), exit 0 |
| Nonexistent repo (no account can read) | `NO_ACCESS`, exit 0 |

The wiring checks (items **3A/3B**) were validated against **live Maestro/BAR + git** for net11 Preview 6: `maestro_subscriptions(targetBranch="release/11.0.1xx-preview6")` → **0 rows** (FYI note correctly surfaced); `maestro_latest_build(".NET 11.0.1xx SDK Preview 6")` → build #321033 @ `6e35dc58d0` == branch HEAD (feed current); Check C (component pins) → dotnet/dotnet `11.0.0-preview.6.26325.125`, dotnet/macios `26.5.11717-net11-p6`, dotnet/android `37.0.0-ci.main.51` all **byte-identical to `net11.0` HEAD** = clean cut.

The **Action-owned best-effort component section** (item **6**) is unit-tested (9 assertions over `Get-BranchComponentPins`: parse correctness, name preference, `[xml]` attribute/child handling, unreadable-file → `$null`) and validated end-to-end by dispatching the real GitHub Action against this PR branch — the section rendered on #35866 sourced purely from `eng/Version.Details.xml` and self-refreshed to the post-#36433 pins with no local tracker access. Full suite: **794 passed / 0 failed**. Docs/skill-only change — no product code or public API is affected.