### PR TITLE
[WIP] Fix Shell.TitleView not being centered

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarTests.Windows.cs
@@ -125,5 +125,42 @@ namespace Microsoft.Maui.DeviceTests
 				return Task.CompletedTask;
 			});
 		}
+
+		[Fact(DisplayName = "Toolbar Content Grid Width Excludes Space Reserved For ToolbarItems")]
+		public async Task ToolbarContentGridWidthExcludesToolbarItemsWidth()
+		{
+			SetupBuilder();
+
+			var item1 = new ToolbarItem() { Text = "Item 1" };
+			var item2 = new ToolbarItem() { Text = "Item 2" };
+
+			var page = new ContentPage { Title = "Test Page" };
+			page.ToolbarItems.Add(item1);
+			page.ToolbarItems.Add(item2);
+			NavigationPage.SetTitleView(page, new Microsoft.Maui.Controls.Image());
+
+			var navPage = new NavigationPage(page);
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), async (handler) =>
+			{
+				var toolbar = (Toolbar)(navPage.Window as IToolbarElement).Toolbar;
+				var platformCommandBar = ((MauiToolbar)toolbar.Handler.PlatformView).CommandBar;
+
+				// Allow layout to settle so ActualWidth values are populated.
+				await Task.Delay(100);
+
+				var contentGrid = Assert.IsType<Microsoft.UI.Xaml.Controls.Grid>(platformCommandBar.Content);
+				var contentHost = Assert.IsAssignableFrom<Microsoft.UI.Xaml.FrameworkElement>(
+					Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(contentGrid));
+
+				// contentGrid must track the width WinUI actually reserves for Content...
+				Assert.Equal(contentHost.ActualWidth, contentGrid.Width, precision: 1);
+
+				// ...which must be smaller than the full CommandBar width once PrimaryCommands
+				// (the toolbar items added above) are claiming their own horizontal space.
+				Assert.True(contentGrid.Width < platformCommandBar.ActualWidth,
+					"contentGrid should not be sized to the full CommandBar width when PrimaryCommands are present.");
+			});
+		}
 	}
 }

--- a/src/Core/src/Platform/Windows/MauiToolbar.xaml.cs
+++ b/src/Core/src/Platform/Windows/MauiToolbar.xaml.cs
@@ -25,6 +25,12 @@ namespace Microsoft.Maui.Platform
 		public MauiToolbar()
 		{
 			InitializeComponent();
+			this.SizeChanged += (s, e) =>
+			{
+				if (contentGrid.Width != this.ActualWidth)
+					contentGrid.Width = this.ActualWidth;
+			};
+
 		}
 
 		internal string? Title


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Rootcause:

In WinUI's `DefaultCommandBarStyle` template, the CommandBar.Content is hosted inside a ContentControl whose column (ContentControlColumnDefinition) defaults to Width="*". However, the DynamicOverflowEnabled VisualState sets it to Width="Auto" — which collapses the content to its natural size.

The `.NET 11 Preview 6` XAML compiler appears to generate initialization code that causes DynamicOverflowEnabled to be triggered (or HorizontalContentAlignment="Stretch" to not propagate correctly), even when there are no toolbar items to overflow.

### Description of Change:
dded a SizeChanged event handler that updates contentGrid.Width, ensuring the content grid always matches the toolbar's width whenever its size changes.

### Issues Fixed:
Fixes #36322 

### Tested the behaviour in the following platforms
- [ ] Android
- [x] Windows
- [ ] iOS
- [ ] Mac

### Output Screenshot
Before Issue Fix | After Issue Fix |
|----------|----------|
|<image width="400" height="200" alt="Before Fix" src="https://github.com/user-attachments/assets/f54df19f-993b-4c56-b47b-823f85cf0b9a">|<image width="400" height="200" alt="After Fix" src="https://github.com/user-attachments/assets/ad043a05-8bdf-4906-8335-8db545d5edb7">|