### PR TITLE
[release/11.0.1xx-preview7] Suppress CA1416 for legacy iOS image scaling

### DIFF
--- a/src/Graphics/src/Graphics/Platforms/iOS/UIImageExtensions.cs
+++ b/src/Graphics/src/Graphics/Platforms/iOS/UIImageExtensions.cs
@@ -56,10 +56,12 @@ namespace Microsoft.Maui.Graphics.Platform
 
 		public static UIImage ScaleImage(this UIImage target, CGSize size, bool disposeOriginal = false)
 		{
+#pragma warning disable CA1416 // Preserve the existing rendering behavior while these unsupported APIs are replaced.
 			UIGraphics.BeginImageContext(size);
 			target.Draw(new CGRect(CGPoint.Empty, size));
 			var image = UIGraphics.GetImageFromCurrentImageContext();
 			UIGraphics.EndImageContext();
+#pragma warning restore CA1416
 
 			if (disposeOriginal)
 			{


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

This narrowly suppresses CA1416 around the existing legacy UIKit image-context calls to preserve the established iOS image scaling behavior for Preview 7.

This unblocks the build-before-tests failure from build 1537895, where the .NET 11 iOS 26.5 bindings produce these diagnostics, promoted to errors:

```text
src/Graphics/src/Graphics/Platforms/iOS/UIImageExtensions.cs(59,4): error CA1416: This call site is reachable on: 'iOS' 13.0 and later, 'maccatalyst' 13.0 and later. 'UIGraphics.BeginImageContext(CGSize)' is unsupported on: 'ios' 17.0 and later, 'maccatalyst' 17.0 and later. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416)
src/Graphics/src/Graphics/Platforms/iOS/UIImageExtensions.cs(61,16): error CA1416: This call site is reachable on: 'iOS' 13.0 and later, 'maccatalyst' 13.0 and later. 'UIGraphics.GetImageFromCurrentImageContext()' is unsupported on: 'ios' 17.0 and later, 'maccatalyst' 17.0 and later. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416)
src/Graphics/src/Graphics/Platforms/iOS/UIImageExtensions.cs(62,4): error CA1416: This call site is reachable on: 'iOS' 13.0 and later, 'maccatalyst' 13.0 and later. 'UIGraphics.EndImageContext()' is unsupported on: 'ios' 17.0 and later, 'maccatalyst' 17.0 and later. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416)
```

Replacing the unsupported UIKit APIs is intentionally deferred to RC1; this PR does not claim to fix a runtime regression.

Validation: the surgical diff and whitespace checks pass. The smallest affected local build (`Microsoft.Maui.Graphics` for `net11.0-ios`) is blocked before compilation because this machine has .NET SDK 10.0.203 rather than the branch-required .NET 11 Preview 7 SDK.