### PR TITLE
[release/11.0.1xx-preview7] Fix Label UI test page recreation

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/FeatureMatrix/Label/LabelControlPage.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/FeatureMatrix/Label/LabelControlPage.xaml.cs
@@ -17,6 +17,7 @@ public class LabelControlPage : NavigationPage
 public partial class LabelControlMainPage : ContentPage
 {
 	private LabelViewModel _viewModel;
+	private bool _recreating;
 
 	public LabelControlMainPage(LabelViewModel viewModel)
 	{
@@ -33,6 +34,12 @@ public partial class LabelControlMainPage : ContentPage
 
 	async void MainLabel_Tapped(object sender, TappedEventArgs e)
 	{
+		// Guard against re-entrancy: repeated taps before PopAsync completes would otherwise
+		// insert multiple pages and pop the wrong one. Recreation runs at most once per instance.
+		if (_recreating)
+			return;
+		_recreating = true;
+
 		// Recreate the page to verify initial mappers
 		// Clear BindingContext first so old Label properly detaches the FormattedString
 		// (triggers propertyChanging which unsubscribes events and calls RemoveSpans)

--- a/src/Controls/tests/TestCases.HostApp/FeatureMatrix/Label/LabelControlPage.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/FeatureMatrix/Label/LabelControlPage.xaml.cs
@@ -31,15 +31,13 @@ public partial class LabelControlMainPage : ContentPage
 		await Navigation.PushAsync(new LabelOptionsPage(_viewModel));
 	}
 
-	void MainLabel_Tapped(object sender, TappedEventArgs e)
+	async void MainLabel_Tapped(object sender, TappedEventArgs e)
 	{
 		// Recreate the page to verify initial mappers
 		// Clear BindingContext first so old Label properly detaches the FormattedString
 		// (triggers propertyChanging which unsubscribes events and calls RemoveSpans)
-		ToolbarItems.Clear();
 		BindingContext = null;
-		Content = new ContentView();
-		InitializeComponent();
-		BindingContext = _viewModel;
+		Navigation.InsertPageBefore(new LabelControlMainPage(_viewModel), this);
+		await Navigation.PopAsync(false);
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

The Label feature-matrix tests verify both subsequent property updates and initial mapper application by tapping the label and taking a second screenshot. The tap handler was re-running `InitializeComponent()` on the existing `ContentPage`, which left the Windows page layout shifted. The first screenshot passed, while the second screenshot failed and caused 17 cascading Label visual failures.

Recreate the `LabelControlMainPage` through the navigation stack instead. Clearing the old binding context still detaches the existing `FormattedString`, while the replacement page gets a clean name scope, toolbar, content tree, and handler lifecycle.

### CI Evidence

In [maui-pr-uitests build 1537359](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1537359), `VerifyLabelWithTextAndFontColor` passed its first screenshot and failed the second screenshot after `MainLabel_Tapped` (`LabelFeatureTests.cs:590`). The resulting vertical layout shift then affected the remaining Label visual tests.

### Testing

The existing Label feature-matrix UI tests cover this path by comparing screenshots before and after page recreation.