### PR TITLE
[ci-fix-net11] Guard Blazor sample JS interop calls

### DIFF
--- a/src/BlazorWebView/samples/MauiRazorClassLibrarySample/ExampleJsInterop.cs
+++ b/src/BlazorWebView/samples/MauiRazorClassLibrarySample/ExampleJsInterop.cs
@@ -17,14 +17,31 @@ namespace MauiRazorClassLibrarySample
 
 		public ExampleJsInterop(IJSRuntime jsRuntime)
 		{
-			moduleTask = new(() => jsRuntime.InvokeAsync<IJSObjectReference>(
-			   "import", "./_content/MauiRazorClassLibrarySample/exampleJsInterop.js").AsTask());
+			moduleTask = new(async () =>
+			{
+				try
+				{
+					return await jsRuntime.InvokeAsync<IJSObjectReference>(
+						"import", "./_content/MauiRazorClassLibrarySample/exampleJsInterop.js");
+				}
+				catch (JSException ex)
+				{
+					throw new InvalidOperationException("Unable to import the example JavaScript module.", ex);
+				}
+			});
 		}
 
 		public async ValueTask<string> Prompt(string message)
 		{
-			var module = await moduleTask.Value;
-			return await module.InvokeAsync<string>("showPrompt", message);
+			try
+			{
+				var module = await moduleTask.Value;
+				return await module.InvokeAsync<string>("showPrompt", message);
+			}
+			catch (JSException ex)
+			{
+				throw new InvalidOperationException("Unable to show the JavaScript prompt.", ex);
+			}
 		}
 
 		public async ValueTask DisposeAsync()
@@ -32,7 +49,14 @@ namespace MauiRazorClassLibrarySample
 			if (moduleTask.IsValueCreated)
 			{
 				var module = await moduleTask.Value;
-				await module.DisposeAsync();
+				try
+				{
+					await module.DisposeAsync();
+				}
+				catch (JSDisconnectedException)
+				{
+					// The JavaScript context is already gone, so the module no longer needs disposal.
+				}
 			}
 		}
 	}

--- a/src/BlazorWebView/samples/WebViewAppShared/ExampleJsInterop.cs
+++ b/src/BlazorWebView/samples/WebViewAppShared/ExampleJsInterop.cs
@@ -17,20 +17,44 @@ namespace WebViewAppShared
 
 		public ExampleJsInterop(IJSRuntime jsRuntime)
 		{
-			moduleTask = new(() => jsRuntime.InvokeAsync<IJSObjectReference>(
-			   "import", "./_content/WebViewAppShared/exampleJsInterop.js").AsTask());
+			moduleTask = new(async () =>
+			{
+				try
+				{
+					return await jsRuntime.InvokeAsync<IJSObjectReference>(
+						"import", "./_content/WebViewAppShared/exampleJsInterop.js");
+				}
+				catch (JSException ex)
+				{
+					throw new InvalidOperationException("Unable to import the example JavaScript module.", ex);
+				}
+			});
 		}
 
 		public async ValueTask<string> Prompt(string message)
 		{
-			var module = await moduleTask.Value;
-			return await module.InvokeAsync<string>("showPrompt", message);
+			try
+			{
+				var module = await moduleTask.Value;
+				return await module.InvokeAsync<string>("showPrompt", message);
+			}
+			catch (JSException ex)
+			{
+				throw new InvalidOperationException("Unable to show the JavaScript prompt.", ex);
+			}
 		}
 
 		public async ValueTask UpdateControlDiv(string newValue)
 		{
-			var module = await moduleTask.Value;
-			await module.InvokeVoidAsync("updateControlDiv", newValue);
+			try
+			{
+				var module = await moduleTask.Value;
+				await module.InvokeVoidAsync("updateControlDiv", newValue);
+			}
+			catch (JSException ex)
+			{
+				throw new InvalidOperationException("Unable to update the control div from JavaScript.", ex);
+			}
 		}
 
 		public async ValueTask DisposeAsync()
@@ -38,7 +62,14 @@ namespace WebViewAppShared
 			if (moduleTask.IsValueCreated)
 			{
 				var module = await moduleTask.Value;
-				await module.DisposeAsync();
+				try
+				{
+					await module.DisposeAsync();
+				}
+				catch (JSDisconnectedException)
+				{
+					// The JavaScript context is already gone, so the module no longer needs disposal.
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

Extracts both validated BL0016 sample fixes from dependency PR #36838 onto `net11.0`:

- `src/BlazorWebView/samples/WebViewAppShared/ExampleJsInterop.cs`
- `src/BlazorWebView/samples/MauiRazorClassLibrarySample/ExampleJsInterop.cs`

The updated .NET 11 Preview 7 SDK flowing through #36838 enables BL0016 analysis for these JavaScript interop calls. This focused change prepares `net11.0` for that flowed SDK; it does not assert that the branch's older SDK currently fails these builds.

## Exception semantics

Operational module import, prompt, and DOM update calls catch `JSException` and rethrow `InvalidOperationException` with operation-specific context. Module disposal catches only `JSDisconnectedException`, because a disconnected JavaScript context no longer requires disposal; other disposal failures continue to propagate.

## CI evidence

- [maui-pr build 1528734](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1528734) surfaced BL0016 diagnostics in both `ExampleJsInterop` copies after the Preview 7 dependency update.
- [maui-pr build 1529843](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1529843), after the `WebViewAppShared` source fix, had no remaining diagnostics for that copy and still identified the Razor class library copy, motivating the second validated fix.

## Validation

- `dotnet build src/BlazorWebView/samples/WebViewAppShared/WebViewAppShared.csproj -f net11.0 -c Debug` — passed, 0 warnings and 0 errors
- `dotnet build src/BlazorWebView/samples/WebViewAppShared/WebViewAppShared.csproj -f net11.0 -c Release` — passed, 0 warnings and 0 errors
- `dotnet build src/BlazorWebView/samples/MauiRazorClassLibrarySample/MauiRazorClassLibrarySample.csproj -f net11.0 -c Debug` — passed, 0 warnings and 0 errors
- `dotnet build src/BlazorWebView/samples/MauiRazorClassLibrarySample/MauiRazorClassLibrarySample.csproj -f net11.0 -c Release` — passed, 0 warnings and 0 errors
- Searched `src/BlazorWebView/samples/**`: exactly two `ExampleJsInterop` implementations and seven relevant `IJSRuntime`/`IJSObjectReference` invocation or disposal call sites; all operational calls are guarded and disconnection is ignored only during disposal.
- `git diff --check` passed.