### PR TITLE
[Android] Fix scrolling performance in shadowed containers

### DIFF
--- a/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformWrapperView.java
+++ b/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformWrapperView.java
@@ -153,25 +153,18 @@ public abstract class PlatformWrapperView extends PlatformContentViewGroup {
 
     @Override
     public void onDescendantInvalidated(@NonNull View child, @NonNull View target) {
-        // API 26+: On modern Android, when a hardware-accelerated child view calls invalidate()
-        // (e.g., SwitchCompat animating its thumb), the framework calls onDescendantInvalidated()
-        // on the parent instead of invalidateChildInParent().
-        //
-        // CRITICAL: In hardware-accelerated mode, each view has its own RenderNode display list.
-        // When a child invalidates, only the CHILD's RenderNode is re-recorded — the parent's
-        // display list is replayed from cache (including the stale shadow draw call baked in).
-        //
-        // Without invalidate(): SwitchCompat redraws (thumb moves) but PlatformWrapperView's
-        // display list is replayed unchanged → shadow stays at its original OFF/ON position.
-        // With invalidate(): PlatformWrapperView's display list is marked dirty → dispatchDraw()
-        // is re-invoked next frame → shadow is redrawn at the correct current thumb position.
-        //
-        // Guard: only force re-invalidation when this wrapper has an active shadow — avoids
-        // unnecessary redraws for clip/border-only wrappers.
         super.onDescendantInvalidated(child, target);
-        if (this.hasShadow) {
+
+        if (shouldInvalidateShadow(child, target)) {
             invalidate();
         }
+    }
+
+    protected final boolean shouldInvalidateShadow(@NonNull View child, @NonNull View target) {
+        // Shadowed controls such as Switch need a wrapper redraw when the immediate child
+        // animates. Deeper descendants redraw through their own RenderNodes; invalidating the
+        // wrapper for them makes scrolling content redraw the entire shadowed container.
+        return this.hasShadow && child == target;
     }
 
     // API 25 and below: invalidateChildInParent() is the legacy path called when a

--- a/src/Core/src/Transforms/Metadata.xml
+++ b/src/Core/src/Transforms/Metadata.xml
@@ -21,6 +21,7 @@
   <attr path="//class[@name='PlatformWrapperView']/method[@name='setNoShadow']" name="visibility">internal</attr>
   <attr path="//class[@name='PlatformWrapperView']/method[@name='setRadialGradientShadow']" name="visibility">internal</attr>
   <attr path="//class[@name='PlatformWrapperView']/method[@name='setSolidShadow']" name="visibility">internal</attr>
+  <attr path="//class[@name='PlatformWrapperView']/method[@name='shouldInvalidateShadow']" name="visibility">internal</attr>
   <attr path="//class[@name='PlatformDrawable']/method" name="visibility">internal</attr>
   <attr path="//class[@name='PlatformDrawable']/constructor" name="visibility">public</attr>
 

--- a/src/Core/tests/DeviceTests/Handlers/View/ViewHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/View/ViewHandlerTests.Android.cs
@@ -3,6 +3,8 @@ using Android.Views;
 using Android.Widget;
 using Microsoft.Maui.Handlers;
 using Xunit;
+using AColor = Android.Graphics.Color;
+using AView = Android.Views.View;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -27,6 +29,26 @@ namespace Microsoft.Maui.DeviceTests
 
 				Assert.Equal(ViewStates.Visible, wrapper.Visibility);
 				Assert.Equal(ViewStates.Visible, child.Visibility);
+			});
+		}
+
+		[Fact]
+		public async Task ShadowInvalidationOnlyFollowsImmediateChild()
+		{
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var wrapper = new WrapperView(MauiContext.Context);
+				var child = new AView(MauiContext.Context);
+				var descendant = new AView(MauiContext.Context);
+
+				wrapper.SetSolidShadow(10, 0, 0, AColor.Black.ToArgb());
+
+				Assert.True(wrapper.ShouldInvalidateShadow(child, child));
+				Assert.False(wrapper.ShouldInvalidateShadow(child, descendant));
+
+				wrapper.SetNoShadow();
+
+				Assert.False(wrapper.ShouldInvalidateShadow(child, child));
 			});
 		}
 	}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause

#35623 made `PlatformWrapperView.onDescendantInvalidated()` call `invalidate()` for every descendant update whenever the wrapper had a shadow. That keeps an immediate child animation such as a shadowed `Switch` in sync, but it also makes scrolling descendants redraw the entire shadowed container for every item update.

The complete reproduction from [MrLazyLee/ScrollPerformance](https://github.com/MrLazyLee/ScrollPerformance) has two large shadow wrappers around the `CollectionView`:

- The CommunityToolkit popup's default shadow.
- An explicit shadow on the inner `Border`.

Instrumentation over four up/down scroll cycles recorded:

| Wrapper | Descendant invalidations | Immediate-child invalidations |
|---|---:|---:|
| Popup, 1079 x 1678 | 1,859 | 3 |
| Border, 1026 x 1306 | 1,803 | 2 |

The current code therefore forces thousands of full-popup redraws even though only five invalidations originate from the immediate children whose shadows may need to move.

### Description of Change

Only invalidate a shadow wrapper when Android reports that the invalidation target is its immediate child (`child == target`). Deeper descendants continue to redraw through their own RenderNodes without forcing the whole shadowed ancestor to re-record its display list.

This preserves the #35623 behavior for controls such as `Switch`, while removing the scrolling regression for nested `CollectionView` and `ScrollView` content.

### Verification

The author reproduction was built with the exact 10.0.90 source and the same locally-built native AAR for both control and patched runs. Each row below used the same emulator and automated eight-cycle scroll sequence without screen recording:

| Variant | 50th percentile | 90th percentile | Slow UI-thread frames |
|---|---:|---:|---:|
| 10.0.80 | 34 ms | 53 ms | 29 |
| 10.0.90 control | 42-44 ms | 53-61 ms | 106-118 |
| 10.0.90 with this fix | 34-38 ms | 57-61 ms | 28-47 |

The patched result returns to the 10.0.80 range. The Android Core `View` device-test category also passes: 76 run, 74 passed, 2 ignored, 0 failed. A focused test verifies that an immediate child still invalidates a shadow while a deeper descendant does not.

### Videos

**10.0.80 baseline**

https://github.com/user-attachments/assets/4a7e8b4a-8ebd-499b-9477-718886608ab8

**10.0.90 regression**

https://github.com/user-attachments/assets/fc2dceb7-5f1f-4eae-9461-2c53fcc6bc90

**10.0.90 with this fix**

https://github.com/user-attachments/assets/0ea77dab-5cd8-4cb5-956a-169c9b12c31b

### Issues Fixed

Fixes #37281

Regressed by #35623.
