### PR TITLE
[iOS/Mac Catalyst] Fix stale MapElementId left on other map elements after updating one

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Map/MapTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Map/MapTests.cs
@@ -120,7 +120,8 @@ namespace Microsoft.Maui.DeviceTests
 		public async Task UpdatingSingleElementPreservesTrackingForOtherElements()
 		{
 			var map = new Map();
-			await CreateHandlerAsync<Microsoft.Maui.Maps.Handlers.MapHandler>(map);
+			var handler = await CreateHandlerAsync<Microsoft.Maui.Maps.Handlers.MapHandler>(map);
+			var platformView = handler.PlatformView;
 
 			var polyline1 = new Polyline
 			{
@@ -148,7 +149,16 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.NotNull(polyline1.MapElementId);
 			Assert.NotNull(polyline2.MapElementId);
 
+			var overlaysBefore = await InvokeOnMainThreadAsync(() => platformView.Overlays?.Length);
+			var polyline2IdBefore = polyline2.MapElementId;
+
 			await InvokeOnMainThreadAsync(() => polyline1.Geopath.Add(new Location(47.62, -122.33)));
+
+			// Updating polyline1 must not leak/drop native overlays or disturb polyline2's overlay.
+			var overlaysAfter = await InvokeOnMainThreadAsync(() => platformView.Overlays?.Length);
+			Assert.Equal(overlaysBefore, overlaysAfter);
+			Assert.Same(polyline2IdBefore, polyline2.MapElementId);
+
 			await InvokeOnMainThreadAsync(() => map.MapElements.Clear());
 
 			Assert.Null(polyline1.MapElementId);

--- a/src/Controls/tests/DeviceTests/Elements/Map/MapTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Map/MapTests.cs
@@ -116,6 +116,45 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.NotNull(polygon2.MapElementId);
 		}
 
+		[Fact]
+		public async Task UpdatingSingleElementPreservesTrackingForOtherElements()
+		{
+			var map = new Map();
+			await CreateHandlerAsync<Microsoft.Maui.Maps.Handlers.MapHandler>(map);
+
+			var polyline1 = new Polyline
+			{
+				Geopath =
+				{
+					new Location(47.60, -122.33),
+					new Location(47.61, -122.33)
+				}
+			};
+			var polyline2 = new Polyline
+			{
+				Geopath =
+				{
+					new Location(47.62, -122.34),
+					new Location(47.63, -122.34)
+				}
+			};
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				map.MapElements.Add(polyline1);
+				map.MapElements.Add(polyline2);
+			});
+
+			Assert.NotNull(polyline1.MapElementId);
+			Assert.NotNull(polyline2.MapElementId);
+
+			await InvokeOnMainThreadAsync(() => polyline1.Geopath.Add(new Location(47.62, -122.33)));
+			await InvokeOnMainThreadAsync(() => map.MapElements.Clear());
+
+			Assert.Null(polyline1.MapElementId);
+			Assert.Null(polyline2.MapElementId);
+		}
+
 		// Regression test for https://github.com/dotnet/maui/issues/35479
 		[Fact]
 		public async Task DisconnectClearsNativeMapStateBeforePooling()

--- a/src/Core/maps/src/Platform/iOS/MauiMKMapView.cs
+++ b/src/Core/maps/src/Platform/iOS/MauiMKMapView.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.Maps.Platform
 		WeakReference<IMapHandler> _handlerRef;
 		object? _lastTouchedView;
 		UITapGestureRecognizer? _mapClickedGestureRecognizer;
-		List<IMapElement>? _trackedMapElements;
+		HashSet<IMapElement>? _trackedMapElements;
 
 		public MauiMKMapView(IMapHandler handler)
 		{
@@ -168,14 +168,11 @@ namespace Microsoft.Maui.Maps.Platform
 
 		internal void AddElements(IList elements)
 		{
-			_trackedMapElements ??= new List<IMapElement>();
+			_trackedMapElements ??= new HashSet<IMapElement>(ReferenceEqualityComparer.Instance);
 
 			foreach (IMapElement element in elements)
 			{
-				if (!_trackedMapElements.Contains(element))
-				{
-					_trackedMapElements.Add(element);
-				}
+				_trackedMapElements.Add(element);
 
 				IMKOverlay? overlay = null;
 				switch (element)

--- a/src/Core/maps/src/Platform/iOS/MauiMKMapView.cs
+++ b/src/Core/maps/src/Platform/iOS/MauiMKMapView.cs
@@ -168,11 +168,14 @@ namespace Microsoft.Maui.Maps.Platform
 
 		internal void AddElements(IList elements)
 		{
-			_trackedMapElements = new List<IMapElement>();
+			_trackedMapElements ??= new List<IMapElement>();
 
 			foreach (IMapElement element in elements)
 			{
-				_trackedMapElements.Add(element);
+				if (!_trackedMapElements.Contains(element))
+				{
+					_trackedMapElements.Add(element);
+				}
 
 				IMKOverlay? overlay = null;
 				switch (element)
@@ -208,6 +211,9 @@ namespace Microsoft.Maui.Maps.Platform
 			{
 				if (element.MapElementId is IMKOverlay overlay)
 					RemoveOverlay(overlay);
+
+				_trackedMapElements?.Remove(element);
+				element.MapElementId = null;
 			}
 		}
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
- On iOS and Mac Catalyst, when a Map has multiple MapElements and one Polyline's Geopath is updated, the other untouched Polylines silently lose their tracking, so when the map is later cleared, their MapElementId is left stale instead of being reset to null.


### Root Cause
- MauiMKMapView.AddElements  on iOS/Mac Catalyst unconditionally replaced its internal  _trackedMapElements  list on every call, so when a single  MapElement  was updated (e.g. via  Geopath.Add(...)  triggering  UpdateMapElement), tracking for every other previously-added element was silently wiped, leaving them with a stale  MapElementId  after the map was later cleared.

### Description of Change
- Modified AddElements in MauiMKMapView.cs to initialize _trackedMapElements only if it's null and to prevent adding duplicate elements to the tracking list.
- Updated RemoveElements in MauiMKMapView.cs to ensure that elements are removed from _trackedMapElements and their MapElementId is cleared when they are removed from the map.

### Issues Fixed
Fixes #37229

### Validated the behaviour in the following platforms
- [ ] Windows
- [ ] Android
- [x] iOS
- [x] Mac

### Output
| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/e235775a-f0e3-445e-a2a1-ea88a676407a"> | <video src="https://github.com/user-attachments/assets/f2336093-24df-410a-aa29-f4f1c4cbced6"> |