### PR TITLE
Revert - [iOS] Fix Font autoscaling does not work in realtime (#34445)

### DIFF
--- a/src/Core/src/Fonts/FontManager.iOS.cs
+++ b/src/Core/src/Fonts/FontManager.iOS.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using Foundation;
 using Microsoft.Extensions.Logging;
 using UIKit;
 
 namespace Microsoft.Maui
 {
 	/// <inheritdoc/>
-	public class FontManager : IFontManager, IDisposable
+	public class FontManager : IFontManager
 	{
 		// UIFontWeight[Constant] is internal in Xamarin.iOS but the convertion from
 		// the public (int-based) enum is not helpful in this case.
@@ -29,7 +28,6 @@ namespace Microsoft.Maui
 		readonly IFontRegistrar _fontRegistrar;
 		readonly IServiceProvider? _serviceProvider;
 
-		NSObject? _contentSizeCategoryObserver;
 		UIFont? _defaultFont;
 
 		/// <summary>
@@ -42,11 +40,6 @@ namespace Microsoft.Maui
 		{
 			_fontRegistrar = fontRegistrar;
 			_serviceProvider = serviceProvider;
-
-			// When the preferred content size category changes (Dynamic Type),
-			// clear the font cache so subsequent requests create new fonts
-			// with the current content size category scaling.
-			_contentSizeCategoryObserver = UIApplication.Notifications.ObserveContentSizeCategoryChanged((sender, args) => _fonts.Clear());
 		}
 
 		/// <inheritdoc/>
@@ -188,12 +181,6 @@ namespace Microsoft.Maui
 
 				return uiFont;
 			}
-		}
-
-		public void Dispose()
-		{
-			_contentSizeCategoryObserver?.Dispose();
-			_contentSizeCategoryObserver = null;
 		}
 
 		string? CleanseFontName(string fontName)

--- a/src/Core/src/Platform/iOS/PageViewController.cs
+++ b/src/Core/src/Platform/iOS/PageViewController.cs
@@ -75,16 +75,6 @@ namespace Microsoft.Maui.Platform
 					var application = handler.GetRequiredService<IApplication>();
 					application.UpdateUserInterfaceStyle();
 					application.ThemeChanged();
-
-					// When the preferred content size category changes (Dynamic Type),
-					// re-apply fonts to all text elements so they reflect the new
-					// scaling immediately without an app restart. The font cache is
-					// cleared via ObserveContentSizeCategoryChanged in FontManager.
-					if (previousTraitCollection is not null &&
-						previousTraitCollection.PreferredContentSizeCategory != TraitCollection.PreferredContentSizeCategory)
-					{
-						InvalidateFontsOnContentSizeChanged(CurrentView as IView);
-					}
 				}
 				catch (ObjectDisposedException)
 				{
@@ -96,31 +86,6 @@ namespace Microsoft.Maui.Platform
 #pragma warning disable CA1422 // Validate platform compatibility
 			base.TraitCollectionDidChange(previousTraitCollection);
 #pragma warning restore CA1422 // Validate platform compatibility
-		}
-
-		static void InvalidateFontsOnContentSizeChanged(IView? view)
-		{
-			if (view is null)
-			{
-				return;
-			}
-
-			if (view is ITextStyle { Font.AutoScalingEnabled: true } && view.Handler is not null)
-			{
-				view.Handler.UpdateValue(nameof(ITextStyle.Font));
-				view.InvalidateMeasure();
-			}
-
-			if (view is IVisualTreeElement vte)
-			{
-				foreach (var child in vte.GetVisualChildren())
-				{
-					if (child is IView childView)
-					{
-						InvalidateFontsOnContentSizeChanged(childView);
-					}
-				}
-			}
 		}
 	}
 }

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,5 +1,4 @@
 ﻿#nullable enable
-Microsoft.Maui.FontManager.Dispose() -> void
 override Microsoft.Maui.Handlers.LabelHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Handlers.ShapeViewHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Handlers.StepperHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,5 +1,4 @@
 ﻿#nullable enable
-Microsoft.Maui.FontManager.Dispose() -> void
 override Microsoft.Maui.Handlers.LabelHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Handlers.ShapeViewHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Handlers.StepperHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size


### PR DESCRIPTION
In macOS, some Label feature test cases are failing in the candidate PR https://github.com/dotnet/maui/pull/36411 CI due to changes in Label text. These failures cannot be reproduced locally. The PR https://github.com/dotnet/maui/pull/34445 is suspected, so its changes were reverted to confirm the cause of the failures.

https://dev.azure.com/dnceng-public/public/_build/results?buildId=1528004&view=ms.vss-test-web.build-test-results-tab&runId=42075328&resultId=100079&paneView=debug

<img width="426" height="129" alt="image" src="https://github.com/user-attachments/assets/962cf80e-269d-44f1-b115-e41a31ab8e6b" />


**Note: Do not merge this PR**