### PR TITLE
[Windows] WebAuthenticator: add protocol callback support via app activation

### DIFF
--- a/src/Core/src/Hosting/EssentialsMauiAppBuilderExtensions.cs
+++ b/src/Core/src/Hosting/EssentialsMauiAppBuilderExtensions.cs
@@ -66,6 +66,10 @@ namespace Microsoft.Maui.Hosting
 					}));
 #elif WINDOWS
 				life.AddWindows(windows => windows
+					.OnAppInstanceActivated((application, args) =>
+					{
+						return ApplicationModel.Platform.OnAppInstanceActivated(application, args);
+					})
 					.OnActivated((window, args) =>
 					{
 						ApplicationModel.Platform.OnActivated(window, args);

--- a/src/Essentials/src/Platform/Platform.shared.cs
+++ b/src/Essentials/src/Platform/Platform.shared.cs
@@ -154,6 +154,15 @@ namespace Microsoft.Maui.ApplicationModel
 		public static void OnActivated(UI.Xaml.Window window, UI.Xaml.WindowActivatedEventArgs args) =>
 			WindowStateManager.Default.OnActivated(window, args);
 
+		/// <summary>
+		/// Called when the Windows application receives activation arguments that may be handled by platform features.
+		/// </summary>
+		/// <param name="application">The application instance that received the activation.</param>
+		/// <param name="args">The activation arguments.</param>
+		/// <returns><see langword="true"/> if a platform feature handled the activation; otherwise, <see langword="false"/>.</returns>
+		public static bool OnAppInstanceActivated(UI.Xaml.Application application, Microsoft.Windows.AppLifecycle.AppActivationArguments args) =>
+			WebAuthenticator.Default.OnAppInstanceActivated(args);
+
 #elif TIZEN
 		/// <summary>
 		/// Gets a <see cref="Tizen.Applications.Package"/> object with information about the current application package.

--- a/src/Essentials/src/Platform/PlatformMethods.windows.cs
+++ b/src/Essentials/src/Platform/PlatformMethods.windows.cs
@@ -78,6 +78,10 @@ namespace Microsoft.Maui.ApplicationModel
 		public static extern IntPtr CallWindowProc(IntPtr lpPrevWndFunc, IntPtr hWnd, uint uMsg, IntPtr wParam, IntPtr lParam);
 
 		[DllImport("user32.dll")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		public static extern bool SetForegroundWindow(IntPtr hWnd);
+
+		[DllImport("user32.dll")]
 		public static extern bool SetWindowPos(IntPtr hWnd, SpecialWindowHandles hWndInsertAfter, int x, int y, int width, int height, SetWindowPosFlags uFlags);
 
 		[DllImport("user32.dll")]

--- a/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,4 +1,7 @@
 #nullable enable
+Microsoft.Maui.Authentication.IPlatformWebAuthenticatorCallback.OnAppInstanceActivatedCallback(Microsoft.Windows.AppLifecycle.AppActivationArguments! args) -> bool
+static Microsoft.Maui.ApplicationModel.Platform.OnAppInstanceActivated(Microsoft.UI.Xaml.Application! application, Microsoft.Windows.AppLifecycle.AppActivationArguments! args) -> bool
+static Microsoft.Maui.Authentication.WebAuthenticatorExtensions.OnAppInstanceActivated(this Microsoft.Maui.Authentication.IWebAuthenticator! webAuthenticator, Microsoft.Windows.AppLifecycle.AppActivationArguments! args) -> bool
 *REMOVED*Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult!>?>!
 *REMOVED*static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.shared.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.shared.cs
@@ -22,10 +22,10 @@ namespace Microsoft.Maui.Authentication
 		/// <param name="webAuthenticatorOptions">A <see cref="WebAuthenticatorOptions"/> instance containing additional configuration for this authentication call.</param>
 		/// <returns>A <see cref="WebAuthenticatorResult"/> object with the results of this operation.</returns>
 		/// <exception cref="TaskCanceledException">Thrown when the user canceled the authentication flow.</exception>
-		/// <exception cref="PlatformNotSupportedException">Windows: Thrown when called on Windows.</exception>
 		/// <exception cref="FeatureNotSupportedException">iOS/macOS: Thrown when iOS version is less than 13 is used or macOS less than 13.1 is used.</exception>
 		/// <exception cref="InvalidOperationException">
 		/// <para>Android: Thrown when the no IntentFilter has been created for the callback URL.</para>
+		/// <para>Windows: Thrown when the callback URL is invalid, its protocol is not registered, the browser cannot be launched, or another app instance is already waiting for the callback scheme.</para>
 		/// </exception>
 		Task<WebAuthenticatorResult> AuthenticateAsync(WebAuthenticatorOptions webAuthenticatorOptions);
 
@@ -36,10 +36,10 @@ namespace Microsoft.Maui.Authentication
 		/// <param name="cancellationToken">A <see cref="CancellationToken"/> to monitor for cancellation requests.</param>
 		/// <returns>A <see cref="WebAuthenticatorResult"/> object with the results of this operation.</returns>
 		/// <exception cref="TaskCanceledException">Thrown when the user canceled the authentication flow.</exception>
-		/// <exception cref="PlatformNotSupportedException">Windows: Thrown when called on Windows.</exception>
 		/// <exception cref="FeatureNotSupportedException">iOS/macOS: Thrown when iOS version is less than 13 is used or macOS less than 13.1 is used.</exception>
 		/// <exception cref="InvalidOperationException">
 		/// <para>Android: Thrown when the no IntentFilter has been created for the callback URL.</para>
+		/// <para>Windows: Thrown when the callback URL is invalid, its protocol is not registered, the browser cannot be launched, or another app instance is already waiting for the callback scheme.</para>
 		/// </exception>
 		Task<WebAuthenticatorResult> AuthenticateAsync(WebAuthenticatorOptions webAuthenticatorOptions, CancellationToken cancellationToken);
 
@@ -64,6 +64,13 @@ namespace Microsoft.Maui.Authentication
 		/// <param name="intent">An <see cref="Intent"/> object containing additional data about this resume operation.</param>
 		/// <returns><see langword="true"/> when the callback can be processed, otherwise <see langword="false"/>.</returns>
 		bool OnResumeCallback(Intent intent);
+#elif WINDOWS
+		/// <summary>
+		/// Called when the app receives an activation that may complete an authentication flow.
+		/// </summary>
+		/// <param name="args">The activation arguments delivered by the OS.</param>
+		/// <returns><see langword="true"/> when the activation was handled, otherwise <see langword="false"/>.</returns>
+		bool OnAppInstanceActivatedCallback(Microsoft.Windows.AppLifecycle.AppActivationArguments args);
 #endif
 	}
 
@@ -93,9 +100,6 @@ namespace Microsoft.Maui.Authentication
 		/// <param name="url"> Url to navigate to, beginning the authentication flow.</param>
 		/// <param name="callbackUrl"> Expected callback url that the navigation flow will eventually redirect to.</param>
 		/// <returns>Returns a result parsed out from the callback url.</returns>
-#if !NETSTANDARD
-		[System.Runtime.Versioning.UnsupportedOSPlatform("windows")]
-#endif
 		public static Task<WebAuthenticatorResult> AuthenticateAsync(Uri url, Uri callbackUrl)
 			=> Current.AuthenticateAsync(url, callbackUrl);
 
@@ -104,18 +108,12 @@ namespace Microsoft.Maui.Authentication
 		/// <param name="callbackUrl"> Expected callback url that the navigation flow will eventually redirect to.</param>
 		/// <param name="cancellationToken">A <see cref="CancellationToken"/> to monitor for cancellation requests.</param>
 		/// <returns>Returns a result parsed out from the callback url.</returns>
-#if !NETSTANDARD
-		[System.Runtime.Versioning.UnsupportedOSPlatform("windows")]
-#endif
 		public static Task<WebAuthenticatorResult> AuthenticateAsync(Uri url, Uri callbackUrl, CancellationToken cancellationToken)
 			=> Current.AuthenticateAsync(url, callbackUrl, cancellationToken);
 
 		/// <summary>Begin an authentication flow by navigating to the specified url and waiting for a callback/redirect to the callbackUrl scheme.The start url and callbackUrl are specified in the webAuthenticatorOptions.</summary>
 		/// <param name="webAuthenticatorOptions">Options to configure the authentication request.</param>
 		/// <returns>Returns a result parsed out from the callback url.</returns>
-#if !NETSTANDARD
-		[System.Runtime.Versioning.UnsupportedOSPlatform("windows")]
-#endif
 		public static Task<WebAuthenticatorResult> AuthenticateAsync(WebAuthenticatorOptions webAuthenticatorOptions)
 			=> Current.AuthenticateAsync(webAuthenticatorOptions);
 
@@ -123,9 +121,6 @@ namespace Microsoft.Maui.Authentication
 		/// <param name="webAuthenticatorOptions">Options to configure the authentication request.</param>
 		/// <param name="cancellationToken">A <see cref="CancellationToken"/> to monitor for cancellation requests.</param>
 		/// <returns>Returns a result parsed out from the callback url.</returns>
-#if !NETSTANDARD
-		[System.Runtime.Versioning.UnsupportedOSPlatform("windows")]
-#endif
 		public static Task<WebAuthenticatorResult> AuthenticateAsync(WebAuthenticatorOptions webAuthenticatorOptions, CancellationToken cancellationToken)
 			=> Current.AuthenticateAsync(webAuthenticatorOptions, cancellationToken);
 
@@ -210,6 +205,10 @@ namespace Microsoft.Maui.Authentication
 		/// <inheritdoc cref="IPlatformWebAuthenticatorCallback.OnResumeCallback(Intent)"/>
 		public static bool OnResume(this IWebAuthenticator webAuthenticator, Intent intent) =>
 			webAuthenticator.AsPlatformCallback().OnResumeCallback(intent);
+#elif WINDOWS
+		/// <inheritdoc cref="IPlatformWebAuthenticatorCallback.OnAppInstanceActivatedCallback(Microsoft.Windows.AppLifecycle.AppActivationArguments)"/>
+		public static bool OnAppInstanceActivated(this IWebAuthenticator webAuthenticator, Microsoft.Windows.AppLifecycle.AppActivationArguments args) =>
+			webAuthenticator.AsPlatformCallback().OnAppInstanceActivatedCallback(args);
 #endif
 	}
 

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.windows.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.windows.cs
@@ -1,18 +1,327 @@
+#nullable enable
 using System;
+using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Linq;
+using System.Xml.XPath;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Storage;
+using Microsoft.UI.Windowing;
+using Microsoft.Windows.AppLifecycle;
+using Windows.ApplicationModel.Activation;
 
 namespace Microsoft.Maui.Authentication
 {
-	partial class WebAuthenticatorImplementation : IWebAuthenticator
+	partial class WebAuthenticatorImplementation : IWebAuthenticator, IPlatformWebAuthenticatorCallback
 	{
-		public Task<WebAuthenticatorResult> AuthenticateAsync(WebAuthenticatorOptions webAuthenticatorOptions)
+		const string CallbackRouteKeyPrefix = "Microsoft.Maui.WebAuthenticator:";
+
+		readonly object locker = new();
+
+		TaskCompletionSource<WebAuthenticatorResult>? tcsResponse;
+		Uri? currentRedirectUri;
+		WebAuthenticatorOptions? currentOptions;
+		AppWindow? currentAppWindow;
+
+		public bool OnAppInstanceActivatedCallback(AppActivationArguments args)
 		{
-			throw new PlatformNotSupportedException("This implementation of WebAuthenticator does not support Windows. See https://github.com/microsoft/WindowsAppSDK/issues/441 for more details.");
+			if (args.Kind != ExtendedActivationKind.Protocol ||
+				args.Data is not IProtocolActivatedEventArgs protocolArgs)
+			{
+				return false;
+			}
+
+			var callbackUri = protocolArgs.Uri;
+
+			TaskCompletionSource<WebAuthenticatorResult>? response;
+			Uri? redirectUri;
+			WebAuthenticatorOptions? options;
+			AppWindow? appWindow;
+
+			bool isLocalCallbackRoute;
+
+			lock (locker)
+			{
+				response = tcsResponse;
+				redirectUri = currentRedirectUri;
+				options = currentOptions;
+				appWindow = currentAppWindow;
+
+				isLocalCallbackRoute = redirectUri is not null && IsSameCallbackRoute(redirectUri, callbackUri);
+			}
+
+			if (response?.Task.IsCompleted == false &&
+				redirectUri is not null &&
+				WebUtils.CanHandleCallback(redirectUri, callbackUri))
+			{
+				try
+				{
+					var result = new WebAuthenticatorResult(callbackUri, options?.ResponseDecoder);
+
+					// Only the callback that completes the request may restore its window.
+					if (response.TrySetResult(result))
+						TryBringToForeground(appWindow);
+				}
+				catch (Exception ex)
+				{
+					response.TrySetException(ex);
+				}
+
+				return true;
+			}
+
+			// A callback can have the expected scheme and still fail host/path validation.
+			// Leave the active route registered so a later valid callback can complete it.
+			if (isLocalCallbackRoute)
+				return false;
+
+			var routeOwner = FindCallbackRouteOwner(callbackUri);
+			if (routeOwner is null)
+				return false;
+
+			return RedirectActivationAndExit(routeOwner, args);
 		}
-		public Task<WebAuthenticatorResult> AuthenticateAsync(WebAuthenticatorOptions webAuthenticatorOptions, CancellationToken cancellationToken)
+
+		public async Task<WebAuthenticatorResult> AuthenticateAsync(WebAuthenticatorOptions webAuthenticatorOptions)
+			=> await AuthenticateAsync(webAuthenticatorOptions, CancellationToken.None);
+
+		public async Task<WebAuthenticatorResult> AuthenticateAsync(WebAuthenticatorOptions webAuthenticatorOptions, CancellationToken cancellationToken)
 		{
-			throw new PlatformNotSupportedException("This implementation of WebAuthenticator does not support Windows. See https://github.com/microsoft/WindowsAppSDK/issues/441 for more details.");
+			ArgumentNullException.ThrowIfNull(webAuthenticatorOptions);
+
+			var url = webAuthenticatorOptions.Url ??
+				throw new ArgumentNullException(nameof(webAuthenticatorOptions.Url));
+			var callbackUrl = webAuthenticatorOptions.CallbackUrl ??
+				throw new ArgumentNullException(nameof(webAuthenticatorOptions.CallbackUrl));
+
+			ValidateCallbackUrl(callbackUrl);
+
+			var response = new TaskCompletionSource<WebAuthenticatorResult>();
+			TaskCompletionSource<WebAuthenticatorResult>? previousResponse;
+
+			// Capture the request window so a multi-window app restores the same window
+			// after authentication completes.
+			var appWindow = TryGetActiveAppWindow();
+
+			lock (locker)
+			{
+				RegisterCallbackRoute(callbackUrl);
+
+				previousResponse = tcsResponse;
+				tcsResponse = response;
+				currentRedirectUri = callbackUrl;
+				currentOptions = webAuthenticatorOptions;
+				currentAppWindow = appWindow;
+			}
+
+			previousResponse?.TrySetCanceled();
+
+			using (cancellationToken.Register(() => response.TrySetCanceled()))
+			{
+				try
+				{
+					var launched = await global::Windows.System.Launcher.LaunchUriAsync(url);
+					if (!launched)
+						throw new InvalidOperationException("Failed to launch the browser for authentication.");
+
+					return await response.Task;
+				}
+				finally
+				{
+					lock (locker)
+					{
+						if (ReferenceEquals(tcsResponse, response))
+							ClearCurrentAuthentication();
+					}
+				}
+			}
+		}
+
+		void ClearCurrentAuthentication()
+		{
+			// Keep the route for the process lifetime. Windows App SDK cannot re-register an
+			// AppInstance after UnregisterKey (microsoft/WindowsAppSDK#4420).
+			tcsResponse = null;
+			currentRedirectUri = null;
+			currentOptions = null;
+			currentAppWindow = null;
+		}
+
+		static AppWindow? TryGetActiveAppWindow()
+		{
+			try
+			{
+				return WindowStateManager.Default.GetActiveAppWindow(false);
+			}
+			catch (Exception ex)
+			{
+				Debug.WriteLine($"Unable to identify the WebAuthenticator window: {ex}");
+				return null;
+			}
+		}
+
+		static void TryBringToForeground(AppWindow? appWindow)
+		{
+			if (appWindow is null)
+				return;
+
+			try
+			{
+				var windowHandle = UI.Win32Interop.GetWindowFromWindowId(appWindow.Id);
+				if (windowHandle == IntPtr.Zero)
+				{
+					Debug.WriteLine("Unable to retrieve the WebAuthenticator window handle.");
+					return;
+				}
+
+				// AppWindow APIs are agile. Restore or show without activation so the native
+				// call below makes the only best-effort foreground request.
+				if (appWindow.Presenter is OverlappedPresenter presenter &&
+					presenter.State == OverlappedPresenterState.Minimized)
+				{
+					presenter.Restore(false);
+				}
+
+				if (!appWindow.IsVisible)
+					appWindow.Show(false);
+
+				// RedirectActivationToAsync attempts to transfer foreground permission to the
+				// route owner, but Windows can still deny this request.
+				if (!PlatformMethods.SetForegroundWindow(windowHandle))
+					Debug.WriteLine("Windows denied the WebAuthenticator window foreground activation.");
+			}
+			catch (Exception ex)
+			{
+				Debug.WriteLine($"Unable to bring the WebAuthenticator window to the foreground: {ex}");
+			}
+		}
+
+		static void ValidateCallbackUrl(Uri callbackUrl)
+		{
+			if (!callbackUrl.IsAbsoluteUri)
+				throw new InvalidOperationException("The callback URI must be absolute.");
+
+			if (callbackUrl.Scheme is "http" or "https")
+			{
+				throw new InvalidOperationException(
+					$"{callbackUrl.Scheme}:// schemes are not supported for the callback URI on Windows. " +
+					"Use a custom URI scheme instead.");
+			}
+
+			if (AppInfoUtils.IsPackagedApp)
+			{
+				if (!IsUriProtocolDeclared(callbackUrl.Scheme))
+				{
+					throw new InvalidOperationException(
+						$"You need to declare the windows.protocol usage of the " +
+						$"protocol/scheme `{callbackUrl.Scheme}` in your AppxManifest.xml file.");
+				}
+			}
+			else if (!IsRegistryDeclared(callbackUrl.Scheme))
+			{
+				throw new InvalidOperationException(
+					$"The URI scheme '{callbackUrl.Scheme}' is not registered. " +
+					"Call ActivationRegistrationManager.RegisterForProtocolActivation when running unpackaged.");
+			}
+		}
+
+		static void RegisterCallbackRoute(Uri callbackUrl)
+		{
+			var currentInstance = AppInstance.GetCurrent();
+			var routeKey = CreateCallbackRouteKey(callbackUrl);
+			var currentKey = currentInstance.Key;
+
+			if (string.Equals(currentKey, routeKey, StringComparison.Ordinal))
+				return;
+
+			// Preserve application-owned AppInstance routing.
+			if (!CanRegisterCallbackRoute(currentKey))
+				return;
+
+			var routeOwner = AppInstance.FindOrRegisterForKey(routeKey);
+			if (routeOwner is null)
+			{
+				throw new InvalidOperationException(
+					$"Unable to register the callback route for scheme '{callbackUrl.Scheme}'.");
+			}
+
+			if (!routeOwner.IsCurrent)
+			{
+				throw new InvalidOperationException(
+					$"Another app instance is already waiting for the callback scheme '{callbackUrl.Scheme}'.");
+			}
+
+			if (!string.Equals(routeOwner.Key, routeKey, StringComparison.Ordinal))
+			{
+				throw new InvalidOperationException(
+					$"Unable to register the callback route for scheme '{callbackUrl.Scheme}'.");
+			}
+		}
+
+		static AppInstance? FindCallbackRouteOwner(Uri callbackUri)
+		{
+			var routeKey = CreateCallbackRouteKey(callbackUri);
+
+			return AppInstance.GetInstances().FirstOrDefault(instance =>
+				!instance.IsCurrent &&
+				string.Equals(instance.Key, routeKey, StringComparison.Ordinal));
+		}
+
+		static bool RedirectActivationAndExit(AppInstance routeOwner, AppActivationArguments args)
+		{
+			try
+			{
+				// Complete redirection before terminating this transient callback process.
+				routeOwner.RedirectActivationToAsync(args).AsTask().GetAwaiter().GetResult();
+			}
+			catch (Exception ex)
+			{
+				Debug.WriteLine($"Unable to redirect WebAuthenticator callback activation: {ex}");
+				return false;
+			}
+
+			Process.GetCurrentProcess().Kill();
+			return true;
+		}
+
+		// AppInstance keys are app-defined, so keep WebAuthenticator routes separate from application-owned keys.
+		internal static string CreateCallbackRouteKey(Uri callbackUrl) =>
+			$"{CallbackRouteKeyPrefix}{callbackUrl.Scheme}";
+
+		internal static bool CanRegisterCallbackRoute(string? currentKey) =>
+			string.IsNullOrEmpty(currentKey) ||
+			currentKey.StartsWith(CallbackRouteKeyPrefix, StringComparison.Ordinal);
+
+		internal static bool IsSameCallbackRoute(Uri expectedCallbackUrl, Uri callbackUrl) =>
+			string.Equals(
+				CreateCallbackRouteKey(expectedCallbackUrl),
+				CreateCallbackRouteKey(callbackUrl),
+				StringComparison.Ordinal);
+
+		static bool IsUriProtocolDeclared(string scheme)
+		{
+			var docPath = FileSystemUtils.PlatformGetFullAppPackageFilePath(PlatformUtils.AppManifestFilename);
+			var doc = XDocument.Load(docPath, LoadOptions.None);
+
+			using var reader = doc.CreateReader();
+			var namespaceManager = new XmlNamespaceManager(reader.NameTable);
+			namespaceManager.AddNamespace("uap", PlatformUtils.AppManifestUapXmlns);
+
+			var root = doc.Root ?? throw new InvalidOperationException("The app manifest could not be loaded.");
+			var declarations = root.XPathSelectElements(
+				$"//uap:Extension[@Category='windows.protocol']/uap:Protocol[@Name='{scheme}']",
+				namespaceManager);
+
+			return declarations.Any();
+		}
+
+		static bool IsRegistryDeclared(string scheme)
+		{
+			using var key = Win32.Registry.ClassesRoot.OpenSubKey(scheme);
+			return key?.GetValue("URL Protocol") is not null;
 		}
 	}
 }

--- a/src/Essentials/test/DeviceTests/Platforms/Windows/Package.appxmanifest
+++ b/src/Essentials/test/DeviceTests/Platforms/Windows/Package.appxmanifest
@@ -33,6 +33,11 @@
         <uap:DefaultTile Square71x71Logo="$placeholder$.png" Wide310x150Logo="$placeholder$.png" Square310x310Logo="$placeholder$.png" />
         <uap:SplashScreen Image="$placeholder$.png" />
       </uap:VisualElements>
+      <Extensions>
+        <uap:Extension Category="windows.protocol">
+          <uap:Protocol Name="xamarinessentials" />
+        </uap:Extension>
+      </Extensions>
     </Application>
   </Applications>
 

--- a/src/Essentials/test/DeviceTests/Tests/WebAuthenticator_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/WebAuthenticator_Tests.cs
@@ -22,21 +22,15 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		[Trait(Traits.InteractionType, Traits.InteractionTypes.Human)]
 		public async Task Redirect(string urlBase, string callbackScheme, string accessToken, string refreshToken, int expires)
 		{
-#pragma warning disable CA1416 // Validate platform compatibility: Not supported on Windows
 			var authenticationTask = WebAuthenticator.AuthenticateAsync(
 				new Uri($"{urlBase}?access_token={accessToken}&refresh_token={refreshToken}&expires={expires}"),
 				new Uri($"{callbackScheme}://"));
-#pragma warning restore CA1416 // Validate platform compatibility
 
-#if WINDOWS
-			var exception = await Assert.ThrowsAsync<PlatformNotSupportedException>(async () => await authenticationTask);
-#else
 			var r = await authenticationTask.ConfigureAwait(false);
 			Assert.Equal(accessToken, r?.AccessToken);
 			Assert.Equal(refreshToken, r?.RefreshToken);
 			Assert.NotNull(r?.ExpiresIn);
 			Assert.True(r?.ExpiresIn > DateTime.UtcNow);
-#endif
 		}
 
 		[Theory]
@@ -50,24 +44,18 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		public async Task RedirectWithResponseDecoder(string urlBase, string callbackScheme, string accessToken, string refreshToken, int expires)
 		{
 			var responseDecoder = new TestResponseDecoder();
-#pragma warning disable CA1416 // Validate platform compatibility: Not supported on Windows
 			var authenticationTask = WebAuthenticator.AuthenticateAsync(new WebAuthenticatorOptions
 			{
 				Url = new Uri($"{urlBase}?access_token={accessToken}&refresh_token={refreshToken}&expires={expires}"),
 				CallbackUrl = new Uri($"{callbackScheme}://"),
 				ResponseDecoder = responseDecoder
 			});
-#pragma warning restore CA1416 // Validate platform compatibility
-#if WINDOWS
-			var exception = await Assert.ThrowsAsync<PlatformNotSupportedException>(async () => await authenticationTask);
-#else
 			var r = await authenticationTask.ConfigureAwait(false);
 			Assert.Equal(accessToken, r?.AccessToken);
 			Assert.Equal(refreshToken, r?.RefreshToken);
 			Assert.NotNull(r?.ExpiresIn);
 			Assert.True(r?.ExpiresIn > DateTime.UtcNow);
 			Assert.Equal(1, responseDecoder.CallCount);
-#endif
 		}
 
 
@@ -81,23 +69,16 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		[Trait(Traits.InteractionType, Traits.InteractionTypes.Human)]
 		public async Task Redirect_WithCancellation(string urlBase, string callbackScheme, string accessToken, string refreshToken, int expires)
 		{
-#pragma warning disable CA1416 // Validate platform compatibility: Not supported on Windows
 			using var cts = new CancellationTokenSource();
 			var authenticationTask = WebAuthenticator.AuthenticateAsync(
 				new Uri($"{urlBase}?access_token={accessToken}&refresh_token={refreshToken}&expires={expires}"),
 				new Uri($"{callbackScheme}://"),
 				cts.Token);
-#pragma warning restore CA1416 // Validate platform compatibility
-
-#if WINDOWS
-			var exception = await Assert.ThrowsAsync<PlatformNotSupportedException>(async () => await authenticationTask);
-#else
 			var r = await authenticationTask;
 			Assert.Equal(accessToken, r?.AccessToken);
 			Assert.Equal(refreshToken, r?.RefreshToken);
 			Assert.NotNull(r?.ExpiresIn);
 			Assert.True(r?.ExpiresIn > DateTime.UtcNow);
-#endif
 		}
 
 		[Theory]
@@ -111,7 +92,6 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		public async Task RedirectWithResponseDecoder_WithCancellation(string urlBase, string callbackScheme, string accessToken, string refreshToken, int expires)
 		{
 			var responseDecoder = new TestResponseDecoder();
-#pragma warning disable CA1416 // Validate platform compatibility: Not supported on Windows
 			using var cts = new CancellationTokenSource();
 			var authenticationTask = WebAuthenticator.AuthenticateAsync(new WebAuthenticatorOptions
 			{
@@ -119,17 +99,12 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 				CallbackUrl = new Uri($"{callbackScheme}://"),
 				ResponseDecoder = responseDecoder
 			}, cts.Token);
-#pragma warning restore CA1416 // Validate platform compatibility
-#if WINDOWS
-			var exception = await Assert.ThrowsAsync<PlatformNotSupportedException>(async () => await authenticationTask);
-#else
 			var r = await authenticationTask;
 			Assert.Equal(accessToken, r?.AccessToken);
 			Assert.Equal(refreshToken, r?.RefreshToken);
 			Assert.NotNull(r?.ExpiresIn);
 			Assert.True(r?.ExpiresIn > DateTime.UtcNow);
 			Assert.Equal(1, responseDecoder.CallCount);
-#endif
 		}
 
 

--- a/src/Essentials/test/DeviceTests/Tests/WebAuthenticator_Windows_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/WebAuthenticator_Windows_Tests.cs
@@ -1,0 +1,52 @@
+#if WINDOWS
+using System;
+using Microsoft.Maui.Authentication;
+using Xunit;
+
+namespace Microsoft.Maui.Essentials.DeviceTests
+{
+	[Category("WebAuthenticator")]
+	public class WebAuthenticator_Windows_Tests
+	{
+		[Theory]
+		[InlineData("maui-auth://", "Microsoft.Maui.WebAuthenticator:maui-auth")]
+		[InlineData("MAUI-AUTH://", "Microsoft.Maui.WebAuthenticator:maui-auth")]
+		[InlineData("maui-auth://callback", "Microsoft.Maui.WebAuthenticator:maui-auth")]
+		[InlineData("maui-auth://other/path?code=123", "Microsoft.Maui.WebAuthenticator:maui-auth")]
+		public void CreateCallbackRouteKeyUsesSchemeOnly(string callbackUrl, string expected)
+		{
+			var routeKey = WebAuthenticatorImplementation.CreateCallbackRouteKey(new Uri(callbackUrl));
+
+			Assert.Equal(expected, routeKey);
+		}
+
+		[Theory]
+		[InlineData(null, true)]
+		[InlineData("", true)]
+		[InlineData("Maui.App", false)]
+		[InlineData("Microsoft.Maui.WebAuthenticator:maui-auth", true)]
+		[InlineData("Microsoft.Maui.WebAuthenticator:other-auth", true)]
+		[InlineData("Microsoft.Maui.WebAuthenticator2:maui-auth", false)]
+		public void CanRegisterCallbackRoutePreservesApplicationKeys(string currentKey, bool expected)
+		{
+			var actual = WebAuthenticatorImplementation.CanRegisterCallbackRoute(currentKey);
+
+			Assert.Equal(expected, actual);
+		}
+
+		[Theory]
+		[InlineData("maui-auth://callback", "maui-auth://callback", true)]
+		[InlineData("maui-auth://callback", "maui-auth://other/path", true)]
+		[InlineData("MAUI-AUTH://callback", "maui-auth://callback", true)]
+		[InlineData("maui-auth://callback", "other-auth://callback", false)]
+		public void IsSameCallbackRouteUsesSchemeOnly(string expectedCallbackUrl, string callbackUrl, bool expected)
+		{
+			var actual = WebAuthenticatorImplementation.IsSameCallbackRoute(
+				new Uri(expectedCallbackUrl),
+				new Uri(callbackUrl));
+
+			Assert.Equal(expected, actual);
+		}
+	}
+}
+#endif

--- a/src/Essentials/test/UnitTests/WebUtils_Tests.cs
+++ b/src/Essentials/test/UnitTests/WebUtils_Tests.cs
@@ -115,5 +115,22 @@ namespace Tests
 			var result = Microsoft.Maui.WebUtils.RemovePossibleQueryString(input);
 			Assert.Equal(expected, result);
 		}
+
+		// ============================================================
+		// CanHandleCallback
+		// ============================================================
+
+		[Theory]
+		[InlineData("maui-auth://", "maui-auth://callback?code=123", true)]
+		[InlineData("MAUI-AUTH://", "maui-auth://callback?code=123", true)]
+		[InlineData("maui-auth://callback", "MAUI-AUTH://CALLBACK?code=123", true)]
+		[InlineData("maui-auth://callback", "maui-auth://other?code=123", false)]
+		[InlineData("maui-auth://callback", "other-auth://callback?code=123", false)]
+		public void CanHandleCallback_ReturnsExpected(string expectedUrl, string callbackUrl, bool expected)
+		{
+			var result = Microsoft.Maui.WebUtils.CanHandleCallback(new Uri(expectedUrl), new Uri(callbackUrl));
+
+			Assert.Equal(expected, result);
+		}
 	}
 }


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could <a href=https://github.com/dotnet/maui/wiki/Testing-PR-Builds>test the resulting artifacts</a> from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause

`WebAuthenticator` is unsupported on Windows. A custom-protocol callback may launch a second app process, so Windows needs both protocol activation handling and cross-instance routing back to the process that owns the pending authentication.

Windows App SDK also cannot reliably re-register an `AppInstance` after `UnregisterKey()` ([microsoft/WindowsAppSDK#4420](https://github.com/microsoft/WindowsAppSDK/issues/4420)). Releasing the route after the first authentication caused a subsequent callback process to find no route owner.

After a redirected callback completes, the existing MAUI window is not automatically restored or brought in front of the browser. The request must retain its originating window and perform a best-effort foreground activation only after a valid callback completes it.

### Description of Change

Adds a Windows implementation that preserves the existing cross-platform contract: caller-provided authentication URL and callback URL in, `WebAuthenticatorResult` out.

- opens the system browser with `Launcher.LaunchUriAsync`
- handles protocol callbacks through `OnAppInstanceActivated` from #34883
- registers a WebAuthenticator-specific `AppInstance` route for the callback scheme
- redirects transient callback processes to the instance that owns that route
- keeps the route registered for the lifetime of the process while keeping pending authentication state request-scoped
- validates packaged manifest and unpackaged protocol registration
- forwards callbacks through the existing `IPlatformWebAuthenticatorCallback`
- captures the `AppWindow` that started each authentication so multi-window callbacks return to the correct window
- restores minimized or hidden windows without intermediate activation, then makes one best-effort foreground request

This intentionally does **not** use `OAuth2Manager`. The caller still owns `state`, PKCE, provider parameters, and token exchange.

### Key Technical Details

- route keys use `Microsoft.Maui.WebAuthenticator:{scheme}`
- application-owned `AppInstance` keys are preserved
- transient processes use `AppInstance.GetInstances()` to find the route owner without registering another key
- final callback matching still uses `WebUtils.CanHandleCallback(...)`
- only one WebAuthenticator request can be pending per app instance, matching the existing platform model
- redirect completion is awaited before the transient callback process exits
- the route remains registered for the process lifetime to avoid the `UnregisterKey()` re-registration issue
- the persistent route is routing infrastructure; the TCS and expected callback URI determine whether a callback is currently handled
- only the callback that wins `TrySetResult` may restore and foreground its captured window
- cancellation, invalid callbacks, duplicate callbacks, and late callbacks do not request foreground activation
- minimized windows use `OverlappedPresenter.Restore(false)` and hidden windows use `AppWindow.Show(false)` so `SetForegroundWindow` is the only explicit activation request
- foreground work is isolated behind best-effort exception handling and never changes the OAuth result

`RedirectActivationToAsync` already requests foreground permission for the route-owner process through `AllowSetForegroundWindow` in Windows App SDK [`AppInstance::QueueRequest`](https://github.com/microsoft/WindowsAppSDK/blob/91160b078668051e58ba1e19eb699f4efc8c5b20/dev/AppLifecycle/AppInstance.cpp). MAUI therefore does not duplicate that call.

The foreground path intentionally does not use `AppWindow.DispatcherQueue`. [`AppWindow`](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.windowing.appwindow?view=windows-app-sdk-1.8) and [`OverlappedPresenter`](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.windowing.overlappedpresenter?view=windows-app-sdk-1.8) are agile, and a dispatcher queue is not guaranteed to be available in the redirected activation context.

Packaged apps declare the callback scheme in `AppxManifest.xml`; unpackaged apps register it with `ActivationRegistrationManager.RegisterForProtocolActivation(...)`.

### Foreground Behavior

Windows ultimately decides whether [`SetForegroundWindow`](https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-setforegroundwindow) succeeds. Foreground activation is therefore best effort by design: failure is diagnostic only and never changes a successful authentication result.

### Testing

The routing revision passed Unit, Public API, Windows build, sample build, and all 14 WebAuthenticator Windows device tests.

The foreground revision was validated with:

- `Microsoft.Maui.Essentials` Windows build: 0 warnings, 0 errors
- manual OAuth callback verification confirming that the existing MAUI window returns in front of the browser
- runtime verification that accessing `AppWindow.DispatcherQueue` from the redirected activation context can fail with `COMException`; the final implementation does not depend on it

Additional human-interaction validation remains useful for minimized, maximized, multi-window, cancellation followed by retry, invalid callback, and consecutive-authentication scenarios.

### Breaking Changes

None.

### Issues Fixed

- Alternative implementation to #34887
- Related to #30056
- Stacked on #34883
- Related Windows App SDK behavior: [microsoft/WindowsAppSDK#4420](https://github.com/microsoft/WindowsAppSDK/issues/4420)

Looking forward to your feedback, thanks!

@mattleibow
@dotMorten