### PR TITLE
Update new dotnet/dotnet barid 322330 and dotnet/macios barid 322326

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,12 +1,12 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.Sdk" Version="11.0.100-preview.6.26357.118">
+    <Dependency Name="Microsoft.NET.Sdk" Version="11.0.100-preview.6.26359.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
+      <Sha>ba53d0ed335bed4ab7bfd01988c8e3953ee5ffbe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-preview.6.26357.118">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-preview.6.26359.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
+      <Sha>ba53d0ed335bed4ab7bfd01988c8e3953ee5ffbe</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Android.Sdk.Windows" Version="37.0.0-preview.6.59">
       <Uri>https://github.com/dotnet/android</Uri>
@@ -53,109 +53,109 @@
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="11.0.0-preview.6.26357.118">
+    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="11.0.0-preview.6.26359.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
+      <Sha>ba53d0ed335bed4ab7bfd01988c8e3953ee5ffbe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="11.0.0-preview.6.26357.118">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="11.0.0-preview.6.26359.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
+      <Sha>ba53d0ed335bed4ab7bfd01988c8e3953ee5ffbe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="11.0.0-preview.6.26357.118">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="11.0.0-preview.6.26359.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
+      <Sha>ba53d0ed335bed4ab7bfd01988c8e3953ee5ffbe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="11.0.0-preview.6.26357.118">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="11.0.0-preview.6.26359.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
+      <Sha>ba53d0ed335bed4ab7bfd01988c8e3953ee5ffbe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components" Version="11.0.0-preview.6.26357.118">
+    <Dependency Name="Microsoft.AspNetCore.Components" Version="11.0.0-preview.6.26359.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
+      <Sha>ba53d0ed335bed4ab7bfd01988c8e3953ee5ffbe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="11.0.0-preview.6.26357.118">
+    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="11.0.0-preview.6.26359.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
+      <Sha>ba53d0ed335bed4ab7bfd01988c8e3953ee5ffbe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="11.0.0-preview.6.26357.118">
+    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="11.0.0-preview.6.26359.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
+      <Sha>ba53d0ed335bed4ab7bfd01988c8e3953ee5ffbe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="11.0.0-preview.6.26357.118">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="11.0.0-preview.6.26359.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
+      <Sha>ba53d0ed335bed4ab7bfd01988c8e3953ee5ffbe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="11.0.0-preview.6.26357.118">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="11.0.0-preview.6.26359.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
+      <Sha>ba53d0ed335bed4ab7bfd01988c8e3953ee5ffbe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="11.0.0-preview.6.26357.118">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="11.0.0-preview.6.26359.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
+      <Sha>ba53d0ed335bed4ab7bfd01988c8e3953ee5ffbe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="11.0.0-preview.6.26357.118">
+    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="11.0.0-preview.6.26359.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
+      <Sha>ba53d0ed335bed4ab7bfd01988c8e3953ee5ffbe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="11.0.0-preview.6.26357.118">
+    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="11.0.0-preview.6.26359.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
+      <Sha>ba53d0ed335bed4ab7bfd01988c8e3953ee5ffbe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.JSInterop" Version="11.0.0-preview.6.26357.118">
+    <Dependency Name="Microsoft.JSInterop" Version="11.0.0-preview.6.26359.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
+      <Sha>ba53d0ed335bed4ab7bfd01988c8e3953ee5ffbe</Sha>
     </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-preview.2.22102.8">
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>3f4da9ced34942d83054e647f3b1d9d7dde281e8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration" Version="11.0.0-preview.6.26357.118">
+    <Dependency Name="Microsoft.Extensions.Configuration" Version="11.0.0-preview.6.26359.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
+      <Sha>ba53d0ed335bed4ab7bfd01988c8e3953ee5ffbe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="11.0.0-preview.6.26357.118">
+    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="11.0.0-preview.6.26359.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
+      <Sha>ba53d0ed335bed4ab7bfd01988c8e3953ee5ffbe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="11.0.0-preview.6.26357.118">
+    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="11.0.0-preview.6.26359.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
+      <Sha>ba53d0ed335bed4ab7bfd01988c8e3953ee5ffbe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="11.0.0-preview.6.26357.118">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="11.0.0-preview.6.26359.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
+      <Sha>ba53d0ed335bed4ab7bfd01988c8e3953ee5ffbe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="11.0.0-preview.6.26357.118">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="11.0.0-preview.6.26359.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
+      <Sha>ba53d0ed335bed4ab7bfd01988c8e3953ee5ffbe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="11.0.0-preview.6.26357.118">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="11.0.0-preview.6.26359.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
+      <Sha>ba53d0ed335bed4ab7bfd01988c8e3953ee5ffbe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="11.0.0-preview.6.26357.118">
+    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="11.0.0-preview.6.26359.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
+      <Sha>ba53d0ed335bed4ab7bfd01988c8e3953ee5ffbe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="11.0.0-preview.6.26357.118">
+    <Dependency Name="Microsoft.Extensions.Logging" Version="11.0.0-preview.6.26359.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
+      <Sha>ba53d0ed335bed4ab7bfd01988c8e3953ee5ffbe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="11.0.0-preview.6.26357.118">
+    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="11.0.0-preview.6.26359.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
+      <Sha>ba53d0ed335bed4ab7bfd01988c8e3953ee5ffbe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="11.0.0-preview.6.26357.118">
+    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="11.0.0-preview.6.26359.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
+      <Sha>ba53d0ed335bed4ab7bfd01988c8e3953ee5ffbe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Primitives" Version="11.0.0-preview.6.26357.118">
+    <Dependency Name="Microsoft.Extensions.Primitives" Version="11.0.0-preview.6.26359.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
+      <Sha>ba53d0ed335bed4ab7bfd01988c8e3953ee5ffbe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="11.0.0-preview.6.26357.118">
+    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="11.0.0-preview.6.26359.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
+      <Sha>ba53d0ed335bed4ab7bfd01988c8e3953ee5ffbe</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="11.0.0-prerelease.26064.3">
       <Uri>https://github.com/dotnet/xharness</Uri>
@@ -175,37 +175,37 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="11.0.0-beta.26357.118">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="11.0.0-beta.26359.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
+      <Sha>ba53d0ed335bed4ab7bfd01988c8e3953ee5ffbe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26357.118">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26359.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
+      <Sha>ba53d0ed335bed4ab7bfd01988c8e3953ee5ffbe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="11.0.0-beta.26357.118">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="11.0.0-beta.26359.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
+      <Sha>ba53d0ed335bed4ab7bfd01988c8e3953ee5ffbe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="11.0.0-beta.26357.118">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="11.0.0-beta.26359.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
+      <Sha>ba53d0ed335bed4ab7bfd01988c8e3953ee5ffbe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26357.118">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26359.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
+      <Sha>ba53d0ed335bed4ab7bfd01988c8e3953ee5ffbe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="11.0.0-beta.26357.118">
+    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="11.0.0-beta.26359.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
+      <Sha>ba53d0ed335bed4ab7bfd01988c8e3953ee5ffbe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="11.0.0-beta.26357.118">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="11.0.0-beta.26359.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
+      <Sha>ba53d0ed335bed4ab7bfd01988c8e3953ee5ffbe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="11.0.0-beta.26357.118">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="11.0.0-beta.26359.118">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2461daa1d76b420ad12e4ebd73e64a4421cc365f</Sha>
+      <Sha>ba53d0ed335bed4ab7bfd01988c8e3953ee5ffbe</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -17,21 +17,21 @@
       <Uri>https://github.com/dotnet/android</Uri>
       <Sha>d549e1dc4e2a083b08b4f24cb5495e81b99d79b5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net11.0_26.5" Version="26.5.11719-net11-p6">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net11.0_26.5" Version="26.5.11720-net11-p6">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>7f0236e0f25c0edc3f3a8b543a6bb2d84d97a729</Sha>
+      <Sha>624e2ab62edc07bfa325abb6ff16ec058c7cbcff</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net11.0_26.5" Version="26.5.11719-net11-p6">
+    <Dependency Name="Microsoft.macOS.Sdk.net11.0_26.5" Version="26.5.11720-net11-p6">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>7f0236e0f25c0edc3f3a8b543a6bb2d84d97a729</Sha>
+      <Sha>624e2ab62edc07bfa325abb6ff16ec058c7cbcff</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net11.0_26.5" Version="26.5.11719-net11-p6">
+    <Dependency Name="Microsoft.iOS.Sdk.net11.0_26.5" Version="26.5.11720-net11-p6">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>7f0236e0f25c0edc3f3a8b543a6bb2d84d97a729</Sha>
+      <Sha>624e2ab62edc07bfa325abb6ff16ec058c7cbcff</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net11.0_26.5" Version="26.5.11719-net11-p6">
+    <Dependency Name="Microsoft.tvOS.Sdk.net11.0_26.5" Version="26.5.11720-net11-p6">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>7f0236e0f25c0edc3f3a8b543a6bb2d84d97a729</Sha>
+      <Sha>624e2ab62edc07bfa325abb6ff16ec058c7cbcff</Sha>
     </Dependency>
     <!-- Previous .NET iOS version(s) -->
     <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_26.5" Version="26.5.10301" CoherentParentDependency="Microsoft.MacCatalyst.Sdk.net11.0_26.5">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -31,10 +31,10 @@
     <!-- Current previous .NET SDK major version's stable release of MAUI packages -->
     <MicrosoftMauiPreviousDotNetReleasedVersion>10.0.20</MicrosoftMauiPreviousDotNetReleasedVersion>
     <!-- dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>11.0.100-preview.6.26357.118</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>11.0.100-preview.6.26359.118</MicrosoftNETSdkPackageVersion>
     <MicrosoftDotnetSdkInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-preview.6.26357.118</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-preview.6.26359.118</MicrosoftNETCoreAppRefPackageVersion>
     <SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextJsonPackageVersion>
     <SystemTextEncodingsWebPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextEncodingsWebPackageVersion>
     <MicrosoftBclAsyncInterfacesPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftBclAsyncInterfacesPackageVersion>
@@ -42,18 +42,18 @@
     <optimizationandroidx64MIBCRuntimePackageVersion>1.0.0-prerelease.26317.1</optimizationandroidx64MIBCRuntimePackageVersion>
     <!-- Microsoft/Extensions -->
     <SystemCodeDomPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemCodeDomPackageVersion>
-    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.6.26357.118</MicrosoftExtensionsConfigurationVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsVersion>11.0.0-preview.6.26357.118</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationJsonVersion>11.0.0-preview.6.26357.118</MicrosoftExtensionsConfigurationJsonVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>11.0.0-preview.6.26357.118</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>11.0.0-preview.6.26357.118</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
-    <MicrosoftExtensionsFileProvidersAbstractionsVersion>11.0.0-preview.6.26357.118</MicrosoftExtensionsFileProvidersAbstractionsVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>11.0.0-preview.6.26357.118</MicrosoftExtensionsLoggingAbstractionsVersion>
-    <MicrosoftExtensionsLoggingVersion>11.0.0-preview.6.26357.118</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>11.0.0-preview.6.26357.118</MicrosoftExtensionsLoggingConsoleVersion>
-    <MicrosoftExtensionsLoggingDebugVersion>11.0.0-preview.6.26357.118</MicrosoftExtensionsLoggingDebugVersion>
-    <MicrosoftExtensionsPrimitivesVersion>11.0.0-preview.6.26357.118</MicrosoftExtensionsPrimitivesVersion>
-    <MicrosoftExtensionsHostingAbstractionsVersion>11.0.0-preview.6.26357.118</MicrosoftExtensionsHostingAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.6.26359.118</MicrosoftExtensionsConfigurationVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>11.0.0-preview.6.26359.118</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationJsonVersion>11.0.0-preview.6.26359.118</MicrosoftExtensionsConfigurationJsonVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>11.0.0-preview.6.26359.118</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>11.0.0-preview.6.26359.118</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
+    <MicrosoftExtensionsFileProvidersAbstractionsVersion>11.0.0-preview.6.26359.118</MicrosoftExtensionsFileProvidersAbstractionsVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>11.0.0-preview.6.26359.118</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingVersion>11.0.0-preview.6.26359.118</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>11.0.0-preview.6.26359.118</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingDebugVersion>11.0.0-preview.6.26359.118</MicrosoftExtensionsLoggingDebugVersion>
+    <MicrosoftExtensionsPrimitivesVersion>11.0.0-preview.6.26359.118</MicrosoftExtensionsPrimitivesVersion>
+    <MicrosoftExtensionsHostingAbstractionsVersion>11.0.0-preview.6.26359.118</MicrosoftExtensionsHostingAbstractionsVersion>
     <MicrosoftExtensionsAIVersion>10.3.0</MicrosoftExtensionsAIVersion>
     <MicrosoftExtensionsAIAbstractionsVersion>10.3.0</MicrosoftExtensionsAIAbstractionsVersion>
     <MicrosoftExtensionsHttpVersion>11.0.0-preview.2.26103.111</MicrosoftExtensionsHttpVersion>
@@ -84,19 +84,19 @@
     <MicrosoftGraphicsWin2DPackageVersion>1.3.2</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.3179.45</MicrosoftWindowsWebView2PackageVersion>
     <!-- Everything else -->
-    <MicrosoftAspNetCoreAuthorizationPackageVersion>11.0.0-preview.6.26357.118</MicrosoftAspNetCoreAuthorizationPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>11.0.0-preview.6.26357.118</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>11.0.0-preview.6.26357.118</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
-    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>11.0.0-preview.6.26357.118</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
-    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>11.0.0-preview.6.26357.118</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreComponentsFormsPackageVersion>11.0.0-preview.6.26357.118</MicrosoftAspNetCoreComponentsFormsPackageVersion>
-    <MicrosoftAspNetCoreComponentsPackageVersion>11.0.0-preview.6.26357.118</MicrosoftAspNetCoreComponentsPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebPackageVersion>11.0.0-preview.6.26357.118</MicrosoftAspNetCoreComponentsWebPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>11.0.0-preview.6.26357.118</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>11.0.0-preview.6.26357.118</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>11.0.0-preview.6.26357.118</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
-    <MicrosoftAspNetCoreMetadataPackageVersion>11.0.0-preview.6.26357.118</MicrosoftAspNetCoreMetadataPackageVersion>
-    <MicrosoftJSInteropPackageVersion>11.0.0-preview.6.26357.118</MicrosoftJSInteropPackageVersion>
+    <MicrosoftAspNetCoreAuthorizationPackageVersion>11.0.0-preview.6.26359.118</MicrosoftAspNetCoreAuthorizationPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>11.0.0-preview.6.26359.118</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>11.0.0-preview.6.26359.118</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
+    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>11.0.0-preview.6.26359.118</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
+    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>11.0.0-preview.6.26359.118</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreComponentsFormsPackageVersion>11.0.0-preview.6.26359.118</MicrosoftAspNetCoreComponentsFormsPackageVersion>
+    <MicrosoftAspNetCoreComponentsPackageVersion>11.0.0-preview.6.26359.118</MicrosoftAspNetCoreComponentsPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebPackageVersion>11.0.0-preview.6.26359.118</MicrosoftAspNetCoreComponentsWebPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>11.0.0-preview.6.26359.118</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>11.0.0-preview.6.26359.118</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>11.0.0-preview.6.26359.118</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
+    <MicrosoftAspNetCoreMetadataPackageVersion>11.0.0-preview.6.26359.118</MicrosoftAspNetCoreMetadataPackageVersion>
+    <MicrosoftJSInteropPackageVersion>11.0.0-preview.6.26359.118</MicrosoftJSInteropPackageVersion>
     <!-- Everything else (previous edition) -->
     <MicrosoftAspNetCorePackageVersion>10.0.2</MicrosoftAspNetCorePackageVersion>
     <MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>$(MicrosoftAspNetCorePackageVersion)</MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>
@@ -146,13 +146,13 @@
     <TizenUIExtensionsVersion>0.9.0</TizenUIExtensionsVersion>
     <ExCSSPackageVersion>4.2.3</ExCSSPackageVersion>
     <SystemDrawingCommonPackageVersion>9.0.0</SystemDrawingCommonPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>11.0.0-beta.26357.118</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetBuildTasksInstallersPackageVersion>11.0.0-beta.26357.118</MicrosoftDotNetBuildTasksInstallersPackageVersion>
-    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>11.0.0-beta.26357.118</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26357.118</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>11.0.0-beta.26359.118</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksInstallersPackageVersion>11.0.0-beta.26359.118</MicrosoftDotNetBuildTasksInstallersPackageVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>11.0.0-beta.26359.118</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26359.118</MicrosoftDotNetHelixSdkPackageVersion>
     <MicroBuildPluginsSwixBuildDotnetPackageVersion>1.1.87-gba258badda</MicroBuildPluginsSwixBuildDotnetPackageVersion>
-    <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.26357.118</MicrosoftDotNetRemoteExecutorPackageVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>11.0.0-beta.26357.118</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.26359.118</MicrosoftDotNetRemoteExecutorPackageVersion>
+    <MicrosoftDotNetXUnitExtensionsPackageVersion>11.0.0-beta.26359.118</MicrosoftDotNetXUnitExtensionsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftNETTestSdkPackageVersion>17.6.0</MicrosoftNETTestSdkPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -67,10 +67,10 @@
     <MicrosoftNETSdkAndroidManifest100100PackageVersion>36.1.69</MicrosoftNETSdkAndroidManifest100100PackageVersion>
     <AndroidNetPreviousVersion>$(MicrosoftNetSdkAndroidManifest100100PackageVersion)</AndroidNetPreviousVersion>
     <!-- dotnet/macios -->
-    <MicrosoftMacCatalystSdknet110_265PackageVersion>26.5.11719-net11-p6</MicrosoftMacCatalystSdknet110_265PackageVersion>
-    <MicrosoftmacOSSdknet110_265PackageVersion>26.5.11719-net11-p6</MicrosoftmacOSSdknet110_265PackageVersion>
-    <MicrosoftiOSSdknet110_265PackageVersion>26.5.11719-net11-p6</MicrosoftiOSSdknet110_265PackageVersion>
-    <MicrosofttvOSSdknet110_265PackageVersion>26.5.11719-net11-p6</MicrosofttvOSSdknet110_265PackageVersion>
+    <MicrosoftMacCatalystSdknet110_265PackageVersion>26.5.11720-net11-p6</MicrosoftMacCatalystSdknet110_265PackageVersion>
+    <MicrosoftmacOSSdknet110_265PackageVersion>26.5.11720-net11-p6</MicrosoftmacOSSdknet110_265PackageVersion>
+    <MicrosoftiOSSdknet110_265PackageVersion>26.5.11720-net11-p6</MicrosoftiOSSdknet110_265PackageVersion>
+    <MicrosofttvOSSdknet110_265PackageVersion>26.5.11720-net11-p6</MicrosofttvOSSdknet110_265PackageVersion>
     <!-- This is a subscription of the .NET 10 latest stable versions of our packages -->
     <MicrosoftMacCatalystSdknet100_265PackageVersion>26.5.10301</MicrosoftMacCatalystSdknet100_265PackageVersion>
     <MicrosoftmacOSSdknet100_265PackageVersion>26.5.10301</MicrosoftmacOSSdknet100_265PackageVersion>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "11.0.100-preview.6.26356.105"
+    "dotnet": "11.0.100-preview.6.26359.118"
   },
   "sdk": {
     "paths": [

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "11.0.100-preview.6.26357.118"
+    "dotnet": "11.0.100-preview.6.26356.105"
   },
   "sdk": {
     "paths": [
@@ -11,7 +11,7 @@
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44",
     "Microsoft.Build.NoTargets": "3.7.0",
-    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26357.118",
-    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26357.118"
+    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26359.118",
+    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26359.118"
   }
 }


### PR DESCRIPTION
```
darc update-dependencies --id 322330
darc update-dependencies --id 322326 #macios
```

This pull request updates several dependency versions in the project to newer preview builds. The changes are focused on aligning the .NET SDK, runtime, Extensions, and macOS/iOS/tvOS/MacCatalyst SDKs to the latest available versions for improved stability and compatibility.

Dependency version updates:

* Updated `Microsoft.NET.Sdk` and `Microsoft.NETCore.App.Ref` to version `11.0.100-preview.6.26359.118` in both `eng/Version.Details.xml` and `eng/Versions.props`, ensuring the project uses the latest .NET SDK and runtime. [[1]](diffhunk://#diff-fb62e94a1d6f29f863e3d0a22aa38269f6cd1d7f03b109dc06e2cbf2548b86d3L3-R9) [[2]](diffhunk://#diff-1ea18ff65faa2ae6fed570b83747086d0317f5e4bc325064f6c14319a9c4ff67L34-R56)
* Updated multiple `Microsoft.Extensions.*` package versions to `11.0.0-preview.6.26359.118` in both dependency and version property files, keeping the Extensions libraries consistent with the latest preview. [[1]](diffhunk://#diff-fb62e94a1d6f29f863e3d0a22aa38269f6cd1d7f03b109dc06e2cbf2548b86d3L56-R158) [[2]](diffhunk://#diff-1ea18ff65faa2ae6fed570b83747086d0317f5e4bc325064f6c14319a9c4ff67L34-R56)
* Updated `Microsoft.AspNetCore.*` and related dependencies to `11.0.0-preview.6.26359.118` in `eng/Version.Details.xml` for improved ASP.NET Core support.
* Updated macOS, iOS, tvOS, and MacCatalyst SDK dependencies to `26.5.11720-net11-p6` in both dependency and version property files, ensuring the latest platform SDKs are used. [[1]](diffhunk://#diff-fb62e94a1d6f29f863e3d0a22aa38269f6cd1d7f03b109dc06e2cbf2548b86d3L20-R34) [[2]](diffhunk://#diff-1ea18ff65faa2ae6fed570b83747086d0317f5e4bc325064f6c14319a9c4ff67L70-R73)
* Updated various toolset dependencies (e.g., `Microsoft.DotNet.Build.Tasks.Feed`, `Microsoft.DotNet.Arcade.Sdk`) to `11.0.0-beta.26359.118` for build infrastructure improvements.