### PR TITLE
[Resizetizer] Invalidate image outputs when platform type changes

### DIFF
--- a/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
+++ b/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
@@ -341,7 +341,7 @@
         <!-- This allows us to invalidate the build based on not just input image files changing but project item metadata as well -->
         <WriteLinesToFile
             File="$(_ResizetizerInputsFile)"
-            Lines="@(MauiImage->'File=%(Identity);Link=%(Link);BaseSize=%(BaseSize);Resize=%(Resize);TintColor=%(TintColor);Color=%(Color);IsAppIcon=%(IsAppIcon);ForegroundScale=%(ForegroundScale);ForegroundFile=%(ForegroundFile);MonochromeFile=%(MonochromeFile)')"
+            Lines="PlatformType=$(ResizetizerPlatformType);@(MauiImage->'File=%(Identity);Link=%(Link);BaseSize=%(BaseSize);Resize=%(Resize);TintColor=%(TintColor);Color=%(Color);IsAppIcon=%(IsAppIcon);ForegroundScale=%(ForegroundScale);ForegroundFile=%(ForegroundFile);MonochromeFile=%(MonochromeFile)')"
             Overwrite="true"
             WriteOnlyWhenDifferent="true" />
 

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/ResizetizerTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/ResizetizerTests.cs
@@ -144,7 +144,7 @@ public class ResizetizerTests : BaseBuildTest
 				"<ResizetizerPlatformType>generic</ResizetizerPlatformType>",
 				"<ResizetizerPlatformType>android</ResizetizerPlatformType>",
 				StringComparison.Ordinal));
-		File.SetLastWriteTimeUtc(stampFile, DateTime.UtcNow.AddMinutes(1));
+		File.SetLastWriteTimeUtc(stampFile, DateTime.UtcNow.AddHours(1));
 		var invalidationSentinel = File.GetLastWriteTimeUtc(stampFile);
 
 		Assert.True(DotnetInternal.Build(projectFile, "Debug", target: "ResizetizeImages", properties: BuildProps, output: _output),

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/ResizetizerTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/ResizetizerTests.cs
@@ -102,6 +102,73 @@ public class ResizetizerTests : BaseBuildTest
 	}
 
 	[Fact]
+	public void ChangingExternalBackendPlatformTypeInvalidatesImages()
+	{
+		SetTestIdentifier("external-backend-platform-invalidation");
+		var projectDir = TestDirectory;
+		var projectFile = Path.Combine(projectDir, "ExternalBackend.csproj");
+		var imageFile = Path.Combine(projectDir, "image.svg");
+
+		File.WriteAllText(imageFile, BlankSvgContents);
+		File.WriteAllText(projectFile,
+			$$"""
+			<Project Sdk="Microsoft.NET.Sdk">
+			  <PropertyGroup>
+			    <TargetFramework>{{DotNetCurrent}}</TargetFramework>
+			    <ResizetizerPlatformType>generic</ResizetizerPlatformType>
+			  </PropertyGroup>
+			  <ItemGroup>
+			    <PackageReference Include="Microsoft.Maui.Resizetizer" Version="{{MauiPackageVersion}}" />
+			    <MauiImage Include="image.svg" />
+			  </ItemGroup>
+			</Project>
+			""");
+
+		Assert.True(DotnetInternal.Build(projectFile, "Debug", target: "ResizetizeImages", properties: BuildProps, output: _output),
+			"External backend project failed to process generic images. Check test output for errors.");
+
+		var intermediateDir = Path.Combine(projectDir, "obj", "Debug", DotNetCurrent);
+		var outputsFile = Path.Combine(intermediateDir, "mauiimage.outputs");
+		var stampFile = Path.Combine(intermediateDir, "mauiimage.stamp");
+		Assert.True(File.Exists(outputsFile), $"Resizetizer output list does not exist: {outputsFile}");
+		Assert.True(File.Exists(stampFile), $"Resizetizer stamp does not exist: {stampFile}");
+
+		var genericImages = File.ReadAllLines(outputsFile);
+		Assert.Equal(2, genericImages.Length);
+		Assert.Contains(genericImages, path => path.EndsWith("image.png", StringComparison.OrdinalIgnoreCase));
+		Assert.Contains(genericImages, path => path.EndsWith("image@2x.png", StringComparison.OrdinalIgnoreCase));
+
+		File.WriteAllText(
+			projectFile,
+			File.ReadAllText(projectFile).Replace(
+				"<ResizetizerPlatformType>generic</ResizetizerPlatformType>",
+				"<ResizetizerPlatformType>android</ResizetizerPlatformType>",
+				StringComparison.Ordinal));
+		File.SetLastWriteTimeUtc(stampFile, DateTime.UtcNow.AddMinutes(1));
+		var invalidationSentinel = File.GetLastWriteTimeUtc(stampFile);
+
+		Assert.True(DotnetInternal.Build(projectFile, "Debug", target: "ResizetizeImages", properties: BuildProps, output: _output),
+			"External backend project failed after changing its platform type to android.");
+		Assert.True(File.GetLastWriteTimeUtc(stampFile) < invalidationSentinel,
+			"ResizetizeImages should rerun when only ResizetizerPlatformType changes.");
+
+		var androidImages = File.ReadAllLines(outputsFile);
+		Assert.Equal(5, androidImages.Length);
+		Assert.All(androidImages, path =>
+		{
+			Assert.StartsWith("drawable-", Path.GetFileName(Path.GetDirectoryName(path)), StringComparison.OrdinalIgnoreCase);
+			Assert.True(File.Exists(path), $"Processed Android image does not exist: {path}");
+		});
+		Assert.All(genericImages, path => Assert.False(File.Exists(path), $"Stale generic image still exists: {path}"));
+
+		File.SetLastWriteTimeUtc(stampFile, DateTime.UtcNow.AddMinutes(1));
+		var noOpSentinel = File.GetLastWriteTimeUtc(stampFile);
+		Assert.True(DotnetInternal.Build(projectFile, "Debug", target: "ResizetizeImages", properties: BuildProps, output: _output),
+			"External backend project failed on an unchanged rebuild.");
+		Assert.Equal(noOpSentinel, File.GetLastWriteTimeUtc(stampFile));
+	}
+
+	[Fact]
 	public void CustomBackendProcessesImagesWithoutBuiltInOutputInjection()
 	{
 		SetTestIdentifier("custom-backend");


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

- Persist `ResizetizerPlatformType` in `mauiimage.inputs` so platform-only changes invalidate `ResizetizeImages`.
- Add a shipping-package integration test that switches an external backend from generic output paths to Android density folders, verifies stale generic outputs are removed, and verifies the following unchanged build skips.

## Root cause

The external-backend support merged in #36653 passes `ResizetizerPlatformType` to the image task, but the value was not part of the persisted inputs manifest. Changing only that property therefore left `$(_ResizetizerInputsFile)` unchanged, allowing MSBuild to skip `ResizetizeImages` and preserve the previous platform's output shape.

The platform value belongs in the persisted manifest because `WriteOnlyWhenDifferent` turns a semantic property change into an input-file timestamp change. Putting the raw property directly in the target's `Inputs=` list would make MSBuild interpret the platform name as a file path rather than as input state.

## Behavior

Before this change, switching only `ResizetizerPlatformType` from `generic` to `android` kept the two generic outputs and skipped image processing. After this change, image processing reruns, produces five Android `drawable-*` outputs, removes the stale generic files, and then skips on the next unchanged build.

## Validation

- `pwsh .github/skills/run-integration-tests/scripts/Run-IntegrationTests.ps1 -TestFilter "FullyQualifiedName~ChangingExternalBackendPlatformTypeInvalidatesImages" -SkipBuild -SkipInstall -ResultsDirectory "artifacts/integration-tests/platform-invalidation-restored-fix"` — passed: 1/1.
- RED-on-revert: after reverting only the production manifest line and repacking the same shipping package, the focused test failed with `ResizetizeImages should rerun when only ResizetizerPlatformType changes.` Restoring the line and repacking returned the test to green.
- `.dotnet/dotnet pack src/SingleProject/Resizetizer/src/Resizetizer.csproj -c Debug --no-restore -p:WarnAsError=false` — passed.
- `.dotnet/dotnet format src/TestUtils/src/Microsoft.Maui.IntegrationTests/Microsoft.Maui.IntegrationTests.csproj --no-restore --include src/TestUtils/src/Microsoft.Maui.IntegrationTests/ResizetizerTests.cs --exclude-diagnostics CA1822 --verbosity quiet` — passed.

The full integration skill build/pack lane was attempted first but was blocked locally by `NETSDK1147` requesting the `ios` workload for `net11.0-ios26.5`, even though the workload installation step reported success. The focused test still ran through the skill script against the freshly packed `Microsoft.Maui.Resizetizer.11.0.0-dev.nupkg`.

Related to #34099 and #35022. Follow-up to merged #36653.
