### PR TITLE
Revert - [ci] Remove trimming workaround #33624

### DIFF
--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.Common.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.Common.targets
@@ -11,6 +11,12 @@
     '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'tizen')">True</UseInterpreter>
   </PropertyGroup>
 
+	<!-- FIXME: https://github.com/xamarin/xamarin-macios/pull/21351 -->
+	<PropertyGroup Condition=" '$(_MauiDoNotConfigureTrimAnalyzer)' != 'true' and '$(PublishAot)' != 'true' and '$(TrimMode)' != 'full' ">
+		<EnableTrimAnalyzer>false</EnableTrimAnalyzer>
+		<SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="GenKind" />
 		<CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="ManifestResourceName" />


### PR DESCRIPTION
In candidate PR https://github.com/dotnet/maui/pull/36411 build fails in CI. However, the build failures are not reproduced locally. I suspect this PR https://github.com/dotnet/maui/pull/33624. so I reverted the changes to confirm the causing PR.

Build Link - https://dev.azure.com/dnceng-public/public/_build/results?buildId=1496819&view=results
<img width="1258" height="249" alt="image" src="https://github.com/user-attachments/assets/8feacf84-48c4-4d59-8709-c86014addc32" />

