### PR TITLE
[release/11.0.1xx-preview7] Limit Android modal leak test to Android

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
@@ -722,6 +722,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 #endif
 
+#if ANDROID
 		[Fact("Dont leak with Animation")]
 		public async Task ModalPageDontLeakWithAnimation()
 		{
@@ -751,6 +752,7 @@ namespace Microsoft.Maui.DeviceTests
 
 			await AssertionExtensions.WaitForGC(references.ToArray());
 		}
+#endif
 
 		class PageTypes : IEnumerable<object[]>
 		{


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Restrict `ModalPageDontLeakWithAnimation` to Android.

The test was added by #29702 to validate cleanup in `ModalNavigationManager.Android.cs`, but it currently runs on every platform. On the Preview 7 branch, the unrelated iOS Mono device shard intermittently retained the modal `ContentPage` and native `ContentView` during Apple transition cleanup.

This keeps the original Android regression coverage while removing the test from platforms whose modal animation lifecycle it was not written to validate. No product code changes.

## Validation

- Android `Category=Modal`: the target leak test passed in both discovered variants.
- iOS Controls device-test build: passed.
- Compiled assemblies contain `ModalPageDontLeakWithAnimation` on Android and exclude it on iOS.

The full local Android Modal category had one unrelated existing timeout in `PushModalModalWithoutAwaiting(useShell: True)`.
