### PR TITLE
[release/11.0.1xx-preview7] Update to final blessed Preview 7 SDK/runtime

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -17,21 +17,21 @@
       <Uri>https://github.com/dotnet/android</Uri>
       <Sha>d549e1dc4e2a083b08b4f24cb5495e81b99d79b5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net11.0_26.5" Version="26.5.11991-net11-p7">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net11.0_26.5" Version="26.5.11917-net11-p7">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>9f5d610822e4dc76ba3b786a1112bb7bd2fc5ba1</Sha>
+      <Sha>2d32f7aa5a7667fbd22f57ad4072b0ecf0890ebf</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net11.0_26.5" Version="26.5.11991-net11-p7">
+    <Dependency Name="Microsoft.macOS.Sdk.net11.0_26.5" Version="26.5.11917-net11-p7">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>9f5d610822e4dc76ba3b786a1112bb7bd2fc5ba1</Sha>
+      <Sha>2d32f7aa5a7667fbd22f57ad4072b0ecf0890ebf</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net11.0_26.5" Version="26.5.11991-net11-p7">
+    <Dependency Name="Microsoft.iOS.Sdk.net11.0_26.5" Version="26.5.11917-net11-p7">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>9f5d610822e4dc76ba3b786a1112bb7bd2fc5ba1</Sha>
+      <Sha>2d32f7aa5a7667fbd22f57ad4072b0ecf0890ebf</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net11.0_26.5" Version="26.5.11991-net11-p7">
+    <Dependency Name="Microsoft.tvOS.Sdk.net11.0_26.5" Version="26.5.11917-net11-p7">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>9f5d610822e4dc76ba3b786a1112bb7bd2fc5ba1</Sha>
+      <Sha>2d32f7aa5a7667fbd22f57ad4072b0ecf0890ebf</Sha>
     </Dependency>
     <!-- Previous .NET iOS version(s) -->
     <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_26.5" Version="26.5.10310" CoherentParentDependency="Microsoft.MacCatalyst.Sdk.net11.0_26.5">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,12 +1,12 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.Sdk" Version="11.0.100-preview.7.26376.106">
+    <Dependency Name="Microsoft.NET.Sdk" Version="11.0.100-preview.7.26360.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7bcb9009c40399c9073e7db938250486229cc85d</Sha>
+      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-preview.7.26376.106">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-preview.7.26360.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7bcb9009c40399c9073e7db938250486229cc85d</Sha>
+      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Android.Sdk.Windows" Version="37.0.0-preview.7.2129">
       <Uri>https://github.com/dotnet/android</Uri>
@@ -53,109 +53,109 @@
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="11.0.0-preview.7.26376.106">
+    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="11.0.0-preview.7.26360.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7bcb9009c40399c9073e7db938250486229cc85d</Sha>
+      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="11.0.0-preview.7.26376.106">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="11.0.0-preview.7.26360.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7bcb9009c40399c9073e7db938250486229cc85d</Sha>
+      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="11.0.0-preview.7.26376.106">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="11.0.0-preview.7.26360.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7bcb9009c40399c9073e7db938250486229cc85d</Sha>
+      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="11.0.0-preview.7.26376.106">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="11.0.0-preview.7.26360.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7bcb9009c40399c9073e7db938250486229cc85d</Sha>
+      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components" Version="11.0.0-preview.7.26376.106">
+    <Dependency Name="Microsoft.AspNetCore.Components" Version="11.0.0-preview.7.26360.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7bcb9009c40399c9073e7db938250486229cc85d</Sha>
+      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="11.0.0-preview.7.26376.106">
+    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="11.0.0-preview.7.26360.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7bcb9009c40399c9073e7db938250486229cc85d</Sha>
+      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="11.0.0-preview.7.26376.106">
+    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="11.0.0-preview.7.26360.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7bcb9009c40399c9073e7db938250486229cc85d</Sha>
+      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="11.0.0-preview.7.26376.106">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="11.0.0-preview.7.26360.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7bcb9009c40399c9073e7db938250486229cc85d</Sha>
+      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="11.0.0-preview.7.26376.106">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="11.0.0-preview.7.26360.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7bcb9009c40399c9073e7db938250486229cc85d</Sha>
+      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="11.0.0-preview.7.26376.106">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="11.0.0-preview.7.26360.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7bcb9009c40399c9073e7db938250486229cc85d</Sha>
+      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="11.0.0-preview.7.26376.106">
+    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="11.0.0-preview.7.26360.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7bcb9009c40399c9073e7db938250486229cc85d</Sha>
+      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="11.0.0-preview.7.26376.106">
+    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="11.0.0-preview.7.26360.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7bcb9009c40399c9073e7db938250486229cc85d</Sha>
+      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.JSInterop" Version="11.0.0-preview.7.26376.106">
+    <Dependency Name="Microsoft.JSInterop" Version="11.0.0-preview.7.26360.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7bcb9009c40399c9073e7db938250486229cc85d</Sha>
+      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
     </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-preview.2.22102.8">
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>3f4da9ced34942d83054e647f3b1d9d7dde281e8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration" Version="11.0.0-preview.7.26376.106">
+    <Dependency Name="Microsoft.Extensions.Configuration" Version="11.0.0-preview.7.26360.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7bcb9009c40399c9073e7db938250486229cc85d</Sha>
+      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="11.0.0-preview.7.26376.106">
+    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="11.0.0-preview.7.26360.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7bcb9009c40399c9073e7db938250486229cc85d</Sha>
+      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="11.0.0-preview.7.26376.106">
+    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="11.0.0-preview.7.26360.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7bcb9009c40399c9073e7db938250486229cc85d</Sha>
+      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="11.0.0-preview.7.26376.106">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="11.0.0-preview.7.26360.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7bcb9009c40399c9073e7db938250486229cc85d</Sha>
+      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="11.0.0-preview.7.26376.106">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="11.0.0-preview.7.26360.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7bcb9009c40399c9073e7db938250486229cc85d</Sha>
+      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="11.0.0-preview.7.26376.106">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="11.0.0-preview.7.26360.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7bcb9009c40399c9073e7db938250486229cc85d</Sha>
+      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="11.0.0-preview.7.26376.106">
+    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="11.0.0-preview.7.26360.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7bcb9009c40399c9073e7db938250486229cc85d</Sha>
+      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="11.0.0-preview.7.26376.106">
+    <Dependency Name="Microsoft.Extensions.Logging" Version="11.0.0-preview.7.26360.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7bcb9009c40399c9073e7db938250486229cc85d</Sha>
+      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="11.0.0-preview.7.26376.106">
+    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="11.0.0-preview.7.26360.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7bcb9009c40399c9073e7db938250486229cc85d</Sha>
+      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="11.0.0-preview.7.26376.106">
+    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="11.0.0-preview.7.26360.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7bcb9009c40399c9073e7db938250486229cc85d</Sha>
+      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Primitives" Version="11.0.0-preview.7.26376.106">
+    <Dependency Name="Microsoft.Extensions.Primitives" Version="11.0.0-preview.7.26360.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7bcb9009c40399c9073e7db938250486229cc85d</Sha>
+      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="11.0.0-preview.7.26376.106">
+    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="11.0.0-preview.7.26360.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7bcb9009c40399c9073e7db938250486229cc85d</Sha>
+      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="11.0.0-prerelease.26064.3">
       <Uri>https://github.com/dotnet/xharness</Uri>
@@ -175,37 +175,37 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="11.0.0-beta.26376.106">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="11.0.0-beta.26360.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7bcb9009c40399c9073e7db938250486229cc85d</Sha>
+      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26376.106">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26360.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7bcb9009c40399c9073e7db938250486229cc85d</Sha>
+      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="11.0.0-beta.26376.106">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="11.0.0-beta.26360.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7bcb9009c40399c9073e7db938250486229cc85d</Sha>
+      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="11.0.0-beta.26376.106">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="11.0.0-beta.26360.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7bcb9009c40399c9073e7db938250486229cc85d</Sha>
+      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26376.106">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26360.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7bcb9009c40399c9073e7db938250486229cc85d</Sha>
+      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="11.0.0-beta.26376.106">
+    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="11.0.0-beta.26360.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7bcb9009c40399c9073e7db938250486229cc85d</Sha>
+      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="11.0.0-beta.26376.106">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="11.0.0-beta.26360.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7bcb9009c40399c9073e7db938250486229cc85d</Sha>
+      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="11.0.0-beta.26376.106">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="11.0.0-beta.26360.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7bcb9009c40399c9073e7db938250486229cc85d</Sha>
+      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,12 +1,12 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.Sdk" Version="11.0.100-preview.7.26360.102">
+    <Dependency Name="Microsoft.NET.Sdk" Version="11.0.100-preview.7.26378.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
+      <Sha>ab4a9a5f25db0b29e980a7acfab46bc4eca924c3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-preview.7.26360.102">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-preview.7.26378.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
+      <Sha>ab4a9a5f25db0b29e980a7acfab46bc4eca924c3</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Android.Sdk.Windows" Version="37.0.0-preview.7.2129">
       <Uri>https://github.com/dotnet/android</Uri>
@@ -17,21 +17,21 @@
       <Uri>https://github.com/dotnet/android</Uri>
       <Sha>d549e1dc4e2a083b08b4f24cb5495e81b99d79b5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net11.0_26.5" Version="26.5.11917-net11-p7">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net11.0_26.5" Version="26.5.11991-net11-p7">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>2d32f7aa5a7667fbd22f57ad4072b0ecf0890ebf</Sha>
+      <Sha>9f5d610822e4dc76ba3b786a1112bb7bd2fc5ba1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net11.0_26.5" Version="26.5.11917-net11-p7">
+    <Dependency Name="Microsoft.macOS.Sdk.net11.0_26.5" Version="26.5.11991-net11-p7">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>2d32f7aa5a7667fbd22f57ad4072b0ecf0890ebf</Sha>
+      <Sha>9f5d610822e4dc76ba3b786a1112bb7bd2fc5ba1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net11.0_26.5" Version="26.5.11917-net11-p7">
+    <Dependency Name="Microsoft.iOS.Sdk.net11.0_26.5" Version="26.5.11991-net11-p7">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>2d32f7aa5a7667fbd22f57ad4072b0ecf0890ebf</Sha>
+      <Sha>9f5d610822e4dc76ba3b786a1112bb7bd2fc5ba1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net11.0_26.5" Version="26.5.11917-net11-p7">
+    <Dependency Name="Microsoft.tvOS.Sdk.net11.0_26.5" Version="26.5.11991-net11-p7">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>2d32f7aa5a7667fbd22f57ad4072b0ecf0890ebf</Sha>
+      <Sha>9f5d610822e4dc76ba3b786a1112bb7bd2fc5ba1</Sha>
     </Dependency>
     <!-- Previous .NET iOS version(s) -->
     <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_26.5" Version="26.5.10310" CoherentParentDependency="Microsoft.MacCatalyst.Sdk.net11.0_26.5">
@@ -53,109 +53,109 @@
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="11.0.0-preview.7.26360.102">
+    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="11.0.0-preview.7.26378.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
+      <Sha>ab4a9a5f25db0b29e980a7acfab46bc4eca924c3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="11.0.0-preview.7.26360.102">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="11.0.0-preview.7.26378.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
+      <Sha>ab4a9a5f25db0b29e980a7acfab46bc4eca924c3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="11.0.0-preview.7.26360.102">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="11.0.0-preview.7.26378.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
+      <Sha>ab4a9a5f25db0b29e980a7acfab46bc4eca924c3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="11.0.0-preview.7.26360.102">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="11.0.0-preview.7.26378.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
+      <Sha>ab4a9a5f25db0b29e980a7acfab46bc4eca924c3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components" Version="11.0.0-preview.7.26360.102">
+    <Dependency Name="Microsoft.AspNetCore.Components" Version="11.0.0-preview.7.26378.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
+      <Sha>ab4a9a5f25db0b29e980a7acfab46bc4eca924c3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="11.0.0-preview.7.26360.102">
+    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="11.0.0-preview.7.26378.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
+      <Sha>ab4a9a5f25db0b29e980a7acfab46bc4eca924c3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="11.0.0-preview.7.26360.102">
+    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="11.0.0-preview.7.26378.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
+      <Sha>ab4a9a5f25db0b29e980a7acfab46bc4eca924c3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="11.0.0-preview.7.26360.102">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="11.0.0-preview.7.26378.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
+      <Sha>ab4a9a5f25db0b29e980a7acfab46bc4eca924c3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="11.0.0-preview.7.26360.102">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="11.0.0-preview.7.26378.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
+      <Sha>ab4a9a5f25db0b29e980a7acfab46bc4eca924c3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="11.0.0-preview.7.26360.102">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="11.0.0-preview.7.26378.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
+      <Sha>ab4a9a5f25db0b29e980a7acfab46bc4eca924c3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="11.0.0-preview.7.26360.102">
+    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="11.0.0-preview.7.26378.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
+      <Sha>ab4a9a5f25db0b29e980a7acfab46bc4eca924c3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="11.0.0-preview.7.26360.102">
+    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="11.0.0-preview.7.26378.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
+      <Sha>ab4a9a5f25db0b29e980a7acfab46bc4eca924c3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.JSInterop" Version="11.0.0-preview.7.26360.102">
+    <Dependency Name="Microsoft.JSInterop" Version="11.0.0-preview.7.26378.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
+      <Sha>ab4a9a5f25db0b29e980a7acfab46bc4eca924c3</Sha>
     </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-preview.2.22102.8">
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>3f4da9ced34942d83054e647f3b1d9d7dde281e8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration" Version="11.0.0-preview.7.26360.102">
+    <Dependency Name="Microsoft.Extensions.Configuration" Version="11.0.0-preview.7.26378.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
+      <Sha>ab4a9a5f25db0b29e980a7acfab46bc4eca924c3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="11.0.0-preview.7.26360.102">
+    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="11.0.0-preview.7.26378.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
+      <Sha>ab4a9a5f25db0b29e980a7acfab46bc4eca924c3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="11.0.0-preview.7.26360.102">
+    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="11.0.0-preview.7.26378.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
+      <Sha>ab4a9a5f25db0b29e980a7acfab46bc4eca924c3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="11.0.0-preview.7.26360.102">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="11.0.0-preview.7.26378.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
+      <Sha>ab4a9a5f25db0b29e980a7acfab46bc4eca924c3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="11.0.0-preview.7.26360.102">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="11.0.0-preview.7.26378.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
+      <Sha>ab4a9a5f25db0b29e980a7acfab46bc4eca924c3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="11.0.0-preview.7.26360.102">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="11.0.0-preview.7.26378.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
+      <Sha>ab4a9a5f25db0b29e980a7acfab46bc4eca924c3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="11.0.0-preview.7.26360.102">
+    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="11.0.0-preview.7.26378.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
+      <Sha>ab4a9a5f25db0b29e980a7acfab46bc4eca924c3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="11.0.0-preview.7.26360.102">
+    <Dependency Name="Microsoft.Extensions.Logging" Version="11.0.0-preview.7.26378.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
+      <Sha>ab4a9a5f25db0b29e980a7acfab46bc4eca924c3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="11.0.0-preview.7.26360.102">
+    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="11.0.0-preview.7.26378.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
+      <Sha>ab4a9a5f25db0b29e980a7acfab46bc4eca924c3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="11.0.0-preview.7.26360.102">
+    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="11.0.0-preview.7.26378.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
+      <Sha>ab4a9a5f25db0b29e980a7acfab46bc4eca924c3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Primitives" Version="11.0.0-preview.7.26360.102">
+    <Dependency Name="Microsoft.Extensions.Primitives" Version="11.0.0-preview.7.26378.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
+      <Sha>ab4a9a5f25db0b29e980a7acfab46bc4eca924c3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="11.0.0-preview.7.26360.102">
+    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="11.0.0-preview.7.26378.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
+      <Sha>ab4a9a5f25db0b29e980a7acfab46bc4eca924c3</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="11.0.0-prerelease.26064.3">
       <Uri>https://github.com/dotnet/xharness</Uri>
@@ -175,37 +175,37 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="11.0.0-beta.26360.102">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="11.0.0-beta.26378.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
+      <Sha>ab4a9a5f25db0b29e980a7acfab46bc4eca924c3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26360.102">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26378.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
+      <Sha>ab4a9a5f25db0b29e980a7acfab46bc4eca924c3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="11.0.0-beta.26360.102">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="11.0.0-beta.26378.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
+      <Sha>ab4a9a5f25db0b29e980a7acfab46bc4eca924c3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="11.0.0-beta.26360.102">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="11.0.0-beta.26378.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
+      <Sha>ab4a9a5f25db0b29e980a7acfab46bc4eca924c3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26360.102">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26378.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
+      <Sha>ab4a9a5f25db0b29e980a7acfab46bc4eca924c3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="11.0.0-beta.26360.102">
+    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="11.0.0-beta.26378.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
+      <Sha>ab4a9a5f25db0b29e980a7acfab46bc4eca924c3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="11.0.0-beta.26360.102">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="11.0.0-beta.26378.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
+      <Sha>ab4a9a5f25db0b29e980a7acfab46bc4eca924c3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="11.0.0-beta.26360.102">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="11.0.0-beta.26378.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c98e79e96affb873c827e32c779a68b1368cc480</Sha>
+      <Sha>ab4a9a5f25db0b29e980a7acfab46bc4eca924c3</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -67,10 +67,10 @@
     <MicrosoftNETSdkAndroidManifest100100PackageVersion>36.1.69</MicrosoftNETSdkAndroidManifest100100PackageVersion>
     <AndroidNetPreviousVersion>$(MicrosoftNetSdkAndroidManifest100100PackageVersion)</AndroidNetPreviousVersion>
     <!-- dotnet/macios -->
-    <MicrosoftMacCatalystSdknet110_265PackageVersion>26.5.11991-net11-p7</MicrosoftMacCatalystSdknet110_265PackageVersion>
-    <MicrosoftmacOSSdknet110_265PackageVersion>26.5.11991-net11-p7</MicrosoftmacOSSdknet110_265PackageVersion>
-    <MicrosoftiOSSdknet110_265PackageVersion>26.5.11991-net11-p7</MicrosoftiOSSdknet110_265PackageVersion>
-    <MicrosofttvOSSdknet110_265PackageVersion>26.5.11991-net11-p7</MicrosofttvOSSdknet110_265PackageVersion>
+    <MicrosoftMacCatalystSdknet110_265PackageVersion>26.5.11917-net11-p7</MicrosoftMacCatalystSdknet110_265PackageVersion>
+    <MicrosoftmacOSSdknet110_265PackageVersion>26.5.11917-net11-p7</MicrosoftmacOSSdknet110_265PackageVersion>
+    <MicrosoftiOSSdknet110_265PackageVersion>26.5.11917-net11-p7</MicrosoftiOSSdknet110_265PackageVersion>
+    <MicrosofttvOSSdknet110_265PackageVersion>26.5.11917-net11-p7</MicrosofttvOSSdknet110_265PackageVersion>
     <!-- This is a subscription of the .NET 10 latest stable versions of our packages -->
     <MicrosoftMacCatalystSdknet100_265PackageVersion>26.5.10310</MicrosoftMacCatalystSdknet100_265PackageVersion>
     <MicrosoftmacOSSdknet100_265PackageVersion>26.5.10310</MicrosoftmacOSSdknet100_265PackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -31,10 +31,10 @@
     <!-- Current previous .NET SDK major version's stable release of MAUI packages -->
     <MicrosoftMauiPreviousDotNetReleasedVersion>10.0.20</MicrosoftMauiPreviousDotNetReleasedVersion>
     <!-- dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>11.0.100-preview.7.26360.102</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>11.0.100-preview.7.26378.106</MicrosoftNETSdkPackageVersion>
     <MicrosoftDotnetSdkInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-preview.7.26360.102</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-preview.7.26378.106</MicrosoftNETCoreAppRefPackageVersion>
     <SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextJsonPackageVersion>
     <SystemTextEncodingsWebPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextEncodingsWebPackageVersion>
     <MicrosoftBclAsyncInterfacesPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftBclAsyncInterfacesPackageVersion>
@@ -42,18 +42,18 @@
     <optimizationandroidx64MIBCRuntimePackageVersion>1.0.0-prerelease.26317.1</optimizationandroidx64MIBCRuntimePackageVersion>
     <!-- Microsoft/Extensions -->
     <SystemCodeDomPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemCodeDomPackageVersion>
-    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.7.26360.102</MicrosoftExtensionsConfigurationVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsVersion>11.0.0-preview.7.26360.102</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationJsonVersion>11.0.0-preview.7.26360.102</MicrosoftExtensionsConfigurationJsonVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>11.0.0-preview.7.26360.102</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>11.0.0-preview.7.26360.102</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
-    <MicrosoftExtensionsFileProvidersAbstractionsVersion>11.0.0-preview.7.26360.102</MicrosoftExtensionsFileProvidersAbstractionsVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>11.0.0-preview.7.26360.102</MicrosoftExtensionsLoggingAbstractionsVersion>
-    <MicrosoftExtensionsLoggingVersion>11.0.0-preview.7.26360.102</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>11.0.0-preview.7.26360.102</MicrosoftExtensionsLoggingConsoleVersion>
-    <MicrosoftExtensionsLoggingDebugVersion>11.0.0-preview.7.26360.102</MicrosoftExtensionsLoggingDebugVersion>
-    <MicrosoftExtensionsPrimitivesVersion>11.0.0-preview.7.26360.102</MicrosoftExtensionsPrimitivesVersion>
-    <MicrosoftExtensionsHostingAbstractionsVersion>11.0.0-preview.7.26360.102</MicrosoftExtensionsHostingAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.7.26378.106</MicrosoftExtensionsConfigurationVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>11.0.0-preview.7.26378.106</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationJsonVersion>11.0.0-preview.7.26378.106</MicrosoftExtensionsConfigurationJsonVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>11.0.0-preview.7.26378.106</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>11.0.0-preview.7.26378.106</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
+    <MicrosoftExtensionsFileProvidersAbstractionsVersion>11.0.0-preview.7.26378.106</MicrosoftExtensionsFileProvidersAbstractionsVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>11.0.0-preview.7.26378.106</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingVersion>11.0.0-preview.7.26378.106</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>11.0.0-preview.7.26378.106</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingDebugVersion>11.0.0-preview.7.26378.106</MicrosoftExtensionsLoggingDebugVersion>
+    <MicrosoftExtensionsPrimitivesVersion>11.0.0-preview.7.26378.106</MicrosoftExtensionsPrimitivesVersion>
+    <MicrosoftExtensionsHostingAbstractionsVersion>11.0.0-preview.7.26378.106</MicrosoftExtensionsHostingAbstractionsVersion>
     <MicrosoftExtensionsAIVersion>10.3.0</MicrosoftExtensionsAIVersion>
     <MicrosoftExtensionsAIAbstractionsVersion>10.3.0</MicrosoftExtensionsAIAbstractionsVersion>
     <MicrosoftExtensionsHttpVersion>11.0.0-preview.2.26103.111</MicrosoftExtensionsHttpVersion>
@@ -67,10 +67,10 @@
     <MicrosoftNETSdkAndroidManifest100100PackageVersion>36.1.69</MicrosoftNETSdkAndroidManifest100100PackageVersion>
     <AndroidNetPreviousVersion>$(MicrosoftNetSdkAndroidManifest100100PackageVersion)</AndroidNetPreviousVersion>
     <!-- dotnet/macios -->
-    <MicrosoftMacCatalystSdknet110_265PackageVersion>26.5.11917-net11-p7</MicrosoftMacCatalystSdknet110_265PackageVersion>
-    <MicrosoftmacOSSdknet110_265PackageVersion>26.5.11917-net11-p7</MicrosoftmacOSSdknet110_265PackageVersion>
-    <MicrosoftiOSSdknet110_265PackageVersion>26.5.11917-net11-p7</MicrosoftiOSSdknet110_265PackageVersion>
-    <MicrosofttvOSSdknet110_265PackageVersion>26.5.11917-net11-p7</MicrosofttvOSSdknet110_265PackageVersion>
+    <MicrosoftMacCatalystSdknet110_265PackageVersion>26.5.11991-net11-p7</MicrosoftMacCatalystSdknet110_265PackageVersion>
+    <MicrosoftmacOSSdknet110_265PackageVersion>26.5.11991-net11-p7</MicrosoftmacOSSdknet110_265PackageVersion>
+    <MicrosoftiOSSdknet110_265PackageVersion>26.5.11991-net11-p7</MicrosoftiOSSdknet110_265PackageVersion>
+    <MicrosofttvOSSdknet110_265PackageVersion>26.5.11991-net11-p7</MicrosofttvOSSdknet110_265PackageVersion>
     <!-- This is a subscription of the .NET 10 latest stable versions of our packages -->
     <MicrosoftMacCatalystSdknet100_265PackageVersion>26.5.10310</MicrosoftMacCatalystSdknet100_265PackageVersion>
     <MicrosoftmacOSSdknet100_265PackageVersion>26.5.10310</MicrosoftmacOSSdknet100_265PackageVersion>
@@ -84,19 +84,19 @@
     <MicrosoftGraphicsWin2DPackageVersion>1.3.2</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.3179.45</MicrosoftWindowsWebView2PackageVersion>
     <!-- Everything else -->
-    <MicrosoftAspNetCoreAuthorizationPackageVersion>11.0.0-preview.7.26360.102</MicrosoftAspNetCoreAuthorizationPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>11.0.0-preview.7.26360.102</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>11.0.0-preview.7.26360.102</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
-    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>11.0.0-preview.7.26360.102</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
-    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>11.0.0-preview.7.26360.102</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreComponentsFormsPackageVersion>11.0.0-preview.7.26360.102</MicrosoftAspNetCoreComponentsFormsPackageVersion>
-    <MicrosoftAspNetCoreComponentsPackageVersion>11.0.0-preview.7.26360.102</MicrosoftAspNetCoreComponentsPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebPackageVersion>11.0.0-preview.7.26360.102</MicrosoftAspNetCoreComponentsWebPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>11.0.0-preview.7.26360.102</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>11.0.0-preview.7.26360.102</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>11.0.0-preview.7.26360.102</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
-    <MicrosoftAspNetCoreMetadataPackageVersion>11.0.0-preview.7.26360.102</MicrosoftAspNetCoreMetadataPackageVersion>
-    <MicrosoftJSInteropPackageVersion>11.0.0-preview.7.26360.102</MicrosoftJSInteropPackageVersion>
+    <MicrosoftAspNetCoreAuthorizationPackageVersion>11.0.0-preview.7.26378.106</MicrosoftAspNetCoreAuthorizationPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>11.0.0-preview.7.26378.106</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>11.0.0-preview.7.26378.106</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
+    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>11.0.0-preview.7.26378.106</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
+    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>11.0.0-preview.7.26378.106</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreComponentsFormsPackageVersion>11.0.0-preview.7.26378.106</MicrosoftAspNetCoreComponentsFormsPackageVersion>
+    <MicrosoftAspNetCoreComponentsPackageVersion>11.0.0-preview.7.26378.106</MicrosoftAspNetCoreComponentsPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebPackageVersion>11.0.0-preview.7.26378.106</MicrosoftAspNetCoreComponentsWebPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>11.0.0-preview.7.26378.106</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>11.0.0-preview.7.26378.106</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>11.0.0-preview.7.26378.106</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
+    <MicrosoftAspNetCoreMetadataPackageVersion>11.0.0-preview.7.26378.106</MicrosoftAspNetCoreMetadataPackageVersion>
+    <MicrosoftJSInteropPackageVersion>11.0.0-preview.7.26378.106</MicrosoftJSInteropPackageVersion>
     <!-- Everything else (previous edition) -->
     <MicrosoftAspNetCorePackageVersion>10.0.2</MicrosoftAspNetCorePackageVersion>
     <MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>$(MicrosoftAspNetCorePackageVersion)</MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>
@@ -146,13 +146,13 @@
     <TizenUIExtensionsVersion>0.9.0</TizenUIExtensionsVersion>
     <ExCSSPackageVersion>4.2.3</ExCSSPackageVersion>
     <SystemDrawingCommonPackageVersion>9.0.0</SystemDrawingCommonPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>11.0.0-beta.26360.102</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetBuildTasksInstallersPackageVersion>11.0.0-beta.26360.102</MicrosoftDotNetBuildTasksInstallersPackageVersion>
-    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>11.0.0-beta.26360.102</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26360.102</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>11.0.0-beta.26378.106</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksInstallersPackageVersion>11.0.0-beta.26378.106</MicrosoftDotNetBuildTasksInstallersPackageVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>11.0.0-beta.26378.106</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26378.106</MicrosoftDotNetHelixSdkPackageVersion>
     <MicroBuildPluginsSwixBuildDotnetPackageVersion>1.1.87-gba258badda</MicroBuildPluginsSwixBuildDotnetPackageVersion>
-    <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.26360.102</MicrosoftDotNetRemoteExecutorPackageVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>11.0.0-beta.26360.102</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.26378.106</MicrosoftDotNetRemoteExecutorPackageVersion>
+    <MicrosoftDotNetXUnitExtensionsPackageVersion>11.0.0-beta.26378.106</MicrosoftDotNetXUnitExtensionsPackageVersion>
     <MicrosoftWixVersion>6.0.3-dotnet.4</MicrosoftWixVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -31,10 +31,10 @@
     <!-- Current previous .NET SDK major version's stable release of MAUI packages -->
     <MicrosoftMauiPreviousDotNetReleasedVersion>10.0.20</MicrosoftMauiPreviousDotNetReleasedVersion>
     <!-- dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>11.0.100-preview.7.26376.106</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>11.0.100-preview.7.26360.102</MicrosoftNETSdkPackageVersion>
     <MicrosoftDotnetSdkInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-preview.7.26376.106</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-preview.7.26360.102</MicrosoftNETCoreAppRefPackageVersion>
     <SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextJsonPackageVersion>
     <SystemTextEncodingsWebPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextEncodingsWebPackageVersion>
     <MicrosoftBclAsyncInterfacesPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftBclAsyncInterfacesPackageVersion>
@@ -42,18 +42,18 @@
     <optimizationandroidx64MIBCRuntimePackageVersion>1.0.0-prerelease.26317.1</optimizationandroidx64MIBCRuntimePackageVersion>
     <!-- Microsoft/Extensions -->
     <SystemCodeDomPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemCodeDomPackageVersion>
-    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.7.26376.106</MicrosoftExtensionsConfigurationVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsVersion>11.0.0-preview.7.26376.106</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationJsonVersion>11.0.0-preview.7.26376.106</MicrosoftExtensionsConfigurationJsonVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>11.0.0-preview.7.26376.106</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>11.0.0-preview.7.26376.106</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
-    <MicrosoftExtensionsFileProvidersAbstractionsVersion>11.0.0-preview.7.26376.106</MicrosoftExtensionsFileProvidersAbstractionsVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>11.0.0-preview.7.26376.106</MicrosoftExtensionsLoggingAbstractionsVersion>
-    <MicrosoftExtensionsLoggingVersion>11.0.0-preview.7.26376.106</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>11.0.0-preview.7.26376.106</MicrosoftExtensionsLoggingConsoleVersion>
-    <MicrosoftExtensionsLoggingDebugVersion>11.0.0-preview.7.26376.106</MicrosoftExtensionsLoggingDebugVersion>
-    <MicrosoftExtensionsPrimitivesVersion>11.0.0-preview.7.26376.106</MicrosoftExtensionsPrimitivesVersion>
-    <MicrosoftExtensionsHostingAbstractionsVersion>11.0.0-preview.7.26376.106</MicrosoftExtensionsHostingAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.7.26360.102</MicrosoftExtensionsConfigurationVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>11.0.0-preview.7.26360.102</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationJsonVersion>11.0.0-preview.7.26360.102</MicrosoftExtensionsConfigurationJsonVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>11.0.0-preview.7.26360.102</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>11.0.0-preview.7.26360.102</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
+    <MicrosoftExtensionsFileProvidersAbstractionsVersion>11.0.0-preview.7.26360.102</MicrosoftExtensionsFileProvidersAbstractionsVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>11.0.0-preview.7.26360.102</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingVersion>11.0.0-preview.7.26360.102</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>11.0.0-preview.7.26360.102</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingDebugVersion>11.0.0-preview.7.26360.102</MicrosoftExtensionsLoggingDebugVersion>
+    <MicrosoftExtensionsPrimitivesVersion>11.0.0-preview.7.26360.102</MicrosoftExtensionsPrimitivesVersion>
+    <MicrosoftExtensionsHostingAbstractionsVersion>11.0.0-preview.7.26360.102</MicrosoftExtensionsHostingAbstractionsVersion>
     <MicrosoftExtensionsAIVersion>10.3.0</MicrosoftExtensionsAIVersion>
     <MicrosoftExtensionsAIAbstractionsVersion>10.3.0</MicrosoftExtensionsAIAbstractionsVersion>
     <MicrosoftExtensionsHttpVersion>11.0.0-preview.2.26103.111</MicrosoftExtensionsHttpVersion>
@@ -84,19 +84,19 @@
     <MicrosoftGraphicsWin2DPackageVersion>1.3.2</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.3179.45</MicrosoftWindowsWebView2PackageVersion>
     <!-- Everything else -->
-    <MicrosoftAspNetCoreAuthorizationPackageVersion>11.0.0-preview.7.26376.106</MicrosoftAspNetCoreAuthorizationPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>11.0.0-preview.7.26376.106</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>11.0.0-preview.7.26376.106</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
-    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>11.0.0-preview.7.26376.106</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
-    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>11.0.0-preview.7.26376.106</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreComponentsFormsPackageVersion>11.0.0-preview.7.26376.106</MicrosoftAspNetCoreComponentsFormsPackageVersion>
-    <MicrosoftAspNetCoreComponentsPackageVersion>11.0.0-preview.7.26376.106</MicrosoftAspNetCoreComponentsPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebPackageVersion>11.0.0-preview.7.26376.106</MicrosoftAspNetCoreComponentsWebPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>11.0.0-preview.7.26376.106</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>11.0.0-preview.7.26376.106</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>11.0.0-preview.7.26376.106</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
-    <MicrosoftAspNetCoreMetadataPackageVersion>11.0.0-preview.7.26376.106</MicrosoftAspNetCoreMetadataPackageVersion>
-    <MicrosoftJSInteropPackageVersion>11.0.0-preview.7.26376.106</MicrosoftJSInteropPackageVersion>
+    <MicrosoftAspNetCoreAuthorizationPackageVersion>11.0.0-preview.7.26360.102</MicrosoftAspNetCoreAuthorizationPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>11.0.0-preview.7.26360.102</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>11.0.0-preview.7.26360.102</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
+    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>11.0.0-preview.7.26360.102</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
+    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>11.0.0-preview.7.26360.102</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreComponentsFormsPackageVersion>11.0.0-preview.7.26360.102</MicrosoftAspNetCoreComponentsFormsPackageVersion>
+    <MicrosoftAspNetCoreComponentsPackageVersion>11.0.0-preview.7.26360.102</MicrosoftAspNetCoreComponentsPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebPackageVersion>11.0.0-preview.7.26360.102</MicrosoftAspNetCoreComponentsWebPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>11.0.0-preview.7.26360.102</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>11.0.0-preview.7.26360.102</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>11.0.0-preview.7.26360.102</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
+    <MicrosoftAspNetCoreMetadataPackageVersion>11.0.0-preview.7.26360.102</MicrosoftAspNetCoreMetadataPackageVersion>
+    <MicrosoftJSInteropPackageVersion>11.0.0-preview.7.26360.102</MicrosoftJSInteropPackageVersion>
     <!-- Everything else (previous edition) -->
     <MicrosoftAspNetCorePackageVersion>10.0.2</MicrosoftAspNetCorePackageVersion>
     <MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>$(MicrosoftAspNetCorePackageVersion)</MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>
@@ -146,13 +146,13 @@
     <TizenUIExtensionsVersion>0.9.0</TizenUIExtensionsVersion>
     <ExCSSPackageVersion>4.2.3</ExCSSPackageVersion>
     <SystemDrawingCommonPackageVersion>9.0.0</SystemDrawingCommonPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>11.0.0-beta.26376.106</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetBuildTasksInstallersPackageVersion>11.0.0-beta.26376.106</MicrosoftDotNetBuildTasksInstallersPackageVersion>
-    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>11.0.0-beta.26376.106</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26376.106</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>11.0.0-beta.26360.102</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksInstallersPackageVersion>11.0.0-beta.26360.102</MicrosoftDotNetBuildTasksInstallersPackageVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>11.0.0-beta.26360.102</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26360.102</MicrosoftDotNetHelixSdkPackageVersion>
     <MicroBuildPluginsSwixBuildDotnetPackageVersion>1.1.87-gba258badda</MicroBuildPluginsSwixBuildDotnetPackageVersion>
-    <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.26376.106</MicrosoftDotNetRemoteExecutorPackageVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>11.0.0-beta.26376.106</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.26360.102</MicrosoftDotNetRemoteExecutorPackageVersion>
+    <MicrosoftDotNetXUnitExtensionsPackageVersion>11.0.0-beta.26360.102</MicrosoftDotNetXUnitExtensionsPackageVersion>
     <MicrosoftWixVersion>6.0.3-dotnet.4</MicrosoftWixVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "11.0.100-preview.7.26376.106"
+    "dotnet": "11.0.100-preview.7.26360.102"
   },
   "sdk": {
     "paths": [
@@ -11,7 +11,7 @@
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44",
     "Microsoft.Build.NoTargets": "3.7.0",
-    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26376.106",
-    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26376.106"
+    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26360.102",
+    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26360.102"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "11.0.100-preview.7.26360.102"
+    "dotnet": "11.0.100-preview.7.26378.106"
   },
   "sdk": {
     "paths": [
@@ -11,7 +11,7 @@
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44",
     "Microsoft.Build.NoTargets": "3.7.0",
-    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26360.102",
-    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26360.102"
+    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26378.106",
+    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26378.106"
   }
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

- Replace the `26376.106` VMR SDK/runtime dependency set merged by #36838 with the final release-designated Preview 7 `26378.106` build.
- Update all 35 dependencies originating from `dotnet/dotnet` to VMR BAR 324774.
- Keep Android at `37.0.0-preview.7.2129` and restore the four net11 Apple workload pins to `26.5.11991-net11-p7` from Apple BAR 324578.
- Preserve the net10 Apple `26.5.10310` pins, WiX `6.0.3-dotnet.4`, and the merged AppTheme and Blazor fixes.

## Provenance

- **.NET Release Tracker:** SDK `11.0.100-preview.7.26378.106`; runtime `11.0.0-preview.7.26378.106`; stage build `3033875` (`Staging Done`).
- **VMR BAR/Maestro:** BAR `324774`; build `20260728.6`; branch `release/11.0.1xx-preview7`; commit `ab4a9a5f25db0b29e980a7acfab46bc4eca924c3`; channel `.NET 11.0.1xx SDK Preview 7`.
- **Apple BAR/Maestro:** BAR `324578`; build `20260723.14`; branch `release/11.0.1xx-preview7`; package version `26.5.11991-net11-p7`; commit `9f5d610822e4dc76ba3b786a1112bb7bd2fc5ba1`; channels `.NET 11 Workload Release` and `.NET 11.0.1xx SDK Preview 7`.
- **Android BAR/Maestro:** BAR `324594`; version `37.0.0-preview.7.2129`; commit `d7f90faae8e11b59d6be85902d01136643bc848b`; unchanged by this PR.
- Release Tracker designates the SDK/runtime versions. Android and Apple component provenance comes from BAR/Maestro.

## Validation

- Darc read-only queries reconfirmed BAR 324774 and BAR 324578, including repository, branch, commit, build number, and channels.
- `darc update-dependencies` applied both BAR builds; the generated intermediate net10 Apple coherency rewrite was rejected so the existing `26.5.10310` subscriptions remain unchanged.
- All 35 `dotnet/dotnet` dependencies exactly match BAR 324774 assets and commit `ab4a9a5f...`.
- All four net11 Apple dependencies exactly match BAR 324578 assets and commit `9f5d6108...`; all four net10 Apple dependencies remain `26.5.10310` at `e9727264...`.
- Repository workload provisioning installed SDK/runtime `26378.106`, Android `37.0.0-preview.7.2129`, and Apple `26.5.11991-net11-p7`. The final iOS manifest requests net10 Apple `26.5.10310`, not unavailable `26.5.10304`.
- `Controls.Build.Tasks` built with 0 warnings and 0 errors under SDK/runtime `26378.106`.
- The actual binding project `src/Core/src/Core.csproj` built for `net11.0-ios26.5` (`iossimulator-arm64`) with 0 warnings and 0 errors, exercising `bgen.dll` through the project's `ObjcBindingApiDefinition` items.
- XML and JSON parsing passed; `git diff --check` passed.
- `darc verify` still reports existing repository-wide duplicate/casing/version issues for `TizenUIExtensions`, `XUnitAnalyzers`, and `Microsoft.DotNet.XHarness.CLI`; none are changed by this PR.