### PR TITLE
[Android] SafeArea: Apply insets to views attached during IME animations

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Window/MauiWindowInsetListenerTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/MauiWindowInsetListenerTests.Android.cs
@@ -1,0 +1,171 @@
+#nullable enable
+using System.Threading.Tasks;
+using AndroidX.Core.View;
+using Microsoft.Maui.Platform;
+using Xunit;
+using AContext = Android.Content.Context;
+using AInsets = AndroidX.Core.Graphics.Insets;
+using AView = Android.Views.View;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	// Deterministic coverage for the IsImeAnimating gate in MauiWindowInsetListener,
+	// driving the listener directly (OnPrepare → NotifyViewAttached → OnApplyWindowInsets →
+	// OnEnd) with no emulator IME timing involved. The Issue37012 UI test remains the
+	// end-to-end smoke check for the real keyboard scenario.
+	[Category(TestCategory.Window)]
+	public partial class MauiWindowInsetListenerTests : ControlsHandlerTestBase
+	{
+		static WindowInsetsAnimationCompat CreateImeAnimation() =>
+			new(WindowInsetsCompat.Type.Ime(), null, 250);
+
+		static WindowInsetsCompat CreateInsets() =>
+			new WindowInsetsCompat.Builder()
+				.SetInsets(WindowInsetsCompat.Type.SystemBars(), AInsets.Of(0, 60, 0, 30))!
+				.Build()!;
+
+		// Records inset dispatches that make it through the listener's gate, bypassing
+		// the safe-area math entirely
+		sealed class InsetRecordingView : AView, IHandleWindowInsets
+		{
+			public InsetRecordingView(AContext context) : base(context)
+			{
+			}
+
+			public int HandledCount { get; private set; }
+
+			public WindowInsetsCompat? HandleWindowInsets(AView view, WindowInsetsCompat insets)
+			{
+				HandledCount++;
+				return insets;
+			}
+
+			public void ResetWindowInsets(AView view)
+			{
+			}
+		}
+
+		[Fact]
+		public async Task ViewTrackedBeforeImeAnimationStaysGatedAndAttachedViewBypassesGate()
+		{
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var listener = new MauiWindowInsetListener();
+				var gated = new InsetRecordingView(MauiContext.Context!);
+				var exempt = new InsetRecordingView(MauiContext.Context!);
+				var insets = CreateInsets();
+
+				// Sanity: with no animation in flight, dispatches process normally
+				listener.OnApplyWindowInsets(gated, insets);
+				Assert.Equal(1, gated.HandledCount);
+
+				listener.OnPrepare(CreateImeAnimation());
+
+				// Negative case: a view that was already tracked before the animation
+				// started must remain gated for the whole animation
+				listener.OnApplyWindowInsets(gated, insets);
+				Assert.Equal(1, gated.HandledCount);
+
+				// A view that (re)attached mid-animation has no valid padding yet and
+				// must bypass the gate (#37012)
+				listener.NotifyViewAttached(exempt);
+				listener.OnApplyWindowInsets(exempt, insets);
+				Assert.Equal(1, exempt.HandledCount);
+
+				listener.OnEnd(CreateImeAnimation());
+			});
+		}
+
+		[Fact]
+		public async Task GateExemptionDoesNotOutliveTheAnimation()
+		{
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var listener = new MauiWindowInsetListener();
+				var view = new InsetRecordingView(MauiContext.Context!);
+				var insets = CreateInsets();
+
+				listener.OnPrepare(CreateImeAnimation());
+				listener.NotifyViewAttached(view);
+				listener.OnEnd(CreateImeAnimation());
+
+				// The exemption was granted during animation N; in animation N+1 the same
+				// view is tracked state again and must be gated
+				listener.OnPrepare(CreateImeAnimation());
+				listener.OnApplyWindowInsets(view, insets);
+				Assert.Equal(0, view.HandledCount);
+
+				listener.OnEnd(CreateImeAnimation());
+			});
+		}
+
+		[Fact]
+		public async Task GateReleasesSynchronouslyWhenNoPendingViewIsAttached()
+		{
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var listener = new MauiWindowInsetListener();
+				var detached = new InsetRecordingView(MauiContext.Context!);
+				var other = new InsetRecordingView(MauiContext.Context!);
+				var insets = CreateInsets();
+
+				listener.OnPrepare(CreateImeAnimation());
+				listener.OnApplyWindowInsets(detached, insets);
+				Assert.Equal(0, detached.HandledCount);
+
+				// The only pending view is detached; posting the gate release through it
+				// would park the runnable until that view re-attaches (possibly never),
+				// leaving every view sharing this listener without safe-area updates.
+				// The release must happen synchronously instead.
+				listener.OnEnd(CreateImeAnimation());
+
+				listener.OnApplyWindowInsets(other, insets);
+				Assert.Equal(1, other.HandledCount);
+			});
+		}
+
+		[Fact]
+		public async Task AllGatedViewsProcessDispatchesAfterAnimationEnds()
+		{
+			var container = await InvokeOnMainThreadAsync(() => new global::Android.Widget.LinearLayout(MauiContext.Context!));
+
+			await container.AttachAndRun(async () =>
+			{
+				var listener = new MauiWindowInsetListener();
+				var first = new InsetRecordingView(MauiContext.Context!);
+				var second = new InsetRecordingView(MauiContext.Context!);
+				var insets = CreateInsets();
+
+				container.AddView(first);
+				container.AddView(second);
+
+				try
+				{
+					listener.OnPrepare(CreateImeAnimation());
+
+					listener.OnApplyWindowInsets(first, insets);
+					listener.OnApplyWindowInsets(second, insets);
+					Assert.Equal(0, first.HandledCount);
+					Assert.Equal(0, second.HandledCount);
+
+					// Both views are attached, so the gate release is posted one
+					// main-looper turn after OnEnd; yield to let it run
+					listener.OnEnd(CreateImeAnimation());
+					await Task.Delay(100);
+
+					// The gate must be open again and every previously gated view must
+					// process dispatches — not just the one the release was posted on
+					listener.OnApplyWindowInsets(first, insets);
+					listener.OnApplyWindowInsets(second, insets);
+					Assert.Equal(1, first.HandledCount);
+					Assert.Equal(1, second.HandledCount);
+				}
+				finally
+				{
+					container.RemoveView(first);
+					container.RemoveView(second);
+				}
+			});
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/Window/MauiWindowInsetListenerTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/MauiWindowInsetListenerTests.Android.cs
@@ -24,8 +24,18 @@ namespace Microsoft.Maui.DeviceTests
 				.SetInsets(WindowInsetsCompat.Type.SystemBars(), AInsets.Of(0, 60, 0, 30))!
 				.Build()!;
 
-		// Records inset dispatches that make it through the listener's gate, bypassing
-		// the safe-area math entirely
+		// Awaits one main-looper turn posted through the given view, so a runnable the
+		// listener posted earlier through any attached view is guaranteed to have run
+		static Task NextLooperTurnAsync(AView view)
+		{
+			var turn = new TaskCompletionSource<bool>();
+			view.Post(() => turn.SetResult(true));
+			return turn.Task;
+		}
+
+		// Records both inset dispatches that make it through the listener's gate (bypassing
+		// the safe-area math entirely) and the RequestApplyInsets re-apply issued by the
+		// end-of-animation drain
 		sealed class InsetRecordingView : AView, IHandleWindowInsets
 		{
 			public InsetRecordingView(AContext context) : base(context)
@@ -33,6 +43,8 @@ namespace Microsoft.Maui.DeviceTests
 			}
 
 			public int HandledCount { get; private set; }
+
+			public int RequestApplyInsetsCount { get; private set; }
 
 			public WindowInsetsCompat? HandleWindowInsets(AView view, WindowInsetsCompat insets)
 			{
@@ -43,10 +55,16 @@ namespace Microsoft.Maui.DeviceTests
 			public void ResetWindowInsets(AView view)
 			{
 			}
+
+			public override void RequestApplyInsets()
+			{
+				RequestApplyInsetsCount++;
+				base.RequestApplyInsets();
+			}
 		}
 
 		[Fact]
-		public async Task ViewTrackedBeforeImeAnimationStaysGatedAndAttachedViewBypassesGate()
+		public async Task ViewTrackedBeforeImeAnimationStaysGatedAndAttachedViewBypassesGateOnce()
 		{
 			await InvokeOnMainThreadAsync(() =>
 			{
@@ -67,8 +85,13 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.Equal(1, gated.HandledCount);
 
 				// A view that (re)attached mid-animation has no valid padding yet and
-				// must bypass the gate (#37012)
+				// must bypass the gate for its initial apply (#37012)
 				listener.NotifyViewAttached(exempt);
+				listener.OnApplyWindowInsets(exempt, insets);
+				Assert.Equal(1, exempt.HandledCount);
+
+				// The exemption is one-shot: once padded, the view is gated like the rest
+				// for the remainder of the animation
 				listener.OnApplyWindowInsets(exempt, insets);
 				Assert.Equal(1, exempt.HandledCount);
 
@@ -125,46 +148,101 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact]
-		public async Task AllGatedViewsProcessDispatchesAfterAnimationEnds()
+		public async Task AllGatedViewsAreReappliedWhenAnimationEnds()
 		{
-			var container = await InvokeOnMainThreadAsync(() => new global::Android.Widget.LinearLayout(MauiContext.Context!));
-
-			await container.AttachAndRun(async () =>
+			await InvokeOnMainThreadAsync(async () =>
 			{
-				var listener = new MauiWindowInsetListener();
-				var first = new InsetRecordingView(MauiContext.Context!);
-				var second = new InsetRecordingView(MauiContext.Context!);
-				var insets = CreateInsets();
+				var container = new global::Android.Widget.LinearLayout(MauiContext.Context!);
 
-				container.AddView(first);
-				container.AddView(second);
-
-				try
+				await container.AttachAndRun(async () =>
 				{
-					listener.OnPrepare(CreateImeAnimation());
+					var listener = new MauiWindowInsetListener();
+					var first = new InsetRecordingView(MauiContext.Context!);
+					var second = new InsetRecordingView(MauiContext.Context!);
+					var insets = CreateInsets();
 
-					listener.OnApplyWindowInsets(first, insets);
-					listener.OnApplyWindowInsets(second, insets);
-					Assert.Equal(0, first.HandledCount);
-					Assert.Equal(0, second.HandledCount);
+					container.AddView(first);
+					container.AddView(second);
 
-					// Both views are attached, so the gate release is posted one
-					// main-looper turn after OnEnd; yield to let it run
-					listener.OnEnd(CreateImeAnimation());
-					await Task.Delay(100);
+					try
+					{
+						listener.OnPrepare(CreateImeAnimation());
 
-					// The gate must be open again and every previously gated view must
-					// process dispatches — not just the one the release was posted on
-					listener.OnApplyWindowInsets(first, insets);
-					listener.OnApplyWindowInsets(second, insets);
-					Assert.Equal(1, first.HandledCount);
-					Assert.Equal(1, second.HandledCount);
-				}
-				finally
+						listener.OnApplyWindowInsets(first, insets);
+						listener.OnApplyWindowInsets(second, insets);
+						Assert.Equal(0, first.HandledCount);
+						Assert.Equal(0, second.HandledCount);
+
+						// Both views are attached, so the gate release is posted one
+						// main-looper turn after OnEnd; sequence on the same looper
+						// instead of racing a fixed delay
+						listener.OnEnd(CreateImeAnimation());
+						await NextLooperTurnAsync(container);
+
+						// The drain must issue RequestApplyInsets for *every* gated view —
+						// the pre-fix code remembered only the last one
+						Assert.Equal(1, first.RequestApplyInsetsCount);
+						Assert.Equal(1, second.RequestApplyInsetsCount);
+
+						// And the gate must be open again for everyone
+						listener.OnApplyWindowInsets(first, insets);
+						listener.OnApplyWindowInsets(second, insets);
+						Assert.Equal(1, first.HandledCount);
+						Assert.Equal(1, second.HandledCount);
+					}
+					finally
+					{
+						container.RemoveView(first);
+						container.RemoveView(second);
+					}
+				});
+			});
+		}
+
+		[Fact]
+		public async Task StaleGateReleaseDoesNotOpenTheGateOfTheNextAnimation()
+		{
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var container = new global::Android.Widget.LinearLayout(MauiContext.Context!);
+
+				await container.AttachAndRun(async () =>
 				{
-					container.RemoveView(first);
-					container.RemoveView(second);
-				}
+					var listener = new MauiWindowInsetListener();
+					var view = new InsetRecordingView(MauiContext.Context!);
+					var insets = CreateInsets();
+
+					container.AddView(view);
+
+					try
+					{
+						// Animation 1 ends with a pending attached view, so its gate
+						// release is posted for the next looper turn...
+						listener.OnPrepare(CreateImeAnimation());
+						listener.OnApplyWindowInsets(view, insets);
+						listener.OnEnd(CreateImeAnimation());
+
+						// ...but animation 2 starts before that runnable runs
+						// (hide immediately followed by show)
+						listener.OnPrepare(CreateImeAnimation());
+						await NextLooperTurnAsync(container);
+
+						// The stale release from animation 1 must not have opened the
+						// gate in the middle of animation 2
+						listener.OnApplyWindowInsets(view, insets);
+						Assert.Equal(0, view.HandledCount);
+
+						listener.OnEnd(CreateImeAnimation());
+						await NextLooperTurnAsync(container);
+
+						listener.OnApplyWindowInsets(view, insets);
+						Assert.Equal(1, view.HandledCount);
+					}
+					finally
+					{
+						container.RemoveView(view);
+					}
+				});
 			});
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/Window/MauiWindowInsetListenerTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/MauiWindowInsetListenerTests.Android.cs
@@ -33,9 +33,8 @@ namespace Microsoft.Maui.DeviceTests
 			return turn.Task;
 		}
 
-		// Records both inset dispatches that make it through the listener's gate (bypassing
-		// the safe-area math entirely) and the RequestApplyInsets re-apply issued by the
-		// end-of-animation drain
+		// Records inset dispatches that make it through the listener's gate (bypassing the
+		// safe-area math entirely) and any RequestApplyInsets the animation-end release issues
 		sealed class InsetRecordingView : AView, IHandleWindowInsets
 		{
 			public InsetRecordingView(AContext context) : base(context)
@@ -100,7 +99,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact]
-		public async Task GateExemptionDoesNotOutliveTheAnimation()
+		public async Task GateExemptionIsClearedWhenTheAnimationEnds()
 		{
 			await InvokeOnMainThreadAsync(() =>
 			{
@@ -112,8 +111,8 @@ namespace Microsoft.Maui.DeviceTests
 				listener.NotifyViewAttached(view);
 				listener.OnEnd(CreateImeAnimation());
 
-				// The exemption was granted during animation N; in animation N+1 the same
-				// view is tracked state again and must be gated
+				// Assert between OnEnd and the next OnPrepare, so this discriminates the
+				// clear in OnEnd specifically rather than passing on either clear site
 				listener.OnPrepare(CreateImeAnimation());
 				listener.OnApplyWindowInsets(view, insets);
 				Assert.Equal(0, view.HandledCount);
@@ -123,7 +122,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact]
-		public async Task GateReleasesSynchronouslyWhenNoPendingViewIsAttached()
+		public async Task GateReleasesSynchronouslyWhenNoAttachedViewIsAvailable()
 		{
 			await InvokeOnMainThreadAsync(() =>
 			{
@@ -132,14 +131,16 @@ namespace Microsoft.Maui.DeviceTests
 				var other = new InsetRecordingView(MauiContext.Context!);
 				var insets = CreateInsets();
 
+				// The listener knows about a view that carries padding, but it is detached
+				listener.TrackView(detached);
+
 				listener.OnPrepare(CreateImeAnimation());
 				listener.OnApplyWindowInsets(detached, insets);
 				Assert.Equal(0, detached.HandledCount);
 
-				// The only pending view is detached; posting the gate release through it
-				// would park the runnable until that view re-attaches (possibly never),
-				// leaving every view sharing this listener without safe-area updates.
-				// The release must happen synchronously instead.
+				// Posting the release through a detached view would park the runnable until
+				// that view re-attaches (possibly never), leaving every view sharing this
+				// listener without safe-area updates. It must release synchronously instead.
 				listener.OnEnd(CreateImeAnimation());
 
 				listener.OnApplyWindowInsets(other, insets);
@@ -148,7 +149,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact]
-		public async Task AllGatedViewsAreReappliedWhenAnimationEnds()
+		public async Task GatedDispatchesTriggerOneReapplyWhenTheAnimationEnds()
 		{
 			await InvokeOnMainThreadAsync(async () =>
 			{
@@ -163,6 +164,7 @@ namespace Microsoft.Maui.DeviceTests
 
 					container.AddView(first);
 					container.AddView(second);
+					listener.TrackView(first);
 
 					try
 					{
@@ -173,18 +175,18 @@ namespace Microsoft.Maui.DeviceTests
 						Assert.Equal(0, first.HandledCount);
 						Assert.Equal(0, second.HandledCount);
 
-						// Both views are attached, so the gate release is posted one
-						// main-looper turn after OnEnd; sequence on the same looper
-						// instead of racing a fixed delay
+						// The release is posted through an attached view; sequence on the same
+						// looper instead of racing a fixed delay
 						listener.OnEnd(CreateImeAnimation());
 						await NextLooperTurnAsync(container);
 
-						// The drain must issue RequestApplyInsets for *every* gated view —
-						// the pre-fix code remembered only the last one
+						// A single RequestApplyInsets reaches the ViewRootImpl and re-dispatches
+						// insets across the whole hierarchy, so exactly one call is expected —
+						// not one per gated view
 						Assert.Equal(1, first.RequestApplyInsetsCount);
-						Assert.Equal(1, second.RequestApplyInsetsCount);
+						Assert.Equal(0, second.RequestApplyInsetsCount);
 
-						// And the gate must be open again for everyone
+						// And the gate must be open again for every view, not just the poster
 						listener.OnApplyWindowInsets(first, insets);
 						listener.OnApplyWindowInsets(second, insets);
 						Assert.Equal(1, first.HandledCount);
@@ -213,17 +215,18 @@ namespace Microsoft.Maui.DeviceTests
 					var insets = CreateInsets();
 
 					container.AddView(view);
+					listener.TrackView(view);
 
 					try
 					{
-						// Animation 1 ends with a pending attached view, so its gate
-						// release is posted for the next looper turn...
+						// Animation 1 ends with a gated dispatch, so its gate release is
+						// posted for the next looper turn...
 						listener.OnPrepare(CreateImeAnimation());
 						listener.OnApplyWindowInsets(view, insets);
 						listener.OnEnd(CreateImeAnimation());
 
 						// ...but animation 2 starts before that runnable runs
-						// (hide immediately followed by show)
+						// (a hide immediately followed by a show)
 						listener.OnPrepare(CreateImeAnimation());
 						await NextLooperTurnAsync(container);
 

--- a/src/Controls/tests/DeviceTests/Elements/Window/MauiWindowInsetListenerTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/MauiWindowInsetListenerTests.Android.cs
@@ -149,6 +149,53 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact]
+		public async Task ReapplyStaysOwedWhenTheAnimationEndsWithNoUsablePoster()
+		{
+			var container = await InvokeOnMainThreadAsync(() =>
+				new global::Android.Widget.LinearLayout(MauiContext.Context!));
+
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				await container.AttachAndRun(async () =>
+				{
+					var listener = new MauiWindowInsetListener();
+					var detached = new InsetRecordingView(MauiContext.Context!);
+					var attached = new InsetRecordingView(MauiContext.Context!);
+					var insets = CreateInsets();
+
+					container.AddView(attached);
+
+					try
+					{
+						// Only a detached view is known, so the animation has to end without
+						// being able to issue the re-apply it owes
+						listener.TrackView(detached);
+						listener.OnPrepare(CreateImeAnimation());
+						listener.OnApplyWindowInsets(detached, insets);
+						listener.OnEnd(CreateImeAnimation());
+						await NextLooperTurnAsync(container);
+
+						Assert.Equal(0, detached.RequestApplyInsetsCount);
+
+						// The settled insets are still owed, so the next animation that *can*
+						// reach an attached view must deliver them rather than the request
+						// having been silently dropped
+						listener.TrackView(attached);
+						listener.OnPrepare(CreateImeAnimation());
+						listener.OnEnd(CreateImeAnimation());
+						await NextLooperTurnAsync(container);
+
+						Assert.Equal(1, attached.RequestApplyInsetsCount);
+					}
+					finally
+					{
+						container.RemoveView(attached);
+					}
+				});
+			});
+		}
+
+		[Fact]
 		public async Task GatedDispatchesTriggerOneReapplyWhenTheAnimationEnds()
 		{
 			await InvokeOnMainThreadAsync(async () =>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue37012.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue37012.cs
@@ -1,0 +1,179 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 37012, "Safe-area padding stale for the whole IME hide animation when swapping pages", PlatformAffected.Android)]
+public class Issue37012 : NavigationPage
+{
+	public Issue37012() : base(new Issue37012PageA())
+	{
+	}
+}
+
+public class Issue37012PageA : ContentPage
+{
+	readonly Label _resultLabel;
+	bool _captureArmed;
+
+	public Issue37012PageA()
+	{
+		NavigationPage.SetHasNavigationBar(this, false);
+		SafeAreaEdges = SafeAreaEdges.All;
+
+		_resultLabel = new Label
+		{
+			Text = "Waiting",
+			AutomationId = "ResultLabel"
+		};
+
+		var openPageBButton = new Button
+		{
+			Text = "Open Page B",
+			AutomationId = "OpenPageB"
+		};
+
+		openPageBButton.Clicked += async (sender, e) =>
+		{
+			_resultLabel.Text = "Waiting";
+			_captureArmed = true;
+			await Navigation.PushAsync(new Issue37012PageB(), animated: false);
+		};
+
+		Content = new VerticalStackLayout
+		{
+			Spacing = 12,
+			Children =
+			{
+				new Label { Text = "Issue 37012 - Page A" },
+				openPageBButton,
+				_resultLabel
+			}
+		};
+
+		Loaded += OnPageLoaded;
+	}
+
+	void OnPageLoaded(object sender, EventArgs e)
+	{
+		if (!_captureArmed)
+		{
+			return;
+		}
+
+		_captureArmed = false;
+		StartPaddingCapture();
+	}
+
+	// Captures the platform view's top padding on the first frame drawn after the page
+	// re-attaches, and again once the IME hide animation has certainly completed. Without
+	// the fix the first frame renders with zero safe-area padding (content under the status
+	// bar) and the padding only arrives when the IME animation ends.
+	void StartPaddingCapture()
+	{
+#if ANDROID
+		if (Handler?.PlatformView is not Android.Views.View platformView)
+		{
+			_resultLabel.Text = "Fail: platform view unavailable";
+			return;
+		}
+
+		var firstDrawPadding = -1;
+		var preDrawListener = new FirstPreDrawListener(platformView, padding => firstDrawPadding = padding);
+		platformView.ViewTreeObserver.AddOnPreDrawListener(preDrawListener);
+
+		Dispatcher.StartTimer(TimeSpan.FromMilliseconds(800), () =>
+		{
+			preDrawListener.Detach();
+			var finalPadding = platformView.PaddingTop;
+
+			if (finalPadding > 0 && firstDrawPadding == finalPadding)
+			{
+				_resultLabel.Text = $"Success: first={firstDrawPadding} final={finalPadding}";
+			}
+			else
+			{
+				_resultLabel.Text = $"Fail: first={firstDrawPadding} final={finalPadding}";
+			}
+
+			return false;
+		});
+#else
+		_resultLabel.Text = "Success: not applicable on this platform";
+#endif
+	}
+
+#if ANDROID
+	sealed class FirstPreDrawListener : Java.Lang.Object, Android.Views.ViewTreeObserver.IOnPreDrawListener
+	{
+		readonly Android.Views.View _view;
+		Action<int> _onFirstPreDraw;
+
+		public FirstPreDrawListener(Android.Views.View view, Action<int> onFirstPreDraw)
+		{
+			_view = view;
+			_onFirstPreDraw = onFirstPreDraw;
+		}
+
+		public bool OnPreDraw()
+		{
+			_onFirstPreDraw?.Invoke(_view.PaddingTop);
+			Detach();
+			return true;
+		}
+
+		public void Detach()
+		{
+			if (_onFirstPreDraw is null)
+			{
+				return;
+			}
+
+			_onFirstPreDraw = null;
+			if (_view.ViewTreeObserver?.IsAlive == true)
+			{
+				_view.ViewTreeObserver.RemoveOnPreDrawListener(this);
+			}
+		}
+	}
+#endif
+}
+
+public class Issue37012PageB : ContentPage
+{
+	public Issue37012PageB()
+	{
+		NavigationPage.SetHasNavigationBar(this, false);
+		SafeAreaEdges = SafeAreaEdges.All;
+
+		var entry = new Entry
+		{
+			AutomationId = "PageBEntry",
+			Placeholder = "Tap to open keyboard"
+		};
+
+		var hideAndPopButton = new Button
+		{
+			Text = "Hide keyboard and pop",
+			AutomationId = "HideAndPopButton"
+		};
+
+		hideAndPopButton.Clicked += async (sender, e) =>
+		{
+			// Mirror the issue repro: request the keyboard hide, then swap pages while the
+			// IME hide animation is still in flight. The short delay guarantees the hide
+			// animation has started before Page A's platform views re-attach.
+			_ = entry.HideSoftInputAsync(CancellationToken.None);
+			await Task.Delay(50);
+			await Navigation.PopAsync(animated: false);
+		};
+
+		Content = new VerticalStackLayout
+		{
+			Spacing = 12,
+			Children =
+			{
+				new Label { Text = "Issue 37012 - Page B" },
+				entry,
+				hideAndPopButton
+			}
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue37012.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue37012.cs
@@ -55,6 +55,11 @@ public class Issue37012PageA : ContentPage
 	{
 		if (!_captureArmed)
 		{
+#if ANDROID
+			// Clean up any tracker left behind by a scenario run that never completed
+			// (the HostApp process is shared across UI tests)
+			Issue37012ImeAnimationTracker.Uninstall();
+#endif
 			return;
 		}
 
@@ -72,6 +77,7 @@ public class Issue37012PageA : ContentPage
 		if (Handler?.PlatformView is not Android.Views.View platformView)
 		{
 			_resultLabel.Text = "Fail: platform view unavailable";
+			Issue37012ImeAnimationTracker.Uninstall();
 			return;
 		}
 
@@ -151,6 +157,11 @@ public class Issue37012PageA : ContentPage
 			{
 				_resultLabel.Text = $"Success: top={finalTop} bottom={finalBottom} firstBottom={firstDrawBottom}";
 			}
+		}
+		catch (Exception ex)
+		{
+			// async void: an unhandled exception would crash the shared HostApp process
+			_resultLabel.Text = $"Fail: {ex.Message}";
 		}
 		finally
 		{

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue37012.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue37012.cs
@@ -62,11 +62,11 @@ public class Issue37012PageA : ContentPage
 		StartPaddingCapture();
 	}
 
-	// Captures the platform view's top padding on the first frame drawn after the page
-	// re-attaches, and again once the IME hide animation has certainly completed. Without
-	// the fix the first frame renders with zero safe-area padding (content under the status
-	// bar) and the padding only arrives when the IME animation ends.
-	void StartPaddingCapture()
+	// Captures the platform view's padding on the first frame drawn after the page
+	// re-attaches, and again once the IME hide animation has completed and the padding has
+	// settled. Without the fix the first frame renders with zero safe-area padding (content
+	// under the status bar) and the padding only arrives when the IME animation ends.
+	async void StartPaddingCapture()
 	{
 #if ANDROID
 		if (Handler?.PlatformView is not Android.Views.View platformView)
@@ -75,28 +75,91 @@ public class Issue37012PageA : ContentPage
 			return;
 		}
 
-		var firstDrawPadding = -1;
-		var preDrawListener = new FirstPreDrawListener(platformView, padding => firstDrawPadding = padding);
+		// The bug only reproduces when the page re-attaches while the IME hide animation is
+		// still in flight; the decor-view tracker installed by Page B makes that observable
+		// so a run where the animation already finished reports Inconclusive, not Success.
+		bool imeAnimatingAtReattach = Issue37012ImeAnimationTracker.IsImeAnimating;
+
+		var firstDrawTop = -1;
+		var firstDrawBottom = -1;
+		var preDrawListener = new FirstPreDrawListener(platformView, (top, bottom) =>
+		{
+			firstDrawTop = top;
+			firstDrawBottom = bottom;
+		});
 		platformView.ViewTreeObserver.AddOnPreDrawListener(preDrawListener);
 
-		Dispatcher.StartTimer(TimeSpan.FromMilliseconds(800), () =>
+		try
 		{
-			preDrawListener.Detach();
-			var finalPadding = platformView.PaddingTop;
-
-			if (finalPadding > 0 && firstDrawPadding == finalPadding)
+			// Poll until the IME is fully gone and the padding is stable across consecutive
+			// samples instead of sampling once at a fixed delay — slow CI emulators can
+			// exceed any hard-coded animation estimate.
+			int stableSamples = 0;
+			int lastTop = -1, lastBottom = -1;
+			for (int i = 0; i < 40 && stableSamples < 3; i++)
 			{
-				_resultLabel.Text = $"Success: first={firstDrawPadding} final={finalPadding}";
+				await Task.Delay(100);
+
+				var rootInsets = AndroidX.Core.View.ViewCompat.GetRootWindowInsets(platformView);
+				bool imeVisible = rootInsets?.IsVisible(AndroidX.Core.View.WindowInsetsCompat.Type.Ime()) ?? false;
+				if (Issue37012ImeAnimationTracker.IsImeAnimating || imeVisible)
+				{
+					stableSamples = 0;
+					continue;
+				}
+
+				if (platformView.PaddingTop == lastTop && platformView.PaddingBottom == lastBottom)
+				{
+					stableSamples++;
+				}
+				else
+				{
+					stableSamples = 0;
+					lastTop = platformView.PaddingTop;
+					lastBottom = platformView.PaddingBottom;
+				}
+			}
+
+			var finalTop = platformView.PaddingTop;
+			var finalBottom = platformView.PaddingBottom;
+
+			// With the keyboard fully hidden, the bottom safe-area padding must equal the
+			// non-IME insets — a larger value means keyboard-height padding leaked past the
+			// end of the animation (the stale-bottom-padding risk of the gate exemption)
+			var settledInsets = AndroidX.Core.View.ViewCompat.GetRootWindowInsets(platformView);
+			var expectedBottom = settledInsets?.GetInsets(
+				AndroidX.Core.View.WindowInsetsCompat.Type.SystemBars() |
+				AndroidX.Core.View.WindowInsetsCompat.Type.DisplayCutout())?.Bottom ?? 0;
+
+			if (!imeAnimatingAtReattach)
+			{
+				_resultLabel.Text = "Inconclusive: IME animation completed before re-attach";
+			}
+			else if (finalTop == 0)
+			{
+				_resultLabel.Text = "Inconclusive: no top inset on this device";
+			}
+			else if (firstDrawTop != finalTop)
+			{
+				_resultLabel.Text = $"Fail: first frame top={firstDrawTop} settled top={finalTop}";
+			}
+			else if (finalBottom != expectedBottom)
+			{
+				_resultLabel.Text = $"Fail: stale bottom padding {finalBottom}, expected {expectedBottom}";
 			}
 			else
 			{
-				_resultLabel.Text = $"Fail: first={firstDrawPadding} final={finalPadding}";
+				_resultLabel.Text = $"Success: top={finalTop} bottom={finalBottom} firstBottom={firstDrawBottom}";
 			}
-
-			return false;
-		});
+		}
+		finally
+		{
+			preDrawListener.Detach();
+			Issue37012ImeAnimationTracker.Uninstall();
+		}
 #else
-		_resultLabel.Text = "Success: not applicable on this platform";
+		_resultLabel.Text = "Skipped: not applicable on this platform";
+		await Task.CompletedTask;
 #endif
 	}
 
@@ -104,9 +167,9 @@ public class Issue37012PageA : ContentPage
 	sealed class FirstPreDrawListener : Java.Lang.Object, Android.Views.ViewTreeObserver.IOnPreDrawListener
 	{
 		readonly Android.Views.View _view;
-		Action<int> _onFirstPreDraw;
+		Action<int, int> _onFirstPreDraw;
 
-		public FirstPreDrawListener(Android.Views.View view, Action<int> onFirstPreDraw)
+		public FirstPreDrawListener(Android.Views.View view, Action<int, int> onFirstPreDraw)
 		{
 			_view = view;
 			_onFirstPreDraw = onFirstPreDraw;
@@ -114,7 +177,7 @@ public class Issue37012PageA : ContentPage
 
 		public bool OnPreDraw()
 		{
-			_onFirstPreDraw?.Invoke(_view.PaddingTop);
+			_onFirstPreDraw?.Invoke(_view.PaddingTop, _view.PaddingBottom);
 			Detach();
 			return true;
 		}
@@ -158,9 +221,10 @@ public class Issue37012PageB : ContentPage
 		hideAndPopButton.Clicked += async (sender, e) =>
 		{
 			// Mirror the issue repro: request the keyboard hide, then swap pages while the
-			// IME hide animation is still in flight. The short delay guarantees the hide
-			// animation has started before Page A's platform views re-attach.
-			_ = entry.HideSoftInputAsync(CancellationToken.None);
+			// IME hide animation is still in flight. The short delay lets the hide animation
+			// start before Page A's platform views re-attach; whether it was still running at
+			// re-attach is verified by the tracker, not assumed.
+			await entry.HideSoftInputAsync(CancellationToken.None);
 			await Task.Delay(50);
 			await Navigation.PopAsync(animated: false);
 		};
@@ -175,5 +239,79 @@ public class Issue37012PageB : ContentPage
 				hideAndPopButton
 			}
 		};
+
+#if ANDROID
+		Loaded += (sender, e) => Issue37012ImeAnimationTracker.Install();
+#endif
 	}
 }
+
+#if ANDROID
+// Observes IME animations from the activity decor view (which MAUI does not attach its own
+// animation callback to) so the test pages can verify the "re-attached mid-animation"
+// precondition. DispatchModeContinueOnSubtree keeps the normal child dispatch intact.
+sealed class Issue37012ImeAnimationTracker : AndroidX.Core.View.WindowInsetsAnimationCompat.Callback
+{
+	static Issue37012ImeAnimationTracker _installed;
+
+	public static bool IsImeAnimating { get; private set; }
+
+	Issue37012ImeAnimationTracker() : base(DispatchModeContinueOnSubtree)
+	{
+	}
+
+	public static void Install()
+	{
+		if (_installed is null &&
+			Microsoft.Maui.ApplicationModel.Platform.CurrentActivity?.Window?.DecorView is Android.Views.View decorView)
+		{
+			_installed = new Issue37012ImeAnimationTracker();
+			AndroidX.Core.View.ViewCompat.SetWindowInsetsAnimationCallback(decorView, _installed);
+		}
+	}
+
+	// The HostApp process is shared across UI tests; remove the decor callback once the
+	// scenario completes so it cannot affect unrelated tests.
+	public static void Uninstall()
+	{
+		if (_installed is not null &&
+			Microsoft.Maui.ApplicationModel.Platform.CurrentActivity?.Window?.DecorView is Android.Views.View decorView)
+		{
+			AndroidX.Core.View.ViewCompat.SetWindowInsetsAnimationCallback(decorView, null);
+		}
+
+		_installed = null;
+		IsImeAnimating = false;
+	}
+
+	static bool IsIme(AndroidX.Core.View.WindowInsetsAnimationCompat animation) =>
+		(animation.TypeMask & AndroidX.Core.View.WindowInsetsCompat.Type.Ime()) != 0;
+
+	public override void OnPrepare(AndroidX.Core.View.WindowInsetsAnimationCompat animation)
+	{
+		if (IsIme(animation))
+		{
+			IsImeAnimating = true;
+		}
+
+		base.OnPrepare(animation);
+	}
+
+	public override AndroidX.Core.View.WindowInsetsCompat OnProgress(
+		AndroidX.Core.View.WindowInsetsCompat insets,
+		IList<AndroidX.Core.View.WindowInsetsAnimationCompat> runningAnimations)
+	{
+		return insets;
+	}
+
+	public override void OnEnd(AndroidX.Core.View.WindowInsetsAnimationCompat animation)
+	{
+		if (IsIme(animation))
+		{
+			IsImeAnimating = false;
+		}
+
+		base.OnEnd(animation);
+	}
+}
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue37012.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue37012.cs
@@ -27,8 +27,12 @@ public class Issue37012 : _IssuesUITest
 			App.WaitForElement("PageBEntry");
 			App.Tap("PageBEntry");
 
-			// Ensure the keyboard is fully shown before triggering the hide + pop sequence
-			App.WaitForKeyboardToShow();
+			// Ensure the keyboard is fully shown before triggering the hide + pop sequence.
+			// This returns false on timeout rather than throwing, and without the keyboard
+			// there is no IME animation to race — which would otherwise be indistinguishable
+			// from a genuinely lost race and silently report Inconclusive forever.
+			Assert.That(App.WaitForKeyboardToShow(TimeSpan.FromSeconds(5)), Is.True,
+				"Keyboard never appeared; the IME-hide race cannot be exercised on this device.");
 
 			App.Tap("HideAndPopButton");
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue37012.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue37012.cs
@@ -1,0 +1,37 @@
+#if ANDROID // Test validates Android-specific IME/safe-area behavior with Android-only instrumentation in the HostApp page
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue37012 : _IssuesUITest
+{
+	public Issue37012(TestDevice device) : base(device) { }
+
+	public override string Issue => "Safe-area padding stale for the whole IME hide animation when swapping pages";
+
+	[Test]
+	[Category(UITestCategories.SafeAreaEdges)]
+	public void SafeAreaPaddingAppliedToPageReattachedDuringImeHideAnimation()
+	{
+		App.WaitForElement("OpenPageB");
+		App.Tap("OpenPageB");
+
+		App.WaitForElement("PageBEntry");
+		App.Tap("PageBEntry");
+
+		// Ensure the keyboard is fully shown before triggering the hide + pop sequence
+		App.WaitForKeyboardToShow();
+
+		App.Tap("HideAndPopButton");
+
+		// Page A reports its safe-area padding captured on the first frame drawn after
+		// re-attach vs. the padding once the IME hide animation has completed.
+		App.WaitForElement("ResultLabel");
+		var success = App.WaitForTextToBePresentInElement("ResultLabel", "Success", timeout: TimeSpan.FromSeconds(5));
+		var resultText = App.FindElement("ResultLabel").GetText();
+		Assert.That(success, Is.True, $"Expected safe-area padding on the first frame after re-attach, but got: {resultText}");
+	}
+}
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue37012.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue37012.cs
@@ -15,23 +15,66 @@ public class Issue37012 : _IssuesUITest
 	[Category(UITestCategories.SafeAreaEdges)]
 	public void SafeAreaPaddingAppliedToPageReattachedDuringImeHideAnimation()
 	{
-		App.WaitForElement("OpenPageB");
-		App.Tap("OpenPageB");
+		// The scenario races a page pop against the IME hide animation; the page verifies the
+		// race was actually won (re-attach happened mid-animation) and reports Inconclusive
+		// otherwise, so retry a few times before giving up as inconclusive.
+		string resultText = string.Empty;
+		for (int attempt = 1; attempt <= 3; attempt++)
+		{
+			App.WaitForElement("OpenPageB");
+			App.Tap("OpenPageB");
 
-		App.WaitForElement("PageBEntry");
-		App.Tap("PageBEntry");
+			App.WaitForElement("PageBEntry");
+			App.Tap("PageBEntry");
 
-		// Ensure the keyboard is fully shown before triggering the hide + pop sequence
-		App.WaitForKeyboardToShow();
+			// Ensure the keyboard is fully shown before triggering the hide + pop sequence
+			App.WaitForKeyboardToShow();
 
-		App.Tap("HideAndPopButton");
+			App.Tap("HideAndPopButton");
 
-		// Page A reports its safe-area padding captured on the first frame drawn after
-		// re-attach vs. the padding once the IME hide animation has completed.
-		App.WaitForElement("ResultLabel");
-		var success = App.WaitForTextToBePresentInElement("ResultLabel", "Success", timeout: TimeSpan.FromSeconds(5));
-		var resultText = App.FindElement("ResultLabel").GetText();
-		Assert.That(success, Is.True, $"Expected safe-area padding on the first frame after re-attach, but got: {resultText}");
+			// Page A reports its safe-area padding captured on the first frame drawn after
+			// re-attach vs. the padding once the IME hide animation completed and settled.
+			App.WaitForElement("ResultLabel");
+			resultText = WaitForResult();
+
+			if (resultText.StartsWith("Success", StringComparison.OrdinalIgnoreCase))
+			{
+				return;
+			}
+
+			if (!resultText.StartsWith("Inconclusive", StringComparison.OrdinalIgnoreCase))
+			{
+				break;
+			}
+		}
+
+		if (resultText.StartsWith("Inconclusive", StringComparison.OrdinalIgnoreCase))
+		{
+			Assert.Inconclusive($"Could not reproduce the mid-animation re-attach precondition: {resultText}");
+		}
+
+		Assert.Fail($"Expected safe-area padding on the first frame after re-attach, but got: {resultText}");
+	}
+
+	string WaitForResult()
+	{
+		// The page writes Success/Fail/Inconclusive when its polling loop settles (up to ~4s
+		// on its side); poll the label instead of waiting a fixed time
+		var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(15);
+		string text;
+		do
+		{
+			text = App.FindElement("ResultLabel").GetText() ?? string.Empty;
+			if (!string.IsNullOrEmpty(text) && text != "Waiting")
+			{
+				return text;
+			}
+
+			Thread.Sleep(500);
+		}
+		while (DateTime.UtcNow < deadline);
+
+		return text;
 	}
 }
 #endif

--- a/src/Core/src/Platform/Android/MauiWindowInsetListener.cs
+++ b/src/Core/src/Platform/Android/MauiWindowInsetListener.cs
@@ -31,7 +31,16 @@ namespace Microsoft.Maui.Platform
 		readonly HashSet<AView> _trackedViews = [];
 		bool IsImeAnimating { get; set; }
 
-		AView? _pendingView;
+		// Views whose dispatches were gated while an IME animation was in flight; they all get
+		// RequestApplyInsets once the animation ends so no view is left with stale insets.
+		readonly HashSet<AView> _pendingViews = [];
+
+		// Views that started using this listener while an IME animation was in flight.
+		// The IsImeAnimating gate exists to keep already-correct views stable during the
+		// animation; a view that just (re)attached has no valid safe-area padding yet, so it
+		// must bypass the gate or it stays without padding until the animation ends (#37012).
+		// Cleared when an animation ends or a new one starts.
+		readonly HashSet<AView> _viewsAttachedDuringImeAnimation = [];
 
 		// Static tracking for views that have local inset listeners.
 		// This registry allows child views to find their appropriate listener without
@@ -230,19 +239,35 @@ namespace Microsoft.Maui.Platform
 		{
 		}
 
+		/// <summary>
+		/// Notifies this listener that a view has (re)attached to the window and started using it.
+		/// Views attached while an IME animation is in flight are exempted from the IsImeAnimating
+		/// gate for the remainder of that animation so they can obtain their safe-area padding.
+		/// Must be called on UI thread.
+		/// </summary>
+		/// <param name="view">The view that attached</param>
+		internal void NotifyViewAttached(AView view)
+		{
+			if (IsImeAnimating)
+			{
+				_viewsAttachedDuringImeAnimation.Add(view);
+			}
+		}
+
 		public virtual WindowInsetsCompat? OnApplyWindowInsets(AView? v, WindowInsetsCompat? insets)
 		{
-			if (insets is null || !insets.HasInsets || v is null || IsImeAnimating)
+			if (insets is null || !insets.HasInsets || v is null ||
+				(IsImeAnimating && !_viewsAttachedDuringImeAnimation.Contains(v)))
 			{
-				if (IsImeAnimating)
+				if (IsImeAnimating && v is not null)
 				{
-					_pendingView = v;
+					_pendingViews.Add(v);
 				}
 
 				return insets;
 			}
 
-			_pendingView = null;
+			_pendingViews.Remove(v);
 
 			// Handle custom inset views first
 			if (v is IHandleWindowInsets customHandler)
@@ -370,6 +395,8 @@ namespace Microsoft.Maui.Platform
 			}
 
 			_trackedViews.Remove(view);
+			_pendingViews.Remove(view);
+			_viewsAttachedDuringImeAnimation.Remove(view);
 		}
 
 		public void ResetAllViews()
@@ -429,6 +456,8 @@ namespace Microsoft.Maui.Platform
 			if (disposing)
 			{
 				ResetAllViews();
+				_pendingViews.Clear();
+				_viewsAttachedDuringImeAnimation.Clear();
 			}
 			base.Dispose(disposing);
 		}
@@ -438,7 +467,7 @@ namespace Microsoft.Maui.Platform
 			base.OnPrepare(animation);
 			if (IsImeAnimation(animation))
 			{
-				IsImeAnimating = true;
+				StartImeAnimation();
 			}
 		}
 
@@ -446,10 +475,21 @@ namespace Microsoft.Maui.Platform
 		{
 			if (IsImeAnimation(animation))
 			{
-				IsImeAnimating = true;
+				StartImeAnimation();
 			}
 
 			return bounds;
+		}
+
+		void StartImeAnimation()
+		{
+			if (!IsImeAnimating)
+			{
+				IsImeAnimating = true;
+
+				// Exemptions only apply to the animation during which the view attached
+				_viewsAttachedDuringImeAnimation.Clear();
+			}
 		}
 
 		public override WindowInsetsCompat? OnProgress(WindowInsetsCompat? insets, IList<WindowInsetsAnimationCompat>? runningAnimations)
@@ -478,13 +518,19 @@ namespace Microsoft.Maui.Platform
 
 			if (IsImeAnimation(animation))
 			{
-				if (_pendingView is AView view)
+				_viewsAttachedDuringImeAnimation.Clear();
+
+				if (_pendingViews.Count > 0)
 				{
-					_pendingView = null;
-					view.Post(() =>
+					var pendingViews = _pendingViews.ToArray();
+					_pendingViews.Clear();
+					pendingViews[0].Post(() =>
 					{
 						IsImeAnimating = false;
-						ViewCompat.RequestApplyInsets(view);
+						foreach (var view in pendingViews)
+						{
+							ViewCompat.RequestApplyInsets(view);
+						}
 					});
 				}
 				else
@@ -521,6 +567,7 @@ internal static class MauiWindowInsetListenerExtensions
 		{
 			ViewCompat.SetOnApplyWindowInsetsListener(view, localListener);
 			ViewCompat.SetWindowInsetsAnimationCallback(view, localListener);
+			localListener.NotifyViewAttached(view);
 			return true;
 		}
 
@@ -550,6 +597,7 @@ internal static class MauiWindowInsetListenerExtensions
 		{
 			ViewCompat.SetOnApplyWindowInsetsListener(view, listener);
 			ViewCompat.SetWindowInsetsAnimationCallback(view, listener);
+			listener.NotifyViewAttached(view);
 			return true;
 		}
 

--- a/src/Core/src/Platform/Android/MauiWindowInsetListener.cs
+++ b/src/Core/src/Platform/Android/MauiWindowInsetListener.cs
@@ -38,6 +38,11 @@ namespace Microsoft.Maui.Platform
 		// single call on any attached view covers every gated view.
 		bool _reapplyInsetsWhenAnimationEnds;
 
+		// The most recent view whose dispatch was gated. _trackedViews only holds views that
+		// have had padding applied, so a gated view is often absent from it; this keeps a
+		// poster candidate for the end-of-animation re-apply. Cleared when the animation ends.
+		AView? _lastGatedView;
+
 		// Views that started using this listener while an IME animation was in flight.
 		// The IsImeAnimating gate exists to keep already-correct views stable during the
 		// animation; a view that just (re)attached has no valid safe-area padding yet, so it
@@ -265,6 +270,7 @@ namespace Microsoft.Maui.Platform
 				if (IsImeAnimating && v is not null)
 				{
 					_reapplyInsetsWhenAnimationEnds = true;
+					_lastGatedView = v;
 				}
 
 				return insets;
@@ -408,6 +414,11 @@ namespace Microsoft.Maui.Platform
 
 			_trackedViews.Remove(view);
 			_viewsAttachedDuringImeAnimation.Remove(view);
+
+			if (ReferenceEquals(_lastGatedView, view))
+			{
+				_lastGatedView = null;
+			}
 		}
 
 		public void ResetAllViews()
@@ -580,6 +591,14 @@ namespace Microsoft.Maui.Platform
 				}
 			}
 
+			// _trackedViews only holds views that actually had padding applied, and a view
+			// gated during this animation has by definition not applied any yet — so fall
+			// back to the gated view itself, which is what the pre-PR code posted through
+			if (_lastGatedView.IsAlive() && _lastGatedView.IsAttachedToWindow)
+			{
+				return _lastGatedView;
+			}
+
 			return null;
 		}
 
@@ -587,20 +606,23 @@ namespace Microsoft.Maui.Platform
 		{
 			IsImeAnimating = false;
 			_gateReleaseScheduled = false;
+			_viewsAttachedDuringImeAnimation.Clear();
+			_lastGatedView = null;
 
 			if (!_reapplyInsetsWhenAnimationEnds)
 			{
 				return;
 			}
 
-			_reapplyInsetsWhenAnimationEnds = false;
-
-			// The poster was captured a looper turn earlier, so it can have been disposed
-			// by a page teardown in the meantime
+			// IsAlive covers null as well as a peer disposed during the one-looper-turn delay.
+			// Leave the flag set when we cannot act on it: the re-apply is still owed, and
+			// consuming it here would drop the settled insets entirely.
 			if (!reapplyThrough.IsAlive())
 			{
 				return;
 			}
+
+			_reapplyInsetsWhenAnimationEnds = false;
 
 			// One call is enough: this reaches the ViewRootImpl and re-dispatches insets
 			// across the whole hierarchy, so every gated view gets its settled insets

--- a/src/Core/src/Platform/Android/MauiWindowInsetListener.cs
+++ b/src/Core/src/Platform/Android/MauiWindowInsetListener.cs
@@ -267,7 +267,17 @@ namespace Microsoft.Maui.Platform
 				return insets;
 			}
 
-			_pendingViews.Remove(v);
+			if (IsImeAnimating)
+			{
+				// v was exempted through the gate and may be applying transient animation-time
+				// IME insets (e.g. keyboard-height bottom padding mid hide-animation); keep it
+				// pending so the end of the animation re-applies the final insets
+				_pendingViews.Add(v);
+			}
+			else
+			{
+				_pendingViews.Remove(v);
+			}
 
 			// Handle custom inset views first
 			if (v is IHandleWindowInsets customHandler)
@@ -516,26 +526,68 @@ namespace Microsoft.Maui.Platform
 		{
 			base.OnEnd(animation);
 
-			if (IsImeAnimation(animation))
+			if (!IsImeAnimation(animation))
 			{
-				_viewsAttachedDuringImeAnimation.Clear();
+				return;
+			}
 
-				if (_pendingViews.Count > 0)
+			_viewsAttachedDuringImeAnimation.Clear();
+
+			// Keep the gate up for one more main-looper turn: the system's deferred
+			// post-animation inset dispatches can still carry animation-time IME insets.
+			// EndImeAnimation drains the *live* pending set, so dispatches gated between
+			// OnEnd and the posted runnable are flushed instead of silently dropped.
+			AView? poster = null;
+			foreach (var view in _pendingViews)
+			{
+				if (view.Handle != IntPtr.Zero && view.IsAttachedToWindow)
 				{
-					var pendingViews = _pendingViews.ToArray();
-					_pendingViews.Clear();
-					pendingViews[0].Post(() =>
-					{
-						IsImeAnimating = false;
-						foreach (var view in pendingViews)
-						{
-							ViewCompat.RequestApplyInsets(view);
-						}
-					});
+					poster = view;
+					break;
 				}
-				else
+			}
+
+			if (poster is not null)
+			{
+				poster.Post(EndImeAnimation);
+			}
+			else
+			{
+				// Nothing pending, or every pending view is detached: a detached view's Post
+				// only runs if that view re-attaches, which would leave the gate stuck for the
+				// whole subtree — end the animation synchronously instead.
+				EndImeAnimation();
+			}
+		}
+
+		void EndImeAnimation()
+		{
+			IsImeAnimating = false;
+
+			if (_pendingViews.Count == 0)
+			{
+				return;
+			}
+
+			var pendingViews = _pendingViews.ToArray();
+			_pendingViews.Clear();
+
+			foreach (var view in pendingViews)
+			{
+				// The page-pop scenarios that gate views here can also detach and dispose them
+				// before this runnable executes; skip dead peers instead of aborting the loop
+				if (view.Handle == IntPtr.Zero)
 				{
-					IsImeAnimating = false;
+					continue;
+				}
+
+				try
+				{
+					ViewCompat.RequestApplyInsets(view);
+				}
+				catch (ObjectDisposedException)
+				{
+					// The view was disposed while the re-apply was in flight; nothing to re-apply
 				}
 			}
 		}
@@ -597,7 +649,10 @@ internal static class MauiWindowInsetListenerExtensions
 		{
 			ViewCompat.SetOnApplyWindowInsetsListener(view, listener);
 			ViewCompat.SetWindowInsetsAnimationCallback(view, listener);
-			listener.NotifyViewAttached(view);
+			// Deliberately no NotifyViewAttached here: this is a SafeAreaEdges configuration
+			// change on a live, already-padded view — it must stay subject to the IME gate
+			// (it gets its updated insets at the end of any in-flight animation), whereas the
+			// gate exemption is only for views with no valid padding yet (fresh attach).
 			return true;
 		}
 

--- a/src/Core/src/Platform/Android/MauiWindowInsetListener.cs
+++ b/src/Core/src/Platform/Android/MauiWindowInsetListener.cs
@@ -31,9 +31,12 @@ namespace Microsoft.Maui.Platform
 		readonly HashSet<AView> _trackedViews = [];
 		bool IsImeAnimating { get; set; }
 
-		// Views whose dispatches were gated while an IME animation was in flight; they all get
-		// RequestApplyInsets once the animation ends so no view is left with stale insets.
-		readonly HashSet<AView> _pendingViews = [];
+		// Set when a dispatch was gated (or an exempted view applied animation-time insets)
+		// while an IME animation was in flight, so the end of the animation re-applies the
+		// settled insets. RequestApplyInsets is not per-view: it walks up to the ViewRootImpl
+		// and re-dispatches insets across the whole hierarchy on the next traversal, so a
+		// single call on any attached view covers every gated view.
+		bool _reapplyInsetsWhenAnimationEnds;
 
 		// Views that started using this listener while an IME animation was in flight.
 		// The IsImeAnimating gate exists to keep already-correct views stable during the
@@ -261,7 +264,7 @@ namespace Microsoft.Maui.Platform
 			{
 				if (IsImeAnimating && v is not null)
 				{
-					_pendingViews.Add(v);
+					_reapplyInsetsWhenAnimationEnds = true;
 				}
 
 				return insets;
@@ -271,15 +274,11 @@ namespace Microsoft.Maui.Platform
 			{
 				// The exemption is one-shot: it exists to give a freshly attached view its initial
 				// padding, and after this first successful apply the view is correct and gets gated
-				// like every other view for the rest of the animation. It also stays pending: the
-				// insets it just applied are animation-time values (e.g. keyboard-height bottom
-				// padding mid hide-animation), so the end of the animation re-applies final insets.
+				// like every other view for the rest of the animation. The insets it just applied
+				// are animation-time values (e.g. keyboard-height bottom padding mid
+				// hide-animation), so the end of the animation must re-apply the settled ones.
 				_viewsAttachedDuringImeAnimation.Remove(v);
-				_pendingViews.Add(v);
-			}
-			else
-			{
-				_pendingViews.Remove(v);
+				_reapplyInsetsWhenAnimationEnds = true;
 			}
 
 			// Handle custom inset views first
@@ -408,7 +407,6 @@ namespace Microsoft.Maui.Platform
 			}
 
 			_trackedViews.Remove(view);
-			_pendingViews.Remove(view);
 			_viewsAttachedDuringImeAnimation.Remove(view);
 		}
 
@@ -469,7 +467,6 @@ namespace Microsoft.Maui.Platform
 			if (disposing)
 			{
 				ResetAllViews();
-				_pendingViews.Clear();
 				_viewsAttachedDuringImeAnimation.Clear();
 			}
 			base.Dispose(disposing);
@@ -546,17 +543,10 @@ namespace Microsoft.Maui.Platform
 
 			// Keep the gate up for one more main-looper turn: the system's deferred
 			// post-animation inset dispatches can still carry animation-time IME insets.
-			// EndImeAnimation drains the *live* pending set, so dispatches gated between
-			// OnEnd and the posted runnable are flushed instead of silently dropped.
-			AView? poster = null;
-			foreach (var view in _pendingViews)
-			{
-				if (view.Handle != IntPtr.Zero && view.IsAttachedToWindow)
-				{
-					poster = view;
-					break;
-				}
-			}
+			// The release must be posted through an *attached* view — a detached view's Post
+			// only runs if that view re-attaches, which would leave the gate closed for every
+			// view sharing this listener.
+			var poster = FindAttachedTrackedView();
 
 			if (poster is not null)
 			{
@@ -567,50 +557,54 @@ namespace Microsoft.Maui.Platform
 					// this ran means the release belongs to the old one and must be skipped
 					if (_gateReleaseScheduled)
 					{
-						EndImeAnimation();
+						EndImeAnimation(poster);
 					}
 				});
 			}
 			else
 			{
-				// Nothing pending, or every pending view is detached: a detached view's Post
-				// only runs if that view re-attaches, which would leave the gate stuck for the
-				// whole subtree — end the animation synchronously instead.
-				EndImeAnimation();
+				// No attached view to post through; release synchronously rather than
+				// leaving the gate stuck
+				EndImeAnimation(null);
 			}
 		}
 
-		void EndImeAnimation()
+		AView? FindAttachedTrackedView()
+		{
+			foreach (var view in _trackedViews)
+			{
+				// A view can be disposed while still tracked when a cleanup path is skipped
+				if (view.IsAlive() && view.IsAttachedToWindow)
+				{
+					return view;
+				}
+			}
+
+			return null;
+		}
+
+		void EndImeAnimation(AView? reapplyThrough)
 		{
 			IsImeAnimating = false;
 			_gateReleaseScheduled = false;
 
-			if (_pendingViews.Count == 0)
+			if (!_reapplyInsetsWhenAnimationEnds)
 			{
 				return;
 			}
 
-			var pendingViews = _pendingViews.ToArray();
-			_pendingViews.Clear();
+			_reapplyInsetsWhenAnimationEnds = false;
 
-			foreach (var view in pendingViews)
+			// The poster was captured a looper turn earlier, so it can have been disposed
+			// by a page teardown in the meantime
+			if (!reapplyThrough.IsAlive())
 			{
-				// The page-pop scenarios that gate views here can also detach and dispose them
-				// before this runnable executes; skip dead peers instead of aborting the loop
-				if (view.Handle == IntPtr.Zero)
-				{
-					continue;
-				}
-
-				try
-				{
-					ViewCompat.RequestApplyInsets(view);
-				}
-				catch (ObjectDisposedException)
-				{
-					// The view was disposed while the re-apply was in flight; nothing to re-apply
-				}
+				return;
 			}
+
+			// One call is enough: this reaches the ViewRootImpl and re-dispatches insets
+			// across the whole hierarchy, so every gated view gets its settled insets
+			ViewCompat.RequestApplyInsets(reapplyThrough);
 		}
 
 		/// <summary>
@@ -671,9 +665,13 @@ internal static class MauiWindowInsetListenerExtensions
 			ViewCompat.SetOnApplyWindowInsetsListener(view, listener);
 			ViewCompat.SetWindowInsetsAnimationCallback(view, listener);
 			// Deliberately no NotifyViewAttached here: this is a SafeAreaEdges configuration
-			// change on a live, already-padded view — it must stay subject to the IME gate
-			// (it gets its updated insets at the end of any in-flight animation), whereas the
-			// gate exemption is only for views with no valid padding yet (fresh attach).
+			// change, which for an already-listening view means it is already padded and must
+			// stay subject to the IME gate (it gets its updated insets at the end of any
+			// in-flight animation), whereas the exemption is for fresh attaches.
+			// Caveat: a view transitioning from ineligible to eligible (e.g. SafeAreaEdges
+			// None -> All) has no padding yet, so if that lands mid-animation it stays
+			// unpadded until the animation ends. Closing that would mean threading the
+			// callers' _isInsetListenerSet state through this method.
 			return true;
 		}
 

--- a/src/Core/src/Platform/Android/MauiWindowInsetListener.cs
+++ b/src/Core/src/Platform/Android/MauiWindowInsetListener.cs
@@ -269,9 +269,12 @@ namespace Microsoft.Maui.Platform
 
 			if (IsImeAnimating)
 			{
-				// v was exempted through the gate and may be applying transient animation-time
-				// IME insets (e.g. keyboard-height bottom padding mid hide-animation); keep it
-				// pending so the end of the animation re-applies the final insets
+				// The exemption is one-shot: it exists to give a freshly attached view its initial
+				// padding, and after this first successful apply the view is correct and gets gated
+				// like every other view for the rest of the animation. It also stays pending: the
+				// insets it just applied are animation-time values (e.g. keyboard-height bottom
+				// padding mid hide-animation), so the end of the animation re-applies final insets.
+				_viewsAttachedDuringImeAnimation.Remove(v);
 				_pendingViews.Add(v);
 			}
 			else
@@ -491,8 +494,16 @@ namespace Microsoft.Maui.Platform
 			return bounds;
 		}
 
+		// Set when OnEnd posts a gate release and cleared when an animation starts, so a
+		// release posted by a previous animation cannot open the gate mid-flight: with
+		// back-to-back animations (a hide immediately followed by a show) the new OnPrepare
+		// can arrive before the posted runnable executes.
+		bool _gateReleaseScheduled;
+
 		void StartImeAnimation()
 		{
+			_gateReleaseScheduled = false;
+
 			if (!IsImeAnimating)
 			{
 				IsImeAnimating = true;
@@ -549,7 +560,16 @@ namespace Microsoft.Maui.Platform
 
 			if (poster is not null)
 			{
-				poster.Post(EndImeAnimation);
+				_gateReleaseScheduled = true;
+				poster.Post(() =>
+				{
+					// StartImeAnimation clears the flag, so a new animation started before
+					// this ran means the release belongs to the old one and must be skipped
+					if (_gateReleaseScheduled)
+					{
+						EndImeAnimation();
+					}
+				});
 			}
 			else
 			{
@@ -563,6 +583,7 @@ namespace Microsoft.Maui.Platform
 		void EndImeAnimation()
 		{
 			IsImeAnimating = false;
+			_gateReleaseScheduled = false;
 
 			if (_pendingViews.Count == 0)
 			{


### PR DESCRIPTION
### Description of Change

On Android, `MauiWindowInsetListener` gates inset dispatches while an IME animation is in flight. Because safe-area padding is reset when a view detaches, a page platform view that reattaches while the keyboard is animating closed can otherwise draw its first frame with zero safe-area padding and jump into place only after the animation ends.

This PR changes `src/Core/src/Platform/Android/MauiWindowInsetListener.cs` in two ways:

1. **A view attached during an IME animation can bypass the gate for one valid inset dispatch.** `TrySetMauiWindowInsetListener`, used by the `OnAttachedToWindow` paths of `ContentViewGroup`, `LayoutViewGroup`, and `MauiScrollView`, calls a new `NotifyViewAttached` hook. The exemption is one-shot: after a valid dispatch gives the newly attached view initial padding, it is gated like existing views for the rest of the animation. Invalid or empty inset dispatches do not consume the exemption. Because the applied values are animation-time values, a settled hierarchy redispatch remains owed. `RefreshMauiWindowInsetListener` is a configuration refresh rather than a fresh attach and does not grant the exemption.

2. **The animation gate no longer depends on posting through a detached pending view.** Gated or exempted dispatches record that settled insets must be reapplied. At animation end, the listener selects an alive, attached tracked or gated view and posts the gate release for the next looper turn; if no usable poster exists, it releases the gate synchronously while retaining the owed redispatch for a later animation with an attached poster. A release posted by an earlier animation cannot open the gate after a new animation has started.

One `RequestApplyInsets` is enough because it reaches the `ViewRootImpl` and redispatches insets across the hierarchy on the next traversal. The added state is listener-scoped and bounded by the animation, with no per-frame work in `OnProgress`.

### Tests

`MauiWindowInsetListenerTests` Android device tests cover:

- an existing view remaining gated while a newly attached view bypasses the gate once;
- attach exemptions being cleared at animation end;
- synchronous gate release when no attached poster is available;
- an owed redispatch being retained when an animation ends without a usable poster and delivered later;
- one hierarchy-wide `RequestApplyInsets` for multiple gated views; and
- a stale release from one animation not opening the next animation's gate.

The Android `Issue37012` UI test hides the keyboard and pops from Page B to Page A during the IME hide animation. It verifies that Page A has safe-area padding on its first frame after reattach and that keyboard-height bottom padding is not retained after the IME settles.

### Issues Fixed

Fixes #37012
