### PR TITLE
[Android] Fix PickPhotosAsync remains pending when its activity is recreated while Photo Picker is open

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue36523.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue36523.cs
@@ -1,0 +1,149 @@
+using Microsoft.Maui.Media;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 36523, "MediaPicker.PickPhotosAsync hangs after device rotation on API 33+", PlatformAffected.Android)]
+public class Issue36523 : ContentPage
+{
+	public Issue36523()
+	{
+		var openButton = new Button { AutomationId = "OpenRotationActivityButton", Text = "Open Rotation Activity" };
+		openButton.Clicked += (_, _) =>
+		{
+#if ANDROID
+			Issue36523State.Reset();
+			var activity = Microsoft.Maui.ApplicationModel.Platform.CurrentActivity!;
+			activity.StartActivity(new Android.Content.Intent(activity, typeof(Issue36523RotationActivity)));
+#endif
+		};
+		Content = new VerticalStackLayout { Padding = 30, Children = { openButton } };
+	}
+}
+
+#if ANDROID
+static class Issue36523State
+{
+	static readonly object s_gate = new();
+	static Task s_pickerTask;
+	static int s_launchActivityId;
+	static string s_outcome = "READY";
+
+	public static void Reset() { lock (s_gate) { s_pickerTask = null; s_launchActivityId = 0; s_outcome = "READY"; } }
+	public static string GetOutcome() { lock (s_gate) return s_outcome; }
+	public static void Complete(string outcome) { lock (s_gate) s_outcome = outcome; }
+
+	public static void BeginPick(int activityId, Task task)
+	{
+		lock (s_gate)
+		{ s_launchActivityId = activityId; s_pickerTask = task; s_outcome = "WAITING"; }
+	}
+
+	public static bool CheckForHang(int currentActivityId)
+	{
+		lock (s_gate)
+		{
+			if (s_pickerTask is { IsCompleted: false } && s_launchActivityId != currentActivityId)
+			{
+				s_outcome = "FAIL: picker task hung after activity recreation";
+				return true;
+			}
+			return false;
+		}
+	}
+}
+
+[Android.App.Activity(Label = "Issue36523", Theme = "@style/Maui.SplashTheme")]
+public class Issue36523RotationActivity : AndroidX.AppCompat.App.AppCompatActivity
+{
+	static int s_nextId;
+	readonly int _id = Interlocked.Increment(ref s_nextId);
+	Android.Widget.TextView _status = null!;
+	CancellationTokenSource _cts;
+
+	protected override void OnCreate(Android.OS.Bundle savedInstanceState)
+	{
+		base.OnCreate(savedInstanceState);
+		Microsoft.Maui.ApplicationModel.Platform.Init(this, savedInstanceState);
+
+		var layout = new Android.Widget.LinearLayout(this) { Orientation = Android.Widget.Orientation.Vertical };
+		var statusBarHeight = 0;
+		var resourceId = Resources.GetIdentifier("status_bar_height", "dimen", "android");
+		if (resourceId > 0)
+		{
+			statusBarHeight = Resources.GetDimensionPixelSize(resourceId);
+		}
+		layout.SetPadding(50, statusBarHeight + 50, 50, 50);
+
+		_status = new Android.Widget.TextView(this) { Text = $"Status: {Issue36523State.GetOutcome()}" };
+		SetAutomationId(_status, "RotationActivityStatusLabel");
+
+		var btn = new Android.Widget.Button(this) { Text = "Pick Photos" };
+		SetAutomationId(btn, "RotationActivityPickButton");
+		btn.Click += OnPick;
+
+		layout.AddView(_status);
+		layout.AddView(btn);
+		SetContentView(layout);
+	}
+
+	public override void OnWindowFocusChanged(bool hasFocus)
+	{
+		base.OnWindowFocusChanged(hasFocus);
+		_cts?.Cancel();
+		_cts?.Dispose();
+		_cts = null;
+		if (!hasFocus)
+		{
+			return;
+		}
+		_cts = new CancellationTokenSource();
+		_ = DelayedHangCheck(_cts.Token);
+	}
+
+	async Task DelayedHangCheck(CancellationToken ct)
+	{
+		try
+		{
+			await Task.Delay(3000, ct);
+			if (!IsDestroyed)
+			{
+				RunOnUiThread(() => { Issue36523State.CheckForHang(_id); _status.Text = $"Status: {Issue36523State.GetOutcome()}"; });
+			}
+		}
+		catch (OperationCanceledException) { }
+	}
+
+	async void OnPick(object s, EventArgs e)
+	{
+		_status.Text = "Status: WAITING";
+		try
+		{
+			var task = MediaPicker.PickPhotosAsync();
+			Issue36523State.BeginPick(_id, task);
+			var r = await task;
+			Issue36523State.Complete(r?.Count > 0 ? $"PASS: got {r.Count} photo(s)" : "PASS: cancelled");
+		}
+		catch (OperationCanceledException) { Issue36523State.Complete("PASS: cancelled"); }
+		catch (Exception ex) { Issue36523State.Complete($"ERROR: {ex.Message}"); }
+		if (!IsDestroyed)
+		{
+			_status.Text = $"Status: {Issue36523State.GetOutcome()}";
+		}
+	}
+
+	protected override void OnDestroy() { _cts?.Cancel(); _cts?.Dispose(); _cts = null; base.OnDestroy(); }
+
+	void SetAutomationId(Android.Views.View view, string id)
+	{
+		AndroidX.Core.View.ViewCompat.SetAccessibilityDelegate(view,
+			new IdDelegate($"{PackageName}:id/{id}"));
+	}
+
+	class IdDelegate(string name) : AndroidX.Core.View.AccessibilityDelegateCompat
+	{
+		public override void OnInitializeAccessibilityNodeInfo(Android.Views.View host,
+			AndroidX.Core.View.Accessibility.AccessibilityNodeInfoCompat info)
+		{ base.OnInitializeAccessibilityNodeInfo(host, info); info.ViewIdResourceName = name; }
+	}
+}
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36523.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36523.cs
@@ -1,0 +1,66 @@
+#if ANDROID
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue36523 : _IssuesUITest
+{
+	public Issue36523(TestDevice device) : base(device) { }
+
+	public override string Issue => "MediaPicker.PickPhotosAsync hangs after device rotation on API 33+";
+
+	[TearDown]
+	public void TearDown()
+	{
+		App.SetOrientationPortrait();
+	}
+
+	[Test]
+	[Category(UITestCategories.Essentials)]
+	public void PickPhotosAsyncShouldReturnAfterRotation()
+	{
+		// Bug only manifests on API 33+ where the native Photo Picker is used.
+		if (App is AppiumApp appiumApp)
+		{
+			var apiLevel = (long?)appiumApp.Driver.Capabilities.GetCapability("deviceApiLevel") ?? 0;
+			if (apiLevel < 33)
+			{
+				Assert.Ignore($"Issue #36523 only manifests on Android API 33+. Current device API: {apiLevel}.");
+			}
+		}
+
+		App.WaitForElement("OpenRotationActivityButton");
+		App.Tap("OpenRotationActivityButton");
+
+		App.WaitForElement("RotationActivityPickButton");
+		App.WaitForElement("RotationActivityStatusLabel");
+
+		App.Tap("RotationActivityPickButton");
+		Task.Delay(2000).Wait();
+
+		// Rotate while picker is open — triggers activity destroy/recreate
+		App.SetOrientationLandscape();
+		Task.Delay(2000).Wait();
+
+		// Cancel the picker
+		App.Back();
+
+		// With fix: task completes → "PASS". Without fix: task hangs → "FAIL".
+		var returned = App.WaitForTextToBePresentInElement("RotationActivityStatusLabel", "PASS",
+			timeout: TimeSpan.FromSeconds(30));
+
+		var resultText = App.FindElement("RotationActivityStatusLabel").GetText();
+
+		Assert.That(resultText, Does.Contain("PASS"),
+			$"PickPhotosAsync must complete after device rotation. Actual: '{resultText}'.");
+
+		Assert.That(resultText, Does.Not.Contain("FAIL"),
+			$"Picker task hung after activity recreation: '{resultText}'.");
+
+		App.Back();
+		App.WaitForElement("OpenRotationActivityButton");
+	}
+}
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36523.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36523.cs
@@ -38,18 +38,20 @@ public class Issue36523 : _IssuesUITest
 		App.WaitForElement("RotationActivityStatusLabel");
 
 		App.Tap("RotationActivityPickButton");
-		Task.Delay(2000).Wait();
+		Task.Delay(4000).Wait();
 
 		// Rotate while picker is open — triggers activity destroy/recreate
 		App.SetOrientationLandscape();
-		Task.Delay(2000).Wait();
+		Task.Delay(4000).Wait();
 
 		// Cancel the picker
 		App.Back();
 
 		// With fix: task completes → "PASS". Without fix: task hangs → "FAIL".
-		var returned = App.WaitForTextToBePresentInElement("RotationActivityStatusLabel", "PASS",
-			timeout: TimeSpan.FromSeconds(30));
+		Assert.That(
+			App.WaitForTextToBePresentInElement("RotationActivityStatusLabel", "PASS",
+				timeout: TimeSpan.FromSeconds(30)),
+			Is.True, "Timed out waiting for PASS — picker task likely hung after rotation.");
 
 		var resultText = App.FindElement("RotationActivityStatusLabel").GetText();
 

--- a/src/Essentials/src/Platform/ActivityForResultRequest.android.cs
+++ b/src/Essentials/src/Platform/ActivityForResultRequest.android.cs
@@ -48,6 +48,10 @@ internal abstract class ActivityForResultRequest<TContract, TResult>
 	// This prevents Activity B from overwriting Activity A's pending request.
 	readonly ConditionalWeakTable<ComponentActivity, TaskCompletionSource<TResult>> _pendingRequests = new();
 
+	// Strong reference to the launching activity — prevents GC from collecting the CWT entry
+	// before Register() can migrate the TCS to the new activity after a config change.
+	volatile ComponentActivity _inFlightActivity;
+
 	/// <summary>
 	/// Gets a value indicating whether the request has a launcher registered for the
 	/// currently focused activity.
@@ -71,6 +75,9 @@ internal abstract class ActivityForResultRequest<TContract, TResult>
 		if (_activityLaunchers.TryGetValue(componentActivity, out _))
 			return;
 
+		// Migrate pending TCS from the old activity to the new one on config change (e.g. rotation).
+		MigratePendingRequests(componentActivity);
+
 		var contract = new TContract();
 
 		// CRITICAL: capture the same `componentActivity` instance the launcher is being
@@ -83,6 +90,7 @@ internal abstract class ActivityForResultRequest<TContract, TResult>
 		var registeredActivity = componentActivity;
 		var callback = new ActivityResultCallback<TResult>(result =>
 		{
+			_inFlightActivity = null;
 			if (_pendingRequests.TryGetValue(registeredActivity, out var tcs))
 			{
 				_pendingRequests.Remove(registeredActivity);
@@ -147,6 +155,7 @@ internal abstract class ActivityForResultRequest<TContract, TResult>
 
 		var tcs = new TaskCompletionSource<TResult>();
 		_pendingRequests.Add(launchingActivity, tcs);
+		_inFlightActivity = launchingActivity;
 
 		// Get the launcher for this specific activity
 		if (!_activityLaunchers.TryGetValue(launchingActivity, out var launcher))
@@ -156,6 +165,7 @@ internal abstract class ActivityForResultRequest<TContract, TResult>
 			                Ensure your Activity inherits from ComponentActivity and call Microsoft.Maui.ApplicationModel.Platform.Init(Activity, Bundle) in OnCreate.
 			                """);
 			_pendingRequests.Remove(launchingActivity);
+			_inFlightActivity = null;
 			tcs.SetCanceled();
 			return tcs.Task;
 		}
@@ -167,6 +177,7 @@ internal abstract class ActivityForResultRequest<TContract, TResult>
 		catch (Exception ex)
 		{
 			_pendingRequests.Remove(launchingActivity);
+			_inFlightActivity = null;
 			tcs.TrySetException(ex);
 		}
 
@@ -197,5 +208,32 @@ internal abstract class ActivityForResultRequest<TContract, TResult>
 		}
 
 		return null;
+	}
+
+	/// <summary>
+	/// Migrates any pending TCS from the old (destroyed) activity to the new activity
+	/// during a configuration change, so the result callback can find the TCS under the
+	/// new activity's key.
+	/// </summary>
+	void MigratePendingRequests(ComponentActivity newActivity)
+	{
+		var oldActivity = _inFlightActivity;
+		if (oldActivity is null || ReferenceEquals(oldActivity, newActivity))
+		{
+			return;
+		}
+
+		// Only migrate on config change — not when the activity was finished normally.
+		if (!oldActivity.IsChangingConfigurations)
+		{
+			return;
+		}
+
+		if (_pendingRequests.TryGetValue(oldActivity, out var tcs))
+		{
+			_pendingRequests.Remove(oldActivity);
+			_pendingRequests.Add(newActivity, tcs);
+			_inFlightActivity = newActivity;
+		}
 	}
 }

--- a/src/Essentials/src/Platform/ActivityForResultRequest.android.cs
+++ b/src/Essentials/src/Platform/ActivityForResultRequest.android.cs
@@ -50,7 +50,7 @@ internal abstract class ActivityForResultRequest<TContract, TResult>
 
 	// Strong reference to the launching activity — prevents GC from collecting the CWT entry
 	// before Register() can migrate the TCS to the new activity after a config change.
-	volatile ComponentActivity _inFlightActivity;
+	ComponentActivity _inFlightActivity;
 
 	/// <summary>
 	/// Gets a value indicating whether the request has a launcher registered for the
@@ -195,6 +195,7 @@ internal abstract class ActivityForResultRequest<TContract, TResult>
 		if (_pendingRequests.TryGetValue(componentActivity, out var tcs))
 		{
 			_pendingRequests.Remove(componentActivity);
+			_inFlightActivity = null;
 			tcs?.TrySetCanceled();
 		}
 	}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details:

- MediaPicker.PickPhotosAsync()  hangs forever when the device is rotated while the photo picker is open.

### Root Cause of the issue
**Regression:**

- Introduced by PR #35944, which changed  ActivityForResultRequest  from a single shared  TaskCompletionSource  to per-activity storage using  ConditionalWeakTable<ComponentActivity, TCS> . Reproduced on API 33 and 36, not on API 30 (different code path).
- After rotation, Android destroys Activity-1 and creates Activity-2. The TCS is stored under Activity-1's key, but Activity-2's callback looks up Activity-2's key → miss → result silently dropped → task hangs permanently. Additionally,  ConditionalWeakTable  uses weak keys, so the GC can silently collect Activity-1's entry (including the TCS) with no error.


### Description of Change

**Bug fix for activity recreation and pending requests:**

* Added a strong reference (`_inFlightActivity`) to the launching `ComponentActivity` within `ActivityForResultRequest` to prevent garbage collection and ensure that pending requests survive configuration changes such as device rotation.
* Implemented `MigratePendingRequests`, which transfers any pending `TaskCompletionSource` from the old activity to the new one during a configuration change, preventing hangs when the activity is recreated. This migration is triggered in `Register` and ensures the result callback can still complete the task. 
* Updated code paths in `Launch` and the activity result callback to clear `_inFlightActivity` when the request completes, is canceled, or fails, ensuring proper cleanup and preventing memory leaks. 

**Test coverage:**

* Added a new shared test case and UI test (`Issue36523`) that reproduces the rotation scenario and verifies that `PickPhotosAsync` completes (rather than hanging) after device rotation and picker cancellation.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #36523

### Tested the behavior in the following platforms
 
- [ ] Windows
- [x] Android
- [ ] iOS
- [ ] Mac

### Output
 
| Before | After |
|----------|----------|
| <img src="https://github.com/user-attachments/assets/b054d308-c65e-4cb0-ba84-0a06cf5268e7"> | <img src="https://github.com/user-attachments/assets/c819e6e5-3b14-4a6d-b7e1-b5230c694d71"> |





<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
