### PR TITLE
Flatten inter-branch merge policy matchers

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -718,7 +718,9 @@ configuration:
       - addLabel:
           label: partner/syncfusion
       description: Add 'partner/syncfusion' label to issues opened by the Syncfusion partner team
-    - if:
+    - description: '[Inter-branch merge] Auto-approve main to net11.0'
+      triggerOnOwnActions: false
+      if:
       - payloadType: Pull_Request
       - isPullRequest
       - isActivitySender:
@@ -726,36 +728,75 @@ configuration:
           issueAuthor: False
       - isAction:
           action: Opened
-      - or:
-        - and:
-          - targetsBranch:
-              branch: net11.0
-          - titleContains:
-              pattern: '^\[automated\] Merge branch ''main'' => ''net11\.0''$'
-              isRegex: True
-        - and:
-          - targetsBranch:
-              branch: release/11.0.1xx-preview7
-          - titleContains:
-              pattern: '^\[automated\] Merge branch ''net11\.0'' => ''release/11\.0\.1xx-preview7''$'
-              isRegex: True
-        - and:
-          - targetsBranch:
-              branch: release/11.0.1xx-rc1
-          - titleContains:
-              pattern: '^\[automated\] Merge branch ''net11\.0'' => ''release/11\.0\.1xx-rc1''$'
-              isRegex: True
-        - and:
-          - targetsBranch:
-              branch: release/11.0.1xx-rc2
-          - titleContains:
-              pattern: '^\[automated\] Merge branch ''net11\.0'' => ''release/11\.0\.1xx-rc2''$'
-              isRegex: True
+      - titleContains:
+          pattern: '^\[automated\] Merge branch ''main'' => ''net11\.0''$'
+          isRegex: True
+      - targetsBranch:
+          branch: net11.0
       then:
       - approvePullRequest:
           comment: Auto-approved automated inter-branch merge.
       - enableAutoMerge:
           mergeMethod: merge
-      description: '[Inter-branch merge] Auto-approve and enable auto-merge for exact forward-merge flows'
+    - description: '[Inter-branch merge] Auto-approve net11.0 to preview7'
+      triggerOnOwnActions: false
+      if:
+      - payloadType: Pull_Request
+      - isPullRequest
+      - isActivitySender:
+          user: github-actions[bot]
+          issueAuthor: False
+      - isAction:
+          action: Opened
+      - titleContains:
+          pattern: '^\[automated\] Merge branch ''net11\.0'' => ''release/11\.0\.1xx-preview7''$'
+          isRegex: True
+      - targetsBranch:
+          branch: release/11.0.1xx-preview7
+      then:
+      - approvePullRequest:
+          comment: Auto-approved automated inter-branch merge.
+      - enableAutoMerge:
+          mergeMethod: merge
+    - description: '[Inter-branch merge] Auto-approve net11.0 to rc1'
+      triggerOnOwnActions: false
+      if:
+      - payloadType: Pull_Request
+      - isPullRequest
+      - isActivitySender:
+          user: github-actions[bot]
+          issueAuthor: False
+      - isAction:
+          action: Opened
+      - titleContains:
+          pattern: '^\[automated\] Merge branch ''net11\.0'' => ''release/11\.0\.1xx-rc1''$'
+          isRegex: True
+      - targetsBranch:
+          branch: release/11.0.1xx-rc1
+      then:
+      - approvePullRequest:
+          comment: Auto-approved automated inter-branch merge.
+      - enableAutoMerge:
+          mergeMethod: merge
+    - description: '[Inter-branch merge] Auto-approve net11.0 to rc2'
+      triggerOnOwnActions: false
+      if:
+      - payloadType: Pull_Request
+      - isPullRequest
+      - isActivitySender:
+          user: github-actions[bot]
+          issueAuthor: False
+      - isAction:
+          action: Opened
+      - titleContains:
+          pattern: '^\[automated\] Merge branch ''net11\.0'' => ''release/11\.0\.1xx-rc2''$'
+          isRegex: True
+      - targetsBranch:
+          branch: release/11.0.1xx-rc2
+      then:
+      - approvePullRequest:
+          comment: Auto-approved automated inter-branch merge.
+      - enableAutoMerge:
+          mergeMethod: merge
 onFailure: 
 onSuccess: 

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -724,8 +724,6 @@ configuration:
       - isActivitySender:
           user: github-actions[bot]
           issueAuthor: False
-      - isActivitySender:
-          issueAuthor: True
       - isAction:
           action: Opened
       - or:


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Split the inter-branch merge Policy Service rule into four flat rules, one for each exact allowed target/title pair.

Fresh bot-opened PRs #36989, #37007, and #37042 received neither a Policy Service review nor an auto-merge request. The latest test, #37042, exactly matched the configured sender, `Opened` action, target branch, and anchored title, while Policy Service continued processing other MAUI PR events normally.

The investigation ruled out sender normalization, configuration parsing, regex matching, task-count limits, missing App permissions, and unsupported individual primitives. The remaining MAUI-specific difference from working policies is the nested `or`-of-`and` matcher that combines `targetsBranch` with anchored regex titles. Policy Service swallows condition/action exceptions without a visible GitHub diagnostic, so its hosted failure cannot be distinguished further without service-side evaluation logs.

This change removes that unique compound shape. Each flow now uses the flat condition layout already used by working dotnet-org policies:

- exact `github-actions[bot]` sender
- fresh `Opened` events only
- exact anchored title regex
- exact target branch
- explicit `triggerOnOwnActions: false`
- Policy Service approval and merge-method auto-merge

### Security

The allow-list is unchanged. The rules still reject synchronize events, non-bot senders, mismatched titles, and mismatched target branches. Splitting the rule does not broaden any accepted source/target pair or change the merge method.

### Verification

- Deserialized the complete policy with the production `GitOps.PullRequestIssueManagement` NuGet package (`0.1.182`). It loads all 24 event responder tasks and all four flat rules with the expected condition/action types.
- Verified each anchored regex matches only its corresponding generated title sample.
- Asserted the four exact target/title pairs, `Opened`-only behavior, explicit own-action suppression, approval action, and `merge` auto-merge method.
- Parsed the complete file as YAML.
- `git diff --check` passes with the repository's CRLF convention.

### Follow-up validation

After this policy change merges, close #37042 and let the existing workflow create a fresh PR. The success criteria are a `dotnet-policy-service` approval, a `MERGE` auto-merge request, and automatic completion after `maui-pr` passes.

### Issues Fixed

Follow-up to #36875 and #36992.