### PR TITLE
[Inflight/Candidate] Fix the Build errors when build src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj in release.

### DIFF
--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -532,12 +532,21 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			}
 
 			TypeReference tSourceRef = null;
+			// True when tSourceRef is inferred from a RelativeSource AncestorType rather than an
+			// explicit x:DataType declared on the binding node itself. AncestorType only identifies
+			// the *nearest ancestor of that type (or a subtype)* that will be resolved at runtime -
+			// it does not guarantee the actual runtime instance is exactly that type. A derived type
+			// (e.g. a custom base page/view) commonly declares the bound property, so failing to find
+			// the property on the literal AncestorType is not necessarily a real binding error.
+			bool tSourceRefIsAncestorTypeInferred = false;
 			if (HasRelativeOrReferenceSource(node) && xDataTypeIsInOuterScope)
 			{
 				if (!TryGetRelativeSourceAncestorTypeReference(node, context, module, out tSourceRef))
 				{
 					return false;
 				}
+
+				tSourceRefIsAncestorTypeInferred = true;
 			}
 
 			if (tSourceRef is null)
@@ -586,7 +595,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			if (tSourceRef == null)
 				return false; //throw
 
-			if (!TryParsePath(context, path, tSourceRef, node as IXmlLineInfo, module, out var properties))
+			if (!TryParsePath(context, path, tSourceRef, node as IXmlLineInfo, module, out var properties, suppressPropertyNotFoundError: tSourceRefIsAncestorTypeInferred))
 			{
 				return false;
 			}
@@ -798,7 +807,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			}
 		}
 
-		static bool TryParsePath(ILContext context, string path, TypeReference tSourceRef, IXmlLineInfo lineInfo, ModuleDefinition module, out IList<(PropertyDefinition property, TypeReference propDeclTypeRef, string indexArg)> pathProperties)
+		static bool TryParsePath(ILContext context, string path, TypeReference tSourceRef, IXmlLineInfo lineInfo, ModuleDefinition module, out IList<(PropertyDefinition property, TypeReference propDeclTypeRef, string indexArg)> pathProperties, bool suppressPropertyNotFoundError = false)
 		{
 			pathProperties = null;
 
@@ -839,6 +848,17 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 					if (property is null)
 					{
 						context.LoggingHelper.LogWarningOrError(BindingPropertyNotFound, context.XamlFilePath, lineInfo.LineNumber, lineInfo.LinePosition, 0, 0, p, previousPartTypeRef);
+						// When the source type was inferred from RelativeSource AncestorType (rather
+						// than an explicit x:DataType), a missing property doesn't necessarily mean the
+						// binding is invalid - the actual runtime ancestor may be a subtype that declares
+						// the property. Silently fall back to a regular (reflection-based) Binding instead
+						// of failing the build, matching the pre-existing behavior for RelativeSource
+						// bindings without an explicit x:DataType and the SourceGen inflator's equivalent
+						// fallback in KnownMarkups.ProvideValueForBindingExtension.
+						if (!suppressPropertyNotFoundError)
+						{
+							context.LoggingHelper.LogWarningOrError(BindingPropertyNotFound, context.XamlFilePath, lineInfo.LineNumber, lineInfo.LinePosition, 0, 0, p, previousPartTypeRef);
+						}
 						return false;
 					}
 

--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -847,7 +847,6 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 					var property = previousPartTypeRef.GetProperty(context.Cache, pd => pd.Name == p && pd.GetMethod != null && pd.GetMethod.IsPublic && !pd.GetMethod.IsStatic, out var propDeclTypeRef);
 					if (property is null)
 					{
-						context.LoggingHelper.LogWarningOrError(BindingPropertyNotFound, context.XamlFilePath, lineInfo.LineNumber, lineInfo.LinePosition, 0, 0, p, previousPartTypeRef);
 						// When the source type was inferred from RelativeSource AncestorType (rather
 						// than an explicit x:DataType), a missing property doesn't necessarily mean the
 						// binding is invalid - the actual runtime ancestor may be a subtype that declares


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details:

 Build error occurs when build src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj in release.
       
### Root Cause:
 
Release uses the XamlC inflator by default, which fully compiles bindings at build time. PR #35798's new  TryGetRelativeSourceAncestorTypeReference  logic in  SetPropertiesVisitor.cs  now treats  AncestorType={x:Type ContentPage}  as the effective source type for validation, and since  SelectedItem / NavigateCommand  only exist on  BasePage  (not  ContentPage), it raises  XC0045  and fails the build.

### Description of Change:

The fix was applied at the source level in  src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs . A new  tSourceRefIsAncestorTypeInferred  flag now tracks whether the binding's source type came purely from  AncestorType  inference rather than an explicit  x:DataType  on the binding node. When property-path resolution against that inferred type fails, and this flag is set, the error is suppressed and the method returns  false  to gracefully skip  TypedBinding  compilation — falling back to the original reflection-based  Binding , exactly as XamlC always did before PR #35798 for these ambiguous cases. This also mirrors the SourceGen inflator's existing equivalent fallback in  KnownMarkups.ProvideValueForBindingExtension . Bindings with an explicit  x:DataType , or where the property genuinely doesn't exist anywhere in the runtime ancestor chain, are unaffected and continue to raise  XC0045  as intended, preserving PR #35798's original AOT-safety fix.

**Tested the behavior in the following platforms:**

- [ ] Android
- [ ] Windows
- [x] iOS
- [x] Mac

### Reference:

N/A

### Issues Fixed:

Fixes  #36563