### PR TITLE
[inflight regression][iOS] Fix CarouselView2 dropping scrolls after ItemsSource swap/reset

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
@@ -126,6 +126,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		{
 			UnsubscribeCollectionItemsSourceChanged(ItemsSource);
 			_isUpdating = true;
+			// Pending scroll target belongs to the old source; clear it.
+			_gotoPosition = -1;
 			base.UpdateItemsSource();
 			//we don't need to Subscribe because base calls CreateItemsViewSource
 			_carouselViewLoopManager?.SetItemsSource(LoopItemsSource);
@@ -134,6 +136,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			{
 				carousel.SetValueFromRenderer(CarouselView.CurrentItemProperty, null);
 				carousel.SetValueFromRenderer(CarouselView.PositionProperty, 0);
+				// The Position=0 reset above sets _gotoPosition; clear it so later programmatic Position/CurrentItem changes aren't suppressed.
+				_gotoPosition = -1;
 			}
 			_isUpdating = false;
 		}
@@ -215,6 +219,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			_isUpdating = false;
 			_isRotating = false;
 			_isInternalCollectionUpdate = false;
+			// Don't let a pending scroll target survive re-attach.
+			_gotoPosition = -1;
 		}
 
 		internal void UpdateScrollingConstraints()
@@ -366,6 +372,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 			_isUpdating = false;
 			ScrollToPosition(targetPosition, targetPosition, false, true);
+			// The forced scroll above sets _gotoPosition but fires no callback when already at the target; clear it so a later user-initiated scroll isn't suppressed.
+			_gotoPosition = -1;
 		}
 
 		int GetPositionWhenAddingItems(int carouselPosition, int currentItemPosition)

--- a/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
@@ -136,7 +136,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			{
 				carousel.SetValueFromRenderer(CarouselView.CurrentItemProperty, null);
 				carousel.SetValueFromRenderer(CarouselView.PositionProperty, 0);
-				// The Position=0 reset above sets _gotoPosition; clear it so later programmatic Position/CurrentItem changes aren't suppressed.
+				// The Position=0 reset above indirectly sets _gotoPosition via
+				// UpdateFromPosition -> ScrollToPosition(0, oldPos, ...); clear it so later
+				// programmatic Position/CurrentItem changes aren't suppressed.
 				_gotoPosition = -1;
 			}
 			_isUpdating = false;
@@ -480,6 +482,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			CollectionView.ReloadData();
 
 			ScrollToPosition(carouselPosition, carouselPosition, false, true);
+
+			// Symmetric to CollectionViewUpdated: this forced re-center may leave
+			// _gotoPosition stuck (no-op scroll, or dropped while another scroll was
+			// in-flight), so clear it to avoid blocking future programmatic scrolls.
+			_gotoPosition = -1;
 		}
 
 		void UpdateScrollBarVisibility()


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
- On iOS 18.5 and Mac (CI only), the CarouselViewShouldScrollToRightPosition and VerifyCarouselScrollsToEndItemAfterReset UI test are failing in candidate PR #36411 due to the fix in PR #35848.

### Root Cause
- PR #35848's _gotoPosition guard in CarouselViewController2 (iOS) is set by every call to ScrollToPosition and expected to be cleared by the scroll callback, but two internal scrolls — the SetValueFromRenderer(Position, 0) in UpdateItemsSource's reset branch and the forced ScrollToPosition(target, target, animated:false, forceScroll:true) at the end of CollectionViewUpdated — set it without producing a callback, so the stale value silently drops the next programmatic scroll.

### Description of Change
- Cleared _gotoPosition when updating the items source to prevent scroll targets from the old source affecting the new data.
- Cleared _gotoPosition after resetting the Position property to ensure future programmatic changes are not suppressed.
- Cleared _gotoPosition during teardown to avoid leftover scroll targets when the view is re-attached.
- Cleared _gotoPosition after a forced scroll in CollectionViewUpdated to prevent suppression of later user-initiated scrolls.
- Cleared _gotoPosition after the forced scroll in UpdateLoop() to prevent it from becoming stale when the Loop property is toggled and the previous re-centering scroll is skipped or does not generate a callback.



### Issues Fixed
Fixes #36718

### Validated the behaviour in the following platforms

- [ ] Windows
- [ ] Android
- [x] iOS
- [x] Mac

### Output

| TestCase | Before | After |
|----------|----------|----------|
| VerifyCarouselScrollsToEndItemAfterReset | <img src="https://github.com/user-attachments/assets/a5c7bf90-cd77-4153-bafd-be60a0b90e14"> | <img src="https://github.com/user-attachments/assets/30823197-0c81-4f0a-9f1e-f591e58c1bc2"> |
| CarouselViewShouldScrollToRightPosition | <img src="https://github.com/user-attachments/assets/661a65a8-a2ce-4b20-ac8b-4ff70f2c9b4d"> | <img src="https://github.com/user-attachments/assets/eaaabfd2-f408-4713-9941-5383ef71d9e8"> |