### PR TITLE
[iOS] Horizontal CollectionView jumps to beginning

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/ItemsViewHandler2.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items2/ItemsViewHandler2.iOS.cs
@@ -44,6 +44,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			ItemsView.ScrollToRequested -= ScrollToRequested;
 			_layout = null;
 			Controller?.DisposeItemsSource();
+			Controller?.DisposeObserver();
 			base.DisconnectHandler(platformView);
 		}
 

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -91,6 +91,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 			if (disposing)
 			{
+				DisposeObserver();
 				ItemsSource?.Dispose();
 
 				((IUIViewLifeCycleEvents)CollectionView).MovedToWindow -= MovedToWindow;
@@ -193,12 +194,26 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			// Rotation doesn't invalidate a UICollectionViewCompositionalLayout by default (its
 			// ShouldInvalidateLayoutForBoundsChange override returns false), so cells that were
 			// already measured before the rotation can end up with stale/empty content 
-			_orientationObserver = NSNotificationCenter.DefaultCenter.AddObserver(UIDevice.OrientationDidChangeNotification, DeviceOrientationChanged);
+			var weakController = new WeakReference<ItemsViewController2<TItemsView>>(this);
+			UIDevice.CurrentDevice.BeginGeneratingDeviceOrientationNotifications();
+			_orientationObserver = NSNotificationCenter.DefaultCenter.AddObserver(UIDevice.OrientationDidChangeNotification, _ => DeviceOrientationChanged(weakController));
 		}
 
-		void DeviceOrientationChanged(NSNotification notification)
+		static void DeviceOrientationChanged(WeakReference<ItemsViewController2<TItemsView>> weakController)
 		{
-			_isRotating = true;
+			var orientation = UIDevice.CurrentDevice.Orientation;
+			if (orientation is not (UIDeviceOrientation.Portrait
+				or UIDeviceOrientation.PortraitUpsideDown
+				or UIDeviceOrientation.LandscapeLeft
+				or UIDeviceOrientation.LandscapeRight))
+			{
+				return;
+			}
+
+			if (weakController.TryGetTarget(out var controller))
+			{
+				controller._isRotating = true;
+			}
 		}
 
 		public override void LoadView()
@@ -313,11 +328,14 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		// remove the orientation observer when the controller is disposed to avoid a memory leak
 		internal void DisposeObserver()
 		{
-			if (_orientationObserver is not null)
+			if (_orientationObserver is null)
 			{
-				NSNotificationCenter.DefaultCenter.RemoveObserver(_orientationObserver);
-				_orientationObserver = null;
+				return;
 			}
+
+			NSNotificationCenter.DefaultCenter.RemoveObserver(_orientationObserver);
+			_orientationObserver = null;
+			UIDevice.CurrentDevice.EndGeneratingDeviceOrientationNotifications();
 		}
 
 		void EnsureLayoutInitialized()

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -35,6 +35,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		bool _isEmpty = true;
 		bool _emptyViewDisplayed;
 		bool _disposed;
+		bool _isRotating;
+		NSObject _orientationObserver;
 
 		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		UIView _emptyUIView;
@@ -100,6 +102,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 				_emptyUIView = null;
 
 				_emptyViewFormsElement = null;
+
+				if (_orientationObserver is not null)
+				{
+					NSNotificationCenter.DefaultCenter.RemoveObserver(_orientationObserver);
+					_orientationObserver = null;
+				}
 
 				ItemsViewLayout?.Dispose();
 				CollectionView?.Dispose();
@@ -187,6 +195,16 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			RegisterViewTypes();
 
 			EnsureLayoutInitialized();
+
+			// Rotation doesn't invalidate a UICollectionViewCompositionalLayout by default (its
+			// ShouldInvalidateLayoutForBoundsChange override returns false), so cells that were
+			// already measured before the rotation can end up with stale/empty content 
+			_orientationObserver = NSNotificationCenter.DefaultCenter.AddObserver(UIDevice.OrientationDidChangeNotification, DeviceOrientationChanged);
+		}
+
+		void DeviceOrientationChanged(NSNotification notification)
+		{
+			_isRotating = true;
 		}
 
 		public override void LoadView()
@@ -203,6 +221,15 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			{
 				InvalidateLayoutIfItemsMeasureChanged();
 				collectionView.NeedsCellLayout = false;
+			}
+
+			if (_isRotating)
+			{
+				_isRotating = false;
+
+				// Force a genuine layout invalidation so cells are re-measured/re-rendered with
+				// their new bounds after the rotation completes 
+				CollectionView?.CollectionViewLayout?.InvalidateLayout();
 			}
 
 			base.ViewWillLayoutSubviews();

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -103,12 +103,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 				_emptyViewFormsElement = null;
 
-				if (_orientationObserver is not null)
-				{
-					NSNotificationCenter.DefaultCenter.RemoveObserver(_orientationObserver);
-					_orientationObserver = null;
-				}
-
 				ItemsViewLayout?.Dispose();
 				CollectionView?.Dispose();
 			}
@@ -314,6 +308,16 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			ItemsSource?.Dispose();
 			ItemsSource = new Items.EmptySource();
 			ReloadData();
+		}
+
+		// remove the orientation observer when the controller is disposed to avoid a memory leak
+		internal void DisposeObserver()
+		{
+			if (_orientationObserver is not null)
+			{
+				NSNotificationCenter.DefaultCenter.RemoveObserver(_orientationObserver);
+				_orientationObserver = null;
+			}
 		}
 
 		void EnsureLayoutInitialized()

--- a/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
@@ -630,20 +630,6 @@ internal static class LayoutFactory2
 			}
 		}
 
-		public override bool ShouldInvalidateLayoutForBoundsChange(CGRect newBounds)
-        {
-            // If the size hasn't changed, use the base implementation
-			if (newBounds.Size.IsCloseTo(_currentSize))
-            {
-                return base.ShouldInvalidateLayoutForBoundsChange(newBounds);
-            }
- 
-            // Size has changed (e.g., rotation), so we need to invalidate the layout
-            // to ensure cells are properly measured and displayed
-            _currentSize = newBounds.Size;
-            return true;
-        }
-
 		public override CGPoint TargetContentOffset(CGPoint proposedContentOffset, CGPoint scrollingVelocity)
 		{
 			var snapPointsType = _snapInfo.SnapType;

--- a/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
@@ -558,6 +558,35 @@ internal static class LayoutFactory2
 			_headerFooterInfo = headerFooterInfo;
 		}
 
+		public override void PrepareLayout()
+		{
+			base.PrepareLayout();
+
+			// Track the CollectionView's own bounds size so ShouldInvalidateLayoutForBoundsChange
+			// can tell a genuine resize of this CollectionView apart from an unrelated ancestor
+			// layout pass (e.g. a sibling's MaximumHeightRequest changing) that merely re-runs
+			// layout without actually changing this view's size. Mirrors ItemsViewLayout (CV1),
+			// which already guards against this — see dotnet/maui#36546.
+			if (CollectionView is { } collectionView)
+			{
+				_currentSize = collectionView.Bounds.Size;
+			}
+		}
+
+		public override bool ShouldInvalidateLayoutForBoundsChange(CGRect newBounds)
+		{
+			if (newBounds.Size.IsCloseTo(_currentSize))
+			{
+				// 	The CollectionView's own size hasn't actually changed, so there's no need to
+				// invalidate(and potentially reset scroll position / content offset).This is what
+				// prevents an unrelated sibling resize from jumping this CollectionView's scroll
+				// back to the start.
+				return false;
+			}
+
+			return base.ShouldInvalidateLayoutForBoundsChange(newBounds);
+		}
+
 		public override void FinalizeCollectionViewUpdates()
 		{
 			base.FinalizeCollectionViewUpdates();


### PR DESCRIPTION
<!-- Please keep the note below for people who find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment whether this change resolves your issue. Thank you!

This pull request resolves a build-breaking duplicate-method conflict between two independent `CustomUICollectionViewCompositionalLayout` fixes on iOS, while preserving the rotation-invalidation behavior that #32664 introduced for #32435.

### Issue Details

PR #36546's fix added a `ShouldInvalidateLayoutForBoundsChange(CGRect newBounds)` override (with `_currentSize` tracking via `PrepareLayout()`) to `CustomUICollectionViewCompositionalLayout` in `LayoutFactory2.cs`, to stop unrelated ancestor/sibling layout passes from resetting the CollectionView's scroll position.

PR #32664 had already added a **second** override of the exact same method (`ShouldInvalidateLayoutForBoundsChange`) in the same class, to fix #32435 — text disappearing in a horizontal CollectionView after rotating the simulator, because the compositional layout's default `ShouldInvalidateLayoutForBoundsChange` returns `false` and never re-measures cells after a bounds change.

Having two overrides of the same method in the same class does not compile (`CS0111: Type already defines a member with the same parameter types`).

### Description of Change

**Removed the duplicate override:**
* Removed the second `ShouldInvalidateLayoutForBoundsChange(CGRect newBounds)` override from `CustomUICollectionViewCompositionalLayout` in `LayoutFactory2.cs`. The `_currentSize`/`PrepareLayout()`-based override from #36546 is kept, since it already covers the "ignore same-size bounds changes" case for both scenarios.

**Restored rotation invalidation via the view controller instead of the layout:**
* The rotation handling was moved up to `ItemsViewController2`:
  * Added `_isRotating` and `_orientationObserver` fields.
  * Subscribed to `UIDevice.OrientationDidChangeNotification` in `ViewDidLoad()`, setting `_isRotating = true` in the `DeviceOrientationChanged` handler.
  * Unsubscribed the observer in `Dispose(bool)` to avoid leaks.
  * In `ViewWillLayoutSubviews()`, when `_isRotating` is set, explicitly call `CollectionView.CollectionViewLayout.InvalidateLayout()` to force cells to re-measure/re-render after the rotation completes, then reset `_isRotating`.

This keeps the #36546 scroll-jump fix intact (layout still returns `false` for same-size bounds changes) while independently guaranteeing a genuine invalidation happens after a real device rotation, without needing two competing overrides of the same UIKit method.

### Why tests not added
The scroll-reset scenario from #36546 is intermittent and doesn't reproduce reliably at the same item/position, so it isn't suited to an automated test. The rotation fix for #32435 already has manual UI test coverage from #32664 (`Issue32435.cs` in `TestCases.HostApp`/`TestCases.Shared.Tests`), which continues to apply here.
<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #36546 

### Tested the behavior in the following platforms

- [ ] Windows
- [ ] Android
- [x] iOS
- [ ] Mac


| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/364db60f-a126-42b4-bca9-96b48fb79cdb"> | <video src="https://github.com/user-attachments/assets/5c2c12cf-9461-4429-82e2-5a97fa53e0b8"> |

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
