### PR TITLE
[WIP] [iOS] Attach TapGestureRecognizer to native UIButton for Button and ImageButton

### DIFF
--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
@@ -103,7 +103,9 @@ namespace Microsoft.Maui.Controls.Platform
 					if (uiGestureRecognizer is null)
 						continue;
 
-					PlatformView?.RemoveGestureRecognizer(uiGestureRecognizer);
+					// The gesture may have been attached to the inner UIControl instead of the container
+					// (see LoadRecognizers). Remove from whichever view actually holds it.
+					(uiGestureRecognizer.View ?? PlatformView)?.RemoveGestureRecognizer(uiGestureRecognizer);
 					uiGestureRecognizer.ShouldReceiveTouch = null;
 					uiGestureRecognizer.Dispose();
 				}
@@ -817,12 +819,30 @@ namespace Microsoft.Maui.Controls.Platform
 				_gestureRecognizers[recognizer] = nativeRecognizers;
 				foreach (UIGestureRecognizer? nativeRecognizer in nativeRecognizers)
 				{
-					if (nativeRecognizer != null && PlatformView != null)
+					// Cache PlatformView locally so nullable flow analysis carries through the block
+					// (PlatformView is a WeakReference-backed property, so each access is a separate call).
+					var platformView = PlatformView;
+					if (nativeRecognizer != null && platformView != null)
 					{
 						_proxy ??= new ShouldReceiveTouchProxy(this);
 						nativeRecognizer.ShouldReceiveTouch = _proxy.ShouldReceiveTouch;
 
-						PlatformView.AddGestureRecognizer(nativeRecognizer);
+						// If the inner platform view is a UIControl (e.g. UIButton, ImageButton) different
+						// from the container, adding the tap gesture to the container is unreliable because
+						// UIControl consumes touches via its own tracking mechanism. Attach the gesture
+						// directly to the UIControl so it fires when the user taps the control, and set
+						// CancelsTouchesInView = false so the control's own actions (e.g. Button.Clicked)
+						// continue to fire. See https://github.com/dotnet/maui/issues/19099.
+						UIView targetView = platformView;
+						if (nativeRecognizer is UITapGestureRecognizer &&
+							_handler.PlatformView is UIControl innerControl &&
+							!ReferenceEquals(innerControl, platformView))
+						{
+							nativeRecognizer.CancelsTouchesInView = false;
+							targetView = innerControl;
+						}
+
+						targetView.AddGestureRecognizer(nativeRecognizer);
 
 					}
 				}
@@ -856,7 +876,10 @@ namespace Microsoft.Maui.Controls.Platform
 					if (uiRecognizer is null)
 						continue;
 
-					PlatformView?.RemoveGestureRecognizer(uiRecognizer);
+					// The gesture may have been attached to the inner UIControl instead of the container
+					// (see the AddGestureRecognizer call earlier in this method). Remove from whichever
+					// view actually holds it.
+					(uiRecognizer.View ?? PlatformView)?.RemoveGestureRecognizer(uiRecognizer);
 
 					if (TryGetTapGestureRecognizer(gestureRecognizer, out TapGestureRecognizer? tapGestureRecognizer) &&
 						tapGestureRecognizer != null)

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
@@ -68,6 +68,25 @@ namespace Microsoft.Maui.Controls.Platform
 			}
 		}
 
+		// Returns the view that native gesture recognizers should be attached to.
+		//
+		// UIControl subclasses (UIButton, UISwitch, UISlider, UITextField, UISearchBar, etc.)
+		// consume touches through their own tracking mechanism (beginTracking/continueTracking),
+		// so a gesture recognizer attached to an ancestor container never receives the touch.
+		// This affects any control whose inner platform view is a UIControl once it ends up
+		// wrapped in a container - whether that's because a handler statically sets
+		// NeedsContainer => true (Button, ImageButton, Switch), or dynamically because Clip,
+		// Shadow, or Border is set on any other control (Slider, Entry, SearchBar, etc.). The
+		// check is therefore based on the actual inner platform view type rather than on why the
+		// wrapping occurred. See https://github.com/dotnet/maui/issues/19099.
+		UIView GetGestureTargetView(PlatformView container)
+		{
+			if (_handler.PlatformView is UIControl innerControl && !ReferenceEquals(innerControl, container))
+				return innerControl;
+
+			return container;
+		}
+
 		ObservableCollection<IGestureRecognizer>? ElementGestureRecognizers =>
 			(_handler.VirtualView as Element)?.GetCompositeGestureRecognizers() as ObservableCollection<IGestureRecognizer>;
 
@@ -827,19 +846,16 @@ namespace Microsoft.Maui.Controls.Platform
 						_proxy ??= new ShouldReceiveTouchProxy(this);
 						nativeRecognizer.ShouldReceiveTouch = _proxy.ShouldReceiveTouch;
 
-						// If the inner platform view is a UIControl (e.g. UIButton, ImageButton) different
-						// from the container, adding the tap gesture to the container is unreliable because
-						// UIControl consumes touches via its own tracking mechanism. Attach the gesture
-						// directly to the UIControl so it fires when the user taps the control, and set
-						// CancelsTouchesInView = false so the control's own actions (e.g. Button.Clicked)
-						// continue to fire. See https://github.com/dotnet/maui/issues/19099.
-						UIView targetView = platformView;
-						if (nativeRecognizer is UITapGestureRecognizer &&
-							_handler.PlatformView is UIControl innerControl &&
-							!ReferenceEquals(innerControl, platformView))
+						UIView targetView = GetGestureTargetView(platformView);
+						if (!ReferenceEquals(targetView, platformView))
 						{
+							// The gesture recognizer is attached directly to the inner UIControl instead
+							// of the container, so it participates in the control's own touch tracking.
+							// CancelsTouchesInView defaults to true, which would cancel the touch sequence
+							// delivered to the control once the gesture recognizes, suppressing the
+							// control's native action (e.g. Button.Clicked). Set it to false so both the
+							// gesture and the native action fire. See https://github.com/dotnet/maui/issues/19099.
 							nativeRecognizer.CancelsTouchesInView = false;
-							targetView = innerControl;
 						}
 
 						targetView.AddGestureRecognizer(nativeRecognizer);

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue19099.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue19099.cs
@@ -1,0 +1,41 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 19099, "TapGestureRecognizer no longer works on Button", PlatformAffected.iOS)]
+public class Issue19099 : ContentPage
+{
+    public Issue19099()
+    {
+        var resultLabel = new Label
+        {
+            AutomationId = "GestureResultLabel",
+            Text = "Not tapped"
+        };
+
+        var gestureButton = new Button
+        {
+            AutomationId = "GestureButton",
+            Text = "Tap me"
+        };
+
+        gestureButton.GestureRecognizers.Add(new TapGestureRecognizer
+        {
+            Command = new Command(() => resultLabel.Text = "Tapped")
+        });
+
+        Content = new VerticalStackLayout
+        {
+            Padding = new Thickness(20),
+            Spacing = 12,
+            Children =
+            {
+                new Label
+                {
+                    Text = "Tap the button. The test passes when the TapGestureRecognizer command updates the result label.",
+                    AutomationId = "InstructionLabel"
+                },
+                gestureButton,
+                resultLabel
+            }
+        };
+    }
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issue19099.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issue19099.cs
@@ -1,0 +1,25 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue19099 : _IssuesUITest
+{
+	public Issue19099(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue => "TapGestureRecognizer no longer works on Button";
+
+	[Test]
+	[Category(UITestCategories.Gestures)]
+	public void TapGestureRecognizerOnButtonInvokesCommand()
+	{
+		App.WaitForElement("GestureButton");
+		App.Tap("GestureButton");
+
+		var resultText = App.WaitForElement("GestureResultLabel").GetText();
+		Assert.That(resultText, Is.EqualTo("Tapped"), "The TapGestureRecognizer command on the Button did not run.");
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Description
On iOS, a `TapGestureRecognizer` attached to a `Button` or `ImageButton` does not fire when the control is tapped, while the `Clicked` event continues to work.

### Root Cause
`Button` and `ImageButton` always set `NeedsContainer = true`, causing the `TapGestureRecognizer` to be attached to the wrapper view instead of the native `UIButton`. However, touch events are handled by the inner `UIButton` (`UIControl`), which consumes the tap through its control tracking mechanism before the wrapper's gesture recognizer can receive it.

Unlike `Button` and `ImageButton`, controls such as `Slider`, `Stepper`, `Entry`, `SearchBar`, and `DatePicker` enable a container only when clipping, shadow, or border is required.

### Regression Details

This issue was introduced by PR #16868 when `NeedsContainer` was enabled for `ButtonHandler` on iOS to support the `Loaded` and `Unloaded` events. As a result, gesture recognizers were attached to the wrapper view instead of the native `UIButton`.

### Fix Description

- Updated `GesturePlatformManager.iOS.cs` to attach the `UITapGestureRecognizer` directly to the inner `UIControl` (`UIButton`) instead of the wrapper container for `Button` and `ImageButton`. 
- The recognizer is configured with `CancelsTouchesInView = false` so that both the `TapGestureRecognizer` and the `Button.Clicked` event are raised. 
- The cleanup logic was also updated to remove the gesture recognizer from `uiRecognizer.View ?? PlatformView`, ensuring proper disposal.

### Issues Fixed
Fixes #19099 

### Tested the behaviour in the following platforms
- [ ] Android
- [ ] Windows
- [x] iOS
- [x] Mac


### Output Screenshot
Before Issue Fix | After Issue Fix |
|----------|----------|
|<video width="100" height="100" alt="Before Fix" src="https://github.com/user-attachments/assets/6aff1b02-ee7b-4e08-9526-93eea3255378">|<video width="100" height="100" alt="After Fix" src="https://github.com/user-attachments/assets/f9c282d0-4403-4cfd-bf5b-0222f2a91cc2">|


