### PR TITLE
[Windows] Bump Windows App SDK, SDK BuildTools, WebView2 and Win2D

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -79,10 +79,10 @@
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>8.0.148</SamsungTizenSdkPackageVersion>
     <!-- wasdk -->
-    <MicrosoftWindowsAppSDKPackageVersion>1.8.251106002</MicrosoftWindowsAppSDKPackageVersion>
-    <MicrosoftWindowsSDKBuildToolsPackageVersion>10.0.26100.4654</MicrosoftWindowsSDKBuildToolsPackageVersion>
-    <MicrosoftGraphicsWin2DPackageVersion>1.3.2</MicrosoftGraphicsWin2DPackageVersion>
-    <MicrosoftWindowsWebView2PackageVersion>1.0.3179.45</MicrosoftWindowsWebView2PackageVersion>
+    <MicrosoftWindowsAppSDKPackageVersion>2.3.1</MicrosoftWindowsAppSDKPackageVersion>
+    <MicrosoftWindowsSDKBuildToolsPackageVersion>10.0.28000.2526</MicrosoftWindowsSDKBuildToolsPackageVersion>
+    <MicrosoftGraphicsWin2DPackageVersion>1.4.0</MicrosoftGraphicsWin2DPackageVersion>
+    <MicrosoftWindowsWebView2PackageVersion>1.0.4078.44</MicrosoftWindowsWebView2PackageVersion>
     <!-- Everything else -->
     <MicrosoftAspNetCoreAuthorizationPackageVersion>11.0.0-preview.7.26365.101</MicrosoftAspNetCoreAuthorizationPackageVersion>
     <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>11.0.0-preview.7.26365.101</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description

Bumps the Windows-related NuGet pins in `eng/Versions.props` to the latest stable releases. These four properties are consumed centrally via `eng/NuGetVersions.targets` (`<PackageReference Update=... />`), so this single file is the only change needed.

| Package | Property | Old | New |
| --- | --- | --- | --- |
| `Microsoft.WindowsAppSDK` | `MicrosoftWindowsAppSDKPackageVersion` | `1.8.251106002` | **`2.3.1`** |
| `Microsoft.Windows.SDK.BuildTools` | `MicrosoftWindowsSDKBuildToolsPackageVersion` | `10.0.26100.4654` | **`10.0.28000.2526`** |
| `Microsoft.Web.WebView2` | `MicrosoftWindowsWebView2PackageVersion` | `1.0.3179.45` | **`1.0.4078.44`** |
| `Microsoft.Graphics.Win2D` | `MicrosoftGraphicsWin2DPackageVersion` | `1.3.2` | **`1.4.0`** |

All four were verified as the latest *listed stable* versions against the NuGet flat-container index.

### Windows App SDK 1.8 → 2.3.1 (major version jump)

This is the notable part of the change, so it got extra scrutiny. **No source changes were required.** Findings:

- **No API/namespace churn.** The `Microsoft.UI.Xaml` surface that MAUI consumes is unchanged; Core, Controls, Essentials and Graphics.Win2D all compile against 2.3.1 with zero new errors.
- **No minimum-TFM bump.** `Directory.Build.targets` keeps `TargetPlatformMinVersion`/`SupportedOSPlatformVersion` at `10.0.17763.0`. WinAppSDK 2.x validates against `WindowsSdkPackageVersion` (repo value `10.0.19041.44`) and that check passes unchanged.
- **Bootstrapper / packaging behavior is unchanged for us.** Unpackaged apps still resolve `WindowsAppSDKSelfContained=true` and packaged apps still resolve `WindowsPackageType=MSIX`, exactly as before the bump. An unpackaged self-contained publish was verified to emit the full bootstrap set (`Microsoft.WindowsAppRuntime.Bootstrap.dll`, `Microsoft.WindowsAppRuntime.Bootstrap.Net.dll`, `Microsoft.WindowsAppRuntime.dll`) plus all expected `.pri` resources.
- **Transitive graph resolves cleanly** — `Microsoft.WindowsAppSDK.WinUI 2.3.0`, `Foundation 2.3.5`, `Base 2.0.4`, `Runtime 2.3.1`, etc.

### NuGet feeds

No `NuGet.config` change is required. All four versions were confirmed present in the `dotnet-public` dnceng feed already configured by the repo, and restore succeeds from the existing sources — `nuget.org` was **not** added.

### Helix device tests

`eng/devices/run-windows-devicetests.cmd` derives the Windows App Runtime installer URL by parsing major.minor out of `MicrosoftWindowsAppSDKPackageVersion`, so it follows this bump automatically with no edit. Verified that the resulting channel URL `https://aka.ms/windowsappsdk/2.3/latest/windowsappruntimeinstall-x64.exe` resolves successfully.

### Validation

All builds below were run against a **fully pristine tree** — `artifacts/`, `.buildtasks/` and every `obj`/`bin` removed, with MSBuild node reuse shut down first so no stale task assemblies were reused.

| Build | Result |
| --- | --- |
| `Microsoft.Maui.BuildTasks.slnf` (full, incl. both Windows TFMs) | ✅ 0 errors |
| `Maui.Controls.Sample` — `net11.0-windows10.0.19041.0` | ✅ 0 errors |
| `Maui.Controls.Sample` — `net11.0-windows10.0.20348.0` | ✅ 0 errors |
| `Essentials.Sample` (MSIX packaged) — `net11.0-windows10.0.19041.0` | ✅ 0 errors |
| `Core.DeviceTests` (MSIX packaged) — `net11.0-windows10.0.19041.0` | ✅ 0 errors |
| `Core.DeviceTests` (unpackaged, self-contained publish, `win-x64`) | ✅ 0 errors |

Build-only validation; no apps were launched. Warning counts are unchanged from the pre-bump baseline.

### Notes

- `MicrosoftWindowsSDKBuildToolsWinAppPackageVersion` is intentionally untouched — that property does not exist on `net11.0` and is owned by #36889.
- `src/Templates/src/cgmanifest.json` contains the old version strings but is auto-generated (regenerated in CI via `eng/scripts/update-cgmanifest.ps1`) and is deliberately **not** committed here.