### PR TITLE
[XSG] Infer IAsyncRelayCommand for async [RelayCommand] members in compiled bindings

### DIFF
--- a/src/Controls/src/BindingSourceGen/ITypeSymbolExtensions.cs
+++ b/src/Controls/src/BindingSourceGen/ITypeSymbolExtensions.cs
@@ -63,7 +63,7 @@ public static class ITypeSymbolExtensions
 	/// <param name="symbol">The type to search</param>
 	/// <param name="propertyName">The name of the property to find (should end with "Command")</param>
 	/// <param name="compilation">The compilation (can be null)</param>
-	/// <param name="commandType">The inferred ICommand type if a RelayCommand method is found</param>
+	/// <param name="commandType">The inferred command interface type if a RelayCommand method is found</param>
 	/// <returns>True if a RelayCommand method was found that would generate this property</returns>
 	public static bool TryGetRelayCommandPropertyType(this ITypeSymbol symbol, string propertyName, Compilation? compilation, out ITypeSymbol? commandType)
 	{
@@ -96,18 +96,53 @@ public static class ITypeSymbolExtensions
 
 				if (hasRelayCommand)
 				{
-					// Try to find the ICommand interface type
-					var icommandType = compilation.GetTypeByMetadataName("System.Windows.Input.ICommand");
-					if (icommandType != null)
+					foreach (var metadataName in GetRelayCommandInterfaceMetadataNames(method))
 					{
-						commandType = icommandType;
-						return true;
+						commandType = compilation.GetTypeByMetadataName(metadataName);
+						if (commandType != null)
+						{
+							return true;
+						}
 					}
 				}
 			}
 		}
 
 		return false;
+	}
+
+	private static string[] GetRelayCommandInterfaceMetadataNames(IMethodSymbol method)
+	{
+		if (IsAsyncRelayCommandMethod(method))
+		{
+			return new[]
+			{
+				"CommunityToolkit.Mvvm.Input.IAsyncRelayCommand",
+				"CommunityToolkit.Mvvm.Input.IRelayCommand",
+				"System.Windows.Input.ICommand",
+			};
+		}
+
+		return new[]
+		{
+			"CommunityToolkit.Mvvm.Input.IRelayCommand",
+			"System.Windows.Input.ICommand",
+		};
+	}
+
+	private static bool IsAsyncRelayCommandMethod(IMethodSymbol method)
+	{
+		if (method.ReturnType is not INamedTypeSymbol returnType)
+			return false;
+
+		var originalDefinition = returnType.OriginalDefinition;
+		if (originalDefinition.ContainingNamespace.ToDisplayString() != "System.Threading.Tasks")
+			return false;
+
+		return originalDefinition.MetadataName == "Task"
+			|| originalDefinition.MetadataName == "Task`1"
+			|| originalDefinition.MetadataName == "ValueTask"
+			|| originalDefinition.MetadataName == "ValueTask`1";
 	}
 
 	private static System.Collections.Generic.IEnumerable<string> GetRelayCommandMethodNameCandidates(string methodName)

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui34998.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui34998.xaml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui34998"
+             x:DataType="local:Maui34998ViewModel">
+    <ContentPage.BindingContext>
+        <local:Maui34998ViewModel />
+    </ContentPage.BindingContext>
+    <CheckBox x:Name="checkBox"
+              IsEnabled="{Binding FirstCommand.IsRunning}" />
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui34998.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui34998.xaml.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Windows.Input;
+using Xunit;
+
+using static Microsoft.Maui.Controls.Xaml.UnitTests.MockSourceGenerator;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public interface Maui34998RunningCommand : ICommand
+{
+	bool IsRunning { get; }
+}
+
+public interface Maui34998AsyncCommand : Maui34998RunningCommand
+{
+}
+
+public class Maui34998Command : Maui34998AsyncCommand
+{
+	public bool IsRunning { get; set; }
+
+	public event EventHandler? CanExecuteChanged
+	{
+		add { }
+		remove { }
+	}
+
+	public bool CanExecute(object? parameter) => true;
+
+	public void Execute(object? parameter)
+	{
+	}
+}
+
+public class Maui34998ViewModel
+{
+	public Maui34998AsyncCommand FirstCommand { get; } = new Maui34998Command();
+}
+
+public partial class Maui34998 : ContentPage
+{
+	public Maui34998() => InitializeComponent();
+
+	[Collection("Issue")]
+	public class Tests
+	{
+		const string SourceGenAdditionalSource = """
+using System;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using CommunityToolkit.Mvvm.Input;
+
+namespace CommunityToolkit.Mvvm.Input
+{
+	[AttributeUsage(AttributeTargets.Method)]
+	public sealed class RelayCommandAttribute : Attribute
+	{
+	}
+
+	public interface IRelayCommand : ICommand
+	{
+	}
+
+	public interface IRunningCommand : IRelayCommand
+	{
+		bool IsRunning { get; }
+	}
+
+	public interface IAsyncRelayCommand : IRunningCommand
+	{
+	}
+}
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests
+{
+	[XamlProcessing(XamlInflator.Runtime, true)]
+	public partial class Maui34998 : ContentPage
+	{
+		public Maui34998() => InitializeComponent();
+	}
+
+	public partial class Maui34998ViewModel
+	{
+		[RelayCommand]
+		Task FirstAsync() => Task.CompletedTask;
+	}
+}
+""";
+
+		[Theory]
+		[XamlInflatorData]
+		internal void SourceGenResolvesRelayCommandInterfaceBaseMembers(XamlInflator inflator)
+		{
+			if (inflator == XamlInflator.SourceGen)
+			{
+				var result = CreateMauiCompilation()
+					.WithAdditionalSource(SourceGenAdditionalSource)
+					.RunMauiSourceGenerator(typeof(Maui34998));
+
+				Assert.DoesNotContain(result.Diagnostics, d => d.Id == "MAUIG2045");
+				Assert.Contains("TypedBinding", result.GeneratedInitializeComponent(), StringComparison.Ordinal);
+			}
+			else
+			{
+				var page = new Maui34998(inflator);
+				Assert.False(page.checkBox.IsEnabled);
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description

Fixes #34998.

When binding to a member of a CommunityToolkit.Mvvm `[RelayCommand]`-generated command in XAML with the SourceGen (XSG) compiled-bindings pipeline — e.g. `{Binding FirstCommand.IsRunning}` — the generator emitted:

> MAUIG2045 : Binding: Property "IsRunning" not found on "global::System.Windows.Input.ICommand". The binding will use slower reflection-based binding at runtime.

and fell back to reflection-based binding.

### Root cause

`ITypeSymbolExtensions.TryGetRelayCommandPropertyType` recognises that a `XxxCommand` property is generated by a `[RelayCommand]` method, but it always inferred the property type as `System.Windows.Input.ICommand`. The CommunityToolkit generator actually emits `IAsyncRelayCommand` for `async`/`Task`/`ValueTask` methods, and `IRelayCommand` otherwise. Because the path walker only saw `ICommand`, the next path segment (`IsRunning`, defined on `IAsyncRelayCommand`) could not be resolved, producing the false `MAUIG2045` and the reflection fallback.

### Change

For async `[RelayCommand]` methods (return type `Task`, `Task<T>`, `ValueTask`, `ValueTask<T>`), infer the property type as `CommunityToolkit.Mvvm.Input.IAsyncRelayCommand`, falling back to `IRelayCommand` then `ICommand` when those types are not referenced by the compilation. This mirrors what the CommunityToolkit source generator emits, so members such as `IsRunning` resolve and a compiled binding is generated.

- `src/Controls/src/BindingSourceGen/ITypeSymbolExtensions.cs`

### Tests

Added `src/Controls/tests/Xaml.UnitTests/Issues/Maui34998.xaml(.cs)`, which binds to a command-like property whose declared interface inherits the bound member through a base interface. It asserts no `MAUIG2045` diagnostic is produced under SourceGen. Verified the test fails before this change (emits the exact issue warning) and passes after, across Runtime/XamlC/SourceGen.

No public API changes.
