### PR TITLE
Fix Color equality regression for derived types by sealing the record

### DIFF
--- a/src/Graphics/src/Graphics/Color.cs
+++ b/src/Graphics/src/Graphics/Color.cs
@@ -11,10 +11,15 @@ namespace Microsoft.Maui.Graphics
 	/// <summary>
 	/// Represents an RGBA color with floating-point components in the range of 0.0 to 1.0.
 	/// </summary>
+	/// <remarks>
+	/// <see cref="Color"/> is a sealed record type, so equality (via <see cref="Equals(Color?)"/>, <c>==</c>, and <c>!=</c>)
+	/// is always value-based, comparing the underlying ARGB representation regardless of how the instance was created.
+	/// Sealing prevents subclassing, which guarantees this value-based equality can never be silently broken by a derived type.
+	/// </remarks>
 	[DebuggerDisplay("Red={Red}, Green={Green}, Blue={Blue}, Alpha={Alpha}")]
 	[TypeConverter(typeof(Converters.ColorTypeConverter))]
 	[ImmutableObject(true)]
-	public record class Color
+	public sealed record class Color
 	{
 		/// <summary>
 		/// The red component of the color, ranging from 0.0 to 1.0.
@@ -119,7 +124,7 @@ namespace Microsoft.Maui.Graphics
 		/// <summary>
 		/// Determines whether the specified <see cref="Color"/> is equal to the current color using byte-precision comparison.
 		/// </summary>
-		public virtual bool Equals(Color? other)
+		public bool Equals(Color? other)
 		{
 			if (other is null)
 				return false;

--- a/src/Graphics/src/Graphics/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,12 +1,9 @@
 #nullable enable
-Microsoft.Maui.Graphics.Color.Color(Microsoft.Maui.Graphics.Color! original) -> void
 override Microsoft.Maui.Graphics.Color.Equals(object? obj) -> bool
 static Microsoft.Maui.Graphics.Color.operator !=(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
 static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
-virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
-virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
-virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
-virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color? other) -> bool
+Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
+Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color? other) -> bool
 Microsoft.Maui.Graphics.Color.AddLuminosity(float delta) -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.ToArgbHex(bool includeAlpha = false) -> string!
 Microsoft.Maui.Graphics.Color.ToRgbaHex(bool includeAlpha = false) -> string!

--- a/src/Graphics/src/Graphics/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,12 +1,9 @@
 #nullable enable
-Microsoft.Maui.Graphics.Color.Color(Microsoft.Maui.Graphics.Color! original) -> void
 override Microsoft.Maui.Graphics.Color.Equals(object? obj) -> bool
 static Microsoft.Maui.Graphics.Color.operator !=(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
 static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
-virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
-virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
-virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color? other) -> bool
-virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
+Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
+Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color? other) -> bool
 Microsoft.Maui.Graphics.Color.AsPaint() -> Microsoft.Maui.Graphics.Paint!
 Microsoft.Maui.Graphics.Color.MultiplyAlpha(float multiplyBy) -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.WithAlpha(float alpha) -> Microsoft.Maui.Graphics.Color!

--- a/src/Graphics/src/Graphics/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,12 +1,9 @@
 #nullable enable
-Microsoft.Maui.Graphics.Color.Color(Microsoft.Maui.Graphics.Color! original) -> void
 override Microsoft.Maui.Graphics.Color.Equals(object? obj) -> bool
 static Microsoft.Maui.Graphics.Color.operator !=(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
 static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
-virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
-virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
-virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color? other) -> bool
-virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
+Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
+Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color? other) -> bool
 Microsoft.Maui.Graphics.Color.AsPaint() -> Microsoft.Maui.Graphics.Paint!
 Microsoft.Maui.Graphics.Color.MultiplyAlpha(float multiplyBy) -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.WithAlpha(float alpha) -> Microsoft.Maui.Graphics.Color!

--- a/src/Graphics/src/Graphics/PublicAPI/net-macos/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-macos/PublicAPI.Unshipped.txt
@@ -1,12 +1,9 @@
 #nullable enable
-Microsoft.Maui.Graphics.Color.Color(Microsoft.Maui.Graphics.Color! original) -> void
 override Microsoft.Maui.Graphics.Color.Equals(object? obj) -> bool
 static Microsoft.Maui.Graphics.Color.operator !=(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
 static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
-virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
-virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
-virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
-virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color? other) -> bool
+Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
+Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color? other) -> bool
 Microsoft.Maui.Graphics.Color.AddLuminosity(float delta) -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.GetComplementary() -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.ToArgbHex(bool includeAlpha = false) -> string!

--- a/src/Graphics/src/Graphics/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,12 +1,9 @@
 #nullable enable
-Microsoft.Maui.Graphics.Color.Color(Microsoft.Maui.Graphics.Color! original) -> void
 override Microsoft.Maui.Graphics.Color.Equals(object? obj) -> bool
 static Microsoft.Maui.Graphics.Color.operator !=(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
 static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
-virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
-virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
-virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
-virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color? other) -> bool
+Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
+Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color? other) -> bool
 Microsoft.Maui.Graphics.Color.AddLuminosity(float delta) -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.GetComplementary() -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.ToArgbHex(bool includeAlpha = false) -> string!

--- a/src/Graphics/src/Graphics/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,12 +1,9 @@
 #nullable enable
-Microsoft.Maui.Graphics.Color.Color(Microsoft.Maui.Graphics.Color! original) -> void
 override Microsoft.Maui.Graphics.Color.Equals(object? obj) -> bool
 static Microsoft.Maui.Graphics.Color.operator !=(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
 static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
-virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
-virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
-virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
-virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color? other) -> bool
+Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
+Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color? other) -> bool
 Microsoft.Maui.Graphics.Color.AddLuminosity(float delta) -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.GetComplementary() -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.ToArgbHex(bool includeAlpha = false) -> string!

--- a/src/Graphics/src/Graphics/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,22 +1,24 @@
-﻿#nullable enable
+#nullable enable
+override Microsoft.Maui.Graphics.Color.Equals(object? obj) -> bool
+static Microsoft.Maui.Graphics.Color.operator !=(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
+static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
 Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
-Microsoft.Maui.Graphics.Color.AddLuminosity(float delta) -> Microsoft.Maui.Graphics.Color!
-Microsoft.Maui.Graphics.Color.AsPaint() -> Microsoft.Maui.Graphics.Paint!
 Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color? other) -> bool
-Microsoft.Maui.Graphics.Color.GetComplementary() -> Microsoft.Maui.Graphics.Color!
+Microsoft.Maui.Graphics.Color.AsPaint() -> Microsoft.Maui.Graphics.Paint!
 Microsoft.Maui.Graphics.Color.MultiplyAlpha(float multiplyBy) -> Microsoft.Maui.Graphics.Color!
+Microsoft.Maui.Graphics.Color.WithAlpha(float alpha) -> Microsoft.Maui.Graphics.Color!
+override Microsoft.Maui.Graphics.Color.ToString() -> string!
+static Microsoft.Maui.Graphics.Color.FromHex(string! colorAsArgbHex) -> Microsoft.Maui.Graphics.Color!
+Microsoft.Maui.Graphics.Color.AddLuminosity(float delta) -> Microsoft.Maui.Graphics.Color!
+Microsoft.Maui.Graphics.Color.GetComplementary() -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.ToArgbHex(bool includeAlpha = false) -> string!
 Microsoft.Maui.Graphics.Color.ToHex() -> string!
 Microsoft.Maui.Graphics.Color.ToHex(bool includeAlpha) -> string!
 Microsoft.Maui.Graphics.Color.ToRgbaHex(bool includeAlpha = false) -> string!
-Microsoft.Maui.Graphics.Color.WithAlpha(float alpha) -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.WithHue(float hue) -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.WithLuminosity(float luminosity) -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.WithSaturation(float saturation) -> Microsoft.Maui.Graphics.Color!
-override Microsoft.Maui.Graphics.Color.Equals(object? obj) -> bool
-override Microsoft.Maui.Graphics.Color.ToString() -> string!
 static Microsoft.Maui.Graphics.Color.FromArgb(string! colorAsHex) -> Microsoft.Maui.Graphics.Color!
-static Microsoft.Maui.Graphics.Color.FromHex(string! colorAsArgbHex) -> Microsoft.Maui.Graphics.Color!
 static Microsoft.Maui.Graphics.Color.FromHsla(double h, double s, double l, double a = 1) -> Microsoft.Maui.Graphics.Color!
 static Microsoft.Maui.Graphics.Color.FromHsla(float h, float s, float l, float a = 1) -> Microsoft.Maui.Graphics.Color!
 static Microsoft.Maui.Graphics.Color.FromHsv(float h, float s, float v) -> Microsoft.Maui.Graphics.Color!
@@ -37,5 +39,3 @@ static Microsoft.Maui.Graphics.Color.FromUint(uint argb) -> Microsoft.Maui.Graph
 static Microsoft.Maui.Graphics.Color.Parse(string! value) -> Microsoft.Maui.Graphics.Color!
 static Microsoft.Maui.Graphics.Color.TryParse(string! value, out Microsoft.Maui.Graphics.Color! color) -> bool
 static Microsoft.Maui.Graphics.Color.implicit operator Microsoft.Maui.Graphics.Color!(System.Numerics.Vector4 color) -> Microsoft.Maui.Graphics.Color!
-static Microsoft.Maui.Graphics.Color.operator !=(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
-static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool

--- a/src/Graphics/src/Graphics/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,27 +1,22 @@
-#nullable enable
-Microsoft.Maui.Graphics.Color.Color(Microsoft.Maui.Graphics.Color! original) -> void
-override Microsoft.Maui.Graphics.Color.Equals(object? obj) -> bool
-static Microsoft.Maui.Graphics.Color.operator !=(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
-static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
-virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
-virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
-virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color? other) -> bool
-virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
-Microsoft.Maui.Graphics.Color.AsPaint() -> Microsoft.Maui.Graphics.Paint!
-Microsoft.Maui.Graphics.Color.MultiplyAlpha(float multiplyBy) -> Microsoft.Maui.Graphics.Color!
-Microsoft.Maui.Graphics.Color.WithAlpha(float alpha) -> Microsoft.Maui.Graphics.Color!
-override Microsoft.Maui.Graphics.Color.ToString() -> string!
-static Microsoft.Maui.Graphics.Color.FromHex(string! colorAsArgbHex) -> Microsoft.Maui.Graphics.Color!
+﻿#nullable enable
+Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.AddLuminosity(float delta) -> Microsoft.Maui.Graphics.Color!
+Microsoft.Maui.Graphics.Color.AsPaint() -> Microsoft.Maui.Graphics.Paint!
+Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color? other) -> bool
 Microsoft.Maui.Graphics.Color.GetComplementary() -> Microsoft.Maui.Graphics.Color!
+Microsoft.Maui.Graphics.Color.MultiplyAlpha(float multiplyBy) -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.ToArgbHex(bool includeAlpha = false) -> string!
 Microsoft.Maui.Graphics.Color.ToHex() -> string!
 Microsoft.Maui.Graphics.Color.ToHex(bool includeAlpha) -> string!
 Microsoft.Maui.Graphics.Color.ToRgbaHex(bool includeAlpha = false) -> string!
+Microsoft.Maui.Graphics.Color.WithAlpha(float alpha) -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.WithHue(float hue) -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.WithLuminosity(float luminosity) -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.WithSaturation(float saturation) -> Microsoft.Maui.Graphics.Color!
+override Microsoft.Maui.Graphics.Color.Equals(object? obj) -> bool
+override Microsoft.Maui.Graphics.Color.ToString() -> string!
 static Microsoft.Maui.Graphics.Color.FromArgb(string! colorAsHex) -> Microsoft.Maui.Graphics.Color!
+static Microsoft.Maui.Graphics.Color.FromHex(string! colorAsArgbHex) -> Microsoft.Maui.Graphics.Color!
 static Microsoft.Maui.Graphics.Color.FromHsla(double h, double s, double l, double a = 1) -> Microsoft.Maui.Graphics.Color!
 static Microsoft.Maui.Graphics.Color.FromHsla(float h, float s, float l, float a = 1) -> Microsoft.Maui.Graphics.Color!
 static Microsoft.Maui.Graphics.Color.FromHsv(float h, float s, float v) -> Microsoft.Maui.Graphics.Color!
@@ -42,3 +37,5 @@ static Microsoft.Maui.Graphics.Color.FromUint(uint argb) -> Microsoft.Maui.Graph
 static Microsoft.Maui.Graphics.Color.Parse(string! value) -> Microsoft.Maui.Graphics.Color!
 static Microsoft.Maui.Graphics.Color.TryParse(string! value, out Microsoft.Maui.Graphics.Color! color) -> bool
 static Microsoft.Maui.Graphics.Color.implicit operator Microsoft.Maui.Graphics.Color!(System.Numerics.Vector4 color) -> Microsoft.Maui.Graphics.Color!
+static Microsoft.Maui.Graphics.Color.operator !=(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
+static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool

--- a/src/Graphics/src/Graphics/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,22 +1,24 @@
-﻿#nullable enable
+#nullable enable
+override Microsoft.Maui.Graphics.Color.Equals(object? obj) -> bool
+static Microsoft.Maui.Graphics.Color.operator !=(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
+static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
 Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
-Microsoft.Maui.Graphics.Color.AddLuminosity(float delta) -> Microsoft.Maui.Graphics.Color!
-Microsoft.Maui.Graphics.Color.AsPaint() -> Microsoft.Maui.Graphics.Paint!
 Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color? other) -> bool
-Microsoft.Maui.Graphics.Color.GetComplementary() -> Microsoft.Maui.Graphics.Color!
+Microsoft.Maui.Graphics.Color.AsPaint() -> Microsoft.Maui.Graphics.Paint!
 Microsoft.Maui.Graphics.Color.MultiplyAlpha(float multiplyBy) -> Microsoft.Maui.Graphics.Color!
+Microsoft.Maui.Graphics.Color.WithAlpha(float alpha) -> Microsoft.Maui.Graphics.Color!
+override Microsoft.Maui.Graphics.Color.ToString() -> string!
+static Microsoft.Maui.Graphics.Color.FromHex(string! colorAsArgbHex) -> Microsoft.Maui.Graphics.Color!
+Microsoft.Maui.Graphics.Color.AddLuminosity(float delta) -> Microsoft.Maui.Graphics.Color!
+Microsoft.Maui.Graphics.Color.GetComplementary() -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.ToArgbHex(bool includeAlpha = false) -> string!
 Microsoft.Maui.Graphics.Color.ToHex() -> string!
 Microsoft.Maui.Graphics.Color.ToHex(bool includeAlpha) -> string!
 Microsoft.Maui.Graphics.Color.ToRgbaHex(bool includeAlpha = false) -> string!
-Microsoft.Maui.Graphics.Color.WithAlpha(float alpha) -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.WithHue(float hue) -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.WithLuminosity(float luminosity) -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.WithSaturation(float saturation) -> Microsoft.Maui.Graphics.Color!
-override Microsoft.Maui.Graphics.Color.Equals(object? obj) -> bool
-override Microsoft.Maui.Graphics.Color.ToString() -> string!
 static Microsoft.Maui.Graphics.Color.FromArgb(string! colorAsHex) -> Microsoft.Maui.Graphics.Color!
-static Microsoft.Maui.Graphics.Color.FromHex(string! colorAsArgbHex) -> Microsoft.Maui.Graphics.Color!
 static Microsoft.Maui.Graphics.Color.FromHsla(double h, double s, double l, double a = 1) -> Microsoft.Maui.Graphics.Color!
 static Microsoft.Maui.Graphics.Color.FromHsla(float h, float s, float l, float a = 1) -> Microsoft.Maui.Graphics.Color!
 static Microsoft.Maui.Graphics.Color.FromHsv(float h, float s, float v) -> Microsoft.Maui.Graphics.Color!
@@ -37,5 +39,3 @@ static Microsoft.Maui.Graphics.Color.FromUint(uint argb) -> Microsoft.Maui.Graph
 static Microsoft.Maui.Graphics.Color.Parse(string! value) -> Microsoft.Maui.Graphics.Color!
 static Microsoft.Maui.Graphics.Color.TryParse(string! value, out Microsoft.Maui.Graphics.Color! color) -> bool
 static Microsoft.Maui.Graphics.Color.implicit operator Microsoft.Maui.Graphics.Color!(System.Numerics.Vector4 color) -> Microsoft.Maui.Graphics.Color!
-static Microsoft.Maui.Graphics.Color.operator !=(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
-static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool

--- a/src/Graphics/src/Graphics/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,27 +1,22 @@
-#nullable enable
-Microsoft.Maui.Graphics.Color.Color(Microsoft.Maui.Graphics.Color! original) -> void
-override Microsoft.Maui.Graphics.Color.Equals(object? obj) -> bool
-static Microsoft.Maui.Graphics.Color.operator !=(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
-static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
-virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
-virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
-virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color? other) -> bool
-virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
-Microsoft.Maui.Graphics.Color.AsPaint() -> Microsoft.Maui.Graphics.Paint!
-Microsoft.Maui.Graphics.Color.MultiplyAlpha(float multiplyBy) -> Microsoft.Maui.Graphics.Color!
-Microsoft.Maui.Graphics.Color.WithAlpha(float alpha) -> Microsoft.Maui.Graphics.Color!
-override Microsoft.Maui.Graphics.Color.ToString() -> string!
-static Microsoft.Maui.Graphics.Color.FromHex(string! colorAsArgbHex) -> Microsoft.Maui.Graphics.Color!
+﻿#nullable enable
+Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.AddLuminosity(float delta) -> Microsoft.Maui.Graphics.Color!
+Microsoft.Maui.Graphics.Color.AsPaint() -> Microsoft.Maui.Graphics.Paint!
+Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color? other) -> bool
 Microsoft.Maui.Graphics.Color.GetComplementary() -> Microsoft.Maui.Graphics.Color!
+Microsoft.Maui.Graphics.Color.MultiplyAlpha(float multiplyBy) -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.ToArgbHex(bool includeAlpha = false) -> string!
 Microsoft.Maui.Graphics.Color.ToHex() -> string!
 Microsoft.Maui.Graphics.Color.ToHex(bool includeAlpha) -> string!
 Microsoft.Maui.Graphics.Color.ToRgbaHex(bool includeAlpha = false) -> string!
+Microsoft.Maui.Graphics.Color.WithAlpha(float alpha) -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.WithHue(float hue) -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.WithLuminosity(float luminosity) -> Microsoft.Maui.Graphics.Color!
 Microsoft.Maui.Graphics.Color.WithSaturation(float saturation) -> Microsoft.Maui.Graphics.Color!
+override Microsoft.Maui.Graphics.Color.Equals(object? obj) -> bool
+override Microsoft.Maui.Graphics.Color.ToString() -> string!
 static Microsoft.Maui.Graphics.Color.FromArgb(string! colorAsHex) -> Microsoft.Maui.Graphics.Color!
+static Microsoft.Maui.Graphics.Color.FromHex(string! colorAsArgbHex) -> Microsoft.Maui.Graphics.Color!
 static Microsoft.Maui.Graphics.Color.FromHsla(double h, double s, double l, double a = 1) -> Microsoft.Maui.Graphics.Color!
 static Microsoft.Maui.Graphics.Color.FromHsla(float h, float s, float l, float a = 1) -> Microsoft.Maui.Graphics.Color!
 static Microsoft.Maui.Graphics.Color.FromHsv(float h, float s, float v) -> Microsoft.Maui.Graphics.Color!
@@ -42,3 +37,5 @@ static Microsoft.Maui.Graphics.Color.FromUint(uint argb) -> Microsoft.Maui.Graph
 static Microsoft.Maui.Graphics.Color.Parse(string! value) -> Microsoft.Maui.Graphics.Color!
 static Microsoft.Maui.Graphics.Color.TryParse(string! value, out Microsoft.Maui.Graphics.Color! color) -> bool
 static Microsoft.Maui.Graphics.Color.implicit operator Microsoft.Maui.Graphics.Color!(System.Numerics.Vector4 color) -> Microsoft.Maui.Graphics.Color!
+static Microsoft.Maui.Graphics.Color.operator !=(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
+static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool

--- a/src/Graphics/tests/Graphics.Tests/ColorUnitTests.cs
+++ b/src/Graphics/tests/Graphics.Tests/ColorUnitTests.cs
@@ -468,5 +468,37 @@ namespace Microsoft.Maui.Graphics.Tests
 				Assert.Equal(expected, actual);
 			}
 		}
+
+		[Fact]
+		public void ColorTypeIsSealed()
+		{
+			// Sealing Color guarantees every instance shares the same runtime type, so its
+			// record-generated equality (based on the ARGB value) can never be broken by a subclass.
+			Assert.True(typeof(Color).IsSealed);
+		}
+
+		[Fact]
+		public void EqualsIsValueBasedForSameArgbValue()
+		{
+			var color1 = new Color(1f, 0f, 0f, 1f);
+			var color2 = new Color(1f, 0f, 0f, 1f);
+
+			Assert.Equal(color1, color2);
+			Assert.True(color1 == color2);
+			Assert.True(color1.Equals(color2));
+			Assert.True(EqualityComparer<Color>.Default.Equals(color1, color2));
+			Assert.Equal(color1.GetHashCode(), color2.GetHashCode());
+		}
+
+		[Fact]
+		public void EqualsIsFalseForDifferentArgbValue()
+		{
+			var color1 = new Color(1f, 0f, 0f, 1f);
+			var color2 = new Color(0f, 1f, 0f, 1f);
+
+			Assert.NotEqual(color1, color2);
+			Assert.True(color1 != color2);
+			Assert.False(color1.Equals(color2));
+		}
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->


### Issue Details
Color.Equals()  returns  false  when comparing a base  Color  and a subclassed  Color  with identical RGBA values, even though  ToInt()  matches. Regression starting .NET MAUI 11 preview 3.

### Root Cause
Color  was converted from a  class  to a  record class . Records auto-generate an  EqualityContract  check in  Equals  that requires both objects to have the exact same runtime type — so a base  Color  and a derived  DerivedColor  never match, even with identical byte values.

### Description of Change
Made  Color  a  sealed record class , so it can never be subclassed — every instance now shares the same  EqualityContract , restoring pure value-based (ARGB) equality. Also removed the now-illegal  virtual  modifier on  Equals(Color? other)  since sealed types can't declare virtual members.
 
### Issues Fixed
  
Fixes #36034 

### Reference : 
https://github.com/dotnet/maui/pull/36076

https://github.com/dotnet/maui/pull/36076#issuecomment-4782959118

