### PR TITLE
Add missing YAML frontmatter to find-regression-risk SKILL.md

### DIFF
--- a/.github/skills/find-regression-risk/SKILL.md
+++ b/.github/skills/find-regression-risk/SKILL.md
@@ -1,3 +1,21 @@
+---
+name: find-regression-risk
+description: >-
+  Detects potential regression risks in a PR by cross-referencing lines the PR
+  REMOVES against lines ADDED by recent labeled bug-fix PRs (`i/regression`,
+  `t/bug`, `p/0`, `p/1`) touching the same files. Purely mechanical — no AI/LLM.
+  Emits a CLEAN / OVERLAP / REVERT verdict plus structured findings. Triggers on:
+  "does this PR revert a previous fix", "check PR for regression risk",
+  "find regression risks in PR", "is this change reverting a bug fix".
+  Do NOT use for: assessing ship-readiness of a release branch (use
+  release-readiness), investigating CI failures (use azdo-build-investigator),
+  or general code review (use code-review).
+metadata:
+  author: dotnet-maui
+  version: "1.0"
+compatibility: Requires PowerShell (pwsh), git, and GitHub CLI (gh) authenticated against the target repository.
+---
+
 # find-regression-risk
 
 Detects potential regression risks in a PR by cross-referencing removed lines against lines added by recent labeled bug-fix PRs.

--- a/.github/workflows/skill-validation.yml
+++ b/.github/workflows/skill-validation.yml
@@ -254,10 +254,9 @@ jobs:
       # nonstandard filename with --eval-spec. This also SKIPS SKILL.md structural
       # linting. We do NOT
       # lint SKILL.md / *.agent.md here on purpose: vally's skill linter flags
-      # two PRE-EXISTING repo issues unrelated to this migration (try-fix
-      # SKILL.md exceeds the 500-line limit; find-regression-risk is missing
-      # name/description frontmatter) that would false-red this gate. Those are
-      # tracked as follow-ups in the PR description.
+      # a PRE-EXISTING repo issue unrelated to this migration (try-fix
+      # SKILL.md exceeds the 500-line limit) that would false-red this gate.
+      # That is tracked as a follow-up in the PR description.
       - name: Lint eval specs
         id: check
         shell: bash


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

The `find-regression-risk` skill was missing its YAML frontmatter, so Copilot CLI refused to load it:

```
The following skills failed to load:
* .github/skills/find-regression-risk/SKILL.md: missing or malformed YAML frontmatter
```

Every other `SKILL.md` under `.github/skills/` opens with a `---` block declaring at least `name` and `description`. This one was the sole exception, which made the skill invisible to the CLI skill loader — and to vally's skill linter.

This PR adds a frontmatter block following the conventions used by the sibling skills (`name`, `description`, `metadata.author`, `metadata.version`, `compatibility`). The description covers the skill's purpose, trigger phrases, and "Do NOT use for" guidance, matching the style of `code-review`, `evaluate-pr-tests`, and `pr-finalize`.

It also refreshes a now-stale comment in `.github/workflows/skill-validation.yml`. That comment explained why SKILL.md structural linting is skipped in the eval-spec lint gate, citing **two** pre-existing failures — the try-fix 500-line overrun and this missing frontmatter. With the frontmatter fixed, only the try-fix issue remains, so the comment now reflects reality.

No behavioral change to the skill itself — `Find-RegressionRisks.ps1` and its tests are untouched.

### Issues Fixed

None filed — reported directly via the Copilot CLI startup error shown above.

### Validation

Linted with the exact vally version the workflow pins (`VALLY_VERSION: "0.10.0"`):

```console
$ npx -y @microsoft/vally-cli@0.10.0 lint .github/skills/find-regression-risk
✅ find-regression-risk (2/2 checks passed)

1 skill(s) linted, 1 passed
```

Before the change the skill was not even discovered by the linter. The frontmatter YAML and the edited workflow YAML were both confirmed to parse.
