### PR TITLE
Decouple SDK package versions from in-development builds

### DIFF
--- a/eng/NuGetVersions.targets
+++ b/eng/NuGetVersions.targets
@@ -1,4 +1,70 @@
 <Project>
+  <PropertyGroup>
+    <UseLatestDotNetPackageVersions Condition="'$(UseLatestDotNetPackageVersions)' == '' and '$(MauiTestProject)' == 'true'">true</UseLatestDotNetPackageVersions>
+    <!-- Shipping projects use the previous publicly available preview. Tests opt into the current SDK versions below. -->
+    <_MicrosoftExtensionsConfigurationVersion>$(MicrosoftExtensionsPreviousPublishedPackageVersion)</_MicrosoftExtensionsConfigurationVersion>
+    <_MicrosoftExtensionsConfigurationAbstractionsVersion>$(MicrosoftExtensionsPreviousPublishedPackageVersion)</_MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <_MicrosoftExtensionsConfigurationJsonVersion>$(MicrosoftExtensionsPreviousPublishedPackageVersion)</_MicrosoftExtensionsConfigurationJsonVersion>
+    <_MicrosoftExtensionsDependencyInjectionVersion>$(MicrosoftExtensionsPreviousPublishedPackageVersion)</_MicrosoftExtensionsDependencyInjectionVersion>
+    <_MicrosoftExtensionsDependencyInjectionAbstractionsVersion>$(MicrosoftExtensionsPreviousPublishedPackageVersion)</_MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
+    <_MicrosoftExtensionsFileProvidersAbstractionsVersion>$(MicrosoftExtensionsPreviousPublishedPackageVersion)</_MicrosoftExtensionsFileProvidersAbstractionsVersion>
+    <_MicrosoftExtensionsHostingAbstractionsVersion>$(MicrosoftExtensionsPreviousPublishedPackageVersion)</_MicrosoftExtensionsHostingAbstractionsVersion>
+    <_MicrosoftExtensionsHttpVersion>$(MicrosoftExtensionsPreviousPublishedPackageVersion)</_MicrosoftExtensionsHttpVersion>
+    <_MicrosoftExtensionsLoggingAbstractionsVersion>$(MicrosoftExtensionsPreviousPublishedPackageVersion)</_MicrosoftExtensionsLoggingAbstractionsVersion>
+    <_MicrosoftExtensionsLoggingVersion>$(MicrosoftExtensionsPreviousPublishedPackageVersion)</_MicrosoftExtensionsLoggingVersion>
+    <_MicrosoftExtensionsLoggingConsoleVersion>$(MicrosoftExtensionsPreviousPublishedPackageVersion)</_MicrosoftExtensionsLoggingConsoleVersion>
+    <_MicrosoftExtensionsLoggingDebugVersion>$(MicrosoftExtensionsPreviousPublishedPackageVersion)</_MicrosoftExtensionsLoggingDebugVersion>
+    <_MicrosoftExtensionsPrimitivesVersion>$(MicrosoftExtensionsPreviousPublishedPackageVersion)</_MicrosoftExtensionsPrimitivesVersion>
+    <_MicrosoftAspNetCoreAuthorizationPackageVersion>$(MicrosoftAspNetCorePreviousPublishedPackageVersion)</_MicrosoftAspNetCoreAuthorizationPackageVersion>
+    <_MicrosoftAspNetCoreAuthenticationGooglePackageVersion>$(MicrosoftAspNetCorePreviousPublishedPackageVersion)</_MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
+    <_MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>$(MicrosoftAspNetCorePreviousPublishedPackageVersion)</_MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
+    <_MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>$(MicrosoftAspNetCorePreviousPublishedPackageVersion)</_MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
+    <_MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>$(MicrosoftAspNetCorePreviousPublishedPackageVersion)</_MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
+    <_MicrosoftAspNetCoreComponentsFormsPackageVersion>$(MicrosoftAspNetCorePreviousPublishedPackageVersion)</_MicrosoftAspNetCoreComponentsFormsPackageVersion>
+    <_MicrosoftAspNetCoreComponentsPackageVersion>$(MicrosoftAspNetCorePreviousPublishedPackageVersion)</_MicrosoftAspNetCoreComponentsPackageVersion>
+    <_MicrosoftAspNetCoreComponentsWebViewPackageVersion>$(MicrosoftAspNetCorePreviousPublishedPackageVersion)</_MicrosoftAspNetCoreComponentsWebViewPackageVersion>
+    <_MicrosoftAspNetCoreComponentsWebPackageVersion>$(MicrosoftAspNetCorePreviousPublishedPackageVersion)</_MicrosoftAspNetCoreComponentsWebPackageVersion>
+    <_MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>$(MicrosoftAspNetCorePreviousPublishedPackageVersion)</_MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
+    <_MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>$(MicrosoftAspNetCorePreviousPublishedPackageVersion)</_MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
+    <_MicrosoftAspNetCoreMetadataPackageVersion>$(MicrosoftAspNetCorePreviousPublishedPackageVersion)</_MicrosoftAspNetCoreMetadataPackageVersion>
+    <_MicrosoftJSInteropPackageVersion>$(MicrosoftAspNetCorePreviousPublishedPackageVersion)</_MicrosoftJSInteropPackageVersion>
+    <_SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPreviousPublishedPackageVersion)</_SystemTextJsonPackageVersion>
+    <_SystemTextEncodingsWebPackageVersion>$(MicrosoftNETCoreAppRefPreviousPublishedPackageVersion)</_SystemTextEncodingsWebPackageVersion>
+    <_SystemCodeDomPackageVersion>$(MicrosoftNETCoreAppRefPreviousPublishedPackageVersion)</_SystemCodeDomPackageVersion>
+    <_MicrosoftBclAsyncInterfacesPackageVersion>$(MicrosoftNETCoreAppRefPreviousPublishedPackageVersion)</_MicrosoftBclAsyncInterfacesPackageVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(UseLatestDotNetPackageVersions)' == 'true'">
+    <_MicrosoftExtensionsConfigurationVersion>$(MicrosoftExtensionsConfigurationVersion)</_MicrosoftExtensionsConfigurationVersion>
+    <_MicrosoftExtensionsConfigurationAbstractionsVersion>$(MicrosoftExtensionsConfigurationAbstractionsVersion)</_MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <_MicrosoftExtensionsConfigurationJsonVersion>$(MicrosoftExtensionsConfigurationJsonVersion)</_MicrosoftExtensionsConfigurationJsonVersion>
+    <_MicrosoftExtensionsDependencyInjectionVersion>$(MicrosoftExtensionsDependencyInjectionVersion)</_MicrosoftExtensionsDependencyInjectionVersion>
+    <_MicrosoftExtensionsDependencyInjectionAbstractionsVersion>$(MicrosoftExtensionsDependencyInjectionAbstractionsVersion)</_MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
+    <_MicrosoftExtensionsFileProvidersAbstractionsVersion>$(MicrosoftExtensionsFileProvidersAbstractionsVersion)</_MicrosoftExtensionsFileProvidersAbstractionsVersion>
+    <_MicrosoftExtensionsHostingAbstractionsVersion>$(MicrosoftExtensionsHostingAbstractionsVersion)</_MicrosoftExtensionsHostingAbstractionsVersion>
+    <_MicrosoftExtensionsHttpVersion>$(MicrosoftExtensionsHttpVersion)</_MicrosoftExtensionsHttpVersion>
+    <_MicrosoftExtensionsLoggingAbstractionsVersion>$(MicrosoftExtensionsLoggingAbstractionsVersion)</_MicrosoftExtensionsLoggingAbstractionsVersion>
+    <_MicrosoftExtensionsLoggingVersion>$(MicrosoftExtensionsLoggingVersion)</_MicrosoftExtensionsLoggingVersion>
+    <_MicrosoftExtensionsLoggingConsoleVersion>$(MicrosoftExtensionsLoggingConsoleVersion)</_MicrosoftExtensionsLoggingConsoleVersion>
+    <_MicrosoftExtensionsLoggingDebugVersion>$(MicrosoftExtensionsLoggingDebugVersion)</_MicrosoftExtensionsLoggingDebugVersion>
+    <_MicrosoftExtensionsPrimitivesVersion>$(MicrosoftExtensionsPrimitivesVersion)</_MicrosoftExtensionsPrimitivesVersion>
+    <_MicrosoftAspNetCoreAuthorizationPackageVersion>$(MicrosoftAspNetCoreAuthorizationPackageVersion)</_MicrosoftAspNetCoreAuthorizationPackageVersion>
+    <_MicrosoftAspNetCoreAuthenticationGooglePackageVersion>$(MicrosoftAspNetCoreAuthenticationGooglePackageVersion)</_MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
+    <_MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>$(MicrosoftAspNetCoreAuthenticationFacebookPackageVersion)</_MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
+    <_MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>$(MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion)</_MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
+    <_MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>$(MicrosoftAspNetCoreComponentsAnalyzersPackageVersion)</_MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
+    <_MicrosoftAspNetCoreComponentsFormsPackageVersion>$(MicrosoftAspNetCoreComponentsFormsPackageVersion)</_MicrosoftAspNetCoreComponentsFormsPackageVersion>
+    <_MicrosoftAspNetCoreComponentsPackageVersion>$(MicrosoftAspNetCoreComponentsPackageVersion)</_MicrosoftAspNetCoreComponentsPackageVersion>
+    <_MicrosoftAspNetCoreComponentsWebViewPackageVersion>$(MicrosoftAspNetCoreComponentsWebViewPackageVersion)</_MicrosoftAspNetCoreComponentsWebViewPackageVersion>
+    <_MicrosoftAspNetCoreComponentsWebPackageVersion>$(MicrosoftAspNetCoreComponentsWebPackageVersion)</_MicrosoftAspNetCoreComponentsWebPackageVersion>
+    <_MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>$(MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion)</_MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
+    <_MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>$(MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion)</_MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
+    <_MicrosoftAspNetCoreMetadataPackageVersion>$(MicrosoftAspNetCoreMetadataPackageVersion)</_MicrosoftAspNetCoreMetadataPackageVersion>
+    <_MicrosoftJSInteropPackageVersion>$(MicrosoftJSInteropPackageVersion)</_MicrosoftJSInteropPackageVersion>
+    <_SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</_SystemTextJsonPackageVersion>
+    <_SystemTextEncodingsWebPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</_SystemTextEncodingsWebPackageVersion>
+    <_SystemCodeDomPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</_SystemCodeDomPackageVersion>
+    <_MicrosoftBclAsyncInterfacesPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</_MicrosoftBclAsyncInterfacesPackageVersion>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference
         Update="HarfBuzzSharp"
@@ -90,55 +156,55 @@
     />
     <PackageReference
         Update="Microsoft.Extensions.Configuration"
-        Version="$(MicrosoftExtensionsConfigurationVersion)"
+        Version="$(_MicrosoftExtensionsConfigurationVersion)"
     />
     <PackageReference
         Update="Microsoft.Extensions.Configuration.Abstractions"
-        Version="$(MicrosoftExtensionsConfigurationAbstractionsVersion)"
+        Version="$(_MicrosoftExtensionsConfigurationAbstractionsVersion)"
     />
     <PackageReference
         Update="Microsoft.Extensions.Configuration.Json"
-        Version="$(MicrosoftExtensionsConfigurationJsonVersion)"
+        Version="$(_MicrosoftExtensionsConfigurationJsonVersion)"
     />
     <PackageReference
         Update="Microsoft.Extensions.DependencyInjection"
-        Version="$(MicrosoftExtensionsDependencyInjectionVersion)"
+        Version="$(_MicrosoftExtensionsDependencyInjectionVersion)"
     />
     <PackageReference
         Update="Microsoft.Extensions.DependencyInjection.Abstractions"
-        Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsVersion)"
+        Version="$(_MicrosoftExtensionsDependencyInjectionAbstractionsVersion)"
     />
     <PackageReference
         Update="Microsoft.Extensions.FileProviders.Abstractions"
-        Version="$(MicrosoftExtensionsFileProvidersAbstractionsVersion)"
+        Version="$(_MicrosoftExtensionsFileProvidersAbstractionsVersion)"
     />
     <PackageReference
         Update="Microsoft.Extensions.Hosting.Abstractions"
-        Version="$(MicrosoftExtensionsHostingAbstractionsVersion)"
+        Version="$(_MicrosoftExtensionsHostingAbstractionsVersion)"
     />
     <PackageReference
         Update="Microsoft.Extensions.Http"
-        Version="$(MicrosoftExtensionsHttpVersion)"
+        Version="$(_MicrosoftExtensionsHttpVersion)"
     />
     <PackageReference
         Update="Microsoft.Extensions.Logging.Abstractions"
-        Version="$(MicrosoftExtensionsLoggingAbstractionsVersion)"
+        Version="$(_MicrosoftExtensionsLoggingAbstractionsVersion)"
     />
     <PackageReference
         Update="Microsoft.Extensions.Logging"
-        Version="$(MicrosoftExtensionsLoggingVersion)"
+        Version="$(_MicrosoftExtensionsLoggingVersion)"
     />
     <PackageReference
         Update="Microsoft.Extensions.Logging.Console"
-        Version="$(MicrosoftExtensionsLoggingConsoleVersion)"
+        Version="$(_MicrosoftExtensionsLoggingConsoleVersion)"
     />
     <PackageReference
         Update="Microsoft.Extensions.Logging.Debug"
-        Version="$(MicrosoftExtensionsLoggingDebugVersion)"
+        Version="$(_MicrosoftExtensionsLoggingDebugVersion)"
     />
     <PackageReference
         Update="Microsoft.Extensions.Primitives"
-        Version="$(MicrosoftExtensionsPrimitivesVersion)"
+        Version="$(_MicrosoftExtensionsPrimitivesVersion)"
     />
     <PackageReference
         Update="Microsoft.IO.RecyclableMemoryStream"
@@ -164,39 +230,55 @@
     />
     <PackageReference
         Update="Microsoft.AspNetCore.Authorization"
-        Version="$(MicrosoftAspNetCoreAuthorizationPackageVersion)"
+        Version="$(_MicrosoftAspNetCoreAuthorizationPackageVersion)"
     />
     <PackageReference
         Update="Microsoft.AspNetCore.Authentication.Google"
-        Version="$(MicrosoftAspNetCoreAuthenticationGooglePackageVersion)"
+        Version="$(_MicrosoftAspNetCoreAuthenticationGooglePackageVersion)"
     />
     <PackageReference
         Update="Microsoft.AspNetCore.Authentication.Facebook"
-        Version="$(MicrosoftAspNetCoreAuthenticationFacebookPackageVersion)"
+        Version="$(_MicrosoftAspNetCoreAuthenticationFacebookPackageVersion)"
     />
     <PackageReference
         Update="Microsoft.AspNetCore.Authentication.MicrosoftAccount"
-        Version="$(MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion)"
+        Version="$(_MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion)"
+    />
+    <PackageReference
+        Update="Microsoft.AspNetCore.Components.Analyzers"
+        Version="$(_MicrosoftAspNetCoreComponentsAnalyzersPackageVersion)"
+    />
+    <PackageReference
+        Update="Microsoft.AspNetCore.Components.Forms"
+        Version="$(_MicrosoftAspNetCoreComponentsFormsPackageVersion)"
+    />
+    <PackageReference
+        Update="Microsoft.AspNetCore.Components"
+        Version="$(_MicrosoftAspNetCoreComponentsPackageVersion)"
     />
     <PackageReference
         Update="Microsoft.AspNetCore.Components.WebView"
-        Version="$(MicrosoftAspNetCoreComponentsWebViewPackageVersion)"
+        Version="$(_MicrosoftAspNetCoreComponentsWebViewPackageVersion)"
     />
     <PackageReference
         Update="Microsoft.AspNetCore.Components.Web"
-        Version="$(MicrosoftAspNetCoreComponentsWebPackageVersion)"
+        Version="$(_MicrosoftAspNetCoreComponentsWebPackageVersion)"
     />
     <PackageReference
         Update="Microsoft.AspNetCore.Components.WebAssembly"
-        Version="$(MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion)"
+        Version="$(_MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion)"
     />
     <PackageReference
         Update="Microsoft.AspNetCore.Components.WebAssembly.Server"
-        Version="$(MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion)"
+        Version="$(_MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion)"
+    />
+    <PackageReference
+        Update="Microsoft.AspNetCore.Metadata"
+        Version="$(_MicrosoftAspNetCoreMetadataPackageVersion)"
     />
     <PackageReference
         Update="Microsoft.JSInterop"
-        Version="$(MicrosoftJSInteropPackageVersion)"
+        Version="$(_MicrosoftJSInteropPackageVersion)"
     />
     <PackageReference
         Update="Microsoft.AspNetCore.Authorization"
@@ -216,6 +298,21 @@
     <PackageReference
         Update="Microsoft.AspNetCore.Authentication.MicrosoftAccount"
         Version="$(MicrosoftAspNetCoreAuthenticationMicrosoftAccountPreviousPackageVersion)"
+        Condition="$(TargetFramework.StartsWith('$(_MauiPreviousDotNetTfm)'))"
+    />
+    <PackageReference
+        Update="Microsoft.AspNetCore.Components.Analyzers"
+        Version="$(MicrosoftAspNetCoreComponentsAnalyzersPreviousPackageVersion)"
+        Condition="$(TargetFramework.StartsWith('$(_MauiPreviousDotNetTfm)'))"
+    />
+    <PackageReference
+        Update="Microsoft.AspNetCore.Components.Forms"
+        Version="$(MicrosoftAspNetCoreComponentsFormsPreviousPackageVersion)"
+        Condition="$(TargetFramework.StartsWith('$(_MauiPreviousDotNetTfm)'))"
+    />
+    <PackageReference
+        Update="Microsoft.AspNetCore.Components"
+        Version="$(MicrosoftAspNetCoreComponentsPreviousPackageVersion)"
         Condition="$(TargetFramework.StartsWith('$(_MauiPreviousDotNetTfm)'))"
     />
     <PackageReference
@@ -239,25 +336,30 @@
         Condition="$(TargetFramework.StartsWith('$(_MauiPreviousDotNetTfm)'))"
     />
     <PackageReference
+        Update="Microsoft.AspNetCore.Metadata"
+        Version="$(MicrosoftAspNetCoreMetadataPreviousPackageVersion)"
+        Condition="$(TargetFramework.StartsWith('$(_MauiPreviousDotNetTfm)'))"
+    />
+    <PackageReference
         Update="Microsoft.JSInterop"
         Version="$(MicrosoftJSInteropPreviousPackageVersion)"
         Condition="$(TargetFramework.StartsWith('$(_MauiPreviousDotNetTfm)'))"
     />
     <PackageReference
         Update="System.Text.Json"
-        Version="$(SystemTextJsonPackageVersion)"
+        Version="$(_SystemTextJsonPackageVersion)"
     />
     <PackageReference
         Update="System.Text.Encodings.Web"
-        Version="$(SystemTextEncodingsWebPackageVersion)"
+        Version="$(_SystemTextEncodingsWebPackageVersion)"
     />
     <PackageReference
         Update="System.CodeDom"
-        Version="$(SystemCodeDomPackageVersion)"
+        Version="$(_SystemCodeDomPackageVersion)"
     />
     <PackageReference
         Update="Microsoft.Bcl.AsyncInterfaces"
-        Version="$(MicrosoftBclAsyncInterfacesPackageVersion)"
+        Version="$(_MicrosoftBclAsyncInterfacesPackageVersion)"
     />
     <PackageReference
         Update="Microsoft.CodeAnalysis.PublicApiAnalyzers"

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -35,11 +35,14 @@
     <MonoPackageVersion>10.0.100</MonoPackageVersion>
     <!-- dotnet/runtime -->
     <MicrosoftNETCoreAppRefPackageVersion>10.0.0</MicrosoftNETCoreAppRefPackageVersion>
-    <SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextJsonPackageVersion>
-    <SystemTextEncodingsWebPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextEncodingsWebPackageVersion>
-    <MicrosoftBclAsyncInterfacesPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftBclAsyncInterfacesPackageVersion>
+    <!-- Keep shipping references on the latest version already published publicly. During previews this is N-1; at GA it matches the current stable version. -->
+    <MicrosoftNETCoreAppRefPreviousPublishedPackageVersion>10.0.0</MicrosoftNETCoreAppRefPreviousPublishedPackageVersion>
+    <SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPreviousPublishedPackageVersion)</SystemTextJsonPackageVersion>
+    <SystemTextEncodingsWebPackageVersion>$(MicrosoftNETCoreAppRefPreviousPublishedPackageVersion)</SystemTextEncodingsWebPackageVersion>
+    <MicrosoftBclAsyncInterfacesPackageVersion>$(MicrosoftNETCoreAppRefPreviousPublishedPackageVersion)</MicrosoftBclAsyncInterfacesPackageVersion>
     <!-- Microsoft/Extensions -->
-    <SystemCodeDomPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemCodeDomPackageVersion>
+    <SystemCodeDomPackageVersion>$(MicrosoftNETCoreAppRefPreviousPublishedPackageVersion)</SystemCodeDomPackageVersion>
+    <MicrosoftExtensionsPreviousPublishedPackageVersion>10.0.0</MicrosoftExtensionsPreviousPublishedPackageVersion>
     <MicrosoftExtensionsConfigurationVersion>10.0.0</MicrosoftExtensionsConfigurationVersion>
     <MicrosoftExtensionsConfigurationAbstractionsVersion>10.0.0</MicrosoftExtensionsConfigurationAbstractionsVersion>
     <MicrosoftExtensionsConfigurationJsonVersion>10.0.0</MicrosoftExtensionsConfigurationJsonVersion>
@@ -75,6 +78,7 @@
     <MicrosoftGraphicsWin2DPackageVersion>1.3.2</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.3179.45</MicrosoftWindowsWebView2PackageVersion>
     <!-- Everything else -->
+    <MicrosoftAspNetCorePreviousPublishedPackageVersion>10.0.0</MicrosoftAspNetCorePreviousPublishedPackageVersion>
     <MicrosoftAspNetCoreAuthorizationPackageVersion>10.0.0</MicrosoftAspNetCoreAuthorizationPackageVersion>
     <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>10.0.0</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
     <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>10.0.0</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>

--- a/eng/scripts/update-cgmanifest.ps1
+++ b/eng/scripts/update-cgmanifest.ps1
@@ -45,9 +45,9 @@ $packageVersionMappings = @{
     'coverlet.collector' = 'CoverletCollectorPackageVersion'
     
     # Microsoft Extensions packages
-    'Microsoft.Extensions.Logging.Debug' = 'MicrosoftExtensionsLoggingDebugVersion'
-    'Microsoft.Extensions.Configuration' = 'MicrosoftExtensionsConfigurationVersion'
-    'Microsoft.Extensions.DependencyInjection' = 'MicrosoftExtensionsDependencyInjectionVersion'
+    'Microsoft.Extensions.Logging.Debug' = 'MicrosoftExtensionsPreviousPublishedPackageVersion'
+    'Microsoft.Extensions.Configuration' = 'MicrosoftExtensionsPreviousPublishedPackageVersion'
+    'Microsoft.Extensions.DependencyInjection' = 'MicrosoftExtensionsPreviousPublishedPackageVersion'
     
     # Other packages
     'Microsoft.WindowsAppSDK' = 'MicrosoftWindowsAppSDKPackageVersion'

--- a/src/Compatibility/Core/tests/Compatibility.UnitTests/Compatibility.Core.UnitTests.csproj
+++ b/src/Compatibility/Core/tests/Compatibility.UnitTests/Compatibility.Core.UnitTests.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>$(_MauiDotNetTfm)</TargetFramework>
     <AssemblyName>Microsoft.Maui.Compatibility.Core.UnitTests</AssemblyName>
     <IsPackable>false</IsPackable>
+    <UseLatestDotNetPackageVersions>true</UseLatestDotNetPackageVersions>
     <NoWarn>0114;0672;0108;0067;0168;0169;0219;0612;0618;1998;4014</NoWarn>
     <RootNamespace>Microsoft.Maui.Compatibility.Core.UnitTests</RootNamespace>
   </PropertyGroup>

--- a/src/Controls/src/Build.Tasks/Controls.Build.Tasks.csproj
+++ b/src/Controls/src/Build.Tasks/Controls.Build.Tasks.csproj
@@ -24,7 +24,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Mono.Cecil" Version="0.11.5" PrivateAssets="all" GeneratePathProperty="true" />
-		<PackageReference Include="System.CodeDom" Version="7.0.0" PrivateAssets="all" GeneratePathProperty="true" />
+		<PackageReference Include="System.CodeDom" PrivateAssets="all" GeneratePathProperty="true" />
 		<PackageReference Include="Microsoft.Build.Framework" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.Build.Utilities.Core" PrivateAssets="all" />
 	</ItemGroup>

--- a/src/Controls/tests/Core.UnitTests/Controls.Core.UnitTests.csproj
+++ b/src/Controls/tests/Core.UnitTests/Controls.Core.UnitTests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>$(_MauiDotNetTfm)</TargetFramework>
     <AssemblyName>Microsoft.Maui.Controls.Core.UnitTests</AssemblyName>
     <IsPackable>false</IsPackable>
+    <UseLatestDotNetPackageVersions>true</UseLatestDotNetPackageVersions>
     <NoWarn>0114;0672;0108;0067;0168;0169;0219;0612;0618;1998</NoWarn>
     <RootNamespace>Microsoft.Maui.Controls.Core.UnitTests</RootNamespace>
   </PropertyGroup>

--- a/src/Controls/tests/ManualTests/Controls.ManualTests.csproj
+++ b/src/Controls/tests/ManualTests/Controls.ManualTests.csproj
@@ -13,6 +13,7 @@
     <OutputType>Exe</OutputType>
     <SingleProject>true</SingleProject>
     <IsPackable>false</IsPackable>
+    <UseLatestDotNetPackageVersions>true</UseLatestDotNetPackageVersions>
 		<RootNamespace>Microsoft.Maui.ManualTests</RootNamespace>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>disable</Nullable>
@@ -84,7 +85,7 @@
   </ItemGroup>
   
 	<ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	</ItemGroup>

--- a/src/Controls/tests/TestCases.HostApp/Controls.TestCases.HostApp.csproj
+++ b/src/Controls/tests/TestCases.HostApp/Controls.TestCases.HostApp.csproj
@@ -6,6 +6,7 @@
     <OutputType>Exe</OutputType>
     <SingleProject>true</SingleProject>
     <MauiTestProject>true</MauiTestProject>
+    <UseLatestDotNetPackageVersions>true</UseLatestDotNetPackageVersions>
     <IsPackable>false</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
     <!-- On CI, build universal binaries for iOS/MacCatalyst to support both x64 and arm64 test agents -->

--- a/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
+++ b/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
@@ -1,4 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <UseLatestDotNetPackageVersions>true</UseLatestDotNetPackageVersions>
+  </PropertyGroup>
 
   <PropertyGroup>
     <TargetFramework>$(_MauiDotNetTfm)</TargetFramework>
@@ -25,7 +28,7 @@
     <PackageReference Include="NSubstitute" Version="$(NSubstitutePackageVersion)" />
     <PackageReference Include="xunit" Version="$(XunitPackageVersion)" />
     <PackageReference Include="Mono.Cecil" Version="0.11.5" />
-    <PackageReference Include="System.CodeDom" Version="7.0.0" />
+    <PackageReference Include="System.CodeDom" />
     <PackageReference Include="Microsoft.Build.Framework" PrivateAssets="all" Publish="true" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" PrivateAssets="all" Publish="true" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.1.0" />

--- a/src/Core/tests/Benchmarks/Core.Benchmarks.csproj
+++ b/src/Core/tests/Benchmarks/Core.Benchmarks.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>$(_MauiDotNetTfm)</TargetFramework>
     <EmitCompilerGeneratedFiles Condition="'$(Configuration)' == 'Debug'">true</EmitCompilerGeneratedFiles>
+    <UseLatestDotNetPackageVersions>true</UseLatestDotNetPackageVersions>
     <InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);Microsoft.Maui.Controls.Generated</InterceptorsPreviewNamespaces>
   </PropertyGroup>
 

--- a/src/Core/tests/DeviceTests.Shared/Core.DeviceTests.Shared.csproj
+++ b/src/Core/tests/DeviceTests.Shared/Core.DeviceTests.Shared.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(MauiDeviceTestsPlatforms)</TargetFrameworks>
     <SingleProject>true</SingleProject>
     <MauiTestProject>true</MauiTestProject>
+    <UseLatestDotNetPackageVersions>true</UseLatestDotNetPackageVersions>
     <RootNamespace>Microsoft.Maui.DeviceTests</RootNamespace>
     <AssemblyName>Microsoft.Maui.DeviceTests.Shared</AssemblyName>
     <!--<Nullable>enable</Nullable>-->
@@ -18,7 +19,7 @@
     <PackageReference Include="xunit" Version="$(XunitPackageVersion)"/>
     <PackageReference Include="xunit.runner.utility" Version="$(XunitPackageVersion)"/>
     <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="$(MicrosoftDotNetXHarnessTestRunnersXunitVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Core/tests/UnitTests/Core.UnitTests.csproj
+++ b/src/Core/tests/UnitTests/Core.UnitTests.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>Microsoft.Maui.UnitTests</AssemblyName>
     <IsPackable>false</IsPackable>
     <MauiTestProject>true</MauiTestProject>
+    <UseLatestDotNetPackageVersions>true</UseLatestDotNetPackageVersions>
     <!--
       NOTE: Keep this project on C# 9 to avoid changes in overload resolution, test failures:
       CanAddMultipleEventsViaMultipleConfigureLifecycleEvents, CanAddMultipleEventsViaBuilder, EventsFireExactlyOnce

--- a/src/Templates/src/Microsoft.Maui.Templates.csproj
+++ b/src/Templates/src/Microsoft.Maui.Templates.csproj
@@ -40,6 +40,10 @@
     <ContentTargetFolders>content</ContentTargetFolders>
     <!-- This project has no .NET assemblies, so disable the warning for that -->
     <NoWarn>$(NoWarn);NU5128</NoWarn>
+    <MicrosoftExtensionsTemplatePackageVersion>$(MicrosoftExtensionsPreviousPublishedPackageVersion)</MicrosoftExtensionsTemplatePackageVersion>
+    <MicrosoftExtensionsTemplatePackageVersion Condition="$(MicrosoftExtensionsLoggingDebugVersion.Contains('-'))">*</MicrosoftExtensionsTemplatePackageVersion>
+    <MicrosoftAspNetCoreTemplatePackageVersion>$(MicrosoftAspNetCorePreviousPublishedPackageVersion)</MicrosoftAspNetCoreTemplatePackageVersion>
+    <MicrosoftAspNetCoreTemplatePackageVersion Condition="$(MicrosoftAspNetCoreComponentsWebPackageVersion.Contains('-'))">*</MicrosoftAspNetCoreTemplatePackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -67,12 +71,10 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <BeforePack>_UpdateTemplateVersions;_UpdateTemplateDotFiles</BeforePack>
+    <BeforePack>TestDotNetPackageVersionSelection;_UpdateTemplateVersions;_UpdateTemplateDotFiles</BeforePack>
   </PropertyGroup>
 
-  <Target Name="_UpdateTemplateVersions" DependsOnTargets="SetVersions;LocalizeTemplatesAfterBuild"
-      Inputs="@(TemplateJsonInput)"
-      Outputs="%(TemplateJsonInput.IntermediateLocation)">
+  <Target Name="_UpdateTemplateVersions" DependsOnTargets="SetVersions;LocalizeTemplatesAfterBuild">
 
      <!-- Copy files to their output name -->
     <Copy
@@ -90,13 +92,62 @@
         InputFilename="%(TemplateJsonInput.IntermediateLocation)"
         OutputFilename="%(TemplateJsonInput.IntermediateLocation)"
         MatchExpression="DOTNET_TFM_VALUE;DOTNET_TFM_VERSION_VALUE;DOTNET_TFM_VERSION_MAJOR_VALUE;MS_EXT_LOG_DEBUG_VERSION_VALUE;MS_COMPONENTS_WEB_VERSION_VALUE;MS_COMPONENTS_WEBASSEMBLY_VERSION_VALUE;MS_COMPONENTS_WEBASSEMBLY_SERVER_VERSION_VALUE"
-        ReplacementText="$(_MauiDotNetTfm);$(_MauiDotNetVersion);$(_MauiDotNetVersionMajor)000;$(MicrosoftExtensionsLoggingDebugVersion);$(MicrosoftAspNetCoreComponentsWebPackageVersion);$(MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion);$(MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion)" />
+        ReplacementText="$(_MauiDotNetTfm);$(_MauiDotNetVersion);$(_MauiDotNetVersionMajor)000;$(MicrosoftExtensionsTemplatePackageVersion);$(MicrosoftAspNetCoreTemplatePackageVersion);$(MicrosoftAspNetCoreTemplatePackageVersion);$(MicrosoftAspNetCoreTemplatePackageVersion)" />
 
     <ItemGroup>
       <FileWrites Include="%(TemplateJsonInput.IntermediateLocation)" />
       <Content Include="%(TemplateJsonInput.IntermediateLocation)" PackagePath="$(ContentTargetFolders)\%(TemplateJsonInput.PackageDestination)" Pack="true" />
     </ItemGroup>
 
+  </Target>
+
+  <Target Name="_GetDotNetPackageVersionSelection" Returns="@(_DotNetPackageVersionSelection)">
+    <ItemGroup>
+      <_DotNetPackageVersionSelection Include="Extensions=$(_MicrosoftExtensionsLoggingDebugVersion)" />
+      <_DotNetPackageVersionSelection Include="AspNetCore=$(_MicrosoftAspNetCoreComponentsWebPackageVersion)" />
+      <_DotNetPackageVersionSelection Include="Runtime=$(_SystemTextJsonPackageVersion)" />
+      <_DotNetPackageVersionSelection Include="TemplateExtensions=$([MSBuild]::Escape('$(MicrosoftExtensionsTemplatePackageVersion)'))" />
+      <_DotNetPackageVersionSelection Include="TemplateAspNetCore=$([MSBuild]::Escape('$(MicrosoftAspNetCoreTemplatePackageVersion)'))" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="TestDotNetPackageVersionSelection">
+    <MSBuild
+        Projects="$(MSBuildProjectFullPath)"
+        Targets="_GetDotNetPackageVersionSelection"
+        Properties="MicrosoftExtensionsPreviousPublishedPackageVersion=11.0.0-preview.6.26301.12;MicrosoftAspNetCorePreviousPublishedPackageVersion=11.0.0-preview.6.26301.12;MicrosoftNETCoreAppRefPreviousPublishedPackageVersion=11.0.0-preview.6.26301.12;MicrosoftExtensionsLoggingDebugVersion=11.0.0-preview.7.26351.4;MicrosoftAspNetCoreComponentsWebPackageVersion=11.0.0-preview.7.26351.4;MicrosoftNETCoreAppRefPackageVersion=11.0.0-preview.7.26351.4">
+      <Output TaskParameter="TargetOutputs" ItemName="_PreviewShippingVersions" />
+    </MSBuild>
+    <MSBuild
+        Projects="$(MSBuildProjectFullPath)"
+        Targets="_GetDotNetPackageVersionSelection"
+        Properties="UseLatestDotNetPackageVersions=true;MicrosoftExtensionsPreviousPublishedPackageVersion=11.0.0-preview.6.26301.12;MicrosoftAspNetCorePreviousPublishedPackageVersion=11.0.0-preview.6.26301.12;MicrosoftNETCoreAppRefPreviousPublishedPackageVersion=11.0.0-preview.6.26301.12;MicrosoftExtensionsLoggingDebugVersion=11.0.0-preview.7.26351.4;MicrosoftAspNetCoreComponentsWebPackageVersion=11.0.0-preview.7.26351.4;MicrosoftNETCoreAppRefPackageVersion=11.0.0-preview.7.26351.4">
+      <Output TaskParameter="TargetOutputs" ItemName="_PreviewTestVersions" />
+    </MSBuild>
+    <MSBuild
+        Projects="$(MSBuildProjectFullPath)"
+        Targets="_GetDotNetPackageVersionSelection"
+        Properties="MicrosoftExtensionsPreviousPublishedPackageVersion=10.0.0;MicrosoftAspNetCorePreviousPublishedPackageVersion=10.0.0;MicrosoftNETCoreAppRefPreviousPublishedPackageVersion=10.0.0;MicrosoftExtensionsLoggingDebugVersion=11.0.0-preview.1.26104.118;MicrosoftAspNetCoreComponentsWebPackageVersion=11.0.0-preview.1.26104.118;MicrosoftNETCoreAppRefPackageVersion=11.0.0-preview.1.26104.118">
+      <Output TaskParameter="TargetOutputs" ItemName="_FirstPreviewShippingVersions" />
+    </MSBuild>
+    <MSBuild
+        Projects="$(MSBuildProjectFullPath)"
+        Targets="_GetDotNetPackageVersionSelection"
+        Properties="MicrosoftExtensionsPreviousPublishedPackageVersion=11.0.0;MicrosoftAspNetCorePreviousPublishedPackageVersion=11.0.0;MicrosoftNETCoreAppRefPreviousPublishedPackageVersion=11.0.0;MicrosoftExtensionsLoggingDebugVersion=11.0.0;MicrosoftAspNetCoreComponentsWebPackageVersion=11.0.0;MicrosoftNETCoreAppRefPackageVersion=11.0.0">
+      <Output TaskParameter="TargetOutputs" ItemName="_StableShippingVersions" />
+    </MSBuild>
+    <Error
+        Condition="'@(_PreviewShippingVersions)' != 'Extensions=11.0.0-preview.6.26301.12;AspNetCore=11.0.0-preview.6.26301.12;Runtime=11.0.0-preview.6.26301.12;TemplateExtensions=*;TemplateAspNetCore=*'"
+        Text="Preview shipping package version selection failed: @(_PreviewShippingVersions)" />
+    <Error
+        Condition="'@(_PreviewTestVersions)' != 'Extensions=11.0.0-preview.7.26351.4;AspNetCore=11.0.0-preview.7.26351.4;Runtime=11.0.0-preview.7.26351.4;TemplateExtensions=*;TemplateAspNetCore=*'"
+        Text="Preview test package version selection failed: @(_PreviewTestVersions)" />
+    <Error
+        Condition="'@(_FirstPreviewShippingVersions)' != 'Extensions=10.0.0;AspNetCore=10.0.0;Runtime=10.0.0;TemplateExtensions=*;TemplateAspNetCore=*'"
+        Text="First preview shipping package version selection failed: @(_FirstPreviewShippingVersions)" />
+    <Error
+        Condition="'@(_StableShippingVersions)' != 'Extensions=11.0.0;AspNetCore=11.0.0;Runtime=11.0.0;TemplateExtensions=11.0.0;TemplateAspNetCore=11.0.0'"
+        Text="Stable shipping package version selection failed: @(_StableShippingVersions)" />
   </Target>
 
   <Target Name="_UpdateTemplateDotFiles"

--- a/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
+++ b/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
@@ -1,4 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <UseLatestDotNetPackageVersions>true</UseLatestDotNetPackageVersions>
+  </PropertyGroup>
 
   <PropertyGroup>
     <TargetFrameworks>$(MauiDeviceTestsPlatforms)</TargetFrameworks>
@@ -22,7 +25,7 @@
     <PackageReference Include="xunit.runner.utility" Version="$(XunitPackageVersion)" />
     <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="$(MicrosoftDotNetXHarnessTestRunnersXunitVersion)" />
     <PackageReference Include="xunit.abstractions" Version="$(XunitAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Workload/Microsoft.NET.Sdk.Maui.Manifest/Microsoft.NET.Sdk.Maui.Manifest.csproj
+++ b/src/Workload/Microsoft.NET.Sdk.Maui.Manifest/Microsoft.NET.Sdk.Maui.Manifest.csproj
@@ -45,14 +45,14 @@
       <_VersionsToReplace Include="DotNetMauiManifestVersionBand" />
       <_VersionsToReplace Include="DotNetAndroidManifestVersionBand" />
       <_VersionsToReplace Include="DotNetMaciOSManifestVersionBand" />
-      <_VersionsToReplace Include="MicrosoftAspNetCoreAuthorizationPackageVersion" />
-      <_VersionsToReplace Include="MicrosoftAspNetCoreComponentsAnalyzersPackageVersion" />
-      <_VersionsToReplace Include="MicrosoftAspNetCoreComponentsFormsPackageVersion" />
-      <_VersionsToReplace Include="MicrosoftAspNetCoreComponentsPackageVersion" />
-      <_VersionsToReplace Include="MicrosoftAspNetCoreComponentsWebPackageVersion" />
-      <_VersionsToReplace Include="MicrosoftAspNetCoreComponentsWebViewPackageVersion" />
-      <_VersionsToReplace Include="MicrosoftAspNetCoreMetadataPackageVersion" />
-      <_VersionsToReplace Include="MicrosoftJSInteropPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftAspNetCoreAuthorizationPackageVersion" PropertyName="MicrosoftAspNetCorePreviousPublishedPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftAspNetCoreComponentsAnalyzersPackageVersion" PropertyName="MicrosoftAspNetCorePreviousPublishedPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftAspNetCoreComponentsFormsPackageVersion" PropertyName="MicrosoftAspNetCorePreviousPublishedPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftAspNetCoreComponentsPackageVersion" PropertyName="MicrosoftAspNetCorePreviousPublishedPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftAspNetCoreComponentsWebPackageVersion" PropertyName="MicrosoftAspNetCorePreviousPublishedPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftAspNetCoreComponentsWebViewPackageVersion" PropertyName="MicrosoftAspNetCorePreviousPublishedPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftAspNetCoreMetadataPackageVersion" PropertyName="MicrosoftAspNetCorePreviousPublishedPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftJSInteropPackageVersion" PropertyName="MicrosoftAspNetCorePreviousPublishedPackageVersion" />
       <_VersionsToReplace Include="MicrosoftWindowsAppSDKPackageVersion" />
       <_VersionsToReplace Include="MicrosoftWindowsSDKBuildToolsPackageVersion" />
       <_VersionsToReplace Include="MicrosoftGraphicsWin2DPackageVersion" />
@@ -62,7 +62,9 @@
       <_VersionsToReplace Include="AppiumXCUITestDriverVersion" />
       <_VersionsToReplace Include="AppiumMac2DriverVersion" />
       <_VersionsToReplace Include="AppiumUIAutomator2DriverVersion" />
-      <_VersionsToReplace Update="@(_VersionsToReplace)" PropertyName="%(Identity)" />
+      <_VersionsToReplace Update="@(_VersionsToReplace)">
+        <PropertyName Condition="'%(_VersionsToReplace.PropertyName)' == ''">%(_VersionsToReplace.Identity)</PropertyName>
+      </_VersionsToReplace>
       <_VersionsToReplace Include="VERSION" PropertyName="PackageReferenceVersion" />
       <_VersionsToReplace Include="MAUI_DOTNET_VERSION_MAJOR" PropertyName="_MauiDotNetVersionMajor" />
       <_VersionsToReplace Include="MAUI_DOTNET_VERSION" PropertyName="_MauiDotNetVersion" />


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause

MAUI used the package-specific versions flowed from each in-development .NET SDK build for both shipping projects and tests. That forced shipping packages to move with every SDK preview. Template packing also substituted those exact prerelease versions, and its file-only incremental inputs could reuse stale generated metadata when only version properties changed.

### Description of Change

- introduces coherent previous-published properties for Microsoft.Extensions.*, Microsoft.AspNetCore.*, Microsoft.JSInterop, and runtime-coupled packages used by shipping/source projects
- preserves the package-specific SDK-flowed properties as the current versions and opts tests, benchmarks, manual tests, and device runners into them
- removes stale hardcoded test and build-task versions so centralized selection applies consistently
- emits floating `*` versions from generated templates while the current dependency is prerelease, then emits the concrete previous-published stable version automatically at GA
- reruns template substitution on every pack so version-only changes cannot leave stale template defaults
- aligns workload substitutions and component-governance metadata with previous-published shipping versions
- runs preview N-1, first-preview/prior-stable, current-preview test, and stable-GA assertions as part of template packing

### Key Technical Details

The SDK-flowed package-specific properties remain unchanged for dependency automation. `MicrosoftExtensionsPreviousPublishedPackageVersion`, `MicrosoftAspNetCorePreviousPublishedPackageVersion`, and `MicrosoftNETCoreAppRefPreviousPublishedPackageVersion` define the coherent shipping baseline; `UseLatestDotNetPackageVersions` switches test projects back to current N.

Template floating behavior is based on whether the current SDK-flowed dependency is prerelease, not whether N-1 is prerelease. This keeps Preview 1 floating even when its previous published fallback is the prior stable major.

### Tests

- `dotnet test src\Core\tests\UnitTests\Core.UnitTests.csproj -v:minimal` (831 passed, 3 skipped)
- `dotnet build src\Controls\tests\Xaml.UnitTests\Controls.Xaml.UnitTests.csproj -v:minimal`
- `dotnet build src\Workload\Microsoft.NET.Sdk.Maui.Manifest\Microsoft.NET.Sdk.Maui.Manifest.csproj -v:minimal`
- `dotnet build src\Templates\src\Microsoft.Maui.Templates.csproj -v:minimal`
- preview and stable template packs, including consecutive packs without cleaning, produced `*` and `11.0.0` respectively

### Alternatives Considered

No existing PR referencing this issue or the decoupling title was found. Hardcoding N-1 independently in every source project was rejected because it would duplicate policy and discard the current package-specific properties needed by dependency automation and tests.

### Issues Fixed

Fixes #36434