### PR TITLE
[release/11.0.1xx-preview7] Fix MacCatalyst Shell tab bar visibility

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellItemRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellItemRenderer.cs
@@ -670,7 +670,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			if (OperatingSystem.IsMacCatalystVersionAtLeast(18) || OperatingSystem.IsIOSVersionAtLeast(18))
 			{
 #if MACCATALYST
-				if (TabBar != null && TabBar.Hidden != !ShellItemController.ShowTabs)
+				if (TabBar != null && (TabBar.Hidden != !ShellItemController.ShowTabs || TabBar.Alpha != 1.0f))
 				{
 					// Root Cause: On MacCatalyst 18+, DisableiOS18ToolbarTabs() sets Mode = TabSidebar 
 					// which causes iOS to set TabBar.Hidden = true and Alpha = 0 by the system.


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

The Preview 7 MacCatalyst Shell job failed `TabBarShouldbeVisibleNavigatingBackFromNonTabbedPage` after navigation reached `InnerTab` but the tab bar remained absent. On MacCatalyst 18+, UIKit can leave the tab bar with the expected `Hidden` value while its `Alpha` remains `0`. The Shell workaround only repaired the native state when `Hidden` differed, unlike the equivalent `TabbedRenderer` workaround.

This change also repairs an alpha mismatch, restoring the visible tab bar after hidden/visible navigation transitions.

## Validation

- Built `Controls.Core.csproj` for `net11.0-maccatalyst26.5`.
- Existing UI regression coverage: `Issue26598.TabBarShouldbeVisibleNavigatingBackFromNonTabbedPage`.