### PR TITLE
Flatten inter-branch merge Policy Service rules

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -718,7 +718,9 @@ configuration:
       - addLabel:
           label: partner/syncfusion
       description: Add 'partner/syncfusion' label to issues opened by the Syncfusion partner team
-    - if:
+    - description: '[Inter-branch merge] Auto-approve main to net11.0'
+      triggerOnOwnActions: false
+      if:
       - payloadType: Pull_Request
       - isPullRequest
       - isActivitySender:
@@ -726,36 +728,75 @@ configuration:
           issueAuthor: False
       - isAction:
           action: Opened
-      - or:
-        - and:
-          - targetsBranch:
-              branch: net11.0
-          - titleContains:
-              pattern: '^\[automated\] Merge branch ''main'' => ''net11\.0''$'
-              isRegex: True
-        - and:
-          - targetsBranch:
-              branch: release/11.0.1xx-preview7
-          - titleContains:
-              pattern: '^\[automated\] Merge branch ''net11\.0'' => ''release/11\.0\.1xx-preview7''$'
-              isRegex: True
-        - and:
-          - targetsBranch:
-              branch: release/11.0.1xx-rc1
-          - titleContains:
-              pattern: '^\[automated\] Merge branch ''net11\.0'' => ''release/11\.0\.1xx-rc1''$'
-              isRegex: True
-        - and:
-          - targetsBranch:
-              branch: release/11.0.1xx-rc2
-          - titleContains:
-              pattern: '^\[automated\] Merge branch ''net11\.0'' => ''release/11\.0\.1xx-rc2''$'
-              isRegex: True
+      - titleContains:
+          pattern: '^\[automated\] Merge branch ''main'' => ''net11\.0''$'
+          isRegex: True
+      - targetsBranch:
+          branch: net11.0
       then:
       - approvePullRequest:
           comment: Auto-approved automated inter-branch merge.
       - enableAutoMerge:
           mergeMethod: merge
-      description: '[Inter-branch merge] Auto-approve and enable auto-merge for exact forward-merge flows'
+    - description: '[Inter-branch merge] Auto-approve net11.0 to preview7'
+      triggerOnOwnActions: false
+      if:
+      - payloadType: Pull_Request
+      - isPullRequest
+      - isActivitySender:
+          user: github-actions[bot]
+          issueAuthor: False
+      - isAction:
+          action: Opened
+      - titleContains:
+          pattern: '^\[automated\] Merge branch ''net11\.0'' => ''release/11\.0\.1xx-preview7''$'
+          isRegex: True
+      - targetsBranch:
+          branch: release/11.0.1xx-preview7
+      then:
+      - approvePullRequest:
+          comment: Auto-approved automated inter-branch merge.
+      - enableAutoMerge:
+          mergeMethod: merge
+    - description: '[Inter-branch merge] Auto-approve net11.0 to rc1'
+      triggerOnOwnActions: false
+      if:
+      - payloadType: Pull_Request
+      - isPullRequest
+      - isActivitySender:
+          user: github-actions[bot]
+          issueAuthor: False
+      - isAction:
+          action: Opened
+      - titleContains:
+          pattern: '^\[automated\] Merge branch ''net11\.0'' => ''release/11\.0\.1xx-rc1''$'
+          isRegex: True
+      - targetsBranch:
+          branch: release/11.0.1xx-rc1
+      then:
+      - approvePullRequest:
+          comment: Auto-approved automated inter-branch merge.
+      - enableAutoMerge:
+          mergeMethod: merge
+    - description: '[Inter-branch merge] Auto-approve net11.0 to rc2'
+      triggerOnOwnActions: false
+      if:
+      - payloadType: Pull_Request
+      - isPullRequest
+      - isActivitySender:
+          user: github-actions[bot]
+          issueAuthor: False
+      - isAction:
+          action: Opened
+      - titleContains:
+          pattern: '^\[automated\] Merge branch ''net11\.0'' => ''release/11\.0\.1xx-rc2''$'
+          isRegex: True
+      - targetsBranch:
+          branch: release/11.0.1xx-rc2
+      then:
+      - approvePullRequest:
+          comment: Auto-approved automated inter-branch merge.
+      - enableAutoMerge:
+          mergeMethod: merge
 onFailure: 
 onSuccess: 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

Replaces #37050 with a clean, one-commit branch from current `main`.

## Motivation

Live generated inter-branch PRs #37007 and #37042 matched the configured bot sender, `Opened` event, exact title, and exact target branch, but hosted Policy Service supplied neither an approval nor an auto-merge request. Local evaluation with the production package successfully deserializes and matches the current nested rule, while Policy Service remains active for other MAUI rules.

The nested `or`-of-`and` structure is therefore the remaining evidence-backed hosted-runtime compatibility hypothesis. This is **not** a service-log-confirmed root cause: hosted evaluation catches task exceptions internally, so predicate-level diagnostics are unavailable from GitHub.

## Change

Replace the single nested matcher with four flat rules, one for each allowed title/target pair. Every rule preserves the existing security restrictions:

- sender must be `github-actions[bot]`
- action must be `Opened`
- title must match the exact anchored regular expression
- target branch must match the exact allow-listed branch
- auto-merge uses a merge commit
- Policy Service does not retrigger on its own actions

No `Synchronize` behavior or broader matching is added.

## Validation

- full YAML parse
- production `GitOps.PullRequestIssueManagement` `0.1.182` deserialization: 24 tasks, 4 flat inter-branch tasks
- exact sender, title regex, target branch, approval, merge-auto-merge, and `triggerOnOwnActions` assertions for all four rules
- CRLF-aware `git diff --check`

This change is an experiment to remove the remaining unique matcher shape. Definitive validation requires merging it and observing a fresh generated inter-branch PR receive the Policy Service approval and auto-merge request.
