### PR TITLE
[release/11.0.1xx-preview7] Wait for Entry keyboard before snapshot

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/EntryFeatureTests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/EntryFeatureTests.cs
@@ -213,7 +213,7 @@ public class EntryFeatureTests : _GalleryUITest
 		App.WaitForElement("TestEntry");
 		App.Tap("TestEntry");
 		if (App is AppiumIOSApp)
-			App.WaitForKeyboardToShow();
+			Assert.That(App.WaitForKeyboardToShow(), Is.True, "The iOS keyboard did not appear before the snapshot.");
 		VerifyScreenshotWithKeyboardHandling();
 	}
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/EntryFeatureTests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/EntryFeatureTests.cs
@@ -212,7 +212,8 @@ public class EntryFeatureTests : _GalleryUITest
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
 		App.Tap("TestEntry");
-		App.WaitForKeyboardToShow();
+		if (App is AppiumIOSApp)
+			App.WaitForKeyboardToShow();
 		VerifyScreenshotWithKeyboardHandling();
 	}
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/EntryFeatureTests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/EntryFeatureTests.cs
@@ -212,6 +212,7 @@ public class EntryFeatureTests : _GalleryUITest
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
 		App.Tap("TestEntry");
+		App.WaitForKeyboardToShow();
 		VerifyScreenshotWithKeyboardHandling();
 	}
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

The preview7 iOS UI retry still failed `VerifyTextWhenClearButtonVisibleSetNever` because the screenshot could be captured while the focused Entry and software keyboard were still transitioning. The test intentionally keeps focus on iOS and crops the keyboard, so dismissing it would change coverage.

Wait for the keyboard to be visible before taking the screenshot. This uses the existing Appium condition rather than an arbitrary delay and preserves the focused-state baseline.

The targeted UI-test pipeline is requested below.