### PR TITLE
[ci] Add net11.0 as production branch and drop net10.0 from nightly

### DIFF
--- a/.azuredevops/policies/branchClassification.yml
+++ b/.azuredevops/policies/branchClassification.yml
@@ -10,6 +10,7 @@ configuration:
       - main
       - release/*
       - internal/release/*
+      - net11.0
       - net10.0
       - net9.0
       - inflight/current

--- a/eng/pipelines/ci-official.yml
+++ b/eng/pipelines/ci-official.yml
@@ -29,6 +29,10 @@ schedules:
     - main
     - net*.0
     - inflight/current
+    exclude:
+    # net10.0 is no longer an active development branch; .NET 10 work happens
+    # in main and release/10.0.1xx-* so there is no need for a nightly build.
+    - net10.0
   always: true
 
 variables:


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Two CI configuration fixes.

**1. Add `net11.0` to the production branch classification**

The internal official build fails the 1ES PT branch validation on the APIScan stage:

```
1ES PT Non-Blocking Error: Branch validation failed. Production releases must use a
production branch: main, release/*, internal/release/*, net10.0, net9.0, inflight/current
```

That branch list comes from `.azuredevops/policies/branchClassification.yml`. `net11.0` was already added to that file **on the `net11.0` branch** (commit 56d631f, January 2026) — but Azure DevOps reads policy-as-code from the repository's **default branch**, which is `main` on the `dnceng/internal/dotnet-maui` mirror. Because `main` never received the entry, `net11.0` is still classified as `nonproduction` and the APIScan release job (`type: releaseJob`, `isProduction: true`) fails branch validation on every net11.0 official build.

Adding the entry to `main` is what actually takes effect.

**2. Drop the dead `net10.0` branch from the nightly official build**

The 5:00 UTC schedule in `eng/pipelines/ci-official.yml` includes the `net*.0` glob, which matches `net9.0`, `net10.0` and `net11.0`. The `net10.0` branch is dead — last commit 2026-06-26 — since .NET 10 work now happens in `main` and `release/10.0.1xx-*`. It no longer needs a nightly official build.

The `net*.0` glob is intentionally kept so future branches (e.g. `net12.0`) are still picked up automatically; only an explicit `net10.0` exclude is added, and an exact branch match takes precedence over the glob.

A companion PR makes the same nightly-schedule change on the `net11.0` branch.

### Issues Fixed

None (CI infrastructure fix).