### PR TITLE
Make the PR-finalize symlink tests self-sufficient and drop a localized assertion

### DIFF
--- a/.github/scripts/Apply-PRFinalize.Tests.ps1
+++ b/.github/scripts/Apply-PRFinalize.Tests.ps1
@@ -371,7 +371,14 @@ Describe 'New-ExclusiveTempFile' {
             $n = "forced$($script:ForcedIndex)"; $script:ForcedIndex++; $n
         }
         try {
-            # It must have skipped the planted path entirely...
+            # Proves the helper actually *reached* the planted path and moved past it.
+            # Without this, an implementation that ignores the seam and picks its own random
+            # name also passes — the planted symlink would never have been in its way, so the
+            # skip logic goes unexercised and the test leans on the exhaustion test to catch
+            # seam-ignoring. Asserting the generator advanced makes this test self-sufficient.
+            $script:ForcedIndex | Should -BeGreaterThan 1
+            $path | Should -Be (Join-Path $script:SandboxDir 'pr-finalize-body-123-forced1.md')
+
             $path | Should -Not -Be $planted
             'REPLACEMENT BODY' | Set-Content -LiteralPath $path -Encoding UTF8
             # ...so the symlink target is untouched, and the link is still a link.
@@ -394,6 +401,10 @@ Describe 'New-ExclusiveTempFile' {
             $n = "dangle$($script:DangleIndex)"; $script:DangleIndex++; $n
         }
         try {
+            # As above: pins that the planted path was tried and skipped, not bypassed.
+            $script:DangleIndex | Should -BeGreaterThan 1
+            $path | Should -Be (Join-Path $script:SandboxDir 'pr-finalize-body-123-dangle1.md')
+
             $path | Should -Not -Be $planted
             'REPLACEMENT BODY' | Set-Content -LiteralPath $path -Encoding UTF8
             # Writing through a dangling link would have created the target.
@@ -452,8 +463,18 @@ Describe 'New-ExclusiveTempFile' {
         $env:AGENT_TEMPDIRECTORY = $script:SandboxDir
         try {
             $script:Calls = 0
-            { New-ExclusiveTempFile -Prefix 'missing-dir/nope/body' -NameGenerator { $script:Calls++; 'x' } } |
-                Should -Throw -ExpectedMessage '*Could not find a part of the path*'
+            # Assert on the exception *type*, not the message: .NET message strings are
+            # localized, so matching "Could not find a part of the path" would fail on a
+            # non-en-US agent. The type is culture-invariant.
+            $thrown = $null
+            try {
+                New-ExclusiveTempFile -Prefix 'missing-dir/nope/body' -NameGenerator { $script:Calls++; 'x' }
+            } catch {
+                $thrown = $_.Exception
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown | Should -BeOfType ([System.IO.DirectoryNotFoundException])
             $script:Calls | Should -Be 1
         } finally {
             $env:AGENT_TEMPDIRECTORY = $saved

--- a/.github/scripts/Apply-PRFinalize.Tests.ps1
+++ b/.github/scripts/Apply-PRFinalize.Tests.ps1
@@ -323,6 +323,7 @@ Describe 'New-ExclusiveTempFile' {
     BeforeAll {
         $script:SandboxDir = Join-Path ([System.IO.Path]::GetTempPath()) "apply-prfinalize-tests-$([System.IO.Path]::GetRandomFileName())"
         New-Item -ItemType Directory -Path $script:SandboxDir -Force | Out-Null
+        $script:RealNewItem = Get-Command New-Item -CommandType Cmdlet
         $script:OriginalAgentTemp = $env:AGENT_TEMPDIRECTORY
         $env:AGENT_TEMPDIRECTORY = $script:SandboxDir
     }
@@ -367,15 +368,21 @@ Describe 'New-ExclusiveTempFile' {
         # $script: scope is required — a plain $i++ inside the scriptblock would mutate a
         # local copy, so every attempt would re-request the planted name.
         $script:ForcedIndex = 0
+        $script:AttemptedPaths = @()
+        Mock New-Item {
+            $script:AttemptedPaths += $Path
+            & $script:RealNewItem -ItemType $ItemType -Path $Path -ErrorAction Stop
+        } -ParameterFilter { $ItemType -eq 'File' }
+
         $path = New-ExclusiveTempFile -Prefix 'pr-finalize-body-123' -NameGenerator {
             $n = "forced$($script:ForcedIndex)"; $script:ForcedIndex++; $n
         }
         try {
-            # Proves the helper actually *reached* the planted path and moved past it.
-            # Without this, an implementation that ignores the seam and picks its own random
-            # name also passes — the planted symlink would never have been in its way, so the
-            # skip logic goes unexercised and the test leans on the exhaustion test to catch
-            # seam-ignoring. Asserting the generator advanced makes this test self-sufficient.
+            # The spy proves New-Item actually attempted the planted path before moving on.
+            # Generator consumption alone is insufficient: an implementation could generate
+            # forced0, skip it without calling New-Item, then successfully create forced1.
+            $script:AttemptedPaths[0] | Should -Be $planted
+            $script:AttemptedPaths[1] | Should -Be (Join-Path $script:SandboxDir 'pr-finalize-body-123-forced1.md')
             $script:ForcedIndex | Should -BeGreaterThan 1
             $path | Should -Be (Join-Path $script:SandboxDir 'pr-finalize-body-123-forced1.md')
 
@@ -397,11 +404,19 @@ Describe 'New-ExclusiveTempFile' {
         New-Item -ItemType SymbolicLink -Path $planted -Target $missingTarget | Out-Null
 
         $script:DangleIndex = 0
+        $script:AttemptedPaths = @()
+        Mock New-Item {
+            $script:AttemptedPaths += $Path
+            & $script:RealNewItem -ItemType $ItemType -Path $Path -ErrorAction Stop
+        } -ParameterFilter { $ItemType -eq 'File' }
+
         $path = New-ExclusiveTempFile -Prefix 'pr-finalize-body-123' -NameGenerator {
             $n = "dangle$($script:DangleIndex)"; $script:DangleIndex++; $n
         }
         try {
-            # As above: pins that the planted path was tried and skipped, not bypassed.
+            # As above: pins that the planted path was attempted and skipped, not bypassed.
+            $script:AttemptedPaths[0] | Should -Be $planted
+            $script:AttemptedPaths[1] | Should -Be (Join-Path $script:SandboxDir 'pr-finalize-body-123-dangle1.md')
             $script:DangleIndex | Should -BeGreaterThan 1
             $path | Should -Be (Join-Path $script:SandboxDir 'pr-finalize-body-123-dangle1.md')
 

--- a/.github/scripts/apply-pr-finalize.ps1
+++ b/.github/scripts/apply-pr-finalize.ps1
@@ -296,6 +296,10 @@ function New-ExclusiveTempFile {
     for ($attempt = 0; $attempt -lt $MaxAttempts; $attempt++) {
         $candidate = Join-Path $baseDir "$Prefix-$(& $NameGenerator).md"
         try {
+            # -Path, not -LiteralPath: New-Item has no -LiteralPath parameter (binding it
+            # throws ParameterBindingException), and -Path does not glob when *creating* —
+            # it takes the path literally, so it will not resolve onto an existing file.
+            # Reviewers have suggested -LiteralPath here twice; it is not applicable.
             $file = New-Item -ItemType File -Path $candidate -ErrorAction Stop
             return $file.FullName
         } catch [System.IO.DirectoryNotFoundException] {

--- a/.github/scripts/apply-pr-finalize.ps1
+++ b/.github/scripts/apply-pr-finalize.ps1
@@ -297,9 +297,11 @@ function New-ExclusiveTempFile {
         $candidate = Join-Path $baseDir "$Prefix-$(& $NameGenerator).md"
         try {
             # -Path, not -LiteralPath: New-Item has no -LiteralPath parameter (binding it
-            # throws ParameterBindingException), and -Path does not glob when *creating* —
-            # it takes the path literally, so it will not resolve onto an existing file.
-            # Reviewers have suggested -LiteralPath here twice; it is not applicable.
+            # throws ParameterBindingException). For this invocation, a complete leaf path
+            # without -Name is treated literally, so it cannot resolve onto an existing file.
+            # New-Item can expand wildcards when -Path is combined with -Name; do not infer
+            # a general no-globbing guarantee from this call. Reviewers have suggested
+            # -LiteralPath here twice, but it is not applicable.
             $file = New-Item -ItemType File -Path $candidate -ErrorAction Stop
             return $file.FullName
         } catch [System.IO.DirectoryNotFoundException] {


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Follow-up to #36919. This PR closes the remaining test-contract gaps around `New-ExclusiveTempFile`; production behavior is unchanged.

#### Prove `New-Item` actually attempts the planted symlink

The first version asserted that the deterministic name generator advanced from `forced0` to `forced1`. @kubaflo correctly demonstrated that this did not prove `New-Item` saw `forced0`: a mutant could consume that name, skip before `New-Item`, and create `forced1`. Both symlink tests still passed and relied on a separate test as a backstop.

The tests now install a call-through Pester `Mock New-Item`. It records each attempted `-Path` while invoking the real cmdlet, preserving the filesystem behavior under test. Each symlink test asserts:

1. The planted link is the first path passed to `New-Item`.
2. The next deterministic candidate is attempted second.
3. The planted target remains untouched (or remains missing for a dangling link).
4. The returned file is the second candidate.

The exact reported mutant now fails both symlink tests directly:

```powershell
$candidate = Join-Path $baseDir "$Prefix-$(& $NameGenerator).md"
if ($attempt -eq 0) { continue } # consume forced0 without calling New-Item
```

Result: **37 passed, 3 failed**, including both symlink tests. The real implementation remains **40/40**.

#### Assert a culture-invariant exception contract

The missing-directory test previously matched the localized text `Could not find a part of the path`. It now captures the exception and asserts `System.IO.DirectoryNotFoundException`, which is both culture-invariant and more precise about the contract being tested.

#### Document the actual `New-Item -Path` invariant

`New-Item` has no `-LiteralPath` parameter, so replacing `-Path` would throw `ParameterBindingException`. For this invocation, the helper supplies a complete leaf path and does not pass `-Name`; that path is treated literally and cannot glob onto an existing file.

A three-reviewer adversarial pass found 2/3 consensus that the original comment stated this too broadly: `New-Item -Path ... -Name ...` can expand wildcards across matching directories. The comment now scopes the guarantee to this exact invocation and explicitly warns not to infer a general no-globbing guarantee.

### Issues Fixed

Follow-up to #36919; no separate issue.

### Testing

- `Apply-PRFinalize.Tests.ps1`: **40/40**
- `Apply-PRFinalize.Tests.ps1`, `Review-PR.Tests.ps1`, and `Post-AISummaryComment.Tests.ps1`: **102/102**
- Both modified PowerShell scripts parse cleanly.
- The skip-first mutant fails both symlink tests directly.

`maui-pr` is path-filtered for script-only changes, so the Pester suites are the meaningful validation for this PR.