### PR TITLE
[Revert][Android] Fix CollectionView inside disabled RefreshView blocks scroll

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
@@ -42,11 +42,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public override bool OnInterceptTouchEvent(MotionEvent ev)
 		{
-			// If ItemsView is explicitly disabled, defer to the base implementation so it can
-			// intercept all touch events and block interaction. Returning false here (for either
-			// the swipe-disabled or off-axis delegation paths) would bypass that guard and allow
-			// a disabled CarouselView to delegate gestures to a nested child.
-			if (ItemsView?.IsEnabled == false && !ItemsView.IsExplicitlyEnabled)
+			// If ItemsView is disabled, defer to the base implementation to intercept all touch events and prevent interactions
+			if (ItemsView?.IsEnabled == false)
 			{
 				return base.OnInterceptTouchEvent(ev);
 			}

--- a/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
@@ -670,10 +670,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public override bool OnTouchEvent(MotionEvent e)
 		{
-			// If ItemsView is disabled, don't handle touch events.
-			// But only when the ItemsView itself is explicitly disabled, not when it inherits
-			// IsEnabled=false from a parent (e.g. RefreshView.IsEnabled=false propagating down).
-			if (ItemsView?.IsEnabled == false && !ItemsView.IsExplicitlyEnabled)
+			// If ItemsView is disabled, don't handle touch events
+			if (ItemsView?.IsEnabled == false)
 			{
 				return false;
 			}
@@ -685,7 +683,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public override bool DispatchTouchEvent(MotionEvent e)
 		{
-			if (ItemsView?.IsEnabled == false && !ItemsView.IsExplicitlyEnabled)
+			if (ItemsView?.IsEnabled == false)
 			{
 				return base.DispatchTouchEvent(e);
 			}
@@ -700,10 +698,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public override bool OnInterceptTouchEvent(MotionEvent e)
 		{
-			// If ItemsView is disabled, intercept all touch events to prevent interactions.
-			// But only when the ItemsView itself is explicitly disabled, not when it inherits
-			// IsEnabled=false from a parent (e.g. RefreshView.IsEnabled=false propagating down).
-			if (ItemsView?.IsEnabled == false && !ItemsView.IsExplicitlyEnabled)
+			// If ItemsView is disabled, intercept all touch events to prevent interactions
+			if (ItemsView?.IsEnabled == false)
 			{
 				return true;
 			}

--- a/src/Controls/src/Core/Handlers/Items/iOS/SelectableItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/SelectableItemsViewController.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		// _Only_ called if the user initiates the selection change; will not be called for programmatic selection
 		public override void ItemSelected(UICollectionView collectionView, NSIndexPath indexPath)
 		{
-			if (ItemsView?.ItemsSource is null || !ItemsView.IsExplicitlyEnabled)
+			if (ItemsView?.ItemsSource is null || !ItemsView.IsEnabled)
 			{
 				return;
 			}
@@ -35,7 +35,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		// _Only_ called if the user initiates the selection change; will not be called for programmatic selection
 		public override void ItemDeselected(UICollectionView collectionView, NSIndexPath indexPath)
 		{
-			if (ItemsView?.ItemsSource is null || !ItemsView.IsExplicitlyEnabled)
+			if (ItemsView?.ItemsSource is null || !ItemsView.IsEnabled)
 			{
 				return;
 			}
@@ -185,7 +185,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		internal void UpdateSelectionMode()
 		{
 			var mode = ItemsView.SelectionMode;
-			var isEnabled = ItemsView.IsExplicitlyEnabled;
+			var isEnabled = ItemsView.IsEnabled;
 
 			switch (mode)
 			{

--- a/src/Controls/src/Core/Handlers/Items2/iOS/SelectableItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/SelectableItemsViewController2.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		// _Only_ called if the user initiates the selection change; will not be called for programmatic selection
 		public override void ItemSelected(UICollectionView collectionView, NSIndexPath indexPath)
 		{
-			if (ItemsView?.ItemsSource is null || !ItemsView.IsExplicitlyEnabled)
+			if (ItemsView?.ItemsSource is null || !ItemsView.IsEnabled)
 			{
 				return;
 			}
@@ -36,7 +36,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		// _Only_ called if the user initiates the selection change; will not be called for programmatic selection
 		public override void ItemDeselected(UICollectionView collectionView, NSIndexPath indexPath)
 		{
-			if (ItemsView?.ItemsSource is null || !ItemsView.IsExplicitlyEnabled)
+			if (ItemsView?.ItemsSource is null || !ItemsView.IsEnabled)
 			{
 				return;
 			}
@@ -186,7 +186,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		internal void UpdateSelectionMode()
 		{
 			var mode = ItemsView.SelectionMode;
-			var isEnabled = ItemsView.IsExplicitlyEnabled;
+			var isEnabled = ItemsView.IsEnabled;
 
 			switch (mode)
 			{

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -39,12 +39,6 @@ namespace Microsoft.Maui.Controls
 
 		bool _isEnabledExplicit = (bool)IsEnabledProperty.DefaultValue;
 
-		/// <summary>
-		/// Gets the explicit value of <see cref="IsEnabled"/> set directly on this element,
-		/// before coercion by <see cref="IsEnabledCore"/> which factors in parent state.
-		/// </summary>
-		internal bool IsExplicitlyEnabled => _isEnabledExplicit;
-
 		/// <summary>Bindable property for <see cref="IsEnabled"/>.</summary>
 		public static readonly BindableProperty IsEnabledProperty = BindableProperty.Create(nameof(IsEnabled), typeof(bool),
 			typeof(VisualElement), BooleanBoxes.TrueBox, propertyChanged: OnIsEnabledPropertyChanged, coerceValue: CoerceIsEnabledProperty);

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34666.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34666.cs
@@ -1,6 +1,6 @@
 namespace Maui.Controls.Sample.Issues
 {
-	[Issue(IssueTracker.Github, 34666, "The C6 page cannot scroll on Windows and Android platforms", PlatformAffected.All)]
+	[Issue(IssueTracker.Github, 34666, "Disabling RefreshView cascades IsEnabled=false to its child CollectionView, preventing scrolling", PlatformAffected.All)]
 	public class Issue34666 : ContentPage
 	{
 		public Issue34666()

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34666.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34666.cs
@@ -1,4 +1,3 @@
-#if TEST_FAILS_ON_ANDROID
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -23,4 +22,3 @@ public class Issue34666 : _IssuesUITest
 		App.WaitForElement("Baboon");
 	}
 }
-#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34666.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34666.cs
@@ -11,11 +11,11 @@ public class Issue34666 : _IssuesUITest
 	{
 	}
 
-	public override string Issue => "The C6 page cannot scroll on Windows and Android platforms";
+	public override string Issue => "Disabling RefreshView cascades IsEnabled=false to its child CollectionView, preventing scrolling";
 
 	[Test]
 	[Category(UITestCategories.CollectionView)]
-	public void CollectionViewScrollsWhenRefreshViewDisabled()
+	public void CollectionViewDoesNotScrollWhenRefreshViewDisabled()
 	{
 		App.WaitForElement("Baboon");
 		App.ScrollDown("CollectionView");

--- a/src/Core/src/Platform/Android/MauiSwipeRefreshLayout.cs
+++ b/src/Core/src/Platform/Android/MauiSwipeRefreshLayout.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Maui.Platform
 
 		public override bool OnInterceptTouchEvent(MotionEvent? ev)
 		{
-			if (ev is null)
+			if (ev is null || !Enabled)
 				return false;
 
 			switch (ev.ActionMasked)

--- a/src/Core/src/Platform/Android/MauiSwipeRefreshLayout.cs
+++ b/src/Core/src/Platform/Android/MauiSwipeRefreshLayout.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Maui.Platform
 
 		public override bool OnInterceptTouchEvent(MotionEvent? ev)
 		{
-			if (ev is null || !Enabled)
+			if (ev is null)
 				return false;
 
 			switch (ev.ActionMasked)


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

- Reverts the IsExplicitlyEnabled carve-out introduced in PR #34702, which bypassed VisualElement's built-in IsEnabled cascading (via CoerceIsEnabledProperty) specifically for ItemsView touch handling on Android and iOS. This restores the default behavior, where disabling a parent (for example, RefreshView.IsEnabled = false) also disables touch interaction for its child views (for example, CollectionView).

### Reason
IsEnabled cascading from parent to child is expected, by-design behavior — VisualElement.IsEnabledCore (src/Controls/src/Core/VisualElement/VisualElement.cs) coerces a child's IsEnabled to false whenever any ancestor is disabled.

Issue #34666 was filed with an "Expected Behavior" of "Page C6 can scroll" — but the C6 manual test's own written pass-criteria only checks that the refresh spinner does not appear; it never specifies that the CollectionView must remain scrollable. The reporter's expectation goes beyond what C6 actually tests for, and contradicts  IsEnabled 's cascading behavior (per  IsEnabledCore) — the correct API for "block only the refresh gesture, keep content interactive" is  RefreshView.IsRefreshEnabled = false , not  IsEnabled = false .

### Changes
- **VisualElement.cs**: Removed the IsExplicitlyEnabled property entirely.
- **MauiCarouselRecyclerView.cs (Android)**: Reverted `OnInterceptTouchEvent` to check plain `IsEnabled` instead of `IsEnabled && !IsExplicitlyEnabled`, removing the same `IsExplicitlyEnabled` carve-out from `CarouselView`'s touch interception.
- **MauiRecyclerView.cs (Android)**: Reverted OnTouchEvent, DispatchTouchEvent, and OnInterceptTouchEvent to check plain IsEnabled instead of IsEnabled && !IsExplicitlyEnabled, restoring cascading block behavior.
- **SelectableItemsViewController.cs / SelectableItemsViewController2.cs (iOS)**: Reverted ItemSelected, ItemDeselected, and UpdateSelectionMode to use IsEnabled instead of IsExplicitlyEnabled.
- **Issue34666.cs (both TestCases.Shared.Tests and TestCases.HostApp**): Updated to reflect the restored, correct behavior:
    - Removed the `#if TEST_FAILS_ON_ANDROID` guard entirely so the test now runs on all platforms, since Android and iOS/macOS both correctly block scrolling.
    - Renamed CollectionViewScrollsWhenRefreshViewDisabled → CollectionViewDoesNotScrollWhenRefreshViewDisabled.
    - Changed the final assertion from "Gelada" (requires successful scroll) to "Baboon" (confirms scroll is blocked).
    - Updated the Issue description from "The C6 page cannot scroll on Windows and Android platforms" to "Disabling RefreshView cascades IsEnabled = false to its child CollectionView, preventing scrolling" since this is now the intended, correct behavior rather than an open bug.

### Issues Fixed
Relates to https://github.com/dotnet/maui/issues/34666 — the underlying report is describing  IsEnabled 's expected, by-design cascading behavior, not a bug; the correct fix for the reporter's actual use case is  IsRefreshEnabled = false , not  IsEnabled = false.