### PR TITLE
Fix irregular placement of views with margins

### DIFF
--- a/src/Core/src/Layouts/LayoutExtensions.cs
+++ b/src/Core/src/Layouts/LayoutExtensions.cs
@@ -84,14 +84,21 @@ namespace Microsoft.Maui.Layouts
 				desiredWidth = IsExplicitSet(view.Width) ? desiredWidth : Math.Min(bounds.Width, view.MaximumWidth);
 			}
 
-			return AlignHorizontal(bounds.X, margin.Left, margin.Right, bounds.Width, desiredWidth, alignment);
+			var clampMarginOverflow = view.Parent is not IFlexLayout;
+
+			return AlignHorizontal(bounds.X, margin.Left, margin.Right, bounds.Width, desiredWidth, alignment, clampMarginOverflow);
 		}
 
 		static double AlignHorizontal(double startX, double startMargin, double endMargin, double boundsWidth,
-			double desiredWidth, LayoutAlignment horizontalLayoutAlignment)
+			double desiredWidth, LayoutAlignment horizontalLayoutAlignment, bool clampMarginOverflow)
 		{
 			double frameX = startX + startMargin;
-			var availableWidth = Math.Max(0, boundsWidth - desiredWidth);
+			var availableWidth = boundsWidth - desiredWidth;
+
+			if (clampMarginOverflow && availableWidth < 0 && startMargin > 0 && desiredWidth - startMargin - endMargin <= boundsWidth)
+			{
+				availableWidth = 0;
+			}
 
 			switch (horizontalLayoutAlignment)
 			{
@@ -123,7 +130,13 @@ namespace Microsoft.Maui.Layouts
 			}
 
 			double frameY = bounds.Y + margin.Top;
-			var availableHeight = Math.Max(0, bounds.Height - desiredHeight);
+			var availableHeight = bounds.Height - desiredHeight;
+
+			if (view.Parent is not IFlexLayout && availableHeight < 0 && margin.Top > 0 &&
+				desiredHeight - margin.VerticalThickness <= bounds.Height)
+			{
+				availableHeight = 0;
+			}
 
 			switch (alignment)
 			{

--- a/src/Core/src/Layouts/LayoutExtensions.cs
+++ b/src/Core/src/Layouts/LayoutExtensions.cs
@@ -91,15 +91,16 @@ namespace Microsoft.Maui.Layouts
 			double desiredWidth, LayoutAlignment horizontalLayoutAlignment)
 		{
 			double frameX = startX + startMargin;
+			var availableWidth = Math.Max(0, boundsWidth - desiredWidth);
 
 			switch (horizontalLayoutAlignment)
 			{
 				case LayoutAlignment.Center:
-					frameX += (boundsWidth - desiredWidth) / 2;
+					frameX += availableWidth / 2;
 					break;
 
 				case LayoutAlignment.End:
-					frameX += boundsWidth - desiredWidth;
+					frameX += availableWidth;
 					break;
 			}
 
@@ -122,15 +123,16 @@ namespace Microsoft.Maui.Layouts
 			}
 
 			double frameY = bounds.Y + margin.Top;
+			var availableHeight = Math.Max(0, bounds.Height - desiredHeight);
 
 			switch (alignment)
 			{
 				case LayoutAlignment.Center:
-					frameY += (bounds.Height - desiredHeight) / 2;
+					frameY += availableHeight / 2;
 					break;
 
 				case LayoutAlignment.End:
-					frameY += bounds.Height - desiredHeight;
+					frameY += availableHeight;
 					break;
 			}
 

--- a/src/Core/tests/UnitTests/Layouts/LayoutExtensionTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/LayoutExtensionTests.cs
@@ -57,6 +57,36 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			Assert.Equal(0, frame.Width);
 		}
 
+		[Theory]
+		[InlineData(LayoutAlignment.Center)]
+		[InlineData(LayoutAlignment.End)]
+		public void VerticalAlignmentDoesNotReverseWhenMarginExceedsBounds(LayoutAlignment layoutAlignment)
+		{
+			var element = Substitute.For<IView>();
+			element.Margin.Returns(new Thickness(0, 40, 0, 0));
+			element.DesiredSize.Returns(new Size(20, 60));
+			element.VerticalLayoutAlignment.Returns(layoutAlignment);
+
+			var frame = element.ComputeFrame(new Rect(0, 0, 40, 40));
+
+			Assert.Equal(40, frame.Top);
+		}
+
+		[Theory]
+		[InlineData(LayoutAlignment.Center)]
+		[InlineData(LayoutAlignment.End)]
+		public void HorizontalAlignmentDoesNotReverseWhenMarginExceedsBounds(LayoutAlignment layoutAlignment)
+		{
+			var element = Substitute.For<IView>();
+			element.Margin.Returns(new Thickness(40, 0, 0, 0));
+			element.DesiredSize.Returns(new Size(60, 20));
+			element.HorizontalLayoutAlignment.Returns(layoutAlignment);
+
+			var frame = element.ComputeFrame(new Rect(0, 0, 40, 40));
+
+			Assert.Equal(40, frame.Left);
+		}
+
 		[Fact]
 		public void DesiredSizeIncludesMargin()
 		{


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
- When a view’s margin makes its desired size larger than its parent’s available bounds, Center and End alignment apply a negative offset that moves the view backward past the Start position, causing irregular or visually reversed placement.

### Root Cause
- DesiredSize includes the view’s margins. When those margins make the desired size larger than the available bounds, boundsWidth - desiredWidth or bounds.Height - desiredHeight becomes negative. Center and End alignment then use that negative value as an offset, moving the view backward past its Start position and visually reversing the layout. 

### Description of Change
- Clamp the available alignment space to a minimum of zero in AlignHorizontal and AlignVertical. When a view’s desired size exceeds its bounds, Center and End no longer apply a negative offset and instead retain the margin-adjusted Start position.
- Reference =>  [Layout.cs](https://github.com/dotnet/maui/blob/a1521eda4980d8b6a890323ee3273e2e96f71703/src/Controls/src/Core/LegacyLayouts/Layout.cs#L259)

### Issues Fixed
Fixes #8324

### Validated the behaviour in the following platforms
- [x] Windows
- [x] Android
- [x] iOS
- [x] Mac

### Output
| Platform | Before | After |
|----------|----------|----------|
| iOS | <img src="https://github.com/user-attachments/assets/86c94004-a6dc-480a-abb1-5dbb89f4e978"> | <img src="https://github.com/user-attachments/assets/5eb63737-4547-4908-8d11-57e175bc74c3"> |
| Mac | <img src="https://github.com/user-attachments/assets/53479831-a10f-49ce-a78b-8e5b11c95395"> | <img src="https://github.com/user-attachments/assets/fd6d5a5c-d69b-4e71-ae17-7438d328aefa"> |
| Windows | <img src="https://github.com/user-attachments/assets/f0a1ad5b-0f55-455e-92db-55a2b63e1e87"> | <img src="https://github.com/user-attachments/assets/379f63fd-4535-4c9d-a173-7b2db3482015"> |
| Android | <img src="https://github.com/user-attachments/assets/6d3577e0-d58c-4cd9-a74f-da83644ee16a"> | <img src="https://github.com/user-attachments/assets/47c32295-64cf-41e2-8f92-8404ba08ff36"> |