### PR TITLE
[Android] Map: Unsubscribe removed pins from PropertyChanged to avoid leaking the handler

### DIFF
--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -50,6 +50,10 @@ namespace Microsoft.Maui.Maps.Handlers
 
 		CancellationTokenSource? _addPinsCts;
 
+		// Pins subscribed to PropertyChanged; tracked so DisconnectPins can unsubscribe pins already
+		// removed from VirtualView.Pins (the live collection no longer lists them).
+		readonly HashSet<INotifyPropertyChanged> _subscribedPins = new();
+
 		public GoogleMap? Map { get; private set; }
 
 		static Bundle? s_bundle;
@@ -723,6 +727,7 @@ namespace Microsoft.Maui.Maps.Handlers
 				// -= before += because ReclusterPins re-runs AddPins on zoom without DisconnectPins.
 				observable.PropertyChanged -= PinOnPropertyChanged;
 				observable.PropertyChanged += PinOnPropertyChanged;
+				_subscribedPins.Add(observable);
 			}
 
 			AddPinAsync(pin, ct).FireAndForget();
@@ -776,17 +781,18 @@ namespace Microsoft.Maui.Maps.Handlers
 
 		void DisconnectPins()
 		{
+			// Unsubscribe every pin we actually subscribed to, including ones already removed from
+			// VirtualView.Pins, so a removed-but-subscribed pin can no longer keep this handler alive.
+			foreach (var observable in _subscribedPins)
+				observable.PropertyChanged -= PinOnPropertyChanged;
+			_subscribedPins.Clear();
+
 			if (VirtualView == null)
 				return;
 
 			for (int i = 0; i < VirtualView.Pins.Count; i++)
 			{
-				var pin = VirtualView.Pins[i];
-				if (pin is INotifyPropertyChanged observable)
-				{
-					observable.PropertyChanged -= PinOnPropertyChanged;
-				}
-				pin?.Handler?.DisconnectHandler();
+				VirtualView.Pins[i]?.Handler?.DisconnectHandler();
 			}
 		}
 

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -51,8 +51,10 @@ namespace Microsoft.Maui.Maps.Handlers
 		CancellationTokenSource? _addPinsCts;
 
 		// Pins subscribed to PropertyChanged; tracked so DisconnectPins can unsubscribe pins already
-		// removed from VirtualView.Pins (the live collection no longer lists them).
-		readonly HashSet<INotifyPropertyChanged> _subscribedPins = new();
+		// removed from VirtualView.Pins (the live collection no longer lists them). Uses reference
+		// equality because Pin.Equals/GetHashCode are value-based over mutable properties, which would
+		// otherwise collapse distinct-but-equal pins into a single tracked entry.
+		readonly HashSet<INotifyPropertyChanged> _subscribedPins = new(ReferenceEqualityComparer.Instance);
 
 		public GoogleMap? Map { get; private set; }
 


### PR DESCRIPTION
### Description of Change

Follow-up to #36235 (AI review flagged this as a `[major]` finding).

On Android, `MapHandler` subscribes pins to `PropertyChanged` (`PinOnPropertyChanged`) in `AddRegularPin`, but `DisconnectPins` unsubscribed by iterating the **live** `VirtualView.Pins` collection.

When a pin is removed from `Map.Pins`, `PinsOnCollectionChanged` re-runs the `Pins` mapper (`DisconnectPins` + `AddPins`) **after** the collection has already changed, so the removed pin is no longer enumerated and never gets `PropertyChanged -= PinOnPropertyChanged`. Because the subscription makes the pin reference the handler, a removed-but-retained pin (e.g. one kept in a view model) keeps the `MapHandler` — and its `Map`/`MapView`/page — alive, and `PinOnPropertyChanged` keeps firing for it.

**Fix:** track the pins the handler actually subscribed to in a `HashSet<INotifyPropertyChanged>` and unsubscribe that set in `DisconnectPins`, independent of the current `Pins` collection. Handler disconnection for the current pins is unchanged.

**Note:** this is a pre-existing issue — `DisconnectPins` predates #36235 and the non-clustered path already subscribed pins the same way; #36235 only widened the surface by also subscribing single-pin clusters. Other platforms are unaffected: iOS applies pin images via `GetViewForAnnotation` without a handler-level `PropertyChanged` subscription, and Windows/Tizen/Standard don't implement pins.

#### Testing

The Android `Map` handler is not covered by automated tests (device tests for `Map` are gated to iOS/MacCatalyst — `MapTests` is wrapped in `#if IOS || MACCATALYST` because Android requires a Google Maps API key to instantiate `MapView`, which isn't available in CI). Verified by building `Microsoft.Maui.Maps` for `net11.0-android` (0 warnings/errors) and manually on a physical device (Samsung SM-X230): pins with custom icons add/remove/re-add correctly with clustering enabled.

### Issues Fixed

Follow-up to #36235
