### PR TITLE
Fix sample template seed initialization

### DIFF
--- a/src/Templates/src/templates/maui-mobile/Data/SeedDataService.cs
+++ b/src/Templates/src/templates/maui-mobile/Data/SeedDataService.cs
@@ -42,50 +42,49 @@ public class SeedDataService
 
 		await using Stream templateStream = await FileSystem.OpenAppPackageFileAsync(_seedDataFilePath);
 
-		ProjectsJson? payload = null;
+		ProjectsJson payload;
 		try
 		{
-			payload = JsonSerializer.Deserialize(templateStream, JsonContext.Default.ProjectsJson);
+			payload = JsonSerializer.Deserialize(templateStream, JsonContext.Default.ProjectsJson)
+				?? throw new InvalidDataException("Seed data did not contain a project payload.");
 		}
 		catch (Exception e)
 		{
 			_logger.LogError(e, "Error deserializing seed data");
+			throw;
 		}
 
 		try
 		{
-			if (payload is not null)
+			foreach (var project in payload.Projects)
 			{
-				foreach (var project in payload.Projects)
+				if (project is null)
 				{
-					if (project is null)
+					continue;
+				}
+
+				if (project.Category is not null)
+				{
+					await _categoryRepository.SaveItemAsync(project.Category);
+					project.CategoryID = project.Category.ID;
+				}
+
+				await _projectRepository.SaveItemAsync(project);
+
+				if (project.Tasks is not null)
+				{
+					foreach (var task in project.Tasks)
 					{
-						continue;
+						task.ProjectID = project.ID;
+						await _taskRepository.SaveItemAsync(task);
 					}
+				}
 
-					if (project.Category is not null)
+				if (project.Tags is not null)
+				{
+					foreach (var tag in project.Tags)
 					{
-						await _categoryRepository.SaveItemAsync(project.Category);
-						project.CategoryID = project.Category.ID;
-					}
-
-					await _projectRepository.SaveItemAsync(project);
-
-					if (project?.Tasks is not null)
-					{
-						foreach (var task in project.Tasks)
-						{
-							task.ProjectID = project.ID;
-							await _taskRepository.SaveItemAsync(task);
-						}
-					}
-
-					if (project?.Tags is not null)
-					{
-						foreach (var tag in project.Tags)
-						{
-							await _tagRepository.SaveItemAsync(tag, project.ID);
-						}
+						await _tagRepository.SaveItemAsync(tag, project.ID);
 					}
 				}
 			}

--- a/src/Templates/src/templates/maui-mobile/Data/SeedDataService.cs
+++ b/src/Templates/src/templates/maui-mobile/Data/SeedDataService.cs
@@ -24,7 +24,7 @@ public class SeedDataService
 
 	public async Task LoadSeedDataAsync()
 	{
-		ClearTables();
+		await ClearTablesAsync();
 
 		await using Stream templateStream = await FileSystem.OpenAppPackageFileAsync(_seedDataFilePath);
 
@@ -83,19 +83,18 @@ public class SeedDataService
 		}
 	}
 
-	private async void ClearTables()
+	private async Task ClearTablesAsync()
 	{
 		try
 		{
-			await Task.WhenAll(
-				_projectRepository.DropTableAsync(),
-				_taskRepository.DropTableAsync(),
-				_tagRepository.DropTableAsync(),
-				_categoryRepository.DropTableAsync());
+			// ProjectRepository also drops the related task and tag tables.
+			await _projectRepository.DropTableAsync();
+			await _categoryRepository.DropTableAsync();
 		}
 		catch (Exception e)
 		{
-			Console.WriteLine(e);
+			_logger.LogError(e, "Error clearing tables");
+			throw;
 		}
 	}
 }

--- a/src/Templates/src/templates/maui-mobile/Data/SeedDataService.cs
+++ b/src/Templates/src/templates/maui-mobile/Data/SeedDataService.cs
@@ -45,8 +45,7 @@ public class SeedDataService
 		try
 		{
 			string json = await reader.ReadToEndAsync();
-			payload = JsonSerializer.Deserialize(json, JsonContext.Default.ProjectsJson)
-				?? throw new InvalidDataException("Seed data did not contain a project payload.");
+			payload = DeserializeSeedData(json);
 
 			if (payload.Projects.Count == 0)
 			{
@@ -102,6 +101,71 @@ public class SeedDataService
 			throw;
 		}
 	}
+
+	private static ProjectsJson DeserializeSeedData(string json)
+	{
+		using JsonDocument document = JsonDocument.Parse(json);
+		JsonElement projectsElement = document.RootElement.GetProperty(nameof(ProjectsJson.Projects));
+		var projects = new List<Project>();
+
+		foreach (JsonElement projectElement in projectsElement.EnumerateArray())
+		{
+			var project = new Project
+			{
+				Name = GetRequiredString(projectElement, nameof(Project.Name)),
+				Description = GetRequiredString(projectElement, nameof(Project.Description)),
+				Icon = GetRequiredString(projectElement, nameof(Project.Icon)),
+				Category = DeserializeCategory(projectElement.GetProperty(nameof(Project.Category))),
+				Tasks = DeserializeTasks(projectElement.GetProperty(nameof(Project.Tasks))),
+				Tags = DeserializeTags(projectElement.GetProperty(nameof(Project.Tags)))
+			};
+
+			projects.Add(project);
+		}
+
+		return new ProjectsJson { Projects = projects };
+	}
+
+	private static Category DeserializeCategory(JsonElement categoryElement) =>
+		new()
+		{
+			Title = GetRequiredString(categoryElement, nameof(Category.Title)),
+			Color = GetRequiredString(categoryElement, nameof(Category.Color))
+		};
+
+	private static List<ProjectTask> DeserializeTasks(JsonElement tasksElement)
+	{
+		var tasks = new List<ProjectTask>();
+		foreach (JsonElement taskElement in tasksElement.EnumerateArray())
+		{
+			tasks.Add(new ProjectTask
+			{
+				Title = GetRequiredString(taskElement, nameof(ProjectTask.Title)),
+				IsCompleted = taskElement.GetProperty(nameof(ProjectTask.IsCompleted)).GetBoolean()
+			});
+		}
+
+		return tasks;
+	}
+
+	private static List<Tag> DeserializeTags(JsonElement tagsElement)
+	{
+		var tags = new List<Tag>();
+		foreach (JsonElement tagElement in tagsElement.EnumerateArray())
+		{
+			tags.Add(new Tag
+			{
+				Title = GetRequiredString(tagElement, nameof(Tag.Title)),
+				Color = GetRequiredString(tagElement, nameof(Tag.Color))
+			});
+		}
+
+		return tags;
+	}
+
+	private static string GetRequiredString(JsonElement element, string propertyName) =>
+		element.GetProperty(propertyName).GetString()
+			?? throw new InvalidDataException($"Seed data property '{propertyName}' was null.");
 
 	private async Task ClearTablesAsync()
 	{

--- a/src/Templates/src/templates/maui-mobile/Data/SeedDataService.cs
+++ b/src/Templates/src/templates/maui-mobile/Data/SeedDataService.cs
@@ -38,21 +38,28 @@ public class SeedDataService
 
 	private async Task LoadSeedDataCoreAsync()
 	{
-		await ClearTablesAsync();
-
 		await using Stream templateStream = await FileSystem.OpenAppPackageFileAsync(_seedDataFilePath);
+		using var reader = new StreamReader(templateStream);
 
 		ProjectsJson payload;
 		try
 		{
-			payload = JsonSerializer.Deserialize(templateStream, JsonContext.Default.ProjectsJson)
+			string json = await reader.ReadToEndAsync();
+			payload = JsonSerializer.Deserialize(json, JsonContext.Default.ProjectsJson)
 				?? throw new InvalidDataException("Seed data did not contain a project payload.");
+
+			if (payload.Projects.Count == 0)
+			{
+				throw new InvalidDataException("Seed data did not contain any projects.");
+			}
 		}
 		catch (Exception e)
 		{
 			_logger.LogError(e, "Error deserializing seed data");
 			throw;
 		}
+
+		await ClearTablesAsync();
 
 		try
 		{

--- a/src/Templates/src/templates/maui-mobile/Data/SeedDataService.cs
+++ b/src/Templates/src/templates/maui-mobile/Data/SeedDataService.cs
@@ -12,6 +12,7 @@ public class SeedDataService
 	private readonly CategoryRepository _categoryRepository;
 	private readonly string _seedDataFilePath = "SeedData.json";
 	private readonly ILogger<SeedDataService> _logger;
+	private readonly SemaphoreSlim _seedLock = new(1, 1);
 
 	public SeedDataService(ProjectRepository projectRepository, TaskRepository taskRepository, TagRepository tagRepository, CategoryRepository categoryRepository, ILogger<SeedDataService> logger)
 	{
@@ -23,6 +24,19 @@ public class SeedDataService
 	}
 
 	public async Task LoadSeedDataAsync()
+	{
+		await _seedLock.WaitAsync();
+		try
+		{
+			await LoadSeedDataCoreAsync();
+		}
+		finally
+		{
+			_seedLock.Release();
+		}
+	}
+
+	private async Task LoadSeedDataCoreAsync()
 	{
 		await ClearTablesAsync();
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause

The sample-content template cleared its SQLite schema through an unawaited `async void` method and started several related table drops concurrently. Errors from cleanup and JSON loading were then logged and suppressed, allowing `MainPageModel` to persist `is_seeded=true` even when no rows had been inserted.

On .NET 11 CoreCLR with iOS 26.5, source-generated deserialization of the packaged seed payload materialized the four-element `Projects` collection without usable `Project` objects. The loop therefore inserted no rows, but initialization was still treated as successful and the app remained permanently blank.

### Description of Change

- Await and serialize the complete seed operation.
- Drop related SQLite tables sequentially; `ProjectRepository.DropTableAsync()` already handles task and tag tables.
- Read the packaged JSON stream completely and parse its fixed schema deterministically with `JsonDocument`.
- Reject malformed or empty seed payloads and propagate cleanup, parsing, and database errors.
- Validate the payload before clearing existing tables, so a loading failure cannot destroy previously stored data.

### What NOT to Do

- Do not use fire-and-forget `async void` for schema changes.
- Do not concurrently drop tables whose repository cleanup paths overlap.
- Do not convert seed failures into success or set `is_seeded` after a suppressed error.
- Do not depend on source-generated object materialization for this packaged seed payload on .NET 11 CoreCLR/iOS 26.5.

### Validation

Fresh installs of generated .NET 11 sample apps are validated against the expected 4 projects, 4 categories, 12 tasks, and 5 tags on iOS, Android, and Mac Catalyst. The template project builds with zero warnings and errors.

### Issues Fixed

Related to #36571.
