### PR TITLE
[net11.0] Avoid build task staging races

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -1,7 +1,9 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Build tasks always needed first -->
   <ItemGroup Condition="'$(BuildDeviceTests)' != 'true'">
-    <ProjectToBuild Include="$(RepoRoot)Microsoft.Maui.BuildTasks.slnf" BuildInParallel="false"/>
+    <ProjectToBuild Include="$(RepoRoot)Microsoft.Maui.BuildTasks.slnf" BuildInParallel="false">
+      <AdditionalProperties>BuildTaskOnlyBuild=true</AdditionalProperties>
+    </ProjectToBuild>
   </ItemGroup>
 
   <!-- Pack only: Microsoft.Maui.Packages -->

--- a/eng/pipelines/arcade/setup-test-env.yml
+++ b/eng/pipelines/arcade/setup-test-env.yml
@@ -85,7 +85,7 @@ steps:
       displayName: Build MSBuild Tasks
       mauiSourcePath: ${{ parameters.mauiSourcePath }}
       project: ${{ parameters.mauiSourcePath }}/Microsoft.Maui.BuildTasks.slnf
-      arguments: '-c ${{ parameters.buildConfig }} -bl:${{ parameters.repoLogPath }}/Microsoft.Maui.BuildTasks.binlog'
+      arguments: '-c ${{ parameters.buildConfig }} -p:BuildTaskOnlyBuild=true -bl:${{ parameters.repoLogPath }}/Microsoft.Maui.BuildTasks.binlog'
 
 - template: /eng/pipelines/common/run-dotnet-preview.yml
   parameters:

--- a/src/Controls/src/BindingSourceGen/Controls.BindingSourceGen.csproj
+++ b/src/Controls/src/BindingSourceGen/Controls.BindingSourceGen.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
   </ItemGroup>
 
-  <Target Name="_CopyToBuildTasksDir" AfterTargets="Build">
+  <Target Name="_CopyToBuildTasksDir" AfterTargets="Build" Condition="'$(BuildTaskOnlyBuild)' == 'true' or '$(TF_BUILD)' != 'true'">
     <ItemGroup>
       <_CopyItems Include="$(TargetDir)*.dll" Exclude="$(TargetDir)System.*.dll" />
       <_CopyItems Include="$(TargetDir)*.pdb" Exclude="$(TargetDir)System.*.pdb" />

--- a/src/Controls/src/Build.Tasks/Controls.Build.Tasks.csproj
+++ b/src/Controls/src/Build.Tasks/Controls.Build.Tasks.csproj
@@ -73,7 +73,7 @@
 		</EmbeddedResource>
 	</ItemGroup>
 
-	<Target Name="_CopyToBuildTasksDir" AfterTargets="Build">
+	<Target Name="_CopyToBuildTasksDir" AfterTargets="Build" Condition="'$(BuildTaskOnlyBuild)' == 'true' or '$(TF_BUILD)' != 'true'">
 		<ItemGroup>
 			<_CopyItems Include="nuget\buildTransitive\**" Exclude="nuget\buildTransitive\*;nuget\buildTransitive\netstandard2.0\**" />
 			<_CopyItems Include="nuget\buildTransitive\netstandard2.0\**" />

--- a/src/Controls/src/SourceGen/Controls.SourceGen.csproj
+++ b/src/Controls/src/SourceGen/Controls.SourceGen.csproj
@@ -84,7 +84,7 @@
     <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
   </ItemGroup>
 
-  <Target Name="_CopyToBuildTasksDir" AfterTargets="Build">
+  <Target Name="_CopyToBuildTasksDir" AfterTargets="Build" Condition="'$(BuildTaskOnlyBuild)' == 'true' or '$(TF_BUILD)' != 'true'">
     <ItemGroup>
       <_CopyItems Include="$(TargetDir)*.dll" Exclude="$(TargetDir)System.*.dll" />
       <_CopyItems Include="$(TargetDir)*.pdb" Exclude="$(TargetDir)System.*.pdb" />

--- a/src/Core/src/Core.csproj
+++ b/src/Core/src/Core.csproj
@@ -103,7 +103,7 @@
     <Compile Remove="HybridWebViewSourceGen\**" />
   </ItemGroup>
 
-  <Target Name="_CopyToBuildTasksDir" AfterTargets="Build">
+  <Target Name="_CopyToBuildTasksDir" AfterTargets="Build" Condition="'$(BuildTaskOnlyBuild)' == 'true' or '$(TF_BUILD)' != 'true'">
     <ItemGroup>
       <_CopyItems Include="nuget\buildTransitive\**" SubFolder="" Exclude="nuget\**\*.in.*;nuget\**\net-*\*" />
       <_CopyItems Include="nuget\buildTransitive\net-windows\**" SubFolder="net$(_MauiMinimumSupportedDotNetTfm)-windows$(MinimumWindowsTargetFrameworkVersion)" />

--- a/src/Core/src/HybridWebViewSourceGen/Core.HybridWebViewSourceGen.csproj
+++ b/src/Core/src/HybridWebViewSourceGen/Core.HybridWebViewSourceGen.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
   </ItemGroup>
 
-  <Target Name="_CopyToBuildTasksDir" AfterTargets="Build">
+  <Target Name="_CopyToBuildTasksDir" AfterTargets="Build" Condition="'$(BuildTaskOnlyBuild)' == 'true' or '$(TF_BUILD)' != 'true'">
     <ItemGroup>
       <_CopyItems Include="$(TargetDir)*.dll" Exclude="$(TargetDir)System.*.dll" />
       <_CopyItems Include="$(TargetDir)*.pdb" Exclude="$(TargetDir)System.*.pdb" />

--- a/src/SingleProject/Resizetizer/src/Resizetizer.csproj
+++ b/src/SingleProject/Resizetizer/src/Resizetizer.csproj
@@ -74,7 +74,7 @@
     </EmbeddedResource>
   </ItemGroup>
  
-  <Target Name="_CopyToBuildTasksDir" AfterTargets="Build">
+  <Target Name="_CopyToBuildTasksDir" AfterTargets="Build" Condition="'$(BuildTaskOnlyBuild)' == 'true' or '$(TF_BUILD)' != 'true'">
     <ItemGroup>
       <_CopyItems Include="$(TargetDir)$(AssemblyName).dll" />
       <_CopyItems Include="$(TargetDir)$(AssemblyName).pdb" />


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Prevents the full Azure DevOps solution build from restaging in-repo build tasks into the shared `.buildtasks` directory while parallel projects are importing those files. The dedicated build-task pass (`BuildTaskOnlyBuild=true`) remains responsible for staging in CI, while local builds retain their existing behavior.

The race predates Preview 7 and is intermittent rather than a product/runtime regression, so this targets `net11.0` for RC1 instead of taking the CI infrastructure change into Preview 7.

The issue was confirmed by Preview 7 build [1538149](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1538149):

- macOS read `Microsoft.Maui.Resizetizer.targets` while its `Before` and `After` imports were absent.
- Windows logged repeated MSB3026 sharing violations while overwriting build-task assemblies, then MSB4024 while reading `Microsoft.Maui.Core.BundledVersions.targets` during a concurrent write.

The same race affected all six projects that stage files into `.buildtasks`, so the guard is applied consistently to each staging target. Every dedicated build-task entry point now explicitly sets `BuildTaskOnlyBuild=true`, including the Arcade build and test-environment paths, so staging does not depend on an earlier Cake invocation.

## Validation

- Verified all six `_CopyToBuildTasksDir` targets skip copying when `TF_BUILD=true` during the full-build mode.
- Verified staging still executes with `TF_BUILD=true` and `BuildTaskOnlyBuild=true`.
- Verified local builds remain eligible to stage when `TF_BUILD` is not set.
- Verified the Arcade `ProjectToBuild` metadata and test-environment template propagate `BuildTaskOnlyBuild=true` to the build-task solution.

The full build-task solution cannot complete on this macOS machine because the .NET Framework 4.7.2 reference assemblies are unavailable; CI provides the required cross-platform validation.