### PR TITLE
[release/11.0.1xx-preview7] Avoid null TypedBinding source during ancestor detach

### DIFF
--- a/src/Controls/src/Core/TypedBinding.cs
+++ b/src/Controls/src/Core/TypedBinding.cs
@@ -321,8 +321,8 @@ namespace Microsoft.Maui.Controls.Internals
 		// ApplyCore  100000 (w/o INPC, w/o unnapply)	: 20ms.
 		internal void ApplyCore(object sourceObject, BindableObject target, BindableProperty property, bool fromTarget, SetterSpecificity specificity)
 		{
-			// Use cached type check after first apply (source type doesn't change)
-			var isTSource = _isTSource;
+			// Use the cached type check after first apply, but don't reuse it while a relative source is unresolved.
+			var isTSource = sourceObject is not null && _isTSource;
 			if (!_hasDefaultValue)
 			{
 				isTSource = sourceObject is TSource;

--- a/src/Controls/tests/Core.UnitTests/RelativeSourceBindingTests.cs
+++ b/src/Controls/tests/Core.UnitTests/RelativeSourceBindingTests.cs
@@ -74,6 +74,43 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public void RelativeSourceBinding_FindAncestorBindingContext_TypedBindingDoesNotInvokeGetterWithNullSource()
+		{
+			var person = new PersonViewModel
+			{
+				Name = "Person 0"
+			};
+			var stack = new StackLayout
+			{
+				BindingContext = person
+			};
+			var label = new Label();
+			stack.Children.Add(label);
+			var nullSourceGetterCalls = 0;
+			var binding = new TypedBinding<PersonViewModel, string>(
+				source =>
+				{
+					if (source is null)
+						nullSourceGetterCalls++;
+
+					return (source?.Name, true);
+				},
+				null,
+				null)
+			{
+				Source = new RelativeBindingSource(RelativeBindingSourceMode.FindAncestorBindingContext, typeof(PersonViewModel), 1)
+			};
+
+			label.SetBinding(Label.TextProperty, binding);
+			Assert.Equal(person.Name, label.Text);
+
+			stack.Children.Clear();
+
+			Assert.Equal(0, nullSourceGetterCalls);
+			Assert.Null(label.Text);
+		}
+
+		[Fact]
 		public void RelativeSourceBinding_TemplatedParent()
 		{
 			Label label = null;


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause

`TypedBinding.ApplyCore` caches a successful `TSource` type check. Relative source ancestor bindings can temporarily resolve to `null` when an item is detached or recycled, but the cached result remained `true`. This caused the generated binding getter to be invoked with a null source, producing a first-chance `NullReferenceException` that was swallowed by the binding engine but surfaced in the debugger.

This became visible in Preview 7 after #34408 began compiling `RelativeSource AncestorType` bindings into `TypedBinding` instances.

### Description of Change

Do not reuse the cached successful source type result when the current source is null. This skips subscriptions and getter invocation during the transient detach state while preserving the cached result when the ancestor is resolved again.

Add a regression test that detaches a `FindAncestorBindingContext` target and verifies its typed getter is never invoked with a null source.

### Issues Fixed

- https://devdiv.visualstudio.com/DevDiv/_workitems/edit/3042564

### Test Coverage

- `RelativeSourceBindingTests`