### PR TITLE
Gracefully degrade a reviewer gate timeout to a normal AI Summary

### DIFF
--- a/.github/scripts/Post-AISummaryComment.Tests.ps1
+++ b/.github/scripts/Post-AISummaryComment.Tests.ps1
@@ -183,6 +183,15 @@ Describe 'Get-GateStatus' {
             Should -Be 'Inconclusive'
     }
 
+    It 'maps a TIMEDOUT gate (synthesized section) to Timed Out' {
+        Get-GateStatus -GateContent "### Gate Result: TIMEDOUT — test verification did not finish`n`nThe automated test-verification gate did not complete on this run." |
+            Should -Be 'Timed Out'
+    }
+
+    It 'maps prose describing a timed-out gate to Timed Out' {
+        Get-GateStatus -GateContent 'The gate timed out before it could finish.' | Should -Be 'Timed Out'
+    }
+
     It 'returns Unknown for empty gate content' {
         Get-GateStatus -GateContent '' | Should -Be 'Unknown'
     }
@@ -268,6 +277,13 @@ Describe 'Get-AIReviewEventForRun' {
     It 'keeps APPROVE when the trusted gate verdict is INCONCLUSIVE (build/env error must not block)' {
         Get-AIReviewEventForRun -ReportContent '## ✅ Final Recommendation: APPROVE' -PRAgentDir $script:testDir -TrustedGateResult 'INCONCLUSIVE' |
             Should -Be 'APPROVE'
+    }
+
+    It 'vetoes APPROVE to REQUEST_CHANGES when the trusted gate verdict is TIMEDOUT (fix unverified)' {
+        # A gate that never finished (hang-safety timeout / no verdict) leaves the fix unverified,
+        # so an APPROVE recommendation must be vetoed just like a FAILED gate.
+        Get-AIReviewEventForRun -ReportContent '## ✅ Final Recommendation: APPROVE' -PRAgentDir $script:testDir -TrustedGateResult 'TIMEDOUT' |
+            Should -Be 'REQUEST_CHANGES'
     }
 
     It 'softens APPROVE to COMMENT when the deep-UI run had no passing signal (all setup-failed)' {

--- a/.github/scripts/post-ai-summary-comment.ps1
+++ b/.github/scripts/post-ai-summary-comment.ps1
@@ -48,7 +48,10 @@ param(
     # review over a FAILED gate. Empty/omitted (local/manual runs that never post
     # APPROVE) is treated as the non-blocking 'SKIPPED' sentinel.
     [Parameter(Mandatory = $false)]
-    [ValidateSet('PASSED', 'SKIPPED', 'INCONCLUSIVE', 'FAILED', '')]
+    # TIMEDOUT is a pipeline-supplied sentinel meaning the Gate task itself did not finish
+    # (stopped by its 120-min hang-safety timeout, or it produced no verdict). It renders an
+    # honest "gate did not complete" section and vetoes APPROVE (the fix was not verified).
+    [ValidateSet('PASSED', 'SKIPPED', 'INCONCLUSIVE', 'FAILED', 'TIMEDOUT', '')]
     [string]$TrustedGateResult = ''
 )
 
@@ -229,19 +232,24 @@ function Get-GateStatus {
     # the bug" = passes with and without the fix). Surface those as 'Partial' rather than a
     # flat 'Failed'. A SKIPPED gate means no runnable tests were detected → 'No Tests'.
     # INCONCLUSIVE means the tests could not be built/run (build or env error) → 'Inconclusive'.
+    # TIMEDOUT means the gate task itself was stopped by its hang-safety timeout (or produced no
+    # verdict at all) → 'Timed Out': the fix was NOT verified, but this is an infra outcome, not a
+    # real test failure, so it renders teal like Inconclusive rather than red.
     $isPartial = ($GateContent -match '(?i)Regression in another test' -or
                   $GateContent -match '(?i)Test does not reproduce the bug')
 
-    if ($GateContent -match '(?im)Gate Result:\s*(?:\S+\s*)?(FAILED|PASSED|SKIPPED|INCONCLUSIVE)') {
+    if ($GateContent -match '(?im)Gate Result:\s*(?:\S+\s*)?(FAILED|PASSED|SKIPPED|INCONCLUSIVE|TIMEDOUT)') {
         switch ($Matches[1].ToUpperInvariant()) {
             'PASSED'       { return 'Passed' }
             'SKIPPED'      { return 'No Tests' }
             'INCONCLUSIVE' { return 'Inconclusive' }
+            'TIMEDOUT'     { return 'Timed Out' }
             'FAILED'       { if ($isPartial) { return 'Partial' } else { return 'Failed' } }
         }
     }
 
     if ($GateContent -match '(?i)\binconclusive\b') { return 'Inconclusive' }
+    if ($GateContent -match '(?i)\btimed[\s-]?out\b') { return 'Timed Out' }
     if ($isPartial) { return 'Partial' }
     if ($GateContent -match '(?i)\bfailed\b') { return 'Failed' }
     if ($GateContent -match '(?i)\bpassed\b') { return 'Passed' }
@@ -298,6 +306,7 @@ function New-StatusChipRow {
         'Passed'       { '1a7f37' }   # green
         'Partial'      { 'bf8700' }   # amber — mixed/inconclusive
         'Inconclusive' { '0e7490' }   # teal — could not build/run (infra), not a real fail (avoid purple ~ GitHub "merged")
+        'Timed Out'    { '0e7490' }   # teal — gate stopped by its hang-safety timeout (infra), fix unverified
         'No Tests'     { '57606a' }   # neutral gray — nothing to verify
         'Failed'       { 'd1242f' }   # red
         default        { 'd1242f' }
@@ -464,7 +473,9 @@ function Test-RunValidationFailed {
     # gate/gate-result.txt or gate/content.md from $PRAgentDir — both live in the agent-writable
     # worktree/artifact, so a prompt-injected review agent could overwrite a real FAILED gate
     # with "PASSED" before this trusted posting step and bypass the APPROVE veto.
-    if ($TrustedGateResult -match '(?im)^\s*FAILED\s*$') { return $true }
+    # FAILED = a real test regression; TIMEDOUT = the gate never finished (fix unverified) —
+    # both must veto an APPROVE. INCONCLUSIVE/SKIPPED stay non-blocking sentinels.
+    if ($TrustedGateResult -match '(?im)^\s*(FAILED|TIMEDOUT)\s*$') { return $true }
 
     # UI tests: the pipeline render writes "❌ **Deep UI tests** — N passed, M failed …" with no
     # "Result:" line, so detect the failure icon on a bold test header or a non-zero "N failed"
@@ -601,6 +612,36 @@ $gateContent
     }
 } else {
     Write-Host "  ⏭️  gate (not found)" -ForegroundColor Gray
+}
+
+# When the pipeline reports a timed-out / no-verdict gate (its 120-min hang-safety cap fired,
+# or the gate task crashed before writing a verdict), the agent-written gate/content.md is
+# usually absent. Synthesize an honest Gate section from the trusted TIMEDOUT verdict so the
+# AI Summary still renders normally (the rest of the review ran fine) and the Gate section
+# itself explains why test verification did not complete. Guarded to TIMEDOUT so normal runs
+# and local/manual runs (empty verdict → SKIPPED) are unaffected.
+if ([string]::IsNullOrWhiteSpace($gateContent) -and $TrustedGateResult -match '(?i)TIMEDOUT') {
+    $gateContent = @'
+### Gate Result: TIMEDOUT — test verification did not finish
+
+The automated **test-verification gate** did not complete on this run. It was stopped by the pipeline's **hang-safety timeout** (the gate is capped at 120 min to catch an emulator/simulator boot or an Appium hang that would otherwise run to the job limit), or it could not produce a verdict.
+
+- This is almost always a transient **infrastructure** issue on the CI agent — **not** a problem with your PR.
+- Because the gate could not finish, **the fix was not verified by tests** on this run, so this review is **not eligible for APPROVE**.
+- The rest of the review below (expert analysis and findings) ran as usual.
+
+**Next step:** re-comment `/review` to retry the gate on a fresh agent.
+'@
+    Write-Host "  ⏱️  gate (synthesized TIMEDOUT section — gate did not complete)" -ForegroundColor Yellow
+    $gateSection = @"
+<details open>
+<summary><strong>🚦 Gate — Test Before & After Fix</strong></summary>
+<br/>
+
+$gateContent
+
+</details>
+"@
 }
 
 $phaseSections = @()

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -1080,6 +1080,14 @@ stages:
               fi
             name: RunReview
             displayName: 'Task 3: Copilot Review (expert review + try-fix)'
+            # succeededOrFailed so the expert review STILL runs when the Gate (Task 2) was
+            # stopped by its 120-min hang-safety timeout — a killed gate step is marked FAILED,
+            # which the default succeeded() would treat as a reason to SKIP the review, leaving
+            # the PR with only a terse "could not complete" notice. Now the review runs "as
+            # usual" and the gate timeout is explained in the AI Summary's Gate section instead.
+            # (A genuine test FAILURE exits 0 → Task 2 succeeds, so this does not change that
+            # path. A true CANCEL — the 180-min review cap — is neither, so this still skips.)
+            condition: succeededOrFailed()
             timeoutInMinutes: 180
             env:
               COPILOT_GITHUB_TOKEN: $(COPILOT_TOKEN)
@@ -1145,6 +1153,13 @@ stages:
               echo "Review output saved to $(Build.ArtifactStagingDirectory)/copilot-logs/"
             name: RunPost                       # Stage 3 (UpdateAISummaryComment) reads aiSummaryReviewId via $(stageDependencies.ReviewPR.CopilotReview.outputs['RunPost.aiSummaryReviewId']). Note: detectedCategories comes from RunGate, not RunPost.
             displayName: 'Task 4: Post (comments + labels)'
+            # succeededOrFailed so Post STILL runs after a Gate hang-safety timeout (see Task 3).
+            # In defer mode this emits aiSummaryReviewId=DEFERRED, which is what lets the
+            # downstream UpdateAISummaryComment stage post the full AI Summary (with the
+            # synthesized TIMEDOUT Gate section) instead of the fallback "no review produced"
+            # notice. Without this, a gate timeout would skip Post → empty aiSummaryReviewId →
+            # the summary stage would not run.
+            condition: succeededOrFailed()
             env:
               GH_TOKEN: $(GH_COMMENT_TOKEN)
               PARAM_PR_NUMBER: ${{ parameters.PRNumber }}
@@ -1207,24 +1222,19 @@ stages:
             condition: and(succeededOrFailed(), ne(variables['LogDirectory'], ''))
 
           # ─────────────────────────────────────────────────────────────────
-          #  FALLBACK — guarantee every /review yields visible feedback.
+          #  FALLBACK — last-resort notice when NO AI Summary could be produced.
           #
-          #  Task 3 (review) and Task 4 (RunPost) both default to condition
-          #  succeeded(), so when an EARLIER step is killed by its hang-safety
-          #  timeout — most commonly the Gate (Task 2, 120m) stalling on an
-          #  emulator/simulator boot — Task 3/4 are SKIPPED and the PR gets a
-          #  RED build with NO comment at all (observed: build 14651883 on
-          #  #35606: gate timed out at 120m → review + post skipped → silence).
-          #
-          #  In the pipeline RunPost ALWAYS defers, emitting
-          #  aiSummaryReviewId="DEFERRED"; an EMPTY value here therefore means
-          #  RunPost never ran → no review was produced (covers the gate-timeout
-          #  AND the review-timeout silence paths). succeededOrFailed() ensures
-          #  this step still runs after an earlier step-timeout (empirically a
-          #  gate timeout is treated as failed, not canceled, so later
-          #  succeededOrFailed() steps DO run). Post a concise, AI-attributed
-          #  notice so the maintainer always knows to re-trigger. Skips on every
-          #  normal run (aiSummaryReviewId is non-empty).
+          #  Task 3 (review) and Task 4 (RunPost) now use succeededOrFailed(), so a
+          #  Gate (Task 2) hang-safety timeout NO LONGER silences the review — the
+          #  review runs and the AI Summary posts with a synthesized "gate timed out"
+          #  Gate section (see the TIMEDOUT handling in Stage 3 / post-ai-summary-comment.ps1).
+          #  This fallback therefore only fires in the residual cases where RunPost never
+          #  emitted aiSummaryReviewId at all: the review/post stage was CANCELED by its own
+          #  180-min timeout, or ReviewPR crashed before Task 4 ran. RunPost defers with
+          #  aiSummaryReviewId="DEFERRED", so an EMPTY value here means no review was produced.
+          #  succeededOrFailed() lets this run after a failed earlier step (a bare cancel skips
+          #  it too). Post a concise, AI-attributed notice so the maintainer knows to re-trigger.
+          #  Skips on every normal run (aiSummaryReviewId is non-empty).
           # ─────────────────────────────────────────────────────────────────
           - bash: |
               echo "═══ FALLBACK: no review was posted → emitting review-incomplete notice ═══"
@@ -1242,7 +1252,7 @@ stages:
                 echo "> [!WARNING]"
                 echo "> ### 🔍 Automated review could not complete"
                 echo ">"
-                echo "> A stage of the reviewer pipeline was stopped by its hang-safety timeout — most often the test-verification **gate** stalling on an emulator/simulator boot or an Appium hang on the CI agent. This is almost always a transient **infrastructure** issue, **not** a problem with your PR. Because the pipeline could not finish, **no review was produced** for this run."
+                echo "> A stage of the reviewer pipeline could not finish, so **no review summary was produced** for this run — most often the review stage itself hanging, or the run being canceled by its overall timeout. This is almost always a transient **infrastructure** issue on the CI agent, **not** a problem with your PR. (Note: a test-verification **gate** timeout no longer lands here — it now posts a normal AI Summary whose Gate section explains the timeout.)"
                 echo ">"
                 echo "> Please re-comment \`/review\` to retry on a fresh agent."
                 echo ">"
@@ -2954,6 +2964,13 @@ stages:
                   if (Test-Path $postScript) {
                     Write-Host "Posting full AI summary review with deep results..."
                     $trustedGate = "$(trustedGateResult)"
+                    # An EMPTY trusted verdict here means RunGate produced no gateResult — the
+                    # Gate task was stopped by its 120-min hang-safety timeout (or crashed before
+                    # writing a verdict). Map it to the TIMEDOUT sentinel so the renderer shows an
+                    # honest "gate did not finish" Gate section AND vetoes APPROVE (the fix was not
+                    # verified). A gate that actually ran always sets PASSED/SKIPPED/INCONCLUSIVE/FAILED,
+                    # so this only ever fires on the timeout/crash path.
+                    if ([string]::IsNullOrWhiteSpace($trustedGate)) { $trustedGate = 'TIMEDOUT' }
                     Write-Host "Trusted gate verdict for veto: '$trustedGate'"
                     $output = & $postScript -PRNumber $prNumber -TrustedGateResult $trustedGate
                     $output | ForEach-Object { Write-Host $_ }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Problem

When the reviewer pipeline's **test-verification Gate** (Task 2) is stopped by its 120-min hang-safety timeout, the killed step is marked **FAILED**. Task 3 (review) and Task 4 (post) defaulted to `condition: succeeded()`, so they were **SKIPPED** — the PR got only a terse *"Automated review could not complete"* warning, even though the expert review and findings would have run fine.

Per maintainer request: *"when only the gate didn't work and the rest worked as usual then we should comment the normal AI Summary — and explain in the Gate section why it failed."*

### Change

A gate-only timeout now **degrades gracefully**: the review still runs and a **normal AI Summary** is posted, whose **Gate section explains the timeout**, and the run is **not eligible for APPROVE** (the fix was never verified).

**`eng/pipelines/ci-copilot.yml`**
- Task 3 `RunReview` + Task 4 `RunPost` → `condition: succeededOrFailed()` so they run after a gate timeout. In defer mode `RunPost` emits `aiSummaryReviewId=DEFERRED`, which lets `UpdateAISummaryComment` post the full summary (without this, the summary stage would not run).
- Stage 3: an **empty** trusted gate verdict (RunGate never set `gateResult`) is mapped to the `TIMEDOUT` sentinel before rendering. A gate that actually ran always sets `PASSED/SKIPPED/INCONCLUSIVE/FAILED`, so this only fires on the timeout/crash path.
- Reworded the fallback notice — it now only fires when the **review stage itself** produced nothing (review canceled/crashed), not on gate timeouts.

**`.github/scripts/post-ai-summary-comment.ps1`**
- Accept `TIMEDOUT` in `-TrustedGateResult`.
- Synthesize an honest, **open-by-default** Gate section when `gate/content.md` is absent (gate killed before writing it).
- `Get-GateStatus` → **`Timed Out`**; chip renders **teal** (infra, not a red failure).
- `Test-RunValidationFailed` → **vetoes APPROVE** on `TIMEDOUT` (like `FAILED`; `INCONCLUSIVE/SKIPPED` stay non-blocking).

**`.github/scripts/Post-AISummaryComment.Tests.ps1`**
- Added Pester coverage: `TIMEDOUT` status mapping (2) + APPROVE veto (1).

### Validation

- ✓ PowerShell parses clean; `ci-copilot.yml` YAML parses clean.
- ✓ **Pester: 41/41 pass** (incl. the 3 new cases).
- ✓ End-to-end `-DryRun -TrustedGateResult TIMEDOUT` render (gate content absent) produces: `Gate: Timed Out` teal chip, an open Gate section with the timeout explanation, the rest of the summary normal, and the event correctly vetoed `APPROVE → REQUEST_CHANGES`.

> Targets `improved-reviewer` (the current reviewer branch). If `feature/enhanced-reviewer` is the active reviewer branch instead, this cherry-picks cleanly.

---
> 🔍 _This PR was prepared by an AI agent on @kubaflo's behalf._
