### PR TITLE
Fix milestone tag audit PR parsing

### DIFF
--- a/.github/scripts/Fix-MilestoneDrift.Tests.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.Tests.ps1
@@ -129,6 +129,60 @@ Describe 'Resolve-MergedAfterCutoff' {
     }
 }
 
+Describe 'Get-PrNumbersFromGitLog — terminal squash PR suffix' {
+    It 'parses an ordinary terminal PR suffix' {
+        $result = @(Get-PrNumbersFromGitLog @('abc1234 Fix a layout regression (#35031)'))
+        $result.Count | Should -Be 1
+        $result[0] | Should -Be 35031
+    }
+
+    It 'returns only the terminal PR when an issue reference appears earlier' {
+        $result = @(Get-PrNumbersFromGitLog @(
+            'abc1234 Fix Shell.Items.Clear() memory leak (#34898) (#35031)'
+        ))
+        $result.Count | Should -Be 1
+        $result[0] | Should -Be 35031
+    }
+
+    It 'returns only the terminal PR after multiple earlier parenthesized references' {
+        $result = @(Get-PrNumbersFromGitLog @(
+            'abc1234 Reconcile reports (#100) and (#200) before the fix (#34719)'
+        ))
+        $result.Count | Should -Be 1
+        $result[0] | Should -Be 34719
+    }
+
+    It 'ignores a subject with no terminal PR suffix' {
+        @(Get-PrNumbersFromGitLog @(
+            'abc1234 Follow up on (#35031) without a squash suffix'
+        )).Count | Should -Be 0
+    }
+
+    It 'ignores malformed or non-numeric terminal references "<Reference>"' -ForEach @(
+        @{ Reference = '(#)' }
+        @{ Reference = '(#abc)' }
+        @{ Reference = '(#12x)' }
+        @{ Reference = '(#999999999999999999999999999999)' }
+    ) {
+        @(Get-PrNumbersFromGitLog @("abc1234 Malformed reference $Reference")).Count | Should -Be 0
+    }
+
+    It 'tolerates trailing whitespace after the terminal PR suffix' {
+        $result = @(Get-PrNumbersFromGitLog @('abc1234 Fix a layout regression (#35031)   '))
+        $result.Count | Should -Be 1
+        $result[0] | Should -Be 35031
+    }
+
+    It 'deduplicates repeated PR subjects and sorts the result' {
+        $result = @(Get-PrNumbersFromGitLog @(
+            'abc1234 First appearance (#35031)',
+            'def5678 Another PR (#34719)',
+            'fed9876 Cherry-pick the first PR (#35031)'
+        ))
+        ($result -join ',') | Should -Be '34719,35031'
+    }
+}
+
 Describe 'Get-PrInfo — merged-after cutoff enforcement' {
     BeforeAll {
         # Build a GitHub-pulls-API-shaped object (ConvertFrom-Json style) for the mock.
@@ -1613,6 +1667,46 @@ Describe 'Get-OnBranchShaFromLog — grep fallback subject precision' {
 
     It 'returns null for empty input' {
         Get-OnBranchShaFromLog @() 42 | Should -BeNullOrEmpty
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Git-log PR parsing integration block (no mocks, no GitHub).
+# ---------------------------------------------------------------------------
+Describe 'Git-log PR parsing paths (unmocked)' -Skip:(-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    BeforeAll {
+        $script:prLogTmp = Join-Path ([IO.Path]::GetTempPath()) "prlogtest-$(New-Guid)"
+        New-Item -ItemType Directory -Path $script:prLogTmp -Force | Out-Null
+
+        git -C $script:prLogTmp init -q
+        git -C $script:prLogTmp config user.email 'milestone-test@example.invalid'
+        git -C $script:prLogTmp config user.name 'Milestone Test'
+        git -C $script:prLogTmp config commit.gpgsign false
+
+        git -C $script:prLogTmp commit -q --allow-empty -m 'Base change (#100)'
+        git -C $script:prLogTmp tag 'from'
+        git -C $script:prLogTmp commit -q --allow-empty -m 'Fix Shell.Items.Clear() memory leak (#34898) (#35031)'
+        git -C $script:prLogTmp commit -q --allow-empty -m 'Fix VisualStateGroups (#50) (#34716) (#34719)'
+        git -C $script:prLogTmp commit -q --allow-empty -m 'Subject mentions (#99999) but has no terminal PR suffix'
+        git -C $script:prLogTmp commit -q --allow-empty -m 'Malformed suffix (#not-a-pr)'
+        git -C $script:prLogTmp commit -q --allow-empty -m 'Duplicate cherry-pick (#35031)'
+        git -C $script:prLogTmp tag 'to'
+    }
+
+    AfterAll {
+        if ($script:prLogTmp -and (Test-Path $script:prLogTmp)) {
+            Remove-Item -Recurse -Force $script:prLogTmp -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'Get-PrNumbersBetweenTags returns only terminal PR suffixes and deduplicates them' {
+        $result = @(Get-PrNumbersBetweenTags 'from' 'to' $script:prLogTmp)
+        ($result -join ',') | Should -Be '34719,35031'
+    }
+
+    It 'Get-PrNumbersReachableFromTag uses the same terminal-suffix behavior' {
+        $result = @(Get-PrNumbersReachableFromTag 'to' $script:prLogTmp)
+        ($result -join ',') | Should -Be '100,34719,35031'
     }
 }
 

--- a/.github/scripts/Fix-MilestoneDrift.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.ps1
@@ -239,29 +239,33 @@ function Get-OnBranchShaFromLog([string[]]$LogLines, [int]$PrNum) {
     return $null
 }
 
-function Get-PrNumbersBetweenTags([string]$TagFrom, [string]$TagTo, [string]$Repo) {
-    $output = git -C $Repo --no-pager log --oneline "$TagFrom..$TagTo" 2>&1
-    if ($LASTEXITCODE -ne 0) { throw "git log failed: $output" }
+function Get-PrNumbersFromGitLog([string[]]$LogLines) {
+    <# GitHub squash and merge commit subjects end with the merged PR token.
+       Earlier parenthesized references may be linked issues and must not be
+       treated as PRs. #>
     $prs = [System.Collections.Generic.HashSet[int]]::new()
-    foreach ($line in ($output -split "`n")) {
-        foreach ($m in [regex]::Matches($line, '\(#(\d+)\)')) {
-            [void]$prs.Add([int]$m.Groups[1].Value)
+    foreach ($line in $LogLines) {
+        if ($line -match '\(#(\d+)\)\s*$') {
+            $prNumber = 0
+            if ([int]::TryParse($Matches[1], [ref]$prNumber)) {
+                [void]$prs.Add($prNumber)
+            }
         }
     }
     return ($prs | Sort-Object)
+}
+
+function Get-PrNumbersBetweenTags([string]$TagFrom, [string]$TagTo, [string]$Repo) {
+    $output = git -C $Repo --no-pager log --oneline "$TagFrom..$TagTo" 2>&1
+    if ($LASTEXITCODE -ne 0) { throw "git log failed: $output" }
+    return Get-PrNumbersFromGitLog ($output -split "`n")
 }
 
 function Get-PrNumbersReachableFromTag([string]$TagName, [string]$Repo) {
     <# Returns PR numbers reachable from a tag (all commits up to and including the tag). #>
     $output = git -C $Repo --no-pager log --oneline $TagName 2>&1
     if ($LASTEXITCODE -ne 0) { throw "git log failed: $output" }
-    $prs = [System.Collections.Generic.HashSet[int]]::new()
-    foreach ($line in ($output -split "`n")) {
-        foreach ($m in [regex]::Matches($line, '\(#(\d+)\)')) {
-            [void]$prs.Add([int]$m.Groups[1].Value)
-        }
-    }
-    return ($prs | Sort-Object)
+    return Get-PrNumbersFromGitLog ($output -split "`n")
 }
 
 function Find-TagContainingPr([int]$PrNum, [string]$Repo, [int]$Major) {


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

#### Root cause

`Get-PrNumbersBetweenTags` and `Get-PrNumbersReachableFromTag` treated every parenthesized `(#N)` reference in a commit subject as a merged PR. GitHub squash subjects can contain linked issue references before the actual PR suffix, so preview6 attempted to fetch issues #34716 and #34898 through the pulls API and logged two false 404 errors.

#### Fix

Add one shared `Get-PrNumbersFromGitLog` helper used by both tag paths. It accepts only the final numeric `(#N)` suffix (with optional trailing whitespace), ignores malformed or non-terminal references, and preserves sorted deduplication.

#### Preview6 proof

For `11.0.0-preview.5.26304.4..11.0.0-preview.6.26360.8`:

- Before: 192 candidate references; false #34716 and #34898 included.
- After: 190 candidate PRs; #34716 and #34898 excluded while actual PRs #34719 and #35031 remain.
- Real dry run exited 0 and resolved `.NET 11.0-preview6` (#129).
- 39 relevant PRs checked, 151 wrong-branch PRs skipped, 15 linked issues checked, and 40 items already correct.
- All 14 legitimate milestone corrections remain, with zero report errors.
- `-CloseFixedIssues` remained a dry run: two open issues would close and 13 were already closed; no GitHub state was changed.

#### Tests

- New parser regression selection: 12 tests; restoring the former parser produces 6 failures.
- `Fix-MilestoneDrift.Tests.ps1`: 212 passed.
- `MilestoneTrigger.Tests.ps1`: 116 passed.

#### Non-goals

This fixes tag-audit parsing on `main`. It does not address the missed historical preview6 workflow launch: the preview6 tag was created from a net11.0 commit that did not yet contain the already-merged `main` tag-push trigger. Branch-flow/backport policy is intentionally unchanged.

### Issues Fixed

N/A — this defect was discovered while auditing the preview6 tag.