### PR TITLE
[release/11.0.1xx-preview7] Align with blessed SDK build

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,12 +1,12 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.Sdk" Version="11.0.100-preview.7.26379.122">
+    <Dependency Name="Microsoft.NET.Sdk" Version="11.0.100-preview.7.26381.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>efef326b25491fc490152dc80eb6df02332c6e33</Sha>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-preview.7.26379.122">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-preview.7.26381.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>efef326b25491fc490152dc80eb6df02332c6e33</Sha>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Android.Sdk.Windows" Version="37.0.0-preview.7.2131">
       <Uri>https://github.com/dotnet/android</Uri>
@@ -53,109 +53,109 @@
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="11.0.0-preview.7.26379.122">
+    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="11.0.0-preview.7.26381.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>efef326b25491fc490152dc80eb6df02332c6e33</Sha>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="11.0.0-preview.7.26379.122">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="11.0.0-preview.7.26381.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>efef326b25491fc490152dc80eb6df02332c6e33</Sha>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="11.0.0-preview.7.26379.122">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="11.0.0-preview.7.26381.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>efef326b25491fc490152dc80eb6df02332c6e33</Sha>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="11.0.0-preview.7.26379.122">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="11.0.0-preview.7.26381.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>efef326b25491fc490152dc80eb6df02332c6e33</Sha>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components" Version="11.0.0-preview.7.26379.122">
+    <Dependency Name="Microsoft.AspNetCore.Components" Version="11.0.0-preview.7.26381.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>efef326b25491fc490152dc80eb6df02332c6e33</Sha>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="11.0.0-preview.7.26379.122">
+    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="11.0.0-preview.7.26381.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>efef326b25491fc490152dc80eb6df02332c6e33</Sha>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="11.0.0-preview.7.26379.122">
+    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="11.0.0-preview.7.26381.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>efef326b25491fc490152dc80eb6df02332c6e33</Sha>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="11.0.0-preview.7.26379.122">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="11.0.0-preview.7.26381.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>efef326b25491fc490152dc80eb6df02332c6e33</Sha>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="11.0.0-preview.7.26379.122">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="11.0.0-preview.7.26381.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>efef326b25491fc490152dc80eb6df02332c6e33</Sha>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="11.0.0-preview.7.26379.122">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="11.0.0-preview.7.26381.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>efef326b25491fc490152dc80eb6df02332c6e33</Sha>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="11.0.0-preview.7.26379.122">
+    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="11.0.0-preview.7.26381.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>efef326b25491fc490152dc80eb6df02332c6e33</Sha>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="11.0.0-preview.7.26379.122">
+    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="11.0.0-preview.7.26381.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>efef326b25491fc490152dc80eb6df02332c6e33</Sha>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.JSInterop" Version="11.0.0-preview.7.26379.122">
+    <Dependency Name="Microsoft.JSInterop" Version="11.0.0-preview.7.26381.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>efef326b25491fc490152dc80eb6df02332c6e33</Sha>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-preview.2.22102.8">
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>3f4da9ced34942d83054e647f3b1d9d7dde281e8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration" Version="11.0.0-preview.7.26379.122">
+    <Dependency Name="Microsoft.Extensions.Configuration" Version="11.0.0-preview.7.26381.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>efef326b25491fc490152dc80eb6df02332c6e33</Sha>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="11.0.0-preview.7.26379.122">
+    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="11.0.0-preview.7.26381.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>efef326b25491fc490152dc80eb6df02332c6e33</Sha>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="11.0.0-preview.7.26379.122">
+    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="11.0.0-preview.7.26381.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>efef326b25491fc490152dc80eb6df02332c6e33</Sha>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="11.0.0-preview.7.26379.122">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="11.0.0-preview.7.26381.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>efef326b25491fc490152dc80eb6df02332c6e33</Sha>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="11.0.0-preview.7.26379.122">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="11.0.0-preview.7.26381.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>efef326b25491fc490152dc80eb6df02332c6e33</Sha>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="11.0.0-preview.7.26379.122">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="11.0.0-preview.7.26381.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>efef326b25491fc490152dc80eb6df02332c6e33</Sha>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="11.0.0-preview.7.26379.122">
+    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="11.0.0-preview.7.26381.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>efef326b25491fc490152dc80eb6df02332c6e33</Sha>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="11.0.0-preview.7.26379.122">
+    <Dependency Name="Microsoft.Extensions.Logging" Version="11.0.0-preview.7.26381.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>efef326b25491fc490152dc80eb6df02332c6e33</Sha>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="11.0.0-preview.7.26379.122">
+    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="11.0.0-preview.7.26381.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>efef326b25491fc490152dc80eb6df02332c6e33</Sha>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="11.0.0-preview.7.26379.122">
+    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="11.0.0-preview.7.26381.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>efef326b25491fc490152dc80eb6df02332c6e33</Sha>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Primitives" Version="11.0.0-preview.7.26379.122">
+    <Dependency Name="Microsoft.Extensions.Primitives" Version="11.0.0-preview.7.26381.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>efef326b25491fc490152dc80eb6df02332c6e33</Sha>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="11.0.0-preview.7.26379.122">
+    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="11.0.0-preview.7.26381.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>efef326b25491fc490152dc80eb6df02332c6e33</Sha>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="11.0.0-prerelease.26064.3">
       <Uri>https://github.com/dotnet/xharness</Uri>
@@ -175,37 +175,37 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="11.0.0-beta.26379.122">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="11.0.0-beta.26381.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>efef326b25491fc490152dc80eb6df02332c6e33</Sha>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26379.122">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26381.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>efef326b25491fc490152dc80eb6df02332c6e33</Sha>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="11.0.0-beta.26379.122">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="11.0.0-beta.26381.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>efef326b25491fc490152dc80eb6df02332c6e33</Sha>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="11.0.0-beta.26379.122">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="11.0.0-beta.26381.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>efef326b25491fc490152dc80eb6df02332c6e33</Sha>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26379.122">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26381.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>efef326b25491fc490152dc80eb6df02332c6e33</Sha>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="11.0.0-beta.26379.122">
+    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="11.0.0-beta.26381.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>efef326b25491fc490152dc80eb6df02332c6e33</Sha>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="11.0.0-beta.26379.122">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="11.0.0-beta.26381.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>efef326b25491fc490152dc80eb6df02332c6e33</Sha>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="11.0.0-beta.26379.122">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="11.0.0-beta.26381.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>efef326b25491fc490152dc80eb6df02332c6e33</Sha>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -31,10 +31,10 @@
     <!-- Current previous .NET SDK major version's stable release of MAUI packages -->
     <MicrosoftMauiPreviousDotNetReleasedVersion>10.0.20</MicrosoftMauiPreviousDotNetReleasedVersion>
     <!-- dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>11.0.100-preview.7.26379.122</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>11.0.100-preview.7.26381.103</MicrosoftNETSdkPackageVersion>
     <MicrosoftDotnetSdkInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-preview.7.26379.122</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-preview.7.26381.103</MicrosoftNETCoreAppRefPackageVersion>
     <SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextJsonPackageVersion>
     <SystemTextEncodingsWebPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextEncodingsWebPackageVersion>
     <MicrosoftBclAsyncInterfacesPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftBclAsyncInterfacesPackageVersion>
@@ -42,18 +42,18 @@
     <optimizationandroidx64MIBCRuntimePackageVersion>1.0.0-prerelease.26317.1</optimizationandroidx64MIBCRuntimePackageVersion>
     <!-- Microsoft/Extensions -->
     <SystemCodeDomPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemCodeDomPackageVersion>
-    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.7.26379.122</MicrosoftExtensionsConfigurationVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsVersion>11.0.0-preview.7.26379.122</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationJsonVersion>11.0.0-preview.7.26379.122</MicrosoftExtensionsConfigurationJsonVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>11.0.0-preview.7.26379.122</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>11.0.0-preview.7.26379.122</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
-    <MicrosoftExtensionsFileProvidersAbstractionsVersion>11.0.0-preview.7.26379.122</MicrosoftExtensionsFileProvidersAbstractionsVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>11.0.0-preview.7.26379.122</MicrosoftExtensionsLoggingAbstractionsVersion>
-    <MicrosoftExtensionsLoggingVersion>11.0.0-preview.7.26379.122</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>11.0.0-preview.7.26379.122</MicrosoftExtensionsLoggingConsoleVersion>
-    <MicrosoftExtensionsLoggingDebugVersion>11.0.0-preview.7.26379.122</MicrosoftExtensionsLoggingDebugVersion>
-    <MicrosoftExtensionsPrimitivesVersion>11.0.0-preview.7.26379.122</MicrosoftExtensionsPrimitivesVersion>
-    <MicrosoftExtensionsHostingAbstractionsVersion>11.0.0-preview.7.26379.122</MicrosoftExtensionsHostingAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.7.26381.103</MicrosoftExtensionsConfigurationVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>11.0.0-preview.7.26381.103</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationJsonVersion>11.0.0-preview.7.26381.103</MicrosoftExtensionsConfigurationJsonVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>11.0.0-preview.7.26381.103</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>11.0.0-preview.7.26381.103</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
+    <MicrosoftExtensionsFileProvidersAbstractionsVersion>11.0.0-preview.7.26381.103</MicrosoftExtensionsFileProvidersAbstractionsVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>11.0.0-preview.7.26381.103</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingVersion>11.0.0-preview.7.26381.103</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>11.0.0-preview.7.26381.103</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingDebugVersion>11.0.0-preview.7.26381.103</MicrosoftExtensionsLoggingDebugVersion>
+    <MicrosoftExtensionsPrimitivesVersion>11.0.0-preview.7.26381.103</MicrosoftExtensionsPrimitivesVersion>
+    <MicrosoftExtensionsHostingAbstractionsVersion>11.0.0-preview.7.26381.103</MicrosoftExtensionsHostingAbstractionsVersion>
     <MicrosoftExtensionsAIVersion>10.3.0</MicrosoftExtensionsAIVersion>
     <MicrosoftExtensionsAIAbstractionsVersion>10.3.0</MicrosoftExtensionsAIAbstractionsVersion>
     <MicrosoftExtensionsHttpVersion>11.0.0-preview.2.26103.111</MicrosoftExtensionsHttpVersion>
@@ -86,19 +86,19 @@
     <MicrosoftGraphicsWin2DPackageVersion>1.3.2</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.3179.45</MicrosoftWindowsWebView2PackageVersion>
     <!-- Everything else -->
-    <MicrosoftAspNetCoreAuthorizationPackageVersion>11.0.0-preview.7.26379.122</MicrosoftAspNetCoreAuthorizationPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>11.0.0-preview.7.26379.122</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>11.0.0-preview.7.26379.122</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
-    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>11.0.0-preview.7.26379.122</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
-    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>11.0.0-preview.7.26379.122</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreComponentsFormsPackageVersion>11.0.0-preview.7.26379.122</MicrosoftAspNetCoreComponentsFormsPackageVersion>
-    <MicrosoftAspNetCoreComponentsPackageVersion>11.0.0-preview.7.26379.122</MicrosoftAspNetCoreComponentsPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebPackageVersion>11.0.0-preview.7.26379.122</MicrosoftAspNetCoreComponentsWebPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>11.0.0-preview.7.26379.122</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>11.0.0-preview.7.26379.122</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>11.0.0-preview.7.26379.122</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
-    <MicrosoftAspNetCoreMetadataPackageVersion>11.0.0-preview.7.26379.122</MicrosoftAspNetCoreMetadataPackageVersion>
-    <MicrosoftJSInteropPackageVersion>11.0.0-preview.7.26379.122</MicrosoftJSInteropPackageVersion>
+    <MicrosoftAspNetCoreAuthorizationPackageVersion>11.0.0-preview.7.26381.103</MicrosoftAspNetCoreAuthorizationPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>11.0.0-preview.7.26381.103</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>11.0.0-preview.7.26381.103</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
+    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>11.0.0-preview.7.26381.103</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
+    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>11.0.0-preview.7.26381.103</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreComponentsFormsPackageVersion>11.0.0-preview.7.26381.103</MicrosoftAspNetCoreComponentsFormsPackageVersion>
+    <MicrosoftAspNetCoreComponentsPackageVersion>11.0.0-preview.7.26381.103</MicrosoftAspNetCoreComponentsPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebPackageVersion>11.0.0-preview.7.26381.103</MicrosoftAspNetCoreComponentsWebPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>11.0.0-preview.7.26381.103</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>11.0.0-preview.7.26381.103</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>11.0.0-preview.7.26381.103</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
+    <MicrosoftAspNetCoreMetadataPackageVersion>11.0.0-preview.7.26381.103</MicrosoftAspNetCoreMetadataPackageVersion>
+    <MicrosoftJSInteropPackageVersion>11.0.0-preview.7.26381.103</MicrosoftJSInteropPackageVersion>
     <MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion>11.0.0-rc.1.26379.102</MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion>
     <MicrosoftEntityFrameworkCoreSqlitePackageVersion>11.0.0-rc.1.26379.102</MicrosoftEntityFrameworkCoreSqlitePackageVersion>
     <!-- Everything else (previous edition) -->
@@ -150,13 +150,13 @@
     <TizenUIExtensionsVersion>0.9.0</TizenUIExtensionsVersion>
     <ExCSSPackageVersion>4.2.3</ExCSSPackageVersion>
     <SystemDrawingCommonPackageVersion>9.0.0</SystemDrawingCommonPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>11.0.0-beta.26379.122</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetBuildTasksInstallersPackageVersion>11.0.0-beta.26379.122</MicrosoftDotNetBuildTasksInstallersPackageVersion>
-    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>11.0.0-beta.26379.122</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26379.122</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>11.0.0-beta.26381.103</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksInstallersPackageVersion>11.0.0-beta.26381.103</MicrosoftDotNetBuildTasksInstallersPackageVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>11.0.0-beta.26381.103</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26381.103</MicrosoftDotNetHelixSdkPackageVersion>
     <MicroBuildPluginsSwixBuildDotnetPackageVersion>1.1.87-gba258badda</MicroBuildPluginsSwixBuildDotnetPackageVersion>
-    <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.26379.122</MicrosoftDotNetRemoteExecutorPackageVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>11.0.0-beta.26379.122</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.26381.103</MicrosoftDotNetRemoteExecutorPackageVersion>
+    <MicrosoftDotNetXUnitExtensionsPackageVersion>11.0.0-beta.26381.103</MicrosoftDotNetXUnitExtensionsPackageVersion>
     <MicrosoftWixVersion>6.0.3-dotnet.4</MicrosoftWixVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "11.0.100-preview.7.26379.122"
+    "dotnet": "11.0.100-preview.7.26381.103"
   },
   "sdk": {
     "paths": [
@@ -11,7 +11,7 @@
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44",
     "Microsoft.Build.NoTargets": "3.7.0",
-    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26379.122",
-    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26379.122"
+    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26381.103",
+    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26381.103"
   }
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

- Align all 35 dependencies originating from `dotnet/dotnet` with the release-designated .NET 11 Preview 7 SDK/runtime build.
- Update the repository SDK and Arcade/Helix toolset selections in `global.json`.
- Preserve the current Android, macOS/iOS, and source-only package pins unchanged.

## Provenance

- **.NET Release Tracker (authoritative SDK/runtime source, 2026-08-03):** stage `Staging Done`; runtime `11.0.0-preview.7.26381.103`; SDK `11.0.100-preview.7.26381.103`.
- **VMR BAR/Maestro:** BAR `325220`; build `20260731.3`; branch `release/11.0.1xx-preview7`; commit `e2c1e00b3d0f96afb892fb261d5921565b400246`.

## Validation

- Confirmed all 35 `dotnet/dotnet` dependencies use the designated VMR commit and coherent SDK/runtime/toolset versions.
- Built `src/Controls/src/Build.Tasks/Controls.Build.Tasks.csproj` for `netstandard2.0` in Release with 0 warnings and 0 errors using SDK `11.0.100-preview.7.26381.103`.
- XML and JSON parsing passed; `git diff --check` passed.

### Issues Fixed

N/A
