### PR TITLE
Avoid duplicate startup refresh in .NET MAUI mobile template

### DIFF
--- a/src/Templates/src/templates/maui-mobile/PageModels/MainPageModel.cs
+++ b/src/Templates/src/templates/maui-mobile/PageModels/MainPageModel.cs
@@ -98,7 +98,6 @@ public partial class MainPageModel : ObservableObject, IProjectTaskPageModel
 		}
 
 		Preferences.Default.Set("is_seeded", true);
-		await Refresh();
 	}
 
 	[RelayCommand]


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

`MainPageModel.InitData()` called `Refresh()`, and `Appearing()` called it again immediately after initialization. This caused the .NET MAUI mobile sample-content template to load its startup data twice.

This change removes the `Refresh()` call from `InitData()`. `Appearing()` remains responsible for the initial refresh, so startup loads data once while later appearances continue to refresh as before.

Template layout and shimmer markup are unchanged.

#### Profiling results

| Metric | Baseline | Single refresh | Change |
| --- | ---: | ---: | ---: |
| `LoadData` occurrences | 2 | 1 | -50% |
| `ComputeDesiredSize` | 1.54s | 1.17s | -24% |
| Grid first measure | 596ms | 442ms | -26% |
| Syncfusion measurement | 339ms | 248ms | -27% |
| Pull-to-refresh measurement | 266ms | 211ms | -21% |
| Item binding | 194ms | 160ms | -17% |
| Trace events | Baseline | Single refresh | -19% |

#### Testing

- Built `src/Templates/src/Microsoft.Maui.Templates.csproj` successfully with no warnings or errors.
- Existing `--sample-content` integration cases cover generated mobile-template compilation; no behavioral page-model test harness is available.

### Issues Fixed

N/A