### PR TITLE
Add Microsoft.Windows.SDK.BuildTools.WinApp dependency for Windows apps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,7 @@ updates:
       patterns:
         - "Microsoft.Graphics.Win2D"
         - "Microsoft.Windows.SDK.BuildTools"
+        - "Microsoft.Windows.SDK.BuildTools.WinApp"
         - "Microsoft.WindowsAppSDK"
         - "Microsoft.Web.WebView2"
     xunit:

--- a/NuGet.config
+++ b/NuGet.config
@@ -28,7 +28,6 @@
     <add key="dotnet10-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10-transport/nuget/v3/index.json" />
     <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
     <add key="dotnet9-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9-transport/nuget/v3/index.json" />
-    <add key="nuget-org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <activePackageSource>
     <add key="All" value="(Aggregate source)" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -28,6 +28,7 @@
     <add key="dotnet10-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10-transport/nuget/v3/index.json" />
     <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
     <add key="dotnet9-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9-transport/nuget/v3/index.json" />
+    <add key="nuget-org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <activePackageSource>
     <add key="All" value="(Aggregate source)" />

--- a/eng/NuGetVersions.targets
+++ b/eng/NuGetVersions.targets
@@ -159,6 +159,10 @@
         Version="$(MicrosoftWindowsSDKBuildToolsPackageVersion)"
     />
     <PackageReference
+        Update="Microsoft.Windows.SDK.BuildTools.WinApp"
+        Version="$(MicrosoftWindowsSDKBuildToolsWinAppPackageVersion)"
+    />
+    <PackageReference
         Update="Microsoft.Graphics.Win2D"
         Version="$(MicrosoftGraphicsWin2DPackageVersion)"
     />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -81,6 +81,7 @@
     <!-- wasdk -->
     <MicrosoftWindowsAppSDKPackageVersion>1.8.251106002</MicrosoftWindowsAppSDKPackageVersion>
     <MicrosoftWindowsSDKBuildToolsPackageVersion>10.0.26100.4654</MicrosoftWindowsSDKBuildToolsPackageVersion>
+    <MicrosoftWindowsSDKBuildToolsWinAppPackageVersion>0.5.0</MicrosoftWindowsSDKBuildToolsWinAppPackageVersion>
     <MicrosoftGraphicsWin2DPackageVersion>1.3.2</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.3179.45</MicrosoftWindowsWebView2PackageVersion>
     <!-- Everything else -->

--- a/src/Controls/samples/Controls.Sample/Properties/launchSettings.json
+++ b/src/Controls/samples/Controls.Sample/Properties/launchSettings.json
@@ -1,7 +1,7 @@
 {
   "profiles": {
     "Windows Machine": {
-      "commandName": "Project",
+      "commandName": "MsixPackage",
       "nativeDebugging": true
     }
   }

--- a/src/Core/src/Core.csproj
+++ b/src/Core/src/Core.csproj
@@ -50,6 +50,7 @@
     <PackageReference Include="Microsoft.WindowsAppSDK" />
     <PackageReference Include="Microsoft.Web.WebView2" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" />
     <PackageReference Include="Microsoft.Graphics.Win2D" />
     <ProjectReference Include="..\..\Graphics\src\Graphics.Win2D\Graphics.Win2D.csproj" />
   </ItemGroup>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Adds the [`Microsoft.Windows.SDK.BuildTools.WinApp`](https://www.nuget.org/packages/Microsoft.Windows.SDK.BuildTools.WinApp) NuGet package (v0.5.0) as a dependency for all MAUI Windows apps. This package provides MSBuild targets that enable `dotnet run` for MSIX-packaged Windows applications by automatically registering loose-layout packages and launching the app via `winapp run`.

## Changes

- **`eng/Versions.props`** — Add `MicrosoftWindowsSDKBuildToolsWinAppPackageVersion` version variable
- **`eng/NuGetVersions.targets`** — Add central version pinning for the package
- **`src/Core/src/Core.csproj`** — Add `PackageReference` in the Windows ItemGroup (flows transitively to all MAUI Windows apps)
- **`.github/dependabot.yml`** — Add to `WindowsAppSDK` dependabot group for automated version bumps
- **`src/Controls/samples/Controls.Sample/Properties/launchSettings.json`** — Update `commandName` to `MsixPackage` to match MSIX packaging mode
