### PR TITLE
Remove invalid CODEOWNERS configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-*       @dotnet/dotnet-maui-reviewers


### PR DESCRIPTION
### Description of Change

Removes `.github/CODEOWNERS`, whose only entry is currently invalid:

```text
* @dotnet/dotnet-maui-reviewers
```

GitHub's CODEOWNERS errors API reports this owner as unknown because the team has **Read** access to `dotnet/maui` (`pull: true`, `push: false`). GitHub requires teams named in CODEOWNERS to have explicit Write access, so the line is ignored today.

This does **not** remove an effective review gate:

- `MAUI protection` independently continues to require one approving review.
- Its `require_code_owner_review` setting has no matching valid code owner today, so removing the rejected file preserves the current effective behavior.
- There is no fallback CODEOWNERS file elsewhere in the repository.
- No repository automation reads this file; the only text references are generic content embedded in generated workflow lock files.

The entry was introduced in #16682 on August 10, 2023 to auto-request the MAUI reviewers team. Repository team permissions are not stored in git, so it is not possible to determine from public history whether the team had Write access then and lost it later, or whether the entry was invalid from the start.

Removing it makes the repository configuration accurately reflect its current behavior and prevents a future team-permission change from unexpectedly activating code-owner enforcement and blocking automation.

A separate repository-settings cleanup can turn off the currently ineffective **Require review from Code Owners** checkbox. That settings change is intentionally not represented as code in this PR.

Related context: #36875

### Issues Fixed

None; repository policy cleanup.
