### PR TITLE
[Test] Fix Issue13323 test failure in CI for candidate branch

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue13323.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue13323.cs
@@ -19,7 +19,7 @@ public class Issue13323 : _IssuesUITest
 
 		App.Tap("GoToItem2");
 		App.WaitForTextToBePresentInElement("PositionLabel", "Position:2");
-		App.WaitForElement("CenterEntry_2", timeout: TimeSpan.FromSeconds(10));
+		App.WaitForElement("CenterEntry_2");
 
 		App.Tap("CenterEntry_2");
 
@@ -40,7 +40,7 @@ public class Issue13323 : _IssuesUITest
 
 		App.Tap("LoopGoToItem2");
 		App.WaitForTextToBePresentInElement("LoopPositionLabel", "LoopPosition:2");
-		App.WaitForElement("LoopCenterEntry_2", timeout: TimeSpan.FromSeconds(10));
+		App.WaitForElement("LoopCenterEntry_2");
 
 		App.Tap("LoopCenterEntry_2");
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue13323.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue13323.cs
@@ -16,18 +16,15 @@ public class Issue13323 : _IssuesUITest
 	public void CarouselView_EntryTap_DoesNotChangePosition()
 	{
 		App.WaitForElement("CarouselView13323", timeout: TimeSpan.FromSeconds(30));
-		App.WaitForElement("PositionLabel", timeout: TimeSpan.FromSeconds(15));
 
 		App.Tap("GoToItem2");
+		App.WaitForTextToBePresentInElement("PositionLabel", "Position:2");
 		App.WaitForElement("CenterEntry_2", timeout: TimeSpan.FromSeconds(10));
-
-		var positionBefore = App.FindElement("PositionLabel").GetText();
-		Assert.That(positionBefore, Is.EqualTo("Position:2"), $"CarouselView did not reach Position:2 before tapping Entry. Actual: {positionBefore}");
 
 		App.Tap("CenterEntry_2");
 
-		var positionAfter = App.FindElement("PositionLabel").GetText();
-		Assert.That(positionAfter, Is.EqualTo("Position:2"), $"CarouselView jumped after tapping Center-aligned Entry. Before: {positionBefore}, After: {positionAfter}");
+		Assert.That(App.FindElement("PositionLabel").GetText(), Is.EqualTo("Position:2"),
+			"CarouselView jumped after tapping Center-aligned Entry.");
 
 		App.DismissKeyboard();
 #if ANDROID
@@ -40,18 +37,15 @@ public class Issue13323 : _IssuesUITest
 	public void CarouselView_Loop_EntryTap_DoesNotChangePosition()
 	{
 		App.WaitForElement("LoopCarouselView13323", timeout: TimeSpan.FromSeconds(30));
-		App.WaitForElement("LoopPositionLabel", timeout: TimeSpan.FromSeconds(15));
 
 		App.Tap("LoopGoToItem2");
+		App.WaitForTextToBePresentInElement("LoopPositionLabel", "LoopPosition:2");
 		App.WaitForElement("LoopCenterEntry_2", timeout: TimeSpan.FromSeconds(10));
-
-		var positionBefore = App.FindElement("LoopPositionLabel").GetText();
-		Assert.That(positionBefore, Is.EqualTo("LoopPosition:2"), $"Loop CarouselView did not reach LoopPosition:2 before tapping Entry. Actual: {positionBefore}");
 
 		App.Tap("LoopCenterEntry_2");
 
-		var positionAfter = App.FindElement("LoopPositionLabel").GetText();
-		Assert.That(positionAfter, Is.EqualTo("LoopPosition:2"), $"CarouselView (Loop=true) jumped after tapping Center-aligned Entry. Before: {positionBefore}, After: {positionAfter}");
+		Assert.That(App.FindElement("LoopPositionLabel").GetText(), Is.EqualTo("LoopPosition:2"),
+			"CarouselView (Loop=true) jumped after tapping Center-aligned Entry.");
 
 		App.DismissKeyboard();
 #if ANDROID


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Context

Issue13323 tests were failing in CI with  `TimeoutException`  but passing locally. The issue does not replicate locally — CI emulators are slower, causing view to exceed the wait window after programmatic  `ScrollTo` .

### Changes

• Added  `WaitForTextToBePresentInElement`  on position labels as the authoritative scroll-settled signal before waiting for Entry elements — based on the existing  Issue29261  pattern
• Removed explicit 10s timeout (was lower than the 15s framework default) from both  `WaitForElement`  calls