### PR TITLE
Upgrade Vally CLI to 0.10.0

### DIFF
--- a/.github/skills/agentic-labeler/tests/eval.vally.yaml
+++ b/.github/skills/agentic-labeler/tests/eval.vally.yaml
@@ -37,7 +37,8 @@
 # Legacy scenarios AND-gated up to ~15 `output_not_contains` assertions
 # (every triage/partner/kind label spelled out) plus, for noop scenarios,
 # a fragile ~10-branch alternation regex matching phrasings of "no labels."
-# Under @microsoft/vally@0.6.0 the trial score is the UNWEIGHTED MEAN of
+# With scoring.weights omitted, Vally 0.10 computes the trial score as the
+# UNWEIGHTED MEAN of
 # grader scores, so piling on 12 floors drowns the judge (1/13 weight) and
 # a single wrong label can't move the aggregate. This port keeps, per
 # scenario, only:
@@ -51,8 +52,8 @@
 # wrong/missing label fails BOTH the floor and the judge and the mean
 # drops below threshold — falsifiable without the brittleness.
 #
-# Scoring: scoring.weights is ignored by 0.6.0; only scoring.threshold is
-# active (0.6). See the scoring block.
+# Scoring: scoring.weights is deliberately omitted, so the equal-weight
+# aggregate and threshold are active (0.6). See the scoring block.
 # ─────────────────────────────────────────────────────────────────────────────
 
 name: agentic-labeler-capabilities
@@ -720,8 +721,8 @@ stimuli:
     constraints: { max_duration: 5m, expect_skills: [agentic-labeler] }
 
 scoring:
-  # @microsoft/vally@0.6.0 ignores scoring.weights; only scoring.threshold is
-  # active. Trial score = unweighted mean of grader [0,1] scores; stimulus
+  # This suite deliberately omits scoring.weights, so Vally 0.10 uses the
+  # unweighted mean of grader [0,1] scores; stimulus
   # passes when the mean across runs >= threshold. Threshold set to 0.85 so
   # the LLM judge is decisive even for multi-floor stimuli: with N floors,
   # the minimum trial score (judge=0) is N/(N+1). At threshold 0.85 the

--- a/.github/skills/analyze-sessions/SKILL.md
+++ b/.github/skills/analyze-sessions/SKILL.md
@@ -242,7 +242,7 @@ scoring:
 Then validate every emitted file:
 
 ```bash
-npx -y @microsoft/vally-cli@0.6.0 lint --eval-spec <path-to-eval> --strict
+npx -y @microsoft/vally-cli@0.10.0 lint --eval-spec <path-to-eval> --strict
 ```
 
 ## Privacy & safety

--- a/.github/skills/analyze-sessions/references/design-rationale.md
+++ b/.github/skills/analyze-sessions/references/design-rationale.md
@@ -162,7 +162,7 @@ generic `.github/evals/` paths are not valid targets. A different skill's
 Each eval pairs a refutation-proof **structural floor** (`output-matches` on a
 forced token line) with **one LLM judge** (`scale_1_5`, `threshold: 0.6`) so the
 judge carries ~half the weight. Each emitted file must pass
-`npx -y @microsoft/vally-cli@0.6.0 lint --eval-spec <f> --strict`. This is the
+`npx -y @microsoft/vally-cli@0.10.0 lint --eval-spec <f> --strict`. This is the
 mechanism that makes the analysis *iterative*: a failure found today becomes a
 regression test that fails if we regress tomorrow.
 

--- a/.github/skills/analyze-sessions/tests/eval.vally.yaml
+++ b/.github/skills/analyze-sessions/tests/eval.vally.yaml
@@ -19,7 +19,7 @@
 # line — immune to "mentions the word" false-fails) with ONE LLM JUDGE
 # (scale_1_5, threshold 0.6) so the judge carries ~50% of every score.
 #
-# Scoring: @microsoft/vally-cli@0.6.0 ignores scoring.weights; trial score =
+# Scoring: this suite deliberately omits scoring.weights, so Vally 0.10 uses the
 # unweighted mean of grader [0,1] scores; a stimulus passes when the mean across
 # runs >= scoring.threshold (0.6). With a scale_1_5 judge (normalized =
 # (raw-1)/4):
@@ -295,8 +295,8 @@ stimuli:
       reject_skills: [analyze-sessions]
 
 scoring:
-  # @microsoft/vally-cli@0.6.0 ignores scoring.weights — only scoring.threshold
-  # is active. Trial score = unweighted mean of each stimulus's two graders
+  # This suite deliberately omits scoring.weights, so Vally 0.10 uses the
+  # unweighted mean of each stimulus's two graders
   # (one refutation-proof structural floor + one LLM judge), keeping the judge
   # at ~50% of every score per the house convention.
   threshold: 0.6

--- a/.github/skills/code-review/tests/eval.capability.vally.yaml
+++ b/.github/skills/code-review/tests/eval.capability.vally.yaml
@@ -472,9 +472,9 @@ stimuli:
         - code-review
 
 scoring:
-  # NOTE: @microsoft/vally@0.6.0 does NOT consume `scoring.weights` (verified
-  # in dist/scoring/scorer.js). Only `scoring.threshold` is active. A trial's
-  # score is the UNWEIGHTED mean of its graders' [0,1] scores. The `prompt`
+  # Vally 0.10 supports scoring.weights, but this suite deliberately omits
+  # them so a trial's score is the unweighted mean of its graders' [0,1]
+  # scores. The `prompt`
   # grader contributes ONE holistic score, so rubric criteria are not
   # individually AND-gated (the de-brittling goal). Most scenarios here use
   # 1–2 small floors + the judge; with N graders the judge carries 1/N of the

--- a/.github/skills/code-review/tests/eval.inline-findings.vally.yaml
+++ b/.github/skills/code-review/tests/eval.inline-findings.vally.yaml
@@ -159,8 +159,8 @@ stimuli:
         - code-review
 
 scoring:
-  # @microsoft/vally@0.6.0 ignores scoring.weights — only scoring.threshold is
-  # active. Trial score = unweighted mean of the two graders' [0,1] scores;
+  # This suite deliberately omits scoring.weights, so Vally 0.10 uses the
+  # unweighted mean of the two graders' [0,1] scores;
   # the stimulus passes when the mean across runs >= threshold, and the CI
   # check keys off that mean-vs-threshold `passed` property. Two graders (one
   # structural readback floor + one LLM judge that verifies the write from the

--- a/.github/skills/code-review/tests/eval.vally.yaml
+++ b/.github/skills/code-review/tests/eval.vally.yaml
@@ -262,10 +262,9 @@ stimuli:
         - code-review
 
 scoring:
-  # NOTE: @microsoft/vally@0.6.0 does NOT consume `scoring.weights` — the
-  # scorer ignores it (verified in dist/scoring/scorer.js +
-  # dist/pipeline/grading.js). Only `scoring.threshold` is active. A trial's
-  # score is the UNWEIGHTED mean of its graders' [0,1] scores; the stimulus
+  # Vally 0.10 supports scoring.weights, but this suite deliberately omits
+  # them so a trial's score is the unweighted mean of its graders' [0,1]
+  # scores; the stimulus
   # score is the mean across runs; the skill passes when that mean >=
   # threshold. The `prompt` grader contributes ONE holistic score (its rubric
   # criteria are aggregated by the judge into a single overall_score, then

--- a/.github/skills/code-review/tests/hermeticity.vally.yaml
+++ b/.github/skills/code-review/tests/hermeticity.vally.yaml
@@ -101,8 +101,8 @@ stimuli:
       max_turns: 10
 
 scoring:
-  # @microsoft/vally@0.6.0 ignores scoring.weights; only scoring.threshold is
-  # active. threshold 1.0 means the single stimulus must score a perfect 1.0
+  # This suite deliberately omits scoring.weights, so Vally 0.10 uses the
+  # unweighted mean. Threshold 1.0 means the single stimulus must score a perfect 1.0
   # to "pass" — i.e. the agent's output matched the anonymous rate limit
   # (CORE_LIMIT:60). The hermeticity-gate job reads the verdict directly:
   # pass = hermetic (anonymous), fail = not verified (token leaked or probe

--- a/.github/skills/evaluate-pr-tests/tests/eval.vally.yaml
+++ b/.github/skills/evaluate-pr-tests/tests/eval.vally.yaml
@@ -33,14 +33,15 @@
 # |...)` — try to anticipate the wording of a semantic judgment and are
 # brittle (a correct finding phrased differently fails). Those move into
 # the LLM-judge rubric. Each scenario keeps at most 1–2 structural / crisp-
-# negative floors so the judge stays decisive (recall vally 0.6.0 scores a
-# trial as the UNWEIGHTED MEAN of its graders). The two purely-semantic
+# negative floors so the judge stays decisive (this suite omits
+# scoring.weights, so Vally 0.10 scores a trial as the unweighted mean of its
+# graders). The two purely-semantic
 # detection scenarios (weak assertions, edge-case gaps) are judge-only — a
 # single prompt grader means the trial score IS the judge's normalized
 # rubric score.
 #
-# Scoring: scoring.weights is ignored by 0.6.0; only scoring.threshold is
-# active (0.6).
+# Scoring: scoring.weights is deliberately omitted, so Vally 0.10 uses the
+# equal-weight aggregate and the 0.6 threshold remains active.
 # ─────────────────────────────────────────────────────────────────────────────
 
 name: evaluate-pr-tests-capabilities
@@ -403,8 +404,8 @@ stimuli:
     constraints: { max_duration: 5m, expect_skills: [evaluate-pr-tests] }
 
 scoring:
-  # @microsoft/vally@0.6.0 ignores scoring.weights; only scoring.threshold is
-  # active. Trial score = unweighted mean of grader [0,1] scores; skill passes
+  # This suite deliberately omits scoring.weights, so Vally 0.10 uses the
+  # unweighted mean of grader [0,1] scores; skill passes
   # when the mean across runs >= threshold. Structural section-heading floors
   # are kept only where producing the report format IS the capability; the
   # semantic detection criteria live in the judge rubric so a correct finding

--- a/.github/skills/pr-review/tests/eval.gh-auth.vally.yaml
+++ b/.github/skills/pr-review/tests/eval.gh-auth.vally.yaml
@@ -137,8 +137,8 @@ stimuli:
       max_duration: 5m
 
 scoring:
-  # @microsoft/vally@0.6.0 ignores scoring.weights — only scoring.threshold is
-  # active. Trial score = unweighted mean of the two graders' [0,1] scores;
+  # This suite deliberately omits scoring.weights, so Vally 0.10 uses the
+  # unweighted mean of the two graders' [0,1] scores;
   # the stimulus passes when the mean across runs >= threshold. Two graders
   # (a structural yes/no floor + one LLM judge) put the judge at ~50% of every
   # score. Threshold is 0.7 (above the house 0.6) on purpose: because the floor

--- a/.github/skills/try-fix/tests/eval.vally.yaml
+++ b/.github/skills/try-fix/tests/eval.vally.yaml
@@ -20,9 +20,9 @@
 #   phrasings. Only crisp, unambiguous failure-mode strings stay as
 #   structural floors (e.g. "claims PASS when no device was available").
 #
-# Scoring (see scoring block): @microsoft/vally@0.6.0 ignores
-# scoring.weights; trial score is the unweighted mean of grader [0,1]
-# scores; skill passes when the mean >= scoring.threshold (0.6). Several
+# Scoring (see scoring block): this suite deliberately omits scoring.weights,
+# so Vally 0.10 uses the unweighted mean of grader [0,1] scores; skill passes
+# when the mean >= scoring.threshold (0.6). Several
 # scenarios are judge-only — a single prompt grader means the trial score
 # IS the judge's normalized rubric score, which is the cleanest possible
 # de-brittled signal.
@@ -381,9 +381,8 @@ stimuli:
         - try-fix
 
 scoring:
-  # @microsoft/vally@0.6.0 ignores scoring.weights — only scoring.threshold
-  # is active (verified in dist/scoring/scorer.js). Trial score = unweighted
-  # mean of grader [0,1] scores; skill passes when the mean across runs >=
+  # This suite deliberately omits scoring.weights, so Vally 0.10 uses the
+  # unweighted mean of grader [0,1] scores; skill passes when the mean across runs >=
   # threshold. Judge-only scenarios reduce to "judge normalized score >=
   # 0.6" (raw >= 3.4/5); two-grader scenarios average a crisp floor with
   # the judge. Threshold DEFAULTS to 1.0 when omitted, so it is set here.

--- a/.github/skills/verify-tests-fail-without-fix/tests/eval.vally.yaml
+++ b/.github/skills/verify-tests-fail-without-fix/tests/eval.vally.yaml
@@ -21,8 +21,8 @@
 # are better judged semantically (the failure is concluding the WRONG
 # thing, which can be phrased many ways), so they move into the rubric.
 #
-# Scoring: @microsoft/vally@0.6.0 ignores scoring.weights; trial score =
-# unweighted mean of grader [0,1] scores; skill passes when the mean >=
+# Scoring: this suite deliberately omits scoring.weights, so Vally 0.10 uses
+# the unweighted mean of grader [0,1] scores; skill passes when the mean >=
 # scoring.threshold (0.6). See the scoring block.
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -370,9 +370,8 @@ stimuli:
         - verify-tests-fail-without-fix
 
 scoring:
-  # @microsoft/vally@0.6.0 ignores scoring.weights — only scoring.threshold
-  # is active (verified in dist/scoring/scorer.js). Trial score = unweighted
-  # mean of grader [0,1] scores; skill passes when the mean across runs >=
+  # This suite deliberately omits scoring.weights, so Vally 0.10 uses the
+  # unweighted mean of grader [0,1] scores; skill passes when the mean across runs >=
   # threshold. Judge-only scenarios reduce to "judge normalized score >=
   # 0.6" (raw >= 3.4/5). Threshold DEFAULTS to 1.0 when omitted, so it is
   # set here.

--- a/.github/workflows/skill-validation.yml
+++ b/.github/workflows/skill-validation.yml
@@ -79,9 +79,8 @@ permissions:
 
 env:
   # Vally CLI is run via npx from npm. Pinned for reproducibility.
-  # @github/copilot-sdk (vally's executor) requires Node ^20.19 || >=22.12,
-  # so we pin Node 22 on the runners.
-  VALLY_VERSION: "0.6.0"
+  # Vally 0.10 requires Node >=22, so we pin Node 22 on the runners.
+  VALLY_VERSION: "0.10.0"
   NODE_VERSION: "22"
 
 jobs:
@@ -246,8 +245,10 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       # ── Lint eval specs with Vally ────────────────────────────────
-      # Lint ONLY the *.vally.yaml eval specs. `vally lint --eval-spec <file>`
-      # validates the spec and SKIPS SKILL.md structural linting. We do NOT
+      # Lint ONLY the explicitly enumerated *.vally.yaml eval specs. Vally's
+      # directory discovery only recognizes eval.yaml/eval.yml, so pass each
+      # nonstandard filename with --eval-spec. This also SKIPS SKILL.md structural
+      # linting. We do NOT
       # lint SKILL.md / *.agent.md here on purpose: vally's skill linter flags
       # two PRE-EXISTING repo issues unrelated to this migration (try-fix
       # SKILL.md exceeds the 500-line limit; find-regression-risk is missing
@@ -561,8 +562,10 @@ jobs:
           TESTS_PATH: ${{ matrix.entry.tests_path }}
           RUNS: ${{ github.event.inputs.runs }}
         run: |
-          # Collect this skill's capability specs. The eval*.vally.yaml glob
-          # EXCLUDES hermeticity.vally.yaml (run by its own gate job).
+          # Collect this skill's capability specs. Pass every nonstandard
+          # eval*.vally.yaml filename explicitly because Vally directory discovery
+          # only recognizes eval.yaml/eval.yml. This EXCLUDES hermeticity.vally.yaml
+          # (run by its own gate job).
           SPECS=()
           for f in "$TESTS_PATH"/eval*.vally.yaml; do
             [ -e "$f" ] || continue


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary
- Upgrade the Skill Validation workflow from `@microsoft/vally-cli@0.6.0` to `0.10.0`.
- Preserve MAUI's explicit `*.vally.yaml` enumeration because Vally directory discovery recognizes only `eval.yaml` and `eval.yml` by default.
- Update all 0.6-specific scoring guidance: these specs intentionally omit `scoring.weights`, retaining Vally 0.10's equal-weight aggregation and existing thresholds.

## Validation
- Ran strict lint with `@microsoft/vally-cli@0.10.0` for all 10 MAUI eval specs.
- Parsed `.github/workflows/skill-validation.yml` as YAML and ran `git diff --check`.

## Scope
This PR is limited to the Vally 0.10.0 upgrade. It intentionally excludes the Trim/AOT fixture-workflow changes from #34962.