### PR TITLE
[inflight] Fix netstandard build break: ReferenceEqualityComparer in GradientBrush

### DIFF
--- a/src/Controls/src/Core/GradientBrush.cs
+++ b/src/Controls/src/Core/GradientBrush.cs
@@ -10,7 +10,11 @@ namespace Microsoft.Maui.Controls
 	[ContentProperty(nameof(GradientStops))]
 	public abstract class GradientBrush : Brush
 	{
-		readonly Dictionary<GradientStop, int> _subscriptionRefCounts = new(ReferenceEqualityComparer.Instance);
+		// Keyed by reference identity so distinct GradientStop instances that compare equal by value
+		// still get independent subscription ref-counts. System.Collections.Generic.ReferenceEqualityComparer
+		// is .NET 5+ only, but Controls.Core also targets netstandard2.0/2.1, so use a small
+		// cross-TFM reference-equality comparer instead (avoids a netstandard build break).
+		readonly Dictionary<GradientStop, int> _subscriptionRefCounts = new(GradientStopReferenceComparer.Instance);
 
 		/// <summary>Initializes a new instance of the <see cref="GradientBrush"/> class.</summary>
 		public GradientBrush()
@@ -211,6 +215,16 @@ namespace Microsoft.Maui.Controls
 		void Invalidate()
 		{
 			InvalidateGradientBrushRequested?.Invoke(this, EventArgs.Empty);
+		}
+
+		// Reference-identity comparer usable on every Controls.Core TFM (netstandard2.0/2.1 lack the
+		// BCL System.Collections.Generic.ReferenceEqualityComparer). Matches its semantics: equality by
+		// object reference, hash from RuntimeHelpers.GetHashCode.
+		sealed class GradientStopReferenceComparer : IEqualityComparer<GradientStop>
+		{
+			public static readonly GradientStopReferenceComparer Instance = new();
+			public bool Equals(GradientStop x, GradientStop y) => ReferenceEquals(x, y);
+			public int GetHashCode(GradientStop obj) => System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(obj);
 		}
 	}
 }


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Problem
`GradientBrush` (added in #36746) keys its subscription ref-count dictionary with `System.Collections.Generic.ReferenceEqualityComparer.Instance`, which is **.NET 5+ only**. `Controls.Core` also targets **netstandard2.0/2.1**, so the shared build breaks:

```
src/Controls/src/Core/GradientBrush.cs(13,71): error CS0122: 'ReferenceEqualityComparer' is inaccessible due to its protection level [Controls.Core.csproj::TargetFramework=netstandard2.0]
```

This blocks every build of `inflight/current` (including Copilot PR reviews on inflight PRs, e.g. #36776, where the gate could not build the base).

### Fix
Replace the BCL comparer with a small self-contained reference-identity comparer that works on **every** TFM — equality by object reference, hash from `RuntimeHelpers.GetHashCode` — preserving the leak fix's exact semantics.

The other `ReferenceEqualityComparer` uses (`ShellRenderer.cs`, `MapHandler.Android.cs`) are in platform-specific files that only compile for .NET TFMs, so they are unaffected.

### Risk
Minimal — behaviorally identical to `ReferenceEqualityComparer.Instance`; no public API change.