### PR TITLE
[Android] Shell: Fix fragment teardown crash

### DIFF
--- a/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Android.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Android.cs
@@ -1197,7 +1197,9 @@ namespace Microsoft.Maui.Controls.Handlers
             // Disconnect the handler to unsubscribe from events and clean up resources.
             ((IElementHandler)_handler).DisconnectHandler();
 
-            _wrapperFragment?.Dispose();
+            // Do not dispose the wrapper fragment here; AndroidX FragmentManager still owns
+            // it and will call OnDestroyView/OnDestroy on its own teardown schedule. Disposing
+            // the managed wrapper early crashes native callbacks that run after this point.
             _wrapperFragment = null;
         }
     }

--- a/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Android.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Android.cs
@@ -1106,7 +1106,9 @@ namespace Microsoft.Maui.Controls.Handlers
             // Disconnect the handler to unsubscribe from required events and clean up resources.
             ((IElementHandler)_handler).DisconnectHandler();
 
-            _wrapperFragment?.Dispose();
+            // Do not dispose the wrapper fragment here; AndroidX FragmentManager still owns
+            // it and will call OnDestroyView/OnDestroy on its own teardown schedule. Disposing
+            // the managed wrapper early crashes native callbacks that run after this point.
             _wrapperFragment = null;
         }
     }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Preview 7 Android Mono Controls device tests repeatedly crashed on separate machines after Shell tests with:

```
System.NotSupportedException: Unable to activate instance of type Microsoft.Maui.Controls.Handlers.ShellItemWrapperFragment from native handle
```

The stack ran through `TypeManager.CreateInstance -> AndroidValueManager.CreatePeer -> Fragment.n_OnDestroyView`. A preceding CoreCLR run stack-overflowed repeatedly in the same `Fragment.n_OnDestroyView` native callback.

**Root cause:** `ShellItemHandlerAdapter.Dispose()` and `ShellSectionHandlerAdapter.Dispose()` called `_wrapperFragment?.Dispose()` on the managed callable wrapper before AndroidX `FragmentManager` had finished native fragment teardown. `FragmentManager` still owned the fragment and later invoked `OnDestroyView`/`OnDestroy`; the managed peer had already been disposed, so the native-to-managed callback failed.

**Fix:** Remove the premature `_wrapperFragment?.Dispose()` call in both adapters. `Destroyed?.Invoke`, `DisconnectHandler()`, and clearing `_wrapperFragment` are preserved, so handler cleanup and event semantics are unchanged. AndroidX completes the fragment lifecycle and releases its native references, after which the managed wrapper can be collected normally.

## Changes

- `ShellItemHandlerAdapter.Dispose()` no longer disposes its FragmentManager-owned wrapper fragment.
- `ShellSectionHandlerAdapter.Dispose()` applies the same ownership correction.
- Both sites document why native lifecycle completion must precede managed peer release.

## Validation

- [`maui-pr` build 1537782](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1537782) completed successfully.
- [`maui-pr-devicetests` build 1537785](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1537785) completed. The overall pipeline is red only for unrelated, baseline/platform-mismatched test failures listed below.
- **Android CoreCLR Controls:** [Helix job `285167e7-e91d-48bf-affa-af69928f75e4`](https://helix.dot.net/api/jobs/285167e7-e91d-48bf-affa-af69928f75e4/details) completed the full Controls suite. Its log contains no `Stack overflow`, `Fragment.n_OnDestroyView` crash, wrapper activation exception, or `DEVICE_NOT_FOUND`.
- **Android Mono Controls:** [Helix job `83a0120e-b322-4681-8d71-152b5fe03b4a`](https://helix.dot.net/api/jobs/83a0120e-b322-4681-8d71-152b5fe03b4a/details) likewise completed the full Controls suite with none of the prior crash signatures.
- Both Android runtimes reported the same two unrelated Entry failures (`setSpan (5001 ... 5001) ends beyond length 5000`). The identical Entry failures already occur on the exact-base build [`1537360`](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1537360), including its Mono [Controls work item](https://helix.dot.net/api/2019-06-17/jobs/4fcb5af5-e6c8-48e0-92ba-8f37342680bf/workitems/com.microsoft.maui.controls.devicetests-Signed/console).
- Both Android Core work items reported the two existing `StatusBarThemeAppliesWhenHandlerConnects` failures (`MauiContext did not have a valid window`), identical to exact-base build `1537360` on both runtimes.
- The iOS Helix failures are unrelated to this Android-only diff: the existing `StatusBarThemeFlowsThroughRootController` failure is also present on exact-base build `1537360`; one CoreCLR iOS 26 WebView URL-encoding test also failed.
- The separately-triggered [`maui-pr-uitests` build 1537784](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1537784) remains in progress. Its completed WinUI failures are unrelated: `DragEvents` and the Label visual-baseline failures reproduce on exact-base UI build [`1537359`](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1537359); `HorizontalGridFooterExpandsToContentWidth` runs on Windows, where these `.Android.cs` changes are not compiled.
- A MAUI-specific lifecycle review found no high-confidence ownership, teardown-ordering, or leak issue. Retention lasts only until FragmentManager finishes teardown.
- Focused local Android execution was blocked because this machine does not have the repository-required `11.0.100-preview.7.26379.122` SDK or XHarness installed. No local test result is claimed.