### PR TITLE
[Windows] Add AppInstance activation lifecycle hook and WebAuthenticator support

### DIFF
--- a/src/Controls/samples/Controls.Sample/MauiProgram.cs
+++ b/src/Controls/samples/Controls.Sample/MauiProgram.cs
@@ -296,7 +296,8 @@ namespace Maui.Controls.Sample
 						LogEvent(nameof(WindowsLifecycle.OnAppInstanceActivated), args.Kind.ToString());
 
 						// This sample opts into single-instancing from the MAUI lifecycle callback
-						// instead of a custom Program.cs entry point.
+						// instead of a custom Program.cs entry point. An app-owned key must redirect
+						// every activation the main instance handles, including protocol callbacks.
 						var keyInstance = AppInstance.FindOrRegisterForKey("Maui.Controls.Sample");
 
 						if (!keyInstance.IsCurrent)

--- a/src/Controls/samples/Controls.Sample/MauiProgram.cs
+++ b/src/Controls/samples/Controls.Sample/MauiProgram.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using Maui.Controls.Sample.Controls;
 using Maui.Controls.Sample.Pages;
 using Maui.Controls.Sample.Services;
@@ -300,11 +301,7 @@ namespace Maui.Controls.Sample
 
 						if (!keyInstance.IsCurrent)
 						{
-							// The WinAppSDK single-instance guidance redirects the activation and then
-							// terminates the losing instance immediately. Using Kill here avoids leaving
-							// a headless process around that can continue to hold build outputs open.
-							keyInstance.RedirectActivationToAsync(args).AsTask().GetAwaiter().GetResult();
-							Process.GetCurrentProcess().Kill();
+							_ = RedirectActivationAndExitAsync(keyInstance, args);
 							return true;
 						}
 
@@ -348,5 +345,36 @@ namespace Maui.Controls.Sample
 
 			return appBuilder.Build();
 		}
+
+#if WINDOWS
+		static async Task RedirectActivationAndExitAsync(AppInstance keyInstance, AppActivationArguments args)
+		{
+			try
+			{
+				await keyInstance.RedirectActivationToAsync(args).AsTask().ConfigureAwait(false);
+			}
+			catch (Exception ex)
+			{
+				Debug.WriteLine($"Unable to redirect the Controls Sample activation: {ex}");
+			}
+			finally
+			{
+				TerminateCurrentProcess();
+			}
+		}
+
+		static void TerminateCurrentProcess()
+		{
+			try
+			{
+				Process.GetCurrentProcess().Kill();
+			}
+			catch (Exception ex)
+			{
+				Debug.WriteLine($"Unable to terminate the transient Controls Sample process: {ex}");
+				Environment.Exit(1);
+			}
+		}
+#endif
 	}
 }

--- a/src/Controls/samples/Controls.Sample/MauiProgram.cs
+++ b/src/Controls/samples/Controls.Sample/MauiProgram.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
 using Maui.Controls.Sample.Controls;
 using Maui.Controls.Sample.Pages;
 using Maui.Controls.Sample.Services;

--- a/src/Controls/samples/Controls.Sample/MauiProgram.cs
+++ b/src/Controls/samples/Controls.Sample/MauiProgram.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using Maui.Controls.Sample.Controls;
 using Maui.Controls.Sample.Pages;
 using Maui.Controls.Sample.Services;
@@ -24,6 +25,8 @@ using Microsoft.Maui.LifecycleEvents;
 #if ANDROID
 using Android.Gms.Common;
 using Android.Gms.Maps;
+#elif WINDOWS
+using Microsoft.Windows.AppLifecycle;
 #endif
 
 namespace Maui.Controls.Sample
@@ -261,6 +264,7 @@ namespace Maui.Controls.Sample
 					events.AddWindows(windows => windows
 						// .OnPlatformMessage((a, b) => 
 						//	LogEvent(nameof(WindowsLifecycle.OnPlatformMessage)))
+						.OnAppInstanceActivated((application, args) => HandleWindowsAppInstanceActivated(application, args))
 						.OnActivated((a, b) => LogEvent(nameof(WindowsLifecycle.OnActivated)))
 						.OnClosed((a, b) => LogEvent(nameof(WindowsLifecycle.OnClosed)))
 						.OnLaunched((a, b) => LogEvent(nameof(WindowsLifecycle.OnLaunched)))
@@ -285,6 +289,41 @@ namespace Maui.Controls.Sample
 						Debug.WriteLine($"Lifecycle event: {eventName}{(type == null ? "" : $" ({type})")}");
 						return true;
 					}
+
+#if WINDOWS
+					static bool HandleWindowsAppInstanceActivated(Microsoft.UI.Xaml.Application application, AppActivationArguments args)
+					{
+						LogEvent(nameof(WindowsLifecycle.OnAppInstanceActivated), args.Kind.ToString());
+
+						// This sample opts into single-instancing from the MAUI lifecycle callback
+						// instead of a custom Program.cs entry point.
+						var keyInstance = AppInstance.FindOrRegisterForKey("Maui.Controls.Sample");
+
+						if (!keyInstance.IsCurrent)
+						{
+							// The WinAppSDK single-instance guidance redirects the activation and then
+							// terminates the losing instance immediately. Using Kill here avoids leaving
+							// a headless process around that can continue to hold build outputs open.
+							keyInstance.RedirectActivationToAsync(args).AsTask().GetAwaiter().GetResult();
+							Process.GetCurrentProcess().Kill();
+							return true;
+						}
+
+						if (Application.Current?.Windows.FirstOrDefault() is Window window)
+						{
+							Application.Current.ActivateWindow(window);
+
+							if (window.Page is Page page)
+							{
+								_ = page.DisplayAlertAsync("App Activated",
+									$"This window was brought to the foreground because the app was re-launched. " +
+									$"Activation kind: {args.Kind}", "OK");
+							}
+						}
+
+						return false;
+					}
+#endif
 				});
 
 			// Adapt to dual-screen and foldable Android devices like Surface Duo, includes TwoPaneView layout control

--- a/src/Core/src/Hosting/EssentialsMauiAppBuilderExtensions.cs
+++ b/src/Core/src/Hosting/EssentialsMauiAppBuilderExtensions.cs
@@ -66,6 +66,10 @@ namespace Microsoft.Maui.Hosting
 					}));
 #elif WINDOWS
 				life.AddWindows(windows => windows
+					.OnAppInstanceActivated((application, args) =>
+					{
+						return ApplicationModel.Platform.OnAppInstanceActivated(application, args);
+					})
 					.OnActivated((window, args) =>
 					{
 						ApplicationModel.Platform.OnActivated(window, args);

--- a/src/Core/src/LifecycleEvents/Windows/WindowsLifecycle.cs
+++ b/src/Core/src/LifecycleEvents/Windows/WindowsLifecycle.cs
@@ -1,7 +1,10 @@
-﻿namespace Microsoft.Maui.LifecycleEvents
+using Microsoft.Windows.AppLifecycle;
+
+namespace Microsoft.Maui.LifecycleEvents
 {
 	public static class WindowsLifecycle
 	{
+		public delegate bool OnAppInstanceActivated(UI.Xaml.Application application, AppActivationArguments args);
 		public delegate void OnActivated(UI.Xaml.Window window, UI.Xaml.WindowActivatedEventArgs args);
 		public delegate void OnClosed(UI.Xaml.Window window, UI.Xaml.WindowEventArgs args);
 		public delegate void OnLaunched(UI.Xaml.Application application, UI.Xaml.LaunchActivatedEventArgs args);

--- a/src/Core/src/LifecycleEvents/Windows/WindowsLifecycleBuilderExtensions.cs
+++ b/src/Core/src/LifecycleEvents/Windows/WindowsLifecycleBuilderExtensions.cs
@@ -2,6 +2,7 @@
 {
 	public static class WindowsLifecycleBuilderExtensions
 	{
+		public static IWindowsLifecycleBuilder OnAppInstanceActivated(this IWindowsLifecycleBuilder lifecycle, WindowsLifecycle.OnAppInstanceActivated del) => lifecycle.OnEvent(del);
 		public static IWindowsLifecycleBuilder OnActivated(this IWindowsLifecycleBuilder lifecycle, WindowsLifecycle.OnActivated del) => lifecycle.OnEvent(del);
 		public static IWindowsLifecycleBuilder OnClosed(this IWindowsLifecycleBuilder lifecycle, WindowsLifecycle.OnClosed del) => lifecycle.OnEvent(del);
 		public static IWindowsLifecycleBuilder OnLaunching(this IWindowsLifecycleBuilder lifecycle, WindowsLifecycle.OnLaunching del) => lifecycle.OnEvent(del);

--- a/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.LifecycleEvents;
@@ -94,13 +95,35 @@ namespace Microsoft.Maui
 			{
 				// WinAppSDK delivers redirected activations on a worker thread, while MAUI
 				// lifecycle handlers are UI-facing.
-				if (dispatcher.IsDispatchRequired)
+				if (!dispatcher.IsDispatchRequired)
 				{
-					dispatcher.Dispatch(() => OnAppInstanceActivated(args));
+					OnAppInstanceActivated(args);
 					return;
 				}
 
-				OnAppInstanceActivated(args);
+				DispatchAppInstanceActivationAndWait(args);
+			}
+
+			void DispatchAppInstanceActivationAndWait(AppActivationArguments args)
+			{
+				// Redirected activation data can depend on resources owned by the redirecting process.
+				// Keep this event callback alive until the UI lifecycle handlers finish consuming it.
+				using var activationCompleted = new ManualResetEventSlim();
+
+				var dispatched = dispatcher.Dispatch(() =>
+				{
+					try
+					{
+						OnAppInstanceActivated(args);
+					}
+					finally
+					{
+						activationCompleted.Set();
+					}
+				});
+
+				if (dispatched)
+					activationCompleted.Wait();
 			}
 		}
 

--- a/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.LifecycleEvents;
+using Microsoft.Windows.AppLifecycle;
 
 namespace Microsoft.Maui
 {
@@ -20,9 +21,17 @@ namespace Microsoft.Maui
 
 		protected override void OnLaunched(UI.Xaml.LaunchActivatedEventArgs args)
 		{
-			// Windows running on a different thread will "launch" the app again
+			LaunchActivatedEventArgs = args;
+
+			var launchActivation = AppInstance.GetCurrent().GetActivatedEventArgs();
+
+			// A running WinUI app can be activated again without rebuilding the MAUI application.
+			// Reuse the existing services and let activation handlers short-circuit the relaunch path.
 			if (_application != null && _services != null)
 			{
+				if (launchActivation is AppActivationArguments activatedEventArgs && OnAppInstanceActivated(activatedEventArgs))
+					return;
+
 				_services.InvokeLifecycleEvents<WindowsLifecycle.OnLaunching>(del => del(this, args));
 				_services.InvokeLifecycleEvents<WindowsLifecycle.OnLaunched>(del => del(this, args));
 				return;
@@ -37,6 +46,14 @@ namespace Microsoft.Maui
 
 			_services = applicationContext.Services;
 
+			// Future AppInstance activation callbacks need the app-level services to exist first.
+			RegisterForAppInstanceActivated();
+
+			// Run the initial activation after services are available, but before OnLaunching/window creation,
+			// so handlers can redirect or suppress the default startup flow.
+			if (launchActivation is AppActivationArguments initialActivation && OnAppInstanceActivated(initialActivation))
+				return;
+
 			_services.InvokeLifecycleEvents<WindowsLifecycle.OnLaunching>(del => del(this, args));
 
 			_application = _services.GetRequiredService<IApplication>();
@@ -48,9 +65,50 @@ namespace Microsoft.Maui
 			_services.InvokeLifecycleEvents<WindowsLifecycle.OnLaunched>(del => del(this, args));
 		}
 
+		protected virtual bool OnAppInstanceActivated(AppActivationArguments args)
+		{
+			var wasHandled = false;
+
+			_services?.InvokeLifecycleEvents<WindowsLifecycle.OnAppInstanceActivated>(del =>
+			{
+				// Preserve any earlier "handled" result so multiple listeners can participate safely.
+				wasHandled = del(this, args) || wasHandled;
+			});
+
+			return wasHandled;
+		}
+
+		void RegisterForAppInstanceActivated()
+		{
+			if (_isRegisteredForAppInstanceActivated)
+				return;
+
+			var dispatcher = _services!.GetRequiredApplicationDispatcher();
+
+			_isRegisteredForAppInstanceActivated = true;
+
+			// After startup, later file/protocol/redirected activations are delivered through AppInstance.
+			AppInstance.GetCurrent().Activated += HandleAppInstanceActivated;
+
+			void HandleAppInstanceActivated(object? sender, AppActivationArguments args)
+			{
+				// WinAppSDK delivers redirected activations on a worker thread, while MAUI
+				// lifecycle handlers are UI-facing.
+				if (dispatcher.IsDispatchRequired)
+				{
+					dispatcher.Dispatch(() => OnAppInstanceActivated(args));
+					return;
+				}
+
+				OnAppInstanceActivated(args);
+			}
+		}
+
 		public static new MauiWinUIApplication Current => (MauiWinUIApplication)UI.Xaml.Application.Current;
 
 		public UI.Xaml.LaunchActivatedEventArgs LaunchActivatedEventArgs { get; protected set; } = null!;
+
+		bool _isRegisteredForAppInstanceActivated;
 
 		IServiceProvider? _services;
 

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
+Microsoft.Maui.LifecycleEvents.WindowsLifecycle.OnAppInstanceActivated
 Microsoft.Maui.Platform.MauiLayoutAutomationPeer
 Microsoft.Maui.Platform.MauiLayoutAutomationPeer.MauiLayoutAutomationPeer(Microsoft.Maui.Platform.LayoutPanel! owner) -> void
 override Microsoft.Maui.Platform.LayoutPanel.OnCreateAutomationPeer() -> Microsoft.UI.Xaml.Automation.Peers.AutomationPeer!
@@ -14,6 +15,9 @@ Microsoft.Maui.IHybridWebView.Invoker.get -> Microsoft.Maui.HybridWebViewInvoker
 Microsoft.Maui.IHybridWebView.Invoker.set -> void
 Microsoft.Maui.IHybridWebView.SetInvokeJavaScriptTarget<T>(T! target, System.Text.Json.Serialization.JsonSerializerContext! jsonSerializerContext) -> void
 abstract Microsoft.Maui.HybridWebViewInvoker.InvokeMethodAsync(string! methodName, string![]? paramJsonValues) -> System.Threading.Tasks.Task<string?>!
+static Microsoft.Maui.LifecycleEvents.WindowsLifecycleBuilderExtensions.OnAppInstanceActivated(this Microsoft.Maui.LifecycleEvents.IWindowsLifecycleBuilder! lifecycle, Microsoft.Maui.LifecycleEvents.WindowsLifecycle.OnAppInstanceActivated! del) -> Microsoft.Maui.LifecycleEvents.IWindowsLifecycleBuilder!
+virtual Microsoft.Maui.LifecycleEvents.WindowsLifecycle.OnAppInstanceActivated.Invoke(Microsoft.UI.Xaml.Application! application, Microsoft.Windows.AppLifecycle.AppActivationArguments! args) -> bool
+virtual Microsoft.Maui.MauiWinUIApplication.OnAppInstanceActivated(Microsoft.Windows.AppLifecycle.AppActivationArguments! args) -> bool
 override Microsoft.Maui.Platform.ContentPanel.OnCreateAutomationPeer() -> Microsoft.UI.Xaml.Automation.Peers.AutomationPeer!
 override Microsoft.Maui.Platform.MauiPasswordTextBox.OnCreateAutomationPeer() -> Microsoft.UI.Xaml.Automation.Peers.AutomationPeer!
 Microsoft.Maui.ITab

--- a/src/Core/tests/DeviceTests.Shared/MauiProgramDefaults.cs
+++ b/src/Core/tests/DeviceTests.Shared/MauiProgramDefaults.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		public static MauiApp CreateMauiApp(Func<IServiceProvider, TestOptions> options)
+		public static MauiApp CreateMauiApp(Func<IServiceProvider, TestOptions> options, Action<MauiAppBuilder> configureBuilder = null)
 		{
 			var appBuilder = MauiApp.CreateBuilder();
 
@@ -94,6 +94,8 @@ namespace Microsoft.Maui.DeviceTests
 				ValidateOnBuild = true,
 				ValidateScopes = true,
 			}));
+
+			configureBuilder?.Invoke(appBuilder);
 
 			var mauiApp = appBuilder.Build();
 

--- a/src/Core/tests/DeviceTests/LifecycleEventOrderTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/LifecycleEventOrderTests.Windows.cs
@@ -51,7 +51,16 @@ namespace Microsoft.Maui.DeviceTests
 		[Fact(DisplayName = "OnAppInstanceActivated fires exactly once during startup")]
 		public void OnAppInstanceActivatedFiresExactlyOnce()
 		{
-			var count = MauiProgram.LifecycleEventLog.Count(e => e == nameof(WindowsLifecycle.OnAppInstanceActivated));
+			var log = MauiProgram.LifecycleEventLog;
+			var launchingIndex = log.IndexOf(nameof(WindowsLifecycle.OnLaunching));
+
+			Assert.True(launchingIndex >= 0,
+				$"Expected {nameof(WindowsLifecycle.OnLaunching)} in the lifecycle log. Log: [{string.Join(", ", log)}]");
+
+			var count = log
+				.Take(launchingIndex)
+				.Count(e => e == nameof(WindowsLifecycle.OnAppInstanceActivated));
+
 			Assert.Equal(1, count);
 		}
 	}

--- a/src/Core/tests/DeviceTests/LifecycleEventOrderTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/LifecycleEventOrderTests.Windows.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Maui.LifecycleEvents;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.Lifecycle)]
+	public class LifecycleEventOrderTests
+	{
+		[Fact(DisplayName = "Windows lifecycle events fire during startup")]
+		public void WindowsLifecycleEventsFireDuringStartup()
+		{
+			var log = MauiProgram.LifecycleEventLog;
+
+			Assert.Contains(nameof(WindowsLifecycle.OnAppInstanceActivated), log);
+			Assert.Contains(nameof(WindowsLifecycle.OnLaunching), log);
+			Assert.Contains(nameof(WindowsLifecycle.OnLaunched), log);
+			Assert.Contains(nameof(WindowsLifecycle.OnWindowCreated), log);
+		}
+
+		[Fact(DisplayName = "Windows lifecycle events fire in correct order")]
+		public void WindowsLifecycleEventsFireInCorrectOrder()
+		{
+			var log = MauiProgram.LifecycleEventLog;
+
+			var activatedIndex = AssertEventIndex(log, nameof(WindowsLifecycle.OnAppInstanceActivated));
+			var launchingIndex = AssertEventIndex(log, nameof(WindowsLifecycle.OnLaunching));
+			var windowCreatedIndex = AssertEventIndex(log, nameof(WindowsLifecycle.OnWindowCreated));
+			var launchedIndex = AssertEventIndex(log, nameof(WindowsLifecycle.OnLaunched));
+
+			// Expected startup order: OnAppInstanceActivated → OnLaunching → OnWindowCreated → OnLaunched
+			Assert.True(activatedIndex < launchingIndex,
+				$"Expected OnAppInstanceActivated before OnLaunching. Log: [{string.Join(", ", log)}]");
+			Assert.True(launchingIndex < windowCreatedIndex,
+				$"Expected OnLaunching before OnWindowCreated. Log: [{string.Join(", ", log)}]");
+			Assert.True(windowCreatedIndex < launchedIndex,
+				$"Expected OnWindowCreated before OnLaunched. Log: [{string.Join(", ", log)}]");
+
+			static int AssertEventIndex(IList<string> log, string eventName)
+			{
+				var index = log.IndexOf(eventName);
+
+				Assert.True(index >= 0,
+					$"Expected {eventName} in the lifecycle log. Log: [{string.Join(", ", log)}]");
+
+				return index;
+			}
+		}
+
+		[Fact(DisplayName = "OnAppInstanceActivated fires exactly once during startup")]
+		public void OnAppInstanceActivatedFiresExactlyOnce()
+		{
+			var count = MauiProgram.LifecycleEventLog.Count(e => e == nameof(WindowsLifecycle.OnAppInstanceActivated));
+			Assert.Equal(1, count);
+		}
+	}
+}

--- a/src/Core/tests/DeviceTests/MauiProgram.cs
+++ b/src/Core/tests/DeviceTests/MauiProgram.cs
@@ -14,10 +14,19 @@ namespace Microsoft.Maui.DeviceTests
 		public static UI.Xaml.Window DefaultWindow => MauiProgramDefaults.DefaultWindow;
 #endif
 
+		/// <summary>
+		/// Records platform lifecycle event names in the order they fire during app startup.
+		/// Used by LifecycleEventOrderTests to validate event ordering.
+		/// </summary>
+		public static List<string> LifecycleEventLog { get; } = new();
+
 		public static IApplication DefaultTestApp { get; private set; }
 
-		public static MauiApp CreateMauiApp() =>
-			MauiProgramDefaults.CreateMauiApp((sp) =>
+		public static MauiApp CreateMauiApp()
+		{
+			LifecycleEventLog.Clear();
+
+			return MauiProgramDefaults.CreateMauiApp((sp) =>
 			{
 				var options = new TestOptions
 				{
@@ -29,6 +38,29 @@ namespace Microsoft.Maui.DeviceTests
 				};
 
 				return options;
+			},
+			configureBuilder: builder =>
+			{
+#if WINDOWS
+				builder.ConfigureLifecycleEvents(life =>
+				{
+					life.AddWindows(windows =>
+					{
+						windows.OnAppInstanceActivated((app, args) =>
+						{
+							LifecycleEventLog.Add(nameof(WindowsLifecycle.OnAppInstanceActivated));
+							return false;
+						});
+						windows.OnLaunching((app, args) =>
+							LifecycleEventLog.Add(nameof(WindowsLifecycle.OnLaunching)));
+						windows.OnLaunched((app, args) =>
+							LifecycleEventLog.Add(nameof(WindowsLifecycle.OnLaunched)));
+						windows.OnWindowCreated(w =>
+							LifecycleEventLog.Add(nameof(WindowsLifecycle.OnWindowCreated)));
+					});
+				});
+#endif
 			});
+		}
 	}
 }

--- a/src/Core/tests/DeviceTests/TestCategory.cs
+++ b/src/Core/tests/DeviceTests/TestCategory.cs
@@ -51,5 +51,6 @@
 		public const string View = "View";
 		public const string WebView = "WebView";
 		public const string Window = "Window";
+		public const string Lifecycle = "Lifecycle";
 	}
 }

--- a/src/Essentials/src/Platform/Platform.shared.cs
+++ b/src/Essentials/src/Platform/Platform.shared.cs
@@ -154,6 +154,15 @@ namespace Microsoft.Maui.ApplicationModel
 		public static void OnActivated(UI.Xaml.Window window, UI.Xaml.WindowActivatedEventArgs args) =>
 			WindowStateManager.Default.OnActivated(window, args);
 
+		/// <summary>
+		/// Called when the Windows application receives activation arguments that may be handled by platform features.
+		/// </summary>
+		/// <param name="application">The application instance that received the activation.</param>
+		/// <param name="args">The activation arguments.</param>
+		/// <returns><see langword="true"/> if a platform feature handled the activation; otherwise, <see langword="false"/>.</returns>
+		public static bool OnAppInstanceActivated(UI.Xaml.Application application, Microsoft.Windows.AppLifecycle.AppActivationArguments args) =>
+			WebAuthenticator.Default.OnAppInstanceActivated(args);
+
 #elif TIZEN
 		/// <summary>
 		/// Gets a <see cref="Tizen.Applications.Package"/> object with information about the current application package.

--- a/src/Essentials/src/Platform/PlatformMethods.windows.cs
+++ b/src/Essentials/src/Platform/PlatformMethods.windows.cs
@@ -78,6 +78,10 @@ namespace Microsoft.Maui.ApplicationModel
 		public static extern IntPtr CallWindowProc(IntPtr lpPrevWndFunc, IntPtr hWnd, uint uMsg, IntPtr wParam, IntPtr lParam);
 
 		[DllImport("user32.dll")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		public static extern bool SetForegroundWindow(IntPtr hWnd);
+
+		[DllImport("user32.dll")]
 		public static extern bool SetWindowPos(IntPtr hWnd, SpecialWindowHandles hWndInsertAfter, int x, int y, int width, int height, SetWindowPosFlags uFlags);
 
 		[DllImport("user32.dll")]

--- a/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,9 +1,12 @@
 #nullable enable
+Microsoft.Maui.Authentication.IPlatformWebAuthenticatorCallback.OnAppInstanceActivatedCallback(Microsoft.Windows.AppLifecycle.AppActivationArguments! args) -> bool
 Microsoft.Maui.ApplicationModel.IPermissions
 Microsoft.Maui.ApplicationModel.IPermissions.CheckStatusAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
 Microsoft.Maui.ApplicationModel.IPermissions.RequestAsync<TPermission>() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>!
 Microsoft.Maui.ApplicationModel.IPermissions.ShouldShowRationale<TPermission>() -> bool
 static Microsoft.Maui.ApplicationModel.Permissions.Current.get -> Microsoft.Maui.ApplicationModel.IPermissions!
+static Microsoft.Maui.ApplicationModel.Platform.OnAppInstanceActivated(Microsoft.UI.Xaml.Application! application, Microsoft.Windows.AppLifecycle.AppActivationArguments! args) -> bool
+static Microsoft.Maui.Authentication.WebAuthenticatorExtensions.OnAppInstanceActivated(this Microsoft.Maui.Authentication.IWebAuthenticator! webAuthenticator, Microsoft.Windows.AppLifecycle.AppActivationArguments! args) -> bool
 *REMOVED*Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 *REMOVED*static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 Microsoft.Maui.Devices.Sensors.GeolocationListeningRequest.MinimumDistance.get -> double

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.shared.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.shared.cs
@@ -22,10 +22,10 @@ namespace Microsoft.Maui.Authentication
 		/// <param name="webAuthenticatorOptions">A <see cref="WebAuthenticatorOptions"/> instance containing additional configuration for this authentication call.</param>
 		/// <returns>A <see cref="WebAuthenticatorResult"/> object with the results of this operation.</returns>
 		/// <exception cref="TaskCanceledException">Thrown when the user canceled the authentication flow.</exception>
-		/// <exception cref="PlatformNotSupportedException">Windows: Thrown when called on Windows.</exception>
 		/// <exception cref="FeatureNotSupportedException">iOS/macOS: Thrown when iOS version is less than 13 is used or macOS less than 13.1 is used.</exception>
 		/// <exception cref="InvalidOperationException">
 		/// <para>Android: Thrown when the no IntentFilter has been created for the callback URL.</para>
+		/// <para>Windows: Thrown when the callback URL is invalid, its protocol is not registered, the browser cannot be launched, or another app instance is already waiting for the callback scheme.</para>
 		/// </exception>
 		Task<WebAuthenticatorResult> AuthenticateAsync(WebAuthenticatorOptions webAuthenticatorOptions);
 
@@ -36,10 +36,10 @@ namespace Microsoft.Maui.Authentication
 		/// <param name="cancellationToken">A <see cref="CancellationToken"/> to monitor for cancellation requests.</param>
 		/// <returns>A <see cref="WebAuthenticatorResult"/> object with the results of this operation.</returns>
 		/// <exception cref="TaskCanceledException">Thrown when the user canceled the authentication flow.</exception>
-		/// <exception cref="PlatformNotSupportedException">Windows: Thrown when called on Windows.</exception>
 		/// <exception cref="FeatureNotSupportedException">iOS/macOS: Thrown when iOS version is less than 13 is used or macOS less than 13.1 is used.</exception>
 		/// <exception cref="InvalidOperationException">
 		/// <para>Android: Thrown when the no IntentFilter has been created for the callback URL.</para>
+		/// <para>Windows: Thrown when the callback URL is invalid, its protocol is not registered, the browser cannot be launched, or another app instance is already waiting for the callback scheme.</para>
 		/// </exception>
 		Task<WebAuthenticatorResult> AuthenticateAsync(WebAuthenticatorOptions webAuthenticatorOptions, CancellationToken cancellationToken);
 
@@ -64,6 +64,13 @@ namespace Microsoft.Maui.Authentication
 		/// <param name="intent">An <see cref="Intent"/> object containing additional data about this resume operation.</param>
 		/// <returns><see langword="true"/> when the callback can be processed, otherwise <see langword="false"/>.</returns>
 		bool OnResumeCallback(Intent intent);
+#elif WINDOWS
+		/// <summary>
+		/// Called when the app receives an activation that may complete an authentication flow.
+		/// </summary>
+		/// <param name="args">The activation arguments delivered by the OS.</param>
+		/// <returns><see langword="true"/> when the activation was handled, otherwise <see langword="false"/>.</returns>
+		bool OnAppInstanceActivatedCallback(Microsoft.Windows.AppLifecycle.AppActivationArguments args);
 #endif
 	}
 
@@ -93,9 +100,6 @@ namespace Microsoft.Maui.Authentication
 		/// <param name="url"> Url to navigate to, beginning the authentication flow.</param>
 		/// <param name="callbackUrl"> Expected callback url that the navigation flow will eventually redirect to.</param>
 		/// <returns>Returns a result parsed out from the callback url.</returns>
-#if !NETSTANDARD
-		[System.Runtime.Versioning.UnsupportedOSPlatform("windows")]
-#endif
 		public static Task<WebAuthenticatorResult> AuthenticateAsync(Uri url, Uri callbackUrl)
 			=> Current.AuthenticateAsync(url, callbackUrl);
 
@@ -104,18 +108,12 @@ namespace Microsoft.Maui.Authentication
 		/// <param name="callbackUrl"> Expected callback url that the navigation flow will eventually redirect to.</param>
 		/// <param name="cancellationToken">A <see cref="CancellationToken"/> to monitor for cancellation requests.</param>
 		/// <returns>Returns a result parsed out from the callback url.</returns>
-#if !NETSTANDARD
-		[System.Runtime.Versioning.UnsupportedOSPlatform("windows")]
-#endif
 		public static Task<WebAuthenticatorResult> AuthenticateAsync(Uri url, Uri callbackUrl, CancellationToken cancellationToken)
 			=> Current.AuthenticateAsync(url, callbackUrl, cancellationToken);
 
 		/// <summary>Begin an authentication flow by navigating to the specified url and waiting for a callback/redirect to the callbackUrl scheme.The start url and callbackUrl are specified in the webAuthenticatorOptions.</summary>
 		/// <param name="webAuthenticatorOptions">Options to configure the authentication request.</param>
 		/// <returns>Returns a result parsed out from the callback url.</returns>
-#if !NETSTANDARD
-		[System.Runtime.Versioning.UnsupportedOSPlatform("windows")]
-#endif
 		public static Task<WebAuthenticatorResult> AuthenticateAsync(WebAuthenticatorOptions webAuthenticatorOptions)
 			=> Current.AuthenticateAsync(webAuthenticatorOptions);
 
@@ -123,9 +121,6 @@ namespace Microsoft.Maui.Authentication
 		/// <param name="webAuthenticatorOptions">Options to configure the authentication request.</param>
 		/// <param name="cancellationToken">A <see cref="CancellationToken"/> to monitor for cancellation requests.</param>
 		/// <returns>Returns a result parsed out from the callback url.</returns>
-#if !NETSTANDARD
-		[System.Runtime.Versioning.UnsupportedOSPlatform("windows")]
-#endif
 		public static Task<WebAuthenticatorResult> AuthenticateAsync(WebAuthenticatorOptions webAuthenticatorOptions, CancellationToken cancellationToken)
 			=> Current.AuthenticateAsync(webAuthenticatorOptions, cancellationToken);
 
@@ -210,6 +205,10 @@ namespace Microsoft.Maui.Authentication
 		/// <inheritdoc cref="IPlatformWebAuthenticatorCallback.OnResumeCallback(Intent)"/>
 		public static bool OnResume(this IWebAuthenticator webAuthenticator, Intent intent) =>
 			webAuthenticator.AsPlatformCallback().OnResumeCallback(intent);
+#elif WINDOWS
+		/// <inheritdoc cref="IPlatformWebAuthenticatorCallback.OnAppInstanceActivatedCallback(Microsoft.Windows.AppLifecycle.AppActivationArguments)"/>
+		public static bool OnAppInstanceActivated(this IWebAuthenticator webAuthenticator, Microsoft.Windows.AppLifecycle.AppActivationArguments args) =>
+			webAuthenticator.AsPlatformCallback().OnAppInstanceActivatedCallback(args);
 #endif
 	}
 

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.shared.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.shared.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Maui.Authentication
 		/// </summary>
 		/// <param name="args">The activation arguments delivered by the OS.</param>
 		/// <returns><see langword="true"/> when the activation was handled, otherwise <see langword="false"/>.</returns>
-		bool OnAppInstanceActivatedCallback(Microsoft.Windows.AppLifecycle.AppActivationArguments args);
+		bool OnAppInstanceActivatedCallback(Microsoft.Windows.AppLifecycle.AppActivationArguments args) => false;
 #endif
 	}
 

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.windows.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.windows.cs
@@ -142,8 +142,8 @@ namespace Microsoft.Maui.Authentication
 
 		void ClearCurrentAuthentication()
 		{
-			// Keep the route for the process lifetime. Windows App SDK cannot re-register an
-			// AppInstance after UnregisterKey (microsoft/WindowsAppSDK#4420).
+			// Do not call UnregisterKey here. Windows App SDK cannot safely register another
+			// key after UnregisterKey (microsoft/WindowsAppSDK#4420).
 			tcsResponse = null;
 			currentRedirectUri = null;
 			currentOptions = null;

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.windows.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.windows.cs
@@ -97,6 +97,8 @@ namespace Microsoft.Maui.Authentication
 			var callbackUrl = webAuthenticatorOptions.CallbackUrl ??
 				throw new ArgumentNullException(nameof(webAuthenticatorOptions.CallbackUrl));
 
+			cancellationToken.ThrowIfCancellationRequested();
+
 			ValidateCallbackUrl(callbackUrl);
 
 			var response = new TaskCompletionSource<WebAuthenticatorResult>();

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.windows.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.windows.cs
@@ -1,18 +1,328 @@
+#nullable enable
 using System;
+using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Linq;
+using System.Xml.XPath;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Storage;
+using Microsoft.UI.Windowing;
+using Microsoft.Windows.AppLifecycle;
+using Windows.ApplicationModel.Activation;
 
 namespace Microsoft.Maui.Authentication
 {
-	partial class WebAuthenticatorImplementation : IWebAuthenticator
+	partial class WebAuthenticatorImplementation : IWebAuthenticator, IPlatformWebAuthenticatorCallback
 	{
-		public Task<WebAuthenticatorResult> AuthenticateAsync(WebAuthenticatorOptions webAuthenticatorOptions)
+		const string CallbackRouteKeyPrefix = "Microsoft.Maui.WebAuthenticator:";
+
+		readonly object locker = new();
+
+		TaskCompletionSource<WebAuthenticatorResult>? tcsResponse;
+		Uri? currentRedirectUri;
+		WebAuthenticatorOptions? currentOptions;
+		AppWindow? currentAppWindow;
+
+		public bool OnAppInstanceActivatedCallback(AppActivationArguments args)
 		{
-			throw new PlatformNotSupportedException("This implementation of WebAuthenticator does not support Windows. See https://github.com/microsoft/WindowsAppSDK/issues/441 for more details.");
+			if (args.Kind != ExtendedActivationKind.Protocol ||
+				args.Data is not IProtocolActivatedEventArgs protocolArgs)
+			{
+				return false;
+			}
+
+			var callbackUri = protocolArgs.Uri;
+
+			TaskCompletionSource<WebAuthenticatorResult>? response;
+			Uri? redirectUri;
+			WebAuthenticatorOptions? options;
+			AppWindow? appWindow;
+
+			bool isLocalCallbackRoute;
+
+			lock (locker)
+			{
+				response = tcsResponse;
+				redirectUri = currentRedirectUri;
+				options = currentOptions;
+				appWindow = currentAppWindow;
+
+				isLocalCallbackRoute = redirectUri is not null && IsSameCallbackRoute(redirectUri, callbackUri);
+			}
+
+			if (response?.Task.IsCompleted == false &&
+				redirectUri is not null &&
+				WebUtils.CanHandleCallback(redirectUri, callbackUri))
+			{
+				try
+				{
+					var result = new WebAuthenticatorResult(callbackUri, options?.ResponseDecoder);
+
+					// Only the callback that completes the request may restore its window.
+					if (response.TrySetResult(result))
+						TryBringToForeground(appWindow);
+				}
+				catch (Exception ex)
+				{
+					response.TrySetException(ex);
+				}
+
+				return true;
+			}
+
+			// A callback can have the expected scheme and still fail host validation.
+			// Leave the active route registered so a later valid callback can complete it.
+			if (isLocalCallbackRoute)
+				return false;
+
+			var routeOwner = FindCallbackRouteOwner(callbackUri);
+			if (routeOwner is null)
+				return false;
+
+			return RedirectActivationAndExit(routeOwner, args);
 		}
-		public Task<WebAuthenticatorResult> AuthenticateAsync(WebAuthenticatorOptions webAuthenticatorOptions, CancellationToken cancellationToken)
+
+		public async Task<WebAuthenticatorResult> AuthenticateAsync(WebAuthenticatorOptions webAuthenticatorOptions)
+			=> await AuthenticateAsync(webAuthenticatorOptions, CancellationToken.None);
+
+		public async Task<WebAuthenticatorResult> AuthenticateAsync(WebAuthenticatorOptions webAuthenticatorOptions, CancellationToken cancellationToken)
 		{
-			throw new PlatformNotSupportedException("This implementation of WebAuthenticator does not support Windows. See https://github.com/microsoft/WindowsAppSDK/issues/441 for more details.");
+			ArgumentNullException.ThrowIfNull(webAuthenticatorOptions);
+
+			var url = webAuthenticatorOptions.Url ??
+				throw new ArgumentNullException(nameof(webAuthenticatorOptions.Url));
+			var callbackUrl = webAuthenticatorOptions.CallbackUrl ??
+				throw new ArgumentNullException(nameof(webAuthenticatorOptions.CallbackUrl));
+
+			ValidateCallbackUrl(callbackUrl);
+
+			var response = new TaskCompletionSource<WebAuthenticatorResult>();
+			TaskCompletionSource<WebAuthenticatorResult>? previousResponse;
+
+			// Capture the request window so a multi-window app restores the same window
+			// after authentication completes.
+			var appWindow = TryGetActiveAppWindow();
+
+			lock (locker)
+			{
+				RegisterCallbackRoute(callbackUrl);
+
+				previousResponse = tcsResponse;
+				tcsResponse = response;
+				currentRedirectUri = callbackUrl;
+				currentOptions = webAuthenticatorOptions;
+				currentAppWindow = appWindow;
+			}
+
+			previousResponse?.TrySetCanceled();
+
+			using (cancellationToken.Register(() => response.TrySetCanceled()))
+			{
+				try
+				{
+					var launched = await global::Windows.System.Launcher.LaunchUriAsync(url);
+					if (!launched)
+						throw new InvalidOperationException("Failed to launch the browser for authentication.");
+
+					return await response.Task;
+				}
+				finally
+				{
+					lock (locker)
+					{
+						if (ReferenceEquals(tcsResponse, response))
+							ClearCurrentAuthentication();
+					}
+				}
+			}
+		}
+
+		void ClearCurrentAuthentication()
+		{
+			// Keep the route for the process lifetime. Windows App SDK cannot re-register an
+			// AppInstance after UnregisterKey (microsoft/WindowsAppSDK#4420).
+			tcsResponse = null;
+			currentRedirectUri = null;
+			currentOptions = null;
+			currentAppWindow = null;
+		}
+
+		static AppWindow? TryGetActiveAppWindow()
+		{
+			try
+			{
+				return WindowStateManager.Default.GetActiveAppWindow(false);
+			}
+			catch (Exception ex)
+			{
+				Debug.WriteLine($"Unable to identify the WebAuthenticator window: {ex}");
+				return null;
+			}
+		}
+
+		static void TryBringToForeground(AppWindow? appWindow)
+		{
+			if (appWindow is null)
+				return;
+
+			try
+			{
+				var windowHandle = UI.Win32Interop.GetWindowFromWindowId(appWindow.Id);
+				if (windowHandle == IntPtr.Zero)
+				{
+					Debug.WriteLine("Unable to retrieve the WebAuthenticator window handle.");
+					return;
+				}
+
+				// AppWindow APIs are agile. Restore or show without activation so the native
+				// call below makes the only best-effort foreground request.
+				if (appWindow.Presenter is OverlappedPresenter presenter &&
+					presenter.State == OverlappedPresenterState.Minimized)
+				{
+					presenter.Restore(false);
+				}
+
+				if (!appWindow.IsVisible)
+					appWindow.Show(false);
+
+				// RedirectActivationToAsync attempts to transfer foreground permission to the
+				// route owner, but Windows can still deny this request.
+				if (!PlatformMethods.SetForegroundWindow(windowHandle))
+					Debug.WriteLine("Windows denied the WebAuthenticator window foreground activation.");
+			}
+			catch (Exception ex)
+			{
+				Debug.WriteLine($"Unable to bring the WebAuthenticator window to the foreground: {ex}");
+			}
+		}
+
+		static void ValidateCallbackUrl(Uri callbackUrl)
+		{
+			if (!callbackUrl.IsAbsoluteUri)
+				throw new InvalidOperationException("The callback URI must be absolute.");
+
+			if (callbackUrl.Scheme is "http" or "https")
+			{
+				throw new InvalidOperationException(
+					$"{callbackUrl.Scheme}:// schemes are not supported for the callback URI on Windows. " +
+					"Use a custom URI scheme instead.");
+			}
+
+			if (AppInfoUtils.IsPackagedApp)
+			{
+				if (!IsUriProtocolDeclared(callbackUrl.Scheme))
+				{
+					throw new InvalidOperationException(
+						$"You need to declare the windows.protocol usage of the " +
+						$"protocol/scheme `{callbackUrl.Scheme}` in your AppxManifest.xml file.");
+				}
+			}
+			else if (!IsRegistryDeclared(callbackUrl.Scheme))
+			{
+				throw new InvalidOperationException(
+					$"The URI scheme '{callbackUrl.Scheme}' is not registered. " +
+					"Call ActivationRegistrationManager.RegisterForProtocolActivation when running unpackaged.");
+			}
+		}
+
+		static void RegisterCallbackRoute(Uri callbackUrl)
+		{
+			var currentInstance = AppInstance.GetCurrent();
+			var routeKey = CreateCallbackRouteKey(callbackUrl);
+			var currentKey = currentInstance.Key;
+
+			if (string.Equals(currentKey, routeKey, StringComparison.Ordinal))
+				return;
+
+			// Preserve application-owned AppInstance routing. Such apps must redirect protocol
+			// activations to this instance so the lifecycle callback above can complete the request.
+			if (!CanRegisterCallbackRoute(currentKey))
+				return;
+
+			var routeOwner = AppInstance.FindOrRegisterForKey(routeKey);
+			if (routeOwner is null)
+			{
+				throw new InvalidOperationException(
+					$"Unable to register the callback route for scheme '{callbackUrl.Scheme}'.");
+			}
+
+			if (!routeOwner.IsCurrent)
+			{
+				throw new InvalidOperationException(
+					$"Another app instance is already waiting for the callback scheme '{callbackUrl.Scheme}'.");
+			}
+
+			if (!string.Equals(routeOwner.Key, routeKey, StringComparison.Ordinal))
+			{
+				throw new InvalidOperationException(
+					$"Unable to register the callback route for scheme '{callbackUrl.Scheme}'.");
+			}
+		}
+
+		static AppInstance? FindCallbackRouteOwner(Uri callbackUri)
+		{
+			var routeKey = CreateCallbackRouteKey(callbackUri);
+
+			return AppInstance.GetInstances().FirstOrDefault(instance =>
+				!instance.IsCurrent &&
+				string.Equals(instance.Key, routeKey, StringComparison.Ordinal));
+		}
+
+		static bool RedirectActivationAndExit(AppInstance routeOwner, AppActivationArguments args)
+		{
+			try
+			{
+				// Complete redirection before terminating this transient callback process.
+				routeOwner.RedirectActivationToAsync(args).AsTask().GetAwaiter().GetResult();
+			}
+			catch (Exception ex)
+			{
+				Debug.WriteLine($"Unable to redirect WebAuthenticator callback activation: {ex}");
+				return false;
+			}
+
+			Process.GetCurrentProcess().Kill();
+			return true;
+		}
+
+		// AppInstance keys are app-defined, so keep WebAuthenticator routes separate from application-owned keys.
+		internal static string CreateCallbackRouteKey(Uri callbackUrl) =>
+			$"{CallbackRouteKeyPrefix}{callbackUrl.Scheme}";
+
+		internal static bool CanRegisterCallbackRoute(string? currentKey) =>
+			string.IsNullOrEmpty(currentKey) ||
+			currentKey.StartsWith(CallbackRouteKeyPrefix, StringComparison.Ordinal);
+
+		internal static bool IsSameCallbackRoute(Uri expectedCallbackUrl, Uri callbackUrl) =>
+			string.Equals(
+				CreateCallbackRouteKey(expectedCallbackUrl),
+				CreateCallbackRouteKey(callbackUrl),
+				StringComparison.Ordinal);
+
+		static bool IsUriProtocolDeclared(string scheme)
+		{
+			var docPath = FileSystemUtils.PlatformGetFullAppPackageFilePath(PlatformUtils.AppManifestFilename);
+			var doc = XDocument.Load(docPath, LoadOptions.None);
+
+			using var reader = doc.CreateReader();
+			var namespaceManager = new XmlNamespaceManager(reader.NameTable);
+			namespaceManager.AddNamespace("uap", PlatformUtils.AppManifestUapXmlns);
+
+			var root = doc.Root ?? throw new InvalidOperationException("The app manifest could not be loaded.");
+			var declarations = root.XPathSelectElements(
+				$"//uap:Extension[@Category='windows.protocol']/uap:Protocol[@Name='{scheme}']",
+				namespaceManager);
+
+			return declarations.Any();
+		}
+
+		static bool IsRegistryDeclared(string scheme)
+		{
+			using var key = Win32.Registry.ClassesRoot.OpenSubKey(scheme);
+			return key?.GetValue("URL Protocol") is not null;
 		}
 	}
 }

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.windows.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.windows.cs
@@ -273,19 +273,37 @@ namespace Microsoft.Maui.Authentication
 
 		static bool RedirectActivationAndExit(AppInstance routeOwner, AppActivationArguments args)
 		{
+			_ = RedirectActivationAndExitAsync(routeOwner, args);
+			return true;
+		}
+
+		static async Task RedirectActivationAndExitAsync(AppInstance routeOwner, AppActivationArguments args)
+		{
 			try
 			{
-				// Complete redirection before terminating this transient callback process.
-				routeOwner.RedirectActivationToAsync(args).AsTask().GetAwaiter().GetResult();
+				await routeOwner.RedirectActivationToAsync(args).AsTask().ConfigureAwait(false);
 			}
 			catch (Exception ex)
 			{
 				Debug.WriteLine($"Unable to redirect WebAuthenticator callback activation: {ex}");
-				return false;
 			}
+			finally
+			{
+				TerminateCurrentProcess();
+			}
+		}
 
-			Process.GetCurrentProcess().Kill();
-			return true;
+		static void TerminateCurrentProcess()
+		{
+			try
+			{
+				Process.GetCurrentProcess().Kill();
+			}
+			catch (Exception ex)
+			{
+				Debug.WriteLine($"Unable to terminate the transient WebAuthenticator callback process: {ex}");
+				Environment.Exit(1);
+			}
 		}
 
 		// AppInstance keys are app-defined, so keep WebAuthenticator routes separate from application-owned keys.

--- a/src/Essentials/test/DeviceTests/Platforms/Windows/Package.appxmanifest
+++ b/src/Essentials/test/DeviceTests/Platforms/Windows/Package.appxmanifest
@@ -33,6 +33,11 @@
         <uap:DefaultTile Square71x71Logo="$placeholder$.png" Wide310x150Logo="$placeholder$.png" Square310x310Logo="$placeholder$.png" />
         <uap:SplashScreen Image="$placeholder$.png" />
       </uap:VisualElements>
+      <Extensions>
+        <uap:Extension Category="windows.protocol">
+          <uap:Protocol Name="xamarinessentials" />
+        </uap:Extension>
+      </Extensions>
     </Application>
   </Applications>
 

--- a/src/Essentials/test/DeviceTests/Tests/WebAuthenticator_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/WebAuthenticator_Tests.cs
@@ -22,21 +22,15 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		[Trait(Traits.InteractionType, Traits.InteractionTypes.Human)]
 		public async Task Redirect(string urlBase, string callbackScheme, string accessToken, string refreshToken, int expires)
 		{
-#pragma warning disable CA1416 // Validate platform compatibility: Not supported on Windows
 			var authenticationTask = WebAuthenticator.AuthenticateAsync(
 				new Uri($"{urlBase}?access_token={accessToken}&refresh_token={refreshToken}&expires={expires}"),
 				new Uri($"{callbackScheme}://"));
-#pragma warning restore CA1416 // Validate platform compatibility
 
-#if WINDOWS
-			var exception = await Assert.ThrowsAsync<PlatformNotSupportedException>(async () => await authenticationTask);
-#else
 			var r = await authenticationTask.ConfigureAwait(false);
 			Assert.Equal(accessToken, r?.AccessToken);
 			Assert.Equal(refreshToken, r?.RefreshToken);
 			Assert.NotNull(r?.ExpiresIn);
 			Assert.True(r?.ExpiresIn > DateTime.UtcNow);
-#endif
 		}
 
 		[Theory]
@@ -50,24 +44,18 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		public async Task RedirectWithResponseDecoder(string urlBase, string callbackScheme, string accessToken, string refreshToken, int expires)
 		{
 			var responseDecoder = new TestResponseDecoder();
-#pragma warning disable CA1416 // Validate platform compatibility: Not supported on Windows
 			var authenticationTask = WebAuthenticator.AuthenticateAsync(new WebAuthenticatorOptions
 			{
 				Url = new Uri($"{urlBase}?access_token={accessToken}&refresh_token={refreshToken}&expires={expires}"),
 				CallbackUrl = new Uri($"{callbackScheme}://"),
 				ResponseDecoder = responseDecoder
 			});
-#pragma warning restore CA1416 // Validate platform compatibility
-#if WINDOWS
-			var exception = await Assert.ThrowsAsync<PlatformNotSupportedException>(async () => await authenticationTask);
-#else
 			var r = await authenticationTask.ConfigureAwait(false);
 			Assert.Equal(accessToken, r?.AccessToken);
 			Assert.Equal(refreshToken, r?.RefreshToken);
 			Assert.NotNull(r?.ExpiresIn);
 			Assert.True(r?.ExpiresIn > DateTime.UtcNow);
 			Assert.Equal(1, responseDecoder.CallCount);
-#endif
 		}
 
 
@@ -81,23 +69,16 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		[Trait(Traits.InteractionType, Traits.InteractionTypes.Human)]
 		public async Task Redirect_WithCancellation(string urlBase, string callbackScheme, string accessToken, string refreshToken, int expires)
 		{
-#pragma warning disable CA1416 // Validate platform compatibility: Not supported on Windows
 			using var cts = new CancellationTokenSource();
 			var authenticationTask = WebAuthenticator.AuthenticateAsync(
 				new Uri($"{urlBase}?access_token={accessToken}&refresh_token={refreshToken}&expires={expires}"),
 				new Uri($"{callbackScheme}://"),
 				cts.Token);
-#pragma warning restore CA1416 // Validate platform compatibility
-
-#if WINDOWS
-			var exception = await Assert.ThrowsAsync<PlatformNotSupportedException>(async () => await authenticationTask);
-#else
 			var r = await authenticationTask;
 			Assert.Equal(accessToken, r?.AccessToken);
 			Assert.Equal(refreshToken, r?.RefreshToken);
 			Assert.NotNull(r?.ExpiresIn);
 			Assert.True(r?.ExpiresIn > DateTime.UtcNow);
-#endif
 		}
 
 		[Theory]
@@ -111,7 +92,6 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		public async Task RedirectWithResponseDecoder_WithCancellation(string urlBase, string callbackScheme, string accessToken, string refreshToken, int expires)
 		{
 			var responseDecoder = new TestResponseDecoder();
-#pragma warning disable CA1416 // Validate platform compatibility: Not supported on Windows
 			using var cts = new CancellationTokenSource();
 			var authenticationTask = WebAuthenticator.AuthenticateAsync(new WebAuthenticatorOptions
 			{
@@ -119,17 +99,12 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 				CallbackUrl = new Uri($"{callbackScheme}://"),
 				ResponseDecoder = responseDecoder
 			}, cts.Token);
-#pragma warning restore CA1416 // Validate platform compatibility
-#if WINDOWS
-			var exception = await Assert.ThrowsAsync<PlatformNotSupportedException>(async () => await authenticationTask);
-#else
 			var r = await authenticationTask;
 			Assert.Equal(accessToken, r?.AccessToken);
 			Assert.Equal(refreshToken, r?.RefreshToken);
 			Assert.NotNull(r?.ExpiresIn);
 			Assert.True(r?.ExpiresIn > DateTime.UtcNow);
 			Assert.Equal(1, responseDecoder.CallCount);
-#endif
 		}
 
 

--- a/src/Essentials/test/DeviceTests/Tests/Windows/WebAuthenticator_Windows_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Windows/WebAuthenticator_Windows_Tests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Maui.Authentication;
 using Xunit;
 
@@ -7,6 +9,26 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 	[Category("WebAuthenticator")]
 	public class WebAuthenticator_Windows_Tests
 	{
+		// Pre-canceled authentication should eventually behave consistently across all
+		// WebAuthenticator platforms. This regression test is currently Windows-only
+		// because the other platforms still start their native browser session.
+		[Fact]
+		public async Task AuthenticateAsyncWithPreCanceledTokenStopsBeforePlatformValidation()
+		{
+			var options = new WebAuthenticatorOptions
+			{
+				Url = new Uri("https://example.com/auth"),
+				CallbackUrl = new Uri("https://example.com/callback"),
+			};
+
+			var cancellationToken = new CancellationToken(canceled: true);
+
+			var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+				WebAuthenticator.Default.AuthenticateAsync(options, cancellationToken));
+
+			Assert.Equal(cancellationToken, exception.CancellationToken);
+		}
+
 		[Theory]
 		[InlineData("maui-auth://", "Microsoft.Maui.WebAuthenticator:maui-auth")]
 		[InlineData("MAUI-AUTH://", "Microsoft.Maui.WebAuthenticator:maui-auth")]

--- a/src/Essentials/test/DeviceTests/Tests/Windows/WebAuthenticator_Windows_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Windows/WebAuthenticator_Windows_Tests.cs
@@ -1,0 +1,50 @@
+using System;
+using Microsoft.Maui.Authentication;
+using Xunit;
+
+namespace Microsoft.Maui.Essentials.DeviceTests
+{
+	[Category("WebAuthenticator")]
+	public class WebAuthenticator_Windows_Tests
+	{
+		[Theory]
+		[InlineData("maui-auth://", "Microsoft.Maui.WebAuthenticator:maui-auth")]
+		[InlineData("MAUI-AUTH://", "Microsoft.Maui.WebAuthenticator:maui-auth")]
+		[InlineData("maui-auth://callback", "Microsoft.Maui.WebAuthenticator:maui-auth")]
+		[InlineData("maui-auth://other/path?code=123", "Microsoft.Maui.WebAuthenticator:maui-auth")]
+		public void CreateCallbackRouteKeyUsesSchemeOnly(string callbackUrl, string expected)
+		{
+			var routeKey = WebAuthenticatorImplementation.CreateCallbackRouteKey(new Uri(callbackUrl));
+
+			Assert.Equal(expected, routeKey);
+		}
+
+		[Theory]
+		[InlineData(null, true)]
+		[InlineData("", true)]
+		[InlineData("Maui.App", false)]
+		[InlineData("Microsoft.Maui.WebAuthenticator:maui-auth", true)]
+		[InlineData("Microsoft.Maui.WebAuthenticator:other-auth", true)]
+		[InlineData("Microsoft.Maui.WebAuthenticator2:maui-auth", false)]
+		public void CanRegisterCallbackRoutePreservesApplicationKeys(string currentKey, bool expected)
+		{
+			var actual = WebAuthenticatorImplementation.CanRegisterCallbackRoute(currentKey);
+
+			Assert.Equal(expected, actual);
+		}
+
+		[Theory]
+		[InlineData("maui-auth://callback", "maui-auth://callback", true)]
+		[InlineData("maui-auth://callback", "maui-auth://other/path", true)]
+		[InlineData("MAUI-AUTH://callback", "maui-auth://callback", true)]
+		[InlineData("maui-auth://callback", "other-auth://callback", false)]
+		public void IsSameCallbackRouteUsesSchemeOnly(string expectedCallbackUrl, string callbackUrl, bool expected)
+		{
+			var actual = WebAuthenticatorImplementation.IsSameCallbackRoute(
+				new Uri(expectedCallbackUrl),
+				new Uri(callbackUrl));
+
+			Assert.Equal(expected, actual);
+		}
+	}
+}

--- a/src/Essentials/test/UnitTests/WebUtils_Tests.cs
+++ b/src/Essentials/test/UnitTests/WebUtils_Tests.cs
@@ -115,5 +115,22 @@ namespace Tests
 			var result = Microsoft.Maui.WebUtils.RemovePossibleQueryString(input);
 			Assert.Equal(expected, result);
 		}
+
+		// ============================================================
+		// CanHandleCallback
+		// ============================================================
+
+		[Theory]
+		[InlineData("maui-auth://", "maui-auth://callback?code=123", true)]
+		[InlineData("MAUI-AUTH://", "maui-auth://callback?code=123", true)]
+		[InlineData("maui-auth://callback", "MAUI-AUTH://CALLBACK?code=123", true)]
+		[InlineData("maui-auth://callback", "maui-auth://other?code=123", false)]
+		[InlineData("maui-auth://callback", "other-auth://callback?code=123", false)]
+		public void CanHandleCallback_ReturnsExpected(string expectedUrl, string callbackUrl, bool expected)
+		{
+			var result = Microsoft.Maui.WebUtils.CanHandleCallback(new Uri(expectedUrl), new Uri(callbackUrl));
+
+			Assert.Equal(expected, result);
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

.NET MAUI on Windows currently has two related gaps: it doesn't expose the Windows App SDK `AppActivationArguments` through its lifecycle events, and `WebAuthenticator` isn't supported on Windows. As a result, single-instancing, protocol and file activation, and browser-based authentication callbacks require additional app-specific plumbing.

This PR addresses both areas by adding:

- a Windows `OnAppInstanceActivated` lifecycle hook with handled semantics;
- initial and subsequent `AppInstance` activation delivery through the MAUI lifecycle;
- lifetime-safe UI dispatching for later activation callbacks;
- Windows `WebAuthenticator` support using the system browser, protocol activation, callback routing, result completion, asynchronous activation redirection, and best-effort window foreground activation;
- packaged manifest and unpackaged protocol-registration validation;
- a Controls Sample implementation demonstrating single-instancing and activation redirection;
- Windows lifecycle, WebAuthenticator routing, and callback validation tests.

The implementation keeps the existing cross-platform `WebAuthenticator` contract and uses the established `Launcher` + callback route + pending task model.

### Related Work

This PR fixes #2702 and is also related to #9973.

It is a fresh, self-contained alternative to:

#34883, which introduces the Windows AppInstance lifecycle hook;
#34887, which adds Windows WebAuthenticator support as a stacked OAuth2Manager-based follow-up to #34883.

This version combines both areas in one PR based on the current `net11.0` branch while preserving the existing MAUI WebAuthenticator model.

Related to #9973.

### Testing

- Debug and Release x64 builds passed for Core, Essentials, Controls Sample, Core DeviceTests, and Essentials DeviceTests.
- `WebUtils_Tests`: 20/20 passed.
- Windows WebAuthenticator routing helpers: 14/14 passed.
- Windows lifecycle device tests: 3/3 passed.
- Public API validation passed.
- Controls Sample single-instance redirection was manually validated, including suspending the route owner and resuming it after a second instance attempted redirection.
- Packaged and framework-dependent unpackaged browser/protocol callback transports completed successfully and returned to the existing runner without leaving a second window.
- Application-owned routing completed `owned-ok` in the main process while preserving the `Pr36640.AppOwned` key; the transient process exited and the main process remained alive.
- Sequential authentications using `pr36640-a` and `pr36640-b` both completed in one process, with the route key updating to `Microsoft.Maui.WebAuthenticator:pr36640-b`.
- A focused compatibility harness confirmed the original abstract-member break (`CS0535`), source and binary compatibility with the default member, a default result of `false`, and an overriding result of `true`.
- The public test endpoint returned its literal `ACCESS_TOKEN_VALUE` placeholder instead of `testtokenvalue`, so transport completed but that external-data assertion remained unsuitable as a deterministic pass criterion.

### Review Notes

- **Asynchronous activation redirect:** the lifecycle callback now marks the transient activation handled immediately and starts an asynchronous helper. The helper awaits `RedirectActivationToAsync` and terminates the transient process only after the native operation completes or fails, removing the previous sync-over-async wait from the activation path.
- **Why there is no destructive timeout:** a five-second `WaitAsync` followed by process termination was tested with the route owner suspended. The transient exited at about 5.4 seconds, but resuming the owner produced an unhandled Windows App Runtime failure in `RedirectionRequest.cpp` (`0x8003001E`, `wil::ResultException`). The managed timeout does not safely cancel the pending native redirection. This matches the Windows App SDK guidance that the caller must await redirection before exiting: https://learn.microsoft.com/windows/apps/windows-app-sdk/applifecycle/applifecycle-instancing
- **Redirected activation lifetime:** Windows App SDK keeps the redirected activation request alive through the synchronous `AppInstance.Activated` event. MAUI now waits for the dispatched UI lifecycle handlers to finish before that event callback returns. This prevents the redirecting process from releasing marshaled resources before the UI consumes the activation, while preserving lifecycle exception behavior and avoiding a destructive timeout.
- **Public interface compatibility:** the new Windows member on the already-shipped `IPlatformWebAuthenticatorCallback` has a default implementation returning `false`. Existing custom implementers therefore remain source- and binary-compatible, while implementations that opt in can override it.
- **Warm activation delivery:** the same activation might theoretically reach both `OnLaunched` and `AppInstance.Activated`. This has not been reproduced and should be verified before adding deduplication.
- **Application-owned `AppInstance` key:** when an app owns the key, it also owns activation routing and must redirect protocol callbacks to the instance that started authentication. The Controls Sample now calls this out explicitly. A general fail-fast cannot distinguish a complete cooperative router from an incomplete one without rejecting the supported app-owned scenario.
- **Sequential callback schemes:** Windows App SDK 1.8 can rebind the current instance to a different key without calling `UnregisterKey`; the tested A-to-B flow completed successfully. MAUI intentionally avoids `UnregisterKey` because registering another key after it is unsafe (`microsoft/WindowsAppSDK#4420`).

Thank you @kubaflo for suggesting a fresh PR and for the previous reviews.
