### PR TITLE
[net11.0] Suppress CA1416 for secondary toolbar menu

### DIFF
--- a/src/Controls/src/Core/Platform/iOS/NavigationViewHandlerToolbarHelper.cs
+++ b/src/Controls/src/Core/Platform/iOS/NavigationViewHandlerToolbarHelper.cs
@@ -850,10 +850,12 @@ namespace Microsoft.Maui.Controls
                 var menuIcon = UIImage.GetSystemImage("ellipsis.circle");
                 var menu = UIMenu.Create(string.Empty, null, UIMenuIdentifier.Edit,
                     UIMenuOptions.DisplayInline, secondaries.ToArray());
+#pragma warning disable CA1416 // UIBarButtonItem(UIImage?, UIMenu) is unavailable on iOS 13.
                 var menuButton = new UIBarButtonItem(menuIcon, menu)
                 {
                     AccessibilityIdentifier = "SecondaryToolbarMenuButton"
                 };
+#pragma warning restore CA1416
 
                 primaries ??= new();
                 primaries.Insert(0, menuButton);


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Suppresses CA1416 narrowly around the `UIBarButtonItem(UIImage, UIMenu)` constructor used by the secondary toolbar menu. The API is annotated as unavailable on iOS 13, but this existing compatibility path is intentionally retained for Preview 7.

The Preview 7 dependency pins were also checked before creating this PR. The SDK/runtime, Android, and macOS-iOS dependencies already match their latest blessed Preview 7 builds, so no dependency update is required.

## Validation

- Built `Controls.Core.csproj` for `net11.0-ios26.5` with `TreatWarningsAsErrors=true`
- Result: 0 warnings, 0 errors
