### PR TITLE
[Android] Shell: Defer tab infrastructure for single-page startup

### DIFF
--- a/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Android.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Android.cs
@@ -255,6 +255,14 @@ namespace Microsoft.Maui.Controls.Handlers
             RecreateBottomNavigationAppearanceTracker();
         }
 
+        void RemoveBottomNavigationInfrastructure()
+        {
+            _tabbedViewManager?.SetElement(null);
+            _tabbedViewManager = null;
+            _shellItemAdapter = null;
+            _bottomNavigationView = null;
+        }
+
         /// <summary>
         /// Switches to a new ShellSection using ViewPager2.
         /// The ViewPager2 adapter handles the fragment management.
@@ -359,29 +367,26 @@ namespace Microsoft.Maui.Controls.Handlers
             // Rebuild ViewPager2 adapter for new ShellItem's sections
             SetupViewPagerAdapter();
 
-            if (_tabbedViewManager is null)
-            {
-                SetupTabbedViewManager();
-            }
-            else
-            {
-                // Rebuild bottom navigation for new ShellItem's sections via TabbedViewManager
-                RebuildBottomNavigation();
-            }
-
-            // Apply badges to the rebuilt bottom navigation
-            UpdateAllBadges();
-
-            // Update tab visibility for new ShellItem (may need to show/hide bottom tabs)
             var showTabs = ((IShellItemController)newItem).ShowTabs;
 
             if (showTabs)
             {
+                if (_tabbedViewManager is null)
+                {
+                    SetupTabbedViewManager();
+                }
+                else
+                {
+                    // Rebuild bottom navigation for new ShellItem's sections via TabbedViewManager
+                    RebuildBottomNavigation();
+                }
+
+                UpdateAllBadges();
                 _tabbedViewManager?.SetTabLayout();
             }
             else
             {
-                _tabbedViewManager?.RemoveTabs();
+                RemoveBottomNavigationInfrastructure();
             }
 
             // Re-register appearance observer with new ShellItem
@@ -640,7 +645,7 @@ namespace Microsoft.Maui.Controls.Handlers
 
         void UpdateTabBarVisibility()
         {
-            if (_displayedPage is null || ((ElementHandler)this).VirtualView is null)
+            if (_switchingShellItem || _displayedPage is null || ((ElementHandler)this).VirtualView is null)
             {
                 return;
             }
@@ -879,13 +884,7 @@ namespace Microsoft.Maui.Controls.Handlers
             if (!_preserveFragmentResources)
             {
                 // Full disconnect: fragment is being destroyed — clean everything
-                if (_tabbedViewManager is not null)
-                {
-                    _tabbedViewManager.RemoveTabs();
-                    _tabbedViewManager.SetElement(null);
-                    _tabbedViewManager = null;
-                }
-                _shellItemAdapter = null;
+                RemoveBottomNavigationInfrastructure();
 
                 _toolbarAppearanceTracker?.Dispose();
                 _toolbarAppearanceTracker = null;

--- a/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Android.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Android.cs
@@ -173,14 +173,15 @@ namespace Microsoft.Maui.Controls.Handlers
         /// </summary>
         internal void SetupTabbedViewManager()
         {
-            if (_viewPager is null || VirtualView is null || MauiContext is null)
+            if (_tabbedViewManager is not null || _viewPager is null || VirtualView is null || MauiContext is null)
             {
                 return;
             }
 
-            var shellSections = ((IShellItemController)VirtualView).GetItems();
+            var shellItemController = (IShellItemController)VirtualView;
+            var shellSections = shellItemController.GetItems();
 
-            if (shellSections is null || shellSections.Count == 0)
+            if (shellSections is null || shellSections.Count == 0 || !shellItemController.ShowTabs)
             {
                 return;
             }
@@ -217,6 +218,21 @@ namespace Microsoft.Maui.Controls.Handlers
 
             // Get BNV reference for appearance tracker
             _bottomNavigationView = _tabbedViewManager.BottomNavigationView;
+            RecreateBottomNavigationAppearanceTracker();
+
+            // Initial setup registers the appearance observer immediately afterward. When
+            // setup was deferred, replay the appearance for the newly-created bottom tabs.
+            if (_registeredShell is not null && _displayedPage is not null)
+            {
+                ((IShellController)_registeredShell).AppearanceChanged(_displayedPage, false);
+            }
+        }
+
+        void RecreateBottomNavigationAppearanceTracker()
+        {
+            _appearanceTracker?.Dispose();
+            _shellContext ??= GetShellContext();
+            _appearanceTracker = _shellContext.CreateBottomNavViewAppearanceTracker(VirtualView);
         }
 
         /// <summary>
@@ -236,6 +252,7 @@ namespace Microsoft.Maui.Controls.Handlers
 
             // Update BNV reference (SetElement creates a new BNV)
             _bottomNavigationView = _tabbedViewManager.BottomNavigationView;
+            RecreateBottomNavigationAppearanceTracker();
         }
 
         /// <summary>
@@ -342,8 +359,15 @@ namespace Microsoft.Maui.Controls.Handlers
             // Rebuild ViewPager2 adapter for new ShellItem's sections
             SetupViewPagerAdapter();
 
-            // Rebuild bottom navigation for new ShellItem's sections via TabbedViewManager
-            RebuildBottomNavigation();
+            if (_tabbedViewManager is null)
+            {
+                SetupTabbedViewManager();
+            }
+            else
+            {
+                // Rebuild bottom navigation for new ShellItem's sections via TabbedViewManager
+                RebuildBottomNavigation();
+            }
 
             // Apply badges to the rebuilt bottom navigation
             UpdateAllBadges();
@@ -616,7 +640,7 @@ namespace Microsoft.Maui.Controls.Handlers
 
         void UpdateTabBarVisibility()
         {
-            if (_tabbedViewManager is null || _displayedPage is null || ((ElementHandler)this).VirtualView is null)
+            if (_displayedPage is null || ((ElementHandler)this).VirtualView is null)
             {
                 return;
             }
@@ -625,11 +649,12 @@ namespace Microsoft.Maui.Controls.Handlers
 
             if (showTabs)
             {
-                _tabbedViewManager.SetTabLayout();
+                SetupTabbedViewManager();
+                _tabbedViewManager?.SetTabLayout();
             }
             else
             {
-                _tabbedViewManager.RemoveTabs();
+                _tabbedViewManager?.RemoveTabs();
             }
         }
 
@@ -727,9 +752,9 @@ namespace Microsoft.Maui.Controls.Handlers
                 ((IShellItemController)VirtualView).ItemsCollectionChanged += OnShellItemsChanged;
             }
 
-            // Initialize shell context and appearance tracker early
+            // Initialize the Shell context early. The bottom navigation appearance tracker
+            // is created with the deferred TabbedViewManager when tabs are actually needed.
             _shellContext ??= GetShellContext();
-            _appearanceTracker = _shellContext.CreateBottomNavViewAppearanceTracker(VirtualView);
 
             // NOTE: Appearance observer registration is deferred to RegisterAppearanceObserver()
             // called from OnViewCreated in the wrapper fragment. At ConnectHandler time,
@@ -776,11 +801,14 @@ namespace Microsoft.Maui.Controls.Handlers
                 // 0→N transition: adapter/manager were not created during initial setup
                 // because there were no sections. Now that sections exist, create them.
                 SetupViewPagerAdapter();
-                SetupTabbedViewManager();
             }
 
-            // Rebuild the bottom navigation menu for the updated sections via TabbedViewManager
-            _tabbedViewManager?.RefreshTabs();
+            var existingTabbedViewManager = _tabbedViewManager;
+            SetupTabbedViewManager();
+
+            // Rebuild an existing bottom navigation menu. A newly-created manager was
+            // already populated by SetElement in SetupTabbedViewManager.
+            existingTabbedViewManager?.RefreshTabs();
             UpdateTabBarVisibility();
 
             // Signal that the adapter was just rebuilt. The next SwitchToSection call
@@ -837,7 +865,7 @@ namespace Microsoft.Maui.Controls.Handlers
                 _registeredShell = null;
             }
 
-            // Dispose per-item appearance tracker (ConnectHandler recreates for new item)
+            // Dispose per-item appearance tracker; tab setup or rebuild recreates it as needed.
             _appearanceTracker?.Dispose();
             _appearanceTracker = null;
 

--- a/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Android.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Android.cs
@@ -221,9 +221,10 @@ namespace Microsoft.Maui.Controls.Handlers
             RecreateBottomNavigationAppearanceTracker();
 
             // Initial setup registers the appearance observer immediately afterward. When
-            // setup was deferred, replay the appearance for the newly-created bottom tabs.
+            // setup was deferred, replay state for the newly-created bottom tabs.
             if (_registeredShell is not null && _displayedPage is not null)
             {
+                UpdateAllBadges();
                 ((IShellController)_registeredShell).AppearanceChanged(_displayedPage, false);
             }
         }

--- a/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Android.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Android.cs
@@ -277,14 +277,9 @@ namespace Microsoft.Maui.Controls.Handlers
 
         void SetupTabbedViewManager()
         {
-            if (_tabbedViewManager is not null || VirtualView is null || _viewPager is null || MauiContext is null)
+            if (_tabbedViewManager is not null || VirtualView is null || _viewPager is null || MauiContext is null || _shellContext is null)
             {
                 return;
-            }
-
-            if (_shellContext is null)
-            {
-                throw new InvalidOperationException("Shell context must be initialized before setting up top tabs.");
             }
 
             if (SectionController.GetItems().Count <= 1)

--- a/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Android.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Android.cs
@@ -277,9 +277,14 @@ namespace Microsoft.Maui.Controls.Handlers
 
         void SetupTabbedViewManager()
         {
-            if (_tabbedViewManager is not null || VirtualView is null || _viewPager is null || MauiContext is null || _shellContext is null)
+            if (_tabbedViewManager is not null || VirtualView is null || _viewPager is null || MauiContext is null)
             {
                 return;
+            }
+
+            if (_shellContext is null)
+            {
+                throw new InvalidOperationException("Shell context must be initialized before setting up top tabs.");
             }
 
             if (SectionController.GetItems().Count <= 1)
@@ -339,7 +344,7 @@ namespace Microsoft.Maui.Controls.Handlers
 
         void UpdateTabLayoutVisibility()
         {
-            if (_tabbedViewManager is null || VirtualView is null)
+            if (VirtualView is null)
             {
                 return;
             }
@@ -1035,7 +1040,7 @@ namespace Microsoft.Maui.Controls.Handlers
             toolbarTracker?.Page = page;
 
             // Update CurrentItem
-            virtualView.CurrentItem = newCurrentItem;
+            virtualView.SetValueFromRenderer(ShellSection.CurrentItemProperty, newCurrentItem);
 
             // Trigger appearance update
             if (shell is not null)

--- a/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Android.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Android.cs
@@ -149,21 +149,6 @@ namespace Microsoft.Maui.Controls.Handlers
             _rootLayout = rootView.FindViewById<LinearLayout>(Resource.Id.shellsection_coordinator);
             _viewPager = rootView.FindViewById<ViewPager2>(Resource.Id.shellsection_viewpager);
 
-            // Create TabLayout programmatically (no longer from XML layout).
-            // It will be placed into navigationlayout_toptabs via PlaceTopTabs().
-            var context = MauiContext?.Context
-                ?? throw new InvalidOperationException("MauiContext.Context cannot be null");
-
-            int actionBarHeight = context.GetActionBarHeight();
-
-            _contentTabLayout = new TabLayout(context)
-            {
-                Id = AView.GenerateViewId(),
-                LayoutParameters = new LP(LP.MatchParent, actionBarHeight),
-                Visibility = ViewStates.Gone,  // Hidden by default (shown when > 1 tab)
-                TabMode = TabLayout.ModeScrollable
-            };
-
             return rootView;
         }
 
@@ -253,18 +238,7 @@ namespace Microsoft.Maui.Controls.Handlers
             var visibleItems = SectionController.GetItems();
             _viewPager.OffscreenPageLimit = Math.Max(visibleItems.Count, 1);
 
-            // Setup TabbedViewManager for top tab management.
-            // Pre-assign Shell's TabLayout (specific sizing) before SetElement.
-            _shellSectionAdapter = new ShellSectionTabbedViewAdapter(VirtualView);
-            _tabbedViewManager = new TabbedViewManager(MauiContext, _viewPager)
-            {
-                TabLayout = _contentTabLayout
-            };
-            _tabbedViewManager.SetElement(_shellSectionAdapter);
-
-            // Register page change callback (stored in field for cleanup in DisconnectHandler)
-            _pageChangedCallback = new ViewPagerPageChangeCallback(this);
-            _viewPager.RegisterOnPageChangeCallback(_pageChangedCallback);
+            SetupTabbedViewManager();
 
             // Update TabLayout visibility based on item count
             UpdateTabLayoutVisibility();
@@ -275,10 +249,6 @@ namespace Microsoft.Maui.Controls.Handlers
             // Set initial position
             SetInitialPosition();
 
-            // Setup TabLayout appearance tracker
-            _tabLayoutAppearanceTracker = _shellContext.CreateTabLayoutAppearanceTracker(VirtualView);
-
-            // Register as appearance observer for TabLayout updates
             var shell = VirtualView.FindParentOfType<Shell>();
             if (shell is not null)
             {
@@ -301,6 +271,53 @@ namespace Microsoft.Maui.Controls.Handlers
                     toolbarTracker?.Page = page;
 
                     ((IShellController)shell).AppearanceChanged(page, false);
+                }
+            }
+        }
+
+        void SetupTabbedViewManager()
+        {
+            if (_tabbedViewManager is not null || VirtualView is null || _viewPager is null || MauiContext is null || _shellContext is null)
+            {
+                return;
+            }
+
+            if (SectionController.GetItems().Count <= 1)
+            {
+                return;
+            }
+
+            var context = MauiContext.Context
+                ?? throw new InvalidOperationException("MauiContext.Context cannot be null");
+
+            _contentTabLayout = new TabLayout(context)
+            {
+                Id = AView.GenerateViewId(),
+                LayoutParameters = new LP(LP.MatchParent, context.GetActionBarHeight()),
+                Visibility = ViewStates.Gone,
+                TabMode = TabLayout.ModeScrollable
+            };
+
+            _shellSectionAdapter = new ShellSectionTabbedViewAdapter(VirtualView);
+            _tabbedViewManager = new TabbedViewManager(MauiContext, _viewPager)
+            {
+                TabLayout = _contentTabLayout
+            };
+            _tabbedViewManager.SetElement(_shellSectionAdapter);
+
+            _pageChangedCallback = new ViewPagerPageChangeCallback(this);
+            _viewPager.RegisterOnPageChangeCallback(_pageChangedCallback);
+
+            _tabLayoutAppearanceTracker = _shellContext.CreateTabLayoutAppearanceTracker(VirtualView);
+
+            // Initial setup registers the appearance observer immediately afterward. When
+            // setup was deferred, replay the appearance for the newly-created TabLayout.
+            if (_registeredShell is not null && IsCurrentlyActiveSection() && VirtualView.CurrentItem is ShellContent currentContent)
+            {
+                var page = ((IShellContentController)currentContent).GetOrCreateContent();
+                if (page is not null)
+                {
+                    ((IShellController)_registeredShell).AppearanceChanged(page, false);
                 }
             }
         }
@@ -646,6 +663,7 @@ namespace Microsoft.Maui.Controls.Handlers
             var visibleCount = SectionController.GetItems().Count;
             _viewPager?.OffscreenPageLimit = Math.Max(visibleCount, 1);
 
+            SetupTabbedViewManager();
             UpdateTabLayoutVisibility();
             UpdateViewPagerUserInput();
         }

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellHandlerSubclasses.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellHandlerSubclasses.Android.cs
@@ -52,7 +52,12 @@ namespace Microsoft.Maui.DeviceTests
 
 			var firstPage = new ContentPage();
 			var firstContent = new ShellContent { Content = firstPage };
-			var section = new ShellSection { Items = { firstContent } };
+			var expectedBadgeText = "7";
+			var section = new ShellSection
+			{
+				BadgeText = expectedBadgeText,
+				Items = { firstContent }
+			};
 			var item = new FlyoutItem { Items = { section } };
 			var secondSection = new ShellSection
 			{
@@ -96,6 +101,9 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.NotNull(sectionHandler.ContentTabLayout);
 				var bottomBackground = Assert.IsType<ColorChangeRevealDrawable>(itemHandler.BottomNavigationView.Background);
 				Assert.Equal(expectedTabBackground.ToPlatform(), bottomBackground.EndColor);
+				var badge = itemHandler.BottomNavigationView.GetBadge(0);
+				Assert.NotNull(badge);
+				Assert.Equal(expectedBadgeText, badge.Text);
 				var background = Assert.IsType<ColorDrawable>(sectionHandler.ContentTabLayout.Background);
 				Assert.Equal(expectedTabBackground.ToPlatform(), background.Color);
 				Assert.Equal(1, shellHandler.BottomNavAppearanceTrackerCreationCount);

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellHandlerSubclasses.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellHandlerSubclasses.Android.cs
@@ -1,14 +1,18 @@
+using System.Threading.Tasks;
+using Android.Graphics.Drawables;
+using AndroidX.AppCompat.Graphics.Drawable;
+using AndroidX.CoordinatorLayout.Widget;
+using AndroidX.DrawerLayout.Widget;
+using Google.Android.Material.AppBar;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers;
 using Microsoft.Maui.Controls.Handlers.Items;
+using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Controls.Platform.Compatibility;
 using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
-using AndroidX.DrawerLayout.Widget;
-using AndroidX.AppCompat.Graphics.Drawable;
-using AndroidX.CoordinatorLayout.Widget;
-using Google.Android.Material.AppBar;
 using Microsoft.Maui.Platform;
 using Xunit;
 using AView = Android.Views.View;
@@ -16,11 +20,168 @@ using NativeShellHandler = Microsoft.Maui.Controls.Handlers.ShellHandler;
 
 namespace Microsoft.Maui.DeviceTests
 {
+	public class StartupTrackingShellHandler : NativeShellHandler
+	{
+		public int TabLayoutAppearanceTrackerCreationCount { get; private set; }
+
+		public int BottomNavAppearanceTrackerCreationCount { get; private set; }
+
+		protected override IShellTabLayoutAppearanceTracker CreateTabLayoutAppearanceTracker(ShellSection shellSection)
+		{
+			TabLayoutAppearanceTrackerCreationCount++;
+			return base.CreateTabLayoutAppearanceTracker(shellSection);
+		}
+
+		protected override IShellBottomNavViewAppearanceTracker CreateBottomNavViewAppearanceTracker(ShellItem shellItem)
+		{
+			BottomNavAppearanceTrackerCreationCount++;
+			return base.CreateBottomNavViewAppearanceTracker(shellItem);
+		}
+	}
+
 	[Category(TestCategory.Shell)]
 	[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
 	[Trait(RendererHandlerVariant.TraitName, RendererHandlerVariant.AndroidShellHandler)] // See RendererHandlerVariant.cs
 	public partial class ShellHandlerTests_Shell : ShellTests
 	{
+		[Fact]
+		public async Task SinglePageShellCreatesTabInfrastructureOnlyWhenNeeded()
+		{
+			SetupBuilder();
+
+			var firstPage = new ContentPage();
+			var firstContent = new ShellContent { Content = firstPage };
+			var section = new ShellSection { Items = { firstContent } };
+			var item = new FlyoutItem { Items = { section } };
+			var secondSection = new ShellSection
+			{
+				Title = "Second section",
+				Items = { new ShellContent { Content = new ContentPage() } }
+			};
+			var secondContent = new ShellContent
+			{
+				Title = "Second content",
+				Content = new ContentPage()
+			};
+			var expectedTabBackground = Colors.Red;
+			var shell = await CreateShellAsync(shell =>
+			{
+				Shell.SetBackgroundColor(shell, expectedTabBackground);
+				shell.Items.Add(item);
+			});
+
+			await CreateHandlerAndAddToWindow(shell, async () =>
+			{
+				await OnLoadedAsync(firstPage);
+
+				var shellHandler = Assert.IsType<StartupTrackingShellHandler>(shell.Handler);
+				var itemHandler = Assert.IsType<ShellItemHandler>(item.Handler);
+				var sectionHandler = Assert.IsType<ShellSectionHandler>(section.Handler);
+
+				Assert.Null(itemHandler._tabbedViewManager);
+				Assert.Null(itemHandler._shellItemAdapter);
+				Assert.Null(itemHandler.BottomNavigationView);
+				Assert.Null(sectionHandler.ContentTabLayout);
+				Assert.Equal(0, shellHandler.BottomNavAppearanceTrackerCreationCount);
+				Assert.Equal(0, shellHandler.TabLayoutAppearanceTrackerCreationCount);
+
+				item.Items.Add(secondSection);
+				section.Items.Add(secondContent);
+
+				Assert.NotNull(itemHandler._tabbedViewManager);
+				Assert.NotNull(sectionHandler.ContentTabLayout);
+				var background = Assert.IsType<ColorDrawable>(sectionHandler.ContentTabLayout.Background);
+				Assert.Equal(expectedTabBackground.ToPlatform(), background.Color);
+				Assert.Equal(1, shellHandler.BottomNavAppearanceTrackerCreationCount);
+				Assert.Equal(1, shellHandler.TabLayoutAppearanceTrackerCreationCount);
+
+				var tabbedViewManager = itemHandler._tabbedViewManager;
+				var shellItemAdapter = itemHandler._shellItemAdapter;
+				var bottomNavigationView = itemHandler.BottomNavigationView;
+				var contentTabLayout = sectionHandler.ContentTabLayout;
+
+				item.Items.Remove(secondSection);
+				section.Items.Remove(secondContent);
+				item.Items.Add(secondSection);
+				section.Items.Add(secondContent);
+
+				Assert.Same(tabbedViewManager, itemHandler._tabbedViewManager);
+				Assert.Same(shellItemAdapter, itemHandler._shellItemAdapter);
+				Assert.Same(bottomNavigationView, itemHandler.BottomNavigationView);
+				Assert.Same(contentTabLayout, sectionHandler.ContentTabLayout);
+				Assert.Equal(1, shellHandler.BottomNavAppearanceTrackerCreationCount);
+				Assert.Equal(1, shellHandler.TabLayoutAppearanceTrackerCreationCount);
+			});
+		}
+
+		[Fact]
+		public async Task SwitchingShellItemsRecreatesBottomNavAppearanceTracker()
+		{
+			SetupBuilder();
+
+			var firstPage = new ContentPage();
+			var firstItem = new FlyoutItem
+			{
+				Title = "First item",
+				Items =
+				{
+					new ShellSection
+					{
+						Title = "First section",
+						Items = { new ShellContent { Content = firstPage } }
+					},
+					new ShellSection
+					{
+						Title = "Second section",
+						Items = { new ShellContent { Content = new ContentPage() } }
+					}
+				}
+			};
+			var secondPage = new ContentPage();
+			var secondItem = new FlyoutItem
+			{
+				Title = "Second item",
+				Items =
+				{
+					new ShellSection
+					{
+						Title = "First section",
+						Items = { new ShellContent { Content = secondPage } }
+					},
+					new ShellSection
+					{
+						Title = "Second section",
+						Items = { new ShellContent { Content = new ContentPage() } }
+					}
+				}
+			};
+			var expectedTabBackground = Colors.Blue;
+			var shell = await CreateShellAsync(shell =>
+			{
+				Shell.SetTabBarBackgroundColor(firstItem, Colors.Red);
+				Shell.SetTabBarBackgroundColor(secondItem, expectedTabBackground);
+				shell.Items.Add(firstItem);
+				shell.Items.Add(secondItem);
+				shell.CurrentItem = firstItem;
+			});
+
+			await CreateHandlerAndAddToWindow(shell, async () =>
+			{
+				await OnLoadedAsync(firstPage);
+
+				var shellHandler = Assert.IsType<StartupTrackingShellHandler>(shell.Handler);
+				Assert.Equal(1, shellHandler.BottomNavAppearanceTrackerCreationCount);
+
+				shell.CurrentItem = secondItem;
+				await OnLoadedAsync(secondPage);
+
+				var itemHandler = Assert.IsType<ShellItemHandler>(secondItem.Handler);
+				Assert.Equal(2, shellHandler.BottomNavAppearanceTrackerCreationCount);
+				var background = Assert.IsType<ColorChangeRevealDrawable>(itemHandler.BottomNavigationView.Background);
+				Assert.Equal(expectedTabBackground.ToPlatform(), background.EndColor);
+			});
+		}
+
 		protected override void SetupBuilder()
 		{
 			EnsureHandlerCreated(builder =>
@@ -30,7 +191,7 @@ namespace Microsoft.Maui.DeviceTests
 					// Register all standard handlers first (Layout, Image, Label, Page, Toolbar, MenuBar, etc.)
 					SetupShellHandlers(handlers);
 					// Override Shell with the new NativeShellHandler
-					handlers.AddHandler(typeof(Controls.Shell), typeof(NativeShellHandler));
+					handlers.AddHandler(typeof(Controls.Shell), typeof(StartupTrackingShellHandler));
 					handlers.AddHandler(typeof(ShellItem), typeof(ShellItemHandler));
 					handlers.AddHandler(typeof(ShellSection), typeof(ShellSectionHandler));
 					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
@@ -43,6 +204,11 @@ namespace Microsoft.Maui.DeviceTests
 					handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
 				});
 			});
+		}
+
+		protected override void SetupShellTabColorsTest(Shell shell)
+		{
+			Shell.SetTabBarIsVisible(shell, true);
 		}
 
 		// NativeShellHandler uses MauiDrawerLayout (not ShellFlyoutRenderer), so cast to MauiDrawerLayout.

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellHandlerSubclasses.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellHandlerSubclasses.Android.cs
@@ -16,6 +16,7 @@ using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Platform;
 using Xunit;
 using AView = Android.Views.View;
+using AViewStates = Android.Views.ViewStates;
 using NativeShellHandler = Microsoft.Maui.Controls.Handlers.ShellHandler;
 
 namespace Microsoft.Maui.DeviceTests
@@ -84,12 +85,17 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.Null(sectionHandler.ContentTabLayout);
 				Assert.Equal(0, shellHandler.BottomNavAppearanceTrackerCreationCount);
 				Assert.Equal(0, shellHandler.TabLayoutAppearanceTrackerCreationCount);
+				var topTabsContainer = shellHandler.PlatformView.FindViewById(Resource.Id.navigationlayout_toptabs);
+				Assert.NotNull(topTabsContainer);
+				Assert.Equal(AViewStates.Gone, topTabsContainer.Visibility);
 
 				item.Items.Add(secondSection);
 				section.Items.Add(secondContent);
 
 				Assert.NotNull(itemHandler._tabbedViewManager);
 				Assert.NotNull(sectionHandler.ContentTabLayout);
+				var bottomBackground = Assert.IsType<ColorChangeRevealDrawable>(itemHandler.BottomNavigationView.Background);
+				Assert.Equal(expectedTabBackground.ToPlatform(), bottomBackground.EndColor);
 				var background = Assert.IsType<ColorDrawable>(sectionHandler.ContentTabLayout.Background);
 				Assert.Equal(expectedTabBackground.ToPlatform(), background.Color);
 				Assert.Equal(1, shellHandler.BottomNavAppearanceTrackerCreationCount);
@@ -102,6 +108,7 @@ namespace Microsoft.Maui.DeviceTests
 
 				item.Items.Remove(secondSection);
 				section.Items.Remove(secondContent);
+				Assert.Equal(AViewStates.Gone, topTabsContainer.Visibility);
 				item.Items.Add(secondSection);
 				section.Items.Add(secondContent);
 
@@ -111,6 +118,83 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.Same(contentTabLayout, sectionHandler.ContentTabLayout);
 				Assert.Equal(1, shellHandler.BottomNavAppearanceTrackerCreationCount);
 				Assert.Equal(1, shellHandler.TabLayoutAppearanceTrackerCreationCount);
+			});
+		}
+
+		[Fact]
+		public async Task SwitchingShellItemsCreatesBottomTabsOnlyWhenNeeded()
+		{
+			SetupBuilder();
+
+			var firstPage = new ContentPage();
+			var firstItem = new FlyoutItem
+			{
+				Title = "First item",
+				Items =
+				{
+					new ShellSection
+					{
+						Items = { new ShellContent { Content = firstPage } }
+					}
+				}
+			};
+			var secondPage = new ContentPage();
+			var secondItem = new FlyoutItem
+			{
+				Title = "Second item",
+				Items =
+				{
+					new ShellSection
+					{
+						Title = "First section",
+						Items = { new ShellContent { Content = secondPage } }
+					},
+					new ShellSection
+					{
+						Title = "Second section",
+						Items = { new ShellContent { Content = new ContentPage() } }
+					}
+				}
+			};
+			var expectedTabBackground = Colors.Blue;
+			var shell = await CreateShellAsync(shell =>
+			{
+				Shell.SetTabBarBackgroundColor(secondItem, expectedTabBackground);
+				shell.Items.Add(firstItem);
+				shell.Items.Add(secondItem);
+				shell.CurrentItem = firstItem;
+			});
+
+			await CreateHandlerAndAddToWindow(shell, async () =>
+			{
+				await OnLoadedAsync(firstPage);
+
+				var shellHandler = Assert.IsType<StartupTrackingShellHandler>(shell.Handler);
+				Assert.Equal(0, shellHandler.BottomNavAppearanceTrackerCreationCount);
+
+				shell.CurrentItem = secondItem;
+				await OnLoadedAsync(secondPage);
+
+				var itemHandler = Assert.IsType<ShellItemHandler>(secondItem.Handler);
+				Assert.Equal(1, shellHandler.BottomNavAppearanceTrackerCreationCount);
+				Assert.NotNull(itemHandler._tabbedViewManager);
+				var background = Assert.IsType<ColorChangeRevealDrawable>(itemHandler.BottomNavigationView.Background);
+				Assert.Equal(expectedTabBackground.ToPlatform(), background.EndColor);
+
+				shell.CurrentItem = firstItem;
+				await OnLoadedAsync(firstPage);
+
+				itemHandler = Assert.IsType<ShellItemHandler>(firstItem.Handler);
+				Assert.Equal(1, shellHandler.BottomNavAppearanceTrackerCreationCount);
+				Assert.Null(itemHandler._tabbedViewManager);
+				Assert.Null(itemHandler.BottomNavigationView);
+
+				shell.CurrentItem = secondItem;
+				await OnLoadedAsync(secondPage);
+
+				itemHandler = Assert.IsType<ShellItemHandler>(secondItem.Handler);
+				Assert.Equal(2, shellHandler.BottomNavAppearanceTrackerCreationCount);
+				Assert.NotNull(itemHandler._tabbedViewManager);
 			});
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Android.cs
@@ -585,6 +585,7 @@ namespace Microsoft.Maui.DeviceTests
 			var shell = await CreateShellAsync(shell =>
 			{
 				shell.Items.Add(new Tab() { Items = { new ContentPage() }, Title = "Tab 1" });
+				SetupShellTabColorsTest(shell);
 			});
 
 			await CreateHandlerAndAddToWindow(shell, () =>
@@ -601,6 +602,10 @@ namespace Microsoft.Maui.DeviceTests
 					Assert.Equal(global::Android.Graphics.Color.White, changeRevealDrawable.EndColor);
 				}
 			});
+		}
+
+		protected virtual void SetupShellTabColorsTest(Shell shell)
+		{
 		}
 
 		[Fact(DisplayName = "ShellContentFragment.Destroy handles null _shellContext gracefully")]


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause

The handler-based Android Shell path eagerly created bottom and top tab managers, native tab controls, adapters, callbacks, and appearance trackers for the default single-page Shell shape even though no tabs were visible.

### Description of Change

- Defer bottom-tab infrastructure until the `ShellItem` actually shows tabs.
- Defer top-tab infrastructure until a `ShellSection` has multiple visible contents.
- Create the infrastructure when collections grow dynamically while preserving appearance propagation and native manager reuse.
- Recreate the per-item bottom-navigation appearance tracker when the permanent handler switches `ShellItem`s.
- Add device-test guards for zero startup creation, dynamic growth, reuse, appearance, and ShellItem switching.

### Performance

Post-review retest on Pixel 5 using matched in-tree builds of merge-base `1aa158b771` and final commit `d6437ef8f9`, Release `android-arm64`, Mono profiled AOT, and a mirrored 80-launch sequence:

| Variant | Mean | StdDev |
|---|---:|---:|
| Merge-base control | 1101.53 ms | 13.07 ms |
| Final reviewed patch | 1065.58 ms | 12.39 ms |
| Improvement | **35.95 ms / 3.26%** | |

The absolute values differ from the earlier package-isolated run because this retest uses the current in-tree dependency graph and a minimal C# single-page Shell harness. The relative A/B comparison changes only the two production Shell handler files.

Earlier Preview 7 package-isolated measurements:

| Measurement | Control | Patched | Improvement |
|---|---:|---:|---:|
| `ActivityTaskManager: Displayed`, 20 launches/build | 639.40 ms (σ 10.39) | 626.30 ms (σ 15.83) | **13.10 ms / 2.05%** |
| `am start -W TotalTime`, 40 launches/build | 645.50 ms (σ 12.25) | 636.33 ms (σ 13.76) | **9.18 ms / 1.42%** |

The first comparison isolated only `Microsoft.Maui.Controls.Core` while keeping the remaining Preview 7 package graph, runtime, build tasks, and updated AOT profile identical. The follow-up used matched rebuilt control and patched APKs with mirrored launch ordering.

### Tests

- Android Controls Shell category on Pixel 5: **143/143 passed**.
- The ShellItem-switch regression test failed before the fix with expected tracker count 2 versus actual 1, then passed after tracker recreation was added.

### Issues Fixed

Fixes #37282