### PR TITLE
[Extensibility] SingleProject: Fix dual-path backend activation and Compile filtering

### DIFF
--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.SingleProject.Before.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.SingleProject.Before.targets
@@ -38,10 +38,9 @@
 
     BackendIdentity records the stable, MAUI-owned key for each built-in backend so
     the built-in platforms describe themselves through exactly the same registration
-    metadata that an external backend NuGet contributes. For recognized platform TFMs
-    activation still flows through TargetPlatformIdentifier(s); BackendIdentity here is
-    purely descriptive (built-ins do not declare an ActivationValue, so the neutral-TFM
-    activation branch never fires for them).
+    metadata that an external backend NuGet contributes. A registration can therefore
+    activate through TargetPlatformIdentifier(s) on a recognized platform TFM or through
+    BackendIdentity (via MauiActiveBackend) on a neutral TFM.
   -->
   <ItemGroup>
     <MauiPlatformSpecificFolder Include="$(AndroidProjectFolder)" TargetPlatformIdentifier="android" BackendIdentity="android" />
@@ -59,10 +58,9 @@
       - ActivationValue is back-filled from BackendIdentity so a backend that
         only declares a stable identity key (BackendIdentity="gtk") can be
         activated for a neutral TFM via <MauiActiveBackend>gtk</MauiActiveBackend>
-        without having to repeat the value. Built-in platforms declare a
-        BackendIdentity but no ActivationValue is derived for them here because
-        they are TPI-recognized (see the guard below), so they never take the
-        neutral-activation branch.
+        without having to repeat the value. This default applies whether or not
+        TargetPlatformIdentifier(s) are also present, so one registration supports
+        recognized-TPI and neutral-backend activation.
       - ActivationProperty defaults to the well-known MauiActiveBackend selector
         whenever an ActivationValue is present but no explicit property was named.
       - _MauiResolvedActivationValue captures the *current value* of the property
@@ -91,17 +89,10 @@
         <TargetPlatformIdentifiers>%(MauiPlatformSpecificFolder.TargetPlatformIdentifier)</TargetPlatformIdentifiers>
       </MauiPlatformSpecificFolder>
 
-      <!--
-        Back-fill ActivationValue from BackendIdentity ONLY for folders that are not
-        already TPI-recognized. Built-in platforms carry both a TargetPlatformIdentifier
-        and a BackendIdentity; deriving an ActivationValue for them would let a stray
-        MauiActiveBackend value pull an unrelated built-in folder into a neutral build.
-        Gating on empty TargetPlatformIdentifier(s) keeps the neutral-activation branch
-        exclusive to backends that actually rely on it.
-      -->
+      <!-- Explicit ActivationValue metadata always wins over the BackendIdentity default. -->
       <MauiPlatformSpecificFolder
           Update="@(MauiPlatformSpecificFolder)"
-          Condition=" '%(MauiPlatformSpecificFolder.ActivationValue)' == '' and '%(MauiPlatformSpecificFolder.BackendIdentity)' != '' and '%(MauiPlatformSpecificFolder.TargetPlatformIdentifier)' == '' and '%(MauiPlatformSpecificFolder.TargetPlatformIdentifiers)' == '' ">
+          Condition=" '%(MauiPlatformSpecificFolder.ActivationValue)' == '' and '%(MauiPlatformSpecificFolder.BackendIdentity)' != '' ">
         <ActivationValue>%(MauiPlatformSpecificFolder.BackendIdentity)</ActivationValue>
       </MauiPlatformSpecificFolder>
 

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.SingleProject.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.SingleProject.targets
@@ -167,7 +167,9 @@
           Condition=" '%(Compile.ExcludeFromCurrentConfiguration)' == 'true' "
           Include="@(Compile)" />
       <_MauiCompileItemsOutsidePlatformFolder Include="@(_MauiPlatformCompileToRemove)" />
-      <_MauiPlatformCompileCandidates Include="$(PlatformsProjectFolder)**/*$(DefaultLanguageSourceExtension)" />
+      <_MauiPlatformCompileCandidates
+          Condition=" '@(_MauiPlatformCompileToRemove)' != '' "
+          Include="$(PlatformsProjectFolder)**/*$(DefaultLanguageSourceExtension)" />
       <_MauiCompileItemsOutsidePlatformFolder
           Remove="@(_MauiPlatformCompileCandidates)"
           MatchOnMetadata="FullPath"

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.SingleProject.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.SingleProject.targets
@@ -156,18 +156,34 @@
 
         The Condition references %(Compile.ExcludeFromCurrentConfiguration)
         from inside an Include of a *different* item type — this is MSBuild
-        cross-item-type batching: the filesystem glob is evaluated once per
-        unique value of Compile.ExcludeFromCurrentConfiguration. The blanket
-        <Compile Update> initially marks every $(PlatformsProjectFolder)/**
-        file true, then active-platform updates flip matching items back to
-        false. Keep the Condition so only the true batch is removed; otherwise
-        active-platform files may be removed or inactive files may leak in.
+        cross-item-type batching. Start from the current @(Compile) batch rather
+        than a fresh filesystem glob: the latter also discovers physical files
+        from the false metadata batch and removes them whenever any true item
+        exists. Intersect that true batch with the platform-folder candidates so
+        unrelated true Compile items remain untouched. The helper item type
+        preserves Compile ordering because only the final identities are removed.
       -->
       <_MauiPlatformCompileToRemove
           Condition=" '%(Compile.ExcludeFromCurrentConfiguration)' == 'true' "
-          Include="$(PlatformsProjectFolder)**/*$(DefaultLanguageSourceExtension)"
-          Exclude="@(_MauiPlatformSpecificCompileItems)" />
-      <Compile Remove="@(_MauiPlatformCompileToRemove)" />
+          Include="@(Compile)" />
+      <_MauiCompileItemsOutsidePlatformFolder Include="@(_MauiPlatformCompileToRemove)" />
+      <_MauiPlatformCompileCandidates Include="$(PlatformsProjectFolder)**/*$(DefaultLanguageSourceExtension)" />
+      <_MauiCompileItemsOutsidePlatformFolder
+          Remove="@(_MauiPlatformCompileCandidates)"
+          MatchOnMetadata="FullPath"
+          MatchOnMetadataOptions="PathLike" />
+      <_MauiPlatformCompileToRemove
+          Remove="@(_MauiCompileItemsOutsidePlatformFolder)"
+          MatchOnMetadata="FullPath"
+          MatchOnMetadataOptions="PathLike" />
+      <_MauiPlatformCompileToRemove
+          Remove="@(_MauiPlatformSpecificCompileItems)"
+          MatchOnMetadata="FullPath"
+          MatchOnMetadataOptions="PathLike" />
+      <Compile
+          Remove="@(_MauiPlatformCompileToRemove)"
+          MatchOnMetadata="FullPath"
+          MatchOnMetadataOptions="PathLike" />
 
       <!-- Remove all Windows (WinUI) XAML Files from the Windows folder -->
       <_MauiXamlToRemove

--- a/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
@@ -1446,8 +1446,8 @@ public static class ExcludedMarker
 
 			AddSingleProjectTargetsImport(project);
 
-			// Model a downstream SDK target that explicitly keeps one physical
-			// Platforms/** Compile item without registering a folder allow-list.
+			// Model a downstream SDK target that explicitly keeps one physical Platforms/**
+			// Compile item without registering a folder allow-list.
 			var downstreamCompileTarget = NewElement("Target")
 				.WithAttribute("Name", "_TestMarkCompileIncluded")
 				.WithAttribute("BeforeTargets", "_MauiRemovePlatformCompileItems");
@@ -1457,19 +1457,29 @@ public static class ExcludedMarker
 			var explicitlyIncludedCompile = NewElement("Compile")
 				.WithAttribute("Include", "Platforms\\ExternalFalse\\ExplicitFalseMarker.cs");
 			explicitlyIncludedCompile.Add(NewElement("ExcludeFromCurrentConfiguration").WithValue("false"));
+			explicitlyIncludedCompile.Add(NewElement("TestMetadata").WithValue("preserved"));
 			downstreamCompileMetadata.Add(explicitlyIncludedCompile);
 			downstreamCompileTarget.Add(downstreamCompileMetadata);
-			downstreamCompileTarget.Add(NewElement("Message")
-				.WithAttribute("Importance", "high")
-				.WithAttribute("Text", "COMPILE_META_BEFORE_REMOVE: @(Compile->'%(Filename)=%(ExcludeFromCurrentConfiguration)', '|')"));
 			project.Add(downstreamCompileTarget);
 
 			var dumpTarget = NewElement("Target")
 				.WithAttribute("Name", "_TestDumpCompileItems")
 				.WithAttribute("AfterTargets", "_MauiRemovePlatformCompileItems");
+			var dumpItems = NewElement("ItemGroup");
+			dumpItems.Add(NewElement("_TestKeptCompile")
+				.WithAttribute("Include", "@(Compile)")
+				.WithAttribute("Condition", " '%(Compile.Filename)' == 'ExplicitFalseMarker' "));
+			dumpTarget.Add(dumpItems);
 			dumpTarget.Add(NewElement("Message")
 				.WithAttribute("Importance", "high")
 				.WithAttribute("Text", "COMPILE_ITEMS: @(Compile->'%(Filename)', '|')"));
+			dumpTarget.Add(NewElement("Message")
+				.WithAttribute("Importance", "high")
+				.WithAttribute("Condition", " '%(Compile.Filename)' == 'ExplicitFalseMarker' ")
+				.WithAttribute("Text", "KEEP_META: %(Compile.ExcludeFromCurrentConfiguration)|%(Compile.TestMetadata)"));
+			dumpTarget.Add(NewElement("Message")
+				.WithAttribute("Importance", "high")
+				.WithAttribute("Text", "KEEP_COUNT: @(_TestKeptCompile->Count())"));
 			project.Add(dumpTarget);
 
 			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
@@ -1481,14 +1491,59 @@ public static class ExcludedMarker
 			AssertExists(testDll, nonEmpty: true);
 			AssertTypeExists(testDll, "Microsoft.Maui.Controls.Xaml.UnitTests.ExplicitFalseMarker");
 			AssertTypeDoesNotExist(testDll, "Microsoft.Maui.Controls.Xaml.UnitTests.ExcludedMarker");
-			Assert.Contains(
-				"COMPILE_META_BEFORE_REMOVE: ExcludedMarker=true|ExplicitFalseMarker=false",
-				log,
-				StringComparison.OrdinalIgnoreCase);
-			Assert.Contains(
-				"COMPILE_ITEMS: ExplicitFalseMarker",
-				log,
-				StringComparison.OrdinalIgnoreCase);
+			Assert.Contains("COMPILE_ITEMS: ExplicitFalseMarker", log, StringComparison.OrdinalIgnoreCase);
+			Assert.Contains("KEEP_META: false|preserved", log, StringComparison.OrdinalIgnoreCase);
+			Assert.Contains("KEEP_COUNT: 1", log, StringComparison.OrdinalIgnoreCase);
+		}
+
+		[Fact]
+		public void SingleProject_RemovePlatformCompileItems_MatchesAbsoluteCompilePath()
+		{
+			SetUp();
+			var project = NewElement("Project").WithAttribute("Sdk", "Microsoft.NET.Sdk");
+			var propertyGroup = NewElement("PropertyGroup");
+			propertyGroup.Add(NewElement("TargetFramework").WithValue(GetTfm()));
+			propertyGroup.Add(NewElement("SingleProject").WithValue("true"));
+			propertyGroup.Add(NewElement("EnableDefaultCompileItems").WithValue("false"));
+			project.Add(propertyGroup);
+			AddMauiReferences(project);
+			AddSingleProjectBeforeTargetsImport(project);
+
+			WriteFile("Entry.cs", @"
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public static class Entry
+{
+	public static string Value => ""Entry"";
+}");
+
+			WriteFile("Platforms\\Absolute\\AbsoluteMarker.cs", @"
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public static class AbsoluteMarker
+{
+	public static string Value => ""Absolute"";
+}");
+
+			var compileItems = NewElement("ItemGroup");
+			compileItems.Add(NewElement("Compile").WithAttribute("Include", "Entry.cs"));
+			var absolutePlatformCompile = NewElement("Compile")
+				.WithAttribute("Include", IOPath.Combine(tempDirectory, "Platforms", "Absolute", "AbsoluteMarker.cs"));
+			absolutePlatformCompile.Add(NewElement("ExcludeFromCurrentConfiguration").WithValue("true"));
+			compileItems.Add(absolutePlatformCompile);
+			project.Add(compileItems);
+
+			AddSingleProjectTargetsImport(project);
+
+			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
+			project.Save(projectFile);
+
+			Build(projectFile);
+
+			var testDll = IOPath.Combine(intermediateDirectory, "test.dll");
+			AssertExists(testDll, nonEmpty: true);
+			AssertTypeExists(testDll, "Microsoft.Maui.Controls.Xaml.UnitTests.Entry");
+			AssertTypeDoesNotExist(testDll, "Microsoft.Maui.Controls.Xaml.UnitTests.AbsoluteMarker");
 		}
 
 		// Backward compatibility: a folder that declares only the legacy singular
@@ -1607,6 +1662,46 @@ public static class MacosMarker
 				AssertTypeExists(testDll, "Microsoft.Maui.Controls.Xaml.UnitTests.MacosMarker");
 			else
 				AssertTypeDoesNotExist(testDll, "Microsoft.Maui.Controls.Xaml.UnitTests.MacosMarker");
+		}
+
+		[Fact]
+		public void SingleProject_NeutralTfmCanActivateBuiltInBackendByIdentity()
+		{
+			SetUp();
+			var project = NewElement("Project").WithAttribute("Sdk", "Microsoft.NET.Sdk");
+			var propertyGroup = NewElement("PropertyGroup");
+			propertyGroup.Add(NewElement("TargetFramework").WithValue(GetTfm()));
+			propertyGroup.Add(NewElement("SingleProject").WithValue("true"));
+			project.Add(propertyGroup);
+			AddMauiReferences(project);
+			AddSingleProjectBeforeTargetsImport(project);
+
+			WriteFile("Entry.cs", @"
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public static class Entry
+{
+	public static string Value => ""ok"";
+}");
+
+			WriteFile("Platforms\\Android\\AndroidMarker.cs", @"
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public static class AndroidMarker
+{
+	public static string Value => ""Android"";
+}");
+
+			AddSingleProjectTargetsImport(project);
+
+			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
+			project.Save(projectFile);
+
+			Build(projectFile, additionalArgs: "-p:MauiActiveBackend=android");
+
+			var testDll = IOPath.Combine(intermediateDirectory, "test.dll");
+			AssertExists(testDll, nonEmpty: true);
+			AssertTypeExists(testDll, "Microsoft.Maui.Controls.Xaml.UnitTests.AndroidMarker");
 		}
 
 		// Neutral-TFM activation (the GTK scenario from #35021/#36650). On a plain

--- a/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
@@ -1410,6 +1410,87 @@ public static class After
 				StringComparison.OrdinalIgnoreCase);
 		}
 
+		[Fact]
+		public void SingleProject_RemovePlatformCompileItems_RemovesOnlyCompileItemsMarkedExcluded()
+		{
+			SetUp();
+			var project = NewElement("Project").WithAttribute("Sdk", "Microsoft.NET.Sdk");
+			var propertyGroup = NewElement("PropertyGroup");
+			propertyGroup.Add(NewElement("TargetFramework").WithValue(GetTfm()));
+			propertyGroup.Add(NewElement("SingleProject").WithValue("true"));
+			propertyGroup.Add(NewElement("EnableDefaultCompileItems").WithValue("false"));
+			project.Add(propertyGroup);
+			AddMauiReferences(project);
+			AddSingleProjectBeforeTargetsImport(project);
+
+			var compileItems = NewElement("ItemGroup");
+			compileItems.Add(NewElement("Compile").WithAttribute("Include", "Platforms\\ExternalFalse\\ExplicitFalseMarker.cs"));
+			compileItems.Add(NewElement("Compile").WithAttribute("Include", "Platforms\\ExternalTrue\\ExcludedMarker.cs"));
+			project.Add(compileItems);
+
+			WriteFile("Platforms\\ExternalFalse\\ExplicitFalseMarker.cs", @"
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public static class ExplicitFalseMarker
+{
+	public static string Value => ""False"";
+}");
+
+			WriteFile("Platforms\\ExternalTrue\\ExcludedMarker.cs", @"
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public static class ExcludedMarker
+{
+	public static string Value => ""True"";
+}");
+
+			AddSingleProjectTargetsImport(project);
+
+			// Model a downstream SDK target that explicitly keeps one physical
+			// Platforms/** Compile item without registering a folder allow-list.
+			var downstreamCompileTarget = NewElement("Target")
+				.WithAttribute("Name", "_TestMarkCompileIncluded")
+				.WithAttribute("BeforeTargets", "_MauiRemovePlatformCompileItems");
+			var downstreamCompileMetadata = NewElement("ItemGroup");
+			downstreamCompileMetadata.Add(NewElement("Compile")
+				.WithAttribute("Remove", "Platforms\\ExternalFalse\\ExplicitFalseMarker.cs"));
+			var explicitlyIncludedCompile = NewElement("Compile")
+				.WithAttribute("Include", "Platforms\\ExternalFalse\\ExplicitFalseMarker.cs");
+			explicitlyIncludedCompile.Add(NewElement("ExcludeFromCurrentConfiguration").WithValue("false"));
+			downstreamCompileMetadata.Add(explicitlyIncludedCompile);
+			downstreamCompileTarget.Add(downstreamCompileMetadata);
+			downstreamCompileTarget.Add(NewElement("Message")
+				.WithAttribute("Importance", "high")
+				.WithAttribute("Text", "COMPILE_META_BEFORE_REMOVE: @(Compile->'%(Filename)=%(ExcludeFromCurrentConfiguration)', '|')"));
+			project.Add(downstreamCompileTarget);
+
+			var dumpTarget = NewElement("Target")
+				.WithAttribute("Name", "_TestDumpCompileItems")
+				.WithAttribute("AfterTargets", "_MauiRemovePlatformCompileItems");
+			dumpTarget.Add(NewElement("Message")
+				.WithAttribute("Importance", "high")
+				.WithAttribute("Text", "COMPILE_ITEMS: @(Compile->'%(Filename)', '|')"));
+			project.Add(dumpTarget);
+
+			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
+			project.Save(projectFile);
+
+			var log = Build(projectFile);
+
+			var testDll = IOPath.Combine(intermediateDirectory, "test.dll");
+			AssertExists(testDll, nonEmpty: true);
+			AssertTypeExists(testDll, "Microsoft.Maui.Controls.Xaml.UnitTests.ExplicitFalseMarker");
+			AssertTypeDoesNotExist(testDll, "Microsoft.Maui.Controls.Xaml.UnitTests.ExcludedMarker");
+			Assert.Contains(
+				"COMPILE_META_BEFORE_REMOVE: ExcludedMarker=true|ExplicitFalseMarker=false",
+				log,
+				StringComparison.OrdinalIgnoreCase);
+			Assert.Contains(
+				"COMPILE_ITEMS: ExplicitFalseMarker",
+				log,
+				StringComparison.OrdinalIgnoreCase);
+		}
+
 		// Backward compatibility: a folder that declares only the legacy singular
 		// TargetPlatformIdentifier metadata must continue to match exactly that TPI.
 		[Theory]
@@ -1463,6 +1544,69 @@ public static class LegacyIosMarker
 				AssertTypeExists(testDll, "Microsoft.Maui.Controls.Xaml.UnitTests.LegacyIosMarker");
 			else
 				AssertTypeDoesNotExist(testDll, "Microsoft.Maui.Controls.Xaml.UnitTests.LegacyIosMarker");
+		}
+
+		[Theory]
+		[InlineData("macos", "", true)]
+		[InlineData("", "macos", true)]
+		[InlineData("android", "macos", false)]
+		[InlineData("", "cocoa", false)]
+		public void SingleProject_BackendIdentitySupportsRecognizedAndNeutralActivation(
+			string targetPlatformIdentifier,
+			string activeBackend,
+			bool shouldIncludeMacosFile)
+		{
+			SetUp();
+			var project = NewElement("Project").WithAttribute("Sdk", "Microsoft.NET.Sdk");
+			var propertyGroup = NewElement("PropertyGroup");
+			propertyGroup.Add(NewElement("TargetFramework").WithValue(GetTfm()));
+			propertyGroup.Add(NewElement("SingleProject").WithValue("true"));
+			project.Add(propertyGroup);
+			AddMauiReferences(project);
+			AddSingleProjectBeforeTargetsImport(project);
+
+			var customMappings = NewElement("ItemGroup");
+			customMappings.Add(NewElement("MauiPlatformSpecificFolder")
+				.WithAttribute("Include", "Platforms\\MacOS\\")
+				.WithAttribute("TargetPlatformIdentifiers", "macos")
+				.WithAttribute("BackendIdentity", "macos"));
+			project.Add(customMappings);
+
+			WriteFile("Entry.cs", @"
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public static class Entry
+{
+	public static string Value => ""ok"";
+}");
+
+			WriteFile("Platforms\\MacOS\\MacosMarker.cs", @"
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public static class MacosMarker
+{
+	public static string Value => ""MacOS"";
+}");
+
+			AddSingleProjectTargetsImport(project);
+
+			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
+			project.Save(projectFile);
+
+			var additionalArgs = "";
+			if (!string.IsNullOrEmpty(targetPlatformIdentifier))
+				additionalArgs += $" -p:_SingleProjectTestTargetPlatformIdentifier={targetPlatformIdentifier}";
+			if (!string.IsNullOrEmpty(activeBackend))
+				additionalArgs += $" -p:MauiActiveBackend={activeBackend}";
+			Build(projectFile, additionalArgs: additionalArgs);
+
+			var testDll = IOPath.Combine(intermediateDirectory, "test.dll");
+			AssertExists(testDll, nonEmpty: true);
+
+			if (shouldIncludeMacosFile)
+				AssertTypeExists(testDll, "Microsoft.Maui.Controls.Xaml.UnitTests.MacosMarker");
+			else
+				AssertTypeDoesNotExist(testDll, "Microsoft.Maui.Controls.Xaml.UnitTests.MacosMarker");
 		}
 
 		// Neutral-TFM activation (the GTK scenario from #35021/#36650). On a plain


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description of Change

This focused follow-up addresses two empirically validated gaps found by the GPT-5.6 Sol post-merge verification of #36654.

1. `BackendIdentity` now defaults `ActivationValue` even when `TargetPlatformIdentifier` or `TargetPlatformIdentifiers` is also present. A single registration can therefore activate through a recognized TPI or through `MauiActiveBackend` on a neutral TFM, while explicit `ActivationValue` and `ActivationProperty` metadata still win.
2. platform Compile removal now starts from the `Compile` items in the `ExcludeFromCurrentConfiguration=true` metadata batch and intersects them with physical `Platforms/**` candidates. A fresh filesystem glob can no longer pull an explicitly false Compile item from another metadata bucket into the removal set. The helper-item removal pattern remains in place, preserving active item order and avoiding remove/re-add duplication.

## Before and After

Before this change, a registration such as:

```xml
<MauiPlatformSpecificFolder Include="Platforms/MacOS/" TargetPlatformIdentifiers="macos" BackendIdentity="macos" />
```

worked for recognized TPI `macos` but did not activate on a neutral TFM with `MauiActiveBackend=macos`. It now supports both paths and remains inactive for another recognized TPI or a mismatched backend.

Before this change, the presence of any true Compile metadata batch caused a fresh `Platforms/**` glob to include physical files explicitly marked false by a downstream target. Removal is now constrained to the actual true Compile identities under the platform folder.

## Tests

The real shipping SingleProject targets are covered by regressions for:

- one dual-path macOS registration through recognized TPI and neutral backend activation, plus recognized-TPI and backend mismatch negatives;
- two physical platform Compile files in different metadata buckets with no folder allow-list, asserting only the true item is removed and the surviving list is ordered and duplicate-free.

Validation:

- complete `MSBuildTests.SingleProject_*` matrix: **46 passed, 0 failed**;
- new regression matrix: **7 passed, 0 failed**;
- `Controls.Build.Tasks.csproj` build: **succeeded with 0 warnings and 0 errors**;
- targeted `dotnet format`: completed successfully.

The unfiltered local graph is unavailable on this Mac because the platform project graph requires the iOS workload (`NETSDK1147`) and the full BuildTasks solution filter includes .NET Framework 4.7.2 projects without local reference assemblies (`MSB3644`). The workload-neutral matrix above used the repository-pinned .NET 11 SDK with platform TFMs disabled and imported the exact shipping targets.

### Candidate selection and final review

#36957 is the selected implementation. Alternatives #36955 and #36956 both fail their own new Windows Helix XAML regression by removing the explicit-false Compile item. This branch uses FullPath/PathLike intersection, passes the expanded 46-case matrix, preserves metadata and duplicate count, handles absolute Compile identities, and skips the platform filesystem glob when no removal batch exists.

Neutral activation of built-in backend identities is intentional: #36654 documented that built-ins use the same registration shape and that ActivationValue defaults from BackendIdentity. A dedicated regression now locks that contract.

## Issues Fixed

Part of #34099
Part of #35021
Fixes #36650
Follow-up to #36654
