### PR TITLE
[net11.0] Retarget release merge flow to RC1

### DIFF
--- a/github-merge-flow-release-11.jsonc
+++ b/github-merge-flow-release-11.jsonc
@@ -2,7 +2,7 @@
 {
     "merge-flow-configurations": {
         "net11.0": {
-            "MergeToBranch": "release/11.0.1xx-preview7",
+            "MergeToBranch": "release/11.0.1xx-rc1",
             "ExtraSwitches": "-QuietComments",
             "ResetToTargetPaths": "global.json;NuGet.config;eng/Version.Details.xml;eng/Versions.props;eng/common/*"
         }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

- stop the automated `net11.0` merge flow from targeting `release/11.0.1xx-preview7`
- configure the next merge target as `release/11.0.1xx-rc1`
- let the existing main-to-`net11.0` merge flow carry this configuration into the branch where it is consumed

The RC1 branch has not been cut yet; this intentionally stages the merge automation ahead of the branch creation.

## Validation

- parsed `github-merge-flow-release-11.jsonc` with PowerShell `ConvertFrom-Json`
- verified the configured target passes the workflow's release-branch validation pattern
- verified the main-to-`net11.0` merge configuration does not reset this file
