### PR TITLE
[ci] Remove duplicate .cab signing entry

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -29,11 +29,6 @@
     <FileSignInfo Include="ReconnectModal.razor.js" CertificateName="Microsoft400" />
   </ItemGroup>
 
-  <ItemGroup Label="MSI workload cab signing">
-    <!-- Sign cab files embedded inside MSI workload packs -->
-    <FileExtensionSignInfo Include=".cab" CertificateName="Microsoft400" />
-  </ItemGroup>
-
   <ItemGroup>
     <ItemsToSign Include="$(ArtifactsShippingPackagesDir)\**\*.msi" Condition="'$(PostBuildSign)' != 'true'" />
     <ItemsToSign Include="$(ArtifactsShippingPackagesDir)**\*.wixpack.zip" Condition="'$(PostBuildSign)' != 'true'" />


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

Ports the `.cab` signing fix from #36879 (merged into `release/11.0.1xx-preview7`) to `main`.

### Duplicate `.cab` signing entry

The internal `Pack, Sign` task fails with:

```
Sign.proj(74,5): error : Multiple certificates for extension '.cab' defined for CollisionPriorityId ''.
There should be one certificate per extension per collision priority id.
```

**Cause:** PR #35026 added an explicit `.cab` `FileExtensionSignInfo` to `eng/Signing.props`, but Arcade's built-in `Sign.props` already registers `.cab` by default:

```xml
<FileExtensionSignInfo Include=".dll;.exe;.mibc;.msi;.cab" CertificateName="Microsoft400" />
```

**Fix:** Remove the duplicate entry. Cab files inside workload MSIs are still signed with `Microsoft400` via the Arcade default, so no signing coverage is lost. The `ReconnectModal.razor.js` `FileSignInfo` entry from #35026 is kept.

### Note on the second fix in #36879

#36879 also restored a missing `MicrosoftWixVersion` property in `eng/Versions.props`. **That part does not apply to `main`** — `main` has not taken the WiX 6 migration and still uses `Microsoft.Signed.WiX` / `$(MicrosoftSignedWixVersion)` in `eng/NuGetVersions.targets`. There is no `$(MicrosoftWixVersion)` reference anywhere on `main`, so adding the property would be dead config.