### PR TITLE
Fix GradientBrush.GradientStops.Clear() leaks brushes when stops are shared

### DIFF
--- a/src/Controls/src/Core/GradientBrush.cs
+++ b/src/Controls/src/Core/GradientBrush.cs
@@ -45,7 +45,9 @@ namespace Microsoft.Maui.Controls
 			base.OnBindingContextChanged();
 
 			foreach (var gradientStop in GradientStops)
+			{
 				SetInheritedBindingContext(gradientStop, BindingContext);
+			}
 		}
 
 		void UpdateGradientStops(GradientStopCollection oldCollection, GradientStopCollection newCollection)
@@ -57,24 +59,32 @@ namespace Microsoft.Maui.Controls
 
 		void AttachCollection(GradientStopCollection collection)
 		{
-			if (collection == null)
+			if (collection is null)
+			{
 				return;
+			}
 
 			collection.CollectionChanged += OnGradientStopCollectionChanged;
 
 			foreach (var stop in collection)
+			{
 				SubscribeToGradientStop(stop);
+			}
 		}
 
 		void DetachCollection(GradientStopCollection collection)
 		{
-			if (collection == null)
+			if (collection is null)
+			{
 				return;
+			}
 
 			collection.CollectionChanged -= OnGradientStopCollectionChanged;
 
 			foreach (var stop in collection)
+			{
 				UnsubscribeFromGradientStop(stop);
+			}
 		}
 
 		void OnGradientStopCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
@@ -82,31 +92,39 @@ namespace Microsoft.Maui.Controls
 			switch (e.Action)
 			{
 				case NotifyCollectionChangedAction.Add:
-					if (e.NewItems != null)
+					if (e.NewItems is not null)
 					{
 						foreach (GradientStop stop in e.NewItems)
+						{
 							SubscribeToGradientStop(stop);
+						}
 					}
 					break;
 
 				case NotifyCollectionChangedAction.Remove:
-					if (e.OldItems != null)
+					if (e.OldItems is not null)
 					{
 						foreach (GradientStop stop in e.OldItems)
+						{
 							UnsubscribeFromGradientStop(stop);
+						}
 					}
 					break;
 
 				case NotifyCollectionChangedAction.Replace:
-					if (e.OldItems != null)
+					if (e.OldItems is not null)
 					{
 						foreach (GradientStop stop in e.OldItems)
+						{
 							UnsubscribeFromGradientStop(stop);
+						}
 					}
-					if (e.NewItems != null)
+					if (e.NewItems is not null)
 					{
 						foreach (GradientStop stop in e.NewItems)
+						{
 							SubscribeToGradientStop(stop);
+						}
 					}
 					break;
 
@@ -124,8 +142,10 @@ namespace Microsoft.Maui.Controls
 
 		void SubscribeToGradientStop(GradientStop stop)
 		{
-			if (stop == null)
+			if (stop is null)
+			{
 				return;
+			}
 
 			if (_subscriptionRefCounts.TryGetValue(stop, out var count))
 			{
@@ -140,11 +160,15 @@ namespace Microsoft.Maui.Controls
 
 		void UnsubscribeFromGradientStop(GradientStop stop)
 		{
-			if (stop == null)
+			if (stop is null)
+			{
 				return;
+			}
 
 			if (!_subscriptionRefCounts.TryGetValue(stop, out var count))
+			{
 				return;
+			}
 
 			if (count > 1)
 			{
@@ -172,11 +196,15 @@ namespace Microsoft.Maui.Controls
 		{
 			UnsubscribeFromAllGradientStops();
 
-			if (collection == null)
+			if (collection is null)
+			{
 				return;
+			}
 
 			foreach (var stop in collection)
+			{
 				SubscribeToGradientStop(stop);
+			}
 		}
 
 		void OnGradientStopPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/Controls/src/Core/GradientBrush.cs
+++ b/src/Controls/src/Core/GradientBrush.cs
@@ -1,5 +1,6 @@
 #nullable disable
 using System;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
 
@@ -9,6 +10,8 @@ namespace Microsoft.Maui.Controls
 	[ContentProperty(nameof(GradientStops))]
 	public abstract class GradientBrush : Brush
 	{
+		readonly Dictionary<GradientStop, int> _subscriptionRefCounts = new();
+
 		/// <summary>Initializes a new instance of the <see cref="GradientBrush"/> class.</summary>
 		public GradientBrush()
 		{
@@ -47,59 +50,133 @@ namespace Microsoft.Maui.Controls
 
 		void UpdateGradientStops(GradientStopCollection oldCollection, GradientStopCollection newCollection)
 		{
-			if (oldCollection != null)
-			{
-				oldCollection.CollectionChanged -= OnGradientStopCollectionChanged;
+			DetachCollection(oldCollection);
+			AttachCollection(newCollection);
+			Invalidate();
+		}
 
-				foreach (var oldStop in oldCollection)
-				{
-					oldStop.Parent = null;
-					oldStop.PropertyChanged -= OnGradientStopPropertyChanged;
-				}
-			}
-
-			if (newCollection == null)
+		void AttachCollection(GradientStopCollection collection)
+		{
+			if (collection == null)
 				return;
 
-			newCollection.CollectionChanged += OnGradientStopCollectionChanged;
+			collection.CollectionChanged += OnGradientStopCollectionChanged;
 
-			foreach (var newStop in newCollection)
-			{
-				if (newStop is not null)
-				{
-					newStop.Parent = this;
-					newStop.PropertyChanged += OnGradientStopPropertyChanged;
-				}
-			}
+			foreach (var stop in collection)
+				SubscribeToStop(stop);
+		}
+
+		void DetachCollection(GradientStopCollection collection)
+		{
+			if (collection == null)
+				return;
+
+			collection.CollectionChanged -= OnGradientStopCollectionChanged;
+
+			foreach (var stop in collection)
+				UnsubscribeFromStop(stop);
 		}
 
 		void OnGradientStopCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
-			if (e.OldItems != null)
+			switch (e.Action)
 			{
-				foreach (var oldItem in e.OldItems)
-				{
-					if (!(oldItem is GradientStop oldStop))
-						continue;
+				case NotifyCollectionChangedAction.Add:
+					if (e.NewItems != null)
+					{
+						foreach (GradientStop stop in e.NewItems)
+							SubscribeToStop(stop);
+					}
+					break;
 
-					oldStop.Parent = null;
-					oldStop.PropertyChanged -= OnGradientStopPropertyChanged;
-				}
-			}
+				case NotifyCollectionChangedAction.Remove:
+					if (e.OldItems != null)
+					{
+						foreach (GradientStop stop in e.OldItems)
+							UnsubscribeFromStop(stop);
+					}
+					break;
 
-			if (e.NewItems != null)
-			{
-				foreach (var newItem in e.NewItems)
-				{
-					if (!(newItem is GradientStop newStop))
-						continue;
+				case NotifyCollectionChangedAction.Replace:
+					if (e.OldItems != null)
+					{
+						foreach (GradientStop stop in e.OldItems)
+							UnsubscribeFromStop(stop);
+					}
+					if (e.NewItems != null)
+					{
+						foreach (GradientStop stop in e.NewItems)
+							SubscribeToStop(stop);
+					}
+					break;
 
-					newStop.Parent = this;
-					newStop.PropertyChanged += OnGradientStopPropertyChanged;
-				}
+				case NotifyCollectionChangedAction.Move:
+					// No subscription changes required.
+					break;
+
+				case NotifyCollectionChangedAction.Reset:
+					ResubscribeCollection(sender as GradientStopCollection);
+					break;
 			}
 
 			Invalidate();
+		}
+
+		void SubscribeToStop(GradientStop stop)
+		{
+			if (stop == null)
+				return;
+
+			if (_subscriptionRefCounts.TryGetValue(stop, out var count))
+			{
+				_subscriptionRefCounts[stop] = count + 1;
+				return;
+			}
+
+			_subscriptionRefCounts[stop] = 1;
+			stop.Parent = this;
+			stop.PropertyChanged += OnGradientStopPropertyChanged;
+		}
+
+		void UnsubscribeFromStop(GradientStop stop)
+		{
+			if (stop == null)
+				return;
+
+			if (!_subscriptionRefCounts.TryGetValue(stop, out var count))
+				return;
+
+			if (count > 1)
+			{
+				_subscriptionRefCounts[stop] = count - 1;
+				return;
+			}
+
+			_subscriptionRefCounts.Remove(stop);
+			stop.Parent = null;
+			stop.PropertyChanged -= OnGradientStopPropertyChanged;
+		}
+
+		void UnsubscribeFromAllStops()
+		{
+			foreach (var stop in _subscriptionRefCounts.Keys)
+			{
+				stop.Parent = null;
+				stop.PropertyChanged -= OnGradientStopPropertyChanged;
+			}
+
+			_subscriptionRefCounts.Clear();
+		}
+
+		void ResubscribeCollection(GradientStopCollection collection)
+		{
+			UnsubscribeFromAllStops();
+
+			if (collection == null)
+				return;
+
+			foreach (var stop in collection)
+				SubscribeToStop(stop);
 		}
 
 		void OnGradientStopPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/Controls/src/Core/GradientBrush.cs
+++ b/src/Controls/src/Core/GradientBrush.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Maui.Controls
 			collection.CollectionChanged += OnGradientStopCollectionChanged;
 
 			foreach (var stop in collection)
-				SubscribeToStop(stop);
+				SubscribeToGradientStop(stop);
 		}
 
 		void DetachCollection(GradientStopCollection collection)
@@ -74,7 +74,7 @@ namespace Microsoft.Maui.Controls
 			collection.CollectionChanged -= OnGradientStopCollectionChanged;
 
 			foreach (var stop in collection)
-				UnsubscribeFromStop(stop);
+				UnsubscribeFromGradientStop(stop);
 		}
 
 		void OnGradientStopCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
@@ -85,7 +85,7 @@ namespace Microsoft.Maui.Controls
 					if (e.NewItems != null)
 					{
 						foreach (GradientStop stop in e.NewItems)
-							SubscribeToStop(stop);
+							SubscribeToGradientStop(stop);
 					}
 					break;
 
@@ -93,7 +93,7 @@ namespace Microsoft.Maui.Controls
 					if (e.OldItems != null)
 					{
 						foreach (GradientStop stop in e.OldItems)
-							UnsubscribeFromStop(stop);
+							UnsubscribeFromGradientStop(stop);
 					}
 					break;
 
@@ -101,12 +101,12 @@ namespace Microsoft.Maui.Controls
 					if (e.OldItems != null)
 					{
 						foreach (GradientStop stop in e.OldItems)
-							UnsubscribeFromStop(stop);
+							UnsubscribeFromGradientStop(stop);
 					}
 					if (e.NewItems != null)
 					{
 						foreach (GradientStop stop in e.NewItems)
-							SubscribeToStop(stop);
+							SubscribeToGradientStop(stop);
 					}
 					break;
 
@@ -122,7 +122,7 @@ namespace Microsoft.Maui.Controls
 			Invalidate();
 		}
 
-		void SubscribeToStop(GradientStop stop)
+		void SubscribeToGradientStop(GradientStop stop)
 		{
 			if (stop == null)
 				return;
@@ -138,7 +138,7 @@ namespace Microsoft.Maui.Controls
 			stop.PropertyChanged += OnGradientStopPropertyChanged;
 		}
 
-		void UnsubscribeFromStop(GradientStop stop)
+		void UnsubscribeFromGradientStop(GradientStop stop)
 		{
 			if (stop == null)
 				return;
@@ -157,7 +157,7 @@ namespace Microsoft.Maui.Controls
 			stop.PropertyChanged -= OnGradientStopPropertyChanged;
 		}
 
-		void UnsubscribeFromAllStops()
+		void UnsubscribeFromAllGradientStops()
 		{
 			foreach (var stop in _subscriptionRefCounts.Keys)
 			{
@@ -170,13 +170,13 @@ namespace Microsoft.Maui.Controls
 
 		void ResubscribeCollection(GradientStopCollection collection)
 		{
-			UnsubscribeFromAllStops();
+			UnsubscribeFromAllGradientStops();
 
 			if (collection == null)
 				return;
 
 			foreach (var stop in collection)
-				SubscribeToStop(stop);
+				SubscribeToGradientStop(stop);
 		}
 
 		void OnGradientStopPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/Controls/src/Core/GradientBrush.cs
+++ b/src/Controls/src/Core/GradientBrush.cs
@@ -80,11 +80,7 @@ namespace Microsoft.Maui.Controls
 			}
 
 			collection.CollectionChanged -= OnGradientStopCollectionChanged;
-
-			foreach (var stop in collection)
-			{
-				UnsubscribeFromGradientStop(stop);
-			}
+			UnsubscribeFromAllGradientStops();
 		}
 
 		void OnGradientStopCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)

--- a/src/Controls/src/Core/GradientBrush.cs
+++ b/src/Controls/src/Core/GradientBrush.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Controls
 	[ContentProperty(nameof(GradientStops))]
 	public abstract class GradientBrush : Brush
 	{
-		readonly Dictionary<GradientStop, int> _subscriptionRefCounts = new();
+		readonly Dictionary<GradientStop, int> _subscriptionRefCounts = new(ReferenceEqualityComparer.Instance);
 
 		/// <summary>Initializes a new instance of the <see cref="GradientBrush"/> class.</summary>
 		public GradientBrush()

--- a/src/Controls/tests/Core.UnitTests/LinearGradientBrushTests.cs
+++ b/src/Controls/tests/Core.UnitTests/LinearGradientBrushTests.cs
@@ -237,5 +237,33 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			};
 			Assert.True(Brush.HasTransparency(allSemiTransparentBrush));
 		}
+
+		[Fact]
+		public void ClearUnsubscribesPreviousGradientStopsFromPropertyChanged()
+		{
+			var brush = new LinearGradientBrush();
+			var oldStop = new GradientStop { Color = Colors.Red, Offset = 0.0f };
+			var newStop = new GradientStop { Color = Colors.Blue, Offset = 1.0f };
+			var invalidations = 0;
+
+			brush.InvalidateGradientBrushRequested += (_, _) => invalidations++;
+
+			brush.GradientStops.Add(oldStop);
+			invalidations = 0;
+
+			brush.GradientStops.Clear();
+			invalidations = 0;
+
+			// If Reset handling does not unsubscribe old stops, mutating oldStop
+			// would incorrectly invalidate the brush.
+			oldStop.Color = Colors.Green;
+			Assert.Equal(0, invalidations);
+
+			brush.GradientStops.Add(newStop);
+			invalidations = 0;
+
+			newStop.Color = Colors.Purple;
+			Assert.Equal(1, invalidations);
+		}
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
GradientBrush subscribes to each GradientStop's PropertyChanged event, but GradientStops.Clear() raises a collection Reset with e.OldItems == null. Because GradientBrush.OnGradientStopCollectionChanged only unsubscribes stops from e.OldItems, cleared stops remain subscribed.

### Description of Change

<!-- Enter description of the fix in this section -->
Added a dictionary to track GradientStop subscriptions and manage event subscriptions correctly. Updated the collection change handling to support all collection actions, including Add, Remove, Replace, Move, and Reset. Fixed the Reset scenario by properly unsubscribing from existing GradientStop instances before re-subscribing to the current collection items. Also added reference counting to correctly handle duplicate GradientStop instances and refactored the collection attach/detach logic into helper methods to improve code maintainability.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #36743

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

**Tested the behavior in the following platforms.**
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

| Before  | After  |
|---------|--------|
| **Android**<br> <video src="https://github.com/user-attachments/assets/6c924225-c68a-44e6-8062-e705eaeb8402" width="600" height="300"> | **Android**<br> <video src="https://github.com/user-attachments/assets/28315b3b-05a6-4935-8f86-0316058986a4" width="600" height="300"> |