### PR TITLE
[release/11.0.1xx-preview7] De-flake DragEvents UI test assertions

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/DragAndDropUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/DragAndDropUITests.cs
@@ -44,8 +44,9 @@ namespace Microsoft.Maui.TestCases.Tests
 			// Wait for the label's text to become EXACTLY the expected value. A substring wait is
 			// unreliable here because each label's placeholder (e.g. "DragOverEvents: ") already
 			// contains the expected event name (e.g. "DragOver"), so a Contains-based wait would pass
-			// immediately on the placeholder. The wait already asserts the exact text, so no separate
-			// GetText re-read is needed (it would only re-open a window for transient Appium flakiness).
+			// immediately on the placeholder. WaitForTextEqualToElement polls until the text matches
+			// exactly, so the Assert below fails only on a genuine timeout; no separate GetText re-read
+			// is needed (it would only re-open a window for transient Appium flakiness).
 			Assert.That(
 				App.WaitForTextEqualToElement(automationId, expectedText),
 				Is.True,
@@ -67,7 +68,7 @@ namespace Microsoft.Maui.TestCases.Tests
 			App.WaitForElement("Green");
 			App.DragAndDrop("Red", "Green");
 
-			App.WaitForElement("DragStartEventsLabel");
+			App.WaitForTextEqualToElement("DragStartEventsLabel", "DragStarting");
 			var textAfterDragStart = App.FindElement("DragStartEventsLabel").GetText();
 
 			if (string.IsNullOrEmpty(textAfterDragStart))
@@ -79,7 +80,7 @@ namespace Microsoft.Maui.TestCases.Tests
 				Assert.That(textAfterDragStart, Is.EqualTo("DragStarting"));
 			}
 
-			App.WaitForElement("DragOverEventsLabel");
+			App.WaitForTextEqualToElement("DragOverEventsLabel", "DragOver");
 			var textAfterDragOver = App.FindElement("DragOverEventsLabel").GetText();
 			if (string.IsNullOrEmpty(textAfterDragOver))
 			{
@@ -90,7 +91,7 @@ namespace Microsoft.Maui.TestCases.Tests
 				Assert.That(textAfterDragOver, Is.EqualTo("DragOver"));
 			}
 
-			App.WaitForElement("DragCompletedEventsLabel");
+			App.WaitForTextEqualToElement("DragCompletedEventsLabel", "DropCompleted");
 			var textAfterDragComplete = App.FindElement("DragCompletedEventsLabel").GetText();
 			if (string.IsNullOrEmpty(textAfterDragComplete))
 			{
@@ -112,7 +113,7 @@ namespace Microsoft.Maui.TestCases.Tests
 				Assert.That(rainbowColorText, Is.EqualTo("RainbowColorsAdd:Red"));
 			}
 
-			App.WaitForElement("DropEventsLabel");
+			App.WaitForTextEqualToElement("DropEventsLabel", "Drop");
 			var textAfterDrop = App.FindElement("DropEventsLabel").GetText();
 			if (string.IsNullOrEmpty(textAfterDrop))
 			{

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/DragAndDropUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/DragAndDropUITests.cs
@@ -33,50 +33,19 @@ namespace Microsoft.Maui.TestCases.Tests
 			App.WaitForElement("LabelDragElement");
 			App.DragAndDrop("LabelDragElement", "DragTarget");
 
-			App.WaitForElement("DragStartEventsLabel");
-			var textAfterDragStart = App.FindElement("DragStartEventsLabel").GetText();
+			AssertEventText("DragStartEventsLabel", "DragStarting");
+			AssertEventText("DragOverEventsLabel", "DragOver");
+			AssertEventText("DragCompletedEventsLabel", "DropCompleted");
+			AssertEventText("DropEventsLabel", "Drop");
+		}
 
-			if (string.IsNullOrEmpty(textAfterDragStart))
-			{
-				Assert.Fail("Text was expected: Drag start event");
-			}
-			else
-			{
-				Assert.That(textAfterDragStart, Is.EqualTo("DragStarting"));
-			}
-
-			App.WaitForElement("DragOverEventsLabel");
-			var textAfterDragOver = App.FindElement("DragOverEventsLabel").GetText();
-			if (string.IsNullOrEmpty(textAfterDragOver))
-			{
-				Assert.Fail("Text was expected: Drag over event");
-			}
-			else
-			{
-				Assert.That(textAfterDragOver, Is.EqualTo("DragOver"));
-			}
-
-			App.WaitForElement("DragCompletedEventsLabel");
-			var textAfterDragComplete = App.FindElement("DragCompletedEventsLabel").GetText();
-			if (string.IsNullOrEmpty(textAfterDragComplete))
-			{
-				Assert.Fail("Text was expected: Drag complete event");
-			}
-			else
-			{
-				Assert.That(textAfterDragComplete, Is.EqualTo("DropCompleted"));
-			}
-
-			App.WaitForElement("DropEventsLabel");
-			var textAfterDrop = App.FindElement("DropEventsLabel").GetText();
-			if (string.IsNullOrEmpty(textAfterDrop))
-			{
-				Assert.Fail("Text was expected: Drop event");
-			}
-			else
-			{
-				Assert.That(textAfterDrop, Is.EqualTo("Drop"));
-			}
+		void AssertEventText(string automationId, string expectedText)
+		{
+			Assert.That(
+				App.WaitForTextToBePresentInElement(automationId, expectedText),
+				Is.True,
+				$"Timed out waiting for {automationId} to contain '{expectedText}'.");
+			Assert.That(App.FindElement(automationId).GetText(), Is.EqualTo(expectedText));
 		}
 
 		[Test]

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/DragAndDropUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/DragAndDropUITests.cs
@@ -41,10 +41,14 @@ namespace Microsoft.Maui.TestCases.Tests
 
 		void AssertEventText(string automationId, string expectedText)
 		{
+			// Wait for the label's text to become EXACTLY the expected value. A substring wait is
+			// unreliable here because each label's placeholder (e.g. "DragOverEvents: ") already
+			// contains the expected event name (e.g. "DragOver"), so a Contains-based wait would pass
+			// immediately on the placeholder and the following equality assertion would still flap.
 			Assert.That(
-				App.WaitForTextToBePresentInElement(automationId, expectedText),
+				App.WaitForTextEqualToElement(automationId, expectedText),
 				Is.True,
-				$"Timed out waiting for {automationId} to contain '{expectedText}'.");
+				$"Timed out waiting for {automationId} to become '{expectedText}'.");
 			Assert.That(App.FindElement(automationId).GetText(), Is.EqualTo(expectedText));
 		}
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/DragAndDropUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/DragAndDropUITests.cs
@@ -44,12 +44,12 @@ namespace Microsoft.Maui.TestCases.Tests
 			// Wait for the label's text to become EXACTLY the expected value. A substring wait is
 			// unreliable here because each label's placeholder (e.g. "DragOverEvents: ") already
 			// contains the expected event name (e.g. "DragOver"), so a Contains-based wait would pass
-			// immediately on the placeholder and the following equality assertion would still flap.
+			// immediately on the placeholder. The wait already asserts the exact text, so no separate
+			// GetText re-read is needed (it would only re-open a window for transient Appium flakiness).
 			Assert.That(
 				App.WaitForTextEqualToElement(automationId, expectedText),
 				Is.True,
 				$"Timed out waiting for {automationId} to become '{expectedText}'.");
-			Assert.That(App.FindElement(automationId).GetText(), Is.EqualTo(expectedText));
 		}
 
 		[Test]

--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -1054,32 +1054,7 @@ namespace UITest.Appium
 		}
 
 		public static bool WaitForTextToBePresentInElement(this IApp app, string automationId, string text, TimeSpan? timeout = null)
-		{
-			timeout ??= DefaultTimeout;
-			TimeSpan retryFrequency = TimeSpan.FromMilliseconds(500);
-
-			DateTime start = DateTime.Now;
-
-			while (true)
-			{
-				var element = app.FindElements(automationId).FirstOrDefault();
-
-				if (element is not null && element.TryGetText(out var s) && s.Contains(text, StringComparison.OrdinalIgnoreCase))
-				{
-					return true;
-				}
-
-				long elapsed = DateTime.Now.Subtract(start).Ticks;
-				if (elapsed >= timeout.Value.Ticks)
-				{
-					Debug.WriteLine($">>>>> {elapsed} ticks elapsed, timeout value is {timeout.Value.Ticks}");
-
-					return false;
-				}
-
-				Task.Delay(retryFrequency.Milliseconds).Wait();
-			}
-		}
+			=> app.WaitForText(automationId, text, s => s.Contains(text, StringComparison.OrdinalIgnoreCase), timeout);
 
 		/// <summary>
 		/// Waits until the element's text is exactly equal to <paramref name="text"/> (ordinal), rather
@@ -1088,25 +1063,40 @@ namespace UITest.Appium
 		/// prematurely on the placeholder.
 		/// </summary>
 		public static bool WaitForTextEqualToElement(this IApp app, string automationId, string text, TimeSpan? timeout = null)
+			=> app.WaitForText(automationId, text, s => string.Equals(s, text, StringComparison.Ordinal), timeout);
+
+		/// <summary>
+		/// Shared polling loop for the text-wait helpers. Repeatedly reads the element's text and
+		/// returns <see langword="true"/> as soon as <paramref name="matches"/> is satisfied. On
+		/// timeout it logs the last observed text (and the expected value) so a stalled or
+		/// placeholder-stuck label is distinguishable from a text-read failure, then returns
+		/// <see langword="false"/>.
+		/// </summary>
+		static bool WaitForText(this IApp app, string automationId, string expected, Func<string, bool> matches, TimeSpan? timeout)
 		{
 			timeout ??= DefaultTimeout;
 			TimeSpan retryFrequency = TimeSpan.FromMilliseconds(500);
 
 			DateTime start = DateTime.Now;
+			string? lastObservedText = null;
 
 			while (true)
 			{
 				var element = app.FindElements(automationId).FirstOrDefault();
 
-				if (element is not null && element.TryGetText(out var s) && string.Equals(s, text, StringComparison.Ordinal))
+				if (element is not null && element.TryGetText(out var s))
 				{
-					return true;
+					lastObservedText = s;
+					if (matches(s))
+					{
+						return true;
+					}
 				}
 
 				long elapsed = DateTime.Now.Subtract(start).Ticks;
 				if (elapsed >= timeout.Value.Ticks)
 				{
-					Debug.WriteLine($">>>>> {elapsed} ticks elapsed, timeout value is {timeout.Value.Ticks}");
+					Debug.WriteLine($">>>>> {elapsed} ticks elapsed, timeout value is {timeout.Value.Ticks}; last observed text for '{automationId}' was '{lastObservedText ?? "<unavailable>"}', expected '{expected}'");
 
 					return false;
 				}

--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -1082,6 +1082,40 @@ namespace UITest.Appium
 		}
 
 		/// <summary>
+		/// Waits until the element's text is exactly equal to <paramref name="text"/> (ordinal), rather
+		/// than merely containing it. Use this when the element's placeholder/initial text already
+		/// contains the expected value as a substring, which would make a Contains-based wait pass
+		/// prematurely on the placeholder.
+		/// </summary>
+		public static bool WaitForTextEqualToElement(this IApp app, string automationId, string text, TimeSpan? timeout = null)
+		{
+			timeout ??= DefaultTimeout;
+			TimeSpan retryFrequency = TimeSpan.FromMilliseconds(500);
+
+			DateTime start = DateTime.Now;
+
+			while (true)
+			{
+				var element = app.FindElements(automationId).FirstOrDefault();
+
+				if (element is not null && element.TryGetText(out var s) && string.Equals(s, text, StringComparison.Ordinal))
+				{
+					return true;
+				}
+
+				long elapsed = DateTime.Now.Subtract(start).Ticks;
+				if (elapsed >= timeout.Value.Ticks)
+				{
+					Debug.WriteLine($">>>>> {elapsed} ticks elapsed, timeout value is {timeout.Value.Ticks}");
+
+					return false;
+				}
+
+				Task.Delay(retryFrequency.Milliseconds).Wait();
+			}
+		}
+
+		/// <summary>
 		/// Repeatedly executes a query until it returns a non-empty value or the specified retry count is reached.
 		/// </summary>
 		/// <typeparam name="T">The type of the element.</typeparam>

--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -1111,7 +1111,7 @@ namespace UITest.Appium
 					return false;
 				}
 
-				Task.Delay(retryFrequency.Milliseconds).Wait();
+				Task.Delay(retryFrequency).Wait();
 			}
 		}
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

The Windows `DragEvents` UI test can read event-label text before queued drag/drop event updates are reflected in the accessibility tree. Build 1537359 observed `DragOverEvents:` instead of `DragOver`, while the retry passed.

Wait for each expected event value before asserting its exact text. This preserves coverage for all four drag/drop events without adding sleeps or broad test retries.

## Validation

- `dotnet format Microsoft.Maui.sln --no-restore --include src/Controls/tests/TestCases.Shared.Tests/Tests/DragAndDropUITests.cs --exclude Templates/src --exclude-diagnostics CA1822`
- `git diff --check`