### PR TITLE
[iOS And Windows] Fix Entry IsPassword ignored when Keyboard is set to Password

### DIFF
--- a/src/Core/src/Platform/Windows/MauiPasswordTextBox.cs
+++ b/src/Core/src/Platform/Windows/MauiPasswordTextBox.cs
@@ -56,27 +56,11 @@ namespace Microsoft.Maui.Platform
 		bool _internalChangeFlag;
 		int _cachedCursorPosition;
 		int _cachedTextLength;
-		readonly long _token;
 
 		public MauiPasswordTextBox()
 		{
 			TextChanging += OnNativeTextChanging;
 			TextChanged += OnNativeTextChanged;
-			_token = RegisterPropertyChangedCallback(TextBox.InputScopeProperty, OnInputScopePropertyChanged);
-			Unloaded += (s, e) =>
-			{
-				UnregisterPropertyChangedCallback(TextBox.InputScopeProperty, _token);
-			};
-		}
-
-		static void OnInputScopePropertyChanged(DependencyObject sender, DependencyProperty dp)
-		{
-			if (sender is not MauiPasswordTextBox mauiTxtBox || mauiTxtBox.IsPassword)
-			{
-				return;
-			}
-
-			mauiTxtBox.IsPassword = mauiTxtBox.InputScope?.Names?.Any(x => x.NameValue == InputScopeNameValue.Password) ?? false;
 		}
 
 		public bool IsPassword

--- a/src/Core/src/Platform/iOS/KeyboardExtensions.cs
+++ b/src/Core/src/Platform/iOS/KeyboardExtensions.cs
@@ -43,7 +43,6 @@ namespace Microsoft.Maui.Platform
 			else if (keyboard == Keyboard.Password)
 			{
 				textInput.SetKeyboardType(UIKeyboardType.Default);
-				textInput.SetSecureTextEntry(true);
 			}
 			else if (keyboard is CustomKeyboard)
 			{

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.cs
@@ -140,6 +140,70 @@ namespace Microsoft.Maui.DeviceTests
 				unsetValue);
 		}
 
+		
+#if !ANDROID // Android fix is covered by PR https://github.com/dotnet/maui/pull/36280
+		[Fact(DisplayName = "Password Keyboard Respects IsPassword False Initially")]
+		public async Task PasswordKeyboardRespectsIsPasswordFalseInitially()
+		{
+			var entry = new EntryStub()
+			{
+				Keyboard = Keyboard.Password,
+				IsPassword = false,
+				Text = "1234"
+			};
+
+			await CreateHandlerAsync(entry);
+
+			// Initial state: Keyboard=Password but IsPassword=false → text should NOT be masked
+			await InvokeOnMainThreadAsync(() =>
+			{
+				Assert.False(GetNativeIsPassword(entry.Handler as EntryHandler),
+					"Entry with Keyboard=Password and IsPassword=false should not be masked on initial load");
+			});
+		}
+
+		[Fact(DisplayName = "Password Keyboard IsPassword Toggle Works Correctly")]
+		public async Task PasswordKeyboardIsPasswordToggleWorksCorrectly()
+		{
+			var entry = new EntryStub()
+			{
+				Keyboard = Keyboard.Password,
+				IsPassword = false,
+				Text = "1234"
+			};
+
+			await CreateHandlerAsync(entry);
+
+			// Initial: IsPassword=false → not masked
+			await InvokeOnMainThreadAsync(() =>
+			{
+				Assert.False(GetNativeIsPassword(entry.Handler as EntryHandler),
+					"Initial state: should not be masked");
+			});
+
+			// Toggle to IsPassword=true → masked
+			// EntryStub is not a BindableObject, so we must explicitly call UpdateValue after changing the property.
+			await InvokeOnMainThreadAsync(() =>
+			{
+				entry.IsPassword = true;
+				(entry.Handler as EntryHandler).UpdateValue(nameof(IEntry.IsPassword));
+			});
+			await InvokeOnMainThreadAsync(() =>
+				Assert.True(GetNativeIsPassword(entry.Handler as EntryHandler),
+					"After IsPassword=true: should be masked"));
+
+			// Toggle back to IsPassword=false → not masked
+			await InvokeOnMainThreadAsync(() =>
+			{
+				entry.IsPassword = false;
+				(entry.Handler as EntryHandler).UpdateValue(nameof(IEntry.IsPassword));
+			});
+			await InvokeOnMainThreadAsync(() =>
+				Assert.False(GetNativeIsPassword(entry.Handler as EntryHandler),
+					"After IsPassword=false: should not be masked"));
+		}
+#endif
+
 		[Theory(DisplayName = "TextColor Updates Correctly")]
 		[InlineData(0xFFFF0000, 0xFF0000FF)]
 		[InlineData(0xFF0000FF, 0xFFFF0000)]


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
- An Entry with Keyboard="Password" always renders text as masked, ignoring IsPassword=false. Setting IsPassword=false has no effect on iOS (initial load) and Windows (initial load and runtime toggle) when Keyboard="Password" is set.

### Root Cause
- The MapIsPassword mapper runs before MapKeyboard in EntryHandler.cs on initial setup, so Keyboard.Password hardcodes masking behavior in ApplyKeyboard (iOS: SetSecureTextEntry(true)) and via an InputScope callback (Windows: OnInputScopePropertyChanged), both of which run after MapIsPassword and silently overwrite IsPassword=false.

### Description of Change
- **iOS**: Removed the hardcoded SetSecureTextEntry(true) from the Keyboard.Password branch in KeyboardExtensions.cs. SecureTextEntry is now set exclusively by TextFieldExtensions.UpdateIsPassword, respecting the actual IsPassword value.
- **Windows**: Removed the OnInputScopePropertyChanged callback from MauiPasswordTextBox that automatically forced IsPassword=true whenever InputScope changed to Password, allowing developers to set IsPassword=false even when Keyboard=Password is used.

**Note**: The Android fix for the same issue is tracked separately in PR #36280.


### Issues Fixed
Fixes #35650

### Validated the behaviour in the following platforms

- [x] Windows
- [ ] Android
- [x] iOS
- [x] Mac

### Output

| Platform | Before | After |
|----------|----------|----------|
| iOS | <video src="https://github.com/user-attachments/assets/1b249d36-8e83-434c-a7dc-b7a4b9c5a3f4"> | <video src="https://github.com/user-attachments/assets/1c917876-aa8f-4c39-93ca-22b6b592f213"> |
| Windows | <video src="https://github.com/user-attachments/assets/80ae3ff3-5c9b-4211-9451-eeb9fc13c126"> | <video src="https://github.com/user-attachments/assets/fdd830fe-8017-4b12-882d-bf118be4a9f1"> |