### PR TITLE
[Android] MediaPicker: Stop overwriting picked source files

### DIFF
--- a/src/Essentials/src/FileSystem/FileSystemUtils.android.cs
+++ b/src/Essentials/src/FileSystem/FileSystemUtils.android.cs
@@ -53,6 +53,40 @@ namespace Microsoft.Maui.Storage
 			return tmpFile;
 		}
 
+		// Determines whether a path is a temporary file that MAUI itself created via
+		// GetTemporaryFile - i.e. one that lives under the "<cache>/<EssentialsFolderHash>/"
+		// folder that only GetTemporaryFile ever creates. This is a reliable ownership marker:
+		// files picked from the gallery, an SD card, another app's shared storage, or resolved
+		// to a raw physical path are never located under that folder, so callers can safely
+		// clean up an owned temporary input without any risk of touching a user-owned source.
+		internal static bool IsMauiOwnedTemporaryFile(string path)
+		{
+			if (string.IsNullOrEmpty(path))
+				return false;
+
+			try
+			{
+				var canonicalPath = new Java.IO.File(path).CanonicalPath;
+
+				foreach (var root in new[] { Application.Context.CacheDir, Application.Context.ExternalCacheDir })
+				{
+					if (root is null)
+						continue;
+
+					var ownedRoot = new Java.IO.File(root, EssentialsFolderHash).CanonicalPath + Java.IO.File.Separator;
+					if (canonicalPath.StartsWith(ownedRoot, StringComparison.Ordinal))
+						return true;
+				}
+			}
+			catch
+			{
+				// If the path cannot be canonicalized, err on the side of caution and never treat
+				// it as owned - callers use this to decide whether to delete, so false is the safe default.
+			}
+
+			return false;
+		}
+
 		public static string EnsurePhysicalPath(AndroidUri uri, bool requireExtendedAccess = true)
 		{
 			// if this is a file, use that

--- a/src/Essentials/src/MediaPicker/MediaPicker.android.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.android.cs
@@ -25,66 +25,14 @@ namespace Microsoft.Maui.Media
 		public bool IsCaptureSupported
 			=> Application.Context?.PackageManager?.HasSystemFeature(PackageManager.FeatureCameraAny) ?? false;
 
-		// Rotation never mutates the picked source. The source path is resolved verbatim from the
-		// picker URI and is not a file we own (it may be the user's original on an SD card, in
-		// shared storage, or a file owned by another app), so mutating it in place is incorrect
-		// and risks data loss.
-		internal static Task<string> RotateImage(string filePath, MediaPickerOptions options)
-			=> RotateImageToNewFileAsync(filePath);
+		internal static Task<string> ProcessPhotoAsync(string imagePath, MediaPickerOptions options)
+			=> ProcessImage(imagePath, options);
 
-		internal static async Task<string> ProcessPhotoAsync(string imagePath, MediaPickerOptions options)
-		{
-			// Apply rotation if needed for photos
-			if (imagePath is not null && ImageProcessor.IsRotationNeeded(options))
-			{
-				imagePath = await RotateImage(imagePath, options);
-			}
-
-			// Apply compression/resizing if needed for photos
-			if (imagePath is not null && ImageProcessor.IsProcessingNeeded(options?.MaximumWidth, options?.MaximumHeight, options?.CompressionQuality ?? 100))
-			{
-				imagePath = await CompressImageIfNeeded(imagePath, options);
-			}
-
-			return imagePath;
-		}
-
-		internal static async Task<string> ProcessPhotoPreservingSourceAsync(string imagePath, PersistedPhotoProcessingOptions options)
-		{
-			if (imagePath is null)
-			{
-				return null;
-			}
-
-			var originalImagePath = imagePath;
-			string rotatedImagePath = null;
-
-			// Recovery-sensitive MediaPicker paths must leave the original file intact until the
-			// active recovery record has been cleared or promoted.
-			if (options.RotateImage)
-			{
-				var rotatedPath = await RotateImageToNewFileAsync(imagePath);
-				if (!string.Equals(rotatedPath, imagePath, StringComparison.Ordinal))
-				{
-					rotatedImagePath = rotatedPath;
-				}
-
-				imagePath = rotatedPath;
-			}
-
-			if (ImageProcessor.IsProcessingNeeded(options.MaximumWidth, options.MaximumHeight, options.CompressionQuality))
-			{
-				var compressedImagePath = await CompressImageIfNeeded(imagePath, options);
-				if (ShouldDeleteIntermediateFile(rotatedImagePath, originalImagePath, compressedImagePath))
-				{
-					TryDeleteFile(rotatedImagePath);
-				}
-
-				imagePath = compressedImagePath;
-			}
-
-			return imagePath;
-		}
+		// Recovery-sensitive MediaPicker paths must leave the original file intact until the
+		// active recovery record has been cleared or promoted. ProcessImage never mutates its
+		// input, so this is simply the single-pass processor.
+		internal static Task<string> ProcessPhotoPreservingSourceAsync(string imagePath, PersistedPhotoProcessingOptions options)
+			=> ProcessImage(imagePath, options);
 
 		internal static PersistedPhotoProcessingOptions GetPhotoProcessingOptions(MediaPickerOptions options)
 			=> new(
@@ -272,15 +220,8 @@ namespace Microsoft.Maui.Media
 				{
 					if (photo)
 					{
-						// Apply rotation if needed
-						if (ImageProcessor.IsRotationNeeded(options))
-							path = await RotateImage(path, options);
-
-						// Apply compression/resizing if needed
-						if (ImageProcessor.IsProcessingNeeded(options?.MaximumWidth, options?.MaximumHeight, options?.CompressionQuality ?? 100))
-						{
-							path = await CompressImageIfNeeded(path, options);
-						}
+						// Apply rotation and/or compression if needed
+						path = await ProcessImage(path, options);
 					}
 
 					return new FileResult(path);
@@ -419,116 +360,6 @@ namespace Microsoft.Maui.Media
 			await IntermediateActivity.StartAsync(captureIntent, PlatformUtils.requestCodeMediaCapture, OnCreate);
 
 			return captureFile.AbsolutePath;
-		}
-
-		static async Task<string> RotateImageToNewFileAsync(string imagePath)
-		{
-			if (string.IsNullOrEmpty(imagePath))
-			{
-				return imagePath;
-			}
-
-			if (!File.Exists(imagePath))
-			{
-				return imagePath;
-			}
-
-			await using var inputStream = File.OpenRead(imagePath);
-			var inputFileName = System.IO.Path.GetFileName(imagePath);
-			await using var rotatedStream = await ImageProcessor.RotateImageAsync(inputStream, inputFileName);
-			rotatedStream.Position = 0;
-
-			// Preserve the original filename (see #33258); GetTemporaryFile always creates a fresh
-			// unique folder, so the output can never collide with the input.
-			var outputFileName = inputFileName;
-			if (string.IsNullOrEmpty(System.IO.Path.GetExtension(outputFileName)))
-			{
-				outputFileName += FileExtensions.Jpg;
-			}
-
-			var outputFile = FileSystemUtils.GetTemporaryFile(Application.Context.CacheDir, outputFileName);
-			await using var outputStream = File.Create(outputFile.AbsolutePath);
-			await rotatedStream.CopyToAsync(outputStream);
-
-			return outputFile.AbsolutePath;
-		}
-
-		static bool ShouldDeleteIntermediateFile(string intermediatePath, string originalPath, string finalPath)
-			=> !string.IsNullOrEmpty(intermediatePath) &&
-				!string.Equals(intermediatePath, originalPath, StringComparison.Ordinal) &&
-				!string.Equals(intermediatePath, finalPath, StringComparison.Ordinal);
-
-		static void TryDeleteFile(string filePath)
-		{
-			try
-			{ File.Delete(filePath); }
-			catch { }
-		}
-
-		internal static Task<string> CompressImageIfNeeded(string imagePath, MediaPickerOptions options)
-			=> CompressImageIfNeeded(imagePath, GetPhotoProcessingOptions(options));
-
-		static async Task<string> CompressImageIfNeeded(string imagePath, PersistedPhotoProcessingOptions options)
-		{
-			if (!ImageProcessor.IsProcessingNeeded(options.MaximumWidth, options.MaximumHeight, options.CompressionQuality) || string.IsNullOrEmpty(imagePath))
-				return imagePath;
-
-			try
-			{
-				if (!File.Exists(imagePath))
-				{
-					return imagePath;
-				}
-
-				// Use ImageProcessor for unified image processing
-				using var inputStream = File.OpenRead(imagePath);
-				var inputFileName = System.IO.Path.GetFileName(imagePath);
-				using var processedStream = await ImageProcessor.ProcessImageAsync(
-					inputStream,
-					options.MaximumWidth,
-					options.MaximumHeight,
-					options.CompressionQuality,
-					inputFileName,
-					options.RotateImage,
-					options.PreserveMetaData);
-
-				if (processedStream != null)
-				{
-					// Determine the correct output extension based on the processed format
-					processedStream.Position = 0;
-					var outputExtension = ImageProcessor.DetermineOutputExtension(processedStream, options.CompressionQuality, inputFileName);
-					var originalExtension = System.IO.Path.GetExtension(inputFileName);
-
-					// Preserve the original filename (see #33258), but honor a format change
-					// (e.g. PNG -> JPEG) by swapping the extension.
-					var outputFileName = inputFileName;
-					if (!string.Equals(outputExtension, originalExtension, StringComparison.OrdinalIgnoreCase))
-					{
-						outputFileName = System.IO.Path.ChangeExtension(inputFileName, outputExtension);
-					}
-
-					// Write the processed image to a new MAUI-owned cache file instead of
-					// overwriting the picked source, which is not a file we own.
-					var outputFile = FileSystemUtils.GetTemporaryFile(Application.Context.CacheDir, outputFileName);
-					var outputPath = outputFile.AbsolutePath;
-
-					using var outputStream = File.Create(outputPath);
-					processedStream.Position = 0;
-					await processedStream.CopyToAsync(outputStream);
-
-					return outputPath;
-				}
-
-				// If ImageProcessor returns null (e.g., on .NET Standard), ImageProcessor.IsProcessingNeeded would have returned false,
-				// so we shouldn't reach this point. Return original path as fallback.
-				return imagePath;
-			}
-			catch
-			{
-				// If processing fails, return original path
-			}
-
-			return imagePath;
 		}
 
 		async Task<string> CaptureVideoAsync(Intent captureIntent)
@@ -747,17 +578,8 @@ namespace Microsoft.Maui.Media
 
 					foreach (var path in tempResultList)
 					{
-						string processedPath = path;
-
-						// Apply rotation if needed
-						if (ImageProcessor.IsRotationNeeded(options))
-							processedPath = await RotateImage(processedPath, options);
-
-						// Apply compression/resizing if needed
-						if (ImageProcessor.IsProcessingNeeded(options?.MaximumWidth, options?.MaximumHeight, options?.CompressionQuality ?? 100))
-						{
-							processedPath = await CompressImageIfNeeded(processedPath, options);
-						}
+						// Apply rotation and/or compression if needed
+						var processedPath = await ProcessImage(path, options);
 
 						resultList.Add(new FileResult(processedPath));
 					}
@@ -769,6 +591,95 @@ namespace Microsoft.Maui.Media
 			{
 				return [];
 			}
+		}
+
+		internal static Task<string> ProcessImage(string imagePath, MediaPickerOptions options)
+			=> ProcessImage(imagePath, GetPhotoProcessingOptions(options));
+
+		internal static async Task<string> ProcessImage(string imagePath, PersistedPhotoProcessingOptions options)
+		{
+			if (string.IsNullOrEmpty(imagePath) || !File.Exists(imagePath))
+				return imagePath;
+
+			var needsRotation = options.RotateImage;
+			var needsProcessing = ImageProcessor.IsProcessingNeeded(options.MaximumWidth, options.MaximumHeight, options.CompressionQuality);
+
+			// Nothing to do - return the picked path untouched.
+			if (!needsRotation && !needsProcessing)
+				return imagePath;
+
+			try
+			{
+				var inputFileName = System.IO.Path.GetFileName(imagePath);
+
+				// Compose the transforms without mutating the input: rotation and compression are
+				// chained through in-memory streams and only the final result is written - once - to
+				// a new MAUI-owned cache file (GetTemporaryFile preserves the original filename, see
+				// #33258). External/user-owned sources (the gallery original, an SD card, another
+				// app's storage) are therefore never deleted or overwritten, and recovery-sensitive
+				// callers keep their original file until the recovery record is cleared or promoted.
+				Stream currentStream = File.OpenRead(imagePath);
+				try
+				{
+					if (needsRotation)
+					{
+						var rotatedStream = await ImageProcessor.RotateImageAsync(currentStream, inputFileName);
+						currentStream.Dispose();
+						currentStream = rotatedStream;
+						currentStream.Position = 0;
+					}
+
+					if (needsProcessing)
+					{
+						var processedStream = await ImageProcessor.ProcessImageAsync(
+							currentStream,
+							options.MaximumWidth,
+							options.MaximumHeight,
+							options.CompressionQuality,
+							inputFileName,
+							false, // rotation, if any, has already been applied above
+							options.PreserveMetaData);
+
+						if (processedStream is not null)
+						{
+							currentStream.Dispose();
+							currentStream = processedStream;
+							currentStream.Position = 0;
+						}
+					}
+
+					// Preserve the original filename (see #33258), but honor a format change
+					// (e.g. PNG -> JPEG) by swapping the extension.
+					var outputExtension = ImageProcessor.DetermineOutputExtension(currentStream, options.CompressionQuality, inputFileName);
+					var originalExtension = System.IO.Path.GetExtension(inputFileName);
+					var outputFileName = inputFileName;
+					if (!string.Equals(outputExtension, originalExtension, StringComparison.OrdinalIgnoreCase))
+					{
+						outputFileName = System.IO.Path.ChangeExtension(inputFileName, outputExtension);
+					}
+
+					var outputFile = FileSystemUtils.GetTemporaryFile(Application.Context.CacheDir, outputFileName);
+					var outputPath = outputFile.AbsolutePath;
+
+					using (var outputStream = File.Create(outputPath))
+					{
+						currentStream.Position = 0;
+						await currentStream.CopyToAsync(outputStream);
+					}
+
+					return outputPath;
+				}
+				finally
+				{
+					currentStream.Dispose();
+				}
+			}
+			catch
+			{
+				// If processing fails, leave the picked source untouched and return its path.
+			}
+
+			return imagePath;
 		}
 	}
 }

--- a/src/Essentials/src/MediaPicker/MediaPicker.android.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.android.cs
@@ -25,26 +25,19 @@ namespace Microsoft.Maui.Media
 		public bool IsCaptureSupported
 			=> Application.Context?.PackageManager?.HasSystemFeature(PackageManager.FeatureCameraAny) ?? false;
 
-		static async Task RotateImageInPlace(string filePath, MediaPickerOptions options)
-		{
-			await using var inputStream = File.OpenRead(filePath);
-			var fileName = System.IO.Path.GetFileName(filePath);
-			await using var rotatedStream = await ImageProcessor.RotateImageAsync(inputStream, fileName);
-			rotatedStream.Position = 0;
-			inputStream.Dispose(); // explicit close before delete
-			try
-			{ File.Delete(filePath); }
-			catch { }
-			await using var outputStream = File.Create(filePath);
-			await rotatedStream.CopyToAsync(outputStream);
-		}
+		// Rotation never mutates the picked source. The source path is resolved verbatim from the
+		// picker URI and is not a file we own (it may be the user's original on an SD card, in
+		// shared storage, or a file owned by another app), so mutating it in place is incorrect
+		// and risks data loss.
+		internal static Task<string> RotateImage(string filePath, MediaPickerOptions options)
+			=> RotateImageToNewFileAsync(filePath);
 
 		internal static async Task<string> ProcessPhotoAsync(string imagePath, MediaPickerOptions options)
 		{
 			// Apply rotation if needed for photos
 			if (imagePath is not null && ImageProcessor.IsRotationNeeded(options))
 			{
-				await RotateImageInPlace(imagePath, options);
+				imagePath = await RotateImage(imagePath, options);
 			}
 
 			// Apply compression/resizing if needed for photos
@@ -81,7 +74,7 @@ namespace Microsoft.Maui.Media
 
 			if (ImageProcessor.IsProcessingNeeded(options.MaximumWidth, options.MaximumHeight, options.CompressionQuality))
 			{
-				var compressedImagePath = await CompressImageIfNeeded(imagePath, options, preserveSource: true);
+				var compressedImagePath = await CompressImageIfNeeded(imagePath, options);
 				if (ShouldDeleteIntermediateFile(rotatedImagePath, originalImagePath, compressedImagePath))
 				{
 					TryDeleteFile(rotatedImagePath);
@@ -281,7 +274,7 @@ namespace Microsoft.Maui.Media
 					{
 						// Apply rotation if needed
 						if (ImageProcessor.IsRotationNeeded(options))
-							await RotateImageInPlace(path, options);
+							path = await RotateImage(path, options);
 
 						// Apply compression/resizing if needed
 						if (ImageProcessor.IsProcessingNeeded(options?.MaximumWidth, options?.MaximumHeight, options?.CompressionQuality ?? 100))
@@ -445,13 +438,15 @@ namespace Microsoft.Maui.Media
 			await using var rotatedStream = await ImageProcessor.RotateImageAsync(inputStream, inputFileName);
 			rotatedStream.Position = 0;
 
-			var outputExtension = System.IO.Path.GetExtension(imagePath);
-			if (string.IsNullOrEmpty(outputExtension))
+			// Preserve the original filename (see #33258); GetTemporaryFile always creates a fresh
+			// unique folder, so the output can never collide with the input.
+			var outputFileName = inputFileName;
+			if (string.IsNullOrEmpty(System.IO.Path.GetExtension(outputFileName)))
 			{
-				outputExtension = FileExtensions.Jpg;
+				outputFileName += FileExtensions.Jpg;
 			}
 
-			var outputFile = FileSystemUtils.GetTemporaryFile(Application.Context.CacheDir, Guid.NewGuid().ToString("N") + outputExtension);
+			var outputFile = FileSystemUtils.GetTemporaryFile(Application.Context.CacheDir, outputFileName);
 			await using var outputStream = File.Create(outputFile.AbsolutePath);
 			await rotatedStream.CopyToAsync(outputStream);
 
@@ -470,18 +465,17 @@ namespace Microsoft.Maui.Media
 			catch { }
 		}
 
-		static Task<string> CompressImageIfNeeded(string imagePath, MediaPickerOptions options, bool preserveSource = false)
-			=> CompressImageIfNeeded(imagePath, GetPhotoProcessingOptions(options), preserveSource);
+		internal static Task<string> CompressImageIfNeeded(string imagePath, MediaPickerOptions options)
+			=> CompressImageIfNeeded(imagePath, GetPhotoProcessingOptions(options));
 
-		static async Task<string> CompressImageIfNeeded(string imagePath, PersistedPhotoProcessingOptions options, bool preserveSource = false)
+		static async Task<string> CompressImageIfNeeded(string imagePath, PersistedPhotoProcessingOptions options)
 		{
 			if (!ImageProcessor.IsProcessingNeeded(options.MaximumWidth, options.MaximumHeight, options.CompressionQuality) || string.IsNullOrEmpty(imagePath))
 				return imagePath;
 
 			try
 			{
-				var originalFile = new Java.IO.File(imagePath);
-				if (!originalFile.Exists())
+				if (!File.Exists(imagePath))
 				{
 					return imagePath;
 				}
@@ -503,29 +497,21 @@ namespace Microsoft.Maui.Media
 					// Determine the correct output extension based on the processed format
 					processedStream.Position = 0;
 					var outputExtension = ImageProcessor.DetermineOutputExtension(processedStream, options.CompressionQuality, inputFileName);
-					var originalExtension = System.IO.Path.GetExtension(imagePath);
+					var originalExtension = System.IO.Path.GetExtension(inputFileName);
 
-					// If format changed (e.g., PNG -> JPEG), use new extension
-					string outputPath = imagePath;
+					// Preserve the original filename (see #33258), but honor a format change
+					// (e.g. PNG -> JPEG) by swapping the extension.
+					var outputFileName = inputFileName;
 					if (!string.Equals(outputExtension, originalExtension, StringComparison.OrdinalIgnoreCase))
 					{
-						outputPath = System.IO.Path.ChangeExtension(imagePath, outputExtension);
+						outputFileName = System.IO.Path.ChangeExtension(inputFileName, outputExtension);
 					}
 
-					if (preserveSource)
-					{
-						var outputFile = FileSystemUtils.GetTemporaryFile(Application.Context.CacheDir, Guid.NewGuid().ToString("N") + outputExtension);
-						outputPath = outputFile.AbsolutePath;
-					}
-					else
-					{
-						// Delete original file first
-						try
-						{ originalFile.Delete(); }
-						catch { }
-					}
+					// Write the processed image to a new MAUI-owned cache file instead of
+					// overwriting the picked source, which is not a file we own.
+					var outputFile = FileSystemUtils.GetTemporaryFile(Application.Context.CacheDir, outputFileName);
+					var outputPath = outputFile.AbsolutePath;
 
-					// Write processed image to output path with correct extension
 					using var outputStream = File.Create(outputPath);
 					processedStream.Position = 0;
 					await processedStream.CopyToAsync(outputStream);
@@ -765,7 +751,7 @@ namespace Microsoft.Maui.Media
 
 						// Apply rotation if needed
 						if (ImageProcessor.IsRotationNeeded(options))
-							await RotateImageInPlace(processedPath, options);
+							processedPath = await RotateImage(processedPath, options);
 
 						// Apply compression/resizing if needed
 						if (ImageProcessor.IsProcessingNeeded(options?.MaximumWidth, options?.MaximumHeight, options?.CompressionQuality ?? 100))

--- a/src/Essentials/src/MediaPicker/MediaPicker.android.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.android.cs
@@ -29,10 +29,10 @@ namespace Microsoft.Maui.Media
 			=> ProcessImage(imagePath, options);
 
 		// Recovery-sensitive MediaPicker paths must leave the original file intact until the
-		// active recovery record has been cleared or promoted. ProcessImage never mutates its
-		// input, so this is simply the single-pass processor.
+		// active recovery record has been cleared or promoted, so they opt out of the
+		// MAUI-owned input cleanup that ProcessImage otherwise performs.
 		internal static Task<string> ProcessPhotoPreservingSourceAsync(string imagePath, PersistedPhotoProcessingOptions options)
-			=> ProcessImage(imagePath, options);
+			=> ProcessImage(imagePath, options, preserveSource: true);
 
 		internal static PersistedPhotoProcessingOptions GetPhotoProcessingOptions(MediaPickerOptions options)
 			=> new(
@@ -596,7 +596,7 @@ namespace Microsoft.Maui.Media
 		internal static Task<string> ProcessImage(string imagePath, MediaPickerOptions options)
 			=> ProcessImage(imagePath, GetPhotoProcessingOptions(options));
 
-		internal static async Task<string> ProcessImage(string imagePath, PersistedPhotoProcessingOptions options)
+		internal static async Task<string> ProcessImage(string imagePath, PersistedPhotoProcessingOptions options, bool preserveSource = false)
 		{
 			if (string.IsNullOrEmpty(imagePath) || !File.Exists(imagePath))
 				return imagePath;
@@ -616,8 +616,11 @@ namespace Microsoft.Maui.Media
 				// chained through in-memory streams and only the final result is written - once - to
 				// a new MAUI-owned cache file (GetTemporaryFile preserves the original filename, see
 				// #33258). External/user-owned sources (the gallery original, an SD card, another
-				// app's storage) are therefore never deleted or overwritten, and recovery-sensitive
-				// callers keep their original file until the recovery record is cleared or promoted.
+				// app's storage) are therefore never deleted or overwritten. If the input was itself
+				// a MAUI-owned temporary cache file (a camera capture, or a content:// URI that
+				// EnsurePhysicalPath copied into our cache), it is removed after the output is written
+				// (below) so we don't leave an orphaned duplicate behind - unless the caller opted
+				// into preserving it because a recovery record still points at it.
 				Stream currentStream = File.OpenRead(imagePath);
 				try
 				{
@@ -665,6 +668,19 @@ namespace Microsoft.Maui.Media
 					{
 						currentStream.Position = 0;
 						await currentStream.CopyToAsync(outputStream);
+					}
+
+					// The output is now fully written and closed. If the input was a MAUI-owned
+					// temporary cache file, delete it so we don't accumulate an orphaned duplicate.
+					// External/user-owned sources are never under our cache folder, so they are left
+					// untouched. Deleting only after the output is written avoids any data-loss window.
+					if (!preserveSource &&
+						FileSystemUtils.IsMauiOwnedTemporaryFile(imagePath) &&
+						!string.Equals(imagePath, outputPath, StringComparison.Ordinal))
+					{
+						try
+						{ File.Delete(imagePath); }
+						catch { }
 					}
 
 					return outputPath;

--- a/src/Essentials/test/DeviceTests/Tests/Android/MediaPicker_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Android/MediaPicker_Tests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using Android.App;
 using Android.Graphics;
 using Microsoft.Maui.Media;
 using Microsoft.Maui.Storage;
@@ -56,6 +57,48 @@ namespace Microsoft.Maui.Essentials.DeviceTests.Shared
 			}
 		}
 
+		[Fact]
+		public async Task ProcessImage_MauiOwnedCacheInput_IsReplaced_NotOrphaned()
+		{
+			var baseName = "mp_owned_" + Guid.NewGuid().ToString("N");
+
+			// Create a MAUI-owned temporary cache file, exactly like a camera capture
+			// (CapturePhotoAsync) or a content:// URI that EnsurePhysicalPath copied into cache.
+			var ownedFile = FileSystemUtils.GetTemporaryFile(Application.Context.CacheDir, baseName + ".jpg");
+			var inputPath = ownedFile.AbsolutePath;
+			WriteJpeg(inputPath);
+
+			string outputPath = null;
+			try
+			{
+				var options = new MediaPickerOptions { CompressionQuality = 50 };
+
+				outputPath = await MediaPickerImplementation.ProcessImage(inputPath, options);
+
+				// A new terminal cache file is produced under the app cache dir.
+				Assert.NotEqual(inputPath, outputPath);
+				Assert.True(File.Exists(outputPath));
+				Assert.StartsWith(FileSystem.CacheDirectory, outputPath, StringComparison.Ordinal);
+
+				// The MAUI-owned input is deleted - not left orphaned alongside the output.
+				Assert.False(File.Exists(inputPath));
+
+				// Exactly one terminal cache file remains for this image (the output).
+				var cacheCopies = FindCacheFiles(baseName);
+				Assert.Single(cacheCopies);
+				Assert.Equal(Path.GetFullPath(outputPath), Path.GetFullPath(cacheCopies[0]));
+
+				// The original base filename is preserved (#33258).
+				Assert.Equal(baseName, Path.GetFileNameWithoutExtension(outputPath));
+			}
+			finally
+			{
+				SafeDelete(inputPath);
+				SafeDelete(outputPath);
+				DeleteCacheFiles(baseName);
+			}
+		}
+
 		static async Task AssertProcessedToCacheWithoutTouchingSource(MediaPickerOptions options)
 		{
 			var baseName = "mp_src_" + Guid.NewGuid().ToString("N");
@@ -99,14 +142,15 @@ namespace Microsoft.Maui.Essentials.DeviceTests.Shared
 			Directory.CreateDirectory(dir);
 
 			var filePath = Path.Combine(dir, fileName);
-
-			using (var bitmap = Bitmap.CreateBitmap(64, 64, Bitmap.Config.Argb8888))
-			using (var stream = File.Create(filePath))
-			{
-				bitmap.Compress(Bitmap.CompressFormat.Jpeg, 100, stream);
-			}
-
+			WriteJpeg(filePath);
 			return filePath;
+		}
+
+		static void WriteJpeg(string filePath)
+		{
+			using var bitmap = Bitmap.CreateBitmap(64, 64, Bitmap.Config.Argb8888);
+			using var stream = File.Create(filePath);
+			bitmap.Compress(Bitmap.CompressFormat.Jpeg, 100, stream);
 		}
 
 		static string[] FindCacheFiles(string baseName)

--- a/src/Essentials/test/DeviceTests/Tests/Android/MediaPicker_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Android/MediaPicker_Tests.cs
@@ -13,49 +13,58 @@ namespace Microsoft.Maui.Essentials.DeviceTests.Shared
 	public class Android_MediaPicker_Tests
 	{
 		[Fact]
-		public async Task RotateImage_DoesNotModifySource_And_WritesToCache()
+		public Task ProcessImage_Rotation_DoesNotModifySource_And_WritesSingleCacheFile()
+			=> AssertProcessedToCacheWithoutTouchingSource(
+				new MediaPickerOptions { RotateImage = true });
+
+		[Fact]
+		public Task ProcessImage_Compression_DoesNotModifySource_And_WritesSingleCacheFile()
+			=> AssertProcessedToCacheWithoutTouchingSource(
+				new MediaPickerOptions { CompressionQuality = 50 });
+
+		[Fact]
+		public Task ProcessImage_RotationAndCompression_DoesNotModifySource_And_WritesSingleCacheFile()
+			=> AssertProcessedToCacheWithoutTouchingSource(
+				new MediaPickerOptions { RotateImage = true, CompressionQuality = 50 });
+
+		[Fact]
+		public async Task ProcessImage_NoProcessingNeeded_ReturnsOriginalPath_Unchanged()
 		{
-			var sourcePath = CreateJpegOutsideCache("rotate_source.jpg");
+			var baseName = "mp_noop_" + Guid.NewGuid().ToString("N");
+			var sourcePath = CreateJpegOutsideCache(baseName + ".jpg");
 			var originalBytes = File.ReadAllBytes(sourcePath);
-			string outputPath = null;
 
 			try
 			{
-				var options = new MediaPickerOptions { RotateImage = true };
+				// No rotation, full quality, no resize -> there is nothing to process.
+				var options = new MediaPickerOptions { RotateImage = false, CompressionQuality = 100 };
 
-				outputPath = await MediaPickerImplementation.RotateImage(sourcePath, options);
+				var outputPath = await MediaPickerImplementation.ProcessImage(sourcePath, options);
 
-				// The picked source is left untouched - no in-place overwrite, no data loss.
+				// The original path is returned as-is and the file is untouched.
+				Assert.Equal(sourcePath, outputPath);
 				Assert.True(File.Exists(sourcePath));
 				Assert.Equal(originalBytes, File.ReadAllBytes(sourcePath));
 
-				// The processed image is a brand new file under the app cache dir.
-				Assert.NotEqual(sourcePath, outputPath);
-				Assert.True(File.Exists(outputPath));
-				Assert.StartsWith(FileSystem.CacheDirectory, outputPath, StringComparison.Ordinal);
-
-				// The original filename is preserved (no _processed/_rotated suffix - #33258).
-				Assert.Equal(Path.GetFileName(sourcePath), Path.GetFileName(outputPath));
+				// No cache copy is created when there is nothing to do.
+				Assert.Empty(FindCacheFiles(baseName));
 			}
 			finally
 			{
 				SafeDelete(sourcePath);
-				SafeDelete(outputPath);
+				DeleteCacheFiles(baseName);
 			}
 		}
 
-		[Fact]
-		public async Task CompressImageIfNeeded_DoesNotModifySource_And_WritesToCache()
+		static async Task AssertProcessedToCacheWithoutTouchingSource(MediaPickerOptions options)
 		{
-			var sourcePath = CreateJpegOutsideCache("compress_source.jpg");
+			var baseName = "mp_src_" + Guid.NewGuid().ToString("N");
+			var sourcePath = CreateJpegOutsideCache(baseName + ".jpg");
 			var originalBytes = File.ReadAllBytes(sourcePath);
-			string outputPath = null;
 
 			try
 			{
-				var options = new MediaPickerOptions { CompressionQuality = 50 };
-
-				outputPath = await MediaPickerImplementation.CompressImageIfNeeded(sourcePath, options);
+				var outputPath = await MediaPickerImplementation.ProcessImage(sourcePath, options);
 
 				// The picked source is left untouched - no in-place overwrite, no data loss.
 				Assert.True(File.Exists(sourcePath));
@@ -66,15 +75,19 @@ namespace Microsoft.Maui.Essentials.DeviceTests.Shared
 				Assert.True(File.Exists(outputPath));
 				Assert.StartsWith(FileSystem.CacheDirectory, outputPath, StringComparison.Ordinal);
 
-				// The original filename is preserved (#33258); only the extension may change.
-				Assert.Equal(
-					Path.GetFileNameWithoutExtension(sourcePath),
-					Path.GetFileNameWithoutExtension(outputPath));
+				// The original base filename is preserved (#33258); only the extension may change.
+				Assert.Equal(baseName, Path.GetFileNameWithoutExtension(outputPath));
+
+				// Exactly one terminal cache file is written - no orphaned intermediate,
+				// even when both rotation and compression are applied.
+				var cacheCopies = FindCacheFiles(baseName);
+				Assert.Single(cacheCopies);
+				Assert.Equal(Path.GetFullPath(outputPath), Path.GetFullPath(cacheCopies[0]));
 			}
 			finally
 			{
 				SafeDelete(sourcePath);
-				SafeDelete(outputPath);
+				DeleteCacheFiles(baseName);
 			}
 		}
 
@@ -87,13 +100,27 @@ namespace Microsoft.Maui.Essentials.DeviceTests.Shared
 
 			var filePath = Path.Combine(dir, fileName);
 
-			using (var bitmap = Bitmap.CreateBitmap(8, 8, Bitmap.Config.Argb8888))
+			using (var bitmap = Bitmap.CreateBitmap(64, 64, Bitmap.Config.Argb8888))
 			using (var stream = File.Create(filePath))
 			{
 				bitmap.Compress(Bitmap.CompressFormat.Jpeg, 100, stream);
 			}
 
 			return filePath;
+		}
+
+		static string[] FindCacheFiles(string baseName)
+		{
+			if (!Directory.Exists(FileSystem.CacheDirectory))
+				return Array.Empty<string>();
+
+			return Directory.GetFiles(FileSystem.CacheDirectory, baseName + ".*", SearchOption.AllDirectories);
+		}
+
+		static void DeleteCacheFiles(string baseName)
+		{
+			foreach (var file in FindCacheFiles(baseName))
+				SafeDelete(file);
 		}
 
 		static void SafeDelete(string path)

--- a/src/Essentials/test/DeviceTests/Tests/Android/MediaPicker_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Android/MediaPicker_Tests.cs
@@ -1,0 +1,112 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Android.Graphics;
+using Microsoft.Maui.Media;
+using Microsoft.Maui.Storage;
+using Xunit;
+using Path = System.IO.Path;
+
+namespace Microsoft.Maui.Essentials.DeviceTests.Shared
+{
+	[Category("MediaPicker")]
+	public class Android_MediaPicker_Tests
+	{
+		[Fact]
+		public async Task RotateImage_DoesNotModifySource_And_WritesToCache()
+		{
+			var sourcePath = CreateJpegOutsideCache("rotate_source.jpg");
+			var originalBytes = File.ReadAllBytes(sourcePath);
+			string outputPath = null;
+
+			try
+			{
+				var options = new MediaPickerOptions { RotateImage = true };
+
+				outputPath = await MediaPickerImplementation.RotateImage(sourcePath, options);
+
+				// The picked source is left untouched - no in-place overwrite, no data loss.
+				Assert.True(File.Exists(sourcePath));
+				Assert.Equal(originalBytes, File.ReadAllBytes(sourcePath));
+
+				// The processed image is a brand new file under the app cache dir.
+				Assert.NotEqual(sourcePath, outputPath);
+				Assert.True(File.Exists(outputPath));
+				Assert.StartsWith(FileSystem.CacheDirectory, outputPath, StringComparison.Ordinal);
+
+				// The original filename is preserved (no _processed/_rotated suffix - #33258).
+				Assert.Equal(Path.GetFileName(sourcePath), Path.GetFileName(outputPath));
+			}
+			finally
+			{
+				SafeDelete(sourcePath);
+				SafeDelete(outputPath);
+			}
+		}
+
+		[Fact]
+		public async Task CompressImageIfNeeded_DoesNotModifySource_And_WritesToCache()
+		{
+			var sourcePath = CreateJpegOutsideCache("compress_source.jpg");
+			var originalBytes = File.ReadAllBytes(sourcePath);
+			string outputPath = null;
+
+			try
+			{
+				var options = new MediaPickerOptions { CompressionQuality = 50 };
+
+				outputPath = await MediaPickerImplementation.CompressImageIfNeeded(sourcePath, options);
+
+				// The picked source is left untouched - no in-place overwrite, no data loss.
+				Assert.True(File.Exists(sourcePath));
+				Assert.Equal(originalBytes, File.ReadAllBytes(sourcePath));
+
+				// The processed image is a brand new file under the app cache dir.
+				Assert.NotEqual(sourcePath, outputPath);
+				Assert.True(File.Exists(outputPath));
+				Assert.StartsWith(FileSystem.CacheDirectory, outputPath, StringComparison.Ordinal);
+
+				// The original filename is preserved (#33258); only the extension may change.
+				Assert.Equal(
+					Path.GetFileNameWithoutExtension(sourcePath),
+					Path.GetFileNameWithoutExtension(outputPath));
+			}
+			finally
+			{
+				SafeDelete(sourcePath);
+				SafeDelete(outputPath);
+			}
+		}
+
+		static string CreateJpegOutsideCache(string fileName)
+		{
+			// AppDataDirectory (/data/user/0/<pkg>/files) is separate from the cache dir and
+			// stands in for a picked file that MAUI does not own.
+			var dir = Path.Combine(FileSystem.AppDataDirectory, "mediapicker-source-tests");
+			Directory.CreateDirectory(dir);
+
+			var filePath = Path.Combine(dir, fileName);
+
+			using (var bitmap = Bitmap.CreateBitmap(8, 8, Bitmap.Config.Argb8888))
+			using (var stream = File.Create(filePath))
+			{
+				bitmap.Compress(Bitmap.CompressFormat.Jpeg, 100, stream);
+			}
+
+			return filePath;
+		}
+
+		static void SafeDelete(string path)
+		{
+			try
+			{
+				if (!string.IsNullOrEmpty(path) && File.Exists(path))
+					File.Delete(path);
+			}
+			catch
+			{
+				// best-effort cleanup
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description

On Android, when the `MediaPicker` applies EXIF auto-rotation or compression/resizing to a picked image, it **mutated the picked source file in place** — it deleted the original and wrote a replacement at the *same* resolved path:

- `RotateImageInPlace` → `File.Delete(filePath)` + `File.Create(filePath)`
- `CompressImageIfNeeded` → `originalFile.Delete()` + writes a replacement (sometimes with a changed extension, PNG→JPEG)

That path comes from `FileSystemUtils.EnsurePhysicalPath`, which for a `file://` URI returns `uri.Path` verbatim. **That file is not one MAUI owns** — it can be the user's original photo in the gallery, a file on an SD card, or a file in another app's shared storage. Picking an image should never modify the user's original.

There was also a **data-loss window**: the old code deleted the original *before* writing the processed replacement, so if the write threw, the original was already gone.

Because the image is loaded fully into memory, processed, and written back, mutating the source buys nothing.

### Fix

Treat the picked source as **read-only**. Rotation and compression are now composed together through in-memory streams by a single `ProcessImage` helper, and only the **final** result is written — **once** — to a new MAUI-owned cache file via `FileSystemUtils.GetTemporaryFile(Application.Context.CacheDir, originalFileName)`. The user's source file is never deleted or overwritten.

`GetTemporaryFile` places the output in a unique directory while **preserving the original filename** (`<cache>/<hash>/<guid>/<originalFileName>`), so the filename-preservation behavior from #33258 (no `_processed`/`_rotated` suffix) is kept. A format change (PNG→JPEG) still updates the extension.

#### Owned-input cleanup

Some inputs are themselves **MAUI-owned temporary cache files** — a camera capture from `CapturePhotoAsync`, or a `content://` URI that `EnsurePhysicalPath` copied into our cache — rather than a user-owned source. For those, `ProcessImage` deletes the temporary input **after** the processed output has been fully written, so we don't leave an orphaned full-size duplicate behind.

Ownership is detected reliably via `FileSystemUtils.IsMauiOwnedTemporaryFile`, which recognizes a file we created through `GetTemporaryFile` by its `<cache>/<EssentialsFolderHash>/` location — a folder that only `GetTemporaryFile` ever creates. External/user-owned sources are never under that folder, so they can never be matched or deleted, and deleting only after the output is written means there is no data-loss window.

### What changed

- The separate `RotateImageInPlace` and `CompressImageIfNeeded` methods are replaced by a single `ProcessImage` helper that applies rotation and compression in one pipeline. Rotation, if requested, is applied explicitly first and the compression stage is told not to rotate again.
- All Android photo pick/capture call sites now use `ProcessImage`.
- User-owned source files are never deleted or overwritten.
- MAUI-owned temporary cache inputs are cleaned up after the output is written, so no orphaned duplicate cache file is left behind.
- When no processing is requested, the original path is returned unchanged and no cache file is created.

### Tests

Added Android device tests (`src/Essentials/test/DeviceTests/Tests/Android/MediaPicker_Tests.cs`) covering every path the change touches:

1. rotation-only, compression-only, and rotation+compression each leave an external source file byte-for-byte unchanged and still present,
2. the processed output is a new file under the app cache directory,
3. the original filename is preserved (only the extension may change), and each processed case writes exactly **one** terminal cache file (no intermediate),
4. a MAUI-owned cache input is replaced by a single terminal cache file with the owned input deleted (no orphan left behind), and
5. the no-op case (no rotation, quality 100, no resize) returns the original path unchanged and creates no cache copy.

Verified locally on an Android emulator: all five `MediaPicker` tests pass and the full Essentials device-test suite is green (280 passed / 0 failed).

### Platforms affected

- Android only.

### Behavioral notes

- The user's original file is left untouched; the delete-before-write data-loss window is gone.
- When both rotation and compression run, they are composed through streams and only the terminal output is written to disk.
- A MAUI-owned temporary cache input is deleted only after the processed output has been fully written.