### PR TITLE
Update arcade to 11.0.0-beta.26330.112 WIX migration

### DIFF
--- a/.github/instructions/workload-msi.instructions.md
+++ b/.github/instructions/workload-msi.instructions.md
@@ -1,0 +1,96 @@
+---
+description: "Guidelines for working with workload MSI generation (WiX 6) in src/Workload/"
+globs:
+  - "src/Workload/**"
+  - "eng/NuGetVersions.targets"
+  - "eng/Versions.props"
+---
+
+# Workload MSI Generation (WiX 6)
+
+## Architecture Overview
+
+`src/Workload/workloads.csproj` generates MSIs for Visual Studio workload insertion using the arcade `CreateVisualStudioWorkload` task. As of .NET 11, this uses **WiX 6** (wix.exe) instead of WiX 3 (candle/light).
+
+Full documentation: [docs/design/WorkloadMsi.md](/docs/design/WorkloadMsi.md)
+
+## Critical Rules
+
+### DO NOT
+
+- **Do NOT change TargetFramework** from `netstandard2.0` — this avoids NU1212 errors with `Microsoft.Wix` (DotnetTool package type)
+- **Do NOT remove `ExcludeAssets="all"`** from `Microsoft.Wix` PackageReference — required for DotnetTool compatibility
+- **Do NOT remove `GenerateDependencyFile=false`** — needed for netstandard2.0 project that doesn't produce binaries
+- **Do NOT add `UseWorkloadPackGroupsForVS`** — removed in arcade 11.x, will cause build errors
+- **Do NOT use `WixToolsetPath`** — that's the WiX 3 parameter; use `WixExe`/`HeatExe`/`WixExtensions` instead
+- **Do NOT reference `Microsoft.Signed.WiX`** — that's the old WiX 3 package
+
+### MUST
+
+- **Keep WiX package versions in sync** — All 5 WiX packages must use `$(MicrosoftWixVersion)` from `eng/Versions.props`
+- **Use `GeneratePathProperty="true"`** on all WiX PackageReferences — needed for `$(Pkg*)` path resolution
+- **Extension path pattern**: `$(Pkg<PackageId_dots_to_underscores>)\wixext6\WixToolset.<Name>.wixext.dll`
+- **Test on internal pipeline** (ID 1095 at dnceng/internal) — MSI signing only works in internal builds
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/Workload/workloads.csproj` | Main MSI generation project — WiX 6 config + task invocation |
+| `eng/Versions.props` | `MicrosoftWixVersion` property + arcade task versions |
+| `eng/NuGetVersions.targets` | Central package version pins for WiX packages |
+| `eng/pipelines/common/sdk-insertion.yml` | Pipeline referencing workload build |
+
+## WiX 6 Package Dependencies
+
+```xml
+<!-- Required packages (all use MicrosoftWixVersion) -->
+Microsoft.Wix                           <!-- wix.exe CLI tool -->
+Microsoft.WixToolset.Heat               <!-- heat.exe harvesting tool -->
+Microsoft.WixToolset.UI.wixext          <!-- UI extension -->
+Microsoft.WixToolset.Dependency.wixext  <!-- Dependency provider extension -->
+Microsoft.WixToolset.Util.wixext        <!-- Utility extension -->
+```
+
+## Arcade Task Parameters (WiX 6)
+
+```xml
+<CreateVisualStudioWorkload
+    WixExe="$(WixExe)"              <!-- Path to wix.exe from Microsoft.Wix package -->
+    HeatExe="$(HeatExe)"            <!-- Path to heat.exe from Microsoft.WixToolset.Heat -->
+    WixExtensions="@(WixExtensions)" <!-- Item group of .wixext.dll paths -->
+    ... />
+```
+
+The task requires arcade version **11.0.0-beta.26330.112** or later for WiX 6 support.
+
+## SWIX Build
+
+SWIX projects are built using `MicroBuild.Plugins.SwixBuild.Dotnet`. If this variant is deprecated in the future, the fallback is to use desktop MSBuild via `Exec` (as done in dotnet/dotnet#5265).
+
+## Validation
+
+After any MSI-related changes, verify on internal CI:
+
+1. `Wix4DependencyProvider` table exists in generated MSIs
+2. `ProviderKeyName` is populated in `data/msi.json` (format: `PackageName,Version,Arch`)
+3. All 3 VSDrop zips are produced (components, components-pre, packs)
+4. SWIX vsman JSON has correct providerKey and installSizes
+
+## Troubleshooting
+
+### NU1212: Microsoft.Wix package type incompatibility
+**Cause**: Project TFM is not `netstandard2.0`
+**Fix**: Ensure `<TargetFramework>netstandard2.0</TargetFramework>` and `ExcludeAssets="all"` on Microsoft.Wix
+
+### "WixExe" or "HeatExe" parameter not recognized
+**Cause**: Arcade version too old
+**Fix**: Update `Microsoft.DotNet.Build.Tasks.Workloads` to 11.0.0-beta.26330.112+
+
+### SWIX build failures / CodeTaskFactory errors
+**Cause**: SwixBuild.Dotnet variant incompatible with current .NET
+**Fix**: May need to switch to desktop MSBuild pattern (see dotnet/dotnet#5265)
+
+### Missing WiX extension at expected path
+**Cause**: `GeneratePathProperty="true"` missing from PackageReference
+**Fix**: Add `GeneratePathProperty="true"` to the PackageReference; path follows pattern `$(Pkg<id_with_underscores>)\wixext6\...`

--- a/docs/design/WorkloadMsi.md
+++ b/docs/design/WorkloadMsi.md
@@ -1,0 +1,165 @@
+# Workload MSI Generation
+
+This document describes how .NET MAUI generates MSI installers for Visual Studio workload insertion via the `src/Workload/workloads.csproj` project.
+
+## Overview
+
+MAUI uses the arcade `CreateVisualStudioWorkload` MSBuild task (from `Microsoft.DotNet.Build.Tasks.Workloads`) to:
+
+1. Generate MSIs from NuGet workload packs
+2. Wrap MSIs in NuGet packages (for signing and transport)
+3. Generate SWIX projects for Visual Studio insertion (VSDrop)
+
+The output flows into the VS insertion pipeline, which installs MAUI workload packs via the VS installer.
+
+## WiX 6 Migration (completed in .NET 11)
+
+As of .NET 11, MAUI uses **WiX 6** (wix.exe CLI) instead of WiX 3 (candle.exe/light.exe). This migration was inspired by [dotnet/android#11743](https://github.com/dotnet/android/pull/11743) and follows the pattern from the `Xamarin.yaml-templates` `convert-v5/convert.proj`.
+
+### Key Changes from WiX 3 to WiX 6
+
+| Aspect | WiX 3 (old) | WiX 6 (new) |
+|--------|-------------|-------------|
+| Tool | `candle.exe` / `light.exe` via `WixToolsetPath` | `wix.exe` via `WixExe` property |
+| Package | `Microsoft.Signed.WiX` | `Microsoft.Wix` + extension packages |
+| Extensions | Bundled in WiX install | Separate NuGet packages (`*.wixext`) |
+| Heat | Part of WiX install | Separate `Microsoft.WixToolset.Heat` package |
+| MSI table | `WixDependencyProvider` | `Wix4DependencyProvider` (renamed) |
+| Signing | `CreateLightCommandPackageDrop` + separate sign step | Native `.wixpack` archives |
+| Arcade parameter | `WixToolsetPath` | `WixExe`, `HeatExe`, `WixExtensions` |
+
+### Required Arcade Version
+
+The `CreateVisualStudioWorkload` task supports WiX 6 parameters (`WixExe`, `HeatExe`, `WixExtensions`) starting from arcade **11.0.0-beta.26330.112** or later. Earlier versions only support `WixToolsetPath` (WiX 3).
+
+### NuGet Package Compatibility (NU1212 Fix)
+
+`Microsoft.Wix` has `<PackageType>DotnetTool</PackageType>` in its nuspec. This means:
+- It **cannot** be referenced from projects targeting `net8.0` or similar app TFMs (causes NU1212)
+- **Fix**: Use `TargetFramework=netstandard2.0` and `ExcludeAssets="all"` on the Microsoft.Wix PackageReference
+- `GenerateDependencyFile=false` is also needed since netstandard2.0 doesn't produce a deps file for this project type
+
+### WiX Extension Path Pattern
+
+Extensions are located at: `$(Pkg<PackageId_with_underscores>)\wixext6\WixToolset.<Name>.wixext.dll`
+
+Example:
+```xml
+<WixExtensions Include="$(PkgMicrosoft_WixToolset_Dependency_wixext)\wixext6\WixToolset.Dependency.wixext.dll" />
+```
+
+## Architecture
+
+### File: `src/Workload/workloads.csproj`
+
+This is the central MSI generation project. It:
+
+1. **Restores WiX packages** — `Microsoft.Wix`, `Microsoft.WixToolset.Heat`, and 3 extension packages
+2. **Defines WiX tool paths** — `WixExe`, `HeatExe` properties pointing to package tools
+3. **Lists WiX extensions** — `WixExtensions` item group with paths to `.wixext.dll` files
+4. **Imports `vs-workload.props`** — Generated file listing workload packs to package
+5. **Calls `CreateVisualStudioWorkload`** — Arcade task that orchestrates MSI creation
+6. **Builds SWIX projects** — For VS insertion metadata (component definitions, manifests)
+7. **Creates VSDrop zips** — Three zip files consumed by VS insertion automation
+
+### Task: `CreateVisualStudioWorkload`
+
+From `Microsoft.DotNet.Build.Tasks.Workloads` (arcade). Key parameters:
+
+```xml
+<CreateVisualStudioWorkload
+    AllowMissingPacks="true"
+    PackageSource="$(NuGetPackagePath)"
+    WixExe="$(WixExe)"              <!-- Path to wix.exe -->
+    HeatExe="$(HeatExe)"            <!-- Path to heat.exe -->
+    WixExtensions="@(WixExtensions)" <!-- List of .wixext.dll paths -->
+    WorkloadManifestPackageFiles="@(WorkloadPackages)" >
+  <Output TaskParameter="Msis" ItemName="VSWorkloadMsis" />
+  <Output TaskParameter="SwixProjects" ItemName="SwixProjects" />
+</CreateVisualStudioWorkload>
+```
+
+### SWIX Build
+
+SWIX (Software Installer for Xbox — repurposed for VS) projects generate the VS component definitions. We use `MicroBuild.Plugins.SwixBuild.Dotnet` to build these via MSBuild:
+
+```xml
+<MSBuild Projects="@(PartitionedSwixProjects)" Properties="SwixBuildTargets=$(SwixTargetsPath);ManifestOutputPath=%(ManifestOutputPath)"/>
+```
+
+> **Note**: The dotnet/dotnet (SDK) repository switched to using desktop MSBuild via `Exec` for SWIX builds because the `.Dotnet` variant of SwixBuild uses a `CodeTaskFactory` that may become incompatible with newer .NET. See [dotnet/dotnet#5265](https://github.com/dotnet/dotnet/pull/5265). If SWIX build failures occur in the future, this approach may need to be adopted.
+
+### VSDrop Outputs
+
+Three zip files are produced for VS insertion:
+
+| Zip | Contents | SwixProjects filter |
+|-----|----------|-------------------|
+| `Workload.VSDrop.*.components.zip` | Stable components + manifests | `PackageType == 'component'` (non-preview) + manifests |
+| `Workload.VSDrop.*-pre.components.zip` | Preview components + manifests | `PackageType == 'component'` (preview) + manifests |
+| `Workload.VSDrop.*.packs.zip` | Workload pack MSIs | `PackageType == 'msi-pack'` |
+
+## Validation Criteria
+
+When making changes to MSI generation, validate:
+
+1. **`Wix4DependencyProvider` table in MSI** — The MSI must contain this table (renamed from `WixDependencyProvider`)
+2. **`ProviderKeyName` in `data/msi.json`** — Inside the MSI NuGet package, format: `PackageName,Version,Arch`
+3. **SWIX vsman JSON** — Must have correct `providerKey`, `productCode`, and `installSizes`
+4. **VSDrop zips** — All 3 zips must be produced with correct content
+5. **`RelatedProducts`** — WiX 6 adds `WIX_UPGRADE_DETECTED` / `WIX_DOWNGRADE_DETECTED` entries (feature gain)
+
+### How to Validate Locally
+
+Download artifacts from the internal CI build and inspect:
+
+```bash
+# Check msi.json in an MSI nupkg
+unzip -p Microsoft.Maui.Core.Msi.x64.*.nupkg data/msi.json | python -m json.tool
+
+# Check VSDrop zip contents
+unzip -l Workload.VSDrop.*.components.zip
+```
+
+## Package Version Management
+
+WiX package versions are pinned in `eng/NuGetVersions.targets` using the `MicrosoftWixVersion` property defined in `eng/Versions.props`:
+
+```xml
+<!-- eng/Versions.props -->
+<MicrosoftWixVersion>6.0.3-dotnet.4</MicrosoftWixVersion>
+
+<!-- eng/NuGetVersions.targets -->
+<PackageVersion Include="Microsoft.Wix" Version="$(MicrosoftWixVersion)" />
+<PackageVersion Include="Microsoft.WixToolset.Heat" Version="$(MicrosoftWixVersion)" />
+<PackageVersion Include="Microsoft.WixToolset.UI.wixext" Version="$(MicrosoftWixVersion)" />
+<PackageVersion Include="Microsoft.WixToolset.Dependency.wixext" Version="$(MicrosoftWixVersion)" />
+<PackageVersion Include="Microsoft.WixToolset.Util.wixext" Version="$(MicrosoftWixVersion)" />
+```
+
+## Testing Pipeline
+
+The workload MSI generation runs in the internal signing pipeline:
+- **Pipeline**: `dotnet-maui` (ID: 1095)
+- **Org**: `https://dev.azure.com/dnceng`
+- **Project**: `internal`
+- **Trigger**: Push to any branch in the internal mirror (`dnceng/internal/_git/dotnet-maui`)
+
+The pipeline only runs on internal builds because MSI signing requires MicroBuild infrastructure.
+
+## Related PRs and References
+
+- [dotnet/maui#36297](https://github.com/dotnet/maui/pull/36297) — MAUI WiX 6 migration
+- [dotnet/android#11743](https://github.com/dotnet/android/pull/11743) — Android WiX 6 migration (reference)
+- [dotnet/dotnet#5265](https://github.com/dotnet/dotnet/pull/5265) — Arcade-level WiX 5/6 rewrite (deeper refactor)
+- Xamarin.yaml-templates `convert-v5/convert.proj` — Reference implementation pattern
+
+## Future Considerations
+
+1. **SwixBuild package**: We currently use `MicroBuild.Plugins.SwixBuild.Dotnet` (the .NET-compatible variant). The SDK repo has moved to `Microsoft.VisualStudioEng.MicroBuild.Plugins.SwixBuild` 1.1.922 with desktop MSBuild. If the `.Dotnet` variant is deprecated, MAUI will need to follow the same pattern.
+
+2. **Arcade task evolution**: [dotnet/dotnet#5265](https://github.com/dotnet/dotnet/pull/5265) introduces `CreateWixPacks` (generating `.wixpack` archives for signing) and removes `CreateLightCommandPackageDrop`. When this arcade version ships, MAUI will consume these changes automatically through dependency flow.
+
+3. **`UseWorkloadPackGroupsForVS`**: This property was removed in arcade 11.x. Do not re-add it.
+
+4. **`IceSuppressions`**: WiX 6 doesn't run ICE validation by default (no `LGHT1105` NoWarn needed).

--- a/eng/NuGetVersions.targets
+++ b/eng/NuGetVersions.targets
@@ -328,7 +328,12 @@
     />
 
     <PackageReference Update="Microsoft.DotNet.Build.Tasks.Workloads" Version="$(MicrosoftDotNetBuildTasksWorkloadsPackageVersion)" />
-    <PackageReference Update="Microsoft.Signed.WiX" Version="$(MicrosoftSignedWixVersion)" />
+    <!-- WiX 6 packages -->
+    <PackageReference Update="Microsoft.Wix" Version="$(MicrosoftWixVersion)" />
+    <PackageReference Update="Microsoft.WixToolset.Heat" Version="$(MicrosoftWixVersion)" />
+    <PackageReference Update="Microsoft.WixToolset.UI.wixext" Version="$(MicrosoftWixVersion)" />
+    <PackageReference Update="Microsoft.WixToolset.Dependency.wixext" Version="$(MicrosoftWixVersion)" />
+    <PackageReference Update="Microsoft.WixToolset.Util.wixext" Version="$(MicrosoftWixVersion)" />
     <PackageReference Update="MicroBuild.Plugins.SwixBuild.Dotnet" Version="$(MicroBuildPluginsSwixBuildDotnetPackageVersion)" />
     <PackageReference Update="Microsoft.DotNet.Build.Tasks.Installers" Version="$(MicrosoftDotNetBuildTasksInstallersPackageVersion)"/>
   </ItemGroup>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -179,33 +179,33 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26325.125">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26330.112">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>a9679a8de87742e170318ea39f7f0e2874bcd441</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="11.0.0-beta.26325.125">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="11.0.0-beta.26330.112">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>a9679a8de87742e170318ea39f7f0e2874bcd441</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="11.0.0-beta.26325.125">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="11.0.0-beta.26330.112">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>a9679a8de87742e170318ea39f7f0e2874bcd441</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26325.125">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26330.112">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>a9679a8de87742e170318ea39f7f0e2874bcd441</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="11.0.0-beta.26325.125">
+    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="11.0.0-beta.26330.112">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>a9679a8de87742e170318ea39f7f0e2874bcd441</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="11.0.0-beta.26325.125">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="11.0.0-beta.26330.112">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>a9679a8de87742e170318ea39f7f0e2874bcd441</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="11.0.0-beta.26325.125">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="11.0.0-beta.26330.112">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>a9679a8de87742e170318ea39f7f0e2874bcd441</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -175,9 +175,9 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="11.0.0-beta.26325.125">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="11.0.0-beta.26330.112">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>a9679a8de87742e170318ea39f7f0e2874bcd441</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26330.112">
       <Uri>https://github.com/dotnet/dotnet</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -153,6 +153,7 @@
     <MicroBuildPluginsSwixBuildDotnetPackageVersion>1.1.87-gba258badda</MicroBuildPluginsSwixBuildDotnetPackageVersion>
     <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.26330.112</MicrosoftDotNetRemoteExecutorPackageVersion>
     <MicrosoftDotNetXUnitExtensionsPackageVersion>11.0.0-beta.26330.112</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <MicrosoftWixVersion>6.0.3-dotnet.4</MicrosoftWixVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftNETTestSdkPackageVersion>17.6.0</MicrosoftNETTestSdkPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -146,13 +146,13 @@
     <TizenUIExtensionsVersion>0.9.0</TizenUIExtensionsVersion>
     <ExCSSPackageVersion>4.2.3</ExCSSPackageVersion>
     <SystemDrawingCommonPackageVersion>9.0.0</SystemDrawingCommonPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>11.0.0-beta.26325.125</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetBuildTasksInstallersPackageVersion>11.0.0-beta.26325.125</MicrosoftDotNetBuildTasksInstallersPackageVersion>
-    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>11.0.0-beta.26325.125</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26325.125</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>11.0.0-beta.26330.112</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksInstallersPackageVersion>11.0.0-beta.26330.112</MicrosoftDotNetBuildTasksInstallersPackageVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>11.0.0-beta.26330.112</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26330.112</MicrosoftDotNetHelixSdkPackageVersion>
     <MicroBuildPluginsSwixBuildDotnetPackageVersion>1.1.87-gba258badda</MicroBuildPluginsSwixBuildDotnetPackageVersion>
-    <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.26325.125</MicrosoftDotNetRemoteExecutorPackageVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>11.0.0-beta.26325.125</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.26330.112</MicrosoftDotNetRemoteExecutorPackageVersion>
+    <MicrosoftDotNetXUnitExtensionsPackageVersion>11.0.0-beta.26330.112</MicrosoftDotNetXUnitExtensionsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftNETTestSdkPackageVersion>17.6.0</MicrosoftNETTestSdkPackageVersion>

--- a/eng/pipelines/common/sdk-insertion.yml
+++ b/eng/pipelines/common/sdk-insertion.yml
@@ -49,7 +49,7 @@ jobs:
       Write-Host "##vso[task.setvariable variable=ReleaseDropPrefix]$dropPrefix"
     displayName: Set variable ReleaseDropPrefix
 
-  # Download nugets drop created by nuget-msi-convert/job/v4.yml and publish to maestro
+  # Download nugets drop created by WiX 6 MSI generation and publish to maestro
   - task: ms-vscs-artifact.build-tasks.artifactDropDownloadTask-1.artifactDropDownloadTask@1
     displayName: Download $(ReleaseDropPrefix)/nugets
     inputs:

--- a/global.json
+++ b/global.json
@@ -11,7 +11,7 @@
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44",
     "Microsoft.Build.NoTargets": "3.7.0",
-    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26325.125",
-    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26325.125"
+    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26330.112",
+    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26330.112"
   }
 }

--- a/src/Workload/workloads.csproj
+++ b/src/Workload/workloads.csproj
@@ -2,7 +2,8 @@
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateDependencyFile>false</GenerateDependencyFile>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IncludeBuildOutput>false</IncludeBuildOutput>
 
@@ -21,11 +22,20 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <WixToolsetPath>$(PkgMicrosoft_Signed_Wix)\tools</WixToolsetPath>
+    <!-- WiX 6 tool paths -->
+    <WixExe>$(PkgMicrosoft_Wix)\tools\net6.0\any\wix.exe</WixExe>
+    <HeatExe>$(PkgMicrosoft_WixToolset_Heat)\tools\net472\x64\heat.exe</HeatExe>
     <SwixPluginPath>$(PkgMicroBuild_Plugins_SwixBuild_Dotnet)</SwixPluginPath>
     <SwixBuildTargets>$(SwixPluginPath)\build\MicroBuild.Plugins.SwixBuild.targets</SwixBuildTargets>
-    <SwixTargetsPath>$(PkgMicroBuild_Plugins_SwixBuild_Dotnet)\build\MicroBuild.Plugins.SwixBuild.targets</SwixTargetsPath>
+    <SwixTargetsPath>$(SwixPluginPath)\build\MicroBuild.Plugins.SwixBuild.targets</SwixTargetsPath>
   </PropertyGroup>
+
+  <!-- WiX 6 extension assemblies -->
+  <ItemGroup>
+    <WixExtensions Include="$(PkgMicrosoft_WixToolset_UI_wixext)\wixext6\WixToolset.UI.wixext.dll" />
+    <WixExtensions Include="$(PkgMicrosoft_WixToolset_Dependency_wixext)\wixext6\WixToolset.Dependency.wixext.dll" />
+    <WixExtensions Include="$(PkgMicrosoft_WixToolset_Util_wixext)\wixext6\WixToolset.Util.wixext.dll" />
+  </ItemGroup>
 
   <Import Project="$(WorkloadMsiGenProps)" />
 
@@ -33,7 +43,6 @@
   <PropertyGroup>
     <!-- The following properties can be set to true to opt in to workload pack group MSIs -->
     <CreateWorkloadPackGroups Condition=" '$(CreateWorkloadPackGroups)' == '' ">false</CreateWorkloadPackGroups>
-    <UseWorkloadPackGroupsForVS Condition=" '$(UseWorkloadPackGroupsForVS)' == '' ">false</UseWorkloadPackGroupsForVS>
     <SkipRedundantMsiCreation Condition=" '$(SkipRedundantMsiCreation)' == '' ">false</SkipRedundantMsiCreation>
     <!-- This property should be set to true when producing the last build that will be supported by a major workload version
           https://devblogs.microsoft.com/visualstudio/removing-out-of-support-components-from-your-visual-studio-installations
@@ -49,11 +58,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Workloads" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.Signed.WiX" GeneratePathProperty="true" />
-    <PackageReference Include="MicroBuild.Plugins.SwixBuild.Dotnet" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Installers" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Workloads" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Installers" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="MicroBuild.Plugins.SwixBuild.Dotnet" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0" PrivateAssets="all" />
+    <!-- WiX 6 packages. ExcludeAssets="all" on Microsoft.Wix because it's a DotnetTool package type. -->
+    <PackageReference Include="Microsoft.Wix" ExcludeAssets="all" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.WixToolset.Heat" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.WixToolset.UI.wixext" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.WixToolset.Dependency.wixext" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.WixToolset.Util.wixext" GeneratePathProperty="true" PrivateAssets="all" />
   </ItemGroup>
 
     <Target Name="_SetMsiVersionFromNuGetVersion" >
@@ -114,8 +128,8 @@
       BeforeTargets="SignFiles" >
     <CreateVisualStudioWorkload
         AllowMissingPacks="true"
-        BaseIntermediateOutputPath="$(IntermediateOutputPath)"
-        BaseOutputPath="$(OutputPath)"
+        BaseIntermediateOutputPath="$([System.IO.Path]::GetFullPath('$(IntermediateOutputPath)'))"
+        BaseOutputPath="$([System.IO.Path]::GetFullPath('$(OutputPath)'))"
         ComponentResources="@(ComponentResources)"
         CreateWorkloadPackGroups="$(CreateWorkloadPackGroups)"
         EnableSideBySideManifests="$(EnableSideBySideManifests)"
@@ -123,8 +137,9 @@
         PackageSource="$(NuGetPackagePath)"
         ShortNames="@(ShortNames)"
         SkipRedundantMsiCreation="$(SkipRedundantMsiCreation)"
-        UseWorkloadPackGroupsForVS="$(UseWorkloadPackGroupsForVS)"
-        WixToolsetPath="$(WixToolsetPath)"
+        WixExe="$(WixExe)"
+        HeatExe="$(HeatExe)"
+        WixExtensions="@(WixExtensions)"
         WorkloadManifestPackageFiles="@(WorkloadPackages)" >
       <Output TaskParameter="Msis" ItemName="VSWorkloadMsis" />
       <Output TaskParameter="SwixProjects" ItemName="SwixProjects" />


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Migrate workload MSI generation from WiX 3 (candle/light via `Microsoft.Signed.WiX`) to WiX 6 (wix.exe via `Microsoft.Wix` + extension packages).

Follows the pattern established in dotnet/android#11743 and the yaml-templates `convert-v5/convert.proj` reference implementation.

## Related PRs

- dotnet/android#11743 — Android WiX 6 migration (reference implementation)
- dotnet/dotnet#5265 — Arcade-level WiX 5/6 rewrite (deeper refactor of `CreateVisualStudioWorkload` task internals)

## Changes

### `src/Workload/workloads.csproj`
- Target framework changed to `netstandard2.0` (avoids NU1212 — `Microsoft.Wix` is a DotnetTool package type)
- Added `GenerateDependencyFile=false`
- Replaced `Microsoft.Signed.WiX` with WiX 6 packages (`Microsoft.Wix`, `Microsoft.WixToolset.Heat`, and 3 wixext packages)
- `ExcludeAssets="all"` on `Microsoft.Wix` (required for DotnetTool package type)
- Added `WixExe`, `HeatExe` properties and `WixExtensions` items  
- Updated `CreateVisualStudioWorkload` task invocation: `WixToolsetPath` → `WixExe`/`HeatExe`/`WixExtensions`
- Removed `UseWorkloadPackGroupsForVS` (no longer supported in arcade 11.x)

### `eng/Versions.props`
- Bumped arcade task packages to `11.0.0-beta.26330.112` (required for WiX 6 task parameters)
- Added `MicrosoftWixVersion` = `6.0.3-dotnet.4`

### `eng/NuGetVersions.targets`
- Replaced `Microsoft.Signed.WiX` version pin with 5 WiX 6 package pins

### `eng/pipelines/common/sdk-insertion.yml`
- Removed outdated `v4.yml` comment

## Validation

✅ **Internal CI build [#3013410](https://dev.azure.com/dnceng/internal/_build/results?buildId=3013410) — PASSED**

### Artifact validation (matches dotnet/android#11743 acceptance criteria):

1. **MSI table rename** ✅ — Built with `WiX Dev Build (6.0.3.4)`, uses `Wix4DependencyProvider` table
2. **msi.json in MSI nupkg** ✅ — `ProviderKeyName` correctly populated (e.g., `"Microsoft.Maui.Core,11.0.0-preview.7.26352.12,x64"`)
3. **RelatedProducts** ✅ — `WIX_UPGRADE_DETECTED` / `WIX_DOWNGRADE_DETECTED` entries present (WiX 6 feature gain)
4. **VSDrop SWIX JSON** ✅ — All 3 VSDrop zips produced (components, components-pre, packs), vsman files correctly reference MSI packages with proper providerKey and install sizes

## Comparison with dotnet/dotnet#5265 (Arcade-level Rewrite)

The arcade PR (dotnet/dotnet#5265) performs a deeper refactor of the WiX infrastructure. Here is how our approach compares:

| Aspect | MAUI (this PR) | SDK (dotnet/dotnet#5265) | Status |
|--------|----------------|--------------------------|--------|
| WiX packages | ✅ Same 5 packages | Same | Aligned |
| `WixExe`/`HeatExe`/`WixExtensions` | ✅ Correct | Same | Aligned |
| Arcade version | 26330.112 | Same+ | Aligned |
| SwixBuild package | `.Dotnet` 1.1.87 | Full variant 1.1.922 + desktop MSBuild | **Diverges** — works today |
| SWIX build method | `<MSBuild>` task | `<Exec>` with desktop `msbuild.exe` | **Diverges** — works today |
| `CreateWixPacks` | Not explicitly set (defaults to true) | Explicitly set | Functionally equivalent |
| `LightCommandPackageDrop` | Never had it | Removed | N/A |

### Future considerations

1. **SwixBuild.Dotnet deprecation**: If `MicroBuild.Plugins.SwixBuild.Dotnet` is deprecated, we will need to switch to the full `Microsoft.VisualStudioEng.MicroBuild.Plugins.SwixBuild` + desktop MSBuild pattern (using `vswhere` to locate VS).
2. **Arcade dependency flow**: When the arcade version from dotnet/dotnet#5265 ships, improvements to `CreateVisualStudioWorkload` will flow to us automatically — no code changes needed in MAUI unless the task API changes.
