### PR TITLE
[ci-fix-net11] Fix CS0115 build error in ModalHandlerTests.SetupBuilder override

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Maui.DeviceTests
 	[Trait(RendererHandlerVariant.TraitName, RendererHandlerVariant.AndroidShellRenderer)] // See RendererHandlerVariant.cs
 	public partial class ModalTests : ControlsHandlerTestBase
 	{
-		void SetupBuilder(bool includeNavigationViewHandler = true)
+		protected virtual void SetupBuilder(bool includeNavigationViewHandler = true)
 		{
 			EnsureHandlerCreated(builder =>
 			{

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellHandlerSubclasses.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellHandlerSubclasses.Android.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Maui.DeviceTests
 	[Trait(RendererHandlerVariant.TraitName, RendererHandlerVariant.AndroidShellHandler)] // See RendererHandlerVariant.cs
 	public partial class ModalHandlerTests : ModalTests
 	{
-		protected override void SetupBuilder()
+		protected override void SetupBuilder(bool includeNavigationViewHandler = true)
 		{
 			EnsureHandlerCreated(builder =>
 			{


### PR DESCRIPTION
## Description

This pull request fixes a `CS0115` build error on Android caused by a signature mismatch between PR #36328 and PR #36109.

The `SetupBuilder` method in `ModalTests` is now `protected virtual` and accepts an optional `includeNavigationViewHandler` parameter, which allows subclasses like `ModalHandlerTests` to override it with the same signature.

### Changes

- **ModalTests.cs**: Changed `SetupBuilder` to `protected virtual void SetupBuilder(bool includeNavigationViewHandler = true)` for better extensibility.
- **ShellHandlerSubclasses.Android.cs**: Updated the override in `ModalHandlerTests` to match the new method signature, ensuring consistency between base and derived test classes.