### PR TITLE
[inflight regression] Fix Core.UnitTests/PickerTests fail in candidate PR 36411

### DIFF
--- a/src/Controls/src/Core/Picker/Picker.cs
+++ b/src/Controls/src/Core/Picker/Picker.cs
@@ -338,10 +338,8 @@ namespace Microsoft.Maui.Controls
 				UnsubscribeFromItemsSourceCollection();
 			}
 
-			if (Handler is not null)
-			{
-				SubscribeToItemsSourceCollection(newValue as INotifyCollectionChanged);
-			}
+			// Always subscribe — OnHandlerChanged will unsubscribe when Handler is detached
+			SubscribeToItemsSourceCollection(newValue as INotifyCollectionChanged);
 
 			if (newValue != null)
 			{


### PR DESCRIPTION
### Issue Details
PR #33733 fixed a memory/reactivity leak where a Picker would continue reacting to ItemsSource collection changes even after its page was closed (handler detached). The fix gated the INotifyCollectionChanged subscription behind Handler is not null:
```
if (Handler is not null)
{
    SubscribeToItemsSourceCollection(newValue as INotifyCollectionChanged);
}
```
This introduced a regression: any Picker without a handler attached never subscribes to collection change events. Unit tests don't attach a platform handler, so setting ItemsSource then adding/removing/clearing items has no effect on picker.Items — causing test failures.

### Description of Change

<!-- Enter description of the fix in this section -->
Removed the Handler is not null guard in OnItemsSourceChanged. The subscription now always happens when ItemsSource is set.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #36465 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
