### PR TITLE
[Windows]Fix: Label Formatted Text crashed with out of memory Exception

### DIFF
--- a/src/Controls/src/Core/Platform/Windows/Extensions/FormattedStringExtensions.cs
+++ b/src/Controls/src/Core/Platform/Windows/Extensions/FormattedStringExtensions.cs
@@ -231,6 +231,15 @@ namespace Microsoft.Maui.Controls.Platform
 						lineHeight = endRect.Bottom - endRect.Top;
 					}
 
+					// Guard against a zero (or negative) line height. This can happen when the
+					// TextBlock was measured while collapsed/hidden, which caches a
+					// MeasuredLineHeight of 0. Without this check, causing an infinite loop and an eventual
+					// OutOfMemoryException as lineHeights grows without bound.
+					if (lineHeight <= 0)
+					{
+						break;
+					}
+
 					lineHeights.Add(lineHeight);
 					yaxis += lineHeight;
 				}

--- a/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.Windows.cs
@@ -1,7 +1,9 @@
 ﻿using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
 using Microsoft.Maui.Handlers;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -36,6 +38,45 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				var nativeView = GetPlatformLabel(labelHandler);
 				return nativeView.Visibility == Microsoft.UI.Xaml.Visibility.Visible;
+			});
+		}
+
+		[Fact]
+		public async Task FormattedTextDoesNotHangOrCrashWhenLabelIsShownAfterBeingSetWhileHidden()
+		{
+			SetupBuilder();
+
+			var label = new Label
+			{
+				IsVisible = false,
+				WidthRequest = 30,
+				HorizontalOptions = LayoutOptions.Start,
+				LineBreakMode = LineBreakMode.WordWrap,
+			};
+
+			var layout = new VerticalStackLayout { label };
+
+			await AttachAndRun(layout, async (handler) =>
+			{
+				label.FormattedText = new FormattedString
+				{
+					Spans =
+					{
+						new Span { Text = "Aa Bb Cc" },
+						new Span { Text = "\n" },
+					}
+				};
+
+				await Task.Delay(50);
+
+				// Showing the label triggers a real arrange pass, which calls
+				// RecalculateSpanPositions(). Before the fix, this would hang the UI thread and
+				// eventually crash with an OutOfMemoryException because the label wraps to 3
+				// lines ("Aa", "Bb", "Cc") at this width. Simply completing (instead of hanging or
+				// throwing) proves the fix works.
+				label.IsVisible = true;
+
+				await Task.Delay(250);
 			});
 		}
 	}


### PR DESCRIPTION
<!-- Please keep the note below for people who find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment whether this change resolves your issue. Thank you!

This pull request addresses a critical bug where showing a `Label` with formatted text after it has been hidden could cause the UI thread to hang and eventually crash with an `OutOfMemoryException`. The fix introduces a guard against zero or negative line heights in the `RecalculateSpanPositions` method. Additionally, a new test is added to ensure this scenario is handled correctly.

### Description of Change:
**Bug fix for line height calculation:**

* Added a guard in `RecalculateSpanPositions` (in `FormattedStringExtensions.cs`) to break out of the loop if a zero or negative line height is encountered, preventing infinite loops and memory issues when a `TextBlock` is measured while collapsed or hidden.

**Testing improvements:**

* Added a test (`FormattedTextDoesNotHangOrCrashWhenLabelIsShownAfterBeingSetWhileHidden`) in `LabelTests.Windows.cs` to verify that showing a previously hidden label with formatted text does not hang or crash the UI.
* Added necessary `using` directives for `Microsoft.Maui.Controls` and `Xunit` to support the new test.


<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #35527 

### Tested the behavior in the following platforms

- [x] Windows
- [ ] Android
- [ ] iOS
- [ ] Mac

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <img width="1404" height="560" alt="BeforeFix35527" src="https://github.com/user-attachments/assets/5701a105-c57f-4f84-be87-2e1eacfa97d1" /> | <img width="1417" height="732" alt="AfterFix35527" src="https://github.com/user-attachments/assets/f85350ef-43bb-47a6-8273-eb3446b81c95" /> |
<!--
<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
