### PR TITLE
[release/11.0.1xx-preview7] Wait for SwipeView invoke result in UI test

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36154.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36154.cs
@@ -30,6 +30,11 @@ public class Issue36154 : _IssuesUITest
 		// Swipe left (finger moves left) → reveals RightItems
 		App.DragCoordinates(centerX, centerY, centerX - 200, centerY);
 
-		App.WaitForTextToBePresentInElement("ResultLabel", "RIGHT invoked!");
+		// WaitForTextToBePresentInElement returns false (rather than throwing) on timeout, so assert on
+		// it: otherwise the test would pass even if the SwipeView invoke callback never updated the label.
+		Assert.That(
+			App.WaitForTextToBePresentInElement("ResultLabel", "RIGHT invoked!"),
+			Is.True,
+			"Timed out waiting for ResultLabel to display 'RIGHT invoked!' after the swipe.");
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36154.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36154.cs
@@ -30,6 +30,6 @@ public class Issue36154 : _IssuesUITest
 		// Swipe left (finger moves left) → reveals RightItems
 		App.DragCoordinates(centerX, centerY, centerX - 200, centerY);
 
-		Assert.That(App.WaitForElement("ResultLabel").GetText(), Is.EqualTo("RIGHT invoked!"));
+		App.WaitForTextToBePresentInElement("ResultLabel", "RIGHT invoked!");
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Waits for the SwipeView invoke callback to update `ResultLabel` instead of reading the already-existing label immediately after the drag gesture.

Preview7 UI build 1537883 failed `Issue36154SwipeViewShouldRevealItems` after observing the initial `Swipe result will appear here` text. The same test passed on base build 1537359 and concurrent build 1537882, confirming an interaction timing race rather than a deterministic SwipeView regression.

## Validation

- Built `Controls.TestCases.WinUI.Tests.csproj` successfully with 0 warnings and 0 errors.
