### PR TITLE
 Fix iOS 26 UI test failures in Picker, DatePicker, and TimePicker tests 

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/PickerFeatureTests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/PickerFeatureTests.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Maui.TestCases.Tests
 {
 	public class PickerFeatureTests : _GalleryUITest
 	{
+		string doneButton => App is AppiumIOSApp iosApp && HelperExtensions.IsIOS26OrHigher(iosApp) ? "selected" : "Done";
 		public const string PickerFeatureMatrix = "Picker Feature Matrix";
 		public override string GalleryPageName => PickerFeatureMatrix;
 
@@ -42,8 +43,8 @@ namespace Microsoft.Maui.TestCases.Tests
 			VerifyPickerScreenshot();
 
 #if IOS
-			App.WaitForElement("Done");
-			App.Tap("Done");
+			App.WaitForElement(doneButton);
+			App.Tap(doneButton);
 #elif WINDOWS
 			App.Tap("Option 2 - Second option");
 #endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla41424.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla41424.cs
@@ -10,7 +10,7 @@ public class Bugzilla41424 : _IssuesUITest
 #if ANDROID // Action button on TimePicker dialog is vary on different platforms.
 	const string DatePickerActionButton = "Cancel";
 #elif IOS
-	const string DatePickerActionButton = "Done";
+	string DatePickerActionButton => App is AppiumIOSApp iosApp && HelperExtensions.IsIOS26OrHigher(iosApp) ? "selected" : "Done";
 #elif WINDOWS // No Action button for Windows DatePicker, so picking any date will close the dialog on windows.
 	const string DatePickerActionButton = "1";
 #elif MACCATALYST // Appium cannot locate the dialog elements on a Mac, so tapping outside the dialog closes it.

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla42074.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla42074.cs
@@ -11,7 +11,7 @@ public class Bugzilla42074 : _IssuesUITest
 #if ANDROID // Action button on TimePicker dialog is vary on different platforms
 	const string TimePickerActionButton = "Cancel";
 #elif IOS
-	string TimePickerActionButton => App is AppiumIOSApp iosApp && HelperExtensions.IsIOS26OrHigher(iosApp)? "selected" : "Done";
+	string TimePickerActionButton => App is AppiumIOSApp iosApp && HelperExtensions.IsIOS26OrHigher(iosApp) ? "selected" : "Done";
 #elif WINDOWS
 	const string TimePickerActionButton = "Accept";
 #endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla42074.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla42074.cs
@@ -11,7 +11,7 @@ public class Bugzilla42074 : _IssuesUITest
 #if ANDROID // Action button on TimePicker dialog is vary on different platforms
 	const string TimePickerActionButton = "Cancel";
 #elif IOS
-	const string TimePickerActionButton = "Done";
+	string TimePickerActionButton => App is AppiumIOSApp iosApp && HelperExtensions.IsIOS26OrHigher(iosApp)? "selected" : "Done";
 #elif WINDOWS
 	const string TimePickerActionButton = "Accept";
 #endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31167.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31167.cs
@@ -37,7 +37,7 @@ public class Issue31167 : _IssuesUITest
 		// Simulate user interaction by opening and closing the DatePicker
 		App.Tap("MyDatePicker");
 		
-		// On iOS, tap Done to close the picker
+		// On iOS, tap Done (or "selected" on iOS 26+) to close the picker
 		App.WaitForElement(doneButton);
 		App.Tap(doneButton);
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31167.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31167.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues;
 
 public class Issue31167 : _IssuesUITest
 {
+	string doneButton => App is AppiumIOSApp iosApp && HelperExtensions.IsIOS26OrHigher(iosApp) ? "selected" : "Done";
 	public Issue31167(TestDevice testDevice) : base(testDevice)
 	{
 	}
@@ -37,8 +38,8 @@ public class Issue31167 : _IssuesUITest
 		App.Tap("MyDatePicker");
 		
 		// On iOS, tap Done to close the picker
-		App.WaitForElement("Done");
-		App.Tap("Done");
+		App.WaitForElement(doneButton);
+		App.Tap(doneButton);
 
 		// Verify text still shows 4-digit year after interaction
 		var afterInteractionText = App.WaitForElement("MyDatePicker").GetText();
@@ -109,10 +110,10 @@ public class Issue31167 : _IssuesUITest
 		{
 			// Open picker
 			App.Tap("MyDatePicker");
-			App.WaitForElement("Done");
+			App.WaitForElement(doneButton);
 
 			// Close picker
-			App.Tap("Done");
+			App.Tap(doneButton);
 
 			// Verify format is still consistent
 			var currentText = App.WaitForElement("MyDatePicker").GetText();

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31889.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31889.cs
@@ -12,7 +12,7 @@ public class Issue31889 : _IssuesUITest
 	private const string TestEditorId = "TestEditor";
 	private const string DarkThemeButtonId = "DarkThemeButton";
 	private const string LightThemeButtonId = "LightThemeButton";
-	private const string DoneButtonId = "Done";
+	string DoneButtonId => App is AppiumIOSApp iosApp && HelperExtensions.IsIOS26OrHigher(iosApp) ? "selected" : "Done";
 	private const string TextColorDarkTheme = "EntryAndEditorTextColorAppThemeBindingUpdatesOnDarkTheme";
 	private const string TextColorLightTheme = "EntryAndEditorTextColorAppThemeBindingUpdatesOnLightTheme";
 	private const string PlaceholderColorDarkTheme = "EntryAndEditorPlaceholderTextColorAppThemeBindingUpdatesOnDarkTheme";

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32984.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32984.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues;
 
 public class Issue32984 : _IssuesUITest
 {
+	string doneButton => App is AppiumIOSApp iosApp && HelperExtensions.IsIOS26OrHigher(iosApp) ? "selected" : "Done";
 	public Issue32984(TestDevice device)
 		: base(device)
 	{
@@ -23,8 +24,8 @@ public class Issue32984 : _IssuesUITest
 		App.WaitForElement("Cancel");
 		App.Tap("Cancel");
 #elif IOS || MACCATALYST
-		App.WaitForElement("Done");
-		App.Tap("Done");
+		App.WaitForElement(doneButton);
+		App.Tap(doneButton);
 #elif WINDOWS
 		App.TapCoordinates(10, 10); 
 #endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34848.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34848.cs
@@ -23,7 +23,7 @@ public class Issue34848 : _IssuesUITest
 		App.Tap("Issue34848TestDatePicker");
 
 #if IOS
-		// iOS DatePicker uses a wheel picker, so we can just tap the "Done" button to close it
+		// iOS DatePicker uses a wheel picker, so we can just tap the "Done" button (or "selected" on iOS 26+) to close it
 		App.Tap(doneButton);
 #elif WINDOWS
 		// On Windows, we can tap a date to close the DatePicker

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34848.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34848.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues;
 
 public class Issue34848 : _IssuesUITest
 {
+	string doneButton => App is AppiumIOSApp iosApp && HelperExtensions.IsIOS26OrHigher(iosApp) ? "selected" : "Done";
 	public Issue34848(TestDevice testDevice) : base(testDevice) { }
 
 	public override string Issue => "DatePicker Opened and Closed events are not raised on MacCatalyst";
@@ -23,7 +24,7 @@ public class Issue34848 : _IssuesUITest
 
 #if IOS
 		// iOS DatePicker uses a wheel picker, so we can just tap the "Done" button to close it
-		App.Tap("Done");
+		App.Tap(doneButton);
 #elif WINDOWS
 		// On Windows, we can tap a date to close the DatePicker
 		App.Tap("16");

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue1614.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue1614.cs
@@ -11,7 +11,7 @@ public class Issue1614 : _IssuesUITest
 #if ANDROID
 	const string Done = "Cancel";
 #else
-	const string Done = "Done";
+	string Done => App is AppiumIOSApp iosApp && HelperExtensions.IsIOS26OrHigher(iosApp) ? "selected" : "Done";
 #endif
 
 	public Issue1614(TestDevice testDevice) : base(testDevice)

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue5159.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue5159.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues;
 [Category(UITestCategories.Picker)]
 public class Issue5159 : _IssuesUITest
 {
+	string doneButton => App is AppiumIOSApp iosApp && HelperExtensions.IsIOS26OrHigher(iosApp) ? "selected" : "Done";
 	const string DatePickerButton = "DatePickerButton";
 	const string TimePickerButton = "TimePickerButton";
 	const string PickerButton = "PickerButton";
@@ -22,7 +23,7 @@ public class Issue5159 : _IssuesUITest
 	{
 		App.WaitForElement("DatePickerButton");
 		App.Tap(DatePickerButton);
-		App.WaitForElement("Done");
+		App.WaitForElement(doneButton);
 		App.TapCoordinates(5, 100);
 	}
 
@@ -31,7 +32,7 @@ public class Issue5159 : _IssuesUITest
 	{
 		App.WaitForElement(TimePickerButton);
 		App.Tap(TimePickerButton);
-		App.WaitForElement("Done");
+		App.WaitForElement(doneButton);
 		App.TapCoordinates(5, 100);
 	}
 
@@ -40,7 +41,7 @@ public class Issue5159 : _IssuesUITest
 	{
 		App.WaitForElement(PickerButton);
 		App.Tap(PickerButton);
-		App.WaitForElement("Done");
+		App.WaitForElement(doneButton);
 	}
 }
 #endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/KeyboardScrolling.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/KeyboardScrolling.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Maui.TestCases.Tests
 		internal static void HideKeyboard(IApp app, AppiumDriver? driver, bool isEditor)
 		{
 			if (isEditor)
-				CloseiOSEditorKeyboard(driver);
+				CloseiOSEditorKeyboard(app, driver);
 			else
 				app.DismissKeyboard();
 		}
@@ -118,9 +118,10 @@ namespace Microsoft.Maui.TestCases.Tests
 			return null;
 		}
 
-		internal static void CloseiOSEditorKeyboard(AppiumDriver? driver)
+		internal static void CloseiOSEditorKeyboard(IApp app, AppiumDriver? driver)
 		{
-			var keyboardDoneButton = driver?.FindElement(MobileBy.Name("Done"));
+			var doneButtonName = app is AppiumIOSApp iosApp && HelperExtensions.IsIOS26OrHigher(iosApp) ? "selected" : "Done";
+			var keyboardDoneButton = driver?.FindElement(MobileBy.Name(doneButtonName));
 			keyboardDoneButton?.Click();
 		}
 

--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -80,8 +80,8 @@ namespace UITest.Appium
 		/// <summary>
 		/// Closes a picker dialog using platform-specific dismiss actions.
 		/// For Android, taps the "Cancel" button.
-		/// For iOS/MacCatalyst, taps the "Done" button.
 		/// For Windows, either taps coordinates (if provided) or the "Cancel" button.
+		/// For iOS, taps the "selected" button on iOS 26+, otherwise taps the "Done" button. For MacCatalyst, taps the "Done" button.
 		/// </summary>
 		/// <param name="app">Represents the main gateway to interact with an app.</param>
 		/// <param name="x">Optional X coordinate for Windows tap. Default is 0.</param>

--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -92,6 +92,10 @@ namespace UITest.Appium
 			{
 				app.Tap("Cancel");
 			}
+			else if (app is AppiumIOSApp iosApp && IsIOS26OrHigher(iosApp))
+			{
+				app.Tap("selected");
+			}
 			else if (app is AppiumIOSApp || app is AppiumCatalystApp)
 			{
 				app.Tap("Done");


### PR DESCRIPTION

<!-- Please keep the note below for people who find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment whether this change resolves your issue. Thank you!<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

On iOS 26, the picker dialog's action button label changed from **"Done"** to **"selected"**, which broke several UI tests that hard-coded the `"Done"` accessibility id when dismissing `Picker`, `DatePicker`, and `TimePicker` dialogs. This PR updates the affected tests to dynamically resolve the correct button label based on the iOS version under test, using the existing `HelperExtensions.IsIOS26OrHigher` helper.

**Changes:**
- Added a `doneButton`/`DatePickerActionButton`/`TimePickerActionButton` computed property in each affected test class that returns `"selected"` on iOS 26+ and `"Done"` otherwise (via `App is AppiumIOSApp iosApp && HelperExtensions.IsIOS26OrHigher(iosApp)`).
- Updated `App.WaitForElement`/`App.Tap` calls to use this computed value instead of the hard-coded `"Done"` string.
- Updated `HelperExtensions.cs` to tap `"selected"` instead of `"Done"` when running on iOS 26+.
- Updated `KeyboardScrolling.CloseiOSEditorKeyboard` (used by `HideKeyboard`) to accept the `IApp` instance and resolve `"selected"` vs `"Done"` for the Editor's keyboard "Done" button on iOS 26+, instead of always searching for `"Done"`.

**This resolves the CI failures in the following tests:**
- `Picker_TapPicker_TakeScreenshot`
- `InvisiblePickerShowsDialogOnFocus`
- `InvisibleTimepickerShowsDialogOnFocus`
- `Issue1614Test`
- `Issue32984PickerShouldResize`
- `InvisibleDatepickerShowsDialogOnFocus`
- `PickerCanBeOpenedProgrammatically`
- `DatePickerYearFormat_iOS_ConsistentAfterMultipleInteractions`
- `DatePickerCancelShouldUnfocus`
- `DatePickerYearFormat_UserInteraction_MaintainsFourDigitYear`
- `DatePickerOpenedAndClosedEventsAreRaised`
- `EntryAndEditorPlaceholderTextColorAppThemeBindingUpdatesOnThemeChange`
- `TimePickerCancelShouldUnfocus`
- `KeepEditorCursorAboveKeyboardInScrollView`
- `KeepEditorCursorAboveKeyboardInGrid`
- `EditorsScrollingPageTest`
- `EditorRuntimeTextAlignmentChanged`

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
