### PR TITLE
Re-enable environment gating on review-trigger.yml with copilot-pat-pool

### DIFF
--- a/.github/workflows/review-trigger.yml
+++ b/.github/workflows/review-trigger.yml
@@ -168,6 +168,7 @@ jobs:
     needs: match
     if: needs.match.outputs.matched == 'true' && needs.match.outputs.command == 'review'
     runs-on: ubuntu-latest
+    environment: copilot-pat-pool
     concurrency:
       group: review-trigger-${{ github.event.issue.number || inputs.pr_number }}
       cancel-in-progress: false


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

Re-adds `environment: copilot-pat-pool` to the `trigger-review` job in `review-trigger.yml`.

## Why

Environment gating was originally added in #35974 (`environment: gh-aw-agents`) and then **reverted** in #36005. The revert was necessary because gating changes the GitHub OIDC token subject from `repo:dotnet/maui:ref:refs/heads/main` to an environment-scoped subject, and the managed identity (`Testing-MI-gh2zdo`, behind `AZDO_TRIGGER_CLIENT_ID`) had no federated credential for that subject — so every `/review` command failed with:

```
AADSTS700213: No matching federated identity record found for presented
assertion subject 'repo:dotnet/maui:environment:gh-aw-agents'
```

That was a temporary workaround put in place while we couldn't add/fix the credential on the managed identity. The environment has since been standardized to `copilot-pat-pool` (#36204), and a matching federated credential is being added to the identity:

```
--subject "repo:dotnet/maui:environment:copilot-pat-pool"
```

With that credential in place, the environment gating can be restored.

## What changed

- Re-added `environment: copilot-pat-pool` to the `trigger-review` job (1 line).
- No other jobs affected; `id-token: write` and the OIDC → AzDO token exchange are unchanged.

## ⚠️ Merge prerequisite

**Do not merge until** the federated credential with subject `repo:dotnet/maui:environment:copilot-pat-pool` exists on the `Testing-MI-gh2zdo` managed identity. Merging before the credential is created will break `/review` again with `AADSTS700213`.

## Validation

After merge, run `/review` on a PR and confirm the `trigger-review` job's OIDC → AzDO token exchange succeeds (no `AADSTS700213`) and the `maui-copilot` pipeline is triggered.