### PR TITLE
[Sample] Remove obsolete Router.PreferExactMatches from gallery sample

### DIFF
--- a/src/Controls/samples/Controls.Sample/Main.razor
+++ b/src/Controls/samples/Controls.Sample/Main.razor
@@ -1,4 +1,4 @@
-﻿<Router AppAssembly="@GetType().Assembly" PreferExactMatches="true">
+﻿<Router AppAssembly="@GetType().Assembly">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" />
     </Found>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Running the .NET MAUI gallery sample (`src/Controls/samples/Controls.Sample`) on Windows produced a runtime error as soon as the BlazorWebView page loaded:

```
WebViewIpcReceiver.ts:32 Object of type 'Microsoft.AspNetCore.Components.Routing.Router' does not have a property matching the name 'PreferExactMatches'.
 at Microsoft.AspNetCore.Components.Reflection.ComponentProperties.ThrowForUnknownIncomingParameterName(Type targetType, String parameterName)
 at Microsoft.AspNetCore.Components.Reflection.ComponentProperties.SetProperties(ParameterView& parameters, Object target)
 at Microsoft.AspNetCore.Components.ParameterView.SetParameterProperties(Object target)
 at Microsoft.AspNetCore.Components.Routing.Router.SetParametersAsync(ParameterView parameters)
```

### Root cause

`Router.PreferExactMatches` was a .NET 5-era parameter on `Microsoft.AspNetCore.Components.Routing.Router`. It became a no-op/obsolete in .NET 6 and has now been **removed from the type entirely in ASP.NET Core 11**. Because this branch builds against an ASP.NET Core 11 preview, Blazor's parameter binding no longer finds a matching property and throws `ThrowForUnknownIncomingParameterName` at runtime.

This is documented as an official upstream breaking change:

- 📄 [Obsolete Blazor APIs removed](https://learn.microsoft.com/aspnet/core/breaking-changes/11/blazor-obsolete-apis-removed) (ASP.NET Core 11, source-incompatible) — `Router.PreferExactMatches` is the first entry in the Affected APIs list, with the recommended action: *"Remove the assignment. Exact matching has been the default since .NET 6."*
- 🔧 Upstream removal PR: [dotnet/aspnetcore#62755](https://github.com/dotnet/aspnetcore/pull/62755)
- 📜 Origin of the behavior change: [Blazor: Route precedence logic changed in Blazor apps](https://learn.microsoft.com/aspnet/core/breaking-changes/5/blazor-routing-logic-changed) (.NET 5)

### Fix

Removed the ` PreferExactMatches="true"` attribute from `src/Controls/samples/Controls.Sample/Main.razor`:

```diff
-<Router AppAssembly="@GetType().Assembly" PreferExactMatches="true">
+<Router AppAssembly="@GetType().Assembly">
```

Exact matching is the default (and only) behavior now, so there is **no behavior change** — this matches the recommended action in the breaking-change doc verbatim.

This was the **last remaining occurrence** of `PreferExactMatches` in the repo — every other `<Router>` already omits it, e.g. `src/BlazorWebView/samples/BlazorWpfApp/Main.razor`, `src/BlazorWebView/samples/BlazorWinFormsApp/Main.razor`, `src/BlazorWebView/samples/WebViewAppShared/RouterComponent.razor`, and both Blazor templates under `src/Templates/src/templates/`.

### Issues Fixed

None filed.

### Validation

This is a `.razor` markup change in a sample, so a targeted build was used:

```
dotnet build Microsoft.Maui.BuildTasks.slnf
dotnet build src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj -f net11.0-windows10.0.19041.0
```

Both succeeded with 0 errors and 0 warnings. A repo-wide search confirms there are now zero occurrences of `PreferExactMatches`.
