### PR TITLE
[Android] Fix: WebView clamping small CSS font sizes

### DIFF
--- a/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
+++ b/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
@@ -49,6 +49,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 
 				blazorAndroidWebView.Settings.JavaScriptEnabled = true;
 				blazorAndroidWebView.Settings.DomStorageEnabled = true;
+				blazorAndroidWebView.Settings.MinimumFontSize = 1;
 			}
 
 			_webViewClient = new WebKitWebViewClient(this);

--- a/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
+++ b/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
@@ -50,6 +50,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				blazorAndroidWebView.Settings.JavaScriptEnabled = true;
 				blazorAndroidWebView.Settings.DomStorageEnabled = true;
 				blazorAndroidWebView.Settings.MinimumFontSize = 1;
+				blazorAndroidWebView.Settings.MinimumLogicalFontSize = 1;
 			}
 
 			_webViewClient = new WebKitWebViewClient(this);

--- a/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.Behaviors.cs
+++ b/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.Behaviors.cs
@@ -43,4 +43,75 @@ public partial class BlazorWebViewTests
 		});
 	}
 #endif
+
+#if ANDROID
+	const string SmallFontSpanId = "smallFontSpan";
+	const string SmallFontCssValue = "4.87761px";
+
+	static class SmallFontTestStaticFilesContents
+	{
+		public const string SmallFontIndexHtmlContent = @"<!DOCTYPE html>
+<html>
+
+<head testhtmlloaded=""true"">
+    <meta charset=""utf-8"" />
+    <meta name=""viewport"" content=""width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"" />
+    <title>Blazor app</title>
+    <base href=""/"" />
+</head>
+
+<body>
+    <span id=""" + SmallFontSpanId + @""" style=""font-size:" + SmallFontCssValue + @";"">tiny span text</span>
+    <div id=""app""></div>
+
+    <div id=""blazor-error-ui"">
+        An unhandled error has occurred.
+        <a href="""" class=""reload"">Reload</a>
+        <a class=""dismiss"">🗙</a>
+    </div>
+    <script src=""_framework/blazor.webview.js"" autostart=""false""></script>
+
+</body>
+
+</html>
+";
+	}
+
+	/// <summary>
+	/// Regression test for https://github.com/dotnet/maui/issues/26924 - verifies that
+	/// BlazorWebViewHandler.Android.cs sets MinimumFontSize/MinimumLogicalFontSize to 1 so
+	/// small CSS font sizes (below the Android WebView's default 8px minimum) aren't clamped up.
+	/// </summary>
+	[Fact]
+	public async Task BlazorWebViewDoesNotClampSmallCssFontSizes()
+	{
+		EnsureHandlerCreated(additionalCreationActions: appBuilder =>
+		{
+			appBuilder.Services.AddMauiBlazorWebView();
+		});
+
+		var bwv = new BlazorWebViewWithCustomFiles
+		{
+			HostPage = "wwwroot/index.html",
+			CustomFiles = new Dictionary<string, string>
+			{
+				{ "index.html", SmallFontTestStaticFilesContents.SmallFontIndexHtmlContent },
+			},
+		};
+		bwv.RootComponents.Add(new RootComponent { ComponentType = typeof(NoOpComponent), Selector = "#app", });
+
+		await InvokeOnMainThreadAsync(async () =>
+		{
+			var bwvHandler = CreateHandler<BlazorWebViewHandler>(bwv);
+			var platformWebView = bwvHandler.PlatformView;
+			await WebViewHelpers.WaitForWebViewReady(platformWebView);
+
+			var computedFontSize = await WebViewHelpers.ExecuteScriptAsync(
+				platformWebView,
+				$"window.getComputedStyle(document.getElementById('{SmallFontSpanId}')).fontSize");
+
+			Assert.Equal($"\"{SmallFontCssValue}\"", computedFontSize);
+		});
+	}
+#endif
 }

--- a/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.Behaviors.cs
+++ b/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.Behaviors.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.WebView.Maui;
@@ -105,12 +107,12 @@ public partial class BlazorWebViewTests
 			var bwvHandler = CreateHandler<BlazorWebViewHandler>(bwv);
 			var platformWebView = bwvHandler.PlatformView;
 			await WebViewHelpers.WaitForWebViewReady(platformWebView);
-
-			var computedFontSize = await WebViewHelpers.ExecuteScriptAsync(
+			var computedFontSizeJson = await WebViewHelpers.ExecuteScriptAsync(
 				platformWebView,
-				$"window.getComputedStyle(document.getElementById('{SmallFontSpanId}')).fontSize");
+				$"parseFloat(window.getComputedStyle(document.getElementById('{SmallFontSpanId}')).fontSize)");
+			var computedFontSize = double.Parse(computedFontSizeJson, CultureInfo.InvariantCulture);
 
-			Assert.Equal($"\"{SmallFontCssValue}\"", computedFontSize);
+			Assert.True(computedFontSize < 8, $"Expected computed font size to be under the 8px clamp, but was {computedFontSize}px.");
 		});
 	}
 #endif

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue26924.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue26924.cs
@@ -17,7 +17,7 @@ namespace Maui.Controls.Sample.Issues
 				<html>
 					<head></head>
 					<body>
-					<p>Hii this is Para </p>
+					<p>Hi, this is a paragraph.</p>
 						<span id=""{SmallFontSpanId}"" style=""font-size:{SmallFontCssValue};"">tiny span text</span>
 					</body>
 				</html>";

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue26924.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue26924.cs
@@ -8,7 +8,6 @@ namespace Maui.Controls.Sample.Issues
 		Button _checkButton;
 
 		const string SmallFontSpanId = "smallFontSpan";
-		const string paraFontSpanId = "paraFontSpanId";
 		internal const string SmallFontCssValue = "4.87761px";
 
 		protected override void Init()

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue26924.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue26924.cs
@@ -1,0 +1,70 @@
+namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 26924, "Font Size of span Element Not Rendering Correctly in Mobile Mode in .NET MAUI Blazor", PlatformAffected.All)]
+	public class Issue26924 : TestContentPage
+	{
+		WebView _webView;
+		Label _resultLabel;
+		Button _checkButton;
+
+		const string SmallFontSpanId = "smallFontSpan";
+		const string paraFontSpanId = "paraFontSpanId";
+		internal const string SmallFontCssValue = "4.87761px";
+
+		protected override void Init()
+		{
+			var html = $@"
+				<!DOCTYPE html>
+				<html>
+					<head></head>
+					<body>
+					<p>Hii this is Para </p>
+						<span id=""{SmallFontSpanId}"" style=""font-size:{SmallFontCssValue};"">tiny span text</span>
+					</body>
+				</html>";
+
+			_webView = new WebView
+			{
+				Source = new HtmlWebViewSource { Html = html },
+				HeightRequest = 100,
+				AutomationId = "SmallFontWebView"
+			};
+
+			_resultLabel = new Label
+			{
+				Text = "Not checked yet",
+				AutomationId = "ComputedFontSizeLabel"
+			};
+
+			_checkButton = new Button
+			{
+				Text = "Get computed font size of span",
+				AutomationId = "CheckFontSizeButton",
+				Command = new Command(async () => await CheckComputedFontSizeAsync())
+			};
+
+			// Update the result label once the WebView finishes loading the HTML, so the test
+			// can wait for "WebView loaded" before tapping the button instead of racing navigation.
+			_webView.Navigated += (_, __) => _resultLabel.Text = "WebView loaded";
+
+			Content = new VerticalStackLayout
+			{
+				Children =
+				{
+					new Label { Text = $"Expected computed font-size to stay close to {SmallFontCssValue} (i.e. under 8px), not be clamped up by the platform WebView's minimum font size." },
+					_webView,
+					_checkButton,
+					_resultLabel
+				}
+			};
+		}
+
+		async Task CheckComputedFontSizeAsync()
+		{
+			var computedFontSize = await _webView.EvaluateJavaScriptAsync(
+				$"window.getComputedStyle(document.getElementById('{SmallFontSpanId}')).fontSize");
+
+			_resultLabel.Text = computedFontSize?.Trim('"') ?? string.Empty;
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26924.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26924.cs
@@ -1,0 +1,26 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue26924 : _IssuesUITest
+{
+	public Issue26924(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue => "Font Size of span Element Not Rendering Correctly in Mobile Mode in .NET MAUI Blazor";
+
+	[Test]
+	[Category(UITestCategories.WebView)]
+	public void SmallFontSizeSpanIsNotClampedByMinimumFontSize()
+	{
+		// The result label is updated to "WebView loaded" once the WebView finishes loading
+		// the HTML, so wait for that before tapping the button to avoid racing navigation.
+		App.WaitForTextToBePresentInElement("ComputedFontSizeLabel", "WebView loaded");
+		App.Tap("CheckFontSizeButton");
+		Assert.That(App.WaitForElement("ComputedFontSizeLabel").GetText(), Is.EqualTo("4.87761px"));
+	}
+}
+

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26924.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26924.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -20,7 +21,10 @@ public class Issue26924 : _IssuesUITest
 		// the HTML, so wait for that before tapping the button to avoid racing navigation.
 		App.WaitForTextToBePresentInElement("ComputedFontSizeLabel", "WebView loaded");
 		App.Tap("CheckFontSizeButton");
-		Assert.That(App.WaitForElement("ComputedFontSizeLabel").GetText(), Is.EqualTo("4.87761px"));
+		var computedFontSizeText = App.WaitForElement("ComputedFontSizeLabel").GetText();
+		Assert.That(computedFontSizeText, Is.Not.Null);
+		var computedFontSize = float.Parse(computedFontSizeText!.TrimEnd('p', 'x'), CultureInfo.InvariantCulture);
+		Assert.That(computedFontSize, Is.LessThan(8f));
 	}
 }
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26924.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26924.cs
@@ -21,10 +21,10 @@ public class Issue26924 : _IssuesUITest
 		// the HTML, so wait for that before tapping the button to avoid racing navigation.
 		App.WaitForTextToBePresentInElement("ComputedFontSizeLabel", "WebView loaded");
 		App.Tap("CheckFontSizeButton");
+		App.WaitForTextToBePresentInElement("ComputedFontSizeLabel", "px");
 		var computedFontSizeText = App.WaitForElement("ComputedFontSizeLabel").GetText();
 		Assert.That(computedFontSizeText, Is.Not.Null);
-		var computedFontSize = float.Parse(computedFontSizeText!.TrimEnd('p', 'x'), CultureInfo.InvariantCulture);
-		Assert.That(computedFontSize, Is.LessThan(8f));
+		Assert.That(float.Parse(computedFontSizeText!.Trim().TrimEnd('p', 'x'), CultureInfo.InvariantCulture), Is.LessThan(8f));
 	}
 }
 

--- a/src/Core/src/Platform/Android/WebViewExtensions.cs
+++ b/src/Core/src/Platform/Android/WebViewExtensions.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Maui.Platform
 			// Android WebView defaults MinimumFontSize to 8, which silently
 			// clamps up any CSS font-size below 8px.
 			platformWebView.Settings.MinimumFontSize = 1;
+			platformWebView.Settings.MinimumLogicalFontSize = 1;
 		}
 
 		public static void UpdateUserAgent(this AWebView platformWebView, IWebView webView)

--- a/src/Core/src/Platform/Android/WebViewExtensions.cs
+++ b/src/Core/src/Platform/Android/WebViewExtensions.cs
@@ -39,6 +39,9 @@ namespace Microsoft.Maui.Platform
 
 			platformWebView.Settings.JavaScriptEnabled = javaScriptEnabled;
 			platformWebView.Settings.DomStorageEnabled = domStorageEnabled;
+			// Android WebView defaults MinimumFontSize to 8, which silently
+			// clamps up any CSS font-size below 8px.
+			platformWebView.Settings.MinimumFontSize = 1;
 		}
 
 		public static void UpdateUserAgent(this AWebView platformWebView, IWebView webView)


### PR DESCRIPTION
<!-- Please keep the note below for people who find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment whether this change resolves your issue. Thank you!<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!!  -->

This pull request addresses an issue where small CSS font sizes (below 8px) were being clamped up by the Android WebView's default minimum font size, causing them to render larger than specified in .NET MAUI Blazor apps. The changes ensure that small font size  rendered correctly by explicitly setting lower minimum font size values in the Android WebView settings. Additionally, new test cases have been added to verify the fix.

### Android WebView font size handling

* Explicitly set `MinimumFontSize` and `MinimumLogicalFontSize` to `1` in Android WebView initialization and settings update methods to prevent the platform from clamping small CSS font sizes. [[1]](diffhunk://#diff-745160d3986f59a60c86d338d2bf5659491cb445df33de8fdef26cec9e8b58a5R52-R53) [[2]](diffhunk://#diff-ca62b285e626480e971cc257bb277985d30081c0e2754e25cb58517aca3430f6R42-R45)

### Testing

* Added a new UI test page (`Issue26924`) to demonstrate and verify that a `<span>` with a small font size (4.87761px) renders correctly in a Blazor WebView.
* Added an automated test to assert that the computed font size for the test span remains at 4.87761px, confirming the fix works as intended.

<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #26924

### Tested the behavior in the following platforms

- [ ] Windows
- [x] Android
- [ ] iOS
- [ ] Mac


### Snapshots :

 | Before Fix | After Fix |
 |--------------------------|---------------------------|
 | <img width="1080" height="2400" alt="BeforeFix26924" src="https://github.com/user-attachments/assets/e7712ded-271b-4b75-8807-5433c1721e22" /> | <img width="1080" height="2400" alt="Afterfix26924" src="https://github.com/user-attachments/assets/a820cda0-4674-4793-833a-aa163b559be4" />|
<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
