### PR TITLE
[release/11.0.1xx-preview7] Allow UI tests to apply resolution after test failure

### DIFF
--- a/.github/scripts/Set-ScreenResolution.Tests.ps1
+++ b/.github/scripts/Set-ScreenResolution.Tests.ps1
@@ -1,0 +1,76 @@
+#!/usr/bin/env pwsh
+#Requires -Modules Pester
+
+BeforeAll {
+    $screenResolutionScript = Join-Path $PSScriptRoot '../../eng/scripts/Set-ScreenResolution.ps1'
+    $tokens = $null
+    $parseErrors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+        $screenResolutionScript,
+        [ref]$tokens,
+        [ref]$parseErrors)
+
+    if ($parseErrors.Count -gt 0) {
+        throw "Set-ScreenResolution.ps1 has parse errors: $($parseErrors -join '; ')"
+    }
+
+    $functionDefinitions = $ast.FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.FunctionDefinitionAst]
+    }, $true)
+
+    foreach ($functionName in @(
+        'Get-ScreenResolutionProbeAction',
+        'Test-ScreenResolutionApplySucceeded'
+    )) {
+        $definition = $functionDefinitions |
+            Where-Object Name -EQ $functionName |
+            Select-Object -First 1
+
+        if ($null -eq $definition) {
+            throw "Function '$functionName' was not found in Set-ScreenResolution.ps1"
+        }
+
+        Invoke-Expression $definition.Extent.Text
+    }
+
+    $setResolutionDefinition = $functionDefinitions |
+        Where-Object Name -EQ 'Set-ScreenResolution' |
+        Select-Object -First 1
+
+    if ($null -eq $setResolutionDefinition) {
+        throw "Function 'Set-ScreenResolution' was not found in Set-ScreenResolution.ps1"
+    }
+
+    $setResolutionBody = $setResolutionDefinition.Extent.Text
+}
+
+Describe 'Set-ScreenResolution native result decisions' {
+    It 'returns <Expected> for CDS_TEST result <Result>' -ForEach @(
+        @{ Result = 0; Expected = 'Apply' }
+        @{ Result = -1; Expected = 'Apply' }
+        @{ Result = -2; Expected = 'Reject' }
+        @{ Result = -3; Expected = 'Apply' }
+        @{ Result = -4; Expected = 'Apply' }
+        @{ Result = -5; Expected = 'Apply' }
+    ) {
+        Get-ScreenResolutionProbeAction -Result $Result | Should -Be $Expected
+    }
+
+    It 'returns <Expected> for real apply result <Result>' -ForEach @(
+        @{ Result = 0; Expected = $true }
+        @{ Result = 1; Expected = $true }
+        @{ Result = -1; Expected = $false }
+        @{ Result = -2; Expected = $false }
+        @{ Result = -3; Expected = $false }
+        @{ Result = -4; Expected = $false }
+        @{ Result = -5; Expected = $false }
+    ) {
+        Test-ScreenResolutionApplySucceeded -Result $Result | Should -Be $Expected
+    }
+
+    It 'uses the pure decisions in the native flow' {
+        $setResolutionBody | Should -Match 'Get-ScreenResolutionProbeAction\s+-Result\s+\$testResult'
+        $setResolutionBody | Should -Match 'Test-ScreenResolutionApplySucceeded\s+-Result\s+\$changeResult'
+    }
+}

--- a/eng/scripts/Set-ScreenResolution.ps1
+++ b/eng/scripts/Set-ScreenResolution.ps1
@@ -37,6 +37,26 @@ param (
 Set-StrictMode -Version 2.0
 $ErrorActionPreference = "Stop"
 
+function Get-ScreenResolutionProbeAction {
+    param (
+        [int]$Result
+    )
+
+    if ($Result -eq -2) {
+        return "Reject"
+    }
+
+    return "Apply"
+}
+
+function Test-ScreenResolutionApplySucceeded {
+    param (
+        [int]$Result
+    )
+
+    return ($Result -eq 0 -or $Result -eq 1)
+}
+
 function Set-ScreenResolution {
     param (
         [int]$Width,
@@ -167,33 +187,35 @@ namespace DisplaySettings
         
         if ($testResult -ne [DisplaySettings.NativeMethods]::DISP_CHANGE_SUCCESSFUL) {
             Write-Warning "Resolution test returned code: $testResult"
-            
-            switch ($testResult) {
-                ([DisplaySettings.NativeMethods]::DISP_CHANGE_BADMODE) {
-                    Write-Error "The resolution ${Width}x${Height} is not supported by this display (BADMODE)"
-                    return $false
-                }
-                ([DisplaySettings.NativeMethods]::DISP_CHANGE_FAILED) {
-                    Write-Warning "CDS_TEST returned DISP_CHANGE_FAILED ($testResult) for target ${Width}x${Height}; attempting to apply the resolution anyway..."
-                }
-                default {
-                    Write-Warning "Unexpected test result, attempting to apply anyway..."
-                }
+
+            if ((Get-ScreenResolutionProbeAction -Result $testResult) -eq "Reject") {
+                Write-Error "The resolution ${Width}x${Height} is not supported by this display (BADMODE)"
+                return $false
+            }
+
+            if ($testResult -eq [DisplaySettings.NativeMethods]::DISP_CHANGE_FAILED) {
+                Write-Warning "CDS_TEST returned DISP_CHANGE_FAILED ($testResult) for target ${Width}x${Height}; attempting to apply the resolution anyway..."
+            }
+            else {
+                Write-Warning "Unexpected test result, attempting to apply anyway..."
             }
         }
         
         # Apply the resolution change
         $changeResult = [DisplaySettings.NativeMethods]::ChangeDisplaySettings([ref]$devMode, [DisplaySettings.NativeMethods]::CDS_UPDATEREGISTRY)
-        
-        switch ($changeResult) {
-            ([DisplaySettings.NativeMethods]::DISP_CHANGE_SUCCESSFUL) {
-                Write-Host "Successfully set screen resolution to ${Width}x${Height}"
-                return $true
-            }
-            ([DisplaySettings.NativeMethods]::DISP_CHANGE_RESTART) {
+
+        if (Test-ScreenResolutionApplySucceeded -Result $changeResult) {
+            if ($changeResult -eq [DisplaySettings.NativeMethods]::DISP_CHANGE_RESTART) {
                 Write-Host "Screen resolution set to ${Width}x${Height}. A restart may be required for some applications."
-                return $true
             }
+            else {
+                Write-Host "Successfully set screen resolution to ${Width}x${Height}"
+            }
+
+            return $true
+        }
+
+        switch ($changeResult) {
             ([DisplaySettings.NativeMethods]::DISP_CHANGE_BADMODE) {
                 Write-Error "The resolution ${Width}x${Height} is not supported by this display"
                 return $false

--- a/eng/scripts/Set-ScreenResolution.ps1
+++ b/eng/scripts/Set-ScreenResolution.ps1
@@ -174,7 +174,7 @@ namespace DisplaySettings
                     return $false
                 }
                 ([DisplaySettings.NativeMethods]::DISP_CHANGE_FAILED) {
-                    Write-Warning "The resolution change test failed (FAILED). Attempting to apply the resolution anyway..."
+                    Write-Warning "CDS_TEST returned DISP_CHANGE_FAILED ($testResult) for target ${Width}x${Height}; attempting to apply the resolution anyway..."
                 }
                 default {
                     Write-Warning "Unexpected test result, attempting to apply anyway..."

--- a/eng/scripts/Set-ScreenResolution.ps1
+++ b/eng/scripts/Set-ScreenResolution.ps1
@@ -174,8 +174,7 @@ namespace DisplaySettings
                     return $false
                 }
                 ([DisplaySettings.NativeMethods]::DISP_CHANGE_FAILED) {
-                    Write-Error "The resolution change test failed (FAILED)"
-                    return $false
+                    Write-Warning "The resolution change test failed (FAILED). Attempting to apply the resolution anyway..."
                 }
                 default {
                     Write-Warning "Unexpected test result, attempting to apply anyway..."


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

The Windows UI-test resolution helper is designed to fall back to applying 1920x1080 when display enumeration or the non-mutating `CDS_TEST` probe is unreliable on a hosted agent. However, the generic `DISP_CHANGE_FAILED` probe result was treated as a hard error, so the script exited before attempting the actual resolution change.

Treat that generic probe result as a warning and continue to the real `ChangeDisplaySettings` call. Unsupported modes (`DISP_CHANGE_BADMODE`) still fail immediately, and a failed actual resolution change still fails the script. The native probe/apply result decisions are now isolated in pure helpers so those transitions can be tested without invoking Windows P/Invoke APIs.

### CI Evidence

In [maui-pr-uitests build 1535264](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1535264), a Windows leg could not enumerate the current display and the `CDS_TEST` probe returned `DISP_CHANGE_FAILED`. The build stopped in `Set screen resolution` before any tests ran, even though the helper logged that it would attempt the fallback.

### Testing

- Validated the updated PowerShell script with the PowerShell AST parser.
- Added 14 focused Pester 5.9 tests covering `CDS_TEST` decisions (`FAILED` continues, `BADMODE` rejects), successful/restart apply results, and nonzero real-apply failures.
- Ran the complete `.github/scripts` Pester 5.9 suite: 1,513 passed, 0 failed.

### Issues Fixed

N/A