### PR TITLE
[ci-fix-net11] Fix TopTabUnselectedTextVisibleWhenSwitchingTabs visual regression on Android Material3

### DIFF
--- a/src/Controls/src/Core/Handlers/Shell/ShellContentNavigationFragment.Android.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellContentNavigationFragment.Android.cs
@@ -7,6 +7,7 @@ using Android.OS;
 using Android.Views;
 using Android.Widget;
 using AndroidX.Fragment.App;
+using Microsoft.Maui.Controls.Handlers.Compatibility;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Platform.Compatibility;
 using Microsoft.Maui.Graphics;
@@ -177,19 +178,27 @@ namespace Microsoft.Maui.Controls.Handlers
             // Connect using the adapter (which properly implements IStackNavigationView via page delegation)
             _stackNavigationManager.Connect(_navigationViewAdapter, _navigationContainer);
 
-            // Apply dark/light background to the navigation container when the page has no explicit
-            // Background, matching old ShellPageContainer constructor behavior.
-            // We set it on the container (not the page's platform view) because the page's handler
-            // hasn't been created yet at this point — StackNavigationManager creates it asynchronously.
-            // The page view is transparent by default, so the container background shows through.
+            // Apply background to the navigation container when the page has no explicit Background.
+            // For Material3: use ShellRenderer.DefaultBackgroundColor (colorSurface = #FEF7FF light / #141218 dark)
+            //   matching what the old ShellPageContainer did via GetThemeAttrColor(colorSurface).
+            // For Material2: use the platform default BackgroundLight/BackgroundDark.
             if (_rootPage is IView view && view.Background is null && _navigationContainer is not null)
             {
                 var context = _mauiContext!.Context!;
-                bool isDark = Controls.Application.Current?.RequestedTheme == ApplicationModel.AppTheme.Dark;
-                int bgColor = isDark
-                    ? AndroidX.Core.Content.ContextCompat.GetColor(context, global::Android.Resource.Color.BackgroundDark)
-                    : AndroidX.Core.Content.ContextCompat.GetColor(context, global::Android.Resource.Color.BackgroundLight);
-                _navigationContainer.SetBackgroundColor(new global::Android.Graphics.Color(bgColor));
+                global::Android.Graphics.Color bgColor;
+                if (RuntimeFeature.IsMaterial3Enabled)
+                {
+                    bgColor = ShellRenderer.DefaultBackgroundColor.ToPlatform();
+                }
+                else
+                {
+                    bool isDark = Controls.Application.Current?.RequestedTheme == ApplicationModel.AppTheme.Dark;
+                    int resourceColor = isDark
+                        ? AndroidX.Core.Content.ContextCompat.GetColor(context, global::Android.Resource.Color.BackgroundDark)
+                        : AndroidX.Core.Content.ContextCompat.GetColor(context, global::Android.Resource.Color.BackgroundLight);
+                    bgColor = new global::Android.Graphics.Color(resourceColor);
+                }
+                _navigationContainer.SetBackgroundColor(bgColor);
             }
 
             // Subscribe to navigation events if not already subscribed

--- a/src/Controls/src/Core/Handlers/Shell/ShellContentNavigationFragment.Android.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellContentNavigationFragment.Android.cs
@@ -7,7 +7,6 @@ using Android.OS;
 using Android.Views;
 using Android.Widget;
 using AndroidX.Fragment.App;
-using Microsoft.Maui.Controls.Handlers.Compatibility;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Platform.Compatibility;
 using Microsoft.Maui.Graphics;
@@ -179,26 +178,15 @@ namespace Microsoft.Maui.Controls.Handlers
             _stackNavigationManager.Connect(_navigationViewAdapter, _navigationContainer);
 
             // Apply background to the navigation container when the page has no explicit Background.
-            // For Material3: use ShellRenderer.DefaultBackgroundColor (colorSurface = #FEF7FF light / #141218 dark)
-            //   matching what the old ShellPageContainer did via GetThemeAttrColor(colorSurface).
-            // For Material2: use the platform default BackgroundLight/BackgroundDark.
+            // Matches old ShellPageContainer constructor behavior.
             if (_rootPage is IView view && view.Background is null && _navigationContainer is not null)
             {
                 var context = _mauiContext!.Context!;
-                global::Android.Graphics.Color bgColor;
-                if (RuntimeFeature.IsMaterial3Enabled)
-                {
-                    bgColor = ShellRenderer.DefaultBackgroundColor.ToPlatform();
-                }
-                else
-                {
-                    bool isDark = Controls.Application.Current?.RequestedTheme == ApplicationModel.AppTheme.Dark;
-                    int resourceColor = isDark
-                        ? AndroidX.Core.Content.ContextCompat.GetColor(context, global::Android.Resource.Color.BackgroundDark)
-                        : AndroidX.Core.Content.ContextCompat.GetColor(context, global::Android.Resource.Color.BackgroundLight);
-                    bgColor = new global::Android.Graphics.Color(resourceColor);
-                }
-                _navigationContainer.SetBackgroundColor(bgColor);
+                bool isDark = Controls.Application.Current?.RequestedTheme == ApplicationModel.AppTheme.Dark;
+                int bgColor = RuntimeFeature.IsMaterial3Enabled
+                    ? GetMaterial3Background(context)
+                    : GetResourceBackground(context, isDark);
+                _navigationContainer.SetBackgroundColor(new global::Android.Graphics.Color(bgColor));
             }
 
             // Subscribe to navigation events if not already subscribed
@@ -553,6 +541,20 @@ namespace Microsoft.Maui.Controls.Handlers
                 _rootPage = null;
             }
             base.Dispose(disposing);
+        }
+
+        static int GetMaterial3Background(Context context)
+        {
+            // Material3 colorSurface automatically adapts to light/dark theme.
+            // The theme resolution happens in GetThemeAttrColor based on the active theme.
+            return ContextExtensions.GetThemeAttrColor(context, Resource.Attribute.colorSurface);
+        }
+
+        static int GetResourceBackground(Context context, bool isDark)
+        {
+            return isDark
+                ? AndroidX.Core.Content.ContextCompat.GetColor(context, global::Android.Resource.Color.BackgroundDark)
+                : AndroidX.Core.Content.ContextCompat.GetColor(context, global::Android.Resource.Color.BackgroundLight);
         }
     }
 

--- a/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Android.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Android.cs
@@ -151,14 +151,7 @@ namespace Microsoft.Maui.Controls.Handlers
             var context = MauiContext?.Context
                 ?? throw new InvalidOperationException("MauiContext.Context cannot be null");
 
-            // Resolve ?attr/actionBarSize to match the old XML layout height.
-            // The old shellsectionlayout.axml used android:layout_height="?attr/actionBarSize"
-            // for the TabLayout. Using wrap_content would make tabs ~48dp instead of 56dp,
-            // shifting all content below and causing visual regressions.
-            var actionBarSizeAttribute = new int[] { global::Android.Resource.Attribute.ActionBarSize };
-            var typedArray = context.ObtainStyledAttributes(actionBarSizeAttribute);
-            int actionBarHeight = typedArray.GetDimensionPixelSize(0, LP.WrapContent);
-            typedArray.Recycle();
+            int actionBarHeight = context.GetActionBarHeight();
 
             _contentTabLayout = new TabLayout(context)
             {

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue35125.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue35125.cs
@@ -52,7 +52,6 @@ class Issue35125PageTwo : ContentPage
 	public Issue35125PageTwo()
 	{
 		Title = "Page Two";
-		BackgroundColor = Colors.Green;
 		Content = new Label
 		{
 			Text = "The test passes if the unselected tabs are visible in view.",

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue35125.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue35125.cs
@@ -52,6 +52,7 @@ class Issue35125PageTwo : ContentPage
 	public Issue35125PageTwo()
 	{
 		Title = "Page Two";
+		BackgroundColor = Colors.Green;
 		Content = new Label
 		{
 			Text = "The test passes if the unselected tabs are visible in view.",


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Issue Details:
The TopTabUnselectedTextVisibleWhenSwitchingTabs test failed in .NET 11 because ShellHandler is enabled by default. The failure does not occur when using ShellRenderer.

In the ShellHandler implementation, ShellContentNavigationFragment.ConnectAndInitialize() sets the navigation container background to BackgroundLight (white, #FFFFFF) for all light-mode scenarios. In contrast, the previous ShellPageContainer implementation used ?attr/colorSurface (#FEF7FF) from Material3.
### Description of Change

<!-- Enter description of the fix in this section -->
* Added GetMaterial3Background() — resolves ?attr/colorSurface (#FEF7FF) matching ShellPageContainer
* Added GetResourceBackground() — returns BackgroundLight/BackgroundDark for non-Material3
* Updated ConnectAndInitialize() to call these helpers via RuntimeFeature.IsMaterial3Enabled
* Updated ShellSectionHandler to use the shared Context.GetActionBarHeight() helper when sizing the top-tab TabLayout, preserving the themed actionBarSize height while removing duplicate attribute-resolution logic.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #36856 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
