### PR TITLE
[release/11.0.1xx-preview7] Stabilize unloaded page alert UI test

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33287.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33287.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Threading.Tasks;
+using System.ComponentModel;
 
 namespace Maui.Controls.Sample.Issues;
 
@@ -17,6 +17,12 @@ public class Issue33287MainPage : ContentPage
 	{
 		Title = "Issue 33287";
 
+		var statusLabel = new Label
+		{
+			Text = "Waiting for alert request",
+			AutomationId = "AlertStatusLabel"
+		};
+
 		Content = new VerticalStackLayout
 		{
 			Padding = 20,
@@ -28,13 +34,15 @@ public class Issue33287MainPage : ContentPage
 					Text = "Navigate to Second Page",
 					AutomationId = "NavigateButton",
 					Command = new Command(async () =>
-						await Navigation.PushAsync(new Issue33287SecondPage()))
+						await Navigation.PushAsync(new Issue33287SecondPage(status =>
+							statusLabel.Text = status)))
 				},
 				new Label
 				{
 					Text = "MainPage",
 					AutomationId = "MainPageLabel"
-				}
+				},
+				statusLabel
 			}
 		};
 	}
@@ -42,9 +50,10 @@ public class Issue33287MainPage : ContentPage
 
 public class Issue33287SecondPage : ContentPage
 {
-	public Issue33287SecondPage()
+	public Issue33287SecondPage(Action<string> updateStatus)
 	{
 		Title = "Second Page";
+		PropertyChanged += OnPropertyChanged;
 
 		Content = new VerticalStackLayout
 		{
@@ -59,20 +68,18 @@ public class Issue33287SecondPage : ContentPage
 				}
 			}
 		};
-	}
 
-	protected override async void OnAppearing()
-	{
-		base.OnAppearing();
+		async void OnPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName != nameof(Window) || Window is not null)
+				return;
 
-		// Wait long enough for the user/test to navigate back
-#if MACCATALYST
-		await Task.Delay(4000);
-#else
-		await Task.Delay(2000);
-#endif
+			PropertyChanged -= OnPropertyChanged;
+			updateStatus("Page detached");
 
-		// Without the fix this throws NullReferenceException and crashes the app
-		await DisplayAlertAsync("Test Alert", "This alert was delayed", "OK");
+			// Request the alert before handler teardown changes IsPlatformEnabled.
+			await DisplayAlertAsync("Test Alert", "This alert was delayed", "OK");
+			updateStatus("Alert request completed");
+		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33287.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33287.cs
@@ -23,12 +23,18 @@ public class Issue33287 : _IssuesUITest
 		App.WaitForElement("GoBackButton");
 		App.Tap("GoBackButton");
 
-		// Back on main page — wait for the delayed DisplayAlertAsync to fire.
-		// Without the fix the NRE crashes the app and this element becomes unreachable.
+		// Back on the main page, wait until the detached page's alert request completes.
+		// Without the fix the NRE crashes the app and this status is never updated.
 		App.WaitForElement("MainPageLabel");
-		System.Threading.Thread.Sleep(3000);
+		Assert.That(
+			App.WaitForTextToBePresentInElement(
+				"AlertStatusLabel",
+				"Alert request completed",
+				timeout: TimeSpan.FromSeconds(10)),
+			Is.True,
+			"The detached page's alert request should complete");
 
-		// Verify the app is still alive and responsive after the alert fired on the detached page.
+		// Verify the app is still alive and responsive after the alert request on the detached page.
 		// Without the fix the app process is dead and this call will throw/timeout.
 		Assert.That(App.FindElement("MainPageLabel").GetText(), Is.EqualTo("MainPage"),
 			"App should remain responsive after DisplayAlertAsync on an unloaded page");


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

Stabilizes `Issue33287.DisplayAlertAsyncShouldNotCrashWhenPageUnloaded` without changing product code.

The test previously relied on a fixed delay before requesting the alert. On MacCatalyst, navigation could lose that race and the alert appeared on the second page instead of running after it detached. The UI test then timed out waiting for the main page.

This change:

- requests the alert synchronously when the second page's `Window` changes to `null`, before handler teardown changes `IsPlatformEnabled`
- replaces fixed sleeps with an explicit completion status
- preserves the original regression assertion that the app stays alive after `DisplayAlertAsync` is called on the detached page

## Validation

- iOS: 4 consecutive targeted runs passed, 1/1 each
- With the original `DisplayAlertAsync` implementation temporarily restored, the same targeted test failed because the app crashed
- Exact observed CI failure: `maui-pr-uitests` build 1539070, MacCatalyst run 42385960

Only test and HostApp files are changed.
