### PR TITLE
[Net11][ci-fix-net11][Windows]Fixed HorizontalGridFooterExpand test failure

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/Windows/MauiItemsView.cs
+++ b/src/Controls/src/Core/Handlers/Items2/Windows/MauiItemsView.cs
@@ -335,6 +335,8 @@ internal partial class MauiItemsView : UI.Xaml.Controls.ItemsView, IEmptyView
 		// the viewport — DesiredSize = max(contentWidth, MinWidth), so the ScrollViewer
 		// still sees the full content extent for many-item scenarios.
 		bool itemsWidthChanged = false;
+		var measured = base.MeasureOverride(availableSize);
+
 		if (_isHorizontalLayout && _itemsRepeater is not null)
 		{
 			if (!emptyViewWillFill && !double.IsInfinity(availableSize.Width) && availableSize.Width > 0)
@@ -355,8 +357,6 @@ internal partial class MauiItemsView : UI.Xaml.Controls.ItemsView, IEmptyView
 			_itemsRepeater.ClearValue(MinWidthProperty);
 		}
 
-		var measured = base.MeasureOverride(availableSize);
-
 		// When the EmptyView is visible, stretch it to fill the remaining viewport
 		// space (after Header/Footer/Items) so it occupies the entire available area.
 		// The EmptyView is laid out inside the StackPanel between the items repeater
@@ -373,10 +373,11 @@ internal partial class MauiItemsView : UI.Xaml.Controls.ItemsView, IEmptyView
 		return measured;
 	}
 
-	/// _itemsRepeater MinWidth to the available viewport width minus the
-	/// Header/Footer's own widths, so items stretch to fill the remaining space (needed for
-	/// UniformGridLayout's ItemsStretch=Fill when there are few items) without claiming the
-	/// space the Header/Footer need. Returns true if the MinWidth value changed.
+	/// <summary>
+	/// Sets the _itemsRepeater MinWidth to the available viewport width minus the
+	/// Header/Footer's own widths, so items stretch to fill the remaining space.
+	/// Returns true if the MinWidth value changed.
+	/// </summary>
 	bool ApplyItemsRepeaterMinWidth(global::Windows.Foundation.Size availableSize)
 	{
 		if (_itemsRepeater is null)
@@ -392,7 +393,7 @@ internal partial class MauiItemsView : UI.Xaml.Controls.ItemsView, IEmptyView
 			: 0;
 
 		var remainingWidth = availableSize.Width - headerWidth - footerWidth;
-		var newMinWidth = Math.Max(remainingWidth , 0);
+		var newMinWidth = Math.Max(remainingWidth, 0);
 
 		if (_itemsRepeater.MinWidth == newMinWidth)
 		{

--- a/src/Controls/src/Core/Handlers/Items2/Windows/MauiItemsView.cs
+++ b/src/Controls/src/Core/Handlers/Items2/Windows/MauiItemsView.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Maui.Controls.Platform;
+﻿using System;
+using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Graphics;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -333,11 +334,12 @@ internal partial class MauiItemsView : UI.Xaml.Controls.ItemsView, IEmptyView
 		// Using MinWidth (not Width) preserves horizontal scrolling when content exceeds
 		// the viewport — DesiredSize = max(contentWidth, MinWidth), so the ScrollViewer
 		// still sees the full content extent for many-item scenarios.
+		bool itemsWidthChanged = false;
 		if (_isHorizontalLayout && _itemsRepeater is not null)
 		{
 			if (!emptyViewWillFill && !double.IsInfinity(availableSize.Width) && availableSize.Width > 0)
 			{
-				_itemsRepeater.MinWidth = availableSize.Width;
+				itemsWidthChanged = ApplyItemsRepeaterMinWidth(availableSize);
 			}
 			else
 			{
@@ -360,13 +362,45 @@ internal partial class MauiItemsView : UI.Xaml.Controls.ItemsView, IEmptyView
 		// The EmptyView is laid out inside the StackPanel between the items repeater
 		// and the footer; setting MinHeight/MinWidth here pushes the Footer to the
 		// far edge of the viewport when empty.
-		if (SizeEmptyViewToFillViewport(availableSize))
+		bool emptyViewSizeChanged = SizeEmptyViewToFillViewport(availableSize);
+
+		if (emptyViewSizeChanged || itemsWidthChanged)
 		{
 			// MinHeight/MinWidth changed — re-measure so the StackPanel picks it up.
 			measured = base.MeasureOverride(availableSize);
 		}
 
 		return measured;
+	}
+
+	/// _itemsRepeater MinWidth to the available viewport width minus the
+	/// Header/Footer's own widths, so items stretch to fill the remaining space (needed for
+	/// UniformGridLayout's ItemsStretch=Fill when there are few items) without claiming the
+	/// space the Header/Footer need. Returns true if the MinWidth value changed.
+	bool ApplyItemsRepeaterMinWidth(global::Windows.Foundation.Size availableSize)
+	{
+		if (_itemsRepeater is null)
+		{
+			return false;
+		}
+
+		var headerWidth = (_headerContentControl is not null && _headerContentControl.Visibility == WVisibility.Visible)
+			? _headerContentControl.DesiredSize.Width
+			: 0;
+		var footerWidth = (_footerContentControl is not null && _footerContentControl.Visibility == WVisibility.Visible)
+			? _footerContentControl.DesiredSize.Width
+			: 0;
+
+		var remainingWidth = availableSize.Width - headerWidth - footerWidth;
+		var newMinWidth = Math.Max(remainingWidth , 0);
+
+		if (_itemsRepeater.MinWidth == newMinWidth)
+		{
+			return false;
+		}
+
+		_itemsRepeater.MinWidth = newMinWidth;
+		return true;
 	}
 
 	bool SizeEmptyViewToFillViewport(global::Windows.Foundation.Size availableSize)


### PR DESCRIPTION
<!-- Please keep the note below for people who find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment whether this change resolves your issue. Thank you!

**Failure Test on windows collectionview** : _**HorizontalGridFooterExpandsToContentWidth**_


This pull request refines the layout logic for horizontal `MauiItemsView` on Windows, ensuring that the items area stretches appropriately when headers or footers are present. The main improvement is more accurate sizing of the items area by subtracting header and footer widths, which fixes stretching issues in layouts with few items.

**Layout logic improvements:**

* Added `ApplyItemsRepeaterMinWidth()` to compute the items area width by subtracting header and footer widths from the available viewport, ensuring correct stretching for layouts like `UniformGridLayout` with `ItemsStretch=Fill` and few items. This method only updates the width if it changes.
* Updated `ApplyLayoutOrientation()` to use the new sizing method and to re-measure the layout only if the items width or empty view size changed, reducing unnecessary layout passes. [[1]](diffhunk://#diff-2dd8ad3a609ad111709aca5f67a8af9abd6aa793328409811f72d3c97a653931R337-R342) [[2]](diffhunk://#diff-2dd8ad3a609ad111709aca5f67a8af9abd6aa793328409811f72d3c97a653931L363-R367)

**Code quality:**

* Added missing `using System;` directive to support new code.
<!-- Enter description of the fix in this section -->
### Why no tests added : 

- No new automated test was added in this PR because the existing UI test `HorizontalGridFooterExpandsToContentWidth`  already covers this behavior — it was the test that started failing in net11 CI, which is what prompted this fix. Rather than adding a new test, this PR restores the passing behavior of that existing test

### Tested the behavior in the following platforms

- [x] Windows
- [ ] Android
- [ ] iOS
- [ ] Mac



| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/ca60350b-9eda-4da2-bb48-0215c8fa1ac9"> | <video src="https://github.com/user-attachments/assets/232cb201-84af-4e27-b508-83dc1df286e6"> |


<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
