### PR TITLE
[HotReload] Surface XAML Incremental Hot Reload diagnostics for IDE tooling

### DIFF
--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -214,11 +214,18 @@ static Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadDiagnostics.CurrentVers
 static Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadDiagnostics.UpdateApplied -> System.EventHandler<Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadAppliedEventArgs!>?
 static Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadDiagnostics.UpdateFailed -> System.EventHandler<Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs!>?
 static Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadDiagnostics.UpdateRequested -> System.EventHandler<Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadRequestedEventArgs!>?
+static Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadDiagnostics.UpdateSkipped -> System.EventHandler<Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadSkippedEventArgs!>?
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs.Exception.get -> System.Exception!
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs.Instance.get -> object!
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs.Timestamp.get -> System.DateTimeOffset
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs.UpdatedType.get -> System.Type!
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs.Version.get -> int
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadRequestedEventArgs
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadRequestedEventArgs.HandledTypes.get -> System.Collections.Generic.IReadOnlyList<System.Type!>!
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadRequestedEventArgs.Timestamp.get -> System.DateTimeOffset
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadRequestedEventArgs.UpdatedTypes.get -> System.Collections.Generic.IReadOnlyList<System.Type!>!
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadSkippedEventArgs
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadSkippedEventArgs.HandledTypes.get -> System.Collections.Generic.IReadOnlyList<System.Type!>!
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadSkippedEventArgs.Timestamp.get -> System.DateTimeOffset
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadSkippedEventArgs.UpdatedTypes.get -> System.Collections.Generic.IReadOnlyList<System.Type!>!

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -134,11 +134,18 @@ static Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadDiagnostics.CurrentVers
 static Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadDiagnostics.UpdateApplied -> System.EventHandler<Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadAppliedEventArgs!>?
 static Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadDiagnostics.UpdateFailed -> System.EventHandler<Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs!>?
 static Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadDiagnostics.UpdateRequested -> System.EventHandler<Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadRequestedEventArgs!>?
+static Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadDiagnostics.UpdateSkipped -> System.EventHandler<Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadSkippedEventArgs!>?
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs.Exception.get -> System.Exception!
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs.Instance.get -> object!
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs.Timestamp.get -> System.DateTimeOffset
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs.UpdatedType.get -> System.Type!
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs.Version.get -> int
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadRequestedEventArgs
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadRequestedEventArgs.HandledTypes.get -> System.Collections.Generic.IReadOnlyList<System.Type!>!
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadRequestedEventArgs.Timestamp.get -> System.DateTimeOffset
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadRequestedEventArgs.UpdatedTypes.get -> System.Collections.Generic.IReadOnlyList<System.Type!>!
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadSkippedEventArgs
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadSkippedEventArgs.HandledTypes.get -> System.Collections.Generic.IReadOnlyList<System.Type!>!
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadSkippedEventArgs.Timestamp.get -> System.DateTimeOffset
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadSkippedEventArgs.UpdatedTypes.get -> System.Collections.Generic.IReadOnlyList<System.Type!>!

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -134,11 +134,18 @@ static Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadDiagnostics.CurrentVers
 static Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadDiagnostics.UpdateApplied -> System.EventHandler<Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadAppliedEventArgs!>?
 static Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadDiagnostics.UpdateFailed -> System.EventHandler<Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs!>?
 static Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadDiagnostics.UpdateRequested -> System.EventHandler<Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadRequestedEventArgs!>?
+static Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadDiagnostics.UpdateSkipped -> System.EventHandler<Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadSkippedEventArgs!>?
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs.Exception.get -> System.Exception!
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs.Instance.get -> object!
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs.Timestamp.get -> System.DateTimeOffset
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs.UpdatedType.get -> System.Type!
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs.Version.get -> int
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadRequestedEventArgs
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadRequestedEventArgs.HandledTypes.get -> System.Collections.Generic.IReadOnlyList<System.Type!>!
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadRequestedEventArgs.Timestamp.get -> System.DateTimeOffset
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadRequestedEventArgs.UpdatedTypes.get -> System.Collections.Generic.IReadOnlyList<System.Type!>!
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadSkippedEventArgs
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadSkippedEventArgs.HandledTypes.get -> System.Collections.Generic.IReadOnlyList<System.Type!>!
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadSkippedEventArgs.Timestamp.get -> System.DateTimeOffset
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadSkippedEventArgs.UpdatedTypes.get -> System.Collections.Generic.IReadOnlyList<System.Type!>!

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -129,11 +129,18 @@ static Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadDiagnostics.CurrentVers
 static Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadDiagnostics.UpdateApplied -> System.EventHandler<Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadAppliedEventArgs!>?
 static Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadDiagnostics.UpdateFailed -> System.EventHandler<Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs!>?
 static Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadDiagnostics.UpdateRequested -> System.EventHandler<Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadRequestedEventArgs!>?
+static Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadDiagnostics.UpdateSkipped -> System.EventHandler<Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadSkippedEventArgs!>?
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs.Exception.get -> System.Exception!
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs.Instance.get -> object!
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs.Timestamp.get -> System.DateTimeOffset
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs.UpdatedType.get -> System.Type!
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs.Version.get -> int
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadRequestedEventArgs
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadRequestedEventArgs.HandledTypes.get -> System.Collections.Generic.IReadOnlyList<System.Type!>!
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadRequestedEventArgs.Timestamp.get -> System.DateTimeOffset
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadRequestedEventArgs.UpdatedTypes.get -> System.Collections.Generic.IReadOnlyList<System.Type!>!
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadSkippedEventArgs
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadSkippedEventArgs.HandledTypes.get -> System.Collections.Generic.IReadOnlyList<System.Type!>!
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadSkippedEventArgs.Timestamp.get -> System.DateTimeOffset
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadSkippedEventArgs.UpdatedTypes.get -> System.Collections.Generic.IReadOnlyList<System.Type!>!

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -176,11 +176,18 @@ static Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadDiagnostics.CurrentVers
 static Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadDiagnostics.UpdateApplied -> System.EventHandler<Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadAppliedEventArgs!>?
 static Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadDiagnostics.UpdateFailed -> System.EventHandler<Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs!>?
 static Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadDiagnostics.UpdateRequested -> System.EventHandler<Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadRequestedEventArgs!>?
+static Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadDiagnostics.UpdateSkipped -> System.EventHandler<Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadSkippedEventArgs!>?
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs.Exception.get -> System.Exception!
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs.Instance.get -> object!
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs.Timestamp.get -> System.DateTimeOffset
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs.UpdatedType.get -> System.Type!
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs.Version.get -> int
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadRequestedEventArgs
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadRequestedEventArgs.HandledTypes.get -> System.Collections.Generic.IReadOnlyList<System.Type!>!
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadRequestedEventArgs.Timestamp.get -> System.DateTimeOffset
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadRequestedEventArgs.UpdatedTypes.get -> System.Collections.Generic.IReadOnlyList<System.Type!>!
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadSkippedEventArgs
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadSkippedEventArgs.HandledTypes.get -> System.Collections.Generic.IReadOnlyList<System.Type!>!
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadSkippedEventArgs.Timestamp.get -> System.DateTimeOffset
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadSkippedEventArgs.UpdatedTypes.get -> System.Collections.Generic.IReadOnlyList<System.Type!>!

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -83,9 +83,15 @@ Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs.Exception.get -
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs.Instance.get -> object!
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs.Timestamp.get -> System.DateTimeOffset
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs.UpdatedType.get -> System.Type!
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs.Version.get -> int
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadRequestedEventArgs
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadRequestedEventArgs.HandledTypes.get -> System.Collections.Generic.IReadOnlyList<System.Type!>!
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadRequestedEventArgs.Timestamp.get -> System.DateTimeOffset
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadRequestedEventArgs.UpdatedTypes.get -> System.Collections.Generic.IReadOnlyList<System.Type!>!
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadSkippedEventArgs
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadSkippedEventArgs.HandledTypes.get -> System.Collections.Generic.IReadOnlyList<System.Type!>!
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadSkippedEventArgs.Timestamp.get -> System.DateTimeOffset
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadSkippedEventArgs.UpdatedTypes.get -> System.Collections.Generic.IReadOnlyList<System.Type!>!
 ~const Microsoft.Maui.Controls.AppThemeBinding.AppThemeResource = "__MAUI_ApplicationTheme__" -> string
 override Microsoft.Maui.Controls.GraphicsView.OnBindingContextChanged() -> void
 ~override Microsoft.Maui.Controls.RadioButton.OnPropertyChanged(string propertyName = null) -> void
@@ -112,6 +118,7 @@ static Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadDiagnostics.CurrentVers
 static Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadDiagnostics.UpdateApplied -> System.EventHandler<Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadAppliedEventArgs!>?
 static Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadDiagnostics.UpdateFailed -> System.EventHandler<Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs!>?
 static Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadDiagnostics.UpdateRequested -> System.EventHandler<Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadRequestedEventArgs!>?
+static Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadDiagnostics.UpdateSkipped -> System.EventHandler<Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadSkippedEventArgs!>?
 ~static readonly Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.BaseShellItem.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.BaseShellItem.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -75,9 +75,15 @@ Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs.Exception.get -
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs.Instance.get -> object!
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs.Timestamp.get -> System.DateTimeOffset
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs.UpdatedType.get -> System.Type!
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs.Version.get -> int
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadRequestedEventArgs
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadRequestedEventArgs.HandledTypes.get -> System.Collections.Generic.IReadOnlyList<System.Type!>!
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadRequestedEventArgs.Timestamp.get -> System.DateTimeOffset
 Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadRequestedEventArgs.UpdatedTypes.get -> System.Collections.Generic.IReadOnlyList<System.Type!>!
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadSkippedEventArgs
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadSkippedEventArgs.HandledTypes.get -> System.Collections.Generic.IReadOnlyList<System.Type!>!
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadSkippedEventArgs.Timestamp.get -> System.DateTimeOffset
+Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadSkippedEventArgs.UpdatedTypes.get -> System.Collections.Generic.IReadOnlyList<System.Type!>!
 override Microsoft.Maui.Controls.GraphicsView.OnBindingContextChanged() -> void
 ~override Microsoft.Maui.Controls.RadioButton.OnPropertyChanged(string propertyName = null) -> void
 override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void
@@ -103,6 +109,7 @@ static Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadDiagnostics.CurrentVers
 static Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadDiagnostics.UpdateApplied -> System.EventHandler<Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadAppliedEventArgs!>?
 static Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadDiagnostics.UpdateFailed -> System.EventHandler<Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadErrorEventArgs!>?
 static Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadDiagnostics.UpdateRequested -> System.EventHandler<Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadRequestedEventArgs!>?
+static Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadDiagnostics.UpdateSkipped -> System.EventHandler<Microsoft.Maui.Controls.Xaml.Diagnostics.HotReloadSkippedEventArgs!>?
 ~static readonly Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.BaseShellItem.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.BaseShellItem.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/Xaml/Diagnostics/HotReloadDiagnostics.cs
+++ b/src/Controls/src/Core/Xaml/Diagnostics/HotReloadDiagnostics.cs
@@ -12,9 +12,26 @@ namespace Microsoft.Maui.Controls.Xaml.Diagnostics;
 /// <remarks>
 /// Events are only raised when <see cref="Microsoft.Maui.RuntimeFeature.IsIncrementalHotReloadEnabled"/>
 /// is <see langword="true"/>. All events are raised on the thread where the work occurs:
-/// <see cref="UpdateRequested"/> on the calling thread, <see cref="UpdateApplied"/> and
-/// <see cref="UpdateFailed"/> on the main/UI thread.
+/// <see cref="UpdateRequested"/> and <see cref="UpdateSkipped"/> on the calling thread,
+/// <see cref="UpdateApplied"/> and <see cref="UpdateFailed"/> on the main/UI thread.
 /// </remarks>
+//
+// ── XamlTools contract (please don't break) ──────────────────────────────────────────────────────────
+// The VS / VS Code MAUI hot reload diagnostics ("XamlTools") consume this API BY REFLECTION, binding
+// members BY NAME. Breaking it produces NO compile- or run-time error — XamlTools just silently loses
+// its hot reload reporting (update-type classification, instance/version/duration stats, per-instance
+// failure surfacing). Please treat the following as a stable contract, and coordinate changes with the
+// XamlTools team (VS repo: src\Xaml Diagnostics) — thank you!
+//   • This namespace + type name, and the event names UpdateRequested / UpdateApplied / UpdateFailed
+//     / UpdateSkipped (each an EventHandler<T>). Please don't rename/remove them or change the delegate shape.
+//   • The event-arg property names/types XamlTools reads (see HotReloadEventArgs.cs).
+//   • The firing order/semantics from XamlIncrementalHotReloadHandler: UpdateRequested is synchronous
+//     and pre-dispatch; a DISPATCHED batch raises UpdateApplied once as its terminal event, AFTER every
+//     UpdateFailed for that batch; a recognized-but-empty batch raises UpdateSkipped instead. Please
+//     don't raise BOTH for one batch — XamlTools reads UpdateSkipped as "no apply coming" and would then drop
+//     the apply's stats. A MISSING terminal is non-fatal (XamlTools waits a bounded time, then reports
+//     without the apply stats), but UpdateApplied must stay the LAST event so the failure list it reads
+//     is complete. Keep the version stream gap-free (each increment paired with an UpdateApplied).
 public static class HotReloadDiagnostics
 {
 	static int _version;
@@ -28,14 +45,21 @@ public static class HotReloadDiagnostics
 	/// <summary>Raised when UpdateComponent() fails on a specific instance.</summary>
 	public static event EventHandler<HotReloadErrorEventArgs>? UpdateFailed;
 
+	/// <summary>
+	/// Raised when an update was recognized but nothing was dispatched (no live instances to
+	/// patch), guaranteeing a terminal event for the request even when <see cref="UpdateApplied"/>
+	/// never fires. Raised synchronously on the calling thread.
+	/// </summary>
+	public static event EventHandler<HotReloadSkippedEventArgs>? UpdateSkipped;
+
 	/// <summary>Gets the current global version counter (monotonically increasing).</summary>
 	public static int CurrentVersion => Volatile.Read(ref _version);
 
 	internal static int IncrementVersion() => Interlocked.Increment(ref _version);
 
-	internal static void OnUpdateRequested(IReadOnlyList<Type> updatedTypes)
+	internal static void OnUpdateRequested(IReadOnlyList<Type> updatedTypes, IReadOnlyList<Type> handledTypes)
 	{
-		Raise(UpdateRequested, new HotReloadRequestedEventArgs(updatedTypes, DateTimeOffset.Now));
+		Raise(UpdateRequested, new HotReloadRequestedEventArgs(updatedTypes, handledTypes, DateTimeOffset.Now));
 	}
 
 	internal static void OnUpdateApplied(IReadOnlyList<Type> updatedTypes, int instanceCount, int fromVersion, int toVersion, TimeSpan duration)
@@ -43,9 +67,14 @@ public static class HotReloadDiagnostics
 		Raise(UpdateApplied, new HotReloadAppliedEventArgs(updatedTypes, instanceCount, fromVersion, toVersion, duration, DateTimeOffset.Now));
 	}
 
-	internal static void OnUpdateFailed(Type updatedType, object instance, Exception exception)
+	internal static void OnUpdateFailed(Type updatedType, object instance, Exception exception, int version)
 	{
-		Raise(UpdateFailed, new HotReloadErrorEventArgs(updatedType, instance, exception, DateTimeOffset.Now));
+		Raise(UpdateFailed, new HotReloadErrorEventArgs(updatedType, instance, exception, version, DateTimeOffset.Now));
+	}
+
+	internal static void OnUpdateSkipped(IReadOnlyList<Type> updatedTypes, IReadOnlyList<Type> handledTypes)
+	{
+		Raise(UpdateSkipped, new HotReloadSkippedEventArgs(updatedTypes, handledTypes, DateTimeOffset.Now));
 	}
 
 	// Diagnostics are observational only: a throwing or slow subscriber must never abort the

--- a/src/Controls/src/Core/Xaml/Diagnostics/HotReloadEventArgs.cs
+++ b/src/Controls/src/Core/Xaml/Diagnostics/HotReloadEventArgs.cs
@@ -4,24 +4,37 @@ using System.Collections.Generic;
 
 namespace Microsoft.Maui.Controls.Xaml.Diagnostics;
 
+// XamlTools contract: reads HandledTypes BY NAME (its .Count is the "is this an incremental XAML
+// update" signal used to classify the cycle). Please don't rename it or change it to a non-ICollection type.
 /// <summary>
 /// Fired when the MetadataUpdateHandler receives the list of updated types from the runtime.
 /// </summary>
 public class HotReloadRequestedEventArgs : EventArgs
 {
-	internal HotReloadRequestedEventArgs(IReadOnlyList<Type> updatedTypes, DateTimeOffset timestamp)
+	internal HotReloadRequestedEventArgs(IReadOnlyList<Type> updatedTypes, IReadOnlyList<Type> handledTypes, DateTimeOffset timestamp)
 	{
 		UpdatedTypes = updatedTypes;
+		HandledTypes = handledTypes;
 		Timestamp = timestamp;
 	}
 
 	/// <summary>Gets the types the runtime requested to update.</summary>
 	public IReadOnlyList<Type> UpdatedTypes { get; }
 
+	/// <summary>
+	/// Gets the subset of <see cref="UpdatedTypes"/> that XAML Incremental Hot Reload recognizes —
+	/// the types carrying a source-generated <c>UpdateComponent()</c>. Empty when the update is not
+	/// an incremental XAML update (for example, a pure C# metadata delta). Computed synchronously,
+	/// before any UI-thread dispatch, so tooling can classify the update without awaiting the apply.
+	/// </summary>
+	public IReadOnlyList<Type> HandledTypes { get; }
+
 	/// <summary>Gets the timestamp when the update request was received.</summary>
 	public DateTimeOffset Timestamp { get; }
 }
 
+// XamlTools contract: reads InstanceCount, FromVersion, ToVersion, Duration BY NAME (folded into the
+// IDE hot reload report + telemetry). Please don't rename them or change their types.
 /// <summary>
 /// Fired after all UpdateComponent() calls complete for a batch.
 /// </summary>
@@ -62,16 +75,19 @@ public class HotReloadAppliedEventArgs : EventArgs
 	public DateTimeOffset Timestamp { get; }
 }
 
+// XamlTools contract: reads UpdatedType, Exception, Version BY NAME (surfaced as a per-type hot
+// reload exception in the IDE). Please don't rename them or change their types.
 /// <summary>
 /// Fired when UpdateComponent() throws on a specific instance.
 /// </summary>
 public class HotReloadErrorEventArgs : EventArgs
 {
-	internal HotReloadErrorEventArgs(Type updatedType, object instance, Exception exception, DateTimeOffset timestamp)
+	internal HotReloadErrorEventArgs(Type updatedType, object instance, Exception exception, int version, DateTimeOffset timestamp)
 	{
 		UpdatedType = updatedType;
 		Instance = instance;
 		Exception = exception;
+		Version = version;
 		Timestamp = timestamp;
 	}
 
@@ -84,6 +100,38 @@ public class HotReloadErrorEventArgs : EventArgs
 	/// <summary>Gets the exception thrown.</summary>
 	public Exception Exception { get; }
 
+	/// <summary>Gets the version of the update cycle this failure belongs to; matches the
+	/// corresponding <see cref="HotReloadAppliedEventArgs.ToVersion"/>, so failures can be
+	/// correlated with their apply.</summary>
+	public int Version { get; }
+
 	/// <summary>Gets the timestamp of the failure.</summary>
+	public DateTimeOffset Timestamp { get; }
+}
+
+// XamlTools contract: reads HandledTypes BY NAME. This event is the terminal "no apply coming"
+// signal for a recognized cycle (see HotReloadDiagnostics); please don't rename HandledTypes.
+/// <summary>
+/// Fired when an update was recognized but nothing was dispatched (no live instances to patch).
+/// Guarantees a terminal event for the request even when <see cref="HotReloadAppliedEventArgs"/>
+/// is never raised.
+/// </summary>
+public class HotReloadSkippedEventArgs : EventArgs
+{
+	internal HotReloadSkippedEventArgs(IReadOnlyList<Type> updatedTypes, IReadOnlyList<Type> handledTypes, DateTimeOffset timestamp)
+	{
+		UpdatedTypes = updatedTypes;
+		HandledTypes = handledTypes;
+		Timestamp = timestamp;
+	}
+
+	/// <summary>Gets the types the runtime requested to update.</summary>
+	public IReadOnlyList<Type> UpdatedTypes { get; }
+
+	/// <summary>Gets the recognized incremental-XAML types that had no live instances to patch.
+	/// A subset of <see cref="UpdatedTypes"/>.</summary>
+	public IReadOnlyList<Type> HandledTypes { get; }
+
+	/// <summary>Gets the timestamp when the update was skipped.</summary>
 	public DateTimeOffset Timestamp { get; }
 }

--- a/src/Controls/src/Xaml/HotReload/XamlIncrementalHotReloadHandler.cs
+++ b/src/Controls/src/Xaml/HotReload/XamlIncrementalHotReloadHandler.cs
@@ -67,15 +67,17 @@ public static class XamlIncrementalHotReloadHandler
 
 		var typesArray = (IReadOnlyList<Type>)updatedTypes;
 
-		HotReloadDiagnostics.OnUpdateRequested(typesArray);
-
 		// Start timing at the moment the request is received so Duration includes batch
 		// building and main-thread dispatch latency, not just the UI-thread invoke loop.
 		var sw = Stopwatch.StartNew();
 
 		// Batch dispatch — collect ALL (instance, method, type) tuples across every updated
 		// type, then issue a single MainThread.BeginInvokeOnMainThread that iterates them.
+		// handledTypes records every recognized incremental-XAML type (one carrying a generated
+		// UpdateComponent()), independent of whether it currently has live instances — this is the
+		// synchronous "what kind of update is this" signal surfaced on UpdateRequested/UpdateSkipped.
 		var dispatchBatch = new List<(object Instance, MethodInfo Method, Type Type)>();
+		var handledTypes = new List<Type>();
 
 		foreach (var type in updatedTypes)
 		{
@@ -91,6 +93,8 @@ public static class XamlIncrementalHotReloadHandler
 			if (ucMethod is null)
 				continue;
 
+			handledTypes.Add(type);
+
 			var instances = XamlComponentRegistry.GetInstances(type);
 			if (instances.Count == 0)
 				continue;
@@ -99,8 +103,20 @@ public static class XamlIncrementalHotReloadHandler
 				dispatchBatch.Add((instance, ucMethod, type));
 		}
 
+		// XamlTools contract: raised SYNCHRONOUSLY, before any dispatch, carrying the recognized subset
+		// (HandledTypes) so tooling can classify the update type (XAML Incremental Hot Reload vs. non-XAML)
+		// inline, without awaiting the async apply. Keep this call synchronous and pre-dispatch.
+		HotReloadDiagnostics.OnUpdateRequested(typesArray, handledTypes);
+
 		if (dispatchBatch.Count == 0)
+		{
+			// XamlTools contract: terminal event when nothing is dispatched (no live instances) —
+			// UpdateApplied never fires on this path, so XamlTools uses UpdateSkipped as the definitive
+			// "no apply coming" signal and stops waiting. No version is allocated here, keeping the
+			// diagnostic version stream gap-free (every increment is paired with an UpdateApplied).
+			HotReloadDiagnostics.OnUpdateSkipped(typesArray, handledTypes);
 			return;
+		}
 
 		// Allocate the version range atomically once we know work will happen: toVersion is the
 		// new generation, fromVersion the one before it. Reserving the number only for non-empty
@@ -126,12 +142,16 @@ public static class XamlIncrementalHotReloadHandler
 					var inner = ex.InnerException ?? ex;
 					System.Diagnostics.Debug.WriteLine(
 						$"[XIHR] UpdateComponent failed for {capturedType.Name}: {inner.Message}");
-					HotReloadDiagnostics.OnUpdateFailed(capturedType, capturedInstance, inner);
+					HotReloadDiagnostics.OnUpdateFailed(capturedType, capturedInstance, inner, toVersion);
 				}
 #pragma warning restore CA1031
 			}
 
 			sw.Stop();
+			// XamlTools contract: UpdateApplied is the TERMINAL event of a dispatched batch and must
+			// ALWAYS be raised here, after every per-instance OnUpdateFailed above — even if all failed
+			// (instanceCount == 0). XamlTools blocks briefly awaiting it to fold the stats into its
+			// report; never returning it strands that wait until timeout.
 			HotReloadDiagnostics.OnUpdateApplied(typesArray, instanceCount, fromVersion, toVersion, sw.Elapsed);
 		});
 	}

--- a/src/Controls/tests/Core.UnitTests/XamlIncrementalHotReloadHandlerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/XamlIncrementalHotReloadHandlerTests.cs
@@ -1,0 +1,253 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls.Xaml;
+using Microsoft.Maui.Controls.Xaml.Diagnostics;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	// Runtime tests for XamlIncrementalHotReloadHandler.UpdateApplication and the HotReloadDiagnostics
+	// events it raises: the synchronous HandledTypes classification signal on UpdateRequested, the
+	// terminal UpdateSkipped event, InstanceCount/version reporting on UpdateApplied, and the Version
+	// correlation carried on UpdateFailed.
+	public class XamlIncrementalHotReloadHandlerTests : BaseTestFixture
+	{
+		const string IncrementalHotReloadSwitch = "Microsoft.Maui.RuntimeFeature.IsIncrementalHotReloadEnabled";
+
+		readonly List<object> _registeredPages = new();
+
+		public XamlIncrementalHotReloadHandlerTests()
+		{
+			// The XIHR handler dispatches the UI-thread patch through MainThread.BeginInvokeOnMainThread.
+			// In the unit-test (netstandard Essentials) harness MainThread has no platform backend, so
+			// install a synchronous one that reports "on main thread" and runs callbacks inline.
+			MainThread.SetCustomImplementation(() => true, action => action());
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing)
+			{
+				foreach (var page in _registeredPages)
+					XamlComponentRegistry.Unregister(page);
+				_registeredPages.Clear();
+				AppContext.SetSwitch(IncrementalHotReloadSwitch, false);
+				MainThread.ClearCustomImplementation();
+			}
+
+			base.Dispose(disposing);
+		}
+
+		// -----------------------------------------------------------------------
+		// Fakes. A source-generated XAML page carries a non-public parameterless UpdateComponent();
+		// that is exactly what XamlIncrementalHotReloadHandler reflects for, so these stand in for
+		// generated pages without needing the source generator.
+		// -----------------------------------------------------------------------
+#pragma warning disable IDE0051 // invoked by the handler via reflection, not directly
+		sealed class HotReloadablePage
+		{
+			public int UpdateComponentCalls;
+
+			void UpdateComponent() => UpdateComponentCalls++;
+		}
+
+		sealed class ThrowingHotReloadablePage
+		{
+			public int Attempts;
+
+			void UpdateComponent()
+			{
+				Attempts++;
+				throw new InvalidOperationException("update failed");
+			}
+		}
+#pragma warning restore IDE0051
+
+		// A plain type with no UpdateComponent() — represents a pure-C# (non-XAML) metadata delta.
+		sealed class PlainType
+		{
+		}
+
+		// -----------------------------------------------------------------------
+		// Helpers
+		// -----------------------------------------------------------------------
+		static IDisposable IncrementalHotReloadEnabled()
+		{
+			var previous = AppContext.TryGetSwitch(IncrementalHotReloadSwitch, out var value) && value;
+			AppContext.SetSwitch(IncrementalHotReloadSwitch, true);
+			return new Restore(() => AppContext.SetSwitch(IncrementalHotReloadSwitch, previous));
+		}
+
+		T RegisterLiveInstance<T>() where T : class, new()
+		{
+			var page = new T();
+			XamlComponentRegistry.Register(page, "0", page);
+			_registeredPages.Add(page);
+			return page;
+		}
+
+		sealed class Restore : IDisposable
+		{
+			readonly Action _onDispose;
+			public Restore(Action onDispose) => _onDispose = onDispose;
+			public void Dispose() => _onDispose();
+		}
+
+		sealed class DiagnosticsRecorder : IDisposable
+		{
+			public readonly List<HotReloadRequestedEventArgs> Requested = new();
+			public readonly List<HotReloadAppliedEventArgs> Applied = new();
+			public readonly List<HotReloadErrorEventArgs> Failed = new();
+			public readonly List<HotReloadSkippedEventArgs> Skipped = new();
+
+			readonly EventHandler<HotReloadRequestedEventArgs> _onRequested;
+			readonly EventHandler<HotReloadAppliedEventArgs> _onApplied;
+			readonly EventHandler<HotReloadErrorEventArgs> _onFailed;
+			readonly EventHandler<HotReloadSkippedEventArgs> _onSkipped;
+
+			public DiagnosticsRecorder()
+			{
+				_onRequested = (_, e) => Requested.Add(e);
+				_onApplied = (_, e) => Applied.Add(e);
+				_onFailed = (_, e) => Failed.Add(e);
+				_onSkipped = (_, e) => Skipped.Add(e);
+
+				HotReloadDiagnostics.UpdateRequested += _onRequested;
+				HotReloadDiagnostics.UpdateApplied += _onApplied;
+				HotReloadDiagnostics.UpdateFailed += _onFailed;
+				HotReloadDiagnostics.UpdateSkipped += _onSkipped;
+			}
+
+			public void Dispose()
+			{
+				HotReloadDiagnostics.UpdateRequested -= _onRequested;
+				HotReloadDiagnostics.UpdateApplied -= _onApplied;
+				HotReloadDiagnostics.UpdateFailed -= _onFailed;
+				HotReloadDiagnostics.UpdateSkipped -= _onSkipped;
+			}
+		}
+
+		// -----------------------------------------------------------------------
+		// Tests
+		// -----------------------------------------------------------------------
+
+		[Fact]
+		public void FeatureDisabled_RaisesNoEvents()
+		{
+			// switch defaults to false; do not enable it
+			using var recorder = new DiagnosticsRecorder();
+
+			XamlIncrementalHotReloadHandler.UpdateApplication(new[] { typeof(HotReloadablePage) });
+
+			Assert.Empty(recorder.Requested);
+			Assert.Empty(recorder.Applied);
+			Assert.Empty(recorder.Failed);
+			Assert.Empty(recorder.Skipped);
+		}
+
+		[Fact]
+		public void XamlType_IsReportedInHandledTypes()
+		{
+			using var _ = IncrementalHotReloadEnabled();
+			RegisterLiveInstance<HotReloadablePage>();
+			using var recorder = new DiagnosticsRecorder();
+
+			XamlIncrementalHotReloadHandler.UpdateApplication(new[] { typeof(HotReloadablePage) });
+
+			var requested = Assert.Single(recorder.Requested);
+			Assert.Contains(typeof(HotReloadablePage), requested.UpdatedTypes);
+			Assert.Contains(typeof(HotReloadablePage), requested.HandledTypes);
+		}
+
+		[Fact]
+		public void MixedDelta_HandledTypesContainsOnlyTheXamlType()
+		{
+			using var _ = IncrementalHotReloadEnabled();
+			RegisterLiveInstance<HotReloadablePage>();
+			using var recorder = new DiagnosticsRecorder();
+
+			XamlIncrementalHotReloadHandler.UpdateApplication(new[] { typeof(PlainType), typeof(HotReloadablePage) });
+
+			var requested = Assert.Single(recorder.Requested);
+			Assert.Equal(2, requested.UpdatedTypes.Count);
+			Assert.Equal(new[] { typeof(HotReloadablePage) }, requested.HandledTypes.ToArray());
+		}
+
+		[Fact]
+		public void PureCSharpDelta_HasEmptyHandledTypes_AndIsSkipped()
+		{
+			using var _ = IncrementalHotReloadEnabled();
+			using var recorder = new DiagnosticsRecorder();
+
+			XamlIncrementalHotReloadHandler.UpdateApplication(new[] { typeof(PlainType) });
+
+			var requested = Assert.Single(recorder.Requested);
+			Assert.Empty(requested.HandledTypes);
+
+			var skipped = Assert.Single(recorder.Skipped);
+			Assert.Empty(skipped.HandledTypes);
+			Assert.Empty(recorder.Applied);
+		}
+
+		[Fact]
+		public void RecognizedTypeWithoutLiveInstances_RaisesSkipped_NotApplied()
+		{
+			using var _ = IncrementalHotReloadEnabled();
+			// note: no RegisterLiveInstance — the type is recognized but has nothing to patch
+			using var recorder = new DiagnosticsRecorder();
+
+			XamlIncrementalHotReloadHandler.UpdateApplication(new[] { typeof(HotReloadablePage) });
+
+			var requested = Assert.Single(recorder.Requested);
+			Assert.Contains(typeof(HotReloadablePage), requested.HandledTypes);
+
+			var skipped = Assert.Single(recorder.Skipped);
+			Assert.Contains(typeof(HotReloadablePage), skipped.HandledTypes);
+			Assert.Empty(recorder.Applied);
+		}
+
+		[Fact]
+		public void LiveInstance_IsPatched_AndAppliedReportsInstanceCountAndVersionRange()
+		{
+			using var _ = IncrementalHotReloadEnabled();
+			var page = RegisterLiveInstance<HotReloadablePage>();
+			var versionBefore = HotReloadDiagnostics.CurrentVersion;
+			using var recorder = new DiagnosticsRecorder();
+
+			XamlIncrementalHotReloadHandler.UpdateApplication(new[] { typeof(HotReloadablePage) });
+
+			Assert.Equal(1, page.UpdateComponentCalls);
+			Assert.Empty(recorder.Skipped);
+
+			var applied = Assert.Single(recorder.Applied);
+			Assert.Equal(1, applied.InstanceCount);
+			Assert.Equal(versionBefore, applied.FromVersion);
+			Assert.Equal(versionBefore + 1, applied.ToVersion);
+			Assert.Contains(typeof(HotReloadablePage), applied.UpdatedTypes);
+		}
+
+		[Fact]
+		public void FailingUpdateComponent_RaisesUpdateFailed_CorrelatedByVersion()
+		{
+			using var _ = IncrementalHotReloadEnabled();
+			RegisterLiveInstance<ThrowingHotReloadablePage>();
+			var versionBefore = HotReloadDiagnostics.CurrentVersion;
+			using var recorder = new DiagnosticsRecorder();
+
+			XamlIncrementalHotReloadHandler.UpdateApplication(new[] { typeof(ThrowingHotReloadablePage) });
+
+			var failed = Assert.Single(recorder.Failed);
+			Assert.Equal(typeof(ThrowingHotReloadablePage), failed.UpdatedType);
+			Assert.IsType<InvalidOperationException>(failed.Exception);
+			Assert.Equal(versionBefore + 1, failed.Version);
+
+			// UpdateApplied still fires as the terminal event; the failed instance is not counted.
+			var applied = Assert.Single(recorder.Applied);
+			Assert.Equal(0, applied.InstanceCount);
+			Assert.Equal(failed.Version, applied.ToVersion);
+		}
+	}
+}


### PR DESCRIPTION
### Description

Incremental contribution to `feature/xaml-incremental-hotreload`.

Extends `HotReloadDiagnostics` so IDE tooling (the Visual Studio / VS Code MAUI
Hot Reload diagnostics, a.k.a. "XamlTools") can **classify** a hot reload cycle as
XAML Incremental Hot Reload (XIHR), **report** its apply stats, and **surface**
per-instance failures. Today the tooling only sees a generic managed-code delta, so
it misclassifies XAML SourceGen edits as plain C# and can't report the incremental
apply result.

All changes are **purely additive** to the diagnostics surface — no change to the
hot reload apply itself, and no breaking API changes.

#### New / changed public API (`Microsoft.Maui.Controls.Xaml.Diagnostics`)

- **`HotReloadDiagnostics.UpdateSkipped`** — new event. Terminal signal raised when an
  update is *recognized* (has generated `UpdateComponent()` types) but nothing is
  dispatched because there are no live instances to patch, so observers always get a
  definite outcome even when `UpdateApplied` never fires.
- **`HotReloadRequestedEventArgs.HandledTypes`** — the recognized incremental-XAML
  subset of `UpdatedTypes`. Raised **synchronously, before any UI-thread dispatch**, so
  tooling can classify the update type inline (XIHR vs. non-XAML) without awaiting the
  async apply.
- **`HotReloadErrorEventArgs.Version`** — the update-cycle version a per-instance
  failure belongs to (matches the corresponding `HotReloadAppliedEventArgs.ToVersion`),
  so failures can be correlated with their apply.
- **`HotReloadSkippedEventArgs`** — new event args for `UpdateSkipped` (`UpdatedTypes`,
  `HandledTypes`, `Timestamp`).

#### Handler (`XamlIncrementalHotReloadHandler`)

- Builds the `handledTypes` set and raises `OnUpdateRequested` synchronously before
  dispatch.
- Raises `OnUpdateSkipped` for a recognized-but-empty batch (returns without dispatch).
- Passes `toVersion` to `OnUpdateFailed`.
- Allocates the diagnostic version only for **non-empty** batches, keeping the version
  stream gap-free (every increment is paired with an `UpdateApplied`).

#### Firing contract (documented in-code)

The three files carry brief "XamlTools contract" comments describing the reflection-by-
name binding surface tooling relies on: the type/event/property names, the
`EventHandler<T>` shapes, and the ordering guarantees — `UpdateRequested` is synchronous
and pre-dispatch; a dispatched batch ends with exactly one terminal `UpdateApplied`
(always raised, even if every instance failed) or `UpdateSkipped`; each `UpdateFailed`
precedes its batch's `UpdateApplied`.

### Issues Fixed

Fixes # <!-- link the XIHR-diagnostics tracking issue, if any -->

### Testing

- Added `XamlIncrementalHotReloadHandlerTests` (7 tests, `Controls/tests/Core.UnitTests`)
  covering: `UpdateRequested`/`HandledTypes` classification, `UpdateApplied`
  instance/version/duration, `UpdateFailed` per-instance + `Version` correlation, and the
  `UpdateSkipped` no-live-instances path. Uses a `MainThread` custom-implementation
  harness for the UI-thread dispatch.
- Verified end-to-end on a physical Android device with the consuming IDE tooling:
  a XAML SourceGen edit is classified as `xaml-sourcegen` and the IDE reports the
  incremental apply (instance count, `version 0→1`, duration).

### API Changes

Additive only — see the updated `PublicAPI.Unshipped.txt` for all TFMs.