### PR TITLE
[ci] Fix internal build: duplicate .cab signing + missing MicrosoftWixVersion

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -29,11 +29,6 @@
     <FileSignInfo Include="ReconnectModal.razor.js" CertificateName="Microsoft400" />
   </ItemGroup>
 
-  <ItemGroup Label="MSI workload cab signing">
-    <!-- Sign cab files embedded inside MSI workload packs -->
-    <FileExtensionSignInfo Include=".cab" CertificateName="Microsoft400" />
-  </ItemGroup>
-
   <ItemGroup>
     <ItemsToSign Include="$(ArtifactsShippingPackagesDir)\**\*.msi" Condition="'$(PostBuildSign)' != 'true'" />
     <ItemsToSign Include="$(ArtifactsShippingPackagesDir)**\*.wixpack.zip" Condition="'$(PostBuildSign)' != 'true'" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -153,6 +153,7 @@
     <MicroBuildPluginsSwixBuildDotnetPackageVersion>1.1.87-gba258badda</MicroBuildPluginsSwixBuildDotnetPackageVersion>
     <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.26365.101</MicrosoftDotNetRemoteExecutorPackageVersion>
     <MicrosoftDotNetXUnitExtensionsPackageVersion>11.0.0-beta.26365.101</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <MicrosoftWixVersion>6.0.3-dotnet.4</MicrosoftWixVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftNETTestSdkPackageVersion>17.6.0</MicrosoftNETTestSdkPackageVersion>


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

Fixes two independent issues that were both blocking the internal `dotnet-maui` pipeline on `release/11.0.1xx-preview7`.

### 1. Duplicate `.cab` signing entry

The internal `Pack, Sign` task failed with:

```
Sign.proj(74,5): error : Multiple certificates for extension '.cab' defined for CollisionPriorityId ''.
There should be one certificate per extension per collision priority id.
```

**Cause:** PR #35026 added an explicit `.cab` `FileExtensionSignInfo` to `eng/Signing.props`, but Arcade's built-in `Sign.props` already registers `.cab` by default:

```xml
<FileExtensionSignInfo Include=".dll;.exe;.mibc;.msi;.cab" CertificateName="Microsoft400" />
```

**Fix:** Remove the duplicate entry. Cab files inside workload MSIs are still signed with `Microsoft400` via the Arcade default. The `ReconnectModal.razor.js` `FileSignInfo` entry from #35026 is kept.

Failing build: [internal build 3033388](https://dev.azure.com/dnceng/internal/_build/results?buildId=3033388&view=results).

### 2. Missing `MicrosoftWixVersion` property

After fixing (1), the next internal build ([3033430](https://dev.azure.com/dnceng/internal/_build/results?buildId=3033430&view=results)) failed the `Build Workloads, Sign & Publish` task with:

```
error NU1015: The following PackageReference item(s) do not have a version specified:
  Microsoft.Wix, Microsoft.WixToolset.Dependency.wixext,
  Microsoft.WixToolset.Heat, Microsoft.WixToolset.UI.wixext,
  Microsoft.WixToolset.Util.wixext
```

**Cause:** The WiX 6 migration (commit a8624ba0e3) added `<MicrosoftWixVersion>6.0.3-dotnet.4</MicrosoftWixVersion>` to `eng/Versions.props` and referenced it from `eng/NuGetVersions.targets`. A subsequent merge into `release/11.0.1xx-preview7` dropped the property definition, so the reference resolves to empty and restore fails.

**Fix:** Restore the property with the same value used in the original migration.

### Follow-up

Both fixes should be ported to `main`. Main also has the duplicate `.cab` entry, and `MicrosoftWixVersion` should be double-checked there after a `git merge` audit.
