### PR TITLE
Keep release-readiness trackers fresh: 3h cadence, freshness banner, scoped event triggers

### DIFF
--- a/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
+++ b/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
@@ -1738,6 +1738,17 @@ if ($ciScanIssues.Count -eq 0) {
 
 [void]$md.AppendLine("Generated at $generatedAt for ``$Repository``.")
 [void]$md.AppendLine("")
+# Report freshness banner — DERIVED-AT-RENDER note of how long ago this report was generated,
+# with a ⏳ "may be stale" flag past the threshold. Pure presentation only. (The preview engine
+# emits no semantic hash and refreshes every run, so there is no no-op to protect here; the
+# banner still gives a viewer an at-a-glance staleness cue.) Fail-open if the helper is absent.
+if ($generatedAt -and (Get-Command Format-ReportFreshnessBanner -ErrorAction SilentlyContinue)) {
+    $previewFreshnessBanner = Format-ReportFreshnessBanner -GeneratedAt $generatedAt -Now ([DateTime]::UtcNow)
+    if ($previewFreshnessBanner) {
+        [void]$md.AppendLine($previewFreshnessBanner)
+        [void]$md.AppendLine("")
+    }
+}
 [void]$md.AppendLine("**Tracker:** ``$TrackerKey`` · mode=``$Mode`` · branch=``$Branch`` · survey=``$SurveyRef``")
 [void]$md.AppendLine("")
 if ($Mode -eq 'candidate') {

--- a/.github/skills/release-readiness/scripts/Get-ReleaseReadiness.ps1
+++ b/.github/skills/release-readiness/scripts/Get-ReleaseReadiness.ps1
@@ -3368,6 +3368,19 @@ function Format-MarkdownReport {
     $shaLinked = ConvertTo-LinkedSha -Sha $ctx.srHeadSha -RepoUrl $RepoUrl
     [void]$sb.AppendLine("**HEAD**: $shaLinked — $($ctx.srHeadSubject)")
     [void]$sb.AppendLine("**Generated**: $($ctx.fetchedAt)")
+    # Report freshness banner — a DERIVED-AT-RENDER note of how long ago this report was
+    # generated, with a ⏳ "may be stale" flag past the threshold. Computed here from the
+    # generation timestamp against a render-time clock; it is a pure presentation concern and
+    # is DELIBERATELY NOT folded into Get-ReportSemanticHash (hashing a render-time age would
+    # differ every run and break the idempotent no-op). Fail-open: skip if the helper isn't
+    # loaded or the timestamp is unreadable.
+    if ($ctx.fetchedAt -and (Get-Command Format-ReportFreshnessBanner -ErrorAction SilentlyContinue)) {
+        $freshnessBanner = Format-ReportFreshnessBanner -GeneratedAt $ctx.fetchedAt -Now ([DateTime]::UtcNow)
+        if ($freshnessBanner) {
+            [void]$sb.AppendLine()
+            [void]$sb.AppendLine($freshnessBanner)
+        }
+    }
     # Nightly dogfood feed freshness — surfaces when the feed testers point at has gone
     # stale (no new build), so a captain sees at a glance whether dogfood feedback is being
     # collected against current bits. The banner string is rendered upstream in Invoke-Main

--- a/.github/skills/release-readiness/scripts/NightlyFeed.ps1
+++ b/.github/skills/release-readiness/scripts/NightlyFeed.ps1
@@ -24,6 +24,12 @@
                                   clock access (caller passes -Now), so it is fully
                                   unit-testable offline with fixtures.
 
+      Format-ReportFreshnessBanner — PURE, deterministic renderer for the report's OWN
+                                  freshness banner ("🕐 generated N ago", with a ⏳ stale
+                                  flag past a threshold). Caller passes -Now, so it is
+                                  fully unit-testable. MUST NOT be folded into the SR
+                                  semantic hash (it is a render-time presentation concern).
+
     This file contains ONLY function/constant definitions (no top-level side effects), so
     it is safe to dot-source from either engine or from the test harness.
 
@@ -388,3 +394,85 @@ function Format-NightlyFeedBanner {
     }
     return "**Nightly dogfood feed:** ✅ $lane — latest ``$version`` built $whenPhrase."
 }
+
+function Format-ReportFreshnessBanner {
+    <#
+    .SYNOPSIS
+        Render a one-line markdown banner describing how long ago THIS report was generated,
+        with a ⏳ "may be stale" note once the age crosses a threshold. PURE + deterministic:
+        output depends only on the arguments (no ambient clock — caller passes -Now), so it is
+        fully unit-testable and can exercise the stale path with an injected past -GeneratedAt.
+
+    .DESCRIPTION
+        This is the report's OWN freshness banner (distinct from Format-NightlyFeedBanner, which
+        describes the dogfood FEED build age). It is DERIVED-AT-RENDER from the generation
+        timestamp and is a pure presentation concern — it MUST NOT be folded into
+        Get-ReportSemanticHash. If it were, two runs on identical data would produce different
+        ages → different hashes → the idempotent no-op would break and churn every run.
+
+        In normal operation generation ≈ render, so the age is ~0 and the ⏳ note does not fire;
+        the absolute "**Generated**:" timestamp above this banner remains the durable staleness
+        signal for a body frozen by the no-op. The ⏳ threshold is a safety valve (and is covered
+        by unit tests that inject a far-past -GeneratedAt).
+
+    .PARAMETER GeneratedAt
+        When the report data was generated (the same instant rendered on the "**Generated**:"
+        line). Accepts a [datetime] or an ISO-8601 string; unparseable input returns '' (no banner).
+
+    .PARAMETER Now
+        UTC reference time used to compute age. Caller supplies it so the function is
+        deterministic and testable.
+
+    .PARAMETER StaleHours
+        Age (in hours) at or beyond which the ⏳ "may be stale" note is appended. Default 4.
+    #>
+    param(
+        $GeneratedAt,
+        [datetime]$Now,
+        [double]$StaleHours = 4
+    )
+
+    if ($null -eq $GeneratedAt) { return '' }
+
+    # Normalize GeneratedAt to a UTC [datetime]. Tolerate both a real [datetime] and the
+    # ISO-8601 string the engines store in metadata.fetchedAt / $generatedAt.
+    $genUtc = $null
+    if ($GeneratedAt -is [datetime]) {
+        $genUtc = ([datetime]$GeneratedAt).ToUniversalTime()
+    } else {
+        $parsed = [datetime]::MinValue
+        if ([datetime]::TryParse(
+                [string]$GeneratedAt, [System.Globalization.CultureInfo]::InvariantCulture,
+                [System.Globalization.DateTimeStyles]::AdjustToUniversal -bor
+                [System.Globalization.DateTimeStyles]::AssumeUniversal, [ref]$parsed)) {
+            $genUtc = $parsed.ToUniversalTime()
+        } else {
+            return ''   # unparseable → render nothing rather than a bogus age
+        }
+    }
+
+    $span = $Now.ToUniversalTime() - $genUtc
+    $totalMinutes = $span.TotalMinutes
+    if ($totalMinutes -lt 0) { $totalMinutes = 0 }   # clamp clock skew / just-generated
+
+    # Humanize the age into a compact "<n> minutes/hours/days ago" phrase.
+    if ($totalMinutes -lt 1) {
+        $agePhrase = 'moments ago'
+    } elseif ($totalMinutes -lt 60) {
+        $m = [int][Math]::Floor($totalMinutes)
+        $agePhrase = "$m minute$(if ($m -ne 1) { 's' }) ago"
+    } elseif ($totalMinutes -lt 1440) {
+        $h = [int][Math]::Floor($totalMinutes / 60)
+        $agePhrase = "$h hour$(if ($h -ne 1) { 's' }) ago"
+    } else {
+        $d = [int][Math]::Floor($totalMinutes / 1440)
+        $agePhrase = "$d day$(if ($d -ne 1) { 's' }) ago"
+    }
+
+    if ($span.TotalHours -ge $StaleHours) {
+        $staleH = [int][Math]::Floor($StaleHours)
+        return "> ⏳ _Report generated **$agePhrase** — data may be stale (older than ${staleH}h). A fresh run is scheduled every few hours._"
+    }
+    return "> 🕐 _Report generated $agePhrase._"
+}
+

--- a/.github/skills/release-readiness/scripts/NightlyFeed.ps1
+++ b/.github/skills/release-readiness/scripts/NightlyFeed.ps1
@@ -412,8 +412,12 @@ function Format-ReportFreshnessBanner {
 
         In normal operation generation ≈ render, so the age is ~0 and the ⏳ note does not fire;
         the absolute "**Generated**:" timestamp above this banner remains the durable staleness
-        signal for a body frozen by the no-op. The ⏳ threshold is a safety valve (and is covered
-        by unit tests that inject a far-past -GeneratedAt).
+        signal for a body frozen by the no-op. On the hash-gated SR engine the ⏳ path is
+        therefore effectively test-only: a body the semantic-hash no-op declines to re-render
+        keeps whatever banner text it last wrote, so ⏳ can never NEWLY surface through a frozen
+        body — rely on the absolute "**Generated**:" line there. The ⏳ path IS live on the
+        preview engine, which re-renders every run. Unit tests inject a far-past -GeneratedAt to
+        exercise ⏳ directly.
 
     .PARAMETER GeneratedAt
         When the report data was generated (the same instant rendered on the "**Generated**:"
@@ -470,7 +474,10 @@ function Format-ReportFreshnessBanner {
     }
 
     if ($span.TotalHours -ge $StaleHours) {
-        $staleH = [int][Math]::Floor($StaleHours)
+        # Render the ACTUAL threshold (culture-invariant) so a fractional -StaleHours (e.g.
+        # 2.5) reads "older than 2.5h" rather than a floored, misleading "2h". Whole-number
+        # thresholds (the default 4) still render as "4h".
+        $staleH = ([double]$StaleHours).ToString([System.Globalization.CultureInfo]::InvariantCulture)
         return "> ⏳ _Report generated **$agePhrase** — data may be stale (older than ${staleH}h). A fresh run is scheduled every few hours._"
     }
     return "> 🕐 _Report generated $agePhrase._"

--- a/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
+++ b/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
@@ -2235,6 +2235,11 @@ $mdRenderOld = Format-MarkdownReport -Data $mdFreshOld -RepoUrl 'https://github.
 $mdRenderNew = Format-MarkdownReport -Data $mdFreshNew -RepoUrl 'https://github.com/dotnet/maui' -TrackerKey 'net10-sr7' -MaxBodyBytes 60000
 $shaRenderOld = ([regex]::Match($mdRenderOld, 'release-readiness-hash: sha=([0-9a-f]{64})')).Groups[1].Value
 $shaRenderNew = ([regex]::Match($mdRenderNew, 'release-readiness-hash: sha=([0-9a-f]{64})')).Groups[1].Value
+# Guard against a vacuous pass: if the sha marker were ever renamed/reformatted, BOTH
+# extractions would yield '' and the equality assertion below would pass on ''=='' while
+# silently masking a real regression. Require a genuine 64-hex digest on each render first.
+Assert-Eq -Label "Hash-stability: old render emits a 64-hex sha" -Expected $true -Actual ($shaRenderOld -match '^[0-9a-f]{64}$')
+Assert-Eq -Label "Hash-stability: new render emits a 64-hex sha" -Expected $true -Actual ($shaRenderNew -match '^[0-9a-f]{64}$')
 $banRenderOld = (($mdRenderOld -split "`n") | Where-Object { $_ -match 'Report generated' }) -join ''
 $banRenderNew = (($mdRenderNew -split "`n") | Where-Object { $_ -match 'Report generated' }) -join ''
 Assert-Eq -Label "Freshness banner text differs when fetchedAt differs" -Expected $true `

--- a/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
+++ b/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
@@ -2223,6 +2223,25 @@ $banIdx = $mdBan.IndexOf('Nightly dogfood feed is STALE')
 Assert-Eq -Label "Banner appears after the **Generated** line" -Expected $true `
     -Actual ($genIdx -ge 0 -and $banIdx -gt $genIdx)
 
+# Report freshness banner (🕐/⏳) renders below **Generated** and is DERIVED-AT-RENDER,
+# so it must NOT perturb the semantic hash. Render the report TWICE with DIFFERENT
+# metadata.fetchedAt values: this changes both the **Generated** line AND the freshness
+# banner text, yet the sha= marker MUST stay identical (fetchedAt is excluded from the
+# hash). If the render-time banner ever leaked into Get-ReportSemanticHash, the two
+# hashes would diverge and the workflow's idempotent no-op would churn every run.
+$mdFreshOld = $mdData.Clone(); $mdFreshOld.metadata = $mdData.metadata.Clone(); $mdFreshOld.metadata.fetchedAt = '2025-01-01T00:00:00Z'
+$mdFreshNew = $mdData.Clone(); $mdFreshNew.metadata = $mdData.metadata.Clone(); $mdFreshNew.metadata.fetchedAt = '2026-07-06T12:00:00Z'
+$mdRenderOld = Format-MarkdownReport -Data $mdFreshOld -RepoUrl 'https://github.com/dotnet/maui' -TrackerKey 'net10-sr7' -MaxBodyBytes 60000
+$mdRenderNew = Format-MarkdownReport -Data $mdFreshNew -RepoUrl 'https://github.com/dotnet/maui' -TrackerKey 'net10-sr7' -MaxBodyBytes 60000
+$shaRenderOld = ([regex]::Match($mdRenderOld, 'release-readiness-hash: sha=([0-9a-f]{64})')).Groups[1].Value
+$shaRenderNew = ([regex]::Match($mdRenderNew, 'release-readiness-hash: sha=([0-9a-f]{64})')).Groups[1].Value
+$banRenderOld = (($mdRenderOld -split "`n") | Where-Object { $_ -match 'Report generated' }) -join ''
+$banRenderNew = (($mdRenderNew -split "`n") | Where-Object { $_ -match 'Report generated' }) -join ''
+Assert-Eq -Label "Freshness banner text differs when fetchedAt differs" -Expected $true `
+    -Actual ($banRenderOld -ne '' -and $banRenderNew -ne '' -and $banRenderOld -ne $banRenderNew)
+Assert-Eq -Label "Semantic hash is STABLE despite freshness-banner/fetchedAt change (no-op intact)" `
+    -Expected $shaRenderOld -Actual $shaRenderNew
+
 # Without TrackerKey: no tracker marker, no visible Tracker line
 $mdNoTracker = Format-MarkdownReport -Data $mdData -RepoUrl 'https://github.com/dotnet/maui' `
                                      -MaxBodyBytes 60000
@@ -4341,6 +4360,45 @@ Assert-Eq -Label "banner: future publish → clamped to 'today'" -Expected $true
 # Caller-tunable thresholds: a 4-day-old build is ⚠️ by default but ✅ under a wider window.
 $bWide = Format-NightlyFeedBanner -Freshness (New-NfFresh 'v' ([datetime]::new(2026,6,18,0,0,0,[System.DateTimeKind]::Utc))) -Now $nfNow -AgingDays 10 -StaleDays 20
 Assert-Eq -Label "banner: custom AgingDays=10 → 4d build is ✅ fresh" -Expected $true -Actual ($bWide -match '✅')
+
+# ───── Format-ReportFreshnessBanner: report's own DERIVED-AT-RENDER freshness note ─────
+# PURE (caller passes -Now), so the fresh AND the ⏳-stale paths are both tested offline by
+# injecting a past -GeneratedAt. This banner MUST NOT feed Get-ReportSemanticHash — the
+# render-twice-with-different-fetchedAt hash test below enforces that at the report level.
+Write-Host "`n[Unit] Format-ReportFreshnessBanner (report freshness — pure renderer)" -ForegroundColor Cyan
+$rfGen = [datetime]::new(2026, 6, 22, 12, 0, 0, [System.DateTimeKind]::Utc)
+
+# Fresh (< threshold) → 🕐, no ⏳.
+$rfFresh = Format-ReportFreshnessBanner -GeneratedAt $rfGen -Now $rfGen.AddMinutes(2)
+Assert-Eq -Label "freshness: 2m → 🕐, no ⏳"        -Expected $true  -Actual ($rfFresh -match '🕐' -and $rfFresh -notmatch '⏳' -and $rfFresh -match '2 minutes ago')
+# Zero age clamps to 'moments ago' (no negative / no throw).
+$rfNow = Format-ReportFreshnessBanner -GeneratedAt $rfGen -Now $rfGen
+Assert-Eq -Label "freshness: 0 → 'moments ago'"     -Expected $true  -Actual ($rfNow -match 'moments ago' -and $rfNow -notmatch '⏳')
+# Just under threshold (3h < 4h default) → still fresh.
+$rf3h = Format-ReportFreshnessBanner -GeneratedAt $rfGen -Now $rfGen.AddHours(3)
+Assert-Eq -Label "freshness: 3h → 🕐 (under 4h), no ⏳" -Expected $true -Actual ($rf3h -match '3 hours ago' -and $rf3h -notmatch '⏳')
+# At/over threshold → ⏳ stale flag.
+$rf5h = Format-ReportFreshnessBanner -GeneratedAt $rfGen -Now $rfGen.AddHours(5)
+Assert-Eq -Label "freshness: 5h → ⏳ may be stale"   -Expected $true  -Actual ($rf5h -match '⏳' -and $rf5h -match '5 hours ago' -and $rf5h -match 'older than 4h')
+$rf2d = Format-ReportFreshnessBanner -GeneratedAt $rfGen -Now $rfGen.AddDays(2)
+Assert-Eq -Label "freshness: 2d → ⏳ may be stale"   -Expected $true  -Actual ($rf2d -match '⏳' -and $rf2d -match '2 days ago')
+# Singular/plural correctness.
+$rf1m = Format-ReportFreshnessBanner -GeneratedAt $rfGen -Now $rfGen.AddMinutes(1)
+Assert-Eq -Label "freshness: 1m → singular 'minute'" -Expected $true -Actual ($rf1m -match '1 minute ago' -and $rf1m -notmatch 'minutes')
+$rf1h = Format-ReportFreshnessBanner -GeneratedAt $rfGen -Now $rfGen.AddHours(1)
+Assert-Eq -Label "freshness: 1h → singular 'hour'"   -Expected $true -Actual ($rf1h -match '1 hour ago' -and $rf1h -notmatch 'hours')
+# Custom threshold is honored.
+$rfCustom = Format-ReportFreshnessBanner -GeneratedAt $rfGen -Now $rfGen.AddHours(3) -StaleHours 2
+Assert-Eq -Label "freshness: custom StaleHours=2 → 3h is ⏳" -Expected $true -Actual ($rfCustom -match '⏳' -and $rfCustom -match 'older than 2h')
+# ISO-8601 string input (the shape both engines actually store) parses.
+$rfIso = Format-ReportFreshnessBanner -GeneratedAt '2026-06-22T12:00:00Z' -Now $rfGen.AddHours(5)
+Assert-Eq -Label "freshness: ISO-8601 string → ⏳ stale"  -Expected $true -Actual ($rfIso -match '⏳' -and $rfIso -match '5 hours ago')
+# Fail-open: null / unparseable → '' (renderer appends nothing).
+Assert-Eq -Label "freshness: null → empty string"        -Expected '' -Actual (Format-ReportFreshnessBanner -GeneratedAt $null -Now $rfGen)
+Assert-Eq -Label "freshness: unparseable → empty string"  -Expected '' -Actual (Format-ReportFreshnessBanner -GeneratedAt 'not-a-date' -Now $rfGen)
+# Future generation (clock skew) clamps to 'moments ago', never negative / never ⏳.
+$rfFuture = Format-ReportFreshnessBanner -GeneratedAt $rfGen -Now $rfGen.AddMinutes(-30)
+Assert-Eq -Label "freshness: future gen → clamped 'moments ago', no ⏳" -Expected $true -Actual ($rfFuture -match 'moments ago' -and $rfFuture -notmatch '⏳')
 
 Write-Host "`n[Unit] Nightly-feed freshness query (Get-NightlyFeedFreshness — mocked fetcher)" -ForegroundColor Cyan
 # Self-contained fetcher: emulates the Azure Artifacts service index + a SemVer2

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -43,9 +43,18 @@ on:
 permissions:
   contents: read
 
+# Run-level concurrency. Keyed by event + PR/branch so redundant runs of the SAME
+# kind collapse. cancel-in-progress is TRUE only for pull_request (a new push
+# supersedes a stale validation — saves CI) and FALSE otherwise: a scheduled /
+# dispatched run must never be cancelled mid-flight, because its per-tracker job
+# may be part-way through a `gh issue edit` that splices human-authored Release
+# Captain Notes. Serialize-don't-cancel keeps that write atomic. NOTE: this only
+# serializes runs of the SAME event kind (e.g. two schedules). The real cross-run
+# guard against two DIFFERENT event kinds racing the same tracker's issue edit is
+# the per-tracker concurrency group on the per-tracker-report job below.
 concurrency:
   group: release-readiness-${{ github.event_name }}-${{ github.event.pull_request.number || inputs.branch || 'all' }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # ────────────────────────────────────────────────────────────────────
@@ -139,6 +148,20 @@ jobs:
     needs: detect-trackers
     if: needs.detect-trackers.outputs.has-trackers == 'true'
     runs-on: ubuntu-latest
+    # Per-tracker writer serialization. This is the load-bearing guard against the
+    # Release Captain Notes clobber race: the "Update or create tracker issue" step
+    # re-reads the live issue body and awk-splices the human-notes block back into the
+    # fresh report just before `gh issue edit`. Two runs writing the SAME tracker
+    # concurrently (e.g. a scheduled run and an event-triggered run — added in a later
+    # commit) could interleave read/splice/edit and silently drop notes. Keying this
+    # group on matrix.canonicalKey forces same-tracker writers to run one-at-a-time
+    # ACROSS runs, regardless of event kind (the run-level group only serializes runs
+    # of the same event kind). Different trackers stay parallel (distinct keys).
+    # cancel-in-progress is FALSE on purpose: serialize, don't cancel, so an in-flight
+    # `gh issue edit` always completes rather than being killed part-way.
+    concurrency:
+      group: release-readiness-tracker-${{ matrix.canonicalKey }}
+      cancel-in-progress: false
     permissions:
       contents: read
       issues: write
@@ -308,6 +331,15 @@ jobs:
             # churning the issue when nothing material changed. Both engines emit
             # <!-- release-readiness:human-notes:begin/end --> markers; the SR engine
             # additionally embeds <!-- release-readiness-hash: sha=... -->.
+            #
+            # Concurrency note: the per-tracker `concurrency` group on this job
+            # (release-readiness-tracker-<canonicalKey>, cancel-in-progress:false) is
+            # the PRIMARY guard against two runs racing this splice+edit for the same
+            # tracker — it serializes same-tracker writers across every event kind. The
+            # read-modify-write below (re-read live body → splice notes → edit) is the
+            # defense-in-depth second layer: even if serialization were ever bypassed,
+            # the fetch is taken IMMEDIATELY before the edit and every ambiguous state
+            # skips the edit (see the guards below) rather than risk clobbering notes.
             CUR_BODY_FILE="$(mktemp)"
             # Capture the live issue body. A transient fetch failure must NOT lead
             # to an overwrite: an empty CUR_BODY_FILE would skip the notes splice

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -40,18 +40,48 @@ on:
       - '.github/skills/release-readiness/**'
       - '.github/scripts/shared/MauiReleaseVersioning.psm1'
 
+  # ── Scoped base-repo event triggers (refresh ONLY the affected tracker) ──
+  # These keep trackers fresh between the 3-hourly schedule when a MATERIAL
+  # signal changes, without a full fan-out. The "Detect release trackers" step
+  # maps each event to a BRANCH_FILTER / MAJOR_FILTER so only the relevant
+  # tracker(s) recompute (see that step). All are BASE-REPO events — no fork
+  # code is ever checked out or executed — and every attacker-influencable
+  # field (issue/milestone title, label name) is read via env:, never inlined
+  # into a run: block. pull_request_target is deliberately NOT used (fork
+  # secret-exfil vector).
+  issues:
+    # A regressed-in-* / high-priority label added or an issue closed changes
+    # the regression + high-priority sections of the affected major's tracker.
+    types: [labeled, closed]
+  milestone:
+    # Creating/closing a milestone flips ship-check gates (e.g. the preview
+    # milestone existence check).
+    types: [created, closed]
+  push:
+    # A push advances HEAD on a tracked line, which is exactly what flips CI
+    # freshness to stale. No path filter: any commit on these branches matters.
+    branches:
+      - main
+      - net11.0
+      - 'release/**'
+
 permissions:
   contents: read
 
 # Run-level concurrency. Keyed by event + PR/branch so redundant runs of the SAME
 # kind collapse. cancel-in-progress is TRUE only for pull_request (a new push
-# supersedes a stale validation — saves CI) and FALSE otherwise: a scheduled /
-# dispatched run must never be cancelled mid-flight, because its per-tracker job
-# may be part-way through a `gh issue edit` that splices human-authored Release
-# Captain Notes. Serialize-don't-cancel keeps that write atomic. NOTE: this only
-# serializes runs of the SAME event kind (e.g. two schedules). The real cross-run
-# guard against two DIFFERENT event kinds racing the same tracker's issue edit is
-# the per-tracker concurrency group on the per-tracker-report job below.
+# supersedes a stale validation — saves CI) and FALSE for every writer event
+# (schedule / workflow_dispatch / push / issues / milestone): such a run must
+# never be cancelled mid-flight, because its per-tracker job may be part-way
+# through a `gh issue edit` that splices human-authored Release Captain Notes.
+# cancel-in-progress:false does NOT let bursts pile up — GitHub keeps at most one
+# in-progress run plus one pending run per group and cancels any older PENDING
+# run, so a flurry of pushes/labels collapses to (running + latest-pending)
+# without ever killing the in-flight writer. That bounds the request budget while
+# keeping the issue edit atomic. NOTE: this run-level group only serializes runs
+# of the SAME event kind. The real cross-run guard against two DIFFERENT event
+# kinds racing the same tracker's issue edit is the per-tracker concurrency group
+# on the per-tracker-report job below.
 concurrency:
   group: release-readiness-${{ github.event_name }}-${{ github.event.pull_request.number || inputs.branch || 'all' }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -63,7 +93,10 @@ jobs:
   detect-trackers:
     name: Detect release trackers
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
+    # Skip PR validation runs (handled by the validate job) and never run on a
+    # fork — the writer path manages issues on github.repository, so restrict the
+    # whole pipeline to the canonical repo (mirrors the org gate in rebase.yml).
+    if: github.event_name != 'pull_request' && github.repository == 'dotnet/maui'
     outputs:
       matrix: ${{ steps.detect.outputs.matrix }}
       has-trackers: ${{ steps.detect.outputs.has-trackers }}
@@ -78,10 +111,70 @@ jobs:
         id: detect
         env:
           GH_TOKEN: ${{ github.token }}
-          BRANCH_FILTER: ${{ inputs.branch || '' }}
+          # Raw event context. SECURITY: every attacker-influencable field
+          # (issue label names, milestone title) is passed as an env var here and
+          # parsed with jq/grep in the script below — NONE is interpolated into
+          # the run: block via ${{ }}, so untrusted text can never reach the shell
+          # as code. github.ref_name / inputs.branch are likewise env-passed.
+          EVENT_NAME:      ${{ github.event_name }}
+          DISPATCH_BRANCH: ${{ inputs.branch }}
+          PUSH_REF_NAME:   ${{ github.ref_name }}
+          LABELS_JSON:     ${{ toJson(github.event.issue.labels) }}
+          MILESTONE_TITLE: ${{ github.event.milestone.title }}
         shell: bash
         run: |
           set -euo pipefail
+
+          # ── Resolve the triggering event → scope filters ────────────────────
+          # BRANCH_FILTER matches a tracker's branchName/surveyRef exactly;
+          # MAJOR_FILTER is a comma-list of .NET majors matched against
+          # .majorVersion. Both empty ⇒ full refresh (the scheduled fan-out).
+          # This reuses the existing single-tracker plumbing (workflow_dispatch
+          # already fed BRANCH_FILTER) so events only recompute the tracker(s)
+          # they actually affect.
+          BRANCH_FILTER=""
+          MAJOR_FILTER=""
+          case "$EVENT_NAME" in
+            workflow_dispatch)
+              # Manual single-branch refresh (unchanged behavior).
+              BRANCH_FILTER="${DISPATCH_BRANCH:-}"
+              ;;
+            push)
+              # A push advances HEAD on exactly one branch → refresh the tracker
+              # that surveys it (SR branchName, or a preview surveyRef like net11.0).
+              # A branch with no tracker (e.g. main during an SR-only phase) yields
+              # an empty matrix and the pipeline short-circuits.
+              BRANCH_FILTER="${PUSH_REF_NAME:-}"
+              ;;
+            issues)
+              # Union of the .NET majors named by this issue's regressed-in-<major>*
+              # labels (covers both `labeled` — the new label is already in the set
+              # — and `closed`). Reduced to digits so nothing but a version number
+              # reaches jq; an issue with no regressed-in label yields an empty
+              # MAJOR_FILTER and (with BRANCH_FILTER empty) a full refresh, which is
+              # safe and self-limiting via concurrency.
+              MAJOR_FILTER="$(
+                printf '%s' "${LABELS_JSON:-[]}" \
+                  | jq -r '.[]?.name // empty' 2>/dev/null \
+                  | grep -oiE 'regressed-in-[0-9]+' \
+                  | grep -oE '[0-9]+' | sort -u | paste -sd, - || true
+              )"
+              ;;
+            milestone)
+              # First version-looking number in the milestone title (".NET 11" →
+              # 11, "10.0.1xx-sr8" → 10). Digits only; empty ⇒ full refresh.
+              MAJOR_FILTER="$(
+                printf '%s' "${MILESTONE_TITLE:-}" \
+                  | grep -oE '[0-9]+' | head -1 || true
+              )"
+              ;;
+            *)
+              # schedule (and any future event) → both filters empty → all trackers.
+              :
+              ;;
+          esac
+          echo "Event='$EVENT_NAME'  BranchFilter='${BRANCH_FILTER}'  MajorFilter='${MAJOR_FILTER}'"
+
           pwsh -NoProfile -File .github/skills/release-readiness/scripts/Find-ReleaseReadinessTrackers.ps1 \
             -AllActiveMajors \
             -OutputJson trackers.json
@@ -91,11 +184,16 @@ jobs:
             exit 1
           fi
 
-          # Flatten majors[].trackers[] into a single matrix array. If BRANCH_FILTER
-          # is set, narrow to trackers whose branchName OR surveyRef matches.
-          jq --arg filter "$BRANCH_FILTER" '
+          # Flatten majors[].trackers[] into a single matrix array. Narrow by
+          # BRANCH_FILTER (exact branchName/surveyRef) OR MAJOR_FILTER (any major
+          # in the comma-list vs .majorVersion). Both empty ⇒ keep all trackers.
+          jq --arg filter "$BRANCH_FILTER" --arg major "$MAJOR_FILTER" '
             [ .majors[].trackers[]
-              | select($filter == "" or .branchName == $filter or .surveyRef == $filter)
+              | select(
+                  ($filter == "" and $major == "")
+                  or ($filter != "" and (.branchName == $filter or .surveyRef == $filter))
+                  or ($major  != "" and ((.majorVersion | tostring) as $mv | ($major | split(",")) | index($mv) != null))
+                )
               | {
                   canonicalKey: .canonicalKey,
                   branchType:   .branchType,
@@ -268,7 +366,11 @@ jobs:
           retention-days: 30
 
       - name: Update or create tracker issue
-        if: github.event_name == 'schedule' || inputs.create_issue
+        # Write for every trigger that reaches this job EXCEPT a workflow_dispatch
+        # that explicitly opted out via create_issue=false. schedule/push/issues/
+        # milestone always write; pull_request never reaches here (separate
+        # validate job, gated by the detect-trackers if:).
+        if: github.event_name != 'workflow_dispatch' || inputs.create_issue
         env:
           GH_TOKEN: ${{ github.token }}
           TRACKER_KEY:        ${{ matrix.canonicalKey }}

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -83,7 +83,13 @@ permissions:
 # kinds racing the same tracker's issue edit is the per-tracker concurrency group
 # on the per-tracker-report job below.
 concurrency:
-  group: release-readiness-${{ github.event_name }}-${{ github.event.pull_request.number || inputs.branch || 'all' }}
+  # The pushed branch (github.ref_name) is folded into the key so a burst of pushes to
+  # DIFFERENT tracked branches (main / net11.0 / release/**) does NOT collapse into one
+  # 'push-all' group and drop a needed per-branch refresh when pending-run supersede
+  # cancels the older PENDING run. For non-push events ref_name resolves to the default
+  # branch, so their keys are unchanged (pull_request → PR number; workflow_dispatch →
+  # inputs.branch; schedule/issues/milestone → default branch, i.e. one group each).
+  group: release-readiness-${{ github.event_name }}-${{ github.event.pull_request.number || inputs.branch || github.ref_name || 'all' }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
@@ -128,16 +134,25 @@ jobs:
           # ── Resolve the triggering event → scope filters ────────────────────
           # BRANCH_FILTER matches a tracker's branchName/surveyRef exactly;
           # MAJOR_FILTER is a comma-list of .NET majors matched against
-          # .majorVersion. Both empty ⇒ full refresh (the scheduled fan-out).
-          # This reuses the existing single-tracker plumbing (workflow_dispatch
-          # already fed BRANCH_FILTER) so events only recompute the tracker(s)
-          # they actually affect.
+          # .majorVersion. FANOUT=1 marks the ONLY events for which an empty filter
+          # means "refresh ALL trackers": schedule and workflow_dispatch. For every
+          # scoped EVENT trigger (push / issues / milestone) FANOUT stays 0, so an
+          # empty filter yields an EMPTY matrix and the pipeline short-circuits
+          # (has-trackers=false) instead of fanning out to every tracker. An
+          # unrelated issue close, a non-`regressed-in` label, or a non-versioned
+          # milestone must NOT recompute the world — the 3-hourly schedule backstops
+          # full coverage. This reuses the existing single-tracker plumbing
+          # (workflow_dispatch already fed BRANCH_FILTER) so events only recompute
+          # the tracker(s) they actually affect.
           BRANCH_FILTER=""
           MAJOR_FILTER=""
+          FANOUT="0"
           case "$EVENT_NAME" in
             workflow_dispatch)
-              # Manual single-branch refresh (unchanged behavior).
+              # Manual refresh. Empty branch ⇒ intentional full fan-out (FANOUT=1);
+              # a specific branch narrows via BRANCH_FILTER below.
               BRANCH_FILTER="${DISPATCH_BRANCH:-}"
+              FANOUT="1"
               ;;
             push)
               # A push advances HEAD on exactly one branch → refresh the tracker
@@ -150,9 +165,10 @@ jobs:
               # Union of the .NET majors named by this issue's regressed-in-<major>*
               # labels (covers both `labeled` — the new label is already in the set
               # — and `closed`). Reduced to digits so nothing but a version number
-              # reaches jq; an issue with no regressed-in label yields an empty
-              # MAJOR_FILTER and (with BRANCH_FILTER empty) a full refresh, which is
-              # safe and self-limiting via concurrency.
+              # reaches jq. An issue that names no tracked major yields an empty
+              # MAJOR_FILTER and (FANOUT=0) an EMPTY matrix → the run short-circuits
+              # rather than recomputing every tracker for an unrelated close/label.
+              # The next scheduled run still covers it.
               MAJOR_FILTER="$(
                 printf '%s' "${LABELS_JSON:-[]}" \
                   | jq -r '.[]?.name // empty' 2>/dev/null \
@@ -162,18 +178,27 @@ jobs:
               ;;
             milestone)
               # First version-looking number in the milestone title (".NET 11" →
-              # 11, "10.0.1xx-sr8" → 10). Digits only; empty ⇒ full refresh.
+              # 11, "10.0.1xx-sr8" → 10). Digits only; a non-versioned title
+              # (e.g. "Backlog") yields an empty MAJOR_FILTER and (FANOUT=0) an
+              # empty matrix → skip, not a full fan-out.
               MAJOR_FILTER="$(
                 printf '%s' "${MILESTONE_TITLE:-}" \
                   | grep -oE '[0-9]+' | head -1 || true
               )"
               ;;
+            schedule)
+              # The recurring cron: the ONE event that intentionally recomputes
+              # every tracker. Empty filters + FANOUT=1 ⇒ full fan-out.
+              FANOUT="1"
+              ;;
             *)
-              # schedule (and any future event) → both filters empty → all trackers.
+              # Any future/unrecognized event: leave FANOUT=0 so an empty filter
+              # skips rather than surprising us with an unscoped full fan-out. A new
+              # trigger that WANTS fan-out must opt in with its own case arm above.
               :
               ;;
           esac
-          echo "Event='$EVENT_NAME'  BranchFilter='${BRANCH_FILTER}'  MajorFilter='${MAJOR_FILTER}'"
+          echo "Event='$EVENT_NAME'  BranchFilter='${BRANCH_FILTER}'  MajorFilter='${MAJOR_FILTER}'  Fanout='${FANOUT}'"
 
           pwsh -NoProfile -File .github/skills/release-readiness/scripts/Find-ReleaseReadinessTrackers.ps1 \
             -AllActiveMajors \
@@ -186,11 +211,14 @@ jobs:
 
           # Flatten majors[].trackers[] into a single matrix array. Narrow by
           # BRANCH_FILTER (exact branchName/surveyRef) OR MAJOR_FILTER (any major
-          # in the comma-list vs .majorVersion). Both empty ⇒ keep all trackers.
-          jq --arg filter "$BRANCH_FILTER" --arg major "$MAJOR_FILTER" '
+          # in the comma-list vs .majorVersion). Empty filters keep ALL trackers
+          # ONLY when FANOUT=1 (schedule / workflow_dispatch); for a scoped event
+          # trigger with no computed filter the select matches nothing → empty
+          # matrix → has-trackers=false → the report job is skipped.
+          jq --arg filter "$BRANCH_FILTER" --arg major "$MAJOR_FILTER" --arg fanout "$FANOUT" '
             [ .majors[].trackers[]
               | select(
-                  ($filter == "" and $major == "")
+                  ($fanout == "1" and $filter == "" and $major == "")
                   or ($filter != "" and (.branchName == $filter or .surveyRef == $filter))
                   or ($major  != "" and ((.majorVersion | tostring) as $mv | ($major | split(",")) | index($mv) != null))
                 )

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -16,7 +16,12 @@ name: Release Readiness
 
 on:
   schedule:
-    - cron: "30 8 * * 1-5"  # Weekdays at 08:30 UTC
+    # Every 3h from 08:30 to 20:30 UTC, all 7 days. Runs more often (vs the old
+    # weekdays-only 08:30) so a material change (CI flip, new source PR, milestone
+    # gate) is picked up within ~3h instead of a day — WITHOUT spamming watchers:
+    # the SR engine's semantic-hash no-op skips `gh issue edit` when nothing
+    # material changed, and issue-body edits are notification-silent regardless.
+    - cron: "30 8-20/3 * * *"
   workflow_dispatch:
     inputs:
       branch:


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Why
The `[Release Readiness]` tracker issues (SR9 #35867, preview7 #36138, preview6 #35866) were refreshed once per weekday morning, so they drifted stale as the day progressed. This keeps them fresher without spamming watchers, and surfaces staleness explicitly when a body is frozen by the idempotent no-op.

## What
**1. Cadence + freshness banner** (`release-readiness.yml`, `NightlyFeed.ps1`, both engines)
- Schedule `30 8 * * 1-5` → `30 8-20/3 * * *` (every 3h, 08:30–20:30 UTC, all 7 days).
- New pure helper `Format-ReportFreshnessBanner -GeneratedAt -Now [-StaleHours 4]` renders `🕐 Report generated N ago` and appends `⏳ …data may be stale (older than 4h)` past threshold. Fail-open on null/unparseable; clamps clock skew. Wired into both the SR and preview reports. **Derived at render time from the generation timestamp and deliberately excluded from `Get-ReportSemanticHash`** so it never churns the idempotent no-op.

**2. Same-tracker writer serialization** (`release-readiness.yml`)
- Added a JOB-level `concurrency: group: release-readiness-tracker-${{ matrix.canonicalKey }}` (`cancel-in-progress: false`) on `per-tracker-report`. Same-tracker writers now serialize across ALL event kinds — the old top-level group keyed on `event_name` let two different-event runs race the same `gh issue edit` and clobber Release Captain Notes. Different trackers still run in parallel.
- Top-level `cancel-in-progress` → `${{ github.event_name == 'pull_request' }}` (only PR validation cancels; writer runs are never cancelled mid-edit). The existing re-read-live-body-before-edit + malformed-marker skip guards are preserved as defense-in-depth.

**3. Scoped base-repo event triggers** (`release-readiness.yml`)
- Added `issues` (labeled, closed), `milestone` (created, closed), and `push` (main, net11.0, release/**). **No `pull_request_target`.**
- Detect step maps each event to a scope filter (reusing existing BRANCH_FILTER plumbing + new MAJOR_FILTER): push→pushed branch, issues→majors from `regressed-in-<major>*` labels, milestone→major in title, dispatch/schedule unchanged. Untrusted text (label names, milestone/issue titles) flows ONLY via `env:` and is parsed with jq/grep — never interpolated into a `run:` block. Org gate `github.repository == 'dotnet/maui'` prevents fork activation. `issues: write` stays on the writer job only.

## Tests
- New hash-stability test: renders the report twice with different `fetchedAt`, asserts the banner text differs but the `release-readiness-hash` marker is identical (proves the banner is not hashed).
- 12 new `Format-ReportFreshnessBanner` unit tests (fresh/stale/singular/plural/ISO-string/null/unparseable/clock-skew/custom-threshold).
- Full suite green (838/0 in a networked env).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>