### PR TITLE
Fix memory leak in VisualDiagnostics.VisualTreeChanged by backing the static event with WeakEventManager

### DIFF
--- a/src/Controls/tests/Core.UnitTests/VisualTreeHelperTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualTreeHelperTests.cs
@@ -368,7 +368,6 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			_treeEvents.Clear();
 		}
 
-		// Regression tests for https://github.com/dotnet/maui/issues/37242
 		// The static VisualDiagnostics.VisualTreeChanged event must not keep
 		// its subscribers alive; otherwise every page/view that subscribes leaks.
 		class VisualTreeChangedSubscriber

--- a/src/Controls/tests/Core.UnitTests/VisualTreeHelperTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualTreeHelperTests.cs
@@ -367,5 +367,49 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			_treeEvents.Clear();
 		}
+
+		// Regression tests for https://github.com/dotnet/maui/issues/37242
+		// The static VisualDiagnostics.VisualTreeChanged event must not keep
+		// its subscribers alive; otherwise every page/view that subscribes leaks.
+		class VisualTreeChangedSubscriber
+		{
+			public int Fired;
+			public void Handler(object? sender, VisualTreeChangeEventArgs e) => Fired++;
+		}
+
+		[Fact]
+		public async Task VisualTreeChangedSubscriberIsCollectedWithoutExplicitUnsubscribe()
+		{
+			WeakReference? weak = null;
+
+			new Action(() =>
+			{
+				var s = new VisualTreeChangedSubscriber();
+				weak = new WeakReference(s);
+				VisualDiagnostics.VisualTreeChanged += s.Handler;
+			})();
+
+			Assert.NotNull(weak);
+			Assert.False(await weak!.WaitForCollect(),
+				"Subscriber to VisualDiagnostics.VisualTreeChanged was not garbage collected (issue #37242).");
+		}
+
+		[Fact]
+		public async Task VisualTreeChangedSubscriberIsCollectedAfterExplicitUnsubscribe()
+		{
+			WeakReference? weak = null;
+
+			new Action(() =>
+			{
+				var s = new VisualTreeChangedSubscriber();
+				weak = new WeakReference(s);
+				VisualDiagnostics.VisualTreeChanged += s.Handler;
+				VisualDiagnostics.VisualTreeChanged -= s.Handler;
+			})();
+
+			Assert.NotNull(weak);
+			Assert.False(await weak!.WaitForCollect(),
+				"Subscriber was still alive after unsubscribing from VisualDiagnostics.VisualTreeChanged.");
+		}
 	}
 }

--- a/src/Core/src/VisualDiagnostics/VisualDiagnostics.cs
+++ b/src/Core/src/VisualDiagnostics/VisualDiagnostics.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Maui
 			OnVisualTreeChanged(new VisualTreeChangeEventArgs(parent, child, oldLogicalIndex, VisualTreeChangeType.Remove));
 		}
 
-		static readonly WeakEventManager s_visualTreeChangedWeakEventManager = new WeakEventManager();
+		static readonly WeakEventManager _visualTreeChangedWeakEventManager = new WeakEventManager();
 
 		/// <summary>
 		/// Event fired when the visual tree changes (child added or removed).
@@ -119,21 +119,21 @@ namespace Microsoft.Maui
 			{
 				if (value is not null)
 				{
-					s_visualTreeChangedWeakEventManager.AddEventHandler(value);
+					_visualTreeChangedWeakEventManager.AddEventHandler(value);
 				}
 			}
 			remove
 			{
 				if (value is not null)
 				{
-					s_visualTreeChangedWeakEventManager.RemoveEventHandler(value);
+					_visualTreeChangedWeakEventManager.RemoveEventHandler(value);
 				}
 			}
 		}
 
 		static void OnVisualTreeChanged(VisualTreeChangeEventArgs e)
 		{
-			s_visualTreeChangedWeakEventManager.HandleEvent(e.Parent, e, nameof(VisualTreeChanged));
+			_visualTreeChangedWeakEventManager.HandleEvent(e.Parent, e, nameof(VisualTreeChanged));
 		}
 
 		/// <summary>

--- a/src/Core/src/VisualDiagnostics/VisualDiagnostics.cs
+++ b/src/Core/src/VisualDiagnostics/VisualDiagnostics.cs
@@ -107,7 +107,6 @@ namespace Microsoft.Maui
 			OnVisualTreeChanged(new VisualTreeChangeEventArgs(parent, child, oldLogicalIndex, VisualTreeChangeType.Remove));
 		}
 
-		// Backs VisualTreeChanged with weak references so subscribers can be GC'd without explicit unsubscribe (issue #37242).
 		static readonly WeakEventManager s_visualTreeChangedWeakEventManager = new WeakEventManager();
 
 		/// <summary>
@@ -119,12 +118,16 @@ namespace Microsoft.Maui
 			add
 			{
 				if (value is not null)
+				{
 					s_visualTreeChangedWeakEventManager.AddEventHandler(value);
+				}
 			}
 			remove
 			{
 				if (value is not null)
+				{
 					s_visualTreeChangedWeakEventManager.RemoveEventHandler(value);
+				}
 			}
 		}
 

--- a/src/Core/src/VisualDiagnostics/VisualDiagnostics.cs
+++ b/src/Core/src/VisualDiagnostics/VisualDiagnostics.cs
@@ -107,15 +107,30 @@ namespace Microsoft.Maui
 			OnVisualTreeChanged(new VisualTreeChangeEventArgs(parent, child, oldLogicalIndex, VisualTreeChangeType.Remove));
 		}
 
+		// Backs VisualTreeChanged with weak references so subscribers can be GC'd without explicit unsubscribe (issue #37242).
+		static readonly WeakEventManager s_visualTreeChangedWeakEventManager = new WeakEventManager();
+
 		/// <summary>
 		/// Event fired when the visual tree changes (child added or removed).
 		/// </summary>
 		/// <remarks>Subscribers receive <see cref="VisualTreeChangeEventArgs"/> with change details.</remarks>
-		public static event EventHandler<VisualTreeChangeEventArgs>? VisualTreeChanged;
+		public static event EventHandler<VisualTreeChangeEventArgs>? VisualTreeChanged
+		{
+			add
+			{
+				if (value is not null)
+					s_visualTreeChangedWeakEventManager.AddEventHandler(value);
+			}
+			remove
+			{
+				if (value is not null)
+					s_visualTreeChangedWeakEventManager.RemoveEventHandler(value);
+			}
+		}
 
 		static void OnVisualTreeChanged(VisualTreeChangeEventArgs e)
 		{
-			VisualTreeChanged?.Invoke(e.Parent, e);
+			s_visualTreeChangedWeakEventManager.HandleEvent(e.Parent, e, nameof(VisualTreeChanged));
 		}
 
 		/// <summary>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->


### Issue Details
VisualDiagnostics.VisualTreeChanged is a public static event used by XAML Hot Reload, live visual-tree inspectors, and diagnostic tools.
Because it is a plain multicast event, every subscriber is held by a strong reference in the invocation list.
Any page, view, or object that subscribes stays alive until it explicitly calls -=, silently leaking the entire visual subtree, bindings, and view models.

### Root Cause
The event was a normal static event — .NET stores subscribers with strong references.
Since it's static, the list lives for the app's lifetime, so every subscriber lives forever too.
The only way to escape was to explicitly write -=, which most callers forget.

### Description of Change
Backed the event with a WeakEventManager (MAUI's built-in weak-event helper), so subscribers are held weakly and can be GC'd.
The public event signature is unchanged — callers don't need to change anything.

Validated the behavior in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
### Issues Fixed
  
Fixes #37242 

### Fix reference : 
[maui/src/Controls/src/Core/Application/Application.cs at bf62313db2cecf3215f10c353720b341aba0a4ee · …](https://github.com/dotnet/maui/blob/bf62313db2cecf3215f10c353720b341aba0a4ee/src/Controls/src/Core/Application/Application.cs#L263)
[maui/src/Controls/src/Core/Command.cs at bf62313db2cecf3215f10c353720b341aba0a4ee · dotnet/maui](https://github.com/dotnet/maui/blob/bf62313db2cecf3215f10c353720b341aba0a4ee/src/Controls/src/Core/Command.cs#L128)
[maui/src/Controls/src/Core/ImageSource.cs at bf62313db2cecf3215f10c353720b341aba0a4ee · dotnet/maui](https://github.com/dotnet/maui/blob/bf62313db2cecf3215f10c353720b341aba0a4ee/src/Controls/src/Core/ImageSource.cs#L175)

### Output  ScreenShot

|Before|After|
|--|--|
| <video src="https://github.com/user-attachments/assets/8b1d453a-dedd-48d0-a01d-aae7c7523f82" >| <video src="https://github.com/user-attachments/assets/824df312-de3c-4c4e-b073-9239b7c9d5c9">|
