### PR TITLE
Add public-safe preview release readiness gate to dependency-flow skill

### DIFF
--- a/.github/skills/dependency-flow/SKILL.md
+++ b/.github/skills/dependency-flow/SKILL.md
@@ -391,3 +391,79 @@ When standing up a new preview, **confirm the new preview's subs are in place be
 | Mid-cycle | Verify a sub exists | `darc get-subscriptions --ids "<guid>"` or MCP `maestro_subscription(subscriptionId=...)` |
 | Mid-cycle | Trigger a single sub | `darc trigger-subscriptions --id "<guid>"` (config PR must be merged first) |
 | Preview-ship | Cleanup prior preview | One PR removing per-preview subscription file, per-preview default-channel file, and the 24 lines for that preview in `dotnet-maui.yml`. Reference [PR 61033](https://dev.azure.com/dnceng/internal/_git/maestro-configuration/pullrequest/61033). |
+
+## Preview release readiness
+
+When a contributor asks a "is this preview ready to ship?" style question about a
+`release/X.0.Yxx-previewN` branch, the best available answer depends on whether
+that contributor has access to an authoritative, sometimes-embargoed release
+source. This section defines a tiered workflow that lets contributors **with
+access** benefit automatically while contributors **without access** fall back
+safely to public BAR/Maestro data — and never learn that a private source exists.
+
+### Privacy & security guardrails (read first)
+
+- **Never echo private coordinates.** Do not print or repeat private endpoints,
+  hostnames, AAD/tenant/identity GUIDs, or secrets. None appear in this skill and
+  none should be introduced.
+- **The private source is invisible to no-access users.** In the `NO_ACCESS`
+  tier you must NOT mention that any private plugin or embargoed data source
+  exists. Answer purely from public data.
+- **No fetch-and-exec.** The gate below runs only a local `gh api` read probe and
+  prints a status token. It never downloads or executes remote code.
+- **Comment-only on GitHub.** As everywhere in this skill, never approve, merge,
+  or request changes on PRs.
+
+### Step 1 — run the access gate
+
+Run the deterministic gate script. It performs a cheap local GitHub read probe
+and prints **exactly one** status line — and **no private data** — to stdout:
+
+```bash
+pwsh .github/skills/dependency-flow/scripts/Get-PreviewReleaseReadiness.ps1
+```
+
+It always exits `0` (it can never fail its caller) and emits one of:
+
+| Token | Meaning |
+|-------|---------|
+| `RELEASE_TRACKER_STATUS=NO_ACCESS` | The local `gh` CLI is missing, unauthenticated, or cannot read the private release repo. |
+| `RELEASE_TRACKER_STATUS=AVAILABLE_ENABLED` | The user can read the private release repo AND the authoritative plugin is already enabled in their personal `~/.copilot/settings.json`. |
+| `RELEASE_TRACKER_STATUS=AVAILABLE_NOT_ENABLED` | The user can read the private release repo but has not enabled the authoritative plugin. |
+
+### Step 2 — branch on the token (A/B/C tiers)
+
+**Tier A — `AVAILABLE_ENABLED`:** Use the `dotnet-release-tracker` skill/plugin as
+the **authoritative source** for preview-release-readiness (including which staged
+build is blessed as the official preview). Prefer it over BAR/Maestro when they
+disagree, and present its answer directly.
+
+**Tier B — `AVAILABLE_NOT_ENABLED`:** The user appears to have access but hasn't
+enabled the authoritative plugin. Tell them so and offer an **opt-in** snippet for
+their **personal** `~/.copilot/settings.json`. Do **not** commit plugin enablement
+to the repo, and do not enable it on their behalf:
+
+```jsonc
+// ~/.copilot/settings.json
+"extraKnownMarketplaces": { "dotnet-release": { "source": { "source": "github", "repo": "dotnet/release" } } },
+"enabledPlugins": { "dotnet-release-tracker@dotnet-release": true }
+```
+
+After they enable it and restart, re-running the gate should report
+`AVAILABLE_ENABLED`. Until then, answer from public data (Tier C workflow) but you
+may note that a more authoritative source is available to them.
+
+**Tier C — `NO_ACCESS`:** Silently fall back to the public workflow already
+documented in this skill. Use BAR/Maestro (MCP tools or `mstro`/`darc`) plus
+public `dotnet/core` release metadata to report what public data can show —
+build/channel state, subscription health, and coherency. **Do not** reference any
+private plugin or embargoed source in this tier.
+
+### Honest limitation of the public fallback
+
+Public data (BAR/Maestro + `dotnet/core` release metadata) can surface a lot:
+which builds exist, what channels they're on, subscription health, and coherency
+state. But it **cannot identify which staged build is "blessed"** as the official
+preview — that determination lives in the authoritative source. In the `NO_ACCESS`
+and un-enabled Tier-B cases, be explicit that you can describe build/channel
+readiness but cannot confirm the official/blessed build.

--- a/.github/skills/dependency-flow/scripts/Get-PreviewReleaseReadiness.ps1
+++ b/.github/skills/dependency-flow/scripts/Get-PreviewReleaseReadiness.ps1
@@ -1,0 +1,117 @@
+#!/usr/bin/env pwsh
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Deterministic access gate for the private "preview release readiness" data source.
+
+.DESCRIPTION
+    Some .NET MAUI contributors have access to an authoritative (and sometimes
+    embargoed) preview-release-readiness data source that is delivered as a
+    PRIVATE Copilot plugin. Access is double-gated:
+        1. GitHub read access to the private repository dotnet/release, AND
+        2. an authorized AAD identity (handled by the plugin itself, not here).
+
+    This script performs ONLY the cheap, local GitHub read probe and reports one
+    of three states so a skill can branch its behavior. It emits NO private data:
+    the ONLY thing written to stdout is a single status token. It never prints
+    the repository response, error detail, endpoints, or identity information.
+
+    States (written to stdout as exactly one line):
+        RELEASE_TRACKER_STATUS=NO_ACCESS
+            The local gh CLI is missing, unauthenticated, or cannot read
+            dotnet/release. Callers must fall back to public data (BAR/Maestro)
+            and must NOT reveal that a private source exists.
+
+        RELEASE_TRACKER_STATUS=AVAILABLE_ENABLED
+            The user can read dotnet/release AND the dotnet-release-tracker
+            plugin is already enabled in their personal ~/.copilot/settings.json.
+            Callers should use that plugin as the authoritative source.
+
+        RELEASE_TRACKER_STATUS=AVAILABLE_NOT_ENABLED
+            The user can read dotnet/release but has not enabled the plugin.
+            Callers may offer a personal, opt-in enablement snippet.
+
+    The script ALWAYS exits 0 so it can never fail its caller. Any error while
+    probing access or reading settings is treated as the safe default
+    (NO_ACCESS for the probe, not-enabled for the plugin check).
+
+    Cross-platform: pure PowerShell 7+, no bashisms, no external shell.
+#>
+
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'SilentlyContinue'
+# A non-zero exit from a native command must never throw; we inspect the exit
+# code ourselves to decide access.
+$PSNativeCommandUseErrorActionPreference = $false
+
+function Test-ReleaseRepoAccess {
+    # Returns $true only when the local gh CLI can read the private repo.
+    # Treats a missing gh, an unauthenticated CLI, or any non-zero exit as
+    # "no access". Never surfaces the response or error text.
+    if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+        return $false
+    }
+
+    try {
+        # --silent suppresses the response body; the pipe to Out-Null is a
+        # second safety net; stderr is discarded so nothing private can leak.
+        & gh api 'repos/dotnet/release' --silent 2>$null | Out-Null
+        return ($LASTEXITCODE -eq 0)
+    }
+    catch {
+        return $false
+    }
+}
+
+function Test-ReleaseTrackerEnabled {
+    # Returns $true when the personal settings file enables a
+    # dotnet-release-tracker plugin under any marketplace suffix
+    # (e.g. dotnet-release-tracker@dotnet-release) with a truthy value.
+    $settingsPath = Join-Path -Path $HOME -ChildPath '.copilot/settings.json'
+    if (-not (Test-Path -LiteralPath $settingsPath)) {
+        return $false
+    }
+
+    try {
+        $raw = Get-Content -LiteralPath $settingsPath -Raw -ErrorAction Stop
+        $settings = $raw | ConvertFrom-Json -ErrorAction Stop
+    }
+    catch {
+        return $false
+    }
+
+    if ($null -eq $settings -or
+        -not ($settings.PSObject.Properties.Name -contains 'enabledPlugins')) {
+        return $false
+    }
+
+    $enabled = $settings.enabledPlugins
+    if ($null -eq $enabled) {
+        return $false
+    }
+
+    foreach ($prop in $enabled.PSObject.Properties) {
+        # Match the plugin name with or without a marketplace suffix.
+        if ($prop.Name -match '^dotnet-release-tracker(@.*)?$' -and $prop.Value) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+$status = 'NO_ACCESS'
+if (Test-ReleaseRepoAccess) {
+    if (Test-ReleaseTrackerEnabled) {
+        $status = 'AVAILABLE_ENABLED'
+    }
+    else {
+        $status = 'AVAILABLE_NOT_ENABLED'
+    }
+}
+
+Write-Output "RELEASE_TRACKER_STATUS=$status"
+exit 0


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### What this adds

A **public-safe "Preview release readiness"** capability in the `dependency-flow` skill. This is a docs/skill + script authoring change only — **no API changes, no dependency bumps**.

**Two files:**

1. **`.github/skills/dependency-flow/scripts/Get-PreviewReleaseReadiness.ps1`** — a deterministic access gate. It runs a single local `gh api repos/dotnet/release --silent` read probe and checks the user's personal `~/.copilot/settings.json` for an enabled `dotnet-release-tracker` plugin (tolerant of any marketplace suffix). It emits exactly one status line to stdout and **always exits 0** so it can never fail its caller:
   - `RELEASE_TRACKER_STATUS=NO_ACCESS`
   - `RELEASE_TRACKER_STATUS=AVAILABLE_ENABLED`
   - `RELEASE_TRACKER_STATUS=AVAILABLE_NOT_ENABLED`

2. **`.github/skills/dependency-flow/SKILL.md`** — a new **"## Preview release readiness"** section (appended; existing content untouched) documenting how to run the gate and how to branch on the token.

### A/B/C tiering

- **AVAILABLE_ENABLED** → use the private `dotnet-release-tracker` plugin as the authoritative source.
- **AVAILABLE_NOT_ENABLED** → the user appears to have access; offer a **personal** opt-in snippet for their own `~/.copilot/settings.json` (never commit plugin enablement to the repo).
- **NO_ACCESS** → silently fall back to the existing public BAR/Maestro workflow, **without ever revealing that a private source exists**.

### Privacy / security guardrails

- **No secrets, no internal URLs, no AAD/tenant GUIDs, no endpoint hostnames** anywhere in either file. The only private coordinate referenced is the repo name `dotnet/release`, used purely for the access probe.
- **No fetch-and-exec** — the gate only runs a local `gh api` read check and prints a status token; the probe body and stderr are discarded so no private data leaks to stdout.
- Access is **double-gated** (GitHub read on `dotnet/release` + an authorized AAD identity handled by the plugin, not by this script).
- The private source is **invisible to no-access users**.

### Honest public-data limitation

Public data (BAR/Maestro + `dotnet/core` metadata) can surface build/channel/coherency and subscription health, but **cannot identify which staged build is "blessed"** as the official preview — that determination lives in the authoritative source. The doc calls this out explicitly for the no-access and un-enabled tiers.

### Testing performed

- Real run on a machine **with** access, plugin not enabled → `AVAILABLE_NOT_ENABLED`, exit 0, exactly one line.
- No-access simulation (temp copy probing a nonexistent repo) → `NO_ACCESS`, exit 0, one line; original script untouched.
- Missing `gh` on `PATH` → `NO_ACCESS`, exit 0.
- Enabled-detection across settings variations (any marketplace suffix / no suffix / value `false` / unrelated plugin / missing file / malformed JSON / no `enabledPlugins` key) — all correct and always exit 0.
- PowerShell parse check: no syntax errors.
- Guardrail scan: no suspicious URLs and no GUIDs in the new files.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>