### PR TITLE
[iOS] Stabilize CarouselView leak test cleanup

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/CarouselView/CarouselViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CarouselView/CarouselViewTests.iOS.cs
@@ -41,6 +41,9 @@ namespace Microsoft.Maui.DeviceTests
 				((IElementHandler)handler).DisconnectHandler();
 			});
 
+			// Allow UIKit to release controller-owned references before forcing managed GC.
+			await Task.Delay(100);
+
 			// Force garbage collection
 			await AssertionExtensions.WaitForGC(weakCarouselView, weakHandler);
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Stabilizes `CarouselView Does Not Leak With Default ItemsLayout` on iOS and MacCatalyst without changing product code.

The test disconnected the handler and immediately forced managed garbage collection. UIKit can retain controller-owned references briefly while native teardown completes, so the assertion raced that cleanup and intermittently reported the `CarouselView` as alive.

This adds a bounded 100 ms wait before forcing GC. The test still requires both the `CarouselView` and `CarouselViewHandler2` weak references to be collected.

### Validation

- MacCatalyst without the cleanup wait: reproduced the same live-`CarouselView` failure locally.
- MacCatalyst with the final 100 ms wait: 6 consecutive runs passed, 4/4 each.
- iOS 26 with the final 100 ms wait: 4/4 passed.
- The same failure appeared independently in Preview 7 CI for #37057 and #37082.

### Issues Fixed

Related to #36116 and #36689.
