### PR TITLE
[Testing] Fix net11 CI failure in Picker UI test (Issue34971)

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34971.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34971.cs
@@ -6,6 +6,8 @@ namespace Microsoft.Maui.TestCases.Tests.Issues;
 
 public class Issue34971 : _IssuesUITest
 {
+	string doneButton => App is AppiumIOSApp iosApp && HelperExtensions.IsIOS26OrHigher(iosApp) ? "selected" : "Done";
+
 	public Issue34971(TestDevice device) : base(device)
     {
     }
@@ -37,6 +39,7 @@ public class Issue34971 : _IssuesUITest
 
 	// The picker is presented differently per platform, so it is dismissed differently:
 	// iOS/MacCatalyst confirm the wheel with a Done button (which selects the highlighted item),
+	// on iOS 26+ the button is labeled "selected" instead of "Done".
 	// Android dismisses with Cancel, and Windows dismisses by tapping outside the dropdown.
 	void CloseOpenedPicker()
 	{
@@ -44,8 +47,8 @@ public class Issue34971 : _IssuesUITest
 		App.WaitForElement("Cancel");
 		App.Tap("Cancel");
 #elif IOS || MACCATALYST
-		App.WaitForElement("Done");
-		App.Tap("Done");
+		App.WaitForElement(doneButton);
+		App.Tap(doneButton);
 #elif WINDOWS
 		App.TapCoordinates(10, 10);
 #endif


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

On iOS 26, the picker dialog's action button label changed from **"Done"** to **"selected"**, which broke the `Issue34971` UI test that hard-coded the `"Done"` accessibility id when dismissing the `Picker` dialog. This PR updates the test to dynamically resolve the correct button label based on the iOS version under test, using the existing `HelperExtensions.IsIOS26OrHigher` helper.

**Changes:**
- Added a `doneButton` computed property in `Issue34971` that returns `"selected"` on iOS 26+ and `"Done"` otherwise (via `App is AppiumIOSApp iosApp && HelperExtensions.IsIOS26OrHigher(iosApp)`).
- Updated `App.WaitForElement`/`App.Tap` calls in `CloseOpenedPicker` to use this computed value instead of the hard-coded `"Done"` string.

**Issue Fixed**
 Fixes https://github.com/dotnet/maui/issues/36857
