### PR TITLE
[release/11.0.1xx-preview7] Stabilize initial parent-child SafeArea UI test

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28986_ParentChildTest.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28986_ParentChildTest.cs
@@ -46,43 +46,37 @@ public class Issue28986_ParentChildTest : _IssuesUITest
         // 2. Bottom indicator is inset from screen bottom by safe area (child handles bottom)
         // 3. Both work independently without conflict
 
-        // Get screen dimensions
-        var parentGridRect = App.WaitForElement("ParentGrid").GetRect();
-        var screenTop = parentGridRect.Y;
-        var screenBottom = parentGridRect.Y + parentGridRect.Height;
-
         // Verify initial status
         WaitForText("StatusLabel", "Parent: Top=Container, Bottom=None | Child: Bottom=Container");
 
-        // Measure top indicator position
-        var topIndicatorRect = App.WaitForElement("TopIndicator").GetRect();
-        var topIndicatorTop = topIndicatorRect.Y;
-
-        // Top indicator should be below the screen top (safe area applied)
-        var topInsetFromScreenTop = topIndicatorTop - screenTop;
-        Assert.That(topInsetFromScreenTop, Is.GreaterThan(5),
-            $"Top indicator should be inset from screen top by safe area. " +
-            $"Current inset: {topInsetFromScreenTop}pt (expected >5pt)");
-
-        // Measure bottom indicator position
-        var bottomIndicatorRect = App.WaitForElement("BottomIndicator").GetRect();
-        var bottomIndicatorBottom = bottomIndicatorRect.Y + bottomIndicatorRect.Height;
-
-        // Bottom indicator should be above the screen bottom (safe area applied)
-        var bottomInsetFromScreenBottom = screenBottom - bottomIndicatorBottom;
-        // On devices with bottom safe area (iOS home indicator, Android nav bar), verify meaningful inset.
-        // On gesture-nav Android devices, bottom safe area is correctly 0.
-        if (HasBottomSafeArea(bottomInsetFromScreenBottom))
+        App.RetryAssert(() =>
         {
-            Assert.That(bottomInsetFromScreenBottom, Is.GreaterThan(5),
-                $"Bottom indicator should be inset from screen bottom by safe area. " +
-                $"Current inset: {bottomInsetFromScreenBottom}pt (expected >5pt)");
-        }
-        else
-        {
-            Assert.That(bottomInsetFromScreenBottom, Is.GreaterThanOrEqualTo(0),
-                $"Bottom indicator should not extend below screen bottom. Inset: {bottomInsetFromScreenBottom}pt");
-        }
+            var parentGridRect = App.WaitForElement("ParentGrid").GetRect();
+            var screenTop = parentGridRect.Y;
+            var screenBottom = parentGridRect.Y + parentGridRect.Height;
+
+            var topIndicatorRect = App.WaitForElement("TopIndicator").GetRect();
+            var topInsetFromScreenTop = topIndicatorRect.Y - screenTop;
+            Assert.That(topInsetFromScreenTop, Is.GreaterThan(5),
+                $"Top indicator should be inset from screen top by safe area. " +
+                $"Current inset: {topInsetFromScreenTop}pt (expected >5pt)");
+
+            var bottomIndicatorRect = App.WaitForElement("BottomIndicator").GetRect();
+            var bottomIndicatorBottom = bottomIndicatorRect.Y + bottomIndicatorRect.Height;
+            var bottomInsetFromScreenBottom = screenBottom - bottomIndicatorBottom;
+
+            if (HasBottomSafeArea(bottomInsetFromScreenBottom))
+            {
+                Assert.That(bottomInsetFromScreenBottom, Is.GreaterThan(5),
+                    $"Bottom indicator should be inset from screen bottom by safe area. " +
+                    $"Current inset: {bottomInsetFromScreenBottom}pt (expected >5pt)");
+            }
+            else
+            {
+                Assert.That(bottomInsetFromScreenBottom, Is.GreaterThanOrEqualTo(0),
+                    $"Bottom indicator should not extend below screen bottom. Inset: {bottomInsetFromScreenBottom}pt");
+            }
+        });
     }
 
     [Test, Order(2)]

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28986_ParentChildTest.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28986_ParentChildTest.cs
@@ -51,17 +51,17 @@ public class Issue28986_ParentChildTest : _IssuesUITest
 
         App.RetryAssert(() =>
         {
-            var parentGridRect = App.WaitForElement("ParentGrid").GetRect();
+            var parentGridRect = App.FindElement("ParentGrid").GetRect();
             var screenTop = parentGridRect.Y;
             var screenBottom = parentGridRect.Y + parentGridRect.Height;
 
-            var topIndicatorRect = App.WaitForElement("TopIndicator").GetRect();
+            var topIndicatorRect = App.FindElement("TopIndicator").GetRect();
             var topInsetFromScreenTop = topIndicatorRect.Y - screenTop;
             Assert.That(topInsetFromScreenTop, Is.GreaterThan(5),
                 $"Top indicator should be inset from screen top by safe area. " +
                 $"Current inset: {topInsetFromScreenTop}pt (expected >5pt)");
 
-            var bottomIndicatorRect = App.WaitForElement("BottomIndicator").GetRect();
+            var bottomIndicatorRect = App.FindElement("BottomIndicator").GetRect();
             var bottomIndicatorBottom = bottomIndicatorRect.Y + bottomIndicatorRect.Height;
             var bottomInsetFromScreenBottom = screenBottom - bottomIndicatorBottom;
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

The iOS `VerifyInitialStateParentTopChildBottom` UI test can read geometry before the issue page finishes its initial layout. Preview 7 UI builds 1538078 and 1538179 reported impossible bottom insets of -207 and -58 points, while their teardown page sources showed the settled layout correctly inside the 812-point window with a 34-point bottom inset.

Wrap the initial parent, top-indicator, and bottom-indicator geometry assertions in `RetryAssert`. Each attempt re-queries all rectangles, so the test waits for a coherent layout without weakening any expected inset. A persistent SafeArea regression still fails when the retry timeout expires.

## Tests

- iOS simulator: `VerifyInitialStateParentTopChildBottom` passed in 337 ms.
- The HostApp and iOS test project built through `.github/scripts/BuildAndRunHostApp.ps1`.