### PR TITLE
[inflight regression] Fix Shell UI tests are failing in Candidate PR

### DIFF
--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -397,6 +397,27 @@ namespace Microsoft.Maui.Controls
 		/// <param name="value">The View to be displayed in the navigation bar.</param>
 		public static void SetTitleView(BindableObject obj, View value) => obj.SetValue(TitleViewProperty, value);
 
+		// Determines whether the Shell's Title was set by the user (explicit code, style, or a binding)
+		// as opposed to being mirrored from the current page by the renderer (FromHandler) or never set
+		// at all (DefaultValue). This lets ShellToolbar mirror the page title into Shell.Title for
+		// TitleView bindings without clobbering a title the user set intentionally.
+		internal bool IsTitleSetByUser()
+		{
+			if (GetIsBound(TitleProperty))
+				return true;
+
+			var context = GetContext(TitleProperty);
+			if (context is null)
+				return false;
+
+			var specificity = context.Values.GetSpecificity();
+			return specificity != SetterSpecificity.DefaultValue && specificity != SetterSpecificity.FromHandler;
+		}
+
+		// Returns the Title only when it was set by the user. Used by the native window title
+		// fallback so that a renderer-mirrored page title never leaks into the platform chrome.
+		internal string GetUserSetTitle() => IsTitleSetByUser() ? Title : null;
+
 		static void OnFlyoutBehaviorChanged(BindableObject bindable, object oldValue, object newValue)
 		{
 			var element = (Element)bindable;
@@ -2134,55 +2155,6 @@ namespace Microsoft.Maui.Controls
 			}
 
 			return currentPage;
-		}
-
-		// Returns true when Shell.Title holds a value the developer explicitly set
-		// (a direct value or a binding), as opposed to a title mirrored in from the
-		// current page by the toolbar renderer (SetterSpecificity.FromHandler).
-		// Used to keep renderer-generated titles from leaking into platform chrome
-		// such as the Window title while still exposing them for XAML bindings.
-		internal bool IsTitleSetByUser()
-		{
-			var titleContext = GetContext(TitleProperty);
-			if (titleContext == null)
-				return false;
-
-			if (titleContext.Bindings.Count > 0)
-				return true;
-
-			var specificity = titleContext.Values.GetSpecificity();
-			return specificity != SetterSpecificity.DefaultValue && specificity != SetterSpecificity.FromHandler;
-		}
-
-		// Tracks the last observed "is Title user-set" state so we can detect
-		// specificity flips (user <-> renderer-mirrored) that leave the string
-		// value unchanged. BindableObject suppresses PropertyChanged in that
-		// case, but Window/toolbar consumers still need to react because the
-		// specificity determines whether Title is exposed as the native Window
-		// title. See OnBindablePropertySet below.
-		bool _lastKnownTitleUserSet;
-
-		private protected override void OnBindablePropertySet(BindableProperty property, object original, object value, bool didChange, bool willFirePropertyChanged)
-		{
-			base.OnBindablePropertySet(property, original, value, didChange, willFirePropertyChanged);
-
-			// Fill the notification gap: when a set on TitleProperty flips the
-			// user-set/renderer-mirrored state but the string value is unchanged
-			// (or the incoming set had lower specificity than the current value),
-			// BindableObject won't raise PropertyChanged. Detect that here and
-			// synthesize the standard OnPropertyChanged so existing subscribers
-			// (Window.ShellPropertyChanged, ShellToolbar's Shell.PropertyChanged
-			// handler) refresh consistently — no new event or subscription needed.
-			if (property == TitleProperty)
-			{
-				var currentUserSet = IsTitleSetByUser();
-				if (currentUserSet != _lastKnownTitleUserSet)
-				{
-					_lastKnownTitleUserSet = currentUserSet;
-					if (!willFirePropertyChanged)
-						OnPropertyChanged(TitleProperty.PropertyName);
-				}
-			}
 		}
 
 		Element WalkToPage(Element element)

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -2154,6 +2154,37 @@ namespace Microsoft.Maui.Controls
 			return specificity != SetterSpecificity.DefaultValue && specificity != SetterSpecificity.FromHandler;
 		}
 
+		// Tracks the last observed "is Title user-set" state so we can detect
+		// specificity flips (user <-> renderer-mirrored) that leave the string
+		// value unchanged. BindableObject suppresses PropertyChanged in that
+		// case, but Window/toolbar consumers still need to react because the
+		// specificity determines whether Title is exposed as the native Window
+		// title. See OnBindablePropertySet below.
+		bool _lastKnownTitleUserSet;
+
+		private protected override void OnBindablePropertySet(BindableProperty property, object original, object value, bool didChange, bool willFirePropertyChanged)
+		{
+			base.OnBindablePropertySet(property, original, value, didChange, willFirePropertyChanged);
+
+			// Fill the notification gap: when a set on TitleProperty flips the
+			// user-set/renderer-mirrored state but the string value is unchanged
+			// (or the incoming set had lower specificity than the current value),
+			// BindableObject won't raise PropertyChanged. Detect that here and
+			// synthesize the standard OnPropertyChanged so existing subscribers
+			// (Window.ShellPropertyChanged, ShellToolbar's Shell.PropertyChanged
+			// handler) refresh consistently — no new event or subscription needed.
+			if (property == TitleProperty)
+			{
+				var currentUserSet = IsTitleSetByUser();
+				if (currentUserSet != _lastKnownTitleUserSet)
+				{
+					_lastKnownTitleUserSet = currentUserSet;
+					if (!willFirePropertyChanged)
+						OnPropertyChanged(TitleProperty.PropertyName);
+				}
+			}
+		}
+
 		Element WalkToPage(Element element)
 		{
 			switch (element)

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -2136,6 +2136,24 @@ namespace Microsoft.Maui.Controls
 			return currentPage;
 		}
 
+		// Returns true when Shell.Title holds a value the developer explicitly set
+		// (a direct value or a binding), as opposed to a title mirrored in from the
+		// current page by the toolbar renderer (SetterSpecificity.FromHandler).
+		// Used to keep renderer-generated titles from leaking into platform chrome
+		// such as the Window title while still exposing them for XAML bindings.
+		internal bool IsTitleSetByUser()
+		{
+			var titleContext = GetContext(TitleProperty);
+			if (titleContext == null)
+				return false;
+
+			if (titleContext.Bindings.Count > 0)
+				return true;
+
+			var specificity = titleContext.Values.GetSpecificity();
+			return specificity != SetterSpecificity.DefaultValue && specificity != SetterSpecificity.FromHandler;
+		}
+
 		Element WalkToPage(Element element)
 		{
 			switch (element)

--- a/src/Controls/src/Core/ShellToolbar.cs
+++ b/src/Controls/src/Core/ShellToolbar.cs
@@ -170,7 +170,7 @@ namespace Microsoft.Maui.Controls
 				Shell.GetTitleView(_shell));
 
 			var title = GetCurrentTitle();
-			if (!IsShellTitleSetByUser())
+			if (!_shell.IsTitleSetByUser())
 				_shell.SetValueFromRenderer(Shell.TitleProperty, title);
 
 			if (TitleView != null)
@@ -197,19 +197,6 @@ namespace Microsoft.Maui.Controls
 			}
 
 			return String.Empty;
-		}
-
-		bool IsShellTitleSetByUser()
-		{
-			var titleContext = _shell.GetContext(Shell.TitleProperty);
-			if (titleContext == null)
-				return false;
-
-			if (titleContext.Bindings.Count > 0)
-				return true;
-
-			var specificity = titleContext.Values.GetSpecificity();
-			return specificity != SetterSpecificity.DefaultValue && specificity != SetterSpecificity.FromHandler;
 		}
 	}
 }

--- a/src/Controls/src/Core/ShellToolbar.cs
+++ b/src/Controls/src/Core/ShellToolbar.cs
@@ -170,7 +170,7 @@ namespace Microsoft.Maui.Controls
 				Shell.GetTitleView(_shell));
 
 			var title = GetCurrentTitle();
-			if (!_shell.IsTitleSetByUser())
+			if (!IsShellTitleSetByUser())
 				_shell.SetValueFromRenderer(Shell.TitleProperty, title);
 
 			if (TitleView != null)
@@ -197,6 +197,19 @@ namespace Microsoft.Maui.Controls
 			}
 
 			return String.Empty;
+		}
+
+		bool IsShellTitleSetByUser()
+		{
+			var titleContext = _shell.GetContext(Shell.TitleProperty);
+			if (titleContext == null)
+				return false;
+
+			if (titleContext.Bindings.Count > 0)
+				return true;
+
+			var specificity = titleContext.Values.GetSpecificity();
+			return specificity != SetterSpecificity.DefaultValue && specificity != SetterSpecificity.FromHandler;
 		}
 	}
 }

--- a/src/Controls/src/Core/ShellToolbar.cs
+++ b/src/Controls/src/Core/ShellToolbar.cs
@@ -170,16 +170,18 @@ namespace Microsoft.Maui.Controls
 				Shell.GetTitleView(_shell));
 
 			var title = GetCurrentTitle();
-			if (!IsShellTitleSetByUser())
-				_shell.SetValueFromRenderer(Shell.TitleProperty, title);
 
-			if (TitleView != null)
-			{
-				Title = String.Empty;
-				return;
-			}
+			// Mirror the current page's title into Shell.Title so that bindings inside a custom
+			// TitleView (e.g. {Binding Title, Source={x:Reference shell}}) can resolve to it.
+			// Use SetValueFromRenderer (FromHandler specificity) so the value is recognized as
+			// renderer-generated and does not leak into the native window title (see Window.cs),
+			// and only when the user hasn't explicitly set Shell.Title themselves.
+			if (!_shell.IsTitleSetByUser())
+				_shell.SetValueFromRenderer(Page.TitleProperty, title);
 
-			Title = title;
+			// The native nav-bar title must be empty when a custom TitleView is present,
+			// otherwise it should reflect the current page title.
+			Title = TitleView != null ? String.Empty : title;
 		}
 
 		string GetCurrentTitle()
@@ -197,19 +199,6 @@ namespace Microsoft.Maui.Controls
 			}
 
 			return String.Empty;
-		}
-
-		bool IsShellTitleSetByUser()
-		{
-			var titleContext = _shell.GetContext(Shell.TitleProperty);
-			if (titleContext == null)
-				return false;
-
-			if (titleContext.Bindings.Count > 0)
-				return true;
-
-			var specificity = titleContext.Values.GetSpecificity();
-			return specificity != SetterSpecificity.DefaultValue && specificity != SetterSpecificity.FromHandler;
 		}
 	}
 }

--- a/src/Controls/src/Core/Window/Window.cs
+++ b/src/Controls/src/Core/Window/Window.cs
@@ -131,7 +131,15 @@ namespace Microsoft.Maui.Controls
 			private set => SetValue(IsActivatedPropertyKey, value);
 		}
 
-		string? ITitledElement.Title => Title ?? (Page as Shell)?.Title;
+		string? ITitledElement.Title => Title ?? GetUserSetShellTitle();
+
+		// Only fall back to Shell.Title for the platform Window title when the developer
+		// explicitly set it. The toolbar renderer mirrors the current page title into
+		// Shell.Title (with SetterSpecificity.FromHandler) so it can be used for bindings
+		// inside a custom TitleView; that renderer-generated value must not leak into the
+		// Window title/native chrome.
+		string? GetUserSetShellTitle() =>
+			Page is Shell shell && shell.IsTitleSetByUser() ? shell.Title : null;
 
 		public Page? Page
 		{

--- a/src/Controls/src/Core/Window/Window.cs
+++ b/src/Controls/src/Core/Window/Window.cs
@@ -131,15 +131,7 @@ namespace Microsoft.Maui.Controls
 			private set => SetValue(IsActivatedPropertyKey, value);
 		}
 
-		string? ITitledElement.Title => Title ?? GetUserSetShellTitle();
-
-		// Only fall back to Shell.Title for the platform Window title when the developer
-		// explicitly set it. The toolbar renderer mirrors the current page title into
-		// Shell.Title (with SetterSpecificity.FromHandler) so it can be used for bindings
-		// inside a custom TitleView; that renderer-generated value must not leak into the
-		// Window title/native chrome.
-		string? GetUserSetShellTitle() =>
-			Page is Shell shell && shell.IsTitleSetByUser() ? shell.Title : null;
+		string? ITitledElement.Title => Title ?? (Page as Shell)?.GetUserSetTitle();
 
 		public Page? Page
 		{

--- a/src/Controls/tests/Core.UnitTests/ShellToolbarTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellToolbarTests.cs
@@ -302,6 +302,37 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal("Updated Test Title", label.Text);
 		}
 
+		// Regression test for https://github.com/dotnet/maui/issues/36562
+		// PR #35800 made ShellToolbar mirror the current page's title into Shell.Title (via
+		// SetValueFromRenderer) so TitleView bindings like {Binding Title, Source={x:Reference Shell}}
+		// resolve correctly. That mirrored value leaked into the native window title
+		// (ITitledElement.Title), which previously stayed empty in this scenario, breaking Shell UI
+		// tests around title/flyout layout on macOS/Windows.
+		[Fact]
+		public void WindowNativeTitleDoesNotLeakToolbarMirroredPageTitle()
+		{
+			var contentPage = new ContentPage() { Title = "Test Title" };
+			var titleView = new VerticalStackLayout();
+
+			TestShell testShell = new TestShell(contentPage);
+			var window = new Window()
+			{
+				Page = testShell
+			};
+
+			Shell.SetTitleView(contentPage, titleView);
+
+			// Shell.Title is mirrored from the page for TitleView binding purposes...
+			Assert.Equal("Test Title", testShell.Title);
+
+			// ...but that mirrored value must NOT leak into the native window title fallback.
+			Assert.Null(((ITitledElement)window).Title);
+
+			contentPage.Title = "Updated Test Title";
+			Assert.Equal("Updated Test Title", testShell.Title);
+			Assert.Null(((ITitledElement)window).Title);
+		}
+
 		[Fact]
 		public void ShellTitleBindingIsNotOverwrittenByCurrentPageTitle()
 		{


### PR DESCRIPTION
### Root Cause

- PR #35800 fixed issue #35761, where Shell.Title returned null inside a custom Shell.TitleView, causing bindings such as {Binding Title, Source={x:Reference Shell}} to fail. The fix updated ShellToolbar.UpdateTitle() to mirror the current page's title into Shell.Title using SetValueFromRenderer whenever the user had not explicitly set Shell.Title.
- The regression occurred because Window.cs implements ITitledElement.Title as: string? ITitledElement.Title => Title ?? (Page as Shell)?.Title;
- Before PR #35800, Shell.Title remained null (or String.Empty) when a TitleView was active unless the user explicitly assigned a value. After the change, Shell.Title contained the renderer-mirrored page title. Although this mirrored value was intended only to support TitleView bindings, it was also consumed by Window.cs as the native window title fallback on macOS and Windows.
- As a result, the renderer-generated value unintentionally influenced native window title and layout behavior, causing several existing Shell UI tests (such as TitleViewHeightIsNotZero, VerifyShellFlyout_*, FlyoutContentOffsetsCorrectly, and GitHubIssue9440) to fail on macOS and Windows.


### Description of Change
The fix ensures a clear distinction between user-defined Shell.Title values and renderer-mirrored values while preserving the behavior introduced in PR #35800.

1. **Shell.cs**
- Added internal bool IsTitleSetByUser() to determine whether Shell.Title was explicitly set by the application (by checking bindings and SetterSpecificity, excluding DefaultValue and FromHandler).
- Added internal string? GetUserSetTitle() to return the title only when it was explicitly provided by the user; otherwise, it returns null.

2. **ShellToolbar.cs**
Retained the existing mirroring behavior, but made the intent explicit by mirroring the current page title only when !IsTitleSetByUser().

3. **Window.cs**
Updated ITitledElement.Title to use GetUserSetTitle() instead of directly accessing Shell.Title. This prevents renderer-mirrored values from being used as the native window title while continuing to honor explicitly assigned Shell.Title values.

This approach resolves the regression at the point where it affects native window behavior (Window.cs) without changing the TitleView binding functionality introduced in PR #35800.

### Validated the behaviour in the following platforms
- [ ] Android
- [x] Windows
- [ ] iOS
- [x] Mac

### Issues Fixed:
Fixes #36562 

### Screenshots
| Before  | After |
|---------|--------|
|  <img width="607" height="329" src="https://github.com/user-attachments/assets/01a9daa8-abfc-412e-9f47-49f2bca09f44"> |   <img width="607" height="329" src="https://github.com/user-attachments/assets/2195b1f0-e1a9-484e-99d7-b8bb73ec6060">  |