### PR TITLE
[HouseKeeping] Removed deprecated ViewCompat methods

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellBottomNavViewAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellBottomNavViewAppearanceTracker.cs
@@ -94,13 +94,12 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				if (lastColor != newColor || colorDrawable == null)
 				{
 					// taken from android source code
-					var backgroundColor = new MaterialShapeDrawable();
-					backgroundColor.FillColor = ColorStateList.ValueOf(newColor);
+					var backgroundColor = new MaterialShapeDrawable
+					{
+						FillColor = ColorStateList.ValueOf(newColor)
+					};
 					backgroundColor.InitializeElevationOverlay(bottomView.Context);
-
-#pragma warning disable CS0618 // Obsolete
-					ViewCompat.SetBackground(bottomView, backgroundColor);
-#pragma warning restore CS0618 // Obsolete
+					bottomView.SetBackground(backgroundColor);
 				}
 			}
 			else
@@ -117,10 +116,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 					return;
 
 				var touchPoint = new Point(child.Left + (child.Right - child.Left) / 2, child.Top + (child.Bottom - child.Top) / 2);
-
-#pragma warning disable CS0618 // Obsolete
-				ViewCompat.SetBackground(bottomView, new ColorChangeRevealDrawable(lastColor, newColor, touchPoint));
-#pragma warning restore CS0618 // Obsolete
+				bottomView.SetBackground(new ColorChangeRevealDrawable(lastColor, newColor, touchPoint));
 			}
 		}
 

--- a/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
@@ -706,10 +706,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		protected override void OnLayout(bool changed, int l, int t, int r, int b)
 		{
 			base.OnLayout(changed, l, t, r, b);
-#pragma warning disable CS0618 // Obsolete
-			AViewCompat.SetClipBounds(this, new ARect(0, 0, Width, Height));
-#pragma warning restore CS0618 // Obsolete
-
+			ClipBounds = new ARect(0, 0, Width, Height);
 			// After a direct (non-animated) scroll operation, we may need to make adjustments
 			// to align the target item; if an adjustment is pending, execute it here.
 			// (Deliberately checking the private member here rather than the property accessor; the accessor will

--- a/src/Controls/src/Core/Platform/Android/Extensions/ButtonExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/ButtonExtensions.cs
@@ -2,7 +2,6 @@
 using System;
 using Android.Graphics.Drawables;
 using AndroidX.AppCompat.Widget;
-using AndroidX.Core.Widget;
 using Google.Android.Material.Button;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Handlers;
@@ -28,8 +27,13 @@ namespace Microsoft.Maui.Controls.Platform
 			var context = materialButton.Context;
 			if (context == null)
 				return;
-			Drawable[] drawables = materialButton.GetCompoundDrawablesRelative();
-			var icon = materialButton.Icon ?? drawables[3];
+			var icon = materialButton.Icon;
+
+			if (icon == null)
+			{
+				Drawable[] drawables = materialButton.GetCompoundDrawablesRelative();
+				icon = drawables[3];
+			}
 
 			if (icon != null &&
 				!String.IsNullOrEmpty(button.Text))

--- a/src/Controls/src/Core/Platform/Android/Extensions/ButtonExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/ButtonExtensions.cs
@@ -1,5 +1,6 @@
 #nullable disable
 using System;
+using Android.Graphics.Drawables;
 using AndroidX.AppCompat.Widget;
 using AndroidX.Core.Widget;
 using Google.Android.Material.Button;
@@ -27,11 +28,8 @@ namespace Microsoft.Maui.Controls.Platform
 			var context = materialButton.Context;
 			if (context == null)
 				return;
-
-			var icon = materialButton.Icon ??
-#pragma warning disable CS0618 // Type or member is obsolete
-						TextViewCompat.GetCompoundDrawablesRelative(materialButton)[3];
-#pragma warning restore CS0618 // Type or member is obsolete
+			Drawable[] drawables = materialButton.GetCompoundDrawablesRelative();
+			var icon = materialButton.Icon ?? drawables[3];
 
 			if (icon != null &&
 				!String.IsNullOrEmpty(button.Text))


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

<!-- Enter description of the fix in this section -->
This pull request focuses on modernizing Android code by removing the use of obsolete APIs and replacing them with their recommended alternatives. The main changes involve updating how backgrounds and drawable resources are set and accessed in various controls, leading to cleaner and more maintainable code.

**Android API Modernization:**

* [`ShellBottomNavViewAppearanceTracker.cs`](diffhunk://#diff-cd17e5a1d02db943f7a8b7a5bb908361c8470e51da34853f148002da06af1b86L97-R102): Replaced `ViewCompat.SetBackground` (obsolete) with the direct `SetBackground` method on `BottomNavigationView` for setting background drawables. [[1]](diffhunk://#diff-cd17e5a1d02db943f7a8b7a5bb908361c8470e51da34853f148002da06af1b86L97-R102) [[2]](diffhunk://#diff-cd17e5a1d02db943f7a8b7a5bb908361c8470e51da34853f148002da06af1b86L120-R119)
* [`MauiRecyclerView.cs`](diffhunk://#diff-3f12aa65dec5508d270135c5bb792d8b7e4f163424aa8946c2346816e3bd1224L709-R709): Updated to use the `ClipBounds` property directly instead of the obsolete `AViewCompat.SetClipBounds` method.

**Drawable Access Improvements:**

* [`ButtonExtensions.cs`](diffhunk://#diff-6c6f61bca24a14710459880e6d7d65a0e18b432cff281546e7867660bb9cca2aL30-R32): Replaced the obsolete `TextViewCompat.GetCompoundDrawablesRelative` with the non-obsolete `GetCompoundDrawablesRelative` method for accessing drawables from a `MaterialButton`.
* [`ButtonExtensions.cs`](diffhunk://#diff-6c6f61bca24a14710459880e6d7d65a0e18b432cff281546e7867660bb9cca2aR3): Added missing `using Android.Graphics.Drawables;` to support the updated drawable handling.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
