### PR TITLE
[Windows]Fix ContentPresenter Throws System.ArgumentException When Dynamically Assigning RefreshView or ScrollView Content

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue36298.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue36298.cs
@@ -1,0 +1,69 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 36298, "[Windows] ContentPresenter throws ArgumentException when dynamically switching RefreshView or ScrollView content.", PlatformAffected.UWP)]
+public class Issue36298 : ContentPage
+{
+	ContentView _contentHolder;
+	View _view1;
+	View _view2;
+
+	public Issue36298()
+	{
+		_view1 = new ContentView
+		{
+			Content = new RefreshView
+			{
+				Content = new Label { Text = "View 1 - RefreshView" }
+			}
+		};
+
+		_view2 = new ContentView
+		{
+			Content = new ScrollView
+			{
+				Content = new Label { Text = "View 2 - ScrollView" }
+			}
+		};
+
+		_contentHolder = new ContentView
+		{
+			Content = _view1
+		};
+
+		var switchToView2Button = new Button
+		{
+			Text = "Switch to View 2",
+			AutomationId = "SwitchToView2"
+		};
+		switchToView2Button.Clicked += (_, _) => _contentHolder.Content = _view2;
+
+		var switchToView1Button = new Button
+		{
+			Text = "Switch to View 1",
+			AutomationId = "SwitchToView1"
+		};
+		switchToView1Button.Clicked += (_, _) => _contentHolder.Content = _view1;
+
+		var successLabel = new Label
+		{
+			Text = "Waiting",
+			AutomationId = "SuccessLabel"
+		};
+
+		switchToView2Button.Clicked += (_, _) => successLabel.Text = "View2";
+		switchToView1Button.Clicked += (_, _) => successLabel.Text = "Success";
+
+		Content = new VerticalStackLayout
+		{
+			Spacing = 10,
+			Padding = new Thickness(20),
+			Children =
+			{
+				switchToView2Button,
+				switchToView1Button,
+				_contentHolder,
+				successLabel
+			}
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36298.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36298.cs
@@ -1,0 +1,33 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue36298 : _IssuesUITest
+{
+	public Issue36298(TestDevice device) : base(device) { }
+
+	public override string Issue => "[Windows] ContentPresenter throws ArgumentException when dynamically switching RefreshView or ScrollView content.";
+
+	[Test]
+	[Category(UITestCategories.Layout)]
+	public void SwitchingContentPresenterContentShouldNotCrash()
+	{
+		// Wait for the page to load showing View 1
+		App.WaitForElement("SwitchToView2");
+
+		// Switch to View 2
+		App.Tap("SwitchToView2");
+		App.WaitForElement("SwitchToView1");
+
+		// Switch back to View 1 — this triggered the ArgumentException before the fix
+		App.Tap("SwitchToView1");
+
+		// Label is updated to "Success" only if the switch completed without crashing.
+		// WaitForElement("SuccessLabel") alone is insufficient because the label
+		// is present from page load; we must verify the text was actually updated.
+		App.WaitForElement("SuccessLabel");
+		Assert.That(App.FindElement("SuccessLabel").GetText(), Is.EqualTo("Success"));
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36298.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36298.cs
@@ -23,6 +23,8 @@ public class Issue36298 : _IssuesUITest
 
 		// Switch back to View 1 — this triggered the ArgumentException before the fix
 		App.Tap("SwitchToView1");
+		App.Tap("SwitchToView2");
+		App.Tap("SwitchToView1");
 
 		// Label is updated to "Success" only if the switch completed without crashing.
 		// WaitForElement("SuccessLabel") alone is insufficient because the label

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36298.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36298.cs
@@ -27,7 +27,6 @@ public class Issue36298 : _IssuesUITest
 		// Label is updated to "Success" only if the switch completed without crashing.
 		// WaitForElement("SuccessLabel") alone is insufficient because the label
 		// is present from page load; we must verify the text was actually updated.
-		App.WaitForElement("SuccessLabel");
-		Assert.That(App.FindElement("SuccessLabel").GetText(), Is.EqualTo("Success"));
+		Assert.That(App.WaitForTextToBePresentInElement("SuccessLabel", "Success"), Is.True);
 	}
 }

--- a/src/Core/src/Handlers/Border/BorderHandler.Windows.cs
+++ b/src/Core/src/Handlers/Border/BorderHandler.Windows.cs
@@ -28,13 +28,19 @@ namespace Microsoft.Maui.Handlers
 				var platformView = view.ToPlatform(handler.MauiContext);
 
 				// Detach from existing parent — mirrors Android RemoveFromParent / iOS RemoveFromSuperview.
-				// When the parent is a ContentPanel, use its Content setter so the internal _content
-				// field is cleared consistently (clip/border logic relies on ContentPanel._content).
+				// Always remove via CachedChildren directly: Content = null is a no-op when _content
+				// is null (e.g. ScrollViewHandler adds via paddingShim.CachedChildren.Add, not the
+				// Content setter), leaving the element with a live parent and causing a COM exception
+				// when we try to reparent it. Only clear _content when it actually tracks fwElement.
 				if (platformView is FrameworkElement fwElement && fwElement.Parent is not null)
 				{
 					if (fwElement.Parent is ContentPanel existingContentPanel)
 					{
-						existingContentPanel.Content = null;
+						existingContentPanel.CachedChildren.Remove(fwElement);
+						if (existingContentPanel.Content == fwElement)
+						{
+							existingContentPanel.Content = null;
+						}
 					}
 					else if (fwElement.Parent is MauiPanel existingPanel)
 					{

--- a/src/Core/src/Handlers/Border/BorderHandler.Windows.cs
+++ b/src/Core/src/Handlers/Border/BorderHandler.Windows.cs
@@ -27,11 +27,19 @@ namespace Microsoft.Maui.Handlers
 			{
 				var platformView = view.ToPlatform(handler.MauiContext);
 
-				// Detach from existing parent — mirrors Android RemoveFromParent / iOS RemoveFromSuperview
-				if (platformView is FrameworkElement fwElement &&
-					fwElement.Parent is MauiPanel existingParent)
+				// Detach from existing parent — mirrors Android RemoveFromParent / iOS RemoveFromSuperview.
+				// When the parent is a ContentPanel, use its Content setter so the internal _content
+				// field is cleared consistently (clip/border logic relies on ContentPanel._content).
+				if (platformView is FrameworkElement fwElement && fwElement.Parent is not null)
 				{
-					existingParent.CachedChildren.Remove(fwElement);
+					if (fwElement.Parent is ContentPanel existingContentPanel)
+					{
+						existingContentPanel.Content = null;
+					}
+					else if (fwElement.Parent is MauiPanel existingPanel)
+					{
+						existingPanel.CachedChildren.Remove(fwElement);
+					}
 				}
 
 				handler.PlatformView.Content = platformView;

--- a/src/Core/src/Handlers/Border/BorderHandler.Windows.cs
+++ b/src/Core/src/Handlers/Border/BorderHandler.Windows.cs
@@ -21,7 +21,6 @@ namespace Microsoft.Maui.Handlers
 			_ = handler.VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 			_ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
-			handler.PlatformView.CachedChildren.Clear();
 			handler.PlatformView.EnsureBorderPath();
 
 			if (handler.VirtualView.PresentedContent is IView view)
@@ -36,6 +35,10 @@ namespace Microsoft.Maui.Handlers
 				}
 
 				handler.PlatformView.Content = platformView;
+			}
+			else
+			{
+				handler.PlatformView.CachedChildren.Clear();
 			}
 				
 		}

--- a/src/Core/src/Handlers/Border/BorderHandler.Windows.cs
+++ b/src/Core/src/Handlers/Border/BorderHandler.Windows.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Maui.Handlers
 			}
 			else
 			{
-				handler.PlatformView.CachedChildren.Clear();
+				handler.PlatformView.Content = null;
 			}
 				
 		}

--- a/src/Core/src/Handlers/Border/BorderHandler.Windows.cs
+++ b/src/Core/src/Handlers/Border/BorderHandler.Windows.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.UI.Xaml;
 
 namespace Microsoft.Maui.Handlers
 {
@@ -25,9 +26,16 @@ namespace Microsoft.Maui.Handlers
 
 			if (handler.VirtualView.PresentedContent is IView view)
 			{
-				// Detach the old handler if it exists (prevents WinUI COM exception on reuse)
-				view.Handler?.DisconnectHandler(); 
-				handler.PlatformView.Content = view.ToPlatform(handler.MauiContext);
+				var platformView = view.ToPlatform(handler.MauiContext);
+
+				// Detach from existing parent — mirrors Android RemoveFromParent / iOS RemoveFromSuperview
+				if (platformView is FrameworkElement fwElement &&
+					fwElement.Parent is MauiPanel existingParent)
+				{
+					existingParent.CachedChildren.Remove(fwElement);
+				}
+
+				handler.PlatformView.Content = platformView;
 			}
 				
 		}

--- a/src/Core/src/Handlers/ContentView/ContentViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/ContentView/ContentViewHandler.Windows.cs
@@ -22,8 +22,6 @@ namespace Microsoft.Maui.Handlers
 			_ = handler.VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 			_ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
-			handler.PlatformView.CachedChildren.Clear();
-
 			if (handler.VirtualView.PresentedContent is IView view)
 			{
 				var platformView = view.ToPlatform(handler.MauiContext);
@@ -35,7 +33,11 @@ namespace Microsoft.Maui.Handlers
 					existingParent.CachedChildren.Remove(fwElement);
 				}
 
-				handler.PlatformView.CachedChildren.Add(platformView);
+				handler.PlatformView.Content = platformView;
+			}
+			else
+			{
+				handler.PlatformView.CachedChildren.Clear();
 			}
 		}
 

--- a/src/Core/src/Handlers/ContentView/ContentViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/ContentView/ContentViewHandler.Windows.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.Maui.Graphics;
+using Microsoft.UI.Xaml;
 
 namespace Microsoft.Maui.Handlers
 {

--- a/src/Core/src/Handlers/ContentView/ContentViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/ContentView/ContentViewHandler.Windows.cs
@@ -22,6 +22,8 @@ namespace Microsoft.Maui.Handlers
 			_ = handler.VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 			_ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
+			handler.PlatformView.CachedChildren.Clear();
+			
 			if (handler.VirtualView.PresentedContent is IView view)
 			{
 				var platformView = view.ToPlatform(handler.MauiContext);
@@ -33,7 +35,6 @@ namespace Microsoft.Maui.Handlers
 					existingParent.CachedChildren.Remove(fwElement);
 				}
 
-				handler.PlatformView.CachedChildren.Clear();
 				handler.PlatformView.CachedChildren.Add(platformView);
 			}
 		}

--- a/src/Core/src/Handlers/ContentView/ContentViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/ContentView/ContentViewHandler.Windows.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.Handlers
 			}
 			else
 			{
-				handler.PlatformView.CachedChildren.Clear();
+				handler.PlatformView.Content = null;
 			}
 		}
 

--- a/src/Core/src/Handlers/ContentView/ContentViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/ContentView/ContentViewHandler.Windows.cs
@@ -27,13 +27,19 @@ namespace Microsoft.Maui.Handlers
 				var platformView = view.ToPlatform(handler.MauiContext);
 
 				// Detach from existing parent — mirrors Android RemoveFromParent / iOS RemoveFromSuperview.
-				// When the parent is a ContentPanel, use its Content setter so the internal _content
-				// field is cleared consistently (clip/border logic relies on ContentPanel._content).
+				// Always remove via CachedChildren directly: Content = null is a no-op when _content
+				// is null (e.g. ScrollViewHandler adds via paddingShim.CachedChildren.Add, not the
+				// Content setter), leaving the element with a live parent and causing a COM exception
+				// when we try to reparent it. Only clear _content when it actually tracks fwElement.
 				if (platformView is FrameworkElement fwElement && fwElement.Parent is not null)
 				{
 					if (fwElement.Parent is ContentPanel existingContentPanel)
 					{
-						existingContentPanel.Content = null;
+						existingContentPanel.CachedChildren.Remove(fwElement);
+						if (existingContentPanel.Content == fwElement)
+						{
+							existingContentPanel.Content = null;
+						}
 					}
 					else if (fwElement.Parent is MauiPanel existingPanel)
 					{

--- a/src/Core/src/Handlers/ContentView/ContentViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/ContentView/ContentViewHandler.Windows.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.Handlers
 			_ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
 			handler.PlatformView.CachedChildren.Clear();
-			
+
 			if (handler.VirtualView.PresentedContent is IView view)
 			{
 				var platformView = view.ToPlatform(handler.MauiContext);

--- a/src/Core/src/Handlers/ContentView/ContentViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/ContentView/ContentViewHandler.Windows.cs
@@ -26,11 +26,19 @@ namespace Microsoft.Maui.Handlers
 			{
 				var platformView = view.ToPlatform(handler.MauiContext);
 
-				// Detach from existing parent — mirrors Android RemoveFromParent / iOS RemoveFromSuperview
-				if (platformView is FrameworkElement fwElement &&
-					fwElement.Parent is MauiPanel existingParent)
+				// Detach from existing parent — mirrors Android RemoveFromParent / iOS RemoveFromSuperview.
+				// When the parent is a ContentPanel, use its Content setter so the internal _content
+				// field is cleared consistently (clip/border logic relies on ContentPanel._content).
+				if (platformView is FrameworkElement fwElement && fwElement.Parent is not null)
 				{
-					existingParent.CachedChildren.Remove(fwElement);
+					if (fwElement.Parent is ContentPanel existingContentPanel)
+					{
+						existingContentPanel.Content = null;
+					}
+					else if (fwElement.Parent is MauiPanel existingPanel)
+					{
+						existingPanel.CachedChildren.Remove(fwElement);
+					}
 				}
 
 				handler.PlatformView.Content = platformView;

--- a/src/Core/src/Handlers/ContentView/ContentViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/ContentView/ContentViewHandler.Windows.cs
@@ -21,13 +21,19 @@ namespace Microsoft.Maui.Handlers
 			_ = handler.VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 			_ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
-			handler.PlatformView.CachedChildren.Clear();
-
 			if (handler.VirtualView.PresentedContent is IView view)
 			{
-				// Detach the old handler if it exists (prevents WinUI COM exception on reuse)
-				view.Handler?.DisconnectHandler();
-				handler.PlatformView.CachedChildren.Add(view.ToPlatform(handler.MauiContext));
+				var platformView = view.ToPlatform(handler.MauiContext);
+
+				// Detach from existing parent — mirrors Android RemoveFromParent / iOS RemoveFromSuperview
+				if (platformView is FrameworkElement fwElement &&
+					fwElement.Parent is MauiPanel existingParent)
+				{
+					existingParent.CachedChildren.Remove(fwElement);
+				}
+
+				handler.PlatformView.CachedChildren.Clear();
+				handler.PlatformView.CachedChildren.Add(platformView);
 			}
 		}
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
### Issue Details
A previous fix (#30047) called DisconnectHandler before clearing the old content. This cascaded into child handlers and broke WinUI's internal pointer event routing when views were orphaned from the visual tree.

### Description of Change

<!-- Enter description of the fix in this section -->
Get the platform view first (while the old panel is still live), detach it from any existing parent, then clear and add to the new panel. This avoids touching the internal handler hierarchy of views like ScrollView and RefreshView during a content switch.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #36298 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

**Tested the behavior in the following platforms.**
- [ ] Android
- [x] Windows
- [ ] iOS
- [ ] Mac

| Before  | After  |
|---------|--------|
| **Windows**<br> <video src="https://github.com/user-attachments/assets/10a349ed-eff4-4650-a0ca-274c77add95a" width="600" height="300"> | **Windows**<br> <video src="https://github.com/user-attachments/assets/1eec3997-5959-453d-b52e-1189d05656c8" width="600" height="300"> |
