### PR TITLE
[tests] Re-enable Android memory-leak UI tests (#27411)

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla40955.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla40955.cs
@@ -23,9 +23,6 @@ public class Bugzilla40955 : _IssuesUITest
 	public override string Issue => "Memory leak with FormsAppCompatActivity and NavigationPage";
 
 	[Test]
-#if ANDROID
-	[Ignore("Failing on net10 https://github.com/dotnet/maui/issues/27411")]
-#endif
 	[Category(UITestCategories.Performance)]
 	public void MemoryLeakInFormsAppCompatActivity()
 	{

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla42329.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla42329.cs
@@ -20,9 +20,6 @@ public class Bugzilla42329 : _IssuesUITest
 	public override string Issue => "ListView in Frame and FormsAppCompatActivity Memory Leak";
 
 	[Test]
-#if ANDROID
-	[Ignore("Failing on net10 https://github.com/dotnet/maui/issues/27411")]
-#endif
 	[Category(UITestCategories.ListView)]
 	public async Task MemoryLeakB42329()
 	{

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla44166.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla44166.cs
@@ -15,7 +15,7 @@ public class Bugzilla44166 : _IssuesUITest
 
 	[Test]
 #if ANDROID
-	[Ignore("Failing on net10 https://github.com/dotnet/maui/issues/27411")]
+	[Ignore("FlyoutPage instances are not collected on Android https://github.com/dotnet/maui/issues/36479")]
 #endif
 	[Category(UITestCategories.Performance)]
 	public void Bugzilla44166Test()


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Re-enables the Android memory-leak UI tests that were disabled under #27411.

Verified locally on an Android API 30 emulator (multiple runs, stable):

| Test | Result |
| --- | --- |
| `Bugzilla40955.MemoryLeakInFormsAppCompatActivity` | ✅ now passes — Android `[Ignore]` removed |
| `Bugzilla42329.MemoryLeakB42329` | ✅ now passes — Android `[Ignore]` removed |
| `Bugzilla44166.Bugzilla44166Test` | ❌ still leaks (`FlyoutPage` not collected) — kept skipped, now points at #36479 |

The device-level memory tests referenced by #27411 (`MemoryTests.PagesDoNotLeak`, `NavigationPageTests.ChildPagesDoNotLeak`, `ShellTests.PagesDoNotLeak`) are already enabled on `main`.

This closes out the umbrella #27411 and carves the one remaining Android leak into a dedicated tracking issue.

### Issues Fixed

Fixes #27411
Tracks remaining leak: #36479

---
_This PR was prepared by GitHub Copilot CLI on behalf of @kubaflo, based on local device-test verification._
