### PR TITLE
[Essentials] WebAuthenticator: Centralize request lifecycle handling

### DIFF
--- a/docs/design/WebAuthenticator.md
+++ b/docs/design/WebAuthenticator.md
@@ -1,0 +1,73 @@
+# WebAuthenticator request lifecycle
+
+`WebAuthenticator` opens the platform authentication surface and completes when the app receives
+the configured callback route. OAuth and OIDC protocol responsibilities such as PKCE, state, nonce,
+token exchange, and token validation remain in the application.
+
+## Shared lifecycle
+
+- A process can have one active built-in request. A second valid call throws
+  `InvalidOperationException` without canceling the first request.
+- Options are snapshotted before validation and are not retained as mutable platform state.
+- Callback, cancellation, and failure race through one process-wide completion reservation.
+- Decoder and platform callbacks run outside the manager lock and at most once.
+- Cleanup completes before cancellation-registration disposal; request removal is the final step.
+- A request cannot resume after process termination.
+
+Route-only callbacks match the configured scheme and, when present, host, effective port, and
+non-root path. Scheme and host comparisons ignore case; constrained paths compare exactly. Query
+and fragment do not participate in route matching, and an expected root path does not constrain the
+callback path. A lifecycle callback with a route mismatch is not consumed and leaves the request
+pending. An identity-bound native result with a missing or mismatched URI is terminal for that request.
+
+## Native callback routing
+
+Native lifecycle callbacks attempt the process-wide built-in request before consulting the current
+`WebAuthenticator.Default`. This prevents replacement of the static facade from orphaning an
+active built-in request. Callbacks not handled by the built-in route can still flow to a custom
+implementation or another lifecycle handler, and the built-in implementation is never invoked twice.
+
+## Platform integration
+
+### Windows
+
+Packaged apps declare the callback protocol on the current manifest application. Unpackaged apps
+use a protocol command owned by the current executable. A framework-owned `AppInstance` route key
+identifies the callback owner; transient activation processes redirect to that owner and remain
+alive until redirection completes. The route remains registered after the request because explicit
+unregistration prevents reliable re-registration ([Windows App SDK #4420][windows-appsdk-4420]). A
+later `FindOrRegisterForKey` can replace a previous framework route when the callback scheme changes,
+as implemented by [Windows App SDK 2.3.1][windows-appsdk-appinstance]. If the app already owns the
+current instance key, the framework preserves it and the app must cooperatively route protocol
+activations. The originating window is brought to the foreground on a best-effort basis before
+callback decoding and observable completion.
+
+### iOS and Mac Catalyst
+
+Both targets use `ASWebAuthenticationSession`. HTTPS callbacks require version 17.4 or later, the
+default HTTPS port, and matching Associated Domains configuration. Native completion is posted to
+the main queue before completing the shared request. The framework does not clear shared cookies.
+
+### Android
+
+Android prefers Auth Tab when a verified Custom Tabs provider supports it. Results are correlated
+by request ID. HTTPS callbacks with a non-default port are not eligible for Auth Tab because that
+transport cannot preserve the port. If Auth Tab is unavailable or ineligible, the implementation
+falls back to a Custom Tab and then the system browser. Custom-scheme fallbacks require a matching
+exported callback activity; HTTPS callbacks require matching Digital Asset Links.
+
+## Diagnostics and limitations
+
+Native and operating-system failures can be written to Debug output with their exception details.
+Logs at URI, callback, manager, and application-decoder boundaries remain redacted and must not
+include authorization URLs, callback values, query strings, codes, or tokens.
+
+Native cancellation is reported when the selected transport exposes it. Closing an external
+fallback browser is not always observable. `PrefersEphemeralWebBrowserSession` is best-effort and
+is not guaranteed on Windows.
+
+See the [Essentials samples README](../../src/Essentials/samples/README.md#webauthenticator) for the
+zero-configuration sample and its production-security boundary.
+
+[windows-appsdk-4420]: https://github.com/microsoft/WindowsAppSDK/issues/4420
+[windows-appsdk-appinstance]: https://github.com/microsoft/WindowsAppSDK/blob/v2.3.1/dev/AppLifecycle/AppInstance.cpp

--- a/docs/design/WebAuthenticator.md
+++ b/docs/design/WebAuthenticator.md
@@ -8,6 +8,8 @@ token exchange, and token validation remain in the application.
 
 - A process can have one active built-in request. A second valid call throws
   `InvalidOperationException` without canceling the first request.
+- Applications must serialize authentication attempts, such as by disabling sign-in actions while
+  a request is pending. This replaces the previous behavior where a new request canceled the first.
 - Options are snapshotted before validation and are not retained as mutable platform state.
 - Callback, cancellation, and failure race through one process-wide completion reservation.
 - Decoder and platform callbacks run outside the manager lock and at most once.
@@ -50,7 +52,8 @@ completion.
 
 Both targets use `ASWebAuthenticationSession`. HTTPS callbacks require version 17.4 or later, the
 default HTTPS port, and matching Associated Domains configuration. Native completion is posted to
-the main queue before completing the shared request. The framework does not clear shared cookies.
+the main queue before completing the shared request. Applications supporting earlier OS versions
+must use a custom-scheme callback. The framework does not clear shared cookies.
 
 ### Android
 
@@ -59,9 +62,11 @@ by request ID. HTTPS callbacks with a non-default port are not eligible for Auth
 transport cannot preserve the port. If Auth Tab is unavailable or ineligible, the implementation
 falls back to a Custom Tab and then the system browser. Both fallback transports are launched from
 a request-owned intermediate activity, so returning from the browser without a callback cancels the
-same request. Caller cancellation only targets a matching live intermediate activity and never
-creates a cleanup activity. Custom-scheme fallbacks require a matching exported callback activity;
-HTTPS callbacks require matching Digital Asset Links.
+same request. Bringing the application task to the foreground before a callback is received is also
+treated as a terminal return, even if an external browser task remains open. Caller cancellation only
+targets a matching live intermediate activity and never creates a cleanup activity. Custom-scheme
+fallbacks require a matching exported callback activity; HTTPS callbacks require matching Digital
+Asset Links.
 
 ## Diagnostics and limitations
 

--- a/docs/design/WebAuthenticator.md
+++ b/docs/design/WebAuthenticator.md
@@ -12,6 +12,8 @@ token exchange, and token validation remain in the application.
 - Callback, cancellation, and failure race through one process-wide completion reservation.
 - Decoder and platform callbacks run outside the manager lock and at most once.
 - Cleanup completes before cancellation-registration disposal; request removal is the final step.
+- Until request removal, a matching callback after terminal completion has been reserved is consumed
+  as a duplicate, while a route mismatch remains available to other lifecycle handlers.
 - A request cannot resume after process termination.
 
 Route-only callbacks match the configured scheme and, when present, host, effective port, and
@@ -32,15 +34,17 @@ implementation or another lifecycle handler, and the built-in implementation is 
 ### Windows
 
 Packaged apps declare the callback protocol on the current manifest application. Unpackaged apps
-use a protocol command owned by the current executable. A framework-owned `AppInstance` route key
-identifies the callback owner; transient activation processes redirect to that owner and remain
-alive until redirection completes. The route remains registered after the request because explicit
-unregistration prevents reliable re-registration ([Windows App SDK #4420][windows-appsdk-4420]). A
-later `FindOrRegisterForKey` can replace a previous framework route when the callback scheme changes,
-as implemented by [Windows App SDK 2.3.1][windows-appsdk-appinstance]. If the app already owns the
-current instance key, the framework preserves it and the app must cooperatively route protocol
-activations. The originating window is brought to the foreground on a best-effort basis before
-callback decoding and observable completion.
+use a protocol command owned by the current executable. An absolute command targeting another
+executable is rejected; a framework-dependent command is accepted when it uses the current
+`dotnet.exe` host. A framework-owned `AppInstance` route key identifies the callback owner; transient
+activation processes redirect to that owner and remain alive until redirection completes. The route
+remains registered after the request because explicit unregistration prevents reliable
+re-registration ([Windows App SDK #4420][windows-appsdk-4420]). A later `FindOrRegisterForKey` can
+replace a previous framework route when the callback scheme changes, as implemented by [Windows App
+SDK 2.3.1][windows-appsdk-appinstance]. If the app already owns the current instance key, the
+framework preserves it and the app must cooperatively route protocol activations. The originating
+window is brought to the foreground on a best-effort basis before callback decoding and observable
+completion.
 
 ### iOS and Mac Catalyst
 
@@ -53,8 +57,11 @@ the main queue before completing the shared request. The framework does not clea
 Android prefers Auth Tab when a verified Custom Tabs provider supports it. Results are correlated
 by request ID. HTTPS callbacks with a non-default port are not eligible for Auth Tab because that
 transport cannot preserve the port. If Auth Tab is unavailable or ineligible, the implementation
-falls back to a Custom Tab and then the system browser. Custom-scheme fallbacks require a matching
-exported callback activity; HTTPS callbacks require matching Digital Asset Links.
+falls back to a Custom Tab and then the system browser. Both fallback transports are launched from
+a request-owned intermediate activity, so returning from the browser without a callback cancels the
+same request. Caller cancellation only targets a matching live intermediate activity and never
+creates a cleanup activity. Custom-scheme fallbacks require a matching exported callback activity;
+HTTPS callbacks require matching Digital Asset Links.
 
 ## Diagnostics and limitations
 
@@ -62,9 +69,9 @@ Native and operating-system failures can be written to Debug output with their e
 Logs at URI, callback, manager, and application-decoder boundaries remain redacted and must not
 include authorization URLs, callback values, query strings, codes, or tokens.
 
-Native cancellation is reported when the selected transport exposes it. Closing an external
-fallback browser is not always observable. `PrefersEphemeralWebBrowserSession` is best-effort and
-is not guaranteed on Windows.
+Native cancellation is reported when the selected transport exposes it. Android can close its own
+request lifecycle owner, but cannot guarantee that browser UI hosted in a separate external task is
+forcibly closed. `PrefersEphemeralWebBrowserSession` is best-effort and is not guaranteed on Windows.
 
 See the [Essentials samples README](../../src/Essentials/samples/README.md#webauthenticator) for the
 zero-configuration sample and its production-security boundary.

--- a/src/Essentials/samples/README.md
+++ b/src/Essentials/samples/README.md
@@ -16,10 +16,26 @@ Android), verified by a minimal ASP.NET Core Identity relying-party server.
 
 ### WebAuthenticator
 
-Browser-based OAuth sign-in via `WebAuthenticator`, brokered by a small reference server.
+The sample uses the public reference broker at
+`https://xamarin-essentials-auth-sample.azurewebsites.net/mobileauth/`, so browser launch and
+callback delivery can be tested without configuring provider credentials or running a local
+server. Open the Web Authenticator page, choose a provider, complete sign-in, and verify that the
+page reports a received callback. Token values are not displayed or logged.
 
-- **Guide:** _coming — being reworked_
-- **Reference server:** [`Sample.Server.WebAuthenticator/`](Sample.Server.WebAuthenticator)
+This demonstrates the `WebAuthenticator` transport contract, not a production OAuth architecture.
+Production apps should normally use Authorization Code Flow with PKCE, validate state and OIDC
+tokens as applicable, and never embed a client secret. `WebAuthenticator` itself remains protocol
+agnostic and does not exchange or validate tokens.
+
+Android custom-scheme fallback requires a matching exported callback activity. iOS and Mac
+Catalyst register the callback through `CFBundleURLTypes`. Packaged Windows apps declare the
+protocol on the current manifest application; unpackaged apps register a protocol command owned by
+the current executable. Closing an external fallback browser is not observable on every platform,
+so the page also provides explicit cancellation.
+
+The source under [`Sample.Server.WebAuthenticator/`](Sample.Server.WebAuthenticator) is included
+for reference and is not required by the default public-broker sample path. Automated tests must
+not depend on the public service.
 
 ## Projects
 
@@ -27,7 +43,7 @@ Browser-based OAuth sign-in via `WebAuthenticator`, brokered by a small referenc
   including the **Passkeys** page).
 - **[`Samples.Server.Passkeys/`](Samples.Server.Passkeys)** — the passkeys relying-party (RP) server
   (small and commented — read the code for endpoint/auth details).
-- **[`Sample.Server.WebAuthenticator/`](Sample.Server.WebAuthenticator)** — the WebAuthenticator
-  reference server.
+- **[`Sample.Server.WebAuthenticator/`](Sample.Server.WebAuthenticator)** — source for the
+  WebAuthenticator reference server; it is not required by the default public-broker sample path.
 
 Pick the scenario you want to test from the table above and follow its guide.

--- a/src/Essentials/samples/Samples/Platforms/Android/MainActivity.cs
+++ b/src/Essentials/samples/Samples/Platforms/Android/MainActivity.cs
@@ -54,6 +54,8 @@ namespace Samples.Droid
 		}
 	}
 
+	// Custom-scheme fallback registration. HTTPS Auth Tab callbacks instead require a matching
+	// Digital Asset Links file for this app ID and signing certificate.
 	[Activity(NoHistory = true, LaunchMode = LaunchMode.SingleTop, Exported = true)]
 	[IntentFilter(
 		new[] { Intent.ActionView },

--- a/src/Essentials/samples/Samples/Platforms/MacCatalyst/Info.plist
+++ b/src/Essentials/samples/Samples/Platforms/MacCatalyst/Info.plist
@@ -23,6 +23,7 @@
 	</array>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Access to your location is required for cool things to happen!</string>
+	<!-- Custom-scheme callback. HTTPS callbacks require Mac Catalyst 17.4+ and Associated Domains. -->
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/src/Essentials/samples/Samples/Platforms/Windows/Package.appxmanifest
+++ b/src/Essentials/samples/Samples/Platforms/Windows/Package.appxmanifest
@@ -48,6 +48,7 @@
         </uap:DefaultTile >
       </uap:VisualElements>
       <Extensions>
+        <!-- Protocol must belong to this Application. App-owned AppInstance keys remain registered. -->
         <uap:Extension Category="windows.protocol">
           <uap:Protocol Name="xamarinessentials">
             <uap:DisplayName>Xamarin Essentials</uap:DisplayName>

--- a/src/Essentials/samples/Samples/Platforms/iOS/Info.plist
+++ b/src/Essentials/samples/Samples/Platforms/iOS/Info.plist
@@ -23,6 +23,7 @@
 	</array>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Access to your location is required for cool things to happen!</string>
+	<!-- Custom-scheme callback. HTTPS callbacks require iOS 17.4+ and Associated Domains. -->
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/src/Essentials/samples/Samples/View/WebAuthenticatorPage.xaml
+++ b/src/Essentials/samples/Samples/View/WebAuthenticatorPage.xaml
@@ -9,18 +9,19 @@
     </views:BasePage.BindingContext>
 
     <Grid RowDefinitions="Auto,*">
-        <Label Text="Quickly and easily authenticate and wait for callbacks on external urls." FontAttributes="Bold" Margin="12" />
+        <Label Text="Test browser authentication and callback delivery with the public reference broker." FontAttributes="Bold" Margin="12" />
 
         <ScrollView Grid.Row="1">
             <StackLayout Padding="12,0,12,12" Spacing="6">
 
-                <Button Text="Microsoft" Command="{Binding MicrosoftCommand}" BackgroundColor="#00A4EF" TextColor="White" />
-                <Button Text="Google" Command="{Binding GoogleCommand}" BackgroundColor="#d34836" TextColor="White" />
-                <Button Text="Facebook" Command="{Binding FacebookCommand}" BackgroundColor="#3b5998" TextColor="White" />
-                <Button Text="Apple" Command="{Binding AppleCommand}" BackgroundColor="Black" TextColor="White" />
+                <Button Text="Microsoft" Command="{Binding MicrosoftCommand}" IsEnabled="{Binding IsNotBusy}" BackgroundColor="#00A4EF" TextColor="White" />
+                <Button Text="Google" Command="{Binding GoogleCommand}" IsEnabled="{Binding IsNotBusy}" BackgroundColor="#d34836" TextColor="White" />
+                <Button Text="Facebook" Command="{Binding FacebookCommand}" IsEnabled="{Binding IsNotBusy}" BackgroundColor="#3b5998" TextColor="White" />
+                <Button Text="Apple" Command="{Binding AppleCommand}" IsEnabled="{Binding IsNotBusy}" BackgroundColor="Black" TextColor="White" />
+                <Button Text="Cancel authentication" Command="{Binding CancelCommand}" IsVisible="{Binding IsBusy}" />
 
-                <Label Text="Auth Token:" FontAttributes="Bold" Margin="12,12,12,0" />
-                <Label Text="{Binding AuthToken}" TextColor="Red" FontAttributes="Italic" />
+                <Label Text="Status:" FontAttributes="Bold" Margin="12,12,12,0" />
+                <Label Text="{Binding AuthenticationStatus}" FontAttributes="Italic" />
 
             </StackLayout>
         </ScrollView>

--- a/src/Essentials/samples/Samples/ViewModel/WebAuthenticatorViewModel.cs
+++ b/src/Essentials/samples/Samples/ViewModel/WebAuthenticatorViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using Microsoft.Maui.Authentication;
@@ -10,6 +11,9 @@ namespace Samples.ViewModel
 	public class WebAuthenticatorViewModel : BaseViewModel
 	{
 		const string authenticationUrl = "https://xamarin-essentials-auth-sample.azurewebsites.net/mobileauth/";
+		readonly object cancellationGate = new();
+		CancellationTokenSource authenticationCancellation;
+		string authenticationStatus = "Choose a provider to test browser authentication and callback delivery.";
 
 		public WebAuthenticatorViewModel()
 		{
@@ -17,6 +21,7 @@ namespace Samples.ViewModel
 			GoogleCommand = new Command(async () => await OnAuthenticate("Google"));
 			FacebookCommand = new Command(async () => await OnAuthenticate("Facebook"));
 			AppleCommand = new Command(async () => await OnAuthenticate("Apple"));
+			CancelCommand = new Command(CancelAuthentication);
 		}
 
 		public ICommand MicrosoftCommand { get; }
@@ -27,19 +32,29 @@ namespace Samples.ViewModel
 
 		public ICommand AppleCommand { get; }
 
-		string accessToken = string.Empty;
+		public ICommand CancelCommand { get; }
 
-		public string AuthToken
+		public string AuthenticationStatus
 		{
-			get => accessToken;
-			set => SetProperty(ref accessToken, value);
+			get => authenticationStatus;
+			set => SetProperty(ref authenticationStatus, value);
 		}
 
 		async Task OnAuthenticate(string scheme)
 		{
+			if (IsBusy)
+				return;
+
+			using var cancellation = new CancellationTokenSource();
+			lock (cancellationGate)
+				authenticationCancellation = cancellation;
+
+			IsBusy = true;
+			AuthenticationStatus = "Waiting for browser authentication...";
+
 			try
 			{
-				WebAuthenticatorResult r = null;
+				WebAuthenticatorResult result;
 
 				if (scheme.Equals("Apple", StringComparison.Ordinal)
 					&& DeviceInfo.Platform == DevicePlatform.iOS
@@ -52,37 +67,56 @@ namespace Samples.ViewModel
 						IncludeEmailScope = true,
 						IncludeFullNameScope = true,
 					};
-					r = await AppleSignInAuthenticator.AuthenticateAsync(options);
+					result = await AppleSignInAuthenticator.AuthenticateAsync(options);
+					cancellation.Token.ThrowIfCancellationRequested();
 				}
 				else
 				{
+					// This public broker keeps the sample immediately runnable. It demonstrates
+					// browser launch and callback delivery, not a production OAuth architecture.
 					var authUrl = new Uri(authenticationUrl + scheme);
 					var callbackUrl = new Uri("xamarinessentials://");
 
-					r = await WebAuthenticator.AuthenticateAsync(authUrl, callbackUrl);
+					result = await WebAuthenticator.AuthenticateAsync(authUrl, callbackUrl, cancellation.Token);
 				}
 
-				AuthToken = string.Empty;
-				if (r.Properties.TryGetValue("name", out var name) && !string.IsNullOrEmpty(name))
-					AuthToken += $"Name: {name}{Environment.NewLine}";
-				if (r.Properties.TryGetValue("email", out var email) && !string.IsNullOrEmpty(email))
-					AuthToken += $"Email: {email}{Environment.NewLine}";
-				AuthToken += r?.AccessToken ?? r?.IdToken;
+				AuthenticationStatus = result is null
+					? "Authentication failed because no callback result was returned."
+					: "Authentication completed. The callback was received; token values are not displayed or logged.";
 			}
 			catch (OperationCanceledException)
 			{
-				Console.WriteLine("Login canceled.");
-
-				AuthToken = string.Empty;
-				await DisplayAlertAsync("Login canceled.");
+				AuthenticationStatus = "Authentication canceled.";
 			}
 			catch (Exception ex)
 			{
-				Console.WriteLine($"Failed: {ex.Message}");
-
-				AuthToken = string.Empty;
-				await DisplayAlertAsync($"Failed: {ex.Message}");
+				// Provider responses can contain sensitive values, so log only the exception type.
+				Console.WriteLine($"Web authentication failed ({ex.GetType().Name}).");
+				AuthenticationStatus = "Authentication failed. The public sample service or provider may be unavailable.";
 			}
+			finally
+			{
+				lock (cancellationGate)
+				{
+					if (ReferenceEquals(authenticationCancellation, cancellation))
+						authenticationCancellation = null;
+				}
+
+				IsBusy = false;
+			}
+		}
+
+		void CancelAuthentication()
+		{
+			lock (cancellationGate)
+			{
+				if (authenticationCancellation is null || authenticationCancellation.IsCancellationRequested)
+					return;
+
+				authenticationCancellation.Cancel();
+			}
+
+			AuthenticationStatus = "Canceling authentication...";
 		}
 	}
 }

--- a/src/Essentials/src/Types/Shared/WebUtils.shared.cs
+++ b/src/Essentials/src/Types/Shared/WebUtils.shared.cs
@@ -126,6 +126,10 @@ namespace Microsoft.Maui
 
 		internal static bool CanHandleCallback(Uri expectedUrl, Uri callbackUrl)
 		{
+			if (expectedUrl is null || callbackUrl is null ||
+				!expectedUrl.IsAbsoluteUri || !callbackUrl.IsAbsoluteUri)
+				return false;
+
 			if (!callbackUrl.Scheme.Equals(expectedUrl.Scheme, StringComparison.OrdinalIgnoreCase))
 				return false;
 
@@ -133,7 +137,14 @@ namespace Microsoft.Maui
 			{
 				if (!callbackUrl.Host.Equals(expectedUrl.Host, StringComparison.OrdinalIgnoreCase))
 					return false;
+
+				if (callbackUrl.Port != expectedUrl.Port)
+					return false;
 			}
+
+			if (!string.IsNullOrEmpty(expectedUrl.AbsolutePath) && expectedUrl.AbsolutePath != "/" &&
+				!callbackUrl.AbsolutePath.Equals(expectedUrl.AbsolutePath, StringComparison.Ordinal))
+				return false;
 
 			return true;
 		}
@@ -147,7 +158,7 @@ namespace Microsoft.Maui
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"Unable to create NSUrl from Original string, trying Absolute URI: {ex.Message}");
+                Debug.WriteLine($"Unable to create a native URL from the original value ({ex.GetType().Name}); retrying with the absolute value.");
                 return new Foundation.NSUrl(uri.AbsoluteUri);
             }
         }

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.android.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.android.cs
@@ -129,11 +129,11 @@ namespace Microsoft.Maui.Authentication
 							}
 						});
 					}
-					catch (Exception)
+					catch (Exception ex)
 					{
 						WebAuthenticatorRequestManager.TryFail(
 							request,
-							new InvalidOperationException("Unable to open a browser for web authentication."));
+							new InvalidOperationException("Unable to open a browser for web authentication.", ex));
 					}
 				}
 

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.android.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.android.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,149 +11,227 @@ namespace Microsoft.Maui.Authentication
 {
 	partial class WebAuthenticatorImplementation : IWebAuthenticator, IPlatformWebAuthenticatorCallback
 	{
-		TaskCompletionSource<WebAuthenticatorResult> tcsResponse = null;
-		Uri currentRedirectUri = null;
-		WebAuthenticatorOptions currentOptions = null;
+		public bool OnResumeCallback(Intent intent) =>
+			TryHandleBuiltInCallback(intent);
 
-		internal bool AuthenticatingWithCustomTabs { get; private set; } = false;
-
-		public bool OnResumeCallback(Intent intent)
+		internal static bool TryHandleBuiltInCallback(Intent intent)
 		{
-			// If we aren't waiting on a task, don't handle the url
-			if (tcsResponse?.Task?.IsCompleted ?? true)
+			var callback = intent?.Data?.ToString();
+			if (string.IsNullOrEmpty(callback))
 				return false;
-
-			if (intent?.Data == null)
-			{
-				tcsResponse.TrySetCanceled();
-				return false;
-			}
 
 			try
 			{
-				var intentUri = new Uri(intent.Data.ToString());
-
-				// Only handle schemes we expect
-				if (!WebUtils.CanHandleCallback(currentRedirectUri, intentUri))
-				{
-					tcsResponse.TrySetException(new InvalidOperationException($"Invalid Redirect URI, detected `{intentUri}` but expected a URI in the format of `{currentRedirectUri}`"));
-					return false;
-				}
-				tcsResponse?.TrySetResult(new WebAuthenticatorResult(intentUri, currentOptions?.ResponseDecoder));
-				return true;
+				return WebAuthenticatorRequestManager.TryHandleCallback(new Uri(callback));
 			}
-			catch (Exception ex)
+			catch (Exception)
 			{
-				tcsResponse.TrySetException(ex);
 				return false;
 			}
 		}
 
-		public async Task<WebAuthenticatorResult> AuthenticateAsync(WebAuthenticatorOptions webAuthenticatorOptions)
-			=> await AuthenticateAsync(webAuthenticatorOptions, CancellationToken.None);
+		public Task<WebAuthenticatorResult> AuthenticateAsync(WebAuthenticatorOptions webAuthenticatorOptions) =>
+			AuthenticateAsync(webAuthenticatorOptions, CancellationToken.None);
 
-		public async Task<WebAuthenticatorResult> AuthenticateAsync(WebAuthenticatorOptions webAuthenticatorOptions, CancellationToken cancellationToken)
+		public async Task<WebAuthenticatorResult> AuthenticateAsync(
+			WebAuthenticatorOptions webAuthenticatorOptions,
+			CancellationToken cancellationToken)
 		{
-			currentOptions = webAuthenticatorOptions;
-			var url = webAuthenticatorOptions?.Url;
-			var callbackUrl = webAuthenticatorOptions?.CallbackUrl;
-			var packageName = Application.Context.PackageName;
+			if (webAuthenticatorOptions is null)
+				throw new ArgumentNullException(nameof(webAuthenticatorOptions));
 
-			// Create an intent to see if the app developer wired up the callback activity correctly
-			var intent = new Intent(Intent.ActionView);
+			var url = webAuthenticatorOptions.Url;
+			var callbackUrl = webAuthenticatorOptions.CallbackUrl;
+			var responseDecoder = webAuthenticatorOptions.ResponseDecoder;
+			var prefersEphemeral = webAuthenticatorOptions.PrefersEphemeralWebBrowserSession;
+
+			if (url is null)
+				throw new ArgumentNullException(nameof(webAuthenticatorOptions.Url));
+			if (callbackUrl is null)
+				throw new ArgumentNullException(nameof(webAuthenticatorOptions.CallbackUrl));
+			if (!url.IsAbsoluteUri)
+				throw new ArgumentException("The authentication URL must be absolute.", nameof(webAuthenticatorOptions.Url));
+			if (!callbackUrl.IsAbsoluteUri)
+				throw new ArgumentException("The callback URL must be absolute.", nameof(webAuthenticatorOptions.CallbackUrl));
+			var applicationContext = Application.Context;
+			var callbackActivityAvailable = IsCallbackActivityAvailable(applicationContext, callbackUrl);
+			var customTabsProvider = TryGetCustomTabsProvider(applicationContext);
+			var useAuthTab = CanUseAuthTab(url, callbackUrl) &&
+				IsAuthTabSupported(applicationContext, customTabsProvider);
+
+			if (!useAuthTab && !callbackActivityAvailable)
+			{
+				throw new InvalidOperationException(
+					$"You must subclass {nameof(WebAuthenticatorCallbackActivity)} and register an IntentFilter for the callback route.");
+			}
+
+			cancellationToken.ThrowIfCancellationRequested();
+
+			var parentActivity = ActivityStateManager.Default.GetCurrentActivity(true) ??
+				throw new InvalidOperationException("The current Android Activity is unavailable.");
+			var request = WebAuthenticatorRequestManager.Begin(
+				url,
+				callbackUrl,
+				responseDecoder,
+				prefersEphemeral,
+				cancellationToken);
+
+			var registration = cancellationToken.Register(
+				static state =>
+				{
+					var request = (WebAuthenticatorRequest)state!;
+					WebAuthenticatorRequestManager.TryCancelFromCaller(request);
+				},
+				request);
+
+			var usesIntermediateActivity = false;
+			var callerCancellationWon = false;
+			try
+			{
+				if (!request.Task.IsCompleted)
+				{
+					try
+					{
+						await MainThread.InvokeOnMainThreadAsync(() =>
+						{
+							if (request.Task.IsCompleted)
+								return;
+
+							if (useAuthTab)
+							{
+								WebAuthenticatorIntermediateActivity.StartAuthTab(
+									parentActivity,
+									request.Id,
+									url,
+									callbackUrl,
+									customTabsProvider!,
+									prefersEphemeral,
+									callbackActivityAvailable);
+								usesIntermediateActivity = true;
+							}
+							else if (!string.IsNullOrEmpty(customTabsProvider))
+							{
+								WebAuthenticatorIntermediateActivity.StartCustomTab(
+									parentActivity,
+									request.Id,
+									url,
+									customTabsProvider,
+									prefersEphemeral);
+								usesIntermediateActivity = true;
+							}
+							else
+							{
+								LaunchSystemBrowser(parentActivity, url);
+							}
+						});
+					}
+					catch (Exception)
+					{
+						WebAuthenticatorRequestManager.TryFail(
+							request,
+							new InvalidOperationException("Unable to open a browser for web authentication."));
+					}
+				}
+
+				return await request.Task.ConfigureAwait(false);
+			}
+			catch (OperationCanceledException ex) when (
+				ex.CancellationToken == cancellationToken && cancellationToken.IsCancellationRequested)
+			{
+				callerCancellationWon = true;
+				throw;
+			}
+			finally
+			{
+				if (usesIntermediateActivity && callerCancellationWon)
+				{
+					try
+					{
+						await MainThread.InvokeOnMainThreadAsync(() =>
+							WebAuthenticatorIntermediateActivity.RequestCleanup(applicationContext, request.Id));
+					}
+					catch (Exception ex)
+					{
+						System.Diagnostics.Debug.WriteLine($"Unable to close the Android WebAuthenticator activity ({ex}).");
+					}
+				}
+
+				registration.Dispose();
+				WebAuthenticatorRequestManager.End(request);
+			}
+		}
+
+		internal static bool CanUseAuthTab(Uri url, Uri callbackUrl) =>
+			url.Scheme is "http" or "https" &&
+			callbackUrl.Scheme != "http" &&
+			(callbackUrl.Scheme != "https" || callbackUrl.IsDefaultPort);
+
+		internal static string? TryGetCustomTabsProvider(Context context)
+		{
+			try
+			{
+				return CustomTabsHelper.GetPackageNameToUse(context);
+			}
+			catch (Exception)
+			{
+				return null;
+			}
+		}
+
+		internal static bool IsAuthTabSupported(Context context, string? provider)
+		{
+			if (string.IsNullOrEmpty(provider))
+				return false;
+
+			try
+			{
+				return CustomTabsClient.IsAuthTabSupported(context, provider);
+			}
+			catch (Exception)
+			{
+				return false;
+			}
+		}
+
+		internal static bool IsEphemeralBrowsingSupported(Context context, string? provider)
+		{
+			if (string.IsNullOrEmpty(provider))
+				return false;
+
+			try
+			{
+				return CustomTabsClient.IsEphemeralBrowsingSupported(context, provider);
+			}
+			catch (Exception)
+			{
+				return false;
+			}
+		}
+
+		static bool IsCallbackActivityAvailable(Context context, Uri callbackUrl)
+		{
+			var packageName = context.PackageName;
+			if (string.IsNullOrEmpty(packageName))
+				return false;
+
+			using var intent = new Intent(Intent.ActionView);
 			intent.AddCategory(Intent.CategoryBrowsable);
 			intent.AddCategory(Intent.CategoryDefault);
 			intent.SetPackage(packageName);
 			intent.SetData(global::Android.Net.Uri.Parse(callbackUrl.OriginalString));
 
-			// Try to find the activity for the callback intent
-			if (!PlatformUtils.IsIntentSupported(intent, packageName))
-				throw new InvalidOperationException($"You must subclass the `{nameof(WebAuthenticatorCallbackActivity)}` and create an IntentFilter for it which matches your `{nameof(callbackUrl)}`.");
-
-			// Cancel any previous task that's still pending
-			if (tcsResponse?.Task != null && !tcsResponse.Task.IsCompleted)
-				tcsResponse.TrySetCanceled();
-
-			tcsResponse = new TaskCompletionSource<WebAuthenticatorResult>();
-			currentRedirectUri = callbackUrl;
-
-			// Use the CancellationToken to cancel the authentication if requested
-			using (cancellationToken.Register(() => tcsResponse.TrySetCanceled()))
-			{
-				// Try to start with custom tabs if the system supports it and we resolve it
-				AuthenticatingWithCustomTabs = await StartCustomTabsActivity(url);
-
-				// Fall back to using the system browser if necessary
-				if (!AuthenticatingWithCustomTabs)
-				{
-					// Fall back to opening the system-registered browser if necessary
-					var urlOriginalString = url.OriginalString;
-					var browserIntent = new Intent(Intent.ActionView, global::Android.Net.Uri.Parse(urlOriginalString));
-					Platform.CurrentActivity.StartActivity(browserIntent);
-				}
-
-				return await tcsResponse.Task;
-			}
+			return PlatformUtils.IsIntentSupported(intent, packageName);
 		}
 
-
-		static async Task<bool> StartCustomTabsActivity(Uri url)
+		internal static void LaunchSystemBrowser(Context context, Uri url)
 		{
-			// Is only set to true if BindServiceAsync succeeds and no exceptions are thrown
-			var success = false;
-			var parentActivity = ActivityStateManager.Default.GetCurrentActivity(true);
+			using var browserIntent = new Intent(
+				Intent.ActionView,
+				global::Android.Net.Uri.Parse(url.OriginalString));
+			if (context is not Activity)
+				browserIntent.AddFlags(ActivityFlags.NewTask);
 
-			var customTabsActivityManager = new CustomTabsActivityManager(parentActivity);
-			try
-			{
-				if (await BindServiceAsync(customTabsActivityManager))
-				{
-					var customTabsIntent = new CustomTabsIntent.Builder(customTabsActivityManager.Session)
-						.SetShowTitle(true)
-						.Build();
-
-					customTabsIntent.Intent.SetData(global::Android.Net.Uri.Parse(url.OriginalString));
-
-					if (customTabsIntent.Intent.ResolveActivity(parentActivity.PackageManager) != null)
-					{
-						WebAuthenticatorIntermediateActivity.StartActivity(parentActivity, customTabsIntent.Intent);
-						success = true;
-					}
-				}
-			}
-			finally
-			{
-				try
-				{
-					customTabsActivityManager.Client?.Dispose();
-				}
-				finally
-				{
-				}
-			}
-
-			return success;
-		}
-
-		static Task<bool> BindServiceAsync(CustomTabsActivityManager manager)
-		{
-			var tcs = new TaskCompletionSource<bool>();
-
-			manager.CustomTabsServiceConnected += OnCustomTabsServiceConnected;
-
-			if (!manager.BindService())
-			{
-				manager.CustomTabsServiceConnected -= OnCustomTabsServiceConnected;
-				tcs.TrySetResult(false);
-			}
-
-			return tcs.Task;
-
-			void OnCustomTabsServiceConnected(ComponentName name, CustomTabsClient client)
-			{
-				manager.CustomTabsServiceConnected -= OnCustomTabsServiceConnected;
-				tcs.TrySetResult(true);
-			}
+			context.StartActivity(browserIntent);
 		}
 	}
 }

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.android.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.android.cs
@@ -121,7 +121,11 @@ namespace Microsoft.Maui.Authentication
 							}
 							else
 							{
-								LaunchSystemBrowser(parentActivity, url);
+								WebAuthenticatorIntermediateActivity.StartBrowser(
+									parentActivity,
+									request.Id,
+									url);
+								usesIntermediateActivity = true;
 							}
 						});
 					}
@@ -148,7 +152,7 @@ namespace Microsoft.Maui.Authentication
 					try
 					{
 						await MainThread.InvokeOnMainThreadAsync(() =>
-							WebAuthenticatorIntermediateActivity.RequestCleanup(applicationContext, request.Id));
+							WebAuthenticatorIntermediateActivity.TryRequestCleanup(request.Id));
 					}
 					catch (Exception ex)
 					{

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.ios.tvos.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.ios.tvos.cs
@@ -1,229 +1,333 @@
+#nullable enable
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
+#if IOS || MACCATALYST
 using AuthenticationServices;
-using Foundation;
-#if __IOS__
-using SafariServices;
+using CoreFoundation;
 #endif
+using Foundation;
+using Microsoft.Maui.ApplicationModel;
 using ObjCRuntime;
 using UIKit;
-using WebKit;
-using Microsoft.Maui.Authentication;
-using Microsoft.Maui.ApplicationModel;
-using System.Threading;
 
 namespace Microsoft.Maui.Authentication
 {
 	partial class WebAuthenticatorImplementation : IWebAuthenticator, IPlatformWebAuthenticatorCallback
 	{
-#if __IOS__
+#if IOS || MACCATALYST
 		const int asWebAuthenticationSessionErrorCodeCanceledLogin = 1;
 		const string asWebAuthenticationSessionErrorDomain = "com.apple.AuthenticationServices.WebAuthenticationSession";
-
-		const int sfAuthenticationErrorCanceledLogin = 1;
-		const string sfAuthenticationErrorDomain = "com.apple.SafariServices.Authentication";
 #endif
 
-		TaskCompletionSource<WebAuthenticatorResult> tcsResponse;
-		UIViewController currentViewController;
-		Uri redirectUri;
-		WebAuthenticatorOptions currentOptions;
+		public Task<WebAuthenticatorResult> AuthenticateAsync(WebAuthenticatorOptions webAuthenticatorOptions) =>
+			AuthenticateAsync(webAuthenticatorOptions, CancellationToken.None);
 
-#if __IOS__
-		ASWebAuthenticationSession was;
-		SFAuthenticationSession sf;
-#endif
-
-		public async Task<WebAuthenticatorResult> AuthenticateAsync(WebAuthenticatorOptions webAuthenticatorOptions)
-			=> await AuthenticateAsync(webAuthenticatorOptions, CancellationToken.None);
-
-		public async Task<WebAuthenticatorResult> AuthenticateAsync(WebAuthenticatorOptions webAuthenticatorOptions, CancellationToken cancellationToken)
+		public async Task<WebAuthenticatorResult> AuthenticateAsync(
+			WebAuthenticatorOptions webAuthenticatorOptions,
+			CancellationToken cancellationToken)
 		{
-			currentOptions = webAuthenticatorOptions;
-			var url = webAuthenticatorOptions?.Url;
-			var callbackUrl = webAuthenticatorOptions?.CallbackUrl;
-			var prefersEphemeralWebBrowserSession = webAuthenticatorOptions?.PrefersEphemeralWebBrowserSession ?? false;
+			if (webAuthenticatorOptions is null)
+				throw new ArgumentNullException(nameof(webAuthenticatorOptions));
 
-			if (!VerifyHasUrlSchemeOrDoesntRequire(callbackUrl.Scheme))
-				throw new InvalidOperationException("You must register your URL Scheme handler in your app's Info.plist.");
+			var url = webAuthenticatorOptions.Url;
+			var callbackUrl = webAuthenticatorOptions.CallbackUrl;
+			var responseDecoder = webAuthenticatorOptions.ResponseDecoder;
+			var prefersEphemeral = webAuthenticatorOptions.PrefersEphemeralWebBrowserSession;
 
-			// Cancel any previous task that's still pending
-			if (tcsResponse?.Task != null && !tcsResponse.Task.IsCompleted)
-				tcsResponse.TrySetCanceled();
+			if (url is null)
+				throw new ArgumentNullException(nameof(webAuthenticatorOptions.Url));
+			if (callbackUrl is null)
+				throw new ArgumentNullException(nameof(webAuthenticatorOptions.CallbackUrl));
+			if (!url.IsAbsoluteUri)
+				throw new ArgumentException("The authentication URL must be absolute.", nameof(webAuthenticatorOptions.Url));
+			if (!callbackUrl.IsAbsoluteUri)
+				throw new ArgumentException("The callback URL must be absolute.", nameof(webAuthenticatorOptions.CallbackUrl));
 
-			tcsResponse = new TaskCompletionSource<WebAuthenticatorResult>();
-			redirectUri = callbackUrl;
-			var scheme = redirectUri.Scheme;
-
-			// Use the CancellationToken to cancel the operation
-			using (cancellationToken.Register(() => tcsResponse.TrySetCanceled()))
-			{
-#if __IOS__
-				void AuthSessionCallback(NSUrl cbUrl, NSError error)
-				{
-					if (error == null)
-						OpenUrlCallback(cbUrl);
-					else if (error.Domain == asWebAuthenticationSessionErrorDomain && error.Code == asWebAuthenticationSessionErrorCodeCanceledLogin)
-						tcsResponse.TrySetCanceled();
-					else if (error.Domain == sfAuthenticationErrorDomain && error.Code == sfAuthenticationErrorCanceledLogin)
-						tcsResponse.TrySetCanceled();
-					else
-						tcsResponse.TrySetException(new NSErrorException(error));
-
-					was = null;
-					sf = null;
-				}
-
-				if (OperatingSystem.IsIOSVersionAtLeast(12))
-				{
-#if IOS17_4_OR_GREATER || MACCATALYST17_4_OR_GREATER
-					if (OperatingSystem.IsIOSVersionAtLeast(17, 4) || OperatingSystem.IsMacCatalystVersionAtLeast(17, 4))
-					{
-						var callback = ASWebAuthenticationSessionCallback.Create(scheme);
-						was = new ASWebAuthenticationSession(WebUtils.GetNativeUrl(url), callback, AuthSessionCallback);
-					}
-					else
-#endif
-					{
-						was = new ASWebAuthenticationSession(WebUtils.GetNativeUrl(url), scheme, AuthSessionCallback);
-					}
-
-					if (OperatingSystem.IsIOSVersionAtLeast(13))
-					{
-						var ctx = new ContextProvider(WindowStateManager.Default.GetCurrentUIWindow());
-						was.PresentationContextProvider = ctx;
-						was.PrefersEphemeralWebBrowserSession = prefersEphemeralWebBrowserSession;
-					}
-					else if (prefersEphemeralWebBrowserSession)
-					{
-						ClearCookies();
-					}
-
-					using (was)
-					{
-#pragma warning disable CA1416
-						was.Start();
-#pragma warning restore CA1416
-						return await tcsResponse.Task;
-					}
-				}
-
-				if (prefersEphemeralWebBrowserSession)
-					ClearCookies();
-
-#pragma warning disable CA1422
-				if (OperatingSystem.IsIOSVersionAtLeast(11))
-				{
-					sf = new SFAuthenticationSession(WebUtils.GetNativeUrl(url), scheme, AuthSessionCallback);
-					using (sf)
-					{
-						sf.Start();
-						return await tcsResponse.Task;
-					}
-				}
-#pragma warning restore CA1422
-
-				var controller = new SFSafariViewController(WebUtils.GetNativeUrl(url), false)
-				{
-					Delegate = new NativeSFSafariViewControllerDelegate
-					{
-						DidFinishHandler = (svc) =>
-						{
-							if (!(tcsResponse?.Task?.IsCompleted ?? true))
-								tcsResponse.TrySetCanceled();
-						}
-					},
-				};
-
-				currentViewController = controller;
-				await WindowStateManager.Default.GetCurrentUIViewController().PresentViewControllerAsync(controller, true);
+#if IOS || MACCATALYST
+			ValidateModernSessionUrls(url, callbackUrl);
 #else
-        var opened = UIApplication.SharedApplication.OpenUrl(url);
-        if (!opened)
-            tcsResponse.TrySetException(new Exception("Error opening Safari"));
+			if (!VerifyHasUrlSchemeOrDoesntRequire(callbackUrl.Scheme))
+				throw new InvalidOperationException("You must register the callback URL scheme in the app Info.plist.");
 #endif
-				return await tcsResponse.Task;
-			}
-		}
 
+			cancellationToken.ThrowIfCancellationRequested();
 
-		void ClearCookies()
-		{
-			NSUrlCache.SharedCache.RemoveAllCachedResponses();
-
-#if __IOS__
-			if (OperatingSystem.IsIOSVersionAtLeast(11))
+#if IOS || MACCATALYST
+			ContextProvider contextProvider;
+			try
 			{
-				WKWebsiteDataStore.DefaultDataStore.HttpCookieStore.GetAllCookies((cookies) =>
+				contextProvider = await MainThread.InvokeOnMainThreadAsync(() =>
 				{
-					foreach (var cookie in cookies)
-					{
-#pragma warning disable CA1416 // Known false positive with lambda, here we can also assert the version
-						WKWebsiteDataStore.DefaultDataStore.HttpCookieStore.DeleteCookie(cookie, null);
-#pragma warning restore CA1416
-					}
+					var window = WindowStateManager.Default.GetCurrentUIWindow();
+					if (window is null)
+						throw new InvalidOperationException();
+
+					return new ContextProvider(window);
 				});
 			}
+			catch (Exception)
+			{
+				throw new InvalidOperationException("Unable to identify a presentation window for web authentication.");
+			}
 #endif
-		}
 
-		public bool OpenUrlCallback(Uri uri)
-		{
-			// If we aren't waiting on a task, don't handle the url
-			if (tcsResponse?.Task?.IsCompleted ?? true)
-				return false;
+			var request = WebAuthenticatorRequestManager.Begin(
+				url,
+				callbackUrl,
+				responseDecoder,
+				prefersEphemeral,
+				cancellationToken);
+
+			var registration = cancellationToken.Register(
+				static state =>
+				{
+					var request = (WebAuthenticatorRequest)state!;
+					WebAuthenticatorRequestManager.TryCancelFromCaller(request);
+				},
+				request);
+
+#if IOS || MACCATALYST
+			ASWebAuthenticationSession? session = null;
+#endif
 
 			try
 			{
-				// If we can't handle the url, don't
-				if (!WebUtils.CanHandleCallback(redirectUri, uri))
-					return false;
+				if (!request.Task.IsCompleted)
+				{
+#if IOS || MACCATALYST
+					try
+					{
+						await MainThread.InvokeOnMainThreadAsync(() =>
+						{
+							if (request.Task.IsCompleted)
+								return;
 
-				currentViewController?.DismissViewControllerAsync(true);
-				currentViewController = null;
+							session = CreateSession(request, url, callbackUrl);
+							session.PresentationContextProvider = contextProvider;
+							session.PrefersEphemeralWebBrowserSession = prefersEphemeral;
 
-				tcsResponse.TrySetResult(new WebAuthenticatorResult(uri, currentOptions?.ResponseDecoder));
-				return true;
+							if (!session.Start())
+							{
+								WebAuthenticatorRequestManager.TryFail(
+									request,
+									new InvalidOperationException("The native web authentication session could not be started."));
+							}
+						});
+					}
+					catch (Exception)
+					{
+						WebAuthenticatorRequestManager.TryFail(
+							request,
+							new InvalidOperationException("The native web authentication session could not be started."));
+					}
+#else
+					try
+					{
+						if (!UIApplication.SharedApplication.OpenUrl(WebUtils.GetNativeUrl(url)))
+						{
+							WebAuthenticatorRequestManager.TryFail(
+								request,
+								new InvalidOperationException("The system browser could not be opened for authentication."));
+						}
+					}
+					catch (Exception)
+					{
+						WebAuthenticatorRequestManager.TryFail(
+							request,
+							new InvalidOperationException("The system browser could not be opened for authentication."));
+					}
+#endif
+				}
+
+				return await request.Task.ConfigureAwait(false);
 			}
-			catch (Exception ex)
+			finally
 			{
-				// TODO change this to ILogger?
-				Console.WriteLine(ex);
+#if IOS || MACCATALYST
+				await CancelAndDisposeSessionAsync(session).ConfigureAwait(false);
+				GC.KeepAlive(contextProvider);
+				GC.KeepAlive(session);
+#endif
+				registration.Dispose();
+				WebAuthenticatorRequestManager.End(request);
 			}
-			return false;
 		}
 
+		public bool OpenUrlCallback(Uri uri) =>
+			TryHandleBuiltInCallback(uri);
+
+		internal static bool TryHandleBuiltInCallback(Uri uri) =>
+			WebAuthenticatorRequestManager.TryHandleCallback(uri);
+
+#if IOS || MACCATALYST
+		internal static void ValidateModernSessionUrls(Uri url, Uri callbackUrl)
+		{
+			if (url.Scheme is not "http" and not "https")
+			{
+				throw new InvalidOperationException(
+					"ASWebAuthenticationSession requires an HTTP or HTTPS authentication URL.");
+			}
+
+			if (callbackUrl.Scheme == "http")
+				throw new InvalidOperationException("HTTP callback URLs are not supported by ASWebAuthenticationSession.");
+
+			if (callbackUrl.Scheme != "https")
+				return;
+
+			if (!callbackUrl.IsDefaultPort)
+			{
+				throw new InvalidOperationException(
+					"ASWebAuthenticationSession cannot preserve a non-default HTTPS callback port.");
+			}
+
+#if IOS
+			if (!OperatingSystem.IsIOSVersionAtLeast(17, 4))
+#elif MACCATALYST
+			if (!OperatingSystem.IsMacCatalystVersionAtLeast(17, 4))
+#endif
+			{
+				throw new FeatureNotSupportedException(
+					"HTTPS WebAuthenticator callbacks require iOS or Mac Catalyst 17.4 or later and an Associated Domains configuration.");
+			}
+		}
+
+		static ASWebAuthenticationSession CreateSession(
+			WebAuthenticatorRequest request,
+			Uri url,
+			Uri callbackUrl)
+		{
+			var nativeUrl = WebUtils.GetNativeUrl(url);
+			ASWebAuthenticationSessionCompletionHandler completionHandler = (callbackUrl, error) =>
+				PostNativeCompletion(request, callbackUrl, error);
+
+			if (callbackUrl.Scheme != "https")
+				return new ASWebAuthenticationSession(nativeUrl, callbackUrl.Scheme, completionHandler);
+
+#if IOS
+			if (OperatingSystem.IsIOSVersionAtLeast(17, 4))
+#elif MACCATALYST
+			if (OperatingSystem.IsMacCatalystVersionAtLeast(17, 4))
+#endif
+			{
+				var callback = ASWebAuthenticationSessionCallback.Create(callbackUrl.Host, callbackUrl.AbsolutePath);
+				return new ASWebAuthenticationSession(nativeUrl, callback, completionHandler);
+			}
+
+			throw new FeatureNotSupportedException("HTTPS WebAuthenticator callbacks require iOS or Mac Catalyst 17.4 or later.");
+		}
+
+		internal static void PostNativeCompletion(
+			WebAuthenticatorRequest request,
+			NSUrl? callbackUrl,
+			NSError? error)
+		{
+			string? absoluteCallbackUrl = null;
+			var wasCanceled = false;
+			var failed = false;
+			try
+			{
+				absoluteCallbackUrl = callbackUrl?.AbsoluteString;
+				if (error is not null)
+				{
+					wasCanceled = error.Domain == asWebAuthenticationSessionErrorDomain &&
+						error.Code == asWebAuthenticationSessionErrorCodeCanceledLogin;
+					failed = !wasCanceled;
+				}
+			}
+			catch (Exception)
+			{
+				failed = true;
+			}
+
+			// DispatchQueue.DispatchAsync never runs inline, including when the native callback is already on main.
+			DispatchQueue.MainQueue.DispatchAsync(() =>
+				CompleteNativeSession(request, absoluteCallbackUrl, wasCanceled, failed));
+		}
+
+		internal static void CompleteNativeSession(
+			WebAuthenticatorRequest request,
+			string? absoluteCallbackUrl,
+			bool wasCanceled,
+			bool failed)
+		{
+			if (wasCanceled)
+			{
+				WebAuthenticatorRequestManager.TryCancelFromPlatform(request);
+				return;
+			}
+
+			if (failed)
+			{
+				WebAuthenticatorRequestManager.TryFail(
+					request,
+					new InvalidOperationException("The native web authentication session failed."));
+				return;
+			}
+
+			if (absoluteCallbackUrl is null)
+			{
+				WebAuthenticatorRequestManager.TryHandleTerminalCallback(request, null);
+				return;
+			}
+
+			try
+			{
+				WebAuthenticatorRequestManager.TryHandleTerminalCallback(request, new Uri(absoluteCallbackUrl));
+			}
+			catch (Exception)
+			{
+				WebAuthenticatorRequestManager.TryFail(
+					request,
+					new InvalidOperationException("The native authentication callback URI was invalid."));
+			}
+		}
+
+		static Task CancelAndDisposeSessionAsync(ASWebAuthenticationSession? session)
+		{
+			if (session is null)
+				return Task.CompletedTask;
+
+			var cleanupSource = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+			DispatchQueue.MainQueue.DispatchAsync(() =>
+			{
+				try
+				{
+					session.Cancel();
+					session.Dispose();
+				}
+				catch (Exception ex)
+				{
+					Debug.WriteLine($"Unable to close the native WebAuthenticator session ({ex}).");
+				}
+				finally
+				{
+					cleanupSource.TrySetResult(null);
+				}
+			});
+
+			return cleanupSource.Task;
+		}
+
+		sealed class ContextProvider : NSObject, IASWebAuthenticationPresentationContextProviding
+		{
+			internal ContextProvider(UIWindow window) =>
+				Window = window;
+
+			internal UIWindow Window { get; }
+
+			[Export("presentationAnchorForWebAuthenticationSession:")]
+			public UIWindow GetPresentationAnchor(ASWebAuthenticationSession session) =>
+				Window;
+		}
+#else
 		static bool VerifyHasUrlSchemeOrDoesntRequire(string scheme)
 		{
-			// iOS11+ uses sfAuthenticationSession which handles its own url routing
-			if (OperatingSystem.IsIOSVersionAtLeast(11, 0) || OperatingSystem.IsTvOSVersionAtLeast(11, 0))
+			if (OperatingSystem.IsTvOSVersionAtLeast(11))
 				return true;
 
 			return AppInfoImplementation.VerifyHasUrlScheme(scheme);
-		}
-
-#if __IOS__
-		class NativeSFSafariViewControllerDelegate : SFSafariViewControllerDelegate
-		{
-			public Action<SFSafariViewController> DidFinishHandler { get; set; }
-
-			public override void DidFinish(SFSafariViewController controller) =>
-				DidFinishHandler?.Invoke(controller);
-		}
-
-		class ContextProvider : NSObject, IASWebAuthenticationPresentationContextProviding
-		{
-			public ContextProvider(UIWindow window) =>
-				Window = window;
-
-			public readonly UIWindow Window;
-
-			[Export("presentationAnchorForWebAuthenticationSession:")]
-			public UIWindow GetPresentationAnchor(ASWebAuthenticationSession session)
-				=> Window;
 		}
 #endif
 	}

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.ios.tvos.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.ios.tvos.cs
@@ -116,11 +116,17 @@ namespace Microsoft.Maui.Authentication
 							}
 						});
 					}
-					catch (Exception)
+					catch (FeatureNotSupportedException)
+					{
+						throw;
+					}
+					catch (Exception ex)
 					{
 						WebAuthenticatorRequestManager.TryFail(
 							request,
-							new InvalidOperationException("The native web authentication session could not be started."));
+							new InvalidOperationException(
+								"The native web authentication session could not be started.",
+								ex));
 					}
 #else
 					try

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.ios.tvos.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.ios.tvos.cs
@@ -225,7 +225,7 @@ namespace Microsoft.Maui.Authentication
 		{
 			string? absoluteCallbackUrl = null;
 			var wasCanceled = false;
-			var failed = false;
+			Exception? nativeFailure = null;
 			try
 			{
 				absoluteCallbackUrl = callbackUrl?.AbsoluteString;
@@ -233,24 +233,25 @@ namespace Microsoft.Maui.Authentication
 				{
 					wasCanceled = error.Domain == asWebAuthenticationSessionErrorDomain &&
 						error.Code == asWebAuthenticationSessionErrorCodeCanceledLogin;
-					failed = !wasCanceled;
+					if (!wasCanceled)
+						nativeFailure = new NSErrorException(error);
 				}
 			}
-			catch (Exception)
+			catch (Exception ex)
 			{
-				failed = true;
+				nativeFailure = ex;
 			}
 
 			// DispatchQueue.DispatchAsync never runs inline, including when the native callback is already on main.
 			DispatchQueue.MainQueue.DispatchAsync(() =>
-				CompleteNativeSession(request, absoluteCallbackUrl, wasCanceled, failed));
+				CompleteNativeSession(request, absoluteCallbackUrl, wasCanceled, nativeFailure));
 		}
 
 		internal static void CompleteNativeSession(
 			WebAuthenticatorRequest request,
 			string? absoluteCallbackUrl,
 			bool wasCanceled,
-			bool failed)
+			Exception? nativeFailure)
 		{
 			if (wasCanceled)
 			{
@@ -258,11 +259,13 @@ namespace Microsoft.Maui.Authentication
 				return;
 			}
 
-			if (failed)
+			if (nativeFailure is not null)
 			{
 				WebAuthenticatorRequestManager.TryFail(
 					request,
-					new InvalidOperationException("The native web authentication session failed."));
+					new InvalidOperationException(
+						"The native web authentication session failed.",
+						nativeFailure));
 				return;
 			}
 

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.shared.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.shared.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Maui.Authentication
 		/// <exception cref="InvalidOperationException">
 		/// <para>All platforms: Thrown when another authentication operation is already in progress.</para>
 		/// <para>Android: Thrown when the no IntentFilter has been created for the callback URL.</para>
+		/// <para>iOS and Mac Catalyst: Thrown when the authentication or callback URL is unsupported, including an HTTPS callback with a non-default port, or when the native session cannot be started.</para>
 		/// <para>Windows: Thrown when the callback URL is invalid, its protocol is not registered, the browser cannot be launched, or another app instance is already waiting for the callback scheme.</para>
 		/// </exception>
 		Task<WebAuthenticatorResult> AuthenticateAsync(WebAuthenticatorOptions webAuthenticatorOptions);
@@ -41,6 +42,7 @@ namespace Microsoft.Maui.Authentication
 		/// <exception cref="InvalidOperationException">
 		/// <para>All platforms: Thrown when another authentication operation is already in progress.</para>
 		/// <para>Android: Thrown when the no IntentFilter has been created for the callback URL.</para>
+		/// <para>iOS and Mac Catalyst: Thrown when the authentication or callback URL is unsupported, including an HTTPS callback with a non-default port, or when the native session cannot be started.</para>
 		/// <para>Windows: Thrown when the callback URL is invalid, its protocol is not registered, the browser cannot be launched, or another app instance is already waiting for the callback scheme.</para>
 		/// </exception>
 		Task<WebAuthenticatorResult> AuthenticateAsync(WebAuthenticatorOptions webAuthenticatorOptions, CancellationToken cancellationToken);

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.shared.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.shared.cs
@@ -22,8 +22,9 @@ namespace Microsoft.Maui.Authentication
 		/// <param name="webAuthenticatorOptions">A <see cref="WebAuthenticatorOptions"/> instance containing additional configuration for this authentication call.</param>
 		/// <returns>A <see cref="WebAuthenticatorResult"/> object with the results of this operation.</returns>
 		/// <exception cref="TaskCanceledException">Thrown when the user canceled the authentication flow.</exception>
-		/// <exception cref="FeatureNotSupportedException">iOS/macOS: Thrown when iOS version is less than 13 is used or macOS less than 13.1 is used.</exception>
+		/// <exception cref="FeatureNotSupportedException">Thrown when the platform cannot represent the requested callback, including HTTPS callbacks on iOS or Mac Catalyst before version 17.4.</exception>
 		/// <exception cref="InvalidOperationException">
+		/// <para>All platforms: Thrown when another authentication operation is already in progress.</para>
 		/// <para>Android: Thrown when the no IntentFilter has been created for the callback URL.</para>
 		/// <para>Windows: Thrown when the callback URL is invalid, its protocol is not registered, the browser cannot be launched, or another app instance is already waiting for the callback scheme.</para>
 		/// </exception>
@@ -36,8 +37,9 @@ namespace Microsoft.Maui.Authentication
 		/// <param name="cancellationToken">A <see cref="CancellationToken"/> to monitor for cancellation requests.</param>
 		/// <returns>A <see cref="WebAuthenticatorResult"/> object with the results of this operation.</returns>
 		/// <exception cref="TaskCanceledException">Thrown when the user canceled the authentication flow.</exception>
-		/// <exception cref="FeatureNotSupportedException">iOS/macOS: Thrown when iOS version is less than 13 is used or macOS less than 13.1 is used.</exception>
+		/// <exception cref="FeatureNotSupportedException">Thrown when the platform cannot represent the requested callback, including HTTPS callbacks on iOS or Mac Catalyst before version 17.4.</exception>
 		/// <exception cref="InvalidOperationException">
+		/// <para>All platforms: Thrown when another authentication operation is already in progress.</para>
 		/// <para>Android: Thrown when the no IntentFilter has been created for the callback URL.</para>
 		/// <para>Windows: Thrown when the callback URL is invalid, its protocol is not registered, the browser cannot be launched, or another app instance is already waiting for the callback scheme.</para>
 		/// </exception>
@@ -91,8 +93,14 @@ namespace Microsoft.Maui.Authentication
 	/// A web navigation API intended to be used for Authentication with external web services such as OAuth.
 	/// </summary>
 	/// <remarks>
-	/// This API helps with navigating to a start URL and waiting for a callback URL to the app.  Your app must 
+	/// This API helps with navigating to a start URL and waiting for a callback URL to the app. Your app must
 	/// be registered to handle the callback scheme you provide in the call to authenticate.
+	/// Only one authentication operation can be active in the process. Starting another valid operation throws
+	/// <see cref="InvalidOperationException"/>. Lifecycle callbacks are offered to the active built-in request first,
+	/// but only a matching callback route is consumed; non-matching callbacks remain available to custom implementations
+	/// and other lifecycle handlers. Scheme and host comparisons ignore case, while the effective port and any non-root path
+	/// must match exactly. Query and fragment do not participate in route matching, and an expected root path does not
+	/// constrain the callback path. The app remains responsible for OAuth state, PKCE, nonce validation, and token exchange.
 	/// </remarks>
 	public static class WebAuthenticator
 	{
@@ -150,11 +158,6 @@ namespace Microsoft.Maui.Authentication
 			return platform;
 		}
 
-#if ANDROID
-		internal static bool IsAuthenticatingWithCustomTabs(this IWebAuthenticator webAuthenticator)
-			=> (webAuthenticator as WebAuthenticatorImplementation)?.AuthenticatingWithCustomTabs ?? false;
-#endif
-
 		/// <summary>
 		/// Begin an authentication flow by navigating to the specified url and waiting for a callback/redirect to the callbackUrl scheme.
 		/// </summary>
@@ -178,8 +181,18 @@ namespace Microsoft.Maui.Authentication
 
 #if IOS || MACCATALYST || MACOS
 		/// <inheritdoc cref="IPlatformWebAuthenticatorCallback.OpenUrlCallback(Uri)"/>
-		public static bool OpenUrl(this IWebAuthenticator webAuthenticator, Uri uri) =>
-			webAuthenticator.AsPlatformCallback().OpenUrlCallback(uri);
+		public static bool OpenUrl(this IWebAuthenticator webAuthenticator, Uri uri)
+		{
+#if IOS || MACCATALYST
+			if (WebAuthenticatorImplementation.TryHandleBuiltInCallback(uri))
+				return true;
+
+			return webAuthenticator is not WebAuthenticatorImplementation &&
+				webAuthenticator.AsPlatformCallback().OpenUrlCallback(uri);
+#else
+			return webAuthenticator.AsPlatformCallback().OpenUrlCallback(uri);
+#endif
+		}
 
 		/// <inheritdoc cref="ApplicationModel.Platform.OpenUrl(UIKit.UIApplication, Foundation.NSUrl, Foundation.NSDictionary)"/>
 		public static bool OpenUrl(this IWebAuthenticator webAuthenticator, UIKit.UIApplication app, Foundation.NSUrl url, Foundation.NSDictionary options) 
@@ -203,12 +216,24 @@ namespace Microsoft.Maui.Authentication
 
 #elif ANDROID
 		/// <inheritdoc cref="IPlatformWebAuthenticatorCallback.OnResumeCallback(Intent)"/>
-		public static bool OnResume(this IWebAuthenticator webAuthenticator, Intent intent) =>
-			webAuthenticator.AsPlatformCallback().OnResumeCallback(intent);
+		public static bool OnResume(this IWebAuthenticator webAuthenticator, Intent intent)
+		{
+			if (WebAuthenticatorImplementation.TryHandleBuiltInCallback(intent))
+				return true;
+
+			return webAuthenticator is not WebAuthenticatorImplementation &&
+				webAuthenticator.AsPlatformCallback().OnResumeCallback(intent);
+		}
 #elif WINDOWS
 		/// <inheritdoc cref="IPlatformWebAuthenticatorCallback.OnAppInstanceActivatedCallback(Microsoft.Windows.AppLifecycle.AppActivationArguments)"/>
-		public static bool OnAppInstanceActivated(this IWebAuthenticator webAuthenticator, Microsoft.Windows.AppLifecycle.AppActivationArguments args) =>
-			webAuthenticator.AsPlatformCallback().OnAppInstanceActivatedCallback(args);
+		public static bool OnAppInstanceActivated(this IWebAuthenticator webAuthenticator, Microsoft.Windows.AppLifecycle.AppActivationArguments args)
+		{
+			if (WebAuthenticatorImplementation.TryHandleBuiltInActivation(args))
+				return true;
+
+			return webAuthenticator is not WebAuthenticatorImplementation &&
+				webAuthenticator.AsPlatformCallback().OnAppInstanceActivatedCallback(args);
+		}
 #endif
 	}
 
@@ -231,7 +256,7 @@ namespace Microsoft.Maui.Authentication
 		/// Gets or sets whether the browser used for the authentication flow is short-lived.
 		/// This means it will not share session nor cookies with the regular browser on this device if set the <see langword="true"/>. 
 		/// </summary>
-		/// <remarks>This setting only has effect on iOS.</remarks>
+		/// <remarks>Support varies by platform and browser. This setting is not guaranteed on Windows.</remarks>
 		public bool PrefersEphemeralWebBrowserSession { get; set; }
 
 		/// <summary>

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.windows.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.windows.cs
@@ -120,11 +120,11 @@ namespace Microsoft.Maui.Authentication
 								new InvalidOperationException("Failed to launch the browser for authentication."));
 						}
 					}
-					catch (Exception)
+					catch (Exception ex)
 					{
 						WebAuthenticatorRequestManager.TryFail(
 							request,
-							new InvalidOperationException("Failed to launch the browser for authentication."));
+							new InvalidOperationException("Failed to launch the browser for authentication.", ex));
 					}
 				}
 

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.windows.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.windows.cs
@@ -1,12 +1,13 @@
 #nullable enable
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Xml;
 using System.Xml.Linq;
-using System.Xml.XPath;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Storage;
 using Microsoft.UI.Windowing;
@@ -18,15 +19,13 @@ namespace Microsoft.Maui.Authentication
 	partial class WebAuthenticatorImplementation : IWebAuthenticator, IPlatformWebAuthenticatorCallback
 	{
 		const string CallbackRouteKeyPrefix = "Microsoft.Maui.WebAuthenticator:";
+		const int ErrorSuccess = 0;
+		const int ErrorInsufficientBuffer = 122;
 
-		readonly object locker = new();
+		public bool OnAppInstanceActivatedCallback(AppActivationArguments args) =>
+			TryHandleBuiltInActivation(args);
 
-		TaskCompletionSource<WebAuthenticatorResult>? tcsResponse;
-		Uri? currentRedirectUri;
-		WebAuthenticatorOptions? currentOptions;
-		AppWindow? currentAppWindow;
-
-		public bool OnAppInstanceActivatedCallback(AppActivationArguments args)
+		internal static bool TryHandleBuiltInActivation(AppActivationArguments args)
 		{
 			if (args.Kind != ExtendedActivationKind.Protocol ||
 				args.Data is not IProtocolActivatedEventArgs protocolArgs)
@@ -36,47 +35,9 @@ namespace Microsoft.Maui.Authentication
 
 			var callbackUri = protocolArgs.Uri;
 
-			TaskCompletionSource<WebAuthenticatorResult>? response;
-			Uri? redirectUri;
-			WebAuthenticatorOptions? options;
-			AppWindow? appWindow;
-
-			bool isLocalCallbackRoute;
-
-			lock (locker)
-			{
-				response = tcsResponse;
-				redirectUri = currentRedirectUri;
-				options = currentOptions;
-				appWindow = currentAppWindow;
-
-				isLocalCallbackRoute = redirectUri is not null && IsSameCallbackRoute(redirectUri, callbackUri);
-			}
-
-			if (response?.Task.IsCompleted == false &&
-				redirectUri is not null &&
-				WebUtils.CanHandleCallback(redirectUri, callbackUri))
-			{
-				try
-				{
-					var result = new WebAuthenticatorResult(callbackUri, options?.ResponseDecoder);
-
-					// Only the callback that completes the request may restore its window.
-					if (response.TrySetResult(result))
-						TryBringToForeground(appWindow);
-				}
-				catch (Exception ex)
-				{
-					response.TrySetException(ex);
-				}
-
+			// The built-in process-wide request always gets first refusal for a matching route.
+			if (WebAuthenticatorRequestManager.TryHandleCallback(callbackUri))
 				return true;
-			}
-
-			// A callback can have the expected scheme and still fail host validation.
-			// Leave the active route registered so a later valid callback can complete it.
-			if (isLocalCallbackRoute)
-				return false;
 
 			var routeOwner = FindCallbackRouteOwner(callbackUri);
 			if (routeOwner is null)
@@ -85,71 +46,94 @@ namespace Microsoft.Maui.Authentication
 			return RedirectActivationAndExit(routeOwner, args);
 		}
 
-		public async Task<WebAuthenticatorResult> AuthenticateAsync(WebAuthenticatorOptions webAuthenticatorOptions)
-			=> await AuthenticateAsync(webAuthenticatorOptions, CancellationToken.None);
+		public Task<WebAuthenticatorResult> AuthenticateAsync(WebAuthenticatorOptions webAuthenticatorOptions) =>
+			AuthenticateAsync(webAuthenticatorOptions, CancellationToken.None);
 
-		public async Task<WebAuthenticatorResult> AuthenticateAsync(WebAuthenticatorOptions webAuthenticatorOptions, CancellationToken cancellationToken)
+		public async Task<WebAuthenticatorResult> AuthenticateAsync(
+			WebAuthenticatorOptions webAuthenticatorOptions,
+			CancellationToken cancellationToken)
 		{
-			ArgumentNullException.ThrowIfNull(webAuthenticatorOptions);
+			if (webAuthenticatorOptions is null)
+				throw new ArgumentNullException(nameof(webAuthenticatorOptions));
 
-			var url = webAuthenticatorOptions.Url ??
+			var url = webAuthenticatorOptions.Url;
+			var callbackUrl = webAuthenticatorOptions.CallbackUrl;
+			var responseDecoder = webAuthenticatorOptions.ResponseDecoder;
+			var prefersEphemeral = webAuthenticatorOptions.PrefersEphemeralWebBrowserSession;
+
+			if (url is null)
 				throw new ArgumentNullException(nameof(webAuthenticatorOptions.Url));
-			var callbackUrl = webAuthenticatorOptions.CallbackUrl ??
+			if (callbackUrl is null)
 				throw new ArgumentNullException(nameof(webAuthenticatorOptions.CallbackUrl));
-
-			cancellationToken.ThrowIfCancellationRequested();
+			if (!url.IsAbsoluteUri)
+				throw new ArgumentException("The authentication URL must be absolute.", nameof(webAuthenticatorOptions.Url));
+			if (!callbackUrl.IsAbsoluteUri)
+				throw new ArgumentException("The callback URL must be absolute.", nameof(webAuthenticatorOptions.CallbackUrl));
 
 			ValidateCallbackUrl(callbackUrl);
+			cancellationToken.ThrowIfCancellationRequested();
 
-			var response = new TaskCompletionSource<WebAuthenticatorResult>();
-			TaskCompletionSource<WebAuthenticatorResult>? previousResponse;
-
-			// Capture the request window so a multi-window app restores the same window
-			// after authentication completes.
+			// AppWindow is agile and remains strongly captured by the framework-owned closure.
 			var appWindow = TryGetActiveAppWindow();
+			var request = WebAuthenticatorRequestManager.Begin(
+				url,
+				callbackUrl,
+				responseDecoder,
+				prefersEphemeral,
+				cancellationToken,
+				() => TryBringToForeground(appWindow));
 
-			lock (locker)
-			{
-				RegisterCallbackRoute(callbackUrl);
-
-				previousResponse = tcsResponse;
-				tcsResponse = response;
-				currentRedirectUri = callbackUrl;
-				currentOptions = webAuthenticatorOptions;
-				currentAppWindow = appWindow;
-			}
-
-			previousResponse?.TrySetCanceled();
-
-			using (cancellationToken.Register(() => response.TrySetCanceled()))
-			{
-				try
+			var registration = cancellationToken.Register(
+				static state =>
 				{
-					var launched = await global::Windows.System.Launcher.LaunchUriAsync(url);
-					if (!launched)
-						throw new InvalidOperationException("Failed to launch the browser for authentication.");
+					var request = (WebAuthenticatorRequest)state!;
+					WebAuthenticatorRequestManager.TryCancelFromCaller(request);
+				},
+				request);
 
-					return await response.Task;
-				}
-				finally
+			try
+			{
+				if (!request.Task.IsCompleted)
 				{
-					lock (locker)
+					try
 					{
-						if (ReferenceEquals(tcsResponse, response))
-							ClearCurrentAuthentication();
+						RegisterCallbackRoute(callbackUrl);
+					}
+					catch (Exception)
+					{
+						WebAuthenticatorRequestManager.TryFail(
+							request,
+							new InvalidOperationException("Unable to register the WebAuthenticator callback route."));
 					}
 				}
-			}
-		}
 
-		void ClearCurrentAuthentication()
-		{
-			// Do not call UnregisterKey here. Windows App SDK cannot safely register another
-			// key after UnregisterKey (microsoft/WindowsAppSDK#4420).
-			tcsResponse = null;
-			currentRedirectUri = null;
-			currentOptions = null;
-			currentAppWindow = null;
+				if (!request.Task.IsCompleted)
+				{
+					try
+					{
+						if (!await global::Windows.System.Launcher.LaunchUriAsync(url))
+						{
+							WebAuthenticatorRequestManager.TryFail(
+								request,
+								new InvalidOperationException("Failed to launch the browser for authentication."));
+						}
+					}
+					catch (Exception)
+					{
+						WebAuthenticatorRequestManager.TryFail(
+							request,
+							new InvalidOperationException("Failed to launch the browser for authentication."));
+					}
+				}
+
+				return await request.Task.ConfigureAwait(false);
+			}
+			finally
+			{
+				// Windows has no per-request native object to close. Registration disposal precedes End.
+				registration.Dispose();
+				WebAuthenticatorRequestManager.End(request);
+			}
 		}
 
 		static AppWindow? TryGetActiveAppWindow()
@@ -160,7 +144,7 @@ namespace Microsoft.Maui.Authentication
 			}
 			catch (Exception ex)
 			{
-				Debug.WriteLine($"Unable to identify the WebAuthenticator window: {ex}");
+				Debug.WriteLine($"Unable to identify the WebAuthenticator window ({ex}).");
 				return null;
 			}
 		}
@@ -179,8 +163,6 @@ namespace Microsoft.Maui.Authentication
 					return;
 				}
 
-				// AppWindow APIs are agile. Restore or show without activation so the native
-				// call below makes the only best-effort foreground request.
 				if (appWindow.Presenter is OverlappedPresenter presenter &&
 					presenter.State == OverlappedPresenterState.Minimized)
 				{
@@ -190,22 +172,17 @@ namespace Microsoft.Maui.Authentication
 				if (!appWindow.IsVisible)
 					appWindow.Show(false);
 
-				// RedirectActivationToAsync attempts to transfer foreground permission to the
-				// route owner, but Windows can still deny this request.
 				if (!PlatformMethods.SetForegroundWindow(windowHandle))
 					Debug.WriteLine("Windows denied the WebAuthenticator window foreground activation.");
 			}
 			catch (Exception ex)
 			{
-				Debug.WriteLine($"Unable to bring the WebAuthenticator window to the foreground: {ex}");
+				Debug.WriteLine($"Unable to bring the WebAuthenticator window to the foreground ({ex}).");
 			}
 		}
 
 		static void ValidateCallbackUrl(Uri callbackUrl)
 		{
-			if (!callbackUrl.IsAbsoluteUri)
-				throw new InvalidOperationException("The callback URI must be absolute.");
-
 			if (callbackUrl.Scheme is "http" or "https")
 			{
 				throw new InvalidOperationException(
@@ -218,59 +195,77 @@ namespace Microsoft.Maui.Authentication
 				if (!IsUriProtocolDeclared(callbackUrl.Scheme))
 				{
 					throw new InvalidOperationException(
-						$"You need to declare the windows.protocol usage of the " +
-						$"protocol/scheme `{callbackUrl.Scheme}` in your AppxManifest.xml file.");
+						$"You need to declare the windows.protocol usage of scheme '{callbackUrl.Scheme}' " +
+						"for the current application in AppxManifest.xml.");
 				}
 			}
 			else if (!IsRegistryDeclared(callbackUrl.Scheme))
 			{
 				throw new InvalidOperationException(
-					$"The URI scheme '{callbackUrl.Scheme}' is not registered. " +
+					$"The URI scheme '{callbackUrl.Scheme}' is not registered for this application. " +
 					"Call ActivationRegistrationManager.RegisterForProtocolActivation when running unpackaged.");
 			}
 		}
 
 		static void RegisterCallbackRoute(Uri callbackUrl)
 		{
-			var currentInstance = AppInstance.GetCurrent();
-			var routeKey = CreateCallbackRouteKey(callbackUrl);
-			var currentKey = currentInstance.Key;
+			AppInstance currentInstance;
+			string? currentKey;
 
+			try
+			{
+				currentInstance = AppInstance.GetCurrent();
+				currentKey = currentInstance.Key;
+			}
+			catch (Exception)
+			{
+				throw new InvalidOperationException("Unable to inspect the current application instance.");
+			}
+
+			var routeKey = CreateCallbackRouteKey(callbackUrl);
 			if (string.Equals(currentKey, routeKey, StringComparison.Ordinal))
 				return;
 
-			// Preserve application-owned AppInstance routing. Such apps must redirect protocol
-			// activations to this instance so the lifecycle callback above can complete the request.
+			// App-owned keys are never replaced. The app must redirect protocol activations to this instance.
 			if (!CanRegisterCallbackRoute(currentKey))
 				return;
 
-			var routeOwner = AppInstance.FindOrRegisterForKey(routeKey);
-			if (routeOwner is null)
+			// Keep the framework route registered after the request. Explicitly calling UnregisterKey
+			// prevents reliable re-registration (https://github.com/microsoft/WindowsAppSDK/issues/4420),
+			// while FindOrRegisterForKey replaces a previous framework route when the next request uses
+			// a different callback scheme.
+			AppInstance? routeOwner;
+			try
 			{
-				throw new InvalidOperationException(
-					$"Unable to register the callback route for scheme '{callbackUrl.Scheme}'.");
+				routeOwner = AppInstance.FindOrRegisterForKey(routeKey);
+			}
+			catch (Exception)
+			{
+				throw new InvalidOperationException("Unable to register the WebAuthenticator callback route.");
 			}
 
-			if (!routeOwner.IsCurrent)
+			if (routeOwner is null || !routeOwner.IsCurrent ||
+				!string.Equals(routeOwner.Key, routeKey, StringComparison.Ordinal))
 			{
-				throw new InvalidOperationException(
-					$"Another app instance is already waiting for the callback scheme '{callbackUrl.Scheme}'.");
-			}
-
-			if (!string.Equals(routeOwner.Key, routeKey, StringComparison.Ordinal))
-			{
-				throw new InvalidOperationException(
-					$"Unable to register the callback route for scheme '{callbackUrl.Scheme}'.");
+				throw new InvalidOperationException("Another app instance owns the WebAuthenticator callback route.");
 			}
 		}
 
 		static AppInstance? FindCallbackRouteOwner(Uri callbackUri)
 		{
-			var routeKey = CreateCallbackRouteKey(callbackUri);
+			try
+			{
+				var routeKey = CreateCallbackRouteKey(callbackUri);
 
-			return AppInstance.GetInstances().FirstOrDefault(instance =>
-				!instance.IsCurrent &&
-				string.Equals(instance.Key, routeKey, StringComparison.Ordinal));
+				return AppInstance.GetInstances().FirstOrDefault(instance =>
+					!instance.IsCurrent &&
+					string.Equals(instance.Key, routeKey, StringComparison.Ordinal));
+			}
+			catch (Exception ex)
+			{
+				Debug.WriteLine($"Unable to inspect WebAuthenticator callback route ownership ({ex}).");
+				return null;
+			}
 		}
 
 		static bool RedirectActivationAndExit(AppInstance routeOwner, AppActivationArguments args)
@@ -283,11 +278,12 @@ namespace Microsoft.Maui.Authentication
 		{
 			try
 			{
+				// Both arguments remain captured until the asynchronous redirection has finished.
 				await routeOwner.RedirectActivationToAsync(args).AsTask().ConfigureAwait(false);
 			}
 			catch (Exception ex)
 			{
-				Debug.WriteLine($"Unable to redirect WebAuthenticator callback activation: {ex}");
+				Debug.WriteLine($"Unable to redirect WebAuthenticator callback activation ({ex}).");
 			}
 			finally
 			{
@@ -303,12 +299,11 @@ namespace Microsoft.Maui.Authentication
 			}
 			catch (Exception ex)
 			{
-				Debug.WriteLine($"Unable to terminate the transient WebAuthenticator callback process: {ex}");
+				Debug.WriteLine($"Unable to terminate the transient WebAuthenticator callback process ({ex}).");
 				Environment.Exit(1);
 			}
 		}
 
-		// AppInstance keys are app-defined, so keep WebAuthenticator routes separate from application-owned keys.
 		internal static string CreateCallbackRouteKey(Uri callbackUrl) =>
 			$"{CallbackRouteKeyPrefix}{callbackUrl.Scheme}";
 
@@ -324,25 +319,173 @@ namespace Microsoft.Maui.Authentication
 
 		static bool IsUriProtocolDeclared(string scheme)
 		{
-			var docPath = FileSystemUtils.PlatformGetFullAppPackageFilePath(PlatformUtils.AppManifestFilename);
-			var doc = XDocument.Load(docPath, LoadOptions.None);
+			try
+			{
+				var docPath = FileSystemUtils.PlatformGetFullAppPackageFilePath(PlatformUtils.AppManifestFilename);
+				var document = XDocument.Load(docPath, LoadOptions.None);
+				return IsUriProtocolDeclared(document, TryGetCurrentApplicationId(), scheme);
+			}
+			catch (Exception ex)
+			{
+				Debug.WriteLine($"Unable to inspect the current application protocol declaration ({ex}).");
+				return false;
+			}
+		}
 
-			using var reader = doc.CreateReader();
-			var namespaceManager = new XmlNamespaceManager(reader.NameTable);
-			namespaceManager.AddNamespace("uap", PlatformUtils.AppManifestUapXmlns);
+		internal static bool IsUriProtocolDeclared(XDocument document, string? applicationId, string scheme)
+		{
+			if (document?.Root is null || string.IsNullOrEmpty(scheme))
+				return false;
 
-			var root = doc.Root ?? throw new InvalidOperationException("The app manifest could not be loaded.");
-			var declarations = root.XPathSelectElements(
-				$"//uap:Extension[@Category='windows.protocol']/uap:Protocol[@Name='{scheme}']",
-				namespaceManager);
+			var applications = document.Root
+				.Descendants()
+				.Where(element => element.Name.LocalName == "Application" && element.Parent?.Name.LocalName == "Applications")
+				.ToList();
 
-			return declarations.Any();
+			XElement? currentApplication;
+			if (!string.IsNullOrEmpty(applicationId))
+			{
+				currentApplication = applications.FirstOrDefault(element =>
+					string.Equals((string?)element.Attribute("Id"), applicationId, StringComparison.Ordinal));
+			}
+			else
+			{
+				currentApplication = applications.Count == 1 ? applications[0] : null;
+			}
+
+			if (currentApplication is null)
+				return false;
+
+			return currentApplication
+				.Descendants()
+				.Where(element =>
+					element.Name.LocalName == "Extension" &&
+					string.Equals((string?)element.Attribute("Category"), "windows.protocol", StringComparison.Ordinal))
+				.SelectMany(extension => extension.Descendants().Where(element => element.Name.LocalName == "Protocol"))
+				.Any(protocol => string.Equals(
+					(string?)protocol.Attribute("Name"),
+					scheme,
+					StringComparison.OrdinalIgnoreCase));
+		}
+
+		static string? TryGetCurrentApplicationId()
+		{
+			try
+			{
+				if (global::Windows.Foundation.Metadata.ApiInformation.IsTypePresent("Windows.ApplicationModel.AppInfo"))
+				{
+					var applicationId = global::Windows.ApplicationModel.AppInfo.Current.Id;
+					if (!string.IsNullOrEmpty(applicationId))
+						return applicationId;
+				}
+			}
+			catch (Exception ex)
+			{
+				Debug.WriteLine($"Unable to read the current packaged application identity ({ex}).");
+			}
+
+			return TryGetApplicationIdFromAppUserModelId();
+		}
+
+		static string? TryGetApplicationIdFromAppUserModelId()
+		{
+			try
+			{
+				uint length = 0;
+				var result = GetCurrentApplicationUserModelId(ref length, null);
+				if (result != ErrorInsufficientBuffer || length == 0 || length > 4096)
+					return null;
+
+				var builder = new StringBuilder((int)length);
+				result = GetCurrentApplicationUserModelId(ref length, builder);
+				if (result != ErrorSuccess)
+					return null;
+
+				var appUserModelId = builder.ToString();
+				var separatorIndex = appUserModelId.LastIndexOf("!", StringComparison.Ordinal);
+				return separatorIndex >= 0 && separatorIndex + 1 < appUserModelId.Length
+					? appUserModelId.Substring(separatorIndex + 1)
+					: null;
+			}
+			catch (Exception)
+			{
+				return null;
+			}
 		}
 
 		static bool IsRegistryDeclared(string scheme)
 		{
-			using var key = Win32.Registry.ClassesRoot.OpenSubKey(scheme);
-			return key?.GetValue("URL Protocol") is not null;
+			try
+			{
+				using var key = Win32.Registry.ClassesRoot.OpenSubKey(scheme);
+				if (key?.GetValue("URL Protocol") is null)
+					return false;
+
+				using var commandKey = key.OpenSubKey(@"shell\open\command");
+				var command = commandKey?.GetValue(null) as string;
+				return IsRegistryCommandOwnedByCurrentExecutable(command, Environment.ProcessPath);
+			}
+			catch (Exception)
+			{
+				return false;
+			}
 		}
+
+		internal static bool IsRegistryCommandOwnedByCurrentExecutable(string? command, string? currentExecutablePath)
+		{
+			if (string.IsNullOrWhiteSpace(command) || string.IsNullOrWhiteSpace(currentExecutablePath))
+				return true;
+
+			if (!TryGetCommandExecutable(command, out var registeredExecutable) ||
+				!Path.IsPathFullyQualified(registeredExecutable))
+			{
+				return true;
+			}
+
+			try
+			{
+				return string.Equals(
+					Path.GetFullPath(registeredExecutable),
+					Path.GetFullPath(currentExecutablePath),
+					StringComparison.OrdinalIgnoreCase);
+			}
+			catch (Exception)
+			{
+				// Ambiguous commands must not create a false negative.
+				return true;
+			}
+		}
+
+		static bool TryGetCommandExecutable(string command, out string executable)
+		{
+			executable = string.Empty;
+			var trimmed = command.TrimStart();
+			if (trimmed.Length == 0)
+				return false;
+
+			if (trimmed[0] == '"')
+			{
+				var closingQuote = trimmed.IndexOf("\"", 1, StringComparison.Ordinal);
+				if (closingQuote <= 1)
+					return false;
+
+				executable = trimmed.Substring(1, closingQuote - 1);
+			}
+			else
+			{
+				var separator = trimmed.IndexOfAny(new[] { ' ', '\t' });
+				executable = separator < 0 ? trimmed : trimmed.Substring(0, separator);
+			}
+
+			executable = Environment.ExpandEnvironmentVariables(executable);
+			return !string.IsNullOrWhiteSpace(executable) &&
+				!executable.Contains("%", StringComparison.Ordinal) &&
+				string.Equals(Path.GetExtension(executable), ".exe", StringComparison.OrdinalIgnoreCase);
+		}
+
+		[DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+		static extern int GetCurrentApplicationUserModelId(
+			ref uint applicationUserModelIdLength,
+			StringBuilder? applicationUserModelId);
 	}
 }

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.windows.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.windows.cs
@@ -99,11 +99,13 @@ namespace Microsoft.Maui.Authentication
 					{
 						RegisterCallbackRoute(callbackUrl);
 					}
-					catch (Exception)
+					catch (Exception ex)
 					{
 						WebAuthenticatorRequestManager.TryFail(
 							request,
-							new InvalidOperationException("Unable to register the WebAuthenticator callback route."));
+							CreateCallbackRouteException(
+								"Unable to register the WebAuthenticator callback route.",
+								ex));
 					}
 				}
 
@@ -217,9 +219,11 @@ namespace Microsoft.Maui.Authentication
 				currentInstance = AppInstance.GetCurrent();
 				currentKey = currentInstance.Key;
 			}
-			catch (Exception)
+			catch (Exception ex)
 			{
-				throw new InvalidOperationException("Unable to inspect the current application instance.");
+				throw CreateCallbackRouteException(
+					"Unable to inspect the current application instance.",
+					ex);
 			}
 
 			var routeKey = CreateCallbackRouteKey(callbackUrl);
@@ -239,9 +243,11 @@ namespace Microsoft.Maui.Authentication
 			{
 				routeOwner = AppInstance.FindOrRegisterForKey(routeKey);
 			}
-			catch (Exception)
+			catch (Exception ex)
 			{
-				throw new InvalidOperationException("Unable to register the WebAuthenticator callback route.");
+				throw CreateCallbackRouteException(
+					"Unable to register the WebAuthenticator callback route.",
+					ex);
 			}
 
 			if (routeOwner is null || !routeOwner.IsCurrent ||
@@ -310,6 +316,11 @@ namespace Microsoft.Maui.Authentication
 		internal static bool CanRegisterCallbackRoute(string? currentKey) =>
 			string.IsNullOrEmpty(currentKey) ||
 			currentKey.StartsWith(CallbackRouteKeyPrefix, StringComparison.Ordinal);
+
+		internal static InvalidOperationException CreateCallbackRouteException(
+			string message,
+			Exception innerException) =>
+			new(message, innerException);
 
 		internal static bool IsSameCallbackRoute(Uri expectedCallbackUrl, Uri callbackUrl) =>
 			string.Equals(

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticatorCallbackActivity.android.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticatorCallbackActivity.android.cs
@@ -1,5 +1,4 @@
 using Android.App;
-using Android.Content;
 using Android.OS;
 
 namespace Microsoft.Maui.Authentication
@@ -10,24 +9,7 @@ namespace Microsoft.Maui.Authentication
 		{
 			base.OnCreate(savedInstanceState);
 
-			// Check how we launched the flow initially
-			if (WebAuthenticator.Default.IsAuthenticatingWithCustomTabs())
-			{
-				// start the intermediate activity again with flags to close the custom tabs
-				var intent = new Intent(this, typeof(WebAuthenticatorIntermediateActivity));
-				intent.SetData(Intent.Data);
-				intent.PutExtra(WebAuthenticatorIntermediateActivity.LaunchedExtra, true);
-				intent.AddFlags(ActivityFlags.ClearTop | ActivityFlags.SingleTop);
-				StartActivity(intent);
-			}
-			else
-			{
-				// No intermediate activity if we returned from a system browser
-				// intent since there's no custom tab instance to clean up
-				WebAuthenticator.Default.OnResume(Intent);
-			}
-
-			// finish this activity
+			WebAuthenticatorIntermediateActivity.StartCallback(this, Intent?.Data);
 			Finish();
 		}
 	}

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticatorIntermediateActivity.android.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticatorIntermediateActivity.android.cs
@@ -28,6 +28,10 @@ namespace Microsoft.Maui.Authentication
 		const int ModeCustomTab = 2;
 		const int ModeCallback = 3;
 		const int ModeCleanup = 4;
+		const int ModeBrowser = 5;
+
+		static readonly object liveOwnerLock = new();
+		static WeakReference<WebAuthenticatorIntermediateActivity>? liveOwner;
 
 		readonly ActivityResultCallback<AuthTabIntent.AuthResult> authTabResultCallback;
 		readonly ActivityResultLauncher? authTabLauncher;
@@ -86,8 +90,9 @@ namespace Microsoft.Maui.Authentication
 			callbackUrl = extras.GetString(CallbackUrlExtra);
 			provider = extras.GetString(ProviderExtra);
 
-			if ((mode != ModeAuthTab && mode != ModeCustomTab) ||
-				string.IsNullOrEmpty(url) || string.IsNullOrEmpty(provider) ||
+			if ((mode != ModeAuthTab && mode != ModeCustomTab && mode != ModeBrowser) ||
+				string.IsNullOrEmpty(url) ||
+				(mode != ModeBrowser && string.IsNullOrEmpty(provider)) ||
 				(mode == ModeAuthTab && string.IsNullOrEmpty(callbackUrl)))
 			{
 				Finish();
@@ -96,6 +101,8 @@ namespace Microsoft.Maui.Authentication
 					new InvalidOperationException("The Android WebAuthenticator launch state was incomplete."));
 				return;
 			}
+
+			RegisterLiveOwner(this);
 		}
 
 		protected override void OnResume()
@@ -104,7 +111,7 @@ namespace Microsoft.Maui.Authentication
 
 			if (IsFinishing || requestId <= 0 || !WebAuthenticatorRequestManager.IsActive(requestId))
 			{
-				Finish();
+				FinishAndReleaseOwner();
 				return;
 			}
 
@@ -115,12 +122,14 @@ namespace Microsoft.Maui.Authentication
 					LaunchAuthTabOrFallback();
 				else if (mode == ModeCustomTab)
 					LaunchCustomTabOrBrowser();
+				else if (mode == ModeBrowser)
+					LaunchBrowser();
 				return;
 			}
 
-			if (mode == ModeCustomTab)
+			if (mode == ModeCustomTab || mode == ModeBrowser)
 			{
-				Finish();
+				FinishAndReleaseOwner();
 				WebAuthenticatorRequestManager.TryCancelFromPlatform(requestId);
 			}
 		}
@@ -135,14 +144,20 @@ namespace Microsoft.Maui.Authentication
 			var incomingMode = intent.GetIntExtra(ModeExtra, 0);
 			if (incomingMode == ModeCallback)
 			{
-				Finish();
+				FinishAndReleaseOwner();
 				RouteCallback(intent);
 			}
 			else if (incomingMode == ModeCleanup &&
 				intent.GetLongExtra(RequestIdExtra, 0) == requestId)
 			{
-				Finish();
+				FinishAndReleaseOwner();
 			}
+		}
+
+		protected override void OnDestroy()
+		{
+			ReleaseLiveOwner(this);
+			base.OnDestroy();
 		}
 
 		protected override void OnSaveInstanceState(Bundle outState)
@@ -174,19 +189,24 @@ namespace Microsoft.Maui.Authentication
 				{
 					if (!fallbackAvailable)
 					{
-						Finish();
+						FinishAndReleaseOwner();
 						WebAuthenticatorRequestManager.TryFail(
 							requestId,
 							new InvalidOperationException("The selected Android Auth Tab provider is no longer available."));
 						return;
 					}
 
-					mode = ModeCustomTab;
 					provider = replacementProvider;
 					if (string.IsNullOrEmpty(provider))
-						LaunchBrowserAndFinish();
+					{
+						mode = ModeBrowser;
+						LaunchBrowser();
+					}
 					else
+					{
+						mode = ModeCustomTab;
 						LaunchCustomTabOrBrowser();
+					}
 					return;
 				}
 			}
@@ -232,7 +252,7 @@ namespace Microsoft.Maui.Authentication
 				}
 				else
 				{
-					Finish();
+					FinishAndReleaseOwner();
 					WebAuthenticatorRequestManager.TryFail(
 						requestId,
 						new InvalidOperationException("The selected Android Auth Tab provider could not be launched."));
@@ -242,6 +262,13 @@ namespace Microsoft.Maui.Authentication
 
 		void LaunchCustomTabOrBrowser()
 		{
+			if (string.IsNullOrEmpty(provider))
+			{
+				mode = ModeBrowser;
+				LaunchBrowser();
+				return;
+			}
+
 			try
 			{
 				using var builder = new CustomTabsIntent.Builder();
@@ -257,7 +284,8 @@ namespace Microsoft.Maui.Authentication
 
 				if (launchIntent.ResolveActivity(packageManager) is null)
 				{
-					LaunchBrowserAndFinish();
+					mode = ModeBrowser;
+					LaunchBrowser();
 					return;
 				}
 
@@ -265,28 +293,20 @@ namespace Microsoft.Maui.Authentication
 			}
 			catch (Exception)
 			{
-				LaunchBrowserAndFinish();
+				mode = ModeBrowser;
+				LaunchBrowser();
 			}
 		}
 
-		void LaunchBrowserAndFinish()
+		void LaunchBrowser()
 		{
-			var failed = false;
 			try
 			{
 				WebAuthenticatorImplementation.LaunchSystemBrowser(this, new Uri(url!));
 			}
 			catch (Exception)
 			{
-				failed = true;
-			}
-			finally
-			{
-				Finish();
-			}
-
-			if (failed)
-			{
+				FinishAndReleaseOwner();
 				WebAuthenticatorRequestManager.TryFail(
 					requestId,
 					new InvalidOperationException("No browser could be opened for web authentication."));
@@ -295,8 +315,14 @@ namespace Microsoft.Maui.Authentication
 
 		void OnAuthTabResult(AuthTabIntent.AuthResult? result)
 		{
-			Finish();
+			FinishAndReleaseOwner();
 			HandleAuthTabResult(requestId, result?.ResultCode, result?.ResultUri?.ToString());
+		}
+
+		void FinishAndReleaseOwner()
+		{
+			ReleaseLiveOwner(this);
+			Finish();
 		}
 
 		internal static void HandleAuthTabResult(long requestId, int? resultCode, string? callbackUri)
@@ -395,6 +421,9 @@ namespace Microsoft.Maui.Authentication
 			activity.StartActivity(CreateLaunchIntent(activity, ModeCustomTab, requestId, url, provider, prefersEphemeral));
 		}
 
+		internal static void StartBrowser(Activity activity, long requestId, Uri url) =>
+			activity.StartActivity(CreateLaunchIntent(activity, ModeBrowser, requestId, url, null, false));
+
 		internal static void StartCallback(Context context, global::Android.Net.Uri? callbackUri)
 		{
 			var intent = new Intent(context, typeof(WebAuthenticatorIntermediateActivity));
@@ -406,15 +435,17 @@ namespace Microsoft.Maui.Authentication
 			context.StartActivity(intent);
 		}
 
-		internal static void RequestCleanup(Context context, long requestId)
+		internal static bool TryRequestCleanup(long requestId)
 		{
-			var intent = new Intent(context, typeof(WebAuthenticatorIntermediateActivity));
+			if (!TryGetLiveOwner(requestId, out var activity))
+				return false;
+
+			var intent = new Intent(activity, typeof(WebAuthenticatorIntermediateActivity));
 			intent.PutExtra(ModeExtra, ModeCleanup);
 			intent.PutExtra(RequestIdExtra, requestId);
 			intent.AddFlags(global::Android.Content.ActivityFlags.ClearTop | global::Android.Content.ActivityFlags.SingleTop);
-			if (context is not Activity)
-				intent.AddFlags(global::Android.Content.ActivityFlags.NewTask);
-			context.StartActivity(intent);
+			activity.StartActivity(intent);
+			return true;
 		}
 
 		static Intent CreateLaunchIntent(
@@ -422,16 +453,61 @@ namespace Microsoft.Maui.Authentication
 			int mode,
 			long requestId,
 			Uri url,
-			string provider,
+			string? provider,
 			bool prefersEphemeral)
 		{
 			var intent = new Intent(activity, typeof(WebAuthenticatorIntermediateActivity));
 			intent.PutExtra(ModeExtra, mode);
 			intent.PutExtra(RequestIdExtra, requestId);
 			intent.PutExtra(UrlExtra, url.OriginalString);
-			intent.PutExtra(ProviderExtra, provider);
+			if (!string.IsNullOrEmpty(provider))
+				intent.PutExtra(ProviderExtra, provider);
 			intent.PutExtra(EphemeralExtra, prefersEphemeral);
 			return intent;
+		}
+
+		static void RegisterLiveOwner(WebAuthenticatorIntermediateActivity activity)
+		{
+			lock (liveOwnerLock)
+				liveOwner = new WeakReference<WebAuthenticatorIntermediateActivity>(activity);
+		}
+
+		static bool TryGetLiveOwner(long requestId, out WebAuthenticatorIntermediateActivity activity)
+		{
+			lock (liveOwnerLock)
+			{
+				if (liveOwner is null || !liveOwner.TryGetTarget(out var currentActivity))
+				{
+					liveOwner = null;
+					activity = null!;
+					return false;
+				}
+
+				if (currentActivity.requestId == requestId &&
+					!currentActivity.IsFinishing &&
+					!currentActivity.IsDestroyed)
+				{
+					activity = currentActivity;
+					return true;
+				}
+			}
+
+			activity = null!;
+			return false;
+		}
+
+		static void ReleaseLiveOwner(WebAuthenticatorIntermediateActivity activity)
+		{
+			lock (liveOwnerLock)
+			{
+				if (liveOwner is null)
+					return;
+
+				if (liveOwner.TryGetTarget(out var currentActivity) && !ReferenceEquals(currentActivity, activity))
+					return;
+
+				liveOwner = null;
+			}
 		}
 	}
 }

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticatorIntermediateActivity.android.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticatorIntermediateActivity.android.cs
@@ -1,83 +1,437 @@
+#nullable enable
+using System;
 using Android.App;
 using Android.Content;
 using Android.Content.PM;
 using Android.OS;
+using AndroidX.Activity;
+using AndroidX.Activity.Result;
+using AndroidX.Browser.Auth;
+using AndroidX.Browser.CustomTabs;
+using Microsoft.Maui.ApplicationModel;
 
 namespace Microsoft.Maui.Authentication
 {
 	[Activity(ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize, Exported = false)]
-	class WebAuthenticatorIntermediateActivity : Activity
+	class WebAuthenticatorIntermediateActivity : ComponentActivity
 	{
-		internal const string LaunchedExtra = "launched";
-		internal const string ActualIntentExtra = "actual_intent";
+		const string ModeExtra = "maui.webauthenticator.mode";
+		const string RequestIdExtra = "maui.webauthenticator.request_id";
+		const string UrlExtra = "maui.webauthenticator.url";
+		const string CallbackUrlExtra = "maui.webauthenticator.callback_url";
+		const string ProviderExtra = "maui.webauthenticator.provider";
+		const string EphemeralExtra = "maui.webauthenticator.ephemeral";
+		const string FallbackAvailableExtra = "maui.webauthenticator.fallback_available";
+		const string LaunchedExtra = "maui.webauthenticator.launched";
 
+		const int ModeAuthTab = 1;
+		const int ModeCustomTab = 2;
+		const int ModeCallback = 3;
+		const int ModeCleanup = 4;
+
+		readonly ActivityResultCallback<AuthTabIntent.AuthResult> authTabResultCallback;
+		readonly ActivityResultLauncher? authTabLauncher;
+
+		long requestId;
+		int mode;
 		bool launched;
-		Intent actualIntent;
+		bool prefersEphemeral;
+		bool fallbackAvailable;
+		string? url;
+		string? callbackUrl;
+		string? provider;
 
-		protected override void OnCreate(Bundle savedInstanceState)
+		public WebAuthenticatorIntermediateActivity()
+		{
+			authTabResultCallback = new ActivityResultCallback<AuthTabIntent.AuthResult>(OnAuthTabResult);
+			authTabLauncher = AuthTabIntent.RegisterActivityResultLauncher(this, authTabResultCallback);
+		}
+
+		protected override void OnCreate(Bundle? savedInstanceState)
 		{
 			base.OnCreate(savedInstanceState);
 
-			var extras = savedInstanceState ?? Intent.Extras;
-
-			if (extras == null)
+			var extras = savedInstanceState ?? Intent?.Extras;
+			if (extras is null)
 			{
+				Finish();
 				return;
 			}
 
-			// read the values
-			launched = extras.GetBoolean(LaunchedExtra, false);
-#pragma warning disable 618 // TODO: one day use the API 33+ version: https://developer.android.com/reference/android/os/Bundle#getParcelable(java.lang.String,%20java.lang.Class%3CT%3E)
-#pragma warning disable CA1422 // Validate platform compatibility
-#pragma warning disable CA1416 // Validate platform compatibility
-			actualIntent = extras.GetParcelable(ActualIntentExtra) as Intent;
-#pragma warning restore CA1422 // Validate platform compatibility
-#pragma warning restore CA1416 // Validate platform compatibility
-#pragma warning restore 618
+			mode = extras.GetInt(ModeExtra);
+			if (mode == ModeCallback)
+			{
+				Finish();
+				RouteCallback(Intent);
+				return;
+			}
+
+			requestId = extras.GetLong(RequestIdExtra);
+			if (requestId <= 0 || !WebAuthenticatorRequestManager.IsActive(requestId))
+			{
+				Finish();
+				return;
+			}
+
+			if (mode == ModeCleanup)
+			{
+				Finish();
+				return;
+			}
+
+			launched = extras.GetBoolean(LaunchedExtra);
+			prefersEphemeral = extras.GetBoolean(EphemeralExtra);
+			fallbackAvailable = extras.GetBoolean(FallbackAvailableExtra);
+			url = extras.GetString(UrlExtra);
+			callbackUrl = extras.GetString(CallbackUrlExtra);
+			provider = extras.GetString(ProviderExtra);
+
+			if ((mode != ModeAuthTab && mode != ModeCustomTab) ||
+				string.IsNullOrEmpty(url) || string.IsNullOrEmpty(provider) ||
+				(mode == ModeAuthTab && string.IsNullOrEmpty(callbackUrl)))
+			{
+				Finish();
+				WebAuthenticatorRequestManager.TryFail(
+					requestId,
+					new InvalidOperationException("The Android WebAuthenticator launch state was incomplete."));
+				return;
+			}
 		}
 
 		protected override void OnResume()
 		{
 			base.OnResume();
 
+			if (IsFinishing || requestId <= 0 || !WebAuthenticatorRequestManager.IsActive(requestId))
+			{
+				Finish();
+				return;
+			}
+
 			if (!launched)
 			{
-				// if this is the first time, start the authentication flow
-				StartActivity(actualIntent);
-
 				launched = true;
+				if (mode == ModeAuthTab)
+					LaunchAuthTabOrFallback();
+				else if (mode == ModeCustomTab)
+					LaunchCustomTabOrBrowser();
+				return;
 			}
-			else
-			{
-				// otherwise, resume the auth flow and finish this activity
-				WebAuthenticator.Default.OnResume(Intent!);
 
+			if (mode == ModeCustomTab)
+			{
+				Finish();
+				WebAuthenticatorRequestManager.TryCancelFromPlatform(requestId);
+			}
+		}
+
+		protected override void OnNewIntent(Intent? intent)
+		{
+			base.OnNewIntent(intent);
+			if (intent is null)
+				return;
+
+			Intent = intent;
+			var incomingMode = intent.GetIntExtra(ModeExtra, 0);
+			if (incomingMode == ModeCallback)
+			{
+				Finish();
+				RouteCallback(intent);
+			}
+			else if (incomingMode == ModeCleanup &&
+				intent.GetLongExtra(RequestIdExtra, 0) == requestId)
+			{
 				Finish();
 			}
 		}
 
-		protected override void OnNewIntent(Intent intent)
-		{
-			base.OnNewIntent(intent);
-
-			Intent = intent;
-		}
-
 		protected override void OnSaveInstanceState(Bundle outState)
 		{
-			// save the values
+			outState.PutInt(ModeExtra, mode);
+			outState.PutLong(RequestIdExtra, requestId);
 			outState.PutBoolean(LaunchedExtra, launched);
-			outState.PutParcelable(ActualIntentExtra, actualIntent);
+			outState.PutBoolean(EphemeralExtra, prefersEphemeral);
+			outState.PutBoolean(FallbackAvailableExtra, fallbackAvailable);
+			outState.PutString(UrlExtra, url);
+			outState.PutString(CallbackUrlExtra, callbackUrl);
+			outState.PutString(ProviderExtra, provider);
 
 			base.OnSaveInstanceState(outState);
 		}
 
-		public static void StartActivity(Activity activity, Intent intent)
+		void LaunchAuthTabOrFallback()
 		{
-			var intermediateIntent = new Intent(activity, typeof(WebAuthenticatorIntermediateActivity));
-			intermediateIntent.PutExtra(ActualIntentExtra, intent);
+			var selectedProvider = provider;
+			if (!WebAuthenticatorImplementation.IsAuthTabSupported(this, selectedProvider))
+			{
+				var replacementProvider = WebAuthenticatorImplementation.TryGetCustomTabsProvider(this);
+				if (WebAuthenticatorImplementation.IsAuthTabSupported(this, replacementProvider))
+				{
+					selectedProvider = replacementProvider;
+					provider = replacementProvider;
+				}
+				else
+				{
+					if (!fallbackAvailable)
+					{
+						Finish();
+						WebAuthenticatorRequestManager.TryFail(
+							requestId,
+							new InvalidOperationException("The selected Android Auth Tab provider is no longer available."));
+						return;
+					}
 
-			activity.StartActivity(intermediateIntent);
+					mode = ModeCustomTab;
+					provider = replacementProvider;
+					if (string.IsNullOrEmpty(provider))
+						LaunchBrowserAndFinish();
+					else
+						LaunchCustomTabOrBrowser();
+					return;
+				}
+			}
+
+			try
+			{
+				using var builder = new AuthTabIntent.Builder();
+				if (prefersEphemeral && WebAuthenticatorImplementation.IsEphemeralBrowsingSupported(this, selectedProvider))
+					builder.SetEphemeralBrowsingEnabled(true);
+
+				if (authTabLauncher is null)
+					throw new InvalidOperationException();
+
+				using var authTabIntent = builder.Build() ?? throw new InvalidOperationException();
+				var launchIntent = authTabIntent.Intent ?? throw new InvalidOperationException();
+				var packageManager = PackageManager ?? throw new InvalidOperationException();
+				launchIntent.SetPackage(selectedProvider!);
+				var nativeUrl = global::Android.Net.Uri.Parse(url!);
+				var expectedCallback = new Uri(callbackUrl!);
+
+				if (nativeUrl is null || launchIntent.ResolveActivity(packageManager) is null)
+					throw new ActivityNotFoundException();
+
+				if (expectedCallback.Scheme == "https")
+				{
+					authTabIntent.Launch(
+						authTabLauncher,
+						nativeUrl,
+						expectedCallback.Host,
+						expectedCallback.AbsolutePath);
+				}
+				else
+				{
+					authTabIntent.Launch(authTabLauncher, nativeUrl, expectedCallback.Scheme);
+				}
+			}
+			catch (Exception)
+			{
+				if (fallbackAvailable)
+				{
+					mode = ModeCustomTab;
+					LaunchCustomTabOrBrowser();
+				}
+				else
+				{
+					Finish();
+					WebAuthenticatorRequestManager.TryFail(
+						requestId,
+						new InvalidOperationException("The selected Android Auth Tab provider could not be launched."));
+				}
+			}
+		}
+
+		void LaunchCustomTabOrBrowser()
+		{
+			try
+			{
+				using var builder = new CustomTabsIntent.Builder();
+				builder.SetShowTitle(true);
+				if (prefersEphemeral && WebAuthenticatorImplementation.IsEphemeralBrowsingSupported(this, provider))
+					builder.SetEphemeralBrowsingEnabled(true);
+
+				using var customTabsIntent = builder.Build() ?? throw new InvalidOperationException();
+				var launchIntent = customTabsIntent.Intent ?? throw new InvalidOperationException();
+				var packageManager = PackageManager ?? throw new InvalidOperationException();
+				launchIntent.SetPackage(provider);
+				launchIntent.SetData(global::Android.Net.Uri.Parse(url!));
+
+				if (launchIntent.ResolveActivity(packageManager) is null)
+				{
+					LaunchBrowserAndFinish();
+					return;
+				}
+
+				StartActivity(launchIntent);
+			}
+			catch (Exception)
+			{
+				LaunchBrowserAndFinish();
+			}
+		}
+
+		void LaunchBrowserAndFinish()
+		{
+			var failed = false;
+			try
+			{
+				WebAuthenticatorImplementation.LaunchSystemBrowser(this, new Uri(url!));
+			}
+			catch (Exception)
+			{
+				failed = true;
+			}
+			finally
+			{
+				Finish();
+			}
+
+			if (failed)
+			{
+				WebAuthenticatorRequestManager.TryFail(
+					requestId,
+					new InvalidOperationException("No browser could be opened for web authentication."));
+			}
+		}
+
+		void OnAuthTabResult(AuthTabIntent.AuthResult? result)
+		{
+			Finish();
+			HandleAuthTabResult(requestId, result?.ResultCode, result?.ResultUri?.ToString());
+		}
+
+		internal static void HandleAuthTabResult(long requestId, int? resultCode, string? callbackUri)
+		{
+			if (requestId <= 0 || resultCode is null)
+			{
+				if (requestId > 0)
+				{
+					WebAuthenticatorRequestManager.TryFail(
+						requestId,
+						new InvalidOperationException("Android Auth Tab did not return a result."));
+				}
+				return;
+			}
+
+			if (resultCode == AuthTabIntent.ResultOk)
+			{
+				if (string.IsNullOrEmpty(callbackUri))
+				{
+					WebAuthenticatorRequestManager.TryHandleTerminalCallback(requestId, null);
+					return;
+				}
+
+				try
+				{
+					WebAuthenticatorRequestManager.TryHandleTerminalCallback(requestId, new Uri(callbackUri));
+				}
+				catch (Exception)
+				{
+					WebAuthenticatorRequestManager.TryFail(
+						requestId,
+						new InvalidOperationException("Android Auth Tab returned an invalid callback URI."));
+				}
+			}
+			else if (resultCode == AuthTabIntent.ResultCanceled)
+			{
+				WebAuthenticatorRequestManager.TryCancelFromPlatform(requestId);
+			}
+			else if (resultCode == AuthTabIntent.ResultVerificationFailed)
+			{
+				WebAuthenticatorRequestManager.TryFail(
+					requestId,
+					new InvalidOperationException("Android Auth Tab could not verify the HTTPS callback ownership."));
+			}
+			else if (resultCode == AuthTabIntent.ResultVerificationTimedOut)
+			{
+				WebAuthenticatorRequestManager.TryFail(
+					requestId,
+					new InvalidOperationException("Android Auth Tab timed out while verifying the HTTPS callback ownership."));
+			}
+			else
+			{
+				WebAuthenticatorRequestManager.TryFail(
+					requestId,
+					new InvalidOperationException("Android Auth Tab returned an unknown result."));
+			}
+		}
+
+		static void RouteCallback(Intent? intent)
+		{
+			if (intent is null)
+				return;
+
+			try
+			{
+				WebAuthenticator.Default.OnResume(intent);
+			}
+			catch (Exception)
+			{
+				// Lifecycle routing must never crash the callback activity.
+			}
+		}
+
+		internal static void StartAuthTab(
+			Activity activity,
+			long requestId,
+			Uri url,
+			Uri callbackUrl,
+			string provider,
+			bool prefersEphemeral,
+			bool fallbackAvailable)
+		{
+			var intent = CreateLaunchIntent(activity, ModeAuthTab, requestId, url, provider, prefersEphemeral);
+			intent.PutExtra(CallbackUrlExtra, callbackUrl.OriginalString);
+			intent.PutExtra(FallbackAvailableExtra, fallbackAvailable);
+			activity.StartActivity(intent);
+		}
+
+		internal static void StartCustomTab(
+			Activity activity,
+			long requestId,
+			Uri url,
+			string provider,
+			bool prefersEphemeral)
+		{
+			activity.StartActivity(CreateLaunchIntent(activity, ModeCustomTab, requestId, url, provider, prefersEphemeral));
+		}
+
+		internal static void StartCallback(Context context, global::Android.Net.Uri? callbackUri)
+		{
+			var intent = new Intent(context, typeof(WebAuthenticatorIntermediateActivity));
+			intent.PutExtra(ModeExtra, ModeCallback);
+			intent.SetData(callbackUri);
+			intent.AddFlags(global::Android.Content.ActivityFlags.ClearTop | global::Android.Content.ActivityFlags.SingleTop);
+			if (context is not Activity)
+				intent.AddFlags(global::Android.Content.ActivityFlags.NewTask);
+			context.StartActivity(intent);
+		}
+
+		internal static void RequestCleanup(Context context, long requestId)
+		{
+			var intent = new Intent(context, typeof(WebAuthenticatorIntermediateActivity));
+			intent.PutExtra(ModeExtra, ModeCleanup);
+			intent.PutExtra(RequestIdExtra, requestId);
+			intent.AddFlags(global::Android.Content.ActivityFlags.ClearTop | global::Android.Content.ActivityFlags.SingleTop);
+			if (context is not Activity)
+				intent.AddFlags(global::Android.Content.ActivityFlags.NewTask);
+			context.StartActivity(intent);
+		}
+
+		static Intent CreateLaunchIntent(
+			Activity activity,
+			int mode,
+			long requestId,
+			Uri url,
+			string provider,
+			bool prefersEphemeral)
+		{
+			var intent = new Intent(activity, typeof(WebAuthenticatorIntermediateActivity));
+			intent.PutExtra(ModeExtra, mode);
+			intent.PutExtra(RequestIdExtra, requestId);
+			intent.PutExtra(UrlExtra, url.OriginalString);
+			intent.PutExtra(ProviderExtra, provider);
+			intent.PutExtra(EphemeralExtra, prefersEphemeral);
+			return intent;
 		}
 	}
 }

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticatorRequest.shared.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticatorRequest.shared.cs
@@ -1,0 +1,62 @@
+#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Maui.Authentication
+{
+	sealed class WebAuthenticatorRequest
+	{
+		readonly TaskCompletionSource<WebAuthenticatorResult> responseSource =
+			new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		internal WebAuthenticatorRequest(
+			long id,
+			Uri url,
+			Uri callbackUrl,
+			IWebAuthenticatorResponseDecoder? responseDecoder,
+			bool prefersEphemeralWebBrowserSession,
+			CancellationToken cancellationToken,
+			Action? beforeCallbackCompletion)
+		{
+			Id = id;
+			Url = url;
+			CallbackUrl = callbackUrl;
+			ResponseDecoder = responseDecoder;
+			PrefersEphemeralWebBrowserSession = prefersEphemeralWebBrowserSession;
+			CancellationToken = cancellationToken;
+			BeforeCallbackCompletion = beforeCallbackCompletion;
+		}
+
+		internal long Id { get; }
+
+		internal Uri Url { get; }
+
+		internal Uri CallbackUrl { get; }
+
+		internal IWebAuthenticatorResponseDecoder? ResponseDecoder { get; }
+
+		internal bool PrefersEphemeralWebBrowserSession { get; }
+
+		internal CancellationToken CancellationToken { get; }
+
+		internal Task<WebAuthenticatorResult> Task => responseSource.Task;
+
+		internal Action? BeforeCallbackCompletion { get; }
+
+		// Only WebAuthenticatorRequestManager may read or write this field, and only while holding its process-wide lock.
+		internal bool CompletionClaimed;
+
+		internal bool TrySetResult(WebAuthenticatorResult result) =>
+			responseSource.TrySetResult(result);
+
+		internal bool TrySetCanceled() =>
+			responseSource.TrySetCanceled();
+
+		internal bool TrySetCanceled(CancellationToken cancellationToken) =>
+			responseSource.TrySetCanceled(cancellationToken);
+
+		internal bool TrySetException(Exception exception) =>
+			responseSource.TrySetException(exception);
+	}
+}

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticatorRequestManager.shared.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticatorRequestManager.shared.cs
@@ -1,0 +1,243 @@
+#nullable enable
+using System;
+using System.Diagnostics;
+using System.Threading;
+
+namespace Microsoft.Maui.Authentication
+{
+	static class WebAuthenticatorRequestManager
+	{
+		static readonly object locker = new();
+
+		static WebAuthenticatorRequest? activeRequest;
+		static long nextRequestId;
+
+		internal static WebAuthenticatorRequest Begin(
+			Uri url,
+			Uri callbackUrl,
+			IWebAuthenticatorResponseDecoder? responseDecoder,
+			bool prefersEphemeralWebBrowserSession,
+			CancellationToken cancellationToken,
+			Action? beforeCallbackCompletion = null)
+		{
+			if (url is null)
+				throw new ArgumentNullException(nameof(url));
+			if (callbackUrl is null)
+				throw new ArgumentNullException(nameof(callbackUrl));
+			if (!url.IsAbsoluteUri)
+				throw new ArgumentException("The authentication URL must be absolute.", nameof(url));
+			if (!callbackUrl.IsAbsoluteUri)
+				throw new ArgumentException("The callback URL must be absolute.", nameof(callbackUrl));
+
+			cancellationToken.ThrowIfCancellationRequested();
+
+			lock (locker)
+			{
+				if (activeRequest is not null)
+					throw new InvalidOperationException("Another WebAuthenticator operation is already in progress.");
+
+				nextRequestId = nextRequestId == long.MaxValue ? 1 : nextRequestId + 1;
+
+				activeRequest = new WebAuthenticatorRequest(
+					nextRequestId,
+					url,
+					callbackUrl,
+					responseDecoder,
+					prefersEphemeralWebBrowserSession,
+					cancellationToken,
+					beforeCallbackCompletion);
+
+				return activeRequest;
+			}
+		}
+
+		internal static bool TryHandleCallback(Uri? callbackUri)
+		{
+			WebAuthenticatorRequest request;
+
+			lock (locker)
+			{
+				request = activeRequest!;
+				if (request is null || callbackUri is null || !callbackUri.IsAbsoluteUri)
+					return false;
+
+				if (!WebUtils.CanHandleCallback(request.CallbackUrl, callbackUri))
+					return false;
+
+				// Protect duplicates while the platform is still cleaning up and before End removes the request.
+				if (request.CompletionClaimed)
+					return true;
+
+				request.CompletionClaimed = true;
+			}
+
+			CompleteCallback(request, callbackUri);
+			return true;
+		}
+
+		internal static bool TryHandleTerminalCallback(WebAuthenticatorRequest request, Uri? callbackUri)
+		{
+			if (request is null)
+				throw new ArgumentNullException(nameof(request));
+
+			if (!TryReserve(request))
+				return false;
+
+			CompleteTerminalCallback(request, callbackUri);
+			return true;
+		}
+
+		internal static bool TryHandleTerminalCallback(long requestId, Uri? callbackUri)
+		{
+			if (!TryReserve(requestId, out var request))
+				return false;
+
+			CompleteTerminalCallback(request, callbackUri);
+			return true;
+		}
+
+		internal static bool TryCancelFromCaller(WebAuthenticatorRequest request)
+		{
+			if (request is null)
+				throw new ArgumentNullException(nameof(request));
+
+			if (!TryReserve(request))
+				return false;
+
+			request.TrySetCanceled(request.CancellationToken);
+			return true;
+		}
+
+		internal static bool TryCancelFromPlatform(WebAuthenticatorRequest request)
+		{
+			if (request is null)
+				throw new ArgumentNullException(nameof(request));
+
+			if (!TryReserve(request))
+				return false;
+
+			request.TrySetCanceled();
+			return true;
+		}
+
+		internal static bool TryCancelFromPlatform(long requestId)
+		{
+			if (!TryReserve(requestId, out var request))
+				return false;
+
+			request.TrySetCanceled();
+			return true;
+		}
+
+		internal static bool TryFail(WebAuthenticatorRequest request, Exception exception)
+		{
+			if (request is null)
+				throw new ArgumentNullException(nameof(request));
+			if (exception is null)
+				throw new ArgumentNullException(nameof(exception));
+
+			if (!TryReserve(request))
+				return false;
+
+			request.TrySetException(exception);
+			return true;
+		}
+
+		internal static bool TryFail(long requestId, Exception exception)
+		{
+			if (exception is null)
+				throw new ArgumentNullException(nameof(exception));
+
+			if (!TryReserve(requestId, out var request))
+				return false;
+
+			request.TrySetException(exception);
+			return true;
+		}
+
+		internal static bool End(WebAuthenticatorRequest request)
+		{
+			if (request is null)
+				throw new ArgumentNullException(nameof(request));
+
+			lock (locker)
+			{
+				if (!ReferenceEquals(activeRequest, request))
+					return false;
+
+				activeRequest = null;
+				return true;
+			}
+		}
+
+		internal static bool IsActive(long requestId)
+		{
+			lock (locker)
+				return activeRequest?.Id == requestId;
+		}
+
+		static bool TryReserve(WebAuthenticatorRequest request)
+		{
+			lock (locker)
+			{
+				if (!ReferenceEquals(activeRequest, request) || request.CompletionClaimed)
+					return false;
+
+				request.CompletionClaimed = true;
+				return true;
+			}
+		}
+
+		static bool TryReserve(long requestId, out WebAuthenticatorRequest request)
+		{
+			lock (locker)
+			{
+				request = activeRequest!;
+				if (request is null || request.Id != requestId || request.CompletionClaimed)
+					return false;
+
+				request.CompletionClaimed = true;
+				return true;
+			}
+		}
+
+		static void CompleteTerminalCallback(WebAuthenticatorRequest request, Uri? callbackUri)
+		{
+			if (callbackUri is null || !callbackUri.IsAbsoluteUri)
+			{
+				request.TrySetException(new InvalidOperationException("The native authentication result did not include an absolute callback URI."));
+				return;
+			}
+
+			if (!WebUtils.CanHandleCallback(request.CallbackUrl, callbackUri))
+			{
+				request.TrySetException(new InvalidOperationException("The native authentication result did not match the expected callback route."));
+				return;
+			}
+
+			CompleteCallback(request, callbackUri);
+		}
+
+		static void CompleteCallback(WebAuthenticatorRequest request, Uri callbackUri)
+		{
+			try
+			{
+				request.BeforeCallbackCompletion?.Invoke();
+			}
+			catch (Exception ex)
+			{
+				Debug.WriteLine($"WebAuthenticator pre-completion callback failed ({ex.GetType().Name}).");
+			}
+
+			try
+			{
+				request.TrySetResult(new WebAuthenticatorResult(callbackUri, request.ResponseDecoder));
+			}
+			catch (Exception ex)
+			{
+				// Decoder exceptions are delivered to the caller without logging their contents.
+				request.TrySetException(ex);
+			}
+		}
+	}
+}

--- a/src/Essentials/test/DeviceTests/Tests/Android/WebAuthenticator_Android_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Android/WebAuthenticator_Android_Tests.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 	}
 
 	[Collection(AndroidWebAuthenticatorCollection.CollectionName)]
+	[Category("WebAuthenticator")]
 	public class WebAuthenticator_Android_Tests : IDisposable
 	{
 		readonly List<WebAuthenticatorRequest> requests = new();

--- a/src/Essentials/test/DeviceTests/Tests/Android/WebAuthenticator_Android_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Android/WebAuthenticator_Android_Tests.cs
@@ -1,0 +1,226 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Android.Content;
+using AndroidX.Browser.Auth;
+using Microsoft.Maui.Authentication;
+using Xunit;
+
+namespace Microsoft.Maui.Essentials.DeviceTests
+{
+	[CollectionDefinition(CollectionName, DisableParallelization = true)]
+	public sealed class AndroidWebAuthenticatorCollection
+	{
+		public const string CollectionName = "Android WebAuthenticator";
+	}
+
+	[Collection(AndroidWebAuthenticatorCollection.CollectionName)]
+	public class WebAuthenticator_Android_Tests : IDisposable
+	{
+		readonly List<WebAuthenticatorRequest> requests = new();
+
+		[Theory]
+		[InlineData("https://example.com/authorize", "maui-auth://callback", true)]
+		[InlineData("http://example.com/authorize", "https://app.example/callback", true)]
+		[InlineData("https://example.com/authorize", "https://app.example:8443/callback", false)]
+		[InlineData("https://example.com/authorize", "http://app.example/callback", false)]
+		[InlineData("maui-auth://authorize", "maui-auth://callback", false)]
+		public void AuthTabEligibilityRequiresAWebAuthorizationUrlAndNonHttpCallback(
+			string authorizationUrl,
+			string callbackUrl,
+			bool expected)
+		{
+			Assert.Equal(
+				expected,
+				WebAuthenticatorImplementation.CanUseAuthTab(new Uri(authorizationUrl), new Uri(callbackUrl)));
+		}
+
+		[Fact]
+		public async Task BuiltInCallbackPrecedesCustomFacade()
+		{
+			var request = Begin();
+			var custom = new CallbackAuthenticator();
+			using var intent = new Intent(Intent.ActionView, global::Android.Net.Uri.Parse("maui-auth://callback?code=sample-code"));
+
+			Assert.True(custom.OnResume(intent));
+			Assert.Equal(0, custom.CallbackCount);
+			Assert.Equal("sample-code", (await request.Task).Properties["code"]);
+		}
+
+		[Fact]
+		public void UnhandledCallbackFlowsToCustomFacade()
+		{
+			var custom = new CallbackAuthenticator();
+			using var intent = new Intent(Intent.ActionView, global::Android.Net.Uri.Parse("other-auth://callback"));
+
+			Assert.True(custom.OnResume(intent));
+			Assert.Equal(1, custom.CallbackCount);
+		}
+
+		[Fact]
+		public async Task RouteMismatchFlowsToCustomFacadeAndLeavesBuiltInRequestPending()
+		{
+			var request = Begin();
+			var custom = new CallbackAuthenticator();
+			using var mismatchIntent = new Intent(Intent.ActionView, global::Android.Net.Uri.Parse("maui-auth://other?code=ignored"));
+			using var callbackIntent = new Intent(Intent.ActionView, global::Android.Net.Uri.Parse("maui-auth://callback?code=sample-code"));
+
+			Assert.True(custom.OnResume(mismatchIntent));
+			Assert.Equal(1, custom.CallbackCount);
+			Assert.False(request.Task.IsCompleted);
+
+			Assert.True(custom.OnResume(callbackIntent));
+			Assert.Equal(1, custom.CallbackCount);
+			Assert.Equal("sample-code", (await request.Task).Properties["code"]);
+		}
+
+		[Fact]
+		public async Task SuccessfulAuthTabResultCompletesTheBoundRequest()
+		{
+			var request = Begin();
+
+			WebAuthenticatorIntermediateActivity.HandleAuthTabResult(
+				request.Id,
+				AuthTabIntent.ResultOk,
+				"maui-auth://callback?code=sample-code");
+
+			Assert.Equal("sample-code", (await request.Task).Properties["code"]);
+		}
+
+		[Fact]
+		public async Task AuthTabBackOrCloseCancelsTheBoundRequest()
+		{
+			var request = Begin();
+
+			WebAuthenticatorIntermediateActivity.HandleAuthTabResult(
+				request.Id,
+				AuthTabIntent.ResultCanceled,
+				null);
+
+			await Assert.ThrowsAnyAsync<OperationCanceledException>(() => request.Task);
+		}
+
+		[Theory]
+		[InlineData(AuthTabIntent.ResultVerificationFailed, "verify")]
+		[InlineData(AuthTabIntent.ResultVerificationTimedOut, "timed out")]
+		[InlineData(-42, "unknown")]
+		public async Task AuthTabFailuresAreTerminalAndRedacted(int resultCode, string expectedMessage)
+		{
+			var request = Begin();
+
+			WebAuthenticatorIntermediateActivity.HandleAuthTabResult(request.Id, resultCode, null);
+
+			var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => request.Task);
+			Assert.Contains(expectedMessage, exception.Message, StringComparison.OrdinalIgnoreCase);
+			Assert.DoesNotContain("?", exception.Message, StringComparison.Ordinal);
+		}
+
+		[Fact]
+		public async Task SuccessfulAuthTabResultWithoutCallbackUriFaultsTheBoundRequest()
+		{
+			var request = Begin();
+
+			WebAuthenticatorIntermediateActivity.HandleAuthTabResult(request.Id, AuthTabIntent.ResultOk, null);
+
+			var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => request.Task);
+			Assert.Contains("did not include", exception.Message, StringComparison.OrdinalIgnoreCase);
+		}
+
+		[Fact]
+		public async Task AuthTabTerminalMismatchFaultsTheBoundRequest()
+		{
+			var request = Begin();
+
+			WebAuthenticatorIntermediateActivity.HandleAuthTabResult(
+				request.Id,
+				AuthTabIntent.ResultOk,
+				"maui-auth://wrong-path?code=sample-code");
+
+			var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => request.Task);
+			Assert.Contains("did not match", exception.Message, StringComparison.OrdinalIgnoreCase);
+		}
+
+		[Fact]
+		public async Task StaleAuthTabResultCannotCompleteASuccessor()
+		{
+			var first = Begin();
+			WebAuthenticatorIntermediateActivity.HandleAuthTabResult(
+				first.Id,
+				AuthTabIntent.ResultCanceled,
+				null);
+			await Assert.ThrowsAnyAsync<OperationCanceledException>(() => first.Task);
+			Assert.True(WebAuthenticatorRequestManager.End(first));
+
+			var successor = Begin();
+			WebAuthenticatorIntermediateActivity.HandleAuthTabResult(
+				first.Id,
+				AuthTabIntent.ResultOk,
+				"maui-auth://callback?code=stale");
+
+			Assert.False(successor.Task.IsCompleted);
+
+			WebAuthenticatorIntermediateActivity.HandleAuthTabResult(
+				successor.Id,
+				AuthTabIntent.ResultOk,
+				"maui-auth://callback?code=current");
+			Assert.Equal("current", (await successor.Task).Properties["code"]);
+		}
+
+		[Fact]
+		public async Task MissingOrUnknownRequestIdDoesNotAffectTheCurrentRequest()
+		{
+			var request = Begin();
+
+			WebAuthenticatorIntermediateActivity.HandleAuthTabResult(0, AuthTabIntent.ResultOk, null);
+			WebAuthenticatorIntermediateActivity.HandleAuthTabResult(request.Id + 1, AuthTabIntent.ResultOk, null);
+
+			Assert.False(request.Task.IsCompleted);
+
+			WebAuthenticatorIntermediateActivity.HandleAuthTabResult(
+				request.Id,
+				AuthTabIntent.ResultOk,
+				"maui-auth://callback?code=current");
+			await request.Task;
+		}
+
+		public void Dispose()
+		{
+			for (var index = requests.Count - 1; index >= 0; index--)
+				WebAuthenticatorRequestManager.End(requests[index]);
+		}
+
+		WebAuthenticatorRequest Begin()
+		{
+			var request = WebAuthenticatorRequestManager.Begin(
+				new Uri("https://example.com/authorize"),
+				new Uri("maui-auth://callback"),
+				responseDecoder: null,
+				prefersEphemeralWebBrowserSession: false,
+				cancellationToken: default);
+
+			requests.Add(request);
+			return request;
+		}
+
+		sealed class CallbackAuthenticator : IWebAuthenticator, IPlatformWebAuthenticatorCallback
+		{
+			internal int CallbackCount { get; private set; }
+
+			public bool OnResumeCallback(Intent intent)
+			{
+				CallbackCount++;
+				return true;
+			}
+
+			public Task<WebAuthenticatorResult> AuthenticateAsync(WebAuthenticatorOptions webAuthenticatorOptions) =>
+				throw new NotSupportedException();
+
+			public Task<WebAuthenticatorResult> AuthenticateAsync(
+				WebAuthenticatorOptions webAuthenticatorOptions,
+				CancellationToken cancellationToken) =>
+				throw new NotSupportedException();
+		}
+	}
+}

--- a/src/Essentials/test/DeviceTests/Tests/Android/WebAuthenticator_Android_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Android/WebAuthenticator_Android_Tests.cs
@@ -3,13 +3,44 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Android.App;
 using Android.Content;
 using AndroidX.Browser.Auth;
+using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Authentication;
 using Xunit;
+using ABundle = Android.OS.Bundle;
+using MauiPlatform = Microsoft.Maui.ApplicationModel.Platform;
 
 namespace Microsoft.Maui.Essentials.DeviceTests
 {
+	[Activity(Exported = true)]
+	[IntentFilter(
+		new[] { Intent.ActionView },
+		Categories = new[] { Intent.CategoryDefault, Intent.CategoryBrowsable },
+		DataScheme = "maui-webauth-test")]
+	public sealed class WebAuthenticatorTestBrowserActivity : Activity
+	{
+		internal const string Scheme = "maui-webauth-test";
+
+		static TaskCompletionSource<WebAuthenticatorTestBrowserActivity>? pendingLaunch;
+
+		internal static Task<WebAuthenticatorTestBrowserActivity> PrepareForLaunch()
+		{
+			var launch = new TaskCompletionSource<WebAuthenticatorTestBrowserActivity>(
+				TaskCreationOptions.RunContinuationsAsynchronously);
+			Interlocked.Exchange(ref pendingLaunch, launch);
+			return launch.Task;
+		}
+
+		protected override void OnCreate(ABundle? savedInstanceState)
+		{
+			base.OnCreate(savedInstanceState);
+
+			Interlocked.Exchange(ref pendingLaunch, null)?.TrySetResult(this);
+		}
+	}
+
 	[CollectionDefinition(CollectionName, DisableParallelization = true)]
 	public sealed class AndroidWebAuthenticatorCollection
 	{
@@ -185,6 +216,77 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 			await request.Task;
 		}
 
+		[Fact]
+		public async Task SystemBrowserReturnCancelsTheBoundRequest()
+		{
+			var request = Begin();
+			var browserActivity = await StartBrowserAsync(request);
+
+			try
+			{
+				await FinishActivityAsync(browserActivity);
+				await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+					request.Task.WaitAsync(TimeSpan.FromSeconds(10)));
+			}
+			finally
+			{
+				await FinishActivityAsync(browserActivity);
+			}
+		}
+
+		[Fact]
+		public async Task SystemBrowserCallbackCompletesBeforeReturnCancellation()
+		{
+			var first = Begin();
+			var browserActivity = await StartBrowserAsync(first);
+
+			try
+			{
+				await MainThread.InvokeOnMainThreadAsync(() =>
+					WebAuthenticatorIntermediateActivity.StartCallback(
+						browserActivity,
+						global::Android.Net.Uri.Parse("maui-auth://callback?code=sample-code")));
+
+				Assert.Equal(
+					"sample-code",
+					(await first.Task.WaitAsync(TimeSpan.FromSeconds(10))).Properties["code"]);
+				Assert.False(await TryRequestCleanupAsync(first.Id));
+				Assert.True(WebAuthenticatorRequestManager.End(first));
+
+				var successor = Begin();
+				Assert.False(await TryRequestCleanupAsync(first.Id));
+				Assert.False(successor.Task.IsCompleted);
+				Assert.True(WebAuthenticatorRequestManager.TryCancelFromPlatform(successor));
+				await Assert.ThrowsAnyAsync<OperationCanceledException>(() => successor.Task);
+			}
+			finally
+			{
+				await FinishActivityAsync(browserActivity);
+			}
+		}
+
+		[Fact]
+		public async Task CleanupRequiresAMatchingLiveOwner()
+		{
+			var request = Begin();
+
+			Assert.False(await TryRequestCleanupAsync(request.Id));
+			var browserActivity = await StartBrowserAsync(request);
+
+			try
+			{
+				Assert.False(await TryRequestCleanupAsync(request.Id + 1));
+				Assert.False(request.Task.IsCompleted);
+				Assert.True(WebAuthenticatorRequestManager.TryCancelFromCaller(request));
+				Assert.True(await TryRequestCleanupAsync(request.Id));
+				await Assert.ThrowsAnyAsync<OperationCanceledException>(() => request.Task);
+			}
+			finally
+			{
+				await FinishActivityAsync(browserActivity);
+			}
+		}
+
 		public void Dispose()
 		{
 			for (var index = requests.Count - 1; index >= 0; index--)
@@ -203,6 +305,34 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 			requests.Add(request);
 			return request;
 		}
+
+		static async Task<WebAuthenticatorTestBrowserActivity> StartBrowserAsync(WebAuthenticatorRequest request)
+		{
+			var browserLaunch = WebAuthenticatorTestBrowserActivity.PrepareForLaunch();
+			await MainThread.InvokeOnMainThreadAsync(() =>
+			{
+				var activity = MauiPlatform.CurrentActivity ??
+					throw new InvalidOperationException("The current Android Activity is unavailable.");
+
+				WebAuthenticatorIntermediateActivity.StartBrowser(
+					activity,
+					request.Id,
+					new Uri($"{WebAuthenticatorTestBrowserActivity.Scheme}://authorize"));
+			});
+
+			return await browserLaunch.WaitAsync(TimeSpan.FromSeconds(10));
+		}
+
+		static Task<bool> TryRequestCleanupAsync(long requestId) =>
+			MainThread.InvokeOnMainThreadAsync(() =>
+				WebAuthenticatorIntermediateActivity.TryRequestCleanup(requestId));
+
+		static Task FinishActivityAsync(Activity activity) =>
+			MainThread.InvokeOnMainThreadAsync(() =>
+			{
+				if (!activity.IsFinishing && !activity.IsDestroyed)
+					activity.Finish();
+			});
 
 		sealed class CallbackAuthenticator : IWebAuthenticator, IPlatformWebAuthenticatorCallback
 		{

--- a/src/Essentials/test/DeviceTests/Tests/Windows/WebAuthenticator_Windows_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Windows/WebAuthenticator_Windows_Tests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 using Microsoft.Maui.Authentication;
 using Xunit;
 
@@ -9,11 +10,8 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 	[Category("WebAuthenticator")]
 	public class WebAuthenticator_Windows_Tests
 	{
-		// Pre-canceled authentication should eventually behave consistently across all
-		// WebAuthenticator platforms. This regression test is currently Windows-only
-		// because the other platforms still start their native browser session.
 		[Fact]
-		public async Task AuthenticateAsyncWithPreCanceledTokenStopsBeforePlatformValidation()
+		public async Task PlatformValidationPrecedesPreCanceledToken()
 		{
 			var options = new WebAuthenticatorOptions
 			{
@@ -23,10 +21,10 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 
 			var cancellationToken = new CancellationToken(canceled: true);
 
-			var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+			var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
 				WebAuthenticator.Default.AuthenticateAsync(options, cancellationToken));
 
-			Assert.Equal(cancellationToken, exception.CancellationToken);
+			Assert.Contains("not supported", exception.Message, StringComparison.OrdinalIgnoreCase);
 		}
 
 		[Theory]
@@ -65,6 +63,76 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 			var actual = WebAuthenticatorImplementation.IsSameCallbackRoute(
 				new Uri(expectedCallbackUrl),
 				new Uri(callbackUrl));
+
+			Assert.Equal(expected, actual);
+		}
+
+		[Fact]
+		public void ManifestProtocolLookupUsesCurrentApplicationAndVersionAgnosticUapNamespace()
+		{
+			var document = XDocument.Parse("""
+				<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+				         xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5">
+				  <Applications>
+				    <Application Id="OtherApp">
+				      <Extensions>
+				        <uap5:Extension Category="windows.protocol">
+				          <uap5:Protocol Name="other-auth" />
+				        </uap5:Extension>
+				      </Extensions>
+				    </Application>
+				    <Application Id="CurrentApp">
+				      <Extensions>
+				        <uap5:Extension Category="windows.protocol">
+				          <uap5:Protocol Name="MAUI-AUTH" />
+				        </uap5:Extension>
+				      </Extensions>
+				    </Application>
+				  </Applications>
+				</Package>
+				""");
+
+			Assert.True(WebAuthenticatorImplementation.IsUriProtocolDeclared(document, "CurrentApp", "maui-auth"));
+			Assert.False(WebAuthenticatorImplementation.IsUriProtocolDeclared(document, "CurrentApp", "other-auth"));
+			Assert.False(WebAuthenticatorImplementation.IsUriProtocolDeclared(document, null, "maui-auth"));
+		}
+
+		[Fact]
+		public void ManifestProtocolLookupCanUseTheOnlyApplicationAsIdentityFallback()
+		{
+			var document = XDocument.Parse("""
+				<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+				         xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10">
+				  <Applications>
+				    <Application Id="OnlyApp">
+				      <Extensions>
+				        <uap:Extension Category="windows.protocol">
+				          <uap:Protocol Name="maui-auth" />
+				        </uap:Extension>
+				      </Extensions>
+				    </Application>
+				  </Applications>
+				</Package>
+				""");
+
+			Assert.True(WebAuthenticatorImplementation.IsUriProtocolDeclared(document, null, "MAUI-AUTH"));
+		}
+
+		[Theory]
+		[InlineData(null, true)]
+		[InlineData("", true)]
+		[InlineData("\"C:\\Program Files\\Maui App\\maui.exe\" \"%1\"", true)]
+		[InlineData("\"c:\\PROGRAM FILES\\MAUI APP\\MAUI.EXE\" --protocol \"%1\"", true)]
+		[InlineData("\"C:\\Other\\other.exe\" \"%1\"", false)]
+		[InlineData("C:\\Apps\\maui.exe %1", false)]
+		[InlineData("C:\\Program Files\\Maui App\\maui.exe %1", true)]
+		[InlineData("maui.exe %1", true)]
+		[InlineData("\"unterminated command", true)]
+		public void RegistryOwnershipRejectsOnlyCertainOtherExecutables(string command, bool expected)
+		{
+			var actual = WebAuthenticatorImplementation.IsRegistryCommandOwnedByCurrentExecutable(
+				command,
+				@"C:\Program Files\Maui App\maui.exe");
 
 			Assert.Equal(expected, actual);
 		}

--- a/src/Essentials/test/DeviceTests/Tests/Windows/WebAuthenticator_Windows_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Windows/WebAuthenticator_Windows_Tests.cs
@@ -136,5 +136,31 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 
 			Assert.Equal(expected, actual);
 		}
+
+		[Fact]
+		public void RegistryOwnershipAcceptsDotnetHostedCommand()
+		{
+			var actual = WebAuthenticatorImplementation.IsRegistryCommandOwnedByCurrentExecutable(
+				"\"C:\\Program Files\\dotnet\\dotnet.exe\" \"C:\\Apps\\sample.dll\" \"%1\"",
+				@"C:\Program Files\dotnet\dotnet.exe");
+
+			Assert.True(actual);
+		}
+
+		[Fact]
+		public void CallbackRouteExceptionsPreserveTheRedactedCauseChain()
+		{
+			var nativeCause = new InvalidOperationException("native diagnostic");
+			var inspectionFailure = WebAuthenticatorImplementation.CreateCallbackRouteException(
+				"Unable to inspect the current application instance.",
+				nativeCause);
+			var outerFailure = WebAuthenticatorImplementation.CreateCallbackRouteException(
+				"Unable to register the WebAuthenticator callback route.",
+				inspectionFailure);
+
+			Assert.Equal("Unable to register the WebAuthenticator callback route.", outerFailure.Message);
+			Assert.Same(inspectionFailure, outerFailure.InnerException);
+			Assert.Same(nativeCause, outerFailure.InnerException?.InnerException);
+		}
 	}
 }

--- a/src/Essentials/test/DeviceTests/Tests/iOS/WebAuthenticator_Apple_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/iOS/WebAuthenticator_Apple_Tests.cs
@@ -1,0 +1,203 @@
+#if IOS || MACCATALYST
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Foundation;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Authentication;
+using Xunit;
+
+namespace Microsoft.Maui.Essentials.DeviceTests
+{
+	[CollectionDefinition(CollectionName, DisableParallelization = true)]
+	public sealed class AppleWebAuthenticatorCollection
+	{
+		public const string CollectionName = "Apple WebAuthenticator";
+	}
+
+	[Collection(AppleWebAuthenticatorCollection.CollectionName)]
+	[Category("WebAuthenticator")]
+	public class WebAuthenticator_Apple_Tests : IDisposable
+	{
+		readonly List<WebAuthenticatorRequest> requests = new();
+
+		[Fact]
+		public void ModernSessionRejectsNonWebAuthenticationUrl()
+		{
+			Assert.Throws<InvalidOperationException>(() =>
+				WebAuthenticatorImplementation.ValidateModernSessionUrls(
+					new Uri("maui-auth:/authorize"),
+					new Uri("maui-auth:/callback")));
+		}
+
+		[Fact]
+		public void ModernSessionRejectsHttpCallback()
+		{
+			Assert.Throws<InvalidOperationException>(() =>
+				WebAuthenticatorImplementation.ValidateModernSessionUrls(
+					new Uri("https://example.com/authorize"),
+					new Uri("http://example.com/callback")));
+		}
+
+		[Fact]
+		public void ModernSessionRejectsNonDefaultHttpsCallbackPort()
+		{
+			Assert.Throws<InvalidOperationException>(() =>
+				WebAuthenticatorImplementation.ValidateModernSessionUrls(
+					new Uri("https://example.com/authorize"),
+					new Uri("https://example.com:8443/callback")));
+		}
+
+		[Fact]
+		public void ModernSessionAcceptsCustomSchemeWithRoute()
+		{
+			WebAuthenticatorImplementation.ValidateModernSessionUrls(
+				new Uri("https://example.com/authorize"),
+				new Uri("maui-auth://callback/complete"));
+		}
+
+		[Fact]
+		public void HttpsCallbackAvailabilityMatchesTheRunningPlatform()
+		{
+			var validate = () => WebAuthenticatorImplementation.ValidateModernSessionUrls(
+				new Uri("https://example.com/authorize"),
+				new Uri("https://login.example.com/callback/complete"));
+
+#if IOS
+			if (OperatingSystem.IsIOSVersionAtLeast(17, 4))
+#elif MACCATALYST
+			if (OperatingSystem.IsMacCatalystVersionAtLeast(17, 4))
+#endif
+				validate();
+			else
+				Assert.Throws<FeatureNotSupportedException>(validate);
+		}
+
+		[Fact]
+		public async Task NativeSuccessCompletesTheBoundRequest()
+		{
+			var request = Begin();
+
+			WebAuthenticatorImplementation.CompleteNativeSession(
+				request,
+				"maui-auth://callback?code=sample-code",
+				wasCanceled: false,
+				failed: false);
+
+			Assert.Equal("sample-code", (await request.Task).Properties["code"]);
+		}
+
+		[Fact]
+		public async Task NativeCancellationCancelsTheBoundRequest()
+		{
+			var request = Begin();
+
+			WebAuthenticatorImplementation.CompleteNativeSession(
+				request,
+				absoluteCallbackUrl: null,
+				wasCanceled: true,
+				failed: false);
+
+			await Assert.ThrowsAnyAsync<OperationCanceledException>(() => request.Task);
+		}
+
+		[Fact]
+		public async Task NativeFailureFaultsTheBoundRequest()
+		{
+			var request = Begin();
+
+			WebAuthenticatorImplementation.CompleteNativeSession(
+				request,
+				absoluteCallbackUrl: null,
+				wasCanceled: false,
+				failed: true);
+
+			await Assert.ThrowsAsync<InvalidOperationException>(() => request.Task);
+		}
+
+		[Fact]
+		public Task NativeMissingCallbackCannotLeaveTheBoundRequestPending() =>
+			AssertNativeTerminalFailure(null, "did not include");
+
+		[Fact]
+		public Task NativeMismatchCannotLeaveTheBoundRequestPending() =>
+			AssertNativeTerminalFailure("maui-auth://wrong?code=sample-code", "did not match");
+
+		async Task AssertNativeTerminalFailure(string? callback, string expectedMessage)
+		{
+			var request = Begin();
+
+			WebAuthenticatorImplementation.CompleteNativeSession(
+				request,
+				callback,
+				wasCanceled: false,
+				failed: false);
+
+			var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => request.Task);
+			Assert.Contains(expectedMessage, exception.Message, StringComparison.OrdinalIgnoreCase);
+		}
+
+		[Fact]
+		public async Task LateNativeCallbackCannotCompleteASuccessor()
+		{
+			var first = Begin();
+			WebAuthenticatorImplementation.CompleteNativeSession(first, null, wasCanceled: true, failed: false);
+			await Assert.ThrowsAnyAsync<OperationCanceledException>(() => first.Task);
+			Assert.True(WebAuthenticatorRequestManager.End(first));
+
+			var successor = Begin();
+			WebAuthenticatorImplementation.CompleteNativeSession(
+				first,
+				"maui-auth://callback?code=stale",
+				wasCanceled: false,
+				failed: false);
+			Assert.False(successor.Task.IsCompleted);
+
+			WebAuthenticatorImplementation.CompleteNativeSession(
+				successor,
+				"maui-auth://callback?code=current",
+				wasCanceled: false,
+				failed: false);
+			Assert.Equal("current", (await successor.Task).Properties["code"]);
+		}
+
+		[Fact]
+		public async Task NativePostingDoesNotCompleteInline()
+		{
+			var callerThread = Environment.CurrentManagedThreadId;
+			var insideNativeStack = true;
+			var completedInline = false;
+			var request = Begin(beforeCallbackCompletion: () =>
+				completedInline = insideNativeStack && Environment.CurrentManagedThreadId == callerThread);
+			using var callback = new NSUrl("maui-auth://callback?code=sample-code");
+
+			WebAuthenticatorImplementation.PostNativeCompletion(request, callback, error: null);
+			insideNativeStack = false;
+
+			await request.Task;
+			Assert.False(completedInline);
+		}
+
+		public void Dispose()
+		{
+			for (var index = requests.Count - 1; index >= 0; index--)
+				WebAuthenticatorRequestManager.End(requests[index]);
+		}
+
+		WebAuthenticatorRequest Begin(Action? beforeCallbackCompletion = null)
+		{
+			var request = WebAuthenticatorRequestManager.Begin(
+				new Uri("https://example.com/authorize"),
+				new Uri("maui-auth://callback"),
+				responseDecoder: null,
+				prefersEphemeralWebBrowserSession: false,
+				cancellationToken: default,
+				beforeCallbackCompletion);
+
+			requests.Add(request);
+			return request;
+		}
+	}
+}
+#endif

--- a/src/Essentials/test/DeviceTests/Tests/iOS/WebAuthenticator_Apple_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/iOS/WebAuthenticator_Apple_Tests.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 				request,
 				"maui-auth://callback?code=sample-code",
 				wasCanceled: false,
-				failed: false);
+				nativeFailure: null);
 
 			Assert.Equal("sample-code", (await request.Task).Properties["code"]);
 		}
@@ -97,23 +97,26 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 				request,
 				absoluteCallbackUrl: null,
 				wasCanceled: true,
-				failed: false);
+				nativeFailure: null);
 
 			await Assert.ThrowsAnyAsync<OperationCanceledException>(() => request.Task);
 		}
 
 		[Fact]
-		public async Task NativeFailureFaultsTheBoundRequest()
+		public async Task NativeFailurePreservesNSErrorDetails()
 		{
 			var request = Begin();
+			const string domain = "com.example.WebAuthenticatorTests";
+			using var nativeDomain = new NSString(domain);
+			using var nativeError = NSError.FromDomain(nativeDomain, (nint)42);
 
-			WebAuthenticatorImplementation.CompleteNativeSession(
-				request,
-				absoluteCallbackUrl: null,
-				wasCanceled: false,
-				failed: true);
+			WebAuthenticatorImplementation.PostNativeCompletion(request, callbackUrl: null, error: nativeError);
 
-			await Assert.ThrowsAsync<InvalidOperationException>(() => request.Task);
+			var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => request.Task);
+			Assert.Equal("The native web authentication session failed.", exception.Message);
+			var nativeException = Assert.IsType<NSErrorException>(exception.InnerException);
+			Assert.Equal(domain, nativeException.Domain);
+			Assert.Equal((nint)42, nativeException.Code);
 		}
 
 		[Fact]
@@ -132,7 +135,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 				request,
 				callback,
 				wasCanceled: false,
-				failed: false);
+				nativeFailure: null);
 
 			var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => request.Task);
 			Assert.Contains(expectedMessage, exception.Message, StringComparison.OrdinalIgnoreCase);
@@ -142,7 +145,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		public async Task LateNativeCallbackCannotCompleteASuccessor()
 		{
 			var first = Begin();
-			WebAuthenticatorImplementation.CompleteNativeSession(first, null, wasCanceled: true, failed: false);
+			WebAuthenticatorImplementation.CompleteNativeSession(first, null, wasCanceled: true, nativeFailure: null);
 			await Assert.ThrowsAnyAsync<OperationCanceledException>(() => first.Task);
 			Assert.True(WebAuthenticatorRequestManager.End(first));
 
@@ -151,14 +154,14 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 				first,
 				"maui-auth://callback?code=stale",
 				wasCanceled: false,
-				failed: false);
+				nativeFailure: null);
 			Assert.False(successor.Task.IsCompleted);
 
 			WebAuthenticatorImplementation.CompleteNativeSession(
 				successor,
 				"maui-auth://callback?code=current",
 				wasCanceled: false,
-				failed: false);
+				nativeFailure: null);
 			Assert.Equal("current", (await successor.Task).Properties["code"]);
 		}
 

--- a/src/Essentials/test/UnitTests/WebAuthenticatorRequestManager_Tests.cs
+++ b/src/Essentials/test/UnitTests/WebAuthenticatorRequestManager_Tests.cs
@@ -1,0 +1,565 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Maui.Authentication;
+using Xunit;
+
+namespace Tests
+{
+	[CollectionDefinition(CollectionName, DisableParallelization = true)]
+	public sealed class WebAuthenticatorRequestManagerCollection
+	{
+		public const string CollectionName = "WebAuthenticator request manager";
+	}
+
+	[Collection(WebAuthenticatorRequestManagerCollection.CollectionName)]
+	public class WebAuthenticatorRequestManager_Tests : IDisposable
+	{
+		readonly List<WebAuthenticatorRequest> requests = new();
+
+		[Fact]
+		public async Task FakeTransportRejectsNullOptions()
+		{
+			var transport = CreateTransport();
+
+			await Assert.ThrowsAsync<ArgumentNullException>(() => transport.AuthenticateAsync(null!));
+			Assert.Equal(0, transport.LaunchCount);
+		}
+
+		[Fact]
+		public async Task FakeTransportRejectsNullUrlsInOrder()
+		{
+			var transport = CreateTransport();
+			var options = new WebAuthenticatorOptions();
+
+			var urlException = await Assert.ThrowsAsync<ArgumentNullException>(() => transport.AuthenticateAsync(options));
+			Assert.Equal("Url", urlException.ParamName);
+
+			options.Url = new Uri("https://example.com/authorize");
+			var callbackException = await Assert.ThrowsAsync<ArgumentNullException>(() => transport.AuthenticateAsync(options));
+			Assert.Equal("CallbackUrl", callbackException.ParamName);
+			Assert.Equal(0, transport.LaunchCount);
+		}
+
+		[Fact]
+		public async Task FakeTransportRejectsRelativeUrisBeforePublishing()
+		{
+			var transport = CreateTransport();
+
+			await Assert.ThrowsAsync<ArgumentException>(() => transport.AuthenticateAsync(new WebAuthenticatorOptions
+			{
+				Url = new Uri("authorize", UriKind.Relative),
+				CallbackUrl = new Uri("maui-auth://callback"),
+			}));
+
+			await Assert.ThrowsAsync<ArgumentException>(() => transport.AuthenticateAsync(new WebAuthenticatorOptions
+			{
+				Url = new Uri("https://example.com/authorize"),
+				CallbackUrl = new Uri("callback", UriKind.Relative),
+			}));
+
+			Assert.Equal(0, transport.LaunchCount);
+		}
+
+		[Fact]
+		public async Task PreCanceledTokenIsPreservedAndDoesNotLaunch()
+		{
+			var transport = CreateTransport();
+			using var cancellationSource = new CancellationTokenSource();
+			cancellationSource.Cancel();
+
+			var task = transport.AuthenticateAsync(CreateOptions(), cancellationSource.Token);
+			var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
+
+			Assert.Equal(TaskStatus.Canceled, task.Status);
+			Assert.Equal(cancellationSource.Token, exception.CancellationToken);
+			Assert.Equal(0, transport.LaunchCount);
+			Assert.Null(transport.Request);
+		}
+
+		[Fact]
+		public async Task OptionsAreSnapshottedBeforeConcurrentMutation()
+		{
+			var originalDecoder = new CallbackDecoder(_ => new Dictionary<string, string> { ["snapshot"] = "original" });
+			var replacementDecoder = new CallbackDecoder(_ => new Dictionary<string, string> { ["snapshot"] = "replacement" });
+			var options = CreateOptions();
+			options.ResponseDecoder = originalDecoder;
+			options.PrefersEphemeralWebBrowserSession = true;
+
+			var transport = CreateTransport();
+			transport.AfterSnapshot = () =>
+			{
+				options.Url = new Uri("https://mutated.example/authorize");
+				options.CallbackUrl = new Uri("mutated-auth://callback");
+				options.ResponseDecoder = replacementDecoder;
+				options.PrefersEphemeralWebBrowserSession = false;
+			};
+
+			var task = transport.AuthenticateAsync(options);
+			var request = Assert.IsType<WebAuthenticatorRequest>(transport.Request);
+
+			Assert.Equal("example.com", request.Url.Host);
+			Assert.Equal("maui-auth", request.CallbackUrl.Scheme);
+			Assert.Same(originalDecoder, request.ResponseDecoder);
+			Assert.True(request.PrefersEphemeralWebBrowserSession);
+
+			Assert.True(WebAuthenticatorRequestManager.TryHandleCallback(new Uri("maui-auth://callback?code=ok")));
+			var result = await task;
+
+			Assert.Equal("original", result.Properties["snapshot"]);
+			Assert.Equal(1, originalDecoder.CallCount);
+			Assert.Equal(0, replacementDecoder.CallCount);
+		}
+
+		[Fact]
+		public void BeginRejectsASecondValidRequest()
+		{
+			_ = Begin();
+
+			Assert.Throws<InvalidOperationException>(() => Begin());
+		}
+
+		[Fact]
+		public async Task InvalidSecondCallKeepsValidationPrecedence()
+		{
+			var firstTransport = CreateTransport();
+			var firstTask = firstTransport.AuthenticateAsync(CreateOptions());
+			var secondTransport = CreateTransport();
+
+			var nullUrl = await Assert.ThrowsAsync<ArgumentNullException>(() =>
+				secondTransport.AuthenticateAsync(new WebAuthenticatorOptions { CallbackUrl = new Uri("maui-auth://callback") }));
+			Assert.Equal("Url", nullUrl.ParamName);
+
+			await Assert.ThrowsAsync<InvalidOperationException>(() => secondTransport.AuthenticateAsync(CreateOptions()));
+
+			Assert.True(WebAuthenticatorRequestManager.TryHandleCallback(new Uri("maui-auth://callback?code=ok")));
+			await firstTask;
+		}
+
+		[Fact]
+		public async Task RouteOnlyCallbackCompletesMatchingRequest()
+		{
+			var request = Begin();
+
+			Assert.True(WebAuthenticatorRequestManager.TryHandleCallback(new Uri("MAUI-AUTH://CALLBACK?code=ok#state=kept")));
+
+			var result = await request.Task;
+			Assert.Equal("ok", result.Properties["code"]);
+		}
+
+		[Fact]
+		public async Task RouteOnlyMismatchIsUnhandledAndRemainsPending()
+		{
+			var request = Begin(callbackUrl: new Uri("maui-auth://callback/complete"));
+
+			Assert.False(WebAuthenticatorRequestManager.TryHandleCallback(new Uri("maui-auth://callback/wrong?code=bad")));
+			Assert.False(request.Task.IsCompleted);
+			Assert.False(WebAuthenticatorRequestManager.TryHandleCallback(new Uri("another-auth://callback/complete")));
+			Assert.False(request.Task.IsCompleted);
+
+			Assert.True(WebAuthenticatorRequestManager.TryHandleCallback(new Uri("maui-auth://callback/complete?code=ok")));
+			Assert.Equal("ok", (await request.Task).Properties["code"]);
+		}
+
+		[Fact]
+		public async Task TerminalCallbackCompletesOnlyMatchingRequest()
+		{
+			var request = Begin(callbackUrl: new Uri("maui-auth://callback:4567/complete"));
+
+			Assert.True(WebAuthenticatorRequestManager.TryHandleTerminalCallback(
+				request,
+				new Uri("MAUI-AUTH://CALLBACK:4567/complete?code=ok")));
+
+			Assert.Equal("ok", (await request.Task).Properties["code"]);
+		}
+
+		[Fact]
+		public async Task TerminalMismatchFaultsTheBoundRequestWithoutSensitiveUris()
+		{
+			var request = Begin(callbackUrl: new Uri("maui-auth://callback/complete"));
+
+			Assert.True(WebAuthenticatorRequestManager.TryHandleTerminalCallback(
+				request,
+				new Uri("maui-auth://callback/wrong?code=secret")));
+
+			var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => request.Task);
+			Assert.DoesNotContain("secret", exception.Message, StringComparison.Ordinal);
+			Assert.DoesNotContain("maui-auth", exception.Message, StringComparison.OrdinalIgnoreCase);
+		}
+
+		[Fact]
+		public async Task TerminalCallbackWithoutUriFaultsTheBoundRequest()
+		{
+			var request = Begin();
+
+			Assert.True(WebAuthenticatorRequestManager.TryHandleTerminalCallback(request, null));
+
+			await Assert.ThrowsAsync<InvalidOperationException>(() => request.Task);
+		}
+
+		[Fact]
+		public async Task DuplicateRouteCallbackIsConsumedWithoutRepeatingCompletion()
+		{
+			var decoder = new CallbackDecoder(_ => new Dictionary<string, string>());
+			var beforeCompletionCalls = 0;
+			var request = Begin(decoder: decoder, beforeCallbackCompletion: () => beforeCompletionCalls++);
+
+			Assert.True(WebAuthenticatorRequestManager.TryHandleCallback(new Uri("maui-auth://callback?code=first")));
+			Assert.True(WebAuthenticatorRequestManager.TryHandleCallback(new Uri("maui-auth://callback?code=second")));
+			await request.Task;
+
+			Assert.Equal(1, decoder.CallCount);
+			Assert.Equal(1, beforeCompletionCalls);
+		}
+
+		[Fact]
+		public void CallbackWithoutRequestIsNotHandled()
+		{
+			Assert.False(WebAuthenticatorRequestManager.TryHandleCallback(new Uri("maui-auth://callback")));
+		}
+
+		[Fact]
+		public async Task LateReferenceAndIdCannotCompleteSuccessor()
+		{
+			var first = Begin();
+			Assert.True(WebAuthenticatorRequestManager.TryCancelFromPlatform(first));
+			await Assert.ThrowsAnyAsync<OperationCanceledException>(() => first.Task);
+			Assert.True(WebAuthenticatorRequestManager.End(first));
+
+			var second = Begin();
+			Assert.False(WebAuthenticatorRequestManager.TryHandleTerminalCallback(first, new Uri("maui-auth://callback?code=late")));
+			Assert.False(WebAuthenticatorRequestManager.TryHandleTerminalCallback(first.Id, new Uri("maui-auth://callback?code=late")));
+			Assert.False(WebAuthenticatorRequestManager.TryCancelFromPlatform(first.Id));
+			Assert.False(WebAuthenticatorRequestManager.TryFail(first.Id, new InvalidOperationException("late")));
+			Assert.False(second.Task.IsCompleted);
+
+			Assert.True(WebAuthenticatorRequestManager.TryHandleTerminalCallback(second.Id, new Uri("maui-auth://callback?code=current")));
+			Assert.Equal("current", (await second.Task).Properties["code"]);
+		}
+
+		[Fact]
+		public async Task CancelByIdIsIdentitySafe()
+		{
+			var request = Begin();
+
+			Assert.False(WebAuthenticatorRequestManager.TryCancelFromPlatform(request.Id + 1));
+			Assert.False(request.Task.IsCompleted);
+			Assert.True(WebAuthenticatorRequestManager.TryCancelFromPlatform(request.Id));
+			await Assert.ThrowsAnyAsync<OperationCanceledException>(() => request.Task);
+		}
+
+		[Fact]
+		public async Task FailByIdIsIdentitySafe()
+		{
+			var expected = new InvalidOperationException("redacted failure");
+			var request = Begin();
+
+			Assert.False(WebAuthenticatorRequestManager.TryFail(request.Id + 1, expected));
+			Assert.False(request.Task.IsCompleted);
+			Assert.True(WebAuthenticatorRequestManager.TryFail(request.Id, expected));
+
+			var actual = await Assert.ThrowsAsync<InvalidOperationException>(() => request.Task);
+			Assert.Same(expected, actual);
+		}
+
+		[Fact]
+		public async Task CallerCancellationPreservesOriginalToken()
+		{
+			using var cancellationSource = new CancellationTokenSource();
+			var request = Begin(cancellationToken: cancellationSource.Token);
+
+			Assert.True(WebAuthenticatorRequestManager.TryCancelFromCaller(request));
+			var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => request.Task);
+
+			Assert.Equal(cancellationSource.Token, exception.CancellationToken);
+			Assert.Equal(TaskStatus.Canceled, request.Task.Status);
+		}
+
+		[Fact]
+		public async Task DecoderRunsOnceAndItsExceptionIsPropagated()
+		{
+			var expected = new DecoderException();
+			var decoder = new CallbackDecoder(_ => throw expected);
+			var request = Begin(decoder: decoder);
+
+			Assert.True(WebAuthenticatorRequestManager.TryHandleCallback(new Uri("maui-auth://callback?code=sensitive")));
+			var actual = await Assert.ThrowsAsync<DecoderException>(() => request.Task);
+
+			Assert.Same(expected, actual);
+			Assert.Equal(1, decoder.CallCount);
+			Assert.True(WebAuthenticatorRequestManager.TryHandleCallback(new Uri("maui-auth://callback?code=duplicate")));
+			Assert.Equal(1, decoder.CallCount);
+		}
+
+		[Fact]
+		public async Task PlatformDelegateRunsBeforeDecoderAndOutsideTheManagerLock()
+		{
+			var order = new List<string>();
+			var lockWasAvailable = false;
+			WebAuthenticatorRequest? request = null;
+			var decoder = new CallbackDecoder(_ =>
+			{
+				order.Add("decoder");
+				return new Dictionary<string, string>();
+			});
+
+			request = Begin(
+				decoder: decoder,
+				beforeCallbackCompletion: () =>
+				{
+					order.Add("platform");
+					lockWasAvailable = Task.Run(() => WebAuthenticatorRequestManager.End(request!)).Wait(TimeSpan.FromSeconds(5));
+				});
+
+			Assert.True(WebAuthenticatorRequestManager.TryHandleCallback(new Uri("maui-auth://callback")));
+			await request.Task;
+
+			Assert.True(lockWasAvailable);
+			Assert.Equal(new[] { "platform", "decoder" }, order);
+		}
+
+		[Fact]
+		public async Task DecoderRunsOutsideTheManagerLock()
+		{
+			var lockWasAvailable = false;
+			WebAuthenticatorRequest? request = null;
+			var decoder = new CallbackDecoder(_ =>
+			{
+				lockWasAvailable = Task.Run(() => WebAuthenticatorRequestManager.End(request!)).Wait(TimeSpan.FromSeconds(5));
+				return new Dictionary<string, string>();
+			});
+			request = Begin(decoder: decoder);
+
+			Assert.True(WebAuthenticatorRequestManager.TryHandleCallback(new Uri("maui-auth://callback")));
+			await request.Task;
+
+			Assert.True(lockWasAvailable);
+		}
+
+		[Fact]
+		public async Task ContinuationsDoNotRunInlineWithCompletion()
+		{
+			var request = Begin();
+			using var continuationStarted = new ManualResetEventSlim();
+			using var releaseContinuation = new ManualResetEventSlim();
+			var continuation = request.Task.ContinueWith(
+				_ =>
+				{
+					continuationStarted.Set();
+					releaseContinuation.Wait(TimeSpan.FromSeconds(5));
+				},
+				CancellationToken.None,
+				TaskContinuationOptions.ExecuteSynchronously,
+				TaskScheduler.Default);
+
+			try
+			{
+				var completion = Task.Run(() => WebAuthenticatorRequestManager.TryHandleCallback(new Uri("maui-auth://callback")));
+				Assert.True(await completion.WaitAsync(TimeSpan.FromSeconds(5)));
+				Assert.True(continuationStarted.Wait(TimeSpan.FromSeconds(5)));
+			}
+			finally
+			{
+				releaseContinuation.Set();
+			}
+
+			await continuation.WaitAsync(TimeSpan.FromSeconds(5));
+		}
+
+		[Fact]
+		public async Task CallbackCancelAndFailRacesHaveOneTerminalOutcome()
+		{
+			for (var iteration = 0; iteration < 100; iteration++)
+			{
+				var decoder = new CallbackDecoder(_ => new Dictionary<string, string>());
+				var request = Begin(decoder: decoder);
+
+				await Task.WhenAll(
+					Task.Run(() => WebAuthenticatorRequestManager.TryHandleTerminalCallback(request, new Uri("maui-auth://callback"))),
+					Task.Run(() => WebAuthenticatorRequestManager.TryCancelFromPlatform(request)),
+					Task.Run(() => WebAuthenticatorRequestManager.TryFail(request, new InvalidOperationException("race"))));
+
+				try
+				{
+					await request.Task;
+				}
+				catch (OperationCanceledException)
+				{
+				}
+				catch (InvalidOperationException)
+				{
+				}
+
+				Assert.True(request.Task.IsCompleted);
+				Assert.InRange(decoder.CallCount, 0, 1);
+				Assert.True(WebAuthenticatorRequestManager.End(request));
+			}
+		}
+
+		[Fact]
+		public async Task EndIsIdentitySafeAndKeepsConcurrencyClosedUntilCleanup()
+		{
+			var first = Begin();
+			Assert.True(WebAuthenticatorRequestManager.TryHandleCallback(new Uri("maui-auth://callback")));
+			await first.Task;
+
+			Assert.Throws<InvalidOperationException>(() => Begin());
+			Assert.True(WebAuthenticatorRequestManager.End(first));
+
+			var second = Begin();
+			Assert.False(WebAuthenticatorRequestManager.End(first));
+			Assert.True(WebAuthenticatorRequestManager.TryCancelFromPlatform(second));
+			await Assert.ThrowsAnyAsync<OperationCanceledException>(() => second.Task);
+		}
+
+		[Fact]
+		public async Task ActiveBuiltInRequestSurvivesFacadeReplacement()
+		{
+			var request = Begin();
+			var custom = CreateTransport();
+
+			try
+			{
+				WebAuthenticator.SetDefault(custom);
+				Assert.Same(custom, WebAuthenticator.Default);
+				Assert.True(WebAuthenticatorRequestManager.TryHandleCallback(new Uri("maui-auth://callback")));
+				await request.Task;
+			}
+			finally
+			{
+				WebAuthenticator.SetDefault(null);
+			}
+
+			Assert.True(request.Task.IsCompletedSuccessfully);
+		}
+
+		public void Dispose()
+		{
+			for (var index = requests.Count - 1; index >= 0; index--)
+				WebAuthenticatorRequestManager.End(requests[index]);
+		}
+
+		WebAuthenticatorRequest Begin(
+			Uri? callbackUrl = null,
+			IWebAuthenticatorResponseDecoder? decoder = null,
+			CancellationToken cancellationToken = default,
+			Action? beforeCallbackCompletion = null)
+		{
+			var request = WebAuthenticatorRequestManager.Begin(
+				new Uri("https://example.com/authorize"),
+				callbackUrl ?? new Uri("maui-auth://callback"),
+				decoder,
+				false,
+				cancellationToken,
+				beforeCallbackCompletion);
+
+			Track(request);
+			return request;
+		}
+
+		FakeWebAuthenticator CreateTransport() => new(Track);
+
+		void Track(WebAuthenticatorRequest request) => requests.Add(request);
+
+		static WebAuthenticatorOptions CreateOptions() => new()
+		{
+			Url = new Uri("https://example.com/authorize"),
+			CallbackUrl = new Uri("maui-auth://callback"),
+		};
+
+		sealed class FakeWebAuthenticator : IWebAuthenticator
+		{
+			readonly Action<WebAuthenticatorRequest> trackRequest;
+
+			internal FakeWebAuthenticator(Action<WebAuthenticatorRequest> trackRequest) =>
+				this.trackRequest = trackRequest;
+
+			internal Action? AfterSnapshot { get; set; }
+
+			internal int LaunchCount { get; private set; }
+
+			internal WebAuthenticatorRequest? Request { get; private set; }
+
+			public Task<WebAuthenticatorResult> AuthenticateAsync(WebAuthenticatorOptions webAuthenticatorOptions) =>
+				AuthenticateAsync(webAuthenticatorOptions, CancellationToken.None);
+
+			public async Task<WebAuthenticatorResult> AuthenticateAsync(
+				WebAuthenticatorOptions webAuthenticatorOptions,
+				CancellationToken cancellationToken)
+			{
+				if (webAuthenticatorOptions is null)
+					throw new ArgumentNullException(nameof(webAuthenticatorOptions));
+
+				var url = webAuthenticatorOptions.Url;
+				var callbackUrl = webAuthenticatorOptions.CallbackUrl;
+				var responseDecoder = webAuthenticatorOptions.ResponseDecoder;
+				var prefersEphemeral = webAuthenticatorOptions.PrefersEphemeralWebBrowserSession;
+
+				AfterSnapshot?.Invoke();
+
+				if (url is null)
+					throw new ArgumentNullException(nameof(webAuthenticatorOptions.Url));
+				if (callbackUrl is null)
+					throw new ArgumentNullException(nameof(webAuthenticatorOptions.CallbackUrl));
+				if (!url.IsAbsoluteUri)
+					throw new ArgumentException("The authentication URL must be absolute.", nameof(webAuthenticatorOptions.Url));
+				if (!callbackUrl.IsAbsoluteUri)
+					throw new ArgumentException("The callback URL must be absolute.", nameof(webAuthenticatorOptions.CallbackUrl));
+
+				cancellationToken.ThrowIfCancellationRequested();
+
+				var request = WebAuthenticatorRequestManager.Begin(
+					url,
+					callbackUrl,
+					responseDecoder,
+					prefersEphemeral,
+					cancellationToken);
+				Request = request;
+				trackRequest(request);
+
+				var registration = cancellationToken.Register(
+					static state =>
+					{
+						var request = (WebAuthenticatorRequest)state!;
+						WebAuthenticatorRequestManager.TryCancelFromCaller(request);
+					},
+					request);
+
+				try
+				{
+					if (!request.Task.IsCompleted)
+						LaunchCount++;
+
+					return await request.Task.ConfigureAwait(false);
+				}
+				finally
+				{
+					registration.Dispose();
+					WebAuthenticatorRequestManager.End(request);
+				}
+			}
+		}
+
+		sealed class CallbackDecoder : IWebAuthenticatorResponseDecoder
+		{
+			readonly Func<Uri, IDictionary<string, string>> callback;
+
+			internal CallbackDecoder(Func<Uri, IDictionary<string, string>> callback) =>
+				this.callback = callback;
+
+			internal int CallCount { get; private set; }
+
+			public IDictionary<string, string> DecodeResponse(Uri uri)
+			{
+				CallCount++;
+				return callback(uri);
+			}
+		}
+
+		sealed class DecoderException : Exception
+		{
+		}
+	}
+}

--- a/src/Essentials/test/UnitTests/WebAuthenticatorRequestManager_Tests.cs
+++ b/src/Essentials/test/UnitTests/WebAuthenticatorRequestManager_Tests.cs
@@ -278,6 +278,38 @@ namespace Tests
 		}
 
 		[Fact]
+		public async Task CallerCancellationConsumesOnlyMatchingDuplicateCallback()
+		{
+			using var cancellationSource = new CancellationTokenSource();
+			var decoder = new CallbackDecoder(_ => new Dictionary<string, string>());
+			var request = Begin(decoder: decoder, cancellationToken: cancellationSource.Token);
+
+			Assert.True(WebAuthenticatorRequestManager.TryCancelFromCaller(request));
+			Assert.False(WebAuthenticatorRequestManager.TryHandleCallback(new Uri("maui-auth://other?code=ignored")));
+			Assert.True(WebAuthenticatorRequestManager.TryHandleCallback(new Uri("maui-auth://callback?code=duplicate")));
+
+			var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => request.Task);
+			Assert.Equal(cancellationSource.Token, exception.CancellationToken);
+			Assert.Equal(0, decoder.CallCount);
+		}
+
+		[Fact]
+		public async Task FailureConsumesOnlyMatchingDuplicateCallback()
+		{
+			var expected = new InvalidOperationException("redacted failure");
+			var decoder = new CallbackDecoder(_ => new Dictionary<string, string>());
+			var request = Begin(decoder: decoder);
+
+			Assert.True(WebAuthenticatorRequestManager.TryFail(request, expected));
+			Assert.False(WebAuthenticatorRequestManager.TryHandleCallback(new Uri("maui-auth://other?code=ignored")));
+			Assert.True(WebAuthenticatorRequestManager.TryHandleCallback(new Uri("maui-auth://callback?code=duplicate")));
+
+			var actual = await Assert.ThrowsAsync<InvalidOperationException>(() => request.Task);
+			Assert.Same(expected, actual);
+			Assert.Equal(0, decoder.CallCount);
+		}
+
+		[Fact]
 		public async Task DecoderRunsOnceAndItsExceptionIsPropagated()
 		{
 			var expected = new DecoderException();

--- a/src/Essentials/test/UnitTests/WebUtils_Tests.cs
+++ b/src/Essentials/test/UnitTests/WebUtils_Tests.cs
@@ -130,11 +130,34 @@ namespace Tests
 		[InlineData("maui-auth://callback", "MAUI-AUTH://CALLBACK?code=123", true)]
 		[InlineData("maui-auth://callback", "maui-auth://other?code=123", false)]
 		[InlineData("maui-auth://callback", "other-auth://callback?code=123", false)]
+		[InlineData("https://Example.COM/callback", "HTTPS://example.com/callback?code=123#state=abc", true)]
+		[InlineData("https://example.com/callback", "https://example.com/Callback", false)]
+		[InlineData("https://example.com/callback", "https://example.com/callback/child", false)]
+		[InlineData("https://example.com/callback", "https://example.com:443/callback", true)]
+		[InlineData("https://example.com:8443/callback", "https://example.com:8443/callback", true)]
+		[InlineData("https://example.com:8443/callback", "https://example.com:9443/callback", false)]
+		[InlineData("https://example.com/callback", "https://example.com/callback/", false)]
+		[InlineData("https://example.com/", "https://example.com/another/path", true)]
+		[InlineData("maui-auth:/callback", "maui-auth:/callback?code=123", true)]
+		[InlineData("maui-auth:/callback", "maui-auth:/Callback?code=123", false)]
+		[InlineData("maui-auth:/callback%20complete", "maui-auth:/callback%20complete?code=123", true)]
+		[InlineData("maui-auth:/callback%20complete", "maui-auth:/callback complete?code=123", true)]
 		public void CanHandleCallback_ReturnsExpected(string expectedUrl, string callbackUrl, bool expected)
 		{
 			var result = Microsoft.Maui.WebUtils.CanHandleCallback(new Uri(expectedUrl), new Uri(callbackUrl));
 
 			Assert.Equal(expected, result);
+		}
+
+		[Fact]
+		public void CanHandleCallback_RejectsRelativeUris()
+		{
+			Assert.False(Microsoft.Maui.WebUtils.CanHandleCallback(
+				new Uri("callback", UriKind.Relative),
+				new Uri("maui-auth:/callback")));
+			Assert.False(Microsoft.Maui.WebUtils.CanHandleCallback(
+				new Uri("maui-auth:/callback"),
+				new Uri("callback", UriKind.Relative)));
 		}
 	}
 }

--- a/src/Essentials/test/UnitTests/WebUtils_Tests.cs
+++ b/src/Essentials/test/UnitTests/WebUtils_Tests.cs
@@ -136,6 +136,7 @@ namespace Tests
 		[InlineData("https://example.com/callback", "https://example.com:443/callback", true)]
 		[InlineData("https://example.com:8443/callback", "https://example.com:8443/callback", true)]
 		[InlineData("https://example.com:8443/callback", "https://example.com:9443/callback", false)]
+		[InlineData("maui-auth://host", "maui-auth://host:0", false)]
 		[InlineData("https://example.com/callback", "https://example.com/callback/", false)]
 		[InlineData("https://example.com/", "https://example.com/another/path", true)]
 		[InlineData("maui-auth:/callback", "maui-auth:/callback?code=123", true)]


### PR DESCRIPTION
### Description of Change

WebAuthenticator previously relied on platform-specific pending state and completion paths. This made lifecycle edge cases difficult to handle consistently: dismissing Android authentication UI could leave the awaiting task pending, concurrent requests could replace shared state, and callback, cancellation, and cleanup paths were not always bound to the same request identity.

This PR consolidates request ownership and completion while preserving the existing public API and WebAuthenticator's provider-agnostic role.

The change:

- introduces a process-wide, identity-safe request manager that permits one active built-in authentication;
- guarantees exactly-once completion across callbacks, native cancellation, caller cancellation, and failures;
- validates callback scheme, host, effective port, and path before consuming a request;
- routes callbacks to the active built-in request before delegating unhandled callbacks to a custom `IWebAuthenticator`;
- passes non-matching lifecycle callbacks through without completing the active built-in request, so custom authenticators and other lifecycle handlers can process unrelated deep links;
- keeps identity-bound native Auth Tab and `ASWebAuthenticationSession` completions terminal when their callback URI is missing or invalid;
- routes Android Custom Tab and system-browser fallbacks through a request-owned intermediate activity, so returning the application task without a callback cancels the same request even if an external browser task remains open;
- limits Android caller cleanup to the matching live intermediate activity and never creates a cleanup activity;
- uses Auth Tab only for supported HTTPS callback routes; non-default HTTPS ports retain the callback-activity Custom Tab/system-browser path;
- normalizes `ASWebAuthenticationSession` callback, cancellation, and cleanup handling on Apple platforms; HTTPS callbacks require iOS or Mac Catalyst 17.4+, the default port, and Associated Domains, while earlier OS versions must use a custom-scheme callback;
- retains the reserved Windows `AppInstance` route for the process lifetime, avoiding the known unreliable unregister/re-register sequence while allowing a later WebAuthenticator route to replace it;
- preserves a pre-existing application-owned `AppInstance` key and documents the required cooperative activation routing;
- preserves redacted Windows route-registration and Android/Windows browser-launch messages while retaining caught causes through `InnerException`;
- preserves non-cancellation Apple `NSError` details and caught session-start exceptions beneath redacted outer failures, while propagating `FeatureNotSupportedException` unchanged;
- keeps diagnostic logging redacted at callback and application-decoder boundaries;
- updates the Essentials sample to use the existing zero-configuration public broker while clarifying that it demonstrates browser transport and callback delivery, not production OAuth architecture;
- adds contributor-oriented design documentation and focused unit/device coverage.

A second valid built-in authentication throws `InvalidOperationException` while leaving the original request active.

Applications should serialize authentication attempts, such as by disabling sign-in actions while a request is pending. This intentionally replaces the previous behavior where a new request canceled the first.

Callback matching is intentionally strict: scheme and host are case-insensitive, the effective port must match, and a non-root path uses ordinal equality. Query and fragment are ignored, and an expected root path does not constrain the callback path. This follows the redirect URI comparison requirements in [RFC 6749 section 3.1.2.3](https://www.rfc-editor.org/rfc/rfc6749.html#section-3.1.2.3) and the URI comparison rules in [RFC 3986 section 6.2.2.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-6.2.2.1).

The persistent Windows route avoids `UnregisterKey()` because [Windows App SDK issue #4420](https://github.com/microsoft/WindowsAppSDK/issues/4420) remains open. The replacement behavior is documented from the [Windows App SDK 2.3.1 source](https://github.com/microsoft/WindowsAppSDK/blob/v2.3.1/dev/AppLifecycle/AppInstance.cpp) and the A-to-B activation evidence from #36640.

### Issues Fixed

Fixes #32766

Related to #36640

### Validation

- Focused request-manager and URI-matching tests: 61/61 passed.
- Essentials unit tests: 513/513 passed.
- Android DeviceTests: 381/381 passed, including 20/20 WebAuthenticator tests.
- Windows WebAuthenticator DeviceTests: 28/28 passed.
- Full Windows DeviceTests: 291 passed, 14 skipped, and one unchanged unrelated culture-sensitive Preferences failure.
- Essentials/PublicAPI builds passed across .NET, .NET Standard, Android, Windows, iOS, and Mac Catalyst.
- iOS and Mac Catalyst compile-only validation passed; no Apple runtime host was available.
- Android and Windows samples: browser authentication success and cancellation validated manually.
- Repository-native scoped formatter verification and `git diff --check`: passed.

Thanks in advance!
@kubaflo

