### PR TITLE
[release/11.0.1xx-preview7] Fix Android PixelCopy analyzer failure

### DIFF
--- a/src/Essentials/src/Screenshot/Screenshot.android.cs
+++ b/src/Essentials/src/Screenshot/Screenshot.android.cs
@@ -71,6 +71,7 @@ namespace Microsoft.Maui.Media
 			return RenderUsingCanvasDrawing(view) ?? RenderUsingDrawingCache(view);
 		}
 
+		[System.Runtime.Versioning.SupportedOSPlatform("android26.0")]
 		static async Task<Bitmap?> RenderUsingPixelCopyAsync(View view, Window? window)
 		{
 			if (view.Width <= 0 || view.Height <= 0 || !view.IsAttachedToWindow)


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause

The Preview 7 device-test Mono build enables CI platform analyzers. `RenderAsync` guards the private `RenderUsingPixelCopyAsync` call with `OperatingSystem.IsAndroidVersionAtLeast(26)`, but CA1416 does not propagate that caller precondition into the helper body, so `PixelCopy.Request` is reported as reachable on Android 24.

### Description of Change

Mark `RenderUsingPixelCopyAsync` with `SupportedOSPlatform("android26.0")`. This communicates the helper precondition to the analyzer and matches the existing runtime guard without changing screenshot behavior.

### Validation

- Exact Preview 7 base fails the CI-analyzer build with CA1416 at `PixelCopy.Request`.
- The same `net11.0-android37.0` Release build with `ContinuousIntegrationBuild=true` succeeds after the annotation.

### Issues Fixed

Unblocks the Preview 7 Mono device-test build.