### PR TITLE
Add issue-fixer workflow with isolated fix attempts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -286,6 +286,13 @@ Skills are modular capabilities that can be invoked directly or used by agents. 
    - **Phase skill**: `try-fix` — Multi-model fix exploration
    - **Note**: Gate (test verification) runs as a script step in `Review-PR.ps1` before this skill is invoked. Gate result is passed in the prompt.
 
+2. **issue-fixer** (`.github/skills/issue-fixer/SKILL.md`)
+   - **Purpose**: Reproduce-first, root-cause-first workflow for fixing a GitHub **issue** (often with no PR yet). Front-loads a faithful empirical reproduction and true root-cause analysis before any fix, then composes the other skills for the fix and verification.
+   - **Trigger phrases**: "fix issue #XXXXX", "reproduce issue #XXXXX", "root-cause issue #XXXXX", "why does #XXXXX happen", "investigate this bug"
+   - **Composes**: `try-fix` (fix attempts), `verify-tests-fail-without-fix` / `run-device-tests` / `run-helix-tests` / `write-ui-tests` / `write-xaml-tests` (verification), `azdo-build-investigator` (CI escalation)
+   - **Do NOT use for**: A PR that already exists → use `pr-review`. One isolated fix attempt → use `try-fix`.
+   - **Note**: Separates exact-package behavior reproduction from MAUI source provenance (uses `git merge-base` for MAUI-source branches; version labels ≠ git tags), rejects circular tests, and stops to ask before pushing.
+
 2. **issue-triage** (`.github/skills/issue-triage/SKILL.md`)
    - **Purpose**: Query and triage open issues that need milestones, labels, or investigation
    - **Trigger phrases**: "find issues to triage", "show me old Android issues", "what issues need attention"

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -291,7 +291,7 @@ Skills are modular capabilities that can be invoked directly or used by agents. 
    - **Trigger phrases**: "fix issue #XXXXX", "reproduce issue #XXXXX", "root-cause issue #XXXXX", "why does #XXXXX happen", "investigate this bug"
    - **Composes**: `try-fix` (fix attempts), `verify-tests-fail-without-fix` / `run-device-tests` / `run-helix-tests` / `write-ui-tests` / `write-xaml-tests` (verification), `azdo-build-investigator` (CI escalation)
    - **Do NOT use for**: A PR that already exists → use `pr-review`. One isolated fix attempt → use `try-fix`.
-   - **Note**: Separates exact-package behavior reproduction from MAUI source provenance (uses `git merge-base` for MAUI-source branches; version labels ≠ git tags), rejects circular tests, and stops to ask before pushing.
+   - **Note**: Recreates reporter behavior in a repo-owned test or Sandbox (never executes the reporter project), separates source provenance from behavior evidence, rejects circular tests, and stops to ask before pushing.
 
 2. **issue-triage** (`.github/skills/issue-triage/SKILL.md`)
    - **Purpose**: Query and triage open issues that need milestones, labels, or investigation

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -239,10 +239,10 @@ The repository includes specialized custom agents and reusable skills for specif
 ### Available Custom Agents
 
 1. **pr** - Sequential 4-phase workflow for reviewing and working on PRs
-   - **Use when**: A PR already exists and needs review or work, OR an issue needs a fix
+   - **Use when**: A PR already exists and needs review or work, including an issue being fixed through that PR
    - **Capabilities**: PR review, test verification, fix exploration, alternative comparison
-   - **Trigger phrases**: "review PR #XXXXX", "work on PR #XXXXX", "fix issue #XXXXX", "continue PR #XXXXX"
-   - **Do NOT use for**: Just running tests manually → Use `sandbox-agent`
+   - **Trigger phrases**: "review PR #XXXXX", "work on PR #XXXXX", "continue PR #XXXXX", "fix issue #XXXXX through PR #YYYYY"
+   - **Do NOT use for**: An issue with no PR yet → use `issue-fixer`. Just running tests manually → use `sandbox-agent`.
 
 2. **write-tests-agent** - Agent for writing tests. Determines test type (UI vs XAML) and invokes the appropriate skill (`write-ui-tests`, `write-xaml-tests`)
    - **Use when**: Creating new tests for issues or PRs
@@ -277,9 +277,9 @@ Skills are modular capabilities that can be invoked directly or used by agents. 
 
 1. **pr-review** (`.github/skills/pr-review/SKILL.md`)
    - **Purpose**: End-to-end PR review orchestrator — 3 phases: pr-preflight, try-fix, pr-report. Gate runs separately before this skill via Review-PR.ps1.
-   - **Trigger phrases**: "review PR #XXXXX", "work on PR #XXXXX", "fix issue #XXXXX", "continue PR #XXXXX"
+   - **Trigger phrases**: "review PR #XXXXX", "work on PR #XXXXX", "continue PR #XXXXX", "fix issue #XXXXX through PR #YYYYY"
    - **Capabilities**: Multi-model fix exploration, alternative comparison, PR review recommendation
-   - **Do NOT use for**: Just running tests manually → Use `sandbox-agent`
+   - **Do NOT use for**: An issue with no PR yet → use `issue-fixer`. Just running tests manually → use `sandbox-agent`.
    - **Phase instructions** (in `.github/pr-review/`):
      - `pr-preflight.md` — Context gathering from issue/PR
      - `pr-report.md` — Final recommendation
@@ -373,7 +373,7 @@ Skills are modular capabilities that can be invoked directly or used by agents. 
 **Examples of correct delegation**:
 - User: "Review PR #12345" → Immediately invoke **pr** agent
 - User: "Test this PR" → Immediately invoke **sandbox-agent**
-- User: "Fix issue #67890" (no PR exists) → Suggest using `/delegate` command
+- User: "Fix issue #67890" (no PR exists) → Invoke the **issue-fixer** skill
 - User: "Write tests for issue #12345" → Immediately invoke **write-tests-agent**
 - User: "Is SR7 ready to ship?" → Immediately invoke **release-readiness-agent**
 - User: "How does net11 preview6 look?" → Immediately invoke **release-readiness-agent**

--- a/.github/skills/issue-fixer/SKILL.md
+++ b/.github/skills/issue-fixer/SKILL.md
@@ -1,0 +1,421 @@
+---
+name: issue-fixer
+description: "Reproduce-first, root-cause-first workflow for fixing a .NET MAUI GitHub ISSUE (often with no PR yet). Front-loads a faithful empirical reproduction and true root-cause analysis BEFORE any fix, then composes try-fix / verify-tests-fail-without-fix / run-device-tests / run-helix-tests / write-ui-tests / write-xaml-tests / azdo-build-investigator for the fix and verification. Use whenever asked to 'fix issue #XXXXX', 'reproduce issue #XXXXX', 'root-cause issue #XXXXX', 'why does #XXXXX happen', 'investigate this bug', or handed a repro repo/branch and a broken behavior — even if the user doesn't say the word 'reproduce'. Do NOT use to review an existing PR (use pr-review) or to run one isolated fix attempt (use try-fix)."
+metadata:
+  author: dotnet-maui
+  version: "1.0"
+compatibility: Requires git (incl. worktrees), PowerShell 7+ (pwsh), and the .NET MAUI build environment (BuildTasks + platform workloads). Device/Helix verification needs Android SDK/emulator, Xcode, or the run-helix-tests prerequisites depending on platform.
+---
+
+# Issue Fixer — Reproduce First, Root-Cause First
+
+A discipline for fixing a MAUI bug **from the issue up**. The whole point of this skill is to refuse to
+guess: never assume the bug is real, never assume a fix is correct, and never assume a "version" label maps
+to a git tag — **prove everything empirically** before and after you touch code.
+
+This skill exists because the expensive failures in real MAUI bug work are almost never "I couldn't write the
+fix." They're "I fixed the wrong thing," "I calibrated against the wrong source tree," or "my test was
+circular and proved nothing." Front-loading reproduction and root-cause analysis is what prevents those.
+
+**Trigger phrases:** "fix issue #XXXXX", "reproduce issue #XXXXX", "root-cause issue #XXXXX",
+"why does #XXXXX happen", "investigate this bug", "I have a repro repo for this crash/leak".
+
+## When NOT to use this skill (differentiation)
+
+This skill deliberately overlaps in vocabulary with two neighbours. Pick the right one:
+
+| If the situation is… | Use | Why |
+|----------------------|-----|-----|
+| A **PR already exists** and needs review / alternative-fix exploration / a merge recommendation | **`pr-review`** | pr-review is PR-centric: it runs a gate, 4-model try-fix, and writes a review report. It assumes the fix and (usually) a test already exist. |
+| You just need to **run ONE alternative fix idea**, test it, and get a pass/fail back | **`try-fix`** | try-fix is a single-shot building block. This skill *calls* it during Phase 3 — it is not a replacement for it. |
+| You only need to **prove a test catches the bug** (fails without fix / passes with fix) | **`verify-tests-fail-without-fix`** | That skill owns the inverted-semantics verification. This skill *calls* it during Phase 4. |
+| You're asked **"why is CI red / is this PR ready to merge"** | **`azdo-build-investigator`** | CI triage, not issue reproduction. This skill *calls* it only for Phase 4 CI escalation. |
+
+**issue-fixer is different:** it starts from a GitHub **issue** (frequently with **no PR at all**), and it spends
+its first two phases establishing a faithful reproduction and the true root cause *before* any code changes.
+It **composes** the skills above rather than re-implementing them. If a PR already exists for the issue, prefer
+`pr-review`; only fall back here when the issue still needs original reproduction and root-cause work.
+
+## Guardrails (read before doing anything)
+
+- 🚫 **Never push or commit to GitHub without explicit user approval.** When you reach a point where pushing
+  would be the next step, **stop and ask.** The user reviews locally first.
+- 🚫 **Never touch the main checkout.** Do all work in this session's worktree, and create *throwaway*
+  `git worktree` checkouts for reproduction builds (see Phase 1). Never build or mutate the user's primary tree.
+- 🌿 **Follow the repo git rules:** work on the session feature branch; no rebase / squash / force-push unless
+  the user explicitly asks.
+- 🧾 This skill produces **analysis + reproduction evidence + a fix + verification**. It does **not** post PR
+  review approvals and never runs `gh pr review --approve` / `--request-changes`.
+
+## The eight disciplines (the heart of this skill)
+
+These are hard-won lessons. They're written as reasoning, not rote rules, because you'll need to apply them to
+situations they don't literally describe. Internalize the *why*.
+
+1. **Reproduce first, always.** A fix for a bug you haven't reproduced is a hypothesis, not a fix. Treat
+   *"I can't reproduce it"* not as a conclusion but as a signal that a variable is still missing — go hunt it
+   (see discipline 4). Only after you can make the bug happen on demand do you get to reason about causes.
+
+2. **Use the reporter's *exact bits* and resolve source provenance — don't equate a version label with a git
+   tag.** A reporter's *"Version with bug: 10.0.60"* is a **NuGet package label, not necessarily a git tag.**
+   If a repro branch is in the MAUI source commit graph, find its **actual base commit** with `git merge-base`
+   and build MAUI at that commit. If it is an external application repo, pin the app revision and its exact
+   package reference instead — unrelated histories cannot establish a MAUI source base. Reproduce behavior
+   against that exact package even when the version-to-commit mapping remains unresolved; label any source
+   analysis baseline as approximate. (In the case that motivated this skill, the MAUI-source repro branch was
+   based on `main` ~10 days newer than the `10.0.60` tag; calibrating against the tag produced false negatives.)
+   When building MAUI from source, build `Microsoft.Maui.BuildTasks.slnf` first, then the app.
+
+3. **Use the reporter's exact app, supplied build command, and steps.** Fast-deployment debug builds
+   (`-t:Install`, no `EmbedAssembliesIntoApk`) can behave *differently* from embedded-assembly APKs. When the
+   reporter supplies a `dotnet build` invocation, reproduce it exactly; always preserve their exact interaction
+   sequence. If the command is omitted, use only the bounded canonical fallback in Phase 1 and label it as not
+   reporter-exact. Small deviations ("I used the Sandbox instead," "I skipped a tap") routinely hide the bug.
+
+4. **Enumerate and eliminate environmental variables — and record each as tested.** When the bug won't
+   reproduce, systematically vary the things you control and log the result of each:
+   API level; deploy mode (fast-deploy vs embedded-assembly APK); emulator ABI (**arm64-v8a** on Apple Silicon
+   vs **x86_64** on CI/Helix); emulator vs physical device; source commit. Keep a table (template below). When
+   you've exhausted every variable you control and it *still* won't repro, **name the remaining delta you
+   cannot test locally** (e.g. x86_64 Helix) explicitly — don't pretend it's not there and don't declare "not
+   a bug."
+
+5. **Separate symptom from root cause.** A fix that merely severs the last reference or flushes pending state
+   — e.g. `CurrentView = null`, or calling something like `ExecutePendingTransactionsEx()` to force a pending
+   fragment transaction — may be a **symptom fix** if it doesn't remove **what actually roots the object** or
+   **what actually causes the crash.** Always force the question: *what is the true root cause, and does this
+   change address it or just paper over the observable symptom?* Prefer root fixes. If only a symptom fix is
+   feasible right now, **say so** and document what the real root is and why the root fix was deferred.
+
+6. **Reject circular / tautological tests.** A test that asserts the exact field the fix mutates proves
+   nothing about real behavior (fix sets `CurrentView == null`; test asserts `CurrentView == null` → circular).
+   - A **leak** test must use `WeakReference` + `GC.Collect()` + `GC.WaitForPendingFinalizers()` and assert the
+     object graph is **actually collected** — not that some convenience field was nulled.
+   - A **crash** test must actually **exercise the crashing code path** (the real navigation/detail-swap/etc.),
+     not a stand-in.
+   Run the circular-test checklist (below) before you trust any test.
+
+7. **Escalate to CI for ground truth when local repro is genuinely impossible.** When the only remaining
+   variable is one you can't control locally (classically: x86_64 Helix ABI), escalate to a real device test in
+   CI (`maui-pr-devicetests`) and read the **actual** result. Use this decision matrix:
+
+   | Unfixed test result | Fixed test result | Conclusion |
+   |--------------------|-------------------|------------|
+   | **PASSES** unfixed | — | Bug does **not** reproduce on this train → the fix is **redundant here**; don't ship it as a "fix" without saying so. |
+   | **FAILS** unfixed | **PASSES** with fix | Bug is **real** and the fix is **needed** — the clean, shippable outcome. |
+   | **FAILS** unfixed | **FAILS** with fix | Fix is **wrong or incomplete** → back to Phase 2/3. |
+
+   See `.github/skills/azdo-build-investigator/SKILL.md` and `.github/docs/maui-ci-facts.md` for correct
+   pipeline names/IDs and how to read Helix results (including the XHarness exit-0 blind spot).
+
+8. **No shortcuts, no assumptions.** Assume infinite budget: thoroughness beats speed. Every claim in your
+   final report must be backed by an **observed** result — a build that ran, a tap sequence that crashed, a
+   test that went red then green. "It should work" is not evidence.
+
+## Workflow
+
+Run the phases in order. Each phase has an exit condition; don't advance until it's met. If a phase is
+genuinely blocked by the environment, record *why* and what you'd need — don't paper over it.
+
+### Phase 0 — Triage & context
+
+Understand the bug on paper before touching a keyboard.
+
+- Read the issue body **and every comment in chronological order**: symptom, expected vs actual,
+  **stated version(s)**, platform(s), and linked discussion. Human corrections in later comments supersede
+  stale details in the body or earlier agent analysis. `gh issue view <n> --comments`.
+- Collect the reporter's **reproduction assets**: repro repo/branch URL, exact `dotnet build`/run command,
+  exact interaction steps, screenshots/stack traces/logs.
+- **Classify the setup evidence — reporter-exact vs canonical fallback.** The reporter's *exact* launch command
+  is the gold standard and is **required whenever they give it**, because build flags and deploy mode change
+  behavior (discipline 3). But reporters routinely hand you a complete, runnable project + platform/TFM +
+  interaction steps and simply *omit the terminal command*. That omission alone is **not** a reason to block:
+  the app is still runnable. When the command is missing, record the absence explicitly, and note that Phase 1
+  will fall back to a **canonical** launch (see Phase 1) — clearly labeled as *not reporter-exact*. Only treat
+  Phase 0 as truly blocked when there is **no** viable declared target at all (no project, no platform/TFM, or
+  no interaction steps).
+- Search for **existing PRs/issues** that already touch this. If a PR already fixes it → this is probably a
+  `pr-review` job; note it and confirm with the user before continuing here.
+- Write the **falsifiable claim** you're going to prove, e.g. *"On Android, tapping Detail→Swap twice on the
+  reporter's app crashes with `IllegalStateException` in fragment commit."*
+
+**Exit:** you can state the app, platform, interaction steps, and the claim to reproduce, **and** you have
+classified the launch command as either `reporter-exact` (captured verbatim) or `canonical fallback` (command
+absent — absence recorded, fallback flagged for Phase 1). Block only when no runnable target exists.
+
+### Phase 1 — Faithful reproduction
+
+Make the bug happen on demand, against the reporter's real tree. Two independent evidence tracks run here —
+keep them separate so you never over-claim:
+
+- **Source provenance** (what MAUI *bits* the behavior runs on).
+- **Application behavior** (does the app misbehave when driven through the reporter's steps).
+
+1. **Pin the source commit (provenance track).** If a repro branch is in the MAUI source repository (or the
+   same commit graph), `git merge-base` it against `main`/candidate to find its *actual* base — do **not**
+   trust the version label (discipline 2). This `git merge-base` rule is **not** relaxed when a repro branch
+   gives you a MAUI source base. An external application-repo branch instead establishes the app revision, not
+   the MAUI source revision; use the app's exact package reference as its MAUI provenance evidence. If the
+   package version cannot be mapped to a commit, that must **not** block reproducing behavior on the reporter's
+   **exact package version**. Unmapped provenance only limits your *exact-source / root-cause* claims later.
+   If you must build MAUI from source for analysis and can't resolve the commit, use the nearest analysis
+   baseline **only with an explicit "approximate, not the reporter's exact source" label** and report the
+   unresolved mapping.
+2. **Create a throwaway MAUI worktree only when source analysis/building needs a resolved source commit**
+   (never the main checkout):
+   ```bash
+   git worktree add ../maui-repro-<sha> <sha>
+   ```
+   Build `Microsoft.Maui.BuildTasks.slnf` first when building MAUI from source. Build an external reporter app
+   from its own clone/project against its declared package version; do not assume it belongs in the MAUI
+   worktree.
+3. **Launch the app — reporter-exact if given, otherwise a bounded canonical fallback.**
+   - **Reporter-exact (preferred, required when supplied):** use their exact `dotnet build`/run command and
+     deploy mode (discipline 3).
+   - **Canonical fallback (command absent):** derive a **documented, canonical** MAUI launch command from the
+     project's *declared* TFM/platform and the repository's own tooling (e.g. the standard
+     `dotnet build -t:Run -f <declared-tfm>` path, or the repo's device-test/run scripts). **Bounds — do not
+     cross:** don't invent undeclared configuration flags, device identifiers, deployment modes, or extra
+     interaction steps. Record the **exact fallback command**, the **source** that makes it canonical (which
+     declared TFM/tooling it came from), and **every remaining unknown** in the variable table. If there is no
+     viable declared target or tooling to derive a command from, stay **blocked** and say why.
+     > The fallback reproduces **application behavior only** — it is *not* evidence of the reporter's original
+     > build environment. Label any behavior you observe as "reproduced via canonical fallback (not
+     > reporter-exact build env)."
+4. **Run the reporter's exact steps** on the app. Reproduce the crash/leak/misbehavior. A behavior reproduced
+   under the canonical fallback **is sufficient** to continue to root-cause investigation (Phase 2) — just
+   carry the label forward.
+5. **If it won't reproduce, enumerate variables** (discipline 4) and record each attempt:
+
+   | Variable | Value tried | Result | Notes |
+   |----------|-------------|--------|-------|
+   | Application revision | `<sha>` / branch / supplied snapshot | ❌/✅ | external repro app identity |
+   | MAUI source commit | `<sha>` via merge-base / `unresolved` / `N/A exact-package repro` | ❌/✅ | never substitute a package label for a commit |
+   | Launch command | `reporter-exact` / `canonical fallback: <cmd>` | | source of canonical + unknowns |
+   | Package provenance | version→commit `<mapped sha>` / `unmapped` | | approximate-baseline label if unmapped |
+   | API level | e.g. 34 | | |
+   | Deploy mode | fast-deploy `-t:Install` / embedded APK | | unknown if fallback |
+   | Emulator ABI | arm64-v8a (Apple Silicon) / x86_64 (Helix) | | |
+   | Device | emulator / physical | | |
+
+   A canonical fallback that does **not** reproduce is **not** a false negative — enumerate the remaining
+   variables/delta exactly as today (a missing reporter-exact command is itself one such variable). When every
+   controllable variable is exhausted and it still won't repro, **name the uncontrollable delta**
+   (e.g. x86_64 Helix) and carry it to Phase 4 escalation — do **not** conclude "not a bug."
+
+**Exit:** either a reliable local reproduction — labeled `reporter-exact` or `canonical fallback` — **or** an
+explicit, evidence-backed statement of the remaining variable(s) you can't test locally, with provenance
+(mapped/unmapped) recorded.
+
+### Phase 2 — Root-cause analysis
+
+Find *what actually causes* the observed behavior — not the last thing that touches it.
+
+- **Minimize only after faithful reproduction.** Reduce the reproduced case one variable at a time and verify
+  the smaller case still fails. This is a diagnostic accelerator, not a replacement acceptance scenario: the
+  reporter's exact app/steps (or labeled canonical fallback) remains the final behavior check. If minimization
+  loses the failure, keep the faithful repro and record which removed variable mattered.
+- **Form at least 3 meaningfully competing root-cause hypotheses.** For each, record: theory, a discriminating
+  command/observation that could reject it, result (`CONFIRMED`, `DENIED`, or `PARTIAL`), and implications.
+  Three variants of the same symptom are not competing hypotheses. Prefer experiments that distinguish several
+  hypotheses at once; record this in session evidence/report artifacts, not a new planning file in the repo.
+- Trace the failing path in the reproduced app/bits: what roots the leaked object, or what state makes the crash
+  legal? Use the debugger/logs/`lsp` call hierarchy. When package provenance is unresolved, keep runtime
+  observations separate from hypotheses based on an approximate source baseline — don't call approximate
+  source the reproduced tree.
+- Apply **symptom-vs-root** (discipline 5): for every candidate change, ask "does this remove the cause, or
+  just hide the effect?" Write down the root cause hypothesis explicitly.
+- Prefer a **root** fix. If only a symptom fix is viable now, document the real root and why the root fix is
+  deferred, so the follow-up is not lost.
+
+**Exit:** a minimized diagnostic repro (or evidence explaining why it cannot be reduced), a result for each
+competing hypothesis, and an evidence-selected root-cause hypothesis + location where the true fix should live.
+
+### Phase 3 — Fix (multi-model exploration + adversarial consensus)
+
+Don't produce the fix single-track. Borrow `pr-review`'s proven structure — *come up with a fix, then
+challenge that fix* — because a fix that survives being attacked by other models is far likelier to be a
+**root** fix than a symptom fix. This phase mirrors `pr-review` Phase 2 (multi-model `try-fix` +
+cross-pollination + comparison-table selection), then adds an adversarial challenge of the winner.
+
+Don't hand-roll the fix loop — every attempt goes through **`try-fix`**
+(`.github/skills/try-fix/SKILL.md`), which establishes a baseline, applies **one** approach, tests it, records
+artifacts, and reverts.
+
+> 🚨 **Sequential only — never parallel/background.** Run each `try-fix` with `mode: "sync"`, one fully
+> completing before the next starts. try-fix mutates the same target files, shares the emulator/device, and
+> reverts to baseline between runs; running them concurrently corrupts each other's file state and results.
+> Restore baseline between attempts exactly as try-fix/pr-review prescribe.
+
+#### Round 1 — independent exploration
+
+Invoke `try-fix` via `general-purpose` task agents across these 4 models, **SEQUENTIALLY**:
+
+| Order | Model |
+|-------|-------|
+| 1 | `claude-opus-4.6` |
+| 2 | `claude-opus-4.7` |
+| 3 | `gpt-5.3-codex` |
+| 4 | `gpt-5.5` |
+
+Feed each `try-fix` invocation:
+- `problem` — the faithful + minimized reproductions and the Phase 2 evidence-selected root-cause hypothesis
+- `hints` — decisive evidence for the selected hypothesis plus `DENIED` / `PARTIAL` alternatives and why, so
+  each model aims at the root without blindly rediscovering rejected causes (it may challenge them with new
+  evidence)
+- `platform` — the reproduced platform from Phase 1
+- `target_files` — the files identified in Phase 2
+- `test_command` — the strongest empirical command currently available: the planned Phase 4 regression command
+  when a test already exists; otherwise the faithful Phase 1 behavior reproducer through the appropriate repo
+  runner, explicitly labeled provisional. A provisional reproducer does not replace Phase 4's non-circular
+  regression test.
+
+Each model must generate its approach **independently first**, then produce a **DIFFERENT** approach from any
+existing changes (review the diff first). "Different" means a different root-cause hypothesis, not just a
+different line — see discipline 5.
+
+#### Round 2 — cross-pollination (mandatory)
+
+After Round 1, show **each** model the list of attempts + results and ask for NEW ideas
+("NEW IDEA: …" or "NO NEW IDEAS"). Run any new ideas as further **sequential** `try-fix` attempts. Repeat
+until every model says NO NEW IDEAS (max 3 rounds).
+
+#### Selection
+
+Build a comparison table of all ✅-passing candidates and rank them, in priority order:
+1. **Addresses the ROOT cause, not a symptom** (discipline 5) — a fix that merely nulls a reference or flushes
+   pending state is symptom-level and ranks below one that removes what actually roots the object / causes the
+   crash.
+2. **Simplest** — fewest files/lines.
+3. **Most robust** — handles edge cases.
+4. **Matches MAUI codebase style** — consistent with existing patterns.
+
+Pick the winner.
+
+#### Materialize the selected fix
+
+`try-fix` **always restores the working directory to baseline**, so the winner exists only as its recorded
+`fix.diff` after exploration. Apply that exact candidate diff to the session feature worktree, verify the
+materialized diff matches the reviewed candidate and contains no attempt artifacts, then rerun the same
+empirical command. Do not commit or push. This materialized diff — not a prose summary or a reverted attempt —
+is what the adversarial reviewers challenge and what Phase 4 verifies.
+
+#### Adversarial challenge of the selected fix (the "challenge that fix" step)
+
+> **Adaptation vs pr-review:** `pr-review` challenges an **existing PR's** fix. issue-fixer has **no PR yet**,
+> so the artifact under attack here is the winning fix the multi-model exploration *just produced* — not a
+> PR. Everything else about the challenge mirrors the adversarial agree/dispute/discard pattern.
+
+Dispatch the **other** models (not the one that authored the winner) to attack the winning fix. Each returns a
+structured verdict — **AGREE / DISPUTE / DISCARD** — with reasoning, probing specifically:
+- **Root vs symptom** — does it remove the actual cause, or paper over the observable symptom?
+- **Regression risk** — could it reintroduce the leak, or introduce a new crash / lifecycle bug?
+- **Test integrity** — is the Phase 4 verification test circular/tautological (does it fail the circular-test
+  checklist in Phase 4)? If only a provisional behavior reproducer exists, mark this dimension **DEFERRED**
+  rather than treating the absence of a regression test as agreement.
+
+Synthesize consensus:
+- Consensus **AGREE** on the fix → the fix survives; advance to Phase 4. A deferred test-integrity dimension
+  remains a Phase 4 gate.
+- Consensus **DISPUTE / DISCARD** → loop back: to **Phase 2** if the root cause itself was wrong, or to
+  **Phase 3 Round 1** if only the approach was wrong. Only a fix that survives the challenge advances.
+
+**Exit:** the multi-model winner is materialized in the session worktree, builds, and **survived adversarial
+challenge** — believed to remove the root cause. Any deferred test-integrity challenge is recorded for Phase 4.
+
+### Phase 4 — Verification (non-circular, escalate if needed)
+
+Prove the fix works with a test that would actually catch the bug.
+
+1. **Pick / write a non-circular test** (discipline 6). If the issue lacks coverage, compose the right author:
+   - UI interaction bug → **`write-ui-tests`** (`.github/skills/write-ui-tests/SKILL.md`)
+   - XAML parse/XamlC/source-gen bug → **`write-xaml-tests`** (`.github/skills/write-xaml-tests/SKILL.md`)
+   - Then run the **circular-test checklist** below and fix the test if it fails any item.
+   - If Phase 3 deferred the test-integrity challenge, send the final test to the other models for that focused
+     probe now. A dispute loops back to test authoring; don't let the earlier fix consensus waive this gate.
+2. **Verify fail-without-fix / pass-with-fix** via **`verify-tests-fail-without-fix`**
+   (`.github/skills/verify-tests-fail-without-fix/SKILL.md`) — remember its **inverted** semantics
+   (tests *failing* without the fix is the *good* outcome).
+   - Local device/unit runs: **`run-device-tests`** (`.github/skills/run-device-tests/SKILL.md`).
+   - Helix unit projects (XAML, Core, Essentials, Resizetizer, …): **`run-helix-tests`**
+     (`.github/skills/run-helix-tests/SKILL.md`).
+3. **Run the affected area's existing regression sweep.** After targeted red/green proof, run the containing
+   test class/category or smallest established area suite. If it fails, reproduce that failure on the unfixed
+   baseline before calling it pre-existing, unrelated, or flaky. For intermittent failures, record repetitions
+   and observed failure rate; one pass is not evidence of flakiness or safety.
+4. **Escalate to CI when local repro was impossible** (discipline 7). Run the real device test on
+   `maui-pr-devicetests` and read the **actual** Helix/test result (not code attributes, not exit-0). Apply the
+   decision matrix in discipline 7 to decide whether the bug is real and the fix is needed. Use
+   **`azdo-build-investigator`** for reading CI.
+
+**Circular-test checklist** — reject the test if any is true:
+- [ ] Its **setup** does not reproduce the issue's exact relevant scenario (including corrections from comments).
+- [ ] Its **assertions** do not verify the exact user-visible behavior reported broken/fixed.
+- [ ] It asserts the exact field/state the fix mutates (e.g. fix sets `X=null`, test asserts `X==null`).
+- [ ] A leak test lacks `WeakReference` + `GC.Collect()` + `GC.WaitForPendingFinalizers()` and a real
+      collection assertion.
+- [ ] A crash test doesn't actually drive the crashing path (uses a stand-in / mocks the very thing under test).
+- [ ] It passes *without* the fix (then it doesn't catch the bug — see verify-tests-fail-without-fix).
+
+**Exit:** evidence that the test goes **red without the fix** and **green with it** — locally or in CI — plus
+a clean area regression sweep or baseline evidence classifying every additional failure.
+
+### Phase 5 — Report
+
+Summarize with evidence, then **stop and ask before pushing** (guardrails).
+
+Use this structure:
+
+```markdown
+## Issue #XXXXX — <one-line summary>
+
+### Reproduction
+- Application revision: <reporter repo commit / branch / supplied project snapshot>
+- MAUI runtime bits: <source commit | exact NuGet package version>
+- MAUI source provenance: <resolved via merge-base or version→sha | unresolved — analysis baseline <sha> is approximate>
+- Launch command: <reporter-exact: <cmd> | canonical fallback: <cmd> — source: <declared TFM/tooling>; not reporter-exact build env>
+- App / steps: <exact interaction steps>
+- Result: <reproduced ✅ (reporter-exact | canonical fallback) | not reproducible locally — remaining delta: <x86_64 Helix/…>>
+- Variable enumeration: <table or link to it>
+- Remaining unknowns: <flags/device/deploy-mode not derivable from declared config>
+
+### Root cause
+- <the true root cause>
+- Competing hypotheses: <CONFIRMED / DENIED / PARTIAL table with decisive evidence>
+- Symptom-vs-root: <why this is the root, not just the last reference>
+
+### Fix
+- Approach (via try-fix): <what changed, which files, why it removes the root>
+- Alternatives tried and why rejected: <…>
+- Adversarial consensus: <AGREE / DISPUTE / DISCARD — reviewers and decisive reasoning>
+
+### Verification
+- Test: <name> — non-circular because <reason>
+- Fail-without-fix / pass-with-fix: <local result | CI decision-matrix outcome>
+- Regression sweep: <command + result; baseline comparison for every additional failure>
+
+### Status
+- Local checks: <…>
+- ⏸️ Awaiting user approval before pushing.
+```
+
+## Skill composition map
+
+This skill orchestrates; it does not re-implement. Quick reference for what to call and when:
+
+| Phase | Compose | For |
+|-------|---------|-----|
+| 3 | `try-fix` ×4 models (sequential) + cross-pollination + adversarial challenge | Multi-model fix exploration, then attack the winner (AGREE/DISPUTE/DISCARD) before it advances |
+| 4 | `write-ui-tests` / `write-xaml-tests` | Author a non-circular reproducing test |
+| 4 | `verify-tests-fail-without-fix` | Prove fail-without-fix / pass-with-fix (inverted semantics) |
+| 4 | `run-device-tests` / `run-helix-tests` | Actually run the verification locally |
+| 4 | `azdo-build-investigator` | CI escalation + reading Helix/device-test ground truth |
+
+## Origin
+
+The disciplines here were distilled from an intense empirical investigation of a MAUI Android bug — the
+issue #35371 stale-`ContainerView` leak (PRs #35372 / #36169) and the FlyoutPage detail-swap fragment crash —
+where reproduction hinged on the reporter's *actual* base commit (not the `10.0.60` label), on embedded-assembly
+vs fast-deploy, and ultimately on the x86_64-Helix ABI that couldn't be reproduced on Apple-Silicon locally.
+The recurring failure mode was calibrating against the wrong tree and writing circular tests. This skill encodes
+the fix: reproduce faithfully, find the real root, and verify with a test that can actually go red.

--- a/.github/skills/issue-fixer/SKILL.md
+++ b/.github/skills/issue-fixer/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: issue-fixer
-description: "Reproduce-first, root-cause-first workflow for fixing a .NET MAUI GitHub ISSUE (often with no PR yet). Front-loads a faithful empirical reproduction and true root-cause analysis BEFORE any fix, then composes try-fix / verify-tests-fail-without-fix / run-device-tests / run-helix-tests / write-ui-tests / write-xaml-tests / azdo-build-investigator for the fix and verification. Use whenever asked to 'fix issue #XXXXX', 'reproduce issue #XXXXX', 'root-cause issue #XXXXX', 'why does #XXXXX happen', 'investigate this bug', or handed a repro repo/branch and a broken behavior — even if the user doesn't say the word 'reproduce'. Do NOT use to review an existing PR (use pr-review) or to run one isolated fix attempt (use try-fix)."
+description: "Reproduce-first, root-cause-first workflow for fixing a .NET MAUI GitHub ISSUE (often with no PR yet). Recreates the reported behavior in a repo-owned automated test or the MAUI Sandbox — never by executing the reporter's project — before root-cause analysis and any fix. Then composes try-fix / verify-tests-fail-without-fix / run-device-tests / run-helix-tests / write-ui-tests / write-xaml-tests / azdo-build-investigator for the fix and verification. Use whenever asked to 'fix issue #XXXXX', 'reproduce issue #XXXXX', 'root-cause issue #XXXXX', 'why does #XXXXX happen', or 'investigate this bug'. Do NOT use to review an existing PR (use pr-review) or to run one isolated fix attempt (use try-fix)."
 metadata:
   author: dotnet-maui
   version: "1.0"
-compatibility: Requires git (incl. worktrees), PowerShell 7+ (pwsh), and the .NET MAUI build environment (BuildTasks + platform workloads). Device/Helix verification needs Android SDK/emulator, Xcode, or the run-helix-tests prerequisites depending on platform.
+compatibility: Requires git (incl. worktrees), PowerShell 7+ (pwsh), and the .NET MAUI build environment (BuildTasks + platform workloads). Device/Sandbox/Helix verification needs Android SDK/emulator, Xcode/Appium, or the run-helix-tests prerequisites depending on platform.
 ---
 
 # Issue Fixer — Reproduce First, Root-Cause First
@@ -42,6 +42,10 @@ It **composes** the skills above rather than re-implementing them. If a PR alrea
   would be the next step, **stop and ask.** The user reviews locally first.
 - 🚫 **Never touch the main checkout.** Do all work in this session's worktree, and create *throwaway*
   `git worktree` checkouts for reproduction builds (see Phase 1). Never build or mutate the user's primary tree.
+- 🚫 **Never execute reporter-supplied code.** Do not clone/build/run their project, scripts, binaries,
+  workloads, or assets. Treat the issue, comments, snippets, and public repro as a **behavioral specification**
+  to translate into a minimal repo-owned test or Sandbox scenario. This keeps execution inside reviewed
+  repository code and turns the reproduction into maintainable coverage.
 - 🌿 **Follow the repo git rules:** work on the session feature branch; no rebase / squash / force-push unless
   the user explicitly asks.
 - 🧾 This skill produces **analysis + reproduction evidence + a fix + verification**. It does **not** post PR
@@ -52,25 +56,23 @@ It **composes** the skills above rather than re-implementing them. If a PR alrea
 These are hard-won lessons. They're written as reasoning, not rote rules, because you'll need to apply them to
 situations they don't literally describe. Internalize the *why*.
 
-1. **Reproduce first, always.** A fix for a bug you haven't reproduced is a hypothesis, not a fix. Treat
-   *"I can't reproduce it"* not as a conclusion but as a signal that a variable is still missing — go hunt it
-   (see discipline 4). Only after you can make the bug happen on demand do you get to reason about causes.
+1. **Reproduce first in code we control.** A fix for a bug you haven't reproduced is a hypothesis, not a fix.
+   Prefer a failing automated test because it becomes durable regression coverage. Use the MAUI Sandbox only
+   when the behavior depends on live UI/handler/lifecycle interactions that cannot yet be expressed faithfully
+   in an existing test harness. Treat *"I can't reproduce it"* as evidence that a variable is still missing —
+   not as a conclusion.
 
-2. **Use the reporter's *exact bits* and resolve source provenance — don't equate a version label with a git
-   tag.** A reporter's *"Version with bug: 10.0.60"* is a **NuGet package label, not necessarily a git tag.**
-   If a repro branch is in the MAUI source commit graph, find its **actual base commit** with `git merge-base`
-   and build MAUI at that commit. If it is an external application repo, pin the app revision and its exact
-   package reference instead — unrelated histories cannot establish a MAUI source base. Reproduce behavior
-   against that exact package even when the version-to-commit mapping remains unresolved; label any source
-   analysis baseline as approximate. (In the case that motivated this skill, the MAUI-source repro branch was
-   based on `main` ~10 days newer than the `10.0.60` tag; calibrating against the tag produced false negatives.)
-   When building MAUI from source, build `Microsoft.Maui.BuildTasks.slnf` first, then the app.
+2. **Resolve the affected MAUI source/package provenance — don't equate a version label with a git tag.** A
+   reporter's *"Version with bug: 10.0.60"* is a **NuGet package label, not necessarily a git tag.** If a cited
+   branch is in the MAUI source commit graph, find its actual base with `git merge-base`. An external application
+   repo can reveal package/configuration facts but cannot establish a MAUI source base, and must not be executed.
+   Recreate the scenario in a repo-owned harness against the affected source train; label an unresolved
+   version-to-commit mapping and any approximate analysis baseline explicitly.
 
-3. **Use the reporter's exact app, supplied build command, and steps.** Fast-deployment debug builds
-   (`-t:Install`, no `EmbedAssembliesIntoApk`) can behave *differently* from embedded-assembly APKs. When the
-   reporter supplies a `dotnet build` invocation, reproduce it exactly; always preserve their exact interaction
-   sequence. If the command is omitted, use only the bounded canonical fallback in Phase 1 and label it as not
-   reporter-exact. Small deviations ("I used the Sandbox instead," "I skipped a tap") routinely hide the bug.
+3. **Translate the reported scenario; don't run it.** Preserve the relevant control structure, properties,
+   platform, deployment clues, and interaction sequence from the issue, but implement them yourself in the
+   smallest suitable MAUI test or Sandbox page. Fast deployment versus an embedded APK can still matter, so
+   record and vary it in the controlled harness rather than invoking the reporter's command.
 
 4. **Enumerate and eliminate environmental variables — and record each as tested.** When the bug won't
    reproduce, systematically vary the things you control and log the result of each:
@@ -124,88 +126,75 @@ Understand the bug on paper before touching a keyboard.
 - Read the issue body **and every comment in chronological order**: symptom, expected vs actual,
   **stated version(s)**, platform(s), and linked discussion. Human corrections in later comments supersede
   stale details in the body or earlier agent analysis. `gh issue view <n> --comments`.
-- Collect the reporter's **reproduction assets**: repro repo/branch URL, exact `dotnet build`/run command,
-  exact interaction steps, screenshots/stack traces/logs.
-- **Classify the setup evidence — reporter-exact vs canonical fallback.** The reporter's *exact* launch command
-  is the gold standard and is **required whenever they give it**, because build flags and deploy mode change
-  behavior (discipline 3). But reporters routinely hand you a complete, runnable project + platform/TFM +
-  interaction steps and simply *omit the terminal command*. That omission alone is **not** a reason to block:
-  the app is still runnable. When the command is missing, record the absence explicitly, and note that Phase 1
-  will fall back to a **canonical** launch (see Phase 1) — clearly labeled as *not reporter-exact*. Only treat
-  Phase 0 as truly blocked when there is **no** viable declared target at all (no project, no platform/TFM, or
-  no interaction steps).
+- Extract the reporter's **behavioral specification**: relevant code/control structure, package version,
+  platform/TFM, properties, deployment clues, exact interaction steps, screenshots, stack traces, and logs.
+  You may inspect issue text and snippets, but do not clone, build, or execute their project or commands.
+- **Select a controlled reproduction harness:**
+
+  | Reported behavior | Preferred repo-owned harness |
+  |-------------------|------------------------------|
+  | Pure logic, parsing, XAML/XamlC, bindings, or source generation | Unit/XAML test |
+  | Native handler/platform lifecycle without full end-user automation | Device test |
+  | End-user interaction that existing test infrastructure can drive | UI test |
+  | Live UI/navigation/lifecycle behavior not yet expressible faithfully in a test | `Controls.Sample.Sandbox` via `sandbox-agent` |
+
+  Choose the lowest-cost test that still exercises the real failing path. Sandbox is a temporary discovery
+  harness, not final regression coverage; if it reproduces, Phase 4 must convert the scenario into an automated
+  test.
 - Search for **existing PRs/issues** that already touch this. If a PR already fixes it → this is probably a
   `pr-review` job; note it and confirm with the user before continuing here.
 - Write the **falsifiable claim** you're going to prove, e.g. *"On Android, tapping Detail→Swap twice on the
   reporter's app crashes with `IllegalStateException` in fragment commit."*
 
-**Exit:** you can state the app, platform, interaction steps, and the claim to reproduce, **and** you have
-classified the launch command as either `reporter-exact` (captured verbatim) or `canonical fallback` (command
-absent — absence recorded, fallback flagged for Phase 1). Block only when no runnable target exists.
+**Exit:** you can state the reported behavior, platform, exact relevant interaction sequence, falsifiable claim,
+and selected repo-owned harness. Block only when the issue lacks enough behavioral detail to construct a
+controlled scenario.
 
-### Phase 1 — Faithful reproduction
+### Phase 1 — Controlled repo-owned reproduction
 
-Make the bug happen on demand, against the reporter's real tree. Two independent evidence tracks run here —
-keep them separate so you never over-claim:
+Make the reported behavior happen on demand using code in this repository. The reporter's project is evidence,
+not an executable input. Keep two independent evidence tracks so you never over-claim:
 
-- **Source provenance** (what MAUI *bits* the behavior runs on).
-- **Application behavior** (does the app misbehave when driven through the reporter's steps).
+- **Source provenance** — which MAUI source train/package the report concerns.
+- **Controlled behavior** — whether the repo-owned test/Sandbox scenario exhibits the reported failure.
 
-1. **Pin the source commit (provenance track).** If a repro branch is in the MAUI source repository (or the
-   same commit graph), `git merge-base` it against `main`/candidate to find its *actual* base — do **not**
-   trust the version label (discipline 2). This `git merge-base` rule is **not** relaxed when a repro branch
-   gives you a MAUI source base. An external application-repo branch instead establishes the app revision, not
-   the MAUI source revision; use the app's exact package reference as its MAUI provenance evidence. If the
-   package version cannot be mapped to a commit, that must **not** block reproducing behavior on the reporter's
-   **exact package version**. Unmapped provenance only limits your *exact-source / root-cause* claims later.
-   If you must build MAUI from source for analysis and can't resolve the commit, use the nearest analysis
-   baseline **only with an explicit "approximate, not the reporter's exact source" label** and report the
-   unresolved mapping.
-2. **Create a throwaway MAUI worktree only when source analysis/building needs a resolved source commit**
-   (never the main checkout):
+1. **Resolve source provenance.** Map the reported package/source train to a MAUI commit when possible. Use
+   `git merge-base` only for branches in the MAUI commit graph. External app repositories are never run and do
+   not establish source provenance. If mapping remains unresolved, label the selected MAUI analysis baseline
+   approximate; do not manufacture a tag/commit relationship.
+2. **Create a throwaway MAUI worktree when reproduction needs a historical or candidate commit** (never the
+   main checkout):
    ```bash
    git worktree add ../maui-repro-<sha> <sha>
    ```
-   Build `Microsoft.Maui.BuildTasks.slnf` first when building MAUI from source. Build an external reporter app
-   from its own clone/project against its declared package version; do not assume it belongs in the MAUI
-   worktree.
-3. **Launch the app — reporter-exact if given, otherwise a bounded canonical fallback.**
-   - **Reporter-exact (preferred, required when supplied):** use their exact `dotnet build`/run command and
-     deploy mode (discipline 3).
-   - **Canonical fallback (command absent):** derive a **documented, canonical** MAUI launch command from the
-     project's *declared* TFM/platform and the repository's own tooling (e.g. the standard
-     `dotnet build -t:Run -f <declared-tfm>` path, or the repo's device-test/run scripts). **Bounds — do not
-     cross:** don't invent undeclared configuration flags, device identifiers, deployment modes, or extra
-     interaction steps. Record the **exact fallback command**, the **source** that makes it canonical (which
-     declared TFM/tooling it came from), and **every remaining unknown** in the variable table. If there is no
-     viable declared target or tooling to derive a command from, stay **blocked** and say why.
-     > The fallback reproduces **application behavior only** — it is *not* evidence of the reporter's original
-     > build environment. Label any behavior you observe as "reproduced via canonical fallback (not
-     > reporter-exact build env)."
-4. **Run the reporter's exact steps** on the app. Reproduce the crash/leak/misbehavior. A behavior reproduced
-   under the canonical fallback **is sufficient** to continue to root-cause investigation (Phase 2) — just
-   carry the label forward.
-5. **If it won't reproduce, enumerate variables** (discipline 4) and record each attempt:
+   Build `Microsoft.Maui.BuildTasks.slnf` first when building MAUI from source.
+3. **Implement the controlled scenario.**
+   - **Automated test (preferred):** create the smallest behavioral unit/XAML/device/UI test that preserves the
+     relevant setup, steps, and observable failure. Run it unfixed and require the expected failure.
+   - **Sandbox (temporary):** delegate to `sandbox-agent`, implement the scenario in
+     `src/Controls/samples/Controls.Sample.Sandbox/`, and follow
+     `.github/instructions/sandbox.instructions.md`. Use `BuildAndRunSandbox.ps1`; verify actual Appium actions,
+     completion markers, device logs, and the expected failure. A successful launch is not a reproduction.
+4. **If it won't reproduce, enumerate variables** (discipline 4) and record each attempt:
 
    | Variable | Value tried | Result | Notes |
    |----------|-------------|--------|-------|
-   | Application revision | `<sha>` / branch / supplied snapshot | ❌/✅ | external repro app identity |
-   | MAUI source commit | `<sha>` via merge-base / `unresolved` / `N/A exact-package repro` | ❌/✅ | never substitute a package label for a commit |
-   | Launch command | `reporter-exact` / `canonical fallback: <cmd>` | | source of canonical + unknowns |
+   | Harness | unit / XAML / device / UI test / Sandbox | ❌/✅ | path + why selected |
+   | Scenario source | issue body/comments/snippets | | relevant setup/steps translated |
+   | MAUI source commit | `<sha>` via merge-base / approximate `<sha>` | ❌/✅ | never substitute a package label for a commit |
+   | Harness command | repo test runner / `BuildAndRunSandbox.ps1` | | exact command |
    | Package provenance | version→commit `<mapped sha>` / `unmapped` | | approximate-baseline label if unmapped |
    | API level | e.g. 34 | | |
-   | Deploy mode | fast-deploy `-t:Install` / embedded APK | | unknown if fallback |
+   | Deploy mode | fast-deploy / embedded APK | | controlled harness setting |
    | Emulator ABI | arm64-v8a (Apple Silicon) / x86_64 (Helix) | | |
    | Device | emulator / physical | | |
 
-   A canonical fallback that does **not** reproduce is **not** a false negative — enumerate the remaining
-   variables/delta exactly as today (a missing reporter-exact command is itself one such variable). When every
-   controllable variable is exhausted and it still won't repro, **name the uncontrollable delta**
-   (e.g. x86_64 Helix) and carry it to Phase 4 escalation — do **not** conclude "not a bug."
+   When every controllable variable is exhausted and it still won't reproduce, **name the uncontrollable
+   delta** (e.g. x86_64 Helix) and carry it to Phase 4 escalation — do **not** conclude "not a bug."
 
-**Exit:** either a reliable local reproduction — labeled `reporter-exact` or `canonical fallback` — **or** an
-explicit, evidence-backed statement of the remaining variable(s) you can't test locally, with provenance
-(mapped/unmapped) recorded.
+**Exit:** either a failing repo-owned automated test, a repeatable Sandbox reproduction labeled temporary, or
+an explicit evidence-backed statement of the remaining variable(s) you cannot test locally. Source provenance
+and the exact controlled harness command are recorded.
 
 ### Phase 2 — Root-cause analysis
 
@@ -213,8 +202,8 @@ Find *what actually causes* the observed behavior — not the last thing that to
 
 - **Minimize only after faithful reproduction.** Reduce the reproduced case one variable at a time and verify
   the smaller case still fails. This is a diagnostic accelerator, not a replacement acceptance scenario: the
-  reporter's exact app/steps (or labeled canonical fallback) remains the final behavior check. If minimization
-  loses the failure, keep the faithful repro and record which removed variable mattered.
+  controlled scenario must still represent the exact relevant user-visible setup and steps from the issue. If
+  minimization loses the failure, keep the larger repo-owned repro and record which removed variable mattered.
 - **Form at least 3 meaningfully competing root-cause hypotheses.** For each, record: theory, a discriminating
   command/observation that could reject it, result (`CONFIRMED`, `DENIED`, or `PARTIAL`), and implications.
   Three variants of the same symptom are not competing hypotheses. Prefer experiments that distinguish several
@@ -266,9 +255,8 @@ Feed each `try-fix` invocation:
 - `platform` — the reproduced platform from Phase 1
 - `target_files` — the files identified in Phase 2
 - `test_command` — the strongest empirical command currently available: the planned Phase 4 regression command
-  when a test already exists; otherwise the faithful Phase 1 behavior reproducer through the appropriate repo
-  runner, explicitly labeled provisional. A provisional reproducer does not replace Phase 4's non-circular
-  regression test.
+  when Phase 1 produced an automated test; otherwise the Sandbox reproducer, explicitly labeled provisional.
+  A Sandbox reproducer does not replace Phase 4's non-circular regression test.
 
 Each model must generate its approach **independently first**, then produce a **DIFFERENT** approach from any
 existing changes (review the diff first). "Different" means a different root-cause hypothesis, not just a
@@ -327,10 +315,14 @@ challenge** — believed to remove the root cause. Any deferred test-integrity c
 
 Prove the fix works with a test that would actually catch the bug.
 
-1. **Pick / write a non-circular test** (discipline 6). If the issue lacks coverage, compose the right author:
-   - UI interaction bug → **`write-ui-tests`** (`.github/skills/write-ui-tests/SKILL.md`)
-   - XAML parse/XamlC/source-gen bug → **`write-xaml-tests`** (`.github/skills/write-xaml-tests/SKILL.md`)
-   - Then run the **circular-test checklist** below and fix the test if it fails any item.
+1. **Finalize a non-circular automated regression test** (discipline 6).
+   - If Phase 1 already produced a failing test, preserve it and adversarially verify its setup/assertions.
+   - If Phase 1 used Sandbox, translate that proven scenario into the lightest faithful automated test now;
+     Sandbox evidence alone cannot complete the issue.
+   - If coverage must be authored, compose the right author:
+     - UI interaction bug → **`write-ui-tests`** (`.github/skills/write-ui-tests/SKILL.md`)
+     - XAML parse/XamlC/source-gen bug → **`write-xaml-tests`** (`.github/skills/write-xaml-tests/SKILL.md`)
+   - Run the **circular-test checklist** below and fix the test if it fails any item.
    - If Phase 3 deferred the test-integrity challenge, send the final test to the other models for that focused
      probe now. A dispute loops back to test authoring; don't let the earlier fix consensus waive this gate.
 2. **Verify fail-without-fix / pass-with-fix** via **`verify-tests-fail-without-fix`**
@@ -370,14 +362,15 @@ Use this structure:
 ## Issue #XXXXX — <one-line summary>
 
 ### Reproduction
-- Application revision: <reporter repo commit / branch / supplied project snapshot>
-- MAUI runtime bits: <source commit | exact NuGet package version>
+- Behavioral specification: <issue body/comments and relevant setup/interaction sequence>
+- Controlled harness: <test type + path | Sandbox page + temporary status>
+- MAUI runtime bits: <source commit / affected package train>
 - MAUI source provenance: <resolved via merge-base or version→sha | unresolved — analysis baseline <sha> is approximate>
-- Launch command: <reporter-exact: <cmd> | canonical fallback: <cmd> — source: <declared TFM/tooling>; not reporter-exact build env>
-- App / steps: <exact interaction steps>
-- Result: <reproduced ✅ (reporter-exact | canonical fallback) | not reproducible locally — remaining delta: <x86_64 Helix/…>>
+- Harness command: <repo test runner | BuildAndRunSandbox.ps1>
+- Translated setup / steps: <what was recreated from the report>
+- Result: <failing automated test ✅ | repeatable Sandbox reproduction ⚠️ temporary | not reproducible — remaining delta>
 - Variable enumeration: <table or link to it>
-- Remaining unknowns: <flags/device/deploy-mode not derivable from declared config>
+- Reporter code executed: **No**
 
 ### Root cause
 - <the true root cause>
@@ -405,6 +398,7 @@ This skill orchestrates; it does not re-implement. Quick reference for what to c
 
 | Phase | Compose | For |
 |-------|---------|-----|
+| 1 | Appropriate repo test harness / `sandbox-agent` | Prefer a failing automated test; use Sandbox only for temporary UI/lifecycle discovery |
 | 3 | `try-fix` ×4 models (sequential) + cross-pollination + adversarial challenge | Multi-model fix exploration, then attack the winner (AGREE/DISPUTE/DISCARD) before it advances |
 | 4 | `write-ui-tests` / `write-xaml-tests` | Author a non-circular reproducing test |
 | 4 | `verify-tests-fail-without-fix` | Prove fail-without-fix / pass-with-fix (inverted semantics) |
@@ -413,9 +407,9 @@ This skill orchestrates; it does not re-implement. Quick reference for what to c
 
 ## Origin
 
-The disciplines here were distilled from an intense empirical investigation of a MAUI Android bug — the
-issue #35371 stale-`ContainerView` leak (PRs #35372 / #36169) and the FlyoutPage detail-swap fragment crash —
-where reproduction hinged on the reporter's *actual* base commit (not the `10.0.60` label), on embedded-assembly
-vs fast-deploy, and ultimately on the x86_64-Helix ABI that couldn't be reproduced on Apple-Silicon locally.
-The recurring failure mode was calibrating against the wrong tree and writing circular tests. This skill encodes
-the fix: reproduce faithfully, find the real root, and verify with a test that can actually go red.
+The disciplines here were distilled from an intense empirical investigation of a MAUI Android bug — the issue
+#35371 stale-`ContainerView` leak (PRs #35372 / #36169) and the FlyoutPage detail-swap fragment crash — where
+source provenance, embedded-assembly vs fast-deploy, and x86_64 Helix ABI materially changed the result. The
+reporter's artifacts revealed those variables, but future investigations should recreate the behavior in
+repo-owned code rather than execute external repro projects. The recurring failure modes were calibrating
+against the wrong tree and writing circular tests.

--- a/.github/skills/issue-fixer/SKILL.md
+++ b/.github/skills/issue-fixer/SKILL.md
@@ -173,8 +173,9 @@ not an executable input. Keep two independent evidence tracks so you never over-
      relevant setup, steps, and observable failure. Run it unfixed and require the expected failure.
    - **Sandbox (temporary):** delegate to `sandbox-agent`, implement the scenario in
      `src/Controls/samples/Controls.Sample.Sandbox/`, and follow
-     `.github/instructions/sandbox.instructions.md`. Use `BuildAndRunSandbox.ps1`; verify actual Appium actions,
-     completion markers, device logs, and the expected failure. A successful launch is not a reproduction.
+     `.github/instructions/sandbox.instructions.md`. Use `.github/scripts/BuildAndRunSandbox.ps1`; verify
+     actual Appium actions, completion markers, device logs, and the expected failure. A successful launch is
+     not a reproduction.
 4. **If it won't reproduce, enumerate variables** (discipline 4) and record each attempt:
 
    | Variable | Value tried | Result | Notes |
@@ -182,7 +183,7 @@ not an executable input. Keep two independent evidence tracks so you never over-
    | Harness | unit / XAML / device / UI test / Sandbox | ❌/✅ | path + why selected |
    | Scenario source | issue body/comments/snippets | | relevant setup/steps translated |
    | MAUI source commit | `<sha>` via merge-base / approximate `<sha>` | ❌/✅ | never substitute a package label for a commit |
-   | Harness command | repo test runner / `BuildAndRunSandbox.ps1` | | exact command |
+   | Harness command | repo test runner / `.github/scripts/BuildAndRunSandbox.ps1` | | exact command |
    | Package provenance | version→commit `<mapped sha>` / `unmapped` | | approximate-baseline label if unmapped |
    | API level | e.g. 34 | | |
    | Deploy mode | fast-deploy / embedded APK | | controlled harness setting |
@@ -228,24 +229,21 @@ challenge that fix* — because a fix that survives being attacked by other mode
 cross-pollination + comparison-table selection), then adds an adversarial challenge of the winner.
 
 Don't hand-roll the fix loop — every attempt goes through **`try-fix`**
-(`.github/skills/try-fix/SKILL.md`), which establishes a baseline, applies **one** approach, tests it, records
-artifacts, and reverts.
+(`.github/skills/try-fix/SKILL.md`) in **Issue mode**. Before Round 1, read and follow
+[`references/issue-mode-attempts.md`](references/issue-mode-attempts.md): commit the repo-owned reproduction
+only on a temporary local checkpoint branch, create a disposable worktree/branch per attempt, and preserve
+reproduction scaffolding independently from candidate product changes.
 
 > 🚨 **Sequential only — never parallel/background.** Run each `try-fix` with `mode: "sync"`, one fully
 > completing before the next starts. try-fix mutates the same target files, shares the emulator/device, and
-> reverts to baseline between runs; running them concurrently corrupts each other's file state and results.
-> Restore baseline between attempts exactly as try-fix/pr-review prescribe.
+> uses local candidate commits; running tests concurrently still corrupts shared device state. Git isolation
+> comes from one disposable attempt worktree per model — never run issue-mode try-fix in the session worktree.
 
 #### Round 1 — independent exploration
 
-Invoke `try-fix` via `general-purpose` task agents across these 4 models, **SEQUENTIALLY**:
-
-| Order | Model |
-|-------|-------|
-| 1 | `claude-opus-4.6` |
-| 2 | `claude-opus-4.7` |
-| 3 | `gpt-5.3-codex` |
-| 4 | `gpt-5.5` |
+Invoke `try-fix` via `general-purpose` task agents using the **current four-model roster and order** from
+`pr-review`'s `Multi-Model Configuration`, **SEQUENTIALLY**. That section is canonical; do not duplicate or
+substitute the roster here.
 
 Feed each `try-fix` invocation:
 - `problem` — the faithful + minimized reproductions and the Phase 2 evidence-selected root-cause hypothesis
@@ -254,6 +252,8 @@ Feed each `try-fix` invocation:
   evidence)
 - `platform` — the reproduced platform from Phase 1
 - `target_files` — the files identified in Phase 2
+- `mode` — `Issue`
+- `broken_checkpoint` / `attempt_worktree` / `reproduction_paths` — from the issue-mode protocol
 - `test_command` — the strongest empirical command currently available: the planned Phase 4 regression command
   when Phase 1 produced an automated test; otherwise the Sandbox reproducer, explicitly labeled provisional.
   A Sandbox reproducer does not replace Phase 4's non-circular regression test.
@@ -282,11 +282,11 @@ Pick the winner.
 
 #### Materialize the selected fix
 
-`try-fix` **always restores the working directory to baseline**, so the winner exists only as its recorded
-`fix.diff` after exploration. Apply that exact candidate diff to the session feature worktree, verify the
-materialized diff matches the reviewed candidate and contains no attempt artifacts, then rerun the same
-empirical command. Do not commit or push. This materialized diff — not a prose summary or a reverted attempt —
-is what the adversarial reviewers challenge and what Phase 4 verifies.
+Use the winning attempt's reachable `candidate-commit.txt`, not an uncommitted worktree. Export
+source-baseline→winner as a complete binary patch and apply it to the session feature worktree. Verify it
+contains exactly the reproduction + selected fix and no attempt artifacts. Keep a disposable worktree at the
+winning commit for Phase 4's committed-state full verification. Do not commit or push the session branch. The
+materialized session diff is what the adversarial reviewers challenge.
 
 #### Adversarial challenge of the selected fix (the "challenge that fix" step)
 
@@ -327,7 +327,10 @@ Prove the fix works with a test that would actually catch the bug.
      probe now. A dispute loops back to test authoring; don't let the earlier fix consensus waive this gate.
 2. **Verify fail-without-fix / pass-with-fix** via **`verify-tests-fail-without-fix`**
    (`.github/skills/verify-tests-fail-without-fix/SKILL.md`) — remember its **inverted** semantics
-   (tests *failing* without the fix is the *good* outcome).
+   (tests *failing* without the fix is the *good* outcome). In issue mode, run it from the disposable winning
+   candidate worktree with explicit checkpoint base, committed fix files, test type/filter, and
+   **`-RequireFullVerification`** exactly as shown in `references/issue-mode-attempts.md`. Never accept its
+   failure-only mode as proof that the fix passes.
    - Local device/unit runs: **`run-device-tests`** (`.github/skills/run-device-tests/SKILL.md`).
    - Helix unit projects (XAML, Core, Essentials, Resizetizer, …): **`run-helix-tests`**
      (`.github/skills/run-helix-tests/SKILL.md`).
@@ -366,7 +369,7 @@ Use this structure:
 - Controlled harness: <test type + path | Sandbox page + temporary status>
 - MAUI runtime bits: <source commit / affected package train>
 - MAUI source provenance: <resolved via merge-base or version→sha | unresolved — analysis baseline <sha> is approximate>
-- Harness command: <repo test runner | BuildAndRunSandbox.ps1>
+- Harness command: <repo test runner | .github/scripts/BuildAndRunSandbox.ps1>
 - Translated setup / steps: <what was recreated from the report>
 - Result: <failing automated test ✅ | repeatable Sandbox reproduction ⚠️ temporary | not reproducible — remaining delta>
 - Variable enumeration: <table or link to it>

--- a/.github/skills/issue-fixer/SKILL.md
+++ b/.github/skills/issue-fixer/SKILL.md
@@ -253,7 +253,8 @@ Feed each `try-fix` invocation:
 - `platform` — the reproduced platform from Phase 1
 - `target_files` — the files identified in Phase 2
 - `mode` — `Issue`
-- `broken_checkpoint` / `attempt_worktree` / `reproduction_paths` — from the issue-mode protocol
+- `broken_checkpoint` / `attempt_worktree` / `reproduction_paths` / `output_directory` — from the issue-mode
+  protocol; the output directory must be absolute and outside the disposable worktree
 - `test_command` — the strongest empirical command currently available: the planned Phase 4 regression command
   when Phase 1 produced an automated test; otherwise the Sandbox reproducer, explicitly labeled provisional.
   A Sandbox reproducer does not replace Phase 4's non-circular regression test.

--- a/.github/skills/issue-fixer/references/issue-mode-attempts.md
+++ b/.github/skills/issue-fixer/references/issue-mode-attempts.md
@@ -46,12 +46,16 @@ state:
 git worktree add -b issue-<N>-attempt-<K> <temp-root>/attempt-<K> <checkpoint-sha>
 ```
 
+Create `<attempt-output>` as an absolute directory outside `<temp-root>/attempt-<K>` so artifacts survive
+worktree removal.
+
 Invoke `try-fix` with:
 
 - `Mode: Issue`
 - `Broken checkpoint: <checkpoint-sha>`
 - `Attempt worktree: <absolute-path>`
 - `Reproduction paths: <explicit list>`
+- `Output directory: <absolute-attempt-output-path>`
 - the ordinary problem/platform/target-files/test-command/hints inputs
 
 Issue mode must verify before editing:
@@ -94,14 +98,16 @@ pwsh .github/skills/verify-tests-fail-without-fix/scripts/verify-tests-fail.ps1 
   -BaseBranch issue-<N>-repro-checkpoint `
   -FixFiles @(<explicit-candidate-product-paths>) `
   -TestType <type> `
+  -TestProject <unit-project-key-or-csproj-path | device-project-name> `
   -TestFilter "<filter>" `
   -Platform <platform-if-required> `
   -PRNumber <N> `
   -RequireFullVerification
 ```
 
-Both the reproduction and candidate must be committed in this disposable worktree. Never omit
-`-RequireFullVerification`; failure-only mode cannot establish that the candidate passes.
+Both the reproduction and candidate must be committed in this disposable worktree. `-TestProject` is required
+for `UnitTest` and `DeviceTest`; omit it for `UITest`/`XamlUnitTest`. Never omit `-RequireFullVerification`;
+failure-only mode cannot establish that the candidate passes.
 
 ## 5. Materialize and clean up
 

--- a/.github/skills/issue-fixer/references/issue-mode-attempts.md
+++ b/.github/skills/issue-fixer/references/issue-mode-attempts.md
@@ -1,0 +1,120 @@
+# Issue-mode attempt isolation
+
+Use this protocol when `issue-fixer` invokes `try-fix` before a PR/fix commit exists. The ordinary
+`EstablishBrokenBaseline.ps1` path is intentionally PR-shaped: it detects committed non-test changes between
+the merge base and `HEAD`. It cannot represent an issue whose only current change is reproduction scaffolding.
+
+The protocol keeps three states distinct:
+
+1. **Source baseline** — MAUI before the reproduction or fix.
+2. **Broken checkpoint** — source baseline plus the repo-owned reproduction, committed only on a temporary
+   local branch.
+3. **Candidate** — broken checkpoint plus one attempted product fix, committed only on that attempt's
+   temporary local branch.
+
+Temporary commits are isolation artifacts. Never push them, never create them on the user's session branch,
+and remove their worktrees/branches after the selected result is materialized.
+
+## 1. Create the broken checkpoint
+
+Create a dedicated worktree and local branch from the source baseline. Implement Phase 1's repo-owned
+reproduction there, prove the expected failure, then commit **only the explicit reproduction paths**:
+
+```bash
+git worktree add -b issue-<N>-repro-checkpoint <temp-root>/repro <source-ref>
+cd <temp-root>/repro
+git add -- <explicit-reproduction-paths>
+git -c user.name="MAUI Issue Fixer" -c user.email="issue-fixer@example.invalid" \
+  commit -m "Temporary reproduction checkpoint for issue <N>"
+```
+
+Record:
+
+- checkpoint branch and commit SHA
+- source baseline SHA
+- exact reproduction paths
+- test type/filter/command and failing result
+
+Do not use `git add .`. Do not include logs, attempt artifacts, product fixes, or unrelated worktree changes.
+
+## 2. Create one isolated worktree per attempt
+
+Attempts still run **sequentially** because they share the emulator/device, but each gets independent Git
+state:
+
+```bash
+git worktree add -b issue-<N>-attempt-<K> <temp-root>/attempt-<K> <checkpoint-sha>
+```
+
+Invoke `try-fix` with:
+
+- `Mode: Issue`
+- `Broken checkpoint: <checkpoint-sha>`
+- `Attempt worktree: <absolute-path>`
+- `Reproduction paths: <explicit list>`
+- the ordinary problem/platform/target-files/test-command/hints inputs
+
+Issue mode must verify before editing:
+
+- `HEAD` equals the checkpoint SHA
+- the attempt worktree is clean
+- every reproduction path is committed at the checkpoint
+
+The candidate may not modify reproduction paths. A fix that changes its own reproducer is circular and must
+be rejected.
+
+## 3. Capture the complete candidate
+
+After testing and self-review, stage **only explicit candidate product paths**. Include added, modified,
+deleted, and renamed files; exclude reproduction paths and `CustomAgentLogsTmp/`.
+
+Create an ephemeral local candidate commit and export its complete binary diff:
+
+```bash
+git add -- <explicit-candidate-paths>
+git -c user.name="MAUI Issue Fixer" -c user.email="issue-fixer@example.invalid" \
+  commit -m "Temporary issue <N> candidate <K>"
+git diff --binary <checkpoint-sha> HEAD > <attempt-output>/fix.diff
+git rev-parse HEAD > <attempt-output>/candidate-commit.txt
+```
+
+Because both sides are commits, `fix.diff` includes staged changes, new files, deletions, renames, and file
+modes. A plain `git diff` is not an acceptable issue-mode artifact.
+
+The invoker then removes the attempt worktree. Keep the local attempt branch until selection is complete so
+the candidate commit remains reachable.
+
+## 4. Verify the winner from committed state
+
+Create a disposable verification worktree at the winning candidate commit. Run
+`verify-tests-fail-without-fix` in full-verification mode against the checkpoint:
+
+```powershell
+pwsh .github/skills/verify-tests-fail-without-fix/scripts/verify-tests-fail.ps1 `
+  -BaseBranch issue-<N>-repro-checkpoint `
+  -FixFiles @(<explicit-candidate-product-paths>) `
+  -TestType <type> `
+  -TestFilter "<filter>" `
+  -Platform <platform-if-required> `
+  -PRNumber <N> `
+  -RequireFullVerification
+```
+
+Both the reproduction and candidate must be committed in this disposable worktree. Never omit
+`-RequireFullVerification`; failure-only mode cannot establish that the candidate passes.
+
+## 5. Materialize and clean up
+
+After adversarial consensus and full verification, export the complete final change from source baseline to
+the winning candidate, then apply it to the user's session feature worktree:
+
+```bash
+git diff --binary <source-baseline-sha> <winning-candidate-sha> > <temp-root>/selected.patch
+git -C <session-worktree> apply --index <temp-root>/selected.patch
+```
+
+Review the staged paths, unstage them for normal local review if appropriate, and confirm the session
+worktree contains exactly the reproduction + selected fix. Do not commit or push without user approval.
+
+Remove only the explicitly named temporary worktrees and local branches after materialization. Never remove or
+reset the session worktree or the main checkout.

--- a/.github/skills/issue-fixer/references/issue-mode-attempts.md
+++ b/.github/skills/issue-fixer/references/issue-mode-attempts.md
@@ -37,6 +37,16 @@ Record:
 
 Do not use `git add .`. Do not include logs, attempt artifacts, product fixes, or unrelated worktree changes.
 
+Pin the current trusted issue-fixer tooling separately from the source baseline. Historical/candidate
+worktrees may contain an older verifier or no verifier at all:
+
+```bash
+tooling_sha=$(git -C <session-worktree> rev-parse HEAD)
+git worktree add --detach <temp-root>/tooling "$tooling_sha"
+```
+
+Never modify this tooling worktree. Record its SHA and use it for every attempt/verification command.
+
 ## 2. Create one isolated worktree per attempt
 
 Attempts still run **sequentially** because they share the emulator/device, but each gets independent Git
@@ -70,7 +80,12 @@ be rejected.
 ## 3. Capture the complete candidate
 
 After testing and self-review, stage **only explicit candidate product paths**. Include added, modified,
-deleted, and renamed files; exclude reproduction paths and `CustomAgentLogsTmp/`.
+deleted, and renamed files; exclude reproduction paths and `CustomAgentLogsTmp/`. Derive the candidate path
+list with rename detection disabled so a rename contributes both source and destination:
+
+```bash
+git diff --no-renames --name-only <checkpoint-sha> HEAD --
+```
 
 Create an ephemeral local candidate commit and export its complete binary diff:
 
@@ -91,12 +106,18 @@ the candidate commit remains reachable.
 ## 4. Verify the winner from committed state
 
 Create a disposable verification worktree at the winning candidate commit. Run
-`verify-tests-fail-without-fix` in full-verification mode against the checkpoint:
+the verifier from the pinned current tooling worktree, targeting the historical candidate worktree:
 
 ```powershell
-pwsh .github/skills/verify-tests-fail-without-fix/scripts/verify-tests-fail.ps1 `
-  -BaseBranch issue-<N>-repro-checkpoint `
-  -FixFiles @(<explicit-candidate-product-paths>) `
+$toolRoot = "<temp-root>/tooling"
+$targetRoot = "<temp-root>/verification"
+$fixFiles = @(git -C $targetRoot diff --no-renames --name-only <checkpoint-sha> <candidate-sha> --)
+
+pwsh "$toolRoot/.github/skills/verify-tests-fail-without-fix/scripts/verify-tests-fail.ps1" `
+  -ToolRoot $toolRoot `
+  -TargetRepoRoot $targetRoot `
+  -BaseBranch <checkpoint-sha> `
+  -FixFiles $fixFiles `
   -TestType <type> `
   -TestProject <unit-project-key-or-csproj-path | device-project-name> `
   -TestFilter "<filter>" `
@@ -107,7 +128,8 @@ pwsh .github/skills/verify-tests-fail-without-fix/scripts/verify-tests-fail.ps1 
 
 Both the reproduction and candidate must be committed in this disposable worktree. `-TestProject` is required
 for `UnitTest` and `DeviceTest`; omit it for `UITest`/`XamlUnitTest`. Never omit `-RequireFullVerification`;
-failure-only mode cannot establish that the candidate passes.
+failure-only mode cannot establish that the candidate passes. Current tooling supplies the verifier and runner
+scripts; source, projects, and test outputs come from `$targetRoot`.
 
 ## 5. Materialize and clean up
 
@@ -122,5 +144,5 @@ git -C <session-worktree> apply --index <temp-root>/selected.patch
 Review the staged paths, unstage them for normal local review if appropriate, and confirm the session
 worktree contains exactly the reproduction + selected fix. Do not commit or push without user approval.
 
-Remove only the explicitly named temporary worktrees and local branches after materialization. Never remove or
-reset the session worktree or the main checkout.
+Remove only the explicitly named attempt, verification, reproduction, and tooling worktrees and local branches
+after materialization. Never remove or reset the session worktree or the main checkout.

--- a/.github/skills/pr-review/SKILL.md
+++ b/.github/skills/pr-review/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: pr-review
-description: "End-to-end PR reviewer for dotnet/maui. Orchestrates 3 phases — Pre-Flight, Try-Fix, Report. Gate runs separately before this skill. Use when asked to 'review PR #XXXXX', 'work on PR #XXXXX', or 'fix issue #XXXXX'."
+description: "End-to-end PR reviewer for dotnet/maui when a pull request already exists. Orchestrates 3 phases — Pre-Flight, Try-Fix, Report. Gate runs separately before this skill. Use when asked to 'review PR #XXXXX', 'work on PR #XXXXX', or continue/fix an issue through its existing PR. For an issue with no PR yet, use issue-fixer instead."
 ---
 
 # PR Review — 3-Phase Orchestrator
 
 End-to-end PR review workflow that orchestrates phases to explore independent fix alternatives and produce a recommendation.
 
-**Trigger phrases:** "review PR #XXXXX", "work on PR #XXXXX", "fix issue #XXXXX"
+**Trigger phrases:** "review PR #XXXXX", "work on PR #XXXXX", "continue PR #XXXXX", "fix issue #XXXXX through PR #YYYYY"
 
 > 🚨 **NEVER** use `gh pr review --approve` or `--request-changes`. AI agents must NEVER post review comments.
 > 🚨 **DO NOT post any comments to the PR.** This skill only produces output files in `CustomAgentLogsTmp/PRState/`.

--- a/.github/skills/try-fix/SKILL.md
+++ b/.github/skills/try-fix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: try-fix
-description: Attempts ONE alternative fix for a bug, tests it empirically, and reports results. ALWAYS explores a DIFFERENT approach from existing PR fixes. Use when CI or an agent needs to try independent fix alternatives. Invoke with problem description, test command, target files, and optional hints.
+description: Attempts ONE alternative fix for a bug, tests it empirically, and reports results. Supports PR mode (existing committed fix) and issue mode (broken reproduction checkpoint in a disposable worktree). ALWAYS explores a DIFFERENT approach from existing fixes or attempts. Use when CI or an agent needs to try independent fix alternatives. Invoke with problem description, test command, target files, and optional hints.
 compatibility: Requires PowerShell, git, .NET MAUI build environment, Android/iOS device or emulator
 ---
 
@@ -22,7 +22,7 @@ If the prompt does not include a **problem to fix** and a **test command to veri
 
 1. **Always run once activated** - Never question whether to run. The invoker decides WHEN, you decide WHAT alternative to try
 2. **Single-shot** - Each invocation = ONE fix idea, tested, reported
-3. **Alternative-focused** - Always propose something DIFFERENT from existing fixes (review PR changes first)
+3. **Alternative-focused** - Always propose something DIFFERENT from existing fixes/attempts
 4. **Empirical** - Actually implement and test, don't just theorize
 5. **Context-driven** - Work with what's provided and git history; don't search external sources
 6. **Script-only restoration** - The ONLY permitted cleanup command is
@@ -55,16 +55,21 @@ If the prompt does not include a **problem to fix** and a **test command to veri
    `$OUTPUT_DIR` at the start of each later shell command instead of writing a
    repository marker file.
 
-**Every invocation runs all 11 Workflow steps below.** Step 6 (Expert Self-Review) is performed inline against `.github/agents/maui-expert-reviewer.md` — do NOT spawn the `@maui-expert-reviewer` sub-agent. Step 7.5 refreshes the self-review if the test loop modified code so the recorded findings reflect the final diff. Step 8 enforces this via a file-existence gate on `reviewer-findings.json`. Before returning the final report, verify that Step 9 ran with the exact script-only restore command above; if it did not, run it before responding.
+**Every invocation runs all 11 Workflow steps below using its mode-specific baseline/capture mechanics.** Step
+6 (Expert Self-Review) is performed inline against `.github/agents/maui-expert-reviewer.md` — do NOT spawn the
+`@maui-expert-reviewer` sub-agent. Step 7.5 refreshes the self-review if the test loop modified code so the
+recorded findings reflect the final diff. Step 8 enforces this via a file-existence gate on
+`reviewer-findings.json`. Before returning the final report, verify that Step 9 completed: PR mode must run the
+exact script-only restore command above; issue mode must hand the explicitly named disposable worktree back to
+the invoker for targeted removal.
 
 ## ⚠️ CRITICAL: Sequential Execution Only
 
 🚨 **Try-fix runs MUST be executed ONE AT A TIME - NEVER in parallel.**
 
-**Why:** Each try-fix run:
-- Modifies the same target source files
-- Uses the same device/emulator for testing
-- Runs EstablishBrokenBaseline.ps1 which reverts files to a known state
+**Why:** Each try-fix run uses the same device/emulator. PR mode also modifies the same worktree and runs
+`EstablishBrokenBaseline.ps1`; issue mode isolates Git state in separate worktrees but still cannot safely run
+device tests concurrently.
 
 **If run in parallel:**
 - Multiple agents will overwrite each other's code changes
@@ -85,7 +90,11 @@ All inputs are provided by the invoker (CI, agent, or user).
 | Target files | Yes | Files to investigate; any file absent from the baseline state's `RevertedFiles` is read-only |
 | Platform | Yes | Target platform (`android`, `ios`, `windows`, `maccatalyst`) |
 | Hints | Optional | Suggested approaches, prior attempts, or areas to focus on |
-| Baseline | Optional | Git ref or instructions for establishing broken state (default: current state) |
+| Mode | Optional | `PR` (default) or `Issue`. Issue mode is only for a disposable attempt worktree created by `issue-fixer`. |
+| Baseline | Optional | PR mode: base branch/ref hints. Issue mode: the committed broken-checkpoint SHA. |
+| Attempt worktree | Issue mode | Absolute disposable worktree path whose clean `HEAD` equals the broken checkpoint. |
+| Reproduction paths | Issue mode | Explicit repo-owned test/Sandbox paths committed at the checkpoint; candidate fixes may not modify them. |
+| Output directory | Issue mode | Absolute path outside the disposable worktree so artifacts survive worktree removal. |
 
 ## Outputs
 
@@ -99,6 +108,7 @@ Results reported back to the invoker:
 | `analysis` | Why it worked, or why it failed and what was learned |
 | `diff` | The actual code changes made (for review) |
 | `findings_count` | Number of self-review findings recorded (0 = clean self-review) |
+| `candidate_commit` | Issue mode only: ephemeral local commit containing the complete candidate |
 
 ## Output Structure (MANDATORY)
 
@@ -108,13 +118,20 @@ Results reported back to the invoker:
 # Set issue/PR number explicitly (from branch name, PR context, or manual input)
 $IssueNumber = "<ISSUE_OR_PR_NUMBER>"  # Replace with actual number
 
-# Find next attempt number
-$tryFixDir = "CustomAgentLogsTmp/PRState/$IssueNumber/PRAgent/try-fix"
-$existingAttempts = (Get-ChildItem "$tryFixDir/attempt-*" -Directory -ErrorAction SilentlyContinue).Count
-$attemptNum = $existingAttempts + 1
+# PR mode uses the normal repo output tree.
+# Issue mode MUST receive an absolute output directory outside its disposable worktree.
+if ($Mode -eq "Issue") {
+    if (-not [System.IO.Path]::IsPathRooted($ProvidedOutputDirectory)) {
+        throw "Issue mode requires an absolute Output directory outside the attempt worktree."
+    }
+    $OUTPUT_DIR = $ProvidedOutputDirectory
+} else {
+    $tryFixDir = "CustomAgentLogsTmp/PRState/$IssueNumber/PRAgent/try-fix"
+    $existingAttempts = (Get-ChildItem "$tryFixDir/attempt-*" -Directory -ErrorAction SilentlyContinue).Count
+    $attemptNum = $existingAttempts + 1
+    $OUTPUT_DIR = "$tryFixDir/attempt-$attemptNum"
+}
 
-# Create output directory
-$OUTPUT_DIR = "$tryFixDir/attempt-$attemptNum"
 New-Item -ItemType Directory -Path $OUTPUT_DIR -Force | Out-Null
 
 Write-Host "Output directory: $OUTPUT_DIR"
@@ -143,6 +160,7 @@ equivalent repository marker. The only attempt artifacts belong under
 | `fix.diff` | After Step 7 (Test) | Output of `git diff` showing your changes |
 | `test-output.log` | After Step 7 (Test) | Full output from test command |
 | `analysis.md` | After Step 8 (Capture) | Why it worked/failed, insights learned, and a one-line self-review summary |
+| `candidate-commit.txt` | Issue mode, after Step 8 | Ephemeral local candidate commit SHA |
 
 **Example approach.md:**
 ```markdown
@@ -171,7 +189,10 @@ The skill is complete when:
 - [ ] **Expert self-review performed inline (Step 6) and `reviewer-findings.json` written** — `[]` if clean. **Refreshed by Step 7.5 if the test loop modified code, so the saved findings reflect the final diff.**
 - [ ] Analysis provided (success explanation or failure reasoning with evidence)
 - [ ] Artifacts saved to output directory (verified by Step 8 file-existence gate)
-- [ ] Baseline target files restored with no attempt-created changes; pre-existing untracked harness inputs remain untouched
+- [ ] PR mode: baseline restored. Issue mode: complete candidate committed/exported and disposable worktree
+      handed back to the invoker for removal.
+- [ ] Baseline target files restored with no attempt-created changes; pre-existing untracked harness inputs
+      remain untouched
 - [ ] Results reported to invoker (including `findings_count`)
 
 🚨 **CRITICAL: What counts as "Pass" vs "Fail"**
@@ -202,6 +223,42 @@ The skill is complete when:
 **Never stop due to:** Compile errors (fix them), infrastructure blame (debug your code), giving up too early.
 
 > **Session limits:** Each try-fix *invocation* allows up to 3 compile/test iterations. The *calling orchestrator* controls how many invocations (attempts) to run per session (typically 4-5 as part of pr-review Phase 3).
+
+---
+
+## Execution modes
+
+### PR mode (default)
+
+Use the existing workflow exactly as written: `EstablishBrokenBaseline.ps1` detects committed product changes,
+reverts them to the merge-base state, and restores them after artifact capture.
+
+### Issue mode
+
+Issue mode is invoked only by `issue-fixer`. Read
+`.github/skills/issue-fixer/references/issue-mode-attempts.md` before Step 1. The invoker has already created a
+disposable worktree/branch at a committed broken-reproduction checkpoint.
+
+The following substitutions are mandatory throughout Steps 1–10:
+
+1. **Baseline:** Step 2 verifies clean `HEAD == <broken-checkpoint>` and that all reproduction paths are
+   committed. It does **not** run `EstablishBrokenBaseline.ps1`.
+2. **Candidate boundary:** Candidate changes may not touch reproduction paths. After Step 5, stage only explicit
+   candidate product paths; never use `git add .`.
+3. **Diff under review:** Wherever PR mode uses plain `git diff`, issue mode uses
+   `git diff --cached --binary <broken-checkpoint>` after explicit staging. Wherever PR mode lists
+   `git diff --name-only HEAD`, issue mode lists `git diff --cached --name-only <broken-checkpoint>`.
+4. **Test-loop changes:** Restage only explicit candidate paths before Step 7.5 and reject any change to a
+   reproduction path.
+5. **Complete artifact:** Step 8 creates an ephemeral local candidate commit, writes its SHA to
+   `candidate-commit.txt`, and exports
+   `git diff --binary <broken-checkpoint> <candidate-commit>` to `fix.diff`. A plain working-tree diff is
+   forbidden because it omits untracked/staged additions.
+6. **Cleanup:** Step 9 does not restore or reset. It reports the worktree path and candidate branch/commit to
+   the invoker, which removes the explicitly named disposable worktree after artifacts are copied. Never remove,
+   reset, or clean the session worktree.
+
+Temporary issue-mode commits are local isolation artifacts, not user-facing history. Never push them.
 
 ---
 
@@ -242,6 +299,12 @@ The skill is complete when:
 
 ### Step 2: Establish Baseline (MANDATORY)
 
+**Issue mode:** follow the issue-mode substitution above. Verify the disposable worktree path, clean status,
+checkpoint SHA, and committed reproduction paths; write those facts to `baseline.log`. If any check fails,
+report `Blocked`. Do not run the PR baseline script.
+
+**PR mode:**
+
 🚨 **ONLY use EstablishBrokenBaseline.ps1 — NEVER use `git checkout`, `git restore`, or `git reset` to revert fix files.**
 
 The script auto-restores any previous baseline, tracks state, and prevents loops.
@@ -269,7 +332,8 @@ not safely restore added production files.
 
 **If the script fails with "No fix files detected":** Report as `Blocked` — do NOT switch branches.
 
-**If something fails mid-attempt:** `pwsh .github/scripts/EstablishBrokenBaseline.ps1 -Restore`
+**If something fails mid-attempt (PR mode):** `pwsh .github/scripts/EstablishBrokenBaseline.ps1 -Restore`.
+In issue mode, leave the disposable worktree for the invoker's targeted removal.
 
 ### Step 3: Analyze Target Files
 
@@ -317,6 +381,10 @@ Based on your analysis and any provided hints, design a single fix approach:
 ### Step 5: Apply the Fix
 
 Implement your fix. Use `git status --short` and `git diff` to track changes.
+
+**Issue mode:** before Step 6, confirm no reproduction path changed, then stage only the explicit candidate
+product paths. Include additions/deletions/renames; never use `git add .`. All issue-mode self-review and drift
+checks operate on the staged checkpoint→candidate diff.
 
 ### Step 6: Expert Self-Review (MANDATORY — runs BEFORE testing)
 
@@ -499,10 +567,21 @@ See [references/compile-errors.md](references/compile-errors.md) for error patte
 # 1. Save result (MUST be exactly "Pass", "Fail", or "Blocked")
 "Pass" | Set-Content "$OUTPUT_DIR/result.txt"  # or "Fail"
 
-# 2. Save the diff (use Set-Content -Value with Out-String so the file is created
-#    even when the diff is empty — a bare `git diff | Set-Content` does not create
-#    the file when the pipe is empty, which would fail the artifact gate.)
-Set-Content -Path "$OUTPUT_DIR/fix.diff" -Value (git diff | Out-String) -NoNewline
+# 2. Save the complete candidate.
+if ($Mode -eq "Issue") {
+    # Candidate paths were staged explicitly in Step 5/7.5. This temporary local
+    # commit makes added/deleted/renamed files part of a complete, reachable artifact.
+    git -c user.name="MAUI Issue Fixer" -c user.email="issue-fixer@example.invalid" `
+        commit -m "Temporary issue $IssueNumber candidate"
+    if ($LASTEXITCODE -ne 0) { throw "Failed to create issue-mode candidate commit." }
+    $candidateCommit = (git rev-parse HEAD).Trim()
+    $candidateCommit | Set-Content "$OUTPUT_DIR/candidate-commit.txt"
+    Set-Content -Path "$OUTPUT_DIR/fix.diff" `
+        -Value (git diff --binary $BrokenCheckpoint $candidateCommit | Out-String) -NoNewline
+} else {
+    # Use Set-Content -Value with Out-String so the file exists for an empty diff.
+    Set-Content -Path "$OUTPUT_DIR/fix.diff" -Value (git diff | Out-String) -NoNewline
+}
 
 # 3. Save test output (should already exist from Step 7)
 # Copy-Item "path/to/test-output.log" "$OUTPUT_DIR/test-output.log"
@@ -533,7 +612,9 @@ Set-Content -Path "$OUTPUT_DIR/fix.diff" -Value (git diff | Out-String) -NoNewli
 ```powershell
 # Run the file-existence check, but DEFER any throw until after Step 9 has restored the worktree.
 $missing = @()
-@("baseline.log", "approach.md", "result.txt", "fix.diff", "analysis.md", "test-output.log", "reviewer-findings.json", "reviewer-findings.diff") | ForEach-Object {
+$requiredArtifacts = @("baseline.log", "approach.md", "result.txt", "fix.diff", "analysis.md", "test-output.log", "reviewer-findings.json", "reviewer-findings.diff")
+if ($Mode -eq "Issue") { $requiredArtifacts += "candidate-commit.txt" }
+$requiredArtifacts | ForEach-Object {
     if (Test-Path "$OUTPUT_DIR/$_") {
         Write-Host "✅ $_"
     } else {
@@ -558,6 +639,12 @@ if ($missing.Count -gt 0) {
 **Analysis quality matters.** Bad: "Didn't work". Good: "Fix attempted to reset state in OnPageSelected, but this fires after layout measurement. The cached value was already used."
 
 ### Step 9: Restore Working Directory (MANDATORY — runs even if Step 8 gate failed)
+
+**Issue mode:** do not run restore/reset/clean commands. Report the disposable worktree, candidate branch, and
+candidate commit to the invoker. The invoker copies artifacts from the external output directory, then removes
+only that explicitly named worktree. This is the issue-mode equivalent of restoring the baseline.
+
+**PR mode:**
 
 **ALWAYS restore, even if fix failed or Step 8 detected missing artifacts.** Skipping restore corrupts the next sequential try-fix attempt.
 
@@ -600,6 +687,8 @@ Provide structured output to the invoker:
 
 **Result:** ✅ PASS / ❌ FAIL
 
+**Candidate Commit (Issue mode):** [ephemeral local SHA, or N/A]
+
 **Self-Review:** N findings (X critical, Y major, Z moderate/minor) — see `reviewer-findings.json`
 
 **Analysis:**
@@ -629,7 +718,7 @@ contents of `approach.md` or `analysis.md` being visible to the invoker.
 | Test command fails to run | Report build/setup error with details |
 | Test times out | Report timeout, include partial output |
 | Can't determine fix approach | Report "no viable approach identified" with reasoning |
-| Git state unrecoverable | Run `pwsh .github/scripts/EstablishBrokenBaseline.ps1 -Restore` (see Step 2/9) |
+| Git state unrecoverable | PR mode: run baseline restore. Issue mode: stop and return the disposable worktree to the invoker for targeted removal. |
 
 ---
 

--- a/.github/skills/try-fix/SKILL.md
+++ b/.github/skills/try-fix/SKILL.md
@@ -403,7 +403,12 @@ This step runs BEFORE testing so you can catch design flaws before spending time
 
 2. **Identify your changed files:**
    ```powershell
-   git diff --name-only HEAD
+   $changedFiles = if ($Mode -eq "Issue") {
+       git diff --cached --name-only $BrokenCheckpoint
+   } else {
+       git diff --name-only HEAD
+   }
+   $changedFiles
    ```
 
    If you have NO code changes (e.g., Blocked because no device available before any fix was applied), still proceed to step 4 and write `'[]'` — the artifact gate is the enforcement mechanism.
@@ -451,7 +456,12 @@ This step runs BEFORE testing so you can catch design flaws before spending time
    # Snapshot the diff that was reviewed — Step 7.5 uses this to detect whether the test loop mutated code.
    # Use Set-Content -Value with Out-String so the file is created even when the diff is empty
    # (a bare `git diff | Set-Content` does NOT create the file when the pipe is empty).
-   Set-Content -Path "$OUTPUT_DIR/reviewer-findings.diff" -Value (git diff | Out-String) -NoNewline
+   $reviewDiff = if ($Mode -eq "Issue") {
+       git diff --cached --binary $BrokenCheckpoint | Out-String
+   } else {
+       git diff | Out-String
+   }
+   Set-Content -Path "$OUTPUT_DIR/reviewer-findings.diff" -Value $reviewDiff -NoNewline
    ```
 
    **Remember `$findingsCount`** — you will report it as `findings_count` in Step 10 and summarize it in `analysis.md` (Step 8).
@@ -519,7 +529,11 @@ See [references/compile-errors.md](references/compile-errors.md) for error patte
    # Also: `Get-Content -Raw` on a 0-byte file returns $null, not "". The Step 6 snapshot
    # creates a 0-byte file when the diff is empty (the documented Blocked-with-no-diff path),
    # so coalesce $null to "" via `?? ''` to avoid a false-positive "" -ne $null drift detection.
-   $currentDiff  = (git diff | Out-String)
+   $currentDiff = if ($Mode -eq "Issue") {
+       git diff --cached --binary $BrokenCheckpoint | Out-String
+   } else {
+       git diff | Out-String
+   }
    $reviewedDiff = if (Test-Path "$OUTPUT_DIR/reviewer-findings.diff") {
        (Get-Content "$OUTPUT_DIR/reviewer-findings.diff" -Raw) ?? ''
    } else { '' }
@@ -534,7 +548,8 @@ See [references/compile-errors.md](references/compile-errors.md) for error patte
 
 2. **If `$diffChanged` is `$true`, re-do the Step 6 self-review against the new diff.** This is YOU walking the rules again — it is *not* something the script does. Repeat the same procedure from Step 6:
 
-   1. **Re-list changed files:** `git diff --name-only HEAD`
+   1. **Re-list changed files:** issue mode uses
+      `git diff --cached --name-only $BrokenCheckpoint`; PR mode uses `git diff --name-only HEAD`.
    2. **Re-walk the rules** in `.github/agents/maui-expert-reviewer.md` — every Overarching Principle, the always-active dimensions, and any routed dimensions whose file paths now match.
    3. **Rewrite `$OUTPUT_DIR/reviewer-findings.json`** with the new findings (or `'[]'` if clean). The file MUST be overwritten — appending or leaving the old content is a bug. Use the same JSON schema documented in Step 6.
 
@@ -542,7 +557,12 @@ See [references/compile-errors.md](references/compile-errors.md) for error patte
 
    ```powershell
    # Re-snapshot the diff (matches Step 6's snapshot logic — works for empty diffs too).
-   Set-Content -Path "$OUTPUT_DIR/reviewer-findings.diff" -Value (git diff | Out-String) -NoNewline
+   $reviewDiff = if ($Mode -eq "Issue") {
+       git diff --cached --binary $BrokenCheckpoint | Out-String
+   } else {
+       git diff | Out-String
+   }
+   Set-Content -Path "$OUTPUT_DIR/reviewer-findings.diff" -Value $reviewDiff -NoNewline
 
    # Re-validate the JSON parses and capture the new count.
    try {

--- a/.github/skills/try-fix/SKILL.md
+++ b/.github/skills/try-fix/SKILL.md
@@ -589,12 +589,22 @@ See [references/compile-errors.md](references/compile-errors.md) for error patte
 
 # 2. Save the complete candidate.
 if ($Mode -eq "Issue") {
-    # Candidate paths were staged explicitly in Step 5/7.5. This temporary local
-    # commit makes added/deleted/renamed files part of a complete, reachable artifact.
-    git -c user.name="MAUI Issue Fixer" -c user.email="issue-fixer@example.invalid" `
-        commit -m "Temporary issue $IssueNumber candidate"
-    if ($LASTEXITCODE -ne 0) { throw "Failed to create issue-mode candidate commit." }
-    $candidateCommit = (git rev-parse HEAD).Trim()
+    # Candidate paths were staged explicitly in Step 5/7.5. A no-diff attempt is
+    # valid only as Blocked/Fail; retain the checkpoint SHA so structured artifacts
+    # and cleanup still complete.
+    git diff --cached --quiet $BrokenCheckpoint --
+    $diffExitCode = $LASTEXITCODE
+    if ($diffExitCode -eq 0) {
+        "Blocked" | Set-Content "$OUTPUT_DIR/result.txt" -Force
+        $candidateCommit = $BrokenCheckpoint
+    } elseif ($diffExitCode -eq 1) {
+        git -c user.name="MAUI Issue Fixer" -c user.email="issue-fixer@example.invalid" `
+            commit -m "Temporary issue $IssueNumber candidate"
+        if ($LASTEXITCODE -ne 0) { throw "Failed to create issue-mode candidate commit." }
+        $candidateCommit = (git rev-parse HEAD).Trim()
+    } else {
+        throw "Failed to inspect the issue-mode candidate diff."
+    }
     $candidateCommit | Set-Content "$OUTPUT_DIR/candidate-commit.txt"
     Set-Content -Path "$OUTPUT_DIR/fix.diff" `
         -Value (git diff --binary $BrokenCheckpoint $candidateCommit | Out-String) -NoNewline

--- a/.github/skills/verify-tests-fail-without-fix/SKILL.md
+++ b/.github/skills/verify-tests-fail-without-fix/SKILL.md
@@ -101,6 +101,11 @@ verification as Blocked with the observed status instead of cleaning it up.
 
 ## Mode 1: Verify Failure Only (Test Creation)
 
+When supplying `-TestFilter` with `-TestType UnitTest` or `DeviceTest` in either mode, also pass
+`-TestProject`. Unit tests accept a known project key (for example, `Controls.Core.UnitTests`) or a
+repo-relative `.csproj`; device tests accept the `Run-DeviceTests.ps1` project name (`Controls`, `Core`,
+`Essentials`, `Graphics`, or `BlazorWebView`). The script fails explicitly rather than guessing a project.
+
 Use when **creating tests before writing a fix**:
 - Runs tests to verify they **FAIL** (proving they catch the bug)
 - No fix files required
@@ -111,7 +116,7 @@ Use when **creating tests before writing a fix**:
 pwsh .github/skills/verify-tests-fail-without-fix/scripts/verify-tests-fail.ps1 -Platform android
 
 # Explicit test type + filter
-pwsh .github/skills/verify-tests-fail-without-fix/scripts/verify-tests-fail.ps1 -Platform android -TestType UnitTest -TestFilter "Maui12345"
+pwsh .github/skills/verify-tests-fail-without-fix/scripts/verify-tests-fail.ps1 -TestType UnitTest -TestProject Controls.Core.UnitTests -TestFilter "Maui12345"
 ```
 
 ## Mode 2: Full Verification (Fix Validation)
@@ -129,11 +134,6 @@ pwsh .github/skills/verify-tests-fail-without-fix/scripts/verify-tests-fail.ps1 
 ```
 
 **Note:** `-RequireFullVerification` ensures the script errors if no fix files are detected, preventing silent fallback to failure-only mode.
-
-When supplying `-TestFilter` with `-TestType UnitTest` or `DeviceTest`, also pass `-TestProject`. Unit tests
-accept a known project key (for example, `Controls.Core.UnitTests`) or repo-relative `.csproj`; device tests
-accept the `Run-DeviceTests.ps1` project name (`Controls`, `Core`, `Essentials`, `Graphics`, or
-`BlazorWebView`). The script fails explicitly rather than guessing the wrong project.
 
 Full verification requires the with-fix state to be committed in the worktree so it can be restored from
 `HEAD`. Explicit `-FixFiles` may include modified, deleted, or newly added product files; new files are removed

--- a/.github/skills/verify-tests-fail-without-fix/SKILL.md
+++ b/.github/skills/verify-tests-fail-without-fix/SKILL.md
@@ -130,6 +130,11 @@ pwsh .github/skills/verify-tests-fail-without-fix/scripts/verify-tests-fail.ps1 
 
 **Note:** `-RequireFullVerification` ensures the script errors if no fix files are detected, preventing silent fallback to failure-only mode.
 
+Full verification requires the with-fix state to be committed in the worktree so it can be restored from
+`HEAD`. Explicit `-FixFiles` may include modified, deleted, or newly added product files; new files are removed
+for the without-fix run and restored from `HEAD` for the with-fix run. This makes disposable issue-mode
+candidate commits valid inputs as well as ordinary PR commits.
+
 ## Requirements
 
 **Verify Failure Only Mode:**

--- a/.github/skills/verify-tests-fail-without-fix/SKILL.md
+++ b/.github/skills/verify-tests-fail-without-fix/SKILL.md
@@ -130,6 +130,11 @@ pwsh .github/skills/verify-tests-fail-without-fix/scripts/verify-tests-fail.ps1 
 
 **Note:** `-RequireFullVerification` ensures the script errors if no fix files are detected, preventing silent fallback to failure-only mode.
 
+When supplying `-TestFilter` with `-TestType UnitTest` or `DeviceTest`, also pass `-TestProject`. Unit tests
+accept a known project key (for example, `Controls.Core.UnitTests`) or repo-relative `.csproj`; device tests
+accept the `Run-DeviceTests.ps1` project name (`Controls`, `Core`, `Essentials`, `Graphics`, or
+`BlazorWebView`). The script fails explicitly rather than guessing the wrong project.
+
 Full verification requires the with-fix state to be committed in the worktree so it can be restored from
 `HEAD`. Explicit `-FixFiles` may include modified, deleted, or newly added product files; new files are removed
 for the without-fix run and restored from `HEAD` for the with-fix run. This makes disposable issue-mode

--- a/.github/skills/verify-tests-fail-without-fix/SKILL.md
+++ b/.github/skills/verify-tests-fail-without-fix/SKILL.md
@@ -140,6 +140,10 @@ Full verification requires the with-fix state to be committed in the worktree so
 for the without-fix run and restored from `HEAD` for the with-fix run. This makes disposable issue-mode
 candidate commits valid inputs as well as ordinary PR commits.
 
+For historical issue-mode candidates, invoke the current verifier from a pinned tooling checkout and pass
+`-ToolRoot <tooling-checkout>` plus `-TargetRepoRoot <candidate-worktree>`. This keeps current verifier/runner
+semantics while building and testing the historical target tree.
+
 ## Requirements
 
 **Verify Failure Only Mode:**

--- a/.github/skills/verify-tests-fail-without-fix/scripts/Verify-TestsFail.Tests.ps1
+++ b/.github/skills/verify-tests-fail-without-fix/scripts/Verify-TestsFail.Tests.ps1
@@ -52,7 +52,12 @@ BeforeAll {
         "Core.DeviceTests" = "Core"
     }
 
-    foreach ($helperName in @('Resolve-ExplicitTestProject', 'Set-WithoutFixFileState', 'Set-WithFixFileState')) {
+    foreach ($helperName in @(
+        'Resolve-ExplicitTestProject',
+        'New-ExplicitTestEntry',
+        'Set-WithoutFixFileState',
+        'Set-WithFixFileState'
+    )) {
         $helper = $ast.Find({
             $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
             $args[0].Name -eq $helperName
@@ -278,5 +283,33 @@ Describe 'Explicit test project resolution' {
             -TestProject Core -RepoRoot $TestDrive
         $result.Project | Should -Be 'Core'
         $result.ProjectPath | Should -BeNullOrEmpty
+    }
+
+    It 'rejects absolute and traversal unit test project paths' {
+        $outsidePath = Join-Path (Split-Path $TestDrive -Parent) (
+            "outside-" + [Guid]::NewGuid().ToString('N') + ".csproj")
+        '<Project />' | Set-Content $outsidePath
+
+        try {
+            $relativeEscape = [System.IO.Path]::GetRelativePath($TestDrive, $outsidePath)
+            { Resolve-ExplicitTestProject -TestType UnitTest `
+                -TestProject $relativeEscape -RepoRoot $TestDrive } |
+                Should -Throw '*escapes the repository root*'
+
+            { Resolve-ExplicitTestProject -TestType UnitTest `
+                -TestProject $outsidePath -RepoRoot $TestDrive } |
+                Should -Throw '*must be repo-relative*'
+        } finally {
+            Remove-Item -LiteralPath $outsidePath -Force
+        }
+    }
+
+    It 'builds one explicit entry contract for both verification modes' {
+        $entry = New-ExplicitTestEntry -TestType DeviceTest -TestFilter 'Category=Core' `
+            -TestProject Core -RepoRoot $TestDrive
+        $entry.Type | Should -Be 'DeviceTest'
+        $entry.Project | Should -Be 'Core'
+        $entry.Filter | Should -Be 'Category=Core'
+        $entry.Runner | Should -Be 'Run-DeviceTests'
     }
 }

--- a/.github/skills/verify-tests-fail-without-fix/scripts/Verify-TestsFail.Tests.ps1
+++ b/.github/skills/verify-tests-fail-without-fix/scripts/Verify-TestsFail.Tests.ps1
@@ -22,6 +22,7 @@ BeforeAll {
     if ($parseErrors -and $parseErrors.Count -gt 0) {
         throw ($parseErrors | ForEach-Object { $_.Message }) -join [Environment]::NewLine
     }
+    $script:scriptText = Get-Content -LiteralPath $scriptPath -Raw
 
     $function = $ast.Find({
         $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
@@ -55,6 +56,9 @@ BeforeAll {
     foreach ($helperName in @(
         'Resolve-ExplicitTestProject',
         'New-ExplicitTestEntry',
+        'Resolve-RepositoryRelativePath',
+        'Get-ChangedFilesWithoutRenameDetection',
+        'Test-GitTreeContainsPath',
         'Set-WithoutFixFileState',
         'Set-WithFixFileState'
     )) {
@@ -223,6 +227,43 @@ Describe 'Full verification file-state transitions' {
             Remove-Item -LiteralPath $repo -Recurse -Force
         }
     }
+
+    It 'restores both sides of a committed rename' {
+        $repo = Join-Path ([System.IO.Path]::GetTempPath()) ("verifyrename-" + [Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $repo | Out-Null
+
+        try {
+            Push-Location $repo
+            git init --quiet
+            git config user.email "verify-tests@example.invalid"
+            git config user.name "Verify Tests"
+            "original" | Set-Content old-name.txt
+            git add -- old-name.txt
+            git commit --quiet -m "baseline"
+            $mergeBase = (git rev-parse HEAD).Trim()
+
+            git mv old-name.txt new-name.txt
+            git commit --quiet -m "rename"
+
+            $changedFiles = @(Get-ChangedFilesWithoutRenameDetection -MergeBase $mergeBase)
+            $changedFiles | Should -Contain 'old-name.txt'
+            $changedFiles | Should -Contain 'new-name.txt'
+
+            Set-WithoutFixFileState -RepoRoot $repo -MergeBase $mergeBase `
+                -RevertableFiles @('old-name.txt') -NewFiles @('new-name.txt')
+            Test-Path (Join-Path $repo 'old-name.txt') | Should -BeTrue
+            Test-Path (Join-Path $repo 'new-name.txt') | Should -BeFalse
+
+            Set-WithFixFileState -RepoRoot $repo -RevertableFiles @('old-name.txt') `
+                -DeletedByPrFiles @('old-name.txt') -NewFiles @('new-name.txt')
+            Test-Path (Join-Path $repo 'old-name.txt') | Should -BeFalse
+            Test-Path (Join-Path $repo 'new-name.txt') | Should -BeTrue
+            git status --porcelain | Should -BeNullOrEmpty
+        } finally {
+            Pop-Location
+            Remove-Item -LiteralPath $repo -Recurse -Force
+        }
+    }
 }
 
 Describe 'Get-AutoDetectedTests — ordinary PR metadata' {
@@ -257,6 +298,35 @@ Describe 'Explicit test project resolution' {
             -TestProject Controls.Core.UnitTests -RepoRoot $TestDrive
         $result.Project | Should -Be 'Controls.Core.UnitTests'
         $result.ProjectPath | Should -Be 'src/Controls/tests/Core.UnitTests/Controls.Core.UnitTests.csproj'
+    }
+
+    Describe 'FixFiles path validation' {
+        It 'rejects escaped and absolute paths without touching the target' {
+            $victim = Join-Path (Split-Path $TestDrive -Parent) (
+                "fix-victim-" + [Guid]::NewGuid().ToString('N') + ".txt")
+            'keep' | Set-Content -LiteralPath $victim
+
+            try {
+                $escape = [System.IO.Path]::GetRelativePath($TestDrive, $victim)
+                { Resolve-RepositoryRelativePath -RepoRoot $TestDrive -Path $escape `
+                    -ParameterName 'FixFiles entry' } | Should -Throw '*escapes the repository root*'
+                { Resolve-RepositoryRelativePath -RepoRoot $TestDrive -Path $victim `
+                    -ParameterName 'FixFiles entry' } | Should -Throw '*repo-relative path*'
+                Get-Content -LiteralPath $victim | Should -Be 'keep'
+            } finally {
+                Remove-Item -LiteralPath $victim -Force
+            }
+        }
+    }
+
+    Describe 'Pinned tooling root' {
+        It 'uses ToolRoot for tooling and RepoRoot for target projects' {
+            $script:scriptText | Should -Match 'Join-Path \$ToolRoot "\.github/scripts/EstablishBrokenBaseline\.ps1"'
+            $script:scriptText | Should -Match 'Join-Path \$ToolRoot "\.github/scripts/shared/Detect-TestsInDiff\.ps1"'
+            $script:scriptText | Should -Match 'Join-Path \$ToolRoot "\.github/scripts/BuildAndRunHostApp\.ps1"'
+            $script:scriptText | Should -Match 'Join-Path \$ToolRoot "\.github/skills/run-device-tests/scripts/Run-DeviceTests\.ps1"'
+            $script:scriptText | Should -Match 'Join-Path \$RepoRoot "src/Controls/tests/Xaml\.UnitTests/'
+        }
     }
 
     It 'resolves a repo-relative unit test project path' {

--- a/.github/skills/verify-tests-fail-without-fix/scripts/Verify-TestsFail.Tests.ps1
+++ b/.github/skills/verify-tests-fail-without-fix/scripts/Verify-TestsFail.Tests.ps1
@@ -44,12 +44,24 @@ BeforeAll {
     if (-not $invokeTestRunFunction) { throw "Function 'Invoke-TestRun' not found" }
     $script:invokeTestRunText = $invokeTestRunFunction.Extent.Text
 
+    foreach ($helperName in @('Set-WithoutFixFileState', 'Set-WithFixFileState')) {
+        $helper = $ast.Find({
+            $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+            $args[0].Name -eq $helperName
+        }, $true)
+        if (-not $helper) { throw "Function '$helperName' not found" }
+        Invoke-Expression $helper.Extent.Text
+    }
+
+    function Write-Log { param([string]$Message) }
+
     function New-LogFile {
         param([string]$Content)
         $f = Join-Path ([System.IO.Path]::GetTempPath()) ("verifylog-" + [Guid]::NewGuid().ToString('N') + ".log")
         $Content | Set-Content -LiteralPath $f -Encoding UTF8
         return $f
     }
+
 }
 
 Describe 'Invoke-TestRun — host-only target frameworks' {
@@ -79,6 +91,39 @@ Build FAILED.
         $r.Passed | Should -BeFalse
         $r.Error | Should -Match 'MAUIX2017'
         Remove-Item -LiteralPath $log -Force
+    }
+
+    Describe 'Full verification file-state transitions' {
+        It 'removes and restores a fix composed entirely of new committed files' {
+            $repo = Join-Path ([System.IO.Path]::GetTempPath()) ("verifyrepo-" + [Guid]::NewGuid().ToString('N'))
+            New-Item -ItemType Directory -Path $repo | Out-Null
+
+            try {
+                Push-Location $repo
+                git init --quiet
+                git config user.email "verify-tests@example.invalid"
+                git config user.name "Verify Tests"
+                "baseline" | Set-Content baseline.txt
+                git add -- baseline.txt
+                git commit --quiet -m "baseline"
+                $mergeBase = (git rev-parse HEAD).Trim()
+
+                "new product implementation" | Set-Content new-fix.cs
+                git add -- new-fix.cs
+                git commit --quiet -m "add fix"
+
+                Set-WithoutFixFileState -RepoRoot $repo -MergeBase $mergeBase -NewFiles @('new-fix.cs')
+                Test-Path (Join-Path $repo 'new-fix.cs') | Should -BeFalse
+
+                Set-WithFixFileState -RepoRoot $repo -NewFiles @('new-fix.cs')
+                Test-Path (Join-Path $repo 'new-fix.cs') | Should -BeTrue
+                Get-Content (Join-Path $repo 'new-fix.cs') | Should -Be 'new product implementation'
+                git status --porcelain | Should -BeNullOrEmpty
+            } finally {
+                Pop-Location
+                Remove-Item -LiteralPath $repo -Recurse -Force
+            }
+        }
     }
 
     It 'flags CS / MSB / NETSDK / XA compile errors as build errors' {

--- a/.github/skills/verify-tests-fail-without-fix/scripts/Verify-TestsFail.Tests.ps1
+++ b/.github/skills/verify-tests-fail-without-fix/scripts/Verify-TestsFail.Tests.ps1
@@ -44,7 +44,15 @@ BeforeAll {
     if (-not $invokeTestRunFunction) { throw "Function 'Invoke-TestRun' not found" }
     $script:invokeTestRunText = $invokeTestRunFunction.Extent.Text
 
-    foreach ($helperName in @('Set-WithoutFixFileState', 'Set-WithFixFileState')) {
+    $script:UnitTestProjectMap = @{
+        "Controls.Core.UnitTests" = "src/Controls/tests/Core.UnitTests/Controls.Core.UnitTests.csproj"
+    }
+    $script:DeviceTestProjectMap = @{
+        "Controls.DeviceTests" = "Controls"
+        "Core.DeviceTests" = "Core"
+    }
+
+    foreach ($helperName in @('Resolve-ExplicitTestProject', 'Set-WithoutFixFileState', 'Set-WithFixFileState')) {
         $helper = $ast.Find({
             $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
             $args[0].Name -eq $helperName
@@ -91,39 +99,6 @@ Build FAILED.
         $r.Passed | Should -BeFalse
         $r.Error | Should -Match 'MAUIX2017'
         Remove-Item -LiteralPath $log -Force
-    }
-
-    Describe 'Full verification file-state transitions' {
-        It 'removes and restores a fix composed entirely of new committed files' {
-            $repo = Join-Path ([System.IO.Path]::GetTempPath()) ("verifyrepo-" + [Guid]::NewGuid().ToString('N'))
-            New-Item -ItemType Directory -Path $repo | Out-Null
-
-            try {
-                Push-Location $repo
-                git init --quiet
-                git config user.email "verify-tests@example.invalid"
-                git config user.name "Verify Tests"
-                "baseline" | Set-Content baseline.txt
-                git add -- baseline.txt
-                git commit --quiet -m "baseline"
-                $mergeBase = (git rev-parse HEAD).Trim()
-
-                "new product implementation" | Set-Content new-fix.cs
-                git add -- new-fix.cs
-                git commit --quiet -m "add fix"
-
-                Set-WithoutFixFileState -RepoRoot $repo -MergeBase $mergeBase -NewFiles @('new-fix.cs')
-                Test-Path (Join-Path $repo 'new-fix.cs') | Should -BeFalse
-
-                Set-WithFixFileState -RepoRoot $repo -NewFiles @('new-fix.cs')
-                Test-Path (Join-Path $repo 'new-fix.cs') | Should -BeTrue
-                Get-Content (Join-Path $repo 'new-fix.cs') | Should -Be 'new product implementation'
-                git status --porcelain | Should -BeNullOrEmpty
-            } finally {
-                Pop-Location
-                Remove-Item -LiteralPath $repo -Recurse -Force
-            }
-        }
     }
 
     It 'flags CS / MSB / NETSDK / XA compile errors as build errors' {
@@ -212,6 +187,39 @@ Describe 'Get-AutoDetectedTests — frozen worktree isolation' {
     }
 }
 
+Describe 'Full verification file-state transitions' {
+    It 'removes and restores a fix composed entirely of new committed files' {
+        $repo = Join-Path ([System.IO.Path]::GetTempPath()) ("verifyrepo-" + [Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $repo | Out-Null
+
+        try {
+            Push-Location $repo
+            git init --quiet
+            git config user.email "verify-tests@example.invalid"
+            git config user.name "Verify Tests"
+            "baseline" | Set-Content baseline.txt
+            git add -- baseline.txt
+            git commit --quiet -m "baseline"
+            $mergeBase = (git rev-parse HEAD).Trim()
+
+            "new product implementation" | Set-Content new-fix.cs
+            git add -- new-fix.cs
+            git commit --quiet -m "add fix"
+
+            Set-WithoutFixFileState -RepoRoot $repo -MergeBase $mergeBase -NewFiles @('new-fix.cs')
+            Test-Path (Join-Path $repo 'new-fix.cs') | Should -BeFalse
+
+            Set-WithFixFileState -RepoRoot $repo -NewFiles @('new-fix.cs')
+            Test-Path (Join-Path $repo 'new-fix.cs') | Should -BeTrue
+            Get-Content (Join-Path $repo 'new-fix.cs') | Should -Be 'new product implementation'
+            git status --porcelain | Should -BeNullOrEmpty
+        } finally {
+            Pop-Location
+            Remove-Item -LiteralPath $repo -Recurse -Force
+        }
+    }
+}
+
 Describe 'Get-AutoDetectedTests — ordinary PR metadata' {
     It 'uses PR metadata when the explicit base is a branch name' {
         $detector = Join-Path ([System.IO.Path]::GetTempPath()) ("detect-" + [Guid]::NewGuid().ToString('N') + ".ps1")
@@ -235,5 +243,40 @@ Describe 'Get-AutoDetectedTests — ordinary PR metadata' {
         } finally {
             Remove-Item -LiteralPath $detector -Force -ErrorAction SilentlyContinue
         }
+    }
+}
+
+Describe 'Explicit test project resolution' {
+    It 'resolves a known unit test project key' {
+        $result = Resolve-ExplicitTestProject -TestType UnitTest `
+            -TestProject Controls.Core.UnitTests -RepoRoot $TestDrive
+        $result.Project | Should -Be 'Controls.Core.UnitTests'
+        $result.ProjectPath | Should -Be 'src/Controls/tests/Core.UnitTests/Controls.Core.UnitTests.csproj'
+    }
+
+    It 'resolves a repo-relative unit test project path' {
+        $projectPath = 'tests/Custom.UnitTests.csproj'
+        $fullPath = Join-Path $TestDrive $projectPath
+        New-Item -ItemType Directory -Path (Split-Path $fullPath) -Force | Out-Null
+        '<Project />' | Set-Content $fullPath
+
+        $result = Resolve-ExplicitTestProject -TestType UnitTest `
+            -TestProject $projectPath -RepoRoot $TestDrive
+        $result.Project | Should -Be 'Custom.UnitTests'
+        $result.ProjectPath | Should -Be $projectPath
+    }
+
+    It 'requires an explicit project for unit and device tests' {
+        { Resolve-ExplicitTestProject -TestType UnitTest -RepoRoot $TestDrive } |
+            Should -Throw '*requires -TestProject*'
+        { Resolve-ExplicitTestProject -TestType DeviceTest -RepoRoot $TestDrive } |
+            Should -Throw '*requires -TestProject*'
+    }
+
+    It 'resolves a non-Controls device test project without defaulting' {
+        $result = Resolve-ExplicitTestProject -TestType DeviceTest `
+            -TestProject Core -RepoRoot $TestDrive
+        $result.Project | Should -Be 'Core'
+        $result.ProjectPath | Should -BeNullOrEmpty
     }
 }

--- a/.github/skills/verify-tests-fail-without-fix/scripts/verify-tests-fail.ps1
+++ b/.github/skills/verify-tests-fail-without-fix/scripts/verify-tests-fail.ps1
@@ -61,7 +61,7 @@
 
 .EXAMPLE
     # Verify unit tests (no platform needed)
-    ./verify-tests-fail.ps1 -TestType UnitTest -TestFilter "Maui12345"
+    ./verify-tests-fail.ps1 -TestType UnitTest -TestProject Controls.Core.UnitTests -TestFilter "Maui12345"
 
 .EXAMPLE
     # Verify XAML unit tests
@@ -254,11 +254,33 @@ function Resolve-ExplicitTestProject {
                 }
             }
 
-            $candidatePath = Join-Path $RepoRoot $TestProject
-            if ($TestProject.EndsWith(".csproj", [StringComparison]::OrdinalIgnoreCase) -and (Test-Path $candidatePath)) {
+            if ([System.IO.Path]::IsPathRooted($TestProject)) {
+                throw "UnitTest project paths must be repo-relative, not absolute: '$TestProject'."
+            }
+
+            $repoFullPath = [System.IO.Path]::GetFullPath($RepoRoot).TrimEnd(
+                [System.IO.Path]::DirectorySeparatorChar,
+                [System.IO.Path]::AltDirectorySeparatorChar)
+            $repoPrefix = $repoFullPath + [System.IO.Path]::DirectorySeparatorChar
+            $candidatePath = [System.IO.Path]::GetFullPath((Join-Path $repoFullPath $TestProject))
+            $pathComparison = if ([OperatingSystem]::IsWindows()) {
+                [StringComparison]::OrdinalIgnoreCase
+            } else {
+                [StringComparison]::Ordinal
+            }
+
+            if (-not $candidatePath.StartsWith($repoPrefix, $pathComparison)) {
+                throw "UnitTest project path escapes the repository root: '$TestProject'."
+            }
+
+            if ($TestProject.EndsWith(".csproj", [StringComparison]::OrdinalIgnoreCase) -and
+                (Test-Path -LiteralPath $candidatePath -PathType Leaf)) {
+                $relativeProjectPath = ([System.IO.Path]::GetRelativePath(
+                    $repoFullPath,
+                    $candidatePath)).Replace('\', '/')
                 return @{
                     Project = [System.IO.Path]::GetFileNameWithoutExtension($TestProject)
-                    ProjectPath = $TestProject
+                    ProjectPath = $relativeProjectPath
                 }
             }
 
@@ -285,6 +307,32 @@ function Resolve-ExplicitTestProject {
                 ProjectPath = $null
             }
         }
+    }
+}
+
+function New-ExplicitTestEntry {
+    param(
+        [Parameter(Mandatory)][string]$TestType,
+        [Parameter(Mandatory)][string]$TestFilter,
+        [string]$TestProject,
+        [Parameter(Mandatory)][string]$RepoRoot
+    )
+
+    $resolvedProject = Resolve-ExplicitTestProject -TestType $TestType `
+        -TestProject $TestProject -RepoRoot $RepoRoot
+
+    return @{
+        Type = $TestType
+        TestName = $TestFilter
+        Filter = $TestFilter
+        Project = $resolvedProject.Project
+        ProjectPath = $resolvedProject.ProjectPath
+        Runner = switch ($TestType) {
+            "UITest" { "BuildAndRunHostApp" }
+            "DeviceTest" { "Run-DeviceTests" }
+            default { "dotnet-test" }
+        }
+        NeedsPlatform = ($TestType -in @("UITest", "DeviceTest"))
     }
 }
 
@@ -1115,13 +1163,13 @@ if ($DetectedFixFiles.Count -eq 0) {
         }
     } else {
         $effectiveType = if ($TestType) { $TestType } else { "UITest" }
-        $AllDetectedTests = @(@{
-            Type = $effectiveType
-            TestName = $TestFilter
-            Filter = $TestFilter
-            Project = $null
-            ProjectPath = $null
-        })
+        try {
+            $AllDetectedTests = @(New-ExplicitTestEntry -TestType $effectiveType `
+                -TestFilter $TestFilter -TestProject $TestProject -RepoRoot $RepoRoot)
+        } catch {
+            Write-Host "❌ $($_.Exception.Message)" -ForegroundColor Red
+            exit 1
+        }
     }
 
     # Create output directory
@@ -1261,25 +1309,12 @@ if (-not $TestFilter) {
     # Explicit filter provided — use single test entry with given/detected type
     $effectiveType = if ($TestType) { $TestType } else { "UITest" }
     try {
-        $explicitProject = Resolve-ExplicitTestProject -TestType $effectiveType `
-            -TestProject $TestProject -RepoRoot $RepoRoot
+        $AllDetectedTests = @(New-ExplicitTestEntry -TestType $effectiveType `
+            -TestFilter $TestFilter -TestProject $TestProject -RepoRoot $RepoRoot)
     } catch {
         Write-Host "❌ $($_.Exception.Message)" -ForegroundColor Red
         exit 1
     }
-    $AllDetectedTests = @(@{
-        Type = $effectiveType
-        TestName = $TestFilter
-        Filter = $TestFilter
-        Project = $explicitProject.Project
-        ProjectPath = $explicitProject.ProjectPath
-        Runner = switch ($effectiveType) {
-            "UITest" { "BuildAndRunHostApp" }
-            "DeviceTest" { "Run-DeviceTests" }
-            default { "dotnet-test" }
-        }
-        NeedsPlatform = ($effectiveType -in @("UITest", "DeviceTest"))
-    })
 }
 
 # Create output directory

--- a/.github/skills/verify-tests-fail-without-fix/scripts/verify-tests-fail.ps1
+++ b/.github/skills/verify-tests-fail-without-fix/scripts/verify-tests-fail.ps1
@@ -1504,14 +1504,15 @@ function Write-MarkdownReport {
     # ── Fix files (collapsible) ──
     $lines += ""
     $lines += "<details>"
-    $lines += "<summary>📁 Fix files reverted ($($ReportRevertableFiles.Count) files)</summary>"
+    $totalFixFiles = $ReportRevertableFiles.Count + $ReportNewFiles.Count
+    $lines += "<summary>📁 Fix files toggled ($totalFixFiles files)</summary>"
     $lines += ""
     foreach ($f in $ReportRevertableFiles) {
         $lines += "- ``$f``"
     }
     if ($ReportNewFiles.Count -gt 0) {
         $lines += ""
-        $lines += "**New files (not reverted):**"
+        $lines += "**New files (removed for without-fix run):**"
         foreach ($f in $ReportNewFiles) {
             $lines += "- ``$f``"
         }
@@ -1541,9 +1542,69 @@ Write-Log "BaseBranch: $BaseBranchName"
 Write-Log "MergeBase: $MergeBase"
 Write-Log ""
 
+function Set-WithoutFixFileState {
+    param(
+        [Parameter(Mandatory)][string]$RepoRoot,
+        [Parameter(Mandatory)][string]$MergeBase,
+        [string[]]$RevertableFiles = @(),
+        [string[]]$NewFiles = @()
+    )
+
+    foreach ($file in $RevertableFiles) {
+        Write-Log "  Reverting: $file"
+        $gitOutput = git checkout $MergeBase -- $file 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to revert $file from $MergeBase`: $gitOutput"
+        }
+    }
+
+    foreach ($file in $NewFiles) {
+        Write-Log "  Removing new fix file for baseline: $file"
+        git rm -f --ignore-unmatch -- $file 2>&1 | Out-Null
+        $wtPath = Join-Path $RepoRoot $file
+        if (Test-Path $wtPath) {
+            Remove-Item -LiteralPath $wtPath -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Set-WithFixFileState {
+    param(
+        [Parameter(Mandatory)][string]$RepoRoot,
+        [string[]]$RevertableFiles = @(),
+        [string[]]$DeletedByPrFiles = @(),
+        [string[]]$NewFiles = @()
+    )
+
+    foreach ($file in $RevertableFiles) {
+        if ($DeletedByPrFiles -contains $file) {
+            Write-Log "  Re-removing (deleted by PR): $file"
+            git rm -f --ignore-unmatch -- $file 2>&1 | Out-Null
+            $wtPath = Join-Path $RepoRoot $file
+            if (Test-Path $wtPath) {
+                Remove-Item -LiteralPath $wtPath -Force -ErrorAction SilentlyContinue
+            }
+        } else {
+            Write-Log "  Restoring: $file"
+            $gitOutput = git checkout HEAD -- $file 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                throw "Failed to restore $file from HEAD: $gitOutput"
+            }
+        }
+    }
+
+    foreach ($file in $NewFiles) {
+        Write-Log "  Restoring new fix file: $file"
+        $gitOutput = git checkout HEAD -- $file 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to restore new fix file $file from HEAD: $gitOutput"
+        }
+    }
+}
+
 # Verify each fix file is usable. A PR can MODIFY, ADD, or DELETE a fix file:
 #   - modified → exists on disk (HEAD) and at merge-base
-#   - added    → exists on disk (HEAD), not at merge-base  → NewFiles (not reverted)
+#   - added    → exists on disk (HEAD), not at merge-base  → NewFiles (removed for baseline)
 #   - deleted  → does NOT exist on disk (HEAD), exists at merge-base
 # A PR-deleted file legitimately does not exist in the with-fix worktree, so a
 # plain Test-Path is NOT a valid existence gate — it wrongly aborted (→ infra
@@ -1591,21 +1652,17 @@ foreach ($file in $FixFiles) {
         }
     } else {
         $NewFiles += $file
-        Write-Log "  ○ $file (new file - skipping revert)"
+        Write-Log "  ✓ $file (new file - will remove for baseline and restore from HEAD)"
     }
 }
 
-if ($RevertableFiles.Count -eq 0) {
-    Write-Host "❌ No revertable fix files found. All fix files are new." -ForegroundColor Red
-    Write-Host "   Cannot verify test behavior without files to revert." -ForegroundColor Yellow
-    exit 1
-}
-
-# Check for uncommitted changes ONLY on files we will revert
+# Check for uncommitted changes on every fix file. Full verification restores
+# the with-fix state from HEAD, so modified, added, and deleted fix files must
+# all be committed.
 Write-Log ""
-Write-Log "Checking for uncommitted changes on revertable files..."
+Write-Log "Checking for uncommitted changes on fix files..."
 $uncommittedFiles = @()
-foreach ($file in $RevertableFiles) {
+foreach ($file in $FixFiles) {
     # Check if file has uncommitted changes (staged or unstaged)
     $status = git status --porcelain -- $file 2>$null
     if ($status) {
@@ -1618,8 +1675,8 @@ if ($uncommittedFiles.Count -gt 0) {
     Write-Host "╔═══════════════════════════════════════════════════════════╗" -ForegroundColor Red
     Write-Host "║  ERROR: Uncommitted changes detected in fix files         ║" -ForegroundColor Red
     Write-Host "╠═══════════════════════════════════════════════════════════╣" -ForegroundColor Red
-    Write-Host "║  This script requires revertable fix files to be          ║" -ForegroundColor Red
-    Write-Host "║  committed so they can be restored via git checkout HEAD. ║" -ForegroundColor Red
+    Write-Host "║  This script requires all fix files to be committed       ║" -ForegroundColor Red
+    Write-Host "║  so the with-fix state can be restored from HEAD.         ║" -ForegroundColor Red
     Write-Host "╚═══════════════════════════════════════════════════════════╝" -ForegroundColor Red
     Write-Host ""
     Write-Host "Uncommitted files:" -ForegroundColor Yellow
@@ -1631,7 +1688,7 @@ if ($uncommittedFiles.Count -gt 0) {
     exit 1
 }
 
-Write-Log "  ✓ All revertable fix files are committed"
+Write-Log "  ✓ All fix files are committed"
 
 # Step 1: Revert fix files to merge-base state
 Write-Log ""
@@ -1639,17 +1696,15 @@ Write-Log "=========================================="
 Write-Log "STEP 1: Reverting fix files to merge-base ($($MergeBase.Substring(0, 8)))"
 Write-Log "=========================================="
 
-foreach ($file in $RevertableFiles) {
-    Write-Log "  Reverting: $file"
-    $gitOutput = git checkout $MergeBase -- $file 2>&1
-    if ($LASTEXITCODE -ne 0) {
-        Write-Log "  ERROR: Failed to revert $file from $MergeBase"
-        Write-Log "  Git output: $gitOutput"
-        exit 1
-    }
+try {
+    Set-WithoutFixFileState -RepoRoot $RepoRoot -MergeBase $MergeBase `
+        -RevertableFiles $RevertableFiles -NewFiles $NewFiles
+} catch {
+    Write-Log "  ERROR: Failed to form without-fix state: $($_.Exception.Message)"
+    exit 1
 }
 
-Write-Log "  ✓ $($RevertableFiles.Count) fix file(s) reverted to merge-base state"
+Write-Log "  ✓ Baseline formed: $($RevertableFiles.Count) reverted, $($NewFiles.Count) new file(s) removed"
 
 # Step 2: Run ALL tests WITHOUT fix
 Write-Host ""
@@ -1727,28 +1782,15 @@ Write-Log "=========================================="
 Write-Log "STEP 3: Restoring fix files from HEAD"
 Write-Log "=========================================="
 
-foreach ($file in $RevertableFiles) {
-    if ($DeletedByPrFiles -contains $file) {
-        # The PR deleted this file; its with-fix state is "absent". STEP 1
-        # restored it from the merge-base for the baseline run, so re-delete it
-        # (worktree + index) to match HEAD — `git checkout HEAD -- $file` would
-        # fail here because HEAD has no copy of a PR-deleted file.
-        Write-Log "  Re-removing (deleted by PR): $file"
-        git rm -f --ignore-unmatch -- $file 2>&1 | Out-Null
-        $wtPath = Join-Path $RepoRoot $file
-        if (Test-Path $wtPath) { Remove-Item -LiteralPath $wtPath -Force -ErrorAction SilentlyContinue }
-    } else {
-        Write-Log "  Restoring: $file"
-        $gitOutput = git checkout HEAD -- $file 2>&1
-        if ($LASTEXITCODE -ne 0) {
-            Write-Log "  ERROR: Failed to restore $file from HEAD"
-            Write-Log "  Git output: $gitOutput"
-            exit 1
-        }
-    }
+try {
+    Set-WithFixFileState -RepoRoot $RepoRoot -RevertableFiles $RevertableFiles `
+        -DeletedByPrFiles $DeletedByPrFiles -NewFiles $NewFiles
+} catch {
+    Write-Log "  ERROR: Failed to restore with-fix state: $($_.Exception.Message)"
+    exit 1
 }
 
-Write-Log "  ✓ $($RevertableFiles.Count) fix file(s) restored from HEAD"
+Write-Log "  ✓ With-fix state restored: $($RevertableFiles.Count) existing, $($NewFiles.Count) new file(s)"
 
 # Step 4: Run ALL tests WITH fix
 Write-Host ""

--- a/.github/skills/verify-tests-fail-without-fix/scripts/verify-tests-fail.ps1
+++ b/.github/skills/verify-tests-fail-without-fix/scripts/verify-tests-fail.ps1
@@ -37,6 +37,11 @@
     Test filter to pass to dotnet test (e.g., "FullyQualifiedName~Issue12345").
     If not provided, auto-detects from test files in the git diff.
 
+.PARAMETER TestProject
+    Required with an explicit TestFilter for UnitTest and DeviceTest. For UnitTest, pass a key from the unit
+    test project map (for example, Controls.Core.UnitTests) or a repo-relative .csproj path. For DeviceTest,
+    pass the Run-DeviceTests project name (Controls, Core, Essentials, Graphics, or BlazorWebView).
+
 .PARAMETER FixFiles
     (Optional) Array of file paths to revert. If not provided, auto-detects from git diff
     by excluding test directories. If no fix files are found, runs in verify failure only mode.
@@ -79,6 +84,9 @@ param(
 
     [Parameter(Mandatory = $false)]
     [string]$TestFilter,
+
+    [Parameter(Mandatory = $false)]
+    [string]$TestProject,
 
     [Parameter(Mandatory = $false)]
     [string[]]$FixFiles,
@@ -224,6 +232,60 @@ $script:DeviceTestProjectMap = @{
     "Essentials.DeviceTests"           = "Essentials"
     "Graphics.DeviceTests"             = "Graphics"
     "MauiBlazorWebView.DeviceTests"    = "BlazorWebView"
+}
+
+function Resolve-ExplicitTestProject {
+    param(
+        [Parameter(Mandatory)][string]$TestType,
+        [string]$TestProject,
+        [Parameter(Mandatory)][string]$RepoRoot
+    )
+
+    switch ($TestType) {
+        "UnitTest" {
+            if (-not $TestProject) {
+                throw "UnitTest with an explicit TestFilter requires -TestProject (project key or repo-relative .csproj path)."
+            }
+
+            if ($script:UnitTestProjectMap.ContainsKey($TestProject)) {
+                return @{
+                    Project = $TestProject
+                    ProjectPath = $script:UnitTestProjectMap[$TestProject]
+                }
+            }
+
+            $candidatePath = Join-Path $RepoRoot $TestProject
+            if ($TestProject.EndsWith(".csproj", [StringComparison]::OrdinalIgnoreCase) -and (Test-Path $candidatePath)) {
+                return @{
+                    Project = [System.IO.Path]::GetFileNameWithoutExtension($TestProject)
+                    ProjectPath = $TestProject
+                }
+            }
+
+            throw "Unknown UnitTest project '$TestProject'. Use a known project key or repo-relative .csproj path."
+        }
+        "DeviceTest" {
+            if (-not $TestProject) {
+                throw "DeviceTest with an explicit TestFilter requires -TestProject."
+            }
+
+            $knownProjects = @($script:DeviceTestProjectMap.Values)
+            if ($knownProjects -notcontains $TestProject) {
+                throw "Unknown DeviceTest project '$TestProject'. Expected one of: $($knownProjects -join ', ')."
+            }
+
+            return @{
+                Project = $TestProject
+                ProjectPath = $null
+            }
+        }
+        default {
+            return @{
+                Project = $null
+                ProjectPath = $null
+            }
+        }
+    }
 }
 
 function Get-TestTypeFromFiles {
@@ -1198,12 +1260,19 @@ if (-not $TestFilter) {
 } else {
     # Explicit filter provided — use single test entry with given/detected type
     $effectiveType = if ($TestType) { $TestType } else { "UITest" }
+    try {
+        $explicitProject = Resolve-ExplicitTestProject -TestType $effectiveType `
+            -TestProject $TestProject -RepoRoot $RepoRoot
+    } catch {
+        Write-Host "❌ $($_.Exception.Message)" -ForegroundColor Red
+        exit 1
+    }
     $AllDetectedTests = @(@{
         Type = $effectiveType
         TestName = $TestFilter
         Filter = $TestFilter
-        Project = $null
-        ProjectPath = $null
+        Project = $explicitProject.Project
+        ProjectPath = $explicitProject.ProjectPath
         Runner = switch ($effectiveType) {
             "UITest" { "BuildAndRunHostApp" }
             "DeviceTest" { "Run-DeviceTests" }

--- a/.github/skills/verify-tests-fail-without-fix/scripts/verify-tests-fail.ps1
+++ b/.github/skills/verify-tests-fail-without-fix/scripts/verify-tests-fail.ps1
@@ -42,6 +42,14 @@
     test project map (for example, Controls.Core.UnitTests) or a repo-relative .csproj path. For DeviceTest,
     pass the Run-DeviceTests project name (Controls, Core, Essentials, Graphics, or BlazorWebView).
 
+.PARAMETER ToolRoot
+    Optional pinned checkout containing the current trusted `.github/scripts` and `.github/skills` tooling.
+    Defaults to the target repository root for ordinary PR/CI use.
+
+.PARAMETER TargetRepoRoot
+    Optional worktree whose source and tests are being verified. Defaults to the current Git worktree.
+    Issue mode uses this to verify historical candidates with current tooling.
+
 .PARAMETER FixFiles
     (Optional) Array of file paths to revert. If not provided, auto-detects from git diff
     by excluding test directories. If no fix files are found, runs in verify failure only mode.
@@ -89,6 +97,12 @@ param(
     [string]$TestProject,
 
     [Parameter(Mandatory = $false)]
+    [string]$ToolRoot,
+
+    [Parameter(Mandatory = $false)]
+    [string]$TargetRepoRoot,
+
+    [Parameter(Mandatory = $false)]
     [string[]]$FixFiles,
 
     [Parameter(Mandatory = $false)]
@@ -106,7 +120,28 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
-$RepoRoot = git rev-parse --show-toplevel
+$RepoRoot = if ($TargetRepoRoot) {
+    [System.IO.Path]::GetFullPath($TargetRepoRoot)
+} else {
+    (git rev-parse --show-toplevel).Trim()
+}
+
+if (-not (Test-Path -LiteralPath $RepoRoot -PathType Container) -or
+    -not (git -C $RepoRoot rev-parse --is-inside-work-tree 2>$null)) {
+    throw "TargetRepoRoot is not a Git worktree: '$RepoRoot'."
+}
+
+$ToolRoot = if ($ToolRoot) {
+    [System.IO.Path]::GetFullPath($ToolRoot)
+} else {
+    $RepoRoot
+}
+
+if (-not (Test-Path -LiteralPath $ToolRoot -PathType Container)) {
+    throw "ToolRoot does not exist: '$ToolRoot'."
+}
+
+Set-Location -LiteralPath $RepoRoot
 
 # Normalize platform name (accept both "catalyst" and "maccatalyst")
 if ($Platform -eq "maccatalyst") {
@@ -190,14 +225,14 @@ Write-Host "📁 Output directory: $OutputDir" -ForegroundColor Cyan
 # ============================================================
 # Import shared baseline script for merge-base and file detection
 # ============================================================
-$BaselineScript = Join-Path $RepoRoot ".github/scripts/EstablishBrokenBaseline.ps1"
+$BaselineScript = Join-Path $ToolRoot ".github/scripts/EstablishBrokenBaseline.ps1"
 
 # Import Test-IsTestFile and Find-MergeBase from shared script
 $ExplicitBaseBranch = $BaseBranch
 . $BaselineScript
 
 # Import the shared test detection script
-$DetectTestsScript = Join-Path $RepoRoot ".github/scripts/shared/Detect-TestsInDiff.ps1"
+$DetectTestsScript = Join-Path $ToolRoot ".github/scripts/shared/Detect-TestsInDiff.ps1"
 
 
 # ============================================================
@@ -336,6 +371,65 @@ function New-ExplicitTestEntry {
     }
 }
 
+function Resolve-RepositoryRelativePath {
+    param(
+        [Parameter(Mandatory)][string]$RepoRoot,
+        [Parameter(Mandatory)][string]$Path,
+        [string]$ParameterName = "path"
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path) -or [System.IO.Path]::IsPathRooted($Path)) {
+        throw "$ParameterName must be a non-empty repo-relative path: '$Path'."
+    }
+
+    $repoFullPath = [System.IO.Path]::GetFullPath($RepoRoot).TrimEnd(
+        [System.IO.Path]::DirectorySeparatorChar,
+        [System.IO.Path]::AltDirectorySeparatorChar)
+    $repoPrefix = $repoFullPath + [System.IO.Path]::DirectorySeparatorChar
+    $candidatePath = [System.IO.Path]::GetFullPath((Join-Path $repoFullPath $Path))
+    $pathComparison = if ([OperatingSystem]::IsWindows()) {
+        [StringComparison]::OrdinalIgnoreCase
+    } else {
+        [StringComparison]::Ordinal
+    }
+
+    if (-not $candidatePath.StartsWith($repoPrefix, $pathComparison)) {
+        throw "$ParameterName escapes the repository root: '$Path'."
+    }
+
+    $relativePath = ([System.IO.Path]::GetRelativePath($repoFullPath, $candidatePath)).Replace('\', '/')
+    if ($relativePath -eq ".git" -or $relativePath.StartsWith(".git/", [StringComparison]::Ordinal)) {
+        throw "$ParameterName may not target Git metadata: '$Path'."
+    }
+
+    return $relativePath
+}
+
+function Get-ChangedFilesWithoutRenameDetection {
+    param([Parameter(Mandatory)][string]$MergeBase)
+
+    $changedFiles = @(git diff --no-renames --name-only $MergeBase HEAD -- 2>&1)
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to enumerate changed files from $MergeBase`: $($changedFiles -join [Environment]::NewLine)"
+    }
+
+    return $changedFiles
+}
+
+function Test-GitTreeContainsPath {
+    param(
+        [Parameter(Mandatory)][string]$Commit,
+        [Parameter(Mandatory)][string]$Path
+    )
+
+    $output = @(git ls-tree -r --name-only $Commit -- ":(literal)$Path" 2>&1)
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to inspect '$Path' at $Commit`: $($output -join [Environment]::NewLine)"
+    }
+
+    return $output.Count -gt 0
+}
+
 function Get-TestTypeFromFiles {
     <#
     .SYNOPSIS
@@ -464,7 +558,7 @@ function Invoke-TestRun {
                 $script:BootedDeviceUdid = $DeviceUdid
             } else {
                 Write-Host "🔹 Booting $Platform device/simulator (shared across all test runs)..." -ForegroundColor Cyan
-                $startEmulatorScript = Join-Path $RepoRoot ".github/scripts/shared/Start-Emulator.ps1"
+                $startEmulatorScript = Join-Path $ToolRoot ".github/scripts/shared/Start-Emulator.ps1"
                 $emulatorParams = @{ Platform = $emulatorPlatform }
                 $script:BootedDeviceUdid = & $startEmulatorScript @emulatorParams
                 if ($LASTEXITCODE -ne 0) {
@@ -484,7 +578,7 @@ function Invoke-TestRun {
                 Write-Host "❌ UI tests require -Platform (android, ios, catalyst, windows)" -ForegroundColor Red
                 exit 1
             }
-            $buildScript = Join-Path $RepoRoot ".github/scripts/BuildAndRunHostApp.ps1"
+            $buildScript = Join-Path $ToolRoot ".github/scripts/BuildAndRunHostApp.ps1"
             $uiParams = @{
                 Platform   = $Platform
                 TestFilter = $Filter
@@ -574,7 +668,7 @@ function Invoke-TestRun {
             }
             $deviceProject = if ($DetectedProject) { $DetectedProject } else { "Controls" }
 
-            $deviceTestScript = Join-Path $RepoRoot ".github/skills/run-device-tests/scripts/Run-DeviceTests.ps1"
+            $deviceTestScript = Join-Path $ToolRoot ".github/skills/run-device-tests/scripts/Run-DeviceTests.ps1"
             Write-Host "🧪 Running device tests: $deviceProject on $devicePlatform" -ForegroundColor Cyan
             Write-Host "   Filter: $Filter" -ForegroundColor Gray
 
@@ -1085,9 +1179,15 @@ if ($baseInfo.Distance) {
     Write-Host "   ($($baseInfo.Distance) commits ahead of $BaseBranchName)" -ForegroundColor Gray
 }
 
-# Check for fix files (non-test files that changed since merge-base)
+# Check for fix files (non-test files that changed since merge-base). Disabling rename detection makes both
+# sides of a rename explicit, so the without-fix state can restore the source and remove the destination.
 $DetectedFixFiles = @()
-$changedFiles = git diff $MergeBase HEAD --name-only 2>$null
+try {
+    $changedFiles = Get-ChangedFilesWithoutRenameDetection -MergeBase $MergeBase
+} catch {
+    Write-Host "❌ $($_.Exception.Message)" -ForegroundColor Red
+    exit 1
+}
 
 if ($changedFiles) {
     foreach ($file in $changedFiles) {
@@ -1100,6 +1200,15 @@ if ($changedFiles) {
 # Override with explicitly provided fix files
 if ($FixFiles -and $FixFiles.Count -gt 0) {
     $DetectedFixFiles = $FixFiles
+}
+
+try {
+    $DetectedFixFiles = @($DetectedFixFiles | ForEach-Object {
+        Resolve-RepositoryRelativePath -RepoRoot $RepoRoot -Path $_ -ParameterName "FixFiles entry"
+    } | Select-Object -Unique)
+} catch {
+    Write-Host "❌ Invalid FixFiles input: $($_.Exception.Message)" -ForegroundColor Red
+    exit 1
 }
 
 # Error if no fix files detected and RequireFullVerification is set
@@ -1656,7 +1765,7 @@ function Set-WithoutFixFileState {
 
     foreach ($file in $RevertableFiles) {
         Write-Log "  Reverting: $file"
-        $gitOutput = git checkout $MergeBase -- $file 2>&1
+        $gitOutput = git checkout $MergeBase -- ":(literal)$file" 2>&1
         if ($LASTEXITCODE -ne 0) {
             throw "Failed to revert $file from $MergeBase`: $gitOutput"
         }
@@ -1664,10 +1773,12 @@ function Set-WithoutFixFileState {
 
     foreach ($file in $NewFiles) {
         Write-Log "  Removing new fix file for baseline: $file"
-        git rm -f --ignore-unmatch -- $file 2>&1 | Out-Null
-        $wtPath = Join-Path $RepoRoot $file
-        if (Test-Path $wtPath) {
-            Remove-Item -LiteralPath $wtPath -Force -ErrorAction SilentlyContinue
+        $gitOutput = git rm -f -- ":(literal)$file" 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to remove new fix file $file for baseline: $gitOutput"
+        }
+        if (Test-Path -LiteralPath (Join-Path $RepoRoot $file)) {
+            throw "New fix file still exists after baseline removal: $file"
         }
     }
 }
@@ -1683,14 +1794,16 @@ function Set-WithFixFileState {
     foreach ($file in $RevertableFiles) {
         if ($DeletedByPrFiles -contains $file) {
             Write-Log "  Re-removing (deleted by PR): $file"
-            git rm -f --ignore-unmatch -- $file 2>&1 | Out-Null
-            $wtPath = Join-Path $RepoRoot $file
-            if (Test-Path $wtPath) {
-                Remove-Item -LiteralPath $wtPath -Force -ErrorAction SilentlyContinue
+            $gitOutput = git rm -f -- ":(literal)$file" 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                throw "Failed to re-remove deleted fix file ${file}: $gitOutput"
+            }
+            if (Test-Path -LiteralPath (Join-Path $RepoRoot $file)) {
+                throw "Deleted fix file still exists after with-fix restoration: $file"
             }
         } else {
             Write-Log "  Restoring: $file"
-            $gitOutput = git checkout HEAD -- $file 2>&1
+            $gitOutput = git checkout HEAD -- ":(literal)$file" 2>&1
             if ($LASTEXITCODE -ne 0) {
                 throw "Failed to restore $file from HEAD: $gitOutput"
             }
@@ -1699,7 +1812,7 @@ function Set-WithFixFileState {
 
     foreach ($file in $NewFiles) {
         Write-Log "  Restoring new fix file: $file"
-        $gitOutput = git checkout HEAD -- $file 2>&1
+        $gitOutput = git checkout HEAD -- ":(literal)$file" 2>&1
         if ($LASTEXITCODE -ne 0) {
             throw "Failed to restore new fix file $file from HEAD: $gitOutput"
         }
@@ -1719,9 +1832,9 @@ Write-Log "Verifying fix files are present (on disk or at merge-base)..."
 $missingFixFiles = @()
 foreach ($file in $FixFiles) {
     $fullPath = Join-Path $RepoRoot $file
-    if (Test-Path $fullPath) {
+    if (Test-Path -LiteralPath $fullPath) {
         Write-Log "  ✓ $file exists"
-    } elseif (git ls-tree -r $MergeBase --name-only -- $file 2>$null) {
+    } elseif (Test-GitTreeContainsPath -Commit $MergeBase -Path $file) {
         Write-Log "  ○ $file (deleted by PR — exists at merge-base, will be restored to form the baseline)"
     } else {
         Write-Log "ERROR: Fix file not found on disk or at merge-base: $file"
@@ -1743,11 +1856,16 @@ $DeletedByPrFiles = @()
 
 foreach ($file in $FixFiles) {
     # Check if file exists at merge-base commit
-    $existsInBase = git ls-tree -r $MergeBase --name-only -- $file 2>$null
+    try {
+        $existsInBase = Test-GitTreeContainsPath -Commit $MergeBase -Path $file
+        $existsAtHead = Test-GitTreeContainsPath -Commit HEAD -Path $file
+    } catch {
+        Write-Host "❌ $($_.Exception.Message)" -ForegroundColor Red
+        exit 1
+    }
 
     if ($existsInBase) {
         $RevertableFiles += $file
-        $existsAtHead = git ls-tree -r HEAD --name-only -- $file 2>$null
         if ($existsAtHead) {
             Write-Log "  ✓ $file (exists at merge-base - will revert)"
         } else {
@@ -1768,7 +1886,11 @@ Write-Log "Checking for uncommitted changes on fix files..."
 $uncommittedFiles = @()
 foreach ($file in $FixFiles) {
     # Check if file has uncommitted changes (staged or unstaged)
-    $status = git status --porcelain -- $file 2>$null
+    $status = git status --porcelain -- ":(literal)$file" 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "❌ Failed to inspect Git status for fix file: $file" -ForegroundColor Red
+        exit 1
+    }
     if ($status) {
         $uncommittedFiles += $file
     }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Adds a MAUI-specific `issue-fixer` workflow that takes a GitHub issue with no existing PR through controlled reproduction, root-cause analysis, isolated multi-model fix exploration, and empirical verification.

Reporter-provided projects and commands are treated as behavioral specifications only and are never executed. The workflow recreates the scenario in repository-owned code, preferring an automated unit/XAML/device/UI test and using `Controls.Sample.Sandbox` only as a temporary discovery harness.

### Issue-Mode Isolation

`try-fix` was previously PR-shaped: `EstablishBrokenBaseline.ps1` requires committed non-test changes relative to a merge base. That cannot represent an issue whose only current change is reproduction scaffolding.

This PR adds an explicit issue mode:

1. Create a temporary local checkpoint commit containing only the failing repo-owned reproduction.
2. Run each model sequentially in its own disposable worktree/branch from that checkpoint.
3. Keep reproduction paths immutable while the model changes product files.
4. Keep attempt outputs in absolute paths outside disposable worktrees.
5. Capture complete candidates—including additions, deletions, renames, staged files, and empty/blocked attempts—as structured local artifacts.
6. Pin a separate current tooling worktree when verifying historical candidate trees.
7. Materialize the winner on the session branch only after selection and adversarial challenge.
8. Never push temporary checkpoint/candidate/tooling commits.

### Verification and Safety

The winning candidate is verified from committed state against the reproduction checkpoint using `verify-tests-fail-without-fix -RequireFullVerification`. Failure-only mode cannot satisfy the workflow.

The verifier now:

- accepts separate pinned `ToolRoot` and historical `TargetRepoRoot` paths
- canonicalizes every fix path under the target repository before any Git or filesystem operation
- rejects absolute, traversal, escaped, and Git-metadata paths
- uses checked literal Git pathspecs without unchecked filesystem deletion
- disables rename detection for fix-file enumeration so both rename paths transition correctly
- removes newly added product files for the without-fix run and restores them from `HEAD`
- supports fixes composed entirely of new files
- rejects uncommitted fix state
- requires explicit project selection for filtered UnitTest and DeviceTest runs
- rejects repository-escaping unit-test project paths
- never silently defaults an explicit non-Controls device test to Controls

### Additional Workflow Improvements

- `pr-review` handles only issues that already have a PR; issues without a PR route to `issue-fixer`
- `issue-fixer` references `pr-review` as the canonical four-model roster source
- Sandbox commands use the canonical `.github/scripts/BuildAndRunSandbox.ps1` path
- `try-fix` self-review/drift snapshots explicitly use staged checkpoint-to-candidate diffs in issue mode
- competing root-cause hypotheses, adversarial test-integrity checks, area regression sweeps, and CI escalation remain required
- the workflow stops for explicit user approval before committing or pushing the resulting product fix

### Repository Changes

- adds `.github/skills/issue-fixer/SKILL.md` and its issue-mode protocol reference
- adds issue-mode execution semantics to `.github/skills/try-fix/SKILL.md`
- extends `verify-tests-fail-without-fix` for committed issue-mode candidates and adds regression coverage
- makes `pr-review`/`issue-fixer` routing reciprocal
- updates `.github/copilot-instructions.md`

This PR changes agent workflow and test tooling only; it does not change MAUI product behavior or public API.

### Validation

- rebased onto current `main`
- skill-creator `quick_validate.py` for `issue-fixer`, `try-fix`, `pr-review`, and `verify-tests-fail-without-fix`
- `Verify-TestsFail.Tests.ps1`: 18 passed, 0 failed, 0 skipped
- PowerShell parser validation
- `git diff --check`

### Issues Fixed

N/A — agent workflow improvement.