### PR TITLE
[Windows] Fix Shell.Items.Clear() memory leak by disconnecting child handlers on removal

### DIFF
--- a/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Windows.cs
@@ -80,6 +80,16 @@ namespace Microsoft.Maui.Controls.Handlers
 			if (_navigationManager?.NavigationView != null &&
 				_navigationManager.NavigationView != view)
 			{
+				// If the old section is no longer attached to the Shell (e.g., Shell.Items.Clear()),
+				// recursively disconnect handlers on its pages to prevent memory leaks.
+				if (_shellSection?.FindParentOfType<Shell>() is null)
+				{
+					foreach (var page in _navigationManager.NavigationStack)
+					{
+						page?.DisconnectHandlers();
+					}
+				}
+				
 				_navigationManager.Disconnect(_navigationManager.NavigationView, PlatformView);
 
 				if (view is IStackNavigation stackNavigation)

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34898.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34898.cs
@@ -1,6 +1,6 @@
 namespace Maui.Controls.Sample.Issues;
 
-[Issue(IssueTracker.Github, 34898, "Shell.Items.Clear does not disconnect handlers correctly", PlatformAffected.iOS | PlatformAffected.Android | PlatformAffected.macOS)]
+[Issue(IssueTracker.Github, 34898, "Shell.Items.Clear does not disconnect handlers correctly", PlatformAffected.All)]
 public class Issue34898 : TestShell
 {
     static Label _trackedLabel;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34898.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34898.cs
@@ -1,4 +1,3 @@
-#if TEST_FAILS_ON_WINDOWS //Related issue for windows: https://github.com/dotnet/maui/issues/35035
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -37,4 +36,3 @@ public class Issue34898 : _IssuesUITest
             "Button handler should be disconnected after Shell.Items.Clear()");
     }
 }
-#endif


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->


### Issue Details
On Windows, calling Shell.Items.Clear() and navigating to a new root page leaves the old page's handlers (and its children's handlers) connected, causing a memory leak

### Root Cause
ShellSectionHandler.SetVirtualView() reuses the handler for the new ShellSection but never disconnects handlers from the old section's pages when the section is removed from the Shell hierarchy.

### Description of Change
Before the StackNavigationManager switches to the new section, check if the old ShellSection is no longer part of the Shell (FindParentOfType<Shell>() is null). If so, iterate NavigationStack and call DisconnectHandlers() on each page to recursively free all native resources.

Validated the behavior in the following platforms
 
- [ ] Android
- [x] Windows
- [ ] iOS
- [ ] Mac
 
### Issues Fixed
  
Fixes #35035 

### Test case
The [Issue34898](https://github.com/dotnet/maui/blob/main/src/Controls/tests/TestCases.HostApp/Issues/Issue34898.cs#L1) test case is already present in the main source code.

### Output  ScreenShot

|Before|After|
|--|--|
| <video src="https://github.com/user-attachments/assets/87e4c6e5-ccbf-45ee-9b78-a19c50a904d0" >| <video src="https://github.com/user-attachments/assets/03b3b338-765a-4b54-9103-eb880aa580a7">|