### PR TITLE
[release/11.0.1xx-preview7] Stabilize RefreshView interactive refresh UI test

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16910.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16910.cs
@@ -38,8 +38,20 @@ public class Issue16910 : _IssuesUITest
 	public void BindingUpdatesFromInteractiveRefresh()
 	{
 		var scrollViewRect = App.WaitForElement("RefreshScrollView", timeout: TimeSpan.FromSeconds(45)).GetRect();
-		//In CI, using App.ScrollDown sometimes fails to trigger the refresh command, so here use DragCoordinates instead of the ScrollDown action in Appium.
-		App.DragCoordinates(scrollViewRect.CenterX(), scrollViewRect.Y + 50, scrollViewRect.CenterX(), scrollViewRect.Y + scrollViewRect.Height - 50);
+		void PullToRefresh() =>
+			App.DragCoordinates(scrollViewRect.CenterX(), scrollViewRect.Y + 50, scrollViewRect.CenterX(), scrollViewRect.Y + scrollViewRect.Height - 50);
+
+		// In CI, a single pull gesture occasionally does not trigger the refresh command.
+		PullToRefresh();
+		try
+		{
+			App.WaitForElement("IsRefreshing", timeout: TimeSpan.FromSeconds(10));
+		}
+		catch (TimeoutException)
+		{
+			PullToRefresh();
+		}
+
 		App.WaitForElement("IsRefreshing", timeout: TimeSpan.FromSeconds(45));
 		App.Tap("StopRefreshing");
 		App.WaitForElement("IsNotRefreshing", timeout: TimeSpan.FromSeconds(45));


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Retries the pull-to-refresh gesture once when `BindingUpdatesFromInteractiveRefresh` does not observe `IsRefreshing` within 10 seconds. The test keeps its existing final 45-second assertion, so a real RefreshView failure still fails normally.

A broad preview7 UI-test run failed this test twice because the single drag did not trigger the refresh command. The same test passed on the preview7 base build and in five concurrent preview7 runs, consistent with the existing interaction flake tracked by #28368.

## Validation

- Built `Controls.TestCases.iOS.Tests.csproj` successfully with 0 warnings and 0 errors.
