### PR TITLE
[net11.0][iOS] Fix CS8604 build break in BlazorWebViewHandler header marshaling

### DIFF
--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -377,9 +377,11 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				foreach (var key in headers.Keys)
 				{
 					var value = headers[key];
-					if (key is not null && value is not null)
+					var keyString = key?.ToString();
+					var valueString = value?.ToString();
+					if (keyString is not null && valueString is not null)
 					{
-						yield return new KeyValuePair<string, string>(key.ToString(), value.ToString());
+						yield return new KeyValuePair<string, string>(keyString, valueString);
 					}
 				}
 			}

--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -376,10 +376,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 
 				foreach (var key in headers.Keys)
 				{
-					var value = headers[key];
-					var keyString = key?.ToString();
-					var valueString = value?.ToString();
-					if (keyString is not null && valueString is not null)
+					if (key?.ToString() is string keyString &&
+						headers[key]?.ToString() is string valueString)
 					{
 						yield return new KeyValuePair<string, string>(keyString, valueString);
 					}


### PR DESCRIPTION
 <!-- Please let the below note in for people that find this PR -->
   > [!NOTE]
   > Are you waiting for the changes in this PR to be merged?
   > It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue.

### Root Cause

PR #35706 added an iOS helper, `GetRequestHeaders`, which reads request headers from an `NSDictionary` and passes them to the shared cache-policy code as `KeyValuePair<string, string>` entries. The implementation calls `.ToString()` on the dictionary key and value.

Although the key and value objects were already null-checked, `NSObject.ToString()` is itself nullable. The compiler therefore could not guarantee that the resulting strings were non-null when constructing `KeyValuePair<string, string>`, resulting in **CS8604** on `net11.0`.

This was only a warning on `net10.0`, but the stricter nullable analysis in `net11.0` promoted it to an error and caused the CI build failure.

### Description of Change

Null-checked the  .ToString()  results via an inline  is string  pattern-match before yielding them. Semantically identical to the original loop with no behavior or performance impact — it only makes the nullable flow explicit to the compiler.

### Issues Fixed

Fixes the net11.0 CI build failure caused by `CS8604` in  `BlazorWebViewHandler.iOS.cs` 

### Regression Details

Regression from #35706 

### Platforms Tested

- [x] iOS
- [x] MacCatalyst 
- [x] Android 
- [x] Windows 