### PR TITLE
Fix inflight/current build breaks (duplicate MAUIX2017, obsolete AddCircle, Assert.IsTrue)

### DIFF
--- a/src/Controls/src/SourceGen/AnalyzerReleases.Unshipped.md
+++ b/src/Controls/src/SourceGen/AnalyzerReleases.Unshipped.md
@@ -30,7 +30,7 @@ MAUIX2010 | XamlParsing | Info | ExpressionNotSettable
 MAUIX2011 | XamlParsing | Warning | AmbiguousMemberWithStaticType
 MAUIX2012 | XamlParsing | Error | CSharpExpressionsRequirePreviewFeatures
 MAUIX2013 | XamlParsing | Error | AsyncLambdaNotSupported
-MAUIX2017 | XamlParsing | Warning | StructIntermediateNotSettable
+MAUIX2018 | XamlParsing | Warning | StructIntermediateNotSettable
 MAUIX2015 | XamlParsing | Error | XCodeNotChildOfRoot
 MAUIX2016 | XamlParsing | Error | XCodeRequiresXClass
 MAUIX2017 | XamlParsing | Error | LambdaMethodGroupReference

--- a/src/Controls/src/SourceGen/Descriptors.cs
+++ b/src/Controls/src/SourceGen/Descriptors.cs
@@ -351,7 +351,7 @@ namespace Microsoft.Maui.Controls.SourceGen
 			isEnabledByDefault: true);
 
 		public static DiagnosticDescriptor StructIntermediateNotSettable = new DiagnosticDescriptor(
-			id: "MAUIX2017",
+			id: "MAUIX2018",
 			title: "Value type property in path has no setter",
 			messageFormat: "Expression '{0}' contains a value type property without a setter, so two-way binding to '{1}' will be one-way. To enable two-way binding through a struct, add a setter to the intermediate property.",
 			category: "XamlParsing",

--- a/src/Controls/tests/SourceGen.UnitTests/CSharpExpressionDiagnosticsTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/CSharpExpressionDiagnosticsTests.cs
@@ -509,7 +509,7 @@ public partial class TwoWayNoWarningPage : ContentPage
 	}
 
 	[Fact]
-	public void GetOnlyStructIntermediate_OnTwoWayProperty_ReportsMAUIX2017AndOmitsSetter()
+	public void GetOnlyStructIntermediate_OnTwoWayProperty_ReportsMAUIX2018AndOmitsSetter()
 	{
 		var xaml =
 """
@@ -544,7 +544,7 @@ public partial class ReadOnlyStructIntermediatePage : ContentPage
 
 		var (result, output) = RunGenerator(xaml, codeBehind, assertNoCompilationErrors: false);
 
-		var diagnostic = Assert.Single(result.Diagnostics.Where(d => d.Id == "MAUIX2017"));
+		var diagnostic = Assert.Single(result.Diagnostics.Where(d => d.Id == "MAUIX2018"));
 		Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
 		Assert.Contains("ReadOnlyMargin.Top", diagnostic.GetMessage(), StringComparison.Ordinal);
 

--- a/src/SingleProject/Resizetizer/src/SkiaSharpAppIconTools.cs
+++ b/src/SingleProject/Resizetizer/src/SkiaSharpAppIconTools.cs
@@ -155,10 +155,12 @@ namespace Microsoft.Maui.Resizetizer
 				var radius = Math.Min(canvasSize.Width, canvasSize.Height) / 2;
 
 				var clip = new SKPath();
+#pragma warning disable CS0618 // SKPath.AddCircle is obsolete in newer SkiaSharp; keep using it to avoid a hard build break on the current SkiaSharp band.
 				clip.AddCircle(
 					canvasSize.Width / 2,
 					canvasSize.Height / 2,
 					radius);
+#pragma warning restore CS0618
 				return clip;
 			}
 

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
@@ -356,11 +356,11 @@ public class SimpleTemplateTest : BaseTemplateTests
 		var projectContent = File.ReadAllText(expectedProjectFile);
 		Assert.True(projectContent.Contains("<IsAspireSharedProject>true</IsAspireSharedProject>", StringComparison.Ordinal),
 			"Project file should contain Aspire-specific properties.");
-		Assert.IsTrue(projectContent.Contains("<UseMauiCore>true</UseMauiCore>", StringComparison.Ordinal),
+		Assert.True(projectContent.Contains("<UseMauiCore>true</UseMauiCore>", StringComparison.Ordinal),
 			"Project file should contain UseMauiCore property.");
 
 		// Verify the project actually builds
-		Assert.IsTrue(DotnetInternal.Build(expectedProjectFile, "Debug", properties: BuildProps, msbuildWarningsAsErrors: true),
+		Assert.True(DotnetInternal.Build(expectedProjectFile, "Debug", properties: BuildProps, msbuildWarningsAsErrors: true),
 			$"Project {Path.GetFileName(expectedProjectFile)} failed to build. Check test output/attachments for errors.");
 	}
 }


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description

Two build errors currently break `dotnet cake --target=dotnet-buildtasks` on **`inflight/current`**, which blocks the Copilot reviewer (and any tooling that builds BuildTasks) for **every PR targeting `inflight/current`**:

1. **RS2005** — `AnalyzerReleases.Unshipped.md` and `Descriptors.cs` both assigned **`MAUIX2017`** to two different diagnostics: `LambdaMethodGroupReference` **and** `StructIntermediateNotSettable`. The analyzer-release tracker rejects the duplicate rule ID. Fix: reassign the newer `StructIntermediateNotSettable` to the next free ID **`MAUIX2018`** (descriptor + manifest + unit test updated). `LambdaMethodGroupReference` keeps `MAUIX2017`.

2. **CS0618** — `SKPath.AddCircle(...)` is obsolete-as-error under the current SkiaSharp band (`SkiaSharpAppIconTools.cs`). Suppress with a scoped `#pragma warning disable CS0618` (the same pattern already used in the Compatibility Maps renderers) so the circular app-icon clip path keeps working without a hard build break.

### Why this way

- The RS2005 fix is the minimal correct dedup — `MAUIX2018` is the next unused MAUIX ID (2000–2017 are all taken). The test `GetOnlyStructIntermediate_OnTwoWayProperty_Reports…` is updated to assert `MAUIX2018`.
- The `AddCircle` suppression is a low-risk, codebase-consistent choice (vs. an `SKPathBuilder` migration, which would risk breaking other branches on an older SkiaSharp). `AddCircle` still works at runtime; only the compile-time obsolete-as-error needed silencing.

### Testing

Validated by running the Copilot reviewer pipeline against this branch — Build MSBuild Tasks now compiles (previously failed with the two errors above).
