### PR TITLE
[.NET 11] Fix Material3 failures in net 11 branch

### DIFF
--- a/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
@@ -261,8 +261,18 @@ namespace Microsoft.Maui.Controls.Platform
 		static ColorStateList? GetDefaultTitleTextColor(AToolbar nativeToolbar)
 		{
 			var context = nativeToolbar.Context?.GetThemedContext();
-			return PlatformInterop.GetColorStateListForToolbarStyleableAttribute(context,
-				Resource.Attribute.toolbarStyle, Resource.Styleable.Toolbar_titleTextColor);
+			if (RuntimeFeature.IsMaterial3Enabled)
+			{
+				var colorContext = context is null
+				 ? null
+				 : ColorStateList.ValueOf(new global::Android.Graphics.Color(context.GetThemeAttrColor(Resource.Attribute.colorOnSurface)));
+				return colorContext;
+			}
+			else
+			{
+				return PlatformInterop.GetColorStateListForToolbarStyleableAttribute(context,
+				 Resource.Attribute.toolbarStyle, Resource.Styleable.Toolbar_titleTextColor);
+			}
 		}
 
 		static int? GetDefaultNavigationIconColor(AToolbar nativeToolbar)
@@ -271,6 +281,11 @@ namespace Microsoft.Maui.Controls.Platform
 			if (context is null)
 			{
 				return null;
+			}
+
+			if (RuntimeFeature.IsMaterial3Enabled)
+			{
+				return context.GetThemeAttrColor(Resource.Attribute.colorOnSurface);
 			}
 
 			using var icon = new DrawerArrowDrawable(context);

--- a/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
@@ -248,16 +248,6 @@ namespace Microsoft.Maui.Controls.Platform
 			}
 		}
 
-		static Color? GetDefaultForegroundColor()
-		{
-			return Application.Current?.RequestedTheme switch
-			{
-				ApplicationModel.AppTheme.Light => Colors.Black,
-				ApplicationModel.AppTheme.Dark => Colors.White,
-				_ => null
-			};
-		}
-
 		static ColorStateList? GetDefaultTitleTextColor(AToolbar nativeToolbar)
 		{
 			var context = nativeToolbar.Context?.GetThemedContext();
@@ -299,7 +289,7 @@ namespace Microsoft.Maui.Controls.Platform
 				return;
 			}
 
-			var iconColor = toolbar.IconColor ?? toolbar.BarTextColor ?? GetDefaultForegroundColor();
+			var iconColor = toolbar.IconColor ?? toolbar.BarTextColor;
 			if (iconColor is null)
 			{
 				overflowIcon.ClearColorFilter();

--- a/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
@@ -209,10 +209,6 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				nativeToolbar.SetTitleTextColor(defaultTitleTextColor);
 			}
-			else if (GetDefaultForegroundColor() is { } defaultForegroundColor)
-			{
-				nativeToolbar.SetTitleTextColor(defaultForegroundColor.ToPlatform().ToArgb());
-			}
 
 			nativeToolbar.UpdateNavigationIconColor(toolbar);
 			nativeToolbar.UpdateOverflowIconColor(toolbar);
@@ -244,10 +240,6 @@ namespace Microsoft.Maui.Controls.Platform
 				if (textColor != null)
 				{
 					icon.Color = textColor.ToPlatform().ToArgb();
-				}
-				else if (GetDefaultForegroundColor() is { } defaultForegroundColor)
-				{
-					icon.Color = defaultForegroundColor.ToPlatform().ToArgb();
 				}
 				else if (GetDefaultNavigationIconColor(nativeToolbar) is int defaultNavigationIconColor)
 				{


### PR DESCRIPTION
### Root Cause
Cause PR #35463

- On Android with Material 3 enabled, the toolbar’s default title and navigation icon colors were being resolved from legacy AppCompat sources instead of the Material 3 theme.
- GetDefaultTitleTextColor retrieved the color from the AppCompat Toolbar_titleTextColor styleable attribute.
- GetDefaultNavigationIconColor derived the color from the legacy DrawerArrowDrawable.Color default.
- The additional GetDefaultForegroundColor() fallback used a hard-coded black/white value based on RequestedTheme, which could override or mask the actual theme-provided color.
- As a result, the toolbar title and navigation icons could render with an incorrect or low-contrast color that did not match the Material 3 toolbar, contributing to the screenshot test failure.

### Description of Change

- Updated the default toolbar color resolution to use the Material 3 theme’s colorOnSurface attribute while preserving the existing behavior for non-Material 3 themes.
- GetDefaultTitleTextColor: When RuntimeFeature.IsMaterial3Enabled is enabled, returns a ColorStateList based on colorOnSurface. Otherwise, it continues to use the existing AppCompat Toolbar_titleTextColor lookup.
- GetDefaultNavigationIconColor: When Material 3 is enabled, returns the theme’s colorOnSurface. Otherwise, it continues to use the existing DrawerArrowDrawable default.
- Removed the intermediate hard-coded GetDefaultForegroundColor() fallback from the title and navigation icon color paths, allowing the theme-provided color to remain authoritative.
- Explicitly configured IconColor and BarTextColor values continue to take precedence over these defaults.

### `GetDefaultForegroundColor()` Was Removed

* **The foreground color was not originally part of the toolbar fallback chain.** The title text and navigation icon defaults previously relied directly on the theme-provided values (`Toolbar_titleTextColor` and `DrawerArrowDrawable`). `GetDefaultForegroundColor()` was introduced later as an additional fallback in PR #35463, so removing it restores the original toolbar behavior.

* **It returned hard-coded `Black`/`White` values** that do not represent the Material 3 `colorOnSurface` tonal color. This resulted in foreground colors that were inconsistent with the rest of the Material 3 toolbar.

* **It took precedence over the theme-aware default** in the fallback chain. Because it was evaluated earlier, it could short-circuit the resolution process and prevent the correct theme color from being applied.

* **Removing it allows the theme-provided value to remain authoritative** — `colorOnSurface` for Material 3 and the existing legacy theme default otherwise. This ensures the toolbar uses the correct platform/theme color and resolves the failing test.


