### PR TITLE
[Android] Map: Apply custom Pin.ImageSource for clustered single pins

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/ClusteringGallery.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/ClusteringGallery.xaml
@@ -13,10 +13,13 @@
             <Button 
                 Text="Add 50 Pins" 
                 Clicked="OnAdd50PinsClicked" />
-            <Button 
-                Text="Add 100 Pins" 
+            <Button
+                Text="Add 100 Pins"
                 Clicked="OnAdd100PinsClicked" />
-            <Button 
+            <Button
+                Text="Add Custom-Icon Pins"
+                Clicked="OnAddCustomPinsClicked" />
+            <Button
                 Text="Clear Pins"
                 Clicked="OnClearPinsClicked" />
         </HorizontalStackLayout>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/ClusteringGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/ClusteringGallery.xaml.cs
@@ -39,6 +39,30 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 			UpdateStatus();
 		}
 
+		void OnAddCustomPinsClicked(object? sender, EventArgs e)
+		{
+			// Spread these pins far apart so they stay un-clustered (cluster of 1)
+			// even with clustering enabled. Their custom ImageSource must still be
+			// applied - this is the case the Android handler previously dropped.
+			for (int i = 0; i < 5; i++)
+			{
+				double latOffset = (i - 2) * 0.12;
+				double lonOffset = (i - 2) * 0.12;
+
+				var pin = new Pin
+				{
+					Label = $"Custom Pin {i + 1}",
+					Address = "Custom icon pin",
+					Location = new Position(_center.Latitude + latOffset, _center.Longitude + lonOffset),
+					Type = PinType.Place,
+					ClusteringIdentifier = "custom",
+					ImageSource = ImageSource.FromFile("dotnet_bot.png")
+				};
+				clusterMap.Pins.Add(pin);
+			}
+			UpdateStatus();
+		}
+
 		void OnClearPinsClicked(object? sender, EventArgs e)
 		{
 			clusterMap.Pins.Clear();

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -891,14 +891,17 @@ namespace Microsoft.Maui.Maps.Handlers
 			if (mauiContext == null || ct.IsCancellationRequested || (pin.MarkerId as string) != marker.Id)
 				return;
 
+			// Captured before the await; if ImageSource changes meanwhile, this stale load is dropped.
+			var requestedSource = pin.ImageSource;
+
 			BitmapDescriptor? icon = null;
 
-			if (pin.ImageSource != null)
+			if (requestedSource != null)
 			{
 				try
 				{
-					var result = await pin.ImageSource.GetPlatformImageAsync(mauiContext);
-					if (ct.IsCancellationRequested || (pin.MarkerId as string) != marker.Id || result?.Value is not ADrawable drawable)
+					using var result = await requestedSource.GetPlatformImageAsync(mauiContext);
+					if (ct.IsCancellationRequested || !ReferenceEquals(pin.ImageSource, requestedSource) || (pin.MarkerId as string) != marker.Id || result?.Value is not ADrawable drawable)
 						return;
 
 					var bitmap = DrawableToBitmap(drawable);
@@ -914,7 +917,7 @@ namespace Microsoft.Maui.Maps.Handlers
 				}
 			}
 
-			if (!ct.IsCancellationRequested && (pin.MarkerId as string) == marker.Id)
+			if (!ct.IsCancellationRequested && ReferenceEquals(pin.ImageSource, requestedSource) && (pin.MarkerId as string) == marker.Id)
 			{
 				marker.SetIcon(icon);
 			}

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -69,6 +69,10 @@ namespace Microsoft.Maui.Maps.Handlers
 
 		protected override void DisconnectHandler(MapView platformView)
 		{
+			_addPinsCts?.Cancel();
+			_addPinsCts?.Dispose();
+			_addPinsCts = null;
+
 			DisconnectPins();
 
 			base.DisconnectHandler(platformView);
@@ -646,6 +650,7 @@ namespace Microsoft.Maui.Maps.Handlers
 
 			// Cancel any previously running pin additions to avoid stale markers
 			_addPinsCts?.Cancel();
+			_addPinsCts?.Dispose();
 			_addPinsCts = new CancellationTokenSource();
 			var ct = _addPinsCts.Token;
 
@@ -675,15 +680,7 @@ namespace Microsoft.Maui.Maps.Handlers
 					if (cluster.Pins.Count == 1)
 					{
 						// Single pin - add as regular marker
-						var pin = cluster.Pins[0];
-						if (pin is INotifyPropertyChanged observable)
-						{
-							// -= before += because ReclusterPins re-runs AddPins on zoom without DisconnectPins.
-							observable.PropertyChanged -= PinOnPropertyChanged;
-							observable.PropertyChanged += PinOnPropertyChanged;
-						}
-
-						AddPinAsync(pin, ct).FireAndForget();
+						AddRegularPin(cluster.Pins[0], ct);
 					}
 					else
 					{
@@ -714,15 +711,21 @@ namespace Microsoft.Maui.Maps.Handlers
 			// Normal non-clustered pins
 			foreach (var p in pins)
 			{
-				IMapPin pin = (IMapPin)p;
-				if (pin is INotifyPropertyChanged observable)
-				{
-					observable.PropertyChanged += PinOnPropertyChanged;
-				}
-
-				AddPinAsync(pin, ct).FireAndForget();
+				AddRegularPin((IMapPin)p, ct);
 			}
 			_pins = null;
+		}
+
+		void AddRegularPin(IMapPin pin, CancellationToken ct)
+		{
+			if (pin is INotifyPropertyChanged observable)
+			{
+				// -= before += because ReclusterPins re-runs AddPins on zoom without DisconnectPins.
+				observable.PropertyChanged -= PinOnPropertyChanged;
+				observable.PropertyChanged += PinOnPropertyChanged;
+			}
+
+			AddPinAsync(pin, ct).FireAndForget();
 		}
 
 		void PinOnPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -764,6 +767,9 @@ namespace Microsoft.Maui.Maps.Handlers
 					break;
 				case nameof(IMapPin.Address):
 					marker.Snippet = pin.Address;
+					break;
+				case nameof(IMapPin.ImageSource):
+					UpdatePinImageSourceAsync(pin, marker, _addPinsCts?.Token ?? CancellationToken.None).FireAndForget();
 					break;
 			}
 		}
@@ -876,6 +882,42 @@ namespace Microsoft.Maui.Maps.Handlers
 			
 			_markers ??= new List<Marker>();
 			_markers.Add(marker);
+		}
+
+		async Task UpdatePinImageSourceAsync(IMapPin pin, Marker marker, CancellationToken ct)
+		{
+			var mauiContext = MauiContext;
+
+			if (mauiContext == null || ct.IsCancellationRequested || (pin.MarkerId as string) != marker.Id)
+				return;
+
+			BitmapDescriptor? icon = null;
+
+			if (pin.ImageSource != null)
+			{
+				try
+				{
+					var result = await pin.ImageSource.GetPlatformImageAsync(mauiContext);
+					if (ct.IsCancellationRequested || (pin.MarkerId as string) != marker.Id || result?.Value is not ADrawable drawable)
+						return;
+
+					var bitmap = DrawableToBitmap(drawable);
+					if (bitmap != null)
+					{
+						icon = BitmapDescriptorFactory.FromBitmap(bitmap);
+					}
+				}
+				catch (System.Exception ex)
+				{
+					mauiContext.Services.GetService<ILogger<MapHandler>>()?.LogWarning(ex, "Failed to update custom pin icon");
+					return;
+				}
+			}
+
+			if (!ct.IsCancellationRequested && (pin.MarkerId as string) == marker.Id)
+			{
+				marker.SetIcon(icon);
+			}
 		}
 
 		static ABitmap? DrawableToBitmap(ADrawable drawable)

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -849,23 +849,9 @@ namespace Microsoft.Maui.Maps.Handlers
 			// Load custom image if specified
 			if (pin.ImageSource != null)
 			{
-				try
-				{
-					var result = await pin.ImageSource.GetPlatformImageAsync(MauiContext);
-					if (ct.IsCancellationRequested || result?.Value is not ADrawable drawable)
-						return;
-
-					var bitmap = DrawableToBitmap(drawable);
-					if (bitmap != null)
-					{
-						markerOptions.SetIcon(BitmapDescriptorFactory.FromBitmap(bitmap));
-					}
-				}
-				catch (System.Exception ex)
-				{
-					var logger = MauiContext?.Services?.GetService<ILogger<MapHandler>>();
-					logger?.LogWarning(ex, "Failed to load custom pin icon");
-				}
+				var icon = await LoadPinIconAsync(pin.ImageSource, MauiContext, ct);
+				if (icon != null)
+					markerOptions.SetIcon(icon);
 			}
 
 			// Re-check after async operation since handler may have been disconnected
@@ -898,28 +884,36 @@ namespace Microsoft.Maui.Maps.Handlers
 
 			if (requestedSource != null)
 			{
-				try
-				{
-					using var result = await requestedSource.GetPlatformImageAsync(mauiContext);
-					if (ct.IsCancellationRequested || !ReferenceEquals(pin.ImageSource, requestedSource) || (pin.MarkerId as string) != marker.Id || result?.Value is not ADrawable drawable)
-						return;
-
-					var bitmap = DrawableToBitmap(drawable);
-					if (bitmap != null)
-					{
-						icon = BitmapDescriptorFactory.FromBitmap(bitmap);
-					}
-				}
-				catch (System.Exception ex)
-				{
-					mauiContext.Services.GetService<ILogger<MapHandler>>()?.LogWarning(ex, "Failed to update custom pin icon");
+				icon = await LoadPinIconAsync(requestedSource, mauiContext, ct);
+				// null means load failed/cancelled - leave the marker's current icon untouched.
+				if (icon == null)
 					return;
-				}
 			}
 
+			// icon is null here only when ImageSource was cleared, so SetIcon(null) resets to the default.
 			if (!ct.IsCancellationRequested && ReferenceEquals(pin.ImageSource, requestedSource) && (pin.MarkerId as string) == marker.Id)
 			{
 				marker.SetIcon(icon);
+			}
+		}
+
+		// Loads imageSource into a BitmapDescriptor
+		// Returns null on cancel/failure/no drawable.
+		static async Task<BitmapDescriptor?> LoadPinIconAsync(IImageSource imageSource, IMauiContext mauiContext, CancellationToken ct)
+		{
+			try
+			{
+				using var result = await imageSource.GetPlatformImageAsync(mauiContext);
+				if (ct.IsCancellationRequested || result?.Value is not ADrawable drawable)
+					return null;
+
+				var bitmap = DrawableToBitmap(drawable);
+				return bitmap != null ? BitmapDescriptorFactory.FromBitmap(bitmap) : null;
+			}
+			catch (System.Exception ex)
+			{
+				mauiContext.Services.GetService<ILogger<MapHandler>>()?.LogWarning(ex, "Failed to load custom pin icon");
+				return null;
 			}
 		}
 

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -676,16 +676,14 @@ namespace Microsoft.Maui.Maps.Handlers
 					{
 						// Single pin - add as regular marker
 						var pin = cluster.Pins[0];
-						var pinHandler = pin.ToHandler(MauiContext);
-						if (pinHandler is IMapPinHandler iMapPinHandler)
+						if (pin is INotifyPropertyChanged observable)
 						{
-							var marker = Map.AddMarker(iMapPinHandler.PlatformView);
-							if (marker != null)
-							{
-								pin.MarkerId = marker.Id;
-								_markers.Add(marker);
-							}
+							// -= before += because ReclusterPins re-runs AddPins on zoom without DisconnectPins.
+							observable.PropertyChanged -= PinOnPropertyChanged;
+							observable.PropertyChanged += PinOnPropertyChanged;
 						}
+
+						AddPinAsync(pin, ct).FireAndForget();
 					}
 					else
 					{


### PR DESCRIPTION
### Description of Change

On Android, enabling pin clustering (`Map.IsClusteringEnabled = true`) caused a pin's custom `Pin.ImageSource` to be ignored — pins fell back to the default red marker, even when they were not grouped (a "cluster" of a single pin). As a result, enabling clustering silently dropped every custom pin icon.

**Root cause:** in `MapHandler.Android.cs`, the clustering path added a single-pin cluster via `Map.AddMarker(iMapPinHandler.PlatformView)` directly, bypassing `AddPinAsync` — the only path that loads `Pin.ImageSource` and sets it on `MarkerOptions` before `AddMarker` (`MapPinHandler.Android.MapImageSource` is intentionally a no-op for this reason).

**Fix:** route single-pin clusters through `AddPinAsync`, the same path used by non-clustered pins, so the custom image is applied. The pin is also subscribed to `PinOnPropertyChanged` (unsubscribe-first to stay idempotent, since `ReclusterPins` re-runs `AddPins` on every zoom without going through `DisconnectPins`) so runtime `Location`/`Label`/`Address` changes update the marker, matching the non-clustered path.

Runtime `Pin.ImageSource` updates are handled through the marker update path as well. The update path uses per-marker image-update generations so rapid `ImageSource` changes cannot apply stale async image loads, and disposes `GetPlatformImageAsync` results after copying the drawable to avoid retaining Android native image resources.

A new **"Add Custom-Icon Pins"** button is added to the `ClusteringGallery` sample (using `dotnet_bot.png`, consistent with the existing Custom Pin Icons gallery) to exercise the scenario.

> **Targeting `net11.0`:** pin clustering (#33831) currently exists only on the `net11.0` branch, not on `main`, so this fix targets `net11.0`. Happy to retarget if maintainers prefer otherwise.

#### Testing

The Android `Map` handler is not covered by automated tests (device tests for `Map` are disabled on Android because they require a Google Maps API key that isn't available in CI). Verified manually on a physical Android device (Samsung SM-X230): with clustering enabled, un-clustered pins now render their custom `ImageSource` icon; multi-pin clusters keep the default count badge as before.

### Issues Fixed

Fixes #36234