### PR TITLE
Fix Shell.TitleView not being centered

### DIFF
--- a/src/Controls/src/Core/Handlers/Shell/ShellHandler.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellHandler.cs
@@ -14,6 +14,14 @@ namespace Microsoft.Maui.Controls.Handlers
 		public static PropertyMapper<Shell, ShellHandler> Mapper =
 				new PropertyMapper<Shell, ShellHandler>(ElementMapper)
 				{
+#if WINDOWS || TIZEN
+					[nameof(IToolbarElement.Toolbar)] = (handler, view) => ViewHandler.MapToolbar(handler, view),
+					[nameof(IFlyoutView.Flyout)] = MapFlyout,
+					[nameof(Shell.Items)] = MapItems,
+					[nameof(Shell.FlyoutItems)] = MapFlyoutItems,
+					[nameof(Shell.FlyoutIcon)] = MapFlyoutIcon,
+#endif
+
 					[nameof(Shell.CurrentItem)] = MapCurrentItem,
 					[nameof(Shell.FlyoutBackground)] = MapFlyoutBackground,
 					[nameof(Shell.FlyoutBackgroundColor)] = MapFlyoutBackground,
@@ -32,14 +40,6 @@ namespace Microsoft.Maui.Controls.Handlers
 					[nameof(Shell.FlyoutBackgroundImage)] = MapFlyoutBackgroundImage,
 					[nameof(Shell.FlyoutBackgroundImageAspect)] = MapFlyoutBackgroundImage,
 					[nameof(Shell.FlyoutVerticalScrollMode)] = MapFlyoutVerticalScrollMode,
-
-#if WINDOWS || TIZEN
-					[nameof(IToolbarElement.Toolbar)] = (handler, view) => ViewHandler.MapToolbar(handler, view),
-					[nameof(IFlyoutView.Flyout)] = MapFlyout,
-					[nameof(Shell.Items)] = MapItems,
-					[nameof(Shell.FlyoutItems)] = MapFlyoutItems,
-					[nameof(Shell.FlyoutIcon)] = MapFlyoutIcon,
-#endif
 
 #if ANDROID
 					[nameof(Shell.FlyoutHeight)] = MapFlyoutHeight,

--- a/src/Controls/src/Core/Handlers/Shell/ShellHandler.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellHandler.cs
@@ -15,32 +15,32 @@ namespace Microsoft.Maui.Controls.Handlers
 				new PropertyMapper<Shell, ShellHandler>(ElementMapper)
 				{
 #if WINDOWS || TIZEN
-					[nameof(IToolbarElement.Toolbar)] = (handler, view) => ViewHandler.MapToolbar(handler, view),
-					[nameof(IFlyoutView.Flyout)] = MapFlyout,
-					[nameof(Shell.Items)] = MapItems,
-					[nameof(Shell.FlyoutItems)] = MapFlyoutItems,
-					[nameof(Shell.FlyoutIcon)] = MapFlyoutIcon,
+				[nameof(IToolbarElement.Toolbar)] = (handler, view) => ViewHandler.MapToolbar(handler, view),
+				[nameof(IFlyoutView.Flyout)] = MapFlyout,
 #endif
-
-					[nameof(Shell.CurrentItem)] = MapCurrentItem,
-					[nameof(Shell.FlyoutBackground)] = MapFlyoutBackground,
-					[nameof(Shell.FlyoutBackgroundColor)] = MapFlyoutBackground,
-					[nameof(Shell.FlyoutBackdrop)] = MapFlyoutBackdrop,
-					[nameof(Shell.FlyoutHeader)] = MapFlyoutHeader,
-					[nameof(Shell.FlyoutHeaderTemplate)] = MapFlyoutHeader,
-					[nameof(Shell.FlyoutFooter)] = MapFlyoutFooter,
-					[nameof(Shell.FlyoutFooterTemplate)] = MapFlyoutFooter,
-					[nameof(Shell.FlyoutHeaderBehavior)] = MapFlyoutHeaderBehavior,
-					[nameof(IFlyoutView.FlyoutBehavior)] = MapFlyoutBehavior,
-					[nameof(IFlyoutView.FlyoutWidth)] = MapFlyoutWidth,
-					[nameof(IFlyoutView.IsPresented)] = MapIsPresented,
-					[nameof(Shell.FlyoutContent)] = MapFlyout,
-					[nameof(Shell.FlyoutContentTemplate)] = MapFlyout,
-					[nameof(Shell.FlowDirection)] = MapFlowDirection,
-					[nameof(Shell.FlyoutBackgroundImage)] = MapFlyoutBackgroundImage,
-					[nameof(Shell.FlyoutBackgroundImageAspect)] = MapFlyoutBackgroundImage,
-					[nameof(Shell.FlyoutVerticalScrollMode)] = MapFlyoutVerticalScrollMode,
-
+				[nameof(IFlyoutView.IsPresented)] = MapIsPresented,
+				[nameof(IFlyoutView.FlyoutBehavior)] = MapFlyoutBehavior,
+				[nameof(IFlyoutView.FlyoutWidth)] = MapFlyoutWidth,
+				[nameof(Shell.FlyoutBackground)] = MapFlyoutBackground,
+				[nameof(Shell.FlyoutBackgroundColor)] = MapFlyoutBackground,
+				[nameof(Shell.FlyoutContent)] = MapFlyout,
+				[nameof(Shell.CurrentItem)] = MapCurrentItem,
+				[nameof(Shell.FlyoutBackdrop)] = MapFlyoutBackdrop,
+				[nameof(Shell.FlyoutFooter)] = MapFlyoutFooter,
+				[nameof(Shell.FlyoutFooterTemplate)] = MapFlyoutFooter,
+				[nameof(Shell.FlyoutHeader)] = MapFlyoutHeader,
+				[nameof(Shell.FlyoutHeaderTemplate)] = MapFlyoutHeader,
+				[nameof(Shell.FlyoutHeaderBehavior)] = MapFlyoutHeaderBehavior,
+#if WINDOWS || TIZEN
+				[nameof(Shell.Items)] = MapItems,
+				[nameof(Shell.FlyoutItems)] = MapFlyoutItems,
+				[nameof(Shell.FlyoutIcon)] = MapFlyoutIcon,
+#endif
+				[nameof(Shell.FlyoutContentTemplate)] = MapFlyout,
+				[nameof(Shell.FlowDirection)] = MapFlowDirection,
+				[nameof(Shell.FlyoutBackgroundImage)] = MapFlyoutBackgroundImage,
+				[nameof(Shell.FlyoutBackgroundImageAspect)] = MapFlyoutBackgroundImage,
+				[nameof(Shell.FlyoutVerticalScrollMode)] = MapFlyoutVerticalScrollMode,
 #if ANDROID
 					[nameof(Shell.FlyoutHeight)] = MapFlyoutHeight,
 #endif

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
@@ -64,49 +64,6 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Fact(DisplayName = "Shell TitleView Is Centered On Initial Load")]
-		public async Task ShellTitleViewIsCenteredOnInitialLoad()
-		{
-			SetupBuilder();
-
-			var page = new ContentPage
-			{
-				Title = "Page 1",
-				Content = new Label { Text = "Body" }
-			};
-
-			var titleView = new Label
-			{
-				Text = "TitleView",
-				HorizontalOptions = LayoutOptions.Center
-			};
-
-			var shell = await CreateShellAsync(s =>
-			{
-				s.CurrentItem = page;
-				Shell.SetTitleView(s, titleView);
-			});
-
-			await CreateHandlerAndAddToWindow<ShellHandler>(shell, async (handler) =>
-			{
-				await OnFrameSetToNotEmpty(titleView);
-				await AssertEventually(() =>
-				{
-					var toolbar = GetPlatformToolbar(handler);
-					var platformTitleView = GetTitleView(handler);
-
-					return toolbar?.ActualWidth > 0 && platformTitleView?.ActualWidth > 0;
-				});
-
-				var toolbar = GetPlatformToolbar(handler);
-				var platformTitleView = GetTitleView(handler);
-				var titleViewCenterX = platformTitleView.GetLocationRelativeTo(toolbar).Value.X + (platformTitleView.ActualWidth / 2);
-				var toolbarCenterX = toolbar.ActualWidth / 2;
-
-				Assert.InRange(Math.Abs(titleViewCenterX - toolbarCenterX), 0, 2);
-			});
-		}
-
 		static bool IsViewLaidOut(object platformView)
 		{
 			var frameworkElement = platformView as WFrameworkElement;

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
@@ -64,6 +64,49 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact(DisplayName = "Shell TitleView Is Centered On Initial Load")]
+		public async Task ShellTitleViewIsCenteredOnInitialLoad()
+		{
+			SetupBuilder();
+
+			var page = new ContentPage
+			{
+				Title = "Page 1",
+				Content = new Label { Text = "Body" }
+			};
+
+			var titleView = new Label
+			{
+				Text = "TitleView",
+				HorizontalOptions = LayoutOptions.Center
+			};
+
+			var shell = await CreateShellAsync(s =>
+			{
+				s.CurrentItem = page;
+				Shell.SetTitleView(s, titleView);
+			});
+
+			await CreateHandlerAndAddToWindow<ShellHandler>(shell, async (handler) =>
+			{
+				await OnFrameSetToNotEmpty(titleView);
+				await AssertEventually(() =>
+				{
+					var toolbar = GetPlatformToolbar(handler);
+					var platformTitleView = GetTitleView(handler);
+
+					return toolbar?.ActualWidth > 0 && platformTitleView?.ActualWidth > 0;
+				});
+
+				var toolbar = GetPlatformToolbar(handler);
+				var platformTitleView = GetTitleView(handler);
+				var titleViewCenterX = platformTitleView.GetLocationRelativeTo(toolbar).Value.X + (platformTitleView.ActualWidth / 2);
+				var toolbarCenterX = toolbar.ActualWidth / 2;
+
+				Assert.InRange(Math.Abs(titleViewCenterX - toolbarCenterX), 0, 2);
+			});
+		}
+
 		static bool IsViewLaidOut(object platformView)
 		{
 			var frameworkElement = platformView as WFrameworkElement;


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Regression Details 
 Shell.TitleView is not centered on Windows due to the mapper execution order change in ShellHandler in PR (#34758)

### Root Cause:

ShellHandler executes mapper entries in registration order. After a recent change, MapCurrentItem began running before MapToolbar, causing navigation and layout to occur before the toolbar and TitleView were initialized.

Previously, MapToolbar executed first, ensuring the CommandBar was fully initialized before layout occurred. This allowed TitleViewManager.UpdateTitleViewWidth() to use a valid CommandBar.ActualWidth and correctly center the TitleView.

With the updated order, MapCurrentItem triggers navigation and layout before MapToolbar runs. As a result, CommandBar.ActualWidth is not yet valid during the initial width calculation, causing the TitleView width to be computed incorrectly and appear left-aligned instead of centered.

### Description of Change:

Restore the execution order so that MapToolbar runs before MapCurrentItem. This ensures the MauiToolbar and TitleView are fully initialized before navigation triggers layout, allowing TitleViewManager.UpdateTitleViewWidth() to calculate the correct width and center the Shell.TitleView as expected.

### Issues Fixed:
Fixes #36322 

### Tested the behaviour in the following platforms
- [ ] Android
- [x] Windows
- [ ] iOS
- [ ] Mac

### Output Screenshot
Before Issue Fix | After Issue Fix |
|----------|----------|
|<image width="400" height="200" alt="Before Fix" src="https://github.com/user-attachments/assets/f54df19f-993b-4c56-b47b-823f85cf0b9a">|<image width="400" height="200" alt="After Fix" src="https://github.com/user-attachments/assets/ad043a05-8bdf-4906-8335-8db545d5edb7">|