### PR TITLE
Fix UsesReflectionBasedBindingsWhenCompilationOfBindingsWithSourceIsDisabled Xaml.UnitTests fails in candidate branch

### DIFF
--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -798,7 +798,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			}
 		}
 
-		static bool TryParsePath(ILContext context, string path, TypeReference tSourceRef, IXmlLineInfo lineInfo, ModuleDefinition module, out IList<(PropertyDefinition property, TypeReference propDeclTypeRef, string indexArg)> pathProperties, bool suppressPropertyNotFoundWarning = false)
+		static bool TryParsePath(ILContext context, string path, TypeReference tSourceRef, IXmlLineInfo lineInfo, ModuleDefinition module, out IList<(PropertyDefinition property, TypeReference propDeclTypeRef, string indexArg)> pathProperties)
 		{
 			pathProperties = null;
 
@@ -838,14 +838,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 					var property = previousPartTypeRef.GetProperty(context.Cache, pd => pd.Name == p && pd.GetMethod != null && pd.GetMethod.IsPublic && !pd.GetMethod.IsStatic, out var propDeclTypeRef);
 					if (property is null)
 					{
-						// For x:Reference-sourced bindings, resolving against the referenced
-						// element's actual type is a best-effort improvement over always falling
-						// back to reflection. If the path doesn't resolve against that type, we
-						// silently fall back to a reflection-based binding instead of emitting a
-						// new warning — these bindings were never compiled before, so emitting a
-						// warning here would be a regression in diagnostic noise.
-						if (!suppressPropertyNotFoundWarning)
-							context.LoggingHelper.LogWarningOrError(BindingPropertyNotFound, context.XamlFilePath, lineInfo.LineNumber, lineInfo.LinePosition, 0, 0, p, previousPartTypeRef);
+						context.LoggingHelper.LogWarningOrError(BindingPropertyNotFound, context.XamlFilePath, lineInfo.LineNumber, lineInfo.LinePosition, 0, 0, p, previousPartTypeRef);
 						return false;
 					}
 

--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -532,7 +532,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			}
 
 			TypeReference tSourceRef = null;
-			if (HasRelativeOrReferenceSource(node) && !xDataTypeIsOnBindingNode)
+			if (HasRelativeOrReferenceSource(node) && xDataTypeIsInOuterScope)
 			{
 				if (!TryGetRelativeSourceAncestorTypeReference(node, context, module, out tSourceRef))
 				{
@@ -798,7 +798,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			}
 		}
 
-		static bool TryParsePath(ILContext context, string path, TypeReference tSourceRef, IXmlLineInfo lineInfo, ModuleDefinition module, out IList<(PropertyDefinition property, TypeReference propDeclTypeRef, string indexArg)> pathProperties)
+		static bool TryParsePath(ILContext context, string path, TypeReference tSourceRef, IXmlLineInfo lineInfo, ModuleDefinition module, out IList<(PropertyDefinition property, TypeReference propDeclTypeRef, string indexArg)> pathProperties, bool suppressPropertyNotFoundWarning = false)
 		{
 			pathProperties = null;
 
@@ -838,7 +838,14 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 					var property = previousPartTypeRef.GetProperty(context.Cache, pd => pd.Name == p && pd.GetMethod != null && pd.GetMethod.IsPublic && !pd.GetMethod.IsStatic, out var propDeclTypeRef);
 					if (property is null)
 					{
-						context.LoggingHelper.LogWarningOrError(BindingPropertyNotFound, context.XamlFilePath, lineInfo.LineNumber, lineInfo.LinePosition, 0, 0, p, previousPartTypeRef);
+						// For x:Reference-sourced bindings, resolving against the referenced
+						// element's actual type is a best-effort improvement over always falling
+						// back to reflection. If the path doesn't resolve against that type, we
+						// silently fall back to a reflection-based binding instead of emitting a
+						// new warning — these bindings were never compiled before, so emitting a
+						// warning here would be a regression in diagnostic noise.
+						if (!suppressPropertyNotFoundWarning)
+							context.LoggingHelper.LogWarningOrError(BindingPropertyNotFound, context.XamlFilePath, lineInfo.LineNumber, lineInfo.LinePosition, 0, 0, p, previousPartTypeRef);
 						return false;
 					}
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details:

UsesReflectionBasedBindingsWhenCompilationOfBindingsWithSourceIsDisabled test case is failed 

       
### Root Cause:

PR #35798 introduced a guard in  SetPropertiesVisitor.cs  to stop XamlC from compiling a  TypedBinding  whenever  Source  is  RelativeSource / x:Reference  and  x:DataType  isn't declared directly on the binding node ( !xDataTypeIsOnBindingNode ). The problem: this condition is too broad. It was meant to catch one specific dangerous case —  x:DataType  inherited from an enclosing  DataTemplate , which describes the template item type, not the actual  RelativeSource / x:Reference  target — but it also caught a harmless case:  x:DataType  inherited from a plain ancestor like  ContentPage  (no  DataTemplate  involved), where the inherited type is still perfectly valid to bind against directly.

### Description of Change:

The guard condition changed from  !xDataTypeIsOnBindingNode  to  xDataTypeIsInOuterScope  — a flag already computed earlier in the method, set to  true  only when the tree-walk to find  x:DataType  passes through a  DataTemplate  node. This precisely targets the one case #35798 actually needed to guard against (DataTemplate-inherited types being wrongly applied to a RelativeSource/x:Reference target), while leaving alone the case where  x:DataType  is inherited from a normal ancestor (like  ContentPage ) or declared directly on the binding node — both of which can safely use the resolved  dataTypeNode  type as-is. 

**Tested the behavior in the following platforms:**

- [ ] Android
- [ ] Windows
- [x] iOS
- [x] Mac

### Reference:

N/A

### Issues Fixed:

Fixes  #36563

