### PR TITLE
[release/11.0.1xx-preview7] Stabilize Android button rotation screenshot

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22306.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22306.cs
@@ -46,12 +46,9 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 				App.SetOrientationPortrait();
 				WaitForAllElements();
 				// Cannot use the original screenshot as the black bar on bottom is not as dark after rotation
-#if ANDROID
 				// Android can consistently rerasterize the same post-rotation layout with minor antialiasing differences.
-				VerifyScreenshot(TestContext.CurrentContext.Test.MethodName + "Original2", tolerance: 2, retryTimeout: TimeSpan.FromSeconds(2));
-#else
-				VerifyScreenshot(TestContext.CurrentContext.Test.MethodName + "Original2", tolerance: 0.5, retryTimeout: TimeSpan.FromSeconds(2));
-#endif
+				var finalPortraitTolerance = _testDevice == TestDevice.Android ? 2 : 0.5;
+				VerifyScreenshot(TestContext.CurrentContext.Test.MethodName + "Original2", tolerance: finalPortraitTolerance, retryTimeout: TimeSpan.FromSeconds(2));
 			}
 			finally
 			{

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22306.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22306.cs
@@ -46,7 +46,12 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 				App.SetOrientationPortrait();
 				WaitForAllElements();
 				// Cannot use the original screenshot as the black bar on bottom is not as dark after rotation
+#if ANDROID
+				// Android can consistently rerasterize the same post-rotation layout with minor antialiasing differences.
+				VerifyScreenshot(TestContext.CurrentContext.Test.MethodName + "Original2", tolerance: 2, retryTimeout: TimeSpan.FromSeconds(2));
+#else
 				VerifyScreenshot(TestContext.CurrentContext.Test.MethodName + "Original2", tolerance: 0.5, retryTimeout: TimeSpan.FromSeconds(2));
+#endif
 			}
 			finally
 			{


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

- Allows a 2% screenshot tolerance only for Android's final portrait capture in `Issue22306`.
- Keeps the existing 0.5% tolerance on iOS and the other screenshots.
- Leaves the existing screenshot retry behavior unchanged.

The recurring failure in #36591 reports a 1.85% difference after rotating landscape and back to portrait. In build 1539493, all three retry captures were byte-for-byte identical and showed the expected layout with minor Android rerasterization differences, so extending the retry timeout would not help.

## Validation

- Built `Microsoft.Maui.BuildTasks.slnf` in Release.
- Built `Controls.TestCases.Android.Tests.csproj` in Release.
- Confirmed all three failed-run retry captures have the same SHA-256 hash.

Refs #36591
