### PR TITLE
Parent ImageSource values so DynamicResources resolve through the element tree

### DIFF
--- a/src/Controls/src/Core/AppLinkEntry.cs
+++ b/src/Controls/src/Core/AppLinkEntry.cs
@@ -23,7 +23,8 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty DescriptionProperty = BindableProperty.Create(nameof(Description), typeof(string), typeof(AppLinkEntry), default(string));
 
 		/// <summary>Bindable property for <see cref="Thumbnail"/>.</summary>
-		public static readonly BindableProperty ThumbnailProperty = BindableProperty.Create(nameof(Thumbnail), typeof(ImageSource), typeof(AppLinkEntry), default(ImageSource));
+		public static readonly BindableProperty ThumbnailProperty = BindableProperty.Create(nameof(Thumbnail), typeof(ImageSource), typeof(AppLinkEntry), default(ImageSource),
+			propertyChanged: (bindable, oldValue, newValue) => bindable.AddRemoveLogicalChildren(oldValue, newValue));
 
 		/// <summary>Bindable property for <see cref="AppLinkUri"/>.</summary>
 		public static readonly BindableProperty AppLinkUriProperty = BindableProperty.Create(nameof(AppLinkUri), typeof(Uri), typeof(AppLinkEntry), null);

--- a/src/Controls/src/Core/AppLinkEntry.cs
+++ b/src/Controls/src/Core/AppLinkEntry.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.Controls
 
 		/// <summary>Bindable property for <see cref="Thumbnail"/>.</summary>
 		public static readonly BindableProperty ThumbnailProperty = BindableProperty.Create(nameof(Thumbnail), typeof(ImageSource), typeof(AppLinkEntry), default(ImageSource),
-			propertyChanged: (bindable, oldValue, newValue) => bindable.AddRemoveLogicalChildren(oldValue, newValue));
+			propertyChanged: (bindable, oldValue, newValue) => bindable.ReparentImageSource(oldValue, newValue));
 
 		/// <summary>Bindable property for <see cref="AppLinkUri"/>.</summary>
 		public static readonly BindableProperty AppLinkUriProperty = BindableProperty.Create(nameof(AppLinkUri), typeof(Uri), typeof(AppLinkEntry), null);

--- a/src/Controls/src/Core/Application/Application.cs
+++ b/src/Controls/src/Core/Application/Application.cs
@@ -128,7 +128,10 @@ namespace Microsoft.Maui.Controls
 
 				if (value is not null)
 				{
-					value.OnResourcesChanged(this.GetMergedResources());
+					// Push through OnParentResourcesChanged (not OnResourcesChanged) so the page's
+					// own resources shadow application-level values for its resource listeners,
+					// matching the SetParent propagation path (#36822 follow-up)
+					value.OnParentResourcesChanged(this.GetMergedResources());
 					((IElementDefinition)this).AddResourcesChangedListener(value.OnParentResourcesChanged);
 				}
 

--- a/src/Controls/src/Core/BindableObjectExtensions.cs
+++ b/src/Controls/src/Core/BindableObjectExtensions.cs
@@ -192,6 +192,28 @@ namespace Microsoft.Maui.Controls
 				owner.AddLogicalChild(newView);
 		}
 
+		/// <summary>
+		/// Parents an <see cref="ImageSource"/>-valued property through <see cref="Element.Parent"/>
+		/// (the same pattern <see cref="ImageElement"/> uses) so DynamicResources inside the source
+		/// resolve through the element tree. The source is deliberately not added as a logical child:
+		/// logical children surface through IVisualTreeElement.GetVisualChildren(), where compatibility
+		/// renderers would attempt to build a platform view for it, and IControlTemplated owners clear
+		/// their logical children on template changes.
+		/// </summary>
+		internal static void ReparentImageSource(this BindableObject bindable, object oldValue, object newValue)
+		{
+			if (bindable is not Element owner)
+				return;
+
+			// A source can be assigned to more than one owner and the most recent assignment
+			// wins, so only release ownership if this owner still holds it
+			if (oldValue is ImageSource oldSource && ReferenceEquals(oldSource.Parent, owner))
+				oldSource.Parent = null;
+
+			if (newValue is ImageSource newSource)
+				newSource.Parent = owner;
+		}
+
 		internal static bool TrySetAppTheme(
 			this BindableObject self,
 			string lightResourceKey,

--- a/src/Controls/src/Core/Cells/ImageCell.cs
+++ b/src/Controls/src/Core/Cells/ImageCell.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Maui.Controls
 
 			// Parent the image source so DynamicResources inside it resolve through
 			// the element tree (#36822 follow-up)
-			this.AddRemoveLogicalChildren(oldvalue, newvalue);
+			this.ReparentImageSource(oldvalue, newvalue);
 		}
 
 		void OnSourcePropertyChanging(ImageSource oldvalue, ImageSource newvalue)

--- a/src/Controls/src/Core/Cells/ImageCell.cs
+++ b/src/Controls/src/Core/Cells/ImageCell.cs
@@ -51,6 +51,10 @@ namespace Microsoft.Maui.Controls
 				newvalue.SourceChanged += OnSourceChanged;
 				SetInheritedBindingContext(newvalue, BindingContext);
 			}
+
+			// Parent the image source so DynamicResources inside it resolve through
+			// the element tree (#36822 follow-up)
+			this.AddRemoveLogicalChildren(oldvalue, newvalue);
 		}
 
 		void OnSourcePropertyChanging(ImageSource oldvalue, ImageSource newvalue)

--- a/src/Controls/src/Core/ImageElement.cs
+++ b/src/Controls/src/Core/ImageElement.cs
@@ -49,7 +49,13 @@ namespace Microsoft.Maui.Controls
 					oldSource.SourceChanged -= image.OnImageSourceSourceChanged;
 				}
 
-				oldSource.Parent = null;
+				// Only release the parent if this element still owns it. The same source can be
+				// assigned to several owners and the most recent assignment wins, so an older
+				// owner clearing its value must not unparent the source from the current one.
+				if (ReferenceEquals(oldSource.Parent, bindable))
+				{
+					oldSource.Parent = null;
+				}
 			}
 
 			ImageSourceChanging(oldSource);

--- a/src/Controls/src/Core/NavigationPage/NavigationPage.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPage.cs
@@ -34,7 +34,8 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty BarTextColorProperty = BarElement.BarTextColorProperty;
 
 		/// <summary>Bindable property for attached property <c>TitleIconImageSource</c>.</summary>
-		public static readonly BindableProperty TitleIconImageSourceProperty = BindableProperty.CreateAttached("TitleIconImageSource", typeof(ImageSource), typeof(NavigationPage), default(ImageSource));
+		public static readonly BindableProperty TitleIconImageSourceProperty = BindableProperty.CreateAttached("TitleIconImageSource", typeof(ImageSource), typeof(NavigationPage), default(ImageSource),
+			propertyChanged: (bindable, oldValue, newValue) => bindable.AddRemoveLogicalChildren(oldValue, newValue));
 
 		/// <summary>Bindable property for attached property <c>IconColor</c>.</summary>
 		public static readonly BindableProperty IconColorProperty = BindableProperty.CreateAttached("IconColor", typeof(Color), typeof(NavigationPage), null);

--- a/src/Controls/src/Core/NavigationPage/NavigationPage.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPage.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Maui.Controls
 
 		/// <summary>Bindable property for attached property <c>TitleIconImageSource</c>.</summary>
 		public static readonly BindableProperty TitleIconImageSourceProperty = BindableProperty.CreateAttached("TitleIconImageSource", typeof(ImageSource), typeof(NavigationPage), default(ImageSource),
-			propertyChanged: (bindable, oldValue, newValue) => bindable.AddRemoveLogicalChildren(oldValue, newValue));
+			propertyChanged: (bindable, oldValue, newValue) => bindable.ReparentImageSource(oldValue, newValue));
 
 		/// <summary>Bindable property for attached property <c>IconColor</c>.</summary>
 		public static readonly BindableProperty IconColorProperty = BindableProperty.CreateAttached("IconColor", typeof(Color), typeof(NavigationPage), null);

--- a/src/Controls/src/Core/Page/Page.cs
+++ b/src/Controls/src/Core/Page/Page.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Maui.Controls
 
 		/// <summary>Bindable property for <see cref="BackgroundImageSource"/>.</summary>
 		public static readonly BindableProperty BackgroundImageSourceProperty = BindableProperty.Create(nameof(BackgroundImageSource), typeof(ImageSource), typeof(Page), default(ImageSource),
-			propertyChanged: (bindable, oldValue, newValue) => bindable.AddRemoveLogicalChildren(oldValue, newValue));
+			propertyChanged: (bindable, oldValue, newValue) => bindable.ReparentImageSource(oldValue, newValue));
 
 		/// <summary>Bindable property for <see cref="IsBusy"/>.</summary>
 		[Obsolete("Page.IsBusy has been deprecated and will be removed in .NET 11")]
@@ -941,7 +941,7 @@ namespace Microsoft.Maui.Controls
 
 			// Parent the image source so DynamicResources inside it resolve through
 			// the element tree (#36822 follow-up)
-			bindable.AddRemoveLogicalChildren(oldvalue, newValue);
+			bindable.ReparentImageSource(oldvalue, newValue);
 		}
 
 		void OnImageSourceSourceChanged(object sender, EventArgs e)

--- a/src/Controls/src/Core/Page/Page.cs
+++ b/src/Controls/src/Core/Page/Page.cs
@@ -53,7 +53,8 @@ namespace Microsoft.Maui.Controls
 		internal static readonly BindableProperty IgnoresContainerAreaProperty = BindableProperty.Create(nameof(IgnoresContainerArea), typeof(bool), typeof(Page), BooleanBoxes.FalseBox);
 
 		/// <summary>Bindable property for <see cref="BackgroundImageSource"/>.</summary>
-		public static readonly BindableProperty BackgroundImageSourceProperty = BindableProperty.Create(nameof(BackgroundImageSource), typeof(ImageSource), typeof(Page), default(ImageSource));
+		public static readonly BindableProperty BackgroundImageSourceProperty = BindableProperty.Create(nameof(BackgroundImageSource), typeof(ImageSource), typeof(Page), default(ImageSource),
+			propertyChanged: (bindable, oldValue, newValue) => bindable.AddRemoveLogicalChildren(oldValue, newValue));
 
 		/// <summary>Bindable property for <see cref="IsBusy"/>.</summary>
 		[Obsolete("Page.IsBusy has been deprecated and will be removed in .NET 11")]
@@ -937,6 +938,10 @@ namespace Microsoft.Maui.Controls
 
 			if (newValue is ImageSource newImageSource)
 				newImageSource.SourceChanged += ((Page)bindable).OnImageSourceSourceChanged;
+
+			// Parent the image source so DynamicResources inside it resolve through
+			// the element tree (#36822 follow-up)
+			bindable.AddRemoveLogicalChildren(oldvalue, newValue);
 		}
 
 		void OnImageSourceSourceChanged(object sender, EventArgs e)

--- a/src/Controls/src/Core/Shell/BaseShellItem.cs
+++ b/src/Controls/src/Core/Shell/BaseShellItem.cs
@@ -37,7 +37,8 @@ namespace Microsoft.Maui.Controls
 
 		/// <summary>Bindable property for <see cref="FlyoutIcon"/>.</summary>
 		public static readonly BindableProperty FlyoutIconProperty =
-			BindableProperty.Create(nameof(FlyoutIcon), typeof(ImageSource), typeof(BaseShellItem), null, BindingMode.OneTime);
+			BindableProperty.Create(nameof(FlyoutIcon), typeof(ImageSource), typeof(BaseShellItem), null, BindingMode.OneTime,
+				propertyChanged: OnImageSourcePropertyChanged);
 
 		/// <summary>Bindable property for <see cref="Icon"/>.</summary>
 		public static readonly BindableProperty IconProperty =
@@ -245,11 +246,29 @@ namespace Microsoft.Maui.Controls
 
 		static void OnIconChanged(BindableObject bindable, object oldValue, object newValue)
 		{
+			OnImageSourcePropertyChanged(bindable, oldValue, newValue);
+
 			if (newValue == null || bindable.IsSet(FlyoutIconProperty))
 				return;
 
 			var shellItem = (BaseShellItem)bindable;
 			shellItem.FlyoutIcon = (ImageSource)newValue;
+		}
+
+		static void OnImageSourcePropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			var shellItem = (BaseShellItem)bindable;
+
+			// Parent the image source so DynamicResources inside it resolve through the
+			// element tree (#36822 follow-up). Icon forwards to FlyoutIcon, so the same
+			// source can back both properties; only release the parent once this item no
+			// longer references the source at all
+			if (oldValue is ImageSource oldSource && ReferenceEquals(oldSource.Parent, shellItem) &&
+				!ReferenceEquals(shellItem.Icon, oldSource) && !ReferenceEquals(shellItem.FlyoutIcon, oldSource))
+				oldSource.Parent = null;
+
+			if (newValue is ImageSource newSource)
+				newSource.Parent = shellItem;
 		}
 
 		static void OnFlyoutItemIsVisibleChanged(BindableObject bindable, object oldValue, object newValue)

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -1179,7 +1179,8 @@ namespace Microsoft.Maui.Controls
 		/// The flyout background image appears beneath the flyout header and behind any flyout items, menu items, and the flyout footer. 
 		/// </remarks>
 		public static readonly BindableProperty FlyoutBackgroundImageProperty =
-			BindableProperty.Create(nameof(FlyoutBackgroundImage), typeof(ImageSource), typeof(Shell), default(ImageSource), BindingMode.OneTime);
+			BindableProperty.Create(nameof(FlyoutBackgroundImage), typeof(ImageSource), typeof(Shell), default(ImageSource), BindingMode.OneTime,
+				propertyChanged: (bindable, oldValue, newValue) => bindable.AddRemoveLogicalChildren(oldValue, newValue));
 
 		/// <summary>
 		/// The aspect ratio of the background image.
@@ -1245,7 +1246,8 @@ namespace Microsoft.Maui.Controls
 		/// This icon can be changed by setting the FlyoutIcon property.
 		/// </summary>
 		public static readonly BindableProperty FlyoutIconProperty =
-			BindableProperty.Create(nameof(FlyoutIcon), typeof(ImageSource), typeof(Shell), null);
+			BindableProperty.Create(nameof(FlyoutIcon), typeof(ImageSource), typeof(Shell), null,
+				propertyChanged: (bindable, oldValue, newValue) => bindable.AddRemoveLogicalChildren(oldValue, newValue));
 
 		/// <summary>
 		/// Modifies the behavior of the flyout scroll.

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -1180,7 +1180,7 @@ namespace Microsoft.Maui.Controls
 		/// </remarks>
 		public static readonly BindableProperty FlyoutBackgroundImageProperty =
 			BindableProperty.Create(nameof(FlyoutBackgroundImage), typeof(ImageSource), typeof(Shell), default(ImageSource), BindingMode.OneTime,
-				propertyChanged: (bindable, oldValue, newValue) => bindable.AddRemoveLogicalChildren(oldValue, newValue));
+				propertyChanged: (bindable, oldValue, newValue) => bindable.ReparentImageSource(oldValue, newValue));
 
 		/// <summary>
 		/// The aspect ratio of the background image.
@@ -1247,7 +1247,7 @@ namespace Microsoft.Maui.Controls
 		/// </summary>
 		public static readonly BindableProperty FlyoutIconProperty =
 			BindableProperty.Create(nameof(FlyoutIcon), typeof(ImageSource), typeof(Shell), null,
-				propertyChanged: (bindable, oldValue, newValue) => bindable.AddRemoveLogicalChildren(oldValue, newValue));
+				propertyChanged: (bindable, oldValue, newValue) => bindable.ReparentImageSource(oldValue, newValue));
 
 		/// <summary>
 		/// Modifies the behavior of the flyout scroll.

--- a/src/Controls/src/Core/Slider/Slider.cs
+++ b/src/Controls/src/Core/Slider/Slider.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Maui.Controls
 
 		/// <summary>Bindable property for <see cref="ThumbImageSource"/>. This is a bindable property.</summary>
 		public static readonly BindableProperty ThumbImageSourceProperty = BindableProperty.Create(nameof(ThumbImageSource), typeof(ImageSource), typeof(Slider), default(ImageSource),
-			propertyChanged: (bindable, oldValue, newValue) => bindable.AddRemoveLogicalChildren(oldValue, newValue));
+			propertyChanged: (bindable, oldValue, newValue) => bindable.ReparentImageSource(oldValue, newValue));
 
 		/// <summary>Bindable property for <see cref="DragStartedCommand"/>. This is a bindable property.</summary>
 		public static readonly BindableProperty DragStartedCommandProperty = BindableProperty.Create(nameof(DragStartedCommand), typeof(ICommand), typeof(Slider), default(ICommand));

--- a/src/Controls/src/Core/Slider/Slider.cs
+++ b/src/Controls/src/Core/Slider/Slider.cs
@@ -85,7 +85,8 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty ThumbColorProperty = BindableProperty.Create(nameof(ThumbColor), typeof(Color), typeof(Slider), null);
 
 		/// <summary>Bindable property for <see cref="ThumbImageSource"/>. This is a bindable property.</summary>
-		public static readonly BindableProperty ThumbImageSourceProperty = BindableProperty.Create(nameof(ThumbImageSource), typeof(ImageSource), typeof(Slider), default(ImageSource));
+		public static readonly BindableProperty ThumbImageSourceProperty = BindableProperty.Create(nameof(ThumbImageSource), typeof(ImageSource), typeof(Slider), default(ImageSource),
+			propertyChanged: (bindable, oldValue, newValue) => bindable.AddRemoveLogicalChildren(oldValue, newValue));
 
 		/// <summary>Bindable property for <see cref="DragStartedCommand"/>. This is a bindable property.</summary>
 		public static readonly BindableProperty DragStartedCommandProperty = BindableProperty.Create(nameof(DragStartedCommand), typeof(ICommand), typeof(Slider), default(ICommand));

--- a/src/Controls/src/Core/TitleBar/TitleBar.cs
+++ b/src/Controls/src/Core/TitleBar/TitleBar.cs
@@ -149,8 +149,9 @@ namespace Microsoft.Maui.Controls
 		static void OnIconChanged(BindableObject bindable, object oldValue, object newValue)
 		{
 			// Parent the image source so DynamicResources inside it resolve through
-			// the element tree (#36822 follow-up)
-			bindable.AddRemoveLogicalChildren(oldValue, newValue);
+			// the element tree (#36822 follow-up); Parent (not logical child) so a
+			// ControlTemplate change, which clears logical children, can't unparent it
+			bindable.ReparentImageSource(oldValue, newValue);
 
 			var titlebar = (TitleBar)bindable;
 			var imageSource = newValue as ImageSource;

--- a/src/Controls/src/Core/TitleBar/TitleBar.cs
+++ b/src/Controls/src/Core/TitleBar/TitleBar.cs
@@ -148,6 +148,10 @@ namespace Microsoft.Maui.Controls
 
 		static void OnIconChanged(BindableObject bindable, object oldValue, object newValue)
 		{
+			// Parent the image source so DynamicResources inside it resolve through
+			// the element tree (#36822 follow-up)
+			bindable.AddRemoveLogicalChildren(oldValue, newValue);
+
 			var titlebar = (TitleBar)bindable;
 			var imageSource = newValue as ImageSource;
 			if (imageSource is null || imageSource.IsEmpty)

--- a/src/Controls/tests/Core.UnitTests/ImageSourceDynamicResourceTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ImageSourceDynamicResourceTests.cs
@@ -199,6 +199,27 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public void ClearingAnImageSourceFromAnOlderOwnerKeepsTheCurrentOwnersParent()
+		{
+			SetUpAppWithAccentColor();
+
+			var source = new FontImageSource { Glyph = "x" };
+
+			// ImageElement (Image/Button/ImageButton) parents sources too, and the same
+			// source can legitimately be assigned to more than one owner
+			var first = new Image { Source = source };
+			var second = new Image { Source = source };
+
+			Assert.Equal(second, source.Parent);
+
+			// The older owner no longer holds the parent, so clearing it must not unparent
+			// the source from the owner that does
+			first.Source = null;
+
+			Assert.Equal(second, source.Parent);
+		}
+
+		[Fact]
 		public void AllImageSourcePropertiesParentTheirSource()
 		{
 			SetUpAppWithAccentColor();

--- a/src/Controls/tests/Core.UnitTests/ImageSourceDynamicResourceTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ImageSourceDynamicResourceTests.cs
@@ -1,0 +1,99 @@
+using Microsoft.Maui.Graphics;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	// Follow-up to https://github.com/dotnet/maui/issues/36822 (PR #37065):
+	// ImageSource-valued properties are element-valued but were never parented, so
+	// DynamicResources inside them only resolved through the removed Application.Current
+	// fallback (and only for app-level resources). The image sources are now added as
+	// logical children of their owner so they resolve through the element tree.
+	public class ImageSourceDynamicResourceTests : BaseTestFixture
+	{
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing)
+			{
+				Application.ClearCurrent();
+			}
+			base.Dispose(disposing);
+		}
+
+		static Application SetUpAppWithAccentColor()
+		{
+			var app = new MockApplication
+			{
+				Resources = new ResourceDictionary { { "AccentColor", Colors.Red } }
+			};
+			Application.Current = app;
+			return app;
+		}
+
+		[Fact]
+		public void IconImageSourceDynamicResourceResolvesThroughTree()
+		{
+			var app = SetUpAppWithAccentColor();
+
+			var icon = new FontImageSource { Glyph = "x" };
+			icon.SetDynamicResource(FontImageSource.ColorProperty, "AccentColor");
+
+			var page = new ContentPage { IconImageSource = icon };
+			app.LoadPage(page);
+
+			Assert.Equal(page, icon.Parent);
+			Assert.Equal(Colors.Red, icon.Color);
+		}
+
+		[Fact]
+		public void IconImageSourceDynamicResourceResolvesPageLevelResources()
+		{
+			var app = SetUpAppWithAccentColor();
+
+			var icon = new FontImageSource { Glyph = "x" };
+			icon.SetDynamicResource(FontImageSource.ColorProperty, "AccentColor");
+
+			// Page-level resources shadow the application ones; with the old static
+			// Application.Current fallback this resolved the wrong scope
+			var page = new ContentPage
+			{
+				Resources = new ResourceDictionary { { "AccentColor", Colors.Blue } },
+				IconImageSource = icon
+			};
+			app.LoadPage(page);
+
+			Assert.Equal(Colors.Blue, icon.Color);
+		}
+
+		[Fact]
+		public void BackgroundImageSourceDynamicResourceResolvesThroughTree()
+		{
+			var app = SetUpAppWithAccentColor();
+
+			var background = new FontImageSource { Glyph = "x" };
+			background.SetDynamicResource(FontImageSource.ColorProperty, "AccentColor");
+
+			var page = new ContentPage { BackgroundImageSource = background };
+			app.LoadPage(page);
+
+			Assert.Equal(page, background.Parent);
+			Assert.Equal(Colors.Red, background.Color);
+		}
+
+		[Fact]
+		public void ReplacedIconImageSourceIsUnparented()
+		{
+			var app = SetUpAppWithAccentColor();
+
+			var first = new FontImageSource { Glyph = "a" };
+			var second = new FontImageSource { Glyph = "b" };
+
+			var page = new ContentPage { IconImageSource = first };
+			app.LoadPage(page);
+
+			page.IconImageSource = second;
+
+			Assert.Null(first.Parent);
+			Assert.Equal(page, second.Parent);
+		}
+	}
+}

--- a/src/Controls/tests/Core.UnitTests/ImageSourceDynamicResourceTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ImageSourceDynamicResourceTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using Microsoft.Maui.Graphics;
 using Xunit;
 
@@ -6,8 +8,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 	// Follow-up to https://github.com/dotnet/maui/issues/36822 (PR #37065):
 	// ImageSource-valued properties are element-valued but were never parented, so
 	// DynamicResources inside them only resolved through the removed Application.Current
-	// fallback (and only for app-level resources). The image sources are now added as
-	// logical children of their owner so they resolve through the element tree.
+	// fallback (and only for app-level resources). The image sources now get their
+	// Parent assigned to the owning element (the ImageElement pattern) so they resolve
+	// through the element tree without becoming logical/visual children.
 	public class ImageSourceDynamicResourceTests : BaseTestFixture
 	{
 		protected override void Dispose(bool disposing)
@@ -94,6 +97,133 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.Null(first.Parent);
 			Assert.Equal(page, second.Parent);
+		}
+
+		[Fact]
+		public void ImageSourceIsNotExposedAsLogicalOrVisualChild()
+		{
+			var app = SetUpAppWithAccentColor();
+
+			var icon = new FontImageSource { Glyph = "x" };
+			var page = new ContentPage { IconImageSource = icon };
+			app.LoadPage(page);
+
+			Assert.Equal(page, icon.Parent);
+			// Compatibility renderers auto-package visual children; an ImageSource has no
+			// view handler, so it must not surface through the visual tree
+			Assert.DoesNotContain((IVisualTreeElement)icon, ((IVisualTreeElement)page).GetVisualChildren());
+			Assert.DoesNotContain(icon, page.LogicalChildrenInternal);
+		}
+
+		[Fact]
+		public void SharedImageSourceKeepsMostRecentOwnerWhenClearedFromAnother()
+		{
+			SetUpAppWithAccentColor();
+
+			var icon = new FontImageSource { Glyph = "x" };
+			var pageA = new ContentPage { IconImageSource = icon };
+			var pageB = new ContentPage { IconImageSource = icon };
+
+			// The most recent assignment wins
+			Assert.Equal(pageB, icon.Parent);
+
+			// Clearing the property on a non-owner must not steal the parent from the owner
+			pageA.IconImageSource = null;
+
+			Assert.Equal(pageB, icon.Parent);
+		}
+
+		[Fact]
+		public void TitleBarIconStaysParentedAfterControlTemplateChange()
+		{
+			SetUpAppWithAccentColor();
+
+			var icon = new FontImageSource { Glyph = "x" };
+			icon.SetDynamicResource(FontImageSource.ColorProperty, "AccentColor");
+
+			var titleBar = new TitleBar
+			{
+				Resources = new ResourceDictionary { { "AccentColor", Colors.Green } },
+				Icon = icon
+			};
+
+			Assert.Equal(Colors.Green, icon.Color);
+
+			// Replacing the template clears the TitleBar's logical children; the icon must
+			// survive because it is parented directly, not registered as a logical child
+			titleBar.ControlTemplate = new ControlTemplate(() =>
+			{
+				var grid = new Grid();
+				Internals.NameScope.SetNameScope(grid, new Internals.NameScope());
+				return grid;
+			});
+
+			Assert.Equal(titleBar, icon.Parent);
+			Assert.Equal(Colors.Green, icon.Color);
+		}
+
+		[Fact]
+		public void ShellContentIconDynamicResourceResolvesThroughTree()
+		{
+			var app = SetUpAppWithAccentColor();
+
+			var icon = new FontImageSource { Glyph = "x" };
+			icon.SetDynamicResource(FontImageSource.ColorProperty, "AccentColor");
+
+			var shellContent = new ShellContent { Content = new ContentPage() };
+			var shell = new Shell();
+			shell.Items.Add(shellContent);
+			app.LoadPage(shell);
+
+			shellContent.Icon = icon;
+
+			Assert.Equal(shellContent, icon.Parent);
+			Assert.Equal(Colors.Red, icon.Color);
+		}
+
+		[Fact]
+		public void ClearingIconKeepsForwardedFlyoutIconParented()
+		{
+			SetUpAppWithAccentColor();
+
+			var icon = new FontImageSource { Glyph = "x" };
+			var shellContent = new ShellContent { Icon = icon };
+
+			// Icon forwards to FlyoutIcon when FlyoutIcon is not explicitly set
+			Assert.Same(icon, shellContent.FlyoutIcon);
+
+			shellContent.Icon = null;
+
+			// Still referenced through FlyoutIcon, so it must stay parented
+			Assert.Equal(shellContent, icon.Parent);
+		}
+
+		[Fact]
+		public void AllImageSourcePropertiesParentTheirSource()
+		{
+			SetUpAppWithAccentColor();
+
+			var owners = new (string Name, Func<ImageSource, Element> Assign)[]
+			{
+				("Page.IconImageSource", src => new ContentPage { IconImageSource = src }),
+				("Page.BackgroundImageSource", src => new ContentPage { BackgroundImageSource = src }),
+				("NavigationPage.TitleIconImageSource", src => { var page = new ContentPage(); NavigationPage.SetTitleIconImageSource(page, src); return page; }),
+				("Slider.ThumbImageSource", src => new Slider { ThumbImageSource = src }),
+				("ImageCell.ImageSource", src => new ImageCell { ImageSource = src }),
+				("AppLinkEntry.Thumbnail", src => new AppLinkEntry { Thumbnail = src }),
+				("TitleBar.Icon", src => new TitleBar { Icon = src }),
+				("Shell.FlyoutIcon", src => new Shell { FlyoutIcon = src }),
+				("Shell.FlyoutBackgroundImage", src => new Shell { FlyoutBackgroundImage = src }),
+				("BaseShellItem.Icon", src => new ShellContent { Icon = src }),
+				("BaseShellItem.FlyoutIcon", src => new ShellContent { FlyoutIcon = src }),
+			};
+
+			foreach (var (name, assign) in owners)
+			{
+				var source = new FontImageSource { Glyph = "x" };
+				var owner = assign(source);
+				Assert.True(ReferenceEquals(source.Parent, owner), $"{name} should parent its ImageSource");
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Follow-up to #37065 (targets `inflight/current`, where that change lives), addressing the gap flagged in the [post-merge review](https://github.com/dotnet/maui/pull/37065#discussion_r3715686122) and verified with a unit-test probe: `ImageSource`-valued properties are element-valued but were never parented, so a `DynamicResource` inside them (e.g. a `FontImageSource` `Color`) previously resolved **only** through the removed `Application.Current` fallback — and only against application-level resources, never page/window scoping.

Two changes:

1. **`ImageSource` values now get `ImageSource.Parent` assigned directly to their owner** — the established `ImageElement` pattern (`Image`/`ImageButton`/`Button` sources) — so they resolve resources through the element tree. Covered properties: `Page.IconImageSource`, `Page.BackgroundImageSource`, `NavigationPage.TitleIconImageSource`, `Slider.ThumbImageSource`, `ImageCell.ImageSource`, `AppLinkEntry.Thumbnail`, `TitleBar.Icon`, `Shell.FlyoutIcon`, `Shell.FlyoutBackgroundImage`, `BaseShellItem.Icon`, `BaseShellItem.FlyoutIcon`. (`SearchHandler`/`BackButtonBehavior` icons are excluded: those owners are plain `BindableObject`s with no tree position — a separate design question.)

   The first iteration of this PR registered the sources as logical children instead; the AI review correctly identified three problems with that, all fixed by parenting directly:
   - Logical children surface through `IVisualTreeElement.GetVisualChildren()`, where compatibility renderers with `AutoPackage=true` would attempt `ToPlatform()` on an element with no view handler (`HandlerNotFoundException`).
   - `IControlTemplated` owners (`TitleBar`) clear their logical children on `ControlTemplate` changes, permanently unparenting the icon.
   - `AddLogicalChild` has no identity/duplicate guard, so shared or multiply-assigned sources could leave stale entries.

   The direct assignment uses a **guarded release**: an owner only clears `Parent` on the outgoing value if it still holds it, so a source shared between owners keeps its most recent parent when cleared from another. `BaseShellItem` additionally uses an alias-aware release because `Icon` forwards to `FlyoutIcon` on the same owner. Resource propagation and inherited `BindingContext` are unchanged relative to the logical-children iteration, since `AddLogicalChild` parented through the same `SetParent` path.

2. **The legacy `Application.MainPage` setter now pushes resources through `OnParentResourcesChanged` instead of `OnResourcesChanged`.** The old call delivered the raw application snapshot directly to the page's resource listeners, bypassing the shadowing filter in `VisualElement.OnParentResourcesChanged` — so a page-level resource that shadows an application-level key was overridden by the app value on that path. This aligns the legacy path with the `SetParent` propagation path.

> [!NOTE]
> Behavioral change: `ImageSource` instances assigned to the properties above now have a non-null `Parent` (their owning element), exactly as `Image.Source`/`Button.ImageSource` already do via `ImageElement`. They do **not** appear in `GetVisualChildren()` or logical children, so visual-tree consumers and compatibility renderers are unaffected.

### Issues Fixed

Follow-up to #36822 / #37065.

### Tests

`ImageSourceDynamicResourceTests` (Controls.Core.UnitTests):

- `IconImageSourceDynamicResourceResolvesThroughTree` — the reported scenario: app-level resource reaches a `FontImageSource` in `Page.IconImageSource` on attach.
- `IconImageSourceDynamicResourceResolvesPageLevelResources` — page-level resources shadow application ones (previously impossible for image sources; also exercises the `MainPage` setter fix).
- `BackgroundImageSourceDynamicResourceResolvesThroughTree`
- `ReplacedIconImageSourceIsUnparented` — replacing the value unparents the old image source.

New coverage for the review findings:

- `ImageSourceIsNotExposedAsLogicalOrVisualChild` — sources never surface through `GetVisualChildren()`/logical children (compatibility-renderer safety).
- `TitleBarIconStaysParentedAfterControlTemplateChange` — replacing the `ControlTemplate` does not unparent the icon, and its `DynamicResource` keeps resolving.
- `SharedImageSourceKeepsMostRecentOwnerWhenClearedFromAnother` — guarded release for sources shared between owners.
- `ClearingIconKeepsForwardedFlyoutIconParented` — alias-aware release for the `Icon`→`FlyoutIcon` forwarding on `BaseShellItem`.
- `ShellContentIconDynamicResourceResolvesThroughTree` — the `BaseShellItem` gap flagged as a warning.
- `AllImageSourcePropertiesParentTheirSource` — every changed property parents its source.

Verification on the test machine:

- **Without the fix**: the 4 resolution tests FAIL.
- **With the fix**: all 10 pass. Full `Controls.Core.UnitTests` runs show **identical pre-existing failure sets with and without this change** on `inflight/current` (32 `PickerTests.TestItemsSourceCollectionChanged*`-family failures, reproduced on the pristine branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
