### PR TITLE
[Android] CollectionView: Preserve header focus when clearing items

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/Adapters/AdapterNotifier.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/Adapters/AdapterNotifier.cs
@@ -3,7 +3,7 @@ using AndroidX.RecyclerView.Widget;
 
 namespace Microsoft.Maui.Controls.Handlers.Items
 {
-	internal class AdapterNotifier : ICollectionChangedNotifier
+	internal class AdapterNotifier : ICollectionChangedNotifier, ICollectionChangedNotifierWithCleanup
 	{
 		readonly RecyclerView.Adapter _adapter;
 
@@ -16,6 +16,19 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			if (IsValidAdapter())
 				_adapter.NotifyDataSetChanged();
+		}
+
+		internal void NotifyDataSetChangedAndUnbind()
+		{
+			if (IsValidAdapter())
+			{
+				if (_adapter is IItemsViewAdapter itemsViewAdapter)
+				{
+					itemsViewAdapter.UnbindAllItems();
+				}
+
+				_adapter.NotifyDataSetChanged();
+			}
 		}
 
 		public void NotifyItemChanged(IItemsViewSource source, int startIndex)
@@ -56,8 +69,23 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public void NotifyItemRangeRemoved(IItemsViewSource source, int startIndex, int count)
 		{
+			NotifyItemRangeRemoved(startIndex, count, unbind: false);
+		}
+
+		void ICollectionChangedNotifierWithCleanup.NotifyItemRangeRemovedAndUnbind(IItemsViewSource source, int startIndex, int count)
+		{
+			NotifyItemRangeRemoved(startIndex, count, unbind: true);
+		}
+
+		void NotifyItemRangeRemoved(int startIndex, int count, bool unbind)
+		{
 			if (IsValidAdapter())
 			{
+				if (unbind && _adapter is IItemsViewAdapter itemsViewAdapter)
+				{
+					itemsViewAdapter.UnbindItemRange(startIndex, count);
+				}
+
 				_adapter.NotifyItemRangeRemoved(startIndex, count);
 			}
 		}

--- a/src/Controls/src/Core/Handlers/Items/Android/Adapters/CarouselViewAdapter.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/Adapters/CarouselViewAdapter.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 					textViewHolder.TextView.Text = ItemsSource.GetItem(positionInList).ToString();
 					break;
 				case TemplatedItemViewHolder templatedItemViewHolder:
+					TrackBoundViewHolder(templatedItemViewHolder, position);
 					BindTemplatedItemViewHolder(templatedItemViewHolder, ItemsSource.GetItem(positionInList));
 					break;
 			}

--- a/src/Controls/src/Core/Handlers/Items/Android/Adapters/GroupableItemsViewAdapter.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/Adapters/GroupableItemsViewAdapter.cs
@@ -59,6 +59,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			if (holder is TemplatedItemViewHolder templatedItemViewHolder &&
 				(ItemsSource.IsGroupFooter(position) || ItemsSource.IsGroupHeader(position)))
 			{
+				TrackBoundViewHolder(templatedItemViewHolder, position);
 				BindTemplatedItemViewHolder(templatedItemViewHolder, ItemsSource.GetItem(position));
 				return;
 			}

--- a/src/Controls/src/Core/Handlers/Items/Android/Adapters/ItemsViewAdapter.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/Adapters/ItemsViewAdapter.cs
@@ -1,5 +1,6 @@
 ﻿#nullable disable
 using System;
+using System.Collections.Generic;
 using Android.Content;
 using Android.Widget;
 using AndroidX.RecyclerView.Widget;
@@ -8,12 +9,19 @@ using ViewGroup = Android.Views.ViewGroup;
 
 namespace Microsoft.Maui.Controls.Handlers.Items
 {
-	public class ItemsViewAdapter<TItemsView, TItemsViewSource> : RecyclerView.Adapter
+	internal interface IItemsViewAdapter
+	{
+		void UnbindAllItems();
+		void UnbindItemRange(int startIndex, int count);
+	}
+
+	public class ItemsViewAdapter<TItemsView, TItemsViewSource> : RecyclerView.Adapter, IItemsViewAdapter
 		where TItemsView : ItemsView
 		where TItemsViewSource : IItemsViewSource
 	{
 		protected readonly TItemsView ItemsView;
 		readonly Func<View, Context, ItemContentView> _createItemContentView;
+		readonly Dictionary<TemplatedItemViewHolder, int> _boundViewHolders = new();
 		protected internal TItemsViewSource ItemsSource;
 
 		bool _disposed;
@@ -54,10 +62,44 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			if (holder is TemplatedItemViewHolder templatedItemViewHolder)
 			{
+				_boundViewHolders.Remove(templatedItemViewHolder);
 				templatedItemViewHolder.Recycle(ItemsView);
 			}
 
 			base.OnViewRecycled(holder);
+		}
+
+		void IItemsViewAdapter.UnbindItemRange(int startIndex, int count)
+		{
+			var endIndex = startIndex + count;
+			var boundViewHolders = new KeyValuePair<TemplatedItemViewHolder, int>[_boundViewHolders.Count];
+			((ICollection<KeyValuePair<TemplatedItemViewHolder, int>>)_boundViewHolders).CopyTo(boundViewHolders, 0);
+
+			for (int n = 0; n < boundViewHolders.Length; n++)
+			{
+				var viewHolder = boundViewHolders[n].Key;
+				var position = viewHolder.BindingAdapterPosition;
+				if (position == RecyclerView.NoPosition)
+				{
+					position = boundViewHolders[n].Value;
+				}
+
+				if (position >= startIndex && position < endIndex)
+				{
+					viewHolder.Unbind(ItemsView);
+					_boundViewHolders.Remove(viewHolder);
+				}
+			}
+		}
+
+		void IItemsViewAdapter.UnbindAllItems()
+		{
+			foreach (var viewHolder in _boundViewHolders.Keys)
+			{
+				viewHolder.Unbind(ItemsView);
+			}
+
+			_boundViewHolders.Clear();
 		}
 
 		public override void OnBindViewHolder(RecyclerView.ViewHolder holder, int position)
@@ -68,9 +110,15 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 					textViewHolder.TextView.Text = ItemsSource.GetItem(position).ToString();
 					break;
 				case TemplatedItemViewHolder templatedItemViewHolder:
+					TrackBoundViewHolder(templatedItemViewHolder, position);
 					BindTemplatedItemViewHolder(templatedItemViewHolder, ItemsSource.GetItem(position));
 					break;
 			}
+		}
+
+		private protected void TrackBoundViewHolder(TemplatedItemViewHolder viewHolder, int position)
+		{
+			_boundViewHolders[viewHolder] = position;
 		}
 
 		protected virtual bool IsSelectionEnabled(ViewGroup parent, int viewType) => true;
@@ -129,6 +177,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				{
 					ItemsSource?.Dispose();
 					ItemsView.PropertyChanged -= ItemsViewPropertyChanged;
+					_boundViewHolders.Clear();
 				}
 
 				_disposed = true;

--- a/src/Controls/src/Core/Handlers/Items/Android/Adapters/StructuredItemsViewAdapter.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/Adapters/StructuredItemsViewAdapter.cs
@@ -83,6 +83,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			{
 				if (holder is TemplatedItemViewHolder templatedItemViewHolder)
 				{
+					TrackBoundViewHolder(templatedItemViewHolder, position);
 					BindTemplatedItemViewHolder(templatedItemViewHolder, ItemsView.Header);
 				}
 
@@ -93,6 +94,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			{
 				if (holder is TemplatedItemViewHolder templatedItemViewHolder)
 				{
+					TrackBoundViewHolder(templatedItemViewHolder, position);
 					BindTemplatedItemViewHolder(templatedItemViewHolder, ItemsView.Footer);
 				}
 
@@ -106,14 +108,14 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			var itemViewType = templatedItemViewHolder.ItemViewType;
 			if (ItemsView.ItemSizingStrategy == ItemSizingStrategy.MeasureFirstItem && itemViewType != ItemViewType.Header && itemViewType != ItemViewType.Footer && itemViewType != ItemViewType.GroupHeader && itemViewType != ItemViewType.GroupFooter)
- 			{
- 				templatedItemViewHolder.Bind(context, ItemsView, _reportMeasure, _size);
+			{
+				templatedItemViewHolder.Bind(context, ItemsView, _reportMeasure, _size);
 
- 				if (templatedItemViewHolder.ItemView is ItemContentView itemContentView)
- 				{
- 					itemContentView.RetrieveStaticSize = _retrieveStaticSize;
+				if (templatedItemViewHolder.ItemView is ItemContentView itemContentView)
+				{
+					itemContentView.RetrieveStaticSize = _retrieveStaticSize;
 				}
- 			}
+			}
 			else
 			{
 				base.BindTemplatedItemViewHolder(templatedItemViewHolder, context);

--- a/src/Controls/src/Core/Handlers/Items/Android/ItemsSources/ICollectionChangedNotifier.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/ItemsSources/ICollectionChangedNotifier.cs
@@ -13,4 +13,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		void NotifyItemRangeRemoved(IItemsViewSource source, int startIndex, int count);
 		void NotifyItemRemoved(IItemsViewSource source, int startIndex);
 	}
+
+	internal interface ICollectionChangedNotifierWithCleanup
+	{
+		void NotifyItemRangeRemovedAndUnbind(IItemsViewSource source, int startIndex, int count);
+	}
 }

--- a/src/Controls/src/Core/Handlers/Items/Android/ItemsSources/ObservableGroupedSource.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/ItemsSources/ObservableGroupedSource.cs
@@ -6,7 +6,7 @@ using System.Collections.Specialized;
 
 namespace Microsoft.Maui.Controls.Handlers.Items
 {
-	internal class ObservableGroupedSource : IGroupableItemsViewSource, ICollectionChangedNotifier, IObservableItemsViewSource
+	internal class ObservableGroupedSource : IGroupableItemsViewSource, ICollectionChangedNotifier, ICollectionChangedNotifierWithCleanup, IObservableItemsViewSource
 	{
 		readonly GroupableItemsView _groupableItemsView;
 		readonly ICollectionChangedNotifier _notifier;
@@ -145,7 +145,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		public IItemsViewSource GetGroupItemsViewSource(int groupIndex)
 		{
 			// The uint cast is being used as an optimization to handle both negative numbers and out-of-bounds indices in a single comparison
-			if ((uint) groupIndex >= (uint) _groups.Count)
+			if ((uint)groupIndex >= (uint)_groups.Count)
 			{
 				System.Diagnostics.Debug.WriteLine($"Invalid Group index: {groupIndex}, Group count: {_groups.Count}");
 				return null;
@@ -199,6 +199,19 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			localIndex = GetAbsolutePosition(group, localIndex);
 			_notifier.NotifyItemRangeRemoved(this, localIndex, count);
+		}
+
+		void ICollectionChangedNotifierWithCleanup.NotifyItemRangeRemovedAndUnbind(IItemsViewSource group, int localIndex, int count)
+		{
+			localIndex = GetAbsolutePosition(group, localIndex);
+			if (_notifier is ICollectionChangedNotifierWithCleanup notifierWithCleanup)
+			{
+				notifierWithCleanup.NotifyItemRangeRemovedAndUnbind(this, localIndex, count);
+			}
+			else
+			{
+				_notifier.NotifyItemRangeRemoved(this, localIndex, count);
+			}
 		}
 
 		public void NotifyItemRemoved(IItemsViewSource group, int localIndex)
@@ -261,7 +274,13 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				return;
 			}
 
-			_groupableItemsView.Dispatcher.DispatchIfRequired(() => CollectionChanged(args));
+			_groupableItemsView.Dispatcher.DispatchIfRequired(() =>
+			{
+				if (!_disposed)
+				{
+					CollectionChanged(args);
+				}
+			});
 		}
 
 		void CollectionChanged(NotifyCollectionChangedEventArgs args)
@@ -281,11 +300,39 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 					Move(args);
 					break;
 				case NotifyCollectionChangedAction.Reset:
-					Reload();
+					Reset();
 					break;
 				default:
 					throw new ArgumentOutOfRangeException();
 			}
+		}
+
+		void Reset()
+		{
+			var previousItemsCount = Count - (HasHeader ? 1 : 0) - (HasFooter ? 1 : 0);
+
+			UpdateGroupTracking();
+
+			var newItemsCount = Count - (HasHeader ? 1 : 0) - (HasFooter ? 1 : 0);
+			if (newItemsCount == 0)
+			{
+				if (previousItemsCount > 0)
+				{
+					var startIndex = HasHeader ? 1 : 0;
+					if (_notifier is ICollectionChangedNotifierWithCleanup notifierWithCleanup)
+					{
+						notifierWithCleanup.NotifyItemRangeRemovedAndUnbind(this, startIndex, previousItemsCount);
+					}
+					else
+					{
+						_notifier.NotifyItemRangeRemoved(this, startIndex, previousItemsCount);
+					}
+				}
+
+				return;
+			}
+
+			_notifier.NotifyDataSetChanged();
 		}
 
 		void Reload()

--- a/src/Controls/src/Core/Handlers/Items/Android/ItemsSources/ObservableItemsSource.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/ItemsSources/ObservableItemsSource.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		readonly ICollectionChangedNotifier _notifier;
 		readonly WeakNotifyCollectionChangedProxy _proxy = new();
 		readonly NotifyCollectionChangedEventHandler _collectionChanged;
+		int _itemsCount;
 		bool _disposed;
 
 		~ObservableItemsSource() => _proxy.Unsubscribe();
@@ -24,6 +25,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			_container = container;
 			_notifier = notifier;
 			_collectionChanged = CollectionChanged;
+			_itemsCount = ItemsCount();
 			_proxy.Subscribe((INotifyCollectionChanged)itemSource, _collectionChanged);
 		}
 
@@ -108,15 +110,38 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		void CollectionChanged(object sender, NotifyCollectionChangedEventArgs args)
 		{
+			var previousItemsCount = _itemsCount;
+			var newItemsCount = GetNewItemsCount(args);
+			_itemsCount = newItemsCount;
+
 			if (!ObserveChanges)
 			{
 				return;
 			}
 
-			_container.Dispatcher.DispatchIfRequired(() => CollectionChanged(args));
+			_container.Dispatcher.DispatchIfRequired(() =>
+			{
+				if (!_disposed)
+				{
+					CollectionChanged(args, previousItemsCount, newItemsCount);
+				}
+			});
 		}
 
-		void CollectionChanged(NotifyCollectionChangedEventArgs args)
+		int GetNewItemsCount(NotifyCollectionChangedEventArgs args)
+		{
+			return args.Action switch
+			{
+				NotifyCollectionChangedAction.Add => _itemsCount + args.NewItems.Count,
+				NotifyCollectionChangedAction.Remove => _itemsCount - args.OldItems.Count,
+				NotifyCollectionChangedAction.Replace => _itemsCount - args.OldItems.Count + args.NewItems.Count,
+				NotifyCollectionChangedAction.Move => _itemsCount,
+				NotifyCollectionChangedAction.Reset => ItemsCount(),
+				_ => throw new ArgumentOutOfRangeException()
+			};
+		}
+
+		void CollectionChanged(NotifyCollectionChangedEventArgs args, int previousItemsCount, int newItemsCount)
 		{
 			switch (args.Action)
 			{
@@ -133,12 +158,49 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 					Move(args);
 					break;
 				case NotifyCollectionChangedAction.Reset:
-					_notifier.NotifyDataSetChanged();
+					Reset(previousItemsCount, newItemsCount);
 					break;
 				default:
 					throw new ArgumentOutOfRangeException();
 			}
 			CollectionItemsSourceChanged?.Invoke(this, args);
+		}
+
+		void Reset(int previousItemsCount, int newItemsCount)
+		{
+			if (newItemsCount == 0)
+			{
+				if (_container is CarouselView { Loop: true })
+				{
+					if (_notifier is AdapterNotifier adapterNotifier)
+					{
+						adapterNotifier.NotifyDataSetChangedAndUnbind();
+					}
+					else
+					{
+						_notifier.NotifyDataSetChanged();
+					}
+
+					return;
+				}
+
+				if (previousItemsCount > 0)
+				{
+					var startIndex = AdjustPositionForHeader(0);
+					if (_notifier is ICollectionChangedNotifierWithCleanup notifierWithCleanup)
+					{
+						notifierWithCleanup.NotifyItemRangeRemovedAndUnbind(this, startIndex, previousItemsCount);
+					}
+					else
+					{
+						_notifier.NotifyItemRangeRemoved(this, startIndex, previousItemsCount);
+					}
+				}
+
+				return;
+			}
+
+			_notifier.NotifyDataSetChanged();
 		}
 
 		void Move(NotifyCollectionChangedEventArgs args)

--- a/src/Controls/src/Core/Handlers/Items/Android/TemplatedItemViewHolder.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/TemplatedItemViewHolder.cs
@@ -42,6 +42,17 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			itemsView.RemoveLogicalChild(View);
 		}
 
+		internal void Unbind(ItemsView itemsView)
+		{
+			if (View == null)
+			{
+				return;
+			}
+
+			View.BindingContext = null;
+			itemsView.RemoveLogicalChild(View);
+		}
+
 		public void Bind(object itemBindingContext, ItemsView itemsView,
 			Action<Size> reportMeasure = null, Size? size = null)
 		{

--- a/src/Controls/tests/DeviceTests/Elements/CarouselView/CarouselViewTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CarouselView/CarouselViewTests.Android.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.ObjectModel;
+using System.Linq;
 using System.Threading.Tasks;
 using Android.Widget;
 using AndroidX.RecyclerView.Widget;
@@ -7,6 +8,7 @@ using Microsoft.Maui.Controls.Handlers.Items;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using Xunit;
+using static Microsoft.Maui.DeviceTests.AssertHelpers;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -52,6 +54,61 @@ namespace Microsoft.Maui.DeviceTests
 
 				var platformPosition = GetPlatformPosition(handler);
 				Assert.True(CheckPosition(platformPosition, position));
+			});
+		}
+
+		[Fact]
+		public async Task ClearingLoopingItemsSourceDoesNotCrash()
+		{
+			SetupBuilder();
+
+			var data = new ObservableCollection<string> { "Item 1", "Item 2", "Item 3" };
+			var carouselView = new CarouselView
+			{
+				ItemsSource = data,
+				ItemTemplate = new DataTemplate(() => new Label())
+			};
+
+			await CreateHandlerAndAddToWindow<CarouselViewHandler>(carouselView, async handler =>
+			{
+				await handler.PlatformView.WaitForLayoutOrNonZeroSize();
+				await AssertEventually(() =>
+					handler.PlatformView.GetAdapter().ItemCount == CarouselViewLoopManager.LoopScale);
+				await AssertEventually(() => carouselView.LogicalChildrenInternal.Count > 0);
+
+				var logicalChildren = carouselView.LogicalChildrenInternal.ToArray();
+
+				data.Clear();
+
+				await AssertEventually(() => handler.PlatformView.GetAdapter().ItemCount == 0);
+				await AssertEventually(() => logicalChildren.All(logicalChild => logicalChild.BindingContext is null));
+			});
+		}
+
+		[Fact]
+		public async Task ClearingNonLoopingItemsSourceClearsBindingContexts()
+		{
+			SetupBuilder();
+
+			var data = new ObservableCollection<string> { "Item 1", "Item 2", "Item 3" };
+			var carouselView = new CarouselView
+			{
+				ItemsSource = data,
+				ItemTemplate = new DataTemplate(() => new Label()),
+				Loop = false
+			};
+
+			await CreateHandlerAndAddToWindow<CarouselViewHandler>(carouselView, async handler =>
+			{
+				await handler.PlatformView.WaitForLayoutOrNonZeroSize();
+				await AssertEventually(() => carouselView.LogicalChildrenInternal.Count > 0);
+
+				var logicalChildren = carouselView.LogicalChildrenInternal.ToArray();
+
+				data.Clear();
+
+				await AssertEventually(() => handler.PlatformView.GetAdapter().ItemCount == 0);
+				await AssertEventually(() => logicalChildren.All(logicalChild => logicalChild.BindingContext is null));
 			});
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.Android.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
@@ -11,6 +12,7 @@ using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using Xunit;
+using static Microsoft.Maui.DeviceTests.AssertHelpers;
 using AInsets = AndroidX.Core.Graphics.Insets;
 using AView = Android.Views.View;
 
@@ -159,6 +161,268 @@ namespace Microsoft.Maui.DeviceTests
 				count = ois.Count;
 				Assert.Equal(3, ois.Count);
 			});
+		}
+
+		[Fact]
+		public async Task ClearingObservableSourceNotifiesItemRangeRemoval()
+		{
+			SetupBuilder();
+
+			var source = new ObservableCollection<string> { "Item 1", "Item 2", "Item 3" };
+			var notifier = new MockCollectionChangedNotifier();
+			var observableSource = ItemsSourceFactory.Create(source, Application.Current, notifier);
+			observableSource.HasHeader = true;
+
+			await InvokeOnMainThreadAsync(source.Clear);
+
+			Assert.Equal(0, notifier.DataSetChangedCount);
+			Assert.Equal(1, notifier.RangeRemoveStart);
+			Assert.Equal(3, notifier.RangeRemoveCount);
+		}
+
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public async Task ClearingAndAddingItemsKeepsHeaderEntryFocused(bool isGrouped)
+		{
+			SetupBuilder();
+
+			IEnumerable<object> itemsSource;
+			Action clearItems;
+			Action addItems;
+
+			if (isGrouped)
+			{
+				var groups = new ObservableCollection<object>
+				{
+					new ObservableCollection<string> { "Item 1", "Item 2", "Item 3" }
+				};
+				itemsSource = groups;
+				clearItems = groups.Clear;
+				addItems = () => groups.Add(new ObservableCollection<string> { "Item 4", "Item 5", "Item 6" });
+			}
+			else
+			{
+				var items = new ObservableCollection<object> { "Item 1", "Item 2", "Item 3" };
+				itemsSource = items;
+				clearItems = items.Clear;
+				addItems = () =>
+				{
+					items.Add("Item 4");
+					items.Add("Item 5");
+					items.Add("Item 6");
+				};
+			}
+
+			var entry = new Entry();
+			var header = new Grid();
+			header.Add(entry);
+
+			var collectionView = new CollectionView
+			{
+				Header = header,
+				IsGrouped = isGrouped,
+				ItemsSource = itemsSource,
+				ItemTemplate = new DataTemplate(() => new Label())
+			};
+
+			await CreateHandlerAndAddToWindow<CollectionViewHandler>(collectionView, async handler =>
+			{
+				await AssertEventually(() => entry.Handler?.PlatformView is AView { IsShown: true });
+
+				var platformEntry = (AView)entry.Handler.PlatformView;
+				var platformCollectionView = handler.PlatformView;
+				await AssertEventually(() => platformCollectionView.FindViewHolderForAdapterPosition(1) is not null);
+				Assert.True(platformEntry.RequestFocus());
+				await AssertEventually(() => platformEntry.HasFocus);
+
+				clearItems();
+				await AssertEventually(() => platformCollectionView.GetAdapter().ItemCount == 1
+					&& platformCollectionView.FindViewHolderForAdapterPosition(1) is null);
+
+				Assert.True(platformEntry.HasFocus);
+
+				addItems();
+				await AssertEventually(() => platformCollectionView.GetAdapter().ItemCount == 4
+					&& platformCollectionView.FindViewHolderForAdapterPosition(1) is not null);
+
+				Assert.True(platformEntry.HasFocus);
+			});
+		}
+
+		[Fact]
+		public async Task ClearingSourceUnbindsNoPositionItemHolderWithoutUnbindingHeader()
+		{
+			SetupBuilder();
+
+			var header = new object();
+			var item = new object();
+			var items = new ObservableCollection<object> { item };
+			var collectionView = new CollectionView
+			{
+				Header = header,
+				HeaderTemplate = new DataTemplate(() => new Label()),
+				ItemsSource = items,
+				ItemTemplate = new DataTemplate(() => new Label())
+			};
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var handler = CreateHandler<CollectionViewHandler>(collectionView);
+				var adapter = handler.PlatformView.GetAdapter();
+
+				var headerViewType = adapter.GetItemViewType(0);
+				var headerHolder = Assert.IsType<TemplatedItemViewHolder>(
+					adapter.OnCreateViewHolder(handler.PlatformView, headerViewType));
+				adapter.OnBindViewHolder(headerHolder, 0);
+
+				var itemViewType = adapter.GetItemViewType(1);
+				var itemHolder = Assert.IsType<TemplatedItemViewHolder>(
+					adapter.OnCreateViewHolder(handler.PlatformView, itemViewType));
+				adapter.OnBindViewHolder(itemHolder, 1);
+
+				Assert.Equal(global::AndroidX.RecyclerView.Widget.RecyclerView.NoPosition, headerHolder.BindingAdapterPosition);
+				Assert.Equal(global::AndroidX.RecyclerView.Widget.RecyclerView.NoPosition, itemHolder.BindingAdapterPosition);
+				Assert.Same(header, headerHolder.View.BindingContext);
+				Assert.Same(item, itemHolder.View.BindingContext);
+
+				items.Clear();
+
+				Assert.Same(header, headerHolder.View.BindingContext);
+				Assert.Null(itemHolder.View.BindingContext);
+			});
+		}
+
+		[Fact]
+		public async Task ClearingGroupDoesNotUnbindNoPositionHolderFromAnotherGroup()
+		{
+			SetupBuilder();
+
+			var firstItem = new object();
+			var secondItem = new object();
+			var firstGroup = new ObservableCollection<object> { firstItem };
+			var secondGroup = new ObservableCollection<object> { secondItem };
+			var groups = new ObservableCollection<object> { firstGroup, secondGroup };
+			var collectionView = new CollectionView
+			{
+				IsGrouped = true,
+				ItemsSource = groups,
+				ItemTemplate = new DataTemplate(() => new Label())
+			};
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var handler = CreateHandler<CollectionViewHandler>(collectionView);
+				var adapter = handler.PlatformView.GetAdapter();
+
+				var firstHolder = Assert.IsType<TemplatedItemViewHolder>(
+					adapter.OnCreateViewHolder(handler.PlatformView, adapter.GetItemViewType(0)));
+				adapter.OnBindViewHolder(firstHolder, 0);
+
+				var secondHolder = Assert.IsType<TemplatedItemViewHolder>(
+					adapter.OnCreateViewHolder(handler.PlatformView, adapter.GetItemViewType(1)));
+				adapter.OnBindViewHolder(secondHolder, 1);
+
+				Assert.Equal(global::AndroidX.RecyclerView.Widget.RecyclerView.NoPosition, firstHolder.BindingAdapterPosition);
+				Assert.Equal(global::AndroidX.RecyclerView.Widget.RecyclerView.NoPosition, secondHolder.BindingAdapterPosition);
+
+				firstGroup.Clear();
+
+				Assert.Null(firstHolder.View.BindingContext);
+				Assert.Same(secondItem, secondHolder.View.BindingContext);
+			});
+		}
+
+		[Fact]
+		public async Task ClearingGroupedSourceClearsGroupHeaderBindingContext()
+		{
+			SetupBuilder();
+
+			var group = new ObservableCollection<string> { "Item 1", "Item 2", "Item 3" };
+			var groups = new ObservableCollection<object> { group };
+			var collectionView = new CollectionView
+			{
+				IsGrouped = true,
+				ItemsSource = groups,
+				GroupHeaderTemplate = new DataTemplate(() => new Label()),
+				ItemTemplate = new DataTemplate(() => new Label())
+			};
+
+			await CreateHandlerAndAddToWindow<CollectionViewHandler>(collectionView, async _ =>
+			{
+				await AssertEventually(() =>
+					collectionView.LogicalChildrenInternal.Any(child => ReferenceEquals(child.BindingContext, group)));
+
+				var groupHeader = collectionView.LogicalChildrenInternal
+					.First(child => ReferenceEquals(child.BindingContext, group));
+
+				groups.Clear();
+
+				await AssertEventually(() => groupHeader.BindingContext is null);
+			});
+		}
+
+		[Fact]
+		public async Task DisposedItemsSourceIgnoresQueuedCollectionChanges()
+		{
+			SetupBuilder();
+
+			var items = new ObservableCollection<string>();
+			var notifier = new MockCollectionChangedNotifier();
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var observableSource = new ObservableItemsSource(items, Application.Current, notifier);
+				using var collectionChangedQueued = new System.Threading.ManualResetEventSlim();
+
+				var addItem = Task.Run(() =>
+				{
+					items.Add("Item 1");
+					collectionChangedQueued.Set();
+				});
+
+				Assert.True(collectionChangedQueued.Wait(TimeSpan.FromSeconds(5)));
+				addItem.GetAwaiter().GetResult();
+				observableSource.Dispose();
+			});
+
+			await InvokeOnMainThreadAsync(() => { });
+
+			Assert.Equal(0, notifier.InsertCount);
+		}
+
+		[Fact]
+		public async Task DisposedGroupedSourceIgnoresQueuedCollectionChanges()
+		{
+			SetupBuilder();
+
+			var groups = new ObservableCollection<object>();
+			var collectionView = new CollectionView
+			{
+				IsGrouped = true,
+				ItemsSource = groups
+			};
+			var notifier = new MockCollectionChangedNotifier();
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var observableSource = new ObservableGroupedSource(collectionView, notifier);
+				using var collectionChangedQueued = new System.Threading.ManualResetEventSlim();
+
+				var addGroup = Task.Run(() =>
+				{
+					groups.Add(new ObservableCollection<string> { "Item 1" });
+					collectionChangedQueued.Set();
+				});
+
+				Assert.True(collectionChangedQueued.Wait(TimeSpan.FromSeconds(5)));
+				addGroup.GetAwaiter().GetResult();
+				observableSource.Dispose();
+			});
+
+			await InvokeOnMainThreadAsync(() => { });
+
+			Assert.Equal(0, notifier.InsertCount);
 		}
 
 		[Fact(DisplayName = "CollectionView with SelectionMode None should not have click listeners")]
@@ -546,11 +810,15 @@ namespace Microsoft.Maui.DeviceTests
 
 		class MockCollectionChangedNotifier : ICollectionChangedNotifier
 		{
+			public int DataSetChangedCount;
 			public int InsertCount;
+			public int RangeRemoveCount;
+			public int RangeRemoveStart = -1;
 			public int RemoveCount;
 
 			public void NotifyDataSetChanged()
 			{
+				DataSetChangedCount += 1;
 			}
 
 			public void NotifyItemChanged(IItemsViewSource source, int startIndex)
@@ -576,6 +844,8 @@ namespace Microsoft.Maui.DeviceTests
 
 			public void NotifyItemRangeRemoved(IItemsViewSource source, int startIndex, int count)
 			{
+				RangeRemoveStart = startIndex;
+				RangeRemoveCount += count;
 			}
 
 			public void NotifyItemRemoved(IItemsViewSource source, int startIndex)

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Maui.DeviceTests
 					handlers.AddHandler<VerticalStackLayout, LayoutHandler>();
 					handlers.AddHandler<Grid, LayoutHandler>();
 					handlers.AddHandler<Label, LabelHandler>();
+					handlers.AddHandler<Entry, EntryHandler>();
 					handlers.AddHandler<Button, ButtonHandler>();
 					handlers.AddHandler<SwipeView, SwipeViewHandler>();
 					handlers.AddHandler<SwipeItem, SwipeItemMenuItemHandler>();


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Preserves focus on controls in an Android `CollectionView` global header when its grouped or ungrouped `ItemsSource` is cleared.

This is the Android-specific half of the original cross-platform change. The independent iOS/Mac Catalyst implementation remains in #37124.

@Andreas973, once CI publishes the artifacts, could you please [try them with your Android reproduction](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) and let us know whether the fix resolves the issue?

### Root Cause

A reset notification used `NotifyDataSetChanged()`. That full refresh rebound the otherwise unchanged global header, causing its focused `Entry` to lose native focus.

### Fix

- Use precise range removal when a reset leaves the source empty and the previous adapter count is known.
- Retain full refresh behavior for ambiguous custom resets that remain non-empty.
- Track and clean up bound item holders without unbinding the unchanged global header.
- Scope `NO_POSITION` cleanup using each holder's last bound raw adapter position, so clearing one group cannot unbind a holder from another group.
- Handle grouped sources and looping/non-looping `CarouselView` adapter counts safely.
- Ignore queued collection notifications after a source has been disposed or replaced.
- Synchronize device tests with deterministic `AssertEventually` conditions instead of fixed delays.

### Validation

- Reproduced with MAUI 9.0.40 and MAUI 10.0.90.
- Empirically verified with MAUI DevFlow plus genuine `adb shell input text helloworld`. `HeaderEntry.IsFocused` remained `True` through all ten clear/repopulate cycles, while Android's native input-method state kept `HeaderEntry` served and the keyboard visible.
- Android CollectionView device tests: **65 run, 64 passed, 1 ignored, 0 failed**.
- Android CarouselView device tests: **11 run, 11 passed, 0 ignored, 0 failed**.

https://github.com/user-attachments/assets/28d497ce-f577-475e-b584-ecdcefb95e4b

### Issues

Part of #28242