### PR TITLE
[leak-fix] Fix Border.StrokeDashArray memory leak (Fixes #35492)

### DIFF
--- a/src/Controls/src/Core/Border/Border.cs
+++ b/src/Controls/src/Core/Border/Border.cs
@@ -25,11 +25,14 @@ namespace Microsoft.Maui.Controls
 		PropertyChangedEventHandler? _strokeShapeChanged;
 		WeakNotifyPropertyChangedProxy? _strokeProxy = null;
 		PropertyChangedEventHandler? _strokeChanged;
+		WeakNotifyCollectionChangedProxy? _strokeDashArrayProxy = null;
+		NotifyCollectionChangedEventHandler? _strokeDashArrayChanged;
 
 		~Border()
 		{
 			_strokeShapeProxy?.Unsubscribe();
 			_strokeProxy?.Unsubscribe();
+			_strokeDashArrayProxy?.Unsubscribe();
 		}
 
 		/// <summary>Bindable property for <see cref="Content"/>.</summary>
@@ -310,13 +313,21 @@ namespace Microsoft.Maui.Controls
 		{
 			get
 			{
-				if (StrokeDashArray is INotifyCollectionChanged oldCollection)
-					oldCollection.CollectionChanged -= OnStrokeDashArrayChanged;
-
 				_strokeDashPattern = StrokeDashArray?.ToFloatArray();
 
+				// Subscribe weakly so a shared/long-lived DoubleCollection does not strongly
+				// root this Border for the collection's lifetime. The proxy is torn down in
+				// ~Border(), mirroring the Stroke/StrokeShape weak proxies above.
 				if (StrokeDashArray is INotifyCollectionChanged newCollection)
-					newCollection.CollectionChanged += OnStrokeDashArrayChanged;
+				{
+					_strokeDashArrayChanged ??= OnStrokeDashArrayChanged;
+					_strokeDashArrayProxy ??= new();
+					_strokeDashArrayProxy.Subscribe(newCollection, _strokeDashArrayChanged);
+				}
+				else
+				{
+					_strokeDashArrayProxy?.Unsubscribe();
+				}
 
 				return _strokeDashPattern;
 			}

--- a/src/Controls/tests/Core.UnitTests/BorderUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BorderUnitTests.cs
@@ -1,4 +1,6 @@
 #nullable enable
+using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
@@ -43,6 +45,29 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			border.Content = null;
 			Assert.Null(label.Parent);
+		}
+
+		[Fact]
+		public async Task SharedStrokeDashArrayDoesNotLeakBorder()
+		{
+			// A shared / long-lived DoubleCollection, exactly as the issue describes
+			// (e.g. a static field or a value reused from a ResourceDictionary).
+			var sharedDashArray = new DoubleCollection { 2, 2 };
+
+			WeakReference weakBorder;
+			{
+				var border = new Border { StrokeDashArray = sharedDashArray };
+
+				// Reading StrokeDashPattern installs the CollectionChanged subscription,
+				// exactly as the platform border handler does when rendering the dash.
+				_ = border.StrokeDashPattern;
+
+				weakBorder = new WeakReference(border);
+				// Drop the only strong reference to `border`; `sharedDashArray` stays alive.
+			}
+
+			Assert.False(await weakBorder.WaitForCollect(), "Border should not be alive!");
+			GC.KeepAlive(sharedDashArray);
 		}
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

> [!NOTE]
> 🤖 **AI-generated PR.** This fix and its regression test were produced by an AI-driven memory-leak workflow and verified locally. Please review carefully before merging.

Fixes #35492

### The leak

When multiple `Border` controls use the same `DoubleCollection` (e.g. from `Application.Resources`) for `StrokeDashArray`, the `StrokeDashPattern` getter subscribes to that collection with a plain, non-weak delegate — `collection.CollectionChanged += OnStrokeDashArrayChanged` (`src/Controls/src/Core/Border/Border.cs`) — and only detaches when `StrokeDashArray` is reassigned, never on unload. Because the app-level `DoubleCollection` is long-lived, it retains every realized dashed `Border` (and, through normal page-level handlers, can retain the page, its `CollectionView`, and view models). This is the ~180&nbsp;MB-over-20-navigations scenario described in #35492.

### The fix

Subscribe to the `StrokeDashArray` collection through a `WeakNotifyCollectionChangedProxy`, torn down in the **existing `~Border()` finalizer** alongside the already-present `_strokeProxy` / `_strokeShapeProxy` — i.e. this fix simply extends Border's own established weak-proxy pattern to the third collection it listens to. A shared `DoubleCollection` no longer strongly roots the `Border`.

### Regression test

`BorderUnitTests.SharedStrokeDashArrayDoesNotLeakBorder` in `src/Controls/tests/Core.UnitTests/BorderUnitTests.cs`: assigns one shared `DoubleCollection` to a `Border`, drops the border, forces GC, asserts it is collected while the shared collection stays alive.

**Verified locally against this PR's base (`main`), `Controls.Core.UnitTests`:**

| State | Result |
|---|---|
| Without fix (current `main`) | ❌ FAILS — `Border should not be alive!` |
| With fix | ✅ `Passed SharedStrokeDashArrayDoesNotLeakBorder` |

### Scope

Managed cross-platform change → all platforms. No public-API change (the `~Border()` finalizer already existed).
