### PR TITLE
Fix GeometryGroup.Children.Clear() leaking shared child geometries

### DIFF
--- a/src/Controls/src/Core/Shapes/GeometryGroup.cs
+++ b/src/Controls/src/Core/Shapes/GeometryGroup.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Controls.Shapes
 	[ContentProperty("Children")]
 	public class GeometryGroup : Geometry
 	{
-		readonly HashSet<Geometry> _subscribedChildren = new();
+		readonly Dictionary<Geometry, int> _subscriptionRefCounts = new();
 
 		/// <summary>Bindable property for <see cref="Children"/>.</summary>
 		public static readonly BindableProperty ChildrenProperty =
@@ -162,9 +162,13 @@ namespace Microsoft.Maui.Controls.Shapes
 			if (geometry == null)
 				return;
 
-			if (!_subscribedChildren.Add(geometry))
+			if (_subscriptionRefCounts.TryGetValue(geometry, out var count))
+			{
+				_subscriptionRefCounts[geometry] = count + 1;
 				return;
+			}
 
+			_subscriptionRefCounts[geometry] = 1;
 			geometry.PropertyChanged += OnChildrenPropertyChanged;
 		}
 
@@ -173,20 +177,27 @@ namespace Microsoft.Maui.Controls.Shapes
 			if (geometry == null)
 				return;
 
-			if (!_subscribedChildren.Remove(geometry))
+			if (!_subscriptionRefCounts.TryGetValue(geometry, out var count))
 				return;
 
+			if (count > 1)
+			{
+				_subscriptionRefCounts[geometry] = count - 1;
+				return;
+			}
+
+			_subscriptionRefCounts.Remove(geometry);
 			geometry.PropertyChanged -= OnChildrenPropertyChanged;
 		}
 
 		void UnsubscribeFromAllChildren()
 		{
-			foreach (var geometry in _subscribedChildren)
+			foreach (var geometry in _subscriptionRefCounts.Keys)
 			{
 				geometry.PropertyChanged -= OnChildrenPropertyChanged;
 			}
 
-			_subscribedChildren.Clear();
+			_subscriptionRefCounts.Clear();
 		}
 
 		void OnChildrenPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/Controls/src/Core/Shapes/GeometryGroup.cs
+++ b/src/Controls/src/Core/Shapes/GeometryGroup.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Controls.Shapes
 	[ContentProperty("Children")]
 	public class GeometryGroup : Geometry
 	{
-		readonly List<Geometry> _subscribedChildren = new();
+		readonly HashSet<Geometry> _subscribedChildren = new();
 
 		/// <summary>Bindable property for <see cref="Children"/>.</summary>
 		public static readonly BindableProperty ChildrenProperty =
@@ -77,10 +77,7 @@ namespace Microsoft.Maui.Controls.Shapes
 		{
 			if (e.Action == NotifyCollectionChangedAction.Reset)
 			{
-				for (int i = _subscribedChildren.Count - 1; i >= 0; i--)
-				{
-					UnsubscribeFromChildrenPropertyChanged(_subscribedChildren[i]);
-				}
+				UnsubscribeFromAllChildrenPropertyChanged();
 
 				if (sender is GeometryCollection geometryCollection)
 				{
@@ -121,28 +118,28 @@ namespace Microsoft.Maui.Controls.Shapes
 
 		void SubscribeToChildrenPropertyChanged(Geometry geometry)
 		{
-			if (_subscribedChildren.Contains(geometry))
+			if (!_subscribedChildren.Add(geometry))
 				return;
 
 			geometry.PropertyChanged += OnChildrenPropertyChanged;
-			_subscribedChildren.Add(geometry);
 		}
 
 		void UnsubscribeFromChildrenPropertyChanged(Geometry geometry)
 		{
-			if (!_subscribedChildren.Contains(geometry))
+			if (!_subscribedChildren.Remove(geometry))
 				return;
 
 			geometry.PropertyChanged -= OnChildrenPropertyChanged;
-			_subscribedChildren.Remove(geometry);
 		}
 
 		void UnsubscribeFromAllChildrenPropertyChanged()
 		{
-			for (int i = _subscribedChildren.Count - 1; i >= 0; i--)
+			foreach (var geometry in _subscribedChildren)
 			{
-				UnsubscribeFromChildrenPropertyChanged(_subscribedChildren[i]);
+				geometry.PropertyChanged -= OnChildrenPropertyChanged;
 			}
+
+			_subscribedChildren.Clear();
 		}
 
 		void OnChildrenPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/Controls/src/Core/Shapes/GeometryGroup.cs
+++ b/src/Controls/src/Core/Shapes/GeometryGroup.cs
@@ -58,81 +58,128 @@ namespace Microsoft.Maui.Controls.Shapes
 
 		void UpdateChildren(GeometryCollection oldCollection, GeometryCollection newCollection)
 		{
-			oldCollection?.CollectionChanged -= OnChildrenCollectionChanged;
+			DetachCollection(oldCollection);
+			AttachCollection(newCollection);
 
-			UnsubscribeFromAllChildrenPropertyChanged();
+			Invalidate();
+		}
 
-			if (newCollection == null)
+		void AttachCollection(GeometryCollection collection)
+		{
+			if (collection == null)
 				return;
 
-			newCollection.CollectionChanged += OnChildrenCollectionChanged;
+			collection.CollectionChanged += OnChildrenCollectionChanged;
 
-			foreach (var newChildren in newCollection)
+			foreach (var geometry in collection)
 			{
-				SubscribeToChildrenPropertyChanged(newChildren);
+				SubscribeToGeometry(geometry);
+			}
+		}
+
+		void DetachCollection(GeometryCollection collection)
+		{
+			if (collection == null)
+				return;
+
+			collection.CollectionChanged -= OnChildrenCollectionChanged;
+
+			foreach (var geometry in collection)
+			{
+				UnsubscribeFromGeometry(geometry);
 			}
 		}
 
 		void OnChildrenCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
-			if (e.Action == NotifyCollectionChangedAction.Reset)
+			switch (e.Action)
 			{
-				UnsubscribeFromAllChildrenPropertyChanged();
-
-				if (sender is GeometryCollection geometryCollection)
-				{
-					foreach (var geometry in geometryCollection)
+				case NotifyCollectionChangedAction.Add:
+					if (e.NewItems != null)
 					{
-						SubscribeToChildrenPropertyChanged(geometry);
+						foreach (Geometry geometry in e.NewItems)
+						{
+							SubscribeToGeometry(geometry);
+						}
 					}
-				}
+					break;
 
-				Invalidate();
-				return;
-			}
+				case NotifyCollectionChangedAction.Remove:
+					if (e.OldItems != null)
+					{
+						foreach (Geometry geometry in e.OldItems)
+						{
+							UnsubscribeFromGeometry(geometry);
+						}
+					}
+					break;
 
-			if (e.OldItems != null)
-			{
-				foreach (var oldItem in e.OldItems)
-				{
-					if (!(oldItem is Geometry oldGeometry))
-						continue;
+				case NotifyCollectionChangedAction.Replace:
+					if (e.OldItems != null)
+					{
+						foreach (Geometry geometry in e.OldItems)
+						{
+							UnsubscribeFromGeometry(geometry);
+						}
+					}
 
-					UnsubscribeFromChildrenPropertyChanged(oldGeometry);
-				}
-			}
+					if (e.NewItems != null)
+					{
+						foreach (Geometry geometry in e.NewItems)
+						{
+							SubscribeToGeometry(geometry);
+						}
+					}
+					break;
 
-			if (e.NewItems != null)
-			{
-				foreach (var newItem in e.NewItems)
-				{
-					if (!(newItem is Geometry newGeometry))
-						continue;
+				case NotifyCollectionChangedAction.Move:
+					// No subscription changes required.
+					break;
 
-					SubscribeToChildrenPropertyChanged(newGeometry);
-				}
+				case NotifyCollectionChangedAction.Reset:
+					ResubscribeCollection(sender as GeometryCollection);
+					break;
 			}
 
 			Invalidate();
 		}
 
-		void SubscribeToChildrenPropertyChanged(Geometry geometry)
+		void ResubscribeCollection(GeometryCollection collection)
 		{
+			UnsubscribeFromAllChildren();
+
+			if (collection == null)
+				return;
+
+			foreach (var geometry in collection)
+			{
+				SubscribeToGeometry(geometry);
+			}
+		}
+
+		void SubscribeToGeometry(Geometry geometry)
+		{
+			if (geometry == null)
+				return;
+
 			if (!_subscribedChildren.Add(geometry))
 				return;
 
 			geometry.PropertyChanged += OnChildrenPropertyChanged;
 		}
 
-		void UnsubscribeFromChildrenPropertyChanged(Geometry geometry)
+		void UnsubscribeFromGeometry(Geometry geometry)
 		{
+			if (geometry == null)
+				return;
+
 			if (!_subscribedChildren.Remove(geometry))
 				return;
 
 			geometry.PropertyChanged -= OnChildrenPropertyChanged;
 		}
 
-		void UnsubscribeFromAllChildrenPropertyChanged()
+		void UnsubscribeFromAllChildren()
 		{
 			foreach (var geometry in _subscribedChildren)
 			{

--- a/src/Controls/src/Core/Shapes/GeometryGroup.cs
+++ b/src/Controls/src/Core/Shapes/GeometryGroup.cs
@@ -1,5 +1,6 @@
 #nullable disable
 using System;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
 
@@ -11,6 +12,8 @@ namespace Microsoft.Maui.Controls.Shapes
 	[ContentProperty("Children")]
 	public class GeometryGroup : Geometry
 	{
+		readonly List<Geometry> _subscribedChildren = new();
+
 		/// <summary>Bindable property for <see cref="Children"/>.</summary>
 		public static readonly BindableProperty ChildrenProperty =
 			BindableProperty.Create(nameof(Children), typeof(GeometryCollection), typeof(GeometryGroup), null,
@@ -55,15 +58,9 @@ namespace Microsoft.Maui.Controls.Shapes
 
 		void UpdateChildren(GeometryCollection oldCollection, GeometryCollection newCollection)
 		{
-			if (oldCollection != null)
-			{
-				oldCollection.CollectionChanged -= OnChildrenCollectionChanged;
+			oldCollection?.CollectionChanged -= OnChildrenCollectionChanged;
 
-				foreach (var oldChildren in oldCollection)
-				{
-					oldChildren.PropertyChanged -= OnChildrenPropertyChanged;
-				}
-			}
+			UnsubscribeFromAllChildrenPropertyChanged();
 
 			if (newCollection == null)
 				return;
@@ -72,12 +69,31 @@ namespace Microsoft.Maui.Controls.Shapes
 
 			foreach (var newChildren in newCollection)
 			{
-				newChildren.PropertyChanged += OnChildrenPropertyChanged;
+				SubscribeToChildrenPropertyChanged(newChildren);
 			}
 		}
 
 		void OnChildrenCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
+			if (e.Action == NotifyCollectionChangedAction.Reset)
+			{
+				for (int i = _subscribedChildren.Count - 1; i >= 0; i--)
+				{
+					UnsubscribeFromChildrenPropertyChanged(_subscribedChildren[i]);
+				}
+
+				if (sender is GeometryCollection geometryCollection)
+				{
+					foreach (var geometry in geometryCollection)
+					{
+						SubscribeToChildrenPropertyChanged(geometry);
+					}
+				}
+
+				Invalidate();
+				return;
+			}
+
 			if (e.OldItems != null)
 			{
 				foreach (var oldItem in e.OldItems)
@@ -85,7 +101,7 @@ namespace Microsoft.Maui.Controls.Shapes
 					if (!(oldItem is Geometry oldGeometry))
 						continue;
 
-					oldGeometry.PropertyChanged -= OnChildrenPropertyChanged;
+					UnsubscribeFromChildrenPropertyChanged(oldGeometry);
 				}
 			}
 
@@ -96,11 +112,37 @@ namespace Microsoft.Maui.Controls.Shapes
 					if (!(newItem is Geometry newGeometry))
 						continue;
 
-					newGeometry.PropertyChanged += OnChildrenPropertyChanged;
+					SubscribeToChildrenPropertyChanged(newGeometry);
 				}
 			}
 
 			Invalidate();
+		}
+
+		void SubscribeToChildrenPropertyChanged(Geometry geometry)
+		{
+			if (_subscribedChildren.Contains(geometry))
+				return;
+
+			geometry.PropertyChanged += OnChildrenPropertyChanged;
+			_subscribedChildren.Add(geometry);
+		}
+
+		void UnsubscribeFromChildrenPropertyChanged(Geometry geometry)
+		{
+			if (!_subscribedChildren.Contains(geometry))
+				return;
+
+			geometry.PropertyChanged -= OnChildrenPropertyChanged;
+			_subscribedChildren.Remove(geometry);
+		}
+
+		void UnsubscribeFromAllChildrenPropertyChanged()
+		{
+			for (int i = _subscribedChildren.Count - 1; i >= 0; i--)
+			{
+				UnsubscribeFromChildrenPropertyChanged(_subscribedChildren[i]);
+			}
 		}
 
 		void OnChildrenPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/Controls/tests/Core.UnitTests/GeometryGroupTests.cs
+++ b/src/Controls/tests/Core.UnitTests/GeometryGroupTests.cs
@@ -1,0 +1,35 @@
+using Microsoft.Maui.Controls.Shapes;
+using Rect = Microsoft.Maui.Graphics.Rect;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests;
+
+public class GeometryGroupTests : BaseTestFixture
+{
+	[Fact]
+	public void ClearUnsubscribesPreviousChildrenFromPropertyChanged()
+	{
+		var group = new GeometryGroup();
+		var oldChild = new RectangleGeometry(new Rect(0, 0, 10, 10));
+		var newChild = new RectangleGeometry(new Rect(0, 0, 5, 5));
+		var invalidations = 0;
+
+		group.InvalidateGeometryRequested += (_, _) => invalidations++;
+
+		group.Children.Add(oldChild);
+		invalidations = 0;
+
+		group.Children.Clear();
+		invalidations = 0;
+
+		// If Reset handling does not unsubscribe old items, this mutation incorrectly invalidates the group.
+		oldChild.Rect = new Rect(1, 1, 11, 11);
+		Assert.Equal(0, invalidations);
+
+		group.Children.Add(newChild);
+		invalidations = 0;
+
+		newChild.Rect = new Rect(2, 2, 6, 6);
+		Assert.Equal(1, invalidations);
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
GeometryGroup.Children.Clear() triggers a Reset event, but Reset does not provide OldItems, so removed geometries were not unsubscribed from PropertyChanged. This could leave stale event handlers and cause object retention.

### Description of Change

<!-- Enter description of the fix in this section -->
The fix in GeometryGroup.cs tracks subscribed children, handles Reset explicitly by unsubscribing all previously tracked children, and then re-subscribes only the current collection items and also add a logic improvements.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #35795 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

**Tested the behavior in the following platforms.**
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

| Before  | After  |
|---------|--------|
| **iOS**<br> <video src="https://github.com/user-attachments/assets/778c7ca3-c29d-45e4-9183-5cd9e5e057c0" width="600" height="300"> | **iOS**<br> <video src="https://github.com/user-attachments/assets/43fadd22-21b0-4543-8777-0e084b197981" width="600" height="300"> |
