### PR TITLE
[A11y] Fix VoiceOver does not announce project description when navigating project cards

### DIFF
--- a/src/Templates/src/templates/maui-mobile/Pages/ProjectListPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/ProjectListPage.xaml
@@ -32,8 +32,13 @@
             <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="models:Project">
                     <Border 
-                        Background="{AppThemeBinding Light={StaticResource LightSecondaryBackground},Dark={StaticResource DarkSecondaryBackground}}"
-                        SemanticProperties.Description="{Binding Name, StringFormat='{0}'}">
+                        Background="{AppThemeBinding Light={StaticResource LightSecondaryBackground},Dark={StaticResource DarkSecondaryBackground}}">
+                        <SemanticProperties.Description>
+                            <MultiBinding StringFormat="{}{0}, {1}">
+                                <Binding Path="Name" />
+                                <Binding Path="Description" />
+                            </MultiBinding>
+                        </SemanticProperties.Description>
                         <VerticalStackLayout Padding="10">
                             <Label Text="{Binding Name}" FontSize="24" />
                             <Label Text="{Binding Description}" />


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
 
### Issue Details

The voice-over does not announce the project description when the focus moves to the border element within the item template of the CollectionView on the Mac platform.

### Root Cause 

SemanticProperties.Description was bound only to the project Name on the parent Border. Because the card is exposed as one accessible/selectable element, VoiceOver does not announce the child labels separately

### Description of Change
 
Combined both Name and Description values into the Border semantic description.
 
### Issues Fixed
 
Fixes #37142 
 
**Tested the behavior in the following platforms.**
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
| Before  | After  |
|---------|--------|
| <video src="https://github.com/user-attachments/assets/20884ac2-7f4c-4907-8d97-02326a093be2" Width="600" Height="400"/>| <video src="https://github.com/user-attachments/assets/c0f63c4e-4e12-4af4-976d-439970db7a67" Width="600" Height="400"/> |