### PR TITLE
Fix WebView SwipeView gestures on Android

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue36154.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue36154.cs
@@ -1,0 +1,126 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 36154, "WebView inside SwipeView no longer responds to swipe gestures on Android", PlatformAffected.Android)]
+public class Issue36154 : ContentPage
+{
+	public Issue36154()
+	{
+		var directionLabel = new Label
+		{
+			AutomationId = "DirectionLabel",
+			Text = "Direction: —    Offset: 0",
+			HorizontalOptions = LayoutOptions.Center,
+			Margin = new Thickness(4, 8),
+			FontSize = 13
+		};
+
+		var resultLabel = new Label
+		{
+			AutomationId = "ResultLabel",
+			Text = "Swipe result will appear here",
+			HorizontalOptions = LayoutOptions.Center,
+			Margin = new Thickness(4, 0, 4, 12),
+			FontSize = 13,
+			TextColor = Colors.Gray
+		};
+
+		var webView = new WebView
+		{
+			AutomationId = "TheWebView",
+			HorizontalOptions = LayoutOptions.Fill,
+			VerticalOptions = LayoutOptions.Fill,
+			// Long scrollable page so vertical scroll can be verified
+			Source = new HtmlWebViewSource
+			{
+				Html = """
+					<html>
+					<body style="font-family:sans-serif;padding:16px">
+					<h3>Issue 36154 – WebView scroll test</h3>
+					<p>Scroll down to verify WebView vertical scrolling works inside SwipeView.</p>
+					<p>Then swipe left/right to reveal swipe items.</p>
+					<p>At the top edge, swipe down to reveal TopItems.</p>
+					<p>At the bottom edge, swipe up to reveal BottomItems.</p>
+					""" + string.Concat(Enumerable.Range(1, 40).Select(i =>
+						$"<p>Line {i}: Lorem ipsum dolor sit amet consectetur adipiscing elit.</p>"))
+					+ "</body></html>"
+			}
+		};
+
+		var swipeView = new SwipeView
+		{
+			AutomationId = "TheSwipeView",
+			Threshold = 80,
+
+			LeftItems = new SwipeItems(new[]
+			{
+				new SwipeItem
+				{
+					AutomationId = "LeftItem",
+					Text = "◀ LEFT",
+					BackgroundColor = Colors.MediumSeaGreen,
+					Command = new Command(() =>
+					{
+						resultLabel.Text = "LEFT item invoked";
+					})
+				}
+			})
+			{ Mode = SwipeMode.Execute, SwipeBehaviorOnInvoked = SwipeBehaviorOnInvoked.Close },
+
+			RightItems = new SwipeItems(new[]
+			{
+				new SwipeItem
+				{
+					AutomationId = "RightItem",
+					Text = "RIGHT ▶",
+					BackgroundColor = Colors.CornflowerBlue,
+					Command = new Command(() =>
+					{
+						resultLabel.Text = "RIGHT invoked!";
+					})
+				}
+			})
+			{ Mode = SwipeMode.Execute, SwipeBehaviorOnInvoked = SwipeBehaviorOnInvoked.Close },
+
+			Content = webView
+		};
+
+		swipeView.SwipeStarted += (s, e) =>
+		{
+			directionLabel.Text = $"Direction: {e.SwipeDirection}    Offset: 0";
+		};
+
+		swipeView.SwipeChanging += (s, e) =>
+			directionLabel.Text = $"Direction: {e.SwipeDirection}    Offset: {e.Offset:F0}";
+
+		swipeView.SwipeEnded += (s, e) =>
+		{
+			directionLabel.Text = $"Direction: {e.SwipeDirection}    Open: {e.IsOpen}";
+		};
+
+		Content = new Grid
+		{
+			RowDefinitions =
+			[
+				new RowDefinition { Height = GridLength.Auto },
+				new RowDefinition { Height = GridLength.Star },
+				new RowDefinition { Height = GridLength.Auto },
+				new RowDefinition { Height = GridLength.Auto },
+			],
+			Children =
+			{
+				new Label
+				{
+					Text = "Swipe on WebView · scroll mid-page · swipe at edges",
+					HorizontalOptions = LayoutOptions.Center,
+					Margin = new Thickness(8),
+					FontSize = 13,
+					FontAttributes = FontAttributes.Bold
+				}.Row(0),
+
+				swipeView.Row(1),
+				directionLabel.Row(2),
+				resultLabel.Row(3)
+			}
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36154.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36154.cs
@@ -1,0 +1,29 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue36154 : _IssuesUITest
+{
+	public Issue36154(TestDevice testDevice) : base(testDevice)
+	{
+	}
+
+	public override string Issue => "WebView inside SwipeView no longer responds to swipe gestures on Android";
+
+	// Verify that swiping left on the WebView reveals the Right swipe items
+	[Test]
+	[Category(UITestCategories.SwipeView)]
+	public void Issue36154SwipeViewShouldRevealItems()
+	{
+		var rect = App.WaitForElement("TheSwipeView").GetRect();
+		var centerX = rect.X + rect.Width / 2;
+		var centerY = rect.Y + rect.Height / 2;
+
+		// Swipe left (finger moves left) → reveals RightItems
+		App.DragCoordinates(centerX, centerY, centerX - 200, centerY);
+
+		Assert.That(App.WaitForElement("ResultLabel").GetText(), Is.EqualTo("RIGHT invoked!"));
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36154.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36154.cs
@@ -17,7 +17,13 @@ public class Issue36154 : _IssuesUITest
 	[Category(UITestCategories.SwipeView)]
 	public void Issue36154SwipeViewShouldRevealItems()
 	{
-		var rect = App.WaitForElement("TheSwipeView").GetRect();
+#if WINDOWS
+		// WinUI cannot locate SwipeView through WebDriver, so use its WebView child for the gesture coordinates.
+		const string swipeTarget = "TheWebView";
+#else
+		const string swipeTarget = "TheSwipeView";
+#endif
+		var rect = App.WaitForElement(swipeTarget).GetRect();
 		var centerX = rect.X + rect.Width / 2;
 		var centerY = rect.Y + rect.Height / 2;
 

--- a/src/Core/src/Platform/Android/MauiSwipeView.cs
+++ b/src/Core/src/Platform/Android/MauiSwipeView.cs
@@ -133,6 +133,11 @@ namespace Microsoft.Maui.Platform
 			if (_contentView is null || _initialPoint is null)
 				return false;
 
+			if (_contentView is AWebView contentWebView)
+			{
+				return ShouldInterceptWebViewTouch(contentWebView, swipeDirection);
+			}
+
 			var viewGroup = _contentView as ViewGroup;
 
 			if (viewGroup is not null)
@@ -165,6 +170,17 @@ namespace Microsoft.Maui.Platform
 
 			return true;
 		}
+
+		// Determines whether the SwipeView should intercept touch events when the content is a WebView, based on the WebView's scroll position and the swipe direction.
+		static bool ShouldInterceptWebViewTouch(AWebView webView, SwipeDirection swipeDirection) =>
+			swipeDirection switch
+			{
+				SwipeDirection.Right => !webView.CanScrollHorizontally(-1), // at left edge
+				SwipeDirection.Left => !webView.CanScrollHorizontally(1),   // at right edge
+				SwipeDirection.Down => !webView.CanScrollVertically(-1),    // at top
+				SwipeDirection.Up => !webView.CanScrollVertically(1),       // at bottom
+				_ => true,
+			};
 
 		static bool ShouldInterceptScrollChildrenTouch(ViewGroup scrollView, bool isHorizontal)
 		{

--- a/src/Core/src/Platform/Android/MauiWebView.cs
+++ b/src/Core/src/Platform/Android/MauiWebView.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Maui.Platform
 
 		readonly WebViewHandler _handler;
 		readonly Rect _clipRect;
+		bool _hasSwipeViewParent;
 
 		public MauiWebView(WebViewHandler handler, Context context) : base(context)
 		{
@@ -37,6 +38,8 @@ namespace Microsoft.Maui.Platform
 			// Re-evaluate ClipBounds when re-parented (e.g., wrapped in WrapperView for shadow)
 			UpdateClipBounds(Width, Height);
 
+			_hasSwipeViewParent = ((View)this).GetParentOfType<MauiSwipeView>() is not null;
+
 			if (RefreshViewWebViewScrollCapture.IsInsideMauiSwipeRefreshLayout(this))
 			{
 				RefreshViewWebViewScrollCapture.Attach(this);
@@ -55,6 +58,7 @@ namespace Microsoft.Maui.Platform
 		{
 			RefreshViewWebViewScrollCapture.Detach(this);
 			base.OnDetachedFromWindow();
+			_hasSwipeViewParent = false;
 		}
 
 		void UpdateClipBounds(int width, int height)
@@ -93,7 +97,13 @@ namespace Microsoft.Maui.Platform
 			{
 				case MotionEventActions.Down:
 				case MotionEventActions.Move:
-					Parent?.RequestDisallowInterceptTouchEvent(true);
+					// Do not request disallow intercept when inside a SwipeView — that would set
+					// FLAG_DISALLOW_INTERCEPT on the SwipeView and prevent it from detecting
+					// swipe gestures
+					if (!_hasSwipeViewParent)
+					{
+						Parent?.RequestDisallowInterceptTouchEvent(true);
+					}
 					break;
 
 				case MotionEventActions.Up:


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

Fixes #36154.

Forward-ports the final implementation and regression coverage from #36231 to `main`, preserving the newer WebView lifecycle handling already present on `main`.

The Android SwipeView now yields to a nested WebView while it can scroll in the gesture direction, and handles the gesture at the WebView edge.