### PR TITLE
[YML] Removed duplicate deviceType code.

### DIFF
--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -153,11 +153,6 @@ steps:
       $command += " --test-filter ""$testFilter"""
     }
 
-    $deviceType = "${{ parameters.deviceType }}"
-    if ($deviceType) {
-      $command += " --skin=""$deviceType"""
-    }
-    
     $headless = ${{ parameters.headless }}
     if ($headless) {
       $command += " --headless ""$headless"""


### PR DESCRIPTION


### Description of Change
This pull request makes a minor update to the UI test pipeline configuration

- Pipeline configuration simplification:
  * Removed the **duplicate** code that set the `$deviceType` variable and appended the `--skin` argument to the test command in `eng/pipelines/common/ui-tests-steps.yml`.


The same code was already added at [line 133](https://github.com/dotnet/maui/blob/main/eng/pipelines/common/ui-tests-steps.yml#L133) as part of [PR #33409](https://github.com/dotnet/maui/pull/33409).

The duplicate code was also added at [line 156](https://github.com/dotnet/maui/blob/main/eng/pipelines/common/ui-tests-steps.yml#L156) as part of [PR #31631](https://github.com/dotnet/maui/pull/31631).


