### PR TITLE
[release/11.0.1xx-preview7] Bundle test-only stabilizations

### DIFF
--- a/.github/scripts/Set-ScreenResolution.Tests.ps1
+++ b/.github/scripts/Set-ScreenResolution.Tests.ps1
@@ -1,0 +1,76 @@
+#!/usr/bin/env pwsh
+#Requires -Modules Pester
+
+BeforeAll {
+    $screenResolutionScript = Join-Path $PSScriptRoot '../../eng/scripts/Set-ScreenResolution.ps1'
+    $tokens = $null
+    $parseErrors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+        $screenResolutionScript,
+        [ref]$tokens,
+        [ref]$parseErrors)
+
+    if ($parseErrors.Count -gt 0) {
+        throw "Set-ScreenResolution.ps1 has parse errors: $($parseErrors -join '; ')"
+    }
+
+    $functionDefinitions = $ast.FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.FunctionDefinitionAst]
+    }, $true)
+
+    foreach ($functionName in @(
+        'Get-ScreenResolutionProbeAction',
+        'Test-ScreenResolutionApplySucceeded'
+    )) {
+        $definition = $functionDefinitions |
+            Where-Object Name -EQ $functionName |
+            Select-Object -First 1
+
+        if ($null -eq $definition) {
+            throw "Function '$functionName' was not found in Set-ScreenResolution.ps1"
+        }
+
+        Invoke-Expression $definition.Extent.Text
+    }
+
+    $setResolutionDefinition = $functionDefinitions |
+        Where-Object Name -EQ 'Set-ScreenResolution' |
+        Select-Object -First 1
+
+    if ($null -eq $setResolutionDefinition) {
+        throw "Function 'Set-ScreenResolution' was not found in Set-ScreenResolution.ps1"
+    }
+
+    $setResolutionBody = $setResolutionDefinition.Extent.Text
+}
+
+Describe 'Set-ScreenResolution native result decisions' {
+    It 'returns <Expected> for CDS_TEST result <Result>' -ForEach @(
+        @{ Result = 0; Expected = 'Apply' }
+        @{ Result = -1; Expected = 'Apply' }
+        @{ Result = -2; Expected = 'Reject' }
+        @{ Result = -3; Expected = 'Apply' }
+        @{ Result = -4; Expected = 'Apply' }
+        @{ Result = -5; Expected = 'Apply' }
+    ) {
+        Get-ScreenResolutionProbeAction -Result $Result | Should -Be $Expected
+    }
+
+    It 'returns <Expected> for real apply result <Result>' -ForEach @(
+        @{ Result = 0; Expected = $true }
+        @{ Result = 1; Expected = $true }
+        @{ Result = -1; Expected = $false }
+        @{ Result = -2; Expected = $false }
+        @{ Result = -3; Expected = $false }
+        @{ Result = -4; Expected = $false }
+        @{ Result = -5; Expected = $false }
+    ) {
+        Test-ScreenResolutionApplySucceeded -Result $Result | Should -Be $Expected
+    }
+
+    It 'uses the pure decisions in the native flow' {
+        $setResolutionBody | Should -Match 'Get-ScreenResolutionProbeAction\s+-Result\s+\$testResult'
+        $setResolutionBody | Should -Match 'Test-ScreenResolutionApplySucceeded\s+-Result\s+\$changeResult'
+    }
+}

--- a/.github/workflows/powershell-script-tests.yml
+++ b/.github/workflows/powershell-script-tests.yml
@@ -1,4 +1,4 @@
-# Pester regression gate for `.github/scripts/**`.
+# Pester regression gate for `.github/scripts/**` and the scripts covered by those tests.
 #
 # Why this exists: the automation under `.github/scripts` ships a large Pester
 # suite (transport gating, safe-output expectation reconciliation, milestone
@@ -19,6 +19,7 @@ on:
   pull_request:
     paths:
       - '.github/scripts/**'
+      - 'eng/scripts/Set-ScreenResolution.ps1'
       - '.github/workflows/powershell-script-tests.yml'
   workflow_dispatch:
 

--- a/eng/scripts/Set-ScreenResolution.ps1
+++ b/eng/scripts/Set-ScreenResolution.ps1
@@ -37,6 +37,26 @@ param (
 Set-StrictMode -Version 2.0
 $ErrorActionPreference = "Stop"
 
+function Get-ScreenResolutionProbeAction {
+    param (
+        [int]$Result
+    )
+
+    if ($Result -eq -2) {
+        return "Reject"
+    }
+
+    return "Apply"
+}
+
+function Test-ScreenResolutionApplySucceeded {
+    param (
+        [int]$Result
+    )
+
+    return ($Result -eq 0 -or $Result -eq 1)
+}
+
 function Set-ScreenResolution {
     param (
         [int]$Width,
@@ -167,33 +187,35 @@ namespace DisplaySettings
         
         if ($testResult -ne [DisplaySettings.NativeMethods]::DISP_CHANGE_SUCCESSFUL) {
             Write-Warning "Resolution test returned code: $testResult"
-            
-            switch ($testResult) {
-                ([DisplaySettings.NativeMethods]::DISP_CHANGE_BADMODE) {
-                    Write-Error "The resolution ${Width}x${Height} is not supported by this display (BADMODE)"
-                    return $false
-                }
-                ([DisplaySettings.NativeMethods]::DISP_CHANGE_FAILED) {
-                    Write-Warning "CDS_TEST returned DISP_CHANGE_FAILED ($testResult) for target ${Width}x${Height}; attempting to apply the resolution anyway..."
-                }
-                default {
-                    Write-Warning "Unexpected test result, attempting to apply anyway..."
-                }
+
+            if ((Get-ScreenResolutionProbeAction -Result $testResult) -eq "Reject") {
+                Write-Error "The resolution ${Width}x${Height} is not supported by this display (BADMODE)"
+                return $false
+            }
+
+            if ($testResult -eq [DisplaySettings.NativeMethods]::DISP_CHANGE_FAILED) {
+                Write-Warning "CDS_TEST returned DISP_CHANGE_FAILED ($testResult) for target ${Width}x${Height}; attempting to apply the resolution anyway..."
+            }
+            else {
+                Write-Warning "Unexpected test result, attempting to apply anyway..."
             }
         }
         
         # Apply the resolution change
         $changeResult = [DisplaySettings.NativeMethods]::ChangeDisplaySettings([ref]$devMode, [DisplaySettings.NativeMethods]::CDS_UPDATEREGISTRY)
-        
-        switch ($changeResult) {
-            ([DisplaySettings.NativeMethods]::DISP_CHANGE_SUCCESSFUL) {
-                Write-Host "Successfully set screen resolution to ${Width}x${Height}"
-                return $true
-            }
-            ([DisplaySettings.NativeMethods]::DISP_CHANGE_RESTART) {
+
+        if (Test-ScreenResolutionApplySucceeded -Result $changeResult) {
+            if ($changeResult -eq [DisplaySettings.NativeMethods]::DISP_CHANGE_RESTART) {
                 Write-Host "Screen resolution set to ${Width}x${Height}. A restart may be required for some applications."
-                return $true
             }
+            else {
+                Write-Host "Successfully set screen resolution to ${Width}x${Height}"
+            }
+
+            return $true
+        }
+
+        switch ($changeResult) {
             ([DisplaySettings.NativeMethods]::DISP_CHANGE_BADMODE) {
                 Write-Error "The resolution ${Width}x${Height} is not supported by this display"
                 return $false

--- a/eng/scripts/Set-ScreenResolution.ps1
+++ b/eng/scripts/Set-ScreenResolution.ps1
@@ -174,7 +174,7 @@ namespace DisplaySettings
                     return $false
                 }
                 ([DisplaySettings.NativeMethods]::DISP_CHANGE_FAILED) {
-                    Write-Warning "The resolution change test failed (FAILED). Attempting to apply the resolution anyway..."
+                    Write-Warning "CDS_TEST returned DISP_CHANGE_FAILED ($testResult) for target ${Width}x${Height}; attempting to apply the resolution anyway..."
                 }
                 default {
                     Write-Warning "Unexpected test result, attempting to apply anyway..."

--- a/eng/scripts/Set-ScreenResolution.ps1
+++ b/eng/scripts/Set-ScreenResolution.ps1
@@ -174,8 +174,7 @@ namespace DisplaySettings
                     return $false
                 }
                 ([DisplaySettings.NativeMethods]::DISP_CHANGE_FAILED) {
-                    Write-Error "The resolution change test failed (FAILED)"
-                    return $false
+                    Write-Warning "The resolution change test failed (FAILED). Attempting to apply the resolution anyway..."
                 }
                 default {
                     Write-Warning "Unexpected test result, attempting to apply anyway..."

--- a/src/Controls/tests/DeviceTests/Elements/CarouselView/CarouselViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CarouselView/CarouselViewTests.iOS.cs
@@ -41,6 +41,9 @@ namespace Microsoft.Maui.DeviceTests
 				((IElementHandler)handler).DisconnectHandler();
 			});
 
+			// Allow UIKit to release controller-owned references before forcing managed GC.
+			await Task.Delay(100);
+
 			// Force garbage collection
 			await AssertionExtensions.WaitForGC(weakCarouselView, weakHandler);
 

--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
@@ -722,6 +722,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 #endif
 
+#if ANDROID
 		[Fact("Dont leak with Animation")]
 		public async Task ModalPageDontLeakWithAnimation()
 		{
@@ -751,6 +752,7 @@ namespace Microsoft.Maui.DeviceTests
 
 			await AssertionExtensions.WaitForGC(references.ToArray());
 		}
+#endif
 
 		class PageTypes : IEnumerable<object[]>
 		{

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33287.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33287.cs
@@ -69,7 +69,7 @@ public class Issue33287SecondPage : ContentPage
 			}
 		};
 
-		async void OnPropertyChanged(object sender, PropertyChangedEventArgs e)
+		void OnPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName != nameof(Window) || Window is not null)
 				return;
@@ -77,9 +77,10 @@ public class Issue33287SecondPage : ContentPage
 			PropertyChanged -= OnPropertyChanged;
 			updateStatus("Page detached");
 
-			// Request the alert before handler teardown changes IsPlatformEnabled.
-			await DisplayAlertAsync("Test Alert", "This alert was delayed", "OK");
-			updateStatus("Alert request completed");
+			// The original NRE occurs synchronously while creating the alert request.
+			// A detached page may keep the returned task pending until it is reattached.
+			_ = DisplayAlertAsync("Test Alert", "This alert was delayed", "OK");
+			updateStatus("Alert request returned");
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33287.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33287.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Threading.Tasks;
+using System.ComponentModel;
 
 namespace Maui.Controls.Sample.Issues;
 
@@ -17,6 +17,12 @@ public class Issue33287MainPage : ContentPage
 	{
 		Title = "Issue 33287";
 
+		var statusLabel = new Label
+		{
+			Text = "Waiting for alert request",
+			AutomationId = "AlertStatusLabel"
+		};
+
 		Content = new VerticalStackLayout
 		{
 			Padding = 20,
@@ -28,13 +34,15 @@ public class Issue33287MainPage : ContentPage
 					Text = "Navigate to Second Page",
 					AutomationId = "NavigateButton",
 					Command = new Command(async () =>
-						await Navigation.PushAsync(new Issue33287SecondPage()))
+						await Navigation.PushAsync(new Issue33287SecondPage(status =>
+							statusLabel.Text = status)))
 				},
 				new Label
 				{
 					Text = "MainPage",
 					AutomationId = "MainPageLabel"
-				}
+				},
+				statusLabel
 			}
 		};
 	}
@@ -42,9 +50,10 @@ public class Issue33287MainPage : ContentPage
 
 public class Issue33287SecondPage : ContentPage
 {
-	public Issue33287SecondPage()
+	public Issue33287SecondPage(Action<string> updateStatus)
 	{
 		Title = "Second Page";
+		PropertyChanged += OnPropertyChanged;
 
 		Content = new VerticalStackLayout
 		{
@@ -59,20 +68,18 @@ public class Issue33287SecondPage : ContentPage
 				}
 			}
 		};
-	}
 
-	protected override async void OnAppearing()
-	{
-		base.OnAppearing();
+		async void OnPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName != nameof(Window) || Window is not null)
+				return;
 
-		// Wait long enough for the user/test to navigate back
-#if MACCATALYST
-		await Task.Delay(4000);
-#else
-		await Task.Delay(2000);
-#endif
+			PropertyChanged -= OnPropertyChanged;
+			updateStatus("Page detached");
 
-		// Without the fix this throws NullReferenceException and crashes the app
-		await DisplayAlertAsync("Test Alert", "This alert was delayed", "OK");
+			// Request the alert before handler teardown changes IsPlatformEnabled.
+			await DisplayAlertAsync("Test Alert", "This alert was delayed", "OK");
+			updateStatus("Alert request completed");
+		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/DragAndDropUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/DragAndDropUITests.cs
@@ -44,8 +44,9 @@ namespace Microsoft.Maui.TestCases.Tests
 			// Wait for the label's text to become EXACTLY the expected value. A substring wait is
 			// unreliable here because each label's placeholder (e.g. "DragOverEvents: ") already
 			// contains the expected event name (e.g. "DragOver"), so a Contains-based wait would pass
-			// immediately on the placeholder. The wait already asserts the exact text, so no separate
-			// GetText re-read is needed (it would only re-open a window for transient Appium flakiness).
+			// immediately on the placeholder. WaitForTextEqualToElement polls until the text matches
+			// exactly, so the Assert below fails only on a genuine timeout; no separate GetText re-read
+			// is needed (it would only re-open a window for transient Appium flakiness).
 			Assert.That(
 				App.WaitForTextEqualToElement(automationId, expectedText),
 				Is.True,
@@ -67,7 +68,7 @@ namespace Microsoft.Maui.TestCases.Tests
 			App.WaitForElement("Green");
 			App.DragAndDrop("Red", "Green");
 
-			App.WaitForElement("DragStartEventsLabel");
+			App.WaitForTextEqualToElement("DragStartEventsLabel", "DragStarting");
 			var textAfterDragStart = App.FindElement("DragStartEventsLabel").GetText();
 
 			if (string.IsNullOrEmpty(textAfterDragStart))
@@ -79,7 +80,7 @@ namespace Microsoft.Maui.TestCases.Tests
 				Assert.That(textAfterDragStart, Is.EqualTo("DragStarting"));
 			}
 
-			App.WaitForElement("DragOverEventsLabel");
+			App.WaitForTextEqualToElement("DragOverEventsLabel", "DragOver");
 			var textAfterDragOver = App.FindElement("DragOverEventsLabel").GetText();
 			if (string.IsNullOrEmpty(textAfterDragOver))
 			{
@@ -90,7 +91,7 @@ namespace Microsoft.Maui.TestCases.Tests
 				Assert.That(textAfterDragOver, Is.EqualTo("DragOver"));
 			}
 
-			App.WaitForElement("DragCompletedEventsLabel");
+			App.WaitForTextEqualToElement("DragCompletedEventsLabel", "DropCompleted");
 			var textAfterDragComplete = App.FindElement("DragCompletedEventsLabel").GetText();
 			if (string.IsNullOrEmpty(textAfterDragComplete))
 			{
@@ -112,7 +113,7 @@ namespace Microsoft.Maui.TestCases.Tests
 				Assert.That(rainbowColorText, Is.EqualTo("RainbowColorsAdd:Red"));
 			}
 
-			App.WaitForElement("DropEventsLabel");
+			App.WaitForTextEqualToElement("DropEventsLabel", "Drop");
 			var textAfterDrop = App.FindElement("DropEventsLabel").GetText();
 			if (string.IsNullOrEmpty(textAfterDrop))
 			{

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/DragAndDropUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/DragAndDropUITests.cs
@@ -33,50 +33,19 @@ namespace Microsoft.Maui.TestCases.Tests
 			App.WaitForElement("LabelDragElement");
 			App.DragAndDrop("LabelDragElement", "DragTarget");
 
-			App.WaitForElement("DragStartEventsLabel");
-			var textAfterDragStart = App.FindElement("DragStartEventsLabel").GetText();
+			AssertEventText("DragStartEventsLabel", "DragStarting");
+			AssertEventText("DragOverEventsLabel", "DragOver");
+			AssertEventText("DragCompletedEventsLabel", "DropCompleted");
+			AssertEventText("DropEventsLabel", "Drop");
+		}
 
-			if (string.IsNullOrEmpty(textAfterDragStart))
-			{
-				Assert.Fail("Text was expected: Drag start event");
-			}
-			else
-			{
-				Assert.That(textAfterDragStart, Is.EqualTo("DragStarting"));
-			}
-
-			App.WaitForElement("DragOverEventsLabel");
-			var textAfterDragOver = App.FindElement("DragOverEventsLabel").GetText();
-			if (string.IsNullOrEmpty(textAfterDragOver))
-			{
-				Assert.Fail("Text was expected: Drag over event");
-			}
-			else
-			{
-				Assert.That(textAfterDragOver, Is.EqualTo("DragOver"));
-			}
-
-			App.WaitForElement("DragCompletedEventsLabel");
-			var textAfterDragComplete = App.FindElement("DragCompletedEventsLabel").GetText();
-			if (string.IsNullOrEmpty(textAfterDragComplete))
-			{
-				Assert.Fail("Text was expected: Drag complete event");
-			}
-			else
-			{
-				Assert.That(textAfterDragComplete, Is.EqualTo("DropCompleted"));
-			}
-
-			App.WaitForElement("DropEventsLabel");
-			var textAfterDrop = App.FindElement("DropEventsLabel").GetText();
-			if (string.IsNullOrEmpty(textAfterDrop))
-			{
-				Assert.Fail("Text was expected: Drop event");
-			}
-			else
-			{
-				Assert.That(textAfterDrop, Is.EqualTo("Drop"));
-			}
+		void AssertEventText(string automationId, string expectedText)
+		{
+			Assert.That(
+				App.WaitForTextToBePresentInElement(automationId, expectedText),
+				Is.True,
+				$"Timed out waiting for {automationId} to contain '{expectedText}'.");
+			Assert.That(App.FindElement(automationId).GetText(), Is.EqualTo(expectedText));
 		}
 
 		[Test]

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/DragAndDropUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/DragAndDropUITests.cs
@@ -41,10 +41,14 @@ namespace Microsoft.Maui.TestCases.Tests
 
 		void AssertEventText(string automationId, string expectedText)
 		{
+			// Wait for the label's text to become EXACTLY the expected value. A substring wait is
+			// unreliable here because each label's placeholder (e.g. "DragOverEvents: ") already
+			// contains the expected event name (e.g. "DragOver"), so a Contains-based wait would pass
+			// immediately on the placeholder and the following equality assertion would still flap.
 			Assert.That(
-				App.WaitForTextToBePresentInElement(automationId, expectedText),
+				App.WaitForTextEqualToElement(automationId, expectedText),
 				Is.True,
-				$"Timed out waiting for {automationId} to contain '{expectedText}'.");
+				$"Timed out waiting for {automationId} to become '{expectedText}'.");
 			Assert.That(App.FindElement(automationId).GetText(), Is.EqualTo(expectedText));
 		}
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/DragAndDropUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/DragAndDropUITests.cs
@@ -44,12 +44,12 @@ namespace Microsoft.Maui.TestCases.Tests
 			// Wait for the label's text to become EXACTLY the expected value. A substring wait is
 			// unreliable here because each label's placeholder (e.g. "DragOverEvents: ") already
 			// contains the expected event name (e.g. "DragOver"), so a Contains-based wait would pass
-			// immediately on the placeholder and the following equality assertion would still flap.
+			// immediately on the placeholder. The wait already asserts the exact text, so no separate
+			// GetText re-read is needed (it would only re-open a window for transient Appium flakiness).
 			Assert.That(
 				App.WaitForTextEqualToElement(automationId, expectedText),
 				Is.True,
 				$"Timed out waiting for {automationId} to become '{expectedText}'.");
-			Assert.That(App.FindElement(automationId).GetText(), Is.EqualTo(expectedText));
 		}
 
 		[Test]

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/EntryFeatureTests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/EntryFeatureTests.cs
@@ -197,7 +197,7 @@ public class EntryFeatureTests : _GalleryUITest
 		App.WaitForElement("TestEntry");
 		App.Tap("TestEntry");
 		if (App is AppiumIOSApp)
-			App.WaitForKeyboardToShow();
+			Assert.That(App.WaitForKeyboardToShow(), Is.True, "The iOS keyboard did not appear before the snapshot.");
 		VerifyScreenshotWithKeyboardHandling();
 	}
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/EntryFeatureTests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/EntryFeatureTests.cs
@@ -196,7 +196,8 @@ public class EntryFeatureTests : _GalleryUITest
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
 		App.Tap("TestEntry");
-		App.WaitForKeyboardToShow();
+		if (App is AppiumIOSApp)
+			App.WaitForKeyboardToShow();
 		VerifyScreenshotWithKeyboardHandling();
 	}
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/EntryFeatureTests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/EntryFeatureTests.cs
@@ -196,6 +196,7 @@ public class EntryFeatureTests : _GalleryUITest
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
 		App.Tap("TestEntry");
+		App.WaitForKeyboardToShow();
 		VerifyScreenshotWithKeyboardHandling();
 	}
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16910.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16910.cs
@@ -38,8 +38,20 @@ public class Issue16910 : _IssuesUITest
 	public void BindingUpdatesFromInteractiveRefresh()
 	{
 		var scrollViewRect = App.WaitForElement("RefreshScrollView", timeout: TimeSpan.FromSeconds(45)).GetRect();
-		//In CI, using App.ScrollDown sometimes fails to trigger the refresh command, so here use DragCoordinates instead of the ScrollDown action in Appium.
-		App.DragCoordinates(scrollViewRect.CenterX(), scrollViewRect.Y + 50, scrollViewRect.CenterX(), scrollViewRect.Y + scrollViewRect.Height - 50);
+		void PullToRefresh() =>
+			App.DragCoordinates(scrollViewRect.CenterX(), scrollViewRect.Y + 50, scrollViewRect.CenterX(), scrollViewRect.Y + scrollViewRect.Height - 50);
+
+		// In CI, a single pull gesture occasionally does not trigger the refresh command.
+		PullToRefresh();
+		try
+		{
+			App.WaitForElement("IsRefreshing", timeout: TimeSpan.FromSeconds(10));
+		}
+		catch (TimeoutException)
+		{
+			PullToRefresh();
+		}
+
 		App.WaitForElement("IsRefreshing", timeout: TimeSpan.FromSeconds(45));
 		App.Tap("StopRefreshing");
 		App.WaitForElement("IsNotRefreshing", timeout: TimeSpan.FromSeconds(45));

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18896.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18896.cs
@@ -29,6 +29,6 @@ public class Issue18896 : _IssuesUITest
 		// ListView with HasUnevenRows may have variable height row rendering that requires
 		// additional time for images to load and scrollbar to disappear.
 		// Use retryTimeout to adaptively wait for the UI to stabilize.
-		VerifyScreenshot(retryTimeout: TimeSpan.FromSeconds(3));
+		VerifyScreenshot(retryTimeout: TimeSpan.FromSeconds(5));
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22306.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22306.cs
@@ -46,12 +46,9 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 				App.SetOrientationPortrait();
 				WaitForAllElements();
 				// Cannot use the original screenshot as the black bar on bottom is not as dark after rotation
-#if ANDROID
 				// Android can consistently rerasterize the same post-rotation layout with minor antialiasing differences.
-				VerifyScreenshot(TestContext.CurrentContext.Test.MethodName + "Original2", tolerance: 2, retryTimeout: TimeSpan.FromSeconds(2));
-#else
-				VerifyScreenshot(TestContext.CurrentContext.Test.MethodName + "Original2", tolerance: 0.5, retryTimeout: TimeSpan.FromSeconds(2));
-#endif
+				var finalPortraitTolerance = _testDevice == TestDevice.Android ? 2 : 0.5;
+				VerifyScreenshot(TestContext.CurrentContext.Test.MethodName + "Original2", tolerance: finalPortraitTolerance, retryTimeout: TimeSpan.FromSeconds(2));
 			}
 			finally
 			{

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22306.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22306.cs
@@ -46,7 +46,12 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 				App.SetOrientationPortrait();
 				WaitForAllElements();
 				// Cannot use the original screenshot as the black bar on bottom is not as dark after rotation
+#if ANDROID
+				// Android can consistently rerasterize the same post-rotation layout with minor antialiasing differences.
+				VerifyScreenshot(TestContext.CurrentContext.Test.MethodName + "Original2", tolerance: 2, retryTimeout: TimeSpan.FromSeconds(2));
+#else
 				VerifyScreenshot(TestContext.CurrentContext.Test.MethodName + "Original2", tolerance: 0.5, retryTimeout: TimeSpan.FromSeconds(2));
+#endif
 			}
 			finally
 			{

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24496.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24496.cs
@@ -15,19 +15,25 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 		[Test]
 		[Category(UITestCategories.Entry)]
-        public void PickerNewKeyboardIsAboveKeyboard()
-        {
-            App.WaitForElement("Picker6");
+		public void PickerNewKeyboardIsAboveKeyboard()
+		{
+			App.WaitForElement("Picker6");
 			App.Tap("Picker6");
-            VerifyScreenshot(TestContext.CurrentContext.Test.MethodName + "_Picker6");
+			App.WaitForElement(AppiumQuery.ByXPath("//XCUIElementTypePickerWheel"));
+			VerifyScreenshot(TestContext.CurrentContext.Test.MethodName + "_Picker6");
 			if (App is AppiumIOSApp iosApp && HelperExtensions.IsIOS26OrHigher(iosApp))
 			{
 				var rect = App.WaitForElement("ScrollViewId").GetRect();
 				App.DragCoordinates(rect.CenterX(), rect.CenterY(), rect.CenterX(), rect.CenterY() - 60);
 			}
-            App.Tap("Entry7");
-            VerifyScreenshot(TestContext.CurrentContext.Test.MethodName + "_Entry7", cropBottom: 1000);
-        }
-    }
+			App.RetryAssert(() =>
+			{
+				App.Tap("Entry7");
+				Assert.That(App.IsFocused("Entry7"), Is.True, "Entry7 did not receive focus after the picker scroll.");
+			});
+			App.WaitForNoElement(AppiumQuery.ByXPath("//XCUIElementTypePickerWheel"));
+			VerifyScreenshot(TestContext.CurrentContext.Test.MethodName + "_Entry7", cropBottom: 1000, retryTimeout: TimeSpan.FromSeconds(2));
+		}
+	}
 }
 #endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28604.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28604.cs
@@ -17,7 +17,7 @@ public class Issue28604 : _IssuesUITest
     public void FooterShouldDisplayAtBottomOfEmptyView()
     {
         App.WaitForElement("CollectionView");
-        VerifyScreenshot();
+        VerifyScreenshot(retryTimeout: TimeSpan.FromSeconds(3));
     }
 }
 #endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28604.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28604.cs
@@ -17,7 +17,7 @@ public class Issue28604 : _IssuesUITest
     public void FooterShouldDisplayAtBottomOfEmptyView()
     {
         App.WaitForElement("CollectionView");
-        VerifyScreenshot(retryTimeout: TimeSpan.FromSeconds(3));
+        VerifyScreenshot(tolerance: 0.5, retryTimeout: TimeSpan.FromSeconds(2));
     }
 }
 #endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28986_ParentChildTest.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28986_ParentChildTest.cs
@@ -46,43 +46,37 @@ public class Issue28986_ParentChildTest : _IssuesUITest
         // 2. Bottom indicator is inset from screen bottom by safe area (child handles bottom)
         // 3. Both work independently without conflict
 
-        // Get screen dimensions
-        var parentGridRect = App.WaitForElement("ParentGrid").GetRect();
-        var screenTop = parentGridRect.Y;
-        var screenBottom = parentGridRect.Y + parentGridRect.Height;
-
         // Verify initial status
         WaitForText("StatusLabel", "Parent: Top=Container, Bottom=None | Child: Bottom=Container");
 
-        // Measure top indicator position
-        var topIndicatorRect = App.WaitForElement("TopIndicator").GetRect();
-        var topIndicatorTop = topIndicatorRect.Y;
-
-        // Top indicator should be below the screen top (safe area applied)
-        var topInsetFromScreenTop = topIndicatorTop - screenTop;
-        Assert.That(topInsetFromScreenTop, Is.GreaterThan(5),
-            $"Top indicator should be inset from screen top by safe area. " +
-            $"Current inset: {topInsetFromScreenTop}pt (expected >5pt)");
-
-        // Measure bottom indicator position
-        var bottomIndicatorRect = App.WaitForElement("BottomIndicator").GetRect();
-        var bottomIndicatorBottom = bottomIndicatorRect.Y + bottomIndicatorRect.Height;
-
-        // Bottom indicator should be above the screen bottom (safe area applied)
-        var bottomInsetFromScreenBottom = screenBottom - bottomIndicatorBottom;
-        // On devices with bottom safe area (iOS home indicator, Android nav bar), verify meaningful inset.
-        // On gesture-nav Android devices, bottom safe area is correctly 0.
-        if (HasBottomSafeArea(bottomInsetFromScreenBottom))
+        App.RetryAssert(() =>
         {
-            Assert.That(bottomInsetFromScreenBottom, Is.GreaterThan(5),
-                $"Bottom indicator should be inset from screen bottom by safe area. " +
-                $"Current inset: {bottomInsetFromScreenBottom}pt (expected >5pt)");
-        }
-        else
-        {
-            Assert.That(bottomInsetFromScreenBottom, Is.GreaterThanOrEqualTo(0),
-                $"Bottom indicator should not extend below screen bottom. Inset: {bottomInsetFromScreenBottom}pt");
-        }
+            var parentGridRect = App.WaitForElement("ParentGrid").GetRect();
+            var screenTop = parentGridRect.Y;
+            var screenBottom = parentGridRect.Y + parentGridRect.Height;
+
+            var topIndicatorRect = App.WaitForElement("TopIndicator").GetRect();
+            var topInsetFromScreenTop = topIndicatorRect.Y - screenTop;
+            Assert.That(topInsetFromScreenTop, Is.GreaterThan(5),
+                $"Top indicator should be inset from screen top by safe area. " +
+                $"Current inset: {topInsetFromScreenTop}pt (expected >5pt)");
+
+            var bottomIndicatorRect = App.WaitForElement("BottomIndicator").GetRect();
+            var bottomIndicatorBottom = bottomIndicatorRect.Y + bottomIndicatorRect.Height;
+            var bottomInsetFromScreenBottom = screenBottom - bottomIndicatorBottom;
+
+            if (HasBottomSafeArea(bottomInsetFromScreenBottom))
+            {
+                Assert.That(bottomInsetFromScreenBottom, Is.GreaterThan(5),
+                    $"Bottom indicator should be inset from screen bottom by safe area. " +
+                    $"Current inset: {bottomInsetFromScreenBottom}pt (expected >5pt)");
+            }
+            else
+            {
+                Assert.That(bottomInsetFromScreenBottom, Is.GreaterThanOrEqualTo(0),
+                    $"Bottom indicator should not extend below screen bottom. Inset: {bottomInsetFromScreenBottom}pt");
+            }
+        });
     }
 
     [Test, Order(2)]

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28986_ParentChildTest.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28986_ParentChildTest.cs
@@ -51,17 +51,17 @@ public class Issue28986_ParentChildTest : _IssuesUITest
 
         App.RetryAssert(() =>
         {
-            var parentGridRect = App.WaitForElement("ParentGrid").GetRect();
+            var parentGridRect = App.FindElement("ParentGrid").GetRect();
             var screenTop = parentGridRect.Y;
             var screenBottom = parentGridRect.Y + parentGridRect.Height;
 
-            var topIndicatorRect = App.WaitForElement("TopIndicator").GetRect();
+            var topIndicatorRect = App.FindElement("TopIndicator").GetRect();
             var topInsetFromScreenTop = topIndicatorRect.Y - screenTop;
             Assert.That(topInsetFromScreenTop, Is.GreaterThan(5),
                 $"Top indicator should be inset from screen top by safe area. " +
                 $"Current inset: {topInsetFromScreenTop}pt (expected >5pt)");
 
-            var bottomIndicatorRect = App.WaitForElement("BottomIndicator").GetRect();
+            var bottomIndicatorRect = App.FindElement("BottomIndicator").GetRect();
             var bottomIndicatorBottom = bottomIndicatorRect.Y + bottomIndicatorRect.Height;
             var bottomInsetFromScreenBottom = screenBottom - bottomIndicatorBottom;
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33287.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33287.cs
@@ -23,12 +23,18 @@ public class Issue33287 : _IssuesUITest
 		App.WaitForElement("GoBackButton");
 		App.Tap("GoBackButton");
 
-		// Back on main page — wait for the delayed DisplayAlertAsync to fire.
-		// Without the fix the NRE crashes the app and this element becomes unreachable.
+		// Back on the main page, wait until the detached page's alert request completes.
+		// Without the fix the NRE crashes the app and this status is never updated.
 		App.WaitForElement("MainPageLabel");
-		System.Threading.Thread.Sleep(3000);
+		Assert.That(
+			App.WaitForTextToBePresentInElement(
+				"AlertStatusLabel",
+				"Alert request completed",
+				timeout: TimeSpan.FromSeconds(10)),
+			Is.True,
+			"The detached page's alert request should complete");
 
-		// Verify the app is still alive and responsive after the alert fired on the detached page.
+		// Verify the app is still alive and responsive after the alert request on the detached page.
 		// Without the fix the app process is dead and this call will throw/timeout.
 		Assert.That(App.FindElement("MainPageLabel").GetText(), Is.EqualTo("MainPage"),
 			"App should remain responsive after DisplayAlertAsync on an unloaded page");

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33287.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33287.cs
@@ -16,23 +16,23 @@ public class Issue33287 : _IssuesUITest
 	{
 		App.WaitForElement("NavigateButton");
 
-		// Navigate to second page (starts a 2-second delayed DisplayAlertAsync)
+		// Navigate to the second page.
 		App.Tap("NavigateButton");
 
 		// Wait for second page to appear, then go back immediately
 		App.WaitForElement("GoBackButton");
 		App.Tap("GoBackButton");
 
-		// Back on the main page, wait until the detached page's alert request completes.
-		// Without the fix the NRE crashes the app and this status is never updated.
+		// Back on the main page, wait until the detached page creates the alert request.
+		// Without the fix the synchronous NRE crashes the app before this status is updated.
 		App.WaitForElement("MainPageLabel");
 		Assert.That(
 			App.WaitForTextToBePresentInElement(
 				"AlertStatusLabel",
-				"Alert request completed",
+				"Alert request returned",
 				timeout: TimeSpan.FromSeconds(10)),
 			Is.True,
-			"The detached page's alert request should complete");
+			"The detached page should create the alert request without crashing");
 
 		// Verify the app is still alive and responsive after the alert request on the detached page.
 		// Without the fix the app process is dead and this call will throw/timeout.

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36154.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36154.cs
@@ -30,6 +30,11 @@ public class Issue36154 : _IssuesUITest
 		// Swipe left (finger moves left) → reveals RightItems
 		App.DragCoordinates(centerX, centerY, centerX - 200, centerY);
 
-		App.WaitForTextToBePresentInElement("ResultLabel", "RIGHT invoked!");
+		// WaitForTextToBePresentInElement returns false (rather than throwing) on timeout, so assert on
+		// it: otherwise the test would pass even if the SwipeView invoke callback never updated the label.
+		Assert.That(
+			App.WaitForTextToBePresentInElement("ResultLabel", "RIGHT invoked!"),
+			Is.True,
+			"Timed out waiting for ResultLabel to display 'RIGHT invoked!' after the swipe.");
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36154.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36154.cs
@@ -30,6 +30,6 @@ public class Issue36154 : _IssuesUITest
 		// Swipe left (finger moves left) → reveals RightItems
 		App.DragCoordinates(centerX, centerY, centerX - 200, centerY);
 
-		Assert.That(App.WaitForElement("ResultLabel").GetText(), Is.EqualTo("RIGHT invoked!"));
+		App.WaitForTextToBePresentInElement("ResultLabel", "RIGHT invoked!");
 	}
 }

--- a/src/Graphics/tests/DeviceTests/Tests/ImageTests.cs
+++ b/src/Graphics/tests/DeviceTests/Tests/ImageTests.cs
@@ -1,5 +1,11 @@
 ﻿using System;
 using System.Threading.Tasks;
+#if IOS || MACCATALYST
+using CoreFoundation;
+using CoreGraphics;
+using Foundation;
+using UIKit;
+#endif
 using Microsoft.Maui.Graphics.Platform;
 using Microsoft.Maui.Storage;
 using Xunit;
@@ -47,6 +53,171 @@ public class ImageTests
 		Assert.NotNull(newStream);
 		Assert.True(newStream.Length > 0, "Assert.True(newStream.Length > 0)");
 	}
+
+#if IOS || MACCATALYST
+	[Theory]
+	[InlineData(1f)]
+	[InlineData(2f)]
+	[InlineData(3f)]
+	public void ScaleImageUsesOneXBackingScale(float sourceScale)
+	{
+		var sourceSize = new CGSize(30, 20);
+		using var sourceRenderer = new UIGraphicsImageRenderer(sourceSize, new UIGraphicsImageRendererFormat
+		{
+			Opaque = false,
+			Scale = sourceScale,
+		});
+
+		using var source = sourceRenderer.CreateImage(context =>
+		{
+			UIColor.Red.SetFill();
+			context.FillRect(new CGRect(CGPoint.Empty, sourceSize));
+		});
+
+		using var scaled = source.ScaleImage(new CGSize(10, 5));
+
+		Assert.Equal(1, (double)scaled.CurrentScale);
+		Assert.Equal(10, (double)scaled.Size.Width);
+		Assert.Equal(5, (double)scaled.Size.Height);
+		Assert.NotNull(scaled.CGImage);
+		Assert.Equal(10, (int)scaled.CGImage.Width);
+		Assert.Equal(5, (int)scaled.CGImage.Height);
+	}
+
+	[Fact]
+	public async Task ScaleImageCanRunOnBackgroundThread()
+	{
+		var sourceSize = new CGSize(30, 20);
+		using var sourceRenderer = new UIGraphicsImageRenderer(sourceSize, new UIGraphicsImageRendererFormat
+		{
+			Opaque = false,
+			Scale = 2,
+		});
+
+		using var source = sourceRenderer.CreateImage(context =>
+		{
+			UIColor.Red.SetFill();
+			context.FillRect(new CGRect(CGPoint.Empty, sourceSize));
+		});
+
+		using var scaled = await Task.Run(() => source.ScaleImage(new CGSize(10, 5)));
+
+		Assert.Equal(1, (double)scaled.CurrentScale);
+		Assert.Equal(10, (int)scaled.CGImage.Width);
+		Assert.Equal(5, (int)scaled.CGImage.Height);
+	}
+
+	[Fact]
+	public async Task ScaleImageDoesNotRequireMainThreadProgress()
+	{
+		using var source = CreatePatternImage(UIImageOrientation.Up);
+
+		Task<UIImage> scaleTask = null;
+		var completedWhileMainThreadWasBlocked = false;
+
+		void ScaleAndWait()
+		{
+			scaleTask = Task.Run(() => source.ScaleImage(new CGSize(10, 5)));
+			completedWhileMainThreadWasBlocked = scaleTask.Wait(TimeSpan.FromSeconds(5));
+		}
+
+		if (NSThread.IsMain)
+			ScaleAndWait();
+		else
+			DispatchQueue.MainQueue.DispatchSync(ScaleAndWait);
+
+		using var scaled = await scaleTask;
+
+		Assert.True(completedWhileMainThreadWasBlocked, "ScaleImage must not synchronously depend on main-thread progress.");
+		Assert.Equal(10, (int)scaled.CGImage.Width);
+		Assert.Equal(5, (int)scaled.CGImage.Height);
+	}
+
+	[Theory]
+	[InlineData(UIImageOrientation.Up)]
+	[InlineData(UIImageOrientation.Down)]
+	[InlineData(UIImageOrientation.Left)]
+	[InlineData(UIImageOrientation.Right)]
+	[InlineData(UIImageOrientation.UpMirrored)]
+	[InlineData(UIImageOrientation.DownMirrored)]
+	[InlineData(UIImageOrientation.LeftMirrored)]
+	[InlineData(UIImageOrientation.RightMirrored)]
+	public void ScaleImageMatchesUIKitRendering(UIImageOrientation orientation)
+	{
+		var targetSize = new CGSize(12.25, 8.75);
+		using var source = CreatePatternImage(orientation);
+		using var expected = RunOnMainThread(() =>
+		{
+			using var format = new UIGraphicsImageRendererFormat
+			{
+				Opaque = false,
+				PreferredRange = UIGraphicsImageRendererFormatRange.Standard,
+				Scale = 1,
+			};
+			using var renderer = new UIGraphicsImageRenderer(targetSize, format);
+			return renderer.CreateImage(_ => source.Draw(new CGRect(CGPoint.Empty, targetSize)));
+		});
+		using var actual = source.ScaleImage(targetSize);
+
+		Assert.Equal(UIImageOrientation.Up, actual.Orientation);
+		Assert.Equal(GetPixelData(expected), GetPixelData(actual));
+	}
+
+	private static UIImage CreatePatternImage(UIImageOrientation orientation)
+	{
+		using var image = RunOnMainThread(() =>
+		{
+			var sourceSize = new CGSize(30, 20);
+			using var renderer = new UIGraphicsImageRenderer(sourceSize);
+			return renderer.CreateImage(context =>
+			{
+				UIColor.FromRGBA(1f, 0f, 0f, 0.5f).SetFill();
+				context.FillRect(new CGRect(0, 0, 20, 10));
+				UIColor.Blue.SetFill();
+				context.FillRect(new CGRect(20, 0, 10, 20));
+				UIColor.Green.SetFill();
+				context.FillRect(new CGRect(0, 10, 10, 10));
+			});
+		});
+
+		return UIImage.FromImage(image.CGImage, 1, orientation);
+	}
+
+	private static byte[] GetPixelData(UIImage image)
+	{
+		var cgImage = image.CGImage;
+		var width = checked((int)cgImage.Width);
+		var height = checked((int)cgImage.Height);
+		var bytesPerRow = checked(4 * width);
+		var pixels = new byte[checked(bytesPerRow * height)];
+
+		using var colorSpace = CGColorSpace.CreateDeviceRGB();
+		using var context = new CGBitmapContext(
+			pixels,
+			width,
+			height,
+			8,
+			bytesPerRow,
+			colorSpace,
+			CGBitmapFlags.ByteOrder32Little | CGBitmapFlags.PremultipliedFirst);
+
+		context.TranslateCTM(0, height);
+		context.ScaleCTM(1, -1);
+		context.DrawImage(new CGRect(0, 0, width, height), cgImage);
+
+		return pixels;
+	}
+
+	private static T RunOnMainThread<T>(Func<T> action)
+	{
+		if (NSThread.IsMain)
+			return action();
+
+		T result = default!;
+		DispatchQueue.MainQueue.DispatchSync(() => result = action());
+		return result;
+	}
+#endif
 
 	[Theory]
 	[InlineData(ImageFormat.Png, 2.0f)]

--- a/src/Graphics/tests/DeviceTests/Tests/ImageTests.cs
+++ b/src/Graphics/tests/DeviceTests/Tests/ImageTests.cs
@@ -126,9 +126,10 @@ public class ImageTests
 		else
 			DispatchQueue.MainQueue.DispatchSync(ScaleAndWait);
 
+		Assert.True(completedWhileMainThreadWasBlocked, "ScaleImage must not synchronously depend on main-thread progress.");
+
 		using var scaled = await scaleTask;
 
-		Assert.True(completedWhileMainThreadWasBlocked, "ScaleImage must not synchronously depend on main-thread progress.");
 		Assert.Equal(10, (int)scaled.CGImage.Width);
 		Assert.Equal(5, (int)scaled.CGImage.Height);
 	}

--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -1054,32 +1054,7 @@ namespace UITest.Appium
 		}
 
 		public static bool WaitForTextToBePresentInElement(this IApp app, string automationId, string text, TimeSpan? timeout = null)
-		{
-			timeout ??= DefaultTimeout;
-			TimeSpan retryFrequency = TimeSpan.FromMilliseconds(500);
-
-			DateTime start = DateTime.Now;
-
-			while (true)
-			{
-				var element = app.FindElements(automationId).FirstOrDefault();
-
-				if (element is not null && element.TryGetText(out var s) && s.Contains(text, StringComparison.OrdinalIgnoreCase))
-				{
-					return true;
-				}
-
-				long elapsed = DateTime.Now.Subtract(start).Ticks;
-				if (elapsed >= timeout.Value.Ticks)
-				{
-					Debug.WriteLine($">>>>> {elapsed} ticks elapsed, timeout value is {timeout.Value.Ticks}");
-
-					return false;
-				}
-
-				Task.Delay(retryFrequency.Milliseconds).Wait();
-			}
-		}
+			=> app.WaitForText(automationId, text, s => s.Contains(text, StringComparison.OrdinalIgnoreCase), timeout);
 
 		/// <summary>
 		/// Waits until the element's text is exactly equal to <paramref name="text"/> (ordinal), rather
@@ -1088,25 +1063,40 @@ namespace UITest.Appium
 		/// prematurely on the placeholder.
 		/// </summary>
 		public static bool WaitForTextEqualToElement(this IApp app, string automationId, string text, TimeSpan? timeout = null)
+			=> app.WaitForText(automationId, text, s => string.Equals(s, text, StringComparison.Ordinal), timeout);
+
+		/// <summary>
+		/// Shared polling loop for the text-wait helpers. Repeatedly reads the element's text and
+		/// returns <see langword="true"/> as soon as <paramref name="matches"/> is satisfied. On
+		/// timeout it logs the last observed text (and the expected value) so a stalled or
+		/// placeholder-stuck label is distinguishable from a text-read failure, then returns
+		/// <see langword="false"/>.
+		/// </summary>
+		static bool WaitForText(this IApp app, string automationId, string expected, Func<string, bool> matches, TimeSpan? timeout)
 		{
 			timeout ??= DefaultTimeout;
 			TimeSpan retryFrequency = TimeSpan.FromMilliseconds(500);
 
 			DateTime start = DateTime.Now;
+			string? lastObservedText = null;
 
 			while (true)
 			{
 				var element = app.FindElements(automationId).FirstOrDefault();
 
-				if (element is not null && element.TryGetText(out var s) && string.Equals(s, text, StringComparison.Ordinal))
+				if (element is not null && element.TryGetText(out var s))
 				{
-					return true;
+					lastObservedText = s;
+					if (matches(s))
+					{
+						return true;
+					}
 				}
 
 				long elapsed = DateTime.Now.Subtract(start).Ticks;
 				if (elapsed >= timeout.Value.Ticks)
 				{
-					Debug.WriteLine($">>>>> {elapsed} ticks elapsed, timeout value is {timeout.Value.Ticks}");
+					Debug.WriteLine($">>>>> {elapsed} ticks elapsed, timeout value is {timeout.Value.Ticks}; last observed text for '{automationId}' was '{lastObservedText ?? "<unavailable>"}', expected '{expected}'");
 
 					return false;
 				}

--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -1082,6 +1082,40 @@ namespace UITest.Appium
 		}
 
 		/// <summary>
+		/// Waits until the element's text is exactly equal to <paramref name="text"/> (ordinal), rather
+		/// than merely containing it. Use this when the element's placeholder/initial text already
+		/// contains the expected value as a substring, which would make a Contains-based wait pass
+		/// prematurely on the placeholder.
+		/// </summary>
+		public static bool WaitForTextEqualToElement(this IApp app, string automationId, string text, TimeSpan? timeout = null)
+		{
+			timeout ??= DefaultTimeout;
+			TimeSpan retryFrequency = TimeSpan.FromMilliseconds(500);
+
+			DateTime start = DateTime.Now;
+
+			while (true)
+			{
+				var element = app.FindElements(automationId).FirstOrDefault();
+
+				if (element is not null && element.TryGetText(out var s) && string.Equals(s, text, StringComparison.Ordinal))
+				{
+					return true;
+				}
+
+				long elapsed = DateTime.Now.Subtract(start).Ticks;
+				if (elapsed >= timeout.Value.Ticks)
+				{
+					Debug.WriteLine($">>>>> {elapsed} ticks elapsed, timeout value is {timeout.Value.Ticks}");
+
+					return false;
+				}
+
+				Task.Delay(retryFrequency.Milliseconds).Wait();
+			}
+		}
+
+		/// <summary>
 		/// Repeatedly executes a query until it returns a non-empty value or the specified retry count is reached.
 		/// </summary>
 		/// <typeparam name="T">The type of the element.</typeparam>

--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -1111,7 +1111,7 @@ namespace UITest.Appium
 					return false;
 				}
 
-				Task.Delay(retryFrequency.Milliseconds).Wait();
+				Task.Delay(retryFrequency).Wait();
 			}
 		}
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Bundles independently valid Preview 7 test and test-infrastructure stabilizations into one merge path. Changes are cherry-picked or extracted from their source PRs without modifying MAUI runtime or product behavior.

The aggregate currently covers:

- exact DragEvents label polling and shared Appium text-wait behavior;
- waiting for the iOS Entry keyboard before its snapshot;
- adaptive ListView and CollectionView screenshot stabilization;
- RefreshView gesture retry and SwipeView callback-result waiting;
- stable initial SafeArea layout measurement;
- deterministic iOS Picker-to-Entry keyboard transition handling;
- a bounded Android screenshot tolerance for stable post-rotation antialiasing variance;
- independent iOS and MacCatalyst Graphics image-scaling device coverage;
- a bounded UIKit cleanup wait for the CarouselView leak assertion;
- Android-only scoping for the Android modal-animation leak regression test;
- an exact detached-page transition with a synchronous alert-request return signal; and
- resilient Windows test-machine resolution setup, with focused Pester coverage for each fallback and failure path.

Eligible UI tests, device tests, unit tests, test infrastructure, and screenshot baselines can all be included here when they are independently valid without a corresponding product-code change.

### Source PRs

The standalone source PRs below are closed in favor of this aggregate. For #37057, only the independently valid test subset is included; its product-code rewrite remains excluded.

| PR | Included test-side fix |
|---|---|
| #37044 | Windows screen-resolution test infrastructure and Pester coverage |
| #37045 | DragEvents exact-text waits and Appium helper |
| #37053 | iOS Entry keyboard readiness |
| #37055 | ListView screenshot retry window |
| #37057 | Graphics image-scaling device tests that pass without the runtime rewrite |
| #37058 | RefreshView pull-to-refresh retry |
| #37059 | SwipeView result-label wait |
| #37066 | SafeArea initial-layout retry |
| #37069 | Picker keyboard transition stabilization |
| #37074 | Empty CollectionView footer screenshot retry/tolerance |
| #37086 | iOS/MacCatalyst CarouselView leak-test cleanup wait |
| #37088 | Detached-page alert request synchronization |
| #37091 | Android modal-animation leak-test platform scope |
| #37092 | Android Issue22306 post-rotation screenshot tolerance |

### Scope exclusions

Mixed runtime/test fixes are included only when their test-side changes pass independently against the unmodified product code. The current device tests in #37052, the four nonpositive-size cases in #37057, and the device test plus screenshots in #37062 remain excluded because they expose or describe behavior that requires those PRs' functional fixes. #37070 has no test-side changes. Closed ineffective or unsafe fixes are also excluded.

### Validation

- All 25 directly reusable source commits were cherry-picked in their original order.
- The #37057 device-test subset was extracted into one additional test-only commit after proving it against the unmodified product implementation.
- Every directly cherry-picked aggregate file matches the corresponding included source PR head.
- The aggregate diff contains no MAUI runtime or product files.
- Targeted Release builds pass for `UITest.Appium`, `Controls.TestCases.iOS.Tests`, `Controls.TestCases.Mac.Tests`, and `Controls.TestCases.Android.Tests`.
- The focused screen-resolution Pester suite passes 14/14.
- Exact local xUnit XML reports 46/46 Graphics device tests passing on both iOS 26 and MacCatalyst, including all 13 extracted cases.
- The Graphics deadlock regression now asserts the bounded five-second completion result before awaiting the scaling task.
- The CarouselView category passes 6 consecutive MacCatalyst runs at 4/4 each and passes 4/4 on iOS 26 with the final 100 ms cleanup wait.
- The Android modal-animation leak test passes in both discovered Android variants, while the iOS device-test assembly excludes that Android-specific regression test.
- The Issue22306 Android failure's three retries were byte-for-byte identical at a 1.85% visual difference, below the new Android-only 2% tolerance.
- The unloaded-page alert probe now signals immediately after `DisplayAlertAsync` returns, avoiding a teardown-order dependency on the detached page task.
- Rebased the aggregate onto release head `dee83edd121`; the resulting diff remains limited to tests and test infrastructure.
- The Pester workflow now triggers when `eng/scripts/Set-ScreenResolution.ps1` changes.
- A standalone `/azp run` was posted for aggregate head `83da465424b`; exact merge `bad9e4e9a57` builds `1539860`, `1539861`, and `1539862` are required before merge.

### Issues Fixed

Contributes to stabilizing the .NET 11 Preview 7 test branch.

