### PR TITLE
Android: Fix horizontal scrolling for long selected Picker text

### DIFF
--- a/src/Core/src/Platform/Android/PickerManager.cs
+++ b/src/Core/src/Platform/Android/PickerManager.cs
@@ -11,20 +11,184 @@ namespace Microsoft.Maui.Platform
 {
 	internal static class PickerManager
 	{
+		const float DragDirectionRatio = 1.2f;
+		static readonly System.Runtime.CompilerServices.ConditionalWeakTable<EditText, PickerTouchListener> TouchListeners = new();
+
 		public static void Init(EditText editText)
 		{
 			editText.Focusable = true;
 			editText.FocusableInTouchMode = false;
 			editText.Clickable = true;
+			editText.SetHorizontallyScrolling(true);
+			editText.SetSingleLine(true);
+			editText.SetTextIsSelectable(false);
+			editText.LongClickable = false;
+			editText.SetCursorVisible(false);
 
 			// InputType needs to be set before setting KeyListener
 			editText.InputType = InputTypes.Null;
 			editText.KeyListener = null;
+
+			SetTouchListener(editText);
 		}
 
 		public static void Dispose(EditText editText)
 		{
+			RemoveTouchListener(editText);
 			editText.SetOnClickListener(null);
+		}
+
+		static void SetTouchListener(EditText editText)
+		{
+			RemoveTouchListener(editText);
+
+			var listener = new PickerTouchListener();
+			TouchListeners.Add(editText, listener);
+			editText.SetOnTouchListener(listener);
+		}
+
+		static void RemoveTouchListener(EditText editText)
+		{
+			editText.SetOnTouchListener(null);
+
+			if (TouchListeners.TryGetValue(editText, out var listener))
+			{
+				TouchListeners.Remove(editText);
+				listener.Dispose();
+			}
+		}
+
+		static bool OnTouchEvent(
+			EditText editText,
+			MotionEvent? e,
+			ref float startX,
+			ref float startY,
+			ref float lastX,
+			ref bool isHorizontalScrolling)
+		{
+			if (e is null)
+			{
+				return false;
+			}
+
+			if (!CanScrollHorizontally(editText))
+			{
+				if (isHorizontalScrolling)
+				{
+					editText.Parent?.RequestDisallowInterceptTouchEvent(false);
+				}
+
+				isHorizontalScrolling = false;
+				return false;
+			}
+
+			switch (e.ActionMasked)
+			{
+				case MotionEventActions.Down:
+					startX = lastX = e.GetX();
+					startY = e.GetY();
+					isHorizontalScrolling = false;
+					return false;
+
+				case MotionEventActions.Move:
+					var currentX = e.GetX();
+					var totalX = Math.Abs(currentX - startX);
+					var totalY = Math.Abs(e.GetY() - startY);
+
+					if (!isHorizontalScrolling)
+					{
+						var context = editText.Context;
+
+						if (context is null)
+						{
+							return false;
+						}
+
+						var touchSlop = ViewConfiguration.Get(context)?.ScaledTouchSlop ?? 0;
+
+						if (totalX <= touchSlop || totalX <= totalY * DragDirectionRatio)
+						{
+							return false;
+						}
+
+						isHorizontalScrolling = true;
+						editText.Parent?.RequestDisallowInterceptTouchEvent(true);
+					}
+
+					var deltaX = lastX - currentX;
+					lastX = currentX;
+					ScrollHorizontally(editText, deltaX);
+					return true;
+
+				case MotionEventActions.Up:
+				case MotionEventActions.Cancel:
+					var wasHorizontalScrolling = isHorizontalScrolling;
+					isHorizontalScrolling = false;
+
+					if (wasHorizontalScrolling)
+					{
+						editText.Parent?.RequestDisallowInterceptTouchEvent(false);
+					}
+
+					return wasHorizontalScrolling;
+			}
+
+			return false;
+		}
+
+		static bool CanScrollHorizontally(EditText editText)
+		{
+			return editText.Text?.Length > 0 &&
+				editText.Layout is not null &&
+				GetMaxHorizontalScroll(editText) > 0;
+		}
+
+		static void ScrollHorizontally(EditText editText, float deltaX)
+		{
+			var maxScroll = GetMaxHorizontalScroll(editText);
+			var newScrollX = Math.Clamp(editText.ScrollX + (int)Math.Round(deltaX), 0, maxScroll);
+
+			if (newScrollX != editText.ScrollX)
+			{
+				editText.ScrollTo(newScrollX, editText.ScrollY);
+			}
+		}
+
+		static int GetMaxHorizontalScroll(EditText editText)
+		{
+			var layout = editText.Layout;
+
+			if (layout is null || editText.LineCount == 0)
+			{
+				return 0;
+			}
+
+			var availableWidth = editText.Width - editText.TotalPaddingLeft - editText.TotalPaddingRight;
+
+			if (availableWidth <= 0)
+			{
+				return 0;
+			}
+
+			return Math.Max(0, (int)Math.Ceiling(layout.GetLineWidth(0)) - availableWidth);
+		}
+
+		sealed class PickerTouchListener : Java.Lang.Object, View.IOnTouchListener
+		{
+			float _startX;
+			float _startY;
+			float _lastX;
+			bool _isHorizontalScrolling;
+
+			public bool OnTouch(View? v, MotionEvent? e)
+			{
+				if (v is not EditText editText)
+				{
+					return false;
+				}
+
+				return OnTouchEvent(editText, e, ref _startX, ref _startY, ref _lastX, ref _isHorizontalScrolling);
+			}
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.Android.cs
@@ -129,6 +129,8 @@ namespace Microsoft.Maui.DeviceTests
 					Assert.True(platformPicker.ScrollX > 0, $"Expected Picker ScrollX to be greater than 0 after a horizontal drag, but it was {platformPicker.ScrollX}.");
 					Assert.Equal(1, clickCount);
 
+					DispatchTap(platformPicker);
+					Assert.Equal(2, clickCount);
 					platformPicker.Click -= OnPickerClicked;
 
 					void OnPickerClicked(object sender, System.EventArgs e)

--- a/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.Android.cs
@@ -1,6 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using Android.OS;
+using Android.Text;
 using Android.Views;
+using Android.Widget;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
@@ -85,8 +88,127 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(expectedValue, values.PlatformViewValue, EmCoefficientPrecision);
 		}
 
+		[Theory(DisplayName = "Long Selected Text Scrolls Horizontally And Remains Read Only")]
+		[InlineData(false)]
+		[InlineData(true)]
+		public async Task LongSelectedTextScrollsHorizontallyAndRemainsReadOnly(bool useMaterialPicker)
+		{
+			const int pickerWidth = 96;
+			const int pickerHeight = 80;
+			const string longSelectedItem = "This is a very long selected picker item that should scroll horizontally";
+
+			var picker = new PickerStub
+			{
+				Width = pickerWidth,
+				Height = pickerHeight,
+				Items = new[] { longSelectedItem },
+				SelectedIndex = 0
+			};
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var platformPicker = CreateNativePicker(picker, useMaterialPicker);
+
+				try
+				{
+					LayoutNativePicker(platformPicker, pickerWidth, pickerHeight);
+
+					Assert.Equal(longSelectedItem, platformPicker.Text);
+					AssertReadOnlyPicker(platformPicker);
+
+					var clickCount = 0;
+					platformPicker.Click += OnPickerClicked;
+
+					DispatchTap(platformPicker);
+
+					Assert.Equal(1, clickCount);
+
+					platformPicker.ScrollTo(0, platformPicker.ScrollY);
+					DispatchHorizontalDrag(platformPicker);
+
+					Assert.True(platformPicker.ScrollX > 0, $"Expected Picker ScrollX to be greater than 0 after a horizontal drag, but it was {platformPicker.ScrollX}.");
+					Assert.Equal(1, clickCount);
+
+					platformPicker.Click -= OnPickerClicked;
+
+					void OnPickerClicked(object sender, System.EventArgs e)
+					{
+						clickCount++;
+					}
+				}
+				finally
+				{
+					platformPicker.Dispose();
+				}
+			});
+		}
+
 		MauiPicker GetNativePicker(PickerHandler pickerHandler) =>
 			pickerHandler.PlatformView;
+
+		EditText CreateNativePicker(PickerStub picker, bool useMaterialPicker)
+		{
+			if (useMaterialPicker)
+			{
+				var platformPicker = new MauiMaterialPicker(MauiContext.Context);
+				platformPicker.UpdatePicker(picker);
+				return platformPicker;
+			}
+
+			var mauiPicker = new MauiPicker(MauiContext.Context);
+			mauiPicker.UpdatePicker(picker);
+			return mauiPicker;
+		}
+
+		static void LayoutNativePicker(EditText platformPicker, int width, int height)
+		{
+			platformPicker.Measure(
+				View.MeasureSpec.MakeMeasureSpec(width, MeasureSpecMode.Exactly),
+				View.MeasureSpec.MakeMeasureSpec(height, MeasureSpecMode.Exactly));
+
+			platformPicker.Layout(0, 0, width, height);
+		}
+
+		static void AssertReadOnlyPicker(EditText platformPicker)
+		{
+			Assert.Equal(InputTypes.Null, platformPicker.InputType);
+			Assert.Null(platformPicker.KeyListener);
+			Assert.False(platformPicker.IsCursorVisible);
+			Assert.False(platformPicker.IsTextSelectable);
+			Assert.False(platformPicker.LongClickable);
+		}
+
+		static void DispatchHorizontalDrag(EditText platformPicker)
+		{
+			var downTime = SystemClock.UptimeMillis();
+			var y = platformPicker.Height / 2f;
+			var startX = platformPicker.Width - 4f;
+			var midX = platformPicker.Width / 2f;
+			var endX = 4f;
+
+			using var down = MotionEvent.Obtain(downTime, downTime, MotionEventActions.Down, startX, y, 0);
+			using var move = MotionEvent.Obtain(downTime, downTime + 16, MotionEventActions.Move, midX, y, 0);
+			using var secondMove = MotionEvent.Obtain(downTime, downTime + 32, MotionEventActions.Move, endX, y, 0);
+			using var up = MotionEvent.Obtain(downTime, downTime + 48, MotionEventActions.Up, endX, y, 0);
+
+			platformPicker.DispatchTouchEvent(down);
+			platformPicker.DispatchTouchEvent(move);
+			platformPicker.DispatchTouchEvent(secondMove);
+			platformPicker.DispatchTouchEvent(up);
+		}
+
+		static void DispatchTap(EditText platformPicker)
+		{
+			var downTime = SystemClock.UptimeMillis();
+			var x = platformPicker.Width / 2f;
+			var y = platformPicker.Height / 2f;
+
+			using var down = MotionEvent.Obtain(downTime, downTime, MotionEventActions.Down, x, y, 0);
+			using var up = MotionEvent.Obtain(downTime, downTime + 48, MotionEventActions.Up, x, y, 0);
+
+			platformPicker.DispatchTouchEvent(down);
+			platformPicker.DispatchTouchEvent(up);
+		}
 
 		string GetNativeTitle(PickerHandler pickerHandler) =>
 			GetNativePicker(pickerHandler).Hint;


### PR DESCRIPTION
## Description of Change

This change restores horizontal scrolling for long selected text in the Android `Picker`, matching the behavior previously available in Xamarin.Forms.

The fix updates the native Android picker implementation to enable horizontal scrolling while preserving the existing tap behavior and read-only interaction model.

### Validation

- Added Android DeviceTests covering:
  - Horizontal scrolling of long selected text.
  - Tap behavior after horizontal scrolling.
  - Read-only behavior is preserved.
- Manually validated using a standalone reproduction project.
- Verified that:
  - Long selected text scrolls horizontally.
  - Normal tap interaction still opens the picker dialog.
  - No unintended dialog opening occurs while scrolling.
  - The control remains read-only.

### Issue Fixed

Fixes #36834

I also validated the fix using a standalone reproduction project.

The original issue is no longer reproducible:
- Horizontal scrolling works for long selected text.
- Tap interaction continues to open the picker.
- Read-only behavior is preserved.
- No regressions were observed during manual testing.