### PR TITLE
[XAML] Fix local Debug build of Controls.Xaml.UnitTests (stale diagnostic suppressions)

### DIFF
--- a/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
+++ b/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
@@ -8,7 +8,7 @@
     <NoWarn>$(NoWarn);0672;0219;0414;CS0436;CS0618;CA2252</NoWarn>
     <!-- XC0618/XC0619 suppressed: test projects exercise deprecated APIs intentionally.
          XC0619 uses raw LogError (not warning-promotion), so WarningsNotAsErrors is defensive only. -->
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0618;XC0619;XC0022;XC0023;XC0025;XC0045;XC0067;MAUIG2045;MAUID1000;MAUIX2005;MAUIX2015</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0618;XC0619;XC0022;XC0023;XC0025;XC0045;XC0067;MAUIG2045;MAUID1000;MAUIX2005;MAUIX2017</WarningsNotAsErrors>
     <IsPackable>false</IsPackable>
     <DisableMSBuildAssemblyCopyCheck>true</DisableMSBuildAssemblyCopyCheck>
     <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
@@ -79,12 +79,12 @@
     <MauiXaml Update="Issues\Issue2578.xaml" NoWarn="0612" />
     <MauiXaml Update="Issues\Issue2659.xaml" NoWarn="0612" />
     
-    <!-- Suppress XC0067/MAUIX2015 (property set multiple times) for test files that intentionally test this scenario -->
-    <MauiXaml Update="Issues\Bz40906.xaml" NoWarn="67;2015" />
-    <MauiXaml Update="Issues\Maui3059.xaml" NoWarn="67;2015" />
-    <MauiXaml Update="Issues\Maui20616.xaml" NoWarn="67;2015" />
-    <MauiXaml Update="Issues\Maui20818.xaml" NoWarn="67;2015" />
-    <MauiXaml Update="TestSharedResourceDictionary.xaml" NoWarn="67;2015" />
+    <!-- Suppress XC0067/MAUIX2017 (property set multiple times) for test files that intentionally test this scenario -->
+    <MauiXaml Update="Issues\Bz40906.xaml" NoWarn="67;2017" />
+    <MauiXaml Update="Issues\Maui3059.xaml" NoWarn="67;2017" />
+    <MauiXaml Update="Issues\Maui20616.xaml" NoWarn="67;2017" />
+    <MauiXaml Update="Issues\Maui20818.xaml" NoWarn="67;2017" />
+    <MauiXaml Update="TestSharedResourceDictionary.xaml" NoWarn="67;2017" />
 
     <!-- LazyRD feature test -->
     <MauiXaml Update="Issues\LazyResourceDictionary.sgen.xaml" LazyRD="true" />

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui34998.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui34998.xaml.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Windows.Input;
 using Xunit;


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description

Building `Controls.Xaml.UnitTests` locally in **Debug** currently fails with 16 errors. These are stale diagnostic suppressions that only surface in local/dev builds: `Directory.Build.props` defaults `TreatWarningsAsErrors=true`, whereas CI overrides it to `false` (`eng/pipelines/arcade/variables.yml`), so these warnings never broke CI — only local builds.

Two independent stale suppressions:

- **MAUIX2017 — "property is being set multiple times" (5 negative-test fixtures).** The duplicate implicit-content-property diagnostic was renumbered `MAUIX2015` → `MAUIX2017` in the `main`→`net11.0` merge (`1895265f9b`), but the fixtures that intentionally exercise this scenario still suppressed the old number (`NoWarn="67;2015"`), and the project still listed `MAUIX2015` in `WarningsNotAsErrors`. Updated both to `MAUIX2017` for `Bz40906.xaml`, `Maui3059.xaml`, `Maui20616.xaml`, `Maui20818.xaml`, and `TestSharedResourceDictionary.xaml`.
- **CS8632 — nullable annotations without a `#nullable` context (`Issues/Maui34998.xaml.cs`).** The file uses `EventHandler?` / `object?` but had no `#nullable` directive. Added `#nullable enable`.

### Verification

`Controls.Xaml.UnitTests` now builds and runs locally (net TFM, Debug): **2039 passed, 8 skipped**.

> [!NOTE]
> Two unrelated tests (`TwoWayDecimalBinding_INPC`, `TwoWayDecimalBinding_VMToUI`) fail on locales that use a comma decimal separator (e.g. `fr-FR`) — `Expected: 25,75` vs `Actual: 2575`. That's a pre-existing culture-sensitivity issue in those tests, out of scope for this PR.

### Notes

- Test-project-only change; no product code and no public API changes.
- CI is unaffected (it already builds with `TreatWarningsAsErrors=false`); this purely unblocks local Debug builds of the project.
