### PR TITLE
Fix grouped CollectionView section removal on iOS

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/ObservableGroupedSource.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ObservableGroupedSource.cs
@@ -166,7 +166,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			// Force UICollectionView to get the internal accounting straight
 			var collectionView = controller.CollectionView;
-			UpdateSection(collectionView);
+			// For Remove, the source has already changed while UICollectionView still has its old sections.
+			if (args.Action != NotifyCollectionChangedAction.Remove)
+			{
+				UpdateSection(collectionView);
+			}
 
 			switch (args.Action)
 			{

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
@@ -49,6 +49,54 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact(DisplayName = "Removing a grouped CollectionView section does not crash")]
+		public async Task RemovingGroupedCollectionViewSectionDoesNotCrash()
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler<CollectionView, CollectionViewHandler2>();
+					handlers.AddHandler<Label, LabelHandler>();
+				});
+			});
+
+			var data = new List<string> { "item 1", "item 2" };
+			var groupData = new ObservableCollection<CollectionViewStringGroup>
+			{
+				new("Header 1", data),
+				new("Header 2", data),
+				new("Header 3", data)
+			};
+
+			var collectionView = new CollectionView
+			{
+				WidthRequest = 300,
+				HeightRequest = 300,
+				IsGrouped = true,
+				ItemsSource = groupData,
+				ItemTemplate = new DataTemplate(() => new Label())
+			};
+
+			var initialFrame = collectionView.Frame;
+
+			await CreateHandlerAndAddToWindow<CollectionViewHandler2>(collectionView, async handler =>
+			{
+				await WaitForUIUpdate(initialFrame, collectionView);
+
+				var uiCollectionView = handler.Controller.CollectionView;
+				uiCollectionView.SetNeedsLayout();
+				uiCollectionView.LayoutIfNeeded();
+				Assert.Equal(groupData.Count, (int)uiCollectionView.NumberOfSections());
+
+				groupData.RemoveAt(groupData.Count - 1);
+
+				uiCollectionView.SetNeedsLayout();
+				uiCollectionView.LayoutIfNeeded();
+				Assert.Equal(groupData.Count, (int)uiCollectionView.NumberOfSections());
+			});
+		}
+
 		class CollectionViewStringGroup : List<string>
 		{
 			public string GroupHeader { get; private set; }

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		class CollectionViewStringGroup : List<string>
+		class CollectionViewStringGroup : ObservableCollection<string>
 		{
 			public string GroupHeader { get; private set; }
 			public CollectionViewStringGroup(string header, IEnumerable<string> data) : base(data)


### PR DESCRIPTION
### Description of Change

Fixes the grouped iOS `CollectionView` removal path when UIKit still holds the old section count after an `INotifyCollectionChanged.Remove` notification. `UpdateSection` now runs only after `Remove`, when `DeleteSections` has reconciled UIKit with the already-mutated source.

Adds an iOS device regression test for the active `CollectionViewHandler2`. The test explicitly registers Handler2, verifies UIKit has realized all groups before removal, and then verifies the native section count after removal.

This supersedes #34692 and incorporates its review feedback: the test uses the active handler and cannot pass through the unloaded/reload path without exercising the stale-section scenario.

### Issues Fixed

Fixes #34691