### PR TITLE
[inflight regression] Fix HybridWebView JS↔.NET bridge: Android request interception order and Windows NUL-character handling

### DIFF
--- a/src/Core/src/Handlers/HybridWebView/HybridWebView.js
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebView.js
@@ -23,8 +23,10 @@
         // Determine the mechanism to receive messages from the host application.
         if (window.chrome && window.chrome.webview && window.chrome.webview.addEventListener) {
             // Windows WebView2
+            // The .NET side URL-encodes messages (see MauiHybridWebView.SendRawMessage) so embedded
+            // NUL characters survive WebView2's null-terminated string marshalling. Decode here.
             window.chrome.webview.addEventListener('message', (arg) => {
-                dispatchHybridWebViewMessage(arg.data);
+                dispatchHybridWebViewMessage(decodeURIComponent(arg.data));
             });
         }
         else if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.webwindowinterop) {
@@ -56,7 +58,10 @@
         // Determine the function to use to send messages to the host application.
         if (window.chrome && window.chrome.webview) {
             // Windows WebView2
-            sendMessageFunction = msg => window.chrome.webview.postMessage(msg);
+            // URL-encode so embedded NUL characters survive WebView2's null-terminated string
+            // marshalling (TryGetWebMessageAsString returns an LPWSTR); the .NET side decodes it
+            // in HybridWebViewHandler.OnWebMessageReceived.
+            sendMessageFunction = msg => window.chrome.webview.postMessage(encodeURIComponent(msg));
         }
         else if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.webwindowinterop) {
             // iOS and MacCatalyst WKWebView

--- a/src/Core/src/Handlers/HybridWebView/HybridWebView.js
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebView.js
@@ -78,10 +78,7 @@
                     headers: {
                         'Content-Type': 'text/plain',
                         'X-Maui-Invoke-Token': 'HybridWebView',
-                        // URL-encode so the payload survives the HTTP header byte-set restriction
-                        // (headers cannot carry CR/LF/NUL or non-Latin-1 characters). The .NET side
-                        // decodes this in MauiHybridWebViewClient.TryValidateBridgeRequest.
-                        'X-Maui-Request-Body': encodeURIComponent(msg)
+                        'X-Maui-Request-Body': msg
                     },
                     body: msg
                 }).catch(err => {
@@ -153,10 +150,10 @@
      * @param message The message to send to the .NET host application.
      */
     function sendRawMessage(message) {
-        // Byte-set-sensitive transports (the Android fetch X-Maui-Request-Body header) are
-        // handled by encoding the whole message in sendMessageFunction, so no per-message
-        // encoding is needed here.
-        sendMessageToDotNet('__RawMessage', message);
+        // URL-encode the payload so it survives transports that restrict the byte set
+        // (the Android fetch X-Maui-Request-Body header rejects CR/LF/NUL). Decoded
+        // on the .NET side in HybridWebViewHandler.MessageReceived.
+        sendMessageToDotNet('__RawMessage', encodeURIComponent(message));
     }
     /*
      * Invoke a .NET method on the InvokeJavaScriptTarget instance.
@@ -192,10 +189,7 @@
                 'Content-Type': 'application/json',
                 'Accept': 'application/json',
                 'X-Maui-Invoke-Token': 'HybridWebView',
-                // Some platforms (Android) do not expose the POST body, so we also send it as a
-                // header. URL-encode it so it survives the HTTP header byte-set restriction; the
-                // .NET side decodes this in MauiHybridWebViewClient.TryValidateBridgeRequest.
-                'X-Maui-Request-Body': encodeURIComponent(message)
+                'X-Maui-Request-Body': message // Some platforms (Android) do not expose the POST body
             },
             body: message
         });

--- a/src/Core/src/Handlers/HybridWebView/HybridWebView.js
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebView.js
@@ -73,7 +73,10 @@
                     headers: {
                         'Content-Type': 'text/plain',
                         'X-Maui-Invoke-Token': 'HybridWebView',
-                        'X-Maui-Request-Body': msg
+                        // URL-encode so the payload survives the HTTP header byte-set restriction
+                        // (headers cannot carry CR/LF/NUL or non-Latin-1 characters). The .NET side
+                        // decodes this in MauiHybridWebViewClient.TryValidateBridgeRequest.
+                        'X-Maui-Request-Body': encodeURIComponent(msg)
                     },
                     body: msg
                 }).catch(err => {
@@ -145,10 +148,10 @@
      * @param message The message to send to the .NET host application.
      */
     function sendRawMessage(message) {
-        // URL-encode the payload so it survives transports that restrict the byte set
-        // (the Android fetch X-Maui-Request-Body header rejects CR/LF/NUL). Decoded
-        // on the .NET side in HybridWebViewHandler.MessageReceived.
-        sendMessageToDotNet('__RawMessage', encodeURIComponent(message));
+        // Byte-set-sensitive transports (the Android fetch X-Maui-Request-Body header) are
+        // handled by encoding the whole message in sendMessageFunction, so no per-message
+        // encoding is needed here.
+        sendMessageToDotNet('__RawMessage', message);
     }
     /*
      * Invoke a .NET method on the InvokeJavaScriptTarget instance.
@@ -184,7 +187,10 @@
                 'Content-Type': 'application/json',
                 'Accept': 'application/json',
                 'X-Maui-Invoke-Token': 'HybridWebView',
-                'X-Maui-Request-Body': message // Some platforms (Android) do not expose the POST body
+                // Some platforms (Android) do not expose the POST body, so we also send it as a
+                // header. URL-encode it so it survives the HTTP header byte-set restriction; the
+                // .NET side decodes this in MauiHybridWebViewClient.TryValidateBridgeRequest.
+                'X-Maui-Request-Body': encodeURIComponent(message)
             },
             body: message
         });

--- a/src/Core/src/Handlers/HybridWebView/HybridWebView.ts
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebView.ts
@@ -125,10 +125,7 @@ interface DotNetInvokeResult {
                     headers: {
                         'Content-Type': 'text/plain',
                         'X-Maui-Invoke-Token': 'HybridWebView',
-                        // URL-encode so the payload survives the HTTP header byte-set restriction
-                        // (headers cannot carry CR/LF/NUL or non-Latin-1 characters). The .NET side
-                        // decodes this in MauiHybridWebViewClient.TryValidateBridgeRequest.
-                        'X-Maui-Request-Body': encodeURIComponent(msg)
+                        'X-Maui-Request-Body': msg
                     },
                     body: msg
                 }).catch(err => {
@@ -205,10 +202,10 @@ interface DotNetInvokeResult {
      * @param message The message to send to the .NET host application.
      */
     function sendRawMessage(message: string) {
-        // Byte-set-sensitive transports (the Android fetch X-Maui-Request-Body header) are
-        // handled by encoding the whole message in sendMessageFunction, so no per-message
-        // encoding is needed here.
-        sendMessageToDotNet('__RawMessage', message);
+        // URL-encode the payload so it survives transports that restrict the byte set
+        // (the Android fetch X-Maui-Request-Body header rejects CR/LF/NUL). Decoded
+        // on the .NET side in HybridWebViewHandler.MessageReceived.
+        sendMessageToDotNet('__RawMessage', encodeURIComponent(message));
     }
 
     /*
@@ -250,10 +247,7 @@ interface DotNetInvokeResult {
                 'Content-Type': 'application/json',
                 'Accept': 'application/json',
                 'X-Maui-Invoke-Token': 'HybridWebView',
-                // Some platforms (Android) do not expose the POST body, so we also send it as a
-                // header. URL-encode it so it survives the HTTP header byte-set restriction; the
-                // .NET side decodes this in MauiHybridWebViewClient.TryValidateBridgeRequest.
-                'X-Maui-Request-Body': encodeURIComponent(message)
+                'X-Maui-Request-Body': message // Some platforms (Android) do not expose the POST body
             },
             body: message
         });

--- a/src/Core/src/Handlers/HybridWebView/HybridWebView.ts
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebView.ts
@@ -73,8 +73,10 @@ interface DotNetInvokeResult {
         // Determine the mechanism to receive messages from the host application.
         if (window.chrome && window.chrome.webview && window.chrome.webview.addEventListener) {
             // Windows WebView2
+            // The .NET side URL-encodes messages (see MauiHybridWebView.SendRawMessage) so embedded
+            // NUL characters survive WebView2's null-terminated string marshalling. Decode here.
             window.chrome.webview.addEventListener('message', (arg: any) => {
-                dispatchHybridWebViewMessage(arg.data);
+                dispatchHybridWebViewMessage(decodeURIComponent(arg.data));
             });
         } else if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.webwindowinterop) {
             // iOS and MacCatalyst WKWebView
@@ -105,7 +107,10 @@ interface DotNetInvokeResult {
         // Determine the function to use to send messages to the host application.
         if (window.chrome && window.chrome.webview) {
             // Windows WebView2
-            sendMessageFunction = msg => window.chrome.webview.postMessage(msg);
+            // URL-encode so embedded NUL characters survive WebView2's null-terminated string
+            // marshalling (TryGetWebMessageAsString returns an LPWSTR); the .NET side decodes it
+            // in HybridWebViewHandler.OnWebMessageReceived.
+            sendMessageFunction = msg => window.chrome.webview.postMessage(encodeURIComponent(msg));
         } else if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.webwindowinterop) {
             // iOS and MacCatalyst WKWebView
             sendMessageFunction = msg => window.webkit.messageHandlers.webwindowinterop.postMessage(msg);

--- a/src/Core/src/Handlers/HybridWebView/HybridWebView.ts
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebView.ts
@@ -120,7 +120,10 @@ interface DotNetInvokeResult {
                     headers: {
                         'Content-Type': 'text/plain',
                         'X-Maui-Invoke-Token': 'HybridWebView',
-                        'X-Maui-Request-Body': msg
+                        // URL-encode so the payload survives the HTTP header byte-set restriction
+                        // (headers cannot carry CR/LF/NUL or non-Latin-1 characters). The .NET side
+                        // decodes this in MauiHybridWebViewClient.TryValidateBridgeRequest.
+                        'X-Maui-Request-Body': encodeURIComponent(msg)
                     },
                     body: msg
                 }).catch(err => {
@@ -197,10 +200,10 @@ interface DotNetInvokeResult {
      * @param message The message to send to the .NET host application.
      */
     function sendRawMessage(message: string) {
-        // URL-encode the payload so it survives transports that restrict the byte set
-        // (the Android fetch X-Maui-Request-Body header rejects CR/LF/NUL). Decoded
-        // on the .NET side in HybridWebViewHandler.MessageReceived.
-        sendMessageToDotNet('__RawMessage', encodeURIComponent(message));
+        // Byte-set-sensitive transports (the Android fetch X-Maui-Request-Body header) are
+        // handled by encoding the whole message in sendMessageFunction, so no per-message
+        // encoding is needed here.
+        sendMessageToDotNet('__RawMessage', message);
     }
 
     /*
@@ -242,7 +245,10 @@ interface DotNetInvokeResult {
                 'Content-Type': 'application/json',
                 'Accept': 'application/json',
                 'X-Maui-Invoke-Token': 'HybridWebView',
-                'X-Maui-Request-Body': message // Some platforms (Android) do not expose the POST body
+                // Some platforms (Android) do not expose the POST body, so we also send it as a
+                // header. URL-encode it so it survives the HTTP header byte-set restriction; the
+                // .NET side decodes this in MauiHybridWebViewClient.TryValidateBridgeRequest.
+                'X-Maui-Request-Body': encodeURIComponent(message)
             },
             body: message
         });

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Windows.cs
@@ -98,7 +98,10 @@ namespace Microsoft.Maui.Handlers
 
 		private void OnWebMessageReceived(WebView2 sender, CoreWebView2WebMessageReceivedEventArgs args)
 		{
-			MessageReceived(args.TryGetWebMessageAsString());
+			// The JS transport URL-encodes messages so embedded NUL characters survive WebView2's
+			// null-terminated string marshalling (TryGetWebMessageAsString returns an LPWSTR). Decode
+			// the payload before dispatching it.
+			MessageReceived(Uri.UnescapeDataString(args.TryGetWebMessageAsString()));
 		}
 
 		internal static void MapFlowDirection(IHybridWebViewHandler handler, IHybridWebView hybridWebView)

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.cs
@@ -178,7 +178,9 @@ namespace Microsoft.Maui.Handlers
 					}
 					break;
 				case "__RawMessage":
-					VirtualView?.RawMessageReceived(messageContent);
+					// Payload is URL-encoded in JS (HybridWebView.ts sendRawMessage) so it survives
+					// transports that restrict the byte set (Android fetch header forbids CR/LF/NUL).
+					VirtualView?.RawMessageReceived(Uri.UnescapeDataString(messageContent));
 					break;
 				default:
 					throw new ArgumentException($"The message type '{messageType}' is not recognized.", nameof(rawMessage));

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.cs
@@ -178,9 +178,7 @@ namespace Microsoft.Maui.Handlers
 					}
 					break;
 				case "__RawMessage":
-					// Payload is URL-encoded in JS (HybridWebView.ts sendRawMessage) so it survives
-					// transports that restrict the byte set (Android fetch header forbids CR/LF/NUL).
-					VirtualView?.RawMessageReceived(Uri.UnescapeDataString(messageContent));
+					VirtualView?.RawMessageReceived(messageContent);
 					break;
 				default:
 					throw new ArgumentException($"The message type '{messageType}' is not recognized.", nameof(rawMessage));

--- a/src/Core/src/Platform/Android/MauiHybridWebViewClient.cs
+++ b/src/Core/src/Platform/Android/MauiHybridWebViewClient.cs
@@ -69,31 +69,30 @@ namespace Microsoft.Maui.Platform
 
 			if (view is not null && request is not null && !string.IsNullOrEmpty(url))
 			{
-				// 1. Handle framework-internal bridge endpoints (the JS bridge script and the
-				//    JS <-> .NET message/invoke channels) before user interception. A
-				//    WebResourceRequested handler must never receive — or be able to throw on —
-				//    these internal requests. Before JS -> .NET messages were routed over HTTP
-				//    they were invisible to interception, and they should remain so.
-				var bridgeResponse = TryGetBridgeResponse(url, request, logger);
-				if (bridgeResponse is not null)
+				// 1. Framework-internal bridge requests must be handled by the framework and
+				//    never exposed to app-level WebResourceRequested interception. See
+				//    IsFrameworkInternalRequest: each reserved endpoint is bound to BOTH its
+				//    well-known path and (for the message/invoke channels) the protocol marker
+				//    header, so the header alone is never a trust boundary. Before JS -> .NET
+				//    messages were routed over HTTP they were invisible to app interception, and
+				//    this preserves that invariant.
+				if (IsFrameworkInternalRequest(url, request))
 				{
-					return bridgeResponse;
+					// A framework-internal request must be handled by the framework. If it
+					// cannot be resolved, fail fast with a 400 rather than forwarding it to the
+					// app handler.
+					return GetResponse(url, request, logger)
+						?? new WebResourceResponse(null, "UTF-8", 400, "Bad Request", null, new MemoryStream());
 				}
 
-				// 2. Check if the app wants to modify or override the request
-				WebResourceResponse? response = null;
-				try
-				{
-					response = WebRequestInterceptingWebView.TryInterceptResponseStream(Handler, view, request, url, logger);
-				}
-				catch (Exception ex)
-				{
-					// ShouldInterceptRequest runs on a native WebView thread; letting a user
-					// WebResourceRequested handler's exception unwind across the JNI boundary
-					// crashes the app. Log it and fall back to default handling instead.
-					logger?.LogError(ex, "A WebResourceRequested handler threw while intercepting {Url}.", url);
-				}
-
+				// 2. Check if the app wants to modify or override the request. This path is
+				//    intentionally left unwrapped: if a user WebResourceRequested handler throws
+				//    for a legitimate app-origin request, the exception propagates exactly as it
+				//    did before bridge traffic was routed over HTTP. Only the framework's own
+				//    .NET dispatch (Handler.MessageReceived in GetResponse) is exception-isolated,
+				//    because it runs under a JNI stack where an unhandled throw crashes the
+				//    native WebView thread.
+				var response = WebRequestInterceptingWebView.TryInterceptResponseStream(Handler, view, request, url, logger);
 				if (response is not null)
 				{
 					return response;
@@ -113,31 +112,74 @@ namespace Microsoft.Maui.Platform
 			return base.ShouldInterceptRequest(view, request);
 		}
 
-		// Handles the framework-internal HybridWebView bridge endpoints: the bridge script,
-		// the JS -> .NET InvokeDotNet channel, and the JS -> .NET message channel. These are
-		// resolved before user WebResourceRequested interception so app code never sees — or
-		// can block/crash on — the framework's own control requests. Returns null when the
-		// request is not one of these internal endpoints.
-		private WebResourceResponse? TryGetBridgeResponse(string fullUrl, IWebResourceRequest request, ILogger? logger)
+		// Resolves the app-origin-relative path for a request URL. Returns false when the URL is
+		// not under the HybridWebView app origin; returns true otherwise, with relativePath set to
+		// the resolved path (which may itself be null if the path could not be resolved). Shared by
+		// IsFrameworkInternalRequest and GetResponse to keep the URI parsing in one place.
+		private static bool TryGetAppRelativePath(string fullUrl, out string? relativePath)
 		{
-			if (Handler is null || (Handler is IViewHandler ivh && ivh.VirtualView is null))
-			{
-				return null;
-			}
+			relativePath = null;
 
 			var requestUri = WebUtils.RemovePossibleQueryString(fullUrl);
 			if (new Uri(requestUri) is not Uri uri || !HybridWebViewHandler.AppOriginUri.IsBaseOf(uri))
 			{
-				return null;
+				return false;
 			}
 
-			var relativePath = WebUtils.ResolveRelativePath(HybridWebViewHandler.AppOriginUri, uri);
-			if (relativePath is null)
+			relativePath = WebUtils.ResolveRelativePath(HybridWebViewHandler.AppOriginUri, uri);
+			return true;
+		}
+
+		// Returns true when the request targets a reserved HybridWebView bridge endpoint and must
+		// therefore be handled by the framework instead of being exposed to app-level
+		// WebResourceRequested interception. Each endpoint is bound to its well-known path:
+		//  - the bridge bootstrap script is a plain <script> load with no header, matched by path;
+		//  - the message/invoke channels must ALSO carry the protocol marker header, because the
+		//    header name/value are public and a same-origin script could otherwise set it on an
+		//    arbitrary URL to bypass interception.
+		private static bool IsFrameworkInternalRequest(string fullUrl, IWebResourceRequest request)
+		{
+			if (!TryGetAppRelativePath(fullUrl, out var relativePath) || relativePath is null)
+			{
+				return false;
+			}
+
+			if (relativePath == HybridWebViewHandler.HybridWebViewDotJsPath)
+			{
+				return true;
+			}
+
+			if (relativePath == HybridWebViewHandler.InvokeDotNetPath ||
+				relativePath == HybridWebViewHandler.SendMessagePath)
+			{
+				return HybridWebViewHandler.HasExpectedHeaders(request.RequestHeaders);
+			}
+
+			return false;
+		}
+
+		private WebResourceResponse? GetResponse(string fullUrl, IWebResourceRequest request, ILogger? logger)
+		{
+			if (Handler is null || Handler is IViewHandler ivh && ivh.VirtualView is null)
 			{
 				return null;
 			}
 
-			// The bridge script
+			if (!TryGetAppRelativePath(fullUrl, out var relativePath))
+			{
+				// Not an app-origin request; let it proceed unmodified.
+				return null;
+			}
+
+			logger?.LogDebug("Request for {Url} will be handled by .NET MAUI.", fullUrl);
+
+			if (relativePath is null)
+			{
+				logger?.LogDebug("Request for {Url} resolved to an invalid path.", fullUrl);
+				return new WebResourceResponse("text/plain", "UTF-8", 404, "Not Found", GetHeaders("text/plain"), new MemoryStream());
+			}
+
+			// 1.a. Try the special "_framework/hybridwebview.js" path
 			if (relativePath == HybridWebViewHandler.HybridWebViewDotJsPath)
 			{
 				logger?.LogDebug("Request for {Url} will return the hybrid web view script.", fullUrl);
@@ -146,11 +188,9 @@ namespace Microsoft.Maui.Platform
 				{
 					return new WebResourceResponse("application/json", "UTF-8", 200, "OK", GetHeaders("application/json"), jsStream);
 				}
-
-				return null;
 			}
 
-			// The JS -> .NET InvokeDotNet channel
+			// 1.b. Try special InvokeDotNet path
 			if (relativePath == HybridWebViewHandler.InvokeDotNetPath)
 			{
 				logger?.LogDebug("Request for {Url} will be handled by the .NET method invoker.", fullUrl);
@@ -165,7 +205,7 @@ namespace Microsoft.Maui.Platform
 				return new WebResourceResponse("application/json", "UTF-8", 200, "OK", GetHeaders("application/json"), responseStream);
 			}
 
-			// The JS -> .NET message channel
+			// 1.c. Try the special SendMessage path (JS -> .NET messages).
 			if (relativePath == HybridWebViewHandler.SendMessagePath)
 			{
 				logger?.LogDebug("Request for {Url} will be handled by the .NET message receiver.", fullUrl);
@@ -191,36 +231,7 @@ namespace Microsoft.Maui.Platform
 				return new WebResourceResponse(null, "UTF-8", 204, "No Content", null, new MemoryStream());
 			}
 
-			return null;
-		}
-
-		private WebResourceResponse? GetResponse(string fullUrl, IWebResourceRequest request, ILogger? logger)
-		{
-			if (Handler is null || Handler is IViewHandler ivh && ivh.VirtualView is null)
-			{
-				return null;
-			}
-
-			var requestUri = WebUtils.RemovePossibleQueryString(fullUrl);
-			if (new Uri(requestUri) is not Uri uri || !HybridWebViewHandler.AppOriginUri.IsBaseOf(uri))
-			{
-				return null;
-			}
-
-			logger?.LogDebug("Request for {Url} will be handled by .NET MAUI.", fullUrl);
-
-			var relativePath = WebUtils.ResolveRelativePath(HybridWebViewHandler.AppOriginUri, uri);
-			if (relativePath is null)
-			{
-				logger?.LogDebug("Request for {Url} resolved to an invalid path.", fullUrl);
-				return new WebResourceResponse("text/plain", "UTF-8", 404, "Not Found", GetHeaders("text/plain"), new MemoryStream());
-			}
-
-			// The framework-internal bridge endpoints (bridge script, InvokeDotNet and
-			// SendMessage channels) are handled earlier in ShouldInterceptRequest via
-			// TryGetBridgeResponse, so by this point only static app content remains.
-
-			// Try to get static content from the asset path
+			// 2. If nothing found yet, try to get static content from the asset path
 			string? contentType;
 			if (string.IsNullOrEmpty(relativePath))
 			{

--- a/src/Core/src/Platform/Android/MauiHybridWebViewClient.cs
+++ b/src/Core/src/Platform/Android/MauiHybridWebViewClient.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Maui.Platform
 		// not under the HybridWebView app origin; returns true otherwise, with relativePath set to
 		// the resolved path (which may itself be null if the path could not be resolved). Shared by
 		// IsFrameworkInternalRequest and GetResponse to keep the URI parsing in one place.
-		private static bool TryGetAppRelativePath(string fullUrl, out string? relativePath)
+		static bool TryGetAppRelativePath(string fullUrl, out string? relativePath)
 		{
 			relativePath = null;
 
@@ -137,7 +137,7 @@ namespace Microsoft.Maui.Platform
 		//  - the message/invoke channels must ALSO carry the protocol marker header, because the
 		//    header name/value are public and a same-origin script could otherwise set it on an
 		//    arbitrary URL to bypass interception.
-		private static bool IsFrameworkInternalRequest(string fullUrl, IWebResourceRequest request)
+		static bool IsFrameworkInternalRequest(string fullUrl, IWebResourceRequest request)
 		{
 			if (!TryGetAppRelativePath(fullUrl, out var relativePath) || relativePath is null)
 			{
@@ -267,8 +267,7 @@ namespace Microsoft.Maui.Platform
 
 		// Validates a POST-only bridge request that carries its body in the
 		// X-Maui-Request-Body header (Android does not expose the POST body to
-		// ShouldInterceptRequest). The header value is URL-encoded by the JS transport
-		// and decoded here. On success returns true with the decoded body in `body`;
+		// ShouldInterceptRequest). On success returns true with the body in `body`;
 		// on failure returns false with the appropriate error response in `errorResponse`.
 		private static bool TryValidateBridgeRequest(IWebResourceRequest request, string endpointName, ILogger? logger, [NotNullWhen(true)] out string? body, [NotNullWhen(false)] out WebResourceResponse? errorResponse)
 		{
@@ -295,11 +294,6 @@ namespace Microsoft.Maui.Platform
 				errorResponse = new WebResourceResponse(null, "UTF-8", 400, "Bad Request", null, null);
 				return false;
 			}
-
-			// The JS transport URL-encodes the header value so it survives the HTTP header byte-set
-			// restriction (headers cannot carry CR/LF/NUL or non-Latin-1 characters). Decode it here
-			// once for both the InvokeDotNet and SendMessage endpoints.
-			body = Uri.UnescapeDataString(body);
 
 			errorResponse = null;
 			return true;

--- a/src/Core/src/Platform/Android/MauiHybridWebViewClient.cs
+++ b/src/Core/src/Platform/Android/MauiHybridWebViewClient.cs
@@ -215,18 +215,12 @@ namespace Microsoft.Maui.Platform
 					return error;
 				}
 
-				try
-				{
-					Handler.MessageReceived(messageBody);
-				}
-				catch (Exception ex)
-				{
-					// ShouldInterceptRequest runs on a native WebView thread; letting an exception
-					// unwind across the JNI boundary crashes the app (and breaks in the debugger).
-					// Log it and return an error response instead.
-					logger?.LogError(ex, "SendMessage handler threw while processing a JS -> .NET message.");
-					return new WebResourceResponse(null, "UTF-8", 500, "Internal Server Error", null, new MemoryStream());
-				}
+				// Do not wrap this in a try/catch. MessageReceived raises the app-facing message
+				// handlers (e.g. RawMessageReceived); an exception thrown by app code must be allowed
+				// to propagate rather than be swallowed, matching how MAUI treats event handlers such
+				// as Button.Click. Developers who want to handle these exceptions can catch them in
+				// their own handler.
+				Handler.MessageReceived(messageBody);
 
 				return new WebResourceResponse(null, "UTF-8", 204, "No Content", null, new MemoryStream());
 			}

--- a/src/Core/src/Platform/Android/MauiHybridWebViewClient.cs
+++ b/src/Core/src/Platform/Android/MauiHybridWebViewClient.cs
@@ -69,14 +69,37 @@ namespace Microsoft.Maui.Platform
 
 			if (view is not null && request is not null && !string.IsNullOrEmpty(url))
 			{
-				// 1. Check if the app wants to modify or override the request
-				var response = WebRequestInterceptingWebView.TryInterceptResponseStream(Handler, view, request, url, logger);
+				// 1. Handle framework-internal bridge endpoints (the JS bridge script and the
+				//    JS <-> .NET message/invoke channels) before user interception. A
+				//    WebResourceRequested handler must never receive — or be able to throw on —
+				//    these internal requests. Before JS -> .NET messages were routed over HTTP
+				//    they were invisible to interception, and they should remain so.
+				var bridgeResponse = TryGetBridgeResponse(url, request, logger);
+				if (bridgeResponse is not null)
+				{
+					return bridgeResponse;
+				}
+
+				// 2. Check if the app wants to modify or override the request
+				WebResourceResponse? response = null;
+				try
+				{
+					response = WebRequestInterceptingWebView.TryInterceptResponseStream(Handler, view, request, url, logger);
+				}
+				catch (Exception ex)
+				{
+					// ShouldInterceptRequest runs on a native WebView thread; letting a user
+					// WebResourceRequested handler's exception unwind across the JNI boundary
+					// crashes the app. Log it and fall back to default handling instead.
+					logger?.LogError(ex, "A WebResourceRequested handler threw while intercepting {Url}.", url);
+				}
+
 				if (response is not null)
 				{
 					return response;
 				}
 
-				// 2. Check if the request is for a local resource
+				// 3. Check if the request is for a local resource
 				response = GetResponse(url, request, logger);
 				if (response is not null)
 				{
@@ -88,6 +111,87 @@ namespace Microsoft.Maui.Platform
 			logger?.LogDebug("Request for {Url} was not handled.", url);
 
 			return base.ShouldInterceptRequest(view, request);
+		}
+
+		// Handles the framework-internal HybridWebView bridge endpoints: the bridge script,
+		// the JS -> .NET InvokeDotNet channel, and the JS -> .NET message channel. These are
+		// resolved before user WebResourceRequested interception so app code never sees — or
+		// can block/crash on — the framework's own control requests. Returns null when the
+		// request is not one of these internal endpoints.
+		private WebResourceResponse? TryGetBridgeResponse(string fullUrl, IWebResourceRequest request, ILogger? logger)
+		{
+			if (Handler is null || (Handler is IViewHandler ivh && ivh.VirtualView is null))
+			{
+				return null;
+			}
+
+			var requestUri = WebUtils.RemovePossibleQueryString(fullUrl);
+			if (new Uri(requestUri) is not Uri uri || !HybridWebViewHandler.AppOriginUri.IsBaseOf(uri))
+			{
+				return null;
+			}
+
+			var relativePath = WebUtils.ResolveRelativePath(HybridWebViewHandler.AppOriginUri, uri);
+			if (relativePath is null)
+			{
+				return null;
+			}
+
+			// The bridge script
+			if (relativePath == HybridWebViewHandler.HybridWebViewDotJsPath)
+			{
+				logger?.LogDebug("Request for {Url} will return the hybrid web view script.", fullUrl);
+				var jsStream = HybridWebViewHandler.GetEmbeddedStream(HybridWebViewHandler.HybridWebViewDotJsPath);
+				if (jsStream is not null)
+				{
+					return new WebResourceResponse("application/json", "UTF-8", 200, "OK", GetHeaders("application/json"), jsStream);
+				}
+
+				return null;
+			}
+
+			// The JS -> .NET InvokeDotNet channel
+			if (relativePath == HybridWebViewHandler.InvokeDotNetPath)
+			{
+				logger?.LogDebug("Request for {Url} will be handled by the .NET method invoker.", fullUrl);
+
+				if (!TryValidateBridgeRequest(request, "InvokeDotNet", logger, out var requestBody, out var error))
+				{
+					return error;
+				}
+
+				var contentBytesTask = Handler.InvokeDotNetAsync(stringBody: requestBody);
+				var responseStream = new AsyncStream(contentBytesTask, logger);
+				return new WebResourceResponse("application/json", "UTF-8", 200, "OK", GetHeaders("application/json"), responseStream);
+			}
+
+			// The JS -> .NET message channel
+			if (relativePath == HybridWebViewHandler.SendMessagePath)
+			{
+				logger?.LogDebug("Request for {Url} will be handled by the .NET message receiver.", fullUrl);
+
+				if (!TryValidateBridgeRequest(request, "SendMessage", logger, out var messageBody, out var error))
+				{
+					return error;
+				}
+
+				try
+				{
+					Handler.MessageReceived(messageBody);
+				}
+				catch (Exception ex)
+				{
+					// ShouldInterceptRequest runs on a native WebView thread; letting an exception
+					// unwind across the JNI boundary crashes the app (and breaks in the debugger).
+					// Log it and return an error response instead.
+					logger?.LogError(ex, "SendMessage handler threw while processing a JS -> .NET message.");
+					return new WebResourceResponse(null, "UTF-8", 500, "Internal Server Error", null, new MemoryStream());
+				}
+
+				return new WebResourceResponse(null, "UTF-8", 204, "No Content", null, new MemoryStream());
+			}
+
+			return null;
 		}
 
 		private WebResourceResponse? GetResponse(string fullUrl, IWebResourceRequest request, ILogger? logger)
@@ -112,47 +216,11 @@ namespace Microsoft.Maui.Platform
 				return new WebResourceResponse("text/plain", "UTF-8", 404, "Not Found", GetHeaders("text/plain"), new MemoryStream());
 			}
 
-			// 1.a. Try the special "_framework/hybridwebview.js" path
-			if (relativePath == HybridWebViewHandler.HybridWebViewDotJsPath)
-			{
-				logger?.LogDebug("Request for {Url} will return the hybrid web view script.", fullUrl);
-				var jsStream = HybridWebViewHandler.GetEmbeddedStream(HybridWebViewHandler.HybridWebViewDotJsPath);
-				if (jsStream is not null)
-				{
-					return new WebResourceResponse("application/json", "UTF-8", 200, "OK", GetHeaders("application/json"), jsStream);
-				}
-			}
+			// The framework-internal bridge endpoints (bridge script, InvokeDotNet and
+			// SendMessage channels) are handled earlier in ShouldInterceptRequest via
+			// TryGetBridgeResponse, so by this point only static app content remains.
 
-			// 1.b. Try special InvokeDotNet path
-			if (relativePath == HybridWebViewHandler.InvokeDotNetPath)
-			{
-				logger?.LogDebug("Request for {Url} will be handled by the .NET method invoker.", fullUrl);
-
-				if (!TryValidateBridgeRequest(request, "InvokeDotNet", logger, out var requestBody, out var error))
-				{
-					return error;
-				}
-
-				var contentBytesTask = Handler.InvokeDotNetAsync(stringBody: requestBody);
-				var responseStream = new AsyncStream(contentBytesTask, logger);
-				return new WebResourceResponse("application/json", "UTF-8", 200, "OK", GetHeaders("application/json"), responseStream);
-			}
-
-			// 1.c. Try the special SendMessage path (JS -> .NET messages).
-			if (relativePath == HybridWebViewHandler.SendMessagePath)
-			{
-				logger?.LogDebug("Request for {Url} will be handled by the .NET message receiver.", fullUrl);
-
-				if (!TryValidateBridgeRequest(request, "SendMessage", logger, out var messageBody, out var error))
-				{
-					return error;
-				}
-
-				Handler.MessageReceived(messageBody);
-				return new WebResourceResponse(null, "UTF-8", 204, "No Content", null, new MemoryStream());
-			}
-
-			// 2. If nothing found yet, try to get static content from the asset path
+			// Try to get static content from the asset path
 			string? contentType;
 			if (string.IsNullOrEmpty(relativePath))
 			{
@@ -188,7 +256,8 @@ namespace Microsoft.Maui.Platform
 
 		// Validates a POST-only bridge request that carries its body in the
 		// X-Maui-Request-Body header (Android does not expose the POST body to
-		// ShouldInterceptRequest). On success returns true with the body in `body`;
+		// ShouldInterceptRequest). The header value is URL-encoded by the JS transport
+		// and decoded here. On success returns true with the decoded body in `body`;
 		// on failure returns false with the appropriate error response in `errorResponse`.
 		private static bool TryValidateBridgeRequest(IWebResourceRequest request, string endpointName, ILogger? logger, [NotNullWhen(true)] out string? body, [NotNullWhen(false)] out WebResourceResponse? errorResponse)
 		{
@@ -215,6 +284,11 @@ namespace Microsoft.Maui.Platform
 				errorResponse = new WebResourceResponse(null, "UTF-8", 400, "Bad Request", null, null);
 				return false;
 			}
+
+			// The JS transport URL-encodes the header value so it survives the HTTP header byte-set
+			// restriction (headers cannot carry CR/LF/NUL or non-Latin-1 characters). Decode it here
+			// once for both the InvokeDotNet and SendMessage endpoints.
+			body = Uri.UnescapeDataString(body);
 
 			errorResponse = null;
 			return true;

--- a/src/Core/src/Platform/Windows/MauiHybridWebView.cs
+++ b/src/Core/src/Platform/Windows/MauiHybridWebView.cs
@@ -23,7 +23,10 @@ namespace Microsoft.Maui.Platform
 
 		public void SendRawMessage(string rawMessage)
 		{
-			CoreWebView2.PostWebMessageAsString(rawMessage);
+			// WebView2's PostWebMessageAsString marshals to a null-terminated LPCWSTR, so any embedded
+			// NUL character would truncate the message. URL-encode the payload so it survives; the JS
+			// transport decodes it in the WebView2 'message' event listener in hybridwebview.js.
+			CoreWebView2.PostWebMessageAsString(Uri.EscapeDataString(rawMessage));
 		}
 
 		public async void RunAfterInitialize(Action action)


### PR DESCRIPTION
### Failed Test
### Android:

1. RequestsCanBeInterceptedAndCustomDataReturned
2. RequestsCanBeInterceptedAndAsyncCustomDataReturned

### Windows:

1. SendRawMessageRoundTripsSpecialCharacters [InlineData("with\0nul")]

### Root Cause

### Android – Request interception regression

- PR #35850 replaced the native `window.hybridWebViewHost.sendMessage` bridge with an HTTP `fetch()`-based transport that communicates through reserved framework endpoints (`__hwvSendMessage` and `__hwvInvokeDotNet`), which are processed by `MauiHybridWebViewClient.ShouldInterceptRequest`.
- With the bridge now using standard HTTP requests, `ShouldInterceptRequest` invoked the application's `WebResourceRequested` interception before handling the framework's own bridge requests. As a result, internal framework requests that were previously invisible to application code became exposed to custom request handlers.
- Applications that assumed every intercepted request contained application-specific query parameters could throw exceptions (for example, `KeyNotFoundException`). Because these exceptions propagated across the JNI boundary on the WebView thread, they could terminate the application.

### Windows – Existing WebView2 NUL-character limitation

HybridWebView communicates through WebView2's `PostWebMessageAsString` and `TryGetWebMessageAsString` APIs, which internally marshal null-terminated native strings (`LPCWSTR`/`LPWSTR`).

Consequently, an embedded NUL (`\0`) character is treated as the end of the string, truncating any remaining content. This limitation existed before PR #35850 and was not introduced by the Android changes. However, the newly added `SendRawMessageRoundTripsSpecialCharacters` device test—specifically the `"with\0nul"` test case—exposed the issue. Other special-character scenarios (Unicode, `%`, and newline) continued to work correctly.

### Description of Change
### Android
The Android bridge was updated to clearly separate framework-internal bridge traffic from application-defined request interception.

- **Corrected request routing:** `ShouldInterceptRequest` now checks `IsFrameworkInternalRequest` before invoking the application's `WebResourceRequested` callback. Framework bridge requests are handled entirely within the framework and are no longer exposed to application interception, restoring the behavior that existed before PR #35850.
- **Stronger framework request validation:** Internal requests are identified using the reserved bridge endpoint paths together with the expected `X-Maui-Invoke-Token` header where applicable, preventing unrelated application requests from being treated as framework traffic.
- **Framework exception isolation:** Only the framework's internal `Handler.MessageReceived` dispatch is wrapped in a `try/catch`, ensuring unexpected framework exceptions cannot escape across the JNI boundary and crash the WebView thread. Application-defined request interception remains unchanged, preserving existing application behavior.
- Common URI parsing and application-relative path resolution logic was consolidated into a shared `TryGetAppRelativePath` helper, reducing duplication and simplifying request processing.

### Windows
The Windows fix applies URL encoding at the WebView2 transport boundary so embedded NUL characters survive native string marshalling.

- **.NET → JavaScript:** Messages are encoded with `Uri.EscapeDataString` before calling `PostWebMessageAsString`, and JavaScript decodes them using `decodeURIComponent`.
- **JavaScript → .NET:** JavaScript encodes outgoing messages with `encodeURIComponent`, and `OnWebMessageReceived` decodes them using `Uri.UnescapeDataString` before dispatching the message.
- **Shared raw-message path:** The existing shared raw-message pipeline continues to perform a single decode in `HybridWebViewHandler.MessageReceived` via `Uri.UnescapeDataString`, while `sendRawMessage` now URL-encodes its payload with `encodeURIComponent`. This preserves embedded NUL characters and other special characters without changing the shared handler logic or the overall JavaScript bridge design.


### Validated the behaviour in the following platforms
- [x] Android
- [x] Windows
- [ ] iOS
- [ ] Mac

### Issues Fixed:
Fixes #36469 

### Screenshots
| Before  | After |
|---------|--------|
| <video src="https://github.com/user-attachments/assets/ceac9179-e177-4597-b98f-377b6c60d8c8"> | <video src="https://github.com/user-attachments/assets/a2b5387e-a0a4-4af4-9331-8c51d2f04178"> |