### PR TITLE
[ci] Exclude dead net10.0 branch from nightly official build

### DIFF
--- a/eng/pipelines/ci-official.yml
+++ b/eng/pipelines/ci-official.yml
@@ -29,6 +29,10 @@ schedules:
     - main
     - net*.0
     - inflight/current
+    exclude:
+    # net10.0 is no longer an active development branch; .NET 10 work happens
+    # in main and release/10.0.1xx-* so there is no need for a nightly build.
+    - net10.0
   always: true
 
 variables:


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

The 5:00 UTC scheduled official build in `eng/pipelines/ci-official.yml` includes the `net*.0` glob, which matches `net9.0`, `net10.0` and `net11.0`.

The `net10.0` branch is dead — last commit 2026-06-26 — since .NET 10 work now happens in `main` and `release/10.0.1xx-*`. It no longer needs a nightly official build.

The `net*.0` glob is intentionally kept so future branches (e.g. `net12.0`) are still picked up automatically; only an explicit `net10.0` exclude is added, and an exact branch match takes precedence over the glob.

This is the `net11.0` companion to #37160, which makes the same nightly-schedule change on `main` and additionally adds `net11.0` to the production branch classification (that part only takes effect from `main`, so it is not duplicated here).

### Issues Fixed

None (CI infrastructure fix).
