### PR TITLE
[release/10.0.1xx-sr9] Fix Shell.Title binding in TitleView (#35800, #36334)

### DIFF
--- a/src/Controls/src/Core/ShellToolbar.cs
+++ b/src/Controls/src/Core/ShellToolbar.cs
@@ -169,27 +169,47 @@ namespace Microsoft.Maui.Controls
 				Shell.TitleViewProperty,
 				Shell.GetTitleView(_shell));
 
+			var title = GetCurrentTitle();
+			if (!IsShellTitleSetByUser())
+				_shell.SetValueFromRenderer(Shell.TitleProperty, title);
+
 			if (TitleView != null)
 			{
 				Title = String.Empty;
 				return;
 			}
 
+			Title = title;
+		}
+
+		string GetCurrentTitle()
+		{
 			Page? currentPage = _shell.GetCurrentShellPage();
 			if (currentPage?.IsSet(Page.TitleProperty) == true)
 			{
-				Title = currentPage.Title ?? String.Empty;
+				return currentPage.Title ?? String.Empty;
 			}
 			// We only want to use the ShellContent as a title if no pages have been
 			// Pushed onto the stack
 			else if (_shell.Navigation?.NavigationStack?.Count <= 1)
 			{
-				Title = _shell.CurrentContent?.Title ?? String.Empty;
+				return _shell.CurrentContent?.Title ?? String.Empty;
 			}
-			else
-			{
-				Title = String.Empty;
-			}
+
+			return String.Empty;
+		}
+
+		bool IsShellTitleSetByUser()
+		{
+			var titleContext = _shell.GetContext(Shell.TitleProperty);
+			if (titleContext == null)
+				return false;
+
+			if (titleContext.Bindings.Count > 0)
+				return true;
+
+			var specificity = titleContext.Values.GetSpecificity();
+			return specificity != SetterSpecificity.DefaultValue && specificity != SetterSpecificity.FromHandler;
 		}
 	}
 }

--- a/src/Controls/src/Core/ShellToolbar.cs
+++ b/src/Controls/src/Core/ShellToolbar.cs
@@ -170,11 +170,11 @@ namespace Microsoft.Maui.Controls
 				Shell.GetTitleView(_shell));
 
 			var title = GetCurrentTitle();
-			if (!IsShellTitleSetByUser())
-				_shell.SetValueFromRenderer(Shell.TitleProperty, title);
 
 			if (TitleView != null)
 			{
+				if (!IsShellTitleSetByUser())
+					_shell.SetValueFromRenderer(Shell.TitleProperty, title);  // only when TitleView exists
 				Title = String.Empty;
 				return;
 			}

--- a/src/Controls/tests/Core.UnitTests/ShellTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellTests.cs
@@ -1668,6 +1668,53 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal("Shell Title", (window as IWindow).Title);
 		}
 
+		// When a Shell page has a title but no TitleView, the page title must appear
+		// in the in-app navigation bar (Toolbar.Title) but must NOT propagate to
+		// Shell.Title — which would cause it to appear in the native window/status bar
+		// via Window.ITitledElement.Title (= Window.Title ?? Shell.Title).
+		[Fact]
+		public void ShellPageTitleDoesNotPropagateToWindowTitleBar()
+		{
+			var shellContent = CreateShellContent();
+			shellContent.Title = "Page Title";
+
+			TestShell testShell = new TestShell(shellContent);
+
+			Window window = new Window { Page = testShell };
+
+			// In-app navigation bar shows the page title
+			Assert.Equal("Page Title", testShell.Toolbar.Title);
+
+			// Shell.Title must NOT be updated by the renderer — keeps the
+			// native window title bar / status bar free of the page title
+			Assert.Null(testShell.Title);
+			Assert.Null((window as IWindow).Title);
+		}
+
+		// The same invariant must hold after navigating to a pushed page.
+		[Fact]
+		public async Task ShellPageTitleDoesNotPropagateToWindowTitleBarOnNavigation()
+		{
+			var shellContent = CreateShellContent();
+			shellContent.Title = "Page One";
+
+			TestShell testShell = new TestShell(shellContent);
+
+			Window window = new Window { Page = testShell };
+
+			Assert.Equal("Page One", testShell.Toolbar.Title);
+			Assert.Null(testShell.Title);
+			Assert.Null((window as IWindow).Title);
+
+			await testShell.Navigation.PushAsync(new ContentPage { Title = "Page Two" });
+
+			Assert.Equal("Page Two", testShell.Toolbar.Title);
+
+			// Shell.Title must still NOT be updated by the renderer after navigation
+			Assert.Null(testShell.Title);
+			Assert.Null((window as IWindow).Title);
+		}
+
 		[Fact]
 		public void FlyoutIsPresentedRemainsTrueAfterShellIsInitialized()
 		{

--- a/src/Controls/tests/Core.UnitTests/ShellToolbarTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellToolbarTests.cs
@@ -271,6 +271,64 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public void ShellTitleReflectsCurrentPageTitleForTitleViewBindings()
+		{
+			var contentPage = new ContentPage() { Title = "Test Title" };
+			var label = new Label();
+			var titleView = new VerticalStackLayout()
+			{
+				Children =
+				{
+					label
+				}
+			};
+
+			TestShell testShell = new TestShell(contentPage);
+			_ = new Window()
+			{
+				Page = testShell
+			};
+
+			label.SetBinding(Label.TextProperty, new Binding(nameof(Shell.Title), source: testShell));
+			Shell.SetTitleView(contentPage, titleView);
+
+			Assert.Empty(testShell.Toolbar.Title);
+			Assert.Equal("Test Title", testShell.Title);
+			Assert.Equal("Test Title", label.Text);
+
+			contentPage.Title = "Updated Test Title";
+
+			Assert.Equal("Updated Test Title", testShell.Title);
+			Assert.Equal("Updated Test Title", label.Text);
+		}
+
+		[Fact]
+		public void ShellTitleBindingIsNotOverwrittenByCurrentPageTitle()
+		{
+			var contentPage = new ContentPage() { Title = "Page Title" };
+			var titleView = new VerticalStackLayout();
+			var viewModel = new TestShellViewModel() { Text = "App Title" };
+
+			TestShell testShell = new TestShell(contentPage);
+			_ = new Window()
+			{
+				Page = testShell
+			};
+
+			testShell.SetBinding(Shell.TitleProperty, new Binding(nameof(TestShellViewModel.Text), BindingMode.TwoWay, source: viewModel));
+			Shell.SetTitleView(contentPage, titleView);
+
+			Assert.Empty(testShell.Toolbar.Title);
+			Assert.Equal("App Title", testShell.Title);
+			Assert.Equal("App Title", viewModel.Text);
+
+			contentPage.Title = "Updated Page Title";
+
+			Assert.Equal("App Title", testShell.Title);
+			Assert.Equal("App Title", viewModel.Text);
+		}
+
+		[Fact]
 		public void ContentPageColorsPropagateToShellToolbar()
 		{
 			var contentPage = new ContentPage() { Title = "Test Title" };


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

Backports #35800 and #36334 to `release/10.0.1xx-sr9`.

### Why both together
- **#35800** (_Fix Shell.Title binding in TitleView_) restores `Shell.Title` binding when a `TitleView` is present. It was milestoned **.NET 10 SR9** and merged to the SR9 servicing branch (`inflight/current`), but it was never picked into the stabilized `release/10.0.1xx-sr9` branch, so the stable SR9 release is currently missing this fix.
- **#35800 on its own** leaks the page title into the native window/status bar — tracked as **#36225**. **#36334** guards the `SetValueFromRenderer(Shell.TitleProperty, …)` call so it only runs when a `TitleView` exists, which fixes the leak.
- Backporting only #35800 would re-introduce #36225, so **both are included together**. The resulting `ShellToolbar.cs` is byte-identical to the corrected state on `inflight/current`.

### Changes
- `src/Controls/src/Core/ShellToolbar.cs` — guarded title propagation (cherry-picks of #35800 + #36334)
- `src/Controls/tests/Core.UnitTests/ShellToolbarTests.cs` — new tests (#35800)
- `src/Controls/tests/Core.UnitTests/ShellTests.cs` — new leak-guard tests (#36334)

Cherry-picked from:
- `1ee8956882d` (#35800)
- `8123cbb9d08` (#36334)

Fixes #36225 for SR9.
