### PR TITLE
Update PatchVersion from 90 to 100

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
     <!-- The .NET product branding version -->
     <MajorVersion>10</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>90</PatchVersion>
+    <PatchVersion>100</PatchVersion>
     <SdkBandVersion>10.0.100</SdkBandVersion>
     <PreReleaseVersionLabel>ci.main</PreReleaseVersionLabel>
     <PreReleaseVersionLabel Condition="'$(BUILD_SOURCEBRANCH)' == 'refs/heads/inflight/current'">ci.inflight</PreReleaseVersionLabel>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

- Advances `main` from the SR9 `10.0.90` cycle to the SR10 `10.0.100` cycle.
- Keeps `SdkBandVersion` and prerelease settings unchanged.
- Matches the previous cycle bumps in #35433 and #35879.

This clears the `Main bumped to SR10 cycle` release-readiness blocker for 10.0.90.

_This PR was created by GitHub Copilot CLI on behalf of @kubaflo._