### PR TITLE
[XAML] Re-enable Incremental Hot Reload by default in Debug

### DIFF
--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -10,11 +10,13 @@
     <_MauiXamlInflator Condition="' $(MauiXamlInflator)' != '' ">$(MauiXamlInflator)</_MauiXamlInflator>
     <_MauiXamlInflator Condition=" '$(MauiXamlInflator)' == '' ">SourceGen</_MauiXamlInflator>
 
-    <!-- XAML Incremental Hot Reload (XIHR): off by default. Hot reload is a dev-time feature; when
-         enabled it emits per-page registry calls and keeps the runtime feature switch on. Set
-         <EnableMauiIncrementalHotReload>true</...> to opt in (legacy XAML Hot Reload remains the
-         default fallback). Resolves to an explicit true/false so the value always flows to the source
-         generator and runtime config. -->
+    <!-- XAML Incremental Hot Reload (XIHR): on by default for .NET 11 projects (Preview 7). Hot reload is a
+         dev-time feature; when enabled it emits per-page registry calls and keeps the runtime feature
+         switch on, so it defaults on for Debug builds only and stays off for Release/publish, where the
+         registry calls and runtime switch trim away. Set <EnableMauiIncrementalHotReload>false</...> to
+         opt out (legacy XAML Hot Reload remains available as a fallback). Resolves to an explicit
+         true/false so the value always flows to the source generator and runtime config. -->
+    <EnableMauiIncrementalHotReload Condition="'$(EnableMauiIncrementalHotReload)' == '' and '$(Configuration)' == 'Debug'">true</EnableMauiIncrementalHotReload>
     <EnableMauiIncrementalHotReload Condition="'$(EnableMauiIncrementalHotReload)' == ''">false</EnableMauiIncrementalHotReload>
 
     <!-- XAML Hot Reload mode for IDE communication (Legacy or SourceGen) -->

--- a/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
@@ -375,7 +375,7 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			project.Save(projectFile);
 			// Pin XIHR off: this test covers the legacy ResourceProvider2 hot-reload fallback
 			// (InitializeComponentRuntime), which XAML Incremental Hot Reload intentionally supersedes
-			// when enabled. XIHR is off by default (opt-in), but pin it explicitly here. See dotnet/maui#36682.
+			// when enabled (on by default in Debug). See dotnet/maui#36682.
 			Build(projectFile, additionalArgs: $"-c {configuration} -p:MauiXamlInflator=SourceGen -p:EnableMauiIncrementalHotReload=false -p:EmitCompilerGeneratedFiles=True -p:CompilerGeneratedFilesOutputPath=Generated");
 
 			var generatorDirectory = IOPath.Combine(tempDirectory, "Generated", "Microsoft.Maui.Controls.SourceGen", "Microsoft.Maui.Controls.SourceGen.XamlGenerator");


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description

Re-enables XAML Incremental Hot Reload (XIHR) by default for Debug builds on `net11.0`. This undoes the temporary opt-out from #36832 now that the deterministic generation and Edit-and-Continue stability fixes from #36833 are merged.

### Behavior

| Configuration | `EnableMauiIncrementalHotReload` | `MauiXamlHotReload` |
|---|---|---|
| Debug (default) | `true` | `SourceGen` |
| Release / publish (default) | `false` | `Legacy` |
| Debug + explicit `false` | `false` | `Legacy` |
| Release + explicit `true` | `true` | `SourceGen` |

The legacy fallback test remains explicitly pinned to XIHR-off and its comment now reflects the restored Debug default.

### Testing

- Evaluated the MSBuild property cascade for the four configurations above.
- `MSBuildTests.BuildAProject`
- `MSBuildTests.HotReloadSupportForXSG` (Debug and Release)