### PR TITLE
Auto-merge clean inter-branch forward merges

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -721,21 +721,29 @@ configuration:
     - if:
       - payloadType: Pull_Request
       - isPullRequest
-      - isAction:
-          action: Opened
       - isActivitySender:
           user: github-actions[bot]
           issueAuthor: False
-      - targetsBranch:
-          branch: net11.0
-      - titleContains:
-          pattern: "[automated] Merge branch 'main' => 'net11.0'"
-          isRegex: False
+      - or:
+        - isAction:
+            action: Opened
+        - isAction:
+            action: Synchronize
+      - or:
+        - and:
+          - targetsBranch:
+              branch: net11.0
+          - titleContains:
+              pattern: "[automated] Merge branch 'main' => 'net11.0'"
+              isRegex: False
+        - titleContains:
+            pattern: "[automated] Merge branch 'net11.0' => 'release/"
+            isRegex: False
       then:
       - approvePullRequest:
-          comment: Auto-approved automated main to net11.0 merge.
+          comment: Auto-approved automated inter-branch merge.
       - enableAutoMerge:
           mergeMethod: merge
-      description: '[Inter-branch merge] Auto-approve and enable auto-merge for main to net11.0'
+      description: '[Inter-branch merge] Auto-approve and enable auto-merge for main to net11.0 and net11.0 to release'
 onFailure: 
 onSuccess: 

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -718,5 +718,26 @@ configuration:
       - addLabel:
           label: partner/syncfusion
       description: Add 'partner/syncfusion' label to issues opened by the Syncfusion partner team
+    - if:
+      - payloadType: Pull_Request
+      - isPullRequest
+      - isAction:
+          action: Opened
+      - isActivitySender:
+          user: github-actions[bot]
+          issueAuthor: False
+      - or:
+        - titleContains:
+            pattern: "[automated] Merge branch 'main' => 'net11.0'"
+            isRegex: False
+        - titleContains:
+            pattern: "[automated] Merge branch 'net11.0' => 'release/"
+            isRegex: False
+      then:
+      - approvePullRequest:
+          comment: Auto-approved automated inter-branch merge.
+      - enableAutoMerge:
+          mergeMethod: merge
+      description: '[Inter-branch merge] Auto-approve and enable auto-merge on automated branch merge Pull Requests'
 onFailure: 
 onSuccess: 

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -726,11 +726,8 @@ configuration:
           issueAuthor: False
       - isActivitySender:
           issueAuthor: True
-      - or:
-        - isAction:
-            action: Opened
-        - isAction:
-            action: Synchronize
+      - isAction:
+          action: Opened
       - or:
         - and:
           - targetsBranch:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -724,6 +724,8 @@ configuration:
       - isActivitySender:
           user: github-actions[bot]
           issueAuthor: False
+      - isActivitySender:
+          issueAuthor: True
       - or:
         - isAction:
             action: Opened
@@ -734,16 +736,19 @@ configuration:
           - targetsBranch:
               branch: net11.0
           - titleContains:
-              pattern: "[automated] Merge branch 'main' => 'net11.0'"
-              isRegex: False
-        - titleContains:
-            pattern: "[automated] Merge branch 'net11.0' => 'release/"
-            isRegex: False
+              pattern: '^\[automated\] Merge branch ''main'' => ''net11\.0''$'
+              isRegex: True
+        - and:
+          - targetsBranch:
+              branch: release/11.0.1xx-preview7
+          - titleContains:
+              pattern: '^\[automated\] Merge branch ''net11\.0'' => ''release/11\.0\.1xx-preview7''$'
+              isRegex: True
       then:
       - approvePullRequest:
           comment: Auto-approved automated inter-branch merge.
       - enableAutoMerge:
           mergeMethod: merge
-      description: '[Inter-branch merge] Auto-approve and enable auto-merge for main to net11.0 and net11.0 to release'
+      description: '[Inter-branch merge] Auto-approve and enable auto-merge for exact forward-merge flows'
 onFailure: 
 onSuccess: 

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -726,18 +726,16 @@ configuration:
       - isActivitySender:
           user: github-actions[bot]
           issueAuthor: False
-      - or:
-        - titleContains:
-            pattern: "[automated] Merge branch 'main' => 'net11.0'"
-            isRegex: False
-        - titleContains:
-            pattern: "[automated] Merge branch 'net11.0' => 'release/"
-            isRegex: False
+      - targetsBranch:
+          branch: net11.0
+      - titleContains:
+          pattern: "[automated] Merge branch 'main' => 'net11.0'"
+          isRegex: False
       then:
       - approvePullRequest:
-          comment: Auto-approved automated inter-branch merge.
+          comment: Auto-approved automated main to net11.0 merge.
       - enableAutoMerge:
           mergeMethod: merge
-      description: '[Inter-branch merge] Auto-approve and enable auto-merge on automated branch merge Pull Requests'
+      description: '[Inter-branch merge] Auto-approve and enable auto-merge for main to net11.0'
 onFailure: 
 onSuccess: 

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -744,6 +744,18 @@ configuration:
           - titleContains:
               pattern: '^\[automated\] Merge branch ''net11\.0'' => ''release/11\.0\.1xx-preview7''$'
               isRegex: True
+        - and:
+          - targetsBranch:
+              branch: release/11.0.1xx-rc1
+          - titleContains:
+              pattern: '^\[automated\] Merge branch ''net11\.0'' => ''release/11\.0\.1xx-rc1''$'
+              isRegex: True
+        - and:
+          - targetsBranch:
+              branch: release/11.0.1xx-rc2
+          - titleContains:
+              pattern: '^\[automated\] Merge branch ''net11\.0'' => ''release/11\.0\.1xx-rc2''$'
+              isRegex: True
       then:
       - approvePullRequest:
           comment: Auto-approved automated inter-branch merge.

--- a/.github/workflows/merge-main-to-net11.yml
+++ b/.github/workflows/merge-main-to-net11.yml
@@ -44,10 +44,12 @@ jobs:
           pr_number="$(gh pr list \
             --repo "$REPOSITORY" \
             --state open \
+            --app 'github-actions' \
             --head 'merge/main-to-net11.0' \
             --base 'net11.0' \
-            --json number \
-            --jq '.[0].number // empty')"
+            --limit 100 \
+            --json number,isCrossRepository \
+            --jq '[.[] | select(.isCrossRepository == false)][0].number // empty')"
 
           if [[ -n "$pr_number" ]]; then
             echo "Merge PR #$pr_number is still open; leaving its branch unchanged while CI runs."

--- a/.github/workflows/merge-main-to-net11.yml
+++ b/.github/workflows/merge-main-to-net11.yml
@@ -32,6 +32,9 @@ concurrency:
 jobs:
   CheckForOpenMergePullRequest:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
     steps:

--- a/.github/workflows/merge-main-to-net11.yml
+++ b/.github/workflows/merge-main-to-net11.yml
@@ -7,7 +7,7 @@
 #   - ResetToTargetPaths: auto-resets version files to target branch versions
 #   - QuietComments: reduces GitHub notification noise
 #   - Skips PRs when only Maestro bot commits exist
-#   - Updates existing open PR instead of creating new ones
+#   - Keeps each generated PR immutable while CI runs; later commits flow in the next PR
 
 name: Merge main to net11.0
 
@@ -25,8 +25,41 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: merge-main-to-net11
+  cancel-in-progress: false
+
 jobs:
+  CheckForOpenMergePullRequest:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+    steps:
+      - name: Check for an open main to net11.0 merge PR
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          pr_number="$(gh pr list \
+            --repo "$REPOSITORY" \
+            --state open \
+            --head 'merge/main-to-net11.0' \
+            --base 'net11.0' \
+            --json number \
+            --jq '.[0].number // empty')"
+
+          if [[ -n "$pr_number" ]]; then
+            echo "Merge PR #$pr_number is still open; leaving its branch unchanged while CI runs."
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "No open main to net11.0 merge PR exists."
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          fi
+
   Merge:
+    needs: CheckForOpenMergePullRequest
+    if: needs.CheckForOpenMergePullRequest.outputs.should_run == 'true'
     uses: dotnet/arcade/.github/workflows/inter-branch-merge-base.yml@main
     with:
       configuration_file_path: 'github-merge-flow-net11.jsonc'

--- a/.github/workflows/merge-net11-to-release.yml
+++ b/.github/workflows/merge-net11-to-release.yml
@@ -32,7 +32,64 @@ jobs:
       actions: write
       contents: read
     steps:
+      - name: Check that net11.0 has the immutable-snapshot gate
+        id: current
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          main_workflow="$RUNNER_TEMP/merge-net11-to-release-main.yml"
+          net11_workflow="$RUNNER_TEMP/merge-net11-to-release-net11.yml"
+
+          if ! gh api \
+            -H "Accept: application/vnd.github.raw+json" \
+            "repos/$REPOSITORY/contents/.github/workflows/merge-net11-to-release.yml?ref=main" \
+            > "$main_workflow"; then
+            echo "::error::Failed to read the workflow on main."
+            exit 1
+          fi
+
+          if ! gh api \
+            -H "Accept: application/vnd.github.raw+json" \
+            "repos/$REPOSITORY/contents/.github/workflows/merge-net11-to-release.yml?ref=net11.0" \
+            > "$net11_workflow"; then
+            echo "::error::Failed to read the workflow on net11.0."
+            exit 1
+          fi
+
+          if ruby - "$main_workflow" "$net11_workflow" <<'RUBY'
+          require 'yaml'
+
+          main = YAML.safe_load_file(ARGV[0], aliases: true)
+          net11 = YAML.safe_load_file(ARGV[1], aliases: true)
+
+          safety_sections = [
+            ['concurrency'],
+            ['jobs', 'CheckForOpenMergePullRequest'],
+            ['jobs', 'Merge']
+          ]
+
+          def section(workflow, path)
+            path.reduce(workflow) { |value, key| value&.fetch(key, nil) }
+          end
+
+          exit(safety_sections.all? { |path| section(main, path) == section(net11, path) } ? 0 : 2)
+          RUBY
+          then
+            echo "should_dispatch=true" >> "$GITHUB_OUTPUT"
+          else
+            validation_exit="$?"
+            if [[ "$validation_exit" -eq 2 ]]; then
+              echo "::notice::net11.0 does not have the current immutable-snapshot gate yet; skipping the scheduled dispatch."
+              echo "should_dispatch=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "::error::Failed to validate the workflow on net11.0."
+              exit 1
+            fi
+          fi
+
       - name: Dispatch the scheduled run from net11.0
+        if: steps.current.outputs.should_dispatch == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}
@@ -41,6 +98,9 @@ jobs:
   CheckForOpenMergePullRequest:
     if: github.event_name != 'schedule' && github.ref_name == 'net11.0'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
     steps:
@@ -102,4 +162,5 @@ jobs:
     if: github.ref_name == 'net11.0' && needs.CheckForOpenMergePullRequest.outputs.should_run == 'true'
     uses: dotnet/arcade/.github/workflows/inter-branch-merge-base.yml@main
     with:
+      configuration_file_branch: 'net11.0'
       configuration_file_path: 'github-merge-flow-release-11.jsonc'

--- a/.github/workflows/merge-net11-to-release.yml
+++ b/.github/workflows/merge-net11-to-release.yml
@@ -20,10 +20,41 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: merge-net11-to-release
+  cancel-in-progress: false
+
 jobs:
-  Merge:
-    # Only run if triggered from net11.0 (push trigger or correct workflow_dispatch)
+  CheckForOpenMergePullRequest:
     if: github.ref_name == 'net11.0'
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+    steps:
+      - name: Check for an open net11.0 to release merge PR
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          pr_number="$(gh pr list \
+            --repo "$REPOSITORY" \
+            --state open \
+            --json number,headRefName \
+            --jq '[.[] | select(.headRefName | startswith("merge/net11.0-to-release/"))][0].number // empty')"
+
+          if [[ -n "$pr_number" ]]; then
+            echo "Merge PR #$pr_number is still open; leaving its branch unchanged while CI runs."
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "No open net11.0 to release merge PR exists."
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  Merge:
+    needs: CheckForOpenMergePullRequest
+    # Only run if triggered from net11.0 (push trigger or correct workflow_dispatch)
+    if: github.ref_name == 'net11.0' && needs.CheckForOpenMergePullRequest.outputs.should_run == 'true'
     uses: dotnet/arcade/.github/workflows/inter-branch-merge-base.yml@main
     with:
       configuration_file_path: 'github-merge-flow-release-11.jsonc'

--- a/.github/workflows/merge-net11-to-release.yml
+++ b/.github/workflows/merge-net11-to-release.yml
@@ -4,7 +4,7 @@
 # This workflow must be triggered FROM the net11.0 branch because the arcade merge
 # script uses GITHUB_REF_NAME as the config lookup key. When triggered via
 # workflow_dispatch from the GitHub UI, select 'net11.0' from the branch dropdown.
-# The schedule trigger only works when this file exists on net11.0.
+# The default-branch schedule dispatches a second run from net11.0.
 
 name: Merge net11.0 to next release
 
@@ -25,23 +25,68 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  DispatchScheduledRun:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Dispatch the scheduled run from net11.0
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+        run: gh workflow run merge-net11-to-release.yml --repo "$REPOSITORY" --ref net11.0
+
   CheckForOpenMergePullRequest:
-    if: github.ref_name == 'net11.0'
+    if: github.event_name != 'schedule' && github.ref_name == 'net11.0'
     runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
     steps:
+      - name: Resolve the current release target
+        id: target
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          $configText = gh api `
+            -H "Accept: application/vnd.github.raw+json" `
+            "repos/$env:REPOSITORY/contents/github-merge-flow-release-11.jsonc?ref=net11.0" |
+            Out-String
+
+          if ($LASTEXITCODE -ne 0)
+          {
+            throw "Failed to read the net11.0 merge-flow configuration."
+          }
+
+          $config = $configText | ConvertFrom-Json
+          $mergeToBranch = $config.'merge-flow-configurations'.'net11.0'.MergeToBranch
+
+          if ($mergeToBranch -notmatch '^release/[A-Za-z0-9._/-]+$')
+          {
+            throw "Invalid MergeToBranch value '$mergeToBranch'."
+          }
+
+          "merge_to_branch=$mergeToBranch" >> $env:GITHUB_OUTPUT
+
       - name: Check for an open net11.0 to release merge PR
         id: check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MERGE_TO_BRANCH: ${{ steps.target.outputs.merge_to_branch }}
           REPOSITORY: ${{ github.repository }}
         run: |
           pr_number="$(gh pr list \
             --repo "$REPOSITORY" \
             --state open \
-            --json number,headRefName \
-            --jq '[.[] | select(.headRefName | startswith("merge/net11.0-to-release/"))][0].number // empty')"
+            --app github-actions \
+            --head "merge/net11.0-to-$MERGE_TO_BRANCH" \
+            --base "$MERGE_TO_BRANCH" \
+            --limit 100 \
+            --json number,isCrossRepository \
+            --jq '[.[] | select(.isCrossRepository == false)][0].number // empty')"
 
           if [[ -n "$pr_number" ]]; then
             echo "Merge PR #$pr_number is still open; leaving its branch unchanged while CI runs."


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Auto-approve and enable GitHub native auto-merge for immutable snapshots of these exact forward-merge targets:

```text
main    => net11.0
net11.0 => release/11.0.1xx-preview7
net11.0 => release/11.0.1xx-rc1
net11.0 => release/11.0.1xx-rc2
```

### Immutable snapshot design

Each caller workflow checks for its generated merge PR before invoking Arcade:

```text
no open merge PR  -> run Arcade and create a fresh snapshot
open merge PR     -> leave its branch unchanged while CI runs
```

The checks use exact head/base pairs and require the PR authoring App to be `github-actions` with `isCrossRepository == false`. The release workflow resolves the current `MergeToBranch` from `github-merge-flow-release-11.jsonc` on `net11.0`, and passes `configuration_file_branch: net11.0` to Arcade so the gate and merge implementation use the same source of truth.

Workflow runs are serialized with distinct concurrency groups so simultaneous push/schedule/manual runs cannot both pass the check and create or update the same PR. Because scheduled workflows start from the default branch, the release schedule uses a schedule-only job to dispatch `merge-net11-to-release.yml` at ref `net11.0`; the dispatched run is not a schedule event and cannot recurse.

During rollout, the schedule job first compares the parsed safety-critical sections (`concurrency`, `CheckForOpenMergePullRequest`, and `Merge`) between the workflow on `main` and `net11.0`. It skips the dispatch until the full immutable-snapshot gate has propagated, while allowing unrelated branch-specific workflow differences. Fetch or parse failures fail visibly instead of dispatching an unknown definition.

The read-only snapshot checks use read-only `GITHUB_TOKEN` permissions. Only the reusable Arcade merge job retains content and pull-request write access.

New source commits that arrive while a merge PR is open wait for the next generated PR. Once the current PR merges or closes, the next push or daily schedule creates a fresh snapshot containing the remaining commits.

This intentionally stops using Arcade's existing "fast-forward the open merge PR" behavior. The generated PR head does not change during CI, so source-branch pushes do not invalidate its approval or restart CI.

### Policy Service rule

The rule runs only on `Opened`; `Synchronize` is not accepted.

It requires:

- event sender `github-actions[bot]`
- event sender is also the PR author
- exact target branch
- exact, fully anchored generated title

Human conflict-resolution pushes do not trigger reapproval. Bot-attributed `/rebase` synchronization also does not trigger the policy, closing the review-bypass path identified in the adversarial review.

### Review behavior and accepted limitation

`MAUI protection` intentionally remains:

```text
dismiss_stale_reviews_on_push: true
require_last_push_approval: false
required_approving_review_count: 1
```

This preserves the repository's human-review workflow: a maintainer who pushes a fix to another person's PR can provide the subsequent approval without requiring a third reviewer. This PR does not modify repository rulesets or add a bypass.

The generated merge PR remains safe under these settings. Policy Service approves only the initial `Opened` snapshot, the caller workflow refuses to invoke Arcade while the exact bot-authored PR remains open, and any out-of-band head push dismisses the approval with no automatic reapproval path.

Ordinary target-branch advancement does not require the generated PR to update because the required status-check rules use `strict_required_status_checks_policy: false`. If the immutable head remains conflict-free, its approval remains valid, and required checks pass, auto-merge can complete against the advanced base. In the narrower case where base activity actually changes the reviewed diff or merge base, GitHub can dismiss the approval and safely stall the PR. That fail-closed limitation is accepted for this automation.

### Exact branch and title allow-list

```text
net11.0                    + ^[automated] Merge branch 'main' => 'net11.0'$
release/...-preview7       + ^[automated] Merge branch 'net11.0' => 'release/...-preview7'$
release/...-rc1            + ^[automated] Merge branch 'net11.0' => 'release/...-rc1'$
release/...-rc2            + ^[automated] Merge branch 'net11.0' => 'release/...-rc2'$
```

Each entry in the file contains the full literal branch and anchored regex. Targets outside this allow-list remain manual.

### Merge behavior

```yaml
- enableAutoMerge:
    mergeMethod: merge
```

This always creates a true merge commit, never squash or rebase. Arcade relies on merge ancestry to determine what remains to flow.

GitHub completes auto-merge only when the PR has no merge conflict and required checks pass.

### Required checks

| ruleset | checks | Policy Service bypass |
| --- | --- | --- |
| `MAUI required CI checks` | `maui-pr` | **none** |
| `MAUI device and UI test checks` | `maui-pr-devicetests`, `maui-pr-uitests` | pull requests only |

A failing or pending `maui-pr` blocks the merge. Device/UI checks do not.

`MAUI protection` has no Policy Service bypass. It requires one ordinary approval; Policy Service supplies it for the exact authenticated `Opened` events above.

### CODEOWNERS

PR #36890 removes the invalid CODEOWNERS file. `Require review from Code Owners` is disabled in `MAUI protection`; the ordinary one-approval requirement remains.

### Accepted trust boundary

An initial `Opened` event authorizes on exact title/base plus `github-actions[bot]` as both sender and PR author. A collaborator with repository push access could deliberately create a same-repository workflow and matching PR. Real `maui-pr` from Azure Pipelines integration 9426 must still pass, but there is no additional human review under the intentionally ordinary one-review policy.

This tradeoff is accepted for these exact forward-merge target pairs. The immutable-snapshot gate prevents later human content from being reapproved through synchronization. No new App is installed and no bypass is added to `MAUI protection` or the `maui-pr` ruleset.

### Verification

- Both caller workflows pass `actionlint`.
- All three changed YAML files parse successfully.
- The live target resolver returns `release/11.0.1xx-preview7`.
- Exact App/head/base/same-repository queries identify #36886 (`main => net11.0`) and #36880 (`net11.0 => release/11.0.1xx-preview7`).
- The semantic rollout check rejects the current old `net11.0` workflow and accepts matching safety-critical sections.
- Official GitHub documentation confirms that `workflow_dispatch` events created with `GITHUB_TOKEN` start workflow runs; the dispatched event skips the schedule-only job.
- The Policy Service file parses and GitOps schema validation runs on every update.
- The live `MAUI protection` settings and effective non-strict required-status-check rules were reverified on 2026-07-31.

### Issues Fixed

None; infrastructure automation.