### PR TITLE
[XSG] Avoid emitting internal AppThemeBinding constructor for netstandard source generation

### DIFF
--- a/src/Controls/src/SourceGen/KnownMarkups.cs
+++ b/src/Controls/src/SourceGen/KnownMarkups.cs
@@ -813,6 +813,15 @@ internal class KnownMarkups
 	/// </summary>
 	internal static bool ProvideValueForAppThemeBindingExtension(ElementNode node, IndentedTextWriter writer, SourceGenContext context, NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
 	{
+		// AppThemeBinding is internal on netstandard; let the generic markup-extension path call
+		// AppThemeBindingExtension.ProvideValue instead of generating an inaccessible constructor call.
+		if (context.ProjectItem.TargetFramework?.StartsWith("netstandard", StringComparison.OrdinalIgnoreCase) == true)
+		{
+			returnType = null;
+			value = string.Empty;
+			return false;
+		}
+
 		returnType = context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.AppThemeBinding")!;
 
 		if (getNodeValue is null)

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui32424.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui32424.xaml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Shell xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+       xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+       x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui32424"
+       FlyoutBackgroundColor="{OnPlatform WinUI=Transparent,
+                                           Default={AppThemeBinding Light=White,
+                                                                    Dark=Black}}">
+    <ShellContent Title="Home">
+        <ContentPage />
+    </ShellContent>
+</Shell>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui32424.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui32424.xaml.cs
@@ -1,0 +1,87 @@
+using System;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Devices;
+using Microsoft.Maui.Graphics;
+using Xunit;
+
+using static Microsoft.Maui.Controls.Xaml.UnitTests.MockSourceGenerator;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui32424 : Shell
+{
+	public Maui32424() => InitializeComponent();
+
+	[Collection("Xaml Inflation")]
+	public class Tests : IDisposable
+	{
+		readonly MockAppInfo _appInfo;
+		readonly MockApplication _app;
+		readonly MockDeviceInfo _deviceInfo;
+
+		public Tests()
+		{
+			AppInfo.SetCurrent(_appInfo = new MockAppInfo());
+			Application.Current = _app = new MockApplication();
+			DeviceInfo.SetCurrent(_deviceInfo = new MockDeviceInfo());
+		}
+
+		public void Dispose()
+		{
+			DeviceInfo.SetCurrent(null);
+			Application.Current = null;
+			AppInfo.SetCurrent(null);
+		}
+
+		[Theory]
+		[XamlInflatorData]
+		internal void OnPlatformDefaultCanBeNestedAppThemeBinding(XamlInflator inflator)
+		{
+			_deviceInfo.Platform = DevicePlatform.iOS;
+
+			_appInfo.RequestedTheme = AppTheme.Light;
+			_app.NotifyThemeChanged();
+			var shell = new Maui32424(inflator);
+			Assert.Equal(Colors.White, shell.FlyoutBackgroundColor);
+
+			_appInfo.RequestedTheme = AppTheme.Dark;
+			_app.NotifyThemeChanged();
+			shell = new Maui32424(inflator);
+			Assert.Equal(Colors.Black, shell.FlyoutBackgroundColor);
+		}
+
+		[Fact]
+		internal void SourceGenForNetStandardDoesNotReferenceInternalAppThemeBinding()
+		{
+			var result = CreateMauiCompilation()
+				.WithAdditionalSource(
+					"""
+					namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+					public partial class Maui32424 : Microsoft.Maui.Controls.Shell
+					{
+						public Maui32424() => InitializeComponent();
+					}
+					""")
+				.RunMauiSourceGenerator(typeof(Maui32424), targetFramework: "netstandard2.0");
+
+			Assert.Empty(result.Diagnostics);
+
+			var generated = result.GeneratedInitializeComponent();
+			Assert.DoesNotContain("new global::Microsoft.Maui.Controls.AppThemeBinding", generated, StringComparison.Ordinal);
+		}
+
+		[Theory]
+		[XamlInflatorData]
+		internal void OnPlatformMatchingPlatformStillUsesPlatformValue(XamlInflator inflator)
+		{
+			_deviceInfo.Platform = DevicePlatform.WinUI;
+			_appInfo.RequestedTheme = AppTheme.Dark;
+
+			var shell = new Maui32424(inflator);
+
+			Assert.Equal(Colors.Transparent, shell.FlyoutBackgroundColor);
+		}
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description

Fixes #32424.

A nested markup extension where `OnPlatform`'s `Default` is itself an `AppThemeBinding`, e.g.:

```xml
FlyoutBackgroundColor="{OnPlatform WinUI=Transparent,
                                   Default={AppThemeBinding Light=White,
                                                            Dark=Black}}"
```

failed to compile under SourceGen (XSG) when the target framework is `netstandard2.0`.

### Root cause

`AppThemeBinding` is only `public` on `NET11_0_OR_GREATER`; on `netstandard2.0` it is `internal` (see `src/Controls/src/Core/AppThemeBinding.cs`). The XSG `AppThemeBinding` markup handler emitted a direct constructor call (`new global::Microsoft.Maui.Controls.AppThemeBinding(...)`) into the consuming assembly, which is inaccessible on netstandard and produced an inaccessibility compile error. Runtime and XamlC inflation were unaffected.

### Change

When the SourceGen target framework is `netstandard*`, skip the specialized `AppThemeBinding` codegen path and let the generic markup-extension path call `AppThemeBindingExtension.ProvideValue(...)` instead of constructing the internal type directly.

- `src/Controls/src/SourceGen/KnownMarkups.cs`

### Tests

Added `src/Controls/tests/Xaml.UnitTests/Issues/Maui32424.xaml(.cs)`:
- A cross-inflator test (Runtime/XamlC/SourceGen) verifying the nested `OnPlatform Default={AppThemeBinding ...}` resolves to White (Light) / Black (Dark) and still uses the platform value on a matching platform.
- A netstandard-targeted SourceGen test asserting the generated code does **not** reference `new ...AppThemeBinding`.

Verified the netstandard test fails before this change (the internal constructor is emitted) and passes after.

No public API changes.
