### PR TITLE
[release/11.0.1xx-preview7] Stabilize Shell SafeArea tab UI test

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33034.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33034.cs
@@ -12,7 +12,7 @@ public class Issue33034 : TestShell
 		{
 			Title = "First Tab",
 			AutomationId = "FirstTab",
-			ContentTemplate = new DataTemplate(typeof(Issue33034TabContent)),
+			ContentTemplate = new DataTemplate(() => new Issue33034TabContent("FirstEdgeLabel")),
 			Route = "tab1"
 		});
 
@@ -20,7 +20,7 @@ public class Issue33034 : TestShell
 		{
 			Title = "Second Tab",
 			AutomationId = "SecondTab",
-			ContentTemplate = new DataTemplate(typeof(Issue33034TabContent)),
+			ContentTemplate = new DataTemplate(() => new Issue33034TabContent("SecondEdgeLabel")),
 			Route = "tab2"
 		});
 
@@ -31,13 +31,13 @@ public class Issue33034 : TestShell
 
 public class Issue33034TabContent : ContentPage
 {
-	public Issue33034TabContent()
+	public Issue33034TabContent(string edgeLabelAutomationId)
 	{
 		// Full-width label to detect safe area padding on either side
 		var edgeLabel = new Label
 		{
 			Text = "EDGE LABEL",
-			AutomationId = "EdgeLabel",
+			AutomationId = edgeLabelAutomationId,
 			FontSize = 18,
 			FontAttributes = FontAttributes.Bold,
 			BackgroundColor = Colors.Red,
@@ -52,4 +52,3 @@ public class Issue33034TabContent : ContentPage
 		};
 	}
 }
-

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33034.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33034.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Maui.TestCases.Tests.Issues;
 
 public class Issue33034 : _IssuesUITest
 {
+	const string FirstEdgeLabel = "FirstEdgeLabel";
+	const string SecondEdgeLabel = "SecondEdgeLabel";
+
 	public override string Issue => "SafeAreaEdges works correctly only on the first tab in Shell. Other tabs have content colliding with the display cutout in the landscape mode.";
 
 	public Issue33034(TestDevice device) : base(device) { }
@@ -16,17 +19,28 @@ public class Issue33034 : _IssuesUITest
 	[Category(UITestCategories.SafeAreaEdges)]
 	public void SafeAreaShouldWorkOnAllShellTabs()
 	{
-		App.WaitForElement("EdgeLabel");
+		App.WaitForElement(FirstEdgeLabel);
 		App.SetOrientationLandscape();
 		//Adding delay to allow for orientation change to complete
 		Thread.Sleep(2000);
-		var initialRect = App.WaitForElement("EdgeLabel").GetRect();
+		var initialRect = App.WaitForElement(FirstEdgeLabel).GetRect();
+
+		IUIElement WaitForSettledEdgeLabel(string automationId) =>
+			App.WaitForElement(() =>
+			{
+				var element = App.FindElement(automationId);
+				return element is not null && Math.Abs(element.GetRect().X - initialRect.X) <= 5
+					? element
+					: null;
+			}, $"Timed out waiting for {automationId} to settle");
 
 		App.TapTab("Second Tab");
-		App.WaitForElement("EdgeLabel");
+		var secondTabRect = WaitForSettledEdgeLabel(SecondEdgeLabel).GetRect();
 		App.TapTab("First Tab");
-		var afterSwitchRect = App.WaitForElement("EdgeLabel").GetRect();
+		var afterSwitchRect = WaitForSettledEdgeLabel(FirstEdgeLabel).GetRect();
 
+		Assert.That(secondTabRect.X, Is.EqualTo(initialRect.X).Within(5));
+		Assert.That(secondTabRect.Width, Is.EqualTo(initialRect.Width).Within(5));
 		Assert.That(afterSwitchRect.X, Is.EqualTo(initialRect.X).Within(5));
 		Assert.That(afterSwitchRect.Width, Is.EqualTo(initialRect.Width).Within(5));
 	}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33034.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33034.cs
@@ -25,39 +25,18 @@ public class Issue33034 : _IssuesUITest
 		Thread.Sleep(2000);
 		var initialRect = App.WaitForElement(FirstEdgeLabel).GetRect();
 
-		IUIElement WaitForSettledEdgeLabel(string automationId) =>
-			App.WaitForElement(() =>
+		void AssertEdgeLabelSettled(string automationId) =>
+			App.RetryAssert(() =>
 			{
-				try
-				{
-					var element = App.FindElement(automationId);
-					if (element is null)
-						return null;
-
-					// Wait for BOTH X and Width to settle: capturing the rect while width is still
-					// mid-layout would let the later Within(5) assertions flake.
-					var rect = element.GetRect();
-					return Math.Abs(rect.X - initialRect.X) <= 5 && Math.Abs(rect.Width - initialRect.Width) <= 5
-						? element
-						: null;
-				}
-				catch
-				{
-					// WaitForElement(Func<>) rethrows query exceptions, so swallow transient/stale-element
-					// failures from FindElement/GetRect here to keep polling instead of failing immediately.
-					return null;
-				}
-			}, $"Timed out waiting for {automationId} to settle");
+				var rect = App.WaitForElement(automationId).GetRect();
+				Assert.That(rect.X, Is.EqualTo(initialRect.X).Within(5));
+				Assert.That(rect.Width, Is.EqualTo(initialRect.Width).Within(5));
+			});
 
 		App.TapTab("Second Tab");
-		var secondTabRect = WaitForSettledEdgeLabel(SecondEdgeLabel).GetRect();
+		AssertEdgeLabelSettled(SecondEdgeLabel);
 		App.TapTab("First Tab");
-		var afterSwitchRect = WaitForSettledEdgeLabel(FirstEdgeLabel).GetRect();
-
-		Assert.That(secondTabRect.X, Is.EqualTo(initialRect.X).Within(5));
-		Assert.That(secondTabRect.Width, Is.EqualTo(initialRect.Width).Within(5));
-		Assert.That(afterSwitchRect.X, Is.EqualTo(initialRect.X).Within(5));
-		Assert.That(afterSwitchRect.Width, Is.EqualTo(initialRect.Width).Within(5));
+		AssertEdgeLabelSettled(FirstEdgeLabel);
 	}
 }
 #endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33034.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33034.cs
@@ -28,10 +28,25 @@ public class Issue33034 : _IssuesUITest
 		IUIElement WaitForSettledEdgeLabel(string automationId) =>
 			App.WaitForElement(() =>
 			{
-				var element = App.FindElement(automationId);
-				return element is not null && Math.Abs(element.GetRect().X - initialRect.X) <= 5
-					? element
-					: null;
+				try
+				{
+					var element = App.FindElement(automationId);
+					if (element is null)
+						return null;
+
+					// Wait for BOTH X and Width to settle: capturing the rect while width is still
+					// mid-layout would let the later Within(5) assertions flake.
+					var rect = element.GetRect();
+					return Math.Abs(rect.X - initialRect.X) <= 5 && Math.Abs(rect.Width - initialRect.Width) <= 5
+						? element
+						: null;
+				}
+				catch
+				{
+					// WaitForElement(Func<>) rethrows query exceptions, so swallow transient/stale-element
+					// failures from FindElement/GetRect here to keep polling instead of failing immediately.
+					return null;
+				}
 			}, $"Timed out waiting for {automationId} to settle");
 
 		App.TapTab("Second Tab");


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Gives the two Shell tabs in `Issue33034` unique label automation IDs and waits for each selected tab's label to settle at the expected landscape position. The test now verifies the second tab's safe-area geometry directly as well as the first tab after switching back.

Preview7 UI build 1538078 failed because both tab pages exposed `EdgeLabel`; Appium selected the off-screen instance at `X=2046` instead of the visible label at `X=126`. Base build 1537359 passed the same test twice, demonstrating the ambiguous-element race.

## Validation

- Built `Controls.TestCases.Android.Tests.csproj` successfully.
- Built `Controls.TestCases.HostApp.csproj` for `net11.0-android` successfully.
