### PR TITLE
[release/11.0.1xx-preview6] Bump dotnet/dotnet (BAR 321614), dotnet/android (BAR 321622) and dotnet/macios (BAR 321780)

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,12 +1,12 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.Sdk" Version="11.0.100-preview.6.26325.125">
+    <Dependency Name="Microsoft.NET.Sdk" Version="11.0.100-preview.6.26356.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-preview.6.26325.125">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-preview.6.26356.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Android.Sdk.Windows" Version="37.0.0-ci.main.51">
       <Uri>https://github.com/dotnet/android</Uri>
@@ -53,109 +53,109 @@
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="11.0.0-preview.6.26325.125">
+    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="11.0.0-preview.6.26356.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="11.0.0-preview.6.26325.125">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="11.0.0-preview.6.26356.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="11.0.0-preview.6.26325.125">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="11.0.0-preview.6.26356.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="11.0.0-preview.6.26325.125">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="11.0.0-preview.6.26356.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components" Version="11.0.0-preview.6.26325.125">
+    <Dependency Name="Microsoft.AspNetCore.Components" Version="11.0.0-preview.6.26356.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="11.0.0-preview.6.26325.125">
+    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="11.0.0-preview.6.26356.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="11.0.0-preview.6.26325.125">
+    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="11.0.0-preview.6.26356.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="11.0.0-preview.6.26325.125">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="11.0.0-preview.6.26356.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="11.0.0-preview.6.26325.125">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="11.0.0-preview.6.26356.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="11.0.0-preview.6.26325.125">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="11.0.0-preview.6.26356.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="11.0.0-preview.6.26325.125">
+    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="11.0.0-preview.6.26356.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="11.0.0-preview.6.26325.125">
+    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="11.0.0-preview.6.26356.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.JSInterop" Version="11.0.0-preview.6.26325.125">
+    <Dependency Name="Microsoft.JSInterop" Version="11.0.0-preview.6.26356.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-preview.2.22102.8">
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>3f4da9ced34942d83054e647f3b1d9d7dde281e8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration" Version="11.0.0-preview.6.26325.125">
+    <Dependency Name="Microsoft.Extensions.Configuration" Version="11.0.0-preview.6.26356.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="11.0.0-preview.6.26325.125">
+    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="11.0.0-preview.6.26356.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="11.0.0-preview.6.26325.125">
+    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="11.0.0-preview.6.26356.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="11.0.0-preview.6.26325.125">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="11.0.0-preview.6.26356.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="11.0.0-preview.6.26325.125">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="11.0.0-preview.6.26356.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="11.0.0-preview.6.26325.125">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="11.0.0-preview.6.26356.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="11.0.0-preview.6.26325.125">
+    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="11.0.0-preview.6.26356.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="11.0.0-preview.6.26325.125">
+    <Dependency Name="Microsoft.Extensions.Logging" Version="11.0.0-preview.6.26356.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="11.0.0-preview.6.26325.125">
+    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="11.0.0-preview.6.26356.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="11.0.0-preview.6.26325.125">
+    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="11.0.0-preview.6.26356.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Primitives" Version="11.0.0-preview.6.26325.125">
+    <Dependency Name="Microsoft.Extensions.Primitives" Version="11.0.0-preview.6.26356.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="11.0.0-preview.6.26325.125">
+    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="11.0.0-preview.6.26356.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="11.0.0-prerelease.26064.3">
       <Uri>https://github.com/dotnet/xharness</Uri>
@@ -175,37 +175,37 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="11.0.0-beta.26325.125">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="11.0.0-beta.26356.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26325.125">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26356.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="11.0.0-beta.26325.125">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="11.0.0-beta.26356.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="11.0.0-beta.26325.125">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="11.0.0-beta.26356.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26325.125">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26356.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="11.0.0-beta.26325.125">
+    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="11.0.0-beta.26356.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="11.0.0-beta.26325.125">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="11.0.0-beta.26356.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="11.0.0-beta.26325.125">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="11.0.0-beta.26356.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a512c3ad43185e96fc2c2769a4f02af689e3fb99</Sha>
+      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -17,21 +17,21 @@
       <Uri>https://github.com/dotnet/android</Uri>
       <Sha>d549e1dc4e2a083b08b4f24cb5495e81b99d79b5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net11.0_26.5" Version="26.5.11717-net11-p6">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net11.0_26.5" Version="26.5.11719-net11-p6">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>5bf7d00bec4a09ba623398bea41429ab1be795a1</Sha>
+      <Sha>7f0236e0f25c0edc3f3a8b543a6bb2d84d97a729</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net11.0_26.5" Version="26.5.11717-net11-p6">
+    <Dependency Name="Microsoft.macOS.Sdk.net11.0_26.5" Version="26.5.11719-net11-p6">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>5bf7d00bec4a09ba623398bea41429ab1be795a1</Sha>
+      <Sha>7f0236e0f25c0edc3f3a8b543a6bb2d84d97a729</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net11.0_26.5" Version="26.5.11717-net11-p6">
+    <Dependency Name="Microsoft.iOS.Sdk.net11.0_26.5" Version="26.5.11719-net11-p6">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>5bf7d00bec4a09ba623398bea41429ab1be795a1</Sha>
+      <Sha>7f0236e0f25c0edc3f3a8b543a6bb2d84d97a729</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net11.0_26.5" Version="26.5.11717-net11-p6">
+    <Dependency Name="Microsoft.tvOS.Sdk.net11.0_26.5" Version="26.5.11719-net11-p6">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>5bf7d00bec4a09ba623398bea41429ab1be795a1</Sha>
+      <Sha>7f0236e0f25c0edc3f3a8b543a6bb2d84d97a729</Sha>
     </Dependency>
     <!-- Previous .NET iOS version(s) -->
     <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_26.5" Version="26.5.10301" CoherentParentDependency="Microsoft.MacCatalyst.Sdk.net11.0_26.5">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -8,9 +8,9 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="37.0.0-ci.main.51">
+    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="37.0.0-preview.6.59">
       <Uri>https://github.com/dotnet/android</Uri>
-      <Sha>7ab8bac563839df778de1b91409cf4099cc76940</Sha>
+      <Sha>a2d46b3546d1d445a7164dc239a4ae7e5a8332a0</Sha>
     </Dependency>
     <!-- Previous .NET Android version(s) -->
     <Dependency Name="Microsoft.NET.Sdk.Android.Manifest-10.0.100" Version="36.1.69" CoherentParentDependency="Microsoft.Android.Sdk.Windows">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -63,7 +63,7 @@
     <MicrosoftAgentsAIWorkflowsGeneratorsVersion>1.0.0-rc2</MicrosoftAgentsAIWorkflowsGeneratorsVersion>
     <MicrosoftAgentsAIHostingVersion>1.0.0-preview.260225.1</MicrosoftAgentsAIHostingVersion>
     <!-- xamarin/xamarin-android -->
-    <MicrosoftAndroidSdkWindowsPackageVersion>37.0.0-ci.main.51</MicrosoftAndroidSdkWindowsPackageVersion>
+    <MicrosoftAndroidSdkWindowsPackageVersion>37.0.0-preview.6.59</MicrosoftAndroidSdkWindowsPackageVersion>
     <MicrosoftNETSdkAndroidManifest100100PackageVersion>36.1.69</MicrosoftNETSdkAndroidManifest100100PackageVersion>
     <AndroidNetPreviousVersion>$(MicrosoftNetSdkAndroidManifest100100PackageVersion)</AndroidNetPreviousVersion>
     <!-- dotnet/macios -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -31,10 +31,10 @@
     <!-- Current previous .NET SDK major version's stable release of MAUI packages -->
     <MicrosoftMauiPreviousDotNetReleasedVersion>10.0.20</MicrosoftMauiPreviousDotNetReleasedVersion>
     <!-- dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>11.0.100-preview.6.26325.125</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>11.0.100-preview.6.26356.105</MicrosoftNETSdkPackageVersion>
     <MicrosoftDotnetSdkInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-preview.6.26325.125</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-preview.6.26356.105</MicrosoftNETCoreAppRefPackageVersion>
     <SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextJsonPackageVersion>
     <SystemTextEncodingsWebPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextEncodingsWebPackageVersion>
     <MicrosoftBclAsyncInterfacesPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftBclAsyncInterfacesPackageVersion>
@@ -42,18 +42,18 @@
     <optimizationandroidx64MIBCRuntimePackageVersion>1.0.0-prerelease.26317.1</optimizationandroidx64MIBCRuntimePackageVersion>
     <!-- Microsoft/Extensions -->
     <SystemCodeDomPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemCodeDomPackageVersion>
-    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.6.26325.125</MicrosoftExtensionsConfigurationVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsVersion>11.0.0-preview.6.26325.125</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationJsonVersion>11.0.0-preview.6.26325.125</MicrosoftExtensionsConfigurationJsonVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>11.0.0-preview.6.26325.125</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>11.0.0-preview.6.26325.125</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
-    <MicrosoftExtensionsFileProvidersAbstractionsVersion>11.0.0-preview.6.26325.125</MicrosoftExtensionsFileProvidersAbstractionsVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>11.0.0-preview.6.26325.125</MicrosoftExtensionsLoggingAbstractionsVersion>
-    <MicrosoftExtensionsLoggingVersion>11.0.0-preview.6.26325.125</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>11.0.0-preview.6.26325.125</MicrosoftExtensionsLoggingConsoleVersion>
-    <MicrosoftExtensionsLoggingDebugVersion>11.0.0-preview.6.26325.125</MicrosoftExtensionsLoggingDebugVersion>
-    <MicrosoftExtensionsPrimitivesVersion>11.0.0-preview.6.26325.125</MicrosoftExtensionsPrimitivesVersion>
-    <MicrosoftExtensionsHostingAbstractionsVersion>11.0.0-preview.6.26325.125</MicrosoftExtensionsHostingAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.6.26356.105</MicrosoftExtensionsConfigurationVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>11.0.0-preview.6.26356.105</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationJsonVersion>11.0.0-preview.6.26356.105</MicrosoftExtensionsConfigurationJsonVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>11.0.0-preview.6.26356.105</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>11.0.0-preview.6.26356.105</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
+    <MicrosoftExtensionsFileProvidersAbstractionsVersion>11.0.0-preview.6.26356.105</MicrosoftExtensionsFileProvidersAbstractionsVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>11.0.0-preview.6.26356.105</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingVersion>11.0.0-preview.6.26356.105</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>11.0.0-preview.6.26356.105</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingDebugVersion>11.0.0-preview.6.26356.105</MicrosoftExtensionsLoggingDebugVersion>
+    <MicrosoftExtensionsPrimitivesVersion>11.0.0-preview.6.26356.105</MicrosoftExtensionsPrimitivesVersion>
+    <MicrosoftExtensionsHostingAbstractionsVersion>11.0.0-preview.6.26356.105</MicrosoftExtensionsHostingAbstractionsVersion>
     <MicrosoftExtensionsAIVersion>10.3.0</MicrosoftExtensionsAIVersion>
     <MicrosoftExtensionsAIAbstractionsVersion>10.3.0</MicrosoftExtensionsAIAbstractionsVersion>
     <MicrosoftExtensionsHttpVersion>11.0.0-preview.2.26103.111</MicrosoftExtensionsHttpVersion>
@@ -84,19 +84,19 @@
     <MicrosoftGraphicsWin2DPackageVersion>1.3.2</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.3179.45</MicrosoftWindowsWebView2PackageVersion>
     <!-- Everything else -->
-    <MicrosoftAspNetCoreAuthorizationPackageVersion>11.0.0-preview.6.26325.125</MicrosoftAspNetCoreAuthorizationPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>11.0.0-preview.6.26325.125</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>11.0.0-preview.6.26325.125</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
-    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>11.0.0-preview.6.26325.125</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
-    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>11.0.0-preview.6.26325.125</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreComponentsFormsPackageVersion>11.0.0-preview.6.26325.125</MicrosoftAspNetCoreComponentsFormsPackageVersion>
-    <MicrosoftAspNetCoreComponentsPackageVersion>11.0.0-preview.6.26325.125</MicrosoftAspNetCoreComponentsPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebPackageVersion>11.0.0-preview.6.26325.125</MicrosoftAspNetCoreComponentsWebPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>11.0.0-preview.6.26325.125</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>11.0.0-preview.6.26325.125</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>11.0.0-preview.6.26325.125</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
-    <MicrosoftAspNetCoreMetadataPackageVersion>11.0.0-preview.6.26325.125</MicrosoftAspNetCoreMetadataPackageVersion>
-    <MicrosoftJSInteropPackageVersion>11.0.0-preview.6.26325.125</MicrosoftJSInteropPackageVersion>
+    <MicrosoftAspNetCoreAuthorizationPackageVersion>11.0.0-preview.6.26356.105</MicrosoftAspNetCoreAuthorizationPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>11.0.0-preview.6.26356.105</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>11.0.0-preview.6.26356.105</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
+    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>11.0.0-preview.6.26356.105</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
+    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>11.0.0-preview.6.26356.105</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreComponentsFormsPackageVersion>11.0.0-preview.6.26356.105</MicrosoftAspNetCoreComponentsFormsPackageVersion>
+    <MicrosoftAspNetCoreComponentsPackageVersion>11.0.0-preview.6.26356.105</MicrosoftAspNetCoreComponentsPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebPackageVersion>11.0.0-preview.6.26356.105</MicrosoftAspNetCoreComponentsWebPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>11.0.0-preview.6.26356.105</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>11.0.0-preview.6.26356.105</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>11.0.0-preview.6.26356.105</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
+    <MicrosoftAspNetCoreMetadataPackageVersion>11.0.0-preview.6.26356.105</MicrosoftAspNetCoreMetadataPackageVersion>
+    <MicrosoftJSInteropPackageVersion>11.0.0-preview.6.26356.105</MicrosoftJSInteropPackageVersion>
     <!-- Everything else (previous edition) -->
     <MicrosoftAspNetCorePackageVersion>10.0.2</MicrosoftAspNetCorePackageVersion>
     <MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>$(MicrosoftAspNetCorePackageVersion)</MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>
@@ -146,13 +146,13 @@
     <TizenUIExtensionsVersion>0.9.0</TizenUIExtensionsVersion>
     <ExCSSPackageVersion>4.2.3</ExCSSPackageVersion>
     <SystemDrawingCommonPackageVersion>9.0.0</SystemDrawingCommonPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>11.0.0-beta.26325.125</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetBuildTasksInstallersPackageVersion>11.0.0-beta.26325.125</MicrosoftDotNetBuildTasksInstallersPackageVersion>
-    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>11.0.0-beta.26325.125</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26325.125</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>11.0.0-beta.26356.105</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksInstallersPackageVersion>11.0.0-beta.26356.105</MicrosoftDotNetBuildTasksInstallersPackageVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>11.0.0-beta.26356.105</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26356.105</MicrosoftDotNetHelixSdkPackageVersion>
     <MicroBuildPluginsSwixBuildDotnetPackageVersion>1.1.87-gba258badda</MicroBuildPluginsSwixBuildDotnetPackageVersion>
-    <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.26325.125</MicrosoftDotNetRemoteExecutorPackageVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>11.0.0-beta.26325.125</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.26356.105</MicrosoftDotNetRemoteExecutorPackageVersion>
+    <MicrosoftDotNetXUnitExtensionsPackageVersion>11.0.0-beta.26356.105</MicrosoftDotNetXUnitExtensionsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftNETTestSdkPackageVersion>17.6.0</MicrosoftNETTestSdkPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -67,10 +67,10 @@
     <MicrosoftNETSdkAndroidManifest100100PackageVersion>36.1.69</MicrosoftNETSdkAndroidManifest100100PackageVersion>
     <AndroidNetPreviousVersion>$(MicrosoftNetSdkAndroidManifest100100PackageVersion)</AndroidNetPreviousVersion>
     <!-- dotnet/macios -->
-    <MicrosoftMacCatalystSdknet110_265PackageVersion>26.5.11717-net11-p6</MicrosoftMacCatalystSdknet110_265PackageVersion>
-    <MicrosoftmacOSSdknet110_265PackageVersion>26.5.11717-net11-p6</MicrosoftmacOSSdknet110_265PackageVersion>
-    <MicrosoftiOSSdknet110_265PackageVersion>26.5.11717-net11-p6</MicrosoftiOSSdknet110_265PackageVersion>
-    <MicrosofttvOSSdknet110_265PackageVersion>26.5.11717-net11-p6</MicrosofttvOSSdknet110_265PackageVersion>
+    <MicrosoftMacCatalystSdknet110_265PackageVersion>26.5.11719-net11-p6</MicrosoftMacCatalystSdknet110_265PackageVersion>
+    <MicrosoftmacOSSdknet110_265PackageVersion>26.5.11719-net11-p6</MicrosoftmacOSSdknet110_265PackageVersion>
+    <MicrosoftiOSSdknet110_265PackageVersion>26.5.11719-net11-p6</MicrosoftiOSSdknet110_265PackageVersion>
+    <MicrosofttvOSSdknet110_265PackageVersion>26.5.11719-net11-p6</MicrosofttvOSSdknet110_265PackageVersion>
     <!-- This is a subscription of the .NET 10 latest stable versions of our packages -->
     <MicrosoftMacCatalystSdknet100_265PackageVersion>26.5.10301</MicrosoftMacCatalystSdknet100_265PackageVersion>
     <MicrosoftmacOSSdknet100_265PackageVersion>26.5.10301</MicrosoftmacOSSdknet100_265PackageVersion>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "11.0.100-preview.6.26325.125"
+    "dotnet": "11.0.100-preview.6.26356.105"
   },
   "sdk": {
     "paths": [

--- a/global.json
+++ b/global.json
@@ -11,7 +11,7 @@
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44",
     "Microsoft.Build.NoTargets": "3.7.0",
-    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26325.125",
-    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26325.125"
+    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26356.105",
+    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26356.105"
   }
 }


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### What

Bump `release/11.0.1xx-preview6` dependencies to the latest Preview 6 builds from the VMR, dotnet/android, and dotnet/macios.

### Dependencies updated

| Source | BAR | From | To | Commit |
|--------|-----|------|----|--------|
| dotnet/dotnet (VMR) | 321614 | `preview.6.26325.125` | `preview.6.26356.105` | `d6b097b8` |
| dotnet/android | 321622 | `37.0.0-ci.main.51` | `37.0.0-preview.6.59` | `a2d46b35` |
| dotnet/macios | 321780 | `26.5.11717-net11-p6` | `26.5.11719-net11-p6` | `7f0236e0` |

All source builds are on the **.NET 11.0.1xx SDK Preview 6** channel.

### Changes

- **dotnet/dotnet** — SDK / runtime / ASP.NET Core / Extensions / build-tasks package versions -> `preview.6.26356.105` (`beta.26356.105` for arcade/helix); `global.json` `tools.dotnet` and arcade/helix SDKs updated to match.
- **dotnet/android** — `Microsoft.Android.Sdk.Windows` -> `37.0.0-preview.6.59`. This also moves the dependency off a stray `ci.main` stamp onto the correct Preview 6 build.
- **dotnet/macios** — `Microsoft.{iOS,MacCatalyst,macOS,tvOS}.Sdk.net11.0_26.5` -> `26.5.11719-net11-p6`.

`eng/Version.Details.xml` and `eng/Versions.props` updated via `darc update-dependencies`; previous-.NET coherent child dependencies (net10 android manifest, net10 macios SDKs) left untouched.
