### PR TITLE
[XAML HR] Keep UpdateComponent() stable across generations (avoid EnC "deleted member" crash)

### DIFF
--- a/src/Controls/src/SourceGen/UpdateComponentCodeWriter.cs
+++ b/src/Controls/src/SourceGen/UpdateComponentCodeWriter.cs
@@ -147,9 +147,14 @@ static class UpdateComponentCodeWriter
 		INamedTypeSymbol rootType,
 		string accessModifier,
 		List<string> allPatchBodies,
-		int startVersion = 0)
+		int startVersion = 0,
+		bool forceEmitWhenEmpty = false)
 	{
-		if (allPatchBodies.Count == 0)
+		// When forceEmitWhenEmpty is set we still emit an (empty) UpdateComponent() body. This keeps the
+		// method present in the compilation after a structural reset clears the patch chain, so EnC /
+		// Hot Reload metadata-update sees a body *update* rather than a member *deletion* — the latter
+		// crashes the EnC delta emitter for a method that only ever existed in deltas (dotnet/roslyn#79898).
+		if (allPatchBodies.Count == 0 && !forceEmitWhenEmpty)
 			return null;
 
 		using var codeWriter = new IndentedTextWriter(new StringWriter(CultureInfo.InvariantCulture), "\t") { NewLine = NewLine };

--- a/src/Controls/src/SourceGen/XamlGenerator.cs
+++ b/src/Controls/src/SourceGen/XamlGenerator.cs
@@ -313,9 +313,28 @@ public class XamlGenerator : IIncrementalGenerator
 				var code = InitializeComponentCodeWriter.GenerateInitializeComponent(xamlItem, compilation, sourceProductionContext, xmlnsCache, typeCache);
 				sourceProductionContext.AddSource(GetHintName(xamlItem.ProjectItem, "xsg"), code);
 
-				// Emit UC source if a diff was computed
+				// Keep UpdateComponent() alive once it has been emitted for this file. If the branch logic
+				// above did not (re)generate it this iteration — e.g. a C# Hot Reload edit that leaves the
+				// XAML unchanged, an invalid-XAML parse error, or a structural change that cleared the patch
+				// chain — re-emit it anyway: with the current patches, or as an empty no-op body. A
+				// source-generated method that transiently disappears is seen by EnC / Hot Reload metadata-update
+				// as a member deletion, and deleting a method that only ever existed in EnC deltas crashes the
+				// delta emitter (dotnet/roslyn#79898).
+				if (ucCode == null
+					&& xamlItem.ProjectItem.EnableIncrementalHotReload
+					&& xamlItem.Xaml is not null
+					&& XamlHotReloadState.HasEmittedUpdateComponent(assemblyName, targetFramework, stateKey)
+					&& InitializeComponentCodeWriter.TryGetRootType(xamlItem, compilation, xmlnsCache, out var ucRootType, out var ucAccessModifier)
+					&& ucRootType != null)
+				{
+					var existingPatches = XamlHotReloadState.GetPatchBodies(assemblyName, targetFramework, stateKey);
+					ucCode = UpdateComponentCodeWriter.GenerateUpdateComponent(ucRootType, ucAccessModifier, existingPatches, forceEmitWhenEmpty: true);
+				}
+
+				// Emit UC source if present. Once emitted, it is kept alive across generations (see above).
 				if (ucCode != null)
 				{
+					XamlHotReloadState.MarkUpdateComponentEmitted(assemblyName, targetFramework, stateKey);
 					sourceProductionContext.AddSource(GetHintName(xamlItem.ProjectItem, "uc.xsg"), ucCode);
 				}
 			}

--- a/src/Controls/src/SourceGen/XamlHotReloadState.cs
+++ b/src/Controls/src/SourceGen/XamlHotReloadState.cs
@@ -61,6 +61,14 @@ internal static class XamlHotReloadState
 		/// On structural change, this list is cleared.
 		/// </summary>
 		public List<string> PatchBodies { get; } = new();
+
+		/// <summary>
+		/// True once an <c>UpdateComponent()</c> partial has been emitted for this file during the session.
+		/// Once set, the generator keeps re-emitting the method so it never transiently disappears from the
+		/// compilation — a vanished source-generated method is seen by EnC / Hot Reload metadata-update as a
+		/// member deletion and crashes the EnC delta emitter (dotnet/roslyn#79898).
+		/// </summary>
+		public bool UpdateComponentEmitted { get; set; }
 	}
 
 	/// <summary>
@@ -181,6 +189,34 @@ internal static class XamlHotReloadState
 			if (_cache.TryGetValue((assemblyName, targetFramework, relativePath), out var entry))
 				return new List<string>(entry.PatchBodies);
 			return new List<string>();
+		}
+	}
+
+	/// <summary>
+	/// Records that an <c>UpdateComponent()</c> partial has been emitted for the given file, so the
+	/// generator keeps re-emitting it and it never transiently disappears (see <see cref="CacheEntry.UpdateComponentEmitted"/>).
+	/// </summary>
+	public static void MarkUpdateComponentEmitted(string assemblyName, string targetFramework, string relativePath)
+	{
+		lock (_lock)
+		{
+			if (!_cache.TryGetValue((assemblyName, targetFramework, relativePath), out var entry))
+			{
+				entry = new CacheEntry();
+				_cache[(assemblyName, targetFramework, relativePath)] = entry;
+			}
+			entry.UpdateComponentEmitted = true;
+		}
+	}
+
+	/// <summary>
+	/// Returns <see langword="true"/> if an <c>UpdateComponent()</c> partial has already been emitted for the given file.
+	/// </summary>
+	public static bool HasEmittedUpdateComponent(string assemblyName, string targetFramework, string relativePath)
+	{
+		lock (_lock)
+		{
+			return _cache.TryGetValue((assemblyName, targetFramework, relativePath), out var entry) && entry.UpdateComponentEmitted;
 		}
 	}
 

--- a/src/Controls/tests/SourceGen.UnitTests/XamlIncrementalHotReloadPipelineTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/XamlIncrementalHotReloadPipelineTests.cs
@@ -738,6 +738,54 @@ public class XamlIncrementalHotReloadPipelineTests : IDisposable
 	}
 
 	[Fact]
+	public void CSharpOnlyEdit_AfterPatch_KeepsUpdateComponentAlive()
+	{
+		// Regression for dotnet/roslyn#79898: once UpdateComponent() has been emitted, a generator
+		// re-run triggered by a C# Hot Reload edit (the compilation changes while the XAML is
+		// unchanged) must NOT drop the generated UpdateComponent() partial. A source-generated method
+		// that transiently disappears is seen by Edit-and-Continue as a member *deletion*, and deleting
+		// a method that only ever existed in EnC deltas crashes the EnC delta emitter
+		// (DefinitionMap.GetPreviousMethodHandle). Before the fix, run 3 below produced no UC at all.
+		XamlHotReloadState.Reset();
+
+		var compilation = CreateCompilation();
+		var fileV1 = MakeFile(PageXamlV1);
+		var fileV2 = MakeFile(PageXamlV2_PropertyChange);
+
+		ISourceGenerator generator = new XamlGenerator().AsSourceGenerator();
+		var options = new Microsoft.CodeAnalysis.GeneratorDriverOptions(
+			disabledOutputs: Microsoft.CodeAnalysis.IncrementalGeneratorOutputKind.None,
+			trackIncrementalGeneratorSteps: true);
+
+		Microsoft.CodeAnalysis.GeneratorDriver driver = CSharpGeneratorDriver.Create([generator], driverOptions: options)
+			.AddAdditionalTexts(System.Collections.Immutable.ImmutableArray.Create<Microsoft.CodeAnalysis.AdditionalText>(fileV1.Text))
+			.WithUpdatedAnalyzerConfigOptions(new OptionsProvider([fileV1]));
+
+		// Run 1: seed at version 0 — no UC yet.
+		driver = driver.RunGenerators(compilation);
+		Assert.Null(FindUCSource(driver.GetRunResult(), "uc.xsg"));
+
+		// Run 2: real property change → UpdateComponent() is emitted.
+		driver = driver
+			.ReplaceAdditionalText(fileV1.Text, fileV2.Text)
+			.WithUpdatedAnalyzerConfigOptions(new OptionsProvider([fileV2]))
+			.RunGenerators(compilation);
+		Assert.NotNull(FindUCSource(driver.GetRunResult(), "uc.xsg"));
+
+		// Run 3: XAML unchanged, but the compilation changes (a C# Hot Reload edit adds a type). The
+		// generator re-runs for the unchanged XAML; UpdateComponent() must survive, re-emitted with the
+		// same accumulated patch chain (version 0→1) rather than dropped.
+		var compilationAfterCSharpEdit = compilation.AddSyntaxTrees(
+			CSharpSyntaxTree.ParseText("namespace TestApp { class __CSharpEditMarker { } }"));
+		driver = driver.RunGenerators(compilationAfterCSharpEdit);
+
+		var run3Uc = FindUCSource(driver.GetRunResult(), "uc.xsg");
+		Assert.NotNull(run3Uc);
+		Assert.Contains("__version == 0", run3Uc!, StringComparison.Ordinal);
+		Assert.Contains("__version = 1", run3Uc!, StringComparison.Ordinal);
+	}
+
+	[Fact]
 	public void SecondRun_StructuralChange_EmitsUCWithChildAdd()
 	{
 		// Arrange: V3 adds a Button child — our child add/remove support handles this incrementally


### PR DESCRIPTION
## Summary

Under XAML Incremental Hot Reload, the generated `UpdateComponent()` partial (`*.uc.xsg.g.cs`) could **transiently disappear** from the compilation between generator runs. Edit-and-Continue / Hot Reload metadata-update reads a vanished source-generated method as a **member deletion**, and deleting a method that only ever existed in EnC deltas crashes the Roslyn EnC delta emitter with a `NullReferenceException` in `DefinitionMap.GetPreviousMethodHandle` (surfaced to the user as `ENC1002: Cannot apply changes -- unexpected error`). The Hot Reload session then can't apply further updates until a rebuild.

This is the MAUI-side trigger for **dotnet/roslyn#79898**.

## Root cause

`XamlGenerator` only emitted the `uc.xsg` document when the current run produced a `ucCode`. It was left `null` — dropping the already-emitted `UpdateComponent()` — in several common cases:

- a **C# Hot Reload edit** (the compilation changes while the XAML is unchanged, so the generator re-runs but takes the "XAML unchanged" path);
- an **invalid-XAML parse error**;
- a **structural change** that clears the patch chain (`UpdateAndClearPatches`).

## Fix

Once `UpdateComponent()` has been emitted for a file during the session, always re-emit it so EnC only ever sees an **add** (once) followed by **updates** — never a **delete**:

- `XamlHotReloadState` tracks `UpdateComponentEmitted` per file (`MarkUpdateComponentEmitted` / `HasEmittedUpdateComponent`).
- `UpdateComponentCodeWriter.GenerateUpdateComponent` gains `forceEmitWhenEmpty` to emit an **empty no-op body** after a structural reset (instead of returning `null`).
- `XamlGenerator` adds a post-branch fallback: when `ucCode` is `null` but the method was already emitted, re-emit it — with the current patch chain, or empty after a structural reset.

Gated on `HasEmittedUpdateComponent`, so **nothing is introduced into the baseline build** (a file that never emitted `UpdateComponent()` still won't emit one).

## Test

`XamlIncrementalHotReloadPipelineTests.CSharpOnlyEdit_AfterPatch_KeepsUpdateComponentAlive`:

1. Seed (no UC).
2. Property change → `UpdateComponent()` emitted.
3. **XAML unchanged but the compilation changes** (simulating a C# Hot Reload edit) → asserts `UpdateComponent()` is still emitted, re-emitted with the same `__version == 0 → 1` patch chain rather than dropped.

Fails before this change (UC dropped on run 3); passes after. The existing "no UC" / "no-op edit" pipeline tests continue to pass (the fallback is inert until the method is first emitted).

## Notes

- This is a **workaround** that avoids the add/delete churn from the generator side; the underlying Roslyn EnC robustness issue is tracked in **dotnet/roslyn#79898**.
- The `UpdateComponent()` add/delete churn was confirmed from captured EnC file logs: the baseline assembly never contained `UpdateComponent`, the method appeared only in EnC delta metadata, and a later generation regenerated the document without it — the delete that crashes the EnC emitter.
