### PR TITLE
[ci-fix-net11] Fix HybridWebView InvokeJavaScriptAsync exception test failures on iOS, MacCatalyst, and Windows

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_InvokeJavaScriptAsync.cs
+++ b/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_InvokeJavaScriptAsync.cs
@@ -316,7 +316,7 @@ public partial class HybridWebViewTests_InvokeJavaScriptAsync : HybridWebViewTes
 	public Task InvokeJavaScriptMethodThatThrowsNumber(string type) =>
 		RunExceptionTest("EvaluateMeWithParamsThatThrows" + type, 1, ex =>
 		{
-			Assert.Equal("InvokeJavaScript threw an exception: 777.777", ex.Message);
+			Assert.Equal("InvokeJavaScriptAsync threw an exception: 777.777", ex.Message);
 			Assert.Equal("777.777", ex.InnerException?.Message);
 			Assert.Null(ex.InnerException?.Data["JavaScriptErrorName"]);
 			Assert.NotNull(ex.InnerException?.StackTrace);
@@ -328,7 +328,7 @@ public partial class HybridWebViewTests_InvokeJavaScriptAsync : HybridWebViewTes
 	public Task InvokeJavaScriptMethodThatThrowsString(string type) =>
 		RunExceptionTest("EvaluateMeWithParamsThatThrows" + type, 2, ex =>
 		{
-			Assert.Equal("InvokeJavaScript threw an exception: String: 777.777", ex.Message);
+			Assert.Equal("InvokeJavaScriptAsync threw an exception: String: 777.777", ex.Message);
 			Assert.Equal("String: 777.777", ex.InnerException?.Message);
 			Assert.Null(ex.InnerException?.Data["JavaScriptErrorName"]);
 			Assert.NotNull(ex.InnerException?.StackTrace);
@@ -340,7 +340,7 @@ public partial class HybridWebViewTests_InvokeJavaScriptAsync : HybridWebViewTes
 	public Task InvokeJavaScriptMethodThatThrowsError(string type) =>
 		RunExceptionTest("EvaluateMeWithParamsThatThrows" + type, 3, ex =>
 		{
-			Assert.Equal("InvokeJavaScript threw an exception: Generic Error: 777.777", ex.Message);
+			Assert.Equal("InvokeJavaScriptAsync threw an exception: Generic Error: 777.777", ex.Message);
 			Assert.Equal("Generic Error: 777.777", ex.InnerException?.Message);
 			Assert.Equal("Error", ex.InnerException?.Data["JavaScriptErrorName"]);
 			Assert.NotNull(ex.InnerException?.StackTrace);


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Issue Details
PR #35852 (revert of #32491) accidentally rolled back 3 test assertions that PR #35626 had correctly updated — resetting "InvokeJavaScriptAsync threw an exception:" back to "InvokeJavaScript threw an exception:", while the handler still produced InvokeJavaScriptAsync.

### Description of Change

<!-- Enter description of the fix in this section -->
HybridWebViewTests_InvokeJavaScriptAsync.cs to match the exception message format set by the handler in HybridWebViewHandler.cs.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #36805 

