### PR TITLE
[A11y] [Windows] Fix CollectionView items announcing internal type name instead of item content in Narrator

### DIFF
--- a/src/Templates/src/templates/maui-mobile/Pages/Controls/TaskView.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/Controls/TaskView.xaml
@@ -9,8 +9,8 @@
     x:Class="MauiApp._1.Pages.Controls.TaskView"
     StrokeShape="RoundRectangle 20"
     Background="{AppThemeBinding Light={StaticResource LightSecondaryBackground}, Dark={StaticResource DarkSecondaryBackground}}"
-    SemanticProperties.Description="{Binding Title}"
-    x:DataType="models:ProjectTask">
+    x:DataType="models:ProjectTask"
+    SemanticProperties.Description="{OnPlatform WinUI={Binding Title}}">
 
         <shimmer:SfShimmer
             BackgroundColor="Transparent"

--- a/src/Templates/src/templates/maui-mobile/Pages/Controls/TaskView.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/Controls/TaskView.xaml
@@ -9,6 +9,7 @@
     x:Class="MauiApp._1.Pages.Controls.TaskView"
     StrokeShape="RoundRectangle 20"
     Background="{AppThemeBinding Light={StaticResource LightSecondaryBackground}, Dark={StaticResource DarkSecondaryBackground}}"
+    SemanticProperties.Description="{Binding Title}"
     x:DataType="models:ProjectTask">
 
         <shimmer:SfShimmer

--- a/src/Templates/src/templates/maui-mobile/Pages/Controls/TaskView.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/Controls/TaskView.xaml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
+<!-- Issue #36940: Windows only. On iOS/Mac Catalyst, setting Description on the Border makes the container a single accessibility element, preventing VoiceOver from focusing the inner CheckBox. -->
 <Border
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause
On Windows, `CollectionView`'s legacy handler (CV1), which is based on `ListView`, derives each item's screen reader name from the root element of the `DataTemplate`.

When neither `AutomationProperties.Name` nor `SemanticProperties.Description` is set on that root element, WinUI falls back to calling `.ToString()` on the bound item. As a result, Narrator announces the internal type name: `Microsoft.Maui.Controls.Platform.ItemTemplateContext` instead of meaningful item content.

This is native WinUI `ListView` behavior documented by Microsoft and is not specific to MAUI.

### Description of Change
Set `SemanticProperties.Description` on the `DataTemplate` root, `TaskView`'s `Border`, and scope it to Windows only. This ensures Narrator announces the bound task title instead of the internal type name.

Windows-only scoping is necessary because applying `SemanticProperties.Description` on iOS and Mac Catalyst causes the root element to become a single accessibility element, preventing VoiceOver from navigating to the inner `CheckBox`.

### Issues Fixed

Fixes #36940 

### Platforms Tested

- [x] iOS
- [x] Android  
- [x] Windows
- [x] Mac

### Screenshots
| Before Fix | After Fix |
|------------|-----------|
| <video width="350" alt="withoutfix" src="https://github.com/user-attachments/assets/b35e24bc-0c59-4db1-8210-1be4fe5c2333" /> | <video width="350" alt="withfix" src="https://github.com/user-attachments/assets/89ad2456-5c9d-4060-8685-e108e9fe8c3e" /> |