### PR TITLE
[Windows] Fix COMException when changing Image BackgroundColor via binding after navigation

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue36694.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue36694.cs
@@ -1,0 +1,118 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 36694, "Setting BackgroundColor on Image via binding causes COMException after navigation", PlatformAffected.UWP)]
+public class Issue36694 : NavigationPage
+{
+	public Issue36694() : base(new Issue36694MainPage())
+	{
+	}
+}
+
+public class Issue36694MainPage : ContentPage
+{
+	public Issue36694MainPage()
+	{
+		var viewModel = new Issue36694ViewModel();
+		BindingContext = viewModel;
+
+		var image = new Image
+		{
+			WidthRequest = 100,
+			HeightRequest = 100,
+			Source = "dotnet_bot.png",
+			AutomationId = "TestImage"
+		};
+		image.SetBinding(Image.BackgroundColorProperty, nameof(Issue36694ViewModel.ImageBackgroundColor));
+
+		var navigateButton = new Button
+		{
+			Text = "Navigate to Options",
+			AutomationId = "NavigateButton"
+		};
+		navigateButton.Clicked += async (s, e) =>
+		{
+			await Navigation.PushAsync(new Issue36694OptionsPage(viewModel));
+		};
+
+		var resultLabel = new Label
+		{
+			Text = "No exception",
+			AutomationId = "ResultLabel"
+		};
+
+		Content = new VerticalStackLayout
+		{
+			Padding = 20,
+			Spacing = 15,
+			Children =
+			{
+				image,
+				navigateButton,
+				resultLabel
+			}
+		};
+	}
+}
+
+public class Issue36694OptionsPage : ContentPage
+{
+	public Issue36694OptionsPage(Issue36694ViewModel viewModel)
+	{
+		Title = "Options";
+
+		var changeColorButton = new Button
+		{
+			Text = "Change BackgroundColor to Red",
+			AutomationId = "ChangeColorButton"
+		};
+		changeColorButton.Clicked += (s, e) => viewModel.ImageBackgroundColor = Colors.Red;
+
+		var goBackButton = new Button
+		{
+			Text = "Go Back",
+			AutomationId = "GoBackButton"
+		};
+		goBackButton.Clicked += async (s, e) => await Navigation.PopAsync();
+
+		Content = new VerticalStackLayout
+		{
+			Padding = 20,
+			Spacing = 15,
+			Children =
+			{
+				new Label { Text = "Change background color while on a different page:" },
+				changeColorButton,
+				goBackButton
+			}
+		};
+	}
+}
+
+public class Issue36694ViewModel : INotifyPropertyChanged
+{
+	// Must start as null to reproduce the bug. A non-null Background makes
+	// ImageHandler.NeedsContainer true from the first render, so the container
+	// already exists and the COMException never occurs.
+	Color _imageBackgroundColor;
+	public Color ImageBackgroundColor
+	{
+		get => _imageBackgroundColor;
+		set
+		{
+			if (_imageBackgroundColor != value)
+			{
+				_imageBackgroundColor = value;
+				OnPropertyChanged();
+			}
+		}
+	}
+
+	public event PropertyChangedEventHandler PropertyChanged;
+	protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+	{
+		PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36694.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36694.cs
@@ -1,0 +1,24 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue36694 : _IssuesUITest
+{
+	public Issue36694(TestDevice device) : base(device) { }
+
+	public override string Issue => "Setting BackgroundColor on Image via binding causes COMException after navigation";
+
+	[Test]
+	[Category(UITestCategories.Image)]
+	public void ChangingImageBackgroundColorAfterNavigationShouldNotThrowCOMException()
+	{
+		App.WaitForElement("TestImage");
+		App.Tap("NavigateButton");
+		App.WaitForElement("ChangeColorButton");
+		App.Tap("ChangeColorButton");
+		App.Tap("GoBackButton");
+		App.WaitForElement("ResultLabel");
+	}
+}

--- a/src/Core/src/Handlers/Image/ImageHandler.Windows.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.Windows.cs
@@ -137,8 +137,28 @@ namespace Microsoft.Maui.Handlers
 		/// <param name="image">The associated <see cref="Image"/> instance.</param>
 		public static void MapBackground(IImageHandler handler, IImage image)
 		{
-			handler.UpdateValue(nameof(IViewHandler.ContainerView));
-			handler.ToPlatform().UpdateBackground(image);
+			if (handler.PlatformView is null)
+			{
+				return;
+			}
+
+			if (handler is ImageHandler imghandler)
+			{
+				var platformView = imghandler.PlatformView;
+				if (platformView.IsLoaded)
+				{
+					handler.UpdateValue(nameof(IViewHandler.ContainerView));
+					handler.ToPlatform().UpdateBackground(image);
+				}
+				else
+				{
+					// Defer container creation until the view is in the active visual tree.
+					// Manipulating the parent panel while the page is not loaded causes a
+					// COMException. See https://github.com/dotnet/maui/issues/36694
+					platformView.Loaded -= imghandler.OnImageLoaded;
+					platformView.Loaded += imghandler.OnImageLoaded;
+				}
+			}
 		}
 
 		/// <summary>
@@ -187,6 +207,7 @@ namespace Microsoft.Maui.Handlers
 				}
 
 				UpdateValue(nameof(IViewHandler.ContainerView));
+				UpdateValue(nameof(IImage.Background));
 			}
 		}
 

--- a/src/Core/src/Handlers/Image/ImageHandler.Windows.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.Windows.cs
@@ -142,23 +142,20 @@ namespace Microsoft.Maui.Handlers
 				return;
 			}
 
-			if (handler is ImageHandler imghandler)
+			if (handler is ImageHandler imghandler && !imghandler.PlatformView.IsLoaded)
 			{
+				// Defer container creation until the view is in the active visual tree.
+				// Manipulating the parent panel while the page is not loaded causes a
+				// COMException. See https://github.com/dotnet/maui/issues/36694
 				var platformView = imghandler.PlatformView;
-				if (platformView.IsLoaded)
-				{
-					handler.UpdateValue(nameof(IViewHandler.ContainerView));
-					handler.ToPlatform().UpdateBackground(image);
-				}
-				else
-				{
-					// Defer container creation until the view is in the active visual tree.
-					// Manipulating the parent panel while the page is not loaded causes a
-					// COMException. See https://github.com/dotnet/maui/issues/36694
-					platformView.Loaded -= imghandler.OnImageLoaded;
-					platformView.Loaded += imghandler.OnImageLoaded;
-				}
+				platformView.Loaded -= imghandler.OnImageLoaded;
+				platformView.Loaded += imghandler.OnImageLoaded;
+				return;
 			}
+
+			// Applies immediately for a loaded ImageHandler or any other IImageHandler implementation.
+			handler.UpdateValue(nameof(IViewHandler.ContainerView));
+			handler.ToPlatform().UpdateBackground(image);
 		}
 
 		/// <summary>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->


### Issue Details
Setting BackgroundColor on an Image control through a ViewModel binding crashes the app with a COMException on Windows. The crash only happens when the color starts as null and is changed while the user has navigated to a different page. The Image on the previous page is still bound to the ViewModel, so the property change triggers handler code on an unloaded view.

### Root Cause
When the BackgroundColor changes from null to a color, the ImageHandler needs to create a WrapperView container around the native Image. This involves removing the Image from its parent panel and re-adding it inside the new container. On Windows, when the page is navigated away, the Image is unloaded from the visual tree — WinUI throws a COMException because it forbids adding disconnected elements to new panels.

### Description of Change
Added an IsLoaded check in MapBackground before attempting container creation. If the Image is not currently in the visual tree, the work is deferred by subscribing to the Loaded event. When the user navigates back and the page loads again, OnImageLoaded fires and safely creates the container and applies the background

Validated the behavior in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
### Issues Fixed
  
Fixes #36694 

### Output  ScreenShot

|Before|After|
|--|--|
| <video src="https://github.com/user-attachments/assets/f0bf2ce9-48ae-45e5-8a50-635a34436184" >| <video src="https://github.com/user-attachments/assets/f2ae02ca-fec7-4d2f-ad96-d9f066ad9b10">|