### PR TITLE
Turn XAML Incremental Hot Reload (XIHR) off by default

### DIFF
--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -10,13 +10,11 @@
     <_MauiXamlInflator Condition="' $(MauiXamlInflator)' != '' ">$(MauiXamlInflator)</_MauiXamlInflator>
     <_MauiXamlInflator Condition=" '$(MauiXamlInflator)' == '' ">SourceGen</_MauiXamlInflator>
 
-    <!-- XAML Incremental Hot Reload (XIHR): on by default for .NET 11 projects (Preview 7). Hot reload is a
-         dev-time feature; when enabled it emits per-page registry calls and keeps the runtime feature
-         switch on, so it defaults on for Debug builds only and stays off for Release/publish, where the
-         registry calls and runtime switch trim away. Set <EnableMauiIncrementalHotReload>false</...> to
-         opt out (legacy XAML Hot Reload remains available as a fallback). Resolves to an explicit
-         true/false so the value always flows to the source generator and runtime config. -->
-    <EnableMauiIncrementalHotReload Condition="'$(EnableMauiIncrementalHotReload)' == '' and '$(Configuration)' == 'Debug'">true</EnableMauiIncrementalHotReload>
+    <!-- XAML Incremental Hot Reload (XIHR): off by default. Hot reload is a dev-time feature; when
+         enabled it emits per-page registry calls and keeps the runtime feature switch on. Set
+         <EnableMauiIncrementalHotReload>true</...> to opt in (legacy XAML Hot Reload remains the
+         default fallback). Resolves to an explicit true/false so the value always flows to the source
+         generator and runtime config. -->
     <EnableMauiIncrementalHotReload Condition="'$(EnableMauiIncrementalHotReload)' == ''">false</EnableMauiIncrementalHotReload>
 
     <!-- XAML Hot Reload mode for IDE communication (Legacy or SourceGen) -->

--- a/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
@@ -310,7 +310,7 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			project.Save(projectFile);
 			// Pin XIHR off: this test covers the legacy ResourceProvider2 hot-reload fallback
 			// (InitializeComponentRuntime), which XAML Incremental Hot Reload intentionally supersedes
-			// when enabled (on by default in Debug). See dotnet/maui#36682.
+			// when enabled. XIHR is off by default (opt-in), but pin it explicitly here. See dotnet/maui#36682.
 			Build(projectFile, additionalArgs: $"-c {configuration} -p:MauiXamlInflator=SourceGen -p:EnableMauiIncrementalHotReload=false -p:EmitCompilerGeneratedFiles=True -p:CompilerGeneratedFilesOutputPath=Generated");
 
 			var generatorDirectory = IOPath.Combine(tempDirectory, "Generated", "Microsoft.Maui.Controls.SourceGen", "Microsoft.Maui.Controls.SourceGen.XamlGenerator");


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description

XAML Incremental Hot Reload (XIHR) was enabled **by default for Debug builds** on the net11.0 branch, which is causing issues. This PR makes XIHR **opt-in** instead of on-by-default.

### Changes

- `Microsoft.Maui.Controls.targets`: `EnableMauiIncrementalHotReload` now defaults to `false` unless the developer explicitly sets it to `true`. Removed the `Configuration == 'Debug'` branch that defaulted it to `true`.
- Legacy XAML Hot Reload remains the default fallback (`MauiXamlHotReload` stays `Legacy` when XIHR is off).
- Updated a stale comment in `MSBuildTests.cs` that described XIHR as "on by default in Debug".

### Notes

- The runtime feature switch default (`IsIncrementalHotReloadEnabledByDefault`) is already `false`, so this change makes the MSBuild default coherent with the runtime default end-to-end.
- To opt back in, set `<EnableMauiIncrementalHotReload>true</EnableMauiIncrementalHotReload>` in the project.
- Existing XIHR unit tests set the flag explicitly and are unaffected.