### PR TITLE
[release/11.0.1xx-preview7] Preserve Android Entry text during handler reuse

### DIFF
--- a/src/Controls/src/Core/Entry/Entry.Android.cs
+++ b/src/Controls/src/Core/Entry/Entry.Android.cs
@@ -27,7 +27,11 @@ namespace Microsoft.Maui.Controls
 				return;
 			}
 
-			Platform.EditTextExtensions.UpdateText(handler.PlatformView, entry);
+			var isMappingProperties = handler.IsMappingProperties();
+			if (isMappingProperties)
+				handler.UpdateValue(nameof(IEntry.MaxLength));
+
+			Platform.EditTextExtensions.UpdateText(handler.PlatformView, entry, isMappingProperties);
 		}
 
 		// MaterialEntryHandler-specific overloads

--- a/src/Controls/src/Core/Entry/Entry.Android.cs
+++ b/src/Controls/src/Core/Entry/Entry.Android.cs
@@ -58,7 +58,11 @@ namespace Microsoft.Maui.Controls
 				return;
 			}
 
-			Platform.EditTextExtensions.UpdateText(handler.PlatformView.EditText, entry);
+			var isMappingProperties = handler.IsMappingProperties();
+			if (isMappingProperties)
+				handler.UpdateValue(nameof(IEntry.MaxLength));
+
+			Platform.EditTextExtensions.UpdateText(handler.PlatformView.EditText, entry, isMappingProperties);
 		}
 
 		// Material3 specific overload for EntryHandler2

--- a/src/Controls/src/Core/Platform/Android/Extensions/EditTextExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/EditTextExtensions.cs
@@ -35,11 +35,14 @@ namespace Microsoft.Maui.Controls.Platform
 			return (oldText, newText);
 		}
 
-		public static void UpdateText(this EditText editText, InputView inputView)
+		public static void UpdateText(this EditText editText, InputView inputView) =>
+			UpdateText(editText, inputView, false);
+
+		internal static void UpdateText(this EditText editText, InputView inputView, bool forceUpdate)
 		{
 			(var oldText, var newText) = GetTexts(editText, inputView);
 
-			if (oldText != newText)
+			if (forceUpdate || oldText != newText)
 			{
 				editText.Text = newText;
 

--- a/src/Controls/tests/DeviceTests/ControlsDeviceTestExtensions.cs
+++ b/src/Controls/tests/DeviceTests/ControlsDeviceTestExtensions.cs
@@ -15,9 +15,25 @@ namespace Microsoft.Maui.DeviceTests
 	{
 		public static MauiAppBuilder ConfigureTestBuilder(this MauiAppBuilder mauiAppBuilder)
 		{
+#if ANDROID
+			const string material3SwitchName = "Microsoft.Maui.RuntimeFeature.IsMaterial3Enabled";
+			var isMaterial3Enabled = RuntimeFeature.IsMaterial3Enabled;
+			System.AppContext.SetSwitch(material3SwitchName, true);
+			try
+			{
+				// Tests instantiate EntryHandler2 directly, so configure its Controls mappings without changing the suite's default handler.
+				mauiAppBuilder.RemapForControls();
+			}
+			finally
+			{
+				System.AppContext.SetSwitch(material3SwitchName, isMaterial3Enabled);
+			}
+#else
+			mauiAppBuilder.RemapForControls();
+#endif
+
 			return
 				mauiAppBuilder
-					.RemapForControls()
 					.ConfigureLifecycleEvents(lifecycle =>
 					{
 #if IOS || MACCATALYST

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.cs
@@ -297,7 +297,9 @@ namespace Microsoft.Maui.DeviceTests
 			var thirdEntry = new Entry
 			{
 				MaxLength = 2,
-				Text = longText
+				Text = longText,
+				CursorPosition = 1,
+				SelectionLength = 1
 			};
 
 			if (useMaterial3)
@@ -308,7 +310,11 @@ namespace Microsoft.Maui.DeviceTests
 					secondEntry,
 					thirdEntry,
 					longText,
-					() => handler.PlatformView.EditText?.Text);
+					() => handler.PlatformView.EditText?.Text,
+					() => handler.PlatformView.EditText?.SelectionStart ?? -1,
+					() => handler.PlatformView.EditText is { } editText
+						? Math.Abs(editText.SelectionEnd - editText.SelectionStart)
+						: -1);
 			}
 			else
 			{
@@ -318,7 +324,9 @@ namespace Microsoft.Maui.DeviceTests
 					secondEntry,
 					thirdEntry,
 					longText,
-					() => handler.PlatformView.Text);
+					() => handler.PlatformView.Text,
+					() => handler.PlatformView.SelectionStart,
+					() => Math.Abs(handler.PlatformView.SelectionEnd - handler.PlatformView.SelectionStart));
 			}
 		}
 
@@ -327,7 +335,9 @@ namespace Microsoft.Maui.DeviceTests
 			Entry secondEntry,
 			Entry thirdEntry,
 			string expectedText,
-			Func<string?> getPlatformText)
+			Func<string> getPlatformText,
+			Func<int> getPlatformCursorPosition,
+			Func<int> getPlatformSelectionLength)
 			where THandler : IElementHandler
 		{
 			await InvokeOnMainThreadAsync(() => handler.SetVirtualView(secondEntry));
@@ -339,6 +349,10 @@ namespace Microsoft.Maui.DeviceTests
 
 			Assert.Equal("AA", thirdEntry.Text);
 			Assert.Equal(thirdEntry.Text, await InvokeOnMainThreadAsync(getPlatformText));
+			Assert.Equal(1, thirdEntry.CursorPosition);
+			Assert.Equal(1, thirdEntry.SelectionLength);
+			Assert.Equal(thirdEntry.CursorPosition, await InvokeOnMainThreadAsync(getPlatformCursorPosition));
+			Assert.Equal(thirdEntry.SelectionLength, await InvokeOnMainThreadAsync(getPlatformSelectionLength));
 		}
 #endif
 

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.cs
@@ -278,9 +278,11 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 #if ANDROID
-		[Fact(DisplayName = "Entry text respects MaxLength when the handler is reused")]
+		[Theory(DisplayName = "Entry text respects MaxLength when the handler is reused")]
+		[InlineData(false)]
+		[InlineData(true)]
 		[Category(TestCategory.Entry)]
-		public async Task EntryTextRespectsMaxLengthWhenHandlerIsReused()
+		public async Task EntryTextRespectsMaxLengthWhenHandlerIsReused(bool useMaterial3)
 		{
 			var firstEntry = new Entry
 			{
@@ -292,23 +294,51 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				Text = longText
 			};
-
-			var handler = await CreateHandlerAsync<EntryHandler>(firstEntry);
-			await InvokeOnMainThreadAsync(() => handler.SetVirtualView(secondEntry));
-
-			Assert.Equal(longText, secondEntry.Text);
-			Assert.Equal(longText, await GetPlatformText(handler));
-
 			var thirdEntry = new Entry
 			{
 				MaxLength = 2,
 				Text = longText
 			};
 
+			if (useMaterial3)
+			{
+				var handler = await CreateHandlerAsync<EntryHandler2>(firstEntry);
+				await VerifyEntryTextRespectsMaxLengthWhenHandlerIsReused(
+					handler,
+					secondEntry,
+					thirdEntry,
+					longText,
+					() => handler.PlatformView.EditText?.Text);
+			}
+			else
+			{
+				var handler = await CreateHandlerAsync<EntryHandler>(firstEntry);
+				await VerifyEntryTextRespectsMaxLengthWhenHandlerIsReused(
+					handler,
+					secondEntry,
+					thirdEntry,
+					longText,
+					() => handler.PlatformView.Text);
+			}
+		}
+
+		async Task VerifyEntryTextRespectsMaxLengthWhenHandlerIsReused<THandler>(
+			THandler handler,
+			Entry secondEntry,
+			Entry thirdEntry,
+			string expectedText,
+			Func<string?> getPlatformText)
+			where THandler : IElementHandler
+		{
+			await InvokeOnMainThreadAsync(() => handler.SetVirtualView(secondEntry));
+
+			Assert.Equal(expectedText, secondEntry.Text);
+			Assert.Equal(expectedText, await InvokeOnMainThreadAsync(getPlatformText));
+
 			await InvokeOnMainThreadAsync(() => handler.SetVirtualView(thirdEntry));
 
 			Assert.Equal("AA", thirdEntry.Text);
-			Assert.Equal("AA", await GetPlatformText(handler));
+			Assert.Equal(thirdEntry.Text, await InvokeOnMainThreadAsync(getPlatformText));
 		}
 #endif
 

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.cs
@@ -277,6 +277,41 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal("short", await GetPlatformText(handler));
 		}
 
+#if ANDROID
+		[Fact(DisplayName = "Entry text respects MaxLength when the handler is reused")]
+		[Category(TestCategory.Entry)]
+		public async Task EntryTextRespectsMaxLengthWhenHandlerIsReused()
+		{
+			var firstEntry = new Entry
+			{
+				MaxLength = 2,
+				Text = "first"
+			};
+			string longText = new string('A', 5001);
+			var secondEntry = new Entry
+			{
+				Text = longText
+			};
+
+			var handler = await CreateHandlerAsync<EntryHandler>(firstEntry);
+			await InvokeOnMainThreadAsync(() => handler.SetVirtualView(secondEntry));
+
+			Assert.Equal(longText, secondEntry.Text);
+			Assert.Equal(longText, await GetPlatformText(handler));
+
+			var thirdEntry = new Entry
+			{
+				MaxLength = 2,
+				Text = longText
+			};
+
+			await InvokeOnMainThreadAsync(() => handler.SetVirtualView(thirdEntry));
+
+			Assert.Equal("AA", thirdEntry.Text);
+			Assert.Equal("AA", await GetPlatformText(handler));
+		}
+#endif
+
 		[Fact(
 #if WINDOWS
 		Skip = "Fails on Windows"

--- a/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
@@ -70,8 +70,13 @@ namespace Microsoft.Maui.Handlers
 		public static void MapBackground(IEntryHandler handler, IEntry entry) =>
 			handler.PlatformView?.UpdateBackground(entry);
 
-		public static void MapText(IEntryHandler handler, IEntry entry) =>
+		public static void MapText(IEntryHandler handler, IEntry entry)
+		{
+			if (handler.IsMappingProperties())
+				handler.UpdateValue(nameof(IEntry.MaxLength));
+
 			handler.PlatformView?.UpdateText(entry);
+		}
 
 		public static void MapTextColor(IEntryHandler handler, IEntry entry)
 		{
@@ -102,8 +107,16 @@ namespace Microsoft.Maui.Handlers
 		public static void MapIsSpellCheckEnabled(IEntryHandler handler, IEntry entry) =>
 			handler.PlatformView?.UpdateIsSpellCheckEnabled(entry);
 
-		public static void MapMaxLength(IEntryHandler handler, IEntry entry) =>
-			handler.PlatformView?.UpdateMaxLength(entry);
+		public static void MapMaxLength(IEntryHandler handler, IEntry entry)
+		{
+			if (handler.PlatformView is not { } platformView)
+				return;
+
+			if (handler.IsMappingProperties())
+				platformView.SetLengthFilter(entry.MaxLength);
+			else
+				platformView.UpdateMaxLength(entry);
+		}
 
 		public static void MapPlaceholder(IEntryHandler handler, IEntry entry) =>
 			handler.PlatformView?.UpdatePlaceholder(entry);

--- a/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
@@ -27,11 +27,25 @@ namespace Microsoft.Maui.Handlers
 
 		public override void SetVirtualView(IView view)
 		{
+			var cursorPosition = ((IEntry)view).CursorPosition;
+			var selectionLength = ((IEntry)view).SelectionLength;
+			var restoreSelection = _set;
+
+			if (restoreSelection)
+				PlatformView.SelectionChanged -= OnSelectionChanged;
+
 			base.SetVirtualView(view);
 
-			if (!_set)
-				PlatformView.SelectionChanged += OnSelectionChanged;
+			if (restoreSelection)
+			{
+				// Text mapping moves the native selection to the end; preserve the incoming selection when reusing the handler.
+				VirtualView.CursorPosition = cursorPosition;
+				VirtualView.SelectionLength = selectionLength;
+				UpdateValue(nameof(IEntry.CursorPosition));
+				UpdateValue(nameof(IEntry.SelectionLength));
+			}
 
+			PlatformView.SelectionChanged += OnSelectionChanged;
 			_set = true;
 		}
 
@@ -247,6 +261,9 @@ namespace Microsoft.Maui.Handlers
 
 		private void OnSelectionChanged(object? sender, EventArgs e)
 		{
+			if (this.IsMappingProperties())
+				return;
+
 			var cursorPosition = PlatformView.GetCursorPosition();
 			var selectedTextLength = PlatformView.GetSelectedTextLength();
 

--- a/src/Core/src/Handlers/Entry/EntryHandler.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.cs
@@ -19,9 +19,6 @@ namespace Microsoft.Maui.Handlers
 	{
 		private static readonly IPropertyMapper<IEntry, IEntryHandler> TextMapper = new PropertyMapper<IEntry, IEntryHandler>
 		{
-			// Android reapplies its default 5000-character limit when IsPassword maps the native input type.
-			// Apply the configured MaxLength first so long text is not truncated before Text is mapped.
-			[nameof(IEntry.MaxLength)] = MapMaxLength,
 			// Ensure IsPassword is mapped before Text so the native field is secured before
 			// text (and any TextTransform) is applied on initial attachment
 			[nameof(IEntry.IsPassword)] = MapIsPassword,
@@ -29,6 +26,7 @@ namespace Microsoft.Maui.Handlers
 			// due to them being applied to the native object (i.e. AttributedText on iOS) created by mapping Text
 			[nameof(IEntry.Text)] = MapText,
 			[nameof(IEntry.ClearButtonVisibility)] = MapClearButtonVisibility,
+			[nameof(IEntry.MaxLength)] = MapMaxLength,
 			[nameof(IEntry.Font)] = MapFont,
 			[nameof(IEntry.CharacterSpacing)] = MapCharacterSpacing,
 			[nameof(IEntry.TextColor)] = MapTextColor,

--- a/src/Core/src/Handlers/Entry/EntryHandler.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.cs
@@ -19,6 +19,9 @@ namespace Microsoft.Maui.Handlers
 	{
 		private static readonly IPropertyMapper<IEntry, IEntryHandler> TextMapper = new PropertyMapper<IEntry, IEntryHandler>
 		{
+			// Android reapplies its default 5000-character limit when IsPassword maps the native input type.
+			// Apply the configured MaxLength first so long text is not truncated before Text is mapped.
+			[nameof(IEntry.MaxLength)] = MapMaxLength,
 			// Ensure IsPassword is mapped before Text so the native field is secured before
 			// text (and any TextTransform) is applied on initial attachment
 			[nameof(IEntry.IsPassword)] = MapIsPassword,
@@ -26,7 +29,6 @@ namespace Microsoft.Maui.Handlers
 			// due to them being applied to the native object (i.e. AttributedText on iOS) created by mapping Text
 			[nameof(IEntry.Text)] = MapText,
 			[nameof(IEntry.ClearButtonVisibility)] = MapClearButtonVisibility,
-			[nameof(IEntry.MaxLength)] = MapMaxLength,
 			[nameof(IEntry.Font)] = MapFont,
 			[nameof(IEntry.CharacterSpacing)] = MapCharacterSpacing,
 			[nameof(IEntry.TextColor)] = MapTextColor,

--- a/src/Core/src/Handlers/Entry/EntryHandler2.Android.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler2.Android.cs
@@ -117,8 +117,13 @@ public class EntryHandler2 : ViewHandler<IEntry, MauiMaterialTextInputLayout>
 	public static void MapBackground(EntryHandler2 handler, IEntry entry) =>
 		handler.PlatformView?.UpdateBackground(entry);
 
-	public static void MapText(EntryHandler2 handler, IEntry entry) =>
+	public static void MapText(EntryHandler2 handler, IEntry entry)
+	{
+		if (handler.IsMappingProperties())
+			handler.UpdateValue(nameof(IEntry.MaxLength));
+
 		handler.PlatformView.EditText?.UpdateText(entry);
+	}
 
 	public static void MapTextColor(EntryHandler2 handler, IEntry entry) =>
 		handler.PlatformView.EditText?.UpdateTextColor(entry);
@@ -163,8 +168,16 @@ public class EntryHandler2 : ViewHandler<IEntry, MauiMaterialTextInputLayout>
 	public static void MapIsSpellCheckEnabled(EntryHandler2 handler, IEntry entry) =>
 		handler.PlatformView.EditText?.UpdateIsSpellCheckEnabled(entry);
 
-	public static void MapMaxLength(EntryHandler2 handler, IEntry entry) =>
-		handler.PlatformView.EditText?.UpdateMaxLength(entry);
+	public static void MapMaxLength(EntryHandler2 handler, IEntry entry)
+	{
+		if (handler.PlatformView.EditText is not { } editText)
+			return;
+
+		if (handler.IsMappingProperties())
+			editText.SetLengthFilter(entry.MaxLength);
+		else
+			editText.UpdateMaxLength(entry);
+	}
 
 	public static void MapPlaceholder(EntryHandler2 handler, IEntry entry)
 	{

--- a/src/Core/src/Handlers/Entry/EntryHandler2.Android.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler2.Android.cs
@@ -13,6 +13,7 @@ public class EntryHandler2 : ViewHandler<IEntry, MauiMaterialTextInputLayout>
 {
 	ClearButtonClickListener? _clearButtonClickListener;
 	ColorStateList? _defaultHintTextColors;
+	bool _selectionChangedSet;
 
 	public static PropertyMapper<IEntry, EntryHandler2> Mapper =
 	  new(ViewMapper)
@@ -63,12 +64,29 @@ public class EntryHandler2 : ViewHandler<IEntry, MauiMaterialTextInputLayout>
 
 	public override void SetVirtualView(IView view)
 	{
+		var cursorPosition = ((IEntry)view).CursorPosition;
+		var selectionLength = ((IEntry)view).SelectionLength;
+		var restoreSelection = _selectionChangedSet;
+
+		if (restoreSelection && PlatformView.EditText is MauiMaterialEditText editText)
+			editText.SelectionChanged -= OnSelectionChanged;
+
 		base.SetVirtualView(view);
+
+		if (restoreSelection && VirtualView is { } virtualView)
+		{
+			// Text mapping moves the native selection to the end; preserve the incoming selection when reusing the handler.
+			virtualView.CursorPosition = cursorPosition;
+			virtualView.SelectionLength = selectionLength;
+			UpdateValue(nameof(IEntry.CursorPosition));
+			UpdateValue(nameof(IEntry.SelectionLength));
+		}
 
 		if (PlatformView.EditText is MauiMaterialEditText _editText)
 		{
 			_editText.SelectionChanged -= OnSelectionChanged;
 			_editText.SelectionChanged += OnSelectionChanged;
+			_selectionChangedSet = true;
 		}
 	}
 
@@ -91,6 +109,7 @@ public class EntryHandler2 : ViewHandler<IEntry, MauiMaterialTextInputLayout>
 		if (platformView.EditText is MauiMaterialEditText _editText)
 		{
 			_editText.SelectionChanged -= OnSelectionChanged;
+			_selectionChangedSet = false;
 		}
 
 		platformView.EditText?.EditorAction -= OnEditorAction;
@@ -351,7 +370,7 @@ public class EntryHandler2 : ViewHandler<IEntry, MauiMaterialTextInputLayout>
 
 	void OnSelectionChanged(object? sender, EventArgs e)
 	{
-		if (VirtualView is null)
+		if (this.IsMappingProperties() || VirtualView is null)
 		{
 			return;
 		}

--- a/src/Core/src/Platform/Android/EditTextExtensions.cs
+++ b/src/Core/src/Platform/Android/EditTextExtensions.cs
@@ -399,7 +399,7 @@ namespace Microsoft.Maui.Platform
 
 			// If we implement the OnSelectionChanged method, this method is called after a keyboard layout change with SelectionStart = 0,
 			// Let's restore the cursor position to its previous location.
-			editText.SetSelection(Math.Min(previousCursorPosition, editText.Length()));
+			editText.SetSelection(Math.Clamp(previousCursorPosition, 0, editText.Length()));
 		}
 
 		internal static bool IsCompletedAction(this EditorActionEventArgs e, ImeAction currentInputImeFlag)

--- a/src/Core/src/Platform/Android/EditTextExtensions.cs
+++ b/src/Core/src/Platform/Android/EditTextExtensions.cs
@@ -399,7 +399,7 @@ namespace Microsoft.Maui.Platform
 
 			// If we implement the OnSelectionChanged method, this method is called after a keyboard layout change with SelectionStart = 0,
 			// Let's restore the cursor position to its previous location.
-			editText.SetSelection(previousCursorPosition);
+			editText.SetSelection(Math.Min(previousCursorPosition, editText.Length()));
 		}
 
 		internal static bool IsCompletedAction(this EditorActionEventArgs e, ImeAction currentInputImeFlag)


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause

Preview 7 Android device tests fail when an `Entry` starts with 5,001 characters or when a handler is reused after previously applying a restrictive `MaxLength`. Android can retain or reinstall the native length filter while mapping input-type properties, truncating text before `MaxLength` and `Text` finish mapping. The same ordering gap existed in both the standard `EntryHandler` and Material3 `EntryHandler2` paths.

### Description of Change

This change keeps the shared cross-platform mapper order unchanged and makes the Android dependency explicit for both handlers:

- during bulk mapping, update the native length filter before writing text without prematurely trimming stale native text from a reused handler;
- force the bulk Controls text write so an identical incoming value still passes through a newly restrictive `MaxLength` filter;
- preserve normal `MaxLength` truncation when the property changes outside bulk mapping;
- retain the two-sided cursor clamp after input-type changes so restoring selection cannot address outside the native text.

Keeping the shared `Text` then `MaxLength` order preserves WinUI programmatic truncation behavior. Do not solve this by globally reordering the shared mapper.

### Tests

Expanded Android device coverage to reuse one handler in both directions for both `EntryHandler` and Material3 `EntryHandler2`:

- restrictive `MaxLength` to unlimited 5,001-character text;
- unlimited 5,001-character text to an identical value with restrictive `MaxLength`.

Local isolated red/green proof at `1c034b9573`:

- without only the Material3 implementation, the standard row passed and the Material3 row alone failed (`63/64`, expected 5,001 characters, actual `"AA"`);
- with the implementation restored, all Android Entry tests passed (`64/64`).

Current-head CI at `1c034b9573`:

- [Main build 1538560](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1538560) succeeded.
- [Device build 1538562](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1538562) succeeded. Android Mono and CoreCLR each reported 1,031 total, 1,004 passed, and 0 failed. The long-text crash, long-to-short update, and handler-reuse `MaxLength` tests passed in both runtimes.
- [UI build 1538561](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1538561) completed all Entry runs with 0 failures, including the WinUI `MaxLength` regression tests. Its remaining red status is limited to pre-existing WinUI `Controls Label` visual baseline failures also reproduced on base-branch builds 1538409 and 1538078.

### Issues Fixed

Release-branch CI regression; no standalone issue.