### PR TITLE
[release/11.0.1xx-preview7] Extend ListView snapshot stabilization

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18896.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18896.cs
@@ -29,6 +29,6 @@ public class Issue18896 : _IssuesUITest
 		// ListView with HasUnevenRows may have variable height row rendering that requires
 		// additional time for images to load and scrollbar to disappear.
 		// Use retryTimeout to adaptively wait for the UI to stabilize.
-		VerifyScreenshot(retryTimeout: TimeSpan.FromSeconds(3));
+		VerifyScreenshot(retryTimeout: TimeSpan.FromSeconds(5));
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

The preview7 Android UI retry still failed `Issue18896Test` while a `ListView` with uneven rows was settling after gesture scrolling. The test already uses the preferred adaptive screenshot retry mechanism for delayed image loading and scrollbar disappearance, but its three-second window was insufficient in CI.

Extend that stabilization window to five seconds. This keeps retrying the visual comparison and does not add an arbitrary pre-screenshot sleep.

The targeted UI-test pipeline is requested below.