### PR TITLE
[release/11.0.1xx-preview7] Stabilize Picker keyboard transition UI test

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24496.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24496.cs
@@ -15,19 +15,25 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 		[Test]
 		[Category(UITestCategories.Entry)]
-        public void PickerNewKeyboardIsAboveKeyboard()
-        {
-            App.WaitForElement("Picker6");
+		public void PickerNewKeyboardIsAboveKeyboard()
+		{
+			App.WaitForElement("Picker6");
 			App.Tap("Picker6");
-            VerifyScreenshot(TestContext.CurrentContext.Test.MethodName + "_Picker6");
+			App.WaitForElement(AppiumQuery.ByXPath("//XCUIElementTypePickerWheel"));
+			VerifyScreenshot(TestContext.CurrentContext.Test.MethodName + "_Picker6");
 			if (App is AppiumIOSApp iosApp && HelperExtensions.IsIOS26OrHigher(iosApp))
 			{
 				var rect = App.WaitForElement("ScrollViewId").GetRect();
 				App.DragCoordinates(rect.CenterX(), rect.CenterY(), rect.CenterX(), rect.CenterY() - 60);
 			}
-            App.Tap("Entry7");
-            VerifyScreenshot(TestContext.CurrentContext.Test.MethodName + "_Entry7", cropBottom: 1000);
-        }
-    }
+			App.RetryAssert(() =>
+			{
+				App.Tap("Entry7");
+				Assert.That(App.IsFocused("Entry7"), Is.True, "Entry7 did not receive focus after the picker scroll.");
+			});
+			App.WaitForNoElement(AppiumQuery.ByXPath("//XCUIElementTypePickerWheel"));
+			VerifyScreenshot(TestContext.CurrentContext.Test.MethodName + "_Entry7", cropBottom: 1000, retryTimeout: TimeSpan.FromSeconds(2));
+		}
+	}
 }
 #endif


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

The Preview 7 iOS UI run failed `PickerNewKeyboardIsAboveKeyboard` because the test dragged the scroll view and immediately tapped `Entry7`. While the scroll gesture was still settling, iOS could ignore that tap, so the snapshot captured the previous picker state instead of the focused Entry.

This waits for the picker input view, retries the Entry tap until `Entry7` actually owns focus, waits for the picker input view to disappear, and allows the final visual assertion to observe the settled keyboard-driven layout.

## Validation

- Reproduced the stale picker-state snapshot from Preview 7 UI build 1538078.
- The exact Entry transition passed locally on an iOS 26.0 simulator; the committed baselines are unchanged.

Fixes the Preview 7 UI test failure only; no product behavior changes.