### PR TITLE
[Android] Fix status bar icon contrast with custom colorPrimary

### DIFF
--- a/src/Core/src/Platform/Android/WindowExtensions.cs
+++ b/src/Core/src/Platform/Android/WindowExtensions.cs
@@ -2,9 +2,9 @@
 using Android.Content;
 using Android.Content.Res;
 using Android.Views;
+using AndroidX.Core.Graphics;
 using AndroidX.Core.View;
 using AColor = Android.Graphics.Color;
-using AndroidX.Core.Graphics;
 using Microsoft.Maui.Devices;
 using Microsoft.Maui.Platform;
 
@@ -52,36 +52,42 @@ namespace Microsoft.Maui
 				return;
 			}
 
-			// Set appropriate system bar appearance for readability using API 30+ methods
 			var windowInsetsController = WindowCompat.GetInsetsController(window, window.DecorView);
 			if (windowInsetsController is not null)
 			{
-				// Automatically adjust icon/text colors based on app theme
 				var configuration = activity.Resources?.Configuration;
 				var isLightTheme = configuration is null ||
 					(configuration.UiMode & UiMode.NightMask) != UiMode.NightYes;
 
-				// Use white as the fallback so light-theme apps keep dark status bar icons
-				// if the theme color cannot be resolved. The fallback is defensive; Android
-				// themes should normally resolve colorPrimary.
-				var statusBarColor = GetThemeColor(activity, global::Android.Resource.Attribute.ColorPrimary, AColor.White);
-				
-				windowInsetsController.AppearanceLightStatusBars = IsLightColor(statusBarColor);
+				// Resolve the actual status bar background color from the current theme and
+				// choose icon/text appearance based on its luminance. If the theme color cannot
+				// be resolved, preserve the previous theme-based behavior.
+				if (TryGetThemeColor(activity, global::Android.Resource.Attribute.ColorPrimary, out var statusBarColor))
+					windowInsetsController.AppearanceLightStatusBars = IsLightColor(statusBarColor);
+				else
+					windowInsetsController.AppearanceLightStatusBars = isLightTheme;
+
 				windowInsetsController.AppearanceLightNavigationBars = isLightTheme;
 			}
 		}
 
-		static AColor GetThemeColor(Activity activity, int attribute, AColor fallback)
+		static bool TryGetThemeColor(Activity activity, int attribute, out AColor color)
 		{
+			color = default;
+
 			if (activity.Theme is null)
-				return fallback;
+				return false;
 
 			using var ta = activity.Theme.ObtainStyledAttributes([attribute]);
 
-			return new AColor(ta.GetColor(0, fallback.ToArgb()));
+			if (!ta.HasValue(0))
+				return false;
+
+			color = new AColor(ta.GetColor(0, 0));
+			return true;
 		}
 
-		static bool IsLightColor(AColor color)
-	=> AndroidX.Core.Graphics.ColorUtils.CalculateLuminance(color.ToArgb()) > 0.5;
+		static bool IsLightColor(AColor color) =>
+			ColorUtils.CalculateLuminance(color.ToArgb()) > 0.5;
 	}
 }

--- a/src/Core/src/Platform/Android/WindowExtensions.cs
+++ b/src/Core/src/Platform/Android/WindowExtensions.cs
@@ -4,6 +4,7 @@ using Android.Content.Res;
 using Android.Views;
 using AndroidX.Core.View;
 using AColor = Android.Graphics.Color;
+using AndroidX.Core.Graphics;
 using Microsoft.Maui.Devices;
 using Microsoft.Maui.Platform;
 
@@ -60,8 +61,11 @@ namespace Microsoft.Maui
 				var isLightTheme = configuration is null ||
 					(configuration.UiMode & UiMode.NightMask) != UiMode.NightYes;
 
-				var statusBarColor = GetThemeColor(activity, global::Android.Resource.Attribute.ColorPrimary, new AColor(window.StatusBarColor));
-
+				// Use white as the fallback so light-theme apps keep dark status bar icons
+				// if the theme color cannot be resolved. The fallback is defensive; Android
+				// themes should normally resolve colorPrimary.
+				var statusBarColor = GetThemeColor(activity, global::Android.Resource.Attribute.ColorPrimary, AColor.White);
+				
 				windowInsetsController.AppearanceLightStatusBars = IsLightColor(statusBarColor);
 				windowInsetsController.AppearanceLightNavigationBars = isLightTheme;
 			}
@@ -78,9 +82,6 @@ namespace Microsoft.Maui
 		}
 
 		static bool IsLightColor(AColor color)
-		{
-			var luminance = (0.299 * color.R + 0.587 * color.G + 0.114 * color.B) / 255;
-			return luminance > 0.5;
-		}
+	=> AndroidX.Core.Graphics.ColorUtils.CalculateLuminance(color.ToArgb()) > 0.5;
 	}
 }

--- a/src/Core/src/Platform/Android/WindowExtensions.cs
+++ b/src/Core/src/Platform/Android/WindowExtensions.cs
@@ -3,6 +3,7 @@ using Android.Content;
 using Android.Content.Res;
 using Android.Views;
 using AndroidX.Core.View;
+using AColor = Android.Graphics.Color;
 using Microsoft.Maui.Devices;
 using Microsoft.Maui.Platform;
 
@@ -59,9 +60,29 @@ namespace Microsoft.Maui
 				var isLightTheme = configuration is null ||
 					(configuration.UiMode & UiMode.NightMask) != UiMode.NightYes;
 
-				windowInsetsController.AppearanceLightStatusBars = isLightTheme;
+				var statusBarColor = GetThemeColor(activity, global::Android.Resource.Attribute.ColorPrimary, new AColor(window.StatusBarColor));
+
+				windowInsetsController.AppearanceLightStatusBars = IsLightColor(statusBarColor);
 				windowInsetsController.AppearanceLightNavigationBars = isLightTheme;
 			}
+		}
+
+		static AColor GetThemeColor(Activity activity, int attribute, AColor fallback)
+		{
+			var typedValue = new global::Android.Util.TypedValue();
+
+			if (activity.Theme?.ResolveAttribute(attribute, typedValue, true) == true)
+			{
+				return new AColor(typedValue.Data);
+			}
+
+			return fallback;
+		}
+
+		static bool IsLightColor(AColor color)
+		{
+			var luminance = (0.299 * color.R + 0.587 * color.G + 0.114 * color.B) / 255;
+			return luminance > 0.5;
 		}
 	}
 }

--- a/src/Core/src/Platform/Android/WindowExtensions.cs
+++ b/src/Core/src/Platform/Android/WindowExtensions.cs
@@ -69,14 +69,12 @@ namespace Microsoft.Maui
 
 		static AColor GetThemeColor(Activity activity, int attribute, AColor fallback)
 		{
-			var typedValue = new global::Android.Util.TypedValue();
+			if (activity.Theme is null)
+				return fallback;
 
-			if (activity.Theme?.ResolveAttribute(attribute, typedValue, true) == true)
-			{
-				return new AColor(typedValue.Data);
-			}
+			using var ta = activity.Theme.ObtainStyledAttributes([attribute]);
 
-			return fallback;
+			return new AColor(ta.GetColor(0, fallback.ToArgb()));
 		}
 
 		static bool IsLightColor(AColor color)


### PR DESCRIPTION
### Description of Change

Fixes Android status bar icon contrast when `colorPrimary` is customized to a dark or light color.

Previously, MAUI configured `AppearanceLightStatusBars` based only on the current app theme. In a light theme with a dark `colorPrimary`, this caused Android to render dark status bar icons over a dark status bar, making the status bar unreadable.

This change resolves the effective `colorPrimary` from the current Android theme and uses its luminance to decide whether light or dark status bar icons should be used.

### Issues Fixed

Fixes #32987

### Testing

Manually validated on Android with:

- `colorPrimary = #000000` → status bar icons are light/readable
- `colorPrimary = #512BD4` → existing behavior remains readable
- `colorPrimary = #FFFFFF` → status bar icons are dark/readable