### PR TITLE
Add new versions to the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -42,11 +42,13 @@ body:
       label: Version with bug
       description: In what version do you see this issue? Run `dotnet workload list` to find your version.
       options:
+        - 11.0.0-preview.6
         - 11.0.0-preview.5
         - 11.0.0-preview.4
         - 11.0.0-preview.3
         - 11.0.0-preview.2
         - 11.0.0-preview.1
+        - 10.0.90
         - 10.0.80
         - 10.0.71
         - 10.0.70
@@ -176,11 +178,13 @@ body:
         - 10.0.70
         - 10.0.71
         - 10.0.80
+        - 10.0.90
         - 11.0.0-preview.1        
         - 11.0.0-preview.2   
         - 11.0.0-preview.3
         - 11.0.0-preview.4
         - 11.0.0-preview.5
+        - 11.0.0-preview.6
     validations:
       required: true
   - type: dropdown


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

- Adds the recently released `10.0.90` and `11.0.0-preview.6` versions to the bug report issue template dropdowns.
