### PR TITLE
Bump dotnet/dotnet (BAR 321994) to blessed preview.6.26357.118

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,12 +1,12 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.Sdk" Version="11.0.100-preview.6.26356.105">
+    <Dependency Name="Microsoft.NET.Sdk" Version="11.0.100-preview.6.26357.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
+      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-preview.6.26356.105">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-preview.6.26357.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
+      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Android.Sdk.Windows" Version="37.0.0-preview.6.59">
       <Uri>https://github.com/dotnet/android</Uri>
@@ -53,109 +53,109 @@
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="11.0.0-preview.6.26356.105">
+    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="11.0.0-preview.6.26357.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
+      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="11.0.0-preview.6.26356.105">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="11.0.0-preview.6.26357.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
+      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="11.0.0-preview.6.26356.105">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="11.0.0-preview.6.26357.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
+      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="11.0.0-preview.6.26356.105">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="11.0.0-preview.6.26357.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
+      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components" Version="11.0.0-preview.6.26356.105">
+    <Dependency Name="Microsoft.AspNetCore.Components" Version="11.0.0-preview.6.26357.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
+      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="11.0.0-preview.6.26356.105">
+    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="11.0.0-preview.6.26357.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
+      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="11.0.0-preview.6.26356.105">
+    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="11.0.0-preview.6.26357.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
+      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="11.0.0-preview.6.26356.105">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="11.0.0-preview.6.26357.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
+      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="11.0.0-preview.6.26356.105">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="11.0.0-preview.6.26357.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
+      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="11.0.0-preview.6.26356.105">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="11.0.0-preview.6.26357.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
+      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="11.0.0-preview.6.26356.105">
+    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="11.0.0-preview.6.26357.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
+      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="11.0.0-preview.6.26356.105">
+    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="11.0.0-preview.6.26357.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
+      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.JSInterop" Version="11.0.0-preview.6.26356.105">
+    <Dependency Name="Microsoft.JSInterop" Version="11.0.0-preview.6.26357.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
+      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
     </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-preview.2.22102.8">
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>3f4da9ced34942d83054e647f3b1d9d7dde281e8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration" Version="11.0.0-preview.6.26356.105">
+    <Dependency Name="Microsoft.Extensions.Configuration" Version="11.0.0-preview.6.26357.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
+      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="11.0.0-preview.6.26356.105">
+    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="11.0.0-preview.6.26357.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
+      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="11.0.0-preview.6.26356.105">
+    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="11.0.0-preview.6.26357.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
+      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="11.0.0-preview.6.26356.105">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="11.0.0-preview.6.26357.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
+      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="11.0.0-preview.6.26356.105">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="11.0.0-preview.6.26357.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
+      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="11.0.0-preview.6.26356.105">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="11.0.0-preview.6.26357.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
+      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="11.0.0-preview.6.26356.105">
+    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="11.0.0-preview.6.26357.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
+      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="11.0.0-preview.6.26356.105">
+    <Dependency Name="Microsoft.Extensions.Logging" Version="11.0.0-preview.6.26357.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
+      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="11.0.0-preview.6.26356.105">
+    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="11.0.0-preview.6.26357.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
+      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="11.0.0-preview.6.26356.105">
+    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="11.0.0-preview.6.26357.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
+      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Primitives" Version="11.0.0-preview.6.26356.105">
+    <Dependency Name="Microsoft.Extensions.Primitives" Version="11.0.0-preview.6.26357.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
+      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="11.0.0-preview.6.26356.105">
+    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="11.0.0-preview.6.26357.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
+      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="11.0.0-prerelease.26064.3">
       <Uri>https://github.com/dotnet/xharness</Uri>
@@ -175,37 +175,37 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="11.0.0-beta.26356.105">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="11.0.0-beta.26357.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
+      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26356.105">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26357.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
+      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="11.0.0-beta.26356.105">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="11.0.0-beta.26357.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
+      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="11.0.0-beta.26356.105">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="11.0.0-beta.26357.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
+      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26356.105">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26357.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
+      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="11.0.0-beta.26356.105">
+    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="11.0.0-beta.26357.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
+      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="11.0.0-beta.26356.105">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="11.0.0-beta.26357.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
+      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="11.0.0-beta.26356.105">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="11.0.0-beta.26357.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d6b097b81e41939607a265cf95b25302ee9d9bce</Sha>
+      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -31,10 +31,10 @@
     <!-- Current previous .NET SDK major version's stable release of MAUI packages -->
     <MicrosoftMauiPreviousDotNetReleasedVersion>10.0.20</MicrosoftMauiPreviousDotNetReleasedVersion>
     <!-- dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>11.0.100-preview.6.26356.105</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>11.0.100-preview.6.26357.118</MicrosoftNETSdkPackageVersion>
     <MicrosoftDotnetSdkInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-preview.6.26356.105</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-preview.6.26357.118</MicrosoftNETCoreAppRefPackageVersion>
     <SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextJsonPackageVersion>
     <SystemTextEncodingsWebPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextEncodingsWebPackageVersion>
     <MicrosoftBclAsyncInterfacesPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftBclAsyncInterfacesPackageVersion>
@@ -42,18 +42,18 @@
     <optimizationandroidx64MIBCRuntimePackageVersion>1.0.0-prerelease.26317.1</optimizationandroidx64MIBCRuntimePackageVersion>
     <!-- Microsoft/Extensions -->
     <SystemCodeDomPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemCodeDomPackageVersion>
-    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.6.26356.105</MicrosoftExtensionsConfigurationVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsVersion>11.0.0-preview.6.26356.105</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationJsonVersion>11.0.0-preview.6.26356.105</MicrosoftExtensionsConfigurationJsonVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>11.0.0-preview.6.26356.105</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>11.0.0-preview.6.26356.105</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
-    <MicrosoftExtensionsFileProvidersAbstractionsVersion>11.0.0-preview.6.26356.105</MicrosoftExtensionsFileProvidersAbstractionsVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>11.0.0-preview.6.26356.105</MicrosoftExtensionsLoggingAbstractionsVersion>
-    <MicrosoftExtensionsLoggingVersion>11.0.0-preview.6.26356.105</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>11.0.0-preview.6.26356.105</MicrosoftExtensionsLoggingConsoleVersion>
-    <MicrosoftExtensionsLoggingDebugVersion>11.0.0-preview.6.26356.105</MicrosoftExtensionsLoggingDebugVersion>
-    <MicrosoftExtensionsPrimitivesVersion>11.0.0-preview.6.26356.105</MicrosoftExtensionsPrimitivesVersion>
-    <MicrosoftExtensionsHostingAbstractionsVersion>11.0.0-preview.6.26356.105</MicrosoftExtensionsHostingAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.6.26357.118</MicrosoftExtensionsConfigurationVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>11.0.0-preview.6.26357.118</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationJsonVersion>11.0.0-preview.6.26357.118</MicrosoftExtensionsConfigurationJsonVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>11.0.0-preview.6.26357.118</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>11.0.0-preview.6.26357.118</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
+    <MicrosoftExtensionsFileProvidersAbstractionsVersion>11.0.0-preview.6.26357.118</MicrosoftExtensionsFileProvidersAbstractionsVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>11.0.0-preview.6.26357.118</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingVersion>11.0.0-preview.6.26357.118</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>11.0.0-preview.6.26357.118</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingDebugVersion>11.0.0-preview.6.26357.118</MicrosoftExtensionsLoggingDebugVersion>
+    <MicrosoftExtensionsPrimitivesVersion>11.0.0-preview.6.26357.118</MicrosoftExtensionsPrimitivesVersion>
+    <MicrosoftExtensionsHostingAbstractionsVersion>11.0.0-preview.6.26357.118</MicrosoftExtensionsHostingAbstractionsVersion>
     <MicrosoftExtensionsAIVersion>10.3.0</MicrosoftExtensionsAIVersion>
     <MicrosoftExtensionsAIAbstractionsVersion>10.3.0</MicrosoftExtensionsAIAbstractionsVersion>
     <MicrosoftExtensionsHttpVersion>11.0.0-preview.2.26103.111</MicrosoftExtensionsHttpVersion>
@@ -84,19 +84,19 @@
     <MicrosoftGraphicsWin2DPackageVersion>1.3.2</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.3179.45</MicrosoftWindowsWebView2PackageVersion>
     <!-- Everything else -->
-    <MicrosoftAspNetCoreAuthorizationPackageVersion>11.0.0-preview.6.26356.105</MicrosoftAspNetCoreAuthorizationPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>11.0.0-preview.6.26356.105</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>11.0.0-preview.6.26356.105</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
-    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>11.0.0-preview.6.26356.105</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
-    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>11.0.0-preview.6.26356.105</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreComponentsFormsPackageVersion>11.0.0-preview.6.26356.105</MicrosoftAspNetCoreComponentsFormsPackageVersion>
-    <MicrosoftAspNetCoreComponentsPackageVersion>11.0.0-preview.6.26356.105</MicrosoftAspNetCoreComponentsPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebPackageVersion>11.0.0-preview.6.26356.105</MicrosoftAspNetCoreComponentsWebPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>11.0.0-preview.6.26356.105</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>11.0.0-preview.6.26356.105</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>11.0.0-preview.6.26356.105</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
-    <MicrosoftAspNetCoreMetadataPackageVersion>11.0.0-preview.6.26356.105</MicrosoftAspNetCoreMetadataPackageVersion>
-    <MicrosoftJSInteropPackageVersion>11.0.0-preview.6.26356.105</MicrosoftJSInteropPackageVersion>
+    <MicrosoftAspNetCoreAuthorizationPackageVersion>11.0.0-preview.6.26357.118</MicrosoftAspNetCoreAuthorizationPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>11.0.0-preview.6.26357.118</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>11.0.0-preview.6.26357.118</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
+    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>11.0.0-preview.6.26357.118</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
+    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>11.0.0-preview.6.26357.118</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreComponentsFormsPackageVersion>11.0.0-preview.6.26357.118</MicrosoftAspNetCoreComponentsFormsPackageVersion>
+    <MicrosoftAspNetCoreComponentsPackageVersion>11.0.0-preview.6.26357.118</MicrosoftAspNetCoreComponentsPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebPackageVersion>11.0.0-preview.6.26357.118</MicrosoftAspNetCoreComponentsWebPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>11.0.0-preview.6.26357.118</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>11.0.0-preview.6.26357.118</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>11.0.0-preview.6.26357.118</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
+    <MicrosoftAspNetCoreMetadataPackageVersion>11.0.0-preview.6.26357.118</MicrosoftAspNetCoreMetadataPackageVersion>
+    <MicrosoftJSInteropPackageVersion>11.0.0-preview.6.26357.118</MicrosoftJSInteropPackageVersion>
     <!-- Everything else (previous edition) -->
     <MicrosoftAspNetCorePackageVersion>10.0.2</MicrosoftAspNetCorePackageVersion>
     <MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>$(MicrosoftAspNetCorePackageVersion)</MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>
@@ -146,13 +146,13 @@
     <TizenUIExtensionsVersion>0.9.0</TizenUIExtensionsVersion>
     <ExCSSPackageVersion>4.2.3</ExCSSPackageVersion>
     <SystemDrawingCommonPackageVersion>9.0.0</SystemDrawingCommonPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>11.0.0-beta.26356.105</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetBuildTasksInstallersPackageVersion>11.0.0-beta.26356.105</MicrosoftDotNetBuildTasksInstallersPackageVersion>
-    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>11.0.0-beta.26356.105</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26356.105</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>11.0.0-beta.26357.118</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksInstallersPackageVersion>11.0.0-beta.26357.118</MicrosoftDotNetBuildTasksInstallersPackageVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>11.0.0-beta.26357.118</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26357.118</MicrosoftDotNetHelixSdkPackageVersion>
     <MicroBuildPluginsSwixBuildDotnetPackageVersion>1.1.87-gba258badda</MicroBuildPluginsSwixBuildDotnetPackageVersion>
-    <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.26356.105</MicrosoftDotNetRemoteExecutorPackageVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>11.0.0-beta.26356.105</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.26357.118</MicrosoftDotNetRemoteExecutorPackageVersion>
+    <MicrosoftDotNetXUnitExtensionsPackageVersion>11.0.0-beta.26357.118</MicrosoftDotNetXUnitExtensionsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftNETTestSdkPackageVersion>17.6.0</MicrosoftNETTestSdkPackageVersion>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "11.0.100-preview.6.26356.105"
+    "dotnet": "11.0.100-preview.6.26357.118"
   },
   "sdk": {
     "paths": [
@@ -11,7 +11,7 @@
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44",
     "Microsoft.Build.NoTargets": "3.7.0",
-    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26356.105",
-    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26356.105"
+    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26357.118",
+    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26357.118"
   }
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

Re-bumps the **dotnet/dotnet (VMR / SDK)** dependencies to the newly-blessed .NET 11 Preview 6 build.

## What changed

| | From (#36433) | To (blessed) |
|---|---|---|
| SDK | `11.0.100-preview.6.26356.105` | **`11.0.100-preview.6.26357.118`** |
| Runtime / AspNetCore / Extensions (`-preview.6`) | `.26356.105` | **`.26357.118`** |
| Arcade / Helix / Build.Tasks (`-beta`) | `.26356.105` | **`.26357.118`** |
| VMR commit (SHA) | `d6b097b` | **`2461daa1`** |
| BAR build | 321614 | **321994** |

## Why

The .NET Release Tracker re-staged the Preview 6 build; the blessed runtime/SDK is now **`11.0.100-preview.6.26357.118`** (BAR 321994, `stage-3017702`, ships **2026-07-14**), superseding the `26356.105` pin from #36433. BAR 321994 is confirmed on the **`.NET 11.0.1xx SDK Preview 6`** channel.

## Scope

- Only `dotnet/dotnet`-sourced dependencies were updated (`darc update-dependencies --id 321994 --source-repo dotnet/dotnet`), plus the bootstrap `tools.dotnet` SDK version in `global.json`.
- **dotnet/android** (`37.0.0-preview.6.59`) and **dotnet/macios** (`26.5.11719-net11-p6`) pins are **unchanged** — they are still the blessed / channel-latest builds and need no bump.
- Files touched: `eng/Version.Details.xml`, `eng/Versions.props`, `global.json`.
