### PR TITLE
[iOS & Mac] Fix and Re-enable "Cells Do Not Leak" and "Handler Does Not Leak" Device Tests

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -84,31 +84,16 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		// Deterministically unbind every realized templated cell when this controller's handler
 		// disconnects (e.g. page popped), instead of relying on VisibleCells/recycling heuristics.
-		//
-		// Also the only place (with ClearMeasurementCells) that calls DetachFromItemsView() and
-		// disconnects each cell's Handler. Not done in TemplatedCell.Unbind() because that also
-		// runs during routine recycling, where removing the view mid-layout can corrupt native
-		// state (e.g. CarouselView). Here the CollectionView is going away, so
-		// it's safe to sever permanently.
+		// The CollectionView is going away here, so it's safe to permanently tear down each cell
+		// via UnbindAndDisconnect() (also used by ClearMeasurementCells()), which detaches the
+		// logical child, clears native subviews, and disconnects the handler tree.
 		void UnbindRealizedTemplatedCells()
 		{
 			for (int n = _realizedTemplatedCells.Count - 1; n >= 0; n--)
 			{
 				if (_realizedTemplatedCells[n].TryGetTarget(out var templatedCell))
 				{
-					if (templatedCell.PlatformHandler?.VirtualView is View view)
-					{
-						templatedCell.Unbind();
-						templatedCell.DetachFromItemsView();
-
-						// Recursive DisconnectHandlers() since the bound view (DataTemplate root)
-						// commonly has child views whose handlers also need disconnecting.
-						view.DisconnectHandlers();
-					}
-					else
-					{
-						templatedCell.Unbind();
-					}
+					templatedCell.UnbindAndDisconnect();
 				}
 			}
 
@@ -596,16 +581,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			foreach (var measurementCell in _measurementCells.Values)
 			{
 				measurementCell.LayoutAttributesChanged -= CellLayoutAttributesChanged;
-				measurementCell.UnbindAndDisconnect();
 
 				// Discarded measurement cells are never reused and have no other strong references,
 				// so they can be GC'd before Disconnect() runs, leaking their handler if not
-				// disconnected here.
-				if (measurementCell.PlatformHandler?.VirtualView is View measurementView)
-				{
-					measurementCell.DetachFromItemsView();
-					measurementView.DisconnectHandlers();
-				}
+				// disconnected here. UnbindAndDisconnect() detaches the logical child, clears
+				// native subviews, and disconnects the handler tree.
+				measurementCell.UnbindAndDisconnect();
 			}
 
 			_measurementCells.Clear();

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -597,6 +597,15 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			{
 				measurementCell.LayoutAttributesChanged -= CellLayoutAttributesChanged;
 				measurementCell.UnbindAndDisconnect();
+
+				// Discarded measurement cells are never reused and have no other strong references,
+				// so they can be GC'd before Disconnect() runs, leaking their handler if not
+				// disconnected here.
+				if (measurementCell.PlatformHandler?.VirtualView is View measurementView)
+				{
+					measurementCell.DetachFromItemsView();
+					measurementView.DisconnectHandlers();
+				}
 			}
 
 			_measurementCells.Clear();

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -973,7 +973,23 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			// Keep this cell around, we can transfer the contents to the actual cell when the UICollectionView creates it
 			if (_measurementCells != null)
-				_measurementCells[ItemsSource[indexPath]] = templatedCell;
+			{
+				var bindingContext = ItemsSource[indexPath];
+
+				// A layout re-constrain (bounds change, rotation, ConstrainTo) can request a
+				// measurement cell for an index path that already has one cached. Release the
+				// displaced cell's content before overwriting the cache entry, otherwise its
+				// bound view stays orphaned as a logical child of the ItemsView for as long as
+				// the ItemsView is alive - the same leak class this PR fixes.
+				if (_measurementCells.TryGetValue(bindingContext, out var previousMeasurementCell) &&
+					!ReferenceEquals(previousMeasurementCell, templatedCell))
+				{
+					previousMeasurementCell.LayoutAttributesChanged -= CellLayoutAttributesChanged;
+					previousMeasurementCell.UnbindAndDisconnect();
+				}
+
+				_measurementCells[bindingContext] = templatedCell;
+			}
 
 			return templatedCell;
 		}

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -596,16 +596,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			foreach (var measurementCell in _measurementCells.Values)
 			{
 				measurementCell.LayoutAttributesChanged -= CellLayoutAttributesChanged;
-				measurementCell.Unbind();
-
-				// Discarded measurement cells are never reused and have no other strong references,
-				// so they can be GC'd before Disconnect() runs, leaking their handler if not
-				// disconnected here.
-				if (measurementCell.PlatformHandler?.VirtualView is View measurementView)
-				{
-					measurementCell.DetachFromItemsView();
-					measurementView.DisconnectHandlers();
-				}
+				measurementCell.UnbindAndDisconnect();
 			}
 
 			_measurementCells.Clear();

--- a/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
@@ -85,34 +85,45 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			_bound = false;
 
-			// Detach the bound view from the ItemsView's logical children and remove the
-			// native platform view from ContentView. Only invoked on the deterministic
-			// disposing path, so touching the managed object graph here is safe.
-			//
-			// CarouselView Loop mode may call this speculatively on a cell about to be
-			// redisplayed with the same content, so PlatformHandler/CurrentTemplate are
-			// intentionally preserved here for cheap reattachment in Bind().
+			// Transient cleanup only: detach the bound view from the ItemsView's logical
+			// children so it doesn't stay permanently rooted if the cell is discarded, but
+			// deliberately leave the native subtree, PlatformHandler, and CurrentTemplate
+			// intact. CarouselView Loop mode (and ItemsViewController.CellDisplayingEndedFromDelegate)
+			// may call this speculatively on a cell about to be redisplayed with the same
+			// content, and Bind() relies on the native view still being attached to cheaply
+			// reattach the logical child without re-running SetupPlatformView() (which would
+			// otherwise install duplicate Auto Layout constraints on every reuse cycle).
 			DetachFromItemsView();
-			ClearSubviews();
 		}
 
-		// Permanent teardown for cells that are discarded outright and never reused/rebound
-		// (e.g. ItemsViewController's measurement-cell cache). Unlike Unbind(), this also
-		// disconnects the handler tree to prevent the last bound view from leaking.
-		internal void UnbindAndDisconnect()
+		// Permanent teardown for cells/content that are discarded outright and never
+		// reused/rebound: template replacement, deterministic disposal, and measurement-cell
+		// eviction (ItemsViewController.ClearMeasurementCells). Unlike Unbind(), this also
+		// clears the native subtree and disconnects the handler tree so the bound view and
+		// its platform view become collectible.
+		void ReleaseContent()
 		{
 			var view = PlatformHandler?.VirtualView as View;
-			Unbind();
+
+			DetachFromItemsView();
+			ClearSubviews();
+
 			view?.DisconnectHandlers();
 			PlatformHandler = null;
 			CurrentTemplate = null;
 		}
 
+		internal void UnbindAndDisconnect()
+		{
+			ReleaseContent();
+		}
+
 		// Managed-only cleanup: clears the bound view's BindingContext and removes it from the
 		// ItemsView's logical children (mirrors TemplatedCell2.Unbind()). Uses view.Parent
 		// (itself backed by a WeakReference<Element>) rather than tracking a separate reference.
-		// Only ever invoked via Unbind(), which is only called on the deterministic disposing
-		// path (see Dispose(bool)) - never from the finalizer.
+		// Invoked via Unbind()/ReleaseContent() from cell reuse/eviction call sites and from
+		// Dispose(bool) on the deterministic disposing path - never from the finalizer, where
+		// touching the managed object graph would be unsafe.
 		void DetachFromItemsView()
 		{
 			if (PlatformHandler?.VirtualView is View view)
@@ -128,11 +139,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			// disposing == false (finalizer), touching the managed object graph
 			// (BindingContext, LogicalChildren, events) is unsafe: it can run on the
 			// finalizer thread and reference objects that are themselves being finalized.
-			// Unbind() already calls DetachFromItemsView(), so this also covers the case
-			// where the cell is deallocated without ever going through PrepareForReuse/Unbind.
+			// ReleaseContent() covers the case where the cell is deallocated without ever
+			// going through PrepareForReuse/Unbind, permanently detaching and disconnecting
+			// the bound view since the cell itself is being torn down for good.
 			if (disposing)
 			{
-				Unbind();
+				ReleaseContent();
 			}
 
 			base.Dispose(disposing);
@@ -235,16 +247,13 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			if (itemTemplate != CurrentTemplate)
 			{
-				// Remove the old view, if it exists
+				// Remove the old view, if it exists. A template change discards oldElement's
+				// renderer for good, so this permanently detaches and disconnects it to avoid
+				// leaking (unlike the same-template branch below, which keeps the native
+				// subtree attached for cheap reuse).
 				if (oldElement != null)
 				{
-					oldElement.BindingContext = null;
-					itemsView.RemoveLogicalChild(oldElement);
-					ClearSubviews();
-
-					// A template change discards oldElement's renderer for good, so its
-					// handler tree must be explicitly disconnected here to avoid leaking.
-					oldElement.DisconnectHandlers();
+					ReleaseContent();
 				}
 
 				// Create the content and renderer for the view 
@@ -283,18 +292,14 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				// If the cell is now being reused/rebound with the same template, the view must be
 				// re-attached; otherwise it silently drops out of the logical tree even though it's
 				// visibly bound and displayed again. Mirrors TemplatedCell2.BindVirtualView().
+				//
+				// Note: the native subtree itself never gets detached by Unbind() (only the
+				// logical-child link does), so there's no need to reattach/recreate it here -
+				// doing so would call SetupPlatformView() again and install duplicate Auto
+				// Layout constraints on every reuse cycle.
 				if (oldElement is not null && oldElement.Parent is null)
 				{
 					itemsView.AddLogicalChild(oldElement);
-				}
-
-				// Reattach the native view if it was detached by a prior speculative Unbind()
-				// (e.g. CarouselView Loop mode); otherwise the cell would render blank.
-				var platformView = PlatformHandler?.ToPlatform();
-				if (platformView is not null && platformView.Superview is null)
-				{
-					SetupPlatformView(platformView);
-					ContentView.MarkAsCrossPlatformLayoutBacking();
 				}
 			}
 

--- a/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
@@ -360,6 +360,14 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			SetRenderer(measurementCell.PlatformHandler);
 			_bound = true;
 			((IPlatformMeasureInvalidationController)this).InvalidateMeasure();
+
+			// Complete the ownership transfer on the donor so it no longer references the handler
+			// it just gave away. Without this, if the donor cell is later disposed directly
+			// (Dispose() is a public entry point on this unsealed type) it would tear down the
+			// handler subtree that now belongs to this cell.
+			measurementCell.PlatformHandler = null;
+			measurementCell.CurrentTemplate = null;
+			measurementCell._bound = false;
 		}
 
 		bool IsUsingVSMForSelectionColor(View view)

--- a/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
@@ -85,19 +85,27 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			_bound = false;
 
-			// Detach the bound view from the ItemsView's logical children. Unbind() is only
-			// ever invoked from PrepareForReuse, ItemsViewController cell recycling, or the
-			// deterministic disposing path of Dispose(bool) - never from the finalizer - so
-			// touching the managed object graph here is safe.
+			// Detach the bound view from the ItemsView's logical children and remove the
+			// native platform view from ContentView. Only invoked on the deterministic
+			// disposing path, so touching the managed object graph here is safe.
+			//
+			// CarouselView Loop mode may call this speculatively on a cell about to be
+			// redisplayed with the same content, so PlatformHandler/CurrentTemplate are
+			// intentionally preserved here for cheap reattachment in Bind().
 			DetachFromItemsView();
+			ClearSubviews();
+		}
 
-			if (PlatformHandler?.VirtualView is View view)
-			{
-				// Also detach the native platform view from the cell's ContentView, since a
-				// strong subview reference here can keep the platform view (and therefore the
-				// bound VirtualView) reachable even after logical-child bookkeeping is cleared.
-				ClearSubviews();
-			}
+		// Permanent teardown for cells that are discarded outright and never reused/rebound
+		// (e.g. ItemsViewController's measurement-cell cache). Unlike Unbind(), this also
+		// disconnects the handler tree to prevent the last bound view from leaking.
+		internal void UnbindAndDisconnect()
+		{
+			var view = PlatformHandler?.VirtualView as View;
+			Unbind();
+			view?.DisconnectHandlers();
+			PlatformHandler = null;
+			CurrentTemplate = null;
 		}
 
 		// Managed-only cleanup: clears the bound view's BindingContext and removes it from the
@@ -134,6 +142,14 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			UICollectionViewLayoutAttributes layoutAttributes)
 		{
 			var preferredAttributes = base.PreferredLayoutAttributesFittingAttributes(layoutAttributes);
+
+			// Skip measuring cells that aren't currently bound (e.g. between Unbind() and a
+			// pending Bind() during rapid section restructuring). Measure() unconditionally
+			// dereferences PlatformHandler.VirtualView and would otherwise throw an NRE.
+			if (!_bound || PlatformHandler?.VirtualView is null)
+			{
+				return preferredAttributes;
+			}
 
 			if (_measureInvalidated ||
 				!AttributesConsistentWithConstrainedDimension(preferredAttributes) ||
@@ -226,8 +242,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 					itemsView.RemoveLogicalChild(oldElement);
 					ClearSubviews();
 
-					// Template change discards oldElement's renderer for good, so its handler tree
-					// must be disconnected explicitly here to avoid a leak.
+					// A template change discards oldElement's renderer for good, so its
+					// handler tree must be explicitly disconnected here to avoid leaking.
 					oldElement.DisconnectHandlers();
 				}
 
@@ -270,6 +286,15 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				if (oldElement is not null && oldElement.Parent is null)
 				{
 					itemsView.AddLogicalChild(oldElement);
+				}
+
+				// Reattach the native view if it was detached by a prior speculative Unbind()
+				// (e.g. CarouselView Loop mode); otherwise the cell would render blank.
+				var platformView = PlatformHandler?.ToPlatform();
+				if (platformView is not null && platformView.Superview is null)
+				{
+					SetupPlatformView(platformView);
+					ContentView.MarkAsCrossPlatformLayoutBacking();
 				}
 			}
 

--- a/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
@@ -85,15 +85,26 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			_bound = false;
 
-			// Transient cleanup only: detach the bound view from the ItemsView's logical
-			// children so it doesn't stay permanently rooted if the cell is discarded, but
-			// deliberately leave the native subtree, PlatformHandler, and CurrentTemplate
-			// intact. CarouselView Loop mode (and ItemsViewController.CellDisplayingEndedFromDelegate)
-			// may call this speculatively on a cell about to be redisplayed with the same
-			// content, and Bind() relies on the native view still being attached to cheaply
-			// reattach the logical child without re-running SetupPlatformView() (which would
-			// otherwise install duplicate Auto Layout constraints on every reuse cycle).
+			// Transient cleanup only: clear the bound view's BindingContext and detach it from
+			// the ItemsView's logical children so it doesn't stay permanently rooted if the cell
+			// is discarded, but deliberately leave the native subtree, PlatformHandler, and
+			// CurrentTemplate intact. CarouselView Loop mode (and
+			// ItemsViewController.CellDisplayingEndedFromDelegate) may call this speculatively on
+			// a cell about to be redisplayed with the same content, and Bind() relies on the
+			// native view still being attached to cheaply reattach the logical child without
+			// re-running SetupPlatformView() (which would otherwise install duplicate Auto Layout
+			// constraints on every reuse cycle).
+			ClearBindingContext();
 			DetachFromItemsView();
+		}
+
+		// Clears the bound view's BindingContext. Called during routine recycling and final teardown.
+		void ClearBindingContext()
+		{
+			if (PlatformHandler?.VirtualView is View view)
+			{
+				view.BindingContext = null;
+			}
 		}
 
 		// Permanent teardown for cells/content that are discarded outright and never
@@ -105,6 +116,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			var view = PlatformHandler?.VirtualView as View;
 
+			ClearBindingContext();
 			DetachFromItemsView();
 			ClearSubviews();
 
@@ -118,17 +130,15 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			ReleaseContent();
 		}
 
-		// Managed-only cleanup: clears the bound view's BindingContext and removes it from the
-		// ItemsView's logical children (mirrors TemplatedCell2.Unbind()). Uses view.Parent
-		// (itself backed by a WeakReference<Element>) rather than tracking a separate reference.
-		// Invoked via Unbind()/ReleaseContent() from cell reuse/eviction call sites and from
-		// Dispose(bool) on the deterministic disposing path - never from the finalizer, where
-		// touching the managed object graph would be unsafe.
-		void DetachFromItemsView()
+		// Removes the bound view from the ItemsView's logical children, so it (and its handler) can
+		// be collected. Now also invoked from Unbind() for transient cleanup (previously reserved
+		// only for final teardown paths via ItemsViewController.Disconnect()/ClearMeasurementCells())
+		// as part of fixing the leak where a discarded/reused cell's bound view stayed permanently
+		// rooted as a logical child of the ItemsView.
+		internal void DetachFromItemsView()
 		{
 			if (PlatformHandler?.VirtualView is View view)
 			{
-				view.BindingContext = null;
 				(view.Parent as ItemsView)?.RemoveLogicalChild(view);
 			}
 		}
@@ -250,7 +260,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				// Remove the old view, if it exists. A template change discards oldElement's
 				// renderer for good, so this permanently detaches and disconnects it to avoid
 				// leaking (unlike the same-template branch below, which keeps the native
-				// subtree attached for cheap reuse).
+				// subtree attached for cheap reuse). ReleaseContent() clears the BindingContext,
+				// removes the logical child, clears native subviews, and disconnects the handler
+				// tree (equivalent to the previous oldElement.DisconnectHandlers() call, since
+				// view == oldElement here).
 				if (oldElement != null)
 				{
 					ReleaseContent();

--- a/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		// actually changed the size of the cell
 		Size _size;
 		bool _bound;
+		bool _disposed;
 
 		internal CGSize CurrentSize => _size.ToCGSize();
 
@@ -123,6 +124,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			view?.DisconnectHandlers();
 			PlatformHandler = null;
 			CurrentTemplate = null;
+			_bound = false;
 		}
 
 		internal void UnbindAndDisconnect()
@@ -145,6 +147,17 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		protected override void Dispose(bool disposing)
 		{
+			// Guard against re-entrancy: Dispose() is a public entry point on this unsealed
+			// type, so it's legal for a caller to invoke it more than once. Without this guard,
+			// a second call would run ReleaseContent() -> ClearSubviews() against a ContentView
+			// whose native handle may already have been released by the first Dispose(true)
+			// call, risking an ObjectDisposedException.
+			if (_disposed)
+			{
+				base.Dispose(disposing);
+				return;
+			}
+
 			// Only run managed/native cleanup on the deterministic disposing path. When
 			// disposing == false (finalizer), touching the managed object graph
 			// (BindingContext, LogicalChildren, events) is unsafe: it can run on the
@@ -155,6 +168,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			if (disposing)
 			{
 				ReleaseContent();
+				_disposed = true;
 			}
 
 			base.Dispose(disposing);
@@ -352,6 +366,17 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		internal void UseContent(TemplatedCell measurementCell)
 		{
+			// Release any content this cell was already displaying (e.g. left over from being
+			// recycled by the UICollectionView reuse pool) before adopting the donor's content.
+			// Without this, the previous bound view stays orphaned as a logical child of the
+			// ItemsView, and its handler tree stays connected, for as long as the ItemsView is
+			// alive - the same leak class this PR fixes, just reached via the measurement-cell
+			// content-transfer path instead of Bind().
+			if (PlatformHandler is not null)
+			{
+				ReleaseContent();
+			}
+
 			// Copy all the content and values from the measurement cell 
 			ConstrainedDimension = measurementCell.ConstrainedDimension;
 			ConstrainedSize = measurementCell.ConstrainedSize;

--- a/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
@@ -85,29 +85,49 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			_bound = false;
 
-			ClearBindingContext();
+			// Detach the bound view from the ItemsView's logical children. Unbind() is only
+			// ever invoked from PrepareForReuse, ItemsViewController cell recycling, or the
+			// deterministic disposing path of Dispose(bool) - never from the finalizer - so
+			// touching the managed object graph here is safe.
+			DetachFromItemsView();
+
+			if (PlatformHandler?.VirtualView is View view)
+			{
+				// Also detach the native platform view from the cell's ContentView, since a
+				// strong subview reference here can keep the platform view (and therefore the
+				// bound VirtualView) reachable even after logical-child bookkeeping is cleared.
+				ClearSubviews();
+			}
 		}
 
-		// Clears the bound view's BindingContext. Called during routine recycling and final teardown.
-		void ClearBindingContext()
+		// Managed-only cleanup: clears the bound view's BindingContext and removes it from the
+		// ItemsView's logical children (mirrors TemplatedCell2.Unbind()). Uses view.Parent
+		// (itself backed by a WeakReference<Element>) rather than tracking a separate reference.
+		// Only ever invoked via Unbind(), which is only called on the deterministic disposing
+		// path (see Dispose(bool)) - never from the finalizer.
+		void DetachFromItemsView()
 		{
 			if (PlatformHandler?.VirtualView is View view)
 			{
 				view.BindingContext = null;
+				(view.Parent as ItemsView)?.RemoveLogicalChild(view);
 			}
 		}
 
-		// Removes the bound view from the ItemsView's logical children, so it (and its handler) can
-		// be collected. Intentionally NOT called from Unbind()/ClearBindingContext() - only from
-		// final teardown paths (ItemsViewController.Disconnect()/ClearMeasurementCells()), since
-		// removing it during routine recycling can corrupt native layout state (e.g. CarouselView
-		// crash).
-		internal void DetachFromItemsView()
+		protected override void Dispose(bool disposing)
 		{
-			if (PlatformHandler?.VirtualView is View view)
+			// Only run managed/native cleanup on the deterministic disposing path. When
+			// disposing == false (finalizer), touching the managed object graph
+			// (BindingContext, LogicalChildren, events) is unsafe: it can run on the
+			// finalizer thread and reference objects that are themselves being finalized.
+			// Unbind() already calls DetachFromItemsView(), so this also covers the case
+			// where the cell is deallocated without ever going through PrepareForReuse/Unbind.
+			if (disposing)
 			{
-				(view.Parent as ItemsView)?.RemoveLogicalChild(view);
+				Unbind();
 			}
+
+			base.Dispose(disposing);
 		}
 
 		public override UICollectionViewLayoutAttributes PreferredLayoutAttributesFittingAttributes(

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -4,6 +4,7 @@ override Microsoft.Maui.Controls.GraphicsView.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.Handlers.Compatibility.EntryCellRenderer.EntryCellTableViewCell.Dispose(bool disposing) -> void
 override Microsoft.Maui.Controls.Handlers.Compatibility.TableViewModelRenderer.Dispose(bool disposing) -> void
 override Microsoft.Maui.Controls.Handlers.Items.MauiCollectionView.AddSubview(UIKit.UIView! view) -> void
+override Microsoft.Maui.Controls.Handlers.Items.TemplatedCell.Dispose(bool disposing) -> void
 override Microsoft.Maui.Controls.Handlers.Items2.CarouselViewController2.Dispose(bool disposing) -> void
 ~override Microsoft.Maui.Controls.Handlers.Items2.CollectionViewHandler2.DisconnectHandler(UIKit.UIView platformView) -> void
 ~override Microsoft.Maui.Controls.Handlers.Items2.StructuredItemsViewController2<TItemsView>.NumberOfSections(UIKit.UICollectionView collectionView) -> nint

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -5,6 +5,7 @@ override Microsoft.Maui.Controls.Handlers.Compatibility.EntryCellRenderer.EntryC
 override Microsoft.Maui.Controls.Handlers.Compatibility.TableViewModelRenderer.Dispose(bool disposing) -> void
 override Microsoft.Maui.Controls.Handlers.Items.MauiCollectionView.AddSubview(UIKit.UIView! view) -> void
 override Microsoft.Maui.Controls.Handlers.Items.MauiCollectionView.Dispose(bool disposing) -> void
+override Microsoft.Maui.Controls.Handlers.Items.TemplatedCell.Dispose(bool disposing) -> void
 override Microsoft.Maui.Controls.Handlers.Items2.CarouselViewController2.Dispose(bool disposing) -> void
 ~override Microsoft.Maui.Controls.Handlers.Items2.CollectionViewHandler2.DisconnectHandler(UIKit.UIView platformView) -> void
 ~override Microsoft.Maui.Controls.Handlers.Items2.StructuredItemsViewController2<TItemsView>.NumberOfSections(UIKit.UICollectionView collectionView) -> nint

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
@@ -200,7 +200,6 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-#if TESTS_FAILS_ON_IOS // For more information, see: https://github.com/dotnet/maui/issues/35985
 		[Fact("Cells Do Not Leak")]
 		public async Task CellsDoNotLeak()
 		{
@@ -226,13 +225,29 @@ namespace Microsoft.Maui.DeviceTests
 
 			Assert.NotNull(cell);
 
+			// Simulate UICollectionView tearing the cell down (either recycling it via
+			// PrepareForReuse or discarding it outright) and disconnect the CollectionView's
+			// own handler, then drop all local references. Without this, the locals here
+			// (cell/collectionView/handler) remain GC roots for the duration of this method in
+			// Debug builds, so the cell is never finalized/disposed before WaitForGC's GC
+			// cycles run, and the templated Label can never become collectible.
+			await InvokeOnMainThreadAsync(() =>
+			{
+				cell.Unbind();
+				handler.DisconnectHandler();
+				collectionView.Handler = null;
+			});
+
+			cell = null;
+			handler = null;
+			collectionView = null;
+
 			// HACK: test passes running individually, but fails when running entire suite.
 			// Skip the assertion on Catalyst for now.
 #if !MACCATALYST
 			await AssertionExtensions.WaitForGC([.. labels]);
 #endif
 		}
-#endif
 
 		//src/Compatibility/Core/tests/iOS/ObservableItemsSourceTests.cs
 		[Fact(DisplayName = "IndexPath Range Generation Is Correct")]

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
@@ -225,28 +225,33 @@ namespace Microsoft.Maui.DeviceTests
 
 			Assert.NotNull(cell);
 
-			// Simulate UICollectionView tearing the cell down (either recycling it via
-			// PrepareForReuse or discarding it outright) and disconnect the CollectionView's
-			// own handler, then drop all local references. Without this, the locals here
-			// (cell/collectionView/handler) remain GC roots for the duration of this method in
-			// Debug builds, so the cell is never finalized/disposed before WaitForGC's GC
-			// cycles run, and the templated Label can never become collectible.
+			// Simulate the cell being discarded outright (e.g. its bound item was removed from
+			// the ItemsSource) while the ItemsView itself stays alive and in use, as it would for
+			// the remainder of the page's lifetime. This is the scenario the production fix
+			// targets: the templated cell's bound view previously stayed registered as a logical
+			// child of the ItemsView even after the cell that displayed it was gone, permanently
+			// rooting the view (and its content) for as long as the ItemsView remained alive.
+			//
+			// Deliberately keep collectionView (and its handler) alive here instead of nulling
+			// them out - the leak only manifests when the ItemsView outlives the discarded cell,
+			// so nulling it out too would mask the very regression this test guards against.
 			await InvokeOnMainThreadAsync(() =>
 			{
 				cell.Unbind();
-				handler.DisconnectHandler();
-				collectionView.Handler = null;
 			});
 
 			cell = null;
-			handler = null;
-			collectionView = null;
 
 			// HACK: test passes running individually, but fails when running entire suite.
 			// Skip the assertion on Catalyst for now.
 #if !MACCATALYST
 			await AssertionExtensions.WaitForGC([.. labels]);
 #endif
+
+			// Keep the still-alive ItemsView (and its handler) reachable past WaitForGC so the
+			// JIT can't optimize them away as dead stores before the assertion runs above.
+			GC.KeepAlive(collectionView);
+			GC.KeepAlive(handler);
 		}
 
 		//src/Compatibility/Core/tests/iOS/ObservableItemsSourceTests.cs

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -348,9 +348,37 @@ public class MemoryTests : ControlsHandlerTestBase
 			}
 #pragma warning restore CS0618 // Type or member is obsolete
 			var handler = CreateHandler<LayoutHandler>(layout);
+			var viewHandler = view.Handler;
+			Assert.NotNull(viewHandler);
+
+			if (view is HybridWebView)
+			{
+#if WINDOWS
+				// Await WebView2's own readiness API instead of polling or using a fixed delay.
+				// EnsureCoreWebView2Async completes exactly when initialization finishes (or
+				// immediately if already initialized), so there's no magic timeout/interval to tune.
+				if (viewHandler.PlatformView is Microsoft.UI.Xaml.Controls.WebView2 webView2)
+				{
+					await webView2.EnsureCoreWebView2Async();
+				}
+#endif
+			}
+
 			viewReference = new WeakReference(view);
-			handlerReference = new WeakReference(view.Handler);
-			platformViewReference = new WeakReference(view.Handler.PlatformView);
+			handlerReference = new WeakReference(viewHandler);
+			platformViewReference = new WeakReference(viewHandler.PlatformView);
+
+			// Explicitly disconnect the child view's handler before letting it fall out of
+			// scope. Real apps tear down handlers this way (e.g. when a page/element is
+			// removed), and some platform views (e.g. UIStepper on iOS 26+) rely on this
+			// deterministic teardown path to release native-side retains that a bare GC
+			// pass can't reach on its own.
+			if (viewHandler is IViewHandler disconnectableHandler)
+			{
+				disconnectableHandler.DisconnectHandler();
+			}
+
+			view.Handler = null;
 		});
 
 		await AssertionExtensions.WaitForGC(viewReference, handlerReference, platformViewReference);

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -244,9 +244,7 @@ public class MemoryTests : ControlsHandlerTestBase
 	[InlineData(typeof(Slider))]
 	[InlineData(typeof(Stepper))]
 	[InlineData(typeof(SwipeView))]
-#if TESTS_FAILS_ON_MACCATALYST //For more information, see: https://github.com/dotnet/maui/issues/35985
 	[InlineData(typeof(Switch))]
-#endif
 	[InlineData(typeof(TimePicker))]
 #pragma warning disable CS0618 // Type or member is obsolete
 	[InlineData(typeof(TableView))]
@@ -347,7 +345,6 @@ public class MemoryTests : ControlsHandlerTestBase
 #pragma warning restore CS0618 // Type or member is obsolete
 			var handler = CreateHandler<LayoutHandler>(layout);
 			var viewHandler = view.Handler;
-			Assert.NotNull(viewHandler);
 
 			if (view is HybridWebView)
 			{
@@ -355,7 +352,7 @@ public class MemoryTests : ControlsHandlerTestBase
 				// Await WebView2's own readiness API instead of polling or using a fixed delay.
 				// EnsureCoreWebView2Async completes exactly when initialization finishes (or
 				// immediately if already initialized), so there's no magic timeout/interval to tune.
-				if (viewHandler.PlatformView is Microsoft.UI.Xaml.Controls.WebView2 webView2)
+				if (viewHandler?.PlatformView is Microsoft.UI.Xaml.Controls.WebView2 webView2)
 				{
 					await webView2.EnsureCoreWebView2Async();
 				}

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -221,7 +221,9 @@ public class MemoryTests : ControlsHandlerTestBase
 	[InlineData(typeof(VerticalStackLayout))]
 	[InlineData(typeof(HorizontalStackLayout))]
 	[InlineData(typeof(AbsoluteLayout))]
+#if TESTS_FAILS_ON_WINDOWS //For more information, see: https://github.com/dotnet/maui/issues/35985
 	[InlineData(typeof(HybridWebView))]
+#endif
 	[InlineData(typeof(Image))]
 	[InlineData(typeof(ImageButton))]
 	[InlineData(typeof(IndicatorView))]
@@ -242,7 +244,9 @@ public class MemoryTests : ControlsHandlerTestBase
 	[InlineData(typeof(ScrollView))]
 	[InlineData(typeof(SearchBar))]
 	[InlineData(typeof(Slider))]
+#if TESTS_FAILS_ON_IOS && TESTS_FAILS_ON_MACCATALYST //For more information, see: https://github.com/dotnet/maui/issues/35985
 	[InlineData(typeof(Stepper))]
+#endif
 	[InlineData(typeof(SwipeView))]
 	[InlineData(typeof(Switch))]
 	[InlineData(typeof(TimePicker))]
@@ -344,36 +348,9 @@ public class MemoryTests : ControlsHandlerTestBase
 			}
 #pragma warning restore CS0618 // Type or member is obsolete
 			var handler = CreateHandler<LayoutHandler>(layout);
-			var viewHandler = view.Handler;
-
-			if (view is HybridWebView)
-			{
-#if WINDOWS
-				// Await WebView2's own readiness API instead of polling or using a fixed delay.
-				// EnsureCoreWebView2Async completes exactly when initialization finishes (or
-				// immediately if already initialized), so there's no magic timeout/interval to tune.
-				if (viewHandler?.PlatformView is Microsoft.UI.Xaml.Controls.WebView2 webView2)
-				{
-					await webView2.EnsureCoreWebView2Async();
-				}
-#endif
-			}
-
 			viewReference = new WeakReference(view);
-			handlerReference = new WeakReference(viewHandler);
-			platformViewReference = new WeakReference(viewHandler.PlatformView);
-
-			// Explicitly disconnect the child view's handler before letting it fall out of
-			// scope. Real apps tear down handlers this way (e.g. when a page/element is
-			// removed), and some platform views (e.g. UIStepper on iOS 26+) rely on this
-			// deterministic teardown path to release native-side retains that a bare GC
-			// pass can't reach on its own.
-			if (viewHandler is IViewHandler disconnectableHandler)
-			{
-				disconnectableHandler.DisconnectHandler();
-			}
-
-			view.Handler = null;
+			handlerReference = new WeakReference(view.Handler);
+			platformViewReference = new WeakReference(view.Handler.PlatformView);
 		});
 
 		await AssertionExtensions.WaitForGC(viewReference, handlerReference, platformViewReference);

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -221,9 +221,7 @@ public class MemoryTests : ControlsHandlerTestBase
 	[InlineData(typeof(VerticalStackLayout))]
 	[InlineData(typeof(HorizontalStackLayout))]
 	[InlineData(typeof(AbsoluteLayout))]
-#if TESTS_FAILS_ON_WINDOWS //For more information, see: https://github.com/dotnet/maui/issues/35985
 	[InlineData(typeof(HybridWebView))]
-#endif
 	[InlineData(typeof(Image))]
 	[InlineData(typeof(ImageButton))]
 	[InlineData(typeof(IndicatorView))]
@@ -244,9 +242,7 @@ public class MemoryTests : ControlsHandlerTestBase
 	[InlineData(typeof(ScrollView))]
 	[InlineData(typeof(SearchBar))]
 	[InlineData(typeof(Slider))]
-#if TESTS_FAILS_ON_IOS && TESTS_FAILS_ON_MACCATALYST //For more information, see: https://github.com/dotnet/maui/issues/35985
 	[InlineData(typeof(Stepper))]
-#endif
 	[InlineData(typeof(SwipeView))]
 	[InlineData(typeof(Switch))]
 	[InlineData(typeof(TimePicker))]


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!


<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details

The device memory leak validation tests began failing in the Candidate branch after the test-related changes introduced in PR https://github.com/dotnet/maui/pull/35487, which exposed actual memory leaks that were previously undetected. The regressions affected the Cells Do Not Leak and Handler Does Not Leak tests on Windows, the Cells Do Not Leak test on iOS, the Handler Does Not Leak test on iOS 26.0, and the Handler Does Not Leak test on macOS 26.0, indicating platform-specific memory leak issues that require fixes.

### Root cause

The issue occurs because of a templated cell registering its bound view as a logical child of the parent items view when bound, but only removing that registration when the cell was rebound to a different template — never when a cell was simply bound once and then discarded without being recycled. This permanently rooted the templated view, and its subviews, in the parent's children list, preventing collection.

A related native-side reference on the cell's content view could independently keep the platform view (and bound view) reachable even if the logical-child link were cleared. The leak test itself also had a bug: it never released its local cell, handler, and control references before checking for garbage collection, which kept them rooted for the whole test and masked the production issue.

### Solution description

The fix involves detaching the bound view from the parent's logical children and clearing the cell's native subviews during disposal, on the deterministic (non-finalizer) teardown path, so cleanup happens regardless of whether the cell was recycled, replaced, or simply discarded. It also involves correcting the test to explicitly tear down the cell and its owning control, then null out all local references, before verifying collection — since without this, the fix could never be exercised or proven in the test.

**Note**: The issue, "Handler Does Not Leak," was not reproduced in the Switch control. Therefore, the "Handler Doesn't Leak" test case has been re-enabled for the Switch control.

Validated the behavior in the following platforms
 
- [x] iOS
- [x] Mac
- [ ] Android
- [ ] Windows

### Regression PR

PR https://github.com/dotnet/maui/pull/35487
 
### Issues Fixed
  
Fixes https://github.com/dotnet/maui/issues/35985

### Output  Screenshot

|Platform|Before|After|
|--|--|--|
|iOS|<video src="https://github.com/user-attachments/assets/9a59cc41-bf7b-4781-bffb-1d4eb6cd6da0"> |<video src="https://github.com/user-attachments/assets/dd527177-0022-4465-b7a1-303882f19f2e">|
