### PR TITLE
[iOS] Fix: Carouselview restores stale Position over CurrentItem after off-screen ItemsSource Change

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
@@ -139,13 +139,14 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			{
 				carousel.SetValueFromRenderer(CarouselView.CurrentItemProperty, null);
 				carousel.SetValueFromRenderer(CarouselView.PositionProperty, 0);
+
+				// A new items source means a fresh baseline. Reset the tracked position so the next
+				// re-attach treats a subsequent source swap as a reset (Position 0) rather than a
+				// detached position change. This keeps a new ItemsSource/ViewModel resetting to the
+				// first item, matching Android behavior.
+				_lastSyncedPosition = 0;
 			}
 
-			// A new items source means a fresh baseline. Reset the tracked position so the next
-			// re-attach treats the source swap as a reset (Position 0) rather than a detached
-			// position change. This keeps a new ItemsSource/ViewModel resetting to the first item,
-			// matching Android behavior.
-			_lastSyncedPosition = 0;
 			_isUpdating = false;
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/CarouselView/CarouselViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CarouselView/CarouselViewTests.iOS.cs
@@ -2,14 +2,94 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers.Compatibility;
 using Microsoft.Maui.Controls.Handlers.Items2;
+using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
 using Xunit;
+using static Microsoft.Maui.DeviceTests.AssertHelpers;
 
 namespace Microsoft.Maui.DeviceTests
 {
 	public partial class CarouselViewTests
 	{
+		void SetupBuilderForDetachedItemsSourceReplacement()
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler(typeof(Toolbar), typeof(ToolbarHandler));
+					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationRenderer));
+					handlers.AddHandler<Page, PageHandler>();
+					handlers.AddHandler<Window, WindowHandlerStub>();
+					handlers.AddHandler<CarouselView, CarouselViewHandler2>();
+					handlers.AddHandler<IContentView, ContentViewHandler>();
+					handlers.AddHandler<Grid, LayoutHandler>();
+					handlers.AddHandler<Label, LabelHandler>();
+				});
+			});
+		}
+
+		// Reproduces https://github.com/dotnet/maui/issues/36602:
+		// While a CarouselView using CarouselViewHandler2 is detached (navigated away from),
+		// replacing its ItemsSource and setting a new CurrentItem must NOT be overridden by the
+		// stale Position value once the CarouselView is reattached.
+		[Fact(DisplayName = "CarouselView Honors CurrentItem Over Stale Position After Detached ItemsSource Replacement")]
+		public async Task CarouselViewHonorsCurrentItemOverStalePositionAfterDetachedItemsSourceReplacement()
+		{
+			SetupBuilderForDetachedItemsSourceReplacement();
+
+			var catalogA = new List<string> { "A0", "A1", "A2", "A3", "A4" };
+			var catalogB = new List<string> { "B0", "B1", "B2", "B3", "B4" };
+
+			var indicator = new IndicatorView();
+			var carouselView = new CarouselView
+			{
+				ItemsSource = catalogA,
+				ItemTemplate = new DataTemplate(() => new Label()),
+				IndicatorView = indicator
+			};
+
+			var navPage = new NavigationPage(new ContentPage { Content = carouselView });
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), async _ =>
+			{
+				// Establish the initial, valid selection: Position 3 / CurrentItem "A3".
+				carouselView.Position = 3;
+				carouselView.CurrentItem = "A3";
+
+				await AssertEventually(
+					() => carouselView.Position == 3 && (string)carouselView.CurrentItem == "A3",
+					message: "Initial CarouselView state failed to synchronize to Position 3 / CurrentItem A3");
+
+				// Navigate away — this detaches the CarouselView's native view from the window.
+				await navPage.PushAsync(new ContentPage { Content = new Label { Text = "Away" } });
+
+				// While detached, replace ItemsSource with catalog B and select "B1" via CurrentItem.
+				// Position is intentionally left untouched (still 3), mirroring the real-world scenario.
+				carouselView.ItemsSource = catalogB;
+				carouselView.CurrentItem = "B1";
+
+				// Navigate back — this reattaches the CarouselView's native view and triggers position sync.
+				await navPage.PopAsync();
+
+				await AssertEventually(
+					() => carouselView.Position == 1 && (string)carouselView.CurrentItem == "B1",
+					timeout: 3000,
+					message: "CarouselView did not resolve CurrentItem 'B1' at Position 1 after reattaching; " +
+						$"actual Position={carouselView.Position}, CurrentItem={carouselView.CurrentItem}");
+
+				// Expected (fixed behavior): CurrentItem "B1" wins, Position resolves to 1, and the
+				// linked IndicatorView stays in sync. Regressed behavior restores stale Position 3,
+				// which would make CurrentItem resolve to "B3" instead.
+				Assert.Equal("B1", carouselView.CurrentItem);
+				Assert.Equal(1, carouselView.Position);
+				Assert.Equal(1, indicator.Position);
+			});
+		}
+
 		[Fact(DisplayName = "CarouselView Does Not Leak With Default ItemsLayout")]
 		public async Task CarouselViewDoesNotLeakWithDefaultItemsLayout()
 		{


### PR DESCRIPTION
<!-- Please keep the note below for people who find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment whether this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

This pull request addresses an issue with `CarouselView` on iOS where replacing the `ItemsSource` and setting a new `CurrentItem` while the view is detached could result in the wrong item being displayed when reattached. The update ensures that the new `CurrentItem` is respected over any stale `Position` value after the `ItemsSource` is replaced while detached. Additionally, a new test is added to prevent regressions for this scenario.

This is a regression introduced by #36287, which added `_lastSyncedPosition` tracking and a reattach heuristic in `CarouselViewController2.cs`. That change unconditionally reset `_lastSyncedPosition` on every `ItemsSource` update — even while detached, when the `Position`/`CurrentItem` reset is skipped — causing the stale `Position` to be wrongly treated as an explicit user change on reattach and overriding a valid `CurrentItem` set on the replacement source.

### Description of change
**Bug Fixes:**

* Updated `CarouselViewController2.cs` to reset the tracked position correctly when the `ItemsSource` is replaced, ensuring the new `CurrentItem` is honored over a stale `Position` after reattaching the view. This addresses the regression introduced in #36287.

**Testing:**

* Added a new test `CarouselViewHonorsCurrentItemOverStalePositionAfterDetachedItemsSourceReplacement` in `CarouselViewTests.iOS.cs` to verify that replacing the `ItemsSource` and setting a new `CurrentItem` while detached works as expected after reattaching.
* Introduced a helper method `SetupBuilderForDetachedItemsSourceReplacement` to configure handlers for the test scenario.

<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #36602 

### Tested the behavior in the following platforms

- [ ] Windows
- [ ] Android
- [x] iOS
- [ ] Mac


| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/881dbe8f-323b-49ba-894d-f23fd368651c">  | <video src="https://github.com/user-attachments/assets/e55b5e56-4d74-4ad5-83b9-d63b41c6e503"> |

<!--

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
