### PR TITLE
[ci-scan-fix]  Fix for flaky TextInEditorShouldScroll UITest in CI

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue19500.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue19500.cs
@@ -1,4 +1,4 @@
-﻿#if MACCATALYST
+﻿#if MACCATALYST || IOS
 using UIKit;
 using Microsoft.Maui.Platform;
 #endif
@@ -50,7 +50,7 @@ public partial class Issue19500 : TestContentPage
 			Text = GetEditorText()
 		};
 
-#if MACCATALYST
+#if MACCATALYST || IOS
 		editor.HandlerChanged += (_, _) =>
 		{
 			if (editor.Handler?.PlatformView is MauiTextView mauiTextView)

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19500.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19500.cs
@@ -18,15 +18,9 @@ public class Issue19500 : _IssuesUITest
 	[Category(UITestCategories.Editor)]
 	public void TextInEditorShouldScroll()
 	{
-#if IOS
-		if (!OperatingSystem.IsMacOSVersionAtLeast(26)) // Issue Link: https://github.com/dotnet/maui/issues/33879
-		{
-			Assert.Ignore("Ignored the test on iOS if it runs on macOS version less than 26 due to known visual differences");
-		}
-#endif
 		var yPosLabel = App.WaitForElement(yPositionLabel);
 		App.ScrollDown("editor", ScrollStrategy.Gesture, withInertia: false);
-#if MACCATALYST
+#if MACCATALYST || IOS
 		App.ScrollDown("editor"); // To make sure the editor is scrolled down
 		var yPos = yPosLabel.GetText();
 		Assert.That(yPos,Is.GreaterThan("0")); // The Y position should be greater than 0 after scrolling down


### PR DESCRIPTION
This PR addresses flaky UI test failures in CI and includes updates to improve rendering and test stability across platforms. The main changes are as follows:

**Platform Condition Updates:**

* Updated preprocessor directives in `Issue19500.cs` to apply Mac Catalyst-specific logic to both Mac Catalyst and iOS platforms (`#if MACCATALYST || IOS`). [[1]](diffhunk://#diff-2787cce9ce9cf2f3260db1a3b6134a806d0980e33532dc3fc3b788bb0709ff3bL1-R1) [[2]](diffhunk://#diff-2787cce9ce9cf2f3260db1a3b6134a806d0980e33532dc3fc3b788bb0709ff3bL53-R53)
* Adjusted the UI test in `Issue19500.cs` to run the relevant scroll assertion for both Mac Catalyst and iOS, instead of just Mac Catalyst.

**Test Logic Simplification:**

* Removed the version check and early exit for iOS/macOS in the UI test, streamlining the test flow.

**Fixes:** https://github.com/dotnet/maui/issues/37298