### PR TITLE
[Controls] Remove unused DropResult property

### DIFF
--- a/src/Controls/src/Core/DragAndDrop/DropCompletedEventArgs.cs
+++ b/src/Controls/src/Core/DragAndDrop/DropCompletedEventArgs.cs
@@ -7,8 +7,6 @@ namespace Microsoft.Maui.Controls
 	/// </summary>
 	public class DropCompletedEventArgs : EventArgs
 	{
-		DataPackageOperation DropResult { get; }
-
 		/// <summary>
 		/// Initializes a new instance of the <see cref="DropCompletedEventArgs"/> class.
 		/// </summary>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Removes the private `DropCompletedEventArgs.DropResult` property. The property was never assigned or consumed and always held its default value. `DropCompletedEventArgs` remains useful through its public `PlatformArgs` property.

This does not change the public API surface.

### Issues Fixed

Fixes #2839