### PR TITLE
[XAML] Enable Incremental Hot Reload by default in Debug

### DIFF
--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -10,11 +10,13 @@
     <_MauiXamlInflator Condition="' $(MauiXamlInflator)' != '' ">$(MauiXamlInflator)</_MauiXamlInflator>
     <_MauiXamlInflator Condition=" '$(MauiXamlInflator)' == '' ">SourceGen</_MauiXamlInflator>
 
-    <!-- XAML Incremental Hot Reload (XIHR): opt-in for the initial ship (Preview 6). Hot reload is a
+    <!-- XAML Incremental Hot Reload (XIHR): on by default for .NET 11 projects (Preview 7). Hot reload is a
          dev-time feature; when enabled it emits per-page registry calls and keeps the runtime feature
-         switch on. Default off everywhere — set <EnableMauiIncrementalHotReload>true</...> to opt in.
-         Default-on is planned for a later preview (see the .NET 11 Hot Reload plan). Resolves to an
-         explicit true/false so the value always flows to the source generator and runtime config. -->
+         switch on, so it defaults on for Debug builds only and stays off for Release/publish, where the
+         registry calls and runtime switch trim away. Set <EnableMauiIncrementalHotReload>false</...> to
+         opt out (legacy XAML Hot Reload remains available as a fallback). Resolves to an explicit
+         true/false so the value always flows to the source generator and runtime config. -->
+    <EnableMauiIncrementalHotReload Condition="'$(EnableMauiIncrementalHotReload)' == '' and '$(Configuration)' == 'Debug'">true</EnableMauiIncrementalHotReload>
     <EnableMauiIncrementalHotReload Condition="'$(EnableMauiIncrementalHotReload)' == ''">false</EnableMauiIncrementalHotReload>
 
     <!-- XAML Hot Reload mode for IDE communication (Legacy or SourceGen) -->

--- a/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
+++ b/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
@@ -92,6 +92,13 @@
     <!-- Benchmark comparison: with and without LazyRD -->
     <MauiXaml Update="Benchmark.xaml" LazyRD="true" />
     <MauiXaml Update="BenchmarkNoLazy.xaml" LazyRD="false" />
+
+    <!-- These tests exercise the legacy ResourceProvider2 hot-reload fallback (InitializeComponentRuntime),
+         which XAML Incremental Hot Reload intentionally supersedes when enabled. Pin them off so they keep
+         covering the legacy path regardless of the default; XIHR-on codegen is covered by SourceGen.UnitTests.
+         See dotnet/maui#36682. -->
+    <MauiXaml Update="HotReload.xaml" EnableIncrementalHotReload="false" />
+    <MauiXaml Update="InflatorSwitch\XamlInflatorSourceGen.sgen.xaml" EnableIncrementalHotReload="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
@@ -308,7 +308,10 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			project.Add(AddFile("MainPage.xaml", "MauiXaml", Xaml.MainPage));
 			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
 			project.Save(projectFile);
-			Build(projectFile, additionalArgs: $"-c {configuration} -p:MauiXamlInflator=SourceGen -p:EmitCompilerGeneratedFiles=True -p:CompilerGeneratedFilesOutputPath=Generated");
+			// Pin XIHR off: this test covers the legacy ResourceProvider2 hot-reload fallback
+			// (InitializeComponentRuntime), which XAML Incremental Hot Reload intentionally supersedes
+			// when enabled (on by default in Debug). See dotnet/maui#36682.
+			Build(projectFile, additionalArgs: $"-c {configuration} -p:MauiXamlInflator=SourceGen -p:EnableMauiIncrementalHotReload=false -p:EmitCompilerGeneratedFiles=True -p:CompilerGeneratedFilesOutputPath=Generated");
 
 			var generatorDirectory = IOPath.Combine(tempDirectory, "Generated", "Microsoft.Maui.Controls.SourceGen", "Microsoft.Maui.Controls.SourceGen.XamlGenerator");
 			AssertExists(IOPath.Combine(generatorDirectory, "MainPage.xaml.sg.cs"), nonEmpty: true);


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description

XAML Incremental Hot Reload (XIHR) shipped in #34338 as **opt-in**, with `EnableMauiIncrementalHotReload` defaulting to `false` everywhere. Per the .NET 11 Hot Reload plan (Phase 3 — Default-On, Preview 7), this PR **turns it on by default**.

### What changed

A single MSBuild default in `Microsoft.Maui.Controls.targets`:

- `EnableMauiIncrementalHotReload` now defaults to **`true` for `Debug` builds** and stays **`false` for `Release`/publish**.
- As a result, `MauiXamlHotReload` resolves to `SourceGen` (instead of `Legacy`) for Debug builds.

Hot reload is a dev-time feature: gating default-on to `Debug` keeps the per-page registry calls and the `Microsoft.Maui.RuntimeFeature.IsIncrementalHotReloadEnabled` runtime switch **off in shipped apps**, so they trim away in `Release`/publish (the `RuntimeHostConfigurationOption` is emitted with `Trim="true"`). This mirrors the existing `EnableMauiXamlDiagnostics` Debug-gating pattern a few lines below in the same file.

Users can still **opt out** with `<EnableMauiIncrementalHotReload>false</EnableMauiIncrementalHotReload>`; legacy XAML Hot Reload remains available as a fallback (VS / VS Code toggle).

### Behavior matrix

| Configuration | `EnableMauiIncrementalHotReload` | `MauiXamlHotReload` |
|---|---|---|
| Debug (default) | `true` | `SourceGen` |
| Release / publish (default) | `false` | `Legacy` |
| Debug + explicit `false` | `false` | `Legacy` |
| Release + explicit `true` | `true` | `SourceGen` |

### Testing

Validated the MSBuild default cascade across all of the above scenarios (Debug→on/SourceGen, Release→off/Legacy, empty config→off, explicit opt-out/opt-in both respected). No public API changes; templates don't set the flag, so new projects pick up the Debug default automatically. Existing SourceGen unit tests (which set the flag per-file) continue to cover both on and off code-generation paths.
