### PR TITLE
Fix Label is retained in memory when bound to a shared FormattedString

### DIFF
--- a/src/Controls/tests/Core.UnitTests/FormattedStringTests.cs
+++ b/src/Controls/tests/Core.UnitTests/FormattedStringTests.cs
@@ -132,5 +132,34 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			// Ensure the shared FormattedString isn't collected during the test
 			GC.KeepAlive(formattedString);
 		}
+
+		[Fact, Category(TestCategory.Memory)]
+		public async Task LabelIsNotKeptAliveBySpanGestureRecognizers()
+		{
+			// A Span exposes a GestureRecognizers collection, and the Label wires a
+			// subscription to each Span's GestureRecognizersCollectionChanged so it can
+			// forward gesture changes. If that subscription is strong, a long-lived/shared
+			// FormattedString (whose Spans carry gesture recognizers) keeps every Label it
+			// was ever assigned to alive. This verifies the Span -> Label path is weak too.
+			var formattedString = new FormattedString();
+			var span = new Span { Text = "Tap me" };
+			span.GestureRecognizers.Add(new TapGestureRecognizer());
+			formattedString.Spans.Add(span);
+
+			WeakReference CreateReference()
+			{
+				var label = new Label { FormattedText = formattedString };
+				return new(label);
+			}
+
+			WeakReference reference = CreateReference();
+
+			await TestHelpers.Collect();
+
+			Assert.False(await reference.WaitForCollect(), "Label should not be alive!");
+
+			// Ensure the shared FormattedString (and its Span) isn't collected during the test
+			GC.KeepAlive(formattedString);
+		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/FormattedStringTests.cs
+++ b/src/Controls/tests/Core.UnitTests/FormattedStringTests.cs
@@ -117,13 +117,13 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var formattedString = new FormattedString();
 			formattedString.Spans.Add(new Span { Text = "Hello" });
 
-			WeakReference CreateReference()
+			static WeakReference CreateReference(FormattedString fs)
 			{
-				var label = new Label { FormattedText = formattedString };
+				var label = new Label { FormattedText = fs };
 				return new(label);
 			}
 
-			WeakReference reference = CreateReference();
+			WeakReference reference = CreateReference(formattedString);
 
 			await TestHelpers.Collect();
 
@@ -146,13 +146,13 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			span.GestureRecognizers.Add(new TapGestureRecognizer());
 			formattedString.Spans.Add(span);
 
-			WeakReference CreateReference()
+			static WeakReference CreateReference(FormattedString fs)
 			{
-				var label = new Label { FormattedText = formattedString };
+				var label = new Label { FormattedText = fs };
 				return new(label);
 			}
 
-			WeakReference reference = CreateReference();
+			WeakReference reference = CreateReference(formattedString);
 
 			await TestHelpers.Collect();
 

--- a/src/Controls/tests/Core.UnitTests/FormattedStringTests.cs
+++ b/src/Controls/tests/Core.UnitTests/FormattedStringTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.ObjectModel;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
@@ -99,6 +100,37 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Single(fs.Spans);
 			Assert.NotNull(fs.Spans[0]);
 			Assert.Equal(fs.Spans[0].Text, original);
+		}
+
+		[Fact, Category(TestCategory.Memory)]
+		public async Task LabelIsNotKeptAliveBySharedFormattedText()
+		{
+			// A long-lived/shared FormattedString (e.g. from a view-model or
+			// App.Resources) that is assigned to a Label wires three *strong*
+			// subscriptions from the FormattedString back to the Label:
+			//   formattedString.PropertyChanging  += label.OnFormattedTextChanging
+			//   formattedString.PropertyChanged   += label.OnFormattedTextChanged
+			//   formattedString.SpansCollectionChanged += label.Span_CollectionChanged
+			// These are only unwired when the Label's FormattedText is reassigned,
+			// never when the Label alone is collected. If the FormattedString
+			// outlives the Label, those strong delegates keep the Label alive.
+			var formattedString = new FormattedString();
+			formattedString.Spans.Add(new Span { Text = "Hello" });
+
+			WeakReference CreateReference()
+			{
+				var label = new Label { FormattedText = formattedString };
+				return new(label);
+			}
+
+			WeakReference reference = CreateReference();
+
+			await TestHelpers.Collect();
+
+			Assert.False(await reference.WaitForCollect(), "Label should not be alive!");
+
+			// Ensure the shared FormattedString isn't collected during the test
+			GC.KeepAlive(formattedString);
 		}
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details:
A Label assigned a shared or long-lived FormattedString is not garbage collected after it becomes unreachable because strong event subscriptions from the FormattedString and its Spans keep the Label alive, resulting in a memory leak.

### Root Cause
A Label could leak memory when its FormattedText was assigned a shared or long-lived FormattedString (such as one from App.Resources or a view model). The FormattedString and its Spans held strong event subscriptions back to the Label, creating strong references that prevented the Label from being garbage collected. These subscriptions were removed only when a different FormattedString was assigned, so if the Label was discarded without changing FormattedText, it remained in memory for as long as the shared FormattedString existed.

### Description of Change

- The fix replaces all strong event subscriptions between the Label, FormattedString, and its Span's with the existing weak event proxy infrastructure (WeakPropertyChangingProxy, WeakNotifyPropertyChangedProxy, and WeakNotifyCollectionChangedProxy). The Label now maintains weak proxies for FormattedString events and for each Span's gesture recognizer collection, ensuring these event subscriptions no longer hold strong references to the Label.
- A finalizer was also added to Label to explicitly unsubscribe all weak event proxies during cleanup, following the intended usage pattern of the weak event infrastructure. Additionally, the internal SpansCollectionChanged and GestureRecognizersCollectionChanged events were removed, as they are no longer required.
- With these changes, a shared or long-lived FormattedString can no longer keep a discarded Label alive, allowing the garbage collector to reclaim the Label once it is no longer referenced elsewhere.

### Issues Fixed:
Fixes #36320 

### Screenshots
| Before  | After |
|---------|--------|
|  <img width="607" height="329" src="https://github.com/user-attachments/assets/5928ee32-ea6e-4653-95a2-aa4d33748088"> |   <img width="607" height="329" src="https://github.com/user-attachments/assets/36d673a6-2713-4f38-9b05-689e1437a64b">  |

