### PR TITLE
[Android] Fix Shell singleton page rendering blank when re-pushed after absolute route reset

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellItemRendererBase.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellItemRendererBase.cs
@@ -406,25 +406,31 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		void RemoveAllPushedPages(ShellSection shellSection, bool keepCurrent)
 		{
-			if (shellSection.Stack.Count <= 1 || (keepCurrent && shellSection.Stack.Count == 2))
-				return;
-
 			var t = ChildFragmentManager.BeginTransactionEx();
+			bool hasChanges = false;
 
 			foreach (var kvp in _fragmentMap.ToList())
 			{
-				if (kvp.Key.Parent != shellSection)
+				if (kvp.Key is not Page || kvp.Key.Parent != shellSection)
+				{
 					continue;
+				}
 
 				_fragmentMap.Remove(kvp.Key);
 
 				if (keepCurrent && kvp.Value.Fragment == _currentFragment)
+				{
 					continue;
+				}
 
 				t.RemoveEx(kvp.Value.Fragment);
+				hasChanges = true;
 			}
 
-			t.CommitAllowingStateLossEx();
+			if (hasChanges)
+			{
+				t.CommitAllowingStateLossEx();
+			}
 		}
 
 		void RemoveFragment(Fragment fragment)

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellItemRendererBase.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellItemRendererBase.cs
@@ -406,12 +406,11 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		void RemoveAllPushedPages(ShellSection shellSection, bool keepCurrent)
 		{
-			var t = ChildFragmentManager.BeginTransactionEx();
-			bool hasChanges = false;
+			FragmentTransaction t = null;
 
 			foreach (var kvp in _fragmentMap.ToList())
 			{
-				if (kvp.Key is not Page || kvp.Key.Parent != shellSection)
+				if (kvp.Key.Parent != shellSection)
 				{
 					continue;
 				}
@@ -423,14 +422,11 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 					continue;
 				}
 
+				t ??= ChildFragmentManager.BeginTransactionEx();
 				t.RemoveEx(kvp.Value.Fragment);
-				hasChanges = true;
 			}
 
-			if (hasChanges)
-			{
-				t.CommitAllowingStateLossEx();
-			}
+			t?.CommitAllowingStateLossEx();
 		}
 
 		void RemoveFragment(Fragment fragment)

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue36853.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue36853.cs
@@ -1,0 +1,111 @@
+namespace Maui.Controls.Sample.Issues;
+
+// Reproduces the bug: Root → SecondPage (singleton) → ThirdPage → ///Root → SecondPage again → BLANK
+[Issue(IssueTracker.Github, 36853, "Shell singleton page renders blank when re-pushed after absolute route PopToRoot on Android", PlatformAffected.Android)]
+public class Issue36853 : TestShell
+{
+	protected override void Init()
+	{
+		Routing.RegisterRoute("Issue36853Second", typeof(Issue36853SecondPage));
+		Routing.RegisterRoute("Issue36853Third", typeof(Issue36853ThirdPage));
+
+		var mainPage = new ContentPage
+		{
+			Title = "Main",
+			Content = new VerticalStackLayout
+			{
+				Spacing = 20,
+				Padding = 20,
+				Children =
+				{
+					new Label
+					{
+						Text = "Main Page",
+						AutomationId = "Issue36853MainLabel",
+						FontSize = 24
+					},
+					new Button
+					{
+						Text = "Go to Second Page",
+						AutomationId = "Issue36853GoToSecond",
+						Command = new Command(async () =>
+							await Shell.Current.GoToAsync("Issue36853Second"))
+					}
+				}
+			}
+		};
+
+		AddContentPage(mainPage, "Issue36853Main");
+	}
+}
+
+// Registered as Singleton in DI — same instance returned every time the route resolves
+public class Issue36853SecondPage : ContentPage
+{
+	public Issue36853SecondPage()
+	{
+		Title = "Second";
+		Content = new VerticalStackLayout
+		{
+			Spacing = 20,
+			Padding = 20,
+			Children =
+			{
+				new Label
+				{
+					Text = "Second Page Content",
+					AutomationId = "Issue36853SecondLabel",
+					FontSize = 24
+				},
+				new Button
+				{
+					Text = "Go to Third Page",
+					AutomationId = "Issue36853GoToThird",
+					Command = new Command(async () =>
+						await Shell.Current.GoToAsync("Issue36853Third"))
+				}
+			}
+		};
+	}
+}
+
+public class Issue36853ThirdPage : ContentPage
+{
+	public Issue36853ThirdPage()
+	{
+		Title = "Third";
+		Content = new VerticalStackLayout
+		{
+			Spacing = 20,
+			Padding = 20,
+			Children =
+			{
+				new Label
+				{
+					Text = "Third Page Content",
+					AutomationId = "Issue36853ThirdLabel",
+					FontSize = 24
+				},
+				new Button
+				{
+					Text = "Reset to Root (///)",
+					AutomationId = "Issue36853ResetToRoot",
+					Command = new Command(async () =>
+						await Shell.Current.GoToAsync("///Issue36853Main"))
+				}
+			}
+		};
+	}
+}
+
+static class Issue36853Extensions
+{
+	public static MauiAppBuilder Issue36853RegisterServices(this MauiAppBuilder builder)
+	{
+		// SecondPage is singleton — same instance reused across navigations (the bug scenario)
+		builder.Services.AddSingleton<Issue36853SecondPage>();
+		// ThirdPage is transient — new instance each time (normal behavior)
+		builder.Services.AddTransient<Issue36853ThirdPage>();
+		return builder;
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/MauiProgram.cs
+++ b/src/Controls/tests/TestCases.HostApp/MauiProgram.cs
@@ -41,7 +41,8 @@ namespace Maui.Controls.Sample
 				.Issue18720DatePickerAddMappers()
 				.Issue18720TimePickerAddMappers()
 				.Issue28945AddMappers()
-				.Issue25436RegisterNavigationService();
+				.Issue25436RegisterNavigationService()
+				.Issue36853RegisterServices();
 
 #if IOS || MACCATALYST
 			appBuilder.ConfigureCollectionViewHandlers();

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36853.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36853.cs
@@ -1,0 +1,42 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue36853 : _IssuesUITest
+{
+	public override string Issue => "Shell singleton page renders blank when re-pushed after absolute route PopToRoot on Android";
+
+	public Issue36853(TestDevice testDevice) : base(testDevice)
+	{
+	}
+
+	[Test]
+	[Category(UITestCategories.Shell)]
+	public void SingletonPageShouldRenderAfterPopToRootAndRePush()
+	{
+		// Step 1: From root, push SecondPage (singleton)
+		App.WaitForElement("Issue36853GoToSecond");
+		App.Tap("Issue36853GoToSecond");
+
+		// Step 2: Verify SecondPage renders
+		App.WaitForElement("Issue36853SecondLabel");
+
+		// Step 3: Push ThirdPage on top (so stack is Root → Second → Third)
+		App.Tap("Issue36853GoToThird");
+		App.WaitForElement("Issue36853ThirdLabel");
+
+		// Step 4: PopToRoot via absolute route ///
+		App.Tap("Issue36853ResetToRoot");
+		App.WaitForElement("Issue36853MainLabel");
+
+		// Step 5: Re-push SecondPage (same singleton instance)
+		App.Tap("Issue36853GoToSecond");
+
+		// Step 6: SecondPage content must be visible — not blank
+		// Without the fix, WaitForElement will timeout because the stale fragment
+		// has a disconnected handler and OnCreateView never fires — page is blank.
+		App.WaitForElement("Issue36853SecondLabel");
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details:

- A DI-singleton page in Shell navigation renders blank when re-pushed after a  GoToAsync("///MainPage")  stack reset. 

### Root Cause of the issue

- PR #[35476](https://github.com/dotnet/maui/pull/35476) moved  page.DisconnectHandlers()  into  RemovePage() , which runs on all pop paths including PopToRoot. This permanently destroys the handler for singleton pages. On Android, a pre-existing bug in  RemoveAllPushedPages  compounds this — it checks  shellSection.Stack.Count  which is already 1 by the time the platform event fires, so it early-returns and never removes stale fragments from  _fragmentMap . On re-push, the old fragment is reused without calling  OnCreateView , resulting in a blank page since the handler is null.

**Why It Only Affects Singletons**

-  Transient pages get a new instance each push → new fragment → renders fine. Singleton pages reuse the same instance → old stale fragment found → no  OnCreateView  → blank.

### Description of Change

### Bug Fix: Fragment Removal Logic

* Improved the logic in `RemoveAllPushedPages` in `ShellItemRendererBase.cs` to ensure that fragment transactions are only committed if any fragments were actually removed, preventing issues where singleton pages could render blank after navigation.

### New Test Case for Regression

* Added a new test page and scenario in `Issue36853.cs` (HostApp) to reproduce the bug: navigating Root → SecondPage (singleton) → ThirdPage → PopToRoot → re-push SecondPage, which previously resulted in a blank screen.
* Registered `Issue36853SecondPage` as a singleton and `Issue36853ThirdPage` as transient in the DI container, matching the real-world bug scenario. [[1]](diffhunk://#diff-70f90c4c40092b9b58b067b769ce0a5ad5db3b0a8a72359fd7b816a682ad181bR1-R111) [[2]](diffhunk://#diff-d01e2392fa68bd429a87ca25ef57d4ad83147746e650291c69f97c197d92628dL44-R45)

### Automated UITest

* Introduced an automated UITest in `TestCases.Shared.Tests/Tests/Issues/Issue36853.cs` to verify that after PopToRoot and re-pushing the singleton page, its content is visible and not blank.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #36853 
Fixes #36852

### Tested the behavior in the following platforms
 
- [x] Windows
- [x] Android
- [x] iOS
- [x] Mac

### Output
 
| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/bb4201ac-5be1-4553-8f34-2b4f4556dfd9"> | <video src="https://github.com/user-attachments/assets/de6b0981-26d4-4c79-9490-9f1c65e17f92"> |








<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
