### PR TITLE
[Windows] Fix: Border containing SwipeView causes native crash

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue36652.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue36652.cs
@@ -1,0 +1,65 @@
+namespace Maui.Controls.Sample.Issues;
+[Issue(IssueTracker.Github, 36652, "SwipeView directly inside a Border crashes natively on Windows", PlatformAffected.UWP)]
+public class Issue36652 : ContentPage
+{
+	public Issue36652()
+	{
+		var swipeItem = new SwipeItem
+		{
+			BackgroundColor = Colors.Red,
+			Text = "Delete"
+		};
+
+		var swipeItems = new SwipeItems { swipeItem };
+
+		var swipeContent = new Grid
+		{
+			BackgroundColor = Colors.LightBlue,
+			HeightRequest = 60
+		};
+
+		swipeContent.Children.Add(new Label
+		{
+			AutomationId = "SwipeContentLabel",
+			Text = "Swipe Me",
+			HorizontalOptions = LayoutOptions.Center,
+			VerticalOptions = LayoutOptions.Center
+		});
+
+		var swipeView = new SwipeView
+		{
+			AutomationId = "SwipeViewInsideBorder",
+			RightItems = swipeItems,
+			Content = swipeContent
+		};
+
+		// The crash reported in #36652 only occurs when the SwipeView is the direct
+		// Content of a Border (Border > SwipeView), since WinUI applies a geometric
+		// clip straight onto the SwipeControl's visual in that hierarchy.
+		var border = new Border
+		{
+			AutomationId = "BorderWithSwipeViewContent",
+			Stroke = Colors.Black,
+			StrokeThickness = 2,
+			StrokeShape = new Microsoft.Maui.Controls.Shapes.RoundRectangle { CornerRadius = 12 },
+			Margin = new Thickness(24),
+			Content = swipeView
+		};
+
+		var resultLabel = new Label
+		{
+			AutomationId = "ResultLabel",
+			Text = "If you can see this, the app did not crash."
+		};
+
+		Content = new VerticalStackLayout
+		{
+			Padding = new Thickness(12),
+			Children =
+			{
+				resultLabel,
+				border
+			}
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36652.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36652.cs
@@ -1,0 +1,19 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue36652 : _IssuesUITest
+{
+	public Issue36652(TestDevice device) : base(device) { }
+
+	public override string Issue => "SwipeView directly inside a Border crashes natively on Windows";
+
+	[Test]
+	[Category(UITestCategories.Border)]
+	public void SwipeViewInsideBorderDoesNotCrash()
+	{
+		App.WaitForElement("ResultLabel");
+	}
+}

--- a/src/Core/src/Platform/Windows/ContentPanel.cs
+++ b/src/Core/src/Platform/Windows/ContentPanel.cs
@@ -251,6 +251,16 @@ namespace Microsoft.Maui.Platform
 				return;
 			}
 
+			// WinUI has a native crash when a geometric clip is assigned directly to a
+			// SwipeControl's element visual (regardless of load timing):
+			// https://github.com/microsoft/microsoft-ui-xaml/issues/10321
+			// Skip clipping the content in that case; the Border's stroke/path still renders,
+			// only the SwipeView's corners won't be visually clipped to the border shape.
+			if (Content is UI.Xaml.Controls.SwipeControl)
+			{
+				return;
+			}
+
 			var visual = ElementCompositionPreview.GetElementVisual(Content);
 
 			// Prevent clip collision: When ContentView is inside Border, let WrapperView handle 


### PR DESCRIPTION
<!-- Please keep the note below for people who find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment whether this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

This pull request addresses a native crash on Windows when a `SwipeView` is placed directly inside a `Border`. The main fix is to skip applying a geometric clip to the `SwipeControl`'s visual, which avoids the crash. Additional test cases are included to verify the fix.

### Description of Change
### Bug fix: Preventing native crash with SwipeView inside Border

* [`src/Core/src/Platform/Windows/ContentPanel.cs`](diffhunk://#diff-282a53fcf4708a9843eefb152f0572aa6df5de449b7cbaf6c9b49ecbb32fac1eR254-R263): Updated the `UpdateClip` method to skip applying a geometric clip if the content is a `SwipeControl`, preventing the WinUI crash described in [microsoft-ui-xaml#10321](https://github.com/microsoft/microsoft-ui-xaml/issues/10321).

### Test coverage

* [`src/Controls/tests/TestCases.HostApp/Issues/Issue36652.cs`](diffhunk://#diff-1c90ad4ee58981366523b97489991f0010153a35b637879a61cd94cd36696807R1-R65): Added a new test page that reproduces the crash scenario by placing a `SwipeView` directly inside a `Border`.
* [`src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36652.cs`](diffhunk://#diff-e1e4b9d6eb263aa6fcd679a8f2b181402382e905b4e8073e9cfc944ca29d9b07R1-R19): Added a UI test to verify that the app does not crash and the result label is visible when the scenario is loaded.

<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #36652 

### Tested the behavior in the following platforms

- [x] Windows
- [ ] Android
- [ ] iOS
- [ ] Mac

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <img width="1919" height="667" alt="BeforeFix36652" src="https://github.com/user-attachments/assets/fe0752e9-8cfa-45b1-9c80-1f767a3727ca" /> | <img width="1463" height="821" alt="AfterFix3662" src="https://github.com/user-attachments/assets/f46b84b6-568b-45b3-9002-821a080456c8" /> |
<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
