### PR TITLE
[ci-fix] De-flake RootViewSizeDoesntChangeAfterBackground: wait for restored layout to settle (refs #35738)

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue2818.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue2818.cs
@@ -34,7 +34,7 @@ public class Issue2818 : _IssuesUITest
 		Assert.That(positionStart, Is.Not.EqualTo(secondPosition));
 	}
 
-	[Test]  
+	[Test]
 	public async Task RootViewSizeDoesntChangeAfterBackground()
 	{
 		var idiom = App.WaitForElement("Idiom");
@@ -55,15 +55,17 @@ public class Issue2818 : _IssuesUITest
 		// Poll until the width stabilizes. After foregrounding, some platforms (esp. Android/iOS)
 		// may momentarily report an intermediate layout size while the window / flyout re-applies
 		// RTL + orientation constraints. This loop prevents test flakiness by waiting for the
-		// final (restored) size instead of asserting too early
+		// final (restored) size instead of asserting too early. A small tolerance accounts for
+		// sub-pixel rounding differences that can leave the restored size off by ~1px.
+		const double tolerance = 1.0;
 		int retries = 50;
-		while (newWindowSize.GetRect().Width != windowSize.GetRect().Width && retries-- > 0)
+		while (Math.Abs(newWindowSize.GetRect().Width - windowSize.GetRect().Width) > tolerance && retries-- > 0)
 		{
 			await Task.Delay(100);
 		}
 
-		Assert.That(newWindowSize.GetRect().Width, Is.EqualTo(windowSize.GetRect().Width));
-		Assert.That(newWindowSize.GetRect().Height, Is.EqualTo(windowSize.GetRect().Height));
+		Assert.That(newWindowSize.GetRect().Width, Is.EqualTo(windowSize.GetRect().Width).Within(tolerance));
+		Assert.That(newWindowSize.GetRect().Height, Is.EqualTo(windowSize.GetRect().Height).Within(tolerance));
 	}
 
 	[TearDown]


### PR DESCRIPTION
>**Note**

>Are you waiting for the changes in this PR to be merged?
>It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) >from this PR and let us know in a comment if this change resolves your issue. Thank you!

This pull request improves the reliability of the `RootViewSizeDoesntChangeAfterBackground` test by introducing a tolerance for minor sub-pixel differences when comparing window sizes. This helps prevent test failures due to insignificant rounding errors that can occur across different platforms.

**Test stability improvements:**

* Added a `tolerance` constant (1.0) to allow for small sub-pixel differences when comparing window sizes after backgrounding/foregrounding, reducing test flakiness.
* Updated the polling loop and assertions to use the tolerance value, ensuring the test passes even if the restored window size is off by up to 1 pixel.

Fixes #35738 
Fixes #37296