### PR TITLE
[Material 3] Replace Material3 slider touch workaround and remove floating label

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/FeatureMatrix/Slider/SliderControlPage.xaml
+++ b/src/Controls/tests/TestCases.HostApp/FeatureMatrix/Slider/SliderControlPage.xaml
@@ -18,6 +18,7 @@
         RowSpacing="8">
     <!-- Slider Control -->
     <Grid x:Name="SliderGrid"
+          AutomationId="SliderGrid"
           Grid.Row="0"
           Grid.Column="0"
           Grid.ColumnSpan="2">

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/Material3SliderFeatureTests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/Material3SliderFeatureTests.cs
@@ -534,8 +534,8 @@ public class Material3SliderFeatureTests : _GalleryUITest
 	{
 		App.WaitForElement("SliderGrid");
 		DragSlider(30, 70);
-		Assert.That(App.WaitForElement("DragStartStatusLabel").GetText(), Is.EqualTo("Drag Started"));
-		Assert.That(App.WaitForElement("DragCompletedStatusLabel").GetText(), Is.EqualTo("Drag Completed"));
+		App.WaitForTextToBePresentInElement("DragStartStatusLabel", "Drag Started");
+		App.WaitForTextToBePresentInElement("DragCompletedStatusLabel", "Drag Completed");
 	}
 
 	[Test]
@@ -552,10 +552,10 @@ public class Material3SliderFeatureTests : _GalleryUITest
 		App.Tap("Apply");
 		App.WaitForElementTillPageNavigationSettled("SliderGrid");
 
-		Assert.That(App.FindElement("ValueChangedEventStatus").GetText(), Is.EqualTo("Not Raised"));
+		App.WaitForTextToBePresentInElement("ValueChangedEventStatus", "Not Raised");
 
 		DragSlider(10, 60);
-		Assert.That(App.FindElement("ValueChangedEventStatus").GetText(), Is.EqualTo("Raised"));
+		App.WaitForTextToBePresentInElement("ValueChangedEventStatus", "Raised");
 	}
 }
 #endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/Material3SliderFeatureTests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/Material3SliderFeatureTests.cs
@@ -516,5 +516,46 @@ public class Material3SliderFeatureTests : _GalleryUITest
 		App.WaitForElementTillPageNavigationSettled("MinimumValueLabel");
 		VerifyScreenshot(tolerance: 0.5, retryTimeout: TimeSpan.FromSeconds(2));
 	}
+
+	// ========== Event/Interaction Tests ==========
+
+	void DragSlider(int startPercent, int endPercent)
+	{
+		var sliderRect = App.WaitForElement("SliderGrid").GetRect();
+		var startX = sliderRect.X + (sliderRect.Width * startPercent / 100);
+		var centerY = sliderRect.Y + (sliderRect.Height / 2);
+		var endX = sliderRect.X + (sliderRect.Width * endPercent / 100);
+		App.DragCoordinates(startX, centerY, endX, centerY);
+	}
+
+	[Test]
+	[Category(UITestCategories.Material3)]
+	public void Material3Slider_DragStartedAndCompletedEventTriggered()
+	{
+		App.WaitForElement("SliderGrid");
+		DragSlider(30, 70);
+		Assert.That(App.WaitForElement("DragStartStatusLabel").GetText(), Is.EqualTo("Drag Started"));
+		Assert.That(App.WaitForElement("DragCompletedStatusLabel").GetText(), Is.EqualTo("Drag Completed"));
+	}
+
+	[Test]
+	[Category(UITestCategories.Material3)]
+	public void Material3Slider_ValueChangedEvent_FiredOnDrag()
+	{
+		App.WaitForElement("Options");
+		App.Tap("Options");
+		App.WaitForElement("ValueEntry");
+		App.ClearText("ValueEntry");
+		App.EnterText("ValueEntry", "0");
+		App.PressEnter();
+		App.WaitForElement("Apply");
+		App.Tap("Apply");
+		App.WaitForElementTillPageNavigationSettled("SliderGrid");
+
+		Assert.That(App.FindElement("ValueChangedEventStatus").GetText(), Is.EqualTo("Not Raised"));
+
+		DragSlider(10, 60);
+		Assert.That(App.FindElement("ValueChangedEventStatus").GetText(), Is.EqualTo("Raised"));
+	}
 }
 #endif

--- a/src/Core/src/Handlers/Slider/SliderHandler2.Android.cs
+++ b/src/Core/src/Handlers/Slider/SliderHandler2.Android.cs
@@ -28,6 +28,7 @@ public class SliderHandler2 : ViewHandler<ISlider, Slider>
         return new Slider(MauiMaterialContextThemeWrapper.Create(Context))
         {
             DuplicateParentStateEnabled = false,
+            LabelBehavior = LabelFormatter.LabelGone,
         };
     }
 

--- a/src/Core/src/Handlers/Slider/SliderHandler2.Android.cs
+++ b/src/Core/src/Handlers/Slider/SliderHandler2.Android.cs
@@ -45,6 +45,7 @@ public class SliderHandler2 : ViewHandler<ISlider, Slider>
         platformView.StopTrackingTouch -= OnStopTrackingTouch;
     }
 
+    // BaseOnChangeEventArgs: P0 = slider (Object), P1 = value (float), P2 = fromUser (bool)
     void OnChange(object? sender, BaseOnChangeEventArgs e)
     {
         if (e.P2 && VirtualView is not null && (float)VirtualView.Value != e.P1)

--- a/src/Core/src/Handlers/Slider/SliderHandler2.Android.cs
+++ b/src/Core/src/Handlers/Slider/SliderHandler2.Android.cs
@@ -46,8 +46,8 @@ public class SliderHandler2 : ViewHandler<ISlider, Slider>
         platformView.StopTrackingTouch -= OnStopTrackingTouch;
     }
 
-    // BaseOnChangeEventArgs: P0 = slider (Object), P1 = value (float), P2 = fromUser (bool)
-    void OnChange(object? sender, BaseOnChangeEventArgs e)
+    // Slider.ChangeEventArgs: P0 = slider (Slider), P1 = value (float), P2 = fromUser (bool)
+    void OnChange(object? sender, Slider.ChangeEventArgs e)
     {
         if (e.P2 && VirtualView is not null && (float)VirtualView.Value != e.P1)
         {
@@ -55,12 +55,12 @@ public class SliderHandler2 : ViewHandler<ISlider, Slider>
         }
     }
 
-    void OnStartTrackingTouch(object? sender, StartTrackingTouchEventArgs e)
+    void OnStartTrackingTouch(object? sender, Slider.StartTrackingTouchEventArgs e)
     {
         VirtualView?.DragStarted();
     }
 
-    void OnStopTrackingTouch(object? sender, StopTrackingTouchEventArgs e)
+    void OnStopTrackingTouch(object? sender, Slider.StopTrackingTouchEventArgs e)
     {
         VirtualView?.DragCompleted();
     }

--- a/src/Core/src/Handlers/Slider/SliderHandler2.Android.cs
+++ b/src/Core/src/Handlers/Slider/SliderHandler2.Android.cs
@@ -1,4 +1,3 @@
-using Android.Views;
 using Google.Android.Material.Slider;
 
 namespace Microsoft.Maui.Handlers;
@@ -34,51 +33,34 @@ public class SliderHandler2 : ViewHandler<ISlider, Slider>
 
     protected override void ConnectHandler(Slider platformView)
     {
-        // TODO: Material3: Add listeners when https://github.com/dotnet/android-libraries/issues/230 is resolved
-        // Using Touch event as a workaround for missing addOnChangeListener binding
-        // See: https://github.com/dotnet/android-libraries/issues/230#issuecomment-891341936
-        platformView.Touch += Slider_Touch;
-    }
-
-    void Slider_Touch(object? sender, View.TouchEventArgs e)
-    {
-        if (sender is not Slider slider)
-        {
-            return;
-        }
-
-        switch (e.Event?.Action)
-        {
-            case MotionEventActions.Down:
-                {
-                    OnStartTrackingTouch(slider);
-                    break;
-                }
-            case MotionEventActions.Move:
-                {
-                    OnValueChanged(slider, slider.Value);
-                    break;
-                }
-            case MotionEventActions.Up:
-                {
-                    OnValueChanged(slider, slider.Value);
-                    OnStopTrackingTouch(slider);
-                    break;
-                }
-            case MotionEventActions.Cancel:
-                {
-                    OnStopTrackingTouch(slider);
-                    break;
-                }
-        }
-        // Pass through to Material3 Slider so it can update its own visual state
-        e.Handled = false;
+        platformView.Change += OnChange;
+        platformView.StartTrackingTouch += OnStartTrackingTouch;
+        platformView.StopTrackingTouch += OnStopTrackingTouch;
     }
 
     protected override void DisconnectHandler(Slider platformView)
     {
-        // TODO: Material3: Cleanup listeners when implemented
-        platformView.Touch -= Slider_Touch;
+        platformView.Change -= OnChange;
+        platformView.StartTrackingTouch -= OnStartTrackingTouch;
+        platformView.StopTrackingTouch -= OnStopTrackingTouch;
+    }
+
+    void OnChange(object? sender, BaseOnChangeEventArgs e)
+    {
+        if (e.P2 && VirtualView is not null && (float)VirtualView.Value != e.P1)
+        {
+            VirtualView.Value = e.P1;
+        }
+    }
+
+    void OnStartTrackingTouch(object? sender, StartTrackingTouchEventArgs e)
+    {
+        VirtualView?.DragStarted();
+    }
+
+    void OnStopTrackingTouch(object? sender, StopTrackingTouchEventArgs e)
+    {
+        VirtualView?.DragCompleted();
     }
 
     public static void MapValue(SliderHandler2 handler, ISlider slider)
@@ -117,24 +99,5 @@ public class SliderHandler2 : ViewHandler<ISlider, Slider>
 
         handler.PlatformView?.UpdateThumbImageSourceAsync(slider, provider)
             .FireAndForget(handler);
-    }
-
-    void OnStartTrackingTouch(Slider slider) =>
-        VirtualView?.DragStarted();
-
-    void OnStopTrackingTouch(Slider slider) =>
-        VirtualView?.DragCompleted();
-
-    void OnValueChanged(Slider slider, float value)
-    {
-        if (VirtualView is null)
-        {
-            return;
-        }
-
-        if ((float)VirtualView.Value != value)
-        {
-            VirtualView.Value = value;
-        }
     }
 }

--- a/src/Core/src/Handlers/Slider/SliderHandler2.Android.cs
+++ b/src/Core/src/Handlers/Slider/SliderHandler2.Android.cs
@@ -34,6 +34,7 @@ public class SliderHandler2 : ViewHandler<ISlider, Slider>
 
     protected override void ConnectHandler(Slider platformView)
     {
+        base.ConnectHandler(platformView);
         platformView.Change += OnChange;
         platformView.StartTrackingTouch += OnStartTrackingTouch;
         platformView.StopTrackingTouch += OnStopTrackingTouch;
@@ -44,6 +45,7 @@ public class SliderHandler2 : ViewHandler<ISlider, Slider>
         platformView.Change -= OnChange;
         platformView.StartTrackingTouch -= OnStartTrackingTouch;
         platformView.StopTrackingTouch -= OnStopTrackingTouch;
+        base.DisconnectHandler(platformView);
     }
 
     // Slider.ChangeEventArgs: P0 = slider (Slider), P1 = value (float), P2 = fromUser (bool)


### PR DESCRIPTION
This pull request introduces improvements to the Material3 Slider control, particularly for Android, focusing on event handling and test coverage. The changes include switching from a touch-event workaround to proper event handlers, adding new UI tests for slider interactions, and minor code cleanups.

**Event handling improvements:**

* Replaced the previous touch-event workaround with direct use of `Change`, `StartTrackingTouch`, and `StopTrackingTouch` events on the Android Material3 Slider, ensuring more accurate and reliable event handling. The corresponding event handler methods (`OnChange`, `OnStartTrackingTouch`, `OnStopTrackingTouch`) now update the virtual view and fire the appropriate events (`ValueChanged`, `DragStarted`, `DragCompleted`).
* Removed obsolete workaround code and redundant methods (`Slider_Touch`, `OnValueChanged`, etc.), simplifying the handler implementation.
* Set `LabelBehavior` to `LabelFormatter.LabelGone` for the platform view to control label visibility.
* Removed an unused `using` directive for `Android.Views`.

**UI test enhancements:**

* Added new UI tests to verify that the Material3 Slider fires `DragStarted`, `DragCompleted`, and `ValueChanged` events as expected during user interactions. This includes a `DragSlider` helper for simulating drag gestures and assertions for event status labels.
* Added an `AutomationId="SliderGrid"` to the XAML for improved testability and element identification in UI tests.<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->


<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
