### PR TITLE
[Android] Fix Entry password visibility when using Keyboard.Password

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.Android.cs
@@ -207,5 +207,57 @@ namespace Microsoft.Maui.DeviceTests
 				AssertTranslationMatches(nativeView, entry.TranslationX, entry.TranslationY);
 			});
 		}
+
+		[Fact]
+		[Category(TestCategory.Entry)]
+		public async Task KeyboardPasswordDoesNotForcePasswordVisibilityWhenIsPasswordIsFalse()
+		{
+			var entry = new Entry
+			{
+				Keyboard = Keyboard.Password,
+				IsPassword = false,
+				Text = "Password"
+			};
+
+			var handler = await CreateHandlerAsync<EntryHandler>(entry);
+			var platformEntry = GetPlatformControl(handler);
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				Assert.False(platformEntry.InputType.HasFlag(global::Android.Text.InputTypes.TextVariationPassword));
+				Assert.False(platformEntry.InputType.HasFlag(global::Android.Text.InputTypes.NumberVariationPassword));
+			});
+		}
+
+		[Fact]
+		[Category(TestCategory.Entry)]
+		public async Task KeyboardPasswordRespectsIsPasswordToggle()
+		{
+			var entry = new Entry
+			{
+				Keyboard = Keyboard.Password,
+				IsPassword = false,
+				Text = "Password"
+			};
+
+			var handler = await CreateHandlerAsync<EntryHandler>(entry);
+			var platformEntry = GetPlatformControl(handler);
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				Assert.False(platformEntry.InputType.HasFlag(global::Android.Text.InputTypes.TextVariationPassword));
+
+				entry.IsPassword = true;
+				handler.UpdateValue(nameof(IEntry.IsPassword));
+
+				Assert.True(platformEntry.InputType.HasFlag(global::Android.Text.InputTypes.TextVariationPassword));
+
+				entry.IsPassword = false;
+				handler.UpdateValue(nameof(IEntry.IsPassword));
+
+				Assert.False(platformEntry.InputType.HasFlag(global::Android.Text.InputTypes.TextVariationPassword));
+				Assert.False(platformEntry.InputType.HasFlag(global::Android.Text.InputTypes.NumberVariationPassword));
+			});
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.Android.cs
@@ -210,7 +210,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		[Fact]
 		[Category(TestCategory.Entry)]
-		public async Task KeyboardPasswordDoesNotForcePasswordVisibilityWhenIsPasswordIsFalse()
+		public async Task KeyboardPasswordDoesNotForcePasswordVisibilityWhenIsPasswordFalse()
 		{
 			var entry = new Entry
 			{
@@ -257,6 +257,28 @@ namespace Microsoft.Maui.DeviceTests
 
 				Assert.False(platformEntry.InputType.HasFlag(global::Android.Text.InputTypes.TextVariationPassword));
 				Assert.False(platformEntry.InputType.HasFlag(global::Android.Text.InputTypes.NumberVariationPassword));
+			});
+		}
+
+		[Fact]
+		[Category(TestCategory.Entry)]
+		public async Task KeyboardUrlPreservesUrlInputTypeWhenIsPasswordFalse()
+		{
+			var entry = new Entry
+			{
+				Keyboard = Keyboard.Url,
+				IsPassword = false,
+				Text = "https://dot.net"
+			};
+
+			var handler = await CreateHandlerAsync<EntryHandler>(entry);
+			var platformEntry = GetPlatformControl(handler);
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				Assert.True(platformEntry.InputType.HasFlag(global::Android.Text.InputTypes.ClassText));
+				Assert.True(platformEntry.InputType.HasFlag(global::Android.Text.InputTypes.TextVariationUri));
+				Assert.False(platformEntry.InputType.HasFlag(global::Android.Text.InputTypes.TextVariationPassword));
 			});
 		}
 	}

--- a/src/Core/src/Platform/Android/EditTextExtensions.cs
+++ b/src/Core/src/Platform/Android/EditTextExtensions.cs
@@ -387,8 +387,7 @@ namespace Microsoft.Maui.Platform
 				}
 				else
 				{
-					editText.InputType &= ~InputTypes.TextVariationPassword;
-					editText.InputType &= ~InputTypes.NumberVariationPassword;
+					editText.InputType &= ~(InputTypes.TextVariationPassword | InputTypes.NumberVariationPassword);
 				}
 			}
 

--- a/src/Core/src/Platform/Android/EditTextExtensions.cs
+++ b/src/Core/src/Platform/Android/EditTextExtensions.cs
@@ -375,23 +375,13 @@ namespace Microsoft.Maui.Platform
 				editText.KeyListener = LocalizedDigitsKeyListener.Create(editText.InputType);
 			}
 
-			if (textInput is IEntry entry && entry.IsPassword)
-			{
-				if (editText.InputType.HasFlag(InputTypes.ClassText))
-					editText.InputType |= InputTypes.TextVariationPassword;
-				if (editText.InputType.HasFlag(InputTypes.ClassNumber))
-					editText.InputType |= InputTypes.NumberVariationPassword;
-			}
-			else if (textInput is IEntry)
-			{
-				editText.InputType &= ~InputTypes.TextVariationPassword;
-				editText.InputType &= ~InputTypes.NumberVariationPassword;
 			if (textInput is IEntry entry)
 			{
 				if (entry.IsPassword)
-				{				
+				{
 					if (editText.InputType.HasFlag(InputTypes.ClassText))
 						editText.InputType |= InputTypes.TextVariationPassword;
+
 					if (editText.InputType.HasFlag(InputTypes.ClassNumber))
 						editText.InputType |= InputTypes.NumberVariationPassword;
 				}

--- a/src/Core/src/Platform/Android/EditTextExtensions.cs
+++ b/src/Core/src/Platform/Android/EditTextExtensions.cs
@@ -382,6 +382,11 @@ namespace Microsoft.Maui.Platform
 				if (editText.InputType.HasFlag(InputTypes.ClassNumber))
 					editText.InputType |= InputTypes.NumberVariationPassword;
 			}
+			else if (textInput is IEntry)
+			{
+				editText.InputType &= ~InputTypes.TextVariationPassword;
+				editText.InputType &= ~InputTypes.NumberVariationPassword;
+			}
 
 			if (textInput is IEditor)
 				editText.InputType |= InputTypes.TextFlagMultiLine;

--- a/src/Core/src/Platform/Android/EditTextExtensions.cs
+++ b/src/Core/src/Platform/Android/EditTextExtensions.cs
@@ -386,6 +386,20 @@ namespace Microsoft.Maui.Platform
 			{
 				editText.InputType &= ~InputTypes.TextVariationPassword;
 				editText.InputType &= ~InputTypes.NumberVariationPassword;
+			if (textInput is IEntry entry)
+			{
+				if (entry.IsPassword)
+				{				
+					if (editText.InputType.HasFlag(InputTypes.ClassText))
+						editText.InputType |= InputTypes.TextVariationPassword;
+					if (editText.InputType.HasFlag(InputTypes.ClassNumber))
+						editText.InputType |= InputTypes.NumberVariationPassword;
+				}
+				else
+				{
+					editText.InputType &= ~InputTypes.TextVariationPassword;
+					editText.InputType &= ~InputTypes.NumberVariationPassword;
+				}
 			}
 
 			if (textInput is IEditor)

--- a/src/Core/src/Platform/Android/EditTextExtensions.cs
+++ b/src/Core/src/Platform/Android/EditTextExtensions.cs
@@ -387,7 +387,11 @@ namespace Microsoft.Maui.Platform
 				}
 				else
 				{
-					editText.InputType &= ~(InputTypes.TextVariationPassword | InputTypes.NumberVariationPassword);
+					if (editText.InputType.HasFlag(InputTypes.ClassText))
+						editText.InputType &= ~InputTypes.TextVariationPassword;
+
+					if (editText.InputType.HasFlag(InputTypes.ClassNumber))
+						editText.InputType &= ~InputTypes.NumberVariationPassword;
 				}
 			}
 


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!!
-->

### Description of Change

This PR fixes an Android issue where `Entry` configured with `Keyboard.Password` continued to obscure text even when `IsPassword` was set to `false`.

The root cause was that `Keyboard.Password` initializes the underlying `InputType` with the password variation flags, but those flags were never removed when `IsPassword` was `false`. As a result, the platform `EditText` continued behaving as a password field.

This change updates the Android input type configuration to explicitly clear the password variation flags whenever `IsPassword` is `false`, ensuring that `Entry.IsPassword` remains the source of truth for password visibility.

### Issues Fixed

Fixes #35650

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->