### PR TITLE
[inflight regression] Fix: LifeCycleEvents Fire When Navigating Top Tabs test fails in candidate 

### DIFF
--- a/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
@@ -206,7 +206,7 @@ namespace Microsoft.Maui.Controls.Handlers
 					(parentShell.CurrentItem as IShellItemController)?.ProposeSection(shellContent);
 					parentShell.CurrentItem = shellContent;
 				}
-				else if (shellContent.Parent is ShellSection existingSection && existingSection.CurrentItem != shellContent)
+				else if (shellContent.Parent is ShellSection existingSection && existingSection.CurrentItem != shellContent && existingSection.IsVisibleSection)
 				{
 					// Fire OnNavigatingFrom before CurrentItem changes, so it captures the correct outgoing page.
 					parentShell.NavigationManager.ProposeNavigationOutsideGotoAsync(

--- a/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
@@ -208,9 +208,7 @@ namespace Microsoft.Maui.Controls.Handlers
 				}
 				else if (shellContent.Parent is ShellSection existingSection && existingSection.CurrentItem != shellContent)
 				{
-					// Fire OnNavigatingFrom before switching CurrentItem, so it correctly captures
-					// the outgoing page. SetValueFromRenderer marks this as handler-driven, so
-					// ShellSection.OnCurrentItemChanged skips its own (mistimed) navigation call.
+					// Fire OnNavigatingFrom before CurrentItem changes, so it captures the correct outgoing page.
 					parentShell.NavigationManager.ProposeNavigationOutsideGotoAsync(
 						ShellNavigationSource.ShellContentChanged,
 						parentShell.CurrentItem,
@@ -220,6 +218,8 @@ namespace Microsoft.Maui.Controls.Handlers
 						canCancel: false,
 						isAnimated: true);
 
+					// Set ShellSection.CurrentItem directly (using SetValueFromRenderer) to avoid
+					// re-triggering the mistimed-navigation bug via CreateFromShellContent.
 					existingSection.SetValueFromRenderer(ShellSection.CurrentItemProperty, shellContent);
 				}
 				else
@@ -364,7 +364,7 @@ namespace Microsoft.Maui.Controls.Handlers
 					autoSuggestBox.UpdateSearchHandlerBackground(_currentSearchHandler);
 					autoSuggestBox.UpdateSearchHandlerVerticalTextAlignment(_currentSearchHandler);
 					autoSuggestBox.UpdateSearchHandlerHorizontalTextAlignment(_currentSearchHandler);
-					
+
 					_currentSearchHandler.PropertyChanged += OnCurrentSearchHandlerPropertyChanged;
 
 					autoSuggestBox.Visibility = _currentSearchHandler.SearchBoxVisibility == SearchBoxVisibility.Hidden ? Microsoft.UI.Xaml.Visibility.Collapsed : Microsoft.UI.Xaml.Visibility.Visible;

--- a/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
@@ -204,8 +204,28 @@ namespace Microsoft.Maui.Controls.Handlers
 				if (currentItem?.Title != shellContent.Title && currentItem != shellContent.Parent)
 				{
 					(parentShell.CurrentItem as IShellItemController)?.ProposeSection(shellContent);
+					parentShell.CurrentItem = shellContent;
 				}
-				parentShell.CurrentItem = shellContent;
+				else if (shellContent.Parent is ShellSection existingSection && existingSection.CurrentItem != shellContent)
+				{
+					// Fire OnNavigatingFrom before switching CurrentItem, so it correctly captures
+					// the outgoing page. SetValueFromRenderer marks this as handler-driven, so
+					// ShellSection.OnCurrentItemChanged skips its own (mistimed) navigation call.
+					parentShell.NavigationManager.ProposeNavigationOutsideGotoAsync(
+						ShellNavigationSource.ShellContentChanged,
+						parentShell.CurrentItem,
+						existingSection,
+						shellContent,
+						existingSection.Stack,
+						canCancel: false,
+						isAnimated: true);
+
+					existingSection.SetValueFromRenderer(ShellSection.CurrentItemProperty, shellContent);
+				}
+				else
+				{
+					parentShell.CurrentItem = shellContent;
+				}
 			}
 		}
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

This pull request fixes a regression Introduced by PR https://github.com/dotnet/maui/pull/34351 which caused the Windows device test LifeCycleEvents Fire When Navigating Top Tabs to fail in Candidate PR

### Description of Change
PR #34351 added code that fires the  OnNavigatingFrom  event, but only after the page had already switched to the new one. So it wrongly captured the new page as previous, instead of the old page.
 
On Windows, we now fire the  OnNavigatingFrom  event first, before switching the page. This way it correctly captures the old page as previous. Then we switch the page in a special way that tells the shared code "this is already handled," so it doesn't repeat the same mistake.
 
### Issues Fixed
  
Fixes #36466 