### PR TITLE
[Android] SwipeView: Execute SwipeItem commands with TalkBack

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/SwipeView/SwipeViewTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/SwipeView/SwipeViewTests.Android.cs
@@ -69,9 +69,89 @@ namespace Microsoft.Maui.DeviceTests
 
 				await InvokeOnMainThreadAsync(() =>
 				{
+					// A real accessibility service (TalkBack) only dispatches ACTION_CLICK to nodes
+					// that actually advertise the action. Assert discoverability, not just dispatch,
+					// so this test would fail if the node never exposed ACTION_CLICK in the first place.
+					var nodeInfo = AccessibilityNodeInfoCompat.Wrap(swipeItemView.CreateAccessibilityNodeInfo());
+					Assert.Contains(nodeInfo.ActionList, action => action.Id == AccessibilityNodeInfoCompat.AccessibilityActionCompat.ActionClick.Id);
+
 					var actionClickId = AccessibilityNodeInfoCompat.AccessibilityActionCompat.ActionClick.Id;
 #pragma warning disable CS0618 // ViewCompat.PerformAccessibilityAction is obsolete but is the correct API for simulating an accessibility-service action in a test
 					ViewCompat.PerformAccessibilityAction(swipeItemView, actionClickId, null);
+#pragma warning restore CS0618
+				});
+
+				await AssertEventually(() => commandExecuted);
+				Assert.True(commandExecuted);
+			});
+		}
+
+		// Issue #23478 (SwipeItemView variant): SwipeItemView's platform view is a plain ContentViewGroup,
+		// which — unlike SwipeItem's AppCompatButton — is not inherently clickable. This verifies the
+		// accessibility action still reaches the bound Command for custom-content swipe items.
+		[Fact(DisplayName = "SwipeItemView Command Executes Via Accessibility ACTION_CLICK")]
+		public async Task SwipeItemViewCommandExecutesViaAccessibilityActionClick()
+		{
+			SetupBuilder();
+
+			bool commandExecuted = false;
+			ICommand command = new Command(() => commandExecuted = true);
+
+			var content = new Grid
+			{
+				HeightRequest = 60,
+				Background = new SolidPaint(Colors.White)
+			};
+
+			var swipeItemContent = new Grid
+			{
+				BackgroundColor = Colors.Red,
+				WidthRequest = 60,
+			};
+
+			var swipeItemView = new SwipeItemView
+			{
+				Content = swipeItemContent,
+				Command = command
+			};
+
+			var swipeItems = new SwipeItems
+			{
+				swipeItemView
+			};
+
+			var swipeView = new SwipeView()
+			{
+				HeightRequest = 60,
+				LeftItems = swipeItems,
+				Content = content
+			};
+
+			await AttachAndRun(swipeView, async (handler) =>
+			{
+				var platformView = ((SwipeViewHandler)handler).PlatformView;
+
+				swipeView.Open(OpenSwipeItem.LeftItems, false);
+
+				// The SwipeView adds the action-item container as a child dynamically when opened.
+				await AssertEventually(() => platformView.ChildCount > 1);
+
+				var actionView = platformView.GetChildAt(1) as ViewGroup;
+				Assert.NotNull(actionView);
+
+				await AssertEventually(() => actionView.ChildCount > 0);
+
+				var swipeItemPlatformView = actionView.GetChildAt(0);
+				Assert.NotNull(swipeItemPlatformView);
+
+				await InvokeOnMainThreadAsync(() =>
+				{
+					var nodeInfo = AccessibilityNodeInfoCompat.Wrap(swipeItemPlatformView.CreateAccessibilityNodeInfo());
+					Assert.Contains(nodeInfo.ActionList, action => action.Id == AccessibilityNodeInfoCompat.AccessibilityActionCompat.ActionClick.Id);
+
+					var actionClickId = AccessibilityNodeInfoCompat.AccessibilityActionCompat.ActionClick.Id;
+#pragma warning disable CS0618 // ViewCompat.PerformAccessibilityAction is obsolete but is the correct API for simulating an accessibility-service action in a test
+					ViewCompat.PerformAccessibilityAction(swipeItemPlatformView, actionClickId, null);
 #pragma warning restore CS0618
 				});
 

--- a/src/Controls/tests/DeviceTests/Elements/SwipeView/SwipeViewTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/SwipeView/SwipeViewTests.Android.cs
@@ -1,6 +1,9 @@
 ﻿using System.ComponentModel;
 using System.Threading.Tasks;
+using System.Windows.Input;
 using Android.Views;
+using AndroidX.Core.View;
+using AndroidX.Core.View.Accessibility;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
@@ -12,6 +15,71 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class SwipeViewTests : ControlsHandlerTestBase
 	{
+		// Issue #23478: TalkBack's "double tap to activate" invokes View.PerformAccessibilityAction(ACTION_CLICK)
+		// on the focused SwipeItem, a code path distinct from the manual touch hit-testing SwipeView normally
+		// relies on to execute commands. This verifies the accessibility action reaches the bound Command.
+		[Fact(DisplayName = "SwipeItem Command Executes Via Accessibility ACTION_CLICK")]
+		public async Task SwipeItemCommandExecutesViaAccessibilityActionClick()
+		{
+			SetupBuilder();
+
+			bool commandExecuted = false;
+			ICommand command = new Command(() => commandExecuted = true);
+
+			var content = new Grid
+			{
+				HeightRequest = 60,
+				Background = new SolidPaint(Colors.White)
+			};
+
+			var swipeItem = new SwipeItem
+			{
+				BackgroundColor = Colors.Red,
+				Command = command
+			};
+
+			var swipeItems = new SwipeItems
+			{
+				swipeItem
+			};
+
+			var swipeView = new SwipeView()
+			{
+				HeightRequest = 60,
+				LeftItems = swipeItems,
+				Content = content
+			};
+
+			await AttachAndRun(swipeView, async (handler) =>
+			{
+				var platformView = ((SwipeViewHandler)handler).PlatformView;
+
+				swipeView.Open(OpenSwipeItem.LeftItems, false);
+
+				// The SwipeView adds the action-item container as a child dynamically when opened.
+				await AssertEventually(() => platformView.ChildCount > 1);
+
+				var actionView = platformView.GetChildAt(1) as ViewGroup;
+				Assert.NotNull(actionView);
+
+				await AssertEventually(() => actionView.ChildCount > 0);
+
+				var swipeItemView = actionView.GetChildAt(0);
+				Assert.NotNull(swipeItemView);
+
+				await InvokeOnMainThreadAsync(() =>
+				{
+					var actionClickId = AccessibilityNodeInfoCompat.AccessibilityActionCompat.ActionClick.Id;
+#pragma warning disable CS0618 // ViewCompat.PerformAccessibilityAction is obsolete but is the correct API for simulating an accessibility-service action in a test
+					ViewCompat.PerformAccessibilityAction(swipeItemView, actionClickId, null);
+#pragma warning restore CS0618
+				});
+
+				await AssertEventually(() => commandExecuted);
+				Assert.True(commandExecuted);
+			});
+		}
+
 		[Fact(DisplayName = "SwipeItem Size Initializes Correctly")]
 		public async Task SwipeItemSizeInitializesCorrectly()
 		{

--- a/src/Core/src/Platform/Android/MauiSwipeView.cs
+++ b/src/Core/src/Platform/Android/MauiSwipeView.cs
@@ -606,15 +606,8 @@ namespace Microsoft.Maui.Platform
 						_swipeItems.Add(item, swipeItem);
 					}
 
-					if (swipeItem is not null)
-					{
-						swipeItems.Add(swipeItem);
-
-						if (item is not null)
-						{
-							AttachSwipeItemAccessibilityDelegate(swipeItem);
-						}
-					}
+					swipeItems.Add(swipeItem);
+					AttachSwipeItemAccessibilityDelegate(swipeItem);
 				}
 			}
 
@@ -1356,31 +1349,46 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		// TalkBack's "double tap to activate" calls View.PerformAccessibilityAction(ACTION_CLICK).
-		// Swipe-item commands normally execute via manual touch hit-testing (see ProcessTouchSwipeItems
-		// above), so the swipe button has no OnClickListener and PerformClick() is a no-op for TalkBack
-		// users. We install an ACTION_CLICK handler by wrapping the current AccessibilityDelegateCompat and
-		// intercepting ACTION_CLICK in a SwipeItemAccessibilityDelegate. The wrapper delegates all other
-		// accessibility behavior to the original delegate, so this doesn't disturb existing behavior.
 		void AttachSwipeItemAccessibilityDelegate(AView swipeItemView)
 		{
+			// Avoid re-wrapping an already-attached delegate;
+			if (ViewCompat.GetAccessibilityDelegate(swipeItemView) is SwipeItemAccessibilityDelegate)
+			{
+				return;
+			}
+
 			var currentDelegate = ViewCompat.GetAccessibilityDelegate(swipeItemView);
 			ViewCompat.SetAccessibilityDelegate(swipeItemView, new SwipeItemAccessibilityDelegate(this, currentDelegate));
 		}
 
 		bool TryExecuteSwipeItemFromAccessibility(AView? host)
 		{
-			int index = _actionView?.IndexOfChild(host) ?? -1;
-			var swipeItems = GetSwipeItemsByDirection();
-
-			if (_isResettingSwipe || swipeItems is null || index < 0 || index >= swipeItems.Count)
+			if (_isResettingSwipe || host is null || host.Visibility != ViewStates.Visible)
 			{
 				return false;
 			}
 
-			ExecuteSwipeItem(swipeItems[index]);
+			ISwipeItem? swipeItem = null;
 
-			if (swipeItems.SwipeBehaviorOnInvoked != SwipeBehaviorOnInvoked.RemainOpen)
+			foreach (var kvp in _swipeItems)
+			{
+				if (ReferenceEquals(kvp.Value, host))
+				{
+					swipeItem = kvp.Key;
+					break;
+				}
+			}
+
+			if (swipeItem is null)
+			{
+				return false;
+			}
+
+			ExecuteSwipeItem(swipeItem);
+
+			var swipeItems = GetSwipeItemsByDirection();
+
+			if (swipeItems?.SwipeBehaviorOnInvoked != SwipeBehaviorOnInvoked.RemainOpen)
 			{
 				ResetSwipe();
 			}
@@ -1391,6 +1399,19 @@ namespace Microsoft.Maui.Platform
 		sealed class SwipeItemAccessibilityDelegate(MauiSwipeView swipeView, AccessibilityDelegateCompat? originalDelegate) : AccessibilityDelegateCompatWrapper(originalDelegate)
 		{
 			readonly WeakReference<MauiSwipeView> _swipeViewRef = new(swipeView);
+
+			public override void OnInitializeAccessibilityNodeInfo(AView? host, AccessibilityNodeInfoCompat? info)
+			{
+				base.OnInitializeAccessibilityNodeInfo(host, info);
+
+				//Without this, non-clickable platform views never expose the action, so ACTION_CLICK
+				// is never dispatched to PerformAccessibilityAction below.
+				if (info is not null)
+				{
+					info.AddAction(AccessibilityNodeInfoCompat.AccessibilityActionCompat.ActionClick);
+					info.Clickable = true;
+				}
+			}
 
 			public override bool PerformAccessibilityAction(AView? host, int action, Bundle? args)
 			{

--- a/src/Core/src/Platform/Android/MauiSwipeView.cs
+++ b/src/Core/src/Platform/Android/MauiSwipeView.cs
@@ -1359,9 +1359,9 @@ namespace Microsoft.Maui.Platform
 		// TalkBack's "double tap to activate" calls View.PerformAccessibilityAction(ACTION_CLICK).
 		// Swipe-item commands normally execute via manual touch hit-testing (see ProcessTouchSwipeItems
 		// above), so the swipe button has no OnClickListener and PerformClick() is a no-op for TalkBack
-		// users. ReplaceAccessibilityAction installs an ACTION_CLICK handler without a custom
-		// AccessibilityDelegateCompat subclass; AndroidX composes it with any delegate already on the
-		// view, so this doesn't disturb touch dispatch or existing accessibility behavior.
+		// users. We install an ACTION_CLICK handler by wrapping the current AccessibilityDelegateCompat and
+		// intercepting ACTION_CLICK in a SwipeItemAccessibilityDelegate. The wrapper delegates all other
+		// accessibility behavior to the original delegate, so this doesn't disturb existing behavior.
 		void AttachSwipeItemAccessibilityDelegate(AView swipeItemView)
 		{
 			var currentDelegate = ViewCompat.GetAccessibilityDelegate(swipeItemView);
@@ -1396,10 +1396,12 @@ namespace Microsoft.Maui.Platform
 			{
 				if (host is not null &&
 					action == AccessibilityNodeInfoCompat.AccessibilityActionCompat.ActionClick?.Id &&
-					_swipeViewRef.TryGetTarget(out var swipeView)
-					)
+					_swipeViewRef.TryGetTarget(out var swipeView))
 				{
-					return swipeView.TryExecuteSwipeItemFromAccessibility(host);
+					if (swipeView.TryExecuteSwipeItemFromAccessibility(host))
+					{
+						return true;
+					}
 				}
 				return base.PerformAccessibilityAction(host, action, args);
 			}

--- a/src/Core/src/Platform/Android/MauiSwipeView.cs
+++ b/src/Core/src/Platform/Android/MauiSwipeView.cs
@@ -2,9 +2,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using Android.Content;
+using Android.OS;
 using Android.Views;
 using Android.Widget;
 using AndroidX.AppCompat.Widget;
+using AndroidX.Core.View;
+using AndroidX.Core.View.Accessibility;
 using AndroidX.Core.Widget;
 using AndroidX.RecyclerView.Widget;
 using Microsoft.Maui.Graphics;
@@ -603,8 +606,15 @@ namespace Microsoft.Maui.Platform
 						_swipeItems.Add(item, swipeItem);
 					}
 
-					if (swipeItem != null)
+					if (swipeItem is not null)
+					{
 						swipeItems.Add(swipeItem);
+
+						if (item is not null)
+						{
+							AttachSwipeItemAccessibilityDelegate(swipeItem);
+						}
+					}
 				}
 			}
 
@@ -1343,6 +1353,52 @@ namespace Microsoft.Maui.Platform
 						break;
 					}
 				}
+			}
+		}
+
+		// TalkBack's "double tap to activate" calls View.PerformAccessibilityAction(ACTION_CLICK).
+		// Swipe-item commands normally execute via manual touch hit-testing (see ProcessTouchSwipeItems
+		// above), so the swipe button has no OnClickListener and PerformClick() is a no-op for TalkBack
+		// users. ReplaceAccessibilityAction installs an ACTION_CLICK handler without a custom
+		// AccessibilityDelegateCompat subclass; AndroidX composes it with any delegate already on the
+		// view, so this doesn't disturb touch dispatch or existing accessibility behavior.
+		void AttachSwipeItemAccessibilityDelegate(AView swipeItemView)
+		{
+			var currentDelegate = ViewCompat.GetAccessibilityDelegate(swipeItemView);
+			ViewCompat.SetAccessibilityDelegate(swipeItemView, new SwipeItemAccessibilityDelegate(this, currentDelegate));
+		}
+
+		bool TryExecuteSwipeItemFromAccessibility(AView? host)
+		{
+			int index = _actionView?.IndexOfChild(host) ?? -1;
+			var swipeItems = GetSwipeItemsByDirection();
+
+			if (_isResettingSwipe || swipeItems is null)
+			{
+				return false;
+			}
+
+			ExecuteSwipeItem(swipeItems[index]);
+
+			if (swipeItems.SwipeBehaviorOnInvoked != SwipeBehaviorOnInvoked.RemainOpen)
+			{
+				ResetSwipe();
+			}
+
+			return true;
+		}
+
+		sealed class SwipeItemAccessibilityDelegate(MauiSwipeView swipeView, AccessibilityDelegateCompat? originalDelegate) : AccessibilityDelegateCompatWrapper(originalDelegate)
+		{
+			public override bool PerformAccessibilityAction(AView? host, int action, Bundle? args)
+			{
+				if (host is not null &&
+					action == AccessibilityNodeInfoCompat.AccessibilityActionCompat.ActionClick?.Id
+					)
+				{
+					return swipeView.TryExecuteSwipeItemFromAccessibility(host);
+				}
+				return base.PerformAccessibilityAction(host, action, args);
 			}
 		}
 

--- a/src/Core/src/Platform/Android/MauiSwipeView.cs
+++ b/src/Core/src/Platform/Android/MauiSwipeView.cs
@@ -1373,7 +1373,7 @@ namespace Microsoft.Maui.Platform
 			int index = _actionView?.IndexOfChild(host) ?? -1;
 			var swipeItems = GetSwipeItemsByDirection();
 
-			if (_isResettingSwipe || swipeItems is null)
+			if (_isResettingSwipe || swipeItems is null || index < 0 || index >= swipeItems.Count)
 			{
 				return false;
 			}
@@ -1390,10 +1390,13 @@ namespace Microsoft.Maui.Platform
 
 		sealed class SwipeItemAccessibilityDelegate(MauiSwipeView swipeView, AccessibilityDelegateCompat? originalDelegate) : AccessibilityDelegateCompatWrapper(originalDelegate)
 		{
+			readonly WeakReference<MauiSwipeView> _swipeViewRef = new(swipeView);
+
 			public override bool PerformAccessibilityAction(AView? host, int action, Bundle? args)
 			{
 				if (host is not null &&
-					action == AccessibilityNodeInfoCompat.AccessibilityActionCompat.ActionClick?.Id
+					action == AccessibilityNodeInfoCompat.AccessibilityActionCompat.ActionClick?.Id &&
+					_swipeViewRef.TryGetTarget(out var swipeView)
 					)
 				{
 					return swipeView.TryExecuteSwipeItemFromAccessibility(host);


### PR DESCRIPTION
<!-- Please keep the note below for people who find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment whether this change resolves your issue. Thank you!

### Description of Change

This change improves Android accessibility for `SwipeView` by ensuring that revealed swipe-item commands execute when users activate them through accessibility services such as TalkBack.

TalkBack's "double tap to activate" dispatches `ACTION_CLICK` to the focused native view, while `MauiSwipeView` previously executed swipe items only through its touch hit-testing path. The submitted fix bridges that accessibility action to the existing swipe-item invocation behavior.

**Accessibility improvements:**

- Adds `AttachSwipeItemAccessibilityDelegate` in `MauiSwipeView` to install an accessibility delegate on each materialized swipe-item view.
- Adds the sealed `SwipeItemAccessibilityDelegate`, which derives from `AccessibilityDelegateCompatWrapper` so existing accessibility behavior is preserved.
- Advertises `ACTION_CLICK`, handles it through `PerformAccessibilityAction`, resolves the corresponding `ISwipeItem`, executes its command, and applies the existing `SwipeBehaviorOnInvoked` behavior.
- Uses a weak reference to the owning `MauiSwipeView` and delegates unhandled accessibility actions to the prior delegate.
- Updates `UpdateSwipeItems()` to attach the delegate as each swipe-item platform view is created.
- Adds the required `AndroidX.Core.View` and `AndroidX.Core.View.Accessibility` imports.

**Testing:**

- Adds `SwipeItemCommandExecutesViaAccessibilityActionClick` to verify `ACTION_CLICK` is exposed and executes a `SwipeItem` command.
- Adds `SwipeItemViewCommandExecutesViaAccessibilityActionClick` to verify the same behavior for a custom-content `SwipeItemView`, whose Android platform view is not inherently clickable.

### Issues Fixed

Fixes #23478

### Tested the behavior in the following platforms

- [ ] Windows
- [x] Android
- [ ] iOS
- [ ] Mac

| Before Issue Fix | After Issue Fix |
|---|---|
| <video src="https://github.com/user-attachments/assets/e1e141c3-d3d2-4802-89cf-ef2b476b2cba"> | <video src="https://github.com/user-attachments/assets/55fd6980-6ca2-4f5a-a4f4-096a9fe4bdcb"> |