### PR TITLE
[iOS/Mac] Fix UI becoming unresponsive when adding many Entry/Editor children to AbsoluteLayout

### DIFF
--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
@@ -876,9 +876,11 @@ namespace Microsoft.Maui.Controls.Platform
 
 			if (PlatformView != null && OperatingSystem.IsIOSVersionAtLeast(11))
 			{
-				for (int i = PlatformView.Interactions.Length - 1; i >= 0; i--)
+				// Cache Interactions; each access marshals the whole native array (see #34396).
+				var interactions = PlatformView.Interactions;
+				for (int i = interactions.Length - 1; i >= 0; i--)
 				{
-					var interaction = (IUIInteraction)PlatformView.Interactions[i];
+					var interaction = (IUIInteraction)interactions[i];
 					if (interaction is FakeRightClickContextMenuInteraction && !_interactions.Contains(interaction))
 					{
 						PlatformView.RemoveInteraction(interaction);

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34396.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34396.cs
@@ -1,0 +1,140 @@
+using System.Diagnostics;
+using Microsoft.Maui.Layouts;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 34396, "[iOS, MacCatalyst] UI freezes when adding a large number of Editors to a layout", PlatformAffected.iOS | PlatformAffected.macOS)]
+public class Issue34396 : ContentPage
+{
+	public record struct Widget(double X, double Y, double W, double H);
+	readonly List<(Editor Editor, Widget Item)> _items = new();
+
+	readonly AbsoluteLayout _canvas;
+	readonly Label _statusLabel;
+	readonly Button _clickedButton;
+
+	int _count;
+
+	public Issue34396()
+	{
+		var addButton = new Button
+		{
+			Text = "Add 200 Editors",
+			AutomationId = "AddEditorsButton"
+		};
+		addButton.Clicked += OnAddEditorsClicked;
+
+		_clickedButton = new Button
+		{
+			Text = "Clicked 0",
+			AutomationId = "ClickedButton"
+		};
+		_clickedButton.Clicked += Button_Clicked;
+
+		var clearButton = new Button
+		{
+			Text = "Clear",
+			AutomationId = "ClearButton"
+		};
+		clearButton.Clicked += OnClearClicked;
+
+		_statusLabel = new Label
+		{
+			Text = "Ready",
+			AutomationId = "StatusLabel34396"
+		};
+
+		_canvas = new AbsoluteLayout
+		{
+			WidthRequest = 2000,
+			HeightRequest = 3000,
+			BackgroundColor = Color.FromArgb("#202020")
+		};
+
+		var buttons = new HorizontalStackLayout
+		{
+			Spacing = 8,
+			Children = { addButton, _clickedButton, clearButton }
+		};
+
+		var grid = new Grid
+		{
+			Padding = 12,
+			RowDefinitions =
+			{
+				new RowDefinition(GridLength.Auto),
+				new RowDefinition(GridLength.Auto),
+				new RowDefinition(GridLength.Star)
+			}
+		};
+
+		grid.Add(buttons, 0, 0);
+		grid.Add(_statusLabel, 0, 1);
+		grid.Add(new ScrollView { Content = _canvas }, 0, 2);
+
+		Content = grid;
+	}
+
+	void PrepareItems(int count = 200)
+	{
+		_items.Clear();
+
+		for (int i = 0; i < count; i++)
+		{
+			double x = (i * 12) % 1800;
+			double y = (i * 15) % 2800;
+
+			var editor = new Editor
+			{
+				Text = $"Item {i}",
+				FontSize = 12,
+				BackgroundColor = Colors.Gray,
+				TextColor = Colors.White,
+				IsReadOnly = true
+			};
+
+			_items.Add((editor, new Widget(x, y, 120, 30)));
+		}
+
+		_statusLabel.Text = $"Prepared {_items.Count} editors.";
+	}
+
+	void OnAddEditorsClicked(object sender, EventArgs e)
+	{
+		PrepareItems();
+
+		var stopwatch = Stopwatch.StartNew();
+
+		foreach (var item in _items)
+		{
+			Dispatcher.Dispatch(() =>
+			{
+				_canvas.Children.Add(item.Editor);
+				AbsoluteLayout.SetLayoutBounds(
+					item.Editor,
+					new Rect(item.Item.X, item.Item.Y, item.Item.W, item.Item.H));
+			});
+		}
+
+		_statusLabel.Text = "Processing…";
+
+		Dispatcher.Dispatch(() =>
+		{
+			stopwatch.Stop();
+			_statusLabel.Text = $"Completed:{stopwatch.ElapsedMilliseconds}";
+		});
+	}
+
+	void OnClearClicked(object sender, EventArgs e)
+	{
+		_canvas.Children.Clear();
+		_items.Clear();
+		_statusLabel.Text = "Cleared.";
+	}
+
+	void Button_Clicked(object sender, EventArgs e)
+	{
+		_count += 1;
+		_clickedButton.Text = "Clicked " + _count.ToString();
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34396.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34396.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Globalization;
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue34396 : _IssuesUITest
+{
+	public Issue34396(TestDevice device) : base(device) { }
+
+	public override string Issue => "[iOS, MacCatalyst] UI freezes when adding a large number of Editors to a layout";
+
+	[Test]
+	[Category(UITestCategories.Editor)]
+	public void AddingManyEditorsDoesNotFreezeUI()
+	{
+		App.WaitForElement("AddEditorsButton");
+
+		App.Tap("AddEditorsButton");
+
+		App.WaitForTextToBePresentInElement("StatusLabel34396", "Completed:", TimeSpan.FromSeconds(60));
+
+		var status = App.FindElement("StatusLabel34396").GetText() ?? string.Empty;
+		var elapsedMs = long.Parse(status.Replace("Completed:", string.Empty, StringComparison.Ordinal).Trim(), CultureInfo.InvariantCulture);
+
+		Assert.That(elapsedMs, Is.LessThan(10000),
+			$"Adding 200 editors took {elapsedMs} ms on the UI thread. The freeze from #34396 has regressed (expected well under 10000 ms).");
+
+		App.Tap("ClickedButton");
+		Assert.That(App.FindElement("ClickedButton").GetText(), Is.EqualTo("Clicked 1"),
+			"The button should respond after adding 200 editors, proving the UI is not frozen.");
+	}
+}

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -648,9 +648,11 @@ namespace Microsoft.Maui.Platform
 				}
 				else
 				{
-					if (platformView.Interactions is not null)
+					// Cache Interactions; each access marshals the whole native array (see #34396).
+					var interactions = platformView.Interactions;
+					if (interactions is not null)
 					{
-						foreach (var ia in platformView.Interactions)
+						foreach (var ia in interactions)
 						{
 							if (ia is UIToolTipInteraction toolTipInteraction)
 							{


### PR DESCRIPTION
 <!-- Please let the below note in for people that find this PR -->
   > [!NOTE]
   > Are you waiting for the changes in this PR to be merged?
   > It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. 
  Thank you!
 
### Root Cause
On iOS/MacCatalyst, `UIView.Interactions` is a native property — each read marshals the entire interactions array across the managed↔native interop boundary. A `UITextView` (the platform view behind `Editor`) carries ~22 interactions.

Two code paths in the gesture/handler setup re-read this property repeatedly per view instead of once:

* The gesture manager's recognizer-loading loop re-read it on every iteration (~2× per interaction).
* The tooltip lookup read it twice (a null-check followed by an enumeration).

Each `Editor` triggers this setup during layout. At ~200 editors, the redundant reads compounded into thousands of full-array interop marshals on the UI thread, freezing the app for ~20 seconds.

### Description of Change
Cache the `Interactions` array into a local variable and read it once in both paths, then iterate the cached copy.
The change is purely an elimination of redundant interop calls — iteration order, removal logic, and tooltip resolution are unchanged, so behavior is identical.
 
### Issues Fixed
Fixes #34396 
 
Tested the behaviour in the following platforms
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Screenshots
| Before Issue Fix | After Issue Fix |
|------------------|-----------------|
| <video width="350" alt="withoutfix" src="https://github.com/user-attachments/assets/46035bcb-8c52-4dc2-bb7f-5bb9f879a5cc" /><br><sub>iOS</sub> | <video width="350" alt="withfix" src="https://github.com/user-attachments/assets/48de15ae-8d2e-45d9-ad8a-93299285355a" /><br><sub>iOS</sub> |
| <video width="350" alt="withoutfix" src="https://github.com/user-attachments/assets/f2f11304-9bfc-4db4-9524-b1955fcb3482" /><br><sub>MacCatalyst</sub> | <video width="350" alt="withfix" src="https://github.com/user-attachments/assets/9de4605b-ee01-4b38-b444-0ad86b720ac6" /><br><sub>MacCatalyst</sub> |