### PR TITLE
[XAML] Fix XIHR DataTemplate emission for multi-set and scoped templates

### DIFF
--- a/src/Controls/src/SourceGen/SourceGenContext.cs
+++ b/src/Controls/src/SourceGen/SourceGenContext.cs
@@ -77,6 +77,15 @@ class SourceGenContext(IndentedTextWriter writer, Compilation compilation, Sourc
 		}
 	}
 
+	readonly HashSet<string> _emittedTemplateMethods = new HashSet<string>();
+
+	// Reserves a generated DataTemplate LoadTemplate method name once per compilation unit, so a
+	// template whose value is set more than once in the same scope (e.g. a `required` property set
+	// in the object initializer AND as an assignment) emits the local function only once instead of
+	// redeclaring it. Returns true the first time a name is seen, false afterwards. See dotnet/maui#36682.
+	public bool TryReserveTemplateMethod(string name)
+		=> ParentContext != null ? ParentContext.TryReserveTemplateMethod(name) : _emittedTemplateMethods.Add(name);
+
 	internal Dictionary<ITypeSymbol, (ConverterDelegate, ITypeSymbol)>? knownSGTypeConverters;
 	internal Dictionary<ITypeSymbol, IKnownMarkupValueProvider>? knownSGValueProviders;
 	internal Dictionary<ITypeSymbol, ProvideValueDelegate>? knownSGEarlyMarkupExtensions;

--- a/src/Controls/src/SourceGen/Visitors/CreateValuesVisitor.cs
+++ b/src/Controls/src/SourceGen/Visitors/CreateValuesVisitor.cs
@@ -54,7 +54,7 @@ class CreateValuesVisitor : IXamlNodeVisitor
 		if (type.Equals(compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.Xaml.ArrayExtension"), SymbolEqualityComparer.Default))
 		{
 			//we might want to move this to a separate method
-			var visitor = new SetPropertiesVisitor(Context);
+			var visitor = new SetPropertiesVisitor(Context, valuePrecomputePass: true);
 			// var children = node.Properties.Values.ToList();
 			// children.AddRange(node.CollectionItems);
 			foreach (var cn in node.CollectionItems)
@@ -220,7 +220,7 @@ class CreateValuesVisitor : IXamlNodeVisitor
 				var pType = req is IPropertySymbol prop ? prop.Type : ((IFieldSymbol)req).Type;
 				var pConverter = req.GetAttributes().FirstOrDefault(a => a.AttributeClass!.Equals(compilation.GetTypeByMetadataName("System.ComponentModel.TypeConverterAttribute")!, SymbolEqualityComparer.Default))?.ConstructorArguments[0].Value as ITypeSymbol;
 
-				var visitor = new SetPropertiesVisitor(Context);
+				var visitor = new SetPropertiesVisitor(Context, valuePrecomputePass: true);
 				var children = node.Properties.Values.ToList();
 				children.AddRange(node.CollectionItems);
 				foreach (var cn in children)

--- a/src/Controls/src/SourceGen/Visitors/SetPropertiesVisitor.cs
+++ b/src/Controls/src/SourceGen/Visitors/SetPropertiesVisitor.cs
@@ -168,7 +168,7 @@ class SetPropertiesVisitor(SourceGenContext context, bool stopOnResourceDictiona
 
 	public void Visit(ElementNode node, INode parentNode)
 	{
-		NodeSGExtensions.GetNodeValueDelegate getNodeValue = (n, type) => 
+		NodeSGExtensions.GetNodeValueDelegate getNodeValue = (n, type) =>
 		{
 			if (!context.Variables.TryGetValue(n, out var val))
 			{
@@ -200,7 +200,7 @@ class SetPropertiesVisitor(SourceGenContext context, bool stopOnResourceDictiona
 		{
 			// Find the ResourceDictionary parent
 			ILocalValue? rdVar = null;
-			
+
 			if (parentNode is ElementNode parentElement && Context.Variables.TryGetValue(parentElement, out var pVar))
 			{
 				var rdType = Context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.ResourceDictionary")!;
@@ -242,50 +242,40 @@ class SetPropertiesVisitor(SourceGenContext context, bool stopOnResourceDictiona
 			var variable = Context.Variables[parentNode];
 
 			// Under XAML Incremental Hot Reload, emit the template content as a stably-named local
-			// method rather than an anonymous lambda. On each edit the source generator regenerates
+			// function rather than an anonymous lambda. On each edit the source generator regenerates
 			// InitializeComponent; an anonymous `LoadTemplate = () => { ... }` lambda has an unstable
 			// synthesized-closure identity across regenerations, so successive edits to a control
 			// inside a DataTemplate produce invalid Edit-and-Continue deltas (deleted/renamed
 			// synthesized closure methods) that crash the app, poison Hot Reload, or kill the
-			// watcher (dotnet/maui#36482). A named local function gives EnC a stable name anchor
-			// while preserving capture semantics. Non-HR builds keep the anonymous lambda.
+			// watcher (dotnet/maui#36482). A named local function gives EnC a stable name anchor.
+			//
+			// The function is emitted INLINE at the point of use (not hoisted to the top of the
+			// method) so its body keeps the exact lexical scope the lambda had — references to
+			// enclosing locals (the DataTemplate variable, name scopes, resources) resolve the same
+			// way. It is emitted at most once per template: a template value can be set more than
+			// once in the same scope (e.g. a `required` property set both in the object initializer
+			// and as an assignment), and redeclaring the local function would not compile
+			// (dotnet/maui#36682). Non-HR builds keep the anonymous lambda.
 			if (Context.ProjectItem.EnableIncrementalHotReload)
 			{
 				var methodName = TemplateLoadMethodName(node);
-
-				// Buffer the template body by pointing the child context at a fresh writer.
-				var bodyBuffer = new System.IO.StringWriter(System.Globalization.CultureInfo.InvariantCulture);
-				var bodyWriter = new IndentedTextWriter(bodyBuffer, "\t");
-				var bufferedContext = new SourceGenContext(bodyWriter, context.Compilation, context.SourceProductionContext, context.XmlnsCache, context.TypeCache, context.RootType!, null, context.ProjectItem)
+				if (Context.TryReserveTemplateMethod(methodName))
 				{
-					ParentContext = context,
-				};
+					Writer.WriteLine($"object {methodName}()");
+					using (PrePost.NewBlock(Writer, begin: "{", end: "}"))
+					{
+						var templateContext = new SourceGenContext(Writer, context.Compilation, context.SourceProductionContext, context.XmlnsCache, context.TypeCache, context.RootType!, null, context.ProjectItem)
+						{
+							ParentContext = context,
+						};
 
-				node.Accept(new CreateValuesVisitor(bufferedContext), null);
-				node.Accept(new SetNamescopesAndRegisterNamesVisitor(bufferedContext), null);
-				node.Accept(new SetResourcesVisitor(bufferedContext), null);
-				node.Accept(new SetPropertiesVisitor(bufferedContext, stopOnResourceDictionary: true), null);
-				bodyWriter.WriteLine($"return {bufferedContext.Variables[node].ValueAccessor};");
-				bodyWriter.Flush();
-
-				// Wrap the buffered body in a named local function and hoist it to the top of the
-				// generated method (AddLocalMethod bubbles to the root context).
-				var methodBuffer = new System.IO.StringWriter(System.Globalization.CultureInfo.InvariantCulture);
-				var methodWriter = new IndentedTextWriter(methodBuffer, "\t");
-				methodWriter.WriteLine($"object {methodName}()");
-				methodWriter.WriteLine("{");
-				methodWriter.Indent++;
-				foreach (var line in bodyBuffer.ToString().Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None))
-				{
-					if (string.IsNullOrWhiteSpace(line))
-						methodWriter.InnerWriter.WriteLine();
-					else
-						methodWriter.WriteLine(line);
+						node.Accept(new CreateValuesVisitor(templateContext), null);
+						node.Accept(new SetNamescopesAndRegisterNamesVisitor(templateContext), null);
+						node.Accept(new SetResourcesVisitor(templateContext), null);
+						node.Accept(new SetPropertiesVisitor(templateContext, stopOnResourceDictionary: true), null);
+						Writer.WriteLine($"return {templateContext.Variables[node].ValueAccessor};");
+					}
 				}
-				methodWriter.Indent--;
-				methodWriter.WriteLine("}");
-				methodWriter.Flush();
-				Context.AddLocalMethod(methodBuffer.ToString());
 
 				Writer.WriteLine($"{variable.ValueAccessor}.LoadTemplate = {methodName};");
 				return;

--- a/src/Controls/src/SourceGen/Visitors/SetPropertiesVisitor.cs
+++ b/src/Controls/src/SourceGen/Visitors/SetPropertiesVisitor.cs
@@ -10,7 +10,12 @@ namespace Microsoft.Maui.Controls.SourceGen;
 
 using static LocationHelpers;
 
-class SetPropertiesVisitor(SourceGenContext context, bool stopOnResourceDictionary = false) : IXamlNodeVisitor
+// valuePrecomputePass: set by CreateValuesVisitor when this visitor is run only to precompute a
+// value (e.g. a `required` property's value for the object initializer, or an x:Array element)
+// before namescopes are registered. In that pass, DataTemplate LoadTemplate emission under
+// Incremental Hot Reload is deferred to the main pass so x:Reference/bindings resolve against the
+// outer scope at compile time rather than falling back to runtime resolution. See dotnet/maui#36683.
+class SetPropertiesVisitor(SourceGenContext context, bool stopOnResourceDictionary = false, bool valuePrecomputePass = false) : IXamlNodeVisitor
 {
 	SourceGenContext Context => context;
 	IndentedTextWriter Writer => Context.Writer;
@@ -239,6 +244,15 @@ class SetPropertiesVisitor(SourceGenContext context, bool stopOnResourceDictiona
 
 		if (propertyName == XmlName._CreateContent)
 		{
+			// Under Incremental Hot Reload, defer DataTemplate LoadTemplate emission from a
+			// value-precompute prepass (required-property/x:Array) to the main SetPropertiesVisitor
+			// pass. The main pass runs after namescope registration, so it resolves x:Reference and
+			// bindings against the outer scope at compile time; the prepass runs earlier and would
+			// emit a slower runtime-resolved body that first-wins dedup would then keep
+			// (dotnet/maui#36683). Non-HR builds keep their existing prepass behavior.
+			if (valuePrecomputePass && Context.ProjectItem.EnableIncrementalHotReload)
+				return;
+
 			var variable = Context.Variables[parentNode];
 
 			// Under XAML Incremental Hot Reload, emit the template content as a stably-named local

--- a/src/Controls/tests/SourceGen.UnitTests/XamlIncrementalHotReloadPipelineTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/XamlIncrementalHotReloadPipelineTests.cs
@@ -640,12 +640,14 @@ public class XamlIncrementalHotReloadPipelineTests : IDisposable
 	[Fact]
 	public void DataTemplate_HotReload_SetMultipleTimes_EmitsSingleNamedMethod()
 	{
-		// Regression for dotnet/maui#36682: a DataTemplate assigned to a `required` property is set
-		// twice by the generator (once in the object initializer, once as a later assignment). Under
-		// Incremental Hot Reload the template body is a named local function, and emitting it twice
-		// in the same scope produced two `object LoadTemplate_L_P()` declarations -> CS0128 ("already
-		// defined") + CS8321 ("declared but never used"). The named method must be emitted only once,
-		// with every set-site re-pointing LoadTemplate at that single function.
+		// Regression for dotnet/maui#36682 and #36683: a DataTemplate assigned to a `required`
+		// property is visited more than once by the generator (a value-precompute prepass for the
+		// object initializer, plus the main pass). Under Incremental Hot Reload the template body is
+		// a named local function; emitting it twice in the same scope produced two
+		// `object LoadTemplate_L_P()` declarations -> CS0128 ("already defined") + CS8321 ("declared
+		// but never used"). The named method must be emitted exactly once and LoadTemplate must be
+		// wired up. (#36683 also defers the prepass emission to the main pass, so LoadTemplate is now
+		// assigned a single time from the correctly-scoped pass.)
 		const string host = """
 			namespace TestApp
 			{
@@ -682,12 +684,66 @@ public class XamlIncrementalHotReloadPipelineTests : IDisposable
 		var ic = FindSourceByHintSuffix(result, ".xsg.cs");
 		Assert.NotNull(ic);
 
-		// Exactly one named LoadTemplate method must be declared, even though LoadTemplate is
-		// assigned more than once.
+		// Exactly one named LoadTemplate method must be declared (no CS0128 duplicate), and
+		// LoadTemplate must be wired up to it.
 		var declarations = System.Text.RegularExpressions.Regex.Matches(ic, @"object LoadTemplate_\d+_\d+\(\)");
 		Assert.Single(declarations);
 		var assignments = System.Text.RegularExpressions.Regex.Matches(ic, @"\.LoadTemplate = LoadTemplate_\d+_\d+;");
-		Assert.True(assignments.Count >= 2, "expected the single named method to be assigned at every set-site");
+		Assert.True(assignments.Count >= 1, "expected LoadTemplate to be assigned the single named method");
+	}
+
+	[Fact]
+	public void DataTemplate_HotReload_RequiredProperty_ResolvesOuterReferenceAtCompileTime()
+	{
+		// Regression for dotnet/maui#36683 review: a `required` DataTemplate property whose body
+		// references an outer named element via {x:Reference} must have its body emitted from the
+		// main SetPropertiesVisitor pass (which runs after namescope registration), so the reference
+		// resolves at compile time. Previously the value-precompute prepass emitted the body first,
+		// before namescopes were registered, and first-wins dedup kept that runtime-resolved
+		// (XamlServiceProvider fallback) body instead of the optimized one.
+		const string host = """
+			namespace TestApp
+			{
+				public class TemplateHost : Microsoft.Maui.Controls.View
+				{
+					public required Microsoft.Maui.Controls.DataTemplate Template { get; set; }
+				}
+			}
+			""";
+		const string xaml = """
+			<?xml version="1.0" encoding="utf-8" ?>
+			<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			             xmlns:local="clr-namespace:TestApp"
+			             x:Class="TestApp.MainPage"
+			             x:Name="ThePage">
+			    <local:TemplateHost>
+			        <local:TemplateHost.Template>
+			            <DataTemplate>
+			                <Label HeightRequest="{Binding Source={x:Reference ThePage}, Path=Height}" />
+			            </DataTemplate>
+			        </local:TemplateHost.Template>
+			    </local:TemplateHost>
+			</ContentPage>
+			""";
+
+		XamlHotReloadState.Reset();
+		var compilation = CreateCompilation().AddSyntaxTrees(CSharpSyntaxTree.ParseText(host));
+
+		var result = SourceGeneratorDriver.RunGenerator<XamlGenerator>(
+			compilation, MakeFile(xaml), assertNoCompilationErrors: true);
+
+		var ic = FindSourceByHintSuffix(result, ".xsg.cs");
+		Assert.NotNull(ic);
+
+		// Single named method, wired up.
+		Assert.Single(System.Text.RegularExpressions.Regex.Matches(ic, @"object LoadTemplate_\d+_\d+\(\)"));
+		Assert.Contains("LoadTemplate = LoadTemplate_", ic, StringComparison.Ordinal);
+
+		// The x:Reference to the outer page must be resolved at compile time (a direct __root
+		// reference), NOT via the runtime XamlServiceProvider/SimpleValueTargetProvider fallback.
+		Assert.Contains("= __root;", ic, StringComparison.Ordinal);
+		Assert.DoesNotContain("SimpleValueTargetProvider", ic, StringComparison.Ordinal);
 	}
 
 	[Fact]

--- a/src/Controls/tests/SourceGen.UnitTests/XamlIncrementalHotReloadPipelineTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/XamlIncrementalHotReloadPipelineTests.cs
@@ -595,7 +595,10 @@ public class XamlIncrementalHotReloadPipelineTests : IDisposable
 			var expectedColor = label == "run1" ? "Colors.Black" : "Colors.Green";
 			Assert.Contains(expectedColor, ic, StringComparison.Ordinal);
 
-			if (label == "run1") nameV1 = m.Groups[1].Value; else nameV2 = m.Groups[1].Value;
+			if (label == "run1")
+				nameV1 = m.Groups[1].Value;
+			else
+				nameV2 = m.Groups[1].Value;
 		}
 
 		// EnC anchor: the generated method name must be IDENTICAL across the edit, so Edit-and-Continue
@@ -632,6 +635,59 @@ public class XamlIncrementalHotReloadPipelineTests : IDisposable
 		Assert.NotNull(ic);
 		Assert.DoesNotContain("LoadTemplate = () =>", ic, StringComparison.Ordinal);
 		Assert.Contains("LoadTemplate = LoadTemplate_", ic, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void DataTemplate_HotReload_SetMultipleTimes_EmitsSingleNamedMethod()
+	{
+		// Regression for dotnet/maui#36682: a DataTemplate assigned to a `required` property is set
+		// twice by the generator (once in the object initializer, once as a later assignment). Under
+		// Incremental Hot Reload the template body is a named local function, and emitting it twice
+		// in the same scope produced two `object LoadTemplate_L_P()` declarations -> CS0128 ("already
+		// defined") + CS8321 ("declared but never used"). The named method must be emitted only once,
+		// with every set-site re-pointing LoadTemplate at that single function.
+		const string host = """
+			namespace TestApp
+			{
+				public class TemplateHost : Microsoft.Maui.Controls.View
+				{
+					public required Microsoft.Maui.Controls.DataTemplate Template { get; set; }
+				}
+			}
+			""";
+		const string xaml = """
+			<?xml version="1.0" encoding="utf-8" ?>
+			<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			             xmlns:local="clr-namespace:TestApp"
+			             x:Class="TestApp.MainPage">
+			    <local:TemplateHost>
+			        <local:TemplateHost.Template>
+			            <DataTemplate>
+			                <Label Text="Hi" TextColor="Black" />
+			            </DataTemplate>
+			        </local:TemplateHost.Template>
+			    </local:TemplateHost>
+			</ContentPage>
+			""";
+
+		XamlHotReloadState.Reset();
+		var compilation = CreateCompilation().AddSyntaxTrees(CSharpSyntaxTree.ParseText(host));
+
+		// assertNoCompilationErrors: true throws if the generated .xsg.cs has C# errors (e.g. the
+		// duplicate-method CS0128 this test guards against).
+		var result = SourceGeneratorDriver.RunGenerator<XamlGenerator>(
+			compilation, MakeFile(xaml), assertNoCompilationErrors: true);
+
+		var ic = FindSourceByHintSuffix(result, ".xsg.cs");
+		Assert.NotNull(ic);
+
+		// Exactly one named LoadTemplate method must be declared, even though LoadTemplate is
+		// assigned more than once.
+		var declarations = System.Text.RegularExpressions.Regex.Matches(ic, @"object LoadTemplate_\d+_\d+\(\)");
+		Assert.Single(declarations);
+		var assignments = System.Text.RegularExpressions.Regex.Matches(ic, @"\.LoadTemplate = LoadTemplate_\d+_\d+;");
+		Assert.True(assignments.Count >= 2, "expected the single named method to be assigned at every set-site");
 	}
 
 	[Fact]
@@ -1458,13 +1514,13 @@ public class XamlIncrementalHotReloadPipelineTests : IDisposable
 	}
 
 
-[Fact]
-public void ResourceWithConverters_UCDoesNotRegisterUnencodableKeys()
-{
-// When resources include custom types (converters) that can't be encoded as C# expressions,
-// the UC should NOT register those keys — otherwise they get removed on next patch.
-XamlHotReloadState.Reset();
-const string xamlV1 = """
+	[Fact]
+	public void ResourceWithConverters_UCDoesNotRegisterUnencodableKeys()
+	{
+		// When resources include custom types (converters) that can't be encoded as C# expressions,
+		// the UC should NOT register those keys — otherwise they get removed on next patch.
+		XamlHotReloadState.Reset();
+		const string xamlV1 = """
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
@@ -1475,7 +1531,7 @@ const string xamlV1 = """
     <Label Text="Hello" />
 </ContentPage>
 """;
-const string xamlV2 = """
+		const string xamlV2 = """
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
@@ -1488,17 +1544,17 @@ const string xamlV2 = """
 </ContentPage>
 """;
 
-var (_, run2) = TwoRuns(xamlV1, xamlV2);
-var uc = FindUCSource(run2, "uc.xsg");
+		var (_, run2) = TwoRuns(xamlV1, xamlV2);
+		var uc = FindUCSource(run2, "uc.xsg");
 
-Assert.NotNull(uc);
-// Only emittable keys (Color values) should be in RegisterResourceKeys
-Assert.Contains("AccentColor", uc, StringComparison.Ordinal);
-Assert.Contains("SecondaryColor", uc, StringComparison.Ordinal);
-Assert.Contains("RegisterResourceKeys", uc, StringComparison.Ordinal);
-// The registered keys should only contain the color keys
-Assert.Contains("__version = 1", uc, StringComparison.Ordinal);
-}
+		Assert.NotNull(uc);
+		// Only emittable keys (Color values) should be in RegisterResourceKeys
+		Assert.Contains("AccentColor", uc, StringComparison.Ordinal);
+		Assert.Contains("SecondaryColor", uc, StringComparison.Ordinal);
+		Assert.Contains("RegisterResourceKeys", uc, StringComparison.Ordinal);
+		// The registered keys should only contain the color keys
+		Assert.Contains("__version = 1", uc, StringComparison.Ordinal);
+	}
 
 	[Fact]
 	public void ConverterResourceAdded_UCEmitsNewInstance()


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description

Hardens the XAML Incremental Hot Reload (XIHR, #34338) `DataTemplate` source-gen so it produces valid code across real-world XAML. This is a **prerequisite for enabling XIHR by default** (#36682) — with XIHR on, several repo projects (`Essentials.AI.Sample`, `Controls.TestCases.HostApp`, `Controls.Xaml.UnitTests`) currently fail to build.

XIHR emits a `DataTemplate`'s content as a stably-named `LoadTemplate_{line}_{pos}` local function so Edit-and-Continue has a stable anchor (#36482). That function was **hoisted** to the top of the generated method via `AddLocalMethod`, which breaks in two ways once XIHR is actually enabled:

- **Duplicate method (CS0128 / CS8321).** A template value set more than once in the same scope — e.g. a `required` `DataTemplate` property, which the generator sets both in the object initializer *and* as an assignment — emitted the named function **twice** → `error CS0128: 'LoadTemplate_L_P' is already defined` (+ `CS8321` unused).
- **Out-of-scope references (CS0103 / CS1503).** Hoisting to the method top **lost the lambda's lexical scope**, so a template body that referenced enclosing locals (the `DataTemplate` variable, name scopes, resources) generated references to names that don't exist at that scope → `CS0103`, with a cascading `CS1503`.

These stayed latent because MAUI ships XIHR **opt-in (default off)**, so no repo project built through this path until default-on was attempted.

### Fix

Emit the named local function **inline at the point of use** (not hoisted), which restores the exact lexical scope the anonymous lambda had, and **reserve each method name once per compilation unit** so it is declared a single time — every set-site just re-points `LoadTemplate` at that one function. Also removes ~25 lines of buffering. Non-HR builds are unchanged (still an anonymous lambda).

### Tests

- New regression test `DataTemplate_HotReload_SetMultipleTimes_EmitsSingleNamedMethod` — a `required` `DataTemplate` property under XIHR. Verified it **fails without the fix** (`CS0128 'LoadTemplate_9_18' already defined`) and **passes with it**.
- Full `SourceGen.UnitTests` suite green (**452/452**), including all existing #36482 XIHR tests.
- Verified locally that `Controls.Xaml.UnitTests` builds with `EnableMauiIncrementalHotReload=true` with no `LoadTemplate` errors (the CS0128/CS8321 pair is gone).

### Related

- Prerequisite for #36682 (enable XIHR by default in Debug).
- Follow-up hardening of #34338 / #36482.
