### PR TITLE
[release/11.0.1xx-preview7] Stabilize empty CollectionView footer screenshot

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28604.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28604.cs
@@ -17,7 +17,7 @@ public class Issue28604 : _IssuesUITest
     public void FooterShouldDisplayAtBottomOfEmptyView()
     {
         App.WaitForElement("CollectionView");
-        VerifyScreenshot();
+        VerifyScreenshot(retryTimeout: TimeSpan.FromSeconds(3));
     }
 }
 #endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28604.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28604.cs
@@ -17,7 +17,7 @@ public class Issue28604 : _IssuesUITest
     public void FooterShouldDisplayAtBottomOfEmptyView()
     {
         App.WaitForElement("CollectionView");
-        VerifyScreenshot(retryTimeout: TimeSpan.FromSeconds(3));
+        VerifyScreenshot(tolerance: 0.5, retryTimeout: TimeSpan.FromSeconds(2));
     }
 }
 #endif


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

- Give `Issue28604.FooterShouldDisplayAtBottomOfEmptyView` up to two seconds to reach its final MacCatalyst layout before comparing the screenshot.
- Allow the established 0.5% rendering tolerance used by similar visual tests.
- Reuse the existing adaptive `VerifyScreenshot` polling rather than adding a sleep.

## Evidence

Preview 7 branch build 1538409 / test run 42368316 captured the footer transiently directly below the header instead of at the bottom of the empty CollectionView. The comparison missed by 1.00%.

The same test passed in branch builds 1538078, 1537359, and 1535908, and in PR #37070 build 1538419. That progression identifies a visual timing race rather than a persistent rendering regression.

## Validation

- `Microsoft.Maui.BuildTasks.slnf` builds successfully.
- The exact MacCatalyst HostApp and test assembly build successfully and discover the targeted test.
- Prior head `9cc174525e` was proven by exact UI build 1538596: the MacCatalyst CollectionView job succeeded and `Issue28604.FooterShouldDisplayAtBottomOfEmptyView` passed in 2.46 seconds.
- Current head `2ada17e35a` incorporates review feedback to use a two-second retry and 0.5% tolerance; fresh exact-head CI is required.

### Issues Fixed

N/A
