### PR TITLE
[Net11] Fix for MAUIG2045 false-positive warning on unsealed RelativeSource AncestorType bindings

### DIFF
--- a/src/Controls/src/SourceGen/KnownMarkups.cs
+++ b/src/Controls/src/SourceGen/KnownMarkups.cs
@@ -396,14 +396,16 @@ internal class KnownMarkups
 				// Emit property-not-found diagnostic when the source type was known at compile time
 				// but the binding path doesn't exist on that type. Specifically:
 				// - x:DataType bindings: always emit (existing behavior).
-				// - AncestorType bindings with a resolved type: emit, because the type is known and the
-				//   path is provably wrong — consistent with x:DataType behavior. Suppress only when the
-				//   AncestorType itself failed to resolve (ancestorTypeSymbol == null), since no type
-				//   inference was possible.
+				// - AncestorType bindings with a resolved type: emit only when the AncestorType is
+				//   sealed. AncestorType matching is an `is`-style check, so the runtime ancestor may
+				//   be a derived type that declares the missing property; for unsealed types, absence
+				//   on the declared AncestorType doesn't prove the binding is broken. Also suppress
+				//   when the AncestorType itself failed to resolve (ancestorTypeSymbol == null), since
+				//   no type inference was possible.
 				// - x:Reference bindings: always suppress — they were never compiled before.
 				if (propertyNotFoundDiagnostic is not null
 					&& xRefSourceType is null
-					&& (!isAncestorTypeSource || ancestorTypeSymbol is not null))
+					&& (!isAncestorTypeSource || (ancestorTypeSymbol is not null && ancestorTypeSymbol.IsSealed)))
 				{
 					context.ReportDiagnostic(propertyNotFoundDiagnostic);
 				}

--- a/src/Controls/tests/SourceGen.UnitTests/BindingDiagnosticsTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/BindingDiagnosticsTests.cs
@@ -378,7 +378,7 @@ public class ItemModel
 """
 namespace Test;
 
-public partial class TestPage : Microsoft.Maui.Controls.ContentPage { }
+public sealed partial class TestPage : Microsoft.Maui.Controls.ContentPage { }
 
 public class ViewModel
 {
@@ -390,8 +390,9 @@ public class ViewModel
 			.AddSyntaxTrees(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(csharp));
 		var result = RunGenerator<XamlGenerator>(compilation, new AdditionalXamlFile("Test.xaml", xaml), assertNoCompilationErrors: false);
 
-		// AncestorType=TestPage is resolvable at compile time, so the path is provably wrong on
-		// that type — MAUIG2045 must fire, consistent with x:DataType binding behavior.
+		// AncestorType=TestPage is sealed, so no derived runtime ancestor can exist — the path is
+		// provably wrong on that type, so MAUIG2045 must fire, consistent with x:DataType binding
+		// behavior.
 		var diagnostic = result.Diagnostics.FirstOrDefault(d => d.Id == "MAUIG2045");
 		Assert.NotNull(diagnostic);
 		Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
@@ -399,6 +400,67 @@ public class ViewModel
 		var message = diagnostic.GetMessage();
 		Assert.Contains("NonExistentProperty", message, System.StringComparison.Ordinal);
 		Assert.Contains("TestPage", message, System.StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void BindingWithRelativeSourceAncestorTypeMatchingIssue36818Repro_SuppressesPropertyNotFound()
+	{
+		// XAML root is `BasePage : ContentPage`, and `BasePage` declares `SelectedItem`.
+		// The binding declares AncestorType={x:Type ContentPage} (the framework base type, not the
+		// derived BasePage). At runtime the resolved ancestor is the BasePage instance, so the
+		// binding is valid — MAUIG2045 must NOT fire, since ContentPage is unsealed and BasePage (a
+		// real derived type present in this same compilation) legitimately supplies SelectedItem.
+		var xaml =
+"""
+<?xml version="1.0" encoding="UTF-8"?>
+<views:BasePage
+	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	xmlns:views="clr-namespace:Test.Views"
+	xmlns:test="clr-namespace:Test"
+	x:Class="Test.Views.ControlsPage"
+	x:DataType="test:ViewModel">
+	<ContentView>
+		<CollectionView SelectedItem="{Binding SelectedItem, Source={RelativeSource AncestorType={x:Type ContentPage}}, Mode=TwoWay}" />
+	</ContentView>
+</views:BasePage>
+""";
+
+		var csharp =
+"""
+using System.Windows.Input;
+
+namespace Test.Views;
+
+public partial class BasePage : Microsoft.Maui.Controls.ContentPage
+{
+	public static readonly Microsoft.Maui.Controls.BindableProperty SelectedItemProperty =
+		Microsoft.Maui.Controls.BindableProperty.Create(nameof(SelectedItem), typeof(object), typeof(BasePage));
+
+	public object SelectedItem
+	{
+		get => GetValue(SelectedItemProperty);
+		set => SetValue(SelectedItemProperty, value);
+	}
+
+	public ICommand NavigateCommand { get; set; }
+}
+
+namespace Test;
+
+public class ViewModel
+{
+	public string Name { get; set; }
+}
+""";
+
+		var compilation = CreateMauiCompilation()
+			.AddSyntaxTrees(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(csharp));
+		var result = RunGenerator<XamlGenerator>(compilation, new AdditionalXamlFile("ControlsPage.xaml", xaml), assertNoCompilationErrors: false);
+
+		// ContentPage (the declared AncestorType) is unsealed and does not declare SelectedItem, but
+		// the real derived type BasePage does — MAUIG2045 must be suppressed.
+		Assert.DoesNotContain(result.Diagnostics, d => d.Id == "MAUIG2045");
 	}
 
 	[Fact]


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause

The issue occurs because of a change that taught the XAML source generator to compile  RelativeSource AncestorType  bindings at build time instead of always relying on reflection. This introduced a build warning (MAUIG2045) whenever a bound property could not be found on the declared  AncestorType .

This check is unsound because  AncestorType  matching in XAML is polymorphic: at runtime, the framework walks up the visual tree and accepts any ancestor whose type matches the declared type or a subclass of it. A property missing on the declared type (e.g.,  ContentPage ) may still be legitimately supplied by a derived class used at runtime (e.g.,  BasePage : ContentPage  declaring  SelectedItem ). Since the generator checked only the declared type, it produced false positive warnings that broke builds using  TreatWarningsAsErrors=true .

### Description of Change

The fix narrows the diagnostic condition so MAUIG2045 fires only when the declared  AncestorType  is  sealed . A sealed type has no subclasses, so a missing property there provably breaks the binding. For non-sealed types, the compiler cannot rule out a derived ancestor supplying the property, so the diagnostic is suppressed and the binding falls back to reflection at runtime, the same safe fallback already used for  x:Reference  bindings.

This is a minimal, one-line change to the diagnostic condition. It was validated with a regression test reproducing the exact scenario (an unsealed base page whose subclass supplies the bound property), confirming the test fails without the fix and passes with it, while the rest of the test suite is unaffected.

### Regression PR

PR https://github.com/dotnet/maui/pull/34408

Tested the behavior in the following platforms.
 
- [x] Android
- [x] Mac
- [x] iOS
- [x] Windows

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/36818

### Output

|Before Fix|After Fix|
|--|--|
<video src="https://github.com/user-attachments/assets/b53cfaa0-40ca-46a1-b8e4-9d968ee013d0"> |<video src="https://github.com/user-attachments/assets/2ac03219-e022-4115-a225-81cb44f487f6">|

