### PR TITLE
Fix MauiXaml will generate source for every xaml file without respect to its condition by configuration/target

### DIFF
--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.SingleProject.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.SingleProject.targets
@@ -55,6 +55,29 @@
       <_MauiXamlToRemove
           Condition="'$(WindowsProjectFolder)' != ''"
           Include="$(WindowsProjectFolder)**/*.xaml" />
+
+      <!--
+        Remove non-active-platform MAUI XAML files under Platforms/<Platform>. Unlike Compile
+        items, MauiXaml has no ExcludeFromCurrentConfiguration gating, so without this every
+        platform's *.xaml stayed in the MauiXaml item group (and therefore in the XAML SourceGen's
+        AdditionalFiles) for every inner build/TFM, causing files that reuse the same class name
+        per platform (a standard per-platform partial-page pattern) to generate duplicate
+        InitializeComponent/attribute definitions (CS0579/CS0111). See
+        https://github.com/dotnet/maui/issues/36951.
+      -->
+      <_MauiXamlToRemove
+          Condition="'$(AndroidProjectFolder)' != '' and '$(TargetPlatformIdentifier)' != 'android'"
+          Include="$(AndroidProjectFolder)**/*.xaml" />
+      <_MauiXamlToRemove
+          Condition="'$(iOSProjectFolder)' != '' and '$(TargetPlatformIdentifier)' != 'ios'"
+          Include="$(iOSProjectFolder)**/*.xaml" />
+      <_MauiXamlToRemove
+          Condition="'$(MacCatalystProjectFolder)' != '' and '$(TargetPlatformIdentifier)' != 'maccatalyst'"
+          Include="$(MacCatalystProjectFolder)**/*.xaml" />
+      <_MauiXamlToRemove
+          Condition="'$(TizenProjectFolder)' != '' and '$(TargetPlatformIdentifier)' != 'tizen'"
+          Include="$(TizenProjectFolder)**/*.xaml" />
+
       <EmbeddedResource Remove="@(_MauiXamlToRemove)" />
       <MauiXaml Remove="@(_MauiXamlToRemove)" />
     </ItemGroup>

--- a/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
@@ -48,22 +48,7 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 
 			// Deliberately shares the same x:Class across all Platforms/<Platform> variants, to
 			// mirror the common per-platform partial-page pattern from https://github.com/dotnet/maui/issues/36951.
-			public static readonly string TestPage = $@"
-				<ContentPage
-					xmlns=""{MicrosoftMauiControlsFormsDefaultNamespace}""
-					xmlns:x=""{MicrosoftMauiControlsFormsXNamespace}""
-					x:Class=""Microsoft.Maui.Controls.Xaml.UnitTests.TestPage"">
-					<Label x:Name=""label0""/>
-				</ContentPage>";
-
-			public static readonly string SharedPage = $@"
-				<ContentPage
-					xmlns=""{MicrosoftMauiControlsFormsDefaultNamespace}""
-					xmlns:x=""{MicrosoftMauiControlsFormsXNamespace}""
-					x:Class=""Microsoft.Maui.Controls.Xaml.UnitTests.SharedPage"">
-					<Label x:Name=""label0""/>
-				</ContentPage>";
-		}
+			}
 
 		class Css
 		{
@@ -642,76 +627,106 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 		/// <summary>
 		/// Regression test for https://github.com/dotnet/maui/issues/36951.
 		///
-		/// MauiXaml has no ExcludeFromCurrentConfiguration gating like Compile does, so every
-		/// platform's *.xaml files under Platforms/&lt;Platform&gt; used to stay in the MauiXaml item
-		/// group for every inner build/TFM. The XAML SourceGen consumes MauiXaml as AdditionalFiles
-		/// regardless of platform, so files reusing the same class name across Platforms/Android,
-		/// Platforms/iOS, and Platforms/MacCatalyst (a common per-platform partial-page pattern)
-		/// produced duplicate InitializeComponent/attribute definitions (CS0579/CS0111) even though
-		/// only one of them should have participated in any given inner build.
+		/// MauiXaml had no ExcludeFromCurrentConfiguration gating like Compile does, so every
+		/// platform's *.xaml under Platforms/&lt;Platform&gt; stayed in MauiXaml (and therefore in
+		/// the XAML SourceGen's AdditionalFiles) for every inner build/TFM. Files reusing the same
+		/// x:Class across platform folders (a standard per-platform pattern) produced duplicate
+		/// InitializeComponent/attribute definitions (CS0579/CS0111).
 		///
-		/// Only the MauiXaml item belonging to the currently active platform (plus any
-		/// non-platform-folder shared xaml) should survive _MauiRemovePlatformCompileItems.
+		/// After the fix, only the active platform's MauiXaml items (plus shared ones outside any
+		/// Platforms/ sub-folder) should survive _MauiRemovePlatformCompileItems.
 		/// </summary>
 		[Theory]
 		[InlineData("android", "Android")]
 		[InlineData("ios", "iOS")]
 		[InlineData("maccatalyst", "MacCatalyst")]
-		public void SingleProject_RemovePlatformCompileItems_RemovesNonActivePlatformMauiXamlItems(string targetPlatformIdentifier, string activePlatformFolder)
+		[InlineData("tizen", "Tizen")]
+		public void SingleProject_RemovePlatformCompileItems_RetainsActivePlatformMauiXaml(
+			string targetPlatformIdentifier, string activePlatformFolder)
+		{
+			var allFolders = new[] { "Android", "iOS", "MacCatalyst", "Tizen" };
+			var log = BuildMauiXamlFilterProject(targetPlatformIdentifier, allFolders);
+			var itemsLine = GetNormalizedMauiXamlItemsLine(log);
+
+			Assert.Contains("SharedPage.xaml", itemsLine, StringComparison.OrdinalIgnoreCase);
+			Assert.Contains($"Platforms/{activePlatformFolder}/TestPage.xaml", itemsLine, StringComparison.OrdinalIgnoreCase);
+
+			foreach (var folder in allFolders.Where(f => !string.Equals(f, activePlatformFolder, StringComparison.OrdinalIgnoreCase)))
+				Assert.DoesNotContain($"Platforms/{folder}/TestPage.xaml", itemsLine, StringComparison.OrdinalIgnoreCase);
+		}
+
+		/// <summary>
+		/// Windows XAML is WinUI markup — not MAUI XAML — and is unconditionally stripped from
+		/// MauiXaml by _MauiRemovePlatformCompileItems even when Windows is the active platform.
+		/// This behaviour predates issue #36951 and is intentionally separate from the
+		/// Android/iOS/MacCatalyst/Tizen filtering above.
+		/// </summary>
+		[Fact]
+		public void SingleProject_RemovePlatformCompileItems_AlwaysRemovesWindowsMauiXaml()
+		{
+			var log = BuildMauiXamlFilterProject("windows", new[] { "Windows" });
+			var itemsLine = GetNormalizedMauiXamlItemsLine(log);
+
+			Assert.Contains("SharedPage.xaml", itemsLine, StringComparison.OrdinalIgnoreCase);
+			Assert.DoesNotContain("Platforms/Windows/", itemsLine, StringComparison.OrdinalIgnoreCase);
+		}
+
+		/// <summary>
+		/// Builds a minimal project that exercises _MauiRemovePlatformCompileItems and returns
+		/// the MSBuild log. Placeholder XAML files are written under Platforms/&lt;folder&gt;/ so
+		/// the glob in the filter target resolves them. TargetPlatformIdentifier is injected via a
+		/// BeforeTargets target rather than a PropertyGroup so MSBuild does not attempt workload
+		/// resolution at evaluation time (which fails with NETSDK1147 on clean CI agents).
+		/// </summary>
+		string BuildMauiXamlFilterProject(string targetPlatformIdentifier, string[] platformFolders)
 		{
 			SetUp();
+
 			var project = NewElement("Project").WithAttribute("Sdk", "Microsoft.NET.Sdk");
+
 			var propertyGroup = NewElement("PropertyGroup");
 			propertyGroup.Add(NewElement("TargetFramework").WithValue(GetTfm()));
 			propertyGroup.Add(NewElement("SingleProject").WithValue("true"));
 			propertyGroup.Add(NewElement("EnableDefaultCompileItems").WithValue("false"));
 			propertyGroup.Add(NewElement("EnableDefaultEmbeddedResourceItems").WithValue("false"));
-			// Fake the active platform without requiring the real platform TFM/workload to be installed.
-			propertyGroup.Add(NewElement("TargetPlatformIdentifier").WithValue(targetPlatformIdentifier));
 			project.Add(propertyGroup);
 
-			var itemGroup = NewElement("ItemGroup");
-			foreach (var assembly in references)
-			{
-				var reference = NewElement("Reference").WithAttribute("Include", assembly);
-				if (assembly.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-				{
-					reference.Add(NewElement("HintPath").WithValue(IOPath.Combine("..", "..", assembly)));
-				}
-				itemGroup.Add(reference);
-			}
-			project.Add(itemGroup);
+			// Set TargetPlatformIdentifier inside a target, not in PropertyGroup.
+			// Setting it during evaluation triggers SDK workload resolution and fails with
+			// NETSDK1147 on clean CI agents. The filter target reads the property at execution
+			// time, so injecting it via BeforeTargets is equivalent.
+			var setPlatformTarget = NewElement("Target")
+				.WithAttribute("Name", "_TestSetPlatformIdentifier")
+				.WithAttribute("BeforeTargets", "_MauiRemovePlatformCompileItems");
+			var innerPg = NewElement("PropertyGroup");
+			innerPg.Add(NewElement("TargetPlatformIdentifier").WithValue(targetPlatformIdentifier));
+			setPlatformTarget.Add(innerPg);
+			project.Add(setPlatformTarget);
 
-			var beforeTargetsPath = AssemblyInfoTests.GetFilePathFromRoot(IOPath.Combine("src", "Controls", "src", "Build.Tasks", "nuget", "buildTransitive", "netstandard2.0", "Microsoft.Maui.Controls.SingleProject.Before.targets"));
+			var beforeTargetsPath = AssemblyInfoTests.GetFilePathFromRoot(IOPath.Combine(
+				"src", "Controls", "src", "Build.Tasks", "nuget", "buildTransitive", "netstandard2.0",
+				"Microsoft.Maui.Controls.SingleProject.Before.targets"));
 			project.Add(NewElement("Import").WithAttribute("Project", beforeTargetsPath));
 
-			project.Add(AddFile("Entry.cs", "Compile", @"
-namespace Microsoft.Maui.Controls.Xaml.UnitTests;
-
-public static class Entry
-{
-	public static string Value => ""ok"";
-}"));
-
-			// Each platform's TestPage.xaml intentionally reuses the same x:Class so we can prove
-			// that only the active platform's file survives filtering (otherwise SourceGen would
-			// emit duplicate InitializeComponent/attribute definitions for the same type).
-			var platformFolders = new[] { "Android", "iOS", "MacCatalyst" };
+			// Write placeholder files so the glob in _MauiXamlToRemove resolves them.
+			// File content is irrelevant — the filter only cares about paths.
 			var xamlItems = NewElement("ItemGroup");
 			foreach (var folder in platformFolders)
 			{
-				WriteFile($"Platforms\\{folder}\\TestPage.xaml", Xaml.TestPage);
-				xamlItems.Add(NewElement("MauiXaml").WithAttribute("Include", $"Platforms\\{folder}\\TestPage.xaml"));
+				var relativePath = IOPath.Combine("Platforms", folder, "TestPage.xaml");
+				WriteFile(relativePath, "<x/>");
+				xamlItems.Add(NewElement("MauiXaml").WithAttribute("Include", relativePath));
 			}
-			WriteFile("SharedPage.xaml", Xaml.SharedPage);
+			WriteFile("SharedPage.xaml", "<x/>");
 			xamlItems.Add(NewElement("MauiXaml").WithAttribute("Include", "SharedPage.xaml"));
 			project.Add(xamlItems);
 
-			var targetsPath = AssemblyInfoTests.GetFilePathFromRoot(IOPath.Combine("src", "Controls", "src", "Build.Tasks", "nuget", "buildTransitive", "netstandard2.0", "Microsoft.Maui.Controls.SingleProject.targets"));
+			var targetsPath = AssemblyInfoTests.GetFilePathFromRoot(IOPath.Combine(
+				"src", "Controls", "src", "Build.Tasks", "nuget", "buildTransitive", "netstandard2.0",
+				"Microsoft.Maui.Controls.SingleProject.targets"));
 			project.Add(NewElement("Import").WithAttribute("Project", targetsPath));
 
-			// Dump the post-filter MauiXaml item identities to the build log so we can assert on
-			// exactly what survived _MauiRemovePlatformCompileItems for this platform.
+			// Emit surviving MauiXaml item identities to the log for assertions.
 			var dumpTarget = NewElement("Target")
 				.WithAttribute("Name", "_TestDumpMauiXamlItems")
 				.WithAttribute("AfterTargets", "_MauiRemovePlatformCompileItems");
@@ -723,95 +738,14 @@ public static class Entry
 			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
 			project.Save(projectFile);
 
-			var log = Build(projectFile);
-
-			// Normalize separators since Identity may render with '/' or '\' depending on OS.
-			var itemsLine = log.Split('\n').FirstOrDefault(l => l.Contains("MAUIXAML_ITEMS:", StringComparison.OrdinalIgnoreCase)) ?? "";
-			var normalizedItemsLine = itemsLine.Replace('\\', '/');
-
-			Assert.Contains("SharedPage.xaml", normalizedItemsLine, StringComparison.OrdinalIgnoreCase);
-			Assert.Contains($"Platforms/{activePlatformFolder}/TestPage.xaml", normalizedItemsLine, StringComparison.OrdinalIgnoreCase);
-
-			foreach (var folder in platformFolders.Where(f => !string.Equals(f, activePlatformFolder, StringComparison.OrdinalIgnoreCase)))
-			{
-				Assert.DoesNotContain($"Platforms/{folder}/TestPage.xaml", normalizedItemsLine, StringComparison.OrdinalIgnoreCase);
-			}
+			// Run the filter target directly. BeforeTargets will inject TargetPlatformIdentifier
+			// first, and AfterTargets will fire the dump after — no full compilation needed.
+			return Build(projectFile, target: "_MauiRemovePlatformCompileItems");
 		}
 
-		// Windows xaml is WinUI markup, not MAUI XAML, and is never consumed by the MAUI XAML
-		// SourceGen. Unlike Android/iOS/MacCatalyst/Tizen, Platforms/Windows/*.xaml is stripped
-		// from MauiXaml UNCONDITIONALLY by _MauiRemovePlatformCompileItems - even when Windows is
-		// the active platform - because that logic predates and is unrelated to issue #36951.
-		// This is a separate assertion (not a [Theory] case alongside android/ios/maccatalyst)
-		// because the expected behavior for Windows is fundamentally different: the active
-		// platform's own xaml is also expected to be absent from MauiXaml, not retained.
-		[Fact]
-		public void SingleProject_RemovePlatformCompileItems_AlwaysRemovesWindowsMauiXamlItems()
-		{
-			SetUp();
-			var project = NewElement("Project").WithAttribute("Sdk", "Microsoft.NET.Sdk");
-			var propertyGroup = NewElement("PropertyGroup");
-			propertyGroup.Add(NewElement("TargetFramework").WithValue(GetTfm()));
-			propertyGroup.Add(NewElement("SingleProject").WithValue("true"));
-			propertyGroup.Add(NewElement("EnableDefaultCompileItems").WithValue("false"));
-			propertyGroup.Add(NewElement("EnableDefaultEmbeddedResourceItems").WithValue("false"));
-			// Fake the active platform without requiring the real platform TFM/workload to be installed.
-			propertyGroup.Add(NewElement("TargetPlatformIdentifier").WithValue("windows"));
-			project.Add(propertyGroup);
-
-			var itemGroup = NewElement("ItemGroup");
-			foreach (var assembly in references)
-			{
-				var reference = NewElement("Reference").WithAttribute("Include", assembly);
-				if (assembly.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-				{
-					reference.Add(NewElement("HintPath").WithValue(IOPath.Combine("..", "..", assembly)));
-				}
-				itemGroup.Add(reference);
-			}
-			project.Add(itemGroup);
-
-			var beforeTargetsPath = AssemblyInfoTests.GetFilePathFromRoot(IOPath.Combine("src", "Controls", "src", "Build.Tasks", "nuget", "buildTransitive", "netstandard2.0", "Microsoft.Maui.Controls.SingleProject.Before.targets"));
-			project.Add(NewElement("Import").WithAttribute("Project", beforeTargetsPath));
-
-			project.Add(AddFile("Entry.cs", "Compile", @"
-namespace Microsoft.Maui.Controls.Xaml.UnitTests;
-
-public static class Entry
-{
-	public static string Value => ""ok"";
-}"));
-
-			WriteFile("Platforms\\Windows\\WindowsPage.xaml", "<Page />");
-			WriteFile("SharedPage.xaml", Xaml.SharedPage);
-
-			var xamlItems = NewElement("ItemGroup");
-			xamlItems.Add(NewElement("MauiXaml").WithAttribute("Include", "Platforms\\Windows\\WindowsPage.xaml"));
-			xamlItems.Add(NewElement("MauiXaml").WithAttribute("Include", "SharedPage.xaml"));
-			project.Add(xamlItems);
-
-			var targetsPath = AssemblyInfoTests.GetFilePathFromRoot(IOPath.Combine("src", "Controls", "src", "Build.Tasks", "nuget", "buildTransitive", "netstandard2.0", "Microsoft.Maui.Controls.SingleProject.targets"));
-			project.Add(NewElement("Import").WithAttribute("Project", targetsPath));
-
-			var dumpTarget = NewElement("Target")
-				.WithAttribute("Name", "_TestDumpMauiXamlItems")
-				.WithAttribute("AfterTargets", "_MauiRemovePlatformCompileItems");
-			dumpTarget.Add(NewElement("Message")
-				.WithAttribute("Importance", "high")
-				.WithAttribute("Text", "MAUIXAML_ITEMS: @(MauiXaml->'%(Identity)', '|')"));
-			project.Add(dumpTarget);
-
-			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
-			project.Save(projectFile);
-
-			var log = Build(projectFile);
-
-			var itemsLine = log.Split('\n').FirstOrDefault(l => l.Contains("MAUIXAML_ITEMS:", StringComparison.OrdinalIgnoreCase)) ?? "";
-			var normalizedItemsLine = itemsLine.Replace('\\', '/');
-
-			Assert.Contains("SharedPage.xaml", normalizedItemsLine, StringComparison.OrdinalIgnoreCase);
-			Assert.DoesNotContain("Platforms/Windows/WindowsPage.xaml", normalizedItemsLine, StringComparison.OrdinalIgnoreCase);
-		}
+		static string GetNormalizedMauiXamlItemsLine(string log) =>
+			(log.Split('\n').FirstOrDefault(l => l.Contains("MAUIXAML_ITEMS:", StringComparison.OrdinalIgnoreCase)) ?? "")
+			.Replace('\\', '/');
 
 		/// <summary>
 		/// Tests that the SingleProject Before targets use default Entitlements.plist when no custom CodesignEntitlements is set

--- a/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
@@ -738,6 +738,81 @@ public static class Entry
 			}
 		}
 
+		// Windows xaml is WinUI markup, not MAUI XAML, and is never consumed by the MAUI XAML
+		// SourceGen. Unlike Android/iOS/MacCatalyst/Tizen, Platforms/Windows/*.xaml is stripped
+		// from MauiXaml UNCONDITIONALLY by _MauiRemovePlatformCompileItems - even when Windows is
+		// the active platform - because that logic predates and is unrelated to issue #36951.
+		// This is a separate assertion (not a [Theory] case alongside android/ios/maccatalyst)
+		// because the expected behavior for Windows is fundamentally different: the active
+		// platform's own xaml is also expected to be absent from MauiXaml, not retained.
+		[Fact]
+		public void SingleProject_RemovePlatformCompileItems_AlwaysRemovesWindowsMauiXamlItems()
+		{
+			SetUp();
+			var project = NewElement("Project").WithAttribute("Sdk", "Microsoft.NET.Sdk");
+			var propertyGroup = NewElement("PropertyGroup");
+			propertyGroup.Add(NewElement("TargetFramework").WithValue(GetTfm()));
+			propertyGroup.Add(NewElement("SingleProject").WithValue("true"));
+			propertyGroup.Add(NewElement("EnableDefaultCompileItems").WithValue("false"));
+			propertyGroup.Add(NewElement("EnableDefaultEmbeddedResourceItems").WithValue("false"));
+			// Fake the active platform without requiring the real platform TFM/workload to be installed.
+			propertyGroup.Add(NewElement("TargetPlatformIdentifier").WithValue("windows"));
+			project.Add(propertyGroup);
+
+			var itemGroup = NewElement("ItemGroup");
+			foreach (var assembly in references)
+			{
+				var reference = NewElement("Reference").WithAttribute("Include", assembly);
+				if (assembly.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+				{
+					reference.Add(NewElement("HintPath").WithValue(IOPath.Combine("..", "..", assembly)));
+				}
+				itemGroup.Add(reference);
+			}
+			project.Add(itemGroup);
+
+			var beforeTargetsPath = AssemblyInfoTests.GetFilePathFromRoot(IOPath.Combine("src", "Controls", "src", "Build.Tasks", "nuget", "buildTransitive", "netstandard2.0", "Microsoft.Maui.Controls.SingleProject.Before.targets"));
+			project.Add(NewElement("Import").WithAttribute("Project", beforeTargetsPath));
+
+			project.Add(AddFile("Entry.cs", "Compile", @"
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public static class Entry
+{
+	public static string Value => ""ok"";
+}"));
+
+			WriteFile("Platforms\\Windows\\WindowsPage.xaml", "<Page />");
+			WriteFile("SharedPage.xaml", Xaml.SharedPage);
+
+			var xamlItems = NewElement("ItemGroup");
+			xamlItems.Add(NewElement("MauiXaml").WithAttribute("Include", "Platforms\\Windows\\WindowsPage.xaml"));
+			xamlItems.Add(NewElement("MauiXaml").WithAttribute("Include", "SharedPage.xaml"));
+			project.Add(xamlItems);
+
+			var targetsPath = AssemblyInfoTests.GetFilePathFromRoot(IOPath.Combine("src", "Controls", "src", "Build.Tasks", "nuget", "buildTransitive", "netstandard2.0", "Microsoft.Maui.Controls.SingleProject.targets"));
+			project.Add(NewElement("Import").WithAttribute("Project", targetsPath));
+
+			var dumpTarget = NewElement("Target")
+				.WithAttribute("Name", "_TestDumpMauiXamlItems")
+				.WithAttribute("AfterTargets", "_MauiRemovePlatformCompileItems");
+			dumpTarget.Add(NewElement("Message")
+				.WithAttribute("Importance", "high")
+				.WithAttribute("Text", "MAUIXAML_ITEMS: @(MauiXaml->'%(Identity)', '|')"));
+			project.Add(dumpTarget);
+
+			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
+			project.Save(projectFile);
+
+			var log = Build(projectFile);
+
+			var itemsLine = log.Split('\n').FirstOrDefault(l => l.Contains("MAUIXAML_ITEMS:", StringComparison.OrdinalIgnoreCase)) ?? "";
+			var normalizedItemsLine = itemsLine.Replace('\\', '/');
+
+			Assert.Contains("SharedPage.xaml", normalizedItemsLine, StringComparison.OrdinalIgnoreCase);
+			Assert.DoesNotContain("Platforms/Windows/WindowsPage.xaml", normalizedItemsLine, StringComparison.OrdinalIgnoreCase);
+		}
+
 		/// <summary>
 		/// Tests that the SingleProject Before targets use default Entitlements.plist when no custom CodesignEntitlements is set
 		/// </summary>

--- a/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
@@ -45,6 +45,24 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 					x:Class=""Microsoft.Maui.Controls.Xaml.UnitTests.CustomView"">
 					<Label x:Name=""label0""/>
 				</ContentView>";
+
+			// Deliberately shares the same x:Class across all Platforms/<Platform> variants, to
+			// mirror the common per-platform partial-page pattern from https://github.com/dotnet/maui/issues/36951.
+			public static readonly string TestPage = $@"
+				<ContentPage
+					xmlns=""{MicrosoftMauiControlsFormsDefaultNamespace}""
+					xmlns:x=""{MicrosoftMauiControlsFormsXNamespace}""
+					x:Class=""Microsoft.Maui.Controls.Xaml.UnitTests.TestPage"">
+					<Label x:Name=""label0""/>
+				</ContentPage>";
+
+			public static readonly string SharedPage = $@"
+				<ContentPage
+					xmlns=""{MicrosoftMauiControlsFormsDefaultNamespace}""
+					xmlns:x=""{MicrosoftMauiControlsFormsXNamespace}""
+					x:Class=""Microsoft.Maui.Controls.Xaml.UnitTests.SharedPage"">
+					<Label x:Name=""label0""/>
+				</ContentPage>";
 		}
 
 		class Css
@@ -184,6 +202,13 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			var itemGroup = NewElement("ItemGroup");
 			itemGroup.Add(NewElement(buildAction).WithAttribute("Include", name));
 			return itemGroup;
+		}
+
+		void WriteFile(string name, string contents)
+		{
+			var filePath = IOPath.Combine(tempDirectory, name.Replace('\\', IOPath.DirectorySeparatorChar).Replace('/', IOPath.DirectorySeparatorChar));
+			Directory.CreateDirectory(IOPath.GetDirectoryName(filePath));
+			File.WriteAllText(filePath, contents);
 		}
 
 		string Build(string projectFile, string target = "Build", string verbosity = "normal", string additionalArgs = "", bool shouldSucceed = true)
@@ -612,6 +637,105 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			Assert.True(log.Contains("CodesignEntitlements = Custom/Entitlements.plist", StringComparison.Ordinal) ||
 						  log.Contains("CodesignEntitlements = Custom\\Entitlements.plist", StringComparison.Ordinal),
 				"Custom CodesignEntitlements property should be preserved and not overridden by default Entitlements.plist");
+		}
+
+		/// <summary>
+		/// Regression test for https://github.com/dotnet/maui/issues/36951.
+		///
+		/// MauiXaml has no ExcludeFromCurrentConfiguration gating like Compile does, so every
+		/// platform's *.xaml files under Platforms/&lt;Platform&gt; used to stay in the MauiXaml item
+		/// group for every inner build/TFM. The XAML SourceGen consumes MauiXaml as AdditionalFiles
+		/// regardless of platform, so files reusing the same class name across Platforms/Android,
+		/// Platforms/iOS, and Platforms/MacCatalyst (a common per-platform partial-page pattern)
+		/// produced duplicate InitializeComponent/attribute definitions (CS0579/CS0111) even though
+		/// only one of them should have participated in any given inner build.
+		///
+		/// Only the MauiXaml item belonging to the currently active platform (plus any
+		/// non-platform-folder shared xaml) should survive _MauiRemovePlatformCompileItems.
+		/// </summary>
+		[Theory]
+		[InlineData("android", "Android")]
+		[InlineData("ios", "iOS")]
+		[InlineData("maccatalyst", "MacCatalyst")]
+		public void SingleProject_RemovePlatformCompileItems_RemovesNonActivePlatformMauiXamlItems(string targetPlatformIdentifier, string activePlatformFolder)
+		{
+			SetUp();
+			var project = NewElement("Project").WithAttribute("Sdk", "Microsoft.NET.Sdk");
+			var propertyGroup = NewElement("PropertyGroup");
+			propertyGroup.Add(NewElement("TargetFramework").WithValue(GetTfm()));
+			propertyGroup.Add(NewElement("SingleProject").WithValue("true"));
+			propertyGroup.Add(NewElement("EnableDefaultCompileItems").WithValue("false"));
+			propertyGroup.Add(NewElement("EnableDefaultEmbeddedResourceItems").WithValue("false"));
+			// Fake the active platform without requiring the real platform TFM/workload to be installed.
+			propertyGroup.Add(NewElement("TargetPlatformIdentifier").WithValue(targetPlatformIdentifier));
+			project.Add(propertyGroup);
+
+			var itemGroup = NewElement("ItemGroup");
+			foreach (var assembly in references)
+			{
+				var reference = NewElement("Reference").WithAttribute("Include", assembly);
+				if (assembly.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+				{
+					reference.Add(NewElement("HintPath").WithValue(IOPath.Combine("..", "..", assembly)));
+				}
+				itemGroup.Add(reference);
+			}
+			project.Add(itemGroup);
+
+			var beforeTargetsPath = AssemblyInfoTests.GetFilePathFromRoot(IOPath.Combine("src", "Controls", "src", "Build.Tasks", "nuget", "buildTransitive", "netstandard2.0", "Microsoft.Maui.Controls.SingleProject.Before.targets"));
+			project.Add(NewElement("Import").WithAttribute("Project", beforeTargetsPath));
+
+			project.Add(AddFile("Entry.cs", "Compile", @"
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public static class Entry
+{
+	public static string Value => ""ok"";
+}"));
+
+			// Each platform's TestPage.xaml intentionally reuses the same x:Class so we can prove
+			// that only the active platform's file survives filtering (otherwise SourceGen would
+			// emit duplicate InitializeComponent/attribute definitions for the same type).
+			var platformFolders = new[] { "Android", "iOS", "MacCatalyst" };
+			var xamlItems = NewElement("ItemGroup");
+			foreach (var folder in platformFolders)
+			{
+				WriteFile($"Platforms\\{folder}\\TestPage.xaml", Xaml.TestPage);
+				xamlItems.Add(NewElement("MauiXaml").WithAttribute("Include", $"Platforms\\{folder}\\TestPage.xaml"));
+			}
+			WriteFile("SharedPage.xaml", Xaml.SharedPage);
+			xamlItems.Add(NewElement("MauiXaml").WithAttribute("Include", "SharedPage.xaml"));
+			project.Add(xamlItems);
+
+			var targetsPath = AssemblyInfoTests.GetFilePathFromRoot(IOPath.Combine("src", "Controls", "src", "Build.Tasks", "nuget", "buildTransitive", "netstandard2.0", "Microsoft.Maui.Controls.SingleProject.targets"));
+			project.Add(NewElement("Import").WithAttribute("Project", targetsPath));
+
+			// Dump the post-filter MauiXaml item identities to the build log so we can assert on
+			// exactly what survived _MauiRemovePlatformCompileItems for this platform.
+			var dumpTarget = NewElement("Target")
+				.WithAttribute("Name", "_TestDumpMauiXamlItems")
+				.WithAttribute("AfterTargets", "_MauiRemovePlatformCompileItems");
+			dumpTarget.Add(NewElement("Message")
+				.WithAttribute("Importance", "high")
+				.WithAttribute("Text", "MAUIXAML_ITEMS: @(MauiXaml->'%(Identity)', '|')"));
+			project.Add(dumpTarget);
+
+			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
+			project.Save(projectFile);
+
+			var log = Build(projectFile);
+
+			// Normalize separators since Identity may render with '/' or '\' depending on OS.
+			var itemsLine = log.Split('\n').FirstOrDefault(l => l.Contains("MAUIXAML_ITEMS:", StringComparison.OrdinalIgnoreCase)) ?? "";
+			var normalizedItemsLine = itemsLine.Replace('\\', '/');
+
+			Assert.Contains("SharedPage.xaml", normalizedItemsLine, StringComparison.OrdinalIgnoreCase);
+			Assert.Contains($"Platforms/{activePlatformFolder}/TestPage.xaml", normalizedItemsLine, StringComparison.OrdinalIgnoreCase);
+
+			foreach (var folder in platformFolders.Where(f => !string.Equals(f, activePlatformFolder, StringComparison.OrdinalIgnoreCase)))
+			{
+				Assert.DoesNotContain($"Platforms/{folder}/TestPage.xaml", normalizedItemsLine, StringComparison.OrdinalIgnoreCase);
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
 
### Issue Details

MauiXaml will generate source for every xaml file without respect to its condition by configuration/target

### Root Cause 

•  Microsoft.Maui.Controls.Globs.props  globs  **\*.xaml  into the  MauiXaml  item group unconditionally for every inner build/TFM.
•  Microsoft.Maui.Controls.SingleProject.targets  correctly gates  Compile  ( .cs ) items under  Platforms/<Platform>/  via  %(Compile.ExcludeFromCurrentConfiguration) , but its XAML-removal logic only ever stripped Windows  .xaml  (WinUI markup) out of  MauiXaml . It never removed non-active-platform  .xaml  under  Platforms/Android ,  Platforms/iOS ,  Platforms/MacCatalyst , or  Platforms/Tizen .
• Consequence: the XAML SourceGen consumes  MauiXaml  as  AdditionalFiles  regardless of platform, so every platform's xaml leaked into every inner build — producing duplicate  InitializeComponent /attribute/field declarations whenever multiple platforms reused the same class name (a standard, supported pattern).

### Description of Change
 
src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.SingleProject.targets  (shipped via  buildTransitive  in  Microsoft.Maui.Controls.Build.Tasks  → applies to every MAUI app)
 
Extended the  _MauiRemovePlatformCompileItems  target's  _MauiXamlToRemove  computation (previously Windows-only) to also cover Android/iOS/MacCatalyst/Tizen: for each built-in platform folder, its  .xaml  files are queued for removal from  MauiXaml / EmbeddedResource  unless it matches the currently active  $(TargetPlatformIdentifier) . The pre-existing unconditional Windows-folder removal (WinUI markup, not MAUI XAML) is left unchanged.

 
### Issues Fixed
 
Fixes #36951 
 
**Tested the behavior in the following platforms.**
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
| Before  | After  |
|---------|--------|
| <img src="https://github.com/user-attachments/assets/a0fd36d9-2094-4948-a645-c3c0d1bf0e4e" Width="600" Height="300" /> | <img width="600" height="300" alt="image" src="https://github.com/user-attachments/assets/510d9024-dacc-4447-821d-29e7129ed844" /> |