### PR TITLE
[Windows]Fix: Label.FormattedText does not clear previous TextHighlighters

### DIFF
--- a/src/Controls/src/Core/Platform/Windows/Extensions/FormattedStringExtensions.cs
+++ b/src/Controls/src/Core/Platform/Windows/Extensions/FormattedStringExtensions.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Maui.Controls.Platform
 					};
 
 					run.Foreground = textColor?.ToPlatform();
-					textBlock.TextHighlighters.Add(textHighlighter);
+					textHighlighters.Add(textHighlighter);
 				}
 
 				currentTextIndex += runTextLength;

--- a/src/Controls/src/Core/Platform/Windows/Extensions/FormattedStringExtensions.cs
+++ b/src/Controls/src/Core/Platform/Windows/Extensions/FormattedStringExtensions.cs
@@ -58,6 +58,7 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			var textBlockInlines = textBlock.Inlines;
 			textBlockInlines.Clear();
+			textBlock.TextHighlighters.Clear();
 
 			// Have to implement a measure here, otherwise inline.ContentStart and ContentEnd will be null, when used in RecalculatePositions
 			textBlock.Measure(new global::Windows.Foundation.Size(double.MaxValue, double.MaxValue));

--- a/src/Controls/src/Core/Platform/Windows/Extensions/FormattedStringExtensions.cs
+++ b/src/Controls/src/Core/Platform/Windows/Extensions/FormattedStringExtensions.cs
@@ -58,7 +58,8 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			var textBlockInlines = textBlock.Inlines;
 			textBlockInlines.Clear();
-			textBlock.TextHighlighters.Clear();
+			var textHighlighters = textBlock.TextHighlighters;
+			textHighlighters.Clear();
 
 			// Have to implement a measure here, otherwise inline.ContentStart and ContentEnd will be null, when used in RecalculatePositions
 			textBlock.Measure(new global::Windows.Foundation.Size(double.MaxValue, double.MaxValue));

--- a/src/Controls/tests/DeviceTests/Elements/FormattedStringTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/FormattedStringTests.cs
@@ -50,5 +50,56 @@ namespace Microsoft.Maui.DeviceTests
 
 			Assert.Equal("HELLOWORLD", actual);
 		}
+
+		// Covers https://github.com/dotnet/maui/issues/36519
+		// Updating Label.FormattedText must clear any highlighter/background-color state applied
+		// by the previous FormattedText. On Windows specifically, the native TextBlock's
+		// TextHighlighters collection was never cleared, so stale highlighter ranges (from
+		// BackgroundColor/TextColor spans) survived and bled onto the new text, leaking
+		// TextHighlighter instances. This test verifies the rendered output on all platforms,
+		// with an additional native-collection check on Windows.
+		[Fact]
+		public async Task UpdatingFormattedTextClearsPreviousHighlights()
+		{
+			var label = new Label
+			{
+				WidthRequest = 200,
+				HeightRequest = 50,
+				FontSize = 16,
+				FormattedText = new FormattedString
+				{
+					Spans =
+					{
+						new Span { Text = "Highlighted", BackgroundColor = Colors.Red },
+						new Span { Text = " text", TextColor = Colors.Blue },
+					}
+				},
+			};
+
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var handler = CreateHandler<LabelHandler>(label);
+
+#if WINDOWS
+				// Sanity check: highlighters were created for the initial FormattedText
+				Assert.NotEmpty(handler.PlatformView.TextHighlighters);
+#endif
+				await handler.PlatformView.AssertContainsColor(Colors.Red, MauiContext);
+
+				// Update to a FormattedString with no highlighted spans at all
+				label.FormattedText = new FormattedString
+				{
+					Spans =
+					{
+						new Span { Text = "Plain text with no highlights" },
+					}
+				};
+
+#if WINDOWS
+				Assert.Empty(handler.PlatformView.TextHighlighters);
+#endif
+				await handler.PlatformView.AssertDoesNotContainColor(Colors.Red, MauiContext);
+			});
+		}
 	}
 }


### PR DESCRIPTION
<!-- Please keep the note below for people who find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment whether this change resolves your issue. Thank you!<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!!  -->

This pull request addresses an issue where updating a `Label`'s `FormattedText` on Windows did not clear previous text highlighting, causing stale highlighter ranges to persist and affect new text. The fix ensures that highlighter state is properly reset when the formatted text changes. Additionally, a new test is added to verify this behavior across platforms, with extra checks for Windows.
### Description of Change
**Bug fix:**
* [`FormattedStringExtensions.cs`](diffhunk://#diff-3846573c00e8c480581599035bcc2e2aa18da8b62da4d0304c52b6e1b970fa7aR61): Ensures that `TextBlock.TextHighlighters` is cleared whenever the inlines are updated, preventing highlighter leakage when `FormattedText` is changed.

**Testing improvements:**
* [`FormattedStringTests.cs`](diffhunk://#diff-24cf35347d91a39e18539e140d96549832bb6897cbfcd80ae3d0acbd96f5f192R53-R103): Adds a new test, `UpdatingFormattedTextClearsPreviousHighlights`, to confirm that updating a label’s formatted text clears any previous highlight/background color state, with specific validation for the Windows platform.



<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #36519 
### Tested the behavior in the following platforms

- [x] Windows
- [ ] Android
- [ ] iOS
- [ ] Mac


| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/2c4e9dd6-7dde-445d-8900-02fd86ba383a">  | <video src="https://github.com/user-attachments/assets/8983aca5-672e-4d8d-911e-6470fd463ee9"> |

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
