### PR TITLE
[Windows] Fix Entry.Completed firing during IME candidate confirmation

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue36179.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue36179.cs
@@ -1,0 +1,38 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 36179, "Entry.Completed accidentally fired on Enter key press in IME candidate window", PlatformAffected.Windows)]
+public class Issue36179 : TestContentPage
+{
+	protected override void Init()
+	{
+		var entry = new Entry
+		{
+			AutomationId = "TestEntry",
+			Placeholder = "Focus and press Enter"
+		};
+
+		var completedLabel = new Label
+		{
+			Text = "Completed: 0",
+			AutomationId = "CompletedCountLabel"
+		};
+
+		int completedCount = 0;
+
+		entry.Completed += (s, e) =>
+		{
+			completedCount++;
+			completedLabel.Text = $"Completed: {completedCount}";
+		};
+
+		Content = new VerticalStackLayout
+		{
+			new Label
+			{
+				Text = "Test: IME candidate Enter should NOT fire Completed. Real Enter should fire Completed."
+			},
+			entry,
+			completedLabel
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue36179.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue36179.cs
@@ -1,6 +1,6 @@
 namespace Maui.Controls.Sample.Issues;
 
-[Issue(IssueTracker.Github, 36179, "Entry.Completed accidentally fired on Enter key press in IME candidate window", PlatformAffected.Windows)]
+[Issue(IssueTracker.Github, 36179, "Entry.Completed accidentally fired on Enter key press in IME candidate window", PlatformAffected.UWP)]
 public class Issue36179 : TestContentPage
 {
 	protected override void Init()

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36179.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36179.cs
@@ -1,0 +1,47 @@
+#if WINDOWS
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue36179 : _IssuesUITest
+{
+	public override string Issue => "Entry.Completed accidentally fired on Enter key press in IME candidate window";
+
+	public Issue36179(TestDevice device) : base(device) { }
+
+	// Verifies that sending only KeyUp(Enter) — the same sequence produced by IME candidate
+	// confirmation — does NOT fire Entry.Completed.
+	// Without the fix, Completed fires on any KeyUp(Enter) regardless of KeyDown.
+	// With the fix, Completed requires a preceding KeyDown(Enter).
+	[Test]
+	[Category(UITestCategories.Entry)]
+	public void CompletedDoesNotFireOnIMECandidateEnter()
+	{
+		App.WaitForElement("TestEntry");
+		App.Tap("TestEntry");
+
+		// Send ONLY KeyUp(Enter) with no KeyDown — simulates IME candidate confirmation.
+		// The IME swallows KeyDown entirely; only KeyUp(Enter) leaks through.
+		var app = App as AppiumApp;
+		Assert.That(app, Is.Not.Null, "This test requires AppiumApp");
+
+		app!.Driver.ExecuteScript("windows: keys", new Dictionary<string, object>
+		{
+			["actions"] = new[]
+			{
+				new Dictionary<string, object> { ["virtualKeyCode"] = 0x0D, ["down"] = false }
+			}
+		});
+
+		// Completed should NOT have fired
+		Assert.That(App.WaitForElement("CompletedCountLabel").GetText(), Is.EqualTo("Completed: 0"));
+
+		// Now send a real Enter (KeyDown + KeyUp) — Completed SHOULD fire
+		App.PressEnter();
+
+		Assert.That(App.WaitForElement("CompletedCountLabel").GetText(), Is.EqualTo("Completed: 1"));
+	}
+}
+#endif

--- a/src/Core/src/Handlers/Entry/EntryHandler.Windows.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Windows.cs
@@ -14,6 +14,9 @@ namespace Microsoft.Maui.Handlers
 		static readonly bool s_shouldBeDelayed = DeviceInfo.Idiom != DeviceIdiom.Desktop;
 		bool _set;
 
+		// Suppress Completed() for IME candidate-confirmation Enter (VirtualKey.Process at KeyDown, Enter only at KeyUp).
+		bool _enterKeyDownSeen;
+
 		protected override TextBox CreatePlatformView() =>
 			new MauiPasswordTextBox()
 			{
@@ -32,6 +35,7 @@ namespace Microsoft.Maui.Handlers
 
 		protected override void ConnectHandler(TextBox platformView)
 		{
+			platformView.KeyDown += OnPlatformKeyDown;
 			platformView.KeyUp += OnPlatformKeyUp;
 			platformView.TextChanged += OnPlatformTextChanged;
 			platformView.SizeChanged += OnPlatformViewSizeChanged;
@@ -40,6 +44,7 @@ namespace Microsoft.Maui.Handlers
 		protected override void DisconnectHandler(TextBox platformView)
 		{
 			platformView.SizeChanged -= OnPlatformViewSizeChanged;
+			platformView.KeyDown -= OnPlatformKeyDown;
 			platformView.KeyUp -= OnPlatformKeyUp;
 			platformView.TextChanged -= OnPlatformTextChanged;
 
@@ -114,10 +119,32 @@ namespace Microsoft.Maui.Handlers
 				VirtualView?.UpdateText(PlatformView.Text);
 		}
 
+		void OnPlatformKeyDown(object? sender, KeyRoutedEventArgs args)
+		{
+			if (args?.Key == VirtualKey.Enter)
+			{
+				_enterKeyDownSeen = true;
+			}
+			else
+			{
+				_enterKeyDownSeen = false;
+			}
+		}
+
 		void OnPlatformKeyUp(object? sender, KeyRoutedEventArgs args)
 		{
 			if (args?.Key != VirtualKey.Enter)
+			{
 				return;
+			}
+
+			// IME candidate-confirmation Enter has no preceding KeyDown(Enter) — suppress it.
+			if (!_enterKeyDownSeen)
+			{
+				return;
+			}
+
+			_enterKeyDownSeen = false;
 
 			if (VirtualView?.ReturnType == ReturnType.Next)
 			{

--- a/src/Core/src/Handlers/Entry/EntryHandler.Windows.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Windows.cs
@@ -14,7 +14,8 @@ namespace Microsoft.Maui.Handlers
 		static readonly bool s_shouldBeDelayed = DeviceInfo.Idiom != DeviceIdiom.Desktop;
 		bool _set;
 
-		// Suppress Completed() for IME candidate-confirmation Enter (VirtualKey.Process at KeyDown, Enter only at KeyUp).
+		// Some Windows IMEs use Enter to confirm the current composition.
+		// Those Enter presses should not trigger Entry.Completed.
 		bool _enterKeyDownSeen;
 
 		protected override TextBox CreatePlatformView() =>
@@ -125,10 +126,6 @@ namespace Microsoft.Maui.Handlers
 			{
 				_enterKeyDownSeen = true;
 			}
-			else
-			{
-				_enterKeyDownSeen = false;
-			}
 		}
 
 		void OnPlatformKeyUp(object? sender, KeyRoutedEventArgs args)
@@ -138,7 +135,10 @@ namespace Microsoft.Maui.Handlers
 				return;
 			}
 
-			// IME candidate-confirmation Enter has no preceding KeyDown(Enter) — suppress it.
+			// Some Windows IMEs raise KeyDown(Process) followed by KeyUp(Enter)
+			// when Enter is used to confirm an IME candidate. Since this is not a
+			// user submission, suppress Completed unless an actual Enter KeyDown
+			// preceded the KeyUp.
 			if (!_enterKeyDownSeen)
 			{
 				return;

--- a/src/Core/src/Handlers/Entry/EntryHandler.Windows.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Windows.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Maui.Handlers
 		{
 			platformView.KeyDown += OnPlatformKeyDown;
 			platformView.KeyUp += OnPlatformKeyUp;
+			platformView.LostFocus += OnPlatformLostFocus;
 			platformView.TextChanged += OnPlatformTextChanged;
 			platformView.SizeChanged += OnPlatformViewSizeChanged;
 		}
@@ -47,6 +48,7 @@ namespace Microsoft.Maui.Handlers
 			platformView.SizeChanged -= OnPlatformViewSizeChanged;
 			platformView.KeyDown -= OnPlatformKeyDown;
 			platformView.KeyUp -= OnPlatformKeyUp;
+			platformView.LostFocus -= OnPlatformLostFocus;
 			platformView.TextChanged -= OnPlatformTextChanged;
 
 			_enterKeyDownSeen = false;
@@ -120,6 +122,11 @@ namespace Microsoft.Maui.Handlers
 				VirtualView?.UpdateText(passwordBox.Password);
 			else
 				VirtualView?.UpdateText(PlatformView.Text);
+		}
+
+		void OnPlatformLostFocus(object sender, RoutedEventArgs args)
+		{
+			_enterKeyDownSeen = false;
 		}
 
 		void OnPlatformKeyDown(object? sender, KeyRoutedEventArgs args)

--- a/src/Core/src/Handlers/Entry/EntryHandler.Windows.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Windows.cs
@@ -49,6 +49,8 @@ namespace Microsoft.Maui.Handlers
 			platformView.KeyUp -= OnPlatformKeyUp;
 			platformView.TextChanged -= OnPlatformTextChanged;
 
+			_enterKeyDownSeen = false;
+
 			if (_set)
 				platformView.SelectionChanged -= OnPlatformSelectionChanged;
 

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Windows.cs
@@ -9,6 +9,8 @@ using Microsoft.UI.Xaml.Automation.Provider;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
+using Windows.System;
+using Windows.UI.Input.Preview.Injection;
 using Xunit;
 
 using NativeTextAlignment = Microsoft.UI.Xaml.TextAlignment;
@@ -193,6 +195,45 @@ namespace Microsoft.Maui.DeviceTests
 				var ip = ap.GetPattern(PatternInterface.Invoke) as IInvokeProvider;
 				ip?.Invoke();
 			});
+		}
+
+		// Simulates the key-event sequence produced by IME candidate-window confirmation:
+		// The IME intercepts and consumes the physical Enter (no KeyDown(Enter) reaches the TextBox),
+		// and only the KeyUp(Enter) leaks through — which is what caused the original bug.
+		static void SimulateIMECandidateEnter(TextBox platformView)
+		{
+			var injector = InputInjector.TryCreate();
+
+			// Inject ONLY KeyUp(Enter) with no preceding KeyDown(Enter).
+			// This is the exact sequence the TextBox receives during IME candidate confirmation —
+			// the IME swallows the KeyDown entirely; only the physical key-release (KeyUp) leaks.
+			injector.InjectKeyboardInput(new[]
+			{
+				new InjectedInputKeyboardInfo
+				{
+					VirtualKey = (ushort)VirtualKey.Enter,
+					KeyOptions = InjectedInputKeyOptions.KeyUp
+				}
+			});
+		}
+
+		[Fact(DisplayName = "Completed does not fire on IME candidate confirmation Enter")]
+		public async Task CompletedDoesNotFireOnIMECandidateEnter()
+		{
+			var entry = new EntryStub();
+			int completedCount = 0;
+			entry.Completed += (s, e) => completedCount++;
+
+			await AttachAndRun(entry, async (handler) =>
+			{
+				handler.PlatformView.Focus(Microsoft.UI.Xaml.FocusState.Programmatic);
+				await Task.Delay(100);
+
+				SimulateIMECandidateEnter(handler.PlatformView);
+				await Task.Delay(100);
+			});
+
+			Assert.Equal(0, completedCount);
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Windows.cs
@@ -204,6 +204,11 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			var injector = InputInjector.TryCreate();
 
+			if (injector is null)
+			{
+				return;
+			}
+
 			// Inject ONLY KeyUp(Enter) with no preceding KeyDown(Enter).
 			// This is the exact sequence the TextBox receives during IME candidate confirmation —
 			// the IME swallows the KeyDown entirely; only the physical key-release (KeyUp) leaks.
@@ -215,6 +220,31 @@ namespace Microsoft.Maui.DeviceTests
 					KeyOptions = InjectedInputKeyOptions.KeyUp
 				}
 			});
+		}
+
+		// Simulates a real Enter key press (KeyDown + KeyUp).
+		static void SimulateRealEnter(TextBox platformView)
+		{
+			var injector = InputInjector.TryCreate();
+
+			if (injector is null)
+			{
+				return;
+			}
+
+			injector.InjectKeyboardInput(new[]
+			{
+				new InjectedInputKeyboardInfo
+				{
+					VirtualKey = (ushort)VirtualKey.Enter,
+					KeyOptions = InjectedInputKeyOptions.None // KeyDown
+				},
+				new InjectedInputKeyboardInfo
+				{
+					VirtualKey = (ushort)VirtualKey.Enter,
+					KeyOptions = InjectedInputKeyOptions.KeyUp
+				}
+		   });
 		}
 
 		[Fact(DisplayName = "Completed does not fire on IME candidate confirmation Enter")]
@@ -234,6 +264,25 @@ namespace Microsoft.Maui.DeviceTests
 			});
 
 			Assert.Equal(0, completedCount);
+		}
+
+		[Fact(DisplayName = "Completed fires on real Enter key press")]
+		public async Task CompletedFiresOnRealEnterKeyPress()
+		{
+			var entry = new EntryStub();
+			int completedCount = 0;
+			entry.Completed += (s, e) => completedCount++;
+
+			await AttachAndRun(entry, async (handler) =>
+			{
+				handler.PlatformView.Focus(Microsoft.UI.Xaml.FocusState.Programmatic);
+				await Task.Delay(100);
+
+				SimulateRealEnter(handler.PlatformView);
+				await Task.Delay(100);
+			});
+
+			Assert.Equal(1, completedCount);
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Windows.cs
@@ -9,8 +9,6 @@ using Microsoft.UI.Xaml.Automation.Provider;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
-using Windows.System;
-using Windows.UI.Input.Preview.Injection;
 using Xunit;
 
 using NativeTextAlignment = Microsoft.UI.Xaml.TextAlignment;
@@ -195,89 +193,6 @@ namespace Microsoft.Maui.DeviceTests
 				var ip = ap.GetPattern(PatternInterface.Invoke) as IInvokeProvider;
 				ip?.Invoke();
 			});
-		}
-
-		// Simulates the key-event sequence produced by IME candidate-window confirmation:
-		// The IME intercepts and consumes the physical Enter (no KeyDown(Enter) reaches the TextBox),
-		// and only the KeyUp(Enter) leaks through — which is what caused the original bug.
-		static void SimulateIMECandidateEnter(TextBox platformView)
-		{
-			var injector = InputInjector.TryCreate();
-
-			Assert.NotNull(injector);
-
-			// Inject ONLY KeyUp(Enter) with no preceding KeyDown(Enter).
-			// This is the exact sequence the TextBox receives during IME candidate confirmation —
-			// the IME swallows the KeyDown entirely; only the physical key-release (KeyUp) leaks.
-			injector.InjectKeyboardInput(new[]
-			{
-				new InjectedInputKeyboardInfo
-				{
-					VirtualKey = (ushort)VirtualKey.Enter,
-					KeyOptions = InjectedInputKeyOptions.KeyUp
-				}
-			});
-		}
-
-		// Simulates a real Enter key press (KeyDown + KeyUp).
-		static void SimulateRealEnter(TextBox platformView)
-		{
-			var injector = InputInjector.TryCreate();
-
-			Assert.NotNull(injector);
-
-			
-			injector.InjectKeyboardInput(new[]
-			{
-				new InjectedInputKeyboardInfo
-				{
-					VirtualKey = (ushort)VirtualKey.Enter,
-					KeyOptions = InjectedInputKeyOptions.None // KeyDown
-				},
-				new InjectedInputKeyboardInfo
-				{
-					VirtualKey = (ushort)VirtualKey.Enter,
-					KeyOptions = InjectedInputKeyOptions.KeyUp
-				}
-		   });
-		}
-
-		[Fact(DisplayName = "Completed does not fire on IME candidate confirmation Enter")]
-		public async Task CompletedDoesNotFireOnIMECandidateEnter()
-		{
-			var entry = new EntryStub();
-			int completedCount = 0;
-			entry.Completed += (s, e) => completedCount++;
-
-			await AttachAndRun(entry, async (handler) =>
-			{
-				handler.PlatformView.Focus(Microsoft.UI.Xaml.FocusState.Programmatic);
-				await Task.Delay(100);
-
-				SimulateIMECandidateEnter(handler.PlatformView);
-				await Task.Delay(100);
-			});
-
-			Assert.Equal(0, completedCount);
-		}
-
-		[Fact(DisplayName = "Completed fires on real Enter key press")]
-		public async Task CompletedFiresOnRealEnterKeyPress()
-		{
-			var entry = new EntryStub();
-			int completedCount = 0;
-			entry.Completed += (s, e) => completedCount++;
-
-			await AttachAndRun(entry, async (handler) =>
-			{
-				handler.PlatformView.Focus(Microsoft.UI.Xaml.FocusState.Programmatic);
-				await Task.Delay(100);
-
-				SimulateRealEnter(handler.PlatformView);
-				await Task.Delay(100);
-			});
-
-			Assert.Equal(1, completedCount);
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Windows.cs
@@ -204,10 +204,7 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			var injector = InputInjector.TryCreate();
 
-			if (injector is null)
-			{
-				return;
-			}
+			Assert.NotNull(injector);
 
 			// Inject ONLY KeyUp(Enter) with no preceding KeyDown(Enter).
 			// This is the exact sequence the TextBox receives during IME candidate confirmation —
@@ -227,11 +224,9 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			var injector = InputInjector.TryCreate();
 
-			if (injector is null)
-			{
-				return;
-			}
+			Assert.NotNull(injector);
 
+			
 			injector.InjectKeyboardInput(new[]
 			{
 				new InjectedInputKeyboardInfo

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumWindowsVirtualKeyboardActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumWindowsVirtualKeyboardActions.cs
@@ -23,7 +23,8 @@ namespace UITest.Appium
 				{
 					["actions"] = new[]
 					{
-						new Dictionary<string, object> { ["virtualKeyCode"] = 0x0D, ["down"]=false }, // Enter
+						new Dictionary<string, object> { ["virtualKeyCode"] = 0x0D, ["down"] = true },  // Enter KeyDown
+						new Dictionary<string, object> { ["virtualKeyCode"] = 0x0D, ["down"] = false }, // Enter KeyUp
 					}
 				});
 			}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details

- On Windows, pressing Enter inside a Chinese/Japanese IME candidate window unexpectedly fires Entry.Completed, when the user only intended to confirm a word suggestion

### Root Cause of the issue
- When an IME candidate window is active and Enter is pressed to confirm a candidate, the IME completely intercepts and swallows the  KeyDown  event — the  TextBox  never receives a  KeyDown  event at all. However, when the user physically releases the Enter key, Windows still sends a  KeyUp(Enter=13)  to the  TextBox  because the key release cannot be suppressed.
- The existing MAUI handler  OnPlatformKeyUp  fired  Completed()  whenever it saw  VirtualKey.Enter  in  KeyUp  — without ever checking whether a matching  KeyDown(Enter)  had actually occurred. Since the leaked  KeyUp(Enter)  from IME candidate confirmation looks identical to a real Enter's  KeyUp , the handler had no way to tell them apart and fired  Completed()  every time


### Description of Change

**Bug fix: IME Enter key handling in Entry**

* Added an `_enterKeyDownSeen` flag to `EntryHandler.Windows.cs` to track Enter key presses, and updated the event handlers so that `Entry.Completed` only fires if a real Enter KeyDown was detected before KeyUp. This prevents IME candidate confirmation from firing the event.

**Test coverage**

* Added a new test page (`Issue36179`) in `TestCases.HostApp` to manually verify the fix for IME Enter handling.
* Added an automated UI test (`Issue36179`) in `TestCases.Shared.Tests` that simulates IME candidate confirmation by sending only KeyUp(Enter), and verifies that `Entry.Completed` is not fired. It also verifies that a real Enter (KeyDown + KeyUp) does fire the event.

**Test utility improvement**

* Updated `AppiumWindowsVirtualKeyboardActions` to send both KeyDown and KeyUp for Enter in `PressEnter`, ensuring test accuracy for real Enter key submissions.
<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #36179

### Tested the behaviour in the following platforms

- [x] Windows
- [ ] Android
- [ ] iOS
- [ ] Mac

| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/75b49092-3a3e-48ea-bdc7-6739c3230ab1"> | <video src="https://github.com/user-attachments/assets/68f72736-227c-4393-bc6c-8196c5371cb6"> |



<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
