### PR TITLE
 [inflight regression] Fix: ClearPlaceholderIconShouldHideWhenDisabled test fails in candidate 

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellSearchView.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellSearchView.cs
@@ -256,6 +256,9 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			else if (e.PropertyName == SearchHandler.ClearPlaceholderIconProperty.PropertyName)
 			{
 				ApplyImageSource(_clearPlaceholderButton, SearchHandler.ClearPlaceholderIcon, -1, SearchHandler.TextColor?.ToPlatform());
+			}
+			else if (e.PropertyName == SearchHandler.ClearPlaceholderEnabledProperty.PropertyName)
+			{
 				UpdateClearButtonState();
 			}
 		}


### PR DESCRIPTION
<!-- Please keep the note below for people who find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment whether this change resolves your issue. Thank you!<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!!  -->

This pull request fixes a regression Introduced by PR #35893 which caused the Android UI test `ClearPlaceholderIconShouldHideWhenDisabled` to fail in Candidate PR 

### Description of Change

Fixes a regression where changes to `SearchHandler.ClearPlaceholderEnabled` were not reflected in the Android `ShellSearchView` clear button state.

Updated the `ShellSearchView` handler to invoke `UpdateClearButtonState() `whenever the `SearchHandler.ClearPlaceholderEnabled `property changes, ensuring the clear button visibility and enabled state remain synchronized with the property value.
<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #36464 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
