### PR TITLE
[net11] ResourceDictionary: Preserve lazy factories during resource propagation

### DIFF
--- a/src/Controls/src/Core/Application/Application.cs
+++ b/src/Controls/src/Core/Application/Application.cs
@@ -186,7 +186,7 @@ namespace Microsoft.Maui.Controls
 				// Use key-only propagation with an on-demand resolver to avoid resolving lazy resources (issue #35500).
 				OnResourcesChangedKeys(
 					value?.MergedResourcesKeys,
-					key => value != null && value.TryGetValue(key, out var resource) ? resource : null);
+					key => value is not null && value.TryGetValue(key, out var resource) ? resource : null);
 				if (_resources != null)
 					((IResourceDictionary)_resources).ValuesChanged += OnResourcesChanged;
 				OnPropertyChanged();

--- a/src/Controls/src/Core/Application/Application.cs
+++ b/src/Controls/src/Core/Application/Application.cs
@@ -183,7 +183,10 @@ namespace Microsoft.Maui.Controls
 				if (_resources != null)
 					((IResourceDictionary)_resources).ValuesChanged -= OnResourcesChanged;
 				_resources = value;
-				OnResourcesChanged(value);
+				// Use key-only propagation with an on-demand resolver to avoid resolving lazy resources (issue #35500).
+				OnResourcesChangedKeys(
+					value?.MergedResourcesKeys,
+					key => value != null && value.TryGetValue(key, out var resource) ? resource : null);
 				if (_resources != null)
 					((IResourceDictionary)_resources).ValuesChanged += OnResourcesChanged;
 				OnPropertyChanged();
@@ -382,8 +385,9 @@ namespace Microsoft.Maui.Controls
 
 			var innerKeys = new HashSet<string>(StringComparer.Ordinal);
 			var changedResources = new List<KeyValuePair<string, object>>();
-			foreach (KeyValuePair<string, object> c in Resources)
-				innerKeys.Add(c.Key);
+			// Iterate keys only to avoid resolving lazy resources (issue #35500).
+			foreach (string key in Resources.Keys)
+				innerKeys.Add(key);
 			foreach (KeyValuePair<string, object> value in values)
 			{
 				if (innerKeys.Add(value.Key))

--- a/src/Controls/src/Core/Application/Application.cs
+++ b/src/Controls/src/Core/Application/Application.cs
@@ -183,7 +183,8 @@ namespace Microsoft.Maui.Controls
 				if (_resources != null)
 					((IResourceDictionary)_resources).ValuesChanged -= OnResourcesChanged;
 				_resources = value;
-				OnResourcesChanged(value);
+				if (value is not null)
+					OnResourcesChangedKeys(value.MergedResourcesKeys, key => value.TryGetValue(key, out var resource) ? resource : null);
 				if (_resources != null)
 					((IResourceDictionary)_resources).ValuesChanged += OnResourcesChanged;
 				OnPropertyChanged();
@@ -380,13 +381,11 @@ namespace Microsoft.Maui.Controls
 				return;
 			}
 
-			var innerKeys = new HashSet<string>(StringComparer.Ordinal);
+			HashSet<string>? changedKeys = null;
 			var changedResources = new List<KeyValuePair<string, object>>();
-			foreach (KeyValuePair<string, object> c in Resources)
-				innerKeys.Add(c.Key);
 			foreach (KeyValuePair<string, object> value in values)
 			{
-				if (innerKeys.Add(value.Key))
+				if (!Resources.ContainsKey(value.Key) && (changedKeys ??= new HashSet<string>(StringComparer.Ordinal)).Add(value.Key))
 					changedResources.Add(value);
 			}
 			OnResourcesChanged(changedResources);

--- a/src/Controls/src/Core/Application/Application.cs
+++ b/src/Controls/src/Core/Application/Application.cs
@@ -183,8 +183,7 @@ namespace Microsoft.Maui.Controls
 				if (_resources != null)
 					((IResourceDictionary)_resources).ValuesChanged -= OnResourcesChanged;
 				_resources = value;
-				if (value is not null)
-					OnResourcesChangedKeys(value.MergedResourcesKeys, key => value.TryGetValue(key, out var resource) ? resource : null);
+				OnResourcesChanged(value);
 				if (_resources != null)
 					((IResourceDictionary)_resources).ValuesChanged += OnResourcesChanged;
 				OnPropertyChanged();
@@ -381,11 +380,13 @@ namespace Microsoft.Maui.Controls
 				return;
 			}
 
-			HashSet<string>? changedKeys = null;
+			var innerKeys = new HashSet<string>(StringComparer.Ordinal);
 			var changedResources = new List<KeyValuePair<string, object>>();
+			foreach (KeyValuePair<string, object> c in Resources)
+				innerKeys.Add(c.Key);
 			foreach (KeyValuePair<string, object> value in values)
 			{
-				if (!Resources.ContainsKey(value.Key) && (changedKeys ??= new HashSet<string>(StringComparer.Ordinal)).Add(value.Key))
+				if (innerKeys.Add(value.Key))
 					changedResources.Add(value);
 			}
 			OnResourcesChanged(changedResources);

--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -921,8 +921,6 @@ namespace Microsoft.Maui.Controls
 
 				// Only now do we look up the value - on demand
 				object value = resolver(key);
-				if (value == null)
-					continue;
 
 				foreach ((BindableProperty, SetterSpecificity) changedResource in changedResources)
 					OnResourceChanged(changedResource.Item1, value, changedResource.Item2);

--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -921,6 +921,8 @@ namespace Microsoft.Maui.Controls
 
 				// Only now do we look up the value - on demand
 				object value = resolver(key);
+				if (value == null)
+					continue;
 
 				foreach ((BindableProperty, SetterSpecificity) changedResource in changedResources)
 					OnResourceChanged(changedResource.Item1, value, changedResource.Item2);

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -1194,7 +1194,7 @@ namespace Microsoft.Maui.Controls
 				// Use key-only propagation with an on-demand resolver to avoid resolving lazy resources (issue #35500).
 				OnResourcesChangedKeys(
 					value?.MergedResourcesKeys,
-					key => value != null && value.TryGetValue(key, out var resource) ? resource : null);
+					key => value is not null && value.TryGetValue(key, out var resource) ? resource : null);
 				if (_resources != null)
 					((IResourceDictionary)_resources).ValuesChanged += OnResourcesChanged;
 				OnPropertyChanged();

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -1191,7 +1191,10 @@ namespace Microsoft.Maui.Controls
 				if (_resources != null)
 					((IResourceDictionary)_resources).ValuesChanged -= OnResourcesChanged;
 				_resources = value;
-				OnResourcesChanged(value);
+				// Use key-only propagation with an on-demand resolver to avoid resolving lazy resources (issue #35500).
+				OnResourcesChangedKeys(
+					value?.MergedResourcesKeys,
+					key => value != null && value.TryGetValue(key, out var resource) ? resource : null);
 				if (_resources != null)
 					((IResourceDictionary)_resources).ValuesChanged += OnResourcesChanged;
 				OnPropertyChanged();
@@ -1616,8 +1619,9 @@ namespace Microsoft.Maui.Controls
 
 			var innerKeys = new HashSet<string>(StringComparer.Ordinal);
 			var changedResources = new List<KeyValuePair<string, object>>();
-			foreach (KeyValuePair<string, object> c in Resources)
-				innerKeys.Add(c.Key);
+			// Iterate keys only to avoid resolving lazy resources (issue #35500).
+			foreach (string key in Resources.Keys)
+				innerKeys.Add(key);
 			foreach (KeyValuePair<string, object> value in values)
 			{
 				if (innerKeys.Add(value.Key))
@@ -1644,10 +1648,11 @@ namespace Microsoft.Maui.Controls
 				return;
 			}
 
-			// Build a set of keys we already have in our resources (child takes precedence)
+			// Build a set of keys we already have in our resources (child takes precedence).
+			// Iterate keys only to avoid resolving lazy resources (issue #35500).
 			var innerKeys = new HashSet<string>(StringComparer.Ordinal);
-			foreach (KeyValuePair<string, object> c in Resources)
-				innerKeys.Add(c.Key);
+			foreach (string key in Resources.Keys)
+				innerKeys.Add(key);
 
 			// Filter parent keys - only include keys we don't have, except style classes which get merged
 			var filteredKeys = new List<string>();
@@ -1699,10 +1704,11 @@ namespace Microsoft.Maui.Controls
 				return;
 			}
 
-			// Build a set of keys we already have in our resources (child takes precedence)
+			// Build a set of keys we already have in our resources (child takes precedence).
+			// Iterate keys only to avoid resolving lazy resources (issue #35500).
 			var innerKeys = new HashSet<string>(StringComparer.Ordinal);
-			foreach (KeyValuePair<string, object> c in Resources)
-				innerKeys.Add(c.Key);
+			foreach (string key in Resources.Keys)
+				innerKeys.Add(key);
 
 			// Filter parent keys - only include keys we don't have, except style classes which get merged
 			var filteredKeys = new List<string>();

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -1191,7 +1191,7 @@ namespace Microsoft.Maui.Controls
 				if (_resources != null)
 					((IResourceDictionary)_resources).ValuesChanged -= OnResourcesChanged;
 				_resources = value;
-				OnResourcesChanged(value);
+				OnResourcesChangedKeys(value?.MergedResourcesKeys, key => value.TryGetValue(key, out var resource) ? resource : null);
 				if (_resources != null)
 					((IResourceDictionary)_resources).ValuesChanged += OnResourcesChanged;
 				OnPropertyChanged();
@@ -1614,13 +1614,11 @@ namespace Microsoft.Maui.Controls
 				return;
 			}
 
-			var innerKeys = new HashSet<string>(StringComparer.Ordinal);
+			HashSet<string> changedKeys = null;
 			var changedResources = new List<KeyValuePair<string, object>>();
-			foreach (KeyValuePair<string, object> c in Resources)
-				innerKeys.Add(c.Key);
 			foreach (KeyValuePair<string, object> value in values)
 			{
-				if (innerKeys.Add(value.Key))
+				if (!Resources.ContainsKey(value.Key) && (changedKeys ??= new HashSet<string>(StringComparer.Ordinal)).Add(value.Key))
 					changedResources.Add(value);
 				else if (value.Key.StartsWith(Style.StyleClassPrefix, StringComparison.Ordinal))
 				{
@@ -1644,18 +1642,14 @@ namespace Microsoft.Maui.Controls
 				return;
 			}
 
-			// Build a set of keys we already have in our resources (child takes precedence)
-			var innerKeys = new HashSet<string>(StringComparer.Ordinal);
-			foreach (KeyValuePair<string, object> c in Resources)
-				innerKeys.Add(c.Key);
-
 			// Filter parent keys - only include keys we don't have, except style classes which get merged
 			var filteredKeys = new List<string>();
 			var mergedStyleClasses = new List<KeyValuePair<string, object>>();
+			HashSet<string> filteredKeySet = null;
 
 			foreach (string key in keys)
 			{
-				if (innerKeys.Add(key))
+				if (!Resources.ContainsKey(key) && (filteredKeySet ??= new HashSet<string>(StringComparer.Ordinal)).Add(key))
 				{
 					// Key doesn't exist in our resources, include it
 					filteredKeys.Add(key);
@@ -1699,18 +1693,14 @@ namespace Microsoft.Maui.Controls
 				return;
 			}
 
-			// Build a set of keys we already have in our resources (child takes precedence)
-			var innerKeys = new HashSet<string>(StringComparer.Ordinal);
-			foreach (KeyValuePair<string, object> c in Resources)
-				innerKeys.Add(c.Key);
-
 			// Filter parent keys - only include keys we don't have, except style classes which get merged
 			var filteredKeys = new List<string>();
 			var mergedStyleClasses = new List<KeyValuePair<string, object>>();
+			HashSet<string> filteredKeySet = null;
 
 			foreach (string key in keys)
 			{
-				if (innerKeys.Add(key))
+				if (!Resources.ContainsKey(key) && (filteredKeySet ??= new HashSet<string>(StringComparer.Ordinal)).Add(key))
 				{
 					// Key doesn't exist in our resources, include it
 					filteredKeys.Add(key);

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -1191,7 +1191,7 @@ namespace Microsoft.Maui.Controls
 				if (_resources != null)
 					((IResourceDictionary)_resources).ValuesChanged -= OnResourcesChanged;
 				_resources = value;
-				OnResourcesChangedKeys(value?.MergedResourcesKeys, key => value.TryGetValue(key, out var resource) ? resource : null);
+				OnResourcesChanged(value);
 				if (_resources != null)
 					((IResourceDictionary)_resources).ValuesChanged += OnResourcesChanged;
 				OnPropertyChanged();
@@ -1614,11 +1614,13 @@ namespace Microsoft.Maui.Controls
 				return;
 			}
 
-			HashSet<string> changedKeys = null;
+			var innerKeys = new HashSet<string>(StringComparer.Ordinal);
 			var changedResources = new List<KeyValuePair<string, object>>();
+			foreach (KeyValuePair<string, object> c in Resources)
+				innerKeys.Add(c.Key);
 			foreach (KeyValuePair<string, object> value in values)
 			{
-				if (!Resources.ContainsKey(value.Key) && (changedKeys ??= new HashSet<string>(StringComparer.Ordinal)).Add(value.Key))
+				if (innerKeys.Add(value.Key))
 					changedResources.Add(value);
 				else if (value.Key.StartsWith(Style.StyleClassPrefix, StringComparison.Ordinal))
 				{
@@ -1642,14 +1644,18 @@ namespace Microsoft.Maui.Controls
 				return;
 			}
 
+			// Build a set of keys we already have in our resources (child takes precedence)
+			var innerKeys = new HashSet<string>(StringComparer.Ordinal);
+			foreach (KeyValuePair<string, object> c in Resources)
+				innerKeys.Add(c.Key);
+
 			// Filter parent keys - only include keys we don't have, except style classes which get merged
 			var filteredKeys = new List<string>();
 			var mergedStyleClasses = new List<KeyValuePair<string, object>>();
-			HashSet<string> filteredKeySet = null;
 
 			foreach (string key in keys)
 			{
-				if (!Resources.ContainsKey(key) && (filteredKeySet ??= new HashSet<string>(StringComparer.Ordinal)).Add(key))
+				if (innerKeys.Add(key))
 				{
 					// Key doesn't exist in our resources, include it
 					filteredKeys.Add(key);
@@ -1693,14 +1699,18 @@ namespace Microsoft.Maui.Controls
 				return;
 			}
 
+			// Build a set of keys we already have in our resources (child takes precedence)
+			var innerKeys = new HashSet<string>(StringComparer.Ordinal);
+			foreach (KeyValuePair<string, object> c in Resources)
+				innerKeys.Add(c.Key);
+
 			// Filter parent keys - only include keys we don't have, except style classes which get merged
 			var filteredKeys = new List<string>();
 			var mergedStyleClasses = new List<KeyValuePair<string, object>>();
-			HashSet<string> filteredKeySet = null;
 
 			foreach (string key in keys)
 			{
-				if (!Resources.ContainsKey(key) && (filteredKeySet ??= new HashSet<string>(StringComparer.Ordinal)).Add(key))
+				if (innerKeys.Add(key))
 				{
 					// Key doesn't exist in our resources, include it
 					filteredKeys.Add(key);

--- a/src/Controls/tests/Core.UnitTests/ResourceDictionaryTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ResourceDictionaryTests.cs
@@ -170,6 +170,52 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public void AssigningResourcesToElementDoesNotResolveLazyResources()
+		{
+			var invokeCount = 0;
+			var resources = new ResourceDictionary();
+			resources.AddFactory("unused-local-lazy-resource", () =>
+			{
+				invokeCount++;
+				return new Label();
+			}, shared: true);
+
+			Assert.Equal(0, invokeCount);
+
+			var element = new VisualElement();
+
+			element.Resources = resources;
+
+			Assert.Equal(0, invokeCount);
+		}
+
+		[Fact]
+		public void ParentSetDoesNotResolveLocalLazyResources()
+		{
+			var invokeCount = 0;
+			var child = new VisualElement();
+			child.Resources.AddFactory("unused-local-lazy-resource", () =>
+			{
+				invokeCount++;
+				return new Label();
+			}, shared: true);
+
+			Assert.Equal(0, invokeCount);
+
+			var parent = new VisualElement
+			{
+				Resources = new ResourceDictionary {
+					{ "parent-resource", "PARENT" },
+				}
+			};
+
+			child.Parent = parent;
+
+			Assert.Equal(0, invokeCount);
+		}
+
+
+		[Fact]
 		public void ResourcesChangedNotRaisedIfKeyExistsInCurrent()
 		{
 			var elt = new VisualElement
@@ -809,10 +855,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			// The event value should be properly resolved
 			Assert.NotNull(eventValue);
-			
+
 			// The value should be the resolved color
 			Assert.Equal(Colors.Red, eventValue);
-			
+
 			// The value IS correct when accessed directly
 			Assert.Equal(Colors.Red, rd["myColor"]);
 		}
@@ -825,7 +871,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			var rd = new ResourceDictionary();
 			var label = new Label();
-			
+
 			// Set up the page hierarchy so DynamicResource can find resources
 			var page = new ContentPage { Content = label };
 			page.Resources = rd;

--- a/src/Controls/tests/Core.UnitTests/ResourceDictionaryTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ResourceDictionaryTests.cs
@@ -748,51 +748,6 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
-		public void AssigningResourcesToElementDoesNotResolveLazyResources()
-		{
-			var invokeCount = 0;
-			var resources = new ResourceDictionary();
-			resources.AddFactory("unused-local-lazy-resource", () =>
-			{
-				invokeCount++;
-				return new Label();
-			}, shared: true);
-
-			Assert.Equal(0, invokeCount);
-
-			var element = new VisualElement();
-
-			element.Resources = resources;
-
-			Assert.Equal(0, invokeCount);
-		}
-
-		[Fact]
-		public void ParentSetDoesNotResolveLocalLazyResources()
-		{
-			var invokeCount = 0;
-			var child = new VisualElement();
-			child.Resources.AddFactory("unused-local-lazy-resource", () =>
-			{
-				invokeCount++;
-				return new Label();
-			}, shared: true);
-
-			Assert.Equal(0, invokeCount);
-
-			var parent = new VisualElement
-			{
-				Resources = new ResourceDictionary {
-					{ "parent-resource", "PARENT" },
-				}
-			};
-
-			child.Parent = parent;
-
-			Assert.Equal(0, invokeCount);
-		}
-
-		[Fact]
 		public void AddFactory_DoesNotInvokeUntilAccessed()
 		{
 			var rd = new ResourceDictionary();
@@ -854,10 +809,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			// The event value should be properly resolved
 			Assert.NotNull(eventValue);
-
+			
 			// The value should be the resolved color
 			Assert.Equal(Colors.Red, eventValue);
-
+			
 			// The value IS correct when accessed directly
 			Assert.Equal(Colors.Red, rd["myColor"]);
 		}
@@ -870,7 +825,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			var rd = new ResourceDictionary();
 			var label = new Label();
-
+			
 			// Set up the page hierarchy so DynamicResource can find resources
 			var page = new ContentPage { Content = label };
 			page.Resources = rd;

--- a/src/Controls/tests/Core.UnitTests/ResourceDictionaryTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ResourceDictionaryTests.cs
@@ -748,6 +748,51 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public void AssigningResourcesToElementDoesNotResolveLazyResources()
+		{
+			var invokeCount = 0;
+			var resources = new ResourceDictionary();
+			resources.AddFactory("unused-local-lazy-resource", () =>
+			{
+				invokeCount++;
+				return new Label();
+			}, shared: true);
+
+			Assert.Equal(0, invokeCount);
+
+			var element = new VisualElement();
+
+			element.Resources = resources;
+
+			Assert.Equal(0, invokeCount);
+		}
+
+		[Fact]
+		public void ParentSetDoesNotResolveLocalLazyResources()
+		{
+			var invokeCount = 0;
+			var child = new VisualElement();
+			child.Resources.AddFactory("unused-local-lazy-resource", () =>
+			{
+				invokeCount++;
+				return new Label();
+			}, shared: true);
+
+			Assert.Equal(0, invokeCount);
+
+			var parent = new VisualElement
+			{
+				Resources = new ResourceDictionary {
+					{ "parent-resource", "PARENT" },
+				}
+			};
+
+			child.Parent = parent;
+
+			Assert.Equal(0, invokeCount);
+		}
+
+		[Fact]
 		public void AddFactory_DoesNotInvokeUntilAccessed()
 		{
 			var rd = new ResourceDictionary();
@@ -809,10 +854,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			// The event value should be properly resolved
 			Assert.NotNull(eventValue);
-			
+
 			// The value should be the resolved color
 			Assert.Equal(Colors.Red, eventValue);
-			
+
 			// The value IS correct when accessed directly
 			Assert.Equal(Colors.Red, rd["myColor"]);
 		}
@@ -825,7 +870,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			var rd = new ResourceDictionary();
 			var label = new Label();
-			
+
 			// Set up the page hierarchy so DynamicResource can find resources
 			var page = new ContentPage { Content = label };
 			page.Resources = rd;


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
In .NET 11, .NET MAUI added lazy resources — `Func<object>` factories stored in `ResourceDictionary` that build the resource only when first accessed. However, assigning a `ResourceDictionary` to a control or attaching a control to a parent was eagerly resolving every factory, defeating the purpose of laziness. Large apps became up to ~15× slower and used ~7× more memory during resource propagation.

### Root Cause

The `Application.Resources` and `VisualElement.Resources` setters passed the assigned `ResourceDictionary` to value-based resource propagation, while four parent-propagation methods built child key sets by enumerating `KeyValuePair<string, object>` values. `ResourceDictionary.GetEnumerator` calls `ResolveValue`, so these paths executed lazy factories even though propagation generally needed only resource keys.

### Description of Change
- Changed the two `Resources` setters to propagate `MergedResourcesKeys` with an on-demand resolver. Values are fetched only when a matching `DynamicResource` binding needs them.
- Changed the four parent-propagation loops — one in `Application` and three in `VisualElement` — to iterate `Resources.Keys` rather than dictionary values.
- Added regression coverage for assigning resources and setting a parent without resolving unused lazy factories.

Validated the behavior on the following platforms:

- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Issues Fixed

Fixes #35500

### Output Screenshot

| Before | After |
|---|---|
| <video src="https://github.com/user-attachments/assets/5a25998c-739f-43c1-a5a6-5db48d7a0736"> | <video src="https://github.com/user-attachments/assets/68ba980c-088a-4993-93d4-c96948d5d8ef"> |