### PR TITLE
[iOS] Fix for SafeAreaEdges not respected per-edge when parent and child handle different edges

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34563.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34563.cs
@@ -1,0 +1,47 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 34563, "[iOS] Vertical SafeAreaEdge isn't respected when Top and Bottom constraints mismatch", PlatformAffected.iOS)]
+public class Issue34563 : ContentPage
+{
+	public Issue34563()
+	{
+		SafeAreaEdges = new SafeAreaEdges(SafeAreaRegions.None, SafeAreaRegions.None, SafeAreaRegions.None, SafeAreaRegions.Container);
+
+		BackgroundColor = Colors.Red;
+
+		var topSafeBox = new ContentView
+		{
+			AutomationId = "TopSafeBox",
+			BackgroundColor = Colors.LimeGreen,
+			HeightRequest = 60,
+			VerticalOptions = LayoutOptions.Start,
+			SafeAreaEdges = new SafeAreaEdges(SafeAreaRegions.Container),
+		};
+
+		var bottomSafeBox = new ContentView
+		{
+			AutomationId = "BottomSafeBox",
+			BackgroundColor = Colors.LimeGreen,
+			HeightRequest = 60,
+			VerticalOptions = LayoutOptions.End,
+			SafeAreaEdges = new SafeAreaEdges(SafeAreaRegions.Container),
+		};
+
+		var instructions = new Label
+		{
+			AutomationId = "InstructionsLabel",
+			Text = "TopSafeBox and BottomSafeBox (green) must never overlap the red background, which represents the OS safe areas (status bar / home indicator).",
+			Margin = new Thickness(20),
+			HorizontalTextAlignment = TextAlignment.Center,
+			VerticalTextAlignment = TextAlignment.Center,
+			VerticalOptions = LayoutOptions.Center,
+		};
+
+		var grid = new Grid { AutomationId = "RootGrid" };
+		grid.Add(instructions);
+		grid.Add(topSafeBox);
+		grid.Add(bottomSafeBox);
+
+		Content = grid;
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34563.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34563.cs
@@ -1,0 +1,35 @@
+#if IOS || ANDROID // SafeAreaEdges not supported on Catalyst and Windows
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue34563 : _IssuesUITest
+	{
+		public override string Issue => "[iOS] Vertical SafeAreaEdge isn't respected when Top and Bottom constraints mismatch";
+
+		public Issue34563(TestDevice device) : base(device) { }
+
+		[Test]
+		[Category(UITestCategories.SafeAreaEdges)]
+		public void SafeAreaEdgesRespectedWhenTopAndBottomMismatch()
+		{
+			App.WaitForElement("RootGrid");
+
+			var topSafeBoxRect = App.WaitForElement("TopSafeBox").GetRect();
+			Assert.That(topSafeBoxRect.Y, Is.GreaterThan(0),
+				"TopSafeBox opted into SafeAreaEdges.Container and should be inset from the top of the screen, " +
+				"even though the Page's Top edge is None.");
+
+			var bottomSafeBoxRect = App.WaitForElement("BottomSafeBox").GetRect();
+			var rootGridRect = App.WaitForElement("RootGrid").GetRect();
+			var screenBottom = rootGridRect.Y + rootGridRect.Height;
+			var bottomSafeBoxBottom = bottomSafeBoxRect.Y + bottomSafeBoxRect.Height;
+
+			Assert.That(bottomSafeBoxBottom, Is.LessThanOrEqualTo(screenBottom),
+				"BottomSafeBox should not extend past the bottom of its container.");
+		}
+	}
+}
+#endif

--- a/src/Core/src/Platform/iOS/MauiScrollView.cs
+++ b/src/Core/src/Platform/iOS/MauiScrollView.cs
@@ -68,9 +68,14 @@ namespace Microsoft.Maui.Platform
 		/// </summary>
 		bool _safeAreaInvalidated = true;
 
-		// Cached result of whether a parent MauiView is already applying safe area adjustments.
-		// Null means not yet determined. Invalidated when view hierarchy changes.
-		bool? _parentHandlesSafeArea;
+		// Cached per-edge (Left=0, Top=1, Right=2, Bottom=3) result of whether an ancestor
+		// MauiView already applies a real, non-zero safe area inset for that edge. Reused
+		// across layout passes to avoid re-walking the ancestor chain (and the allocation that
+		// walk would otherwise require) on every LayoutSubviews call. Invalidated by the same
+		// events that previously invalidated the whole-view _parentHandlesSafeArea cache:
+		// SafeAreaInsetsDidChange, InvalidateSafeArea, and MovedToWindow.
+		readonly bool[] _blockedEdgesCache = new bool[4];
+		bool _blockedEdgesCacheValid;
 
 		/// <summary>
 		/// Flag indicating whether this scroll view should apply safe area adjustments to its content.
@@ -127,18 +132,19 @@ namespace Microsoft.Maui.Platform
 		}
 
 		/// <summary>
-		/// Checks if any ancestor MauiView is already applying safe area adjustments.
-		/// When a parent already handles safe area, this scroll view should not double-apply insets,
-		/// which would otherwise cause infinite layout cycles (#33595).
+		/// Returns this scroll view's own, already-resolved safe area component for the given edge
+		/// (Left=0, Top=1, Right=2, Bottom=3), used by descendants (or, in principle, callers)
+		/// to determine whether this view has a real, non-zero inset for a specific edge.
 		/// </summary>
-		bool IsParentHandlingSafeArea()
+		double GetSafeAreaComponentForEdge(int edge) => edge switch
 		{
-			if (_parentHandlesSafeArea.HasValue)
-				return _parentHandlesSafeArea.Value;
+			0 => _safeArea.Left,
+			1 => _safeArea.Top,
+			2 => _safeArea.Right,
+			3 => _safeArea.Bottom,
+			_ => 0
+		};
 
-			_parentHandlesSafeArea = this.FindParent(x => x is MauiView mv && mv.AppliesSafeAreaAdjustments) is not null;
-			return _parentHandlesSafeArea.Value;
-		}
 
 		/// <summary>
 		/// Called by iOS when the adjusted content inset changes (e.g., when safe area changes).
@@ -166,7 +172,7 @@ namespace Microsoft.Maui.Platform
 		{
 			// Note: UIKit invokes LayoutSubviews right after this method
 			base.SafeAreaInsetsDidChange();
-			_parentHandlesSafeArea = null;
+			_blockedEdgesCacheValid = false;
 			_safeAreaInvalidated = true;
 		}
 
@@ -175,7 +181,7 @@ namespace Microsoft.Maui.Platform
 		/// </summary>
 		internal void InvalidateSafeArea()
 		{
-			_parentHandlesSafeArea = null;
+			_blockedEdgesCacheValid = false;
 			_safeAreaInvalidated = true;
 			SetNeedsLayout();
 		}
@@ -212,11 +218,15 @@ namespace Microsoft.Maui.Platform
 
 			var safeAreaInsets = SafeAreaInsets;
 
+			// Single ancestor walk resolves all 4 edges at once, cached until invalidated
+			// (see SafeAreaInsetsExtensions.ResolveParentBlockedEdges) to avoid re-walking on every layout pass.
+			var blockedEdges = this.ResolveParentBlockedEdges(_blockedEdgesCache, ref _blockedEdgesCacheValid);
+
 			var manualInset = new UIEdgeInsets(
-					top: GetManualInsetForEdge(topRegion, safeAreaInsets.Top),
-					left: GetManualInsetForEdge(leftRegion, safeAreaInsets.Left),
-					bottom: GetManualInsetForEdge(bottomRegion, safeAreaInsets.Bottom),
-					right: GetManualInsetForEdge(rightRegion, safeAreaInsets.Right)
+					top: GetManualInsetForEdge(topRegion, safeAreaInsets.Top, blockedEdges[1]),
+					left: GetManualInsetForEdge(leftRegion, safeAreaInsets.Left, blockedEdges[0]),
+					bottom: GetManualInsetForEdge(bottomRegion, safeAreaInsets.Bottom, blockedEdges[3]),
+					right: GetManualInsetForEdge(rightRegion, safeAreaInsets.Right, blockedEdges[2])
 				);
 
 			return manualInset;
@@ -263,10 +273,17 @@ namespace Microsoft.Maui.Platform
 			return true;
 		}
 
-		static nfloat GetManualInsetForEdge(SafeAreaRegions safeAreaRegion, nfloat safeAreaInset)
+		static nfloat GetManualInsetForEdge(SafeAreaRegions safeAreaRegion, nfloat safeAreaInset, bool isEdgeBlockedByParent)
 		{
 			// Edge-to-edge content - no safe area padding
 			if (safeAreaRegion == SafeAreaRegions.None)
+				return 0;
+
+			// If an ancestor already applies a real, non-zero safe area inset for this exact
+			// edge, defer to it and don't double-apply here (#33595, #32586). Edges are checked
+			// independently, so a parent handling only Top never blocks this scroll view from
+			// independently handling Bottom (#28986, #34563).
+			if (isEdgeBlockedByParent)
 				return 0;
 
 			return safeAreaInset;
@@ -393,7 +410,13 @@ namespace Microsoft.Maui.Platform
 				_safeArea = SystemAdjustedContentInset.ToSafeAreaInsets();
 
 			var oldApplyingSafeAreaAdjustments = _appliesSafeAreaAdjustments;
-			_appliesSafeAreaAdjustments = !IsParentHandlingSafeArea() && RespondsToSafeArea() && !_safeArea.IsEmpty;
+			// Parent-edge blocking is now resolved per-edge inline while computing GetInset() above
+			// (see ResolveParentBlockedEdges/GetManualInsetForEdge), so _safeArea already reflects
+			// the net, post-ancestor-arbitration state for the manual (mixed-edge) path. For the
+			// uniform-edge path (SystemAdjustedContentInset), iOS's own native content-inset
+			// adjustment already avoids double-padding, so no separate whole-view parent check is
+			// needed either way.
+			_appliesSafeAreaAdjustments = RespondsToSafeArea() && !_safeArea.IsEmpty;
 
 			if (_systemAdjustedContentInset != SystemAdjustedContentInset)
 			{
@@ -701,7 +724,7 @@ namespace Microsoft.Maui.Platform
 
 			// Clear cached scroll view descendant status since the view hierarchy may have changed
 			_scrollViewDescendant = null;
-			_parentHandlesSafeArea = null;
+			_blockedEdgesCacheValid = false;
 
 			// Mark safe area as invalidated since moving to a new window may change safe area
 			_safeAreaInvalidated = true;

--- a/src/Core/src/Platform/iOS/MauiScrollView.cs
+++ b/src/Core/src/Platform/iOS/MauiScrollView.cs
@@ -209,24 +209,30 @@ namespace Microsoft.Maui.Platform
 
 		SafeAreaEdges? _previousEdges;
 
-		UIEdgeInsets GetInset()
+		/// <summary>
+		/// Resolves the manual, per-edge inset to apply given a source set of raw insets.
+		/// Used both for the manual (mixed-edge) path, where <paramref name="sourceInsets"/> is
+		/// this view's SafeAreaInsets, and for the uniform-edge native path, where
+		/// <paramref name="sourceInsets"/> is <see cref="SystemAdjustedContentInset"/> — so both
+		/// paths get identical per-edge ancestor-blocking behavior and neither can double-apply
+		/// an inset a parent already handles (#33595, #32586, #34563).
+		/// </summary>
+		UIEdgeInsets GetInset(UIEdgeInsets sourceInsets)
 		{
 			var leftRegion = GetSafeAreaRegionForEdge(0);
 			var topRegion = GetSafeAreaRegionForEdge(1);
 			var rightRegion = GetSafeAreaRegionForEdge(2);
 			var bottomRegion = GetSafeAreaRegionForEdge(3);
 
-			var safeAreaInsets = SafeAreaInsets;
-
 			// Single ancestor walk resolves all 4 edges at once, cached until invalidated
 			// (see SafeAreaInsetsExtensions.ResolveParentBlockedEdges) to avoid re-walking on every layout pass.
 			var blockedEdges = this.ResolveParentBlockedEdges(_blockedEdgesCache, ref _blockedEdgesCacheValid);
 
 			var manualInset = new UIEdgeInsets(
-					top: GetManualInsetForEdge(topRegion, safeAreaInsets.Top, blockedEdges[1]),
-					left: GetManualInsetForEdge(leftRegion, safeAreaInsets.Left, blockedEdges[0]),
-					bottom: GetManualInsetForEdge(bottomRegion, safeAreaInsets.Bottom, blockedEdges[3]),
-					right: GetManualInsetForEdge(rightRegion, safeAreaInsets.Right, blockedEdges[2])
+					top: GetManualInsetForEdge(topRegion, sourceInsets.Top, blockedEdges[1]),
+					left: GetManualInsetForEdge(leftRegion, sourceInsets.Left, blockedEdges[0]),
+					bottom: GetManualInsetForEdge(bottomRegion, sourceInsets.Bottom, blockedEdges[3]),
+					right: GetManualInsetForEdge(rightRegion, sourceInsets.Right, blockedEdges[2])
 				);
 
 			return manualInset;
@@ -405,17 +411,16 @@ namespace Microsoft.Maui.Platform
 			// This can result in a loop of invalidations as the layout toggles between these states.
 			// To prevent this, we ignore safe area calculations on child views when they are inside a scroll view.
 			if (SystemAdjustedContentInset == UIEdgeInsets.Zero || ContentInsetAdjustmentBehavior == UIScrollViewContentInsetAdjustmentBehavior.Never)
-				_safeArea = GetInset().ToSafeAreaInsets();
+				_safeArea = GetInset(SafeAreaInsets).ToSafeAreaInsets();
 			else
-				_safeArea = SystemAdjustedContentInset.ToSafeAreaInsets();
+				_safeArea = GetInset(SystemAdjustedContentInset).ToSafeAreaInsets();
 
 			var oldApplyingSafeAreaAdjustments = _appliesSafeAreaAdjustments;
 			// Parent-edge blocking is now resolved per-edge inline while computing GetInset() above
-			// (see ResolveParentBlockedEdges/GetManualInsetForEdge), so _safeArea already reflects
-			// the net, post-ancestor-arbitration state for the manual (mixed-edge) path. For the
-			// uniform-edge path (SystemAdjustedContentInset), iOS's own native content-inset
-			// adjustment already avoids double-padding, so no separate whole-view parent check is
-			// needed either way.
+			// (see ResolveParentBlockedEdges/GetManualInsetForEdge) for BOTH the manual (mixed-edge)
+			// path and the uniform-edge native path (SystemAdjustedContentInset), so _safeArea
+			// already reflects the net, post-ancestor-arbitration state either way — no separate
+			// whole-view parent check is needed.
 			_appliesSafeAreaAdjustments = RespondsToSafeArea() && !_safeArea.IsEmpty;
 
 			if (_systemAdjustedContentInset != SystemAdjustedContentInset)

--- a/src/Core/src/Platform/iOS/MauiView.cs
+++ b/src/Core/src/Platform/iOS/MauiView.cs
@@ -140,9 +140,14 @@ namespace Microsoft.Maui.Platform
 		// otherwise, false. Null means not yet determined.
 		bool? _scrollViewDescendant;
 
-		// Cached result of whether a parent MauiView is already handling safe area.
-		// Null means not yet determined. Invalidated when view hierarchy changes.
-		bool? _parentHandlesSafeArea;
+		// Cached per-edge (Left=0, Top=1, Right=2, Bottom=3) result of whether an ancestor
+		// MauiView already applies a real, non-zero safe area inset for that edge. Reused
+		// across layout passes to avoid re-walking the ancestor chain (and the allocation that
+		// walk would otherwise require) on every LayoutSubviews call. Invalidated by the same
+		// events that previously invalidated the whole-view _parentHandlesSafeArea cache:
+		// SafeAreaInsetsDidChange, InvalidateSafeArea, and MovedToWindow.
+		readonly bool[] _blockedEdgesCache = new bool[4];
+		bool _blockedEdgesCacheValid;
 
 		// Indicates whether the measure invalidation has already been propagated
 		// to ancestors during this main loop.
@@ -193,7 +198,7 @@ namespace Microsoft.Maui.Platform
 		/// Returns true if the view implements ISafeAreaView, doesn't ignore safe area,
 		/// and the current iOS version supports safe area insets.
 		/// </summary>
-		bool RespondsToSafeArea()
+		internal bool RespondsToSafeArea()
 		{
 			if (_scrollViewDescendant.HasValue)
 				return !_scrollViewDescendant.Value;
@@ -213,7 +218,7 @@ namespace Microsoft.Maui.Platform
 			return !_scrollViewDescendant.Value;
 		}
 
-		SafeAreaRegions GetSafeAreaRegionForEdge(int edge)
+		internal SafeAreaRegions GetSafeAreaRegionForEdge(int edge)
 		{
 			if (View is ISafeAreaView2 safeAreaPage)
 			{
@@ -231,13 +236,15 @@ namespace Microsoft.Maui.Platform
 
 		// Note: This method was changed from static to instance to access _isKeyboardShowing field
 		// which is needed to determine if SoftInput padding should be applied
-		double GetSafeAreaForEdge(double originalSafeArea, int edge)
+		double GetSafeAreaForEdge(double originalSafeArea, int edge, bool isEdgeBlockedByParent)
 		{
 			var safeAreaRegion = GetSafeAreaRegionForEdge(edge);
 
 			// Edge-to-edge content - no safe area padding
 			if (safeAreaRegion == SafeAreaRegions.None)
+			{
 				return 0;
+			}
 
 			// Handle SoftInput specifically - only apply padding when keyboard is actually showing
 			if (edge == 3 && SafeAreaEdges.IsOnlySoftInput(safeAreaRegion))
@@ -245,7 +252,18 @@ namespace Microsoft.Maui.Platform
 				// SoftInput only applies padding when keyboard is showing
 				// When keyboard is hidden, return 0 to avoid showing home indicator padding
 				if (!_isKeyboardShowing)
+				{
 					return 0;
+				}
+			}
+
+			// If an ancestor already applies a real, non-zero safe area inset for this exact edge,
+			// defer to it and don't double-apply here. This is what prevents double-padding when a
+			// parent and child both handle the same edge (#33595, #32586). Edges are checked
+			// independently, so a parent handling only Top never blocks a child that handles Bottom (#28986).
+			if (isEdgeBlockedByParent)
+			{
+				return 0;
 			}
 
 			// All other regions respect safe area in some form
@@ -258,6 +276,28 @@ namespace Microsoft.Maui.Platform
 			return originalSafeArea;
 		}
 
+		/// <summary>
+		/// Returns this view's own, already-resolved safe area component for the given edge
+		/// (Left=0, Top=1, Right=2, Bottom=3). Reflects the ACTUAL inset this view will apply,
+		/// after its own ancestor-blocking has already been factored in.
+		///
+		/// IMPORTANT: this reads <see cref="_safeArea"/>, which is only refreshed inside this
+		/// view's own <see cref="LayoutSubviews"/> (see the assignment below). Callers rely on
+		/// UIKit's top-down layout pass calling an ancestor's LayoutSubviews before its
+		/// descendants', so by the time a child resolves its own blocked edges via
+		/// <see cref="SafeAreaInsetsExtensions.ResolveParentBlockedEdges"/>, each ancestor's <see cref="_safeArea"/> for
+		/// this pass has already been computed. If that ordering is ever violated (e.g. a
+		/// manual/forced layout of a child ahead of its parent), an ancestor's real inset could
+		/// be read as 0 (stale/default) and a double-padding regression could reappear.
+		/// </summary>
+		internal double GetSafeAreaComponentForEdge(int edge) => edge switch
+		{
+			0 => _safeArea.Left,
+			1 => _safeArea.Top,
+			2 => _safeArea.Right,
+			3 => _safeArea.Bottom,
+			_ => 0
+		};
 
 		/// <summary>
 		/// Adjusts the given bounds rectangle to account for safe area insets.
@@ -455,11 +495,15 @@ namespace Microsoft.Maui.Platform
 
 			if (View is ISafeAreaView2)
 			{
+				// Single ancestor walk resolves all 4 edges at once, cached until invalidated
+				// (see SafeAreaInsetsExtensions.ResolveParentBlockedEdges) to avoid re-walking on every layout pass.
+				var blockedEdges = this.ResolveParentBlockedEdges(_blockedEdgesCache, ref _blockedEdgesCacheValid);
+
 				// Apply safe area selectively per edge based on SafeAreaRegions
-				var left = GetSafeAreaForEdge(baseSafeArea.Left, 0);
-				var top = GetSafeAreaForEdge(baseSafeArea.Top, 1);
-				var right = GetSafeAreaForEdge(baseSafeArea.Right, 2);
-				var bottom = GetSafeAreaForEdge(baseSafeArea.Bottom, 3);
+				var left = GetSafeAreaForEdge(baseSafeArea.Left, 0, blockedEdges[0]);
+				var top = GetSafeAreaForEdge(baseSafeArea.Top, 1, blockedEdges[1]);
+				var right = GetSafeAreaForEdge(baseSafeArea.Right, 2, blockedEdges[2]);
+				var bottom = GetSafeAreaForEdge(baseSafeArea.Bottom, 3, blockedEdges[3]);
 
 				return new SafeAreaPadding(left, right, top, bottom);
 			}
@@ -494,36 +538,6 @@ namespace Microsoft.Maui.Platform
 		/// Used by descendant views to avoid double-applying safe area when a parent already handles it.
 		/// </summary>
 		internal bool AppliesSafeAreaAdjustments => _appliesSafeAreaAdjustments;
-
-		/// <summary>
-		/// Checks if any ancestor MauiView is already applying safe area adjustments for the same edges
-		/// that this view handles. When a parent already handles a specific safe area edge, this view
-		/// should not double-apply insets for that edge — but it may still handle OTHER edges independently.
-		/// This prevents double-padding when parent and child handle the same edges (#33595, #32586),
-		/// while allowing parent and child to handle DIFFERENT edges without conflict (#28986).
-		/// </summary>
-		bool IsParentHandlingSafeArea()
-		{
-			if (_parentHandlesSafeArea.HasValue)
-				return _parentHandlesSafeArea.Value;
-
-			// Check if any ancestor MauiView handles any of the SAME edges we handle.
-			// Edge-aware check: parent handling only TOP doesn't block child handling BOTTOM.
-			_parentHandlesSafeArea = this.FindParent(x =>
-			{
-				if (x is not MauiView mv || !mv._appliesSafeAreaAdjustments)
-					return false;
-				// Return true only if parent handles any edge that this view also handles
-				for (int edge = 0; edge < 4; edge++)
-				{
-					if (GetSafeAreaRegionForEdge(edge) != SafeAreaRegions.None &&
-						mv.GetSafeAreaRegionForEdge(edge) != SafeAreaRegions.None)
-						return true;
-				}
-				return false;
-			}) is not null;
-			return _parentHandlesSafeArea.Value;
-		}
 
 		/// <summary>
 		/// Checks if the current measure information is still valid for the given constraints.
@@ -767,8 +781,11 @@ namespace Microsoft.Maui.Platform
 			var oldSafeArea = _safeArea;
 			_safeArea = GetAdjustedSafeAreaInsets();
 
+			// Parent-edge blocking is now resolved per-edge inline while computing _safeArea above
+			// (see GetSafeAreaForEdge/ResolveParentBlockedEdges), so _safeArea.IsEmpty here already
+			// reflects the net, post-ancestor-arbitration state — no separate whole-view parent check needed.
 			var oldApplyingSafeAreaAdjustments = _appliesSafeAreaAdjustments;
-			_appliesSafeAreaAdjustments = !IsParentHandlingSafeArea() && RespondsToSafeArea() && !_safeArea.IsEmpty;
+			_appliesSafeAreaAdjustments = RespondsToSafeArea() && !_safeArea.IsEmpty;
 
 			// Return whether the way safe area interacts with our view has changed.
 			// Compare at device-pixel resolution to filter sub-pixel noise from animations
@@ -868,7 +885,7 @@ namespace Microsoft.Maui.Platform
 		public override void SafeAreaInsetsDidChange()
 		{
 			_safeAreaInvalidated = true;
-			_parentHandlesSafeArea = null;
+			_blockedEdgesCacheValid = false;
 			base.SafeAreaInsetsDidChange();
 		}
 
@@ -878,7 +895,7 @@ namespace Microsoft.Maui.Platform
 		internal void InvalidateSafeArea()
 		{
 			_safeAreaInvalidated = true;
-			_parentHandlesSafeArea = null;
+			_blockedEdgesCacheValid = false;
 			SetNeedsLayout();
 		}
 
@@ -891,7 +908,7 @@ namespace Microsoft.Maui.Platform
 			base.MovedToWindow();
 
 			_scrollViewDescendant = null;
-			_parentHandlesSafeArea = null;
+			_blockedEdgesCacheValid = false;
 
 			// Notify any subscribers that this view has been moved to a window
 			_movedToWindow?.Invoke(this, EventArgs.Empty);

--- a/src/Core/src/Platform/iOS/SafeAreaPadding.cs
+++ b/src/Core/src/Platform/iOS/SafeAreaPadding.cs
@@ -63,4 +63,55 @@ internal static class SafeAreaInsetsExtensions
 			ApplyTolerance(insets.Bottom)
 		);
 	}
+
+	/// <summary>
+	/// Returns which edges (0=Left, 1=Top, 2=Right, 3=Bottom) are already handled by a parent
+	/// <see cref="MauiView"/> with a real, non-zero resolved inset, performing a single ancestor
+	/// walk only when <paramref name="blockedEdgesCacheValid"/> is false. Shared by
+	/// <see cref="MauiView"/> and <see cref="MauiScrollView"/> so both get identical per-edge
+	/// (rather than all-or-nothing) parent-blocking behavior — a parent that only handles Top
+	/// must not also suppress a descendant's independent Bottom inset, and vice versa (#34563).
+	///
+	/// The result is written into the caller-owned <paramref name="blockedEdges"/> array and
+	/// reused across layout passes via <paramref name="blockedEdgesCacheValid"/> until the
+	/// caller invalidates it (e.g. on SafeAreaInsetsDidChange/InvalidateSafeArea/MovedToWindow),
+	/// so this walk only runs once per invalidation cycle instead of on every layout pass.
+	/// </summary>
+	/// <param name="startingView">The view whose ancestors should be walked.</param>
+	/// <param name="blockedEdges">A caller-owned, length-4 array to populate in place.</param>
+	/// <param name="blockedEdgesCacheValid">
+	/// Whether <paramref name="blockedEdges"/> already holds a valid result. Set to true before
+	/// returning.
+	/// </param>
+	internal static bool[] ResolveParentBlockedEdges(this UIView startingView, bool[] blockedEdges, ref bool blockedEdgesCacheValid)
+	{
+		if (blockedEdgesCacheValid)
+			return blockedEdges;
+
+		Array.Clear(blockedEdges, 0, blockedEdges.Length);
+		int resolvedCount = 0;
+
+		startingView.FindParent(x =>
+		{
+			if (x is not MauiView mv || !mv.RespondsToSafeArea())
+				return false;
+
+			for (int edge = 0; edge < 4; edge++)
+			{
+				if (!blockedEdges[edge] &&
+					mv.GetSafeAreaRegionForEdge(edge) != SafeAreaRegions.None &&
+					mv.GetSafeAreaComponentForEdge(edge) != 0)
+				{
+					blockedEdges[edge] = true;
+					resolvedCount++;
+				}
+			}
+
+			// Stop walking once all 4 edges are resolved
+			return resolvedCount == 4;
+		});
+
+		blockedEdgesCacheValid = true;
+		return blockedEdges;
+	}
 }


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause

The issue occurs because of a scoping limitation in the logic that determines whether a parent view is already handling safe area adjustments on iOS. Rather than evaluating each edge independently, this logic returned a single combined result indicating whether any edge overlapped between a child view and an ancestor that is already applying safe area adjustments, and that single result then governed whether the child applied safe area insets across all of its edges at once.

As a result, when a page configures its top edge to ignore the safe area while its bottom edge respects it, and a child view within that page independently opts into respecting the safe area on all edges, a genuine overlap on the bottom edge incorrectly suppressed the child's handling of the top edge as well, even though the top edge never actually overlapped with the parent. This behavior only becomes noticeable when a page's safe area configuration differs from edge to edge.

### Description of Change

The fix replaces the single, combined overlap check ( IsParentHandlingSafeArea ) with an independent, per-edge evaluation ( ResolveParentBlockedEdges ), so that each of the four edges (Left, Top, Right, Bottom) is assessed separately against the ancestor hierarchy rather than sharing one overall outcome. With this change, an edge is only excluded from safe area handling when that specific edge is confirmed to already be handled by a parent, allowing all other, non-overlapping edges to continue applying their configured safe area insets as intended.

An edge is only considered "already handled by a parent" when the ancestor both declares an intent to handle that edge ( GetSafeAreaRegionForEdge(edge) != SafeAreaRegions.None ) and has a real, non-zero resolved inset for it ( GetSafeAreaComponentForEdge(edge) != 0 ) — not merely a declared intent alone. This additional check matters because most layout containers (e.g.  Grid ,  StackLayout ) declare an intent to handle every edge by default, even when they sit away from any physical screen edge and therefore have no actual inset to apply there. Without this check, such a container could incorrectly be treated as "handling" an edge it has no real inset for, wrongly suppressing a descendant several levels down that does need to apply its own inset on that edge.

This approach preserves the original goal of preventing duplicate padding when a parent and child genuinely share the same edge, while correctly resolving the case where a child needs to handle a different edge independently. To keep the per-edge ancestor walk from running on every layout pass, the resolved per-edge result is cached ( _blockedEdgesCache  /  _blockedEdgesCacheValid ) in both  MauiView  and  MauiScrollView , and invalidated on the same events that previously invalidated the old whole-view cache ( SafeAreaInsetsDidChange ,  InvalidateSafeArea ,  MovedToWindow ), so correctness is preserved without paying the cost of a full ancestor walk on every layout. 

The shared walk logic lives in a single extension method ( SafeAreaInsetsExtensions.ResolveParentBlockedEdges ) so  MauiView  and  MauiScrollView  get identical per-edge behavior, keeping the change minimal and contained to a single, well-defined area of the codebase.

### Regression PR

PR https://github.com/dotnet/maui/pull/34024

Tested the behavior in the following platforms.
 
- [x] iOS
- [x] Android
- [ ] Mac
- [ ] Windows

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/34563

### Output

|Before Fix|After Fix|
|--|--|
<video src="https://github.com/user-attachments/assets/c61be97b-88c1-4269-9b56-00e62e8a62e4"> |<video src="https://github.com/user-attachments/assets/91b47aba-1e67-4215-a666-4094b72efb56">|