### PR TITLE
Fix for memory leak in Accelerometer.ReadingChanged/ShakeDetected by using weak event source

### DIFF
--- a/src/Essentials/src/Accelerometer/Accelerometer.shared.cs
+++ b/src/Essentials/src/Accelerometer/Accelerometer.shared.cs
@@ -204,11 +204,24 @@ namespace Microsoft.Maui.Devices.Sensors
 
 		static bool useSyncContext;
 
-		/// <inheritdoc/>
-		public event EventHandler<AccelerometerChangedEventArgs>? ReadingChanged;
+		// Accelerometer.Default is an app-lifetime singleton, so events are backed by
+		// weak event sources to avoid leaking subscribers that forget to unsubscribe.
+		readonly WeakEventSource<AccelerometerChangedEventArgs> readingChangedSource = new();
+		readonly WeakEventSource shakeDetectedSource = new();
 
 		/// <inheritdoc/>
-		public event EventHandler? ShakeDetected;
+		public event EventHandler<AccelerometerChangedEventArgs>? ReadingChanged
+		{
+			add => readingChangedSource.Subscribe(value);
+			remove => readingChangedSource.Unsubscribe(value);
+		}
+
+		/// <inheritdoc/>
+		public event EventHandler? ShakeDetected
+		{
+			add => shakeDetectedSource.Subscribe(value);
+			remove => shakeDetectedSource.Unsubscribe(value);
+		}
 
 		/// <inheritdoc/>
 		public bool IsMonitoring { get; private set; }
@@ -267,12 +280,18 @@ namespace Microsoft.Maui.Devices.Sensors
 		internal void OnChanged(AccelerometerChangedEventArgs e)
 		{
 			if (useSyncContext)
-				MainThread.BeginInvokeOnMainThread(() => ReadingChanged?.Invoke(null, e));
+			{
+				MainThread.BeginInvokeOnMainThread(() => readingChangedSource.Raise(null, e));
+			}
 			else
-				ReadingChanged?.Invoke(null, e);
+			{
+				readingChangedSource.Raise(null, e);
+			}
 
-			if (ShakeDetected != null)
+			if (shakeDetectedSource.HasHandlers)
+			{
 				ProcessShakeEvent(e.Reading.Acceleration);
+			}
 		}
 
 		void ProcessShakeEvent(Vector3 acceleration)
@@ -292,9 +311,13 @@ namespace Microsoft.Maui.Devices.Sensors
 				var args = new EventArgs();
 
 				if (useSyncContext)
-					MainThread.BeginInvokeOnMainThread(() => ShakeDetected?.Invoke(null, args));
+				{
+					MainThread.BeginInvokeOnMainThread(() => shakeDetectedSource.Raise(null, args));
+				}
 				else
-					ShakeDetected?.Invoke(null, args);
+				{
+					shakeDetectedSource.Raise(null, args);
+				}
 			}
 
 			static long Nanoseconds(DateTime time) =>

--- a/src/Essentials/src/Accelerometer/AccelerometerWeakEventSource.shared.cs
+++ b/src/Essentials/src/Accelerometer/AccelerometerWeakEventSource.shared.cs
@@ -1,0 +1,297 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Microsoft.Maui.Devices.Sensors
+{
+	// Weakly references each subscriber's target (not the delegate itself) so a subscriber
+	// that is never removed with "-=" can still be collected, while a still-alive subscriber
+	// keeps receiving events. Mirrors the shape of Microsoft.Maui.WeakEventManager (Core),
+	// including its use of MethodInfo.Invoke to raise events -- Essentials cannot reference
+	// Core's WeakEventManager directly here (Core already references Essentials, so the
+	// reverse reference would be circular), hence this local equivalent. MethodInfo.Invoke is
+	// used deliberately rather than a dynamically-created delegate (e.g. via
+	// MethodInfo.MakeGenericMethod/Delegate.CreateDelegate for an unknown target type): that
+	// would require RequiresDynamicCode-annotated APIs that are unsafe under NativeAOT, whereas
+	// MethodInfo.Invoke is the same pattern WeakEventManager already ships with
+	// IsAotCompatible=true in Core, so it is proven safe for this codebase's AOT/trimming story.
+	sealed class WeakEventSource<TEventArgs>
+		where TEventArgs : EventArgs
+	{
+		readonly object gate = new object();
+		readonly List<Subscription> subscriptions = new();
+
+		public void Subscribe(EventHandler<TEventArgs>? handler)
+		{
+			if (handler is null)
+			{
+				return;
+			}
+
+			lock (gate)
+			{
+				subscriptions.Add(new Subscription(handler.Target, handler.Method));
+			}
+		}
+
+		public void Unsubscribe(EventHandler<TEventArgs>? handler)
+		{
+			if (handler is null)
+			{
+				return;
+			}
+
+			lock (gate)
+			{
+				for (int i = subscriptions.Count - 1; i >= 0; i--)
+				{
+					var subscription = subscriptions[i];
+
+					if (subscription.IsDead)
+					{
+						subscriptions.RemoveAt(i);
+						continue;
+					}
+
+					if (subscription.Matches(handler.Target, handler.Method))
+					{
+						subscriptions.RemoveAt(i);
+						break;
+					}
+				}
+			}
+		}
+
+		/// <summary>
+		/// Gets whether there is at least one subscription. This is a plain count check and does
+		/// not prune dead subscriptions on every read (pruning happens lazily in <see cref="Raise"/>,
+		/// <see cref="Subscribe"/>, and <see cref="Unsubscribe"/>), so it is cheap to query on every
+		/// sensor reading without the cost of walking/mutating the subscription list each time.
+		/// </summary>
+		public bool HasHandlers
+		{
+			get
+			{
+				lock (gate)
+				{
+					return subscriptions.Count > 0;
+				}
+			}
+		}
+
+		public void Raise(object? sender, TEventArgs args)
+		{
+			(object? target, MethodInfo method)[] toInvoke;
+			int count = 0;
+
+			lock (gate)
+			{
+				if (subscriptions.Count == 0)
+				{
+					return;
+				}
+
+				toInvoke = new (object?, MethodInfo)[subscriptions.Count];
+
+				// Iterate and prune dead entries in a single forward pass, preserving subscription order.
+				for (int i = 0; i < subscriptions.Count; i++)
+				{
+					var subscription = subscriptions[i];
+
+					if (subscription.Target == null)
+					{
+						// Static method target.
+						toInvoke[count++] = (null, subscription.Method);
+						continue;
+					}
+
+					if (subscription.Target.TryGetTarget(out var target))
+					{
+						toInvoke[count++] = (target, subscription.Method);
+					}
+					else
+					{
+						subscriptions.RemoveAt(i);
+						i--;
+					}
+				}
+			}
+
+			// Invoke outside the lock so subscriber code can freely subscribe/unsubscribe/raise.
+			var invokeArgs = new object?[] { sender, args };
+
+			for (int i = 0; i < count; i++)
+			{
+				toInvoke[i].method.Invoke(toInvoke[i].target, invokeArgs);
+			}
+		}
+
+		readonly struct Subscription
+		{
+			public Subscription(object? target, MethodInfo method)
+			{
+				Target = target is null ? null : new WeakReference<object>(target);
+				Method = method;
+			}
+
+			public readonly WeakReference<object>? Target;
+			public readonly MethodInfo Method;
+
+			public bool IsDead => Target != null && !Target.TryGetTarget(out _);
+
+			public bool Matches(object? target, MethodInfo method)
+			{
+				if (Method != method)
+				{
+					return false;
+				}
+
+				if (target is null)
+				{
+					return Target is null;
+				}
+
+				return Target != null && Target.TryGetTarget(out var current) && ReferenceEquals(current, target);
+			}
+		}
+	}
+
+	sealed class WeakEventSource
+	{
+		readonly object gate = new object();
+		readonly List<Subscription> subscriptions = new();
+
+		public void Subscribe(EventHandler? handler)
+		{
+			if (handler is null)
+			{
+				return;
+			}
+
+			lock (gate)
+			{
+				subscriptions.Add(new Subscription(handler.Target, handler.Method));
+			}
+		}
+
+		public void Unsubscribe(EventHandler? handler)
+		{
+			if (handler is null)
+			{
+				return;
+			}
+
+			lock (gate)
+			{
+				for (int i = subscriptions.Count - 1; i >= 0; i--)
+				{
+					var subscription = subscriptions[i];
+
+					if (subscription.IsDead)
+					{
+						subscriptions.RemoveAt(i);
+						continue;
+					}
+
+					if (subscription.Matches(handler.Target, handler.Method))
+					{
+						subscriptions.RemoveAt(i);
+						break;
+					}
+				}
+			}
+		}
+
+		/// <summary>
+		/// Gets whether there is at least one subscription. This is a plain count check and does
+		/// not prune dead subscriptions on every read (pruning happens lazily in <see cref="Raise"/>,
+		/// <see cref="Subscribe"/>, and <see cref="Unsubscribe"/>), so it is cheap to query on every
+		/// sensor reading (e.g. to gate <c>ShakeDetected</c> processing) without the cost of
+		/// walking/mutating the subscription list each time.
+		/// </summary>
+		public bool HasHandlers
+		{
+			get
+			{
+				lock (gate)
+				{
+					return subscriptions.Count > 0;
+				}
+			}
+		}
+
+		public void Raise(object? sender, EventArgs args)
+		{
+			(object? target, MethodInfo method)[] toInvoke;
+			int count = 0;
+
+			lock (gate)
+			{
+				if (subscriptions.Count == 0)
+				{
+					return;
+				}
+
+				toInvoke = new (object?, MethodInfo)[subscriptions.Count];
+
+				for (int i = 0; i < subscriptions.Count; i++)
+				{
+					var subscription = subscriptions[i];
+
+					if (subscription.Target == null)
+					{
+						toInvoke[count++] = (null, subscription.Method);
+						continue;
+					}
+
+					if (subscription.Target.TryGetTarget(out var target))
+					{
+						toInvoke[count++] = (target, subscription.Method);
+					}
+					else
+					{
+						subscriptions.RemoveAt(i);
+						i--;
+					}
+				}
+			}
+
+			var invokeArgs = new object?[] { sender, args };
+
+			for (int i = 0; i < count; i++)
+			{
+				toInvoke[i].method.Invoke(toInvoke[i].target, invokeArgs);
+			}
+		}
+
+		readonly struct Subscription
+		{
+			public Subscription(object? target, MethodInfo method)
+			{
+				Target = target is null ? null : new WeakReference<object>(target);
+				Method = method;
+			}
+
+			public readonly WeakReference<object>? Target;
+			public readonly MethodInfo Method;
+
+			public bool IsDead => Target != null && !Target.TryGetTarget(out _);
+
+			public bool Matches(object? target, MethodInfo method)
+			{
+				if (Method != method)
+				{
+					return false;
+				}
+
+				if (target is null)
+				{
+					return Target is null;
+				}
+
+				return Target != null && Target.TryGetTarget(out var current) && ReferenceEquals(current, target);
+			}
+		}
+	}
+}

--- a/src/Essentials/src/Accelerometer/AccelerometerWeakEventSource.shared.cs
+++ b/src/Essentials/src/Accelerometer/AccelerometerWeakEventSource.shared.cs
@@ -2,25 +2,21 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.Maui.Devices.Sensors
 {
-	// Weakly references each subscriber's target (not the delegate itself) so a subscriber
-	// that is never removed with "-=" can still be collected, while a still-alive subscriber
-	// keeps receiving events. Mirrors the shape of Microsoft.Maui.WeakEventManager (Core),
-	// including its use of MethodInfo.Invoke to raise events -- Essentials cannot reference
-	// Core's WeakEventManager directly here (Core already references Essentials, so the
-	// reverse reference would be circular), hence this local equivalent. MethodInfo.Invoke is
-	// used deliberately rather than a dynamically-created delegate (e.g. via
-	// MethodInfo.MakeGenericMethod/Delegate.CreateDelegate for an unknown target type): that
-	// would require RequiresDynamicCode-annotated APIs that are unsafe under NativeAOT, whereas
-	// MethodInfo.Invoke is the same pattern WeakEventManager already ships with
-	// IsAotCompatible=true in Core, so it is proven safe for this codebase's AOT/trimming story.
+	// Weakly references each subscriber's target so a subscriber that is never removed with "-="
+	// can still be collected, while a still-alive subscriber keeps receiving events. Instance
+	// delegates are kept in a ConditionalWeakTable keyed by their target so the source can invoke
+	// delegates directly without the delegate keeping the target alive for the source lifetime.
 	sealed class WeakEventSource<TEventArgs>
 		where TEventArgs : EventArgs
 	{
 		readonly object gate = new object();
 		readonly List<Subscription> subscriptions = new();
+		readonly ConditionalWeakTable<object, HandlerStore> instanceHandlers = new();
+		int nextId;
 
 		public void Subscribe(EventHandler<TEventArgs>? handler)
 		{
@@ -31,7 +27,16 @@ namespace Microsoft.Maui.Devices.Sensors
 
 			lock (gate)
 			{
-				subscriptions.Add(new Subscription(handler.Target, handler.Method));
+				var target = handler.Target;
+				if (target is null)
+				{
+					subscriptions.Add(Subscription.CreateStatic(handler));
+					return;
+				}
+
+				var id = nextId++;
+				instanceHandlers.GetOrCreateValue(target).Add(id, handler);
+				subscriptions.Add(Subscription.CreateInstance(target, handler.Method, id));
 			}
 		}
 
@@ -56,6 +61,12 @@ namespace Microsoft.Maui.Devices.Sensors
 
 					if (subscription.Matches(handler.Target, handler.Method))
 					{
+						if (handler.Target is not null &&
+							instanceHandlers.TryGetValue(handler.Target, out var store))
+						{
+							store.Remove(subscription.Id);
+						}
+
 						subscriptions.RemoveAt(i);
 						break;
 					}
@@ -75,6 +86,7 @@ namespace Microsoft.Maui.Devices.Sensors
 			{
 				lock (gate)
 				{
+					PruneDeadSubscriptions();
 					return subscriptions.Count > 0;
 				}
 			}
@@ -82,7 +94,7 @@ namespace Microsoft.Maui.Devices.Sensors
 
 		public void Raise(object? sender, TEventArgs args)
 		{
-			(object? target, MethodInfo method)[] toInvoke;
+			EventHandler<TEventArgs>[] toInvoke;
 			int count = 0;
 
 			lock (gate)
@@ -92,23 +104,21 @@ namespace Microsoft.Maui.Devices.Sensors
 					return;
 				}
 
-				toInvoke = new (object?, MethodInfo)[subscriptions.Count];
-
+				toInvoke = new EventHandler<TEventArgs>[subscriptions.Count];
 				// Iterate and prune dead entries in a single forward pass, preserving subscription order.
 				for (int i = 0; i < subscriptions.Count; i++)
 				{
 					var subscription = subscriptions[i];
 
-					if (subscription.Target == null)
+					if (subscription.StaticHandler is not null)
 					{
-						// Static method target.
-						toInvoke[count++] = (null, subscription.Method);
+						toInvoke[count++] = subscription.StaticHandler;
 						continue;
 					}
 
-					if (subscription.Target.TryGetTarget(out var target))
+					if (subscription.TryGetHandler(instanceHandlers, out var handler))
 					{
-						toInvoke[count++] = (target, subscription.Method);
+						toInvoke[count++] = handler;
 					}
 					else
 					{
@@ -119,26 +129,60 @@ namespace Microsoft.Maui.Devices.Sensors
 			}
 
 			// Invoke outside the lock so subscriber code can freely subscribe/unsubscribe/raise.
-			var invokeArgs = new object?[] { sender, args };
-
 			for (int i = 0; i < count; i++)
 			{
-				toInvoke[i].method.Invoke(toInvoke[i].target, invokeArgs);
+				toInvoke[i](sender, args);
 			}
 		}
 
-		readonly struct Subscription
+		void PruneDeadSubscriptions()
 		{
-			public Subscription(object? target, MethodInfo method)
+			for (int i = subscriptions.Count - 1; i >= 0; i--)
 			{
-				Target = target is null ? null : new WeakReference<object>(target);
+				if (subscriptions[i].IsDead)
+				{
+					subscriptions.RemoveAt(i);
+				}
+			}
+		}
+
+		struct Subscription
+		{
+			Subscription(WeakReference<object>? target, MethodInfo method, int id, EventHandler<TEventArgs>? staticHandler)
+			{
+				Target = target;
 				Method = method;
+				Id = id;
+				StaticHandler = staticHandler;
 			}
 
 			public readonly WeakReference<object>? Target;
 			public readonly MethodInfo Method;
+			public readonly int Id;
+			public readonly EventHandler<TEventArgs>? StaticHandler;
+
+			public static Subscription CreateInstance(object target, MethodInfo method, int id) =>
+				new(new WeakReference<object>(target), method, id, null);
+
+			public static Subscription CreateStatic(EventHandler<TEventArgs> handler) =>
+				new(null, handler.Method, -1, handler);
 
 			public bool IsDead => Target != null && !Target.TryGetTarget(out _);
+
+			public bool TryGetHandler(
+				ConditionalWeakTable<object, HandlerStore> instanceHandlers,
+				out EventHandler<TEventArgs> handler)
+			{
+				handler = null!;
+
+				if (Target is null || !Target.TryGetTarget(out var target))
+				{
+					return false;
+				}
+
+				return instanceHandlers.TryGetValue(target, out var store) &&
+					store.TryGetValue(Id, out handler);
+			}
 
 			public bool Matches(object? target, MethodInfo method)
 			{
@@ -155,12 +199,63 @@ namespace Microsoft.Maui.Devices.Sensors
 				return Target != null && Target.TryGetTarget(out var current) && ReferenceEquals(current, target);
 			}
 		}
+
+		sealed class HandlerStore
+		{
+			readonly List<Entry> handlers = new();
+
+			public void Add(int id, EventHandler<TEventArgs> handler) =>
+				handlers.Add(new Entry(id, handler));
+
+			public bool Remove(int id)
+			{
+				for (int i = handlers.Count - 1; i >= 0; i--)
+				{
+					if (handlers[i].Id == id)
+					{
+						handlers.RemoveAt(i);
+						return true;
+					}
+				}
+
+				return false;
+			}
+
+			public bool TryGetValue(int id, out EventHandler<TEventArgs> handler)
+			{
+				for (int i = 0; i < handlers.Count; i++)
+				{
+					if (handlers[i].Id == id)
+					{
+						handler = handlers[i].Handler;
+						return true;
+					}
+				}
+
+				handler = null!;
+				return false;
+			}
+
+			struct Entry
+			{
+				public Entry(int id, EventHandler<TEventArgs> handler)
+				{
+					Id = id;
+					Handler = handler;
+				}
+
+				public readonly int Id;
+				public readonly EventHandler<TEventArgs> Handler;
+			}
+		}
 	}
 
 	sealed class WeakEventSource
 	{
 		readonly object gate = new object();
 		readonly List<Subscription> subscriptions = new();
+		readonly ConditionalWeakTable<object, HandlerStore> instanceHandlers = new();
+		int nextId;
 
 		public void Subscribe(EventHandler? handler)
 		{
@@ -171,7 +266,16 @@ namespace Microsoft.Maui.Devices.Sensors
 
 			lock (gate)
 			{
-				subscriptions.Add(new Subscription(handler.Target, handler.Method));
+				var target = handler.Target;
+				if (target is null)
+				{
+					subscriptions.Add(Subscription.CreateStatic(handler));
+					return;
+				}
+
+				var id = nextId++;
+				instanceHandlers.GetOrCreateValue(target).Add(id, handler);
+				subscriptions.Add(Subscription.CreateInstance(target, handler.Method, id));
 			}
 		}
 
@@ -196,6 +300,12 @@ namespace Microsoft.Maui.Devices.Sensors
 
 					if (subscription.Matches(handler.Target, handler.Method))
 					{
+						if (handler.Target is not null &&
+							instanceHandlers.TryGetValue(handler.Target, out var store))
+						{
+							store.Remove(subscription.Id);
+						}
+
 						subscriptions.RemoveAt(i);
 						break;
 					}
@@ -216,6 +326,7 @@ namespace Microsoft.Maui.Devices.Sensors
 			{
 				lock (gate)
 				{
+					PruneDeadSubscriptions();
 					return subscriptions.Count > 0;
 				}
 			}
@@ -223,7 +334,7 @@ namespace Microsoft.Maui.Devices.Sensors
 
 		public void Raise(object? sender, EventArgs args)
 		{
-			(object? target, MethodInfo method)[] toInvoke;
+			EventHandler[] toInvoke;
 			int count = 0;
 
 			lock (gate)
@@ -233,21 +344,21 @@ namespace Microsoft.Maui.Devices.Sensors
 					return;
 				}
 
-				toInvoke = new (object?, MethodInfo)[subscriptions.Count];
+				toInvoke = new EventHandler[subscriptions.Count];
 
 				for (int i = 0; i < subscriptions.Count; i++)
 				{
 					var subscription = subscriptions[i];
 
-					if (subscription.Target == null)
+					if (subscription.StaticHandler is not null)
 					{
-						toInvoke[count++] = (null, subscription.Method);
+						toInvoke[count++] = subscription.StaticHandler;
 						continue;
 					}
 
-					if (subscription.Target.TryGetTarget(out var target))
+					if (subscription.TryGetHandler(instanceHandlers, out var handler))
 					{
-						toInvoke[count++] = (target, subscription.Method);
+						toInvoke[count++] = handler;
 					}
 					else
 					{
@@ -257,26 +368,60 @@ namespace Microsoft.Maui.Devices.Sensors
 				}
 			}
 
-			var invokeArgs = new object?[] { sender, args };
-
 			for (int i = 0; i < count; i++)
 			{
-				toInvoke[i].method.Invoke(toInvoke[i].target, invokeArgs);
+				toInvoke[i](sender, args);
 			}
 		}
 
-		readonly struct Subscription
+		void PruneDeadSubscriptions()
 		{
-			public Subscription(object? target, MethodInfo method)
+			for (int i = subscriptions.Count - 1; i >= 0; i--)
 			{
-				Target = target is null ? null : new WeakReference<object>(target);
+				if (subscriptions[i].IsDead)
+				{
+					subscriptions.RemoveAt(i);
+				}
+			}
+		}
+
+		struct Subscription
+		{
+			Subscription(WeakReference<object>? target, MethodInfo method, int id, EventHandler? staticHandler)
+			{
+				Target = target;
 				Method = method;
+				Id = id;
+				StaticHandler = staticHandler;
 			}
 
 			public readonly WeakReference<object>? Target;
 			public readonly MethodInfo Method;
+			public readonly int Id;
+			public readonly EventHandler? StaticHandler;
+
+			public static Subscription CreateInstance(object target, MethodInfo method, int id) =>
+				new(new WeakReference<object>(target), method, id, null);
+
+			public static Subscription CreateStatic(EventHandler handler) =>
+				new(null, handler.Method, -1, handler);
 
 			public bool IsDead => Target != null && !Target.TryGetTarget(out _);
+
+			public bool TryGetHandler(
+				ConditionalWeakTable<object, HandlerStore> instanceHandlers,
+				out EventHandler handler)
+			{
+				handler = null!;
+
+				if (Target is null || !Target.TryGetTarget(out var target))
+				{
+					return false;
+				}
+
+				return instanceHandlers.TryGetValue(target, out var store) &&
+					store.TryGetValue(Id, out handler);
+			}
 
 			public bool Matches(object? target, MethodInfo method)
 			{
@@ -291,6 +436,55 @@ namespace Microsoft.Maui.Devices.Sensors
 				}
 
 				return Target != null && Target.TryGetTarget(out var current) && ReferenceEquals(current, target);
+			}
+		}
+
+		sealed class HandlerStore
+		{
+			readonly List<Entry> handlers = new();
+
+			public void Add(int id, EventHandler handler) =>
+				handlers.Add(new Entry(id, handler));
+
+			public bool Remove(int id)
+			{
+				for (int i = handlers.Count - 1; i >= 0; i--)
+				{
+					if (handlers[i].Id == id)
+					{
+						handlers.RemoveAt(i);
+						return true;
+					}
+				}
+
+				return false;
+			}
+
+			public bool TryGetValue(int id, out EventHandler handler)
+			{
+				for (int i = 0; i < handlers.Count; i++)
+				{
+					if (handlers[i].Id == id)
+					{
+						handler = handlers[i].Handler;
+						return true;
+					}
+				}
+
+				handler = null!;
+				return false;
+			}
+
+			struct Entry
+			{
+				public Entry(int id, EventHandler handler)
+				{
+					Id = id;
+					Handler = handler;
+				}
+
+				public readonly int Id;
+				public readonly EventHandler Handler;
 			}
 		}
 	}

--- a/src/Essentials/test/UnitTests/Accelerometer_Tests.cs
+++ b/src/Essentials/test/UnitTests/Accelerometer_Tests.cs
@@ -85,6 +85,30 @@ namespace Tests
 			public void OnReadingChanged(object sender, AccelerometerChangedEventArgs e) => CallCount++;
 		}
 
+		// A weak-event-backed subscriber invocation must surface the subscriber's original
+		// exception instance directly, not a wrapping System.Reflection.TargetInvocationException,
+		// to match plain multicast delegate invocation semantics.
+		[Fact]
+		public void Accelerometer_ReadingChanged_PropagatesSubscriberExceptionDirectly()
+		{
+			var expected = new InvalidOperationException("subscriber failed");
+			EventHandler<AccelerometerChangedEventArgs> handler = (_, _) => throw expected;
+
+			Accelerometer.ReadingChanged += handler;
+
+			try
+			{
+				var implementation = (AccelerometerImplementation)Accelerometer.Default;
+				var actual = Assert.Throws<InvalidOperationException>(() => implementation.OnChanged(new AccelerometerData(1, 2, 3)));
+
+				Assert.Same(expected, actual);
+			}
+			finally
+			{
+				Accelerometer.ReadingChanged -= handler;
+			}
+		}
+
 		[Fact]
 		public void Accelerometer_Start() =>
 			Assert.Throws<NotImplementedInReferenceAssemblyException>(() => Accelerometer.Stop());

--- a/src/Essentials/test/UnitTests/Accelerometer_Tests.cs
+++ b/src/Essentials/test/UnitTests/Accelerometer_Tests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Devices.Sensors;
 using Xunit;
@@ -7,6 +8,83 @@ namespace Tests
 {
 	public class Accelerometer_Tests
 	{
+		// A subscriber that forgets to unsubscribe with "-=" should still be collectible
+		// instead of being retained for the lifetime of the process.
+		[Fact]
+		public void Accelerometer_ReadingChanged_DoesNotLeakForgottenSubscriber()
+		{
+			var subscriberRef = SubscribeWithoutUnsubscribing();
+
+			for (var i = 0; i < 3 && subscriberRef.IsAlive; i++)
+			{
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+				GC.Collect();
+			}
+
+			Assert.False(subscriberRef.IsAlive,
+				"Accelerometer.ReadingChanged subscriber was still alive after GC; " +
+				"a forgotten unsubscribe should not leak the subscriber for the process lifetime.");
+		}
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		static WeakReference SubscribeWithoutUnsubscribing()
+		{
+			var subscriber = new LeakySubscriber();
+			Accelerometer.ReadingChanged += subscriber.OnReadingChanged;
+
+			try
+			{
+				Accelerometer.Stop();
+			}
+			catch
+			{
+				// Not implemented in the reference assembly used by unit tests; the leak
+				// reproduces independently of Start()/Stop() actually running.
+			}
+
+			return new WeakReference(subscriber);
+		}
+
+		sealed class LeakySubscriber
+		{
+			public void OnReadingChanged(object sender, AccelerometerChangedEventArgs e)
+			{
+			}
+		}
+
+		// A weak-reference-based fix must not drop live subscribers: a subscriber that is
+		// still alive should keep receiving ReadingChanged after a GC.
+		[Fact]
+		public void Accelerometer_ReadingChanged_StillNotifiesLiveSubscriberAfterGC()
+		{
+			var subscriber = new CountingSubscriber();
+			Accelerometer.ReadingChanged += subscriber.OnReadingChanged;
+
+			try
+			{
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+				GC.Collect();
+
+				var implementation = (AccelerometerImplementation)Accelerometer.Default;
+				implementation.OnChanged(new AccelerometerData(1, 2, 3));
+
+				Assert.Equal(1, subscriber.CallCount);
+			}
+			finally
+			{
+				Accelerometer.ReadingChanged -= subscriber.OnReadingChanged;
+			}
+		}
+
+		sealed class CountingSubscriber
+		{
+			public int CallCount { get; private set; }
+
+			public void OnReadingChanged(object sender, AccelerometerChangedEventArgs e) => CallCount++;
+		}
+
 		[Fact]
 		public void Accelerometer_Start() =>
 			Assert.Throws<NotImplementedInReferenceAssemblyException>(() => Accelerometer.Stop());


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!


<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details

The Accelerometer.Default  is a singleton instance that persists for the entire lifetime of the application. When a page, view model, or service subscribes to  Accelerometer.ReadingChanged  or  ShakeDetected  using  +=  but does not explicitly unsubscribe with  -=  — a common oversight, since calling  Stop()  may appear to perform cleanup but does not remove the event subscription — the singleton retains a strong reference to the subscriber indefinitely. Consequently, the subscriber, along with any objects it references, is never eligible for garbage collection. This results in a progressively growing memory leak each time the pattern recurs.

### Root Cause

The issue occurs because  Accelerometer.ReadingChanged  and  ShakeDetected  being backed by plain multicast delegate events on  Accelerometer.Default , which is an app-lifetime static singleton. When a subscriber registers with  +=  but never explicitly unsubscribes with  -=  (a common mistake, since calling  Stop()  looks like cleanup but does not clear the delegate), the singleton's multicast delegate holds a strong reference to the subscriber for as long as the process runs, preventing it from ever being garbage collected — even after the subscriber's owning page, view model, or service should have gone out of scope.

### Description of Change

The fix involves replacing the plain multicast delegate events with a custom  WeakEventSource  /  WeakEventSource<TEventArgs>  type that weakly references each subscriber's target object while keeping its closed delegate in a  ConditionalWeakTable  keyed by that target, invoking handlers via direct delegate calls rather than reflection. This avoids the  MethodInfo.Invoke  overhead and exception-wrapping behavior of the pattern used by  Microsoft.Maui.WeakEventManager  elsewhere in the codebase (not reused directly here due to a circular project-reference constraint between Essentials and Core), so subscriber exceptions propagate with their original type and instance intact.

Dead entries are pruned lazily during  Subscribe ,  Unsubscribe ,  Raise , and  HasHandlers . This allows a forgotten subscriber to be collected normally while still-alive subscribers continue to receive events correctly, and ensures a collected subscriber does not keep shake processing enabled indefinitely — verified by unit tests covering the leak scenario, the live-subscriber-after-GC scenario, and direct exception propagation.

Validated the behavior in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
### Issues Fixed
  
Fixes https://github.com/dotnet/maui/issues/36216

### Output  ScreenShot

|Platform|Before|After|
|--|--|--|
|Android| <video src="https://github.com/user-attachments/assets/708f2d8e-8ee4-495c-a2a3-cb3771532121" >| <video src="https://github.com/user-attachments/assets/3d787398-b7fa-43d4-a362-9f1d1eef6380">|
|Mac|<video src="https://github.com/user-attachments/assets/4236c5ed-dbdc-4002-95b6-e08dc6c95ca2"> |<video src="https://github.com/user-attachments/assets/13475a2c-35a6-4065-8097-d62d68e7be76">|
|iOS|<video src="https://github.com/user-attachments/assets/f54329ba-5c30-47d3-94d0-38093ba92cf4">|<video src="https://github.com/user-attachments/assets/6f75dc4e-8ca5-47a2-b357-16fa906b9add">|
|Windows|<video src="https://github.com/user-attachments/assets/e5e9455a-58c7-4ca8-9e2b-a15b4f6ba271">|<video src="https://github.com/user-attachments/assets/2cfc5011-f79a-45d4-aa18-94abd8f6b576"> |