### PR TITLE
[Android] ban [Export] in the banned API analyzers

### DIFF
--- a/eng/BannedSymbols.txt
+++ b/eng/BannedSymbols.txt
@@ -1,6 +1,7 @@
 M:Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton`2(Microsoft.Extensions.DependencyInjection.IServiceCollection);Use a Factory method to create the service instead
 M:Android.Content.Res.ColorStateList.#ctor(System.Int32[][],System.Int32[]);Use Microsoft.Maui.PlatformInterop.Get*ColorStateList() Java methods instead
 M:Android.Widget.ImageView.GetScaleType();Use PlatformInterop.IsImageViewCenterCrop instead (or add a new method)
+T:Java.Interop.ExportAttribute;[Export] pulls in Java.Interop.Export dynamic features that are not trimming or AOT friendly. Declare an abstract class in src/Core/AndroidNative and override it instead, see src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/HybridJavaScriptInterface.java
 P:Microsoft.Maui.MauiWinUIApplication.Services;Use the IPlatformApplication.Current.Services instead
 P:Microsoft.Maui.MauiWinUIApplication.Application;Use the IPlatformApplication.Current.Application instead
 P:Microsoft.UI.Xaml.Window.AppWindow;This API doesn't have null safety. Use GetAppWindow() and make sure to account for the possibility that GetAppWindow() might be null.

--- a/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/RefreshViewJavaScriptInterface.java
+++ b/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/RefreshViewJavaScriptInterface.java
@@ -1,0 +1,6 @@
+package com.microsoft.maui;
+
+public abstract class RefreshViewJavaScriptInterface {
+    @android.webkit.JavascriptInterface
+    public abstract void setCanScrollUp(boolean canScrollUp);
+}

--- a/src/Core/src/Platform/Android/RefreshViewWebViewScrollCapture.cs
+++ b/src/Core/src/Platform/Android/RefreshViewWebViewScrollCapture.cs
@@ -1,6 +1,5 @@
 using Android.Webkit;
 using Java.Interop;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Maui.Platform;
 
@@ -190,7 +189,7 @@ internal static class RefreshViewWebViewScrollCapture
 	// Returns null when the WebView is not inside a RefreshView.
 	internal static ScrollCaptureState? GetAttachedState(WebView? webView) => GetState(webView);
 
-	internal sealed class ScrollCaptureState : Java.Lang.Object
+	internal sealed class ScrollCaptureState : RefreshViewJavaScriptInterface
 	{
 		// These fields are written from the JavaBridge thread (via [JavascriptInterface])
 		// and read from the UI thread, so they must be volatile to ensure visibility on ARM.
@@ -205,9 +204,7 @@ internal static class RefreshViewWebViewScrollCapture
 		internal bool HasReportedState => _hasReportedState;
 
 		[JavascriptInterface]
-		[RequiresUnreferencedCode("Java.Interop.Export uses dynamic features.")]
-		[Export("setCanScrollUp")]
-		public void SetCanScrollUp(bool canScrollUp)
+		public override void SetCanScrollUp(bool canScrollUp)
 		{
 			if (_detached)
 			{


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

Context: https://github.com/dotnet/maui/pull/24744
Context: https://github.com/dotnet/maui/pull/24952

### Description of Change

`Java.Interop.ExportAttribute` is annotated with `[RequiresUnreferencedCode]`, so every use of `[Export]` produces an IL2026 trim warning and depends on `Java.Interop.Export.dll` reflection at runtime. #24744 established the alternative: declare an abstract class in `src/Core/AndroidNative` and `override` it, which lets the Java Callable Wrapper generator emit the method — and its `@android.webkit.JavascriptInterface` annotation — statically.

This adds `T:Java.Interop.ExportAttribute` to `eng/BannedSymbols.txt` so the pattern is enforced by RS0030 going forward, instead of relying on reviewers to catch it. The message points at `HybridJavaScriptInterface.java` as the working example:

```
T:Java.Interop.ExportAttribute;[Export] pulls in Java.Interop.Export dynamic features that are not trimming or AOT friendly. Declare an abstract class in src/Core/AndroidNative and override it instead, see src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/HybridJavaScriptInterface.java
```

Adding the ban flagged the one remaining offender, `RefreshViewWebViewScrollCapture.ScrollCaptureState.SetCanScrollUp()`:

```
src/Core/src/Platform/Android/RefreshViewWebViewScrollCapture.cs(209,4): error RS0030:
The symbol 'Java.Interop.ExportAttribute' is banned in this project: [Export] pulls in
Java.Interop.Export dynamic features that are not trimming or AOT friendly. ...
```

So it is fixed the same way #24744 did: a new `RefreshViewJavaScriptInterface` abstract class in the `maui.aar` Java sources, with `ScrollCaptureState` deriving from it. The `[RequiresUnreferencedCode("Java.Interop.Export uses dynamic features.")]` suppression on `SetCanScrollUp()` is no longer needed and is removed.

Note the base type is deliberately an **abstract class** and not an interface. #24952 reverted `HybridJavaScriptInterface` from an interface back to a class because Java does not inherit method annotations from interfaces — the generated JCW silently lost `@android.webkit.JavascriptInterface` and the JavaScript bridge stopped working. The same applies here.

The remaining `[Export]` usages in the repo are all `Foundation.ExportAttribute` (Apple), which is a different type and is unaffected by this ban.

### Issues Fixed

None; this is a proactive lint rule plus the one cleanup it surfaced.

### Testing

Verified locally by building `src/Core/src/Core.csproj` for `net10.0-android36.0`:

- **Before the fix** — build fails with `error RS0030` at `RefreshViewWebViewScrollCapture.cs(209,4)`, confirming the new banned-symbol entry is actually enforced.
- **After the fix** — `Microsoft.Maui.dll` builds clean, including the Gradle step that compiles the new Java file into `maui.aar`.

No behavior change is expected at runtime: the exported Java method name is still `setCanScrollUp`, and `[JavascriptInterface]` remains on the C# override, matching the shipping `HybridWebViewHandler` pattern.