### PR TITLE
[Material 3] Make Material 3 Slider extension methods public

### DIFF
--- a/src/Core/src/Platform/Android/SliderExtensions.cs
+++ b/src/Core/src/Platform/Android/SliderExtensions.cs
@@ -20,17 +20,14 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateMinimum(this SeekBar seekBar, ISlider slider) => UpdateValue(seekBar, slider);
 
-		// TODO: Make this public in NET 11.
-		internal static void UpdateMinimum(this Slider mSlider, ISlider slider)
+		public static void UpdateMinimum(this Slider mSlider, ISlider slider)
 		{
-
 			mSlider.ValueFrom = (float)slider.Minimum;
 		}
 
 		public static void UpdateMaximum(this SeekBar seekBar, ISlider slider) => UpdateValue(seekBar, slider);
 
-		// TODO: Make this public in NET 11.
-		internal static void UpdateMaximum(this Slider mSlider, ISlider slider)
+		public static void UpdateMaximum(this Slider mSlider, ISlider slider)
 		{
 			mSlider.ValueTo = (float)slider.Maximum;
 		}
@@ -44,8 +41,7 @@ namespace Microsoft.Maui.Platform
 			seekBar.Progress = (int)((value - min) / (max - min) * PlatformMaxValue);
 		}
 
-		// TODO: Make this public in NET 11.
-		internal static void UpdateValue(this Slider mSlider, ISlider slider)
+		public static void UpdateValue(this Slider mSlider, ISlider slider)
 		{
 			if ((float)slider.Value != mSlider.Value)
 			{
@@ -62,8 +58,7 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		// TODO: Make this public in NET 11.
-		internal static void UpdateMinimumTrackColor(this Slider mSlider, ISlider slider)
+		public static void UpdateMinimumTrackColor(this Slider mSlider, ISlider slider)
 		{
 			if (slider.MinimumTrackColor is not null)
 			{
@@ -80,8 +75,7 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		// TODO: Make this public in NET 11.
-		internal static void UpdateMaximumTrackColor(this Slider mSlider, ISlider slider)
+		public static void UpdateMaximumTrackColor(this Slider mSlider, ISlider slider)
 		{
 			if (slider.MaximumTrackColor is not null)
 			{
@@ -92,8 +86,7 @@ namespace Microsoft.Maui.Platform
 		public static void UpdateThumbColor(this SeekBar seekBar, ISlider slider) =>
 			seekBar.Thumb?.SetColorFilter(slider.ThumbColor, FilterMode.SrcIn);
 
-		// TODO: Make this public in NET 11.
-		internal static void UpdateThumbColor(this Slider mSlider, ISlider slider)
+		public static void UpdateThumbColor(this Slider mSlider, ISlider slider)
 		{
 			if (slider.ThumbImageSource is not null && slider.Handler is not null)
 			{
@@ -180,8 +173,7 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		// TODO: Make this public in NET 11.
-		internal static async Task UpdateThumbImageSourceAsync(this Slider mSlider, ISlider slider, IImageSourceServiceProvider provider)
+		public static async Task UpdateThumbImageSourceAsync(this Slider mSlider, ISlider slider, IImageSourceServiceProvider provider)
 		{
 			var context = mSlider.Context;
 

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -276,6 +276,13 @@ static Microsoft.Maui.Platform.SearchViewExtensions.UpdateBackground(this Google
 static Microsoft.Maui.Platform.SearchViewExtensions.UpdateCancelButtonColor(this Google.Android.Material.TextField.TextInputLayout! textInputLayout, Microsoft.Maui.ISearchBar! searchBar) -> void
 static Microsoft.Maui.Platform.SearchViewExtensions.UpdateReturnType(this Android.Widget.EditText! editText, Microsoft.Maui.ISearchBar! searchBar) -> void
 static Microsoft.Maui.Platform.SearchViewExtensions.UpdateText(this Android.Widget.EditText! editText, Microsoft.Maui.ISearchBar! searchBar) -> void
+static Microsoft.Maui.Platform.SliderExtensions.UpdateMaximum(this Google.Android.Material.Slider.Slider! mSlider, Microsoft.Maui.ISlider! slider) -> void
+static Microsoft.Maui.Platform.SliderExtensions.UpdateMaximumTrackColor(this Google.Android.Material.Slider.Slider! mSlider, Microsoft.Maui.ISlider! slider) -> void
+static Microsoft.Maui.Platform.SliderExtensions.UpdateMinimum(this Google.Android.Material.Slider.Slider! mSlider, Microsoft.Maui.ISlider! slider) -> void
+static Microsoft.Maui.Platform.SliderExtensions.UpdateMinimumTrackColor(this Google.Android.Material.Slider.Slider! mSlider, Microsoft.Maui.ISlider! slider) -> void
+static Microsoft.Maui.Platform.SliderExtensions.UpdateThumbColor(this Google.Android.Material.Slider.Slider! mSlider, Microsoft.Maui.ISlider! slider) -> void
+static Microsoft.Maui.Platform.SliderExtensions.UpdateThumbImageSourceAsync(this Google.Android.Material.Slider.Slider! mSlider, Microsoft.Maui.ISlider! slider, Microsoft.Maui.IImageSourceServiceProvider! provider) -> System.Threading.Tasks.Task!
+static Microsoft.Maui.Platform.SliderExtensions.UpdateValue(this Google.Android.Material.Slider.Slider! mSlider, Microsoft.Maui.ISlider! slider) -> void
 static Microsoft.Maui.Platform.SwitchExtensions.UpdateThumbColor(this Google.Android.Material.MaterialSwitch.MaterialSwitch! materialSwitch, Microsoft.Maui.ISwitch! view) -> void
 static Microsoft.Maui.Platform.SwitchExtensions.UpdateTrackColor(this Google.Android.Material.MaterialSwitch.MaterialSwitch! materialSwitch, Microsoft.Maui.ISwitch! view) -> void
 static Microsoft.Maui.Platform.TimePickerExtensions.UpdateFormat(this Microsoft.Maui.Platform.MauiMaterialTimePicker! mauiTimePicker, Microsoft.Maui.ITimePicker! timePicker) -> void


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
This pull request makes several methods in the `SliderExtensions` class public, allowing them to be accessed outside the assembly. It also updates the public API declarations to reflect these changes. These updates are primarily focused on improving the customizability and accessibility of slider controls on Android.

**API Surface Expansion for Slider Customization:**

* Changed the following methods in `SliderExtensions` from `internal` to `public`, making them accessible for external use:
  - `UpdateMinimum`, `UpdateMaximum`, `UpdateValue`, `UpdateMinimumTrackColor`, `UpdateMaximumTrackColor`, `UpdateThumbColor`, and `UpdateThumbImageSourceAsync` for `Slider` (`Google.Android.Material.Slider.Slider`) objects.

**Public API Declaration Updates:**

* Added the newly public `SliderExtensions` methods to `PublicAPI.Unshipped.txt` to formally declare their availability in the public API.


<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
