### PR TITLE
Document nullable-oblivious PublicAPI markers

### DIFF
--- a/.github/instructions/public-api.instructions.md
+++ b/.github/instructions/public-api.instructions.md
@@ -22,6 +22,9 @@ applyTo:
 
 ## PublicAPI.Unshipped.txt
 - Entries must exactly match the actual API shape (namespace, type, member signature)
+- A leading `~` is Microsoft.CodeAnalysis.PublicApiAnalyzers' nullable-oblivious marker. It is unrelated to whether an API is public, internal, static, or instance.
+- Do not manually add or remove `~` based on an entry's appearance or inferred API visibility. Preserve analyzer-generated markers and use `dotnet format analyzers` or the repository's documented PublicAPI generation workflow when correcting entries.
+- Removing a required `~` makes the recorded nullability shape differ from the source API and creates the analyzer mismatch that the marker prevents.
 
 > For PublicAPI.Unshipped.txt file management workflow (never disable analyzers, `dotnet format analyzers`, revert-then-add pattern), see `copilot-instructions.md` § PublicAPI.Unshipped.txt File Management.
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Document that a leading `~` in `PublicAPI.Unshipped.txt` is Microsoft.CodeAnalysis.PublicApiAnalyzers' nullable-oblivious marker, not an indication of public, internal, static, or instance visibility. The guidance tells contributors and reviewers to preserve analyzer-generated markers and use the repository's existing analyzer workflow when correcting entries.

This addresses the concrete failure mode observed in #36876: review comments on the Windows, iOS, and Mac Catalyst PublicAPI entries recommended removing `~` because the corresponding `Brush` members were public static. Those members were declared in source using `#nullable disable`, so the analyzer-generated marker correctly represented their nullability shape. Removing it would instead create a PublicAPI analyzer mismatch.

### Issues Fixed

N/A - guidance follow-up to #36876.
