### PR TITLE
[Net11] [iOS/MacCatalyst] Migrate FlyoutPage to handler architecture

### DIFF
--- a/src/Controls/src/Core/FlyoutPage/FlyoutPage.Mapper.cs
+++ b/src/Controls/src/Core/FlyoutPage/FlyoutPage.Mapper.cs
@@ -1,5 +1,8 @@
 using System;
-using Microsoft.Maui.Controls.Compatibility;
+using Microsoft.Maui.Handlers;
+#if IOS || MACCATALYST
+using UIKit;
+#endif
 
 namespace Microsoft.Maui.Controls
 {
@@ -9,7 +12,20 @@ namespace Microsoft.Maui.Controls
 		internal new static void RemapForControls()
 		{
 			FlyoutViewHandler.Mapper.ReplaceMapping<IFlyoutView, IFlyoutViewHandler>(nameof(FlyoutLayoutBehavior), MapFlyoutLayoutBehavior);
-#if IOS
+#if IOS || MACCATALYST
+			// Fill configuration record (Core → Controls bridge)
+			FlyoutViewHandler.ControlsConfiguration = new(
+				OnPresentedChangedByGesture: FlyoutPage.OnPresentedChangedByGesture,
+				OnLayoutBoundsChanged: FlyoutPage.OnLayoutBoundsChanged,
+				OnLeftBarButtonNeedsUpdate: FlyoutPage.OnLeftBarButtonNeedsUpdate,
+				OnHandlerDisconnected: FlyoutPage.OnHandlerDisconnected
+			);
+
+			// iOS-specific property mappers
+			FlyoutViewHandler.Mapper.AppendToMapping(
+				PlatformConfiguration.iOSSpecific.FlyoutPage.ApplyShadowProperty.PropertyName,
+				MapApplyShadow);
+			FlyoutViewHandler.Mapper.AppendToMapping(nameof(IView.FlowDirection), MapFlowDirection);
 			FlyoutViewHandler.Mapper.ReplaceMapping<IFlyoutView, IFlyoutViewHandler>(nameof(PlatformConfiguration.iOSSpecific.Page.PrefersHomeIndicatorAutoHiddenProperty), MapPrefersHomeIndicatorAutoHiddenProperty);
 			FlyoutViewHandler.Mapper.ReplaceMapping<IFlyoutView, IFlyoutViewHandler>(nameof(PlatformConfiguration.iOSSpecific.Page.PrefersStatusBarHiddenProperty), MapPrefersPrefersStatusBarHiddenProperty);
 #endif
@@ -23,15 +39,21 @@ namespace Microsoft.Maui.Controls
 			handler.UpdateValue(nameof(IFlyoutView.FlyoutBehavior));
 		}
 
-#if IOS
+#if IOS || MACCATALYST
 		internal static void MapPrefersHomeIndicatorAutoHiddenProperty(IFlyoutViewHandler handler, IFlyoutView view)
 		{
-			handler.UpdateValue(nameof(PlatformConfiguration.iOSSpecific.Page.PrefersHomeIndicatorAutoHiddenProperty));
+			if (handler is IPlatformViewHandler { ViewController: { } vc })
+			{
+				vc.SetNeedsUpdateOfHomeIndicatorAutoHidden();
+			}
 		}
 
 		internal static void MapPrefersPrefersStatusBarHiddenProperty(IFlyoutViewHandler handler, IFlyoutView view)
 		{
-			handler.UpdateValue(nameof(PlatformConfiguration.iOSSpecific.Page.PrefersStatusBarHiddenProperty));
+			if (handler is IPlatformViewHandler { ViewController: { } vc })
+			{
+				vc.SetNeedsStatusBarAppearanceUpdate();
+			}
 		}
 #endif
 

--- a/src/Controls/src/Core/FlyoutPage/FlyoutPage.Mapper.cs
+++ b/src/Controls/src/Core/FlyoutPage/FlyoutPage.Mapper.cs
@@ -26,8 +26,8 @@ namespace Microsoft.Maui.Controls
 				PlatformConfiguration.iOSSpecific.FlyoutPage.ApplyShadowProperty.PropertyName,
 				MapApplyShadow);
 			FlyoutViewHandler.Mapper.AppendToMapping(nameof(IView.FlowDirection), MapFlowDirection);
-			FlyoutViewHandler.Mapper.ReplaceMapping<IFlyoutView, IFlyoutViewHandler>(nameof(PlatformConfiguration.iOSSpecific.Page.PrefersHomeIndicatorAutoHiddenProperty), MapPrefersHomeIndicatorAutoHiddenProperty);
-			FlyoutViewHandler.Mapper.ReplaceMapping<IFlyoutView, IFlyoutViewHandler>(nameof(PlatformConfiguration.iOSSpecific.Page.PrefersStatusBarHiddenProperty), MapPrefersPrefersStatusBarHiddenProperty);
+			FlyoutViewHandler.Mapper.ReplaceMapping<IFlyoutView, IFlyoutViewHandler>(PlatformConfiguration.iOSSpecific.Page.PrefersHomeIndicatorAutoHiddenProperty.PropertyName, MapPrefersHomeIndicatorAutoHiddenProperty);
+			FlyoutViewHandler.Mapper.ReplaceMapping<IFlyoutView, IFlyoutViewHandler>(PlatformConfiguration.iOSSpecific.Page.PrefersStatusBarHiddenProperty.PropertyName, MapPrefersPrefersStatusBarHiddenProperty);
 #endif
 #if WINDOWS
 			FlyoutViewHandler.Mapper.ReplaceMapping<IFlyoutView, IFlyoutViewHandler>(nameof(PlatformConfiguration.WindowsSpecific.FlyoutPage.CollapseStyleProperty), MapCollapseStyle);

--- a/src/Controls/src/Core/FlyoutPage/FlyoutPage.iOS.cs
+++ b/src/Controls/src/Core/FlyoutPage/FlyoutPage.iOS.cs
@@ -21,19 +21,14 @@ namespace Microsoft.Maui.Controls
         // we subscribed with.
         PropertyChangedEventHandler? _flyoutPropertyChangedHandler;
 
-        // ═══════════════════════════════════════════════
-        // Write-Back Callbacks (IFlyoutContainerDelegate → Controls)
-        // ═══════════════════════════════════════════════
 
         internal static void OnPresentedChangedByGesture(IFlyoutView view, bool isPresented)
         {
             if (view is FlyoutPage fp)
             {
-                // Guard: don't write IsPresented=false when ShouldShowSplitMode is active.
-                // During rotation (ViewWillTransitionToSize), the orientation hasn't actually
-                // changed yet, so ShouldShowSplitMode may still return true. Writing false
-                // at this point triggers OnIsPresentedPropertyChanging validation which throws
-                // InvalidOperationException. The old renderer had the same guard in UpdatePresented.
+                // Guard: during rotation, ShouldShowSplitMode may still return true while
+                // orientation hasn't settled. Writing false triggers InvalidOperationException
+                // in OnIsPresentedPropertyChanging validation.
                 if (!isPresented && ((IFlyoutPageController)fp).ShouldShowSplitMode)
                 {
                     return;
@@ -63,10 +58,8 @@ namespace Microsoft.Maui.Controls
                 return;
             }
 
-            // Subscribe to Flyout's property changes for icon/title updates
             fp.SubscribeToFlyoutPropertyChanges();
 
-            // Get the detail's ViewController via its handler
             if (fp.Detail?.Handler is not IPlatformViewHandler detailHandler)
             {
                 return;
@@ -78,7 +71,7 @@ namespace Microsoft.Maui.Controls
                 return;
             }
 
-            // If detail VC is a UINavigationController, use its root VC (same as renderer)
+            // If detail VC is a UINavigationController, use its root VC
             var targetVC = detailVC is UINavigationController nav
                 ? nav.ViewControllers?.FirstOrDefault() ?? detailVC
                 : detailVC;
@@ -167,7 +160,6 @@ namespace Microsoft.Maui.Controls
                 flyoutPage.IsPresented = !flyoutPage.IsPresented;
             };
 
-            // Load icon asynchronously (same pattern as renderer)
             var mauiContext = flyoutPage.FindMauiContext();
             if (mauiContext is null)
             {
@@ -180,7 +172,7 @@ namespace Microsoft.Maui.Controls
 
                 if (icon is not null)
                 {
-                    // Scale icon to fit nav bar (max 44pt height) — same as renderer
+                    // Scale icon to fit nav bar (max 44pt height)
                     var originalSize = icon.Size;
                     if (originalSize.Height > 44)
                     {
@@ -198,7 +190,7 @@ namespace Microsoft.Maui.Controls
                     }
                     catch (Exception)
                     {
-                        // Match renderer: catch potential exception from UIBarButtonItem creation
+                        // UIBarButtonItem creation can throw
                     }
                 }
 
@@ -209,8 +201,7 @@ namespace Microsoft.Maui.Controls
                         new UIBarButtonItem(flyoutPage.Flyout?.Title ?? string.Empty, UIBarButtonItemStyle.Plain, onItemTapped);
                 }
 
-                // Give the hamburger button an AutomationId and VoiceOver label/hint,
-                // like the legacy renderer did (NavigationRenderer.SetFlyoutLeftBarButton).
+                // Set AutomationId and VoiceOver label/hint on the hamburger button.
                 if (!string.IsNullOrEmpty(flyoutPage.AutomationId))
                 {
                     targetVC.NavigationItem.LeftBarButtonItem.AccessibilityIdentifier = $"btn_{flyoutPage.AutomationId}";
@@ -225,9 +216,6 @@ namespace Microsoft.Maui.Controls
             });
         }
 
-        // ═══════════════════════════════════════════════
-        // iOS-Specific Mappers
-        // ═══════════════════════════════════════════════
 
         internal static void MapApplyShadow(IFlyoutViewHandler handler, IFlyoutView view)
         {

--- a/src/Controls/src/Core/FlyoutPage/FlyoutPage.iOS.cs
+++ b/src/Controls/src/Core/FlyoutPage/FlyoutPage.iOS.cs
@@ -1,0 +1,254 @@
+using System;
+using System.ComponentModel;
+using System.Linq;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Graphics.Platform;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Platform;
+using UIKit;
+
+namespace Microsoft.Maui.Controls
+{
+    public partial class FlyoutPage
+    {
+        // Track the flyout page this specific FlyoutPage instance is subscribed to
+        // for icon/title property changes. Instance-scoped (not static) so multiple
+        // FlyoutPage instances (multi-window, modal FlyoutPage, etc.) don't clobber
+        // each other's subscriptions.
+        WeakReference<Page>? _subscribedFlyout;
+
+        // Cached delegate instance so we can unsubscribe the exact same handler
+        // we subscribed with.
+        PropertyChangedEventHandler? _flyoutPropertyChangedHandler;
+
+        // ═══════════════════════════════════════════════
+        // Write-Back Callbacks (IFlyoutContainerDelegate → Controls)
+        // ═══════════════════════════════════════════════
+
+        internal static void OnPresentedChangedByGesture(IFlyoutView view, bool isPresented)
+        {
+            if (view is FlyoutPage fp)
+            {
+                // Guard: don't write IsPresented=false when ShouldShowSplitMode is active.
+                // During rotation (ViewWillTransitionToSize), the orientation hasn't actually
+                // changed yet, so ShouldShowSplitMode may still return true. Writing false
+                // at this point triggers OnIsPresentedPropertyChanging validation which throws
+                // InvalidOperationException. The old renderer had the same guard in UpdatePresented.
+                if (!isPresented && ((IFlyoutPageController)fp).ShouldShowSplitMode)
+                {
+                    return;
+                }
+
+                fp.IsPresented = isPresented;
+            }
+            else
+            {
+                view.IsPresented = isPresented;
+            }
+        }
+
+        internal static void OnLayoutBoundsChanged(IFlyoutView view, Rect flyoutBounds, Rect detailBounds)
+        {
+            if (view is IFlyoutPageController controller)
+            {
+                controller.FlyoutBounds = flyoutBounds;
+                controller.DetailBounds = detailBounds;
+            }
+        }
+
+        internal static void OnLeftBarButtonNeedsUpdate(IFlyoutView view)
+        {
+            if (view is not FlyoutPage fp)
+            {
+                return;
+            }
+
+            // Subscribe to Flyout's property changes for icon/title updates
+            fp.SubscribeToFlyoutPropertyChanges();
+
+            // Get the detail's ViewController via its handler
+            if (fp.Detail?.Handler is not IPlatformViewHandler detailHandler)
+            {
+                return;
+            }
+
+            var detailVC = detailHandler.ViewController;
+            if (detailVC is null)
+            {
+                return;
+            }
+
+            // If detail VC is a UINavigationController, use its root VC (same as renderer)
+            var targetVC = detailVC is UINavigationController nav
+                ? nav.ViewControllers?.FirstOrDefault() ?? detailVC
+                : detailVC;
+
+            UpdateFlyoutLeftBarButton(targetVC, fp);
+        }
+
+        /// <summary>
+        /// Called when this FlyoutPage's handler is disconnected, so its flyout
+        /// icon/title subscription doesn't outlive the handler.
+        /// </summary>
+        internal static void OnHandlerDisconnected(IFlyoutView view)
+        {
+            if (view is FlyoutPage fp)
+            {
+                fp.UnsubscribeFlyoutPropertyChanges();
+            }
+        }
+
+        void SubscribeToFlyoutPropertyChanges()
+        {
+            var flyout = Flyout;
+            if (flyout is null)
+            {
+                return;
+            }
+
+            // Unsubscribe from this instance's previous flyout if it changed
+            if (_subscribedFlyout is not null && _subscribedFlyout.TryGetTarget(out var oldFlyout))
+            {
+                if (ReferenceEquals(oldFlyout, flyout))
+                {
+                    return; // Already subscribed to this flyout
+                }
+
+                if (_flyoutPropertyChangedHandler is not null)
+                {
+                    oldFlyout.PropertyChanged -= _flyoutPropertyChangedHandler;
+                }
+            }
+
+            _flyoutPropertyChangedHandler = OnFlyoutPagePropertyChanged;
+            flyout.PropertyChanged += _flyoutPropertyChangedHandler;
+            _subscribedFlyout = new WeakReference<Page>(flyout);
+        }
+
+        /// <summary>
+        /// Unsubscribes from the currently-tracked flyout's property changes.
+        /// Called when this FlyoutPage's handler is disconnected.
+        /// </summary>
+        void UnsubscribeFlyoutPropertyChanges()
+        {
+            if (_subscribedFlyout is not null &&
+                _subscribedFlyout.TryGetTarget(out var flyout) &&
+                _flyoutPropertyChangedHandler is not null)
+            {
+                flyout.PropertyChanged -= _flyoutPropertyChangedHandler;
+            }
+
+            _flyoutPropertyChangedHandler = null;
+            _subscribedFlyout = null;
+        }
+
+        void OnFlyoutPagePropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == Page.IconImageSourceProperty.PropertyName ||
+                e.PropertyName == Page.TitleProperty.PropertyName)
+            {
+                if (sender is Page flyoutPage && flyoutPage.Parent is FlyoutPage fp)
+                {
+                    OnLeftBarButtonNeedsUpdate(fp);
+                }
+            }
+        }
+
+        static void UpdateFlyoutLeftBarButton(UIViewController targetVC, FlyoutPage flyoutPage)
+        {
+            if (!flyoutPage.ShouldShowToolbarButton())
+            {
+                targetVC.NavigationItem.LeftBarButtonItem = null;
+                return;
+            }
+
+            EventHandler onItemTapped = (sender, e) =>
+            {
+                flyoutPage.IsPresented = !flyoutPage.IsPresented;
+            };
+
+            // Load icon asynchronously (same pattern as renderer)
+            var mauiContext = flyoutPage.FindMauiContext();
+            if (mauiContext is null)
+            {
+                return;
+            }
+
+            flyoutPage.Flyout.IconImageSource.LoadImage(mauiContext, result =>
+            {
+                var icon = result?.Value;
+
+                if (icon is not null)
+                {
+                    // Scale icon to fit nav bar (max 44pt height) — same as renderer
+                    var originalSize = icon.Size;
+                    if (originalSize.Height > 44)
+                    {
+                        if (flyoutPage.Flyout.IconImageSource is not FontImageSource fontImageSource ||
+                            !fontImageSource.IsSet(FontImageSource.SizeProperty))
+                        {
+                            icon = icon.ResizeImageSource(originalSize.Width, 44f, originalSize);
+                        }
+                    }
+
+                    try
+                    {
+                        targetVC.NavigationItem.LeftBarButtonItem =
+                            new UIBarButtonItem(icon, UIBarButtonItemStyle.Plain, onItemTapped);
+                    }
+                    catch (Exception)
+                    {
+                        // Match renderer: catch potential exception from UIBarButtonItem creation
+                    }
+                }
+
+                if (icon is null || targetVC.NavigationItem.LeftBarButtonItem is null)
+                {
+                    // Fallback: use Flyout.Title as text button
+                    targetVC.NavigationItem.LeftBarButtonItem =
+                        new UIBarButtonItem(flyoutPage.Flyout?.Title ?? string.Empty, UIBarButtonItemStyle.Plain, onItemTapped);
+                }
+
+                // Give the hamburger button an AutomationId and VoiceOver label/hint,
+                // like the legacy renderer did (NavigationRenderer.SetFlyoutLeftBarButton).
+                if (!string.IsNullOrEmpty(flyoutPage.AutomationId))
+                {
+                    targetVC.NavigationItem.LeftBarButtonItem.AccessibilityIdentifier = $"btn_{flyoutPage.AutomationId}";
+                }
+
+                // Apply FlyoutPage's SemanticProperties (Description/Hint), if set.
+                var semantics = SemanticProperties.UpdateSemantics(flyoutPage, null);
+                if (semantics is not null)
+                {
+                    targetVC.NavigationItem.LeftBarButtonItem.UpdateSemantics(semantics);
+                }
+            });
+        }
+
+        // ═══════════════════════════════════════════════
+        // iOS-Specific Mappers
+        // ═══════════════════════════════════════════════
+
+        internal static void MapApplyShadow(IFlyoutViewHandler handler, IFlyoutView view)
+        {
+            if (handler is FlyoutViewHandler h && h._manager is { } manager && view is BindableObject bo)
+            {
+                var applyShadow = PlatformConfiguration.iOSSpecific.FlyoutPage.GetApplyShadow(bo);
+                manager.UpdateApplyShadow(applyShadow);
+            }
+        }
+
+        internal static void MapFlowDirection(IFlyoutViewHandler handler, IFlyoutView view)
+        {
+            if (handler is FlyoutViewHandler h && h._manager is { } manager && view is IView v)
+            {
+                // Use the effective/inherited flow direction rather than the raw
+                // FlowDirection. A FlyoutPage left at the default MatchParent should
+                // follow an RTL app/window, not be treated as LTR.
+                var flowDirection = (view as IVisualElementController)?.EffectiveFlowDirection.ToFlowDirection()
+                    ?? v.FlowDirection;
+                manager.UpdateFlowDirection(flowDirection);
+            }
+        }
+    }
+}

--- a/src/Controls/src/Core/FlyoutPage/FlyoutPage.iOS.cs
+++ b/src/Controls/src/Core/FlyoutPage/FlyoutPage.iOS.cs
@@ -155,19 +155,31 @@ namespace Microsoft.Maui.Controls
                 return;
             }
 
-            EventHandler onItemTapped = (sender, e) =>
-            {
-                flyoutPage.IsPresented = !flyoutPage.IsPresented;
-            };
-
             var mauiContext = flyoutPage.FindMauiContext();
             if (mauiContext is null)
             {
                 return;
             }
 
+            // Weak reference prevents a pending async callback from keeping
+            // the page alive after the handler is disconnected (memory leak fix).
+            var weakPage = new WeakReference<FlyoutPage>(flyoutPage);
+
+            EventHandler onItemTapped = (sender, e) =>
+            {
+                if (weakPage.TryGetTarget(out var p))
+                {
+                    p.IsPresented = !p.IsPresented;
+                }
+            };
+
             flyoutPage.Flyout.IconImageSource.LoadImage(mauiContext, result =>
             {
+                if (!weakPage.TryGetTarget(out var fp))
+                {
+                    return;
+                }
+
                 var icon = result?.Value;
 
                 if (icon is not null)
@@ -176,7 +188,7 @@ namespace Microsoft.Maui.Controls
                     var originalSize = icon.Size;
                     if (originalSize.Height > 44)
                     {
-                        if (flyoutPage.Flyout.IconImageSource is not FontImageSource fontImageSource ||
+                        if (fp.Flyout.IconImageSource is not FontImageSource fontImageSource ||
                             !fontImageSource.IsSet(FontImageSource.SizeProperty))
                         {
                             icon = icon.ResizeImageSource(originalSize.Width, 44f, originalSize);
@@ -198,17 +210,17 @@ namespace Microsoft.Maui.Controls
                 {
                     // Fallback: use Flyout.Title as text button
                     targetVC.NavigationItem.LeftBarButtonItem =
-                        new UIBarButtonItem(flyoutPage.Flyout?.Title ?? string.Empty, UIBarButtonItemStyle.Plain, onItemTapped);
+                        new UIBarButtonItem(fp.Flyout?.Title ?? string.Empty, UIBarButtonItemStyle.Plain, onItemTapped);
                 }
 
                 // Set AutomationId and VoiceOver label/hint on the hamburger button.
-                if (!string.IsNullOrEmpty(flyoutPage.AutomationId))
+                if (!string.IsNullOrEmpty(fp.AutomationId))
                 {
-                    targetVC.NavigationItem.LeftBarButtonItem.AccessibilityIdentifier = $"btn_{flyoutPage.AutomationId}";
+                    targetVC.NavigationItem.LeftBarButtonItem.AccessibilityIdentifier = $"btn_{fp.AutomationId}";
                 }
 
                 // Apply FlyoutPage's SemanticProperties (Description/Hint), if set.
-                var semantics = SemanticProperties.UpdateSemantics(flyoutPage, null);
+                var semantics = SemanticProperties.UpdateSemantics(fp, null);
                 if (semantics is not null)
                 {
                     targetVC.NavigationItem.LeftBarButtonItem.UpdateSemantics(semantics);

--- a/src/Controls/src/Core/FlyoutPage/FlyoutPage.iOS.cs
+++ b/src/Controls/src/Core/FlyoutPage/FlyoutPage.iOS.cs
@@ -248,6 +248,19 @@ namespace Microsoft.Maui.Controls
                 var flowDirection = (view as IVisualElementController)?.EffectiveFlowDirection.ToFlowDirection()
                     ?? v.FlowDirection;
                 manager.UpdateFlowDirection(flowDirection);
+
+                // NavigationPage isn't auto-walked by Core's FlowDirection propagation, so
+                // manually re-trigger it on each page in the navigation stack.
+                if (view is FlyoutPage fp && fp.Detail is NavigationPage detailNavPage)
+                {
+                    foreach (var page in detailNavPage.Navigation.NavigationStack)
+                    {
+                    	if (page?.Handler is IElementHandler pageHandler)
+                    	{
+                    		pageHandler.UpdateValue(nameof(IView.FlowDirection));
+                    	}
+                    }
+                }
             }
         }
     }

--- a/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
@@ -205,7 +205,7 @@ public static partial class AppHostBuilderExtensions
 #if IOS || MACCATALYST
 		handlersCollection.AddHandler<NavigationPage, NavigationViewHandler>();
 		handlersCollection.AddHandler<TabbedPage, TabbedViewHandler>();
-		handlersCollection.AddHandler(typeof(FlyoutPage), typeof(Handlers.Compatibility.PhoneFlyoutPageRenderer));
+		handlersCollection.AddHandler<FlyoutPage, FlyoutViewHandler>();
 #endif
 
 #if ANDROID || IOS || MACCATALYST || TIZEN

--- a/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.Standard.cs
+++ b/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.Standard.cs
@@ -4,39 +4,13 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class FlyoutViewHandler : ViewHandler<IFlyoutView, object>
 	{
-		protected override object CreatePlatformView()
-		{
-			throw new NotImplementedException();
-		}
+		protected override object CreatePlatformView() => throw new NotImplementedException();
 
-		public static void MapFlyout(IFlyoutViewHandler handler, IFlyoutView flyoutView)
-		{
-			throw new NotImplementedException();
-		}
-
-		public static void MapDetail(IFlyoutViewHandler handler, IFlyoutView flyoutView)
-		{
-			throw new NotImplementedException();
-		}
-
-		public static void MapIsPresented(IFlyoutViewHandler handler, IFlyoutView flyoutView)
-		{
-			throw new NotImplementedException();
-		}
-
-		public static void MapFlyoutBehavior(IFlyoutViewHandler handler, IFlyoutView flyoutView)
-		{
-			throw new NotImplementedException();
-		}
-
-		public static void MapFlyoutWidth(IFlyoutViewHandler handler, IFlyoutView flyoutView)
-		{
-			throw new NotImplementedException();
-		}
-
-		public static void MapIsGestureEnabled(IFlyoutViewHandler handler, IFlyoutView flyoutView)
-		{
-			throw new NotImplementedException();
-		}
+		public static void MapFlyout(IFlyoutViewHandler handler, IFlyoutView flyoutView) { }
+		public static void MapDetail(IFlyoutViewHandler handler, IFlyoutView flyoutView) { }
+		public static void MapIsPresented(IFlyoutViewHandler handler, IFlyoutView flyoutView) { }
+		public static void MapFlyoutBehavior(IFlyoutViewHandler handler, IFlyoutView flyoutView) { }
+		public static void MapFlyoutWidth(IFlyoutViewHandler handler, IFlyoutView flyoutView) { }
+		public static void MapIsGestureEnabled(IFlyoutViewHandler handler, IFlyoutView flyoutView) { }
 	}
 }

--- a/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.Standard.cs
+++ b/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.Standard.cs
@@ -6,7 +6,37 @@ namespace Microsoft.Maui.Handlers
 	{
 		protected override object CreatePlatformView()
 		{
-			throw new System.NotImplementedException();
+			throw new NotImplementedException();
+		}
+
+		public static void MapFlyout(IFlyoutViewHandler handler, IFlyoutView flyoutView)
+		{
+			throw new NotImplementedException();
+		}
+
+		public static void MapDetail(IFlyoutViewHandler handler, IFlyoutView flyoutView)
+		{
+			throw new NotImplementedException();
+		}
+
+		public static void MapIsPresented(IFlyoutViewHandler handler, IFlyoutView flyoutView)
+		{
+			throw new NotImplementedException();
+		}
+
+		public static void MapFlyoutBehavior(IFlyoutViewHandler handler, IFlyoutView flyoutView)
+		{
+			throw new NotImplementedException();
+		}
+
+		public static void MapFlyoutWidth(IFlyoutViewHandler handler, IFlyoutView flyoutView)
+		{
+			throw new NotImplementedException();
+		}
+
+		public static void MapIsGestureEnabled(IFlyoutViewHandler handler, IFlyoutView flyoutView)
+		{
+			throw new NotImplementedException();
 		}
 	}
 }

--- a/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.cs
+++ b/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.cs
@@ -20,19 +20,17 @@ namespace Microsoft.Maui.Handlers
 		// So we have a separate mapper for them.
 		private static readonly IPropertyMapper<IFlyoutView, IFlyoutViewHandler> FlyoutLayoutMapper = new PropertyMapper<IFlyoutView, IFlyoutViewHandler>()
 		{
-#if ANDROID || WINDOWS || TIZEN
 			[nameof(IFlyoutView.Flyout)] = MapFlyout,
 			[nameof(IFlyoutView.Detail)] = MapDetail,
-#endif
 		};
 
 		public static IPropertyMapper<IFlyoutView, IFlyoutViewHandler> Mapper = new PropertyMapper<IFlyoutView, IFlyoutViewHandler>(ViewHandler.ViewMapper, FlyoutLayoutMapper)
 		{
-#if ANDROID || WINDOWS || TIZEN
 			[nameof(IFlyoutView.IsPresented)] = MapIsPresented,
 			[nameof(IFlyoutView.FlyoutBehavior)] = MapFlyoutBehavior,
 			[nameof(IFlyoutView.FlyoutWidth)] = MapFlyoutWidth,
 			[nameof(IFlyoutView.IsGestureEnabled)] = MapIsGestureEnabled,
+#if ANDROID || WINDOWS || TIZEN
 			[nameof(IToolbarElement.Toolbar)] = MapToolbar,
 #endif
 		};
@@ -58,5 +56,20 @@ namespace Microsoft.Maui.Handlers
 		IFlyoutView IFlyoutViewHandler.VirtualView => VirtualView;
 
 		PlatformView IFlyoutViewHandler.PlatformView => PlatformView;
+
+#if IOS || MACCATALYST
+		/// <summary>
+		/// Configuration record filled by Controls layer via RemapForControls().
+		/// Core handler calls these when gestures/layout change — Controls writes back to FlyoutPage.
+		/// </summary>
+		internal sealed record FlyoutViewHandlerControlsConfiguration(
+			Action<IFlyoutView, bool> OnPresentedChangedByGesture,
+			Action<IFlyoutView, Graphics.Rect, Graphics.Rect> OnLayoutBoundsChanged,
+			Action<IFlyoutView> OnLeftBarButtonNeedsUpdate,
+			Action<IFlyoutView> OnHandlerDisconnected
+		);
+
+		internal static FlyoutViewHandlerControlsConfiguration? ControlsConfiguration { get; set; }
+#endif
 	}
 }

--- a/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.iOS.cs
@@ -1,12 +1,154 @@
-﻿using System;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Platform;
+using UIKit;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class FlyoutViewHandler : ViewHandler<IFlyoutView, UIKit.UIView>
+	public partial class FlyoutViewHandler : ViewHandler<IFlyoutView, UIView>, IFlyoutContainerDelegate
 	{
-		protected override UIKit.UIView CreatePlatformView()
+		internal FlyoutContainerManager? _manager;
+		FlyoutContainerViewController? _containerVC;
+
+		protected override UIView CreatePlatformView()
 		{
-			throw new System.NotImplementedException();
+			_manager = new FlyoutContainerManager(this);
+			_containerVC = new FlyoutContainerViewController(_manager);
+
+			// Force view load so SetupContainerViews is called
+			_containerVC.LoadViewIfNeeded();
+			return _containerVC.View!;
+		}
+
+		protected override void ConnectHandler(UIView platformView)
+		{
+			base.ConnectHandler(platformView);
+
+			// Set the ViewController so this handler participates in the VC hierarchy
+			ViewController = _containerVC;
+		}
+
+		protected override void DisconnectHandler(UIView platformView)
+		{
+			// TearDown() before OnHandlerDisconnected so the unsubscribe below runs last and sticks.
+			_manager?.TearDown();
+			_manager = null;
+			_containerVC = null;
+			ViewController = null;
+
+			if (VirtualView is not null)
+			{
+				ControlsConfiguration?.OnHandlerDisconnected(VirtualView);
+			}
+
+			base.DisconnectHandler(platformView);
+		}
+
+		// ═══════════════════════════════════════════════
+		// Mapper Implementations
+		// ═══════════════════════════════════════════════
+
+		public static void MapFlyout(IFlyoutViewHandler handler, IFlyoutView flyoutView)
+		{
+			if (handler is FlyoutViewHandler h && h._manager is { } manager)
+			{
+				var flyoutVC = flyoutView.Flyout?.ToUIViewController(handler.MauiContext!);
+				manager.SetFlyoutViewController(flyoutVC);
+			}
+		}
+
+		public static void MapDetail(IFlyoutViewHandler handler, IFlyoutView flyoutView)
+		{
+			if (handler is FlyoutViewHandler h && h._manager is { } manager)
+			{
+				var detailVC = flyoutView.Detail?.ToUIViewController(handler.MauiContext!);
+				manager.SetDetailViewController(detailVC);
+			}
+		}
+
+		public static void MapIsPresented(IFlyoutViewHandler handler, IFlyoutView flyoutView)
+		{
+			if (handler is FlyoutViewHandler h && h._manager is { } manager)
+			{
+				manager.UpdateIsPresented(flyoutView.IsPresented, animated: true);
+			}
+		}
+
+		public static void MapFlyoutBehavior(IFlyoutViewHandler handler, IFlyoutView flyoutView)
+		{
+			if (handler is FlyoutViewHandler h && h._manager is { } manager)
+			{
+				manager.UpdateFlyoutBehavior(flyoutView.FlyoutBehavior);
+			}
+		}
+
+		public static void MapFlyoutWidth(IFlyoutViewHandler handler, IFlyoutView flyoutView)
+		{
+			if (handler is FlyoutViewHandler h && h._manager is { } manager)
+			{
+				manager.UpdateFlyoutWidth(flyoutView.FlyoutWidth);
+			}
+		}
+
+		public static void MapIsGestureEnabled(IFlyoutViewHandler handler, IFlyoutView flyoutView)
+		{
+			if (handler is FlyoutViewHandler h && h._manager is { } manager)
+			{
+				manager.UpdateIsGestureEnabled(flyoutView.IsGestureEnabled);
+			}
+		}
+
+		// ═══════════════════════════════════════════════
+		// IFlyoutContainerDelegate
+		// ═══════════════════════════════════════════════
+
+		void IFlyoutContainerDelegate.OnPresentedChangedByGesture(bool isPresented)
+		{
+			if (VirtualView is null)
+			{
+				return;
+			}
+
+			ControlsConfiguration?.OnPresentedChangedByGesture(VirtualView, isPresented);
+		}
+
+		void IFlyoutContainerDelegate.OnLayoutBoundsChanged(Rect flyoutBounds, Rect detailBounds)
+		{
+			if (VirtualView is null)
+			{
+				return;
+			}
+
+			ControlsConfiguration?.OnLayoutBoundsChanged(VirtualView, flyoutBounds, detailBounds);
+		}
+
+		void IFlyoutContainerDelegate.OnLeftBarButtonNeedsUpdate()
+		{
+			if (VirtualView is null)
+			{
+				return;
+			}
+
+			ControlsConfiguration?.OnLeftBarButtonNeedsUpdate(VirtualView);
+		}
+
+		void IFlyoutContainerDelegate.OnViewDidAppear()
+		{
+			// Lifecycle: page appeared — let framework handle Appearing event
+		}
+
+		void IFlyoutContainerDelegate.OnViewWillDisappear()
+		{
+			// Lifecycle: page disappearing — let framework handle Disappearing event
+		}
+
+		bool IFlyoutContainerDelegate.GetCurrentIsPresented()
+		{
+			return VirtualView?.IsPresented ?? false;
+		}
+
+		bool IFlyoutContainerDelegate.GetIgnoreSafeArea()
+		{
+			return VirtualView is ISafeAreaView sav && sav.IgnoreSafeArea;
 		}
 	}
 }

--- a/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.iOS.cs
@@ -43,9 +43,6 @@ namespace Microsoft.Maui.Handlers
 			base.DisconnectHandler(platformView);
 		}
 
-		// ═══════════════════════════════════════════════
-		// Mapper Implementations
-		// ═══════════════════════════════════════════════
 
 		public static void MapFlyout(IFlyoutViewHandler handler, IFlyoutView flyoutView)
 		{
@@ -97,9 +94,6 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 
-		// ═══════════════════════════════════════════════
-		// IFlyoutContainerDelegate
-		// ═══════════════════════════════════════════════
 
 		void IFlyoutContainerDelegate.OnPresentedChangedByGesture(bool isPresented)
 		{

--- a/src/Core/src/Platform/iOS/FlyoutContainerManager/FlyoutContainerManager.cs
+++ b/src/Core/src/Platform/iOS/FlyoutContainerManager/FlyoutContainerManager.cs
@@ -1,0 +1,1005 @@
+using System;
+using CoreGraphics;
+using Microsoft.Maui.Graphics;
+using UIKit;
+using PointF = CoreGraphics.CGPoint;
+
+namespace Microsoft.Maui.Platform;
+
+/// <summary>
+/// Manages a flyout/detail split layout with pan gesture, tap-to-close, and animated
+/// show/hide. Pure UIKit — no Controls references.
+/// This is a plain C# class (not a UIViewController subclass) that operates on
+/// a parent VC provided by the handler.
+/// Communicates state changes back through <see cref="IFlyoutContainerDelegate"/>.
+/// </summary>
+internal class FlyoutContainerManager
+{
+	// ═══════════════════════════════════════════════
+	// Fields
+	// ═══════════════════════════════════════════════
+
+	readonly WeakReference<IFlyoutContainerDelegate> _delegateRef;
+	WeakReference<UIViewController>? _parentVCRef;
+
+	// Container views (plain UIViews that hold child VC views)
+	UIView? _flyoutContainerView;
+	UIView? _detailContainerView;
+	UIView? _clickOffView;
+
+	// Gesture recognizers
+	UIPanGestureRecognizer? _panGesture;
+	UITapGestureRecognizer? _tapGesture;
+
+	// Child VCs (managed via parent VC's containment API)
+	UIViewController? _flyoutVC;
+	UIViewController? _detailVC;
+
+	bool _isPresented;
+	bool _isGestureEnabled = true;
+	bool _applyShadow;
+	bool _initialLayoutFinished;
+
+	FlyoutBehavior _flyoutBehavior = FlyoutBehavior.Flyout;
+	FlowDirection _flowDirection = FlowDirection.MatchParent;
+	double _flyoutWidth = -1; // -1 means platform default
+
+	// ═══════════════════════════════════════════════
+	// Constructor
+	// ═══════════════════════════════════════════════
+
+	internal FlyoutContainerManager(IFlyoutContainerDelegate containerDelegate)
+	{
+		_delegateRef = new WeakReference<IFlyoutContainerDelegate>(containerDelegate);
+	}
+
+	// ═══════════════════════════════════════════════
+	// Properties
+	// ═══════════════════════════════════════════════
+
+	/// <summary>
+	/// On iPad, the flyout overlaps the detail (slides over from left).
+	/// On iPhone, the detail slides right to reveal the flyout behind it.
+	/// </summary>
+	static bool FlyoutOverlapsDetailsInPopoverMode =>
+		UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad;
+
+	bool IsRTL => _flowDirection == FlowDirection.RightToLeft;
+
+	UIView? ParentView => _parentVCRef is not null && _parentVCRef.TryGetTarget(out var vc) ? vc.View : null;
+
+	/// <summary>
+	/// The currently-hosted Detail child VC. Used by <see cref="FlyoutContainerViewController"/>
+	/// to route status-bar/home-indicator delegate queries explicitly to Detail, matching the
+	/// legacy renderer's behavior (it never asked the Flyout VC for these).
+	/// </summary>
+	internal UIViewController? ActiveDetailViewController => _detailVC;
+
+	bool ShouldShowSplitMode
+	{
+		get
+		{
+			if (!FlyoutOverlapsDetailsInPopoverMode)
+			{
+				return false; // iPhone never splits
+			}
+
+			// Controls (FlyoutPage.cs) already decides split vs. non-split based on
+			// FlyoutLayoutBehavior + orientation, and passes us the result as
+			// Locked (split) or Flyout (not split). Trust it as-is — don't
+			// recompute split mode from raw bounds, or Popover/SplitOnPortrait
+			// will be split incorrectly.
+			return _flyoutBehavior == FlyoutBehavior.Locked;
+		}
+	}
+
+	// ═══════════════════════════════════════════════
+	// Lifecycle (called by handler)
+	// ═══════════════════════════════════════════════
+
+	/// <summary>
+	/// Called from the container VC's ViewDidLoad. Sets up the view hierarchy
+	/// and stores the parent VC reference for containment API calls.
+	/// </summary>
+	internal void SetupContainerViews(UIViewController parentVC)
+	{
+		_parentVCRef = new WeakReference<UIViewController>(parentVC);
+
+		var parentView = parentVC.View!;
+		_flyoutContainerView = new UIView { ClipsToBounds = true };
+		_detailContainerView = new UIView { BackgroundColor = UIColor.Black, ClipsToBounds = true };
+		_clickOffView = new UIView { BackgroundColor = new UIColor(0, 0, 0, 0) };
+
+		PackContainers(parentView);
+		SetupTapGesture();
+		UpdatePanGesture();
+	}
+
+	/// <summary>
+	/// Called from handler when parent VC's view lays out subviews.
+	/// </summary>
+	internal void OnParentViewDidLayoutSubviews()
+	{
+		LayoutPanes(animated: false);
+
+		if (!_initialLayoutFinished)
+		{
+			_initialLayoutFinished = true;
+
+			// Read IsPresented from virtual view at layout time, as the value
+			// may differ from _isPresented due to FlyoutPage internal validation.
+			bool isPresented = _isPresented;
+			if (_delegateRef.TryGetTarget(out var del))
+			{
+				isPresented = del.GetCurrentIsPresented();
+			}
+
+			if (ShouldShowSplitMode)
+			{
+				SetPresented(true, animated: false, notifyDelegate: false);
+			}
+			else
+			{
+				SetPresented(isPresented, animated: false, notifyDelegate: false);
+			}
+		}
+	}
+
+	/// <summary>
+	/// Called from handler when parent VC transitions size (rotation, multitasking).
+	/// </summary>
+	internal void OnParentViewWillTransitionToSize(CGSize toSize)
+	{
+
+		if (!OperatingSystem.IsMacCatalyst())
+		{
+			bool shouldSplit = ShouldShowSplitMode;
+			if (FlyoutOverlapsDetailsInPopoverMode)
+			{
+				// notifyDelegate: false — rotation is platform-initiated.
+				// Writing back IsPresented during rotation can throw InvalidOperationException
+				// when ShouldShowSplitMode is still in transition.
+				SetPresented(shouldSplit, animated: true, notifyDelegate: false);
+			}
+			else if (!shouldSplit && _isPresented)
+			{
+				// iPhone rotation: notify delegate so virtual view stays in sync.
+				SetPresented(false, animated: true, notifyDelegate: true);
+			}
+		}
+
+		NotifyLeftBarButtonNeedsUpdate();
+	}
+
+	/// <summary>
+	/// Called from container VC's ViewDidAppear.
+	/// </summary>
+	internal void OnViewDidAppear()
+	{
+		if (_delegateRef.TryGetTarget(out var del))
+		{
+			del.OnViewDidAppear();
+		}
+	}
+
+	/// <summary>
+	/// Called from container VC's ViewWillDisappear.
+	/// </summary>
+	internal void OnViewWillDisappear()
+	{
+		if (_delegateRef.TryGetTarget(out var del))
+		{
+			del.OnViewWillDisappear();
+		}
+	}
+
+	// ═══════════════════════════════════════════════
+	// Public API — Content
+	// ═══════════════════════════════════════════════
+
+	internal void SetFlyoutViewController(UIViewController? flyoutVC)
+	{
+		if (_parentVCRef is null || !_parentVCRef.TryGetTarget(out var parentVC))
+		{
+			return;
+		}
+
+		// Remove old
+		if (_flyoutVC is not null)
+		{
+			_flyoutVC.WillMoveToParentViewController(null);
+			_flyoutVC.View?.RemoveFromSuperview();
+			_flyoutVC.RemoveFromParentViewController();
+		}
+
+		_flyoutVC = flyoutVC;
+
+		// Add new
+		if (_flyoutVC is not null && _flyoutContainerView is not null)
+		{
+			parentVC.AddChildViewController(_flyoutVC);
+			if (_flyoutVC.View is not null)
+			{
+				_flyoutContainerView.AddSubview(_flyoutVC.View);
+				_flyoutVC.View.Frame = _flyoutContainerView.Bounds;
+			}
+			_flyoutVC.DidMoveToParentViewController(parentVC);
+		}
+
+		NotifyLeftBarButtonNeedsUpdate();
+	}
+
+	internal void SetDetailViewController(UIViewController? detailVC)
+	{
+		if (_parentVCRef is null || !_parentVCRef.TryGetTarget(out var parentVC))
+		{
+			return;
+		}
+
+		// Remove old
+		if (_detailVC is not null)
+		{
+			_detailVC.WillMoveToParentViewController(null);
+			_detailVC.View?.RemoveFromSuperview();
+			_detailVC.RemoveFromParentViewController();
+		}
+
+		_detailVC = detailVC;
+
+		// Add new
+		if (_detailVC is not null && _detailContainerView is not null)
+		{
+			parentVC.AddChildViewController(_detailVC);
+			if (_detailVC.View is not null)
+			{
+				_detailContainerView.AddSubview(_detailVC.View);
+				_detailVC.View.Frame = _detailContainerView.Bounds;
+			}
+			_detailVC.DidMoveToParentViewController(parentVC);
+		}
+
+		// Detail drives status bar/home-indicator preferences, so invalidate both on swap.
+		parentVC.SetNeedsStatusBarAppearanceUpdate();
+		parentVC.SetNeedsUpdateOfHomeIndicatorAutoHidden();
+
+		ToggleAccessibilityElementsHidden();
+		NotifyLeftBarButtonNeedsUpdate();
+	}
+
+	// ═══════════════════════════════════════════════
+	// Public API — State Updates
+	// ═══════════════════════════════════════════════
+
+	internal void UpdateIsPresented(bool isPresented, bool animated)
+	{
+		if (_isPresented == isPresented)
+		{
+			UpdateClickOffView();
+			return;
+		}
+
+		// Cannot close when Locked (Split) or in split mode
+		if (!isPresented && (_flyoutBehavior == FlyoutBehavior.Locked || ShouldShowSplitMode))
+		{
+			return;
+		}
+
+		SetPresented(isPresented, animated, notifyDelegate: false);
+	}
+
+	internal void UpdateFlyoutBehavior(FlyoutBehavior behavior)
+	{
+		_flyoutBehavior = behavior;
+
+		// Before initial layout, just store the behavior.
+		if (!_initialLayoutFinished)
+		{
+			return;
+		}
+
+		bool shouldPresent = ShouldShowSplitMode;
+		if (behavior == FlyoutBehavior.Flyout || behavior == FlyoutBehavior.Disabled)
+		{
+			shouldPresent = false;
+		}
+		else if (behavior == FlyoutBehavior.Locked)
+		{
+			shouldPresent = true; // Locked = always presented (even on iPhone)
+		}
+
+		if (shouldPresent != _isPresented)
+		{
+			// Notify delegate so VirtualView.IsPresented and IsPresentedChanged stay in sync.
+			// Safe because the mapper fires after ShouldShowSplitMode has settled;
+			// the guard in OnPresentedChangedByGesture handles any remaining edge cases.
+			SetPresented(shouldPresent, animated: true, notifyDelegate: true);
+		}
+		else
+		{
+			LayoutPanes(animated: true);
+			UpdateClickOffView();
+		}
+
+		// Always update the bar button after a behavior change — the hamburger must be
+		// hidden in Split/Locked mode and shown in Popover mode, regardless of whether
+		// the presented state changed.
+		NotifyLeftBarButtonNeedsUpdate();
+	}
+
+	internal void UpdateFlyoutWidth(double width)
+	{
+		_flyoutWidth = width;
+		if (_initialLayoutFinished)
+		{
+			LayoutPanes(animated: false);
+		}
+	}
+
+	internal void UpdateIsGestureEnabled(bool enabled)
+	{
+		_isGestureEnabled = enabled;
+		UpdatePanGesture();
+	}
+
+	internal void UpdateFlowDirection(FlowDirection direction)
+	{
+		_flowDirection = direction;
+		if (_initialLayoutFinished)
+		{
+			LayoutPanes(animated: false);
+		}
+	}
+
+	internal void UpdateApplyShadow(bool applyShadow)
+	{
+		_applyShadow = applyShadow;
+	}
+
+	// ═══════════════════════════════════════════════
+	// Public API — Lifecycle
+	// ═══════════════════════════════════════════════
+
+	internal void TearDown()
+	{
+		if (_tapGesture is not null)
+		{
+			_clickOffView?.RemoveGestureRecognizer(_tapGesture);
+			_tapGesture.Dispose();
+			_tapGesture = null;
+		}
+
+		if (_panGesture is not null)
+		{
+			ParentView?.RemoveGestureRecognizer(_panGesture);
+			_panGesture.Dispose();
+			_panGesture = null;
+		}
+
+		_clickOffView?.RemoveFromSuperview();
+		_clickOffView?.Dispose();
+		_clickOffView = null;
+
+		// Remove child VCs via containment API
+		SetFlyoutViewController(null);
+		SetDetailViewController(null);
+
+		_flyoutContainerView?.RemoveFromSuperview();
+		_flyoutContainerView?.Dispose();
+		_flyoutContainerView = null;
+
+		_detailContainerView?.RemoveFromSuperview();
+		_detailContainerView?.Dispose();
+		_detailContainerView = null;
+	}
+
+	// ═══════════════════════════════════════════════
+	// Layout
+	// ═══════════════════════════════════════════════
+
+	void LayoutPanes(bool animated)
+	{
+		var parentView = ParentView;
+		if (parentView is null || _flyoutContainerView is null || _detailContainerView is null)
+		{
+			return;
+		}
+
+		var frame = parentView.Bounds;
+
+		// Apply safe area insets when the page has opted in (IgnoreSafeArea = false).
+		// By default on iOS, IgnoreSafeArea = true so this is skipped.
+		bool ignoreSafeArea = _delegateRef.TryGetTarget(out var safeAreaDel) && safeAreaDel.GetIgnoreSafeArea();
+		if (OperatingSystem.IsIOSVersionAtLeast(11) && !ignoreSafeArea)
+		{
+			var safeAreaTop = parentView.SafeAreaInsets.Top;
+			if (safeAreaTop > 0)
+			{
+				frame.Y = safeAreaTop;
+				frame.Height -= safeAreaTop;
+			}
+		}
+
+		var flyoutFrame = frame;
+		nfloat opacity = 1;
+
+		// Calculate flyout width
+		if (FlyoutOverlapsDetailsInPopoverMode)
+		{
+			flyoutFrame.Width = GetFlyoutWidth(frame, forOverlap: true);
+		}
+		else
+		{
+			flyoutFrame.Width = GetFlyoutWidth(frame, forOverlap: false);
+		}
+
+		// RTL: flyout on right side (phone mode only)
+		if (IsRTL && !FlyoutOverlapsDetailsInPopoverMode)
+		{
+			flyoutFrame.X = (int)(frame.Width - flyoutFrame.Width);
+		}
+
+		// Calculate detail frame
+		var detailFrame = frame;
+		if (_isPresented)
+		{
+			if (!FlyoutOverlapsDetailsInPopoverMode || ShouldShowSplitMode)
+			{
+				if (IsRTL && ShouldShowSplitMode)
+				{
+					detailFrame.X = 0;
+				}
+				else
+				{
+					detailFrame.X += flyoutFrame.Width;
+				}
+			}
+
+			if (FlyoutOverlapsDetailsInPopoverMode && ShouldShowSplitMode)
+			{
+				detailFrame.Width -= flyoutFrame.Width;
+			}
+
+			if (_applyShadow)
+			{
+				opacity = 0.5f;
+			}
+		}
+
+		// RTL detail offset (phone mode)
+		if (IsRTL && !FlyoutOverlapsDetailsInPopoverMode)
+		{
+			detailFrame.X = detailFrame.X * -1;
+		}
+
+		// Animate or set detail frame
+		var detailChildView = _detailVC?.View;
+		if (animated && !FlyoutOverlapsDetailsInPopoverMode)
+		{
+			UIView.Animate(0.250, 0, UIViewAnimationOptions.CurveEaseOut, () =>
+			{
+				_detailContainerView.Frame = detailFrame;
+				if (detailChildView is not null)
+				{
+					detailChildView.Layer.Opacity = (float)opacity;
+				}
+			}, () => { });
+		}
+		else
+		{
+			_detailContainerView.Frame = detailFrame;
+			if (detailChildView is not null)
+			{
+				detailChildView.Layer.Opacity = (float)opacity;
+			}
+		}
+
+		// Calculate flyout frame for overlap mode (iPad popover)
+		if (FlyoutOverlapsDetailsInPopoverMode)
+		{
+			if (!_isPresented)
+			{
+				if (!IsRTL)
+				{
+					flyoutFrame.X -= flyoutFrame.Width;
+				}
+				else
+				{
+					flyoutFrame.X = frame.Width;
+				}
+			}
+			else if (IsRTL)
+			{
+				if (ShouldShowSplitMode)
+				{
+					flyoutFrame.X = detailFrame.Width;
+				}
+				else
+				{
+					flyoutFrame.X = frame.Width - flyoutFrame.Width;
+				}
+			}
+		}
+
+		// Animate or set flyout frame
+		if (animated && FlyoutOverlapsDetailsInPopoverMode)
+		{
+			UIView.Animate(0.250, 0, UIViewAnimationOptions.CurveEaseOut, () =>
+			{
+				_flyoutContainerView.Frame = flyoutFrame;
+				if (detailChildView is not null)
+				{
+					detailChildView.Layer.Opacity = (float)opacity;
+				}
+			}, () => { });
+		}
+		else
+		{
+			_flyoutContainerView.Frame = flyoutFrame;
+		}
+
+		// Resize child VC views to fill containers
+		ResizeChildToContainer(_flyoutVC, _flyoutContainerView);
+		ResizeChildToContainer(_detailVC, _detailContainerView);
+
+		// Notify delegate of bounds
+		NotifyLayoutBoundsChanged(flyoutFrame, detailFrame, frame);
+
+		if (_isPresented)
+		{
+			UpdateClickOffViewFrame();
+		}
+	}
+
+	static void ResizeChildToContainer(UIViewController? childVC, UIView containerView)
+	{
+		if (childVC?.View is not null)
+		{
+			childVC.View.Frame = containerView.Bounds;
+		}
+	}
+
+	nfloat GetFlyoutWidth(CGRect containerFrame, bool forOverlap)
+	{
+		if (_flyoutWidth > 0)
+		{
+			return (nfloat)_flyoutWidth;
+		}
+
+		if (forOverlap)
+		{
+			return 320;
+		}
+
+		// Phone default: 80% of the shorter dimension, truncated to int.
+		return (nfloat)(int)(Math.Min(containerFrame.Width, containerFrame.Height) * 0.8);
+	}
+
+	// ═══════════════════════════════════════════════
+	// Presented State
+	// ═══════════════════════════════════════════════
+
+	void SetPresented(bool value, bool animated, bool notifyDelegate)
+	{
+		if (_isPresented == value && _initialLayoutFinished)
+		{
+			UpdateClickOffView();
+			return;
+		}
+
+		_isPresented = value;
+		LayoutPanes(animated);
+		UpdateClickOffView();
+		ToggleAccessibilityElementsHidden();
+
+		if (notifyDelegate)
+		{
+			if (_delegateRef.TryGetTarget(out var del))
+			{
+				del.OnPresentedChangedByGesture(value);
+			}
+		}
+	}
+
+	// ═══════════════════════════════════════════════
+	// Click-Off View (tap overlay to dismiss)
+	// ═══════════════════════════════════════════════
+
+	void UpdateClickOffView()
+	{
+		if (_clickOffView is null)
+		{
+			return;
+		}
+
+		if (FlyoutOverlapsDetailsInPopoverMode && ShouldShowSplitMode)
+		{
+			RemoveClickOffView();
+			return;
+		}
+
+		if (_isPresented)
+		{
+			AddClickOffView();
+		}
+		else
+		{
+			RemoveClickOffView();
+		}
+	}
+
+	void AddClickOffView()
+	{
+		var parentView = ParentView;
+		if (_clickOffView is null || parentView is null)
+		{
+			return;
+		}
+
+		if (_clickOffView.Superview == parentView)
+		{
+			return;
+		}
+
+		parentView.AddSubview(_clickOffView);
+		UpdateClickOffViewFrame();
+	}
+
+	void UpdateClickOffViewFrame()
+	{
+		if (_clickOffView is null || _flyoutContainerView is null || _detailContainerView is null)
+		{
+			return;
+		}
+
+		if (FlyoutOverlapsDetailsInPopoverMode)
+		{
+			var detailsFrame = _detailContainerView.Frame;
+			var flyoutWidth = _flyoutContainerView.Frame.Width;
+			var clickOffX = flyoutWidth;
+
+			if (IsRTL)
+			{
+				clickOffX = 0;
+			}
+
+			_clickOffView.Frame = new CGRect(
+				clickOffX,
+				detailsFrame.Y,
+				detailsFrame.Width - flyoutWidth,
+				detailsFrame.Height);
+		}
+		else
+		{
+			_clickOffView.Frame = _detailContainerView.Frame;
+		}
+	}
+
+	void RemoveClickOffView()
+	{
+		_clickOffView?.RemoveFromSuperview();
+	}
+
+	// ═══════════════════════════════════════════════
+	// Container Setup
+	// ═══════════════════════════════════════════════
+
+	void PackContainers(UIView parentView)
+	{
+		if (_flyoutContainerView is null || _detailContainerView is null)
+		{
+			return;
+		}
+
+		if (!FlyoutOverlapsDetailsInPopoverMode)
+		{
+			// Phone: flyout behind, detail on top
+			parentView.AddSubview(_flyoutContainerView);
+			parentView.AddSubview(_detailContainerView);
+		}
+		else
+		{
+			// iPad: detail behind, flyout on top
+			parentView.AddSubview(_detailContainerView);
+			parentView.AddSubview(_flyoutContainerView);
+		}
+	}
+
+	// ═══════════════════════════════════════════════
+	// Gesture — Tap to Close
+	// ═══════════════════════════════════════════════
+
+	void SetupTapGesture()
+	{
+		if (_clickOffView is null)
+		{
+			return;
+		}
+
+		_tapGesture = new UITapGestureRecognizer(() =>
+		{
+			SetPresented(false, animated: true, notifyDelegate: true);
+		});
+
+		if (FlyoutOverlapsDetailsInPopoverMode)
+		{
+			_tapGesture.ShouldReceiveTouch = (_, _) =>
+				!ShouldShowSplitMode && _isPresented;
+		}
+
+		_clickOffView.AddGestureRecognizer(_tapGesture);
+	}
+
+	// ═══════════════════════════════════════════════
+	// Gesture — Pan
+	// ═══════════════════════════════════════════════
+
+	void UpdatePanGesture()
+	{
+		var parentView = ParentView;
+		if (parentView is null)
+		{
+			return;
+		}
+
+		if (!_isGestureEnabled)
+		{
+			if (_panGesture is not null)
+			{
+				parentView.RemoveGestureRecognizer(_panGesture);
+			}
+			return;
+		}
+
+		if (_panGesture is not null)
+		{
+			parentView.AddGestureRecognizer(_panGesture);
+			return;
+		}
+
+		var center = new PointF();
+		_panGesture = new UIPanGestureRecognizer(g =>
+		{
+			int directionModifier = IsRTL ? -1 : 1;
+
+			switch (g.State)
+			{
+				case UIGestureRecognizerState.Began:
+					center = g.LocationInView(g.View);
+					break;
+
+				case UIGestureRecognizerState.Changed:
+					HandlePanChanged(g, center, directionModifier);
+					break;
+
+				case UIGestureRecognizerState.Ended:
+					HandlePanEnded(directionModifier);
+					break;
+			}
+		});
+
+		_panGesture.CancelsTouchesInView = false;
+		_panGesture.ShouldReceiveTouch = (_, t) =>
+			!(t.View is UISlider) &&
+			!IsSwipeView(t.View) &&
+			!ShouldShowSplitMode;
+		_panGesture.MaximumNumberOfTouches = 2;
+
+		parentView.AddGestureRecognizer(_panGesture);
+	}
+
+	void HandlePanChanged(UIPanGestureRecognizer g, PointF center, int directionModifier)
+	{
+		if (_flyoutContainerView is null || _detailContainerView is null)
+		{
+			return;
+		}
+
+		var currentPosition = g.LocationInView(g.View);
+		var motion = (currentPosition.X - center.X) * directionModifier;
+
+		if (!FlyoutOverlapsDetailsInPopoverMode)
+		{
+			// Phone mode: move detail view
+			var targetFrame = _detailContainerView.Frame;
+			var flyoutWidth = _flyoutContainerView.Frame.Width;
+
+			if (_isPresented)
+			{
+				targetFrame.X = (nfloat)Math.Max(0, flyoutWidth + Math.Min(0, motion));
+			}
+			else
+			{
+				targetFrame.X = (nfloat)Math.Min(flyoutWidth, Math.Max(0, motion));
+			}
+
+			targetFrame.X = targetFrame.X * directionModifier;
+			ApplyShadowDuringGesture(targetFrame);
+			_detailContainerView.Frame = targetFrame;
+		}
+		else
+		{
+			// iPad popover mode: move flyout view
+			var targetFrame = _flyoutContainerView.Frame;
+			var flyoutWidth = _flyoutContainerView.Frame.Width;
+
+			if (_isPresented)
+			{
+				targetFrame.X = (nfloat)Math.Max(-flyoutWidth, Math.Min(0, motion));
+			}
+			else
+			{
+				targetFrame.X = (nfloat)Math.Min(0, Math.Max(0, motion) - flyoutWidth);
+			}
+
+			if (IsRTL)
+			{
+				var containerWidth = ParentView!.Bounds.Width;
+				targetFrame.X = (nfloat)(containerWidth - (flyoutWidth + targetFrame.X));
+			}
+
+			ApplyShadowDuringGesture(targetFrame);
+			_flyoutContainerView.Frame = targetFrame;
+		}
+	}
+
+	void HandlePanEnded(int directionModifier)
+	{
+		if (_flyoutContainerView is null || _detailContainerView is null)
+		{
+			return;
+		}
+
+		if (!FlyoutOverlapsDetailsInPopoverMode)
+		{
+			var detailFrame = _detailContainerView.Frame;
+			var flyoutWidth = _flyoutContainerView.Frame.Width;
+
+			if (_isPresented)
+			{
+				if (detailFrame.X * directionModifier < flyoutWidth * 0.75)
+				{
+					SetPresented(false, animated: true, notifyDelegate: true);
+				}
+				else
+				{
+					LayoutPanes(animated: true);
+				}
+			}
+			else
+			{
+				if (detailFrame.X * directionModifier > flyoutWidth * 0.25)
+				{
+					SetPresented(true, animated: true, notifyDelegate: true);
+				}
+				else
+				{
+					LayoutPanes(animated: true);
+				}
+			}
+		}
+		else
+		{
+			var flyoutFrame = _flyoutContainerView.Frame;
+			var flyoutOffsetX = flyoutFrame.X + flyoutFrame.Width;
+
+			if (IsRTL)
+			{
+				flyoutOffsetX = (nfloat)(ParentView!.Bounds.Width - flyoutFrame.X);
+			}
+
+			var flyoutWidth = flyoutFrame.Width;
+
+			if (_isPresented)
+			{
+				if (flyoutOffsetX < flyoutWidth * 0.75)
+				{
+					SetPresented(false, animated: true, notifyDelegate: true);
+				}
+				else
+				{
+					LayoutPanes(animated: true);
+				}
+			}
+			else
+			{
+				if (flyoutOffsetX > flyoutWidth * 0.25)
+				{
+					SetPresented(true, animated: true, notifyDelegate: true);
+				}
+				else
+				{
+					LayoutPanes(animated: true);
+				}
+			}
+		}
+	}
+
+	void ApplyShadowDuringGesture(CGRect targetFrame)
+	{
+		if (!_applyShadow || _flyoutContainerView is null)
+		{
+			return;
+		}
+
+		var detailChildView = _detailVC?.View;
+		if (detailChildView is null)
+		{
+			return;
+		}
+
+		var flyoutWidth = _flyoutContainerView.Frame.Width;
+		nfloat openProgress;
+
+		if (!FlyoutOverlapsDetailsInPopoverMode)
+		{
+			openProgress = !IsRTL
+				? targetFrame.X / flyoutWidth
+				: (nfloat)((ParentView!.Bounds.Width - targetFrame.GetMaxX()) / flyoutWidth);
+		}
+		else
+		{
+			openProgress = !IsRTL
+				? (targetFrame.X + flyoutWidth) / flyoutWidth
+				: (nfloat)((ParentView!.Bounds.Width - targetFrame.X) / flyoutWidth);
+		}
+
+		var opacity = (float)(0.5 + (0.5 * (1 - openProgress)));
+		detailChildView.Layer.Opacity = opacity;
+	}
+
+	// ═══════════════════════════════════════════════
+	// Accessibility
+	// ═══════════════════════════════════════════════
+
+	void ToggleAccessibilityElementsHidden()
+	{
+		if (_flyoutContainerView is not null)
+		{
+			_flyoutContainerView.AccessibilityElementsHidden = !_isPresented;
+		}
+
+		if (_detailContainerView is not null)
+		{
+			_detailContainerView.AccessibilityElementsHidden = _isPresented;
+		}
+	}
+
+	// ═══════════════════════════════════════════════
+	// Helpers
+	// ═══════════════════════════════════════════════
+
+	static bool IsSwipeView(UIView? view)
+	{
+		if (view is null)
+		{
+			return false;
+		}
+
+		if (view.Superview is MauiSwipeView)
+		{
+			return true;
+		}
+
+		return IsSwipeView(view.Superview);
+	}
+
+	void NotifyLayoutBoundsChanged(CGRect flyoutFrame, CGRect detailFrame, CGRect containerFrame)
+	{
+		if (!_delegateRef.TryGetTarget(out var del))
+		{
+			return;
+		}
+
+		var flyoutBounds = new Rect(flyoutFrame.X, 0, flyoutFrame.Width, flyoutFrame.Height);
+		var detailBounds = new Rect(detailFrame.X, 0, containerFrame.Width, containerFrame.Height);
+		del.OnLayoutBoundsChanged(flyoutBounds, detailBounds);
+	}
+
+	void NotifyLeftBarButtonNeedsUpdate()
+	{
+		if (_delegateRef.TryGetTarget(out var del))
+		{
+			del.OnLeftBarButtonNeedsUpdate();
+		}
+	}
+}

--- a/src/Core/src/Platform/iOS/FlyoutContainerManager/FlyoutContainerManager.cs
+++ b/src/Core/src/Platform/iOS/FlyoutContainerManager/FlyoutContainerManager.cs
@@ -263,6 +263,7 @@ internal class FlyoutContainerManager
 
 	internal void UpdateFlyoutBehavior(FlyoutBehavior behavior)
 	{
+		var previousBehavior = _flyoutBehavior;
 		_flyoutBehavior = behavior;
 
 		// Before initial layout, just store the behavior.
@@ -281,7 +282,9 @@ internal class FlyoutContainerManager
 			shouldPresent = true; // Locked = always presented (even on iPhone)
 		}
 
-		if (shouldPresent != _isPresented)
+		bool stateChanged = shouldPresent != _isPresented;
+
+		if (stateChanged)
 		{
 			// Notify delegate so VirtualView.IsPresented and IsPresentedChanged stay in sync.
 			// Safe because the mapper fires after ShouldShowSplitMode has settled;
@@ -294,10 +297,13 @@ internal class FlyoutContainerManager
 			UpdateClickOffView();
 		}
 
-		// Always update the bar button after a behavior change — the hamburger must be
-		// hidden in Split/Locked mode and shown in Popover mode, regardless of whether
-		// the presented state changed.
-		NotifyLeftBarButtonNeedsUpdate();
+		// Only update the bar button when behavior or presented state actually changed.
+		// Skipping redundant calls prevents excessive ShouldShowToolbarButton invocations
+		// when the same behavior is re-applied (e.g., repeated DisplayInfoChanged events).
+		if (previousBehavior != behavior || stateChanged)
+		{
+			NotifyLeftBarButtonNeedsUpdate();
+		}
 	}
 
 	internal void UpdateFlyoutWidth(double width)

--- a/src/Core/src/Platform/iOS/FlyoutContainerManager/FlyoutContainerManager.cs
+++ b/src/Core/src/Platform/iOS/FlyoutContainerManager/FlyoutContainerManager.cs
@@ -7,17 +7,12 @@ using PointF = CoreGraphics.CGPoint;
 namespace Microsoft.Maui.Platform;
 
 /// <summary>
-/// Manages a flyout/detail split layout with pan gesture, tap-to-close, and animated
-/// show/hide. Pure UIKit — no Controls references.
-/// This is a plain C# class (not a UIViewController subclass) that operates on
-/// a parent VC provided by the handler.
+/// Manages flyout/detail split layout with pan gesture, tap-to-close, and animated show/hide.
+/// Pure UIKit — no Controls references.
 /// Communicates state changes back through <see cref="IFlyoutContainerDelegate"/>.
 /// </summary>
 internal class FlyoutContainerManager
 {
-	// ═══════════════════════════════════════════════
-	// Fields
-	// ═══════════════════════════════════════════════
 
 	readonly WeakReference<IFlyoutContainerDelegate> _delegateRef;
 	WeakReference<UIViewController>? _parentVCRef;
@@ -44,18 +39,12 @@ internal class FlyoutContainerManager
 	FlowDirection _flowDirection = FlowDirection.MatchParent;
 	double _flyoutWidth = -1; // -1 means platform default
 
-	// ═══════════════════════════════════════════════
-	// Constructor
-	// ═══════════════════════════════════════════════
 
 	internal FlyoutContainerManager(IFlyoutContainerDelegate containerDelegate)
 	{
 		_delegateRef = new WeakReference<IFlyoutContainerDelegate>(containerDelegate);
 	}
 
-	// ═══════════════════════════════════════════════
-	// Properties
-	// ═══════════════════════════════════════════════
 
 	/// <summary>
 	/// On iPad, the flyout overlaps the detail (slides over from left).
@@ -84,18 +73,13 @@ internal class FlyoutContainerManager
 				return false; // iPhone never splits
 			}
 
-			// Controls (FlyoutPage.cs) already decides split vs. non-split based on
-			// FlyoutLayoutBehavior + orientation, and passes us the result as
-			// Locked (split) or Flyout (not split). Trust it as-is — don't
-			// recompute split mode from raw bounds, or Popover/SplitOnPortrait
-			// will be split incorrectly.
+			// FlyoutBehavior is already resolved by Controls: Locked = split, Flyout = not-split.
+			// Trust it — don't recompute from raw bounds,
+			// or Popover/SplitOnPortrait will split incorrectly.
 			return _flyoutBehavior == FlyoutBehavior.Locked;
 		}
 	}
 
-	// ═══════════════════════════════════════════════
-	// Lifecycle (called by handler)
-	// ═══════════════════════════════════════════════
 
 	/// <summary>
 	/// Called from the container VC's ViewDidLoad. Sets up the view hierarchy
@@ -193,9 +177,6 @@ internal class FlyoutContainerManager
 		}
 	}
 
-	// ═══════════════════════════════════════════════
-	// Public API — Content
-	// ═══════════════════════════════════════════════
 
 	internal void SetFlyoutViewController(UIViewController? flyoutVC)
 	{
@@ -204,7 +185,6 @@ internal class FlyoutContainerManager
 			return;
 		}
 
-		// Remove old
 		if (_flyoutVC is not null)
 		{
 			_flyoutVC.WillMoveToParentViewController(null);
@@ -214,7 +194,6 @@ internal class FlyoutContainerManager
 
 		_flyoutVC = flyoutVC;
 
-		// Add new
 		if (_flyoutVC is not null && _flyoutContainerView is not null)
 		{
 			parentVC.AddChildViewController(_flyoutVC);
@@ -236,7 +215,6 @@ internal class FlyoutContainerManager
 			return;
 		}
 
-		// Remove old
 		if (_detailVC is not null)
 		{
 			_detailVC.WillMoveToParentViewController(null);
@@ -246,7 +224,6 @@ internal class FlyoutContainerManager
 
 		_detailVC = detailVC;
 
-		// Add new
 		if (_detailVC is not null && _detailContainerView is not null)
 		{
 			parentVC.AddChildViewController(_detailVC);
@@ -266,9 +243,6 @@ internal class FlyoutContainerManager
 		NotifyLeftBarButtonNeedsUpdate();
 	}
 
-	// ═══════════════════════════════════════════════
-	// Public API — State Updates
-	// ═══════════════════════════════════════════════
 
 	internal void UpdateIsPresented(bool isPresented, bool animated)
 	{
@@ -355,9 +329,6 @@ internal class FlyoutContainerManager
 		_applyShadow = applyShadow;
 	}
 
-	// ═══════════════════════════════════════════════
-	// Public API — Lifecycle
-	// ═══════════════════════════════════════════════
 
 	internal void TearDown()
 	{
@@ -392,9 +363,6 @@ internal class FlyoutContainerManager
 		_detailContainerView = null;
 	}
 
-	// ═══════════════════════════════════════════════
-	// Layout
-	// ═══════════════════════════════════════════════
 
 	void LayoutPanes(bool animated)
 	{
@@ -574,9 +542,6 @@ internal class FlyoutContainerManager
 		return (nfloat)(int)(Math.Min(containerFrame.Width, containerFrame.Height) * 0.8);
 	}
 
-	// ═══════════════════════════════════════════════
-	// Presented State
-	// ═══════════════════════════════════════════════
 
 	void SetPresented(bool value, bool animated, bool notifyDelegate)
 	{
@@ -600,9 +565,6 @@ internal class FlyoutContainerManager
 		}
 	}
 
-	// ═══════════════════════════════════════════════
-	// Click-Off View (tap overlay to dismiss)
-	// ═══════════════════════════════════════════════
 
 	void UpdateClickOffView()
 	{
@@ -679,9 +641,6 @@ internal class FlyoutContainerManager
 		_clickOffView?.RemoveFromSuperview();
 	}
 
-	// ═══════════════════════════════════════════════
-	// Container Setup
-	// ═══════════════════════════════════════════════
 
 	void PackContainers(UIView parentView)
 	{
@@ -704,9 +663,6 @@ internal class FlyoutContainerManager
 		}
 	}
 
-	// ═══════════════════════════════════════════════
-	// Gesture — Tap to Close
-	// ═══════════════════════════════════════════════
 
 	void SetupTapGesture()
 	{
@@ -729,9 +685,6 @@ internal class FlyoutContainerManager
 		_clickOffView.AddGestureRecognizer(_tapGesture);
 	}
 
-	// ═══════════════════════════════════════════════
-	// Gesture — Pan
-	// ═══════════════════════════════════════════════
 
 	void UpdatePanGesture()
 	{
@@ -947,9 +900,6 @@ internal class FlyoutContainerManager
 		detailChildView.Layer.Opacity = opacity;
 	}
 
-	// ═══════════════════════════════════════════════
-	// Accessibility
-	// ═══════════════════════════════════════════════
 
 	void ToggleAccessibilityElementsHidden()
 	{
@@ -964,9 +914,6 @@ internal class FlyoutContainerManager
 		}
 	}
 
-	// ═══════════════════════════════════════════════
-	// Helpers
-	// ═══════════════════════════════════════════════
 
 	static bool IsSwipeView(UIView? view)
 	{

--- a/src/Core/src/Platform/iOS/FlyoutContainerManager/FlyoutContainerManager.cs
+++ b/src/Core/src/Platform/iOS/FlyoutContainerManager/FlyoutContainerManager.cs
@@ -239,6 +239,10 @@ internal class FlyoutContainerManager
 		parentVC.SetNeedsStatusBarAppearanceUpdate();
 		parentVC.SetNeedsUpdateOfHomeIndicatorAutoHidden();
 
+		// A newly-attached Detail VC (and its UINavigationBar, if any) needs the
+		// current flow direction applied — it won't have picked it up otherwise.
+		ApplySemanticContentAttribute();
+
 		ToggleAccessibilityElementsHidden();
 		NotifyLeftBarButtonNeedsUpdate();
 	}
@@ -324,9 +328,31 @@ internal class FlyoutContainerManager
 	internal void UpdateFlowDirection(FlowDirection direction)
 	{
 		_flowDirection = direction;
+		ApplySemanticContentAttribute();
+
 		if (_initialLayoutFinished)
 		{
 			LayoutPanes(animated: false);
+		}
+	}
+
+	/// <summary>
+	/// Mirrors the Detail's UINavigationController view and NavigationBar for RTL/LTR,
+	/// since neither inherits SemanticContentAttribute from its parent view.
+	/// </summary>
+	void ApplySemanticContentAttribute()
+	{
+		if (_detailVC is UINavigationController navController)
+		{
+			var semanticAttr = IsRTL
+				? UISemanticContentAttribute.ForceRightToLeft
+				: UISemanticContentAttribute.ForceLeftToRight;
+
+			if (navController.View is not null)
+			{
+				navController.View.SemanticContentAttribute = semanticAttr;
+			}
+			navController.NavigationBar.SemanticContentAttribute = semanticAttr;
 		}
 	}
 

--- a/src/Core/src/Platform/iOS/FlyoutContainerManager/FlyoutContainerManager.cs
+++ b/src/Core/src/Platform/iOS/FlyoutContainerManager/FlyoutContainerManager.cs
@@ -256,6 +256,12 @@ internal class FlyoutContainerManager
 			return;
 		}
 
+		// Cannot open when Disabled
+		if (isPresented && _flyoutBehavior == FlyoutBehavior.Disabled)
+		{
+			return;
+		}
+
 		// Cannot close when Locked (Split) or in split mode
 		if (!isPresented && (_flyoutBehavior == FlyoutBehavior.Locked || ShouldShowSplitMode))
 		{
@@ -327,16 +333,22 @@ internal class FlyoutContainerManager
 
 	internal void UpdateFlowDirection(FlowDirection direction)
 	{
+		bool directionChanged = _flowDirection != direction;
 		_flowDirection = direction;
 		ApplySemanticContentAttribute();
 
 		if (_initialLayoutFinished)
 		{
 			LayoutPanes(animated: false);
-		}
 
-		// Recreate the hamburger bar button so it renders correctly under the new flow direction.
-		NotifyLeftBarButtonNeedsUpdate();
+			// Recreate the hamburger bar button on real flow-direction changes so it
+			// renders correctly. Initial setup is notified by SetDetailViewController /
+			// SetFlyoutViewController.
+			if (directionChanged)
+			{
+				NotifyLeftBarButtonNeedsUpdate();
+			}
+		}
 	}
 
 	/// <summary>
@@ -769,7 +781,8 @@ internal class FlyoutContainerManager
 		_panGesture.ShouldReceiveTouch = (_, t) =>
 			!(t.View is UISlider) &&
 			!IsSwipeView(t.View) &&
-			!ShouldShowSplitMode;
+			!ShouldShowSplitMode &&
+			_flyoutBehavior != FlyoutBehavior.Disabled;
 		_panGesture.MaximumNumberOfTouches = 2;
 
 		parentView.AddGestureRecognizer(_panGesture);

--- a/src/Core/src/Platform/iOS/FlyoutContainerManager/FlyoutContainerManager.cs
+++ b/src/Core/src/Platform/iOS/FlyoutContainerManager/FlyoutContainerManager.cs
@@ -942,7 +942,8 @@ internal class FlyoutContainerManager
 
 		if (_detailContainerView is not null)
 		{
-			_detailContainerView.AccessibilityElementsHidden = _isPresented;
+			// Only hide Detail when the Flyout is actually covering it, not in split mode.
+			_detailContainerView.AccessibilityElementsHidden = _isPresented && !ShouldShowSplitMode;
 		}
 	}
 

--- a/src/Core/src/Platform/iOS/FlyoutContainerManager/FlyoutContainerManager.cs
+++ b/src/Core/src/Platform/iOS/FlyoutContainerManager/FlyoutContainerManager.cs
@@ -334,6 +334,9 @@ internal class FlyoutContainerManager
 		{
 			LayoutPanes(animated: false);
 		}
+
+		// Recreate the hamburger bar button so it renders correctly under the new flow direction.
+		NotifyLeftBarButtonNeedsUpdate();
 	}
 
 	/// <summary>

--- a/src/Core/src/Platform/iOS/FlyoutContainerManager/FlyoutContainerViewController.cs
+++ b/src/Core/src/Platform/iOS/FlyoutContainerManager/FlyoutContainerViewController.cs
@@ -1,0 +1,94 @@
+using System;
+using CoreGraphics;
+using UIKit;
+
+namespace Microsoft.Maui.Platform;
+
+/// <summary>
+/// A minimal UIViewController that forwards lifecycle calls to <see cref="FlyoutContainerManager"/>.
+/// The handler sets this as its ViewController so UIKit lifecycle events reach the manager.
+/// </summary>
+internal class FlyoutContainerViewController : UIViewController
+{
+    readonly WeakReference<FlyoutContainerManager> _managerRef;
+
+    internal FlyoutContainerViewController(FlyoutContainerManager manager)
+    {
+        _managerRef = new WeakReference<FlyoutContainerManager>(manager);
+    }
+
+    public override void ViewDidLoad()
+    {
+        base.ViewDidLoad();
+
+        // Set background so status bar area doesn't show black/clear behind the safe area offset
+        View!.BackgroundColor = UIColor.SystemBackground;
+
+        if (_managerRef.TryGetTarget(out var manager))
+        {
+            manager.SetupContainerViews(this);
+        }
+    }
+
+    public override void ViewDidAppear(bool animated)
+    {
+        base.ViewDidAppear(animated);
+
+        if (_managerRef.TryGetTarget(out var manager))
+        {
+            manager.OnViewDidAppear();
+        }
+    }
+
+    public override void ViewWillDisappear(bool animated)
+    {
+        base.ViewWillDisappear(animated);
+
+        if (_managerRef.TryGetTarget(out var manager))
+        {
+            manager.OnViewWillDisappear();
+        }
+    }
+
+    public override void ViewDidLayoutSubviews()
+    {
+        base.ViewDidLayoutSubviews();
+
+        if (_managerRef.TryGetTarget(out var manager))
+        {
+            manager.OnParentViewDidLayoutSubviews();
+        }
+    }
+
+    public override void ViewWillTransitionToSize(CGSize toSize, IUIViewControllerTransitionCoordinator coordinator)
+    {
+        base.ViewWillTransitionToSize(toSize, coordinator);
+
+        if (_managerRef.TryGetTarget(out var manager))
+        {
+            manager.OnParentViewWillTransitionToSize(toSize);
+        }
+    }
+
+    public override UIViewController? ChildViewControllerForStatusBarHidden()
+    {
+        return GetActiveDetailViewController() ?? base.ChildViewControllerForStatusBarHidden();
+    }
+
+    public override UIViewController? ChildViewControllerForStatusBarStyle()
+    {
+        return GetActiveDetailViewController() ?? base.ChildViewControllerForStatusBarStyle();
+    }
+
+    public override UIViewController? ChildViewControllerForHomeIndicatorAutoHidden
+    {
+        get => GetActiveDetailViewController() ?? base.ChildViewControllerForHomeIndicatorAutoHidden;
+    }
+
+    // Always defer to the Detail VC, matching the legacy renderer — never the Flyout VC,
+    // and never just "whichever child was added last" (that can be the Flyout VC if it's
+    // re-added after Detail, silently breaking the visible page's status-bar/home-indicator
+    // preferences).
+    UIViewController? GetActiveDetailViewController() =>
+        _managerRef.TryGetTarget(out var manager) ? manager.ActiveDetailViewController : null;
+}

--- a/src/Core/src/Platform/iOS/FlyoutContainerManager/FlyoutContainerViewController.cs
+++ b/src/Core/src/Platform/iOS/FlyoutContainerManager/FlyoutContainerViewController.cs
@@ -75,10 +75,12 @@ internal class FlyoutContainerViewController : UIViewController
         return GetActiveDetailViewController() ?? base.ChildViewControllerForStatusBarHidden();
     }
 
+#if !MACCATALYST
     public override UIViewController? ChildViewControllerForStatusBarStyle()
     {
         return GetActiveDetailViewController() ?? base.ChildViewControllerForStatusBarStyle();
     }
+#endif
 
     public override UIViewController? ChildViewControllerForHomeIndicatorAutoHidden
     {

--- a/src/Core/src/Platform/iOS/FlyoutContainerManager/IFlyoutContainerDelegate.cs
+++ b/src/Core/src/Platform/iOS/FlyoutContainerManager/IFlyoutContainerDelegate.cs
@@ -1,0 +1,55 @@
+using Microsoft.Maui.Graphics;
+
+namespace Microsoft.Maui.Platform;
+
+/// <summary>
+/// Callback interface for <see cref="FlyoutContainerManager"/> to communicate
+/// state changes back to the handler layer without referencing Controls types.
+/// </summary>
+internal interface IFlyoutContainerDelegate
+{
+    /// <summary>
+    /// Called when a user gesture (pan or tap-to-close) changes the presented state.
+    /// The handler should write this back to the virtual view's IsPresented property.
+    /// </summary>
+    void OnPresentedChangedByGesture(bool isPresented);
+
+    /// <summary>
+    /// Called after layout completes, providing the computed bounds of each pane.
+    /// The handler should write these back to the virtual view for measure/arrange.
+    /// </summary>
+    void OnLayoutBoundsChanged(Rect flyoutBounds, Rect detailBounds);
+
+    /// <summary>
+    /// Called when the detail content changes or split mode toggles,
+    /// indicating the hamburger bar button item needs updating.
+    /// </summary>
+    void OnLeftBarButtonNeedsUpdate();
+
+    /// <summary>
+    /// Called when the container VC's view has appeared (ViewDidAppear).
+    /// Currently unused — the framework handles Appearing automatically.
+    /// Kept for future-proofing if manual lifecycle notification is needed.
+    /// </summary>
+    void OnViewDidAppear();
+
+    /// <summary>
+    /// Called when the container VC's view is about to disappear (ViewWillDisappear).
+    /// Currently unused — the framework handles Disappearing automatically.
+    /// Kept for future-proofing if manual lifecycle notification is needed.
+    /// </summary>
+    void OnViewWillDisappear();
+
+    /// <summary>
+    /// Returns the current IsPresented value from the virtual view.
+    /// Used during initial layout to read the developer's intended value.
+    /// </summary>
+    bool GetCurrentIsPresented();
+
+    /// <summary>
+    /// Returns whether the virtual view has opted out of safe area insets
+    /// (<see cref="ISafeAreaView.IgnoreSafeArea"/>). Used during layout to decide
+    /// whether the flyout/detail container frame should be inset from the safe area.
+    /// </summary>
+    bool GetIgnoreSafeArea();
+}

--- a/src/Core/src/Platform/iOS/FlyoutContainerManager/IFlyoutContainerDelegate.cs
+++ b/src/Core/src/Platform/iOS/FlyoutContainerManager/IFlyoutContainerDelegate.cs
@@ -29,14 +29,12 @@ internal interface IFlyoutContainerDelegate
     /// <summary>
     /// Called when the container VC's view has appeared (ViewDidAppear).
     /// Currently unused — the framework handles Appearing automatically.
-    /// Kept for future-proofing if manual lifecycle notification is needed.
     /// </summary>
     void OnViewDidAppear();
 
     /// <summary>
     /// Called when the container VC's view is about to disappear (ViewWillDisappear).
     /// Currently unused — the framework handles Disappearing automatically.
-    /// Kept for future-proofing if manual lifecycle notification is needed.
     /// </summary>
     void OnViewWillDisappear();
 

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -51,3 +51,11 @@ static Microsoft.Maui.Handlers.SearchBarHandler.MapCursorPosition(Microsoft.Maui
 static Microsoft.Maui.Handlers.SearchBarHandler.MapSelectionLength(Microsoft.Maui.Handlers.ISearchBarHandler! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
 static Microsoft.Maui.Platform.CollectionViewExtensions.UpdateIsEnabled(this UIKit.UICollectionView! collectionView, Microsoft.Maui.IView! view) -> void
 static Microsoft.Maui.Platform.ButtonExtensions.UpdateBackground(this UIKit.UIButton! platformButton, Microsoft.Maui.Graphics.Paint? paint) -> void
+override Microsoft.Maui.Handlers.FlyoutViewHandler.ConnectHandler(UIKit.UIView! platformView) -> void
+override Microsoft.Maui.Handlers.FlyoutViewHandler.DisconnectHandler(UIKit.UIView! platformView) -> void
+static Microsoft.Maui.Handlers.FlyoutViewHandler.MapDetail(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void
+static Microsoft.Maui.Handlers.FlyoutViewHandler.MapFlyout(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void
+static Microsoft.Maui.Handlers.FlyoutViewHandler.MapFlyoutBehavior(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void
+static Microsoft.Maui.Handlers.FlyoutViewHandler.MapFlyoutWidth(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void
+static Microsoft.Maui.Handlers.FlyoutViewHandler.MapIsGestureEnabled(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void
+static Microsoft.Maui.Handlers.FlyoutViewHandler.MapIsPresented(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -48,3 +48,11 @@ static Microsoft.Maui.Handlers.SearchBarHandler.MapCursorPosition(Microsoft.Maui
 static Microsoft.Maui.Handlers.SearchBarHandler.MapSelectionLength(Microsoft.Maui.Handlers.ISearchBarHandler! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
 static Microsoft.Maui.Platform.CollectionViewExtensions.UpdateIsEnabled(this UIKit.UICollectionView! collectionView, Microsoft.Maui.IView! view) -> void
 static Microsoft.Maui.Platform.ButtonExtensions.UpdateBackground(this UIKit.UIButton! platformButton, Microsoft.Maui.Graphics.Paint? paint) -> void
+override Microsoft.Maui.Handlers.FlyoutViewHandler.ConnectHandler(UIKit.UIView! platformView) -> void
+override Microsoft.Maui.Handlers.FlyoutViewHandler.DisconnectHandler(UIKit.UIView! platformView) -> void
+static Microsoft.Maui.Handlers.FlyoutViewHandler.MapDetail(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void
+static Microsoft.Maui.Handlers.FlyoutViewHandler.MapFlyout(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void
+static Microsoft.Maui.Handlers.FlyoutViewHandler.MapFlyoutBehavior(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void
+static Microsoft.Maui.Handlers.FlyoutViewHandler.MapFlyoutWidth(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void
+static Microsoft.Maui.Handlers.FlyoutViewHandler.MapIsGestureEnabled(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void
+static Microsoft.Maui.Handlers.FlyoutViewHandler.MapIsPresented(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void

--- a/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -9,7 +9,6 @@ Microsoft.Maui.HybridWebViewInvoker.HybridWebViewInvoker(object? invokeJavaScrip
 Microsoft.Maui.IHybridWebView.Invoker.get -> Microsoft.Maui.HybridWebViewInvoker!
 Microsoft.Maui.IHybridWebView.Invoker.set -> void
 Microsoft.Maui.IHybridWebView.SetInvokeJavaScriptTarget<T>(T! target, System.Text.Json.Serialization.JsonSerializerContext! jsonSerializerContext) -> void
-abstract Microsoft.Maui.HybridWebViewInvoker.InvokeMethodAsync(string! methodName, string![]? paramJsonValues) -> System.Threading.Tasks.Task<string?>!
 Microsoft.Maui.ITab
 Microsoft.Maui.ITab.Icon.get -> Microsoft.Maui.IImageSource?
 Microsoft.Maui.ITab.IsEnabled.get -> bool
@@ -17,7 +16,14 @@ Microsoft.Maui.ITab.Title.get -> string!
 Microsoft.Maui.TabBarPlacement
 Microsoft.Maui.TabBarPlacement.Bottom = 1 -> Microsoft.Maui.TabBarPlacement
 Microsoft.Maui.TabBarPlacement.Top = 0 -> Microsoft.Maui.TabBarPlacement
+abstract Microsoft.Maui.HybridWebViewInvoker.InvokeMethodAsync(string! methodName, string![]? paramJsonValues) -> System.Threading.Tasks.Task<string?>!
 static Microsoft.Maui.GridLength.implicit operator Microsoft.Maui.GridLength(string! value) -> Microsoft.Maui.GridLength
+static Microsoft.Maui.Handlers.FlyoutViewHandler.MapDetail(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void
+static Microsoft.Maui.Handlers.FlyoutViewHandler.MapFlyout(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void
+static Microsoft.Maui.Handlers.FlyoutViewHandler.MapFlyoutBehavior(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void
+static Microsoft.Maui.Handlers.FlyoutViewHandler.MapFlyoutWidth(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void
+static Microsoft.Maui.Handlers.FlyoutViewHandler.MapIsGestureEnabled(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void
+static Microsoft.Maui.Handlers.FlyoutViewHandler.MapIsPresented(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void
 static Microsoft.Maui.SafeAreaEdges.Container.get -> Microsoft.Maui.SafeAreaEdges
 static Microsoft.Maui.Handlers.ShapeViewHandler.MapFlowDirection(Microsoft.Maui.Handlers.IShapeViewHandler! handler, Microsoft.Maui.IShapeView! shapeView) -> void
 static Microsoft.Maui.Handlers.SearchBarHandler.MapCursorPosition(Microsoft.Maui.Handlers.ISearchBarHandler! handler, Microsoft.Maui.ISearchBar! searchBar) -> void

--- a/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -8,8 +8,6 @@ Microsoft.Maui.HybridWebViewInvoker.HybridWebViewInvoker(object? invokeJavaScrip
 Microsoft.Maui.IHybridWebView.Invoker.get -> Microsoft.Maui.HybridWebViewInvoker!
 Microsoft.Maui.IHybridWebView.Invoker.set -> void
 Microsoft.Maui.IHybridWebView.SetInvokeJavaScriptTarget<T>(T! target, System.Text.Json.Serialization.JsonSerializerContext! jsonSerializerContext) -> void
-abstract Microsoft.Maui.HybridWebViewInvoker.InvokeMethodAsync(string! methodName, string![]? paramJsonValues) -> System.Threading.Tasks.Task<string?>!
-static Microsoft.Maui.SafeAreaEdges.Container.get -> Microsoft.Maui.SafeAreaEdges
 Microsoft.Maui.ITab
 Microsoft.Maui.ITab.Icon.get -> Microsoft.Maui.IImageSource?
 Microsoft.Maui.ITab.IsEnabled.get -> bool
@@ -20,3 +18,11 @@ Microsoft.Maui.TabBarPlacement.Top = 0 -> Microsoft.Maui.TabBarPlacement
 static Microsoft.Maui.Handlers.ShapeViewHandler.MapFlowDirection(Microsoft.Maui.Handlers.IShapeViewHandler! handler, Microsoft.Maui.IShapeView! shapeView) -> void
 static Microsoft.Maui.Handlers.SearchBarHandler.MapCursorPosition(Microsoft.Maui.Handlers.ISearchBarHandler! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
 static Microsoft.Maui.Handlers.SearchBarHandler.MapSelectionLength(Microsoft.Maui.Handlers.ISearchBarHandler! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
+abstract Microsoft.Maui.HybridWebViewInvoker.InvokeMethodAsync(string! methodName, string![]? paramJsonValues) -> System.Threading.Tasks.Task<string?>!
+static Microsoft.Maui.Handlers.FlyoutViewHandler.MapDetail(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void
+static Microsoft.Maui.Handlers.FlyoutViewHandler.MapFlyout(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void
+static Microsoft.Maui.Handlers.FlyoutViewHandler.MapFlyoutBehavior(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void
+static Microsoft.Maui.Handlers.FlyoutViewHandler.MapFlyoutWidth(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void
+static Microsoft.Maui.Handlers.FlyoutViewHandler.MapIsGestureEnabled(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void
+static Microsoft.Maui.Handlers.FlyoutViewHandler.MapIsPresented(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void
+static Microsoft.Maui.SafeAreaEdges.Container.get -> Microsoft.Maui.SafeAreaEdges

--- a/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -8,8 +8,6 @@ Microsoft.Maui.HybridWebViewInvoker.HybridWebViewInvoker(object? invokeJavaScrip
 Microsoft.Maui.IHybridWebView.Invoker.get -> Microsoft.Maui.HybridWebViewInvoker!
 Microsoft.Maui.IHybridWebView.Invoker.set -> void
 Microsoft.Maui.IHybridWebView.SetInvokeJavaScriptTarget<T>(T! target, System.Text.Json.Serialization.JsonSerializerContext! jsonSerializerContext) -> void
-abstract Microsoft.Maui.HybridWebViewInvoker.InvokeMethodAsync(string! methodName, string![]? paramJsonValues) -> System.Threading.Tasks.Task<string?>!
-static Microsoft.Maui.SafeAreaEdges.Container.get -> Microsoft.Maui.SafeAreaEdges
 Microsoft.Maui.ITab
 Microsoft.Maui.ITab.Icon.get -> Microsoft.Maui.IImageSource?
 Microsoft.Maui.ITab.IsEnabled.get -> bool
@@ -20,3 +18,11 @@ Microsoft.Maui.TabBarPlacement.Top = 0 -> Microsoft.Maui.TabBarPlacement
 static Microsoft.Maui.Handlers.ShapeViewHandler.MapFlowDirection(Microsoft.Maui.Handlers.IShapeViewHandler! handler, Microsoft.Maui.IShapeView! shapeView) -> void
 static Microsoft.Maui.Handlers.SearchBarHandler.MapCursorPosition(Microsoft.Maui.Handlers.ISearchBarHandler! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
 static Microsoft.Maui.Handlers.SearchBarHandler.MapSelectionLength(Microsoft.Maui.Handlers.ISearchBarHandler! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
+abstract Microsoft.Maui.HybridWebViewInvoker.InvokeMethodAsync(string! methodName, string![]? paramJsonValues) -> System.Threading.Tasks.Task<string?>!
+static Microsoft.Maui.Handlers.FlyoutViewHandler.MapDetail(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void
+static Microsoft.Maui.Handlers.FlyoutViewHandler.MapFlyout(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void
+static Microsoft.Maui.Handlers.FlyoutViewHandler.MapFlyoutBehavior(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void
+static Microsoft.Maui.Handlers.FlyoutViewHandler.MapFlyoutWidth(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void
+static Microsoft.Maui.Handlers.FlyoutViewHandler.MapIsGestureEnabled(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void
+static Microsoft.Maui.Handlers.FlyoutViewHandler.MapIsPresented(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void
+static Microsoft.Maui.SafeAreaEdges.Container.get -> Microsoft.Maui.SafeAreaEdges


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description of Change

Replaces the monolithic `PhoneFlyoutPageRenderer` (~850 lines, single class that IS a `UIViewController`) with a layered `FlyoutViewHandler` architecture for iOS and MacCatalyst. The handler is registered as the **unconditional default** — no feature flag or opt-in required.

## Issues Fixed

Fixes #33083

> **Note**: The shared Core infrastructure (`FlyoutContainerManager`, `IFlyoutContainerDelegate`) is designed for potential reuse by future `IFlyoutView` consumers, but no other consumer is part of this PR.

## Motivation

The `PhoneFlyoutPageRenderer` is a single class that **IS** a `UIViewController`. It owns pan/tap gesture handling, split-vs-popover layout math, safe-area handling, shadow application, accessibility toggling, hamburger bar-button updates, and status-bar/home-indicator delegation — all in one file. This makes it:

- **Hard to maintain** — layout math, gesture handling, and Controls-specific bar-button logic are all interleaved in a single class
- **Tightly coupled** — the renderer references `FlyoutPage` (a Controls type) directly from platform code, and calls a static method on `NavigationRenderer` (`SetFlyoutLeftBarButton`) to update the hamburger icon — a cross-renderer dependency
- **Inconsistent with handler architecture** — `NavigationPage` (PR-36109) and `TabbedPage` (PR-36507) have already moved to handlers on iOS; `FlyoutPage` was the remaining holdout
- **Prone to retain cycles** — the renderer both IS the UIKit `UIViewController` and holds strong references to child controllers/gesture recognizers, requiring careful manual cleanup (MEM0002 risk)
- **Not multi-instance safe** — uses a `static WeakReference` for the flyout icon/title subscription, so a second `FlyoutPage` instance can silently clobber the first's subscription

## What Changed
### New Files (Core layer — `src/Core/`)

| File | Purpose |
|------|---------|
| `Platform/iOS/FlyoutContainerManager/FlyoutContainerManager.cs` | Shared UIKit manager (952 lines): pan gesture + velocity snap, tap-to-close overlay, animated iPhone/iPad layout, split/popover/locked behaviors, RTL support, safe-area handling, rotation/size-transition handling, accessibility toggling. Plain C# class — not an `NSObject` |
| `Platform/iOS/FlyoutContainerManager/FlyoutContainerViewController.cs` | Minimal `UIViewController` wrapper: forwards `ViewDidLoad`/`ViewDidAppear`/`ViewWillDisappear`/`ViewDidLayoutSubviews`/`ViewWillTransitionToSize` to the manager; routes status-bar/home-indicator queries explicitly to the Detail VC via `ActiveDetailViewController` |
| `Platform/iOS/FlyoutContainerManager/IFlyoutContainerDelegate.cs` | 7-method interface bridging Core ↔ handler: `OnPresentedChangedByGesture`, `OnLayoutBoundsChanged`, `OnLeftBarButtonNeedsUpdate`, `OnViewDidAppear`, `OnViewWillDisappear`, `GetCurrentIsPresented`, `GetIgnoreSafeArea` |
| `Handlers/FlyoutView/FlyoutViewHandler.iOS.cs` | iOS handler body (148 lines): `CreatePlatformView`/`ConnectHandler`/`DisconnectHandler`, mapper method implementations (`MapFlyout`, `MapDetail`, `MapIsPresented`, `MapFlyoutBehavior`, `MapFlyoutWidth`, `MapIsGestureEnabled`), `IFlyoutContainerDelegate` implementation |

### Modified Files (Core layer)

| File | Change |
|------|--------|
| `Handlers/FlyoutView/FlyoutViewHandler.cs` | Opened the `FlyoutLayoutMapper`/`Mapper` gate from `#if ANDROID \|\| WINDOWS \|\| TIZEN` to unconditional (all platforms); added `internal sealed record FlyoutViewHandlerControlsConfiguration` (4-member: `OnPresentedChangedByGesture`, `OnLayoutBoundsChanged`, `OnLeftBarButtonNeedsUpdate`, `OnHandlerDisconnected`) + static `ControlsConfiguration` property, gated `#if IOS \|\| MACCATALYST` |
| `Handlers/FlyoutView/FlyoutViewHandler.Standard.cs` | Added no-op `MapFlyout`/`MapDetail`/`MapIsPresented`/`MapFlyoutBehavior`/`MapFlyoutWidth`/`MapIsGestureEnabled` stubs for non-iOS/Android/Windows/Tizen TFMs |

### New Files (Controls layer — `src/Controls/`)

| File | Purpose |
|------|---------|
| `Core/FlyoutPage/FlyoutPage.iOS.cs` | Controls-side bridge (242 lines): `OnPresentedChangedByGesture`/`OnLayoutBoundsChanged`/`OnLeftBarButtonNeedsUpdate`/`OnHandlerDisconnected` static callbacks; instance-scoped `SubscribeToFlyoutPropertyChanges()`/`UnsubscribeFlyoutPropertyChanges()` for the flyout icon/title (fixes the old renderer's static-subscription multi-instance bug); `UpdateFlyoutLeftBarButton()` — fully self-contained hamburger-button logic (icon load, resize-to-44pt, title fallback, `AutomationId`/`SemanticProperties`); `MapApplyShadow`/`MapFlowDirection` mapper implementations |

### Modified Files (Controls layer)

| File | Change |
|------|--------|
| `Core/FlyoutPage/FlyoutPage.Mapper.cs` | Gate widened from `#if IOS` to `#if IOS \|\| MACCATALYST`; sets `FlyoutViewHandler.ControlsConfiguration` in `RemapForControls()`; appends `MapApplyShadow`/`MapFlowDirection` to the mapper; `MapPrefersHomeIndicatorAutoHiddenProperty`/`MapPrefersPrefersStatusBarHiddenProperty` changed from recursive-looking `handler.UpdateValue(...)` calls to direct `vc.SetNeedsUpdateOfHomeIndicatorAutoHidden()`/`vc.SetNeedsStatusBarAppearanceUpdate()` |
| `Core/Hosting/AppHostBuilderExtensions.cs` | `handlersCollection.AddHandler(typeof(FlyoutPage), typeof(Handlers.Compatibility.PhoneFlyoutPageRenderer))` → `handlersCollection.AddHandler<FlyoutPage, FlyoutViewHandler>()` for iOS/MacCatalyst (unconditional) |

### PublicAPI Surface

Added to `PublicAPI.Unshipped.txt` (`net`, `net-ios`, `net-maccatalyst`, `netstandard`, `netstandard2.0`):
```
override Microsoft.Maui.Handlers.FlyoutViewHandler.ConnectHandler(UIKit.UIView! platformView) -> void
override Microsoft.Maui.Handlers.FlyoutViewHandler.DisconnectHandler(UIKit.UIView! platformView) -> void
static Microsoft.Maui.Handlers.FlyoutViewHandler.MapDetail(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void
static Microsoft.Maui.Handlers.FlyoutViewHandler.MapFlyout(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void
static Microsoft.Maui.Handlers.FlyoutViewHandler.MapFlyoutBehavior(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void
static Microsoft.Maui.Handlers.FlyoutViewHandler.MapFlyoutWidth(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void
static Microsoft.Maui.Handlers.FlyoutViewHandler.MapIsGestureEnabled(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void
static Microsoft.Maui.Handlers.FlyoutViewHandler.MapIsPresented(Microsoft.Maui.Handlers.IFlyoutViewHandler! handler, Microsoft.Maui.IFlyoutView! flyoutView) -> void
```

## Architecture Overview
### Handler Hierarchy

```
┌──────────────────────────────────────────────────────────┐
│                    CONTROLS LAYER                        │
│  FlyoutPage.Mapper.cs           → mappers + config setup │
│  FlyoutPage.iOS.cs              → mapper implementations │
│                                    + hamburger button    │
├──────────────────────────────────────────────────────────┤
│                     CORE LAYER (HANDLER)                 │
│  FlyoutViewHandler.iOS.cs       → mapper methods,        │
│                                    delegate impl         │
├──────────────────────────────────────────────────────────┤
│                     CORE LAYER (PLATFORM)                │
│  FlyoutContainerManager.cs      → gestures, layout,      │
│                                    rotation, animation   │
│  FlyoutContainerViewController  → lifecycle forwarding   │
│  IFlyoutContainerDelegate.cs    → 7-method interface     │
└──────────────────────────────────────────────────────────┘
```


### Key Design Decisions

| Decision | Rationale |
|----------|-----------|
| **Three-layer split (Controls / Core Handler / Core Platform)** | `FlyoutContainerManager` knows only UIKit (`UIView`, `UIViewController`, gestures, frames) — it has no reference to `IFlyoutView`, `FlyoutPage`, or any MAUI type. `FlyoutViewHandler` is the middleman that knows `IFlyoutView` only, not `FlyoutPage`. Controls-specific behavior (hamburger button, icon loading, `FlyoutPage` write-back) lives entirely in the Controls layer |
| **`FlyoutViewHandlerControlsConfiguration` sealed record** | 4-member record (`OnPresentedChangedByGesture`, `OnLayoutBoundsChanged`, `OnLeftBarButtonNeedsUpdate`, `OnHandlerDisconnected`) fills the Core ↔ Controls gap without a circular assembly reference — Controls sets it once in `RemapForControls()` |
| **`FlyoutContainerManager` is a plain C# class, not `NSObject`** | Eliminates the MEM0002 retain-cycle risk the old renderer had as a `UIViewController` subclass; only holds `WeakReference<IFlyoutContainerDelegate>` and `WeakReference<UIViewController>` |
| **`FlyoutContainerViewController` as a thin wrapper** | A minimal `UIViewController` is still required so UIKit lifecycle events (`ViewDidLoad`, rotation, layout) reach the manager — but it only holds a `WeakReference<FlyoutContainerManager>`, so it can't leak the manager either |
| **Explicit `ActiveDetailViewController` for status bar/home indicator** | UIKit's default "whichever child VC was added last" is unsafe — if the Flyout VC is re-added after Detail, the wrong VC's preferences would apply. The container VC always asks the manager for the tracked **Detail** VC specifically, matching the legacy renderer's exact behavior |
| **Instance-scoped `WeakReference<Page>? _subscribedFlyout`** | Fixes a real renderer bug: the old renderer used a `static WeakReference`, so a second `FlyoutPage` instance (multi-window, modal FlyoutPage) would clobber the first instance's icon/title subscription |
| **`notifyDelegate` parameter on `SetPresented`** | Distinguishes platform-initiated state changes (rotation on iPad — `notifyDelegate: false`, avoids `InvalidOperationException` while `ShouldShowSplitMode` is still settling) from user/behavior-initiated changes (gesture, `FlyoutBehavior` change — `notifyDelegate: true`, keeps `IFlyoutView.IsPresented`/`IsPresentedChanged` in sync) |
| **Handler is unconditional default** | No feature flag. Registered in `AppHostBuilderExtensions.cs`. `PhoneFlyoutPageRenderer` still exists in the Compatibility layer for manual opt-out if needed |

### `IFlyoutContainerDelegate` Interface (7 methods)

| Method | Purpose |
|--------|---------|
| `OnPresentedChangedByGesture(bool isPresented)` | User pan/tap changed the presented state — handler writes it back to `IFlyoutView.IsPresented` |
| `OnLayoutBoundsChanged(Rect flyoutBounds, Rect detailBounds)` | Layout completed — handler writes computed bounds back to the virtual view for measure/arrange |
| `OnLeftBarButtonNeedsUpdate()` | Detail changed or split mode toggled — hamburger bar button needs updating |
| `OnViewDidAppear()` | Container VC's view appeared (currently unused — framework handles `Appearing` automatically) |
| `OnViewWillDisappear()` | Container VC's view about to disappear (currently unused — framework handles `Disappearing` automatically) |
| `GetCurrentIsPresented()` | Returns the virtual view's current `IsPresented` — read at first-layout time, after `FlyoutPage`'s internal validation has settled |
| `GetIgnoreSafeArea()` | Returns whether the virtual view opted out of safe-area insets (`ISafeAreaView.IgnoreSafeArea`) |

## Key Behaviors
| Behavior | Implementation |
|----------|-----------------|
| **iPhone layout** | Detail slides right to reveal the Flyout behind it; Flyout width = 80% of `min(width, height)` unless `FlyoutWidth` is set |
| **iPad layout** | Flyout overlaps Detail (slides over from the left) in Popover mode; Split mode (`FlyoutBehavior.Locked`) shows both panes side by side |
| **Gestures** | Pan gesture with 25%/75% velocity-snap thresholds; tap-to-close on a transparent click-off overlay; `IsGestureEnabled` toggles the pan recognizer |
| **RTL** | `FlowDirection` mapped from the effective/inherited flow direction (not the raw `FlowDirection`), flips Flyout anchor edge and pan direction modifier |
| **Shadow** | `ApplyShadow` (iOS platform-specific) dims the Detail pane's opacity while the Flyout is open/dragging |
| **Safe area** | Applied only when `IgnoreSafeArea` is `false` (default on iOS is `true`, matching legacy behavior) |
| **Status bar / Home indicator** | Always delegated to the tracked Detail VC (`ActiveDetailViewController`), invalidated via `SetNeedsStatusBarAppearanceUpdate()`/`SetNeedsUpdateOfHomeIndicatorAutoHidden()` on Detail swap |
| **Rotation** | Skipped entirely on MacCatalyst (free window resizing); iPad recomputes `ShouldShowSplitMode` without notifying the virtual view; iPhone closes the Flyout and notifies the virtual view if it was open and shouldn't split |
| **Dark mode** | Container view background uses `UIColor.SystemBackground` instead of a hardcoded color |
| **Cleanup** | `DisconnectHandler` calls `_manager.TearDown()` (gestures, child VCs, container views) **before** notifying Controls via `ControlsConfiguration.OnHandlerDisconnected`, which unsubscribes the per-instance flyout icon/title `PropertyChanged` handler |

## Feature Parity

Full parity with `PhoneFlyoutPageRenderer` including:

- Flyout open/close (programmatic + gesture)
- Pan gesture with velocity-based snap
- Tap-to-close overlay
- `FlyoutBehavior` (`Flyout` / `Locked` / `Disabled` / `Popover` / `SplitOnLandscape` / `SplitOnPortrait`)
- `IsGestureEnabled`
- `ApplyShadow` (iOS platform-specific)
- RTL / `FlowDirection`
- Safe-area handling (notch devices)
- Left bar button (hamburger icon or title-text fallback)
- iPad split mode (landscape/portrait per behavior)
- Status bar style forwarding (via containment)
- Home indicator forwarding (via containment)
- Rotation/size-transition handling
- Accessibility (`AccessibilityElementsHidden` toggled on Flyout/Detail containers)

### Improvements Over the Renderer (not just parity)

| # | Area | Renderer | Handler |
|---|------|----------|---------|
| 1 | Custom `FlyoutWidth` | Not supported | Supported via `_flyoutWidth` property |
| 2 | Multi-instance safety | `static WeakReference` — 2nd `FlyoutPage` clobbers 1st's subscription | Instance-scoped `WeakReference<Page>?` — isolated per instance |
| 3 | Memory safety | `UIViewController` subclass — MEM0002 retain-cycle risk | Plain C# class + `WeakReference` only |
| 4 | Hamburger button coupling | Static call to `NavigationRenderer.SetFlyoutLeftBarButton()` | Fully self-contained in `FlyoutPage.iOS.cs` |
| 5 | Status bar/home indicator routing | UIKit "last child added" default — could return the wrong VC | Explicit `ActiveDetailViewController`, always Detail |
| 6 | Nav bar button target | `nav.TopViewController` — follows a pushed child page | `nav.ViewControllers?.FirstOrDefault()` — always the root VC |
| 7 | Property dispatch | `OnElementPropertyChanged` if/else chain checking 20+ names | Mapper routes each property directly, no wasted calls |
| 8 | Rotation write-back | Could throw `InvalidOperationException` mid-rotation | `notifyDelegate: false` on the iPad rotation branch avoids the race |
| 9 | `Locked` behavior on iPhone | Complex conditional could fail to present | `shouldPresent = true` unconditionally for `Locked` |

## Handler as Default

The handler is registered as the **unconditional default** in `AppHostBuilderExtensions.cs` — no feature flag or opt-in required.

### What Changes By Default

- `FlyoutPage` uses `FlyoutViewHandler` instead of `PhoneFlyoutPageRenderer` on iOS/MacCatalyst
- Hamburger bar-button logic is now self-contained in `FlyoutPage.iOS.cs` — no more cross-renderer static call into `NavigationRenderer`
- Status bar/home indicator preferences are always explicitly sourced from the Detail VC
- Flyout icon/title `PropertyChanged` subscriptions are per-`FlyoutPage`-instance instead of static/global

### How to Opt Out

If an app needs to fall back to the renderer, register it manually in `MauiProgram.cs`:

```csharp
builder.ConfigureMauiHandlers(handlers =>
{
    handlers.AddHandler<FlyoutPage, PhoneFlyoutPageRenderer>();
});
```

`PhoneFlyoutPageRenderer` remains in the Compatibility layer (`src/Controls/src/Core/Compatibility/Handlers/FlyoutPage/iOS/PhoneFlyoutPageRenderer.cs`) and continues to work.

## Migration Guidance for Custom Renderer Users

If you subclassed `PhoneFlyoutPageRenderer` or accessed its internals, this section maps the old patterns to the new handler architecture.
### Old → New Mapping

| Old (Renderer) | New (Handler) | Notes |
|-----------------|-----------------|-------|
| `PhoneFlyoutPageRenderer` (IS a `UIViewController`) | `FlyoutViewHandler` (HAS a `UIViewController` via `FlyoutContainerManager`/`FlyoutContainerViewController`) | Handler is a `ViewHandler<IFlyoutView, UIView>`, not a VC |
| Override `ViewDidLayoutSubviews` | `FlyoutContainerViewController.ViewDidLayoutSubviews` → `manager.OnParentViewDidLayoutSubviews()` | Forwarded through the manager, not overridable directly |
| Override `ViewWillTransitionToSize` | `FlyoutContainerViewController.ViewWillTransitionToSize` → `manager.OnParentViewWillTransitionToSize(toSize)` | Same pattern |
| `PropertyChanged` switch on `FlyoutPage` | Mapper methods (`MapFlyout`, `MapDetail`, `MapIsPresented`, etc.) | Declarative — one method per property |
| `SetValueFromRenderer(IsPresentedProperty, value)` | Direct `fp.IsPresented = isPresented` | The mapper's own guard (`if (_isPresented == isPresented) return;`) prevents the write-back feedback loop — no special "came from renderer" flag needed |
| `NavigationRenderer.SetFlyoutLeftBarButton(vc, fp)` | `FlyoutPage.UpdateFlyoutLeftBarButton()` | Fully self-contained, no cross-renderer static call |
| `ChildViewControllerForStatusBarHidden` default (last child) | `FlyoutContainerViewController.GetActiveDetailViewController()` | Explicitly always the Detail VC |

### Adapter Pattern for Custom Renderers

If you must preserve custom renderer logic, keep using the renderer:

```csharp
// Keep using PhoneFlyoutPageRenderer with your customizations
builder.ConfigureMauiHandlers(handlers =>
{
    handlers.AddHandler<FlyoutPage, MyCustomFlyoutPageRenderer>();
});
```

### Testing

The existing FlyoutPage device tests continue to run against PhoneFlyoutPageRenderer, so they validate the renderer rather than the new FlyoutViewHandler. As part of this PR, the device tests were not migrated to target the handler. They will be updated once the testing approach introduced in PRs 36109 and 36507 is finalized.