### PR TITLE
[MacCatalyst] Fix page content clipped behind TitleBar on first navigation

### DIFF
--- a/src/Core/src/Platform/iOS/WindowViewController.cs
+++ b/src/Core/src/Platform/iOS/WindowViewController.cs
@@ -160,8 +160,11 @@ internal class WindowViewController : UIViewController
 		
 		IsFirstLayout = true;
 		LayoutTitleBar();
-		// Force immediate constraint processing so _contentWrapperView repositions below the TitleBar.
-		View?.LayoutIfNeeded();
+		if (OperatingSystem.IsMacCatalystVersionAtLeast(26))
+		{
+			// Force immediate constraint processing so _contentWrapperView repositions below the TitleBar.
+			View?.LayoutIfNeeded();
+		}
 	}
 
 	/// <summary>

--- a/src/Core/src/Platform/iOS/WindowViewController.cs
+++ b/src/Core/src/Platform/iOS/WindowViewController.cs
@@ -146,11 +146,6 @@ internal class WindowViewController : UIViewController
 		
 		_isTitleBarVisible = (iTitleBar?.Visibility == Visibility.Visible);
 
-		// Layout the TitleBar first so the constraint reflects the correct height before
-		// hiding the system titlebar, which may synchronously trigger SafeAreaInsetsDidChange.
-		IsFirstLayout = true;
-		LayoutTitleBar();
-
 		var platformTitleBar = platformWindow.WindowScene?.Titlebar;
 
 		if (newTitleBar is not null && platformTitleBar is not null)
@@ -162,7 +157,10 @@ internal class WindowViewController : UIViewController
 		{
 			platformTitleBar.TitleVisibility = UITitlebarTitleVisibility.Visible;
 		}
-			
+		
+		IsFirstLayout = true;
+		LayoutTitleBar();
+		// Force immediate constraint processing so _contentWrapperView repositions below the TitleBar.
 		View?.LayoutIfNeeded();
 	}
 

--- a/src/Core/src/Platform/iOS/WindowViewController.cs
+++ b/src/Core/src/Platform/iOS/WindowViewController.cs
@@ -146,6 +146,11 @@ internal class WindowViewController : UIViewController
 		
 		_isTitleBarVisible = (iTitleBar?.Visibility == Visibility.Visible);
 
+		// Layout the TitleBar first so the constraint reflects the correct height before
+		// hiding the system titlebar, which may synchronously trigger SafeAreaInsetsDidChange.
+		IsFirstLayout = true;
+		LayoutTitleBar();
+
 		var platformTitleBar = platformWindow.WindowScene?.Titlebar;
 
 		if (newTitleBar is not null && platformTitleBar is not null)
@@ -157,9 +162,8 @@ internal class WindowViewController : UIViewController
 		{
 			platformTitleBar.TitleVisibility = UITitlebarTitleVisibility.Visible;
 		}
-
-		IsFirstLayout = true;
-		LayoutTitleBar();
+			
+		View?.LayoutIfNeeded();
 	}
 
 	/// <summary>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->


### Issue Details
On MacCatalyst, page content renders clipped behind a custom TitleBar (with large HeightRequest) on the first navigation. 

### Root Cause
LayoutTitleBar() sets _contentWrapperTopConstraint.Constant to the TitleBar height but UIKit defers applying it — so _contentWrapperView.Frame is not updated immediately, causing content to render behind the TitleBar.

### Description of Change
Added View?.LayoutIfNeeded() after LayoutTitleBar() in SetUpTitleBar() to force UIKit to immediately process the pending constraint and reposition _contentWrapperView.

Validated the behavior in the following platforms
 
- [ ] Android
- [ ] Windows
- [ ] iOS
- [x] Mac
 
### Issues Fixed
  
Fixes #36716 

### Test case

The [Issue24489_2](https://github.com/dotnet/maui/blob/main/src/Controls/tests/TestCases.HostApp/Issues/Issue24489_2.xaml) test case is already present in the main source code.

### Output  ScreenShot

|Before|After|
|--|--|
| <img width="1872" height="1222" alt="image" src="https://github.com/user-attachments/assets/ce6b970d-de21-40a7-b1a2-df5a17c6fd5a" /> | <img width="1872" height="1222" alt="image" src="https://github.com/user-attachments/assets/5c7668c6-fbc7-42be-b91b-99d477a08085" />| 

