### PR TITLE
[release/11.0.1xx-preview7] Fix Android Window device test context

### DIFF
--- a/src/Core/tests/DeviceTests.Shared/Stubs/ContextStub.cs
+++ b/src/Core/tests/DeviceTests.Shared/Stubs/ContextStub.cs
@@ -47,6 +47,9 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 			if (serviceType == typeof(global::Android.Content.Context))
 				return MauiProgramDefaults.DefaultContext;
 
+			if (serviceType == typeof(global::Android.App.Activity))
+				return (global::Android.App.Activity)MauiProgramDefaults.DefaultContext;
+
 			if (serviceType == typeof(NavigationRootManager))
 				return _windowManager ??= new NavigationRootManager(this);
 #elif IOS || MACCATALYST


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

The preview7 Android Core device tests fail both `StatusBarThemeAppliesWhenHandlerConnects` cases because `WindowHandler` requests `Android.App.Activity`, while the device-test `ContextStub` only resolves `Android.Content.Context`. This maps the Activity service to the lifecycle-initialized `MauiProgramDefaults.DefaultContext`, matching the actual Android test host.

## Validation

The branch failure reproduces in both Mono and CoreCLR Android Helix runs with `MauiContext did not have a valid window`. The targeted device-test pipeline is requested below.