### PR TITLE
[release/11.0.1xx-preview7] Forward status bar style through NavigationPage handler

### DIFF
--- a/src/Controls/src/Core/Platform/iOS/NavigationViewHandlerToolbarHelper.cs
+++ b/src/Controls/src/Core/Platform/iOS/NavigationViewHandlerToolbarHelper.cs
@@ -113,6 +113,11 @@ namespace Microsoft.Maui.Controls
         public override UIViewController ChildViewControllerForStatusBarHidden() =>
             (Child?.Handler as IPlatformViewHandler)?.ViewController ?? this;
 
+#if !MACCATALYST
+        public override UIViewController ChildViewControllerForStatusBarStyle() =>
+            (Child?.Handler as IPlatformViewHandler)?.ViewController ?? this;
+#endif
+
         public override bool PrefersStatusBarHidden()
         {
             if ((Child?.Handler as IPlatformViewHandler)?.ViewController is UIViewController childVC)

--- a/src/Controls/src/Core/Platform/iOS/NavigationViewHandlerToolbarHelper.cs
+++ b/src/Controls/src/Core/Platform/iOS/NavigationViewHandlerToolbarHelper.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Maui.Controls
 
 #if !MACCATALYST
         public override UIViewController ChildViewControllerForStatusBarStyle() =>
-            (Child?.Handler as IPlatformViewHandler)?.ViewController ?? this;
+            (Child?.Handler as IPlatformViewHandler)?.ViewController ?? base.ChildViewControllerForStatusBarStyle()!;
 #endif
 
         public override bool PrefersStatusBarHidden()

--- a/src/Core/src/Platform/iOS/NavigationControllerManager/NavigationControllerManager.cs
+++ b/src/Core/src/Platform/iOS/NavigationControllerManager/NavigationControllerManager.cs
@@ -231,6 +231,17 @@ namespace Microsoft.Maui.Platform
                 return base.ChildViewControllerForStatusBarHidden()!;
             }
 
+#if !MACCATALYST
+            public override UIViewController ChildViewControllerForStatusBarStyle()
+            {
+                if (_currentTopVC?.TryGetTarget(out var vc) == true)
+                {
+                    return vc;
+                }
+                return base.ChildViewControllerForStatusBarStyle()!;
+            }
+#endif
+
             [Export("navigationBar:shouldPopItem:")]
             bool ShouldPopItem(UINavigationBar navigationBar, UINavigationItem item)
             {


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

The new iOS `NavigationViewHandler` forwards status-bar hidden queries through its navigation-controller and parenting-controller layers, but does not forward status-bar style queries. UIKit therefore resolves `PreferredStatusBarStyle` on the navigation controller and returns `Default` instead of the current page style.

Forward `ChildViewControllerForStatusBarStyle` through both handler layers, matching the old `NavigationRenderer` behavior. The existing `StatusBarThemeFlowsThroughRootController(NavigationPage)` device test covers the regression.

## Failure evidence

Device build 1537360 failed the same test on all four iOS Mono/CoreCLR and Xcode queue combinations. Other root page types passed.