### PR TITLE
[Windows] Fix GraphicsView crash during repeated drawing

### DIFF
--- a/src/Core/tests/DeviceTests/Handlers/GraphicsView/GraphicsViewHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/GraphicsView/GraphicsViewHandlerTests.Windows.cs
@@ -1,5 +1,8 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Graphics.Win2D;
+using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -7,5 +10,58 @@ namespace Microsoft.Maui.DeviceTests
 	{
 		PlatformTouchGraphicsView GetPlatformGraphicsView(GraphicsViewHandler graphicsViewHandler) =>
 			graphicsViewHandler.PlatformView;
+
+		[Fact(DisplayName = "GraphicsView releases Win2D drawing sessions after repeated drawing")]
+		public async Task GraphicsViewReleasesWin2DDrawingSessionsAfterRepeatedDrawing()
+		{
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var drawable = new CapturingDrawable();
+				var graphicsView = new W2DGraphicsView
+				{
+					Width = 100,
+					Height = 100,
+					Drawable = drawable,
+				};
+
+				await graphicsView.AttachAndRun(
+					async () =>
+					{
+						var canvas = await drawable.NextDraw.WaitAsync(TimeSpan.FromSeconds(5));
+						Assert.Null(canvas.Session);
+
+						for (int i = 0; i < 100; i++)
+						{
+							var nextDraw = drawable.PrepareNextDraw();
+							graphicsView.Invalidate();
+							canvas = await nextDraw.WaitAsync(TimeSpan.FromSeconds(5));
+
+							Assert.Null(canvas.Session);
+						}
+					},
+					MauiContext);
+			});
+		}
+
+		sealed class CapturingDrawable : IDrawable
+		{
+			TaskCompletionSource<W2DCanvas> _nextDraw = CreateCompletionSource();
+
+			public Task<W2DCanvas> NextDraw => _nextDraw.Task;
+
+			public Task<W2DCanvas> PrepareNextDraw()
+			{
+				_nextDraw = CreateCompletionSource();
+				return _nextDraw.Task;
+			}
+
+			public void Draw(ICanvas canvas, RectF dirtyRect)
+			{
+				_nextDraw.TrySetResult(Assert.IsType<W2DCanvas>(canvas));
+			}
+
+			static TaskCompletionSource<W2DCanvas> CreateCompletionSource() =>
+				new(TaskCreationOptions.RunContinuationsAsynchronously);
+		}
 	}
 }

--- a/src/Graphics/src/Graphics/Platforms/Windows/PlatformGraphicsView.cs
+++ b/src/Graphics/src/Graphics/Platforms/Windows/PlatformGraphicsView.cs
@@ -133,8 +133,15 @@ namespace Microsoft.Maui.Graphics.Platform
 			}
 			finally
 			{
-				_canvas.ResetState();
-				PlatformGraphicsService.ThreadLocalCreator = null;
+				try
+				{
+					_canvas.ResetState();
+				}
+				finally
+				{
+					_canvas.Session = null;
+					PlatformGraphicsService.ThreadLocalCreator = null;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description

Fixes #29418.

On Windows, `W2DGraphicsView` stored Win2D's callback-scoped `CanvasDrawingSession` on its persistent canvas. Win2D disposes that native session after the draw callback returns, but the stale managed reference remained available across repeated pointer-driven redraws and shutdown, leading to native access violations and heap corruption.

This change clears the drawing session after canvas state has been reset. The nested cleanup guarantees the session and thread-local canvas owner are released even if state reset throws.

@Kamalesh-Periyasamy, once the PR artifacts are available, could you please try them with your original application and let us know whether they resolve the crash?

### Tests

- Added a Windows device test that performs an initial draw plus 100 explicit invalidation/draw cycles and verifies the drawing session is released after every callback.
- Verified the test fails without the fix by observing the retained, already-disposed `CanvasDrawingSession`.
- Core DeviceTests: 2,092 total, 1,981 passed, 111 skipped, 0 failed.
- Ran the exact issue attachment twice for 120 seconds each with 3,848 presses and 38,480 pointer moves per run; both exited cleanly with code 0 and no correlated Windows application errors.
- Also validated custom/default fonts, `ManipulationMode.All`/`None`, multiple views, redraw, resize, unload, and graceful shutdown.

### Video verification

#### Before — original reported crash

The issue author's original recording shows the attached app failing during pointer interaction:

https://github.com/user-attachments/assets/eecd8e89-17c9-4764-b21e-9e6c15141fb4

#### After — fixed DLL under sustained pointer stress

The exact attached application was rebuilt with an ABI-compatible fixed `Microsoft.Maui.Graphics.Win2D.WinUI.Desktop.dll`, then exercised with real `SendInput` pointer presses and moves for 120 seconds:

https://github.com/user-attachments/assets/41a3e68c-e048-4d09-b677-aec1a9bc3af7

This recorded run delivered 11,622 presses and 116,220 pointer moves, then closed normally with exit code `0`. No correlated `Application Error` or `.NET Runtime` event was recorded.

The native crash is intermittent: fresh recording attempts against the original DLL did not fail during the capture session, so the before clip above is the reporter's genuine original failure rather than a clean run being mislabeled or a crash being staged. The deterministic regression evidence is the baseline test retaining an already-disposed `CanvasDrawingSession`; the same test passes after this change.