### PR TITLE
Remove broken target matchers from inter-branch merge policy

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -731,8 +731,6 @@ configuration:
       - titleContains:
           pattern: '^\[automated\] Merge branch ''main'' => ''net11\.0''$'
           isRegex: True
-      - targetsBranch:
-          branch: net11.0
       then:
       - approvePullRequest:
           comment: Auto-approved automated inter-branch merge.
@@ -751,8 +749,6 @@ configuration:
       - titleContains:
           pattern: '^\[automated\] Merge branch ''net11\.0'' => ''release/11\.0\.1xx-preview7''$'
           isRegex: True
-      - targetsBranch:
-          branch: release/11.0.1xx-preview7
       then:
       - approvePullRequest:
           comment: Auto-approved automated inter-branch merge.
@@ -771,8 +767,6 @@ configuration:
       - titleContains:
           pattern: '^\[automated\] Merge branch ''net11\.0'' => ''release/11\.0\.1xx-rc1''$'
           isRegex: True
-      - targetsBranch:
-          branch: release/11.0.1xx-rc1
       then:
       - approvePullRequest:
           comment: Auto-approved automated inter-branch merge.
@@ -791,8 +785,6 @@ configuration:
       - titleContains:
           pattern: '^\[automated\] Merge branch ''net11\.0'' => ''release/11\.0\.1xx-rc2''$'
           isRegex: True
-      - targetsBranch:
-          branch: release/11.0.1xx-rc2
       then:
       - approvePullRequest:
           comment: Auto-approved automated inter-branch merge.


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

Remove `targetsBranch` from the four Policy Service rules that auto-approve and enable auto-merge for the deterministic inter-branch PRs:

- `main` to `net11.0`
- `net11.0` to preview7, rc1, and rc2

The rules retain the fresh `Opened` event, exact `github-actions[bot]` sender, anchored exact title regex, approval action, and `merge` auto-merge method. No unrelated policy changes are included.

## Evidence and rationale

A hosted deterministic canary in `dotnet/maui-vigilant-guide` isolated `targetsBranch` as the failing matcher:

- `dotnet/maui-vigilant-guide#748` received the trusted Actions `Opened` event and matched the exact title, but the otherwise-identical rule with `targetsBranch: main` did not fire.
- `dotnet/maui-vigilant-guide#750` received `dotnet-policy-service` approval after only `targetsBranch` was removed.
- `dotnet/maui-vigilant-guide#752` again received approval, and GitOps schema validation accepted `Squash`. Full auto-merge could not be exercised because vigilant-guide has `allow_auto_merge=false` and the available token lacks repository-admin PATCH permission. MAUI has `allow_auto_merge=true`.

The title regexes encode each allowed source/target pair exactly, and only trusted repository Actions can be the event sender, so removing the broken branch matcher does not broaden the authorized automation path beyond those deterministic PRs.

## Validation

- YAML parse
- Focused structural assertions against `origin/main`, including exact sender, action, title regexes, approval, merge method, and no changes beyond the four matcher removals
- `git diff --check`
- GitOps Policy Service schema validation requested through this PR
