### PR TITLE
[net11.0] Fix main merge build errors

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -156,11 +156,11 @@
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftNETTestSdkPackageVersion>17.6.0</MicrosoftNETTestSdkPackageVersion>
-    <XunitPackageVersion>2.9.0</XunitPackageVersion>
+    <XunitPackageVersion>2.9.3</XunitPackageVersion>
     <XunitRunnerVisualStudioPackageVersion>2.8.2</XunitRunnerVisualStudioPackageVersion>
-    <XunitExtensibilityExecutionPackageVersion>2.9.0</XunitExtensibilityExecutionPackageVersion>
-    <XunitAssertPackageVersion>2.9.0</XunitAssertPackageVersion>
-    <XUnitAnalyzersPackageVersion>1.15.0</XUnitAnalyzersPackageVersion>
+    <XunitExtensibilityExecutionPackageVersion>$(XunitPackageVersion)</XunitExtensibilityExecutionPackageVersion>
+    <XunitAssertPackageVersion>$(XunitPackageVersion)</XunitAssertPackageVersion>
+    <XUnitAnalyzersPackageVersion>1.18.0</XUnitAnalyzersPackageVersion>
     <XunitAbstractionsPackageVersion>2.0.3</XunitAbstractionsPackageVersion>
     <NSubstitutePackageVersion>5.1.0</NSubstitutePackageVersion>
     <CoverletCollectorPackageVersion>6.0.0</CoverletCollectorPackageVersion>

--- a/src/Essentials/src/Screenshot/Screenshot.android.cs
+++ b/src/Essentials/src/Screenshot/Screenshot.android.cs
@@ -56,10 +56,8 @@ namespace Microsoft.Maui.Media
 			return bitmap is null ? null : new ScreenshotResult(bitmap);
 		}
 
-#nullable enable annotations
 		public Task<IScreenshotResult?> CaptureViewAsync(object platformView) =>
 			platformView is View view ? CaptureAsync(view)! : Task.FromResult<IScreenshotResult?>(null);
-#nullable restore
 
 		static async Task<Bitmap?> RenderAsync(View view, Window? window)
 		{


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

Fixes the compilation and restore blockers found in #36733. This intentionally does not address unrelated failing tests.

## Changes

- Keep nullable annotations enabled throughout `Screenshot.android.cs`, fixing the Android `CS8632` compiler errors.
- Align xUnit packages and analyzers with the `2.9.3` dependencies required by the XHarness package, fixing the `NU1107`, `NU1605`, and `NU1608` restore failures.

## Validation

- `dotnet cake` completes successfully with zero errors.
- The CI-style macOS solution build no longer reports the xUnit/XHarness restore conflicts or `Screenshot.android.cs` compiler errors. The local run proceeds until the machine-specific Xcode 26.6 SDK requirement (`MT0180`).
