### PR TITLE
Fix FlexLayout measuring items wider than their arranged size

### DIFF
--- a/src/Controls/src/Core/Layout/FlexLayout.cs
+++ b/src/Controls/src/Core/Layout/FlexLayout.cs
@@ -528,16 +528,28 @@ namespace Microsoft.Maui.Controls
 						sizeConstraints.Width = (inMeasureMode && sizeConstraints.Width == 0) ? double.PositiveInfinity : sizeConstraints.Width;
 						sizeConstraints.Height = (inMeasureMode && sizeConstraints.Height == 0) ? double.PositiveInfinity : sizeConstraints.Height;
 
-						// Fix for #27520: when the engine already knows the cross-axis size the
-						// item will be arranged at (the incoming w/h, e.g. the size of a stretched
-						// item, which is the container size minus the item's margins), measure
-						// with that size. GetConstraints() returns the whole container size, which
-						// can be wider than the frame the item will actually receive; text
-						// measured against the wider constraint wraps at a width it will never
-						// have at arrange time, and the last line ends up cut off.
-						// Only the cross axis is safe to clamp here: the main-axis value at this
-						// point is the pre-flex basis (explicit size or 0), and grow/shrink can
-						// still change it before the item is arranged.
+						// Fix for #27520: GetConstraints() returns the whole container size, but an
+						// item can never be arranged larger than that container minus its own
+						// margins — grow/shrink only redistribute space within those bounds.
+						// Measuring with the wider constraint lets wrapping content (e.g. Label
+						// text) wrap against a width it will never receive at arrange time, and
+						// the overflowing line ends up cut off. Tighten each axis by the item's
+						// margins first...
+						if (!double.IsPositiveInfinity(sizeConstraints.Width))
+						{
+							sizeConstraints.Width = Math.Max(0, sizeConstraints.Width - (it.MarginLeft + it.MarginRight));
+						}
+
+						if (!double.IsPositiveInfinity(sizeConstraints.Height))
+						{
+							sizeConstraints.Height = Math.Max(0, sizeConstraints.Height - (it.MarginTop + it.MarginBottom));
+						}
+
+						// ...and when the engine has already fixed the final cross-axis size (the
+						// incoming w/h, e.g. a stretched item or an explicit size request), measure
+						// with exactly that. Only the cross axis is safe to clamp from w/h: the
+						// main-axis value at this point is the pre-flex basis (explicit size or 0),
+						// and grow/shrink can still change it before the item is arranged.
 						bool mainAxisIsHorizontal = Direction == FlexDirection.Row || Direction == FlexDirection.RowReverse;
 
 						if (!mainAxisIsHorizontal && !float.IsNaN(w) && w > 0 && w < sizeConstraints.Width)

--- a/src/Controls/src/Core/Layout/FlexLayout.cs
+++ b/src/Controls/src/Core/Layout/FlexLayout.cs
@@ -528,6 +528,23 @@ namespace Microsoft.Maui.Controls
 						sizeConstraints.Width = (inMeasureMode && sizeConstraints.Width == 0) ? double.PositiveInfinity : sizeConstraints.Width;
 						sizeConstraints.Height = (inMeasureMode && sizeConstraints.Height == 0) ? double.PositiveInfinity : sizeConstraints.Height;
 
+						// Fix for #27520: when the engine already knows the size the item will be
+						// arranged at on an axis (the incoming w/h, e.g. the cross-axis size of a
+						// stretched item, which is the container size minus the item's margins),
+						// measure with that size. GetConstraints() returns the whole container
+						// size, which can be wider than the frame the item will actually receive;
+						// text measured against the wider constraint wraps at a width it will
+						// never have at arrange time, and the last line ends up cut off.
+						if (!float.IsNaN(w) && w > 0 && w < sizeConstraints.Width)
+						{
+							sizeConstraints.Width = w;
+						}
+
+						if (!float.IsNaN(h) && h > 0 && h < sizeConstraints.Height)
+						{
+							sizeConstraints.Height = h;
+						}
+
 						if (child is Image)
 						{
 							// This is a hack to get FlexLayout to behave like it did in Forms

--- a/src/Controls/src/Core/Layout/FlexLayout.cs
+++ b/src/Controls/src/Core/Layout/FlexLayout.cs
@@ -528,19 +528,24 @@ namespace Microsoft.Maui.Controls
 						sizeConstraints.Width = (inMeasureMode && sizeConstraints.Width == 0) ? double.PositiveInfinity : sizeConstraints.Width;
 						sizeConstraints.Height = (inMeasureMode && sizeConstraints.Height == 0) ? double.PositiveInfinity : sizeConstraints.Height;
 
-						// Fix for #27520: when the engine already knows the size the item will be
-						// arranged at on an axis (the incoming w/h, e.g. the cross-axis size of a
-						// stretched item, which is the container size minus the item's margins),
-						// measure with that size. GetConstraints() returns the whole container
-						// size, which can be wider than the frame the item will actually receive;
-						// text measured against the wider constraint wraps at a width it will
-						// never have at arrange time, and the last line ends up cut off.
-						if (!float.IsNaN(w) && w > 0 && w < sizeConstraints.Width)
+						// Fix for #27520: when the engine already knows the cross-axis size the
+						// item will be arranged at (the incoming w/h, e.g. the size of a stretched
+						// item, which is the container size minus the item's margins), measure
+						// with that size. GetConstraints() returns the whole container size, which
+						// can be wider than the frame the item will actually receive; text
+						// measured against the wider constraint wraps at a width it will never
+						// have at arrange time, and the last line ends up cut off.
+						// Only the cross axis is safe to clamp here: the main-axis value at this
+						// point is the pre-flex basis (explicit size or 0), and grow/shrink can
+						// still change it before the item is arranged.
+						bool mainAxisIsHorizontal = Direction == FlexDirection.Row || Direction == FlexDirection.RowReverse;
+
+						if (!mainAxisIsHorizontal && !float.IsNaN(w) && w > 0 && w < sizeConstraints.Width)
 						{
 							sizeConstraints.Width = w;
 						}
 
-						if (!float.IsNaN(h) && h > 0 && h < sizeConstraints.Height)
+						if (mainAxisIsHorizontal && !float.IsNaN(h) && h > 0 && h < sizeConstraints.Height)
 						{
 							sizeConstraints.Height = h;
 						}

--- a/src/Controls/src/Core/Layout/FlexLayout.cs
+++ b/src/Controls/src/Core/Layout/FlexLayout.cs
@@ -535,6 +535,11 @@ namespace Microsoft.Maui.Controls
 						// text) wrap against a width it will never receive at arrange time, and
 						// the overflowing line ends up cut off. Tighten each axis by the item's
 						// margins first...
+						// (Note: IView.Measure subtracts the margin from this constraint once more
+						// before the platform measures. That mirrors the arrange path, where the
+						// engine frame is already reduced by the margin and ComputeFrame subtracts
+						// it again from the bounds. What matters for wrapping content is that the
+						// two paths agree on the final size.)
 						if (!double.IsPositiveInfinity(sizeConstraints.Width))
 						{
 							sizeConstraints.Width = Math.Max(0, sizeConstraints.Width - (it.MarginLeft + it.MarginRight));

--- a/src/Controls/tests/Core.UnitTests/Layouts/FlexLayoutTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/FlexLayoutTests.cs
@@ -496,5 +496,40 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 			// ...so its measure constraint must not have been clamped to the 100px basis.
 			Assert.Equal(300, view.MeasuredWidthConstraint);
 		}
+
+		// Simulates content that greedily fills whatever width it is given (like wrapping text).
+		class GreedyWidthConstraintRecordingView : View
+		{
+			public double MeasuredWidthConstraint { get; private set; } = double.NaN;
+
+			protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
+			{
+				MeasuredWidthConstraint = widthConstraint;
+				return new Size(double.IsPositiveInfinity(widthConstraint) ? 1000 : widthConstraint, Math.Min(50, heightConstraint));
+			}
+		}
+
+		// Regression test for https://github.com/dotnet/maui/issues/27520 (Row main axis:
+		// an item with horizontal margins must not be measured at the full container width
+		// and then shrunk below it at arrange time; its margins bound the space it can get).
+		[Fact]
+		public void ShrunkRowItemWithMarginIsMeasuredAtArrangedWidth_Issue27520()
+		{
+			var root = new Grid();
+			var controlsFlexLayout = new FlexLayout { Direction = FlexDirection.Row };
+			var flexLayout = controlsFlexLayout as IFlexLayout;
+			var view = new GreedyWidthConstraintRecordingView { Margin = new Thickness(10, 0, 10, 0) };
+
+			root.Add(controlsFlexLayout);
+			flexLayout.Add(view as IView);
+
+			_ = flexLayout.CrossPlatformMeasure(400, 200);
+			flexLayout.CrossPlatformArrange(new Rect(0, 0, 400, 200));
+
+			var flexFrame = flexLayout.GetFlexFrame(view as IView);
+
+			Assert.Equal(380, flexFrame.Width);
+			Assert.Equal(flexFrame.Width, view.MeasuredWidthConstraint);
+		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/Layouts/FlexLayoutTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/FlexLayoutTests.cs
@@ -399,5 +399,73 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 			Assert.Equal(125, frame1.Width);
 			Assert.Equal(175, frame2.Width);
 		}
+
+		// Records the constraints passed to MeasureOverride so tests can compare them
+		// with the size the view is ultimately arranged at.
+		class ConstraintRecordingView : View
+		{
+			public double MeasuredWidthConstraint { get; private set; } = double.NaN;
+			public double MeasuredHeightConstraint { get; private set; } = double.NaN;
+
+			protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
+			{
+				MeasuredWidthConstraint = widthConstraint;
+				MeasuredHeightConstraint = heightConstraint;
+				return new Size(Math.Min(100, widthConstraint), Math.Min(50, heightConstraint));
+			}
+		}
+
+		// Regression test for https://github.com/dotnet/maui/issues/27520
+		// A stretched item with a margin must be measured at the width it will be arranged at
+		// (the container width minus its margins), not at the full container width. Otherwise
+		// wrapping content (e.g. Label text) wraps against a width the item never receives,
+		// and the overflow is cut off at arrange time.
+		[Fact]
+		public void StretchedItemWithMarginIsMeasuredAtArrangedWidth_Issue27520()
+		{
+			var root = new Grid();
+			var controlsFlexLayout = new FlexLayout { Direction = FlexDirection.Column };
+			var flexLayout = controlsFlexLayout as IFlexLayout;
+			var view = new ConstraintRecordingView { Margin = new Thickness(10) };
+
+			root.Add(controlsFlexLayout);
+			flexLayout.Add(view as IView);
+
+			_ = flexLayout.CrossPlatformMeasure(400, 600);
+			flexLayout.CrossPlatformArrange(new Rect(0, 0, 400, 600));
+
+			// The bounds the child is arranged at (its flex frame) must be the same width
+			// the child was measured with; otherwise wrapping content gets cut off.
+			// Before the fix the child was measured at the full container width (400),
+			// ignoring its own margins, but arranged 20 narrower.
+			var flexFrame = flexLayout.GetFlexFrame(view as IView);
+			Assert.Equal(380, view.MeasuredWidthConstraint);
+			Assert.Equal(flexFrame.Width, view.MeasuredWidthConstraint);
+		}
+
+		// Regression test for https://github.com/dotnet/maui/issues/27520 (Row direction:
+		// the cross axis is vertical, so the height constraint is the one at risk).
+		[Fact]
+		public void StretchedItemWithMarginIsMeasuredAtArrangedHeight_Issue27520()
+		{
+			var root = new Grid();
+			var controlsFlexLayout = new FlexLayout { Direction = FlexDirection.Row };
+			var flexLayout = controlsFlexLayout as IFlexLayout;
+			var view = new ConstraintRecordingView { Margin = new Thickness(10) };
+
+			root.Add(controlsFlexLayout);
+			flexLayout.Add(view as IView);
+
+			_ = flexLayout.CrossPlatformMeasure(600, 400);
+			flexLayout.CrossPlatformArrange(new Rect(0, 0, 600, 400));
+
+			// The bounds the child is arranged at (its flex frame) must be the same height
+			// the child was measured with; otherwise wrapping content gets cut off.
+			// Before the fix the child was measured at the full container height (400),
+			// ignoring its own margins, but arranged 20 shorter.
+			var flexFrame = flexLayout.GetFlexFrame(view as IView);
+			Assert.Equal(380, view.MeasuredHeightConstraint);
+			Assert.Equal(flexFrame.Height, view.MeasuredHeightConstraint);
+		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/Layouts/FlexLayoutTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/FlexLayoutTests.cs
@@ -467,5 +467,34 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 			Assert.Equal(380, view.MeasuredHeightConstraint);
 			Assert.Equal(flexFrame.Height, view.MeasuredHeightConstraint);
 		}
+
+		// Companion to the #27520 fix: the main-axis value passed to the measure callback
+		// is the pre-flex basis (explicit size or 0), and grow/shrink can still change it
+		// before the item is arranged. It must NOT be used to clamp the measure constraint;
+		// a growing item would otherwise be measured at its basis (100) even though it is
+		// arranged at the grown size (300).
+		[Fact]
+		public void GrowingItemMainAxisMeasureConstraintIsNotClampedToBasis_Issue27520()
+		{
+			var root = new Grid();
+			var controlsFlexLayout = new FlexLayout { Direction = FlexDirection.Row };
+			var flexLayout = controlsFlexLayout as IFlexLayout;
+			var view = new ConstraintRecordingView { WidthRequest = 100 };
+
+			FlexLayout.SetGrow(view, 1);
+
+			root.Add(controlsFlexLayout);
+			flexLayout.Add(view as IView);
+
+			_ = flexLayout.CrossPlatformMeasure(300, 200);
+			flexLayout.CrossPlatformArrange(new Rect(0, 0, 300, 200));
+
+			// The item grows to fill the 300px main axis...
+			var flexFrame = flexLayout.GetFlexFrame(view as IView);
+			Assert.Equal(300, flexFrame.Width);
+
+			// ...so its measure constraint must not have been clamped to the 100px basis.
+			Assert.Equal(300, view.MeasuredWidthConstraint);
+		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/Layouts/FlexLayoutTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/FlexLayoutTests.cs
@@ -531,5 +531,47 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 			Assert.Equal(380, flexFrame.Width);
 			Assert.Equal(flexFrame.Width, view.MeasuredWidthConstraint);
 		}
+
+		// Regression test for https://github.com/dotnet/maui/issues/27520, exercising the
+		// real production measure path: a plain View with a (mocked) handler goes through
+		// VisualElement.MeasureOverride -> LayoutExtensions.ComputeDesiredSize, which
+		// subtracts the margin from the constraint before the handler measures — and
+		// ComputeFrame subtracts the margin from the arrange bounds symmetrically. The
+		// width the platform (handler) measures at must equal the width of the frame the
+		// view ends up arranged into, or wrapping platform content gets cut off.
+		[Theory]
+		[InlineData(FlexDirection.Column)] // width is the cross axis (stretch path)
+		[InlineData(FlexDirection.Row)] // width is the main axis (margin/shrink path)
+		public void HandlerBackedItemWithMarginIsMeasuredAtArrangedWidth_Issue27520(FlexDirection direction)
+		{
+			var root = new Grid();
+			var controlsFlexLayout = new FlexLayout { Direction = direction };
+			var flexLayout = controlsFlexLayout as IFlexLayout;
+
+			double handlerMeasuredWidth = double.NaN;
+			var handler = Substitute.For<IViewHandler>();
+			handler.GetDesiredSize(Arg.Any<double>(), Arg.Any<double>())
+				.Returns(args =>
+				{
+					// Greedy, like wrapping text: consume whatever width is offered
+					handlerMeasuredWidth = args.ArgAt<double>(0);
+					return new Size(handlerMeasuredWidth, 50);
+				});
+
+			var view = new View { Margin = new Thickness(10), Handler = handler };
+
+			root.Add(controlsFlexLayout);
+			flexLayout.Add(view as IView);
+
+			_ = flexLayout.CrossPlatformMeasure(400, 600);
+			flexLayout.CrossPlatformArrange(new Rect(0, 0, 400, 600));
+
+			// The width the platform control is measured at must equal the width of the
+			// content frame it is arranged into. Both subtractions happen on both paths:
+			// measure = 400 - flex item margin (20) - ComputeDesiredSize margin (20) = 360;
+			// arrange = engine frame (380) - ComputeFrame margin (20) = 360.
+			Assert.Equal(view.Frame.Width, handlerMeasuredWidth);
+			Assert.Equal(360, handlerMeasuredWidth);
+		}
 	}
 }


### PR DESCRIPTION
FlexLayout's SelfSizing callback measured items using GetConstraints(), which returns the flex container's full size and ignores the item's own margins. The flex engine then arranges the item at the stretched cross-axis size (container minus margins), which is narrower. Wrapping content (e.g. Label text with LineBreakMode=WordWrap) wraps against a width the item never receives, and since the arrange pass never re-measures, the overflow line is cut off.

The engine already passes the correct available size into the callback (the ref w/h parameters); clamp the measure constraints with those values when they are known.

Fixes #27520

Manual testing: See the test file I added in 27520. I have manually tested over 100 repetitions of re-clicking the button to generate new labels and not been able to reproduce the isssue. Previously, around 1 in every 5 re-draws would reproduce the issue.