### PR TITLE
[iOS] Fix ButtonHandler clearing custom UIButton styling when Background null

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue36749.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue36749.cs
@@ -1,0 +1,88 @@
+#if IOS || MACCATALYST
+using Microsoft.Maui.Handlers;
+using UIKit;
+#endif
+
+namespace Maui.Controls.Sample.Issues;
+
+// Regression: ButtonHandler.iOS.cs (introduced in 10.0.80 via PR #33346) unconditionally reset
+// BackgroundColor to UIColor.Clear when the cross-platform Background was null. This wiped native
+// colors set by a custom UIButton subclass returned from CreatePlatformView().
+[Issue(IssueTracker.Github, 36749,
+    "ButtonHandler clears native platform-view styling set by custom handlers when Background/TextColor are null",
+    PlatformAffected.iOS)]
+public class Issue36749 : ContentPage
+{
+    public const string ResultLabelId = "Issue36749Result";
+
+    readonly Label _resultLabel;
+    readonly Button _button;
+
+    public Issue36749()
+    {
+        _resultLabel = new Label
+        {
+            AutomationId = ResultLabelId,
+            Text = "Checking...",
+            HorizontalTextAlignment = TextAlignment.Center
+        };
+
+        // Issue36749Button routes to Issue36749ButtonHandler (registered in MauiProgram.cs).
+        // The handler's CreatePlatformView() returns a UIButton subclass that self-styles with
+        // BackgroundColor = UIColor.Cyan. No cross-platform Background is set on this button.
+        _button = new Issue36749Button
+        {
+            Text = "Test Button",
+            AutomationId = "Issue36749Button"
+        };
+
+        Content = new VerticalStackLayout
+        {
+            Padding = 20,
+            Spacing = 20,
+            Children = { _button, _resultLabel }
+        };
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+
+#if IOS || MACCATALYST
+		if (_button.Handler?.PlatformView is UIButton platformButton)
+		{
+			// The native UIButton subclass sets BackgroundColor = UIColor.Cyan in its constructor.
+			// With the regression: initial null-Background mapping resets it to UIColor.Clear.
+			// With the fix:        the Window-null check skips the reset, preserving Cyan.
+			platformButton.BackgroundColor.GetRGBA(out var r, out var g, out var b, out var a);
+
+			// UIColor.Cyan = R:0, G:1, B:1, A:1
+			bool isCyan = r < 0.01 && g > 0.99 && b > 0.99 && a > 0.99;
+			_resultLabel.Text = isCyan ? "PASS" : "FAIL";
+		}
+#endif
+    }
+}
+
+// Custom Button subtype used purely to route to Issue36749ButtonHandler.
+public class Issue36749Button : Button { }
+
+#if IOS || MACCATALYST
+
+// Simulates a design-system UIButton subclass that self-styles in its constructor.
+// The cross-platform Button intentionally leaves Background and TextColor unset.
+class Issue36749NativeStyledButton : UIButton
+{
+	public Issue36749NativeStyledButton() : base(UIButtonType.System)
+	{
+		BackgroundColor = UIColor.Cyan;
+		SetTitleColor(UIColor.DarkGray, UIControlState.Normal);
+	}
+}
+
+class Issue36749ButtonHandler : ButtonHandler
+{
+	protected override UIButton CreatePlatformView() => new Issue36749NativeStyledButton();
+}
+
+#endif

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue36749.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue36749.cs
@@ -10,7 +10,7 @@ namespace Maui.Controls.Sample.Issues;
 // colors set by a custom UIButton subclass returned from CreatePlatformView().
 [Issue(IssueTracker.Github, 36749,
     "ButtonHandler clears native platform-view styling set by custom handlers when Background/TextColor are null",
-    PlatformAffected.iOS)]
+    PlatformAffected.iOS | PlatformAffected.macOS)]
 public class Issue36749 : ContentPage
 {
     public const string ResultLabelId = "Issue36749Result";
@@ -59,6 +59,12 @@ public class Issue36749 : ContentPage
 			// UIColor.Cyan = R:0, G:1, B:1, A:1
 			bool isCyan = r < 0.01 && g > 0.99 && b > 0.99 && a > 0.99;
 			_resultLabel.Text = isCyan ? "PASS" : "FAIL";
+		}
+		else
+		{
+			// Handler or platform view unavailable — mark as FAIL so the test fails
+			// immediately rather than timing out on "Checking...".
+			_resultLabel.Text = "FAIL";
 		}
 #endif
     }

--- a/src/Controls/tests/TestCases.HostApp/MauiProgram.cs
+++ b/src/Controls/tests/TestCases.HostApp/MauiProgram.cs
@@ -56,6 +56,7 @@ namespace Maui.Controls.Sample
 #endif
 #if IOS || MACCATALYST
 				handlers.AddHandler(typeof(Issue11132Control), typeof(Issue11132ControlHandler));
+				handlers.AddHandler(typeof(Issue36749Button), typeof(Issue36749ButtonHandler));
 #endif
 #if IOS || MACCATALYST || ANDROID
 				handlers.AddHandler(typeof(UITestEditor), typeof(UITestEditorHandler));

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36749.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36749.cs
@@ -1,3 +1,4 @@
+#if IOS || MACCATALYST      //This is an iOS-specific issue and can be reproduced by extending UIButton. Therefore, the test was added only for iOS and Mac Catalyst.
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36749.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36749.cs
@@ -15,10 +15,6 @@ public class Issue36749 : _IssuesUITest
     [Category(UITestCategories.Button)]
     public void NativeStyledButtonShouldPreserveBackgroundColorOnInitialRender()
     {
-        // This regression is iOS-only: the fix is in ButtonExtensions.UpdateBackground (iOS).
-        if (Device != TestDevice.iOS)
-            Assert.Ignore("Test is iOS-only: validates that UpdateBackground preserves native UIButton styling when Background is null.");
-
         App.WaitForElement("Issue36749Result");
 
         var resultText = App.FindElement("Issue36749Result").GetText();
@@ -30,3 +26,4 @@ public class Issue36749 : _IssuesUITest
             "on the initial null-paint mapping, wiping native styling.");
     }
 }
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36749.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36749.cs
@@ -1,0 +1,31 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue36749 : _IssuesUITest
+{
+    public Issue36749(TestDevice device) : base(device) { }
+
+    public override string Issue => "ButtonHandler clears native platform-view styling set by custom handlers when Background/TextColor are null";
+
+    [Test]
+    [Category(UITestCategories.Button)]
+    public void NativeStyledButtonShouldPreserveBackgroundColorOnInitialRender()
+    {
+        // This regression is iOS-only: the fix is in ButtonExtensions.UpdateBackground (iOS).
+        if (Device != TestDevice.iOS)
+            Assert.Ignore("Test is iOS-only: validates that UpdateBackground preserves native UIButton styling when Background is null.");
+
+        App.WaitForElement("Issue36749Result");
+
+        var resultText = App.FindElement("Issue36749Result").GetText();
+
+        Assert.That(resultText, Is.EqualTo("PASS"),
+            "Native BackgroundColor set in a UIButton subclass constructor should be preserved " +
+            "when no cross-platform Background is assigned to the Button. " +
+            "Regression: PR #33346 unconditionally reset BackgroundColor to UIColor.Clear " +
+            "on the initial null-paint mapping, wiping native styling.");
+    }
+}

--- a/src/Core/src/Platform/iOS/ButtonExtensions.cs
+++ b/src/Core/src/Platform/iOS/ButtonExtensions.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Maui.Platform
 				// hasn't been added to the hierarchy yet — skipping here preserves native BackgroundColor
 				// set by custom UIButton subclasses. Once live on screen, null means a VisualState
 				// transition back to Normal, so we do reset. Mirrors the same guard in UpdateTextColor.
-				if (platformButton.Window is UIWindow window)
+				if (platformButton.Window is not null)
 				{
 					platformButton.BackgroundColor = UIColor.Clear;
 				}

--- a/src/Core/src/Platform/iOS/ButtonExtensions.cs
+++ b/src/Core/src/Platform/iOS/ButtonExtensions.cs
@@ -62,9 +62,15 @@ namespace Microsoft.Maui.Platform
 
 			if (paint.IsNullOrEmpty())
 			{
-				// Reset to clear background for buttons when paint is null.
-				// UIColor.Clear ensures proper transparency when VisualState setters are unapplied.
-				platformButton.BackgroundColor = UIColor.Clear;
+				// Only reset to UIColor.Clear when the button is already attached to a window.
+				// During initial property mapping (ConnectHandler), Window is null because the view
+				// hasn't been added to the hierarchy yet — skipping here preserves native BackgroundColor
+				// set by custom UIButton subclasses. Once live on screen, null means a VisualState
+				// transition back to Normal, so we do reset. Mirrors the same guard in UpdateTextColor.
+				if (platformButton.Window is UIWindow window)
+				{
+					platformButton.BackgroundColor = UIColor.Clear;
+				}
 				return;
 			}
 

--- a/src/Core/src/Platform/iOS/ButtonExtensions.cs
+++ b/src/Core/src/Platform/iOS/ButtonExtensions.cs
@@ -57,7 +57,11 @@ namespace Microsoft.Maui.Platform
 		// TODO: Make this public in .NET 11
 		internal static void UpdateBackground(this UIButton platformButton, Graphics.Paint? paint)
 		{
-			// Remove previous background gradient layer if any
+			// Remove previous background gradient layer if any.
+			// Safe to call unconditionally even when Window is null (initial-render path): at that
+			// point MAUI has not yet inserted a named gradient layer, so this is a no-op.
+			// Running it before the Window/paint guard ensures any previously-applied gradient is
+			// cleaned up regardless of the new paint value.
 			platformButton.RemoveBackgroundLayer();
 
 			if (paint.IsNullOrEmpty())


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
PR #33346 changed UpdateBackground(UIButton, Paint?) to unconditionally reset BackgroundColor = UIColor.Clear when paint is null. Since MAUI maps every property during initial setup — including Background = null (the default) — the native constructor-set color gets wiped before the button is ever shown.

### Description of Change

<!-- Enter description of the fix in this section -->
Added a Window check to UpdateBackground, matching the identical guard already present in UpdateTextColor.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #36749 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

**Tested the behavior in the following platforms.**
- [ ] Android
- [ ] Windows
- [x] iOS
- [x] Mac


| Before  | After  |
|---------|--------|
| **iOS**<br> <img src="https://github.com/user-attachments/assets/ddffc469-e4ee-4ead-ac27-5f04599b0409" width="300" height="600"> | **iOS**<br> <img src="https://github.com/user-attachments/assets/f08ca4c8-12a5-4ab4-8baa-f16e7139df5a" width="300" height="600"> |
