### PR TITLE
Fix Shell title binding without leaking page titles

### DIFF
--- a/src/Controls/src/Core/ShellToolbar.cs
+++ b/src/Controls/src/Core/ShellToolbar.cs
@@ -169,27 +169,47 @@ namespace Microsoft.Maui.Controls
 				Shell.TitleViewProperty,
 				Shell.GetTitleView(_shell));
 
+			var title = GetCurrentTitle();
+
 			if (TitleView != null)
 			{
+				if (!IsShellTitleSetByUser())
+					_shell.SetValueFromRenderer(Shell.TitleProperty, title);  // only when TitleView exists
 				Title = String.Empty;
 				return;
 			}
 
+			Title = title;
+		}
+
+		string GetCurrentTitle()
+		{
 			Page? currentPage = _shell.GetCurrentShellPage();
 			if (currentPage?.IsSet(Page.TitleProperty) == true)
 			{
-				Title = currentPage.Title ?? String.Empty;
+				return currentPage.Title ?? String.Empty;
 			}
 			// We only want to use the ShellContent as a title if no pages have been
 			// Pushed onto the stack
 			else if (_shell.Navigation?.NavigationStack?.Count <= 1)
 			{
-				Title = _shell.CurrentContent?.Title ?? String.Empty;
+				return _shell.CurrentContent?.Title ?? String.Empty;
 			}
-			else
-			{
-				Title = String.Empty;
-			}
+
+			return String.Empty;
+		}
+
+		bool IsShellTitleSetByUser()
+		{
+			var titleContext = _shell.GetContext(Shell.TitleProperty);
+			if (titleContext == null)
+				return false;
+
+			if (titleContext.Bindings.Count > 0)
+				return true;
+
+			var specificity = titleContext.Values.GetSpecificity();
+			return specificity != SetterSpecificity.DefaultValue && specificity != SetterSpecificity.FromHandler;
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/ShellTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellTests.cs
@@ -1668,6 +1668,53 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal("Shell Title", (window as IWindow).Title);
 		}
 
+		// When a Shell page has a title but no TitleView, the page title must appear
+		// in the in-app navigation bar (Toolbar.Title) but must NOT propagate to
+		// Shell.Title — which would cause it to appear in the native window/status bar
+		// via Window.ITitledElement.Title (= Window.Title ?? Shell.Title).
+		[Fact]
+		public void ShellPageTitleDoesNotPropagateToWindowTitleBar()
+		{
+			var shellContent = CreateShellContent();
+			shellContent.Title = "Page Title";
+
+			TestShell testShell = new TestShell(shellContent);
+
+			Window window = new Window { Page = testShell };
+
+			// In-app navigation bar shows the page title
+			Assert.Equal("Page Title", testShell.Toolbar.Title);
+
+			// Shell.Title must NOT be updated by the renderer — keeps the
+			// native window title bar / status bar free of the page title
+			Assert.Null(testShell.Title);
+			Assert.Null((window as IWindow).Title);
+		}
+
+		// The same invariant must hold after navigating to a pushed page.
+		[Fact]
+		public async Task ShellPageTitleDoesNotPropagateToWindowTitleBarOnNavigation()
+		{
+			var shellContent = CreateShellContent();
+			shellContent.Title = "Page One";
+
+			TestShell testShell = new TestShell(shellContent);
+
+			Window window = new Window { Page = testShell };
+
+			Assert.Equal("Page One", testShell.Toolbar.Title);
+			Assert.Null(testShell.Title);
+			Assert.Null((window as IWindow).Title);
+
+			await testShell.Navigation.PushAsync(new ContentPage { Title = "Page Two" });
+
+			Assert.Equal("Page Two", testShell.Toolbar.Title);
+
+			// Shell.Title must still NOT be updated by the renderer after navigation
+			Assert.Null(testShell.Title);
+			Assert.Null((window as IWindow).Title);
+		}
+
 		[Fact]
 		public void FlyoutIsPresentedRemainsTrueAfterShellIsInitialized()
 		{

--- a/src/Controls/tests/Core.UnitTests/ShellToolbarTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellToolbarTests.cs
@@ -271,6 +271,64 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public void ShellTitleReflectsCurrentPageTitleForTitleViewBindings()
+		{
+			var contentPage = new ContentPage() { Title = "Test Title" };
+			var label = new Label();
+			var titleView = new VerticalStackLayout()
+			{
+				Children =
+				{
+					label
+				}
+			};
+
+			TestShell testShell = new TestShell(contentPage);
+			_ = new Window()
+			{
+				Page = testShell
+			};
+
+			label.SetBinding(Label.TextProperty, new Binding(nameof(Shell.Title), source: testShell));
+			Shell.SetTitleView(contentPage, titleView);
+
+			Assert.Empty(testShell.Toolbar.Title);
+			Assert.Equal("Test Title", testShell.Title);
+			Assert.Equal("Test Title", label.Text);
+
+			contentPage.Title = "Updated Test Title";
+
+			Assert.Equal("Updated Test Title", testShell.Title);
+			Assert.Equal("Updated Test Title", label.Text);
+		}
+
+		[Fact]
+		public void ShellTitleBindingIsNotOverwrittenByCurrentPageTitle()
+		{
+			var contentPage = new ContentPage() { Title = "Page Title" };
+			var titleView = new VerticalStackLayout();
+			var viewModel = new TestShellViewModel() { Text = "App Title" };
+
+			TestShell testShell = new TestShell(contentPage);
+			_ = new Window()
+			{
+				Page = testShell
+			};
+
+			testShell.SetBinding(Shell.TitleProperty, new Binding(nameof(TestShellViewModel.Text), BindingMode.TwoWay, source: viewModel));
+			Shell.SetTitleView(contentPage, titleView);
+
+			Assert.Empty(testShell.Toolbar.Title);
+			Assert.Equal("App Title", testShell.Title);
+			Assert.Equal("App Title", viewModel.Text);
+
+			contentPage.Title = "Updated Page Title";
+
+			Assert.Equal("App Title", testShell.Title);
+			Assert.Equal("App Title", viewModel.Text);
+		}
+
+		[Fact]
 		public void ContentPageColorsPropagateToShellToolbar()
 		{
 			var contentPage = new ContentPage() { Title = "Test Title" };


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause

The TitleView binding fix from #35800 mirrored the active page title into `Shell.Title` before checking whether a custom `TitleView` existed. Because native window titles fall back to `Shell.Title`, ordinary Shell page titles then leaked into the Windows title bar and Mac Catalyst status bar.

### Description of Change

Forward-ports the final combined implementation from #35800 and #36334 to `main`. The #36334 correction depends on the TitleView binding behavior introduced by #35800, so both are included to keep this PR self-contained.

`Shell.Title` now mirrors the active page title only when a custom `TitleView` needs that binding and the title was not set by the user. Without a `TitleView`, the page title remains in the in-app toolbar and does not propagate to native window chrome.

The core tests cover TitleView binding updates, preservation of user-bound Shell titles, initial page titles, and pushed-page navigation.

### Issues Fixed

Fixes #36225.

### Tests

`Controls.Core.UnitTests`: 18 focused Shell tests passed.