### PR TITLE
[Android] Fix ActivityIndicator remaining visible after IsRunning/IsVisible set to false

### DIFF
--- a/src/Core/src/Platform/Android/ActivityIndicatorExtensions.cs
+++ b/src/Core/src/Platform/Android/ActivityIndicatorExtensions.cs
@@ -7,28 +7,28 @@ namespace Microsoft.Maui.Platform
 	{
 		public static void UpdateIsRunning(this ProgressBar progressBar, IActivityIndicator activityIndicator)
 		{
-			// Guard: check IsDisposed() before accessing any view properties to avoid ObjectDisposedException
-			// on a ProgressBar whose native handle has already been released (see ViewExtensions pattern).
+			// Guard: check IsDisposed() before touching any view properties to avoid an
+			// ObjectDisposedException on a ProgressBar whose native handle was already released.
 			if (progressBar.IsDisposed())
 			{
 				return;
 			}
 
-			// Pre-compute the desired visibility from the current activityIndicator state before deferring,
-			// so the lambda performs a simple write with no risk of reading stale handler state.
-			// Defer via Post() only when a layout traversal is in progress OR the view is not yet attached
-			// (RecyclerView header collapse scenario, see https://github.com/dotnet/maui/issues/33780).
-			// On the common path (attached, idle), apply synchronously so that existing tests and callers
-			// that read state immediately after update continue to work correctly.
+			// Defer via Post() only when a layout traversal is in progress OR the view is not yet
+			// attached (RecyclerView header collapse scenario). On the common path (attached, idle),
+			// apply synchronously so existing tests and callers that read state immediately after the
+			// update continue to work correctly.
 			if (progressBar.IsInLayout || !progressBar.IsAttachedToWindow)
 			{
-				var targetVisibility = GetActivityIndicatorVisibility(activityIndicator);
 				progressBar.Post(() =>
 				{
-					// Guard: skip if the view was recycled/disposed or detached before the runnable fired.
+					// Guard: skip if the view was disposed before the runnable fired.
 					if (!progressBar.IsDisposed())
 					{
-						progressBar.Visibility = targetVisibility;
+						// Re-read the LIVE visibility here instead of capturing a snapshot before the
+						// Post(). Capturing a stale "show" value caused this deferred runnable to
+						// resurrect an indicator that was hidden after it was queued.
+						progressBar.Visibility = GetActivityIndicatorVisibility(activityIndicator);
 					}
 				});
 			}

--- a/src/Core/tests/DeviceTests/Handlers/ActivityIndicator/ActivityIndicatorHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ActivityIndicator/ActivityIndicatorHandlerTests.Android.cs
@@ -32,5 +32,35 @@ namespace Microsoft.Maui.DeviceTests
 			var id = await GetValueAsync(view, handler => GetVisibility(handler));
 			Assert.Equal(view.Visibility, id);
 		}
+
+		[Fact(DisplayName = "Deferred Show Does Not Resurrect A Hidden Indicator")]
+		public async Task DeferredShowDoesNotResurrectHiddenIndicator()
+		{
+			var activityIndicator = new ActivityIndicatorStub
+			{
+				IsRunning = true,
+				Visibility = Visibility.Visible
+			};
+
+			var visibility = await InvokeOnMainThreadAsync(async () =>
+			{
+				var handler = CreateHandler(activityIndicator);
+				var progressBar = handler.PlatformView;
+
+				activityIndicator.IsRunning = false;
+				activityIndicator.Visibility = Visibility.Collapsed;
+
+				ViewStates result = ViewStates.Visible;
+				await progressBar.AttachAndRun(async () =>
+				{
+					await Task.Delay(100);
+					result = progressBar.Visibility;
+				});
+
+				return result;
+			});
+
+			Assert.Equal(ViewStates.Gone, visibility);
+		}
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
- An ActivityIndicator hidden right after page load (IsRunning/IsVisible = false) can stay visibly stuck on screen even though both properties are false.

### Root Cause
- The PR #35358 fixed ActivityIndicators not animating after a CollectionView header height change by deferring the ProgressBar visibility write via Post(...), but it captured the visibility as a snapshot when the runnable was queued — due to which a deferred visibility update could run after a later synchronous hide and re-apply its stale (Visible) value, leaving the indicator stuck visible even though IsRunning/IsVisible were false.


### Description of Change
- Updated ActivityIndicatorExtensions.UpdateIsRunning to re-read the current visibility state inside the deferred Post() lambda, preventing a previously captured "show" value from incorrectly making a hidden indicator visible again.


### Issues Fixed
Fixes #36735

### Validated the behaviour in the following platforms

- [ ] Windows
- [x] Android
- [ ] iOS
- [ ] Mac

### Output

| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/b54863bf-c589-4e79-8ae6-9ef87076e70b"> | <video src="https://github.com/user-attachments/assets/0dc0254c-8fa6-4e20-a033-53b7a7da549f"> |