### PR TITLE
Fix stale StatesChanged subscription when replacing VisualStateGroupList item

### DIFF
--- a/src/Controls/src/Core/VisualStateManager.cs
+++ b/src/Controls/src/Core/VisualStateManager.cs
@@ -415,7 +415,17 @@ namespace Microsoft.Maui.Controls
 		public VisualStateGroup this[int index]
 		{
 			get => _internalList[index];
-			set => _internalList[index] = value;
+			set
+			{
+				if (value == null)
+					throw new ArgumentNullException(nameof(value));
+
+				var oldGroup = _internalList[index];
+				oldGroup.StatesChanged -= ValidateAndNotify;
+				_internalList[index] = value;
+				value.StatesChanged += ValidateAndNotify;
+				ValidateAndNotify(_internalList);
+			}
 		}
 
 		WeakReference<VisualElement> _visualElement;

--- a/src/Controls/tests/Core.UnitTests/VisualStateManagerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualStateManagerTests.cs
@@ -154,6 +154,54 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public void ReplacingGroupUpdatesVisualStateAndValidationSubscription()
+		{
+			var label = new Label();
+			var originalMargin = new Thickness(1);
+			var replacementMargin = new Thickness(2);
+			var groups = new VisualStateGroupList
+			{
+				new VisualStateGroup
+				{
+					States =
+					{
+						new VisualState
+						{
+							Name = NormalStateName,
+							Setters =
+							{
+								new Setter { Property = View.MarginProperty, Value = originalMargin }
+							}
+						}
+					}
+				}
+			};
+
+			VisualStateManager.SetVisualStateGroups(label, groups);
+			Assert.Equal(originalMargin, label.Margin);
+
+			var replacementGroup = new VisualStateGroup
+			{
+				States =
+				{
+					new VisualState
+					{
+						Name = NormalStateName,
+						Setters =
+						{
+							new Setter { Property = View.MarginProperty, Value = replacementMargin }
+						}
+					}
+				}
+			};
+
+			groups[0] = replacementGroup;
+
+			Assert.Equal(replacementMargin, label.Margin);
+			Assert.Throws<InvalidOperationException>(() => replacementGroup.States.Add(new VisualState { Name = NormalStateName }));
+		}
+
+		[Fact]
 		public void StateNamesInGroupMayNotBeNull()
 		{
 			IList<VisualStateGroup> vsgs = CreateTestStateGroups();


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
### Issue Details
Issue Details
When a VisualStateGroup is replaced through the VisualStateGroupList indexer, the existing implementation only updates the internal list:

`visualStateGroups[index] = replacementGroup;`

The replacement bypasses the lifecycle behavior used by Add, Insert, and Remove:
* The old group remains subscribed to StatesChanged.
* The replacement group is not subscribed to StatesChanged.
* Group and state names are not revalidated.
* State triggers are not updated for the replacement.
* The associated VisualElement is not notified to reevaluate its visual state.

### Description of Change

<!-- Enter description of the fix in this section -->
* Updated the VisualStateGroupList indexer setter to correctly manage group replacement:
* Reject null replacement values with ArgumentNullException.
* Unsubscribe ValidateAndNotify from the replaced group.
* Replace the group in the internal collection.
* Subscribe ValidateAndNotify to the new group.
* Explicitly call ValidateAndNotify(_internalList) after replacement.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #37171 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
**Tested the behavior in the following platforms.**
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

| Before  | After  |
|---------|--------|
| **Android**<br> <img src="https://github.com/user-attachments/assets/1e6c5337-afcc-4e55-bba2-6852316fdf6a" width="300" height="600"> | **Android**<br> <img src="https://github.com/user-attachments/assets/006f5544-3393-4f3a-9774-86ff6d966947" width="300" height="600"> |
