### PR TITLE
[Android] SwipeItem Text and IconImageSource are vertically misaligned when SwipeView wraps CollectionView

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/SwipeView/SwipeViewTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/SwipeView/SwipeViewTests.Android.cs
@@ -227,5 +227,76 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.Equal(expectedValue, isEnabled);
 			});
 		}
+
+		[Fact]
+		[Description("SwipeItem icon and text should be vertically aligned when SwipeView has large content")]
+		public async Task SwipeItemIconAndTextVerticallyAligned()
+		{
+			// Regression test for https://github.com/dotnet/maui/issues/36736
+			// When SwipeView wraps tall content (e.g., CollectionView), the SwipeItem button
+			// should self-size its content (AtMost height) rather than being forced to fill
+			// the entire content area (Exactly height), which would misalign icon and text.
+			SetupBuilder();
+
+			var content = new VerticalStackLayout
+			{
+				HeightRequest = 300,
+				Background = new SolidColorBrush(Colors.White)
+			};
+
+			var swipeItem = new SwipeItem
+			{
+				Text = "Delete",
+				BackgroundColor = Colors.Red,
+				IconImageSource = new FontImageSource
+				{
+					Glyph = "X",
+					FontFamily = "Arial",
+					Size = 20
+				}
+			};
+
+			var swipeItems = new SwipeItems
+			{
+				swipeItem
+			};
+
+			var swipeView = new SwipeView()
+			{
+				HeightRequest = 300,
+				LeftItems = swipeItems,
+				Content = content
+			};
+
+			await AttachAndRun(swipeView, async (handler) =>
+			{
+				var platformView = ((SwipeViewHandler)handler).PlatformView;
+				swipeView.Open(OpenSwipeItem.LeftItems, false);
+
+				// Wait for SwipeView to create action view with children
+				await AssertEventually(() => platformView.ChildCount > 1);
+
+				var actionView = platformView.GetChildAt(1) as ViewGroup;
+				Assert.NotNull(actionView);
+
+				await AssertEventually(() => actionView.ChildCount > 0);
+
+				var swipeButton = actionView.GetChildAt(0);
+				Assert.NotNull(swipeButton);
+
+				// Wait for button to be laid out
+				await AssertEventually(() => swipeButton.Height > 0);
+
+				// The button's MeasuredHeight should be LESS than its layout height.
+				// This proves it was measured with AtMost (self-sizing) rather than
+				// Exactly (forced to fill), which keeps icon+text vertically aligned.
+				Assert.True(
+					swipeButton.MeasuredHeight < swipeButton.Height,
+					$"SwipeItem button should self-size (MeasuredHeight={swipeButton.MeasuredHeight}) " +
+					$"rather than fill entire area (Height={swipeButton.Height}). " +
+					$"If MeasuredHeight equals Height, the button is forced to fill, " +
+					$"causing icon and text to misalign.");
+			});
+		}
 	}
 }

--- a/src/Core/src/Platform/Android/MauiSwipeView.cs
+++ b/src/Core/src/Platform/Android/MauiSwipeView.cs
@@ -680,12 +680,13 @@ namespace Microsoft.Maui.Platform
 							break;
 					}
 
-					// AtMost lets custom SwipeItemView content size itself; Exactly forces precise dimensions for default SwipeItems.
-					var measureMode = item is ISwipeItemView ? MeasureSpecMode.AtMost : MeasureSpecMode.Exactly;
+					// Width: Exactly for default SwipeItems (ensures text is visible), AtMost for custom SwipeItemView.
+					// Height: Always AtMost so the button can self-size and keep icon+text vertically centered.
+					var widthMode = item is ISwipeItemView ? MeasureSpecMode.AtMost : MeasureSpecMode.Exactly;
 
 					child.Measure(
-						MeasureSpec.MakeMeasureSpec(swipeItemWidth, measureMode),
-						MeasureSpec.MakeMeasureSpec(swipeItemHeight, measureMode));
+						MeasureSpec.MakeMeasureSpec(swipeItemWidth, widthMode),
+						MeasureSpec.MakeMeasureSpec(swipeItemHeight, MeasureSpecMode.AtMost));
 
 					child.Layout(l, t, r, b);
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details:

- SwipeItem Icon and Text Vertically Misaligned

### Root Cause of the issue

- PR #[27399](https://github.com/dotnet/maui/pull/27399) changed the Android measurement mode to "Exactly" for both width and height to fix text visibility. Only width needed this change — height was unintentional.
- With "Exactly" height, the button is told it's as tall as the entire content area (e.g., 1489px). Since the icon and text live inside the same button, Android spreads them across that space, causing them to separate. With "AtMost", the button self-sizes to just fit icon+text (~126px), keeping them together.


### Description of Change

**Bug fix:**
- Ensured that the height of default `SwipeItem` buttons is always measured with `AtMost` mode, allowing the button to self-size and keep the icon and text vertically centered, regardless of the content's height. The width remains `Exactly` for default items and `AtMost` for custom items. 

**Testing:**
- Added a regression test `SwipeItemIconAndTextVerticallyAligned` to verify that the `SwipeItem` button is self-sizing its height and that the icon and text remain vertically aligned when the `SwipeView` contains large content. 

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #36736

### Tested the behavior in the following platforms
 
- [ ] Windows
- [x] Android
- [ ] iOS
- [ ] Mac

### Output
 
| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/22a4fb48-4b5c-4a5f-8b17-a9e7bcb18b29"> | <video src="https://github.com/user-attachments/assets/be8dbee4-af87-49df-aa8b-96164b5c80f6"> |







<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
