### PR TITLE
[NET11][Android] Fix temporary top gap after keyboard dismissal in Shell

### DIFF
--- a/src/Controls/src/Core/Handlers/Shell/ShellItemWrapperFragment.Android.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellItemWrapperFragment.Android.cs
@@ -60,9 +60,6 @@ namespace Microsoft.Maui.Controls.Handlers
             // BNV is created by TabbedViewManager in SetupTabbedViewManager().
             // It is placed into navigationlayout_bottomtabs via TabbedViewManager.SetTabLayout().
 
-            // Setup window insets for safe area handling
-            MauiWindowInsetListener.SetupViewWithLocalListener(_rootLayout);
-
             return rootView;
         }
 
@@ -199,14 +196,6 @@ namespace Microsoft.Maui.Controls.Handlers
                 _handler._adapter = null;
             }
 
-            // Remove window insets listener before nulling _rootLayout.
-            // Dispose guards on `_rootLayout is not null` — if nulled here first,
-            // Dispose skips the removal and the listener is never unregistered.
-            if (_rootLayout is not null)
-            {
-                MauiWindowInsetListener.RemoveViewWithLocalListener(_rootLayout);
-            }
-
             _rootLayout = null;
 
             // _backPressedCallback is auto-removed by ViewLifecycleOwner when the view is destroyed.
@@ -225,12 +214,6 @@ namespace Microsoft.Maui.Controls.Handlers
                     _backPressedCallback.Remove();
                     _backPressedCallback.Dispose();
                     _backPressedCallback = null;
-                }
-
-                // Remove window insets listener
-                if (_rootLayout is not null)
-                {
-                    MauiWindowInsetListener.RemoveViewWithLocalListener(_rootLayout);
                 }
 
                 _rootLayout = null;


### PR DESCRIPTION
### Issue Details:
On Android, the D23 Editor manual test briefly shows an unwanted gap at the top after submitting a message. The page returns to the correct position shortly afterward.
 
### Root Cause:
The new Android Shell architecture added window-inset handling to both:
* The outer Shell layout
* The nested Shell item layout
When the keyboard changed visibility, both listeners processed the same inset update. This temporarily applied the top spacing twice, causing the visible gap.

### Description of Changes:
Removed the redundant window-inset listener from ShellItemWrapperFragment. 
The outer Shell layout remains responsible for handling system-bar and keyboard insets. This prevents duplicate inset updates while preserving Shell safe-area behavior.

Fixes #37075 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

### Test Cases
The above issue was reproduced only in the manual test project; therefore, a test could not be added for this scenario

**Tested the behavior in the following platforms.**
- [x] Android
- [ ] Windows
- [ ] iOS
- [ ] Mac

| Before  | After  |
|---------|--------|
| **Android**<br> <video src="https://github.com/user-attachments/assets/9bd69cab-6ae8-4f63-95ac-201bab5ea4f9" width="300" height="600"> | **Android**<br> <video src="https://github.com/user-attachments/assets/fb33b39d-f420-4380-a1e9-82389884fa9e" width="300" height="600"> |
