### PR TITLE
[ci-fix-net11] Resolve app theme dynamic resource from parent Application

### DIFF
--- a/src/Controls/src/Core/ResourcesExtensions.cs
+++ b/src/Controls/src/Core/ResourcesExtensions.cs
@@ -141,6 +141,21 @@ namespace Microsoft.Maui.Controls
 
 		public static bool TryGetResource(this IElementDefinition element, string key, out object value)
 		{
+			if (key == AppThemeBinding.AppThemeResource)
+			{
+				var parent = element;
+				while (parent != null)
+				{
+					if (parent is Application app)
+					{
+						value = app.RequestedTheme;
+						return true;
+					}
+
+					parent = parent.Parent;
+				}
+			}
+
 			while (element != null)
 			{
 				if (element is IResourcesProvider ve && ve.IsResourcesCreated && ve.Resources.TryGetValue(key, out value))


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root cause

The .NET 11 lazy parent resource propagation path enumerates synthetic `AppThemeBinding.AppThemeResource` keys through `GetMergedResourceKeys`, but its on-demand `TryGetResource` lookup only searched resource dictionaries. The synthetic key therefore remained unresolved and dynamic resources could retain `AppTheme.Unspecified` when a parent was assigned without an existing resource listener.

### Description of Change

Resolve `AppThemeBinding.AppThemeResource` directly from the `Application` found in the element parent chain. This keeps the lazy keys-only path consistent with full merged-resource snapshots and preserves Application-wins semantics.

### Behavioral impact

App-theme dynamic resources now resolve to `Application.RequestedTheme` when parent propagation occurs, including views that did not already have a resource listener. Other resource lookup behavior is unchanged.

### Validation

- `AppThemeTests.ParentSetResolvesAppThemeDynamicResourceWithoutListener`: Debug 1/1 passed; Release 1/1 passed
- `DynamicResourceTests|ResourceDictionaryTests|AppThemeTests`: Debug 72/72 passed; Release 72/72 passed
- All runs targeted `net11.0` with platform target frameworks disabled
- `git diff --check` passed

### Issues Fixed

Fixes #36794