### PR TITLE
[iOS/MacCatalyst] Fix ActivityIndicator frozen static frame when IsRunning is set to false

### DIFF
--- a/src/Core/src/Platform/iOS/ActivityIndicatorExtensions.cs
+++ b/src/Core/src/Platform/iOS/ActivityIndicatorExtensions.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Platform
 		public static void UpdateIsRunning(this UIActivityIndicatorView activityIndicatorView, IActivityIndicator activityIndicator)
 		{
 			// Since Visibility and IsRunning are dependent on each other, we handle Visibility explicitly.
-			// Only show and animate if both IsRunning AND Visibility == Visible
+			// Only show and animate if both IsRunning AND Visibility == Visible.
 			if (activityIndicator.IsRunning && activityIndicator.Visibility == Visibility.Visible)
 			{
 				activityIndicatorView.Inflate();
@@ -18,19 +18,20 @@ namespace Microsoft.Maui.Platform
 			{
 				if (activityIndicatorView.IsAnimating)
 					activityIndicatorView.StopAnimating();
-				
-                // Collapsed requires layout constraint (CollapseConstraint) to zero out size;
-                // Hidden only sets Hidden = true (preserving layout space).
-                if (activityIndicator.Visibility == Visibility.Collapsed)
-                {
-                    activityIndicatorView.Hidden = true;
-                    activityIndicatorView.Collapse();
-                }
-                else
-                {
-                    activityIndicatorView.Inflate();
-                    activityIndicatorView.Hidden = activityIndicator.Visibility != Visibility.Visible;
-                }
+
+				// Collapsed requires layout constraint (CollapseConstraint) to zero out size;
+				// Hidden only sets Hidden = true (preserving layout space).
+				if (activityIndicator.Visibility == Visibility.Collapsed)
+				{
+					activityIndicatorView.Hidden = true;
+					activityIndicatorView.Collapse();
+				}
+				else
+				{
+					activityIndicatorView.Inflate();
+					// Always hide when not (IsRunning && Visible) — avoids frozen static frame.
+					activityIndicatorView.Hidden = true;
+				}
 			}
 		}
 

--- a/src/Core/tests/DeviceTests/Handlers/ActivityIndicator/ActivityIndicatorHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ActivityIndicator/ActivityIndicatorHandlerTests.iOS.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using ObjCRuntime;
 using UIKit;
+using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -14,5 +16,34 @@ namespace Microsoft.Maui.DeviceTests
 
 		bool GetNativeIsRunning(ActivityIndicatorHandler activityIndicatorHandler) =>
 			GetNativeActivityIndicator(activityIndicatorHandler).IsAnimating;
+
+		[Fact(DisplayName = "Setting IsRunning False While Visible Should Hide Native View")]
+		public async Task SettingIsRunningFalseWhileVisibleShouldHideNativeView()
+		{
+			var activityIndicator = new ActivityIndicatorStub
+			{
+				IsRunning = true,
+				Visibility = Visibility.Visible
+			};
+
+			bool isAnimating = true;
+			bool isHidden = false;
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var handler = CreateHandler(activityIndicator);
+
+				activityIndicator.IsRunning = false;
+				handler.UpdateValue(nameof(IActivityIndicator.IsRunning));
+
+				var nativeView = GetNativeActivityIndicator(handler);
+				isAnimating = nativeView.IsAnimating;
+				isHidden = nativeView.Hidden;
+			});
+
+			Assert.False(isAnimating, "ActivityIndicator should stop animating when IsRunning is false.");
+			Assert.True(isHidden, "ActivityIndicator should be hidden when IsRunning is false.");
+		}
+
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
- Setting the ActivityIndicator's IsRunning property to true and then setting it back to false causes the ActivityIndicator to freeze and to remain visible.

### Root Cause
- PR #28983 added Hidden = activityIndicator.Visibility != Visibility.Visible which runs after StopAnimating(). HidesWhenStopped correctly set Hidden=True, but this line immediately overwrote it with Hidden=False (since Visibility=Visible), leaving the native view visible with no animation — the frozen static frame.

### Description of Change
- Replace activityIndicatorView.Hidden = activityIndicator.Visibility != Visibility.Visible with activityIndicatorView.Hidden = true in the else-else branch of UpdateIsRunning, ensuring the native UIActivityIndicatorView is always hidden when not both running and visible, preventing the frozen static frame regression on iOS/MacCatalyst.

### Issues Fixed
Fixes #36173

### Validated the behaviour in the following platforms

- [ ] Windows
- [ ] Android
- [x] iOS
- [x] Mac

### Output
| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/53e12f75-f395-41a2-b2c2-7fb906143e8c"> | <video src="https://github.com/user-attachments/assets/9e85be45-4ec6-412f-9b5a-92a896bd8f8d"> |