### PR TITLE
[net 11] [Android]Fix: LifeCycleEvents Fire When Navigating Top Tabs test fails

### DIFF
--- a/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Android.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Android.cs
@@ -1017,7 +1017,7 @@ namespace Microsoft.Maui.Controls.Handlers
             toolbarTracker?.Page = page;
 
             // Update CurrentItem
-            virtualView.CurrentItem = newCurrentItem;
+            virtualView.SetValueFromRenderer(ShellSection.CurrentItemProperty, newCurrentItem);
 
             // Trigger appearance update
             if (shell is not null)


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

This pull request fixes a regression introduced by PR #34351 (https://github.com/dotnet/maui/pull/34351), which caused the Android device test "LifeCycleEvents Fire When Navigating Top Tabs" and shell navigation-related UI tests to fail in .NET 11.

### Root cause
PR #34351 added a check in ShellSection.OnCurrentItemChanged that re-triggers navigation (ProposeNavigationOutsideGotoAsync) whenever CurrentItem changes without a FromHandler tag. On Android, OnPageSelected already proposes navigation itself, then sets CurrentItem with a plain assignment (no FromHandler tag) — so the PR's check fires a second, redundant navigation proposal for the same tab tap. This second proposal runs after CurrentItem has already flipped to Page2, so it wrongly re-captures _previousPage as Page2 instead of Page1, causing OnNavigatingFrom to fire on the wrong page.

### Description of Change

In ShellSectionHandler.Android.cs, change virtualView.CurrentItem = newCurrentItem to virtualView.SetValueFromRenderer(ShellSection.CurrentItemProperty, newCurrentItem). This tags the assignment as FromHandler, so OnCurrentItemChanged's check correctly skips the redundant second proposal (Android already proposed it once). _previousPage is then captured only once, at the correct time — while CurrentItem still points to Page1 — so OnNavigatingFrom fires on the correct page.
 
### Test cases
  
Device test 

1. LifeCycleEvents Fire When Navigating Top Tabs

UI test

1. NavEvents_ShellContentChanged_NavigatingEvent_SourceIsShellContentChanged, 2.NavEvents_ShellContentChanged_NavigatedEvent_CurrentIsContent2PreviousIsContent1
