### PR TITLE
Recover /review commands missed by Actions webhooks

### DIFF
--- a/.github/docs/pr-review-workflow.md
+++ b/.github/docs/pr-review-workflow.md
@@ -63,6 +63,8 @@ The trigger is implemented by `.github/workflows/review-trigger.yml`. It:
 
 The workflow intentionally does not handle `/review tests`; that subcommand is reserved for the test-failure review workflow.
 
+GitHub Actions webhook deliveries can occasionally be delayed or dropped during an Actions incident. A deterministic scheduled fallback (`.github/workflows/review-trigger-recovery.yml`) polls recent commands, waits 10 minutes to avoid racing normal delivery, rechecks the commenter's current repository permission, and dispatches the same trusted review workflow. Processed commands are marked so a delayed webhook cannot trigger a duplicate review.
+
 **Note**: Command comments are minimized (collapsed as "Resolved") after authorization to reduce conversation clutter while preserving the comment history. Unauthorized or malformed command comments remain fully visible.
 
 ### Platform inference
@@ -262,7 +264,7 @@ Important safeguards:
 
 | Symptom | Likely cause | What to do |
 | --- | --- | --- |
-| `/review` does nothing | The commenter does not have write/maintain/admin access, or the comment is not on a PR. | Ask a maintainer to run the command on the PR. |
+| `/review` does nothing | The commenter does not have write/maintain/admin access, the comment is not on a PR, or GitHub Actions delayed the webhook. | Authorized commands should be recovered automatically within about 20 minutes. Check GitHub Status if Actions is degraded. |
 | `/review` used the wrong platform | Platform labels were missing or ambiguous. | Re-run with an explicit platform, for example `/review ios`. |
 | `/review tests` says `Insufficient data` | Build/log/Helix evidence was inaccessible or incomplete. | Re-run later, provide a build ID, or run locally with Azure CLI/AzDO auth. |
 | The AI Summary looks stale | New commits or author comments landed after the last review. | Wait for the automatic rerun queue, or ask a maintainer to run `/review` for an immediate review. |
@@ -272,6 +274,8 @@ Important safeguards:
 ## Related files
 
 - `.github/workflows/review-trigger.yml` — GitHub comment trigger for `/review`.
+- `.github/workflows/review-trigger-recovery.yml` — scheduled fallback for missed `/review` webhooks.
+- `.github/scripts/Recover-MissedReviewCommands.ps1` — deterministic recovery and duplicate-prevention logic.
 - `eng/pipelines/ci-copilot.yml` — Azure DevOps PR review pipeline.
 - `.github/scripts/Review-PR.ps1` — local script orchestrating full PR review phases.
 - `.github/scripts/post-ai-summary-comment.ps1` — AI Summary comment formatter.

--- a/.github/scripts/Recover-MissedReviewCommands.Tests.ps1
+++ b/.github/scripts/Recover-MissedReviewCommands.Tests.ps1
@@ -1,0 +1,186 @@
+#!/usr/bin/env pwsh
+#Requires -Modules Pester
+
+BeforeAll {
+    $previousErrorActionPreference = $ErrorActionPreference
+    try {
+        . "$PSScriptRoot/Recover-MissedReviewCommands.ps1"
+    } finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
+
+    function New-RecoveryTestComment {
+        param(
+            [Int64]$Id,
+            [string]$Body,
+            [string]$CreatedAt,
+            [int]$PRNumber = 37148,
+            [string]$Login = 'maintainer',
+            [string]$NodeId = "IC_$Id"
+        )
+
+        [pscustomobject]@{
+            id = $Id
+            node_id = $NodeId
+            body = $Body
+            created_at = $CreatedAt
+            issue_url = "https://api.github.com/repos/dotnet/maui/issues/$PRNumber"
+            user = [pscustomobject]@{ login = $Login }
+        }
+    }
+}
+
+Describe 'Select-ReviewCommandCandidates' {
+    It 'selects only aged normal review commands and preserves parsed options' {
+        $now = [datetimeoffset]'2026-08-06T22:00:00Z'
+        $comments = @(
+            New-RecoveryTestComment -Id 1 -Body '/review -b improved-reviewer -p android' -CreatedAt '2026-08-06T21:43:40Z'
+            New-RecoveryTestComment -Id 2 -Body '/review ios' -CreatedAt '2026-08-06T21:55:00Z'
+            New-RecoveryTestComment -Id 3 -Body '/review tests' -CreatedAt '2026-08-06T21:30:00Z'
+            New-RecoveryTestComment -Id 4 -Body '/review rerun' -CreatedAt '2026-08-06T21:20:00Z'
+            New-RecoveryTestComment -Id 5 -Body 'please review' -CreatedAt '2026-08-06T21:10:00Z'
+            New-RecoveryTestComment -Id 6 -Body '/review windows' -CreatedAt '2026-08-05T20:00:00Z'
+        )
+
+        $result = @(Select-ReviewCommandCandidates `
+            -Comments $comments `
+            -LookbackHours 24 `
+            -MinimumAgeMinutes 10 `
+            -Now $now)
+
+        $result.Count | Should -Be 1
+        $result[0].CommentId | Should -Be 1
+        $result[0].PRNumber | Should -Be 37148
+        $result[0].Platform | Should -Be 'android'
+        $result[0].PipelineRef | Should -Be 'improved-reviewer'
+    }
+}
+
+Describe 'Invoke-MissedReviewCommandRecovery' {
+    BeforeEach {
+        $script:Now = [datetimeoffset]'2026-08-06T22:00:00Z'
+        $script:Comment = New-RecoveryTestComment `
+            -Id 5209319531 `
+            -Body '/review -b improved-reviewer -p android' `
+            -CreatedAt '2026-08-06T21:43:40Z'
+
+        Mock Get-RecentIssueComments { @($script:Comment) }
+        Mock Test-ReviewCommentIsMinimized { $false }
+        Mock Test-ReviewCommentHasRecoveryMarker { $false }
+        Mock Get-ReviewRecoveryPullRequest {
+            [pscustomobject]@{ number = 37148; state = 'open' }
+        }
+        Mock Test-ReviewOptionLoginTrusted { $true }
+        Mock Invoke-ReviewWorkflowDispatch
+        Mock Add-ReviewRecoveryMarker { $true }
+        Mock Hide-ReviewCommandComment { $true }
+    }
+
+    It 'dispatches an authorized unprocessed command with its original options' {
+        $result = Invoke-MissedReviewCommandRecovery -Now $script:Now
+
+        $result.Recovered.Count | Should -Be 1
+        Should -Invoke Invoke-ReviewWorkflowDispatch -Times 1 -Exactly -ParameterFilter {
+            $PRNumber -eq 37148 -and
+            $Platform -eq 'android' -and
+            $PipelineRef -eq 'improved-reviewer'
+        }
+        Should -Invoke Add-ReviewRecoveryMarker -Times 1 -Exactly -ParameterFilter {
+            $CommentId -eq 5209319531
+        }
+        Should -Invoke Hide-ReviewCommandComment -Times 1 -Exactly -ParameterFilter {
+            $NodeId -eq 'IC_5209319531'
+        }
+    }
+
+    It 'does not dispatch minimized commands' {
+        Mock Test-ReviewCommentIsMinimized { $true }
+
+        $result = Invoke-MissedReviewCommandRecovery -Now $script:Now
+
+        $result.Recovered.Count | Should -Be 0
+        Should -Invoke Invoke-ReviewWorkflowDispatch -Times 0 -Exactly
+        Should -Invoke Test-ReviewCommentHasRecoveryMarker -Times 0 -Exactly
+    }
+
+    It 'does not dispatch commands already marked by the recovery bot' {
+        Mock Test-ReviewCommentHasRecoveryMarker { $true }
+
+        $result = Invoke-MissedReviewCommandRecovery -Now $script:Now
+
+        $result.Recovered.Count | Should -Be 0
+        Should -Invoke Invoke-ReviewWorkflowDispatch -Times 0 -Exactly
+    }
+
+    It 'does not dispatch commands from users without current write access' {
+        Mock Test-ReviewOptionLoginTrusted { $false }
+
+        $result = Invoke-MissedReviewCommandRecovery -Now $script:Now
+
+        $result.Recovered.Count | Should -Be 0
+        Should -Invoke Invoke-ReviewWorkflowDispatch -Times 0 -Exactly
+    }
+
+    It 'keeps manual dry runs read-only' {
+        $result = Invoke-MissedReviewCommandRecovery -Now $script:Now -DryRun
+
+        $result.Recovered.Count | Should -Be 1
+        $result.Recovered[0].DryRun | Should -BeTrue
+        Should -Invoke Invoke-ReviewWorkflowDispatch -Times 0 -Exactly
+        Should -Invoke Add-ReviewRecoveryMarker -Times 0 -Exactly
+        Should -Invoke Hide-ReviewCommandComment -Times 0 -Exactly
+    }
+
+    It 'requires at least one durable acknowledgement after dispatch' {
+        Mock Add-ReviewRecoveryMarker { $false }
+        Mock Hide-ReviewCommandComment { $false }
+
+        { Invoke-MissedReviewCommandRecovery -Now $script:Now } |
+            Should -Throw '*could not persist a recovery acknowledgement*'
+    }
+
+    It 'accepts minimized state when the reaction marker write fails' {
+        Mock Add-ReviewRecoveryMarker { $false }
+
+        $result = Invoke-MissedReviewCommandRecovery -Now $script:Now
+
+        $result.Recovered.Count | Should -Be 1
+        Should -Invoke Hide-ReviewCommandComment -Times 1 -Exactly
+    }
+}
+
+Describe 'review trigger recovery workflow safety' {
+    BeforeAll {
+        $workflowPath = Join-Path $PSScriptRoot '..' 'workflows' 'review-trigger-recovery.yml' |
+            Resolve-Path |
+            Select-Object -ExpandProperty Path
+        $script:RecoveryWorkflow = Get-Content -Raw -LiteralPath $workflowPath
+    }
+
+    It 'runs only on a schedule and never on a pull request or manual branch' {
+        $script:RecoveryWorkflow | Should -Match "(?m)^    - cron: '\*/10 \* \* \* \*'$"
+        $script:RecoveryWorkflow | Should -Not -Match 'pull_request_target'
+        $script:RecoveryWorkflow | Should -Not -Match 'workflow_dispatch'
+    }
+
+    It 'pins checkout to trusted main' {
+        $script:RecoveryWorkflow | Should -Match '(?m)^          ref: main$'
+        $script:RecoveryWorkflow | Should -Match '(?m)^          persist-credentials: false$'
+    }
+
+    It 'uses only the permissions needed to poll, dispatch, and mark comments' {
+        $script:RecoveryWorkflow | Should -Match '(?m)^      actions: write$'
+        $script:RecoveryWorkflow | Should -Match '(?m)^      contents: read$'
+        $script:RecoveryWorkflow | Should -Match '(?m)^      issues: write$'
+        $script:RecoveryWorkflow | Should -Match '(?m)^      pull-requests: read$'
+        $script:RecoveryWorkflow | Should -Not -Match 'id-token: write'
+    }
+
+    It 'supports a repository kill switch and calls the deterministic script' {
+        $script:RecoveryWorkflow | Should -Match "vars\.REVIEW_TRIGGER_RECOVERY_DISABLED != 'true'"
+        $script:RecoveryWorkflow | Should -Match '\./\.github/scripts/Recover-MissedReviewCommands\.ps1'
+        $script:RecoveryWorkflow | Should -Match '(?m)^            -LookbackHours 24'
+        $script:RecoveryWorkflow | Should -Match '(?m)^            -MinimumAgeMinutes 10'
+        $script:RecoveryWorkflow | Should -Match '(?m)^            -MaxRecoveries 5'
+    }
+}

--- a/.github/scripts/Recover-MissedReviewCommands.Tests.ps1
+++ b/.github/scripts/Recover-MissedReviewCommands.Tests.ps1
@@ -2,9 +2,10 @@
 #Requires -Modules Pester
 
 BeforeAll {
+    $script:RecoverScriptPath = Join-Path $PSScriptRoot 'Recover-MissedReviewCommands.ps1'
     $previousErrorActionPreference = $ErrorActionPreference
     try {
-        . "$PSScriptRoot/Recover-MissedReviewCommands.ps1"
+        . $script:RecoverScriptPath
     } finally {
         $ErrorActionPreference = $previousErrorActionPreference
     }
@@ -27,6 +28,21 @@ BeforeAll {
             issue_url = "https://api.github.com/repos/dotnet/maui/issues/$PRNumber"
             user = [pscustomobject]@{ login = $Login }
         }
+    }
+}
+
+Describe 'recovery script initialization' {
+    It 'preserves custom repository parameters when importing shared command helpers' {
+        $state = & {
+            . $script:RecoverScriptPath -Owner 'example-owner' -Repo 'example-repo'
+            [pscustomobject]@{
+                Owner = $Owner
+                Repo = $Repo
+            }
+        }
+
+        $state.Owner | Should -Be 'example-owner'
+        $state.Repo | Should -Be 'example-repo'
     }
 }
 

--- a/.github/scripts/Recover-MissedReviewCommands.Tests.ps1
+++ b/.github/scripts/Recover-MissedReviewCommands.Tests.ps1
@@ -72,6 +72,41 @@ Describe 'Select-ReviewCommandCandidates' {
     }
 }
 
+Describe 'Test-ReviewCommentHasRecoveryMarker' {
+    It 'finds a recovery marker after the first page of reactions' {
+        $firstPage = @(
+            1..100 | ForEach-Object {
+                [pscustomobject]@{
+                    content = 'heart'
+                    user = [pscustomobject]@{ login = "user-$_" }
+                }
+            }
+        )
+        $marker = [pscustomobject]@{
+            content = 'rocket'
+            user = [pscustomobject]@{ login = 'github-actions[bot]' }
+        }
+
+        Mock Invoke-ReviewRecoveryGhApi {
+            param([string[]]$Arguments)
+
+            if ($Arguments[0] -match 'page=1$') {
+                return $firstPage
+            }
+
+            return @($marker)
+        }
+
+        Test-ReviewCommentHasRecoveryMarker `
+            -Owner 'dotnet' `
+            -Repo 'maui' `
+            -CommentId 12345 |
+            Should -BeTrue
+
+        Should -Invoke Invoke-ReviewRecoveryGhApi -Times 2 -Exactly
+    }
+}
+
 Describe 'Invoke-MissedReviewCommandRecovery' {
     BeforeEach {
         $script:Now = [datetimeoffset]'2026-08-06T22:00:00Z'

--- a/.github/scripts/Recover-MissedReviewCommands.ps1
+++ b/.github/scripts/Recover-MissedReviewCommands.ps1
@@ -23,7 +23,7 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-. "$PSScriptRoot/Resolve-RerunEligibility.ps1"
+. "$PSScriptRoot/Resolve-RerunEligibility.ps1" -Owner $Owner -Repo $Repo
 
 $script:RecoveryMarker = 'rocket'
 $script:RecoveryMarkerActor = 'github-actions[bot]'

--- a/.github/scripts/Recover-MissedReviewCommands.ps1
+++ b/.github/scripts/Recover-MissedReviewCommands.ps1
@@ -184,10 +184,23 @@ function Test-ReviewCommentHasRecoveryMarker {
         [Parameter(Mandatory = $true)][Int64]$CommentId
     )
 
-    $reactions = @(Invoke-ReviewRecoveryGhApi -Arguments @(
-        "repos/$Owner/$Repo/issues/comments/$CommentId/reactions?per_page=100",
-        '-H', 'Accept: application/vnd.github+json'
-    ))
+    $reactions = [System.Collections.Generic.List[object]]::new()
+    for ($page = 1; ; $page++) {
+        $pageReactions = @(Invoke-ReviewRecoveryGhApi -Arguments @(
+            "repos/$Owner/$Repo/issues/comments/$CommentId/reactions?per_page=100&page=$page",
+            '-H', 'Accept: application/vnd.github+json'
+        ))
+
+        foreach ($reaction in $pageReactions) {
+            if ($null -ne $reaction) {
+                $reactions.Add($reaction)
+            }
+        }
+
+        if ($pageReactions.Count -lt 100) {
+            break
+        }
+    }
 
     return @($reactions | Where-Object {
         $_.content -eq $script:RecoveryMarker -and

--- a/.github/scripts/Recover-MissedReviewCommands.ps1
+++ b/.github/scripts/Recover-MissedReviewCommands.ps1
@@ -1,0 +1,405 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Recovers authorized /review comments missed by GitHub Actions webhooks.
+
+.DESCRIPTION
+    Polls recent repository issue comments, finds unprocessed /review commands,
+    verifies the commenter still has write access, dispatches review-trigger.yml,
+    and marks the source comment so delayed webhook delivery cannot double-trigger.
+
+    The script only reads trusted main when invoked by review-trigger-recovery.yml.
+    It never checks out or executes pull request code.
+#>
+
+param(
+    [string]$Owner = 'dotnet',
+    [string]$Repo = 'maui',
+    [int]$LookbackHours = 24,
+    [int]$MinimumAgeMinutes = 10,
+    [int]$MaxRecoveries = 5,
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = 'Stop'
+
+. "$PSScriptRoot/Resolve-RerunEligibility.ps1"
+
+$script:RecoveryMarker = 'rocket'
+$script:RecoveryMarkerActor = 'github-actions[bot]'
+
+function ConvertTo-RecoveryErrorText {
+    param([AllowNull()][object]$Value)
+
+    $text = (([string]$Value) -replace '[\r\n]+', ' ').Trim()
+    if ($text.Length -gt 500) {
+        return $text.Substring(0, 497) + '...'
+    }
+
+    return $text
+}
+
+function Invoke-ReviewRecoveryGhApi {
+    param(
+        [Parameter(Mandatory = $true)][string[]]$Arguments,
+        [switch]$AllowNotFound
+    )
+
+    $stderrFile = New-TemporaryFile
+    try {
+        $raw = (& gh api @Arguments 2>$stderrFile | Out-String)
+        $exitCode = $LASTEXITCODE
+        $stderr = Get-Content -Raw -LiteralPath $stderrFile -ErrorAction SilentlyContinue
+    } finally {
+        Remove-Item -LiteralPath $stderrFile -Force -ErrorAction SilentlyContinue
+    }
+
+    if ($exitCode -ne 0) {
+        $detail = ConvertTo-RecoveryErrorText $stderr
+        if ($AllowNotFound -and $detail -match '(?i)\bHTTP\s+(404|410)\b') {
+            return $null
+        }
+        if ([string]::IsNullOrWhiteSpace($detail)) {
+            $detail = "gh api exited with code $exitCode."
+        }
+
+        throw "GitHub API request failed: $detail"
+    }
+
+    if ([string]::IsNullOrWhiteSpace($raw)) {
+        return $null
+    }
+
+    try {
+        return $raw | ConvertFrom-Json
+    } catch {
+        throw "GitHub API returned invalid JSON: $(ConvertTo-RecoveryErrorText $_)"
+    }
+}
+
+function Get-RecentIssueComments {
+    param(
+        [string]$Owner,
+        [string]$Repo,
+        [int]$LookbackHours,
+        [datetimeoffset]$Now = [datetimeoffset]::UtcNow,
+        [int]$MaxPages = 50
+    )
+
+    $since = $Now.AddHours(-$LookbackHours).UtcDateTime.ToString('yyyy-MM-ddTHH:mm:ssZ')
+    $encodedSince = [uri]::EscapeDataString($since)
+    $comments = [System.Collections.Generic.List[object]]::new()
+
+    for ($page = 1; $page -le $MaxPages; $page++) {
+        $endpoint = "repos/$Owner/$Repo/issues/comments?sort=created&direction=desc&since=$encodedSince&per_page=100&page=$page"
+        $pageItems = @(Invoke-ReviewRecoveryGhApi -Arguments @($endpoint))
+        foreach ($comment in $pageItems) {
+            if ($null -ne $comment) {
+                $comments.Add($comment)
+            }
+        }
+
+        if ($pageItems.Count -lt 100) {
+            return $comments.ToArray()
+        }
+    }
+
+    throw "Recent issue comment scan exceeded $MaxPages pages; refusing to recover from a truncated result."
+}
+
+function Select-ReviewCommandCandidates {
+    param(
+        [object[]]$Comments,
+        [int]$LookbackHours,
+        [int]$MinimumAgeMinutes,
+        [datetimeoffset]$Now = [datetimeoffset]::UtcNow
+    )
+
+    $oldestAllowed = $Now.AddHours(-$LookbackHours)
+    $newestAllowed = $Now.AddMinutes(-$MinimumAgeMinutes)
+    $candidates = [System.Collections.Generic.List[object]]::new()
+
+    foreach ($comment in @($Comments)) {
+        if ($null -eq $comment) {
+            continue
+        }
+
+        $createdAt = ConvertTo-DateTimeOffset $comment.created_at
+        if ($createdAt -lt $oldestAllowed -or $createdAt -gt $newestAllowed) {
+            continue
+        }
+
+        $parsed = ConvertFrom-ReviewCommand ([string]$comment.body)
+        if (-not $parsed) {
+            continue
+        }
+
+        $issueUrl = [string]$comment.issue_url
+        if ($issueUrl -notmatch '/issues/([1-9][0-9]*)$') {
+            continue
+        }
+        $prNumber = [int]$Matches[1]
+
+        $authorLogin = if ($comment.user) { [string]$comment.user.login } else { '' }
+        $nodeId = [string]$comment.node_id
+        if ([string]::IsNullOrWhiteSpace($authorLogin) -or [string]::IsNullOrWhiteSpace($nodeId)) {
+            continue
+        }
+
+        $candidates.Add([pscustomobject]@{
+            CommentId     = [Int64]$comment.id
+            CommentNodeId = $nodeId
+            PRNumber      = $prNumber
+            AuthorLogin   = $authorLogin
+            CreatedAt     = $createdAt
+            Platform      = [string]$parsed.Platform
+            PipelineRef   = [string]$parsed.PipelineRef
+        })
+    }
+
+    return @($candidates | Sort-Object CreatedAt, CommentId)
+}
+
+function Test-ReviewCommentIsMinimized {
+    param([Parameter(Mandatory = $true)][string]$NodeId)
+
+    $query = 'query($id:ID!){node(id:$id){... on IssueComment{isMinimized}}}'
+    $response = Invoke-ReviewRecoveryGhApi -Arguments @(
+        'graphql',
+        '-f', "query=$query",
+        '-f', "id=$NodeId"
+    )
+
+    if ($null -eq $response.data.node) {
+        throw "Could not resolve issue comment node '$NodeId'."
+    }
+
+    return [bool]$response.data.node.isMinimized
+}
+
+function Test-ReviewCommentHasRecoveryMarker {
+    param(
+        [string]$Owner,
+        [string]$Repo,
+        [Parameter(Mandatory = $true)][Int64]$CommentId
+    )
+
+    $reactions = @(Invoke-ReviewRecoveryGhApi -Arguments @(
+        "repos/$Owner/$Repo/issues/comments/$CommentId/reactions?per_page=100",
+        '-H', 'Accept: application/vnd.github+json'
+    ))
+
+    return @($reactions | Where-Object {
+        $_.content -eq $script:RecoveryMarker -and
+        $_.user -and
+        $_.user.login -eq $script:RecoveryMarkerActor
+    }).Count -gt 0
+}
+
+function Get-ReviewRecoveryPullRequest {
+    param(
+        [string]$Owner,
+        [string]$Repo,
+        [Parameter(Mandatory = $true)][int]$PRNumber
+    )
+
+    return Invoke-ReviewRecoveryGhApi `
+        -Arguments @("repos/$Owner/$Repo/pulls/$PRNumber") `
+        -AllowNotFound
+}
+
+function Invoke-ReviewWorkflowDispatch {
+    param(
+        [string]$Owner,
+        [string]$Repo,
+        [Parameter(Mandatory = $true)][int]$PRNumber,
+        [string]$Platform,
+        [string]$PipelineRef
+    )
+
+    $payloadPath = New-TemporaryFile
+    try {
+        [ordered]@{
+            ref = 'main'
+            inputs = [ordered]@{
+                pr_number = [string]$PRNumber
+                platform = [string]$Platform
+                pipeline_ref = [string]$PipelineRef
+            }
+        } |
+            ConvertTo-Json -Depth 5 |
+            Set-Content -LiteralPath $payloadPath -Encoding utf8 -NoNewline
+
+        Invoke-ReviewRecoveryGhApi -Arguments @(
+            '--method', 'POST',
+            "repos/$Owner/$Repo/actions/workflows/review-trigger.yml/dispatches",
+            '--input', $payloadPath
+        ) | Out-Null
+    } finally {
+        Remove-Item -LiteralPath $payloadPath -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Add-ReviewRecoveryMarker {
+    param(
+        [string]$Owner,
+        [string]$Repo,
+        [Parameter(Mandatory = $true)][Int64]$CommentId
+    )
+
+    $payloadPath = New-TemporaryFile
+    try {
+        @{ content = $script:RecoveryMarker } |
+            ConvertTo-Json -Compress |
+            Set-Content -LiteralPath $payloadPath -Encoding utf8 -NoNewline
+
+        Invoke-ReviewRecoveryGhApi -Arguments @(
+            '--method', 'POST',
+            "repos/$Owner/$Repo/issues/comments/$CommentId/reactions",
+            '-H', 'Accept: application/vnd.github+json',
+            '--input', $payloadPath
+        ) | Out-Null
+        return $true
+    } catch {
+        Write-Warning "Could not add recovery marker to comment $CommentId`: $(ConvertTo-RecoveryErrorText $_)"
+        return $false
+    } finally {
+        Remove-Item -LiteralPath $payloadPath -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Hide-ReviewCommandComment {
+    param([Parameter(Mandatory = $true)][string]$NodeId)
+
+    try {
+        $query = 'mutation($id:ID!){minimizeComment(input:{subjectId:$id,classifier:RESOLVED}){minimizedComment{isMinimized}}}'
+        $response = Invoke-ReviewRecoveryGhApi -Arguments @(
+            'graphql',
+            '-f', "query=$query",
+            '-f', "id=$NodeId"
+        )
+        return [bool]$response.data.minimizeComment.minimizedComment.isMinimized
+    } catch {
+        Write-Warning "Could not hide recovered review command '$NodeId': $(ConvertTo-RecoveryErrorText $_)"
+        return $false
+    }
+}
+
+function Invoke-MissedReviewCommandRecovery {
+    param(
+        [string]$Owner = 'dotnet',
+        [string]$Repo = 'maui',
+        [int]$LookbackHours = 24,
+        [int]$MinimumAgeMinutes = 10,
+        [int]$MaxRecoveries = 5,
+        [switch]$DryRun,
+        [datetimeoffset]$Now = [datetimeoffset]::UtcNow
+    )
+
+    if ($LookbackHours -lt 1 -or $LookbackHours -gt 168) {
+        throw 'LookbackHours must be between 1 and 168.'
+    }
+    if ($MinimumAgeMinutes -lt 1 -or $MinimumAgeMinutes -gt 120) {
+        throw 'MinimumAgeMinutes must be between 1 and 120.'
+    }
+    if ($MaxRecoveries -lt 1 -or $MaxRecoveries -gt 20) {
+        throw 'MaxRecoveries must be between 1 and 20.'
+    }
+
+    Clear-ReviewOptionPermissionCache
+    $comments = @(Get-RecentIssueComments -Owner $Owner -Repo $Repo -LookbackHours $LookbackHours -Now $Now)
+    $candidates = @(Select-ReviewCommandCandidates `
+        -Comments $comments `
+        -LookbackHours $LookbackHours `
+        -MinimumAgeMinutes $MinimumAgeMinutes `
+        -Now $Now)
+    $recovered = [System.Collections.Generic.List[object]]::new()
+
+    foreach ($candidate in $candidates) {
+        if ($recovered.Count -ge $MaxRecoveries) {
+            break
+        }
+
+        if (Test-ReviewCommentIsMinimized -NodeId $candidate.CommentNodeId) {
+            continue
+        }
+        if (Test-ReviewCommentHasRecoveryMarker -Owner $Owner -Repo $Repo -CommentId $candidate.CommentId) {
+            continue
+        }
+
+        $pullRequest = Get-ReviewRecoveryPullRequest -Owner $Owner -Repo $Repo -PRNumber $candidate.PRNumber
+        if (-not $pullRequest -or [string]$pullRequest.state -ne 'open') {
+            continue
+        }
+
+        if (-not (Test-ReviewOptionLoginTrusted `
+            -Login $candidate.AuthorLogin `
+            -Owner $Owner `
+            -Repo $Repo)) {
+            continue
+        }
+
+        if ($DryRun) {
+            Write-Host "[dry-run] Would recover comment $($candidate.CommentId) for PR #$($candidate.PRNumber)."
+        } else {
+            Invoke-ReviewWorkflowDispatch `
+                -Owner $Owner `
+                -Repo $Repo `
+                -PRNumber $candidate.PRNumber `
+                -Platform $candidate.Platform `
+                -PipelineRef $candidate.PipelineRef
+
+            $marked = Add-ReviewRecoveryMarker `
+                -Owner $Owner `
+                -Repo $Repo `
+                -CommentId $candidate.CommentId
+            $hidden = Hide-ReviewCommandComment -NodeId $candidate.CommentNodeId
+            if (-not $marked -and -not $hidden) {
+                throw "Dispatched comment $($candidate.CommentId), but could not persist a recovery acknowledgement."
+            }
+
+            Write-Host "Recovered comment $($candidate.CommentId) for PR #$($candidate.PRNumber)."
+        }
+
+        $recovered.Add([pscustomobject]@{
+            CommentId = $candidate.CommentId
+            PRNumber = $candidate.PRNumber
+            Platform = $candidate.Platform
+            PipelineRef = $candidate.PipelineRef
+            DryRun = [bool]$DryRun
+        })
+    }
+
+    return [pscustomobject]@{
+        CommentsScanned = $comments.Count
+        Candidates = $candidates.Count
+        Recovered = $recovered.ToArray()
+        DryRun = [bool]$DryRun
+    }
+}
+
+if ($MyInvocation.InvocationName -eq '.') {
+    return
+}
+
+$result = Invoke-MissedReviewCommandRecovery `
+    -Owner $Owner `
+    -Repo $Repo `
+    -LookbackHours $LookbackHours `
+    -MinimumAgeMinutes $MinimumAgeMinutes `
+    -MaxRecoveries $MaxRecoveries `
+    -DryRun:$DryRun
+
+$mode = if ($DryRun) { 'dry run' } else { 'apply' }
+Write-Host "Review trigger recovery ($mode): scanned=$($result.CommentsScanned) candidates=$($result.Candidates) recovered=$($result.Recovered.Count)"
+
+if ($env:GITHUB_STEP_SUMMARY) {
+    @"
+## Review trigger recovery
+
+- Mode: $mode
+- Comments scanned: $($result.CommentsScanned)
+- Review command candidates: $($result.Candidates)
+- Commands recovered: $($result.Recovered.Count)
+"@ | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Encoding utf8
+}

--- a/.github/scripts/ReviewTrigger.Tests.ps1
+++ b/.github/scripts/ReviewTrigger.Tests.ps1
@@ -132,6 +132,8 @@ Describe 'review trigger hardening' {
 
     It 'skips delayed webhook deliveries already handled by recovery' {
         $script:MatchJob | Should -Match 'issues/comments/\$\{COMMENT_ID\}/reactions\?per_page=100'
+        $script:MatchJob | Should -Match 'gh api --paginate --slurp'
+        $script:MatchJob | Should -Match "jq -e '\.\[\]\[\] \| select"
         $script:MatchJob | Should -Match '\.content == "rocket" and \.user\.login == "github-actions\[bot\]"'
         $script:MatchJob | Should -Match 'already recovered; skipping delayed duplicate delivery'
         $script:MatchJob | Should -Match 'IssueComment\{isMinimized\}'

--- a/.github/scripts/ReviewTrigger.Tests.ps1
+++ b/.github/scripts/ReviewTrigger.Tests.ps1
@@ -121,11 +121,22 @@ Describe 'review trigger hardening' {
         $script:MatchJob | Should -Match '(?m)^      proceed: \$\{\{ steps\.gate\.outputs\.proceed \}\}$'
         $script:MatchJob | Should -Match '(?m)^      - name: Check actor permission$'
         $script:MatchJob | Should -Match 'ACTOR: \$\{\{ github\.actor \}\}'
+        $script:MatchJob | Should -Match 'COMMENT_ID: \$\{\{ github\.event\.comment\.id \}\}'
+        $script:MatchJob | Should -Match 'COMMENT_NODE_ID: \$\{\{ github\.event\.comment\.node_id \}\}'
         $script:MatchJob | Should -Match 'REPO: \$\{\{ github\.repository \}\}'
         $script:MatchJob | Should -Match 'Permission lookup failed.*treating the caller as unauthorized'
         $script:MatchJob | Should -Match 'PERMISSION="none"'
         $script:TriggerJob | Should -Match "(?m)^    if: needs\.match\.outputs\.proceed == 'true'$"
         $script:TriggerJob | Should -Not -Match '(?m)^        id: auth$'
+    }
+
+    It 'skips delayed webhook deliveries already handled by recovery' {
+        $script:MatchJob | Should -Match 'issues/comments/\$\{COMMENT_ID\}/reactions\?per_page=100'
+        $script:MatchJob | Should -Match '\.content == "rocket" and \.user\.login == "github-actions\[bot\]"'
+        $script:MatchJob | Should -Match 'already recovered; skipping delayed duplicate delivery'
+        $script:MatchJob | Should -Match 'IssueComment\{isMinimized\}'
+        $script:MatchJob | Should -Match 'already minimized by recovery; skipping delayed duplicate delivery'
+        $script:MatchJob | Should -Match '(?m)^          for attempt in 1 2 3; do$'
     }
 
     It 'stops trigger-review extraction at the next top-level job' {
@@ -158,5 +169,8 @@ Describe 'review trigger hardening' {
     It 'only hides commands after the pre-flight authorization gate succeeded' {
         $script:TriggerJob | Should -Not -Match 'steps\.auth'
         $script:TriggerJob | Should -Match "(?m)^        if: \$\{\{ !cancelled\(\) && github\.event_name == 'issue_comment' \}\}$"
+        $script:TriggerJob | Should -Match '(?m)^      - name: Acknowledge and hide the /review command comment$'
+        $script:TriggerJob | Should -Match 'issues/comments/\$\{COMMENT_ID\}/reactions'
+        $script:TriggerJob | Should -Match "-f content='rocket'"
     }
 }

--- a/.github/workflows/powershell-script-tests.yml
+++ b/.github/workflows/powershell-script-tests.yml
@@ -20,6 +20,8 @@ on:
     paths:
       - '.github/scripts/**'
       - '.github/workflows/powershell-script-tests.yml'
+      - '.github/workflows/review-trigger.yml'
+      - '.github/workflows/review-trigger-recovery.yml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/review-trigger-recovery.yml
+++ b/.github/workflows/review-trigger-recovery.yml
@@ -1,0 +1,45 @@
+# Recover authorized /review comments whose issue_comment webhook was not
+# delivered by GitHub Actions. This is deterministic polling, not an agentic
+# workflow: no untrusted PR code is checked out or executed.
+
+name: Review Trigger Recovery
+
+on:
+  schedule:
+    - cron: '*/10 * * * *'
+
+permissions: {}
+
+concurrency:
+  group: review-trigger-recovery
+  cancel-in-progress: false
+
+jobs:
+  recover:
+    if: >-
+      github.repository == 'dotnet/maui' &&
+      vars.REVIEW_TRIGGER_RECOVERY_DISABLED != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: write
+      contents: read
+      issues: write
+      pull-requests: read
+    steps:
+      # Scheduled workflows execute from the default branch; pin the checked-out
+      # recovery script to trusted main as an additional guard.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Recover missed /review commands
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ./.github/scripts/Recover-MissedReviewCommands.ps1 `
+            -LookbackHours 24 `
+            -MinimumAgeMinutes 10 `
+            -MaxRecoveries 5

--- a/.github/workflows/review-trigger.yml
+++ b/.github/workflows/review-trigger.yml
@@ -35,6 +35,7 @@ jobs:
     timeout-minutes: 2
     permissions:
       contents: read
+      issues: read
       pull-requests: read
     outputs:
       matched: ${{ steps.check.outputs.matched }}
@@ -77,6 +78,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           ACTOR: ${{ github.actor }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          COMMENT_NODE_ID: ${{ github.event.comment.node_id }}
           REPO: ${{ github.repository }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
@@ -85,6 +88,53 @@ jobs:
             echo "proceed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+
+          # The scheduled recovery workflow adds a rocket reaction and minimizes
+          # the source comment after it dispatches a missed command. If the
+          # original webhook is delivered later, refuse to trigger the same
+          # review a second time. Retry transient reads before failing closed;
+          # the recovery workflow remains the backstop for a skipped command.
+          REACTIONS_READ=false
+          for attempt in 1 2 3; do
+            if REACTIONS=$(gh api "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions?per_page=100" 2>/dev/null); then
+              REACTIONS_READ=true
+              break
+            fi
+            sleep "${attempt}"
+          done
+          if [ "${REACTIONS_READ}" != "true" ]; then
+            echo "::warning::Could not check whether /review comment ${COMMENT_ID} was already recovered; skipping so the recovery workflow can retry safely."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if echo "${REACTIONS}" | jq -e '.[] | select(.content == "rocket" and .user.login == "github-actions[bot]")' >/dev/null; then
+            echo "::notice::Review comment ${COMMENT_ID} was already recovered; skipping delayed duplicate delivery."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          MINIMIZED_READ=false
+          for attempt in 1 2 3; do
+            if IS_MINIMIZED=$(gh api graphql \
+              -f query='query($id:ID!){node(id:$id){... on IssueComment{isMinimized}}}' \
+              -f id="${COMMENT_NODE_ID}" \
+              --jq '.data.node.isMinimized' 2>/dev/null); then
+              MINIMIZED_READ=true
+              break
+            fi
+            sleep "${attempt}"
+          done
+          if [ "${MINIMIZED_READ}" != "true" ]; then
+            echo "::warning::Could not check whether /review comment ${COMMENT_ID} was minimized; skipping so the recovery workflow can retry safely."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "${IS_MINIMIZED}" = "true" ]; then
+            echo "::notice::Review comment ${COMMENT_ID} was already minimized by recovery; skipping delayed duplicate delivery."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           if ! PERMISSION=$(gh api "repos/${REPO}/collaborators/${ACTOR}/permission" --jq '.permission' 2>/dev/null); then
             echo "::warning::Permission lookup failed for ${ACTOR}; treating the caller as unauthorized."
             PERMISSION="none"
@@ -402,10 +452,11 @@ jobs:
           . .github/scripts/shared/Update-AgentLabels.ps1
           Clear-AgentReviewInProgress -PRNumber $env:PR_NUMBER -Owner '${{ github.repository_owner }}' -Repo '${{ github.event.repository.name }}' | Out-Null
 
-      - name: Hide the /review command comment as resolved
+      - name: Acknowledge and hide the /review command comment
         if: ${{ !cancelled() && github.event_name == 'issue_comment' }}
         env:
           GH_TOKEN: ${{ github.token }}
+          COMMENT_ID: ${{ github.event.comment.id }}
           COMMENT_NODE_ID: ${{ github.event.comment.node_id }}
         run: |
           # This job only runs after the pre-flight authorization gate succeeds, so
@@ -417,6 +468,19 @@ jobs:
           # --branch/--platform options — survives in the REST comment history that the rerun
           # scanner replays. Minimized comments are still returned by the REST list endpoint;
           # only collapsed in the web UI. A failed hide must never fail the review trigger.
+          #
+          # The rocket reaction and minimized state are durable idempotency
+          # signals for the scheduled recovery workflow. Either one prevents a
+          # delayed issue_comment webhook from double-triggering a recovered command.
+          if gh api "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" \
+            --method POST \
+            -f content='rocket' \
+            --silent; then
+            echo "Acknowledged /review command comment ${COMMENT_ID}"
+          else
+            echo "::warning::Could not acknowledge /review command comment ${COMMENT_ID}"
+          fi
+
           if gh api graphql -f query='mutation($id:ID!){minimizeComment(input:{subjectId:$id,classifier:RESOLVED}){minimizedComment{isMinimized}}}' -f id="$COMMENT_NODE_ID" --silent; then
             echo "Hid /review command comment ${COMMENT_NODE_ID} as resolved"
           else

--- a/.github/workflows/review-trigger.yml
+++ b/.github/workflows/review-trigger.yml
@@ -96,7 +96,7 @@ jobs:
           # the recovery workflow remains the backstop for a skipped command.
           REACTIONS_READ=false
           for attempt in 1 2 3; do
-            if REACTIONS=$(gh api "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions?per_page=100" 2>/dev/null); then
+            if REACTIONS=$(gh api --paginate --slurp "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions?per_page=100" 2>/dev/null); then
               REACTIONS_READ=true
               break
             fi
@@ -107,7 +107,7 @@ jobs:
             echo "proceed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if echo "${REACTIONS}" | jq -e '.[] | select(.content == "rocket" and .user.login == "github-actions[bot]")' >/dev/null; then
+          if echo "${REACTIONS}" | jq -e '.[][] | select(.content == "rocket" and .user.login == "github-actions[bot]")' >/dev/null; then
             echo "::notice::Review comment ${COMMENT_ID} was already recovered; skipping delayed duplicate delivery."
             echo "proceed=false" >> "$GITHUB_OUTPUT"
             exit 0


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause

GitHub Actions was in a critical incident when [/review comment 5209319531](https://github.com/dotnet/maui/pull/37148#issuecomment-5209319531) was created. GitHub's 21:30 UTC status update said webhook triggers were throttled and only about 15% were being processed. The comment produced no `issue_comment` workflow run, while a direct `workflow_dispatch` of the unchanged trigger succeeded and queued [maui-copilot build 14898525](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14898525) with `improved-reviewer` and Android.

### Description of Change

- Add a deterministic 10-minute recovery workflow that polls recent `/review` comments after a 10-minute grace period.
- Reuse the existing command parser and current collaborator-permission check before dispatching the trusted `review-trigger.yml` workflow on `main`.
- Mark and minimize recovered commands, and make delayed webhook deliveries recognize both signals so they cannot queue a duplicate review.
- Pin recovery execution to trusted `main`, keep permissions scoped to comment reads/writes and workflow dispatch, cap each run, and provide a repository kill switch.
- Preserve explicit owner/repository parameters when importing the shared review-command helpers.
- Extend the existing Pester gate and maintainer documentation for the recovery path.

### Issues Fixed

No linked issue. This addresses dropped `/review` webhook deliveries during GitHub Actions incidents.

### Validation

- Full `.github/scripts` Pester suite with CI's Pester 5.9.0: 1,617 passed.
- Live dry-run during the incident identified the dropped commands; after manually recovering PR #37148, its minimized command was correctly excluded from recovery.
- Manual trigger run: https://github.com/dotnet/maui/actions/runs/31128616361
