### PR TITLE
[leak-fix] Fix Path.Data/RenderTransform memory leak (Fixes #35860)

### DIFF
--- a/src/Controls/src/Core/Shapes/Path.cs
+++ b/src/Controls/src/Core/Shapes/Path.cs
@@ -52,53 +52,104 @@ namespace Microsoft.Maui.Controls.Shapes
 			get { return (Transform)GetValue(RenderTransformProperty); }
 		}
 
+		WeakGeometryChangedProxy _dataProxy;
+		WeakNotifyPropertyChangedProxy _renderTransformProxy;
+		EventHandler _dataChanged;
+		PropertyChangedEventHandler _renderTransformChanged;
+
+		~Path()
+		{
+			_dataProxy?.Unsubscribe();
+			_renderTransformProxy?.Unsubscribe();
+		}
+
 		static void OnGeometryPropertyChanged(BindableObject bindable, object oldValue, object newValue)
 		{
-			if (oldValue != null)
-			{
-				(oldValue as Geometry).PropertyChanged -= (bindable as Path).OnGeometryPropertyChanged;
+			if (newValue is Geometry geometry)
+				((Path)bindable).NotifyGeometryChanges(geometry);
+			else
+				((Path)bindable).StopNotifyingGeometryChanges();
+		}
 
-				if (oldValue is PathGeometry pathGeometry)
-					pathGeometry.InvalidatePathGeometryRequested -= (bindable as Path).OnInvalidatePathGeometryRequested;
-			}
+		void NotifyGeometryChanges(Geometry geometry)
+		{
+			_dataChanged ??= (sender, e) => OnPropertyChanged(nameof(Data));
+			_dataProxy ??= new();
+			_dataProxy.Subscribe(geometry, _dataChanged);
+		}
 
-			if (newValue != null)
-			{
-				(newValue as Geometry).PropertyChanged += (bindable as Path).OnGeometryPropertyChanged;
-
-				if (newValue is PathGeometry pathGeometry)
-					pathGeometry.InvalidatePathGeometryRequested += (bindable as Path).OnInvalidatePathGeometryRequested;
-			}
+		void StopNotifyingGeometryChanges()
+		{
+			_dataProxy?.Unsubscribe();
 		}
 
 		static void OnTransformPropertyChanged(BindableObject bindable, object oldValue, object newValue)
 		{
-			if (oldValue != null)
+			if (newValue is Transform transform)
+				((Path)bindable).NotifyTransformChanges(transform);
+			else
+				((Path)bindable).StopNotifyingTransformChanges();
+		}
+
+		void NotifyTransformChanges(Transform transform)
+		{
+			_renderTransformChanged ??= (sender, e) =>
 			{
-				(oldValue as Transform).PropertyChanged -= (bindable as Path).OnTransformPropertyChanged;
+				if (e.PropertyName == Transform.ValueProperty.PropertyName)
+					OnPropertyChanged(nameof(RenderTransform));
+			};
+			_renderTransformProxy ??= new();
+			_renderTransformProxy.Subscribe(transform, _renderTransformChanged);
+		}
+
+		void StopNotifyingTransformChanges()
+		{
+			_renderTransformProxy?.Unsubscribe();
+		}
+
+		class WeakGeometryChangedProxy : WeakEventProxy<Geometry, EventHandler>
+		{
+			void OnGeometryChanged(object sender, EventArgs e)
+			{
+				if (TryGetHandler(out var handler))
+				{
+					handler(sender, e);
+				}
+				else
+				{
+					Unsubscribe();
+				}
 			}
 
-			if (newValue != null)
+			public override void Subscribe(Geometry source, EventHandler handler)
 			{
-				(newValue as Transform).PropertyChanged += (bindable as Path).OnTransformPropertyChanged;
+				if (TryGetSource(out var s))
+				{
+					s.PropertyChanged -= OnGeometryChanged;
+
+					if (s is PathGeometry pg)
+						pg.InvalidatePathGeometryRequested -= OnGeometryChanged;
+				}
+
+				source.PropertyChanged += OnGeometryChanged;
+
+				if (source is PathGeometry pathGeometry)
+					pathGeometry.InvalidatePathGeometryRequested += OnGeometryChanged;
+
+				base.Subscribe(source, handler);
 			}
-		}
 
-		void OnGeometryPropertyChanged(object sender, PropertyChangedEventArgs args)
-		{
-			OnPropertyChanged(nameof(Data));
-		}
-
-		void OnInvalidatePathGeometryRequested(object sender, EventArgs e)
-		{
-			OnPropertyChanged(nameof(Data));
-		}
-
-		void OnTransformPropertyChanged(object sender, PropertyChangedEventArgs args)
-		{
-			if (args.PropertyName == Transform.ValueProperty.PropertyName)
+			public override void Unsubscribe()
 			{
-				OnPropertyChanged(nameof(RenderTransform));
+				if (TryGetSource(out var s))
+				{
+					s.PropertyChanged -= OnGeometryChanged;
+
+					if (s is PathGeometry pg)
+						pg.InvalidatePathGeometryRequested -= OnGeometryChanged;
+				}
+
+				base.Unsubscribe();
 			}
 		}
 

--- a/src/Controls/src/Core/Shapes/Path.cs
+++ b/src/Controls/src/Core/Shapes/Path.cs
@@ -136,6 +136,11 @@ namespace Microsoft.Maui.Controls.Shapes
 
 		class WeakGeometryChangedProxy : WeakEventProxy<Geometry, EventHandler>
 		{
+			void OnGeometryChanged(object sender, PropertyChangedEventArgs e)
+			{
+				OnGeometryChanged(sender, (EventArgs)e);
+			}
+
 			void OnGeometryChanged(object sender, EventArgs e)
 			{
 				if (TryGetHandler(out var handler))

--- a/src/Controls/src/Core/Shapes/Path.cs
+++ b/src/Controls/src/Core/Shapes/Path.cs
@@ -105,6 +105,7 @@ namespace Microsoft.Maui.Controls.Shapes
 			WeakGeometryChangedProxy _dataProxy;
 			WeakNotifyPropertyChangedProxy _renderTransformProxy;
 
+			// Event sources retain the weak proxies, so detach them once the owning Path releases this holder.
 			~PathChangeSubscriptions()
 			{
 				_dataProxy?.Unsubscribe();

--- a/src/Controls/src/Core/Shapes/Path.cs
+++ b/src/Controls/src/Core/Shapes/Path.cs
@@ -52,16 +52,9 @@ namespace Microsoft.Maui.Controls.Shapes
 			get { return (Transform)GetValue(RenderTransformProperty); }
 		}
 
-		WeakGeometryChangedProxy _dataProxy;
-		WeakNotifyPropertyChangedProxy _renderTransformProxy;
+		PathChangeSubscriptions _changeSubscriptions;
 		EventHandler _dataChanged;
 		PropertyChangedEventHandler _renderTransformChanged;
-
-		~Path()
-		{
-			_dataProxy?.Unsubscribe();
-			_renderTransformProxy?.Unsubscribe();
-		}
 
 		static void OnGeometryPropertyChanged(BindableObject bindable, object oldValue, object newValue)
 		{
@@ -74,13 +67,13 @@ namespace Microsoft.Maui.Controls.Shapes
 		void NotifyGeometryChanges(Geometry geometry)
 		{
 			_dataChanged ??= (sender, e) => OnPropertyChanged(nameof(Data));
-			_dataProxy ??= new();
-			_dataProxy.Subscribe(geometry, _dataChanged);
+			var subscriptions = _changeSubscriptions ??= new PathChangeSubscriptions();
+			subscriptions.SubscribeData(geometry, _dataChanged);
 		}
 
 		void StopNotifyingGeometryChanges()
 		{
-			_dataProxy?.Unsubscribe();
+			_changeSubscriptions?.UnsubscribeData();
 		}
 
 		static void OnTransformPropertyChanged(BindableObject bindable, object oldValue, object newValue)
@@ -98,13 +91,47 @@ namespace Microsoft.Maui.Controls.Shapes
 				if (e.PropertyName == Transform.ValueProperty.PropertyName)
 					OnPropertyChanged(nameof(RenderTransform));
 			};
-			_renderTransformProxy ??= new();
-			_renderTransformProxy.Subscribe(transform, _renderTransformChanged);
+			var subscriptions = _changeSubscriptions ??= new PathChangeSubscriptions();
+			subscriptions.SubscribeRenderTransform(transform, _renderTransformChanged);
 		}
 
 		void StopNotifyingTransformChanges()
 		{
-			_renderTransformProxy?.Unsubscribe();
+			_changeSubscriptions?.UnsubscribeRenderTransform();
+		}
+
+		sealed class PathChangeSubscriptions
+		{
+			WeakGeometryChangedProxy _dataProxy;
+			WeakNotifyPropertyChangedProxy _renderTransformProxy;
+
+			~PathChangeSubscriptions()
+			{
+				_dataProxy?.Unsubscribe();
+				_renderTransformProxy?.Unsubscribe();
+			}
+
+			public void SubscribeData(Geometry source, EventHandler handler)
+			{
+				_dataProxy ??= new WeakGeometryChangedProxy();
+				_dataProxy.Subscribe(source, handler);
+			}
+
+			public void UnsubscribeData()
+			{
+				_dataProxy?.Unsubscribe();
+			}
+
+			public void SubscribeRenderTransform(Transform source, PropertyChangedEventHandler handler)
+			{
+				_renderTransformProxy ??= new WeakNotifyPropertyChangedProxy();
+				_renderTransformProxy.Subscribe(source, handler);
+			}
+
+			public void UnsubscribeRenderTransform()
+			{
+				_renderTransformProxy?.Unsubscribe();
+			}
 		}
 
 		class WeakGeometryChangedProxy : WeakEventProxy<Geometry, EventHandler>

--- a/src/Controls/src/Core/Shapes/Path.cs
+++ b/src/Controls/src/Core/Shapes/Path.cs
@@ -58,6 +58,7 @@ namespace Microsoft.Maui.Controls.Shapes
 
 		static void OnGeometryPropertyChanged(BindableObject bindable, object oldValue, object newValue)
 		{
+			// The subscription helper owns old-source cleanup, so only the new value determines the next state.
 			if (newValue is Geometry geometry)
 				((Path)bindable).NotifyGeometryChanges(geometry);
 			else
@@ -78,6 +79,7 @@ namespace Microsoft.Maui.Controls.Shapes
 
 		static void OnTransformPropertyChanged(BindableObject bindable, object oldValue, object newValue)
 		{
+			// The subscription helper owns old-source cleanup, so only the new value determines the next state.
 			if (newValue is Transform transform)
 				((Path)bindable).NotifyTransformChanges(transform);
 			else

--- a/src/Controls/tests/Core.UnitTests/PathMemoryTests.cs
+++ b/src/Controls/tests/Core.UnitTests/PathMemoryTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls.Shapes;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	public class PathMemoryTests
+	{
+		// A shared / long-lived Geometry assigned to Path.Data must not keep the Path alive.
+		// Path subscribes to Geometry.PropertyChanged (and PathGeometry.InvalidatePathGeometryRequested)
+		// and previously did so with a plain (strong) delegate, rooting every Path for the
+		// lifetime of the shared geometry.
+		[Theory]
+		[InlineData(typeof(EllipseGeometry))]
+		[InlineData(typeof(RectangleGeometry))]
+		[InlineData(typeof(PathGeometry))]
+		public async Task PathDataDoesNotLeakWhenGeometryOutlivesIt(Type geometryType)
+		{
+			var sharedGeometry = (Geometry)Activator.CreateInstance(geometryType);
+
+			var reference = new WeakReference(new Path { Data = sharedGeometry });
+
+			Assert.False(await reference.WaitForCollect(), "Path should not be alive!");
+
+			// Keep the shared geometry rooted until after measuring so the leak is observable.
+			GC.KeepAlive(sharedGeometry);
+		}
+
+		// A shared / long-lived Transform assigned to Path.RenderTransform must not keep the Path alive.
+		[Fact]
+		public async Task PathRenderTransformDoesNotLeakWhenTransformOutlivesIt()
+		{
+			var sharedTransform = new RotateTransform { Angle = 45 };
+
+			var reference = new WeakReference(new Path { RenderTransform = sharedTransform });
+
+			Assert.False(await reference.WaitForCollect(), "Path should not be alive!");
+
+			GC.KeepAlive(sharedTransform);
+		}
+	}
+}

--- a/src/Controls/tests/Core.UnitTests/PathMemoryTests.cs
+++ b/src/Controls/tests/Core.UnitTests/PathMemoryTests.cs
@@ -108,6 +108,22 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public async Task DirectGeometryPropertyChangesStillNotifyAfterGc()
+		{
+			var geometry = new EllipseGeometry();
+			var path = new Path { Data = geometry };
+			bool changed = false;
+			path.PropertyChanged += (_, e) => changed |= e.PropertyName == nameof(Path.Data);
+
+			await TestHelpers.Collect();
+
+			geometry.RadiusX = 10;
+
+			Assert.True(changed);
+			GC.KeepAlive(path);
+		}
+
+		[Fact]
 		public async Task PathRenderTransformChangesStillNotifyAfterGc()
 		{
 			var transform = new RotateTransform();

--- a/src/Controls/tests/Core.UnitTests/PathMemoryTests.cs
+++ b/src/Controls/tests/Core.UnitTests/PathMemoryTests.cs
@@ -19,7 +19,15 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		{
 			var sharedGeometry = (Geometry)Activator.CreateInstance(geometryType);
 
-			var reference = new WeakReference(new Path { Data = sharedGeometry });
+			static WeakReference CreatePath(Geometry geometry)
+			{
+				var path = new Path { Data = geometry };
+				return new WeakReference(path);
+			}
+
+			var reference = CreatePath(sharedGeometry);
+
+			await TestHelpers.Collect();
 
 			Assert.False(await reference.WaitForCollect(), "Path should not be alive!");
 
@@ -33,11 +41,51 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		{
 			var sharedTransform = new RotateTransform { Angle = 45 };
 
-			var reference = new WeakReference(new Path { RenderTransform = sharedTransform });
+			static WeakReference CreatePath(Transform transform)
+			{
+				var path = new Path { RenderTransform = transform };
+				return new WeakReference(path);
+			}
+
+			var reference = CreatePath(sharedTransform);
+
+			await TestHelpers.Collect();
 
 			Assert.False(await reference.WaitForCollect(), "Path should not be alive!");
 
 			GC.KeepAlive(sharedTransform);
+		}
+
+		[Fact]
+		public async Task PathDataChangesStillNotifyAfterGc()
+		{
+			var geometry = new PathGeometry();
+			var path = new Path { Data = geometry };
+			bool changed = false;
+			path.PropertyChanged += (_, e) => changed |= e.PropertyName == nameof(Path.Data);
+
+			await TestHelpers.Collect();
+
+			geometry.Figures.Add(new PathFigure());
+
+			Assert.True(changed);
+			GC.KeepAlive(path);
+		}
+
+		[Fact]
+		public async Task PathRenderTransformChangesStillNotifyAfterGc()
+		{
+			var transform = new RotateTransform();
+			var path = new Path { RenderTransform = transform };
+			bool changed = false;
+			path.PropertyChanged += (_, e) => changed |= e.PropertyName == nameof(Path.RenderTransform);
+
+			await TestHelpers.Collect();
+
+			transform.Angle = 45;
+
+			Assert.True(changed);
+			GC.KeepAlive(path);
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/PathMemoryTests.cs
+++ b/src/Controls/tests/Core.UnitTests/PathMemoryTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
+	[Category(TestCategory.Memory)]
 	public class PathMemoryTests
 	{
 		// A shared / long-lived Geometry assigned to Path.Data must not keep the Path alive.

--- a/src/Controls/tests/Core.UnitTests/PathMemoryTests.cs
+++ b/src/Controls/tests/Core.UnitTests/PathMemoryTests.cs
@@ -87,5 +87,43 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.True(changed);
 			GC.KeepAlive(path);
 		}
+
+		[Fact]
+		public void PathDataReassignmentMovesChangeSubscription()
+		{
+			var oldGeometry = new PathGeometry();
+			var newGeometry = new PathGeometry();
+			var path = new Path { Data = oldGeometry };
+			path.Data = newGeometry;
+
+			bool changed = false;
+			path.PropertyChanged += (_, e) => changed |= e.PropertyName == nameof(Path.Data);
+
+			oldGeometry.Figures.Add(new PathFigure());
+			Assert.False(changed);
+
+			newGeometry.Figures.Add(new PathFigure());
+			Assert.True(changed);
+			GC.KeepAlive(path);
+		}
+
+		[Fact]
+		public void PathRenderTransformReassignmentMovesChangeSubscription()
+		{
+			var oldTransform = new RotateTransform();
+			var newTransform = new RotateTransform();
+			var path = new Path { RenderTransform = oldTransform };
+			path.RenderTransform = newTransform;
+
+			bool changed = false;
+			path.PropertyChanged += (_, e) => changed |= e.PropertyName == nameof(Path.RenderTransform);
+
+			oldTransform.Angle = 45;
+			Assert.False(changed);
+
+			newTransform.Angle = 45;
+			Assert.True(changed);
+			GC.KeepAlive(path);
+		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/PathMemoryTests.cs
+++ b/src/Controls/tests/Core.UnitTests/PathMemoryTests.cs
@@ -57,6 +57,41 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public async Task SharedResourcesDoNotRetainTransientPaths()
+		{
+			const int pathCount = 32;
+			var sharedGeometry = new PathGeometry();
+			var sharedTransform = new ScaleTransform { ScaleX = 2, ScaleY = 2 };
+
+			static WeakReference[] CreatePaths(Geometry geometry, Transform transform, int count)
+			{
+				var references = new WeakReference[count];
+
+				for (var i = 0; i < count; i++)
+				{
+					var path = new Path
+					{
+						Data = geometry,
+						RenderTransform = transform
+					};
+					references[i] = new WeakReference(path);
+				}
+
+				return references;
+			}
+
+			var references = CreatePaths(sharedGeometry, sharedTransform, pathCount);
+
+			await TestHelpers.Collect();
+
+			foreach (var reference in references)
+				Assert.False(await reference.WaitForCollect(), "Path should not be alive!");
+
+			GC.KeepAlive(sharedGeometry);
+			GC.KeepAlive(sharedTransform);
+		}
+
+		[Fact]
 		public async Task PathDataChangesStillNotifyAfterGc()
 		{
 			var geometry = new PathGeometry();
@@ -108,6 +143,22 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public void PathDataNullAssignmentUnsubscribesOldSource()
+		{
+			var oldGeometry = new PathGeometry();
+			var path = new Path { Data = oldGeometry };
+			path.Data = null;
+
+			bool changed = false;
+			path.PropertyChanged += (_, e) => changed |= e.PropertyName == nameof(Path.Data);
+
+			oldGeometry.Figures.Add(new PathFigure());
+
+			Assert.False(changed);
+			GC.KeepAlive(path);
+		}
+
+		[Fact]
 		public void PathRenderTransformReassignmentMovesChangeSubscription()
 		{
 			var oldTransform = new RotateTransform();
@@ -123,6 +174,22 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			newTransform.Angle = 45;
 			Assert.True(changed);
+			GC.KeepAlive(path);
+		}
+
+		[Fact]
+		public void PathRenderTransformNullAssignmentUnsubscribesOldSource()
+		{
+			var oldTransform = new RotateTransform();
+			var path = new Path { RenderTransform = oldTransform };
+			path.RenderTransform = null;
+
+			bool changed = false;
+			path.PropertyChanged += (_, e) => changed |= e.PropertyName == nameof(Path.RenderTransform);
+
+			oldTransform.Angle = 45;
+
+			Assert.False(changed);
 			GC.KeepAlive(path);
 		}
 	}

--- a/src/Controls/tests/Core.UnitTests/PathMemoryTests.cs
+++ b/src/Controls/tests/Core.UnitTests/PathMemoryTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[Fact]
 		public async Task PathRenderTransformDoesNotLeakWhenTransformOutlivesIt()
 		{
-			var sharedTransform = new RotateTransform { Angle = 45 };
+			var sharedTransform = new ScaleTransform { ScaleX = 2, ScaleY = 2 };
 
 			static WeakReference CreatePath(Transform transform)
 			{


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

> [!NOTE]
> 🤖 **AI-generated PR.** This fix and its regression tests were produced by an AI-driven memory-leak workflow and verified locally. Please review carefully before merging.

Fixes #35860

### The leak

`Path.Data` and `Path.RenderTransform` subscribed the `Path` to change notifications on the assigned geometry or transform using strong handlers. A shared or long-lived value could therefore retain every `Path` using it and, through the `Path`, its visual tree or page.

### The fix

Subscribe through `WeakGeometryChangedProxy` and `WeakNotifyPropertyChangedProxy`, owned by a private, lazily-created `PathChangeSubscriptions` helper. The helper finalizer tears down the proxies when the owner is collected, preventing shared geometry and transform instances from rooting the `Path` without adding a public finalizer or changing the public API surface.

### Regression tests

`PathMemoryTests` in `src/Controls/tests/Core.UnitTests/PathMemoryTests.cs` covers:
- `PathDataDoesNotLeakWhenGeometryOutlivesIt`
- `PathRenderTransformDoesNotLeakWhenTransformOutlivesIt`
- `PathDataChangesStillNotifyAfterGc`
- `DirectGeometryPropertyChangesStillNotifyAfterGc`
- `PathRenderTransformChangesStillNotifyAfterGc`
- `PathDataReassignmentMovesChangeSubscription`
- `PathRenderTransformReassignmentMovesChangeSubscription`
- `SharedResourcesDoNotRetainTransientPaths`
- `PathDataNullAssignmentUnsubscribesOldSource`
- `PathRenderTransformNullAssignmentUnsubscribesOldSource`

The class is tagged with `Category(TestCategory.Memory)` so all 12 regressions can be run through the standard memory-test filter.

**Verified locally against this PR base (`main`), `Controls.Core.UnitTests`:**

| State | Result |
|---|---|
| Without fix | ❌ leak regressions fail |
| With fix | ✅ all 12 targeted `PathMemoryTests` pass |

### Scope

Managed cross-platform change for all platforms. No public API additions.
