### PR TITLE
Fix milestone workflow crash when the target milestone doesn't exist yet

### DIFF
--- a/.github/scripts/Fix-MilestoneDrift.Tests.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.Tests.ps1
@@ -1228,6 +1228,74 @@ Describe 'Invoke-AnalyzeSinglePr — validation context seeding' {
     }
 }
 
+Describe 'Invoke-AnalyzeSinglePr — milestone-not-found skip report shape' {
+    BeforeEach {
+        # Same start-to-finish scaffolding as the validation-context seeding tests, but here we
+        # force Find-MatchingMilestone to return $null so we exercise the graceful-skip path taken
+        # when the expected milestone (e.g. ".NET 11.0-preview7") has not been created in GitHub yet.
+        Mock Initialize-MilestoneValidationContext { }
+        Mock Get-PrInfo {
+            return @{
+                Number         = 42
+                Title          = 'Test PR'
+                Url            = 'u'
+                Milestone      = ''
+                BaseRef        = 'net11.0'
+                MergedAt       = '2025-01-01T00:00:00Z'
+                MergeCommitSha = 'abc123'
+                Body           = ''
+            }
+        }
+        Mock Get-AllTags { return @('10.0.60', '10.0.70', '11.0.0-preview.3') }
+        Mock Get-VersionFromGitRef { return @{ Tag = '11.0.0'; PreLabel = 'preview'; PreIter = 7 } }
+        Mock Find-ReleaseBranchForCommit { return @{ Branch = 'release/11.0.1xx-preview7'; Milestone = '.NET 11.0-preview7' } }
+        Mock ConvertBranchToMilestone { return '.NET 11.0-preview7' }
+        Mock Get-MainBranchForVersion { return 'net11.0' }
+        Mock Get-CurrentMajorVersion { return 11 }
+        # The milestone does not exist yet: Get-AllMilestones has no match and Find-MatchingMilestone
+        # returns $null, driving Invoke-AnalyzeSinglePr into the early-return skip report.
+        Mock Get-AllMilestones { return @(@{ Number = 99; Title = '.NET 11.0-preview6' }) }
+        Mock Find-MatchingMilestone { return $null }
+        Mock Test-PrBelongsToVersion { return $true }
+        Mock Get-LinkedIssues { return @() }
+        Mock Test-AndRecordCorrection { }
+    }
+
+    It 'includes ResolvedMilestone/ResolvedMsNumber keys (set to $null) so downstream writers do not crash under StrictMode' {
+        $report = Invoke-AnalyzeSinglePr -PrNum 42 -ReleaseTag '' -Repo '.'
+
+        # The skip report MUST carry the same key shape as the success-path report. Write-Report
+        # (line ~1326) and Save-ReportJson (line ~1381) read $Report.ResolvedMilestone WITHOUT a
+        # ContainsKey guard; under StrictMode a missing key throws PropertyNotFound -> exit 1.
+        $report.ContainsKey('ResolvedMilestone') | Should -BeTrue
+        $report.ContainsKey('ResolvedMsNumber')  | Should -BeTrue
+        $report.ResolvedMilestone | Should -BeNullOrEmpty
+        $report.ResolvedMsNumber  | Should -BeNullOrEmpty
+        # And the report is genuinely a no-op skip: no corrections to apply.
+        $report.Corrections.Count | Should -Be 0
+    }
+
+    It 'does not crash Write-Report/Save-ReportJson under StrictMode Latest (faithful CI reproduction)' {
+        # StrictMode is intentionally NOT enabled when the script is dot-sourced for Pester (see the
+        # $MyInvocation.InvocationName -ne '.' guard in Fix-MilestoneDrift.ps1). So we must re-create
+        # the exact production condition here: the workflow runs with Set-StrictMode -Version Latest,
+        # under which reading a missing hashtable key throws. Without the fix, this test throws
+        # PropertyNotFound and fails; with the fix it passes.
+        $report = Invoke-AnalyzeSinglePr -PrNum 42 -ReleaseTag '' -Repo '.'
+
+        $tempPath = Join-Path ([System.IO.Path]::GetTempPath()) "milestone-skip-report-$([guid]::NewGuid()).json"
+        try {
+            {
+                Set-StrictMode -Version Latest
+                Write-Report $report
+                Save-ReportJson $report $tempPath
+            } | Should -Not -Throw
+        } finally {
+            Remove-Item $tempPath -ErrorAction SilentlyContinue
+        }
+    }
+}
+
 Describe 'Get-TagsForMilestone — cross-major filter' {
     BeforeEach {
         # Seed validation context as a live workflow run would: target major = 11.

--- a/.github/scripts/Fix-MilestoneDrift.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.ps1
@@ -1149,6 +1149,8 @@ function Invoke-AnalyzeSinglePr([int]$PrNum, [string]$ReleaseTag, [string]$Repo)
         return @{
             Tag               = $ReleaseTag
             ExpectedMilestone = $expectedMs
+            ResolvedMilestone = $null
+            ResolvedMsNumber  = $null
             TotalPrs          = 1
             PrsChecked        = 0
             IssuesChecked     = 0


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Symptom

The **Milestone Management** workflow (`.github/workflows/fix-milestone-drift.yml` → `.github/scripts/Fix-MilestoneDrift.ps1`) auto-sets a PR's milestone on every merge via the `pull_request_target` path (`Fix-MilestoneDrift.ps1 -PrNumber <N> -Apply [-CloseFixedIssues]`).

Right now **every merge to a `net11.0` branch crashes the workflow** because the expected milestone `.NET 11.0-preview7` does not exist in GitHub yet (only `.NET 11.0-preview6` exists). Several recent runs failed with the identical error:

```
Expected milestone: .NET 11.0-preview7
WARNING: No GitHub milestone found matching ".NET 11.0-preview7". The milestone may not have been created yet. Skipping.
Fix-MilestoneDrift.ps1: The property 'ResolvedMilestone' cannot be found on this object. Verify that the property exists.
##[error]Process completed with exit code 1.
```

This is a **pre-existing latent bug** introduced by the original milestone automation (#34686) — **not** by the recent tag-trigger change (#36140). It only surfaces now because the next preview milestone hasn't been created yet.

## Root cause

In `Invoke-AnalyzeSinglePr`, when the target milestone isn't found, the function logs `No GitHub milestone found … Skipping.` and returns an early "skip" report hashtable whose intent (per its own comment) is to *"return empty report — prevents red CI on every auto-triggered merge."*

But that early-return hashtable **omitted the `ResolvedMilestone` / `ResolvedMsNumber` keys** that the success-path report carries. The caller then runs:

- `Write-Report $report`, which reads `$Report.ResolvedMilestone` **unguarded** (no `ContainsKey` check), and
- `Save-ReportJson`, which reads `$Report.ResolvedMilestone` **unguarded** too.

During normal execution the script enables `Set-StrictMode -Version Latest`, under which reading a missing hashtable key throws `PropertyNotFound` → exit 1. So the intended graceful-skip is defeated by the report writer, turning a "milestone not created yet" no-op into a hard CI failure.

The tag/release-mode path (`Invoke-AnalyzeRelease`) intentionally **throws** when a milestone is missing, and is left unchanged — for tag mode, failing loudly is correct. Only the single-PR skip path is fixed here.

## The fix

Add the two missing keys (set to `$null`) to the early-return hashtable in `Invoke-AnalyzeSinglePr` so it matches the success-path report shape:

```powershell
ResolvedMilestone = $null
ResolvedMsNumber  = $null
```

This satisfies every unguarded downstream accessor. `Invoke-ApplyCorrections` iterates the empty `Corrections` list (no-op) and `New-GitHubIssue` only runs when `Corrections.Count > 0`, so no other changes are needed.

## Regression test

Added tests to `.github/scripts/Fix-MilestoneDrift.Tests.ps1` covering the milestone-not-found path.

There's a **StrictMode subtlety** worth calling out: StrictMode is intentionally **not** enabled when the script is dot-sourced for Pester (guarded by `$MyInvocation.InvocationName -ne '.'`). A test that merely calls `Write-Report` on a report missing the key would **not** throw under Pester and would pass even with the bug present (false negative). So the tests do **both**:

1. Drive `Invoke-AnalyzeSinglePr` down the milestone-not-found path (mock `Find-MatchingMilestone` → `$null`) and assert the returned report `.ContainsKey('ResolvedMilestone')` and `.ContainsKey('ResolvedMsNumber')` are `$true` (and reading `.ResolvedMilestone` yields `$null`).
2. A faithful CI reproduction: inside the test, `Set-StrictMode -Version Latest`, then call `Write-Report` and `Save-ReportJson` on that report and assert it does **not** throw — reproducing the exact crash condition.

**Before/after proof** (reverting only the 2-line fix):

- **Fix reverted:** both new tests fail — test #2 throws `The property 'ResolvedMilestone' cannot be found on this object` from `Fix-MilestoneDrift.ps1:1326` (`Write-Report`), exactly matching the CI crash.
- **Fix applied:** full suite green — **316 passed, 0 failed, 0 skipped** (`MilestoneTrigger.Tests.ps1` + `Fix-MilestoneDrift.Tests.ps1`).

## Note

Creating the `.NET 11.0-preview7` milestone in GitHub is a separate operational unblock — orthogonal to this code fix. This change ensures the workflow degrades gracefully (as originally intended) whenever the expected milestone hasn't been created yet, instead of crashing every merge.