### PR TITLE
[ci-fix-net11][WIP] Fix Windows CV2 UITest failures 

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/CollectionViewHandler2.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items2/CollectionViewHandler2.Windows.cs
@@ -278,7 +278,12 @@ public partial class CollectionViewHandler2 : ReorderableItemsViewHandler2<Reord
 			{
 				var actualItem = visualElement.BindingContext;
 				bool isSelected = object.Equals(ItemsView.SelectedItem, actualItem) || ItemsView.SelectedItems.Contains(actualItem);
-				VisualStateManager.GoToState(visualElement, isSelected ? VisualStateManager.CommonStates.Selected : VisualStateManager.CommonStates.Normal);
+				// Use IsItemSelected instead of GoToState directly so that ChangeVisualState()
+				// has the correct selected state when a pointer-enter/leave or IsEnabled change
+				// fires later. IsElementInSelectedState() reads IsItemSelected, so bypassing it
+				// here (as was done before PR #35421) caused PointerOver-exit and re-enable
+				// events to incorrectly transition the item to Normal instead of Selected.
+				visualElement.IsItemSelected = isSelected;
 
 				// When the item template defines a "Selected" visual state, MAUI
 				// handles the selection appearance. Suppress the native WinUI


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Issue Details
PR #35421 changed all selection-state callsites to use visualElement.IsItemSelected = isSelected instead of calling VisualStateManager.GoToState(...) directly. The IsElementInSelectedState() helper now reads IsItemSelected rather than the VSM CurrentState.Name. But UpdateVisualStates() in the Windows CV2 handler was the one callsite that was missed — it kept calling GoToState directly, so IsItemSelected was never set to true for selected items.
This caused two failures:
* PointerOverWithSelectedStateShouldWork
* CollectionViewSelectedItemBackgroundLost

### Description of Change

<!-- Enter description of the fix in this section -->
Replace the direct VisualStateManager.GoToState(...) call with visualElement.IsItemSelected = isSelected in UpdateVisualStates(), exactly matching how all other handlers were updated by PR #35421.