### PR TITLE
[Android] Enable native edge-to-edge and fix dynamic system bar icon colors

### DIFF
--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Threading.Tasks;
 using Android.Content;
+using Android.Content.Res;
 using Android.Graphics.Drawables;
 using Android.OS;
 using Android.Views;
@@ -266,8 +267,30 @@ namespace Microsoft.Maui.Controls.Platform
 				// activity's WindowCompat.EnableEdgeToEdge configuration, so it must be applied here.
 				WindowCompat.EnableEdgeToEdge(dialog.Window);
 
+				// EnableEdgeToEdge handles transparency/scrim but not bar icon colors; apply those
+				// from the app theme so the modal's status/navigation bar icons match the main window.
+				var modalActivity = Context?.GetActivity();
+				if (modalActivity is not null)
+				{
+					dialog.Window.ConfigureTranslucentSystemBars(modalActivity);
+				}
 
 				return dialog;
+			}
+
+			public override void OnConfigurationChanged(Configuration newConfig)
+			{
+				base.OnConfigurationChanged(newConfig);
+
+				// Re-apply system bar icon colors to the modal's own Dialog window on a theme
+				// (light/dark) change. The Dialog is a separate Window that OnCreateDialog configures
+				// once; like the activity, it must be re-applied here so the modal's status/navigation
+				// bar icons track the theme. EnableEdgeToEdge handles transparency/scrim, not icon colors.
+				var modalActivity = Context?.GetActivity();
+				if (Dialog?.Window is { } dialogWindow && modalActivity is not null)
+				{
+					dialogWindow.ConfigureTranslucentSystemBars(modalActivity);
+				}
 			}
 
 			void OnPageHandlerChanged(object? sender, EventArgs e)

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
@@ -261,21 +261,10 @@ namespace Microsoft.Maui.Controls.Platform
 					dialog.Window.SetSoftInputMode(attributes.SoftInputMode);
 				}
 
-				// Configure translucent system bars for modal pages on Android API 30+
-				if (OperatingSystem.IsAndroidVersionAtLeast(30) && Context?.GetActivity() is global::Android.App.Activity activity)
-				{
-					dialog.Window.ConfigureTranslucentSystemBars(activity);
-				}
-				else if (mainActivityWindow is not null)
-				{
-					// Fallback for API < 30: Apply legacy translucent behavior
-					var navigationBarColor = mainActivityWindow.NavigationBarColor;
-					var statusBarColor = mainActivityWindow.StatusBarColor;
-#pragma warning disable CA1422
-					dialog.Window.SetNavigationBarColor(new AColor(navigationBarColor));
-					dialog.Window.SetStatusBarColor(new AColor(statusBarColor));
-#pragma warning restore CA1422
-				}
+				// Enable edge-to-edge on the modal's own Window so its system bars match the
+				// main window. The modal Dialog has a separate Window that does not inherit the
+				// activity's WindowCompat.EnableEdgeToEdge configuration, so it must be applied here.
+				WindowCompat.EnableEdgeToEdge(dialog.Window);
 
 
 				return dialog;

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue32987.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue32987.cs
@@ -75,11 +75,19 @@ class Issue32987BarStatePage : ContentPage
 		if (window is null)
 			return;
 
-#pragma warning disable CA1422 // StatusBarColor/NavigationBarColor getters are deprecated on API 35+ but still report the current value
-		var statusArgb = (uint)window.StatusBarColor;
-		var navArgb = (uint)window.NavigationBarColor;
-#pragma warning restore CA1422
-		bool barsTransparent = (statusArgb >> 24) == 0 && (navArgb >> 24) == 0; // alpha channel == 0
+		// API 35+ enforces edge-to-edge, so the bars are always transparent there. Below 35 the color
+		// getters (not deprecated on those versions) report the actual bar color.
+		bool barsTransparent;
+		if (OperatingSystem.IsAndroidVersionAtLeast(35))
+		{
+			barsTransparent = true;
+		}
+		else
+		{
+			var statusArgb = (uint)window.StatusBarColor;
+			var navArgb = (uint)window.NavigationBarColor;
+			barsTransparent = (statusArgb >> 24) == 0 && (navArgb >> 24) == 0; // alpha channel == 0
+		}
 
 		bool navScrim = OperatingSystem.IsAndroidVersionAtLeast(29) && window.NavigationBarContrastEnforced;
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue32987.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue32987.cs
@@ -1,0 +1,109 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 32987, "Android edge-to-edge: system bars are transparent, the 3-button navigation scrim is removed, and status bar icons follow the app theme", PlatformAffected.Android)]
+public class Issue32987 : NavigationPage
+{
+	public Issue32987() : base(new Issue32987BarStatePage())
+	{
+	}
+}
+
+// Surfaces the Android Window's edge-to-edge state in labels so the Appium test can assert it,
+// since Appium cannot read window flags/colors directly.
+class Issue32987BarStatePage : ContentPage
+{
+	readonly Label _barsTransparent = new() { AutomationId = "BarTransparentValue" };
+	readonly Label _navScrim = new() { AutomationId = "NavScrimValue" };
+	readonly Label _lightIcons = new() { AutomationId = "LightIconsValue" };
+	readonly Label _theme = new() { AutomationId = "ThemeValue" };
+
+	// Invisible markers the test waits on; set in the same pass as the values so they are consistent
+	// when a marker appears. An IsVisible=false element is absent from the tree until made visible.
+	readonly Label _ready = new() { AutomationId = "BarStateReady", IsVisible = false };
+	readonly Label _themeIsLight = new() { AutomationId = "ThemeIsLight", IsVisible = false };
+	readonly Label _themeIsDark = new() { AutomationId = "ThemeIsDark", IsVisible = false };
+
+	public Issue32987BarStatePage()
+	{
+		Title = "Issue 32987";
+
+		Content = new VerticalStackLayout
+		{
+			Padding = new Thickness(20),
+			Spacing = 10,
+			Children =
+			{
+				LabeledRow("Bars transparent:", _barsTransparent),
+				LabeledRow("Nav scrim enforced:", _navScrim),
+				LabeledRow("Status bar light-appearance icons:", _lightIcons),
+				LabeledRow("App theme:", _theme),
+				_ready,
+				_themeIsLight,
+				_themeIsDark,
+			},
+		};
+
+		Application.Current!.RequestedThemeChanged += OnRequestedThemeChanged;
+	}
+
+	static View LabeledRow(string caption, Label value) =>
+		new HorizontalStackLayout
+		{
+			Spacing = 6,
+			Children = { new Label { Text = caption }, value },
+		};
+
+	void OnRequestedThemeChanged(object sender, AppThemeChangedEventArgs e) => ScheduleRefresh();
+
+	protected override void OnAppearing()
+	{
+		base.OnAppearing();
+		// Follow the device theme so the SetLightTheme/SetDarkTheme UI-test helpers drive the app.
+		Application.Current!.UserAppTheme = AppTheme.Unspecified;
+		ScheduleRefresh();
+	}
+
+	// Read after the current frame so the activity's OnConfigurationChanged has re-applied the bar
+	// appearance for the new theme first.
+	void ScheduleRefresh() => Dispatcher.Dispatch(RefreshBarState);
+
+	void RefreshBarState()
+	{
+#if ANDROID
+		var activity = Microsoft.Maui.ApplicationModel.Platform.CurrentActivity;
+		var window = activity?.Window;
+		if (window is null)
+			return;
+
+#pragma warning disable CA1422 // StatusBarColor/NavigationBarColor getters are deprecated on API 35+ but still report the current value
+		var statusArgb = (uint)window.StatusBarColor;
+		var navArgb = (uint)window.NavigationBarColor;
+#pragma warning restore CA1422
+		bool barsTransparent = (statusArgb >> 24) == 0 && (navArgb >> 24) == 0; // alpha channel == 0
+
+		bool navScrim = OperatingSystem.IsAndroidVersionAtLeast(29) && window.NavigationBarContrastEnforced;
+
+		bool lightIcons = false;
+		if (window.DecorView is global::Android.Views.View decorView)
+		{
+			var controller = AndroidX.Core.View.WindowCompat.GetInsetsController(window, decorView);
+			lightIcons = controller?.AppearanceLightStatusBars ?? false;
+		}
+
+		var configuration = activity?.Resources?.Configuration;
+		bool isLightTheme = configuration is null ||
+			(configuration.UiMode & Android.Content.Res.UiMode.NightMask) != Android.Content.Res.UiMode.NightYes;
+
+		_barsTransparent.Text = barsTransparent.ToString();
+		_navScrim.Text = navScrim.ToString();
+		_lightIcons.Text = lightIcons.ToString();
+		_theme.Text = isLightTheme ? "Light" : "Dark";
+
+		// Set markers in the same pass as the values: _ready latches after the first read; the theme
+		// markers signal which theme this read reflected.
+		_themeIsLight.IsVisible = isLightTheme;
+		_themeIsDark.IsVisible = !isLightTheme;
+		_ready.IsVisible = true;
+#endif
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32987.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32987.cs
@@ -1,0 +1,55 @@
+#if ANDROID // Edge-to-edge system bar behavior (transparency, nav scrim, icon theming) is Android-specific.
+
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue32987 : _IssuesUITest
+{
+	public override string Issue => "Android edge-to-edge: system bars are transparent, the 3-button navigation scrim is removed, and status bar icons follow the app theme";
+
+	public Issue32987(TestDevice device) : base(device)
+	{
+	}
+
+	[Test]
+	[Category(UITestCategories.SafeAreaEdges)]
+	public void SystemBarsAreTransparentAndNavScrimRemoved()
+	{
+		App.WaitForElement("BarStateReady");
+
+		Assert.That(App.WaitForElement("BarTransparentValue").GetText(), Is.EqualTo("True"),
+			"Status and navigation bars should be transparent under edge-to-edge.");
+		Assert.That(App.WaitForElement("NavScrimValue").GetText(), Is.EqualTo("False"),
+			"The 3-button navigation bar contrast scrim should be removed under edge-to-edge.");
+	}
+
+	[Test]
+	[Category(UITestCategories.SafeAreaEdges)]
+	public void StatusBarIconsFollowThemeChange()
+	{
+		App.WaitForElement("BarStateReady");
+
+		try
+		{
+			// The theme markers are set in the same pass that reads the bar icons, so the icon value
+			// is settled once the marker appears.
+			App.SetLightTheme();
+			App.WaitForElement("ThemeIsLight");
+			Assert.That(App.WaitForElement("LightIconsValue").GetText(), Is.EqualTo("True"),
+				"Light theme should use dark (light-appearance) status bar icons.");
+
+			App.SetDarkTheme();
+			App.WaitForElement("ThemeIsDark");
+			Assert.That(App.WaitForElement("LightIconsValue").GetText(), Is.EqualTo("False"),
+				"Dark theme should use light status bar icons.");
+		}
+		finally
+		{
+			App.SetLightTheme();
+		}
+	}
+}
+#endif

--- a/src/Core/src/Handlers/Window/WindowHandler.Android.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Android.cs
@@ -19,11 +19,6 @@ namespace Microsoft.Maui.Handlers
 		protected override void ConnectHandler(Activity platformView)
 		{
 			base.ConnectHandler(platformView);
-			if (OperatingSystem.IsAndroidVersionAtLeast(30))
-			{
-				//Edge to Edge enabled for Android API 30+
-				PlatformView.Window.ConfigureTranslucentSystemBars(PlatformView);
-			}
 			UpdateVirtualViewFrame(platformView);
 		}
 

--- a/src/Core/src/Handlers/Window/WindowHandler.Android.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Android.cs
@@ -19,6 +19,11 @@ namespace Microsoft.Maui.Handlers
 		protected override void ConnectHandler(Activity platformView)
 		{
 			base.ConnectHandler(platformView);
+
+			// Edge-to-edge transparency/scrim is enabled in MauiAppCompatActivity via EnableEdgeToEdge,
+			// which does not manage bar icon colors. Apply the initial icon appearance from the app theme.
+			platformView.Window?.ConfigureTranslucentSystemBars(platformView);
+
 			UpdateVirtualViewFrame(platformView);
 		}
 

--- a/src/Core/src/Platform/Android/MauiAppCompatActivity.Lifecycle.cs
+++ b/src/Core/src/Platform/Android/MauiAppCompatActivity.Lifecycle.cs
@@ -34,6 +34,14 @@ namespace Microsoft.Maui
 		{
 			base.OnConfigurationChanged(newConfig);
 
+			// Re-apply system bar icon colors on a theme (light/dark) change. The activity declares
+			// ConfigChanges.UiMode, so it is not recreated and OnCreate's EnableEdgeToEdge does not
+			// re-run. EnableEdgeToEdge does not manage icon appearance, so re-apply it explicitly here.
+			if (Window is not null)
+			{
+				Window.ConfigureTranslucentSystemBars(this);
+			}
+
 			IPlatformApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnConfigurationChanged>(del => del(this, newConfig));
 		}
 

--- a/src/Core/src/Platform/Android/MauiAppCompatActivity.cs
+++ b/src/Core/src/Platform/Android/MauiAppCompatActivity.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Maui
 				: Resource.Style.Maui_MainTheme_NoActionBar);
 
 			base.OnCreate(savedInstanceState);
-			WindowCompat.SetDecorFitsSystemWindows(Window, false);
+			WindowCompat.EnableEdgeToEdge(Window);
 
 			if (IPlatformApplication.Current?.Application is not null)
 			{

--- a/src/Core/src/Platform/Android/MauiWebChromeClient.cs
+++ b/src/Core/src/Platform/Android/MauiWebChromeClient.cs
@@ -109,10 +109,10 @@ namespace Microsoft.Maui.Platform
 			context.RequestedOrientation = ScreenOrientation.Landscape;
 
 			// Handle system UI visibility based on Android version
+			// Note: SetDecorFitsSystemWindows is not called here because edge-to-edge is always
+			// enabled via WindowCompat.EnableEdgeToEdge in MauiAppCompatActivity.
 			if (OperatingSystem.IsAndroidVersionAtLeast(30))
 			{
-				WindowCompat.SetDecorFitsSystemWindows(context.Window, false);
-
 				var controller = context.Window.InsetsController;
 				if (controller != null)
 				{
@@ -142,9 +142,6 @@ namespace Microsoft.Maui.Platform
 				// Hide system bars
 				windowInsetsController.SystemBarsBehavior = WindowInsetsControllerCompat.BehaviorShowTransientBarsBySwipe;
 				windowInsetsController.Hide(WindowInsetsCompat.Type.SystemBars());
-
-				// Make content appear behind system bars
-				WindowCompat.SetDecorFitsSystemWindows(context.Window, false);
 			}
 
 			// Add the CustomView
@@ -176,10 +173,10 @@ namespace Microsoft.Maui.Platform
 			context.RequestedOrientation = _originalOrientation;
 
 			// Restore system UI visibility based on Android version
+			// Note: SetDecorFitsSystemWindows(true) is intentionally not called here — edge-to-edge
+			// is always enabled and must not be reverted when exiting fullscreen video.
 			if (OperatingSystem.IsAndroidVersionAtLeast(30))
 			{
-				WindowCompat.SetDecorFitsSystemWindows(context.Window, true);
-
 				var controller = context.Window.InsetsController;
 				if (controller != null && _isSystemBarVisible)
 				{
@@ -192,12 +189,6 @@ namespace Microsoft.Maui.Platform
 				if (_windowInsetsController != null && _isSystemBarVisible)
 				{
 					_windowInsetsController.Show(WindowInsetsCompat.Type.SystemBars());
-				}
-
-				// Restore content layout
-				if (context.Window != null)
-				{
-					WindowCompat.SetDecorFitsSystemWindows(context.Window, true);
 				}
 			}
 

--- a/src/Core/src/Platform/Android/Resources/values/attr.xml
+++ b/src/Core/src/Platform/Android/Resources/values/attr.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <attr name="maui_splash" format="boolean" />
-  <attr name="maui_edgetoedge_optout" format="boolean" />
 
   <attr name="appBarLayoutStyle" format="reference" />
   <attr name="bottomNavigationViewStyle" format="reference" />

--- a/src/Core/src/Platform/Android/Resources/values/styles-material3.xml
+++ b/src/Core/src/Platform/Android/Resources/values/styles-material3.xml
@@ -2,8 +2,6 @@
 <resources>
     <!-- Material 3 Base Theme (Automatically switches between light/dark) -->
     <style name="Maui.Material3.Theme.Base" parent="Theme.Material3.DayNight">
-        <!-- For .NET 9 we opt out of edge to edge enforcement by default -->
-        <item name="maui_edgetoedge_optout">true</item>
         <item name="maui_splash">false</item>
         <item name="bottomNavigationViewStyle">@style/Widget.Material3.BottomNavigationView</item>
         <item name="materialButtonStyle">@style/MauiMaterialButton</item>

--- a/src/Core/src/Platform/Android/Resources/values/styles.xml
+++ b/src/Core/src/Platform/Android/Resources/values/styles.xml
@@ -3,8 +3,6 @@
 
     <!-- Base application theme. -->
     <style name="Maui.MainTheme.Base" parent="Theme.MaterialComponents.DayNight">
-        <!-- For .NET 9 we optout of edge to edge enforcement by default -->
-        <item name="maui_edgetoedge_optout">true</item>
         <item name="maui_splash">false</item>
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>


### PR DESCRIPTION
   <!-- Please let the below note in for people that find this PR -->
   > [!NOTE]
   > Are you waiting for the changes in this PR to be merged?
   > It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
   
   > Targets **net11.0** (changes default Android edge-to-edge behavior for .NET 11).
   
   ### Description of Change
   
   Migrates the Android backend from the partial, opt-out edge-to-edge setup to the native AndroidX `WindowCompat.EnableEdgeToEdge` API, per Google's recommended approach.
   
   Previously MAUI used `WindowCompat.SetDecorFitsSystemWindows(window, false)` together with a `maui_edgetoedge_optout` theme flag that kept apps from going fully edge-to-edge by default — so system bars stayed opaque below API 35 and the 3‑button navigation bar always drew a contrast scrim.
   
   Committed so far:
   
   * `MauiAppCompatActivity.OnCreate`: `SetDecorFitsSystemWindows(Window, false)` → `WindowCompat.EnableEdgeToEdge(Window)`.
   * Removed the `maui_edgetoedge_optout` attribute/theme entries so edge-to-edge is the default (transparent bars on API < 35, no 3‑button scrim).
   * `MauiWebChromeClient`: stopped toggling `SetDecorFitsSystemWindows` on fullscreen-video enter/exit (edge-to-edge is now always on).
   * Modal pages: apply `EnableEdgeToEdge` to the modal's own `Window`.
   
   Reference: [Android — Edge-to-edge](https://developer.android.com/develop/ui/views/layout/edge-to-edge)
   
### Screenshots
API| Before Issue Fix | After Issue Fix |
|-------|------------------|-----------------|
|API24-Light| <img width="350" alt="withoutfix" src="https://github.com/user-attachments/assets/0143a532-aa2c-49c9-89a9-1f2ce6836aac" /> | <img width="350" alt="withfix" src="https://github.com/user-attachments/assets/54777b6f-4231-4d2a-8ace-e6fa92fcf641" /> |
|API24-Dark| <img width="350" alt="withoutfix" src="https://github.com/user-attachments/assets/78512e67-790b-4da5-b7f4-3fbf69daa3f6" /> | <img width="350" alt="withfix" src="https://github.com/user-attachments/assets/0350bf2a-b3e9-4e03-b75c-12d3bd677185" /> |
|API30-Light| <img width="350" alt="withoutfix" src="https://github.com/user-attachments/assets/de44af57-4455-4fa1-ac4e-99d9808759c5" /> | <img width="350" alt="withfix" src="https://github.com/user-attachments/assets/7ab7605f-b669-4457-a54a-2520f5bebd12" /> |
|API30-Dark| <img width="350" alt="withoutfix" src="https://github.com/user-attachments/assets/77a25277-b31c-44e3-b140-c69164110df5" /> | <img width="350" alt="withfix" src="https://github.com/user-attachments/assets/7ab1e770-4abd-40b1-8c98-d32c377e906a" /> |
|API36-Light| <img width="350" alt="withoutfix" src="https://github.com/user-attachments/assets/09cffe1a-5571-4113-8ac1-f5f847cf6bcd" /> | <img width="350" alt="withfix" src="https://github.com/user-attachments/assets/9534204e-1cd4-4511-b2bd-5761d9b16a50" /> |
|API36-Dark| <img width="350" alt="withoutfix" src="https://github.com/user-attachments/assets/0c192afe-c37a-4367-adb9-36ca77b973b3" /> | <img width="350" alt="withfix" src="https://github.com/user-attachments/assets/edada240-4334-448e-8d5d-b6745dd53199" /> |
|API30-Status bar and Nav bar color applied| <img width="350" alt="withoutfix" src="https://github.com/user-attachments/assets/9e6e34c9-ce0c-4a5e-bb79-257d4849c03b" /> | <img width="350" alt="withfix" src="https://github.com/user-attachments/assets/cf1e5d9c-ec45-4da5-b875-bef988b232b7" /> |
