### PR TITLE
[Net11] Fix Maui.Controls.Sample build fails with MAUIG2045

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Compatibility/ListViewPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Compatibility/ListViewPage.xaml
@@ -8,7 +8,7 @@
     Title="ListView">
 
     <views:BasePage.BindingContext>
-        <viewmodels:ListViewModel />
+        <viewmodels:ListViewModel/>
     </views:BasePage.BindingContext>
     <!-- TODO: Create a ControlTemplate -->
     <Grid
@@ -47,21 +47,21 @@
             BackgroundColor="Transparent"
             ItemsSource="{Binding FilteredItems}"
             SelectionMode="Single"
-            SelectedItem="{Binding SelectedItem, Source={x:RelativeSource AncestorType={x:Type ContentPage}}, Mode=TwoWay}"
-            SelectionChangedCommand="{Binding NavigateCommand, Source={x:RelativeSource AncestorType={x:Type ContentPage}}}"
+            SelectedItem="{Binding SelectedItem, Source={x:RelativeSource AncestorType={x:Type views:BasePage}}, Mode=TwoWay}"
+            SelectionChangedCommand="{Binding NavigateCommand, Source={x:RelativeSource AncestorType={x:Type views:BasePage}}}"
             Margin="6, 12, 6, 0">
             <CollectionView.ItemsLayout>
-                <LinearItemsLayout  
+                <LinearItemsLayout
                     Orientation="Vertical"
                     ItemSpacing="6"/>
             </CollectionView.ItemsLayout>
             <CollectionView.ItemTemplate>
                 <DataTemplate>
-                    <Border     
+                    <Border
                         Style="{StaticResource GalleryItemContainerStyle}">
                         <Border.StrokeShape>
-                            <RoundRectangle                   
-                                CornerRadius="0" />
+                            <RoundRectangle
+                                CornerRadius="0"/>
                         </Border.StrokeShape>
                         <Grid>
                             <StackLayout>

--- a/src/Controls/samples/Controls.Sample/Pages/CompatibilityPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/CompatibilityPage.xaml
@@ -6,7 +6,7 @@
     xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
     xmlns:viewmodels="clr-namespace:Maui.Controls.Sample.ViewModels">
     <views:BasePage.BindingContext>
-        <viewmodels:CompatibilityViewModel />
+        <viewmodels:CompatibilityViewModel/>
     </views:BasePage.BindingContext>
     <!-- TODO: Create a ControlTemplate -->
     <Grid
@@ -46,21 +46,21 @@
             BackgroundColor="Transparent"
             ItemsSource="{Binding FilteredItems}"
             SelectionMode="Single"
-            SelectedItem="{Binding SelectedItem, Source={x:RelativeSource AncestorType={x:Type ContentPage}}, Mode=TwoWay}"
-            SelectionChangedCommand="{Binding NavigateCommand, Source={x:RelativeSource AncestorType={x:Type ContentPage}}}"
+            SelectedItem="{Binding SelectedItem, Source={x:RelativeSource AncestorType={x:Type views:BasePage}}, Mode=TwoWay}"
+            SelectionChangedCommand="{Binding NavigateCommand, Source={x:RelativeSource AncestorType={x:Type views:BasePage}}}"
             Margin="6, 12, 6, 0">
             <CollectionView.ItemsLayout>
-                <LinearItemsLayout  
+                <LinearItemsLayout
                     Orientation="Vertical"
                     ItemSpacing="6"/>
             </CollectionView.ItemsLayout>
             <CollectionView.ItemTemplate>
                 <DataTemplate>
-                    <Border     
+                    <Border
                         Style="{StaticResource GalleryItemContainerStyle}">
                         <Border.StrokeShape>
-                            <RoundRectangle                   
-                                CornerRadius="0" />
+                            <RoundRectangle
+                                CornerRadius="0"/>
                         </Border.StrokeShape>
                         <Grid>
                             <StackLayout>

--- a/src/Controls/samples/Controls.Sample/Pages/ControlsPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/ControlsPage.xaml
@@ -6,7 +6,7 @@
     xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
     xmlns:viewmodels="clr-namespace:Maui.Controls.Sample.ViewModels">
     <views:BasePage.BindingContext>
-        <viewmodels:ControlsViewModel />
+        <viewmodels:ControlsViewModel/>
     </views:BasePage.BindingContext>
     <!-- TODO: Create a ControlTemplate -->
     <Grid
@@ -46,21 +46,21 @@
             BackgroundColor="Transparent"
             ItemsSource="{Binding FilteredItems}"
             SelectionMode="Single"
-            SelectedItem="{Binding SelectedItem, Source={x:RelativeSource AncestorType={x:Type ContentPage}}, Mode=TwoWay}"
-            SelectionChangedCommand="{Binding NavigateCommand, Source={x:RelativeSource AncestorType={x:Type ContentPage}}}"
+            SelectedItem="{Binding SelectedItem, Source={x:RelativeSource AncestorType={x:Type views:BasePage}}, Mode=TwoWay}"
+            SelectionChangedCommand="{Binding NavigateCommand, Source={x:RelativeSource AncestorType={x:Type views:BasePage}}}"
             Margin="6, 12, 6, 0">
             <CollectionView.ItemsLayout>
-                <LinearItemsLayout  
+                <LinearItemsLayout
                     Orientation="Vertical"
                     ItemSpacing="6"/>
             </CollectionView.ItemsLayout>
             <CollectionView.ItemTemplate>
                 <DataTemplate>
-                    <Border     
+                    <Border
                         Style="{StaticResource GalleryItemContainerStyle}">
                         <Border.StrokeShape>
-                            <RoundRectangle 
-                                CornerRadius="0" />
+                            <RoundRectangle
+                                CornerRadius="0"/>
                         </Border.StrokeShape>
                         <Grid>
                             <StackLayout>

--- a/src/Controls/samples/Controls.Sample/Pages/Core/GesturesPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/GesturesPage.xaml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<views:BasePage 
+<views:BasePage
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="Maui.Controls.Sample.Pages.GesturesPage"
@@ -7,7 +7,7 @@
     xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
     xmlns:viewmodels="clr-namespace:Maui.Controls.Sample.ViewModels">
     <views:BasePage.BindingContext>
-        <viewmodels:GesturesViewModel />
+        <viewmodels:GesturesViewModel/>
     </views:BasePage.BindingContext>
     <!-- TODO: Create a ControlTemplate -->
     <Grid
@@ -49,21 +49,21 @@
             BackgroundColor="Transparent"
             ItemsSource="{Binding FilteredItems}"
             SelectionMode="Single"
-            SelectedItem="{Binding SelectedItem, Source={x:RelativeSource AncestorType={x:Type ContentPage}}, Mode=TwoWay}"
-            SelectionChangedCommand="{Binding NavigateCommand, Source={x:RelativeSource AncestorType={x:Type ContentPage}}}"
+            SelectedItem="{Binding SelectedItem, Source={x:RelativeSource AncestorType={x:Type views:BasePage}}, Mode=TwoWay}"
+            SelectionChangedCommand="{Binding NavigateCommand, Source={x:RelativeSource AncestorType={x:Type views:BasePage}}}"
             Margin="6, 12, 6, 0">
             <CollectionView.ItemsLayout>
-                <LinearItemsLayout  
+                <LinearItemsLayout
                     Orientation="Vertical"
                     ItemSpacing="6"/>
             </CollectionView.ItemsLayout>
             <CollectionView.ItemTemplate>
                 <DataTemplate>
-                    <Border     
+                    <Border
                         Style="{StaticResource GalleryItemContainerStyle}">
                         <Border.StrokeShape>
-                            <RoundRectangle 
-                                CornerRadius="0" />
+                            <RoundRectangle
+                                CornerRadius="0"/>
                         </Border.StrokeShape>
                         <Grid>
                             <StackLayout>

--- a/src/Controls/samples/Controls.Sample/Pages/CorePage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/CorePage.xaml
@@ -1,4 +1,4 @@
-﻿<views:BasePage 
+﻿<views:BasePage
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="Maui.Controls.Sample.Pages.CorePage"
@@ -6,7 +6,7 @@
     xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
     xmlns:viewmodels="clr-namespace:Maui.Controls.Sample.ViewModels">
     <views:BasePage.BindingContext>
-        <viewmodels:CoreViewModel />
+        <viewmodels:CoreViewModel/>
     </views:BasePage.BindingContext>
     <!-- TODO: Create a ControlTemplate -->
     <Grid
@@ -46,21 +46,21 @@
             BackgroundColor="Transparent"
             ItemsSource="{Binding FilteredItems}"
             SelectionMode="Single"
-            SelectedItem="{Binding SelectedItem, Source={x:RelativeSource AncestorType={x:Type ContentPage}}, Mode=TwoWay}"
-            SelectionChangedCommand="{Binding NavigateCommand, Source={x:RelativeSource AncestorType={x:Type ContentPage}}}"
+            SelectedItem="{Binding SelectedItem, Source={x:RelativeSource AncestorType={x:Type views:BasePage}}, Mode=TwoWay}"
+            SelectionChangedCommand="{Binding NavigateCommand, Source={x:RelativeSource AncestorType={x:Type views:BasePage}}}"
             Margin="6, 12, 6, 0">
             <CollectionView.ItemsLayout>
-                <LinearItemsLayout  
+                <LinearItemsLayout
                     Orientation="Vertical"
                     ItemSpacing="6"/>
             </CollectionView.ItemsLayout>
             <CollectionView.ItemTemplate>
                 <DataTemplate>
-                    <Border     
+                    <Border
                         Style="{StaticResource GalleryItemContainerStyle}">
                         <Border.StrokeShape>
-                            <RoundRectangle         
-                                CornerRadius="0" />
+                            <RoundRectangle
+                                CornerRadius="0"/>
                         </Border.StrokeShape>
                         <Grid>
                             <StackLayout>

--- a/src/Controls/samples/Controls.Sample/Pages/CustomFlyoutPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/CustomFlyoutPage.xaml
@@ -11,30 +11,30 @@
                 BackgroundColor="Transparent"
                 ItemsSource="{Binding FilteredItems}"
                 SelectionMode="Single"
-                SelectedItem="{Binding SelectedItem, Source={x:RelativeSource AncestorType={x:Type ContentPage}}, Mode=TwoWay}"
-                SelectionChangedCommand="{Binding NavigateCommand, Source={x:RelativeSource AncestorType={x:Type ContentPage}}}"
+                SelectedItem="{Binding SelectedItem, Source={x:RelativeSource AncestorType={x:Type views:BasePage}}, Mode=TwoWay}"
+                SelectionChangedCommand="{Binding NavigateCommand, Source={x:RelativeSource AncestorType={x:Type views:BasePage}}}"
                 Margin="6, 12, 6, 0">
                 <CollectionView.ItemsLayout>
-                    <LinearItemsLayout  
-                    Orientation="Vertical"
-                    ItemSpacing="6"/>
+                    <LinearItemsLayout
+                        Orientation="Vertical"
+                        ItemSpacing="6"/>
                 </CollectionView.ItemsLayout>
                 <CollectionView.ItemTemplate>
                     <DataTemplate>
-                        <Border     
-                        Style="{StaticResource GalleryItemContainerStyle}">
+                        <Border
+                            Style="{StaticResource GalleryItemContainerStyle}">
                             <Border.StrokeShape>
-                                <RoundRectangle         
-                                CornerRadius="0" />
+                                <RoundRectangle
+                                    CornerRadius="0"/>
                             </Border.StrokeShape>
                             <Grid>
                                 <StackLayout>
                                     <Label
-                                    Text="{Binding Title}"
-                                    Style="{StaticResource GalleryItemTitleStyle}"/>
+                                        Text="{Binding Title}"
+                                        Style="{StaticResource GalleryItemTitleStyle}"/>
                                     <Label
-                                    Text="{Binding Description}"
-                                    Style="{StaticResource GalleryItemDescriptionStyle}"/>
+                                        Text="{Binding Description}"
+                                        Style="{StaticResource GalleryItemDescriptionStyle}"/>
                                 </StackLayout>
                             </Grid>
                         </Border>

--- a/src/Controls/samples/Controls.Sample/Pages/Layouts/ScrollViewPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Layouts/ScrollViewPage.xaml
@@ -7,23 +7,23 @@
     xmlns:viewmodels="clr-namespace:Maui.Controls.Sample.ViewModels"
     Title="ScrollView">
     <views:BasePage.BindingContext>
-        <viewmodels:ScrollViewOptionsModel />
+        <viewmodels:ScrollViewOptionsModel/>
     </views:BasePage.BindingContext>
     <views:BasePage.Content>
         <!-- TODO: Create a ControlTemplate -->
         <Grid
-        RowSpacing="0"
-        RowDefinitions="48, 20, *">
+            RowSpacing="0"
+            RowDefinitions="48, 20, *">
             <!-- HEADER -->
             <Image
-            Grid.Row="0"
-            Aspect="AspectFill"
-            Source="header_background"/>
+                Grid.Row="0"
+                Aspect="AspectFill"
+                Source="header_background"/>
             <!-- SEARCH -->
             <Frame
-            Grid.Row="0"
-            Grid.RowSpan="2"
-            Style="{StaticResource SearchBorderStyle}">
+                Grid.Row="0"
+                Grid.RowSpan="2"
+                Style="{StaticResource SearchBorderStyle}">
                 <Grid>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto"/>
@@ -31,47 +31,47 @@
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
                     <controls:BordelessEntry
-                    Grid.Column="1"
-                    Placeholder="Filter"
-                    Text="{Binding FilterValue, Mode=TwoWay}"
-                    PlaceholderColor="{AppThemeBinding Light={StaticResource LightTextSecondaryColor}, Dark={StaticResource DarkTextSecondaryColor}}"
-                    TextColor="{AppThemeBinding Light={StaticResource LightTextPrimaryColor}, Dark={StaticResource DarkTextPrimaryColor}}"
-                    FontSize="Medium"
-                    HorizontalOptions="FillAndExpand"
-                    VerticalOptions="Center"/>
+                        Grid.Column="1"
+                        Placeholder="Filter"
+                        Text="{Binding FilterValue, Mode=TwoWay}"
+                        PlaceholderColor="{AppThemeBinding Light={StaticResource LightTextSecondaryColor}, Dark={StaticResource DarkTextSecondaryColor}}"
+                        TextColor="{AppThemeBinding Light={StaticResource LightTextPrimaryColor}, Dark={StaticResource DarkTextPrimaryColor}}"
+                        FontSize="Medium"
+                        HorizontalOptions="FillAndExpand"
+                        VerticalOptions="Center"/>
                 </Grid>
             </Frame>
             <!-- CONTENT -->
             <CollectionView
-            x:Name="LayoutSections"
-            Grid.Row="2"
-            BackgroundColor="Transparent"
-            ItemsSource="{Binding FilteredItems}"
-            SelectionMode="Single"
-            SelectedItem="{Binding SelectedItem, Source={x:RelativeSource AncestorType={x:Type ContentPage}}, Mode=TwoWay}"
-            SelectionChangedCommand="{Binding NavigateCommand, Source={x:RelativeSource AncestorType={x:Type ContentPage}}}"
-            Margin="6, 12, 6, 0">
+                x:Name="LayoutSections"
+                Grid.Row="2"
+                BackgroundColor="Transparent"
+                ItemsSource="{Binding FilteredItems}"
+                SelectionMode="Single"
+                SelectedItem="{Binding SelectedItem, Source={x:RelativeSource AncestorType={x:Type views:BasePage}}, Mode=TwoWay}"
+                SelectionChangedCommand="{Binding NavigateCommand, Source={x:RelativeSource AncestorType={x:Type views:BasePage}}}"
+                Margin="6, 12, 6, 0">
                 <CollectionView.ItemsLayout>
-                    <LinearItemsLayout  
-                    Orientation="Vertical"
-                    ItemSpacing="6"/>
+                    <LinearItemsLayout
+                        Orientation="Vertical"
+                        ItemSpacing="6"/>
                 </CollectionView.ItemsLayout>
                 <CollectionView.ItemTemplate>
                     <DataTemplate>
-                        <Border     
-                        Style="{StaticResource GalleryItemContainerStyle}">
+                        <Border
+                            Style="{StaticResource GalleryItemContainerStyle}">
                             <Border.StrokeShape>
-                                <RoundRectangle 
-                                CornerRadius="0" />
+                                <RoundRectangle
+                                    CornerRadius="0"/>
                             </Border.StrokeShape>
                             <Grid>
                                 <StackLayout>
                                     <Label
-                                    Text="{Binding Title}"
-                                    Style="{StaticResource GalleryItemTitleStyle}"/>
+                                        Text="{Binding Title}"
+                                        Style="{StaticResource GalleryItemTitleStyle}"/>
                                     <Label
-                                    Text="{Binding Description}"
-                                    Style="{StaticResource GalleryItemDescriptionStyle}"/>
+                                        Text="{Binding Description}"
+                                        Style="{StaticResource GalleryItemDescriptionStyle}"/>
                                 </StackLayout>
                             </Grid>
                         </Border>

--- a/src/Controls/samples/Controls.Sample/Pages/LayoutsPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/LayoutsPage.xaml
@@ -6,7 +6,7 @@
     xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
     xmlns:viewmodels="clr-namespace:Maui.Controls.Sample.ViewModels">
     <views:BasePage.BindingContext>
-        <viewmodels:LayoutsViewModel />
+        <viewmodels:LayoutsViewModel/>
     </views:BasePage.BindingContext>
     <!-- TODO: Create a ControlTemplate -->
     <Grid
@@ -46,21 +46,21 @@
             BackgroundColor="Transparent"
             ItemsSource="{Binding FilteredItems}"
             SelectionMode="Single"
-            SelectedItem="{Binding SelectedItem, Source={x:RelativeSource AncestorType={x:Type ContentPage}}, Mode=TwoWay}"
-            SelectionChangedCommand="{Binding NavigateCommand, Source={x:RelativeSource AncestorType={x:Type ContentPage}}}"
+            SelectedItem="{Binding SelectedItem, Source={x:RelativeSource AncestorType={x:Type views:BasePage}}, Mode=TwoWay}"
+            SelectionChangedCommand="{Binding NavigateCommand, Source={x:RelativeSource AncestorType={x:Type views:BasePage}}}"
             Margin="6, 12, 6, 0">
             <CollectionView.ItemsLayout>
-                <LinearItemsLayout  
+                <LinearItemsLayout
                     Orientation="Vertical"
                     ItemSpacing="6"/>
             </CollectionView.ItemsLayout>
             <CollectionView.ItemTemplate>
                 <DataTemplate>
-                    <Border     
+                    <Border
                         Style="{StaticResource GalleryItemContainerStyle}">
                         <Border.StrokeShape>
-                            <RoundRectangle 
-                                CornerRadius="0" />
+                            <RoundRectangle
+                                CornerRadius="0"/>
                         </Border.StrokeShape>
                         <Grid>
                             <StackLayout>

--- a/src/Controls/samples/Controls.Sample/Pages/MainPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/MainPage.xaml
@@ -11,41 +11,68 @@
     <views:BasePage.Resources>
         <ResourceDictionary>
 
-            <Style x:Key="TitleStyle" TargetType="Label">
-                <Setter Property="FontSize" Value="Title" />
-                <Setter Property="FontFamily" Value="Segoe UI Bold" />
-                <Setter Property="TextColor" Value="{DynamicResource DarkTextPrimaryColor}" />
-                <Setter Property="HorizontalOptions" Value="Center" />
-                <Setter Property="Margin" Value="0, 24, 0, 0" />
+            <Style x:Key="TitleStyle"
+                    TargetType="Label">
+                <Setter Property="FontSize"
+                        Value="Title"/>
+                <Setter Property="FontFamily"
+                        Value="Segoe UI Bold"/>
+                <Setter Property="TextColor"
+                        Value="{DynamicResource DarkTextPrimaryColor}"/>
+                <Setter Property="HorizontalOptions"
+                        Value="Center"/>
+                <Setter Property="Margin"
+                        Value="0, 24, 0, 0"/>
             </Style>
 
-            <Style x:Key="SubTitleStyle" TargetType="Label">
-                <Setter Property="FontSize" Value="Small" />
-                <Setter Property="FontFamily" Value="Segoe UI" />
-                <Setter Property="TextColor" Value="{DynamicResource DarkTextPrimaryColor}" />
-                <Setter Property="HorizontalTextAlignment" Value="Center" />
-                <Setter Property="HorizontalOptions" Value="Center" />
-                <Setter Property="Margin" Value="24, 12" />
+            <Style x:Key="SubTitleStyle"
+                    TargetType="Label">
+                <Setter Property="FontSize"
+                        Value="Small"/>
+                <Setter Property="FontFamily"
+                        Value="Segoe UI"/>
+                <Setter Property="TextColor"
+                        Value="{DynamicResource DarkTextPrimaryColor}"/>
+                <Setter Property="HorizontalTextAlignment"
+                        Value="Center"/>
+                <Setter Property="HorizontalOptions"
+                        Value="Center"/>
+                <Setter Property="Margin"
+                        Value="24, 12"/>
             </Style>
 
             <Color x:Key="SectionItemBorderColor">#C8C8C8</Color>
 
-            <Style x:Key="SectionItemContainerStyle" TargetType="Border">
-                <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource LightBackgroundSecondaryColor}, Dark={StaticResource DarkBackgroundSecondaryColor}}" />
-                <Setter Property="Stroke" Value="{StaticResource SectionItemBorderColor}" />
-                <Setter Property="HeightRequest" Value="120" />
-                <Setter Property="Padding" Value="12" />
-                <Setter Property="Margin" Value="0" />
-                <Setter Property="FlexLayout.Basis" Value="50%"/>
-                <Setter Property="FlexLayout.Grow" Value="0"/>
+            <Style x:Key="SectionItemContainerStyle"
+                    TargetType="Border">
+                <Setter Property="BackgroundColor"
+                        Value="{AppThemeBinding Light={StaticResource LightBackgroundSecondaryColor}, Dark={StaticResource DarkBackgroundSecondaryColor}}"/>
+                <Setter Property="Stroke"
+                        Value="{StaticResource SectionItemBorderColor}"/>
+                <Setter Property="HeightRequest"
+                        Value="120"/>
+                <Setter Property="Padding"
+                        Value="12"/>
+                <Setter Property="Margin"
+                        Value="0"/>
+                <Setter Property="FlexLayout.Basis"
+                        Value="50%"/>
+                <Setter Property="FlexLayout.Grow"
+                        Value="0"/>
             </Style>
 
-            <Style x:Key="FooterStyle" TargetType="Label">
-                <Setter Property="FontSize" Value="Small" />
-                <Setter Property="FontFamily" Value="Segoe UI" />
-                <Setter Property="HorizontalOptions" Value="Center" />
-                <Setter Property="VerticalOptions" Value="End" />
-                <Setter Property="Margin" Value="24" />
+            <Style x:Key="FooterStyle"
+                    TargetType="Label">
+                <Setter Property="FontSize"
+                        Value="Small"/>
+                <Setter Property="FontFamily"
+                        Value="Segoe UI"/>
+                <Setter Property="HorizontalOptions"
+                        Value="Center"/>
+                <Setter Property="VerticalOptions"
+                        Value="End"/>
+                <Setter Property="Margin"
+                        Value="24"/>
             </Style>
 
         </ResourceDictionary>
@@ -85,12 +112,12 @@
             <Grid
                 Grid.Row="1"
                 Margin="12">
-                <CollectionView 
+                <CollectionView
                     x:Name="HomeSections"
                     BackgroundColor="Transparent"
                     ItemsSource="{Binding Items}"
-                    SelectionMode="Single"    
-                    SelectedItem="{Binding SelectedItem, Source={x:RelativeSource AncestorType={x:Type ContentPage}}, Mode=TwoWay}"
+                    SelectionMode="Single"
+                    SelectedItem="{Binding SelectedItem, Source={x:RelativeSource AncestorType={x:Type views:BasePage}}, Mode=TwoWay}"
                     SelectionChangedCommand="{Binding NavigateCommand, Source={x:Reference HomePage}}"
                     Margin="6, 12, 6, 0">
                     <CollectionView.ItemsLayout>
@@ -103,21 +130,21 @@
                     <CollectionView.ItemTemplate>
                         <DataTemplate>
                             <Border
-                               Style="{StaticResource SectionItemContainerStyle}">
+                                Style="{StaticResource SectionItemContainerStyle}">
                                 <Border.StrokeShape>
-                                    <RoundRectangle 
-                                        CornerRadius="0" />
+                                    <RoundRectangle
+                                        CornerRadius="0"/>
                                 </Border.StrokeShape>
                                 <Grid
-                                   RowSpacing="0"
-                                   RowDefinitions="Auto, *">
+                                    RowSpacing="0"
+                                    RowDefinitions="Auto, *">
                                     <Label
-                                       Text="{Binding Title}"
-                                       Style="{StaticResource GalleryItemTitleStyle}"/>
+                                        Text="{Binding Title}"
+                                        Style="{StaticResource GalleryItemTitleStyle}"/>
                                     <Label
-                                       Grid.Row="1"
-                                       Text="{Binding Description}"
-                                       Style="{StaticResource GalleryItemDescriptionStyle}"/>
+                                        Grid.Row="1"
+                                        Text="{Binding Description}"
+                                        Style="{StaticResource GalleryItemDescriptionStyle}"/>
                                 </Grid>
                             </Border>
                         </DataTemplate>
@@ -128,7 +155,7 @@
             <Label
                 Grid.Row="2"
                 Text="{Binding Path=Year, Source={x:Static sys:DateTime.Now}, StringFormat='Microsoft Corporation © {0}'}"
-                Style="{StaticResource FooterStyle}" />
+                Style="{StaticResource FooterStyle}"/>
         </Grid>
     </ScrollView>
 </views:BasePage>

--- a/src/Controls/samples/Controls.Sample/Pages/OthersPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/OthersPage.xaml
@@ -6,7 +6,7 @@
     xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
     xmlns:viewmodels="clr-namespace:Maui.Controls.Sample.ViewModels">
     <views:BasePage.BindingContext>
-        <viewmodels:OthersViewModel />
+        <viewmodels:OthersViewModel/>
     </views:BasePage.BindingContext>
     <!-- TODO: Create a ControlTemplate -->
     <Grid
@@ -46,21 +46,21 @@
             BackgroundColor="Transparent"
             ItemsSource="{Binding FilteredItems}"
             SelectionMode="Single"
-            SelectedItem="{Binding SelectedItem, Source={x:RelativeSource AncestorType={x:Type ContentPage}}, Mode=TwoWay}"
-            SelectionChangedCommand="{Binding NavigateCommand, Source={x:RelativeSource AncestorType={x:Type ContentPage}}}"
+            SelectedItem="{Binding SelectedItem, Source={x:RelativeSource AncestorType={x:Type views:BasePage}}, Mode=TwoWay}"
+            SelectionChangedCommand="{Binding NavigateCommand, Source={x:RelativeSource AncestorType={x:Type views:BasePage}}}"
             Margin="6, 12, 6, 0">
             <CollectionView.ItemsLayout>
-                <LinearItemsLayout  
+                <LinearItemsLayout
                     Orientation="Vertical"
                     ItemSpacing="6"/>
             </CollectionView.ItemsLayout>
             <CollectionView.ItemTemplate>
                 <DataTemplate>
-                    <Border     
+                    <Border
                         Style="{StaticResource GalleryItemContainerStyle}">
                         <Border.StrokeShape>
-                            <RoundRectangle  
-                                CornerRadius="0" />
+                            <RoundRectangle
+                                CornerRadius="0"/>
                         </Border.StrokeShape>
                         <Grid>
                             <StackLayout>
@@ -77,11 +77,20 @@
             </CollectionView.ItemTemplate>
         </CollectionView>
         <!-- FOOTER -->
-        <VerticalStackLayout Grid.Row="3" Margin="0,0,0,100">
-            <Button Margin="5" Text="Add Adorner to TestButton" Clicked="TestVisualTreeHelper" />
-            <Button Margin="5" Text="Enable Visual Diagnostics Element Picker (Will disable UI!)" Clicked="EnableElementPicker" />
-            <Button Margin="5" Text="Enable Test Window Overlay" Clicked="TestAddOverlayWindow" />
-            <Button Margin="5" Text="Disable Test Window Overlay" Clicked="TestRemoveOverlayWindow" />
+        <VerticalStackLayout Grid.Row="3"
+                Margin="0,0,0,100">
+            <Button Margin="5"
+                    Text="Add Adorner to TestButton"
+                    Clicked="TestVisualTreeHelper"/>
+            <Button Margin="5"
+                    Text="Enable Visual Diagnostics Element Picker (Will disable UI!)"
+                    Clicked="EnableElementPicker"/>
+            <Button Margin="5"
+                    Text="Enable Test Window Overlay"
+                    Clicked="TestAddOverlayWindow"/>
+            <Button Margin="5"
+                    Text="Disable Test Window Overlay"
+                    Clicked="TestRemoveOverlayWindow"/>
             <Button
                 x:Name="TestButton"
                 VerticalOptions="Center"

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecificsPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecificsPage.xaml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<views:BasePage 
+<views:BasePage
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="Maui.Controls.Sample.Pages.PlatformSpecificsPage"
@@ -7,7 +7,7 @@
     xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
     xmlns:viewmodels="clr-namespace:Maui.Controls.Sample.ViewModels">
     <views:BasePage.BindingContext>
-        <viewmodels:PlatformSpecificsViewModel />
+        <viewmodels:PlatformSpecificsViewModel/>
     </views:BasePage.BindingContext>
     <!-- TODO: Create a ControlTemplate -->
     <Grid
@@ -47,21 +47,21 @@
             BackgroundColor="Transparent"
             ItemsSource="{Binding FilteredItems}"
             SelectionMode="Single"
-            SelectedItem="{Binding SelectedItem, Source={x:RelativeSource AncestorType={x:Type ContentPage}}, Mode=TwoWay}"
-            SelectionChangedCommand="{Binding NavigateCommand, Source={x:RelativeSource AncestorType={x:Type ContentPage}}}"
+            SelectedItem="{Binding SelectedItem, Source={x:RelativeSource AncestorType={x:Type views:BasePage}}, Mode=TwoWay}"
+            SelectionChangedCommand="{Binding NavigateCommand, Source={x:RelativeSource AncestorType={x:Type views:BasePage}}}"
             Margin="6, 12, 6, 0">
             <CollectionView.ItemsLayout>
-                <LinearItemsLayout  
+                <LinearItemsLayout
                     Orientation="Vertical"
                     ItemSpacing="6"/>
             </CollectionView.ItemsLayout>
             <CollectionView.ItemTemplate>
                 <DataTemplate>
-                    <Border     
+                    <Border
                         Style="{StaticResource GalleryItemContainerStyle}">
                         <Border.StrokeShape>
-                            <RoundRectangle 
-                                CornerRadius="0" />
+                            <RoundRectangle
+                                CornerRadius="0"/>
                         </Border.StrokeShape>
                         <Grid>
                             <StackLayout>

--- a/src/Controls/samples/Controls.Sample/Pages/UserInterfacePage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/UserInterfacePage.xaml
@@ -1,4 +1,4 @@
-﻿<views:BasePage 
+﻿<views:BasePage
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="Maui.Controls.Sample.Pages.UserInterfacePage"
@@ -6,7 +6,7 @@
     xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
     xmlns:viewmodels="clr-namespace:Maui.Controls.Sample.ViewModels">
     <views:BasePage.BindingContext>
-        <viewmodels:UserInterfaceViewModel />
+        <viewmodels:UserInterfaceViewModel/>
     </views:BasePage.BindingContext>
     <!-- TODO: Create a ControlTemplate -->
     <Grid
@@ -46,21 +46,21 @@
             BackgroundColor="Transparent"
             ItemsSource="{Binding FilteredItems}"
             SelectionMode="Single"
-            SelectedItem="{Binding SelectedItem, Source={x:RelativeSource AncestorType={x:Type ContentPage}}, Mode=TwoWay}"
-            SelectionChangedCommand="{Binding NavigateCommand, Source={x:RelativeSource AncestorType={x:Type ContentPage}}}"
+            SelectedItem="{Binding SelectedItem, Source={x:RelativeSource AncestorType={x:Type views:BasePage}}, Mode=TwoWay}"
+            SelectionChangedCommand="{Binding NavigateCommand, Source={x:RelativeSource AncestorType={x:Type views:BasePage}}}"
             Margin="6, 12, 6, 0">
             <CollectionView.ItemsLayout>
-                <LinearItemsLayout  
+                <LinearItemsLayout
                     Orientation="Vertical"
                     ItemSpacing="6"/>
             </CollectionView.ItemsLayout>
             <CollectionView.ItemTemplate>
                 <DataTemplate>
-                    <Border     
+                    <Border
                         Style="{StaticResource GalleryItemContainerStyle}">
                         <Border.StrokeShape>
-                            <RoundRectangle  
-                                CornerRadius="0" />
+                            <RoundRectangle
+                                CornerRadius="0"/>
                         </Border.StrokeShape>
                         <Grid>
                             <StackLayout>


### PR DESCRIPTION
### Issue Details

After merging regression PR #32905 – [XSG] Improve diagnostic reporting during binding compilation, XAML bindings that were previously ignored during source-generated binding compilation started failing the build. The issue was observed in bindings that used:

AncestorType={x:Type ContentPage}

The build now fails with MAUIG2045, which is treated as an Error.

Previously, the source generator silently skipped unsupported or invalid bindings without reporting diagnostics, so these bindings did not block the build.

### Description of Change

<!-- Enter description of the fix in this section -->
PR #32905 updated the binding source generator to report diagnostics instead of silently ignoring invalid bindings.

Previous behavior
```
// In CompiledBindingMarkup.cs
return false; // TODO report diagnostic
```

Updated behavior
```
context.ReportDiagnostic(
    Diagnostic.Create(Descriptors.BindingPropertyNotFound, ...));
```

The PR introduced six new MAUIG diagnostics that align with the older XamlC XC* diagnostics, improving diagnostic visibility during binding compilation.

Because MAUIG2045 is emitted as an Error, bindings using AncestorType={x:Type ContentPage} now fail compilation. To resolve the issue, the bindings were updated to use the correct view type:

AncestorType={x:Type views:BasePage}

This change restores successful compilation while preserving the new diagnostic behavior introduced by PR #32905.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #36827 

