### PR TITLE
[Extensibility] Fix dual-path backend activation and Compile filtering

### DIFF
--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.SingleProject.Before.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.SingleProject.Before.targets
@@ -38,10 +38,9 @@
 
     BackendIdentity records the stable, MAUI-owned key for each built-in backend so
     the built-in platforms describe themselves through exactly the same registration
-    metadata that an external backend NuGet contributes. For recognized platform TFMs
-    activation still flows through TargetPlatformIdentifier(s); BackendIdentity here is
-    purely descriptive (built-ins do not declare an ActivationValue, so the neutral-TFM
-    activation branch never fires for them).
+    metadata that an external backend NuGet contributes. Recognized platform TFMs
+    activate through TargetPlatformIdentifier(s), while a neutral TFM can activate the
+    same registration through BackendIdentity and MauiActiveBackend.
   -->
   <ItemGroup>
     <MauiPlatformSpecificFolder Include="$(AndroidProjectFolder)" TargetPlatformIdentifier="android" BackendIdentity="android" />
@@ -57,12 +56,11 @@
       - TargetPlatformIdentifiers is back-filled from the legacy singular
         TargetPlatformIdentifier when only the singular is set.
       - ActivationValue is back-filled from BackendIdentity so a backend that
-        only declares a stable identity key (BackendIdentity="gtk") can be
-        activated for a neutral TFM via <MauiActiveBackend>gtk</MauiActiveBackend>
-        without having to repeat the value. Built-in platforms declare a
-        BackendIdentity but no ActivationValue is derived for them here because
-        they are TPI-recognized (see the guard below), so they never take the
-        neutral-activation branch.
+        declares a stable identity key (BackendIdentity="gtk") can be activated
+        for a neutral TFM via <MauiActiveBackend>gtk</MauiActiveBackend> without
+        having to repeat the value. This applies even when the same registration
+        also declares TargetPlatformIdentifier(s), allowing one item to support
+        both recognized-TPI and neutral-TFM activation.
       - ActivationProperty defaults to the well-known MauiActiveBackend selector
         whenever an ActivationValue is present but no explicit property was named.
       - _MauiResolvedActivationValue captures the *current value* of the property
@@ -91,17 +89,10 @@
         <TargetPlatformIdentifiers>%(MauiPlatformSpecificFolder.TargetPlatformIdentifier)</TargetPlatformIdentifiers>
       </MauiPlatformSpecificFolder>
 
-      <!--
-        Back-fill ActivationValue from BackendIdentity ONLY for folders that are not
-        already TPI-recognized. Built-in platforms carry both a TargetPlatformIdentifier
-        and a BackendIdentity; deriving an ActivationValue for them would let a stray
-        MauiActiveBackend value pull an unrelated built-in folder into a neutral build.
-        Gating on empty TargetPlatformIdentifier(s) keeps the neutral-activation branch
-        exclusive to backends that actually rely on it.
-      -->
+      <!-- Back-fill ActivationValue without overriding an explicitly supplied value. -->
       <MauiPlatformSpecificFolder
           Update="@(MauiPlatformSpecificFolder)"
-          Condition=" '%(MauiPlatformSpecificFolder.ActivationValue)' == '' and '%(MauiPlatformSpecificFolder.BackendIdentity)' != '' and '%(MauiPlatformSpecificFolder.TargetPlatformIdentifier)' == '' and '%(MauiPlatformSpecificFolder.TargetPlatformIdentifiers)' == '' ">
+          Condition=" '%(MauiPlatformSpecificFolder.ActivationValue)' == '' and '%(MauiPlatformSpecificFolder.BackendIdentity)' != '' ">
         <ActivationValue>%(MauiPlatformSpecificFolder.BackendIdentity)</ActivationValue>
       </MauiPlatformSpecificFolder>
 

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.SingleProject.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.SingleProject.targets
@@ -154,19 +154,27 @@
         part of the current build configuration AND has not been explicitly
         kept by _MauiCollectPlatformSpecificCompileItems above.
 
-        The Condition references %(Compile.ExcludeFromCurrentConfiguration)
-        from inside an Include of a *different* item type — this is MSBuild
-        cross-item-type batching: the filesystem glob is evaluated once per
-        unique value of Compile.ExcludeFromCurrentConfiguration. The blanket
-        <Compile Update> initially marks every $(PlatformsProjectFolder)/**
-        file true, then active-platform updates flip matching items back to
-        false. Keep the Condition so only the true batch is removed; otherwise
-        active-platform files may be removed or inactive files may leak in.
+        Copy the Compile items marked true to a separate item type, then intersect
+        those identities with the platform filesystem candidates. This ensures the
+        removal set contains only Compile items explicitly excluded from the current
+        configuration. Using temporary item types preserves downstream false metadata
+        buckets without removing and re-adding active Compile items, which would
+        perturb ordering and other metadata.
       -->
+      <_MauiCompileItemsMarkedForRemoval
+          Include="@(Compile->WithMetadataValue('ExcludeFromCurrentConfiguration', 'true'))" />
       <_MauiPlatformCompileToRemove
-          Condition=" '%(Compile.ExcludeFromCurrentConfiguration)' == 'true' "
           Include="$(PlatformsProjectFolder)**/*$(DefaultLanguageSourceExtension)"
           Exclude="@(_MauiPlatformSpecificCompileItems)" />
+      <_MauiPlatformCompileNotMarkedForRemoval Include="@(_MauiPlatformCompileToRemove)" />
+      <_MauiPlatformCompileNotMarkedForRemoval
+          Remove="@(_MauiCompileItemsMarkedForRemoval)"
+          MatchOnMetadata="FullPath"
+          MatchOnMetadataOptions="PathLike" />
+      <_MauiPlatformCompileToRemove
+          Remove="@(_MauiPlatformCompileNotMarkedForRemoval)"
+          MatchOnMetadata="FullPath"
+          MatchOnMetadataOptions="PathLike" />
       <Compile Remove="@(_MauiPlatformCompileToRemove)" />
 
       <!-- Remove all Windows (WinUI) XAML Files from the Windows folder -->

--- a/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
@@ -1410,6 +1410,91 @@ public static class After
 				StringComparison.OrdinalIgnoreCase);
 		}
 
+		[Fact]
+		public void SingleProject_RemovePlatformCompileItems_RemovesOnlyCompileItemsMarkedExcluded()
+		{
+			SetUp();
+			var project = NewElement("Project").WithAttribute("Sdk", "Microsoft.NET.Sdk");
+			var propertyGroup = NewElement("PropertyGroup");
+			propertyGroup.Add(NewElement("TargetFramework").WithValue(GetTfm()));
+			propertyGroup.Add(NewElement("SingleProject").WithValue("true"));
+			propertyGroup.Add(NewElement("EnableDefaultCompileItems").WithValue("false"));
+			project.Add(propertyGroup);
+			AddMauiReferences(project);
+			AddSingleProjectBeforeTargetsImport(project);
+
+			var compileItems = NewElement("ItemGroup");
+			compileItems.Add(NewElement("Compile").WithAttribute("Include", "Before.cs"));
+			compileItems.Add(NewElement("Compile").WithAttribute("Include", "Platforms\\Removed\\RemovedMarker.cs"));
+			compileItems.Add(NewElement("Compile").WithAttribute("Include", "Platforms\\Preserved\\PreservedMarker.cs"));
+			compileItems.Add(NewElement("Compile").WithAttribute("Include", "After.cs"));
+			project.Add(compileItems);
+
+			WriteFile("Before.cs", @"
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public static class Before
+{
+	public static string Value => ""Before"";
+}");
+
+			WriteFile("Platforms\\Removed\\RemovedMarker.cs", @"
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public static class RemovedMarker
+{
+	public static string Value => ""Removed"";
+}");
+
+			WriteFile("Platforms\\Preserved\\PreservedMarker.cs", @"
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public static class PreservedMarker
+{
+	public static string Value => ""Preserved"";
+}");
+
+			WriteFile("After.cs", @"
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public static class After
+{
+	public static string Value => ""After"";
+}");
+
+			AddSingleProjectTargetsImport(project);
+
+			var downstreamCompileMetadata = NewElement("ItemGroup");
+			var markActiveCompile = NewElement("Compile").WithAttribute("Update", "Platforms\\Preserved\\PreservedMarker.cs");
+			markActiveCompile.Add(NewElement("ExcludeFromCurrentConfiguration").WithValue("false"));
+			downstreamCompileMetadata.Add(markActiveCompile);
+			project.Add(downstreamCompileMetadata);
+
+			var dumpTarget = NewElement("Target")
+				.WithAttribute("Name", "_TestDumpCompileItems")
+				.WithAttribute("AfterTargets", "_MauiUnflipKeptCompileItemMetadata");
+			dumpTarget.Add(NewElement("Message")
+				.WithAttribute("Importance", "high")
+				.WithAttribute("Text", "COMPILE_ITEMS: @(Compile->'%(Filename)', '|')"));
+			project.Add(dumpTarget);
+
+			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
+			project.Save(projectFile);
+
+			var log = Build(projectFile);
+
+			var testDll = IOPath.Combine(intermediateDirectory, "test.dll");
+			AssertExists(testDll, nonEmpty: true);
+			AssertTypeExists(testDll, "Microsoft.Maui.Controls.Xaml.UnitTests.Before");
+			AssertTypeDoesNotExist(testDll, "Microsoft.Maui.Controls.Xaml.UnitTests.RemovedMarker");
+			AssertTypeExists(testDll, "Microsoft.Maui.Controls.Xaml.UnitTests.PreservedMarker");
+			AssertTypeExists(testDll, "Microsoft.Maui.Controls.Xaml.UnitTests.After");
+			Assert.Contains(
+				"COMPILE_ITEMS: Before|PreservedMarker|After",
+				log,
+				StringComparison.OrdinalIgnoreCase);
+		}
+
 		// Backward compatibility: a folder that declares only the legacy singular
 		// TargetPlatformIdentifier metadata must continue to match exactly that TPI.
 		[Theory]
@@ -1463,6 +1548,69 @@ public static class LegacyIosMarker
 				AssertTypeExists(testDll, "Microsoft.Maui.Controls.Xaml.UnitTests.LegacyIosMarker");
 			else
 				AssertTypeDoesNotExist(testDll, "Microsoft.Maui.Controls.Xaml.UnitTests.LegacyIosMarker");
+		}
+
+		[Theory]
+		[InlineData("macos", "", true)]
+		[InlineData("", "macos", true)]
+		[InlineData("ios", "macos", false)]
+		[InlineData("", "gtk", false)]
+		public void SingleProject_BackendIdentitySupportsRecognizedAndNeutralActivation(
+			string targetPlatformIdentifier,
+			string activeBackend,
+			bool shouldIncludeMacOsFile)
+		{
+			SetUp();
+			var project = NewElement("Project").WithAttribute("Sdk", "Microsoft.NET.Sdk");
+			var propertyGroup = NewElement("PropertyGroup");
+			propertyGroup.Add(NewElement("TargetFramework").WithValue(GetTfm()));
+			propertyGroup.Add(NewElement("SingleProject").WithValue("true"));
+			project.Add(propertyGroup);
+			AddMauiReferences(project);
+			AddSingleProjectBeforeTargetsImport(project);
+
+			var customMappings = NewElement("ItemGroup");
+			customMappings.Add(NewElement("MauiPlatformSpecificFolder")
+				.WithAttribute("Include", "Platforms\\MacOS\\")
+				.WithAttribute("TargetPlatformIdentifiers", "macos")
+				.WithAttribute("BackendIdentity", "macos"));
+			project.Add(customMappings);
+
+			WriteFile("Entry.cs", @"
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public static class Entry
+{
+	public static string Value => ""ok"";
+}");
+
+			WriteFile("Platforms\\MacOS\\MacOsMarker.cs", @"
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public static class MacOsMarker
+{
+	public static string Value => ""MacOS"";
+}");
+
+			AddSingleProjectTargetsImport(project);
+
+			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
+			project.Save(projectFile);
+
+			var args = "";
+			if (!string.IsNullOrEmpty(targetPlatformIdentifier))
+				args = $"-p:_SingleProjectTestTargetPlatformIdentifier={targetPlatformIdentifier}";
+			if (!string.IsNullOrEmpty(activeBackend))
+				args += $" -p:MauiActiveBackend={activeBackend}";
+			Build(projectFile, additionalArgs: args);
+
+			var testDll = IOPath.Combine(intermediateDirectory, "test.dll");
+			AssertExists(testDll, nonEmpty: true);
+
+			if (shouldIncludeMacOsFile)
+				AssertTypeExists(testDll, "Microsoft.Maui.Controls.Xaml.UnitTests.MacOsMarker");
+			else
+				AssertTypeDoesNotExist(testDll, "Microsoft.Maui.Controls.Xaml.UnitTests.MacOsMarker");
 		}
 
 		// Neutral-TFM activation (the GTK scenario from #35021/#36650). On a plain


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

This follows the GPT-5.6 Sol post-merge verification of #36654 and addresses two focused SingleProject gaps found against the merged implementation. It is part of #34099 and a follow-up to #36654; it does not close #34099.

## Root causes and behavior changes

### Dual-path backend identity

`_MauiNormalizePlatformSpecificFolders` only defaulted `ActivationValue` from `BackendIdentity` when both singular and plural target-platform metadata were empty. A registration that intentionally supported both paths, such as `TargetPlatformIdentifiers="macos" BackendIdentity="macos"`, worked for a recognized `macos` TPI but could not activate on a neutral TFM through `MauiActiveBackend=macos`.

The default now applies whenever `ActivationValue` is empty, regardless of TPI metadata. Explicit activation values remain unchanged, explicit activation properties remain authoritative, and the existing neutral-path guard still prevents a backend selector from activating the folder on a different recognized TPI.

### Cross-item Compile batching

`_MauiRemovePlatformCompileItems` created a fresh filesystem glob inside the `ExcludeFromCurrentConfiguration=true` batch. That glob also contained physical files represented by downstream `Compile` items explicitly marked `false`, so a separate true item could cause those active files to be removed.

The target now copies the actual `Compile` identities marked `true` to a temporary item type and intersects those identities with the platform filesystem candidates. It removes only the true identities without updating or re-adding active `Compile` items, preserving their metadata, ordering, and uniqueness.

## Tests

Added real shipping-target regressions to `MSBuildTests`:

- one registration activates through both recognized `macos` TPI and neutral `MauiActiveBackend=macos`, while remaining excluded for recognized `ios` and a different neutral backend;
- two physical platform files in different metadata buckets retain only the explicit-false item, with exact order and no duplicates.

The two failures were reproduced before the target changes with direct workload-neutral MSBuild imports, then passed after the fixes. A 25-case direct shipping-target matrix passed for legacy shared folders, all five built-ins, GTK activation through `ActivationValue` and `BackendIdentity`, whitespace/unresolved fail-closed behavior, bare-activation compatibility, design-time unflip, ordering, and duplicate prevention.

`dotnet format Microsoft.Maui.sln --no-restore --exclude Templates/src --exclude-diagnostics CA1822 --include src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs --verify-no-changes` completed successfully with reference-load warnings.

The repository-native filtered xUnit run and build-task solution build could not complete locally because this machine has .NET SDK 10.0.203 while `global.json` requires 11.0.100-rc.1.26379.102. The filtered test fails with `NETSDK1045`; the build first reports missing restore assets, and the allowed restore attempt confirms `NETSDK1045` for the net11.0 projects.

## Remaining limitations

CI with the pinned .NET 11 SDK is still required to execute the repository-native xUnit matrix and build. This PR remains scoped to SingleProject compile selection and does not implement the broader app-head manifest, entitlement, resource, launch, or design-time extensibility work tracked by #34099.
