### PR TITLE
[ci-fix-net11] [iOS] Fix: NavigationPageChildContentExtendsUnderFloatingTabBar Test Failure

### DIFF
--- a/src/Controls/src/Core/Platform/iOS/NavigationViewHandlerToolbarHelper.cs
+++ b/src/Controls/src/Core/Platform/iOS/NavigationViewHandlerToolbarHelper.cs
@@ -184,7 +184,20 @@ namespace Microsoft.Maui.Controls
             // Match renderer behavior: when the nav bar is opaque, prevent content
             // from extending underneath it. When translucent, allow full extension.
             var isTranslucent = NavigationController?.NavigationBar.Translucent ?? false;
-            EdgesForExtendedLayout = isTranslucent ? UIRectEdge.All : UIRectEdge.None;
+            var edges = isTranslucent ? UIRectEdge.All : UIRectEdge.None;
+
+            // On iOS/MacCatalyst 26+, the tab bar renders as a floating glass overlay.
+            // Extend behind it when inside a visible UITabBarController so content
+            // isn't clipped at the old tab bar boundary.
+            if ((OperatingSystem.IsIOSVersionAtLeast(26) || OperatingSystem.IsMacCatalystVersionAtLeast(26))
+                && TabBarController is { } tbc
+                && !tbc.TabBar.Hidden
+                && tbc.TabBar.Translucent)
+            {
+                edges |= UIRectEdge.Bottom;
+            }
+
+            EdgesForExtendedLayout = edges;
 
             // Re-evaluate per-page IconColor when this page becomes visible
             // (push or pop-back). IconColor is already set before the push,


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

**Failure Test on iOS handler path : NavigationPageChildContentExtendsUnderFloatingTabBar**

### Description of Change

On iOS/Mac Catalyst 26, the tab bar renders as a floating, translucent "glass" overlay instead of the traditional opaque bar docked to the screen edge. The old (legacy) renderer had special-case handling that allowed a page's content to extend underneath this floating tab bar so it wouldn't be clipped at the old tab bar boundary.
### Root cause

Fixed in the Renderer path and merged into `main`, then ported to .NET 11. The Handler path never received the equivalent change, so this issue now fails on .NET 11 — `NavigationPage` content routed through the Handler path is clipped above the floating tab bar instead of extending behind it. This PR applies the same fix to the Handler path

This PR restores that behavior in `NavigationViewHandlerToolbarHelper`:
- When running on iOS/Mac Catalyst 26+, and the page is hosted inside a visible `UITabBarController` whose tab bar is **not hidden** and **translucent** (i.e., the new floating glass style), `EdgesForExtendedLayout` now also includes `UIRectEdge.Bottom`.
- This matches the Renderer's behavior, so content extends underneath the floating tab bar instead of stopping short of it.
- Existing behavior for opaque/non-floating tab bars (and for OS versions prior to 26) is unchanged.

Renderer handling reference: https://github.com/dotnet/maui/pull/35523

### Why no tests added : 

- No new automated test was added in this PR because the existing UI test `NavigationPageChildContentExtendsUnderFloatingTabBar`  already covers this behavior — it was the test that started failing in net11 CI, which is what prompted this fix. Rather than adding a new test, this PR restores the passing behavior of that existing test

### Tested the behavior in the following platforms

- [ ] Windows
- [ ] Android
- [x] iOS
- [x] Mac


| Before Issue Fix | After Issue Fix |
|----------|----------|
|  <img width="1125" height="2436" alt="Simulator Screenshot - iPhone 11 Pro - 2026-08-13 at 18 13 31" src="https://github.com/user-attachments/assets/64276ae4-54d3-4172-b889-811e231859c4" />  | <img width="1125" height="2436" alt="Simulator Screenshot - iPhone 11 Pro - 2026-08-13 at 18 07 31" src="https://github.com/user-attachments/assets/e3653ce4-4ea0-41ff-bb7d-a61ac7f4b74a" />  |
<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
