### PR TITLE
[XAML HR] Keep UpdateComponent() stable across generations to avoid E…

### DIFF
--- a/src/Controls/src/SourceGen/UpdateComponentCodeWriter.cs
+++ b/src/Controls/src/SourceGen/UpdateComponentCodeWriter.cs
@@ -147,9 +147,14 @@ static class UpdateComponentCodeWriter
 		INamedTypeSymbol rootType,
 		string accessModifier,
 		List<string> allPatchBodies,
-		int startVersion = 0)
+		int startVersion = 0,
+		bool forceEmitWhenEmpty = false)
 	{
-		if (allPatchBodies.Count == 0)
+		// When forceEmitWhenEmpty is set we still emit an (empty) UpdateComponent() body. This keeps the
+		// method present in the compilation after a structural reset clears the patch chain, so EnC /
+		// Hot Reload metadata-update sees a body *update* rather than a member *deletion* — the latter
+		// crashes the EnC delta emitter for a method that only ever existed in deltas (dotnet/roslyn#79898).
+		if (allPatchBodies.Count == 0 && !forceEmitWhenEmpty)
 			return null;
 
 		using var codeWriter = new IndentedTextWriter(new StringWriter(CultureInfo.InvariantCulture), "\t") { NewLine = NewLine };

--- a/src/Controls/src/SourceGen/XamlGenerator.cs
+++ b/src/Controls/src/SourceGen/XamlGenerator.cs
@@ -146,8 +146,59 @@ public class XamlGenerator : IIncrementalGenerator
 				throw new InvalidOperationException("Xaml item or target path is null");
 			}
 
+			// Keeps the previously-emitted generated sources for this file alive on iterations that bail out
+			// before (re)generating them — e.g. XAML that fails ShouldGenerateSourceGenInitializeComponent /
+			// CanSourceGenXaml, or that makes InitializeComponent generation throw. A source-generated member
+			// that silently disappears is seen by EnC / Hot Reload metadata-update as a member deletion, and
+			// deleting a member that only ever existed in EnC deltas crashes the EnC delta emitter
+			// (dotnet/roslyn#79898). Both the InitializeComponent partial (which declares the __version field)
+			// and the UpdateComponent partial (which reads it) are re-emitted verbatim, so the retained
+			// UpdateComponent() never references an undeclared __version (CS0103).
+			void KeepGeneratedSourcesAlive()
+			{
+				if (xamlItem?.ProjectItem is not { EnableIncrementalHotReload: true } hrProjectItem)
+					return;
+
+				var asm = compilation.AssemblyName ?? string.Empty;
+				var tfm = hrProjectItem.TargetFramework ?? string.Empty;
+				var key = hrProjectItem.HotReloadStateKey;
+
+				var lastUcSource = XamlHotReloadState.GetLastUpdateComponentSource(asm, tfm, key);
+				if (lastUcSource is null)
+					return; // Nothing has been emitted for this file yet — nothing to keep alive.
+
+				// Re-emit InitializeComponent first: it declares the __version field that UpdateComponent reads,
+				// so emitting the UC partial without it would orphan the method (CS0103).
+				var lastIcSource = XamlHotReloadState.GetLastInitializeComponentSource(asm, tfm, key);
+				if (lastIcSource is not null)
+					TryReemit(GetHintName(hrProjectItem, "xsg"), lastIcSource);
+
+				TryReemit(GetHintName(hrProjectItem, "uc.xsg"), lastUcSource);
+
+				void TryReemit(string hintName, string source)
+				{
+					try
+					{
+						sourceProductionContext.AddSource(hintName, source);
+					}
+					catch (ArgumentException)
+					{
+						// AddSource throws ArgumentException only when this hint name was already added this
+						// iteration — the source is already present, so there is nothing more to do. Any other
+						// exception (e.g. cancellation) is intentionally left to propagate.
+					}
+				}
+			}
+
 			if (!ShouldGenerateSourceGenInitializeComponent(xamlItem, xmlnsCache, compilation))
+			{
+				// Bails out before the try/catch below — e.g. the XAML became invalid this iteration
+				// (LoadXmlDocument throws inside ShouldGenerateSourceGenInitializeComponent and it returns
+				// false) or the root type temporarily can't be resolved. Keep the previously-emitted
+				// generated sources so EnC / Hot Reload metadata-update doesn't see a member deletion.
+				KeepGeneratedSourcesAlive();
 				return;
+			}
 
 			if (!CanSourceGenXaml(xamlItem, compilation, sourceProductionContext, xmlnsCache, typeCache))
 			{
@@ -181,6 +232,10 @@ public class XamlGenerator : IIncrementalGenerator
 					var location = LocationCreate(relativePath, lineInfo, string.Empty);
 					sourceProductionContext.ReportDiagnostic(Diagnostic.Create(Descriptors.XamlParserError, location, errorMessage));
 				}
+
+				// Invalid XAML this iteration — keep the previously-emitted generated sources alive so they
+				// don't look like member deletions to EnC / Hot Reload metadata-update.
+				KeepGeneratedSourcesAlive();
 				return;
 			}
 
@@ -313,10 +368,39 @@ public class XamlGenerator : IIncrementalGenerator
 				var code = InitializeComponentCodeWriter.GenerateInitializeComponent(xamlItem, compilation, sourceProductionContext, xmlnsCache, typeCache);
 				sourceProductionContext.AddSource(GetHintName(xamlItem.ProjectItem, "xsg"), code);
 
-				// Emit UC source if a diff was computed
+				// Remember the InitializeComponent source so it can be re-emitted verbatim alongside the
+				// UpdateComponent partial on later bail-out iterations (it declares the __version field UC reads).
+				if (xamlItem.ProjectItem.EnableIncrementalHotReload)
+					XamlHotReloadState.MarkInitializeComponentEmitted(assemblyName, targetFramework, stateKey, code);
+
+				// Keep UpdateComponent() alive once it has been emitted for this file. If the branch logic
+				// above did not (re)generate it this iteration — e.g. a C# Hot Reload edit that leaves the
+				// XAML unchanged, or a structural change that cleared the patch chain — re-emit it anyway:
+				// with the current patches, or as an empty no-op body. (Iterations where InitializeComponent
+				// generation throws on invalid XAML are handled by the catch block below.) A source-generated
+				// method that transiently disappears is seen by EnC / Hot Reload metadata-update as a member
+				// deletion, and deleting a method that only ever existed in EnC deltas crashes the delta
+				// emitter (dotnet/roslyn#79898).
+				if (ucCode == null
+					&& xamlItem.ProjectItem.EnableIncrementalHotReload
+					&& xamlItem.Xaml is not null
+					&& XamlHotReloadState.HasEmittedUpdateComponent(assemblyName, targetFramework, stateKey)
+					&& InitializeComponentCodeWriter.TryGetRootType(xamlItem, compilation, xmlnsCache, out var ucRootType, out var ucAccessModifier)
+					&& ucRootType != null)
+				{
+					var existingPatches = XamlHotReloadState.GetPatchBodies(assemblyName, targetFramework, stateKey);
+					ucCode = UpdateComponentCodeWriter.GenerateUpdateComponent(ucRootType, ucAccessModifier, existingPatches, forceEmitWhenEmpty: true);
+				}
+
+				// Emit UC source if present. Once emitted, it is kept alive across generations (see above),
+				// including via the catch block below when InitializeComponent generation throws on invalid XAML.
+				// Record it as emitted only AFTER AddSource succeeds (matching the InitializeComponent path above),
+				// so a throwing AddSource (e.g. cancellation) doesn't leave the cache believing a UC was produced
+				// that never actually made it into the compilation.
 				if (ucCode != null)
 				{
 					sourceProductionContext.AddSource(GetHintName(xamlItem.ProjectItem, "uc.xsg"), ucCode);
+					XamlHotReloadState.MarkUpdateComponentEmitted(assemblyName, targetFramework, stateKey, ucCode);
 				}
 			}
 			catch (Exception e)
@@ -342,6 +426,10 @@ public class XamlGenerator : IIncrementalGenerator
 
 				var location = xamlItem?.ProjectItem?.RelativePath is not null ? LocationCreate(xamlItem.ProjectItem.RelativePath, lineInfo, string.Empty) : null;
 				sourceProductionContext.ReportDiagnostic(Diagnostic.Create(Descriptors.XamlParserError, location, errorMessage));
+
+				// InitializeComponent generation threw this iteration — keep the previously-emitted generated
+				// sources alive so they don't look like member deletions to EnC (see local function).
+				KeepGeneratedSourcesAlive();
 			}
 		});
 

--- a/src/Controls/src/SourceGen/XamlHotReloadState.cs
+++ b/src/Controls/src/SourceGen/XamlHotReloadState.cs
@@ -61,6 +61,26 @@ internal static class XamlHotReloadState
 		/// On structural change, this list is cleared.
 		/// </summary>
 		public List<string> PatchBodies { get; } = new();
+
+		/// <summary>
+		/// The source text of the last <c>UpdateComponent()</c> partial emitted for this file during the
+		/// session, or <see langword="null"/> if none has been emitted yet. Once set, the generator keeps
+		/// re-emitting the method — regenerated for the current state, or this cached text when the current
+		/// iteration can't produce one (e.g. invalid XAML makes InitializeComponent generation throw) — so it
+		/// never transiently disappears from the compilation. A vanished source-generated method is seen by
+		/// EnC / Hot Reload metadata-update as a member deletion and crashes the EnC delta emitter
+		/// (dotnet/roslyn#79898).
+		/// </summary>
+		public string? LastUpdateComponentSource { get; set; }
+
+		/// <summary>
+		/// The source text of the last InitializeComponent partial (the <c>xsg</c> document) emitted for this
+		/// file, or <see langword="null"/> if none has been emitted yet. Re-emitted alongside
+		/// <see cref="LastUpdateComponentSource"/> on bail-out iterations: <c>__version</c> is declared only in
+		/// this InitializeComponent partial, so re-emitting the UpdateComponent partial without it would leave an
+		/// orphaned <c>UpdateComponent()</c> that references an undeclared field (CS0103).
+		/// </summary>
+		public string? LastInitializeComponentSource { get; set; }
 	}
 
 	/// <summary>
@@ -181,6 +201,77 @@ internal static class XamlHotReloadState
 			if (_cache.TryGetValue((assemblyName, targetFramework, relativePath), out var entry))
 				return new List<string>(entry.PatchBodies);
 			return new List<string>();
+		}
+	}
+
+	/// <summary>
+	/// Records the source of the <c>UpdateComponent()</c> partial emitted for the given file, so the
+	/// generator keeps re-emitting it and it never transiently disappears (see
+	/// <see cref="CacheEntry.LastUpdateComponentSource"/>).
+	/// </summary>
+	public static void MarkUpdateComponentEmitted(string assemblyName, string targetFramework, string stateKey, string ucSource)
+	{
+		lock (_lock)
+		{
+			if (!_cache.TryGetValue((assemblyName, targetFramework, stateKey), out var entry))
+			{
+				entry = new CacheEntry();
+				_cache[(assemblyName, targetFramework, stateKey)] = entry;
+			}
+			entry.LastUpdateComponentSource = ucSource;
+		}
+	}
+
+	/// <summary>
+	/// Returns <see langword="true"/> if an <c>UpdateComponent()</c> partial has already been emitted for the given file.
+	/// </summary>
+	public static bool HasEmittedUpdateComponent(string assemblyName, string targetFramework, string stateKey)
+	{
+		lock (_lock)
+		{
+			return _cache.TryGetValue((assemblyName, targetFramework, stateKey), out var entry) && entry.LastUpdateComponentSource != null;
+		}
+	}
+
+	/// <summary>
+	/// Returns the source of the last <c>UpdateComponent()</c> partial emitted for the given file, or
+	/// <see langword="null"/> if none has been emitted yet.
+	/// </summary>
+	public static string? GetLastUpdateComponentSource(string assemblyName, string targetFramework, string stateKey)
+	{
+		lock (_lock)
+		{
+			return _cache.TryGetValue((assemblyName, targetFramework, stateKey), out var entry) ? entry.LastUpdateComponentSource : null;
+		}
+	}
+
+	/// <summary>
+	/// Records the source of the InitializeComponent partial (the <c>xsg</c> document) emitted for the given
+	/// file, so it can be re-emitted alongside the UpdateComponent partial on bail-out iterations (see
+	/// <see cref="CacheEntry.LastInitializeComponentSource"/>).
+	/// </summary>
+	public static void MarkInitializeComponentEmitted(string assemblyName, string targetFramework, string stateKey, string icSource)
+	{
+		lock (_lock)
+		{
+			if (!_cache.TryGetValue((assemblyName, targetFramework, stateKey), out var entry))
+			{
+				entry = new CacheEntry();
+				_cache[(assemblyName, targetFramework, stateKey)] = entry;
+			}
+			entry.LastInitializeComponentSource = icSource;
+		}
+	}
+
+	/// <summary>
+	/// Returns the source of the last InitializeComponent partial emitted for the given file, or
+	/// <see langword="null"/> if none has been emitted yet.
+	/// </summary>
+	public static string? GetLastInitializeComponentSource(string assemblyName, string targetFramework, string stateKey)
+	{
+		lock (_lock)
+		{
+			return _cache.TryGetValue((assemblyName, targetFramework, stateKey), out var entry) ? entry.LastInitializeComponentSource : null;
 		}
 	}
 

--- a/src/Controls/tests/SourceGen.UnitTests/XamlIncrementalHotReloadPipelineTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/XamlIncrementalHotReloadPipelineTests.cs
@@ -508,6 +508,24 @@ public class XamlIncrementalHotReloadPipelineTests : IDisposable
 		return null;
 	}
 
+	// Compiles every source produced in a run together and returns the error diagnostics located inside a
+	// generated .xsg.cs file — both the InitializeComponent partial (".xsg.cs") and the UpdateComponent
+	// partial (".uc.xsg.cs", which also ends in ".xsg.cs"). Used to catch an UpdateComponent() that is
+	// re-emitted without its companion InitializeComponent partial (the __version declaration → CS0103).
+	static Diagnostic[] CompileGeneratedXsgErrors(GeneratorDriverRunResult result)
+	{
+		var compilation = CreateCompilation();
+		foreach (var gen in result.Results)
+			foreach (var src in gen.GeneratedSources)
+				compilation = compilation.AddSyntaxTrees(
+					CSharpSyntaxTree.ParseText(src.SourceText.ToString(), path: src.HintName));
+
+		return compilation.GetDiagnostics()
+			.Where(d => d.Severity == DiagnosticSeverity.Error
+				&& d.Location.SourceTree?.FilePath?.EndsWith(".xsg.cs", StringComparison.OrdinalIgnoreCase) == true)
+			.ToArray();
+	}
+
 	// -----------------------------------------------------------------------
 	// Dispose: always reset static state to isolate tests
 	// -----------------------------------------------------------------------
@@ -735,6 +753,131 @@ public class XamlIncrementalHotReloadPipelineTests : IDisposable
 		// Defensive: the broken pre-round-3 behavior would have produced no UC at all OR
 		// a UC that no longer references version 1.
 		Assert.DoesNotContain("__version == 1", run3Uc!, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void CSharpOnlyEdit_AfterPatch_KeepsUpdateComponentAlive()
+	{
+		// Regression for dotnet/roslyn#79898: once UpdateComponent() has been emitted, a generator
+		// re-run triggered by a C# Hot Reload edit (the compilation changes while the XAML is
+		// unchanged) must NOT drop the generated UpdateComponent() partial. A source-generated method
+		// that transiently disappears is seen by Edit-and-Continue as a member *deletion*, and deleting
+		// a method that only ever existed in EnC deltas crashes the EnC delta emitter
+		// (DefinitionMap.GetPreviousMethodHandle). Before the fix, run 3 below produced no UC at all.
+		XamlHotReloadState.Reset();
+
+		var compilation = CreateCompilation();
+		var fileV1 = MakeFile(PageXamlV1);
+		var fileV2 = MakeFile(PageXamlV2_PropertyChange);
+
+		ISourceGenerator generator = new XamlGenerator().AsSourceGenerator();
+		var options = new Microsoft.CodeAnalysis.GeneratorDriverOptions(
+			disabledOutputs: Microsoft.CodeAnalysis.IncrementalGeneratorOutputKind.None,
+			trackIncrementalGeneratorSteps: true);
+
+		Microsoft.CodeAnalysis.GeneratorDriver driver = CSharpGeneratorDriver.Create([generator], driverOptions: options)
+			.AddAdditionalTexts(System.Collections.Immutable.ImmutableArray.Create<Microsoft.CodeAnalysis.AdditionalText>(fileV1.Text))
+			.WithUpdatedAnalyzerConfigOptions(new OptionsProvider([fileV1]));
+
+		// Run 1: seed at version 0 — no UC yet.
+		driver = driver.RunGenerators(compilation);
+		Assert.Null(FindUCSource(driver.GetRunResult(), "uc.xsg"));
+
+		// Run 2: real property change → UpdateComponent() is emitted.
+		driver = driver
+			.ReplaceAdditionalText(fileV1.Text, fileV2.Text)
+			.WithUpdatedAnalyzerConfigOptions(new OptionsProvider([fileV2]))
+			.RunGenerators(compilation);
+		Assert.NotNull(FindUCSource(driver.GetRunResult(), "uc.xsg"));
+
+		// Run 3: XAML unchanged, but the compilation changes (a C# Hot Reload edit adds a type). The
+		// generator re-runs for the unchanged XAML; UpdateComponent() must survive, re-emitted with the
+		// same accumulated patch chain (version 0→1) rather than dropped.
+		var compilationAfterCSharpEdit = compilation.AddSyntaxTrees(
+			CSharpSyntaxTree.ParseText("namespace TestApp { class __CSharpEditMarker { } }"));
+		driver = driver.RunGenerators(compilationAfterCSharpEdit);
+
+		var run3Uc = FindUCSource(driver.GetRunResult(), "uc.xsg");
+		Assert.NotNull(run3Uc);
+		Assert.Contains("__version == 0", run3Uc!, StringComparison.Ordinal);
+		Assert.Contains("__version = 1", run3Uc!, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void MalformedXamlEdit_AfterPatch_KeepsUpdateComponentAliveAndCompiles()
+	{
+		// Review follow-up for dotnet/roslyn#79898: a mid-edit that makes the XAML *malformed* (an XML
+		// well-formedness error) fails LoadXmlDocument inside ShouldGenerateSourceGenInitializeComponent, so
+		// the IC pipeline bails at the early return *before* the try/catch. A previously-emitted
+		// UpdateComponent() must still NOT silently disappear (EnC would read that as a member deletion and
+		// crash). The last-good InitializeComponent + UpdateComponent sources are re-emitted together, so the
+		// retained UpdateComponent() is never left referencing an undeclared __version field (CS0103).
+		XamlHotReloadState.Reset();
+
+		const string malformedXaml = """
+			<?xml version="1.0" encoding="utf-8" ?>
+			<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			             x:Class="TestApp.MainPage">
+			    <VerticalStackLayout>
+			        <Label Text="Hi" />
+			    </Grid>
+			</ContentPage>
+			""";
+
+		// Seed → property change (UC emitted) → malformed XAML (mismatched </Grid> fails XML parsing).
+		var (_, run2, run3) = ThreeRuns(PageXamlV1, PageXamlV2_PropertyChange, malformedXaml);
+
+		Assert.NotNull(FindUCSource(run2, "uc.xsg"));
+
+		// UpdateComponent() must survive the malformed-XAML iteration, re-emitted as the last-good source...
+		var run3Uc = FindUCSource(run3, "uc.xsg");
+		Assert.NotNull(run3Uc);
+		Assert.Contains("__version == 0", run3Uc!, StringComparison.Ordinal);
+
+		// ...together with its companion InitializeComponent partial, so the retained UC does not orphan.
+		// Without the companion re-emit, __version would be undeclared and compiling run 3 would yield CS0103.
+		var run3Errors = CompileGeneratedXsgErrors(run3);
+		Assert.DoesNotContain(run3Errors, d => d.Id == "CS0103" && d.GetMessage().Contains("__version", StringComparison.Ordinal));
+	}
+
+	[Fact]
+	public void SemanticallyInvalidXamlEdit_AfterPatch_KeepsUpdateComponentAlive()
+	{
+		// Review follow-up for dotnet/roslyn#79898: a mid-edit whose XAML is well-formed XML but
+		// *semantically* invalid (here, an unknown element type) passes ShouldGenerateSourceGenInitializeComponent
+		// and enters the try block, where InitializeComponent generation throws — exercising the outer catch
+		// (distinct from the malformed-XML early return covered above). A previously-emitted UpdateComponent()
+		// must still survive that iteration, and its companion InitializeComponent partial is re-emitted so
+		// __version stays declared (no CS0103).
+		XamlHotReloadState.Reset();
+
+		const string semanticallyInvalidXaml = """
+			<?xml version="1.0" encoding="utf-8" ?>
+			<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			             x:Class="TestApp.MainPage">
+			    <ThisControlDoesNotExist />
+			</ContentPage>
+			""";
+
+		// Seed → property change (UC emitted) → well-formed but semantically invalid XAML (IC gen throws).
+		var (_, run2, run3) = ThreeRuns(PageXamlV1, PageXamlV2_PropertyChange, semanticallyInvalidXaml);
+
+		Assert.NotNull(FindUCSource(run2, "uc.xsg"));
+
+		// The generator must have reached the try/catch path (IC generation threw → a parser error is
+		// reported), not the malformed-XML early return.
+		Assert.Contains(run3.Diagnostics, d => d.Id == "MAUIG1001");
+
+		// UpdateComponent() must survive, re-emitted as the last-good source...
+		var run3Uc = FindUCSource(run3, "uc.xsg");
+		Assert.NotNull(run3Uc);
+		Assert.Contains("__version == 0", run3Uc!, StringComparison.Ordinal);
+
+		// ...with its companion InitializeComponent partial, so the retained UC is not orphaned (CS0103).
+		var run3Errors = CompileGeneratedXsgErrors(run3);
+		Assert.DoesNotContain(run3Errors, d => d.Id == "CS0103" && d.GetMessage().Contains("__version", StringComparison.Ordinal));
 	}
 
 	[Fact]


### PR DESCRIPTION
Re-opening, https://github.com/dotnet/maui/pull/36674 was automatically closed because of `feature/xaml-incremental-hotreload` merge to `net11.0`

## Summary

Under XAML Incremental Hot Reload, the generated `UpdateComponent()` partial (`*.uc.xsg.g.cs`) could **transiently disappear** from the compilation between generator runs. Edit-and-Continue / Hot Reload metadata-update reads a vanished source-generated method as a **member deletion**, and deleting a method that only ever existed in EnC deltas crashes the Roslyn EnC delta emitter with a `NullReferenceException` in `DefinitionMap.GetPreviousMethodHandle` (surfaced to the user as `ENC1002: Cannot apply changes -- unexpected error`). The Hot Reload session then can't apply further updates until a rebuild.

This is the MAUI-side trigger for **dotnet/roslyn#79898**.

## Root cause

`XamlGenerator` only emitted the `uc.xsg` document when the current run produced a `ucCode`. It was left `null` — dropping the already-emitted `UpdateComponent()` — in several common cases:

- a **C# Hot Reload edit** (the compilation changes while the XAML is unchanged, so the generator re-runs but takes the "XAML unchanged" path);
- an **invalid-XAML parse error**;
- a **structural change** that clears the patch chain (`UpdateAndClearPatches`).

## Fix

Once `UpdateComponent()` has been emitted for a file during the session, always re-emit it so EnC only ever sees an **add** (once) followed by **updates** — never a **delete**:

- `XamlHotReloadState` tracks `UpdateComponentEmitted` per file (`MarkUpdateComponentEmitted` / `HasEmittedUpdateComponent`).
- `UpdateComponentCodeWriter.GenerateUpdateComponent` gains `forceEmitWhenEmpty` to emit an **empty no-op body** after a structural reset (instead of returning `null`).
- `XamlGenerator` adds a post-branch fallback: when `ucCode` is `null` but the method was already emitted, re-emit it — with the current patch chain, or empty after a structural reset.

Gated on `HasEmittedUpdateComponent`, so **nothing is introduced into the baseline build** (a file that never emitted `UpdateComponent()` still won't emit one).

## Test

`XamlIncrementalHotReloadPipelineTests.CSharpOnlyEdit_AfterPatch_KeepsUpdateComponentAlive`:

1. Seed (no UC).
2. Property change → `UpdateComponent()` emitted.
3. **XAML unchanged but the compilation changes** (simulating a C# Hot Reload edit) → asserts `UpdateComponent()` is still emitted, re-emitted with the same `__version == 0 → 1` patch chain rather than dropped.

Fails before this change (UC dropped on run 3); passes after. The existing "no UC" / "no-op edit" pipeline tests continue to pass (the fallback is inert until the method is first emitted).

## Notes

- This is a **workaround** that avoids the add/delete churn from the generator side; the underlying Roslyn EnC robustness issue is tracked in **dotnet/roslyn#79898**.
- The `UpdateComponent()` add/delete churn was confirmed from captured EnC file logs: the baseline assembly never contained `UpdateComponent`, the method appeared only in EnC delta metadata, and a later generation regenerated the document without it — the delete that crashes the EnC emitter.
