### PR TITLE
[iOS] Button: Fix text updates with CharacterSpacing

### DIFF
--- a/src/Controls/src/Core/Button/Button.iOS.cs
+++ b/src/Controls/src/Core/Button/Button.iOS.cs
@@ -442,6 +442,7 @@ namespace Microsoft.Maui.Controls
 		public static void MapText(IButtonHandler handler, Button button)
 		{
 			handler.PlatformView?.UpdateText(button);
+			ButtonHandler.MapFormatting(handler, button);
 		}
 
 		internal static void MapBorderWidth(IButtonHandler handler, Button button)

--- a/src/Controls/src/Core/Button/Button.iOS.cs
+++ b/src/Controls/src/Core/Button/Button.iOS.cs
@@ -442,7 +442,7 @@ namespace Microsoft.Maui.Controls
 		public static void MapText(IButtonHandler handler, Button button)
 		{
 			handler.PlatformView?.UpdateText(button);
-			ButtonHandler.MapFormatting(handler, button);
+			handler.UpdateValue(nameof(CharacterSpacing));
 		}
 
 		internal static void MapBorderWidth(IButtonHandler handler, Button button)

--- a/src/Controls/src/Core/Platform/iOS/Extensions/ButtonExtensions.cs
+++ b/src/Controls/src/Core/Platform/iOS/Extensions/ButtonExtensions.cs
@@ -88,10 +88,7 @@ namespace Microsoft.Maui.Controls.Platform
 			platformButton.SetTitle(text, UIControlState.Normal);
 
 			// The TitleLabel retains its previous text value even after a new value is assigned. As a result, the label does not display the updated text and reverts to the old value when the button is re-measured
-			if (string.IsNullOrEmpty(button.Text))
-			{
-				platformButton.TitleLabel.Text = string.Empty;
-			}
+			platformButton.TitleLabel.Text = text;
 
 			// Content layout depends on whether or not the text is empty; changing the text means
 			// we may need to update the content layout

--- a/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.iOS.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
 using UIKit;
 using Xunit;
 
@@ -18,6 +19,16 @@ namespace Microsoft.Maui.DeviceTests
 		Task<string?> GetPlatformText(ButtonHandler buttonHandler)
 		{
 			return InvokeOnMainThreadAsync(() => GetPlatformButton(buttonHandler).CurrentTitle);
+		}
+
+		Task<(string? Value, double CharacterSpacing)> GetPlatformAttributedText(ButtonHandler buttonHandler)
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var attributedTitle = GetPlatformButton(buttonHandler).CurrentAttributedTitle;
+
+				return (attributedTitle?.Value, attributedTitle?.GetCharacterSpacing() ?? 0);
+			});
 		}
 
 		UILineBreakMode GetPlatformLineBreakMode(ButtonHandler buttonHandler) =>
@@ -91,6 +102,47 @@ namespace Microsoft.Maui.DeviceTests
 
 			Assert.True(button.Width < gridWidth, $"Button shouldn't occupy entire layout width. Expected: {gridWidth}<, was {button.Width}");
 			Assert.True(button.Height < gridHeight, $"Button shouldn't occupy entire layout height. Expected: {gridHeight}<, was {button.Height}");
+		}
+
+		[Theory]
+		[InlineData(false, TextTransform.Default, "Initial", "Updated")]
+		[InlineData(true, TextTransform.Default, "Initial", "Updated")]
+		[InlineData(false, TextTransform.Uppercase, "INITIAL", "UPDATED")]
+		[Description("The Text property of a Button should update the native attributed title when CharacterSpacing is applied")]
+		public async Task TextUpdatesAttributedTitleWhenCharacterSpacingApplied(bool useContentLayout, TextTransform textTransform, string initialText, string updatedText)
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler<Button, ButtonHandler>();
+				});
+			});
+
+			var button = new Button
+			{
+				Text = "Initial",
+				CharacterSpacing = 15,
+				TextTransform = textTransform
+			};
+
+			if (useContentLayout)
+				button.ContentLayout = new Button.ButtonContentLayout(Button.ButtonContentLayout.ImagePosition.Right, 8);
+
+			await CreateHandlerAndAddToWindow(button, async () =>
+			{
+				var handler = Assert.IsType<ButtonHandler>(button.Handler);
+				var initialAttributedText = await GetPlatformAttributedText(handler);
+
+				Assert.Equal(initialText, initialAttributedText.Value);
+				Assert.Equal(button.CharacterSpacing, initialAttributedText.CharacterSpacing);
+
+				button.Text = "Updated";
+				var updatedAttributedText = await GetPlatformAttributedText(handler);
+
+				Assert.Equal(updatedText, updatedAttributedText.Value);
+				Assert.Equal(button.CharacterSpacing, updatedAttributedText.CharacterSpacing);
+			});
 		}
 
 		[Fact]


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause

Controls replaces the core `Button.Text` mapper on iOS/MacCatalyst so it can handle Controls-specific behavior such as `TextTransform` and `ContentLayout`. That Controls mapper updated the native `UIButton` title but did not rebuild the attributed title used when `CharacterSpacing` is applied, so UIKit could continue displaying the previous `CurrentAttributedTitle` after `Button.Text` changed.

### Description of Change

After Controls updates the native button text on iOS/MacCatalyst, it now reapplies the core button formatting mapper so the attributed title is rebuilt from the latest text.

The iOS Controls `UIButton.UpdateText` helper also keeps `TitleLabel.Text` synchronized with the transformed text for every text update. This gives `UpdateCharacterSpacing` the current text when it rebuilds the attributed title.

### Key Technical Details

- `Button.iOS.cs` now calls `ButtonHandler.MapFormatting(handler, button)` after `UpdateText(button)`.
- `ButtonExtensions.UpdateText` now assigns `platformButton.TitleLabel.Text = text` for all text updates, not only when the logical `Button.Text` is empty.
- The regression test checks the native `CurrentAttributedTitle` text and kerning after `Text` changes with `CharacterSpacing` applied.

### Edge Cases Covered

| Scenario | Coverage |
| --- | --- |
| `CharacterSpacing` + text update | Device test and external repro |
| `CharacterSpacing` + `ContentLayout` + text update | Device test and external repro |
| `CharacterSpacing` + `TextTransform` + text update | Device test and external repro |

@tdeborde2 @weases could you please try the PR artifacts when CI publishes them and confirm whether this resolves the issue in your apps?

### Issues Fixed

Fixes #21488

### Validation

- Reproduced the issue with the external repro project from #21488 on .NET 10 / MAUI 10.0.80.
- Verified the same repro passes when rebuilt against the fixed local MAUI artifacts, including CharacterSpacing, CharacterSpacing + ContentLayout, and CharacterSpacing + TextTransform cases.
- Ran Controls Button device tests on MacCatalyst: 21/21 passed.
- Built the iOS Controls device-test app successfully.