### PR TITLE
Fix and Re-enable "Window Does Not Leak" and "Does Not Leak" Memory Leak Device Test

### DIFF
--- a/src/Controls/src/Core/Platform/Android/MultiPageFragmentStateAdapter.cs
+++ b/src/Controls/src/Core/Platform/Android/MultiPageFragmentStateAdapter.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Maui.Controls.Platform
 	{
 		MultiPage<T> _page;
 		readonly IMauiContext _context;
+		bool _disposed;
+		bool _tearingDown;
 		List<AdapterItemKey> keys = new List<AdapterItemKey>();
 
 		public MultiPageFragmentStateAdapter(
@@ -21,24 +23,64 @@ namespace Microsoft.Maui.Controls.Platform
 			_context = context;
 		}
 
+		protected override void Dispose(bool disposing)
+		{
+			if (!_disposed)
+			{
+				_disposed = true;
+				if (disposing)
+				{
+					_page = null!;
+				}
+			}
+
+			base.Dispose(disposing);
+		}
+
 		public override int ItemCount => CountOverride;
 
 		public int CountOverride { get; set; }
 
 		public override Fragment CreateFragment(int position)
 		{
-			var fragment = FragmentContainer.CreateInstance(GetItemIdByPosition(position), _context);
-			return fragment;
+			// Guard against a pending RecyclerView layout pass calling CreateFragment after
+			// BeginTeardown() reported zero items but before that update has been processed,
+			// which would otherwise dereference a disposed/null _page.
+			if (_tearingDown || _page is null)
+			{
+				return new Fragment();
+			}
+
+			return FragmentContainer.CreateInstance(GetItemIdByPosition(position), _context);
 		}
 
 		public override long GetItemId(int position)
 		{
+			if (_tearingDown || _page is null)
+			{
+				// -1 matches AndroidX RecyclerView.NO_ID.
+				return -1L;
+			}
+
 			return GetItemIdByPosition(position).ItemId;
 		}
 
 		public override bool ContainsItem(long itemId)
 		{
+			if (_tearingDown)
+			{
+				return false;
+			}
+
 			return GetItemByItemId(itemId) != null;
+		}
+
+		internal void BeginTeardown()
+		{
+			_tearingDown = true;
+			CountOverride = 0;
+			keys.Clear();
+			NotifyDataSetChanged();
 		}
 
 		AdapterItemKey GetItemIdByPosition(int position)

--- a/src/Controls/src/Core/Platform/Android/TabbedPageManager.cs
+++ b/src/Controls/src/Core/Platform/Android/TabbedPageManager.cs
@@ -126,9 +126,26 @@ public class TabbedPageManager
 			Element.Disappearing -= OnTabbedPageDisappearing;
 
 			RemoveTabs();
-			
+
+			// Defensively unsubscribe: SetTabLayout only unsubscribes once RootViewChanged fires,
+			// which may never happen if torn down first, otherwise leaking this manager.
+			_context.GetNavigationRootManager().RootViewChanged -= RootViewChanged;
+
 			_viewPager.LayoutChange -= OnLayoutChanged;
-			_viewPager.Adapter = null;
+
+			if (_viewPager.Adapter is MultiPageFragmentStateAdapter<Page> oldAdapter)
+			{
+				// Order matters: BeginTeardown() first so ContainsItem/CreateFragment/GetItemId
+				// treat this adapter as empty; clearing Adapter afterward cancels any pending
+				// layout still in flight from NotifyDataSetChanged() before Dispose() runs.
+				oldAdapter.BeginTeardown();
+				_viewPager.Adapter = null;
+				oldAdapter.Dispose();
+			}
+			else
+			{
+				_viewPager.Adapter = null;
+			}
 
 			if (_currentBarBackground is GradientBrush currentGradientBrush)
 			{
@@ -139,6 +156,9 @@ public class TabbedPageManager
 				currentGradientBrush.InvalidateGradientBrushRequested -= OnBarBackgroundChanged;
 			}
 			_currentBarBackground = null;
+
+			// Clear so this doesn't keep the old CurrentPage/TabbedPage reachable unnecessarily.
+			previousPage = null;
 		}
 
 		Element = tabbedPage;
@@ -318,6 +338,8 @@ public class TabbedPageManager
 
 		if (_context?.Context is Context c)
 		{
+			// If IsStateSaved, the returned IDisposable must be disposed to unregister the
+			// FragmentLifecycleCallbacks, otherwise this manager stays rooted indefinitely.
 			_pendingFragment =
 				rootManager
 					.FragmentManager

--- a/src/Controls/src/Core/TabbedPage/TabbedPage.Android.cs
+++ b/src/Controls/src/Core/TabbedPage/TabbedPage.Android.cs
@@ -54,7 +54,10 @@ namespace Microsoft.Maui.Controls
 				_tabbedPageManager = null;
 			}
 			else if (args.OldHandler != null && args.NewHandler == null)
+			{
 				DisconnectHandler();
+				_tabbedPageManager = null;
+			}
 		}
 
 		void DisconnectHandler()

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
@@ -351,7 +351,6 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-#if TESTS_FAILS_ON_IOS && TESTS_FAILS_ON_MACCATALYST //For more information, see: https://github.com/dotnet/maui/issues/35985
 		[Fact(DisplayName = "Does Not Leak"
 #if WINDOWS || ANDROID
 			, Skip = "Failing https://github.com/dotnet/maui/issues/27411"
@@ -380,7 +379,6 @@ namespace Microsoft.Maui.DeviceTests
 
 			await AssertionExtensions.WaitForGC(references.ToArray());
 		}
-#endif
 
 		[Fact(DisplayName = "Child Pages Do Not Leak"
 #if WINDOWS

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
@@ -359,25 +360,34 @@ namespace Microsoft.Maui.DeviceTests
 		public async Task DoesNotLeak()
 		{
 			SetupBuilder();
-			var references = new List<WeakReference>();
 
-			{
-				var navPage = new NavigationPage(new ContentPage());
-				var window = new Window(navPage);
-
-				await CreateHandlerAndAddToWindow<WindowHandlerStub>(window, (handler) =>
-				{
-					references.Add(new(navPage));
-					references.Add(new(navPage.Handler));
-					references.Add(new(navPage.Handler.PlatformView));
-					references.Add(new(handler));
-
-					// Just replace the page with a new one
-					window.Page = new ContentPage();
-				});
-			}
+			var references = await CreateNavigationPageLeakReferencesAsync();
 
 			await AssertionExtensions.WaitForGC(references.ToArray());
+		}
+
+		// Extracted into a non-inlineable method so the `navPage`/`window` locals aren't hoisted into the
+		// caller's async state machine, which could keep them rooted past the WaitForGC await above.
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		async Task<List<WeakReference>> CreateNavigationPageLeakReferencesAsync()
+		{
+			var references = new List<WeakReference>();
+
+			var navPage = new NavigationPage(new ContentPage());
+			var window = new Window(navPage);
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(window, (handler) =>
+			{
+				references.Add(new(navPage));
+				references.Add(new(navPage.Handler));
+				references.Add(new(navPage.Handler.PlatformView));
+				references.Add(new(handler));
+
+				// Just replace the page with a new one
+				window.Page = new ContentPage();
+			});
+
+			return references;
 		}
 
 		[Fact(DisplayName = "Child Pages Do Not Leak"

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
@@ -441,7 +441,6 @@ namespace Microsoft.Maui.DeviceTests
 			}
 		}
 
-#if TEST_FAILS_ON_ANDROID //For more information, see: https://github.com/dotnet/maui/issues/35985
 		[Fact(DisplayName = "Does Not Leak"
 #if WINDOWS
 			, Skip = "FIXME: fails on Windows"
@@ -470,9 +469,12 @@ namespace Microsoft.Maui.DeviceTests
 				await navPage.Navigation.PopAsync();
 			});
 
+			// Null the locals so they aren't hoisted into the async state machine and kept
+			// alive across the WaitForGC await below.
+			navPage = null;
+
 			await AssertionExtensions.WaitForGC(pageReference);
 		}
-#endif
 
 		TabbedPage CreateBasicTabbedPage(bool bottomTabs = false, bool isSmoothScrollEnabled = true, IEnumerable<Page> pages = null)
 		{

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -768,14 +768,23 @@ public class MemoryTests : ControlsHandlerTestBase
 		Assert.Equal(4, references.Count);
 		await AssertionExtensions.WaitForGC(references[2], references[3]);
 	}
-#if TEST_FAILS_ON_ANDROID && TESTS_FAILS_ON_WINDOWS && TESTS_FAILS_ON_IOS && TESTS_FAILS_ON_MACCATALYST //For more information, see: https://github.com/dotnet/maui/issues/35985
+
 	[Fact("Window Does Not Leak")]
 	public async Task WindowDoesNotLeak()
 	{
 		SetupBuilder();
 
-		var references = new List<WeakReference>();
+		var references = await CreateWindowLeakReferencesAsync();
 
+		await AssertionExtensions.WaitForGC([.. references]);
+	}
+
+	// Extracted into a non-inlineable method so the `window`/`page` locals aren't hoisted into the
+	// caller's async state machine, which could keep them rooted past the WaitForGC await below.
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	async Task<List<WeakReference>> CreateWindowLeakReferencesAsync()
+	{
+		var references = new List<WeakReference>();
 
 		var page = new ContentPage();
 		var window = new Window(page);
@@ -795,9 +804,8 @@ public class MemoryTests : ControlsHandlerTestBase
 			}
 		});
 
-		await AssertionExtensions.WaitForGC([.. references]);
+		return references;
 	}
-#endif
 
 	[Fact("VisualDiagnosticsOverlay Does Not Leak"
 #if IOS || MACCATALYST


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!


<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details

Device memory leak tests started failing in the Candidate branch after PR https://github.com/dotnet/maui/pull/35487, indicating regressions in memory leak validation across Windows, iOS, macOS, and Android. The affected Does Not Leak and Window Does Not Leak tests were failing on these platforms.

### Issue1: Window Does Not Leak 

### Root cause

The  WindowDoesNotLeak  test failed intermittently because  window  and  page  were declared as locals inside an  async Task  method ( WindowDoesNotLeak ) and were referenced across  await  boundaries (both directly and inside the lambda passed to  CreateHandlerAndAddToWindow ). The C# compiler hoists such locals into fields of the generated async state machine, and those fields are not guaranteed to be cleared once the locals are no longer needed. As a result,  window  and  page  remained artificially rooted by the state machine instance for the entire duration of the subsequent  WaitForGC  call, producing a false-positive "still alive" leak report rather than reflecting an actual product defect.

### Solution description

The fix extracts the window/page creation and handler invocation logic out of  WindowDoesNotLeak  into a new, non-inlineable helper method,  CreateWindowLeakReferencesAsync , marked with  [MethodImpl(MethodImplOptions.NoInlining)] . This helper creates  window  and  page , drives the handler lifecycle, and returns only the collected  WeakReference  list. Since  window  and  page  now live in the helper's own async state machine — which is discarded once the helper returns — they are no longer reachable from  WindowDoesNotLeak 's state machine during the subsequent  WaitForGC  call, eliminating the artificial rooting. The dead conditional compilation guard ( #if TEST_FAILS_ON_ANDROID && TESTS_FAILS_ON_WINDOWS && TESTS_FAILS_ON_IOS && TESTS_FAILS_ON_MACCATALYST ) that had disabled the test was also removed to re-enable it.

### Issue2: TabbedPageTests.DoesNotLeak

### Root cause

The issue occurs because of two compounding factors. At the test level, the  navPage  local was captured by an async lambda and accessed again after an  await , causing it to be hoisted into the compiler-generated closure and transitively keep the popped  TabbedPage  alive through its navigation stack. At the platform level on Android,  MultiPageFragmentStateAdapter  was constructed using the host Activity's long-lived  Lifecycle , causing AndroidX to permanently register a lifecycle observer that was never released because the Activity's lifecycle never reached the destroyed state. This kept the adapter, and the  TabbedPage  it referenced, permanently rooted in memory, while AndroidX also failed to reclaim the associated child fragments.

### Solution description

The fix involves nulling the  navPage  local before the  WaitForGC  call at the test level, combined with a production-level Android fix in  MultiPageFragmentStateAdapter.cs  that introduces a teardown routine to make AndroidX reclaim its fragments correctly and explicitly clears the adapter's page reference on disposal. Supporting changes in  TabbedPageManager.cs  and  TabbedPage.Android.cs  ensure the teardown routine executes before the adapter is detached and that manager references are cleared on disconnect. The resolution was verified through repeated on-device Android test runs, all passing successfully.

### Issue3: NavigationPageTests.DoesNotLeak

### Root Cause
 
The issue occurs because of the `navPage` and `window` locals in `NavigationPageTests.DoesNotLeak` being referenced across an `await` boundary — both directly and inside the lambda passed to `CreateHandlerAndAddToWindow`. The C# compiler hoists such locals into fields of the generated async state machine for the test method, and those fields are not guaranteed to be cleared once the locals are no longer needed. As a result, `navPage` and `window` remained artificially rooted by the state machine instance for the duration of the subsequent `WaitForGC` call, producing a false-positive "still alive" leak report rather than reflecting an actual product defect.
 
This issue was only replicated in Release mode, since Release-mode JIT/compiler optimizations affect how and when the hoisted state-machine fields are cleared, whereas Debug builds happened to clear or avoid rooting them, masking the problem locally.
 
### Solution Description
 
The fix involves extracting the `navPage`/`window` creation and handler invocation logic out of `DoesNotLeak` into a new, non-inlineable helper method, `CreateNavigationPageLeakReferencesAsync`, marked with `[MethodImpl(MethodImplOptions.NoInlining)]`. This helper creates `navPage` and `window`, drives the handler lifecycle, and returns only the collected `WeakReference` list.
 
Since `navPage` and `window` now live in the helper's own async state machine — which is discarded once the helper returns — they are no longer reachable from `DoesNotLeak`'s state machine during the subsequent `WaitForGC` call, eliminating the artificial rooting.

Validated the behavior in the following platforms
 
- [x] iOS
- [x] Mac
- [x] Android
- [x] Windows

### Regression PR

PR https://github.com/dotnet/maui/pull/35487
 
### Issues Fixed
  
Fixes https://github.com/dotnet/maui/issues/36613

### Output  Screenshot

### Issue1: Window Does Not Leak 

|Platform|Before|After|
|--|--|--|
|Android| <video src="https://github.com/user-attachments/assets/1d3986aa-5c5f-4d97-ab6e-96c586e53488" >| <video src="https://github.com/user-attachments/assets/3670bafa-6a75-47a8-8505-797901e7abeb">|
|Mac|<video src="https://github.com/user-attachments/assets/461534f8-21dd-46ab-bb62-c10a5f8ac71a"> |<video src="https://github.com/user-attachments/assets/d862eb7f-c33f-4866-a553-5264b1cda411">|
|iOS|<video src="https://github.com/user-attachments/assets/41b71c49-26ac-4dcc-9e01-87dce42d5000">|<video src="https://github.com/user-attachments/assets/9e03f7ca-d803-49b9-a159-4057320591a7">|
|Windows|<video src="https://github.com/user-attachments/assets/73300a73-a9be-403b-b77e-2cc4418d10c9">|<video src="https://github.com/user-attachments/assets/173cf2e3-5bde-4383-b07a-0b6b8422d03b"> |

### Issue2: TabbedPageTests.DoesNotLeak

|Platform|Before|After|
|--|--|--|
|Android| <video src="https://github.com/user-attachments/assets/604316e5-5849-4195-9e16-1c96d710c125" >| <video src="https://github.com/user-attachments/assets/50bc614c-814d-43d1-912b-446886086886">|

### Issue3: NavigationPageTests.DoesNotLeak

|Platform|Before|After|
|--|--|--|
|Mac|<video src="https://github.com/user-attachments/assets/cd6831a8-e8f6-4954-baff-055a2575a576"> |<video src="https://github.com/user-attachments/assets/6198e780-82e9-4eec-b3f5-a805f79d0ddd">|
|iOS|<video src="https://github.com/user-attachments/assets/47edefd0-a416-4245-bbce-3e54c80aefa0">|<video src="https://github.com/user-attachments/assets/84f2c31c-0d9d-4c3e-9f21-9a8f634e671f">|
