### PR TITLE
[iOS/Mac] Fix Image not enlarging to explicit HeightRequest/WidthRequest

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue12879.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue12879.cs
@@ -1,0 +1,57 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 12879, "Image.HeightRequest not respected when Image added in a Horizontal StackLayout", PlatformAffected.iOS)]
+public class Issue12879 : ContentPage
+{
+	const double ExpectedSize = 200;
+	const double Tolerance = 2;
+
+	Image _image;
+	Label _imageStatusLabel;
+
+	public Issue12879()
+	{
+		_imageStatusLabel = new Label
+		{
+			Text = "Tap the button to check if the Image respects the explicit HeightRequest",
+			AutomationId = "ImageStatusLabel"
+		};
+
+		_image = new Image
+		{
+			Source = "blue.png",
+			HeightRequest = ExpectedSize,
+			AutomationId = "TestImage"
+		};
+
+		Button checkImageButton = new Button
+		{
+			Text = "Check Image Size",
+			AutomationId = "CheckImageButton"
+		};
+		checkImageButton.Clicked += OnCheckImageButtonClicked;
+
+		Content = new VerticalStackLayout
+		{
+			Spacing = 20,
+			Children =
+			{
+				_imageStatusLabel,
+				new HorizontalStackLayout
+				{
+					Children = { _image }
+				},
+				checkImageButton
+			}
+		};
+	}
+
+	void OnCheckImageButtonClicked(object sender, EventArgs e)
+	{
+		bool imagePasses = Math.Abs(_image.Width - ExpectedSize) <= Tolerance && Math.Abs(_image.Height - _image.HeightRequest) <= Tolerance;
+
+		_imageStatusLabel.Text = imagePasses
+			? "Success"
+			: $"Fail: Image={_image.Width}x{_image.Height}, Expected={ExpectedSize}x{_image.HeightRequest}";
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue12879.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue12879.cs
@@ -1,0 +1,25 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue12879 : _IssuesUITest
+{
+	public Issue12879(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue => "Image.HeightRequest not respected when Image added in a Horizontal StackLayout";
+
+	[Test]
+	[Category(UITestCategories.Image)]
+	public void ImageScalesUpToExplicitHeightRequestInHorizontalStackLayout()
+	{
+		App.WaitForElement("CheckImageButton");
+		App.Tap("CheckImageButton");
+
+		var statusText = App.WaitForElement("ImageStatusLabel").GetText();
+		Assert.That(statusText, Is.EqualTo("Success"));
+	}
+}

--- a/src/Core/src/Handlers/ViewHandlerExtensions.iOS.cs
+++ b/src/Core/src/Handlers/ViewHandlerExtensions.iOS.cs
@@ -84,10 +84,12 @@ namespace Microsoft.Maui
 			// This also affects ImageButtons
 			if (platformView is UIImageView imageView)
 			{
-				widthConstraint = IsExplicitSet(virtualView.Width) ? virtualView.Width : widthConstraint;
-				heightConstraint = IsExplicitSet(virtualView.Height) ? virtualView.Height : heightConstraint;
+				var widthIsExplicit = IsExplicitSet(virtualView.Width);
+				var heightIsExplicit = IsExplicitSet(virtualView.Height);
+				widthConstraint = widthIsExplicit ? virtualView.Width : widthConstraint;
+				heightConstraint = heightIsExplicit ? virtualView.Height : heightConstraint;
 
-				sizeThatFits = imageView.SizeThatFitsImage(new CGSize((float)widthConstraint, (float)heightConstraint));
+				sizeThatFits = imageView.SizeThatFitsImage(new CGSize((float)widthConstraint, (float)heightConstraint), default, widthIsExplicit, heightIsExplicit);
 			}
 			else if (platformView is LayoutView || platformView is MauiLabel)
 			{

--- a/src/Core/src/Platform/iOS/ImageViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ImageViewExtensions.cs
@@ -104,8 +104,16 @@ namespace Microsoft.Maui.Platform
 				// Compute the raw (uncapped) ratio for each axis. When an axis constraint is +Infinity
 				// (i.e. unconstrained, as happens on the cross axis of a StackLayout), its ratio is also
 				// +Infinity, meaning it never limits the scale factor - only the other (finite/explicit) axis does.
-				var widthRatio = widthConstraint / imageWidth;
-				var heightRatio = heightConstraint / imageHeight;
+				var widthRatio =
+					double.IsPositiveInfinity(widthConstraint)
+						? double.PositiveInfinity
+						: widthConstraint / imageWidth;
+
+				var heightRatio =
+					double.IsPositiveInfinity(heightConstraint)
+						? double.PositiveInfinity
+						: heightConstraint / imageHeight;
+
 				var scaleFactor = Math.Min(widthRatio, heightRatio);
 
 				// Only when NEITHER axis constraint came from an explicit request (WidthRequest/HeightRequest) -

--- a/src/Core/src/Platform/iOS/ImageViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ImageViewExtensions.cs
@@ -68,11 +68,15 @@ namespace Microsoft.Maui.Platform
 		/// <param name="imageView">The <see cref="UIImageView"/> to be measured.</param>
 		/// <param name="constraints">The specified size constraints.</param>
 		/// <param name="padding"></param>
+		/// <param name="widthConstraintIsExplicit">Whether the width constraint comes from an explicit request (e.g. WidthRequest) and may therefore scale the image beyond its native width.</param>
+		/// <param name="heightConstraintIsExplicit">Whether the height constraint comes from an explicit request (e.g. HeightRequest) and may therefore scale the image beyond its native height.</param>
 		/// <returns>The size where the image would fit depending on the aspect ratio.</returns>
 		internal static CGSize SizeThatFitsImage(
 			this UIImageView imageView,
 			CGSize constraints,
-			Thickness padding = default)
+			Thickness padding = default,
+			bool widthConstraintIsExplicit = false,
+			bool heightConstraintIsExplicit = false)
 		{
 			// If there's no image, we don't need to take up any space
 			if (imageView.Image is null)
@@ -87,9 +91,8 @@ namespace Microsoft.Maui.Platform
 			var horizontalThickness = padding.HorizontalThickness;
 			var verticalThickness = padding.VerticalThickness;
 
-			var widthConstraint = constraints.Width - horizontalThickness;
-			var heightConstraint = constraints.Height - verticalThickness;
-
+			double widthConstraint = constraints.Width - horizontalThickness;
+			double heightConstraint = constraints.Height - verticalThickness;
 
 			var constrainedWidth = Math.Min(imageWidth, widthConstraint);
 			var constrainedHeight = Math.Min(imageHeight, heightConstraint);
@@ -98,9 +101,20 @@ namespace Microsoft.Maui.Platform
 			// that can fit it
 			if (imageView.ContentMode == UIViewContentMode.ScaleAspectFit)
 			{
-				var widthRatio = constrainedWidth / imageWidth;
-				var heightRatio = constrainedHeight / imageHeight;
+				// Compute the raw (uncapped) ratio for each axis. When an axis constraint is +Infinity
+				// (i.e. unconstrained, as happens on the cross axis of a StackLayout), its ratio is also
+				// +Infinity, meaning it never limits the scale factor - only the other (finite/explicit) axis does.
+				var widthRatio = widthConstraint / imageWidth;
+				var heightRatio = heightConstraint / imageHeight;
 				var scaleFactor = Math.Min(widthRatio, heightRatio);
+
+				// Only when NEITHER axis constraint came from an explicit request (WidthRequest/HeightRequest) -
+				// i.e. we're simply fitting within available space, not honoring an explicit enlarge request -
+				// do we cap the scale factor at 1 so the image never grows beyond its native size.
+				if (!widthConstraintIsExplicit && !heightConstraintIsExplicit)
+				{
+					scaleFactor = Math.Min(scaleFactor, 1);
+				}
 
 				return new CGSize(imageWidth * scaleFactor + horizontalThickness, imageHeight * scaleFactor + verticalThickness);
 			}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
- On iOS, an Image does not scale up on the unconstrained axis when only HeightRequest or WidthRequest is set—the unconstrained axis remains capped at its native size. This is most visible with HorizontalStackLayout + HeightRequest and VerticalStackLayout + WidthRequest. The reverse combinations can appear to work because the other axis is large enough to mask the same issue. On Android, the Image scales correctly with HeightRequest and WidthRequest in all cases.

### Root Cause
- In SizeThatFitsImage (iOS), the scale factor for ScaleAspectFit images was calculated as Math.Min(imageWidth, widthConstraint) / imageWidth. This could never exceed 1 (since it always divides the image's own size by itself once the constraint is larger), so an image could shrink to fit a smaller space but could never grow beyond its native size, even when an explicit HeightRequest or WidthRequest requested a larger size, regardless of StackLayout orientation.

### Description of Change
- Updated SizeThatFitsImage in ImageViewExtensions.cs to accept flags indicating whether width and height constraints are explicit, and to allow images to scale up to requested sizes when either is set, instead of capping at native size. 
- Modified GetDesiredSizeFromHandler in ViewHandlerExtensions.iOS.cs to pass explicitness flags to SizeThatFitsImage, ensuring correct sizing behavior for images with explicit size requests.


### Issues Fixed
Fixes #12879

### Validated the behaviour in the following platforms
- [ ] Windows
- [ ] Android
- [x] iOS
- [x] Mac

### Output
| Before | After |
----------|----------|
| <img src="https://github.com/user-attachments/assets/c592756b-d87f-40dd-9073-0a4e03add828"> | <img src="https://github.com/user-attachments/assets/c884d1d2-a048-44ee-b1d9-ac59b9c29daf"> |
