### PR TITLE
[net11.0] Fix Learn API documentation findings

### DIFF
--- a/src/Controls/src/Core/GradientStop.cs
+++ b/src/Controls/src/Core/GradientStop.cs
@@ -40,6 +40,8 @@ namespace Microsoft.Maui.Controls
 			Offset = offset;
 		}
 
+		// Explicit crefs replace legacy unqualified inheritdoc entries during mdoc import.
+		/// <inheritdoc cref="object.Equals(object)"/>
 		/// <summary>Determines whether the specified object is equal to the current <see cref="GradientStop"/>, using an approximate comparison for <see cref="Offset"/>.</summary>
 		/// <param name="obj">The object to compare with the current object.</param>
 		/// <returns><see langword="true"/> if the specified object is a <see cref="GradientStop"/> with the same <see cref="Color"/> and an <see cref="Offset"/> value within a small tolerance of the current object; otherwise, <see langword="false"/>.</returns>
@@ -51,6 +53,7 @@ namespace Microsoft.Maui.Controls
 			return Color == dest.Color && global::System.Math.Abs(Offset - dest.Offset) < 0.00001;
 		}
 
+		/// <inheritdoc cref="object.GetHashCode"/>
 		/// <summary>Serves as the default hash function.</summary>
 		/// <returns>A hash code for the current object.</returns>
 		public override int GetHashCode() => Color is null ? 0 : Color.GetHashCode();

--- a/src/Controls/src/Core/HybridWebView/HybridWebView.cs
+++ b/src/Controls/src/Core/HybridWebView/HybridWebView.cs
@@ -171,10 +171,9 @@ namespace Microsoft.Maui.Controls
 				});
 		}
 
-		/// <summary>
-		/// Invokes a JavaScript method named <paramref name="methodName"/> and optionally passes in the parameter values specified
-		/// by <paramref name="paramValues"/> by JSON-encoding each one.
-		/// </summary>
+		// The empty summary lets ECMA inherit it after mdoc replaces the legacy unqualified inheritdoc.
+		/// <inheritdoc cref="InvokeJavaScriptAsync{TReturnType}(string, JsonTypeInfo{TReturnType}, object[], JsonTypeInfo[])"/>
+		/// <summary />
 		/// <param name="methodName">The name of the JavaScript method to invoke.</param>
 		/// <param name="paramValues">Optional array of objects to be passed to the JavaScript method by JSON-encoding each one.</param>
 		/// <param name="paramJsonTypeInfos">Optional array of metadata about serializing the types of the parameters specified by <paramref name="paramValues"/>.</param>

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/UIModalPresentationStyle.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/UIModalPresentationStyle.cs
@@ -5,7 +5,9 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 	/// </summary>
 	public enum UIModalPresentationStyle
 	{
+		// Empty remarks clear legacy field remarks when mdoc imports the compiler XML.
 		/// <summary>The content is displayed in a manner that covers the screen. The views belonging to the presenting view controller are removed after the presentation completes.</summary>
+		/// <remarks />
 		FullScreen,
 
 		/// <summary>The content is displayed in the center of the screen.</summary>
@@ -15,6 +17,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		Automatic,
 
 		/// <summary>The content is displayed in a manner that covers the screen. The views belonging to the presenting view controller are not removed after the presentation completes.</summary>
+		/// <remarks />
 		OverFullScreen,
 
 		/// <summary>The content is displayed in a popover view.</summary>

--- a/src/Controls/src/Core/Shell/ShellAppearance.cs
+++ b/src/Controls/src/Core/Shell/ShellAppearance.cs
@@ -102,6 +102,8 @@ namespace Microsoft.Maui.Controls
 				_doubleArray[i] = -1;
 		}
 
+		// Explicit crefs replace legacy unqualified inheritdoc entries during mdoc import.
+		/// <inheritdoc cref="object.Equals(object)"/>
 		/// <summary>Determines whether the specified object is equal to the current <see cref="ShellAppearance"/>.</summary>
 		/// <param name="obj">The object to compare with the current object.</param>
 		/// <returns><see langword="true"/> if the specified object is equal to the current object; otherwise, <see langword="false"/>.</returns>
@@ -131,6 +133,7 @@ namespace Microsoft.Maui.Controls
 			return true;
 		}
 
+		/// <inheritdoc cref="object.GetHashCode"/>
 		/// <summary>Serves as the default hash function.</summary>
 		/// <returns>A hash code for the current object.</returns>
 		public override int GetHashCode()

--- a/src/Controls/src/Core/SolidColorBrush.cs
+++ b/src/Controls/src/Core/SolidColorBrush.cs
@@ -42,6 +42,8 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(ColorProperty, value);
 		}
 
+		// Explicit crefs replace legacy unqualified inheritdoc entries during mdoc import.
+		/// <inheritdoc cref="object.Equals(object)"/>
 		/// <summary>Determines whether the specified object is equal to the current <see cref="SolidColorBrush"/>.</summary>
 		/// <param name="obj">The object to compare with the current object.</param>
 		/// <returns><see langword="true"/> if the specified object is equal to the current object; otherwise, <see langword="false"/>.</returns>
@@ -53,6 +55,7 @@ namespace Microsoft.Maui.Controls
 			return Equals(Color, dest.Color);
 		}
 
+		/// <inheritdoc cref="object.GetHashCode"/>
 		/// <summary>Serves as the default hash function.</summary>
 		/// <returns>A hash code for the current object.</returns>
 		public override int GetHashCode() => Color?.GetHashCode() ?? 0;

--- a/src/Controls/src/Core/Xaml/Diagnostics/HotReloadDiagnostics.cs
+++ b/src/Controls/src/Core/Xaml/Diagnostics/HotReloadDiagnostics.cs
@@ -10,8 +10,8 @@ namespace Microsoft.Maui.Controls.Xaml.Diagnostics;
 /// Subscribe to these events to observe hot reload lifecycle in tooling or diagnostics overlays.
 /// </summary>
 /// <remarks>
-/// Events are only raised when <see cref="Microsoft.Maui.RuntimeFeature.IsIncrementalHotReloadEnabled"/>
-/// is <see langword="true"/>. All events are raised on the thread where the work occurs:
+/// Events are only raised when the <c>Microsoft.Maui.RuntimeFeature.IsIncrementalHotReloadEnabled</c>
+/// feature switch is <see langword="true"/>. All events are raised on the thread where the work occurs:
 /// <see cref="UpdateRequested"/> and <see cref="UpdateSkipped"/> on the calling thread,
 /// <see cref="UpdateApplied"/> and <see cref="UpdateFailed"/> on the main/UI thread.
 /// </remarks>

--- a/src/Controls/src/Xaml/XamlComponentRegistry.cs
+++ b/src/Controls/src/Xaml/XamlComponentRegistry.cs
@@ -271,7 +271,7 @@ public static class XamlComponentRegistry
 
 	/// <summary>
 	/// Resolves <paramref name="key"/> using full StaticResource lookup semantics: walks the
-	/// element parent chain (each <see cref="IResourcesProvider"/>'s <c>Resources</c>),
+	/// element parent chain and checks each resource provider's <c>Resources</c>,
 	/// then falls back to <c>Application.Current.Resources</c> and system resources.
 	/// Returns <see langword="null"/> if not found.
 	/// </summary>

--- a/src/Core/maps/src/Converters/MapSpanTypeConverter.cs
+++ b/src/Core/maps/src/Converters/MapSpanTypeConverter.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Maui.Maps
 	/// </remarks>
 	public class MapSpanTypeConverter : TypeConverter
 	{
+		// Explicit crefs replace legacy unqualified inheritdoc entries during mdoc import.
+		/// <inheritdoc cref="TypeConverter.CanConvertFrom(ITypeDescriptorContext?, Type)"/>
 		/// <summary>Determines whether conversion is possible from the specified type to <see cref="MapSpan"/>.</summary>
 		/// <param name="context">The format context.</param>
 		/// <param name="sourceType">The source type to check.</param>
@@ -24,6 +26,7 @@ namespace Microsoft.Maui.Maps
 		public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
 			=> sourceType == typeof(string);
 
+		/// <inheritdoc cref="TypeConverter.CanConvertTo(ITypeDescriptorContext?, Type?)"/>
 		/// <summary>Determines whether conversion is possible from <see cref="MapSpan"/> to the specified type.</summary>
 		/// <param name="context">The format context.</param>
 		/// <param name="destinationType">The destination type to check.</param>
@@ -31,6 +34,7 @@ namespace Microsoft.Maui.Maps
 		public override bool CanConvertTo(ITypeDescriptorContext? context, Type? destinationType)
 			=> destinationType == typeof(string);
 
+		/// <inheritdoc cref="TypeConverter.ConvertFrom(ITypeDescriptorContext?, CultureInfo?, object)"/>
 		/// <summary>Converts a string representation to a <see cref="MapSpan"/> object.</summary>
 		/// <param name="context">The format context.</param>
 		/// <param name="culture">The culture info.</param>
@@ -57,6 +61,7 @@ namespace Microsoft.Maui.Maps
 			throw new InvalidOperationException($"Cannot convert \"{strValue}\" into {typeof(MapSpan)}");
 		}
 
+		/// <inheritdoc cref="TypeConverter.ConvertTo(ITypeDescriptorContext?, CultureInfo?, object?, Type)"/>
 		/// <summary>Converts a <see cref="MapSpan"/> object to a string representation.</summary>
 		/// <param name="context">The format context.</param>
 		/// <param name="culture">The culture info.</param>

--- a/src/Core/maps/src/Primitives/Distance.cs
+++ b/src/Core/maps/src/Primitives/Distance.cs
@@ -119,6 +119,8 @@ namespace Microsoft.Maui.Maps
 			return Meters.Equals(other.Meters);
 		}
 
+		// Explicit crefs replace legacy unqualified inheritdoc entries during mdoc import.
+		/// <inheritdoc cref="object.Equals(object)"/>
 		/// <summary>Determines whether the specified object is equal to the current <see cref="Distance"/>.</summary>
 		/// <param name="obj">The object to compare with the current object.</param>
 		/// <returns><see langword="true"/> if the specified object is equal to the current object; otherwise, <see langword="false"/>.</returns>
@@ -129,6 +131,7 @@ namespace Microsoft.Maui.Maps
 			return obj is Distance && Equals((Distance)obj);
 		}
 
+		/// <inheritdoc cref="object.GetHashCode"/>
 		/// <summary>Serves as the default hash function.</summary>
 		/// <returns>A hash code for the current object.</returns>
 		public override int GetHashCode()

--- a/src/Core/maps/src/Primitives/MapSpan.cs
+++ b/src/Core/maps/src/Primitives/MapSpan.cs
@@ -71,6 +71,8 @@ namespace Microsoft.Maui.Maps
 			return new MapSpan(new Location(lat, Center.Longitude), Math.Min(LatitudeDegrees, maxDLat), LongitudeDegrees);
 		}
 
+		// Explicit crefs replace legacy unqualified inheritdoc entries during mdoc import.
+		/// <inheritdoc cref="object.Equals(object)"/>
 		/// <summary>Determines whether the specified object is equal to the current <see cref="MapSpan"/>.</summary>
 		/// <param name="obj">The object to compare with the current object.</param>
 		/// <returns><see langword="true"/> if the specified object is equal to the current object; otherwise, <see langword="false"/>.</returns>
@@ -154,6 +156,7 @@ namespace Microsoft.Maui.Maps
 			return new MapSpan(new Location(centerLat, centerLon), latDegrees, lonDegrees);
 		}
 
+		/// <inheritdoc cref="object.GetHashCode"/>
 		/// <summary>Serves as the default hash function.</summary>
 		/// <returns>A hash code for the current object.</returns>
 		public override int GetHashCode()
@@ -232,6 +235,7 @@ namespace Microsoft.Maui.Maps
 			return latCircumference * longitudeDegrees / 360;
 		}
 
+		/// <inheritdoc cref="object.ToString"/>
 		/// <summary>Returns a string representation of the <see cref="MapSpan"/>.</summary>
 		/// <returns>A string that represents the current <see cref="MapSpan"/>.</returns>
 		public override string ToString()

--- a/src/Core/src/Primitives/GridUnitType.cs
+++ b/src/Core/src/Primitives/GridUnitType.cs
@@ -10,10 +10,12 @@ public enum GridUnitType
 	/// </summary>
 	Absolute,
 
+	// Empty remarks clear legacy field remarks when mdoc imports the compiler XML.
 	/// <summary>
 	/// Interpret the <see cref="GridLength.Value"/> property value as a proportional weight, to be arranged after rows and columns with <see cref="GridUnitType.Absolute"/> or <see cref="GridUnitType.Auto"/>.
 	/// After all Absolute and Auto rows/columns are arranged, remaining Star rows/columns receive a fraction of the leftover space determined by dividing each <see cref="GridLength.Value"/> by the sum of all star values.
 	/// </summary>
+	/// <remarks />
 	Star,
 
 	/// <summary>

--- a/src/Core/src/Primitives/TextType.cs
+++ b/src/Core/src/Primitives/TextType.cs
@@ -10,10 +10,12 @@ public enum TextType
 	/// </summary>
 	Text,
 
+	// Empty remarks clear legacy field remarks when mdoc imports the compiler XML.
 	/// <summary>
 	/// HTML-formatted text content that may include markup.
 	/// The subset of supported HTML tags varies by platform. Each platform's native text rendering engine
 	/// determines which HTML tags and attributes are supported.
 	/// </summary>
+	/// <remarks />
 	Html
 }

--- a/src/Essentials/src/Geolocation/GeolocationError.shared.cs
+++ b/src/Essentials/src/Geolocation/GeolocationError.shared.cs
@@ -7,12 +7,14 @@ namespace Microsoft.Maui.Devices.Sensors
 	/// </summary>
 	public enum GeolocationError
 	{
+		// Empty remarks clear legacy field remarks when mdoc imports the compiler XML.
 		/// <summary>
 		/// The provider was unable to retrieve any position data.
 		/// On Android this is sent when no location provider is available that satisfies the requested geolocation accuracy.
 		/// On iOS this means getting location data has failed.
 		/// On Windows this means no location data is available from any source.
 		/// </summary>
+		/// <remarks />
 		PositionUnavailable,
 
 		/// <summary>
@@ -21,6 +23,7 @@ namespace Microsoft.Maui.Devices.Sensors
 		/// On iOS this means authorization for getting locations has changed.
 		/// On Windows this means location sources are turned off.
 		/// </summary>
+		/// <remarks />
 		Unauthorized,
 	}
 }

--- a/src/Essentials/src/Types/LocationTypeConverter.shared.cs
+++ b/src/Essentials/src/Types/LocationTypeConverter.shared.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Maui.Devices.Sensors
 	/// </remarks>
 	public class LocationTypeConverter : TypeConverter
 	{
+		// Explicit crefs replace legacy unqualified inheritdoc entries during mdoc import.
+		/// <inheritdoc cref="TypeConverter.CanConvertFrom(ITypeDescriptorContext?, Type)"/>
 		/// <summary>Determines whether conversion is possible from the specified type to <see cref="Location"/>.</summary>
 		/// <param name="context">The format context.</param>
 		/// <param name="sourceType">The source type to check.</param>
@@ -23,6 +25,7 @@ namespace Microsoft.Maui.Devices.Sensors
 		public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
 			=> sourceType == typeof(string);
 
+		/// <inheritdoc cref="TypeConverter.CanConvertTo(ITypeDescriptorContext?, Type?)"/>
 		/// <summary>Determines whether conversion is possible from <see cref="Location"/> to the specified type.</summary>
 		/// <param name="context">The format context.</param>
 		/// <param name="destinationType">The destination type to check.</param>
@@ -30,6 +33,7 @@ namespace Microsoft.Maui.Devices.Sensors
 		public override bool CanConvertTo(ITypeDescriptorContext? context, Type? destinationType)
 			=> destinationType == typeof(string);
 
+		/// <inheritdoc cref="TypeConverter.ConvertFrom(ITypeDescriptorContext?, CultureInfo?, object)"/>
 		/// <summary>Converts a string representation of latitude and longitude to a <see cref="Location"/> object.</summary>
 		/// <param name="context">The format context.</param>
 		/// <param name="culture">The culture info.</param>
@@ -54,6 +58,7 @@ namespace Microsoft.Maui.Devices.Sensors
 			throw new InvalidOperationException($"Cannot convert \"{strValue}\" into {typeof(Location)}");
 		}
 
+		/// <inheritdoc cref="TypeConverter.ConvertTo(ITypeDescriptorContext?, CultureInfo?, object?, Type)"/>
 		/// <summary>Converts a <see cref="Location"/> object to a string representation.</summary>
 		/// <param name="context">The format context.</param>
 		/// <param name="culture">The culture info.</param>

--- a/src/Graphics/src/Graphics/PathF.cs
+++ b/src/Graphics/src/Graphics/PathF.cs
@@ -1671,6 +1671,8 @@ namespace Microsoft.Maui.Graphics
 			Invalidate();
 		}
 
+		// Explicit crefs replace legacy unqualified inheritdoc entries during mdoc import.
+		/// <inheritdoc cref="object.Equals(object)"/>
 		/// <summary>Determines whether the specified object is equal to the current <see cref="PathF"/> using tolerance-based comparison for geometric values.</summary>
 		/// <param name="obj">The object to compare with the current object.</param>
 		/// <returns><see langword="true"/> if the specified object represents the same path as the current object, with point and arc values compared within <see cref="GeometryUtil.Epsilon"/>; otherwise, <see langword="false"/>.</returns>
@@ -1719,6 +1721,7 @@ namespace Microsoft.Maui.Graphics
 			return true;
 		}
 
+		/// <inheritdoc cref="object.GetHashCode"/>
 		/// <summary>Serves as the default hash function.</summary>
 		/// <returns>A hash code for the current object.</returns>
 		public override int GetHashCode()


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

> [!IMPORTANT]
> This PR changes code documentation only. The updates are needed for IntelliSense and the public .NET MAUI API documentation browser; they do not change runtime behavior or the public API surface.

Fixes the actionable findings in the August 12 Learn Online API documentation build report while intentionally leaving the first 14 `Missing required attribute: 'name'.` warnings out of scope.

### Missing xrefs

- `HotReloadDiagnostics` linked to the internal `Microsoft.Maui.RuntimeFeature.IsIncrementalHotReloadEnabled` member.
- `XamlComponentRegistry.FindStaticResource` linked to the internal `Microsoft.Maui.Controls.IResourcesProvider` interface.

Internal implementation symbols are excluded from the generated public API reference. The comments now preserve the useful information without creating links that cannot resolve.

### Persisted inheritdoc suggestions

The generated ECMA files retained 22 old unqualified `<inheritdoc/>` nodes. This occurred even after #34895 added explicit source documentation because mdoc preserves an existing node when that node is absent from incoming compiler XML.

This PR emits semantically correct, explicit inheritdoc targets for the affected overrides and converter methods. The specialized summaries, parameters, and return documentation remain in place and take precedence over inherited text. `HybridWebView.InvokeJavaScriptAsync` targets its documented generic overload and uses an empty summary replacement marker so ECMA fills that summary from the target.

### Persisted enum remarks suggestions

#34895 moved useful enum-field remarks into each field's summary, but mdoc retained the old generated `<remarks>` nodes. This PR emits empty remarks replacement markers for the six affected fields. During import, mdoc replaces the old nonempty remarks while the full useful text remains in the summary.

No generated `dotnet-maui-api-docs` files are edited.

## Validation

- Built `Controls.Xaml.csproj` for `net11.0`, including `Controls.Core`, with 0 warnings and 0 errors.
- Built `Maps.csproj` for `net11.0` with 0 warnings and 0 errors.
- Verified compiler XML contains 22 resolved inheritdoc `cref` values and six empty enum remarks nodes.
- Imported the new DLL/XML outputs over the current `dotnet/dotnet-maui-api-docs` ECMA files with mdoc 5.9.8.
- Verified all 21 override/converter entries contain one external parent cref, the HybridWebView cref resolves to its generic overload, all specialized explicit documentation remains, all stale plain inheritdoc nodes on the reported members are removed, and all six enum remarks values are empty.
- `maui-pr` build 1551612 passed all 26 jobs; required checks and Build Analysis are green.
