### PR TITLE
[Android] Entry: Expose SemanticProperties.Description as ContentDescription

### DIFF
--- a/src/Core/src/Platform/Android/SemanticExtensions.cs
+++ b/src/Core/src/Platform/Android/SemanticExtensions.cs
@@ -22,6 +22,8 @@ namespace Microsoft.Maui.Platform
 
 			if (!string.IsNullOrEmpty(desc))
 			{
+				newContentDescription = desc;
+
 				// Edit Text fields won't read anything for the content description
 				if (platformView is EditText et)
 				{
@@ -30,8 +32,6 @@ namespace Microsoft.Maui.Platform
 					else
 						newText = $"{desc}";
 				}
-				else
-					newContentDescription = desc;
 			}
 
 			if (!string.IsNullOrEmpty(hint))

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Android.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using AndroidX.AppCompat.Widget;
+using AndroidX.Core.View.Accessibility;
 using global::Android.Text;
 using global::Android.Text.Method;
 using global::Android.Views.InputMethods;
@@ -8,6 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Platform;
 using Xunit;
 using AColor = Android.Graphics.Color;
 
@@ -15,6 +17,30 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class EntryHandlerTests
 	{
+		[Fact(DisplayName = "Semantic description initializes accessibility content description")]
+		public async Task SemanticDescriptionInitializesAccessibilityContentDescription()
+		{
+			const string description = "Entry description";
+			const string text = "Entry text";
+			var entry = new EntryStub { Text = text };
+			entry.Semantics.Description = description;
+
+			var values = await GetValueAsync(entry, handler =>
+			{
+				using var info = AccessibilityNodeInfoCompat.Obtain();
+				handler.PlatformView.UpdateSemanticNodeInfo(entry, info);
+
+				return new
+				{
+					info.ContentDescription,
+					info.Text
+				};
+			});
+
+			Assert.Equal(description, values.ContentDescription);
+			Assert.Equal($"{description}, {text}", values.Text);
+		}
+
 		[Theory(DisplayName = "Validates Keyboard updates correctly using IsPassword")]
 		[InlineData(nameof(Keyboard.Text), false)]
 		[InlineData(nameof(Keyboard.Numeric), true)]


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details

On Android, `SemanticProperties.Description` was not exposed through an Entry accessibility node's `ContentDescription`. MAUI handled editable Android controls (`EditText`) differently from controls such as Label: for Entry, the semantic description was added only to the accessibility node's `Text` so TalkBack could announce it. Consequently, Appium and UIAutomator reported an empty `content-desc`.

### Description of Change

Updated `SemanticExtensions.UpdateSemanticNodeInfo` to assign `SemanticProperties.Description` to the Android accessibility node's `ContentDescription` for all views, including `EditText`.

The existing synthesized accessibility text for editable controls is preserved. An Entry with description `Entry description` and text `Entry text` now exposes:

- `ContentDescription`: `Entry description`
- `Text`: `Entry description, Entry text`

Added an Android Entry device test in `EntryHandlerTests.Android.cs` that verifies both node values.

This preserves the existing TalkBack-oriented text synthesis while making the semantic description available to Appium, UIAutomator, and other accessibility tools.

### Issues Fixed

Fixes #37151

**Tested the behavior in the following platforms.**
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

| Before  | After  |
|---------|--------|
| **Android**<br> <img src="https://github.com/user-attachments/assets/6213bd4b-2289-49fe-ac22-8db2a0e4a810" width="600" height="300"> | **Android**<br> <img src="https://github.com/user-attachments/assets/4c764c7d-daa1-4f27-a8e8-aba74722c996" width="600" height="300"> |