### PR TITLE
Fix AdaptiveTrigger memory leak when VisualStateGroups are replaced after attach

### DIFF
--- a/.github/workflows/merge-net11-to-release.yml
+++ b/.github/workflows/merge-net11-to-release.yml
@@ -1,5 +1,10 @@
 # Merge net11.0 → next release branch
 # Target branch is configured in /github-merge-flow-release-11.jsonc (MergeToBranch)
+#
+# This workflow must be triggered FROM the net11.0 branch because the arcade merge
+# script uses GITHUB_REF_NAME as the config lookup key. When triggered via
+# workflow_dispatch from the GitHub UI, select 'net11.0' from the branch dropdown.
+# The schedule trigger only works when this file exists on net11.0.
 
 name: Merge net11.0 to next release
 
@@ -17,6 +22,8 @@ permissions:
 
 jobs:
   Merge:
+    # Only run if triggered from net11.0 (push trigger or correct workflow_dispatch)
+    if: github.ref_name == 'net11.0'
     uses: dotnet/arcade/.github/workflows/inter-branch-merge-base.yml@main
     with:
       configuration_file_path: 'github-merge-flow-release-11.jsonc'

--- a/eng/pipelines/ci-official.yml
+++ b/eng/pipelines/ci-official.yml
@@ -104,6 +104,7 @@ extends:
             onlyAndroidPlatformDefaultApis: true
             skipAndroidEmulatorImages: true
             skipAndroidCreateAvds: true
+            skipSimulatorSetup: true
             skipProvisioning: true
             skipXcode: false
             base64Encode: true

--- a/github-merge-flow-release-11.jsonc
+++ b/github-merge-flow-release-11.jsonc
@@ -2,7 +2,7 @@
 {
     "merge-flow-configurations": {
         "net11.0": {
-            "MergeToBranch": "release/11.0.1xx-preview4",
+            "MergeToBranch": "release/11.0.1xx-preview6",
             "ExtraSwitches": "-QuietComments",
             "ResetToTargetPaths": "global.json;NuGet.config;eng/Version.Details.xml;eng/Versions.props;eng/common/*"
         }

--- a/src/Controls/src/Core/AdaptiveTrigger.cs
+++ b/src/Controls/src/Core/AdaptiveTrigger.cs
@@ -8,7 +8,9 @@ namespace Microsoft.Maui.Controls
 	/// </summary>
 	public sealed class AdaptiveTrigger : StateTriggerBase
 	{
-		VisualElement? _visualElement;
+		// Weak reference so the trigger does not prevent the VisualElement from being
+		// garbage-collected if SendDetached() is somehow missed.
+		WeakReference<VisualElement>? _visualElement;
 		Window? _window;
 
 		/// <summary>
@@ -69,9 +71,10 @@ namespace Microsoft.Maui.Controls
 		{
 			DetachEvents();
 
-			_visualElement = VisualState?.VisualStateGroup?.VisualElement;
+			var element = VisualState?.VisualStateGroup?.VisualElement;
+			_visualElement = element is not null ? new WeakReference<VisualElement>(element) : null;
 
-			_window = _visualElement?.Window;
+			_window = element?.Window;
 			if (_window is not null)
 			{
 				_window.SizeChanged += OnWindowSizeChanged;

--- a/src/Controls/src/Core/VisualStateManager.cs
+++ b/src/Controls/src/Core/VisualStateManager.cs
@@ -50,6 +50,14 @@ namespace Microsoft.Maui.Controls
 							setter.UnApply(oldElement, unapplySpecificity);
 						}
 					}
+
+					// Detach state triggers from the outgoing groups so they unsubscribe from
+					// any window/device events they registered in OnAttached() (e.g. AdaptiveTrigger
+					// unsubscribes from Window.SizeChanged). Without this, replaced triggers retain
+					// a strong reference to the VisualElement even after the element leaves the tree.
+					foreach (var visualState in group.States)
+						foreach (var trigger in visualState.StateTriggers)
+							trigger.SendDetached();
 				}
 				oldVisualStateGroupList.VisualElement = null;
 			}
@@ -62,6 +70,12 @@ namespace Microsoft.Maui.Controls
 			visualElement.ChangeVisualState();
 
 			UpdateStateTriggers(visualElement);
+
+			// Attach state triggers from the incoming groups if the element is already in a Window.
+			// Normally triggers are attached via VisualElement.InvalidateStateTriggers(true) when the
+			// element joins a Window, but that event has already fired before this replacement occurs.
+			if (newValue != null && visualElement.Window != null)
+				visualElement.InvalidateStateTriggers(true);
 		}
 
 		/// <summary>

--- a/src/Controls/src/Core/VisualStateManager.cs
+++ b/src/Controls/src/Core/VisualStateManager.cs
@@ -38,6 +38,15 @@ namespace Microsoft.Maui.Controls
 
 				foreach (var group in oldVisualStateGroupList)
 				{
+					// Detach triggers first so OnDetached() unsubscribes window events before visual cleanup.
+					foreach (var visualState in group.States)
+					{
+						foreach (var trigger in visualState.StateTriggers)
+						{
+							trigger.SendDetached();
+						}
+					}
+
 					if (group.CurrentState is { } state)
 					{
 						// Only promote system-driven states (Disabled, Focused, etc.) to full VSM priority.
@@ -48,18 +57,6 @@ namespace Microsoft.Maui.Controls
 						foreach (var setter in state.Setters)
 						{
 							setter.UnApply(oldElement, unapplySpecificity);
-						}
-					}
-
-					// Detach state triggers from the outgoing groups so they unsubscribe from
-					// any window/device events they registered in OnAttached() (e.g. AdaptiveTrigger
-					// unsubscribes from Window.SizeChanged). Without this, replaced triggers retain
-					// a strong reference to the VisualElement even after the element leaves the tree.
-					foreach (var visualState in group.States)
-					{
-						foreach (var trigger in visualState.StateTriggers)
-						{
-							trigger.SendDetached();
 						}
 					}
 				}

--- a/src/Controls/src/Core/VisualStateManager.cs
+++ b/src/Controls/src/Core/VisualStateManager.cs
@@ -56,8 +56,12 @@ namespace Microsoft.Maui.Controls
 					// unsubscribes from Window.SizeChanged). Without this, replaced triggers retain
 					// a strong reference to the VisualElement even after the element leaves the tree.
 					foreach (var visualState in group.States)
+					{
 						foreach (var trigger in visualState.StateTriggers)
+						{
 							trigger.SendDetached();
+						}
+					}
 				}
 				oldVisualStateGroupList.VisualElement = null;
 			}
@@ -75,7 +79,9 @@ namespace Microsoft.Maui.Controls
 			// Normally triggers are attached via VisualElement.InvalidateStateTriggers(true) when the
 			// element joins a Window, but that event has already fired before this replacement occurs.
 			if (newValue != null && visualElement.Window != null)
+			{
 				visualElement.InvalidateStateTriggers(true);
+			}
 		}
 
 		/// <summary>

--- a/src/Controls/tests/Core.UnitTests/AdaptiveTriggerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/AdaptiveTriggerTests.cs
@@ -9,6 +9,62 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 	public class AdaptiveTriggerTests : BaseTestFixture
 	{
+		// Regression tests for https://github.com/dotnet/maui/issues/36032
+		// AdaptiveTrigger leaks VisualElement when VisualStateGroups are replaced after attach
+
+		[Fact]
+		public void OldAdaptiveTriggerDetachedWhenVSGsReplacedAfterAttach()
+		{
+			// Arrange: set up a label with an AdaptiveTrigger, attach it to a Window
+			var label = new Label();
+			var oldTrigger = new AdaptiveTrigger { MinWindowWidth = 300 };
+			var newTrigger = new AdaptiveTrigger { MinWindowWidth = 500 };
+
+			VisualStateManager.SetVisualStateGroups(label, new VisualStateGroupList
+			{
+				new VisualStateGroup
+				{
+					States =
+					{
+						new VisualState
+						{
+							Name = "Large",
+							StateTriggers = { oldTrigger },
+							Setters = { new Setter { Property = Label.BackgroundProperty, Value = new SolidColorBrush(Colors.Green) } }
+						},
+					}
+				}
+			});
+
+			var page = new ContentPage { Content = label };
+			_ = new Window { Page = page };
+
+			// Old trigger should be attached after element joins a Window
+			Assert.True(oldTrigger.IsAttached);
+
+			// Act: replace the VisualStateGroups while the element is already attached to a Window
+			VisualStateManager.SetVisualStateGroups(label, new VisualStateGroupList
+			{
+				new VisualStateGroup
+				{
+					States =
+					{
+						new VisualState
+						{
+							Name = "ExtraLarge",
+							StateTriggers = { newTrigger },
+							Setters = { new Setter { Property = Label.BackgroundProperty, Value = new SolidColorBrush(Colors.Blue) } }
+						},
+					}
+				}
+			});
+
+			// Assert: old trigger must be detached (unsubscribed from Window.SizeChanged)
+			Assert.False(oldTrigger.IsAttached, "Old AdaptiveTrigger should be detached after VSGs are replaced");
+			// Assert: new trigger should now be attached
+			Assert.True(newTrigger.IsAttached, "New AdaptiveTrigger should be attached after VSGs are replaced");
+		}
+
 		[Fact]
 		public void ResizingWindowPageActivatesTrigger()
 		{


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->


### Issue Details
AdaptiveTrigger leaks memory when VisualStateGroups are replaced at runtime on a visible element. This causes entire view models (data) to stay in memory permanently even after navigation, growing by ~3 MB per page visit.

### Root Cause
In VisualStateGroupsPropertyChanged, detach triggers from the old VisualStateGroups before unapplying old setters and clearing the old VisualElement association. This unsubscribes old AdaptiveTrigger instances from Window.SizeChanged when VisualStateGroups are replaced after the element is already attached.

### Description of Change
In VisualStateGroupsPropertyChanged, detach triggers from the old VisualStateGroups before unapplying old setters and clearing the old VisualElement association. This unsubscribes old AdaptiveTrigger instances from Window.SizeChanged when VisualStateGroups are replaced after the element is already attached.

After assigning the new VisualStateGroups, if the element is already in a Window, call visualElement.InvalidateStateTriggers(true) so the new triggers attach and activate immediately instead of waiting for a future Window change.

AdaptiveTrigger now stores its associated VisualElement through a WeakReference<VisualElement> while attached. This avoids a strong AdaptiveTrigger -> VisualElement retention path if a detach path is missed.

Validated the behavior in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
### Issues Fixed
  
Fixes #36032 

### Output  ScreenShot

|Before|After|
|--|--|
| <img width="638" height="576" alt="image" src="https://github.com/user-attachments/assets/177dd499-9351-4edb-bd46-19b9c8d7c3ea" /> | <img width="642" height="613" alt="image" src="https://github.com/user-attachments/assets/136be499-da4b-4f4c-a357-ab7a21316a69" /> |
