### PR TITLE
Fix bot-opened inter-branch merge policy matching

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -724,8 +724,6 @@ configuration:
       - isActivitySender:
           user: github-actions[bot]
           issueAuthor: False
-      - isActivitySender:
-          issueAuthor: True
       - isAction:
           action: Opened
       - or:


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Remove the redundant `isActivitySender: { issueAuthor: True }` predicate from the inter-branch merge Policy Service rule.

The end-to-end retest after #36875 merged created #36989 with the exact expected `github-actions[bot]` author, title, head, and base, but Policy Service did not approve it or enable auto-merge. The additional issue-author predicate is the unique difference from the proven policy used by `dotnet/vscode-csharp`, which successfully auto-approves and enables merge-commit auto-merge for equivalent bot-opened inter-branch merge PRs.

For an `Opened` event, requiring the activity sender to be `github-actions[bot]` already binds the event to the bot that opened the PR. The exact target branch and fully anchored title checks remain unchanged, and `Synchronize` remains excluded.

### Verification

- The branch contains exactly one commit relative to `main`.
- `.github/policies/resourceManagement.yml` parses as YAML.
- `git diff --check` passes.
- The PR diff is exactly one file with two deletions.
- The inter-branch rule retains the exact bot sender, `Opened` action, target branches, anchored titles, approval, and merge-method auto-merge actions.
- Compared against the live known-good `dotnet/vscode-csharp` Policy Service rule and PR #9595, where `dotnet-policy-service` approved and enabled `MERGE` auto-merge for a `github-actions[bot]` inter-branch merge PR.

### Issues Fixed

Follow-up to #36875. Replaces #36990, whose branch retained the original squash-merged PR history.
