### PR TITLE
[net11.0] Bump dotnet/macios to 26.5.11717-net11-p6 (BAR 320913)

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -8,7 +8,7 @@
     <!--  Begin: Package sources from dotnet-android -->
     <!--  End: Package sources from dotnet-android -->
     <!--  Begin: Package sources from dotnet-macios -->
-    <add key="darc-pub-dotnet-macios-90e2eb7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-90e2eb7a/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-macios-e6aeff4" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-e6aeff4e/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-macios -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <!--  Begin: Package sources from dotnet-dotnet -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -17,38 +17,38 @@
       <Uri>https://github.com/dotnet/android</Uri>
       <Sha>d549e1dc4e2a083b08b4f24cb5495e81b99d79b5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net11.0_26.5" Version="26.5.11711-net11-p6">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net11.0_26.5" Version="26.5.11771-net11-p7">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>6f668023025549b851dbdb7ee5d9db48a84c1e51</Sha>
+      <Sha>2f76ba5228f3571731fe7c8674f982c8d5262fd7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net11.0_26.5" Version="26.5.11711-net11-p6">
+    <Dependency Name="Microsoft.macOS.Sdk.net11.0_26.5" Version="26.5.11771-net11-p7">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>6f668023025549b851dbdb7ee5d9db48a84c1e51</Sha>
+      <Sha>2f76ba5228f3571731fe7c8674f982c8d5262fd7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net11.0_26.5" Version="26.5.11711-net11-p6">
+    <Dependency Name="Microsoft.iOS.Sdk.net11.0_26.5" Version="26.5.11771-net11-p7">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>6f668023025549b851dbdb7ee5d9db48a84c1e51</Sha>
+      <Sha>2f76ba5228f3571731fe7c8674f982c8d5262fd7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net11.0_26.5" Version="26.5.11711-net11-p6">
+    <Dependency Name="Microsoft.tvOS.Sdk.net11.0_26.5" Version="26.5.11771-net11-p7">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>6f668023025549b851dbdb7ee5d9db48a84c1e51</Sha>
+      <Sha>2f76ba5228f3571731fe7c8674f982c8d5262fd7</Sha>
     </Dependency>
     <!-- Previous .NET iOS version(s) -->
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_26.5" Version="26.5.10298" CoherentParentDependency="Microsoft.MacCatalyst.Sdk.net11.0_26.5">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_26.5" Version="26.5.10301" CoherentParentDependency="Microsoft.MacCatalyst.Sdk.net11.0_26.5">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>90e2eb7a981084044380d3b34c4d33694bc1a401</Sha>
+      <Sha>e6aeff4eaafa3918d4a27db2dcf5aba43cc3443c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net10.0_26.5" Version="26.5.10298" CoherentParentDependency="Microsoft.macOS.Sdk.net11.0_26.5">
+    <Dependency Name="Microsoft.macOS.Sdk.net10.0_26.5" Version="26.5.10301" CoherentParentDependency="Microsoft.macOS.Sdk.net11.0_26.5">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>90e2eb7a981084044380d3b34c4d33694bc1a401</Sha>
+      <Sha>e6aeff4eaafa3918d4a27db2dcf5aba43cc3443c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net10.0_26.5" Version="26.5.10298" CoherentParentDependency="Microsoft.iOS.Sdk.net11.0_26.5">
+    <Dependency Name="Microsoft.iOS.Sdk.net10.0_26.5" Version="26.5.10301" CoherentParentDependency="Microsoft.iOS.Sdk.net11.0_26.5">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>90e2eb7a981084044380d3b34c4d33694bc1a401</Sha>
+      <Sha>e6aeff4eaafa3918d4a27db2dcf5aba43cc3443c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_26.5" Version="26.5.10298" CoherentParentDependency="Microsoft.tvOS.Sdk.net11.0_26.5">
+    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_26.5" Version="26.5.10301" CoherentParentDependency="Microsoft.tvOS.Sdk.net11.0_26.5">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>90e2eb7a981084044380d3b34c4d33694bc1a401</Sha>
+      <Sha>e6aeff4eaafa3918d4a27db2dcf5aba43cc3443c</Sha>
     </Dependency>
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -17,21 +17,21 @@
       <Uri>https://github.com/dotnet/android</Uri>
       <Sha>d549e1dc4e2a083b08b4f24cb5495e81b99d79b5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net11.0_26.5" Version="26.5.11771-net11-p7">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net11.0_26.5" Version="26.5.11717-net11-p6">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>2f76ba5228f3571731fe7c8674f982c8d5262fd7</Sha>
+      <Sha>5bf7d00bec4a09ba623398bea41429ab1be795a1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net11.0_26.5" Version="26.5.11771-net11-p7">
+    <Dependency Name="Microsoft.macOS.Sdk.net11.0_26.5" Version="26.5.11717-net11-p6">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>2f76ba5228f3571731fe7c8674f982c8d5262fd7</Sha>
+      <Sha>5bf7d00bec4a09ba623398bea41429ab1be795a1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net11.0_26.5" Version="26.5.11771-net11-p7">
+    <Dependency Name="Microsoft.iOS.Sdk.net11.0_26.5" Version="26.5.11717-net11-p6">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>2f76ba5228f3571731fe7c8674f982c8d5262fd7</Sha>
+      <Sha>5bf7d00bec4a09ba623398bea41429ab1be795a1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net11.0_26.5" Version="26.5.11771-net11-p7">
+    <Dependency Name="Microsoft.tvOS.Sdk.net11.0_26.5" Version="26.5.11717-net11-p6">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>2f76ba5228f3571731fe7c8674f982c8d5262fd7</Sha>
+      <Sha>5bf7d00bec4a09ba623398bea41429ab1be795a1</Sha>
     </Dependency>
     <!-- Previous .NET iOS version(s) -->
     <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_26.5" Version="26.5.10301" CoherentParentDependency="Microsoft.MacCatalyst.Sdk.net11.0_26.5">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -67,15 +67,15 @@
     <MicrosoftNETSdkAndroidManifest100100PackageVersion>36.1.69</MicrosoftNETSdkAndroidManifest100100PackageVersion>
     <AndroidNetPreviousVersion>$(MicrosoftNetSdkAndroidManifest100100PackageVersion)</AndroidNetPreviousVersion>
     <!-- dotnet/macios -->
-    <MicrosoftMacCatalystSdknet110_265PackageVersion>26.5.11711-net11-p6</MicrosoftMacCatalystSdknet110_265PackageVersion>
-    <MicrosoftmacOSSdknet110_265PackageVersion>26.5.11711-net11-p6</MicrosoftmacOSSdknet110_265PackageVersion>
-    <MicrosoftiOSSdknet110_265PackageVersion>26.5.11711-net11-p6</MicrosoftiOSSdknet110_265PackageVersion>
-    <MicrosofttvOSSdknet110_265PackageVersion>26.5.11711-net11-p6</MicrosofttvOSSdknet110_265PackageVersion>
+    <MicrosoftMacCatalystSdknet110_265PackageVersion>26.5.11771-net11-p7</MicrosoftMacCatalystSdknet110_265PackageVersion>
+    <MicrosoftmacOSSdknet110_265PackageVersion>26.5.11771-net11-p7</MicrosoftmacOSSdknet110_265PackageVersion>
+    <MicrosoftiOSSdknet110_265PackageVersion>26.5.11771-net11-p7</MicrosoftiOSSdknet110_265PackageVersion>
+    <MicrosofttvOSSdknet110_265PackageVersion>26.5.11771-net11-p7</MicrosofttvOSSdknet110_265PackageVersion>
     <!-- This is a subscription of the .NET 10 latest stable versions of our packages -->
-    <MicrosoftMacCatalystSdknet100_265PackageVersion>26.5.10298</MicrosoftMacCatalystSdknet100_265PackageVersion>
-    <MicrosoftmacOSSdknet100_265PackageVersion>26.5.10298</MicrosoftmacOSSdknet100_265PackageVersion>
-    <MicrosoftiOSSdknet100_265PackageVersion>26.5.10298</MicrosoftiOSSdknet100_265PackageVersion>
-    <MicrosofttvOSSdknet100_265PackageVersion>26.5.10298</MicrosofttvOSSdknet100_265PackageVersion>
+    <MicrosoftMacCatalystSdknet100_265PackageVersion>26.5.10301</MicrosoftMacCatalystSdknet100_265PackageVersion>
+    <MicrosoftmacOSSdknet100_265PackageVersion>26.5.10301</MicrosoftmacOSSdknet100_265PackageVersion>
+    <MicrosoftiOSSdknet100_265PackageVersion>26.5.10301</MicrosoftiOSSdknet100_265PackageVersion>
+    <MicrosofttvOSSdknet100_265PackageVersion>26.5.10301</MicrosofttvOSSdknet100_265PackageVersion>
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>8.0.148</SamsungTizenSdkPackageVersion>
     <!-- wasdk -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -67,10 +67,10 @@
     <MicrosoftNETSdkAndroidManifest100100PackageVersion>36.1.69</MicrosoftNETSdkAndroidManifest100100PackageVersion>
     <AndroidNetPreviousVersion>$(MicrosoftNetSdkAndroidManifest100100PackageVersion)</AndroidNetPreviousVersion>
     <!-- dotnet/macios -->
-    <MicrosoftMacCatalystSdknet110_265PackageVersion>26.5.11771-net11-p7</MicrosoftMacCatalystSdknet110_265PackageVersion>
-    <MicrosoftmacOSSdknet110_265PackageVersion>26.5.11771-net11-p7</MicrosoftmacOSSdknet110_265PackageVersion>
-    <MicrosoftiOSSdknet110_265PackageVersion>26.5.11771-net11-p7</MicrosoftiOSSdknet110_265PackageVersion>
-    <MicrosofttvOSSdknet110_265PackageVersion>26.5.11771-net11-p7</MicrosofttvOSSdknet110_265PackageVersion>
+    <MicrosoftMacCatalystSdknet110_265PackageVersion>26.5.11717-net11-p6</MicrosoftMacCatalystSdknet110_265PackageVersion>
+    <MicrosoftmacOSSdknet110_265PackageVersion>26.5.11717-net11-p6</MicrosoftmacOSSdknet110_265PackageVersion>
+    <MicrosoftiOSSdknet110_265PackageVersion>26.5.11717-net11-p6</MicrosoftiOSSdknet110_265PackageVersion>
+    <MicrosofttvOSSdknet110_265PackageVersion>26.5.11717-net11-p6</MicrosofttvOSSdknet110_265PackageVersion>
     <!-- This is a subscription of the .NET 10 latest stable versions of our packages -->
     <MicrosoftMacCatalystSdknet100_265PackageVersion>26.5.10301</MicrosoftMacCatalystSdknet100_265PackageVersion>
     <MicrosoftmacOSSdknet100_265PackageVersion>26.5.10301</MicrosoftmacOSSdknet100_265PackageVersion>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Summary

Updates **dotnet/macios** on `net11.0` to the latest **Preview 6** build (`.NET 11.0.1xx SDK Preview 6` channel), via `darc`.

For the release, `net11.0` should track the **Preview 6** macios bits. The maestro subscription has advanced `net11.0`'s `.NET 11.0.1xx SDK` channel to the **Preview 7** train, but that flows separately — this PR keeps the manual macios pin on Preview 6.

| Pack set | To |
|----------|----|
| net11 macios SDKs (iOS, MacCatalyst, macOS, tvOS) | **`26.5.11717-net11-p6`** |
| net10 coherent partner SDKs | `26.5.10301` |

- **Source build:** BAR **320913** (macios `20260630.11`, commit [`5bf7d00b`](https://github.com/dotnet/macios/commit/5bf7d00bec4a09ba623398bea41429ab1be795a1)) on channel `.NET 11.0.1xx SDK Preview 6`.
- This PR was originally opened against the Preview 7 build (`26.5.11771-net11-p7`, BAR 320851); a follow-up commit **redirects it back to Preview 6** (`26.5.11717-net11-p6`, BAR 320913) per release guidance. The net10 coherent partner (`26.5.10301`) and macios feed (`darc-pub-dotnet-macios-e6aeff4`) are unchanged by the redirect.

### How it was produced

```bash
darc update-dependencies --id 320913 --source-repo https://github.com/dotnet/macios
darc update-dependencies --coherency-only
```

Verified: `darc update-dependencies --coherency-only --dry-run` reports **"Found no dependencies to update"** (fully coherent); no stale `11771`/`net11-p7` remain; `Versions.props` ↔ `Version.Details.xml` consistent.