### PR TITLE
[iOS] Preserve Liquid Glass Shell tab bar background

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.iOS.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Graphics;
@@ -20,18 +19,7 @@ namespace Microsoft.Maui.DeviceTests
 			var pagerParent = (shell.CurrentPage.Handler as IPlatformViewHandler)
 				.PlatformView.FindParent(x => x.NextResponder is UITabBarController);
 
-			// In macOS 15 Sequoia, the UITabBar is nested within the second subview (index 1) of the pagerParent. 
-			if (OperatingSystem.IsMacCatalystVersionAtLeast(15, 0) || OperatingSystem.IsMacOSVersionAtLeast(15, 0))
-			{
-				var subview = pagerParent.Subviews.ElementAtOrDefault(1);
-
-				if (subview?.Subviews is null)
-					return null;
-
-				return subview.Subviews.OfType<UITabBar>().FirstOrDefault();
-			}
-
-			return pagerParent.Subviews.OfType<UITabBar>().FirstOrDefault();
+			return (pagerParent?.NextResponder as UITabBarController)?.TabBar;
 		}
 
 		async Task ValidateTabBarIconColor(
@@ -66,6 +54,29 @@ namespace Microsoft.Maui.DeviceTests
 				await AssertionExtensions.AssertTabItemTextDoesNotContainColor(GetTabBar(item),
 					item.Title, textColor, MauiContext);
 			}
+		}
+
+		[Fact(DisplayName = "Shell TabBar Background Color Preserves iOS 26 Floating Tab Bar")]
+		public async Task ShellTabBarBackgroundColorPreservesIOS26FloatingTabBar()
+		{
+			if (!OperatingSystem.IsIOSVersionAtLeast(26))
+				return;
+
+			var expectedColor = Colors.Red;
+
+			await RunShellTabBarTests(
+				shell => Shell.SetTabBarBackgroundColor(shell, expectedColor),
+				shell =>
+				{
+					var tabBar = GetTabBar(shell.CurrentSection);
+
+					if (OperatingSystem.IsMacCatalyst())
+						Assert.Equal(expectedColor, tabBar.BackgroundColor.ToColor());
+					else
+						Assert.Null(tabBar.BackgroundColor);
+
+					return Task.CompletedTask;
+				});
 		}
 	}
 }

--- a/src/Core/src/Platform/iOS/TabbedViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/TabbedViewExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Maui.Platform
 			if (effectiveBarColor != null)
 			{
 				_tabBarAppearance.BackgroundColor = effectiveBarColor;
-				if (OperatingSystem.IsIOSVersionAtLeast(26))
+				// A direct view background is required on Mac Catalyst, but obscures iOS 26's floating tab bar.
+				if (OperatingSystem.IsMacCatalystVersionAtLeast(26))
 				{
 					tabBar.BackgroundColor = effectiveBarColor;
 				}


### PR DESCRIPTION
### Issue

Fixes #37423

On iOS 26, setting `UITabBar.BackgroundColor` paints the full-width tab bar view behind the floating Liquid Glass control. This regressed in .NET MAUI 10.0.90 when the direct background assignment was added for #35380 and #35381, which are Mac Catalyst 26 issues.

### Changes

- Restrict the direct `UITabBar.BackgroundColor` assignment to Mac Catalyst 26+, where it is required for custom Shell tab bar colors.
- Preserve the existing `UITabBarAppearance.BackgroundColor` path on iOS so the system floating Liquid Glass appearance remains visible.
- Add device coverage asserting that iOS 26 leaves the tab bar view background unset while Mac Catalyst 26 applies the requested color.
- Make the test helper retrieve the controller's `TabBar` directly instead of depending on UIKit's version-specific subview hierarchy.

### Runtime proof

Same attached repro, `Shell.TabBarBackgroundColor="#FEFCF9"`, iPhone 17 Pro simulator, iOS 26.5:

| MAUI 10.0.90 | This PR |
|---|---|
| ![Full-width opaque field in MAUI 10.0.90](https://github.com/user-attachments/assets/2881049b-fd19-483a-ae8d-9f09c7ce2089) | ![Floating Liquid Glass restored by this PR](https://github.com/user-attachments/assets/72b5bf2e-cbe0-4977-98de-19194d091824) |

The blue page content now extends behind the floating system tab bar; the full-width `#FEFCF9` field is gone while configured tab item colors remain.

### Validation

- Reproduced with the issue's attached `ShellTabBarIssue.zip`, MAUI 10.0.90, and an iPhone 17 Pro simulator running iOS 26.5.
- Rebuilt the same repro against this branch and confirmed the full-width opaque field is gone.
- Ran the iOS Shell device-test category on iOS 26.5: **204 passed, 0 failed**.
- Reviewed independently by three models after implementation; no material issues found.

> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue.
> Thank you!