### PR TITLE
[release/11.0.1xx-preview7] Guard CarouselView invalidation during rotation

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
@@ -398,6 +398,11 @@ internal static class LayoutFactory2
 					return;
 				}
 
+				if (cv2Controller.IsRotating())
+				{
+					return;
+				}
+
 				// Calculate page index accounting for ItemSpacing
 				var itemSpacing = itemsView.ItemsLayout is LinearItemsLayout linearLayout ? linearLayout.ItemSpacing : 0;
 
@@ -464,11 +469,6 @@ internal static class LayoutFactory2
 							isHorizontal ? UICollectionViewScrollPosition.Left : UICollectionViewScrollPosition.Top,
 							false);
 					}
-				}
-
-				if (cv2Controller.IsRotating())
-				{
-					return;
 				}
 
 				//Update the CarouselView position


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

The preview7 iOS UI retry failed `Issue32394CurrentItemShouldnotChange` after device rotation. The current Items2 rotation guard runs only immediately before `SetPosition`, after the invalidation handler has already calculated offsets and may perform loop-correction scrolling. That native scroll can change the visible item during rotation even though the final position update is skipped.

Move the rotation guard to the start of `VisibleItemsInvalidationHandler`, before any offset calculations or loop-correction scrolling. Post-rotation layout then recenters the existing CarouselView position through the controller’s established `BoundsSizeChanged` path.

The targeted UI-test pipeline is requested below.