### PR TITLE
 [Compilation fix][Inflight] Fix PublicAPI.Unshipped.txt duplicate entries and missing MEM0002 suppressions in inflight/Current

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -1407,8 +1407,11 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			List<ToolbarItem> _trackedToolbarItems = new List<ToolbarItem>();
 			bool _toolbarUpdatePending = false;
 
+			[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Proxy scroll view is removed from its superview, disposed, and cleared in RemoveLargeTitleProxyScrollView.")]
 			UIScrollView _largeTitleProxyScrollView;
+			[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Observed scroll view reference is cleared in TearDownLargeTitleProxyScrollView.")]
 			UIScrollView _largeTitleObservedScrollView;
+			[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Observer is disposed and cleared in TearDownLargeTitleProxyScrollView.")]
 			IDisposable _largeTitleContentOffsetObserver;
 			PointF _largeTitleInitialContentOffset;
 			bool _largeTitleProxyScrollObservationArmed;

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/UIContainerCell.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/UIContainerCell.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		IPlatformViewHandler _renderer;
 		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Binding context is unsubscribed from PropertyChanged and cleared in Disconnect.")]
 		object _bindingContext;
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Resources changed listener is removed and the reference cleared in Disconnect.")]
 		IElementDefinition _viewResource;
 
 		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Measure callback is cleared in Disconnect before the cell is released.")]

--- a/src/Controls/src/Core/Handlers/Items/iOS/MauiCollectionView.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/MauiCollectionView.cs
@@ -46,6 +46,7 @@ public class MauiCollectionView : UICollectionView, IUIViewLifeCycleEvents, IPla
 	static readonly nfloat SilentResetThreshold = 10f;
 
 	// KVO observer token for contentOffset — active while the view is attached to a window.
+	[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Observer is disposed and cleared when the view is detached from its window or the view is disposed.")]
 	IDisposable? _contentOffsetObserver;
 
 	internal void SetPendingScrollRestore(int section, int item, UICollectionViewScrollPosition position)

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -18,10 +18,7 @@ override Microsoft.Maui.Controls.Platform.Compatibility.ShellTableViewController
 override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void
 ~override Microsoft.Maui.Controls.SwipeItems.OnPropertyChanged(string propertyName = null) -> void
 override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
-override Microsoft.Maui.Controls.Handlers.Items2.StructuredItemsViewController2<TItemsView>.UpdateFlowDirection() -> void
 Microsoft.Maui.Controls.IndicatorView.~IndicatorView() -> void
-~override Microsoft.Maui.Controls.SwipeItems.OnPropertyChanged(string propertyName = null) -> void
-Microsoft.Maui.Controls.Label.~Label() -> void
 override Microsoft.Maui.Controls.Handlers.Items.MauiCollectionView.LayoutSubviews() -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -20,10 +20,7 @@ override Microsoft.Maui.Controls.Platform.Compatibility.ShellTableViewController
 override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void
 ~override Microsoft.Maui.Controls.SwipeItems.OnPropertyChanged(string propertyName = null) -> void
 override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
-override Microsoft.Maui.Controls.Handlers.Items2.StructuredItemsViewController2<TItemsView>.UpdateFlowDirection() -> void
 Microsoft.Maui.Controls.IndicatorView.~IndicatorView() -> void
-~override Microsoft.Maui.Controls.SwipeItems.OnPropertyChanged(string propertyName = null) -> void
-Microsoft.Maui.Controls.Label.~Label() -> void
 override Microsoft.Maui.Controls.Handlers.Items.MauiCollectionView.LayoutSubviews() -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void


### PR DESCRIPTION
 
Description:

<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

  ## Description

#36312 enabled the `MemoryAnalyzers` Roslyn analyzer at **error severity** for `Controls.Core`
on iOS/MacCatalyst (MEM0001–MEM0003: retained events, retain-cycle-prone strong references,
and non-deterministic event teardown). After that merge landed on `inflight/current`, the
build broke locally in two ways, both fixed here:

**1. Duplicate `PublicAPI.Unshipped.txt` entries** (net-ios, net-maccatalyst) — 3 lines each
were duplicated: `StructuredItemsViewController2<TItemsView>.UpdateFlowDirection()`,
`SwipeItems.OnPropertyChanged(string)`, `Label.~Label()`. Removed the extra copies.

**2. Missing MEM0002 suppressions** on fields that are already cleared in their component's
teardown path but weren't annotated:
- `NavigationRenderer`: `_largeTitleProxyScrollView`, `_largeTitleObservedScrollView`, `_largeTitleContentOffsetObserver`
- `UIContainerCell`: `_viewResource`
- `MauiCollectionView`: `_contentOffsetObserver`

Added justified `[UnconditionalSuppressMessage("Memory", "MEM0002", ...)]` attributes citing
each field's actual disposal path.

No functional/runtime behavior change — purely restores the intended state of #36312.

