### PR TITLE
[Net11][ci-fix-net11] [Android] Fix ShellContent not updating when Content property changes at runtime

### DIFF
--- a/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Android.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Android.cs
@@ -507,6 +507,10 @@ namespace Microsoft.Maui.Controls.Handlers
 
             if (visibleItems is not null && currentItem is not null)
             {
+                {
+                    handler._adapter?.SafeNotifyDataSetChanged();
+                }
+
                 var targetIndex = visibleItems.IndexOf(currentItem);
                 if (targetIndex >= 0 && handler._viewPager.CurrentItem != targetIndex)
                 {
@@ -525,6 +529,60 @@ namespace Microsoft.Maui.Controls.Handlers
             if (e.PropertyName == ShellContent.ContentProperty.PropertyName)
             {
                 _adapter.InvalidateShellContent(shellContent);
+
+                // Keep toolbar state in sync when the active tab's content page is replaced.
+                if (VirtualView?.CurrentItem == shellContent)
+                {
+                    var page = ((IShellContentController)shellContent).GetOrCreateContent();
+                    if (page is not null)
+                    {
+                        var toolbarTracker = ToolbarTracker;
+                        toolbarTracker?.Page = page;
+                    }
+                }
+            }
+        }
+
+        void UpdateContentPropertyChangedSubscriptions(NotifyCollectionChangedEventArgs e)
+        {
+            if (_subscribedItems is null)
+            {
+                return;
+            }
+
+            if (e.Action == NotifyCollectionChangedAction.Reset)
+            {
+                foreach (var item in _subscribedItems)
+                {
+                    item.PropertyChanged -= OnShellContentPropertyChanged;
+                }
+                _subscribedItems.Clear();
+
+                foreach (var item in SectionController.GetItems())
+                {
+                    item.PropertyChanged += OnShellContentPropertyChanged;
+                    _subscribedItems.Add(item);
+                }
+
+                return;
+            }
+
+            if (e.OldItems is not null)
+            {
+                foreach (ShellContent item in e.OldItems)
+                {
+                    item.PropertyChanged -= OnShellContentPropertyChanged;
+                    _subscribedItems.Remove(item);
+                }
+            }
+
+            if (e.NewItems is not null)
+            {
+                foreach (ShellContent item in e.NewItems)
+                {
+                    item.PropertyChanged += OnShellContentPropertyChanged;
+                    _subscribedItems.Add(item);
+                }
             }
         }
 
@@ -534,6 +592,8 @@ namespace Microsoft.Maui.Controls.Handlers
             {
                 return;
             }
+
+            UpdateContentPropertyChangedSubscriptions(e);
 
             // When items go from 0 → N, we must create a fresh adapter because
             // FragmentStateAdapter saves internal fragment state when items are removed.

--- a/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Android.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Android.cs
@@ -508,7 +508,7 @@ namespace Microsoft.Maui.Controls.Handlers
             if (visibleItems is not null && currentItem is not null)
             {
                 {
-                    handler._adapter?.SafeNotifyDataSetChanged();
+                    handler.SafeNotifyDataSetChanged();
                 }
 
                 var targetIndex = visibleItems.IndexOf(currentItem);
@@ -528,7 +528,7 @@ namespace Microsoft.Maui.Controls.Handlers
 
             if (e.PropertyName == ShellContent.ContentProperty.PropertyName)
             {
-                _adapter.InvalidateShellContent(shellContent);
+                InvalidateShellContent(shellContent);
 
                 // Keep toolbar state in sync when the active tab's content page is replaced.
                 if (VirtualView?.CurrentItem == shellContent)
@@ -540,6 +540,35 @@ namespace Microsoft.Maui.Controls.Handlers
                         toolbarTracker?.Page = page;
                     }
                 }
+            }
+        }
+
+        void InvalidateShellContent(ShellContent shellContent)
+        {
+            // The page inside this ShellContent changed — force ViewPager2 to recreate the
+            // fragment so it picks up the new content.
+            _adapter?.InvalidateShellContent(shellContent);
+            SafeNotifyDataSetChanged();
+        }
+
+        void SafeNotifyDataSetChanged()
+        {
+            var adapter = _adapter;
+            var viewPager = _viewPager;
+            if (adapter is null || viewPager is null || !viewPager.IsAlive())
+            {
+                return;
+            }
+
+            // https://stackoverflow.com/questions/43221847/cannot-call-this-method-while-recyclerview-is-computing-a-layout-or-scrolling-wh
+            // ViewPager2 is based on RecyclerView which really doesn't like NotifyDataSetChanged when a layout is happening
+            if (!viewPager.IsInLayout)
+            {
+                adapter.NotifyDataSetChanged();
+            }
+            else
+            {
+                viewPager.Post(() => adapter.NotifyDataSetChanged());
             }
         }
 
@@ -620,7 +649,7 @@ namespace Microsoft.Maui.Controls.Handlers
             }
             else
             {
-                _adapter.SafeNotifyDataSetChanged();
+                SafeNotifyDataSetChanged();
             }
 
             // Update OffscreenPageLimit for new visible count
@@ -826,7 +855,7 @@ namespace Microsoft.Maui.Controls.Handlers
             _visibleItems = newItems;
         }
 
-        public void InvalidateShellContent(ShellContent shellContent)
+        internal void InvalidateShellContent(ShellContent shellContent)
         {
             if (_visibleItems is null || !_visibleItems.Contains(shellContent))
             {
@@ -834,32 +863,6 @@ namespace Microsoft.Maui.Controls.Handlers
             }
 
             _contentIds.Remove(shellContent);
-            SafeNotifyDataSetChanged();
-        }
-
-        public void SafeNotifyDataSetChanged(int iteration = 0)
-        {
-            var viewPager = Handler?.ViewPager;
-            if (viewPager is null || !viewPager.IsAlive())
-            {
-                return;
-            }
-
-            if (iteration >= 10)
-            {
-                _mauiContext.CreateLogger<ShellContentFragmentAdapter>()?
-                    .LogWarning("ViewPager2 stuck in layout, unable to NotifyDataSetChanged;");
-                return;
-            }
-
-            if (!viewPager.IsInLayout)
-            {
-                NotifyDataSetChanged();
-            }
-            else
-            {
-                viewPager.Post(() => SafeNotifyDataSetChanged(++iteration));
-            }
         }
 
         public override Fragment CreateFragment(int position)

--- a/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Android.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Android.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.ComponentModel;
 using System.Linq;
 using Android.Content;
 using Android.OS;
@@ -198,6 +199,10 @@ namespace Microsoft.Maui.Controls.Handlers
             // Subscribe to visible items collection changes (fires on add/remove AND visibility changes)
             SectionController.ItemsCollectionChanged += OnItemsCollectionChanged;
 
+            foreach (var item in SectionController.GetItems())
+            {
+                item.PropertyChanged += OnShellContentPropertyChanged;
+            }
             // Wait for the view to be attached before setting up the adapter
             // This ensures the parent fragment is set
             _rootLayout?.ViewAttachedToWindow += OnRootLayoutAttachedToWindow;
@@ -425,6 +430,10 @@ namespace Microsoft.Maui.Controls.Handlers
 
             SectionController.ItemsCollectionChanged -= OnItemsCollectionChanged;
 
+            foreach (var item in SectionController.GetItems())
+            {
+                item.PropertyChanged -= OnShellContentPropertyChanged;
+            }
             // Only remove top tabs from the shared container if this is the active section.
             // When inactive sections are disconnected (e.g., VP2 adapter updates recreate
             // fragments for bottom tabs that reappeared), their DisconnectHandler must NOT
@@ -493,6 +502,19 @@ namespace Microsoft.Maui.Controls.Handlers
                 {
                     handler._viewPager.SetCurrentItem(targetIndex, true);
                 }
+            }
+        }
+
+        void OnShellContentPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (sender is not ShellContent shellContent || _adapter is null)
+            {
+                return;
+            }
+
+            if (e.PropertyName == ShellContent.ContentProperty.PropertyName)
+            {
+                _adapter.InvalidateShellContent(shellContent);
             }
         }
 
@@ -732,6 +754,17 @@ namespace Microsoft.Maui.Controls.Handlers
                 _contentIds.Remove(item);
 
             _visibleItems = newItems;
+        }
+
+        public void InvalidateShellContent(ShellContent shellContent)
+        {
+            if (_visibleItems is null || !_visibleItems.Contains(shellContent))
+            {
+                return;
+            }
+
+            _contentIds.Remove(shellContent);
+            NotifyDataSetChanged();
         }
 
         public override Fragment CreateFragment(int position)

--- a/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Android.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Android.cs
@@ -13,9 +13,11 @@ using AndroidX.Fragment.App;
 using AndroidX.ViewPager2.Adapter;
 using AndroidX.ViewPager2.Widget;
 using Google.Android.Material.Tabs;
+using Microsoft.Extensions.Logging;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Platform.Compatibility;
 using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Platform;
 using AAnimation = Android.Views.Animations.Animation;
 using AView = Android.Views.View;
 using LP = Android.Views.ViewGroup.LayoutParams;
@@ -42,6 +44,7 @@ namespace Microsoft.Maui.Controls.Handlers
         TabbedViewManager? _tabbedViewManager;
         ShellSectionTabbedViewAdapter? _shellSectionAdapter;
         ViewPagerPageChangeCallback? _pageChangedCallback;
+        List<ShellContent>? _subscribedItems; // Tracks exactly which ShellContents currently have OnShellContentPropertyChanged wired up
 
         /// <summary>
         /// Internal accessor for the ViewPager2 instance. Used by ViewPagerPageChangeCallback
@@ -199,9 +202,12 @@ namespace Microsoft.Maui.Controls.Handlers
             // Subscribe to visible items collection changes (fires on add/remove AND visibility changes)
             SectionController.ItemsCollectionChanged += OnItemsCollectionChanged;
 
+            _subscribedItems ??= new List<ShellContent>();
+            _subscribedItems.Clear();
             foreach (var item in SectionController.GetItems())
             {
                 item.PropertyChanged += OnShellContentPropertyChanged;
+                _subscribedItems.Add(item);
             }
             // Wait for the view to be attached before setting up the adapter
             // This ensures the parent fragment is set
@@ -430,9 +436,13 @@ namespace Microsoft.Maui.Controls.Handlers
 
             SectionController.ItemsCollectionChanged -= OnItemsCollectionChanged;
 
-            foreach (var item in SectionController.GetItems())
+            if (_subscribedItems is not null)
             {
-                item.PropertyChanged -= OnShellContentPropertyChanged;
+                foreach (var item in _subscribedItems)
+                {
+                    item.PropertyChanged -= OnShellContentPropertyChanged;
+                }
+                _subscribedItems.Clear();
             }
             // Only remove top tabs from the shared container if this is the active section.
             // When inactive sections are disconnected (e.g., VP2 adapter updates recreate
@@ -550,7 +560,7 @@ namespace Microsoft.Maui.Controls.Handlers
             }
             else
             {
-                _adapter.NotifyDataSetChanged();
+                _adapter.SafeNotifyDataSetChanged();
             }
 
             // Update OffscreenPageLimit for new visible count
@@ -764,7 +774,32 @@ namespace Microsoft.Maui.Controls.Handlers
             }
 
             _contentIds.Remove(shellContent);
-            NotifyDataSetChanged();
+            SafeNotifyDataSetChanged();
+        }
+
+        public void SafeNotifyDataSetChanged(int iteration = 0)
+        {
+            var viewPager = Handler?.ViewPager;
+            if (viewPager is null || !viewPager.IsAlive())
+            {
+                return;
+            }
+
+            if (iteration >= 10)
+            {
+                _mauiContext.CreateLogger<ShellContentFragmentAdapter>()?
+                    .LogWarning("ViewPager2 stuck in layout, unable to NotifyDataSetChanged;");
+                return;
+            }
+
+            if (!viewPager.IsInLayout)
+            {
+                NotifyDataSetChanged();
+            }
+            else
+            {
+                viewPager.Post(() => SafeNotifyDataSetChanged(++iteration));
+            }
         }
 
         public override Fragment CreateFragment(int position)

--- a/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Android.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Android.cs
@@ -13,7 +13,6 @@ using AndroidX.Fragment.App;
 using AndroidX.ViewPager2.Adapter;
 using AndroidX.ViewPager2.Widget;
 using Google.Android.Material.Tabs;
-using Microsoft.Extensions.Logging;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Platform.Compatibility;
 using Microsoft.Maui.Graphics;
@@ -507,9 +506,7 @@ namespace Microsoft.Maui.Controls.Handlers
 
             if (visibleItems is not null && currentItem is not null)
             {
-                {
-                    handler.SafeNotifyDataSetChanged();
-                }
+                handler.SafeNotifyDataSetChanged();
 
                 var targetIndex = visibleItems.IndexOf(currentItem);
                 if (targetIndex >= 0 && handler._viewPager.CurrentItem != targetIndex)
@@ -617,12 +614,12 @@ namespace Microsoft.Maui.Controls.Handlers
 
         void OnItemsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
+            UpdateContentPropertyChangedSubscriptions(e);
+
             if (_adapter is null || _viewPager is null || _parentFragment is null || VirtualView is null || MauiContext is null)
             {
                 return;
             }
-
-            UpdateContentPropertyChangedSubscriptions(e);
 
             // When items go from 0 → N, we must create a fresh adapter because
             // FragmentStateAdapter saves internal fragment state when items are removed.


### PR DESCRIPTION
<!-- Please keep the note below for people who find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment whether this change resolves your issue. Thank you!

**Faiilure Test on android hanlder path** : _**ShellContentShouldUpdateWhenContentPropertyChanges**_

This pull request introduces significant improvements to how `ShellSectionHandler` on Android manages and updates its `ShellContent` items, especially in response to property changes and collection modifications. The main goals are to ensure proper event subscription management, keep the UI in sync when content changes, and make adapter updates more robust. 

The property-change tracking and invalidation approach added here mirrors what was already implemented for the legacy renderer in [#34630](https://github.com/dotnet/maui/pull/34630), bringing the same `ShellContent.PropertyChanged` subscription/invalidation pattern to the new handler-based Android Shell architecture, since the handler previously had no equivalent logic and silently ignored `Content` changes at runtime.

**ShellContent property change tracking and adapter updates:**

* Added tracking of currently-subscribed `ShellContent` items via a `_subscribedItems` list, ensuring that `PropertyChanged` events are always wired/unwired correctly as items are added/removed. [[1]](diffhunk://#diff-46fc3573f39a6e0c764825dc5fac89c15fa741e4eb17cdc979aca5ed2acba144R47) [[2]](diffhunk://#diff-46fc3573f39a6e0c764825dc5fac89c15fa741e4eb17cdc979aca5ed2acba144R205-R211) [[3]](diffhunk://#diff-46fc3573f39a6e0c764825dc5fac89c15fa741e4eb17cdc979aca5ed2acba144R439-R446) [[4]](diffhunk://#diff-46fc3573f39a6e0c764825dc5fac89c15fa741e4eb17cdc979aca5ed2acba144R522-R597)
* Implemented `OnShellContentPropertyChanged` to handle updates when a `ShellContent`'s content changes, including invalidating the adapter and syncing the toolbar state if the active tab is affected.
* Added `UpdateContentPropertyChangedSubscriptions` to efficiently update event subscriptions in response to collection changes, including handling collection resets, additions, and removals.

**Adapter robustness and notification improvements:**

* Introduced `InvalidateShellContent` and `SafeNotifyDataSetChanged` methods to the adapter, ensuring that UI updates are safely triggered even if `ViewPager2` is in a layout pass, and logging a warning if updates get stuck.
* Replaced direct calls to `NotifyDataSetChanged` with the safer `SafeNotifyDataSetChanged` throughout the handler, reducing the risk of UI inconsistencies or crashes. [[1]](diffhunk://#diff-46fc3573f39a6e0c764825dc5fac89c15fa741e4eb17cdc979aca5ed2acba144R510-R513) [[2]](diffhunk://#diff-46fc3573f39a6e0c764825dc5fac89c15fa741e4eb17cdc979aca5ed2acba144L531-R623) [[3]](diffhunk://#diff-46fc3573f39a6e0c764825dc5fac89c15fa741e4eb17cdc979aca5ed2acba144R829-R864)

**Other improvements:**

* Added missing `using` directives for required types such as `System.ComponentModel`, `Microsoft.Extensions.Logging`, and `Microsoft.Maui.Platform`. [[1]](diffhunk://#diff-46fc3573f39a6e0c764825dc5fac89c15fa741e4eb17cdc979aca5ed2acba144R5) [[2]](diffhunk://#diff-46fc3573f39a6e0c764825dc5fac89c15fa741e4eb17cdc979aca5ed2acba144R16-R20)

These changes collectively make tab content updates more reliable and maintainable, especially when dynamic changes occur in the `ShellSection`, and bring the handler-based Android Shell in line with the equivalent renderer-based fix already merged in [#34630](https://github.com/dotnet/maui/pull/34630).

### Why no tests added : 

- No new automated test was added in this PR because the existing UI test `ShellContentShouldUpdateWhenContentPropertyChanges`  already covers this behavior — it was the test that started failing in net11 CI, which is what prompted this fix. Rather than adding a new test, this PR restores the passing behavior of that existing test

<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #36809 

### Tested the behavior in the following platforms

- [ ] Windows
- [x] Android
- [ ] iOS
- [ ] Mac



| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/cdcb02d6-a663-47fc-a85d-2e1143198070"> | <video src="https://github.com/user-attachments/assets/04e05f85-9b78-4a56-8503-76b1e5fe7b1a"> |

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
