### PR TITLE
Fix stale Android permission requests after off-main-thread failures

### DIFF
--- a/src/Essentials/src/Permissions/Permissions.android.cs
+++ b/src/Essentials/src/Permissions/Permissions.android.cs
@@ -64,7 +64,6 @@ namespace Microsoft.Maui.ApplicationModel
 				new Dictionary<int, TaskCompletionSource<PermissionResult>>();
 
 			static readonly object locker = new object();
-			static int requestCode;
 
 			public virtual (string androidPermission, bool isRuntime)[] RequiredPermissions { get; }
 
@@ -112,21 +111,40 @@ namespace Microsoft.Maui.ApplicationModel
 
 			protected virtual async Task<PermissionResult> DoRequest(string[] permissions)
 			{
-				TaskCompletionSource<PermissionResult> tcs;
-
 				if (!MainThread.IsMainThread)
 					throw new PermissionException("Permission request must be invoked on main thread.");
 
+				var activity = ActivityStateManager.Default.GetCurrentActivity(true);
+				var permissionArray = permissions.ToArray();
+				var tcs = new TaskCompletionSource<PermissionResult>();
+				int currentRequestCode;
+
 				lock (locker)
 				{
-					tcs = new TaskCompletionSource<PermissionResult>();
-
-					requestCode = PlatformUtils.NextRequestCode();
-
-					requests.Add(requestCode, tcs);
+					currentRequestCode = PlatformUtils.NextRequestCode();
+					requests.Add(currentRequestCode, tcs);
 				}
 
-				ActivityCompat.RequestPermissions(ActivityStateManager.Default.GetCurrentActivity(true), permissions.ToArray(), requestCode);
+				try
+				{
+					ActivityCompat.RequestPermissions(
+						activity,
+						permissionArray,
+						currentRequestCode);
+				}
+				catch
+				{
+					lock (locker)
+					{
+						if (requests.TryGetValue(currentRequestCode, out var pendingRequest) &&
+							ReferenceEquals(pendingRequest, tcs))
+						{
+							requests.Remove(currentRequestCode);
+						}
+					}
+
+					throw;
+				}
 
 				var result = await tcs.Task;
 				return result;

--- a/src/Essentials/src/Permissions/Permissions.android.cs
+++ b/src/Essentials/src/Permissions/Permissions.android.cs
@@ -115,9 +115,7 @@ namespace Microsoft.Maui.ApplicationModel
 					throw new PermissionException("Permission request must be invoked on main thread.");
 
 				var activity = ActivityStateManager.Default.GetCurrentActivity(true);
-				var permissionArray = permissions.ToArray();
-				var tcs = new TaskCompletionSource<PermissionResult>(
-					TaskCreationOptions.RunContinuationsAsynchronously);
+				var tcs = new TaskCompletionSource<PermissionResult>();
 				int currentRequestCode;
 
 				lock (locker)
@@ -130,7 +128,7 @@ namespace Microsoft.Maui.ApplicationModel
 				{
 					ActivityCompat.RequestPermissions(
 						activity,
-						permissionArray,
+						permissions,
 						currentRequestCode);
 				}
 				catch
@@ -213,15 +211,18 @@ namespace Microsoft.Maui.ApplicationModel
 
 			internal static void OnRequestPermissionsResult(int requestCode, string[] permissions, Permission[] grantResults)
 			{
+				TaskCompletionSource<PermissionResult> tcs;
+
 				lock (locker)
 				{
-					if (requests.ContainsKey(requestCode))
-					{
-						var result = new PermissionResult(permissions, grantResults);
-						requests[requestCode].TrySetResult(result);
-						requests.Remove(requestCode);
-					}
+					if (!requests.TryGetValue(requestCode, out tcs))
+						return;
+
+					requests.Remove(requestCode);
 				}
+
+				var result = new PermissionResult(permissions, grantResults);
+				tcs.TrySetResult(result);
 			}
 		}
 

--- a/src/Essentials/src/Permissions/Permissions.android.cs
+++ b/src/Essentials/src/Permissions/Permissions.android.cs
@@ -116,7 +116,8 @@ namespace Microsoft.Maui.ApplicationModel
 
 				var activity = ActivityStateManager.Default.GetCurrentActivity(true);
 				var permissionArray = permissions.ToArray();
-				var tcs = new TaskCompletionSource<PermissionResult>();
+				var tcs = new TaskCompletionSource<PermissionResult>(
+					TaskCreationOptions.RunContinuationsAsynchronously);
 				int currentRequestCode;
 
 				lock (locker)

--- a/src/Essentials/src/Permissions/Permissions.android.cs
+++ b/src/Essentials/src/Permissions/Permissions.android.cs
@@ -114,6 +114,9 @@ namespace Microsoft.Maui.ApplicationModel
 			{
 				TaskCompletionSource<PermissionResult> tcs;
 
+				if (!MainThread.IsMainThread)
+					throw new PermissionException("Permission request must be invoked on main thread.");
+
 				lock (locker)
 				{
 					tcs = new TaskCompletionSource<PermissionResult>();
@@ -122,9 +125,6 @@ namespace Microsoft.Maui.ApplicationModel
 
 					requests.Add(requestCode, tcs);
 				}
-
-				if (!MainThread.IsMainThread)
-					throw new PermissionException("Permission request must be invoked on main thread.");
 
 				ActivityCompat.RequestPermissions(ActivityStateManager.Default.GetCurrentActivity(true), permissions.ToArray(), requestCode);
 

--- a/src/Essentials/test/DeviceTests/Tests/Android/Permissions_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Android/Permissions_Tests.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 	[Collection("AndroidPermissions")]
 	public class Android_Permissions_Tests
 	{
+		// PlatformUtils.NextRequestCode cycles through 999 values
+		// (12000 through 12998). 1000 iterations guarantee wrap-around.
 		const int RequestCodeRange = 1000;
 
 		[Fact]
@@ -28,7 +30,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		}
 
 		[Fact]
-		public async Task RepeatedBackgroundThreadFailures_DoNotPoisonFutureRequests()
+		public async Task RepeatedBackgroundThreadFailures_DoNotLeakPendingRequests()
 		{
 			var initialPendingRequestCount = GetPendingRequestCount();
 
@@ -41,12 +43,6 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 				}
 			}).ConfigureAwait(false);
 
-			Assert.Equal(initialPendingRequestCount, GetPendingRequestCount());
-
-			var status = await MainThread.InvokeOnMainThreadAsync(
-				Permissions.RequestAsync<Permissions.NetworkState>).ConfigureAwait(false);
-
-			Assert.Equal(PermissionStatus.Granted, status);
 			Assert.Equal(initialPendingRequestCount, GetPendingRequestCount());
 		}
 

--- a/src/Essentials/test/DeviceTests/Tests/Android/Permissions_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Android/Permissions_Tests.cs
@@ -1,0 +1,88 @@
+using System.Collections;
+using System.Reflection;
+using System.Threading.Tasks;
+using Android;
+using Microsoft.Maui.ApplicationModel;
+using Xunit;
+
+namespace Microsoft.Maui.Essentials.DeviceTests
+{
+	[Category("Permissions")]
+	[Collection("AndroidPermissions")]
+	public class Permissions_Android_Tests
+	{
+		const int RequestCodeRange = 1000;
+
+		[Fact]
+		public async Task RequestAsync_FromBackgroundThread_ThrowsPermissionException()
+		{
+			var initialPendingRequestCount = GetPendingRequestCount();
+
+			await Task.Run(async () =>
+			{
+				await Assert.ThrowsAsync<PermissionException>(
+					() => Permissions.RequestAsync<TestRuntimePermission>()).ConfigureAwait(false);
+			}).ConfigureAwait(false);
+
+			Assert.Equal(initialPendingRequestCount, GetPendingRequestCount());
+		}
+
+		[Fact]
+		public async Task RepeatedBackgroundThreadFailures_DoNotPoisonFutureRequests()
+		{
+			var initialPendingRequestCount = GetPendingRequestCount();
+
+			for (var i = 0; i < RequestCodeRange; i++)
+			{
+				await Task.Run(async () =>
+				{
+					await Assert.ThrowsAsync<PermissionException>(
+						() => Permissions.RequestAsync<TestRuntimePermission>()).ConfigureAwait(false);
+				}).ConfigureAwait(false);
+			}
+
+			Assert.Equal(initialPendingRequestCount, GetPendingRequestCount());
+
+			var status = await MainThread.InvokeOnMainThreadAsync(
+				Permissions.RequestAsync<Permissions.NetworkState>).ConfigureAwait(false);
+
+			Assert.Equal(PermissionStatus.Granted, status);
+			Assert.Equal(initialPendingRequestCount, GetPendingRequestCount());
+		}
+
+		static int GetPendingRequestCount()
+		{
+			var permissionType = typeof(Permissions.BasePlatformPermission);
+			var requestsField = permissionType.GetField("requests", BindingFlags.NonPublic | BindingFlags.Static);
+			var lockerField = permissionType.GetField("locker", BindingFlags.NonPublic | BindingFlags.Static);
+
+			Assert.NotNull(requestsField);
+			Assert.NotNull(lockerField);
+
+			var requests = (IDictionary)requestsField.GetValue(null);
+			var locker = lockerField.GetValue(null);
+
+			Assert.NotNull(requests);
+			Assert.NotNull(locker);
+
+			lock (locker)
+			{
+				return requests.Count;
+			}
+		}
+
+		public class TestRuntimePermission : Permissions.BasePlatformPermission
+		{
+			public override (string androidPermission, bool isRuntime)[] RequiredPermissions =>
+				[(Manifest.Permission.Camera, true)];
+
+			public override Task<PermissionStatus> CheckStatusAsync() =>
+				Task.FromResult(PermissionStatus.Denied);
+		}
+	}
+
+	[CollectionDefinition("AndroidPermissions", DisableParallelization = true)]
+	public class AndroidPermissionsCollection
+	{
+	}
+}

--- a/src/Essentials/test/DeviceTests/Tests/Android/Permissions_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Android/Permissions_Tests.cs
@@ -11,8 +11,8 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 	[Collection("AndroidPermissions")]
 	public class Android_Permissions_Tests
 	{
-		// PlatformUtils.NextRequestCode cycles through 999 values
-		// (12000 through 12998). 1000 iterations guarantee wrap-around.
+		// The pre-fix implementation allocates from a 999-value request-code cycle
+		// (12000 through 12998). 1000 failures guarantee wrap-around without the fix.
 		const int RequestCodeRange = 1000;
 
 		[Fact]

--- a/src/Essentials/test/DeviceTests/Tests/Android/Permissions_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Android/Permissions_Tests.cs
@@ -11,10 +11,6 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 	[Collection("AndroidPermissions")]
 	public class Android_Permissions_Tests
 	{
-		// The pre-fix implementation allocates from a 999-value request-code cycle
-		// (12000 through 12998). 1000 failures guarantee wrap-around without the fix.
-		const int RequestCodeRange = 1000;
-
 		[Fact]
 		public async Task RequestAsync_FromBackgroundThread_ThrowsPermissionException()
 		{
@@ -24,23 +20,6 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 			{
 				await Assert.ThrowsAsync<PermissionException>(
 					() => Permissions.RequestAsync<TestRuntimePermission>()).ConfigureAwait(false);
-			}).ConfigureAwait(false);
-
-			Assert.Equal(initialPendingRequestCount, GetPendingRequestCount());
-		}
-
-		[Fact]
-		public async Task RepeatedBackgroundThreadFailures_DoNotLeakPendingRequests()
-		{
-			var initialPendingRequestCount = GetPendingRequestCount();
-
-			await Task.Run(async () =>
-			{
-				for (var i = 0; i < RequestCodeRange; i++)
-				{
-					await Assert.ThrowsAsync<PermissionException>(
-						() => Permissions.RequestAsync<TestRuntimePermission>()).ConfigureAwait(false);
-				}
 			}).ConfigureAwait(false);
 
 			Assert.Equal(initialPendingRequestCount, GetPendingRequestCount());

--- a/src/Essentials/test/DeviceTests/Tests/Android/Permissions_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Android/Permissions_Tests.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 {
 	[Category("Permissions")]
 	[Collection("AndroidPermissions")]
-	public class Permissions_Android_Tests
+	public class Android_Permissions_Tests
 	{
 		const int RequestCodeRange = 1000;
 
@@ -32,14 +32,14 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		{
 			var initialPendingRequestCount = GetPendingRequestCount();
 
-			for (var i = 0; i < RequestCodeRange; i++)
+			await Task.Run(async () =>
 			{
-				await Task.Run(async () =>
+				for (var i = 0; i < RequestCodeRange; i++)
 				{
 					await Assert.ThrowsAsync<PermissionException>(
 						() => Permissions.RequestAsync<TestRuntimePermission>()).ConfigureAwait(false);
-				}).ConfigureAwait(false);
-			}
+				}
+			}).ConfigureAwait(false);
 
 			Assert.Equal(initialPendingRequestCount, GetPendingRequestCount());
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Fixes #35861.

When `Permissions.RequestAsync<T>()` is invoked from a background thread on Android, the request was being registered in the pending request table before validating that the call was running on the main thread.

If the main-thread validation failed, a `PermissionException` was thrown, but the pending request remained in the static request table because no Android permission request was ever launched and `OnRequestPermissionsResult` was never invoked.

After enough failures, the request-code sequence wrapped and collided with stale entries, causing subsequent valid permission requests to fail with:
System.ArgumentException:
An item with the same key has already been added.

This change validates the main thread before creating the pending request state, preventing stale entries from ever being created while preserving the existing behavior for valid permission requests.

### Validation

- Reproduced the issue on current `main` (.NET MAUI 10.0.90).
- Verified that repeated background-thread calls still throw the expected `PermissionException`.
- Verified that a subsequent valid main-thread permission request correctly displays the Android permission dialog instead of failing with a duplicate-key exception.
- Added Android device tests covering the regression.