### PR TITLE
Fix grouped CollectionView EmptyView state updates

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/ItemsSources/ObservableGroupedSource.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/ItemsSources/ObservableGroupedSource.cs
@@ -319,6 +319,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			var groupIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : _groupSource.IndexOf(args.NewItems[0]);
 			var groupCount = args.NewItems.Count;
+			var previousGroupCount = _groups.Count;
 
 			UpdateGroupTracking();
 
@@ -328,7 +329,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			if (itemCount == 0)
 			{
-				_notifier.NotifyDataSetChanged();
+				if (previousGroupCount == 0 && GroupCount > 0)
+				{
+					_notifier.NotifyDataSetChanged();
+				}
+
 				return;
 			}
 
@@ -378,12 +383,17 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			// Figure out how many items are in the groups we're removing
 			var itemCount = CountItemsInGroups(groupIndex, groupCount);
+			var previousGroupCount = _groups.Count;
 
 			UpdateGroupTracking();
 
 			if (itemCount == 0)
 			{
-				_notifier.NotifyDataSetChanged();
+				if (previousGroupCount > 0 && GroupCount == 0)
+				{
+					_notifier.NotifyDataSetChanged();
+				}
+
 				return;
 			}
 

--- a/src/Controls/src/Core/Handlers/Items/Android/ItemsSources/ObservableGroupedSource.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/ItemsSources/ObservableGroupedSource.cs
@@ -33,6 +33,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			}
 		}
 
+		internal int GroupCount => _groups.Count;
+
 		public bool HasHeader { get; set; }
 		public bool HasFooter { get; set; }
 		public bool ObserveChanges { get; set; } = true;
@@ -324,6 +326,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			var absolutePosition = GetAbsolutePosition(_groups[groupIndex], 0);
 			var itemCount = CountItemsInGroups(groupIndex, groupCount);
 
+			if (itemCount == 0)
+			{
+				_notifier.NotifyDataSetChanged();
+				return;
+			}
+
 			if (itemCount == 1)
 			{
 				_notifier.NotifyItemInserted(this, absolutePosition);
@@ -371,18 +379,21 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			// Figure out how many items are in the groups we're removing
 			var itemCount = CountItemsInGroups(groupIndex, groupCount);
 
+			UpdateGroupTracking();
+
+			if (itemCount == 0)
+			{
+				_notifier.NotifyDataSetChanged();
+				return;
+			}
+
 			if (itemCount == 1)
 			{
 				_notifier.NotifyItemRemoved(this, absolutePosition);
-
-				UpdateGroupTracking();
-
 				return;
 			}
 
 			_notifier.NotifyItemRangeRemoved(this, absolutePosition, itemCount);
-
-			UpdateGroupTracking();
 		}
 
 		void Replace(NotifyCollectionChangedEventArgs args)

--- a/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
@@ -1060,7 +1060,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 					itemCount++;
 			}
 
-			var showEmptyView = (ItemsView?.EmptyView is not null || ItemsView?.EmptyViewTemplate is not null) && ItemsViewAdapter.ItemCount == itemCount;
+			var sourceIsEmpty = ItemsView is GroupableItemsView { IsGrouped: true }
+				&& ItemsViewAdapter.ItemsSource is ObservableGroupedSource groupedSource
+					? groupedSource.GroupCount == 0
+					: ItemsViewAdapter.ItemCount == itemCount;
+			var showEmptyView = (ItemsView?.EmptyView is not null || ItemsView?.EmptyViewTemplate is not null) && sourceIsEmpty;
 
 			var currentAdapter = GetAdapter();
 			if (showEmptyView && currentAdapter != _emptyViewAdapter)

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		bool _initialized;
 		bool _laidOut;
 		bool _isEmpty = true;
+		bool _hasNoItems = true;
 		bool _emptyViewDisplayed;
 		bool _disposed;
 
@@ -134,10 +135,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		void CheckForEmptySource()
 		{
 			var wasEmpty = _isEmpty;
+			var hadNoItems = _hasNoItems;
 
-			_isEmpty = ItemsSource.ItemCount == 0;
+			_hasNoItems = ItemsSource.ItemCount == 0;
+			_isEmpty = IsEmptySource();
 
-			if (_isEmpty)
+			if (_hasNoItems)
 			{
 				ClearMeasurementCells();
 				ItemsViewLayout?.ClearCellSizeCache();
@@ -148,7 +151,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				UpdateEmptyViewVisibility(_isEmpty);
 			}
 
-			if (wasEmpty && !_isEmpty)
+			if (hadNoItems && !_hasNoItems)
 			{
 				// If we're going from empty to having stuff, it's possible that we've never actually measured
 				// a prototype cell and our itemSize or estimatedItemSize are wrong/unset
@@ -779,7 +782,19 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			UpdateView(ItemsView?.EmptyView, ItemsView?.EmptyViewTemplate, ref _emptyUIView, ref _emptyViewFormsElement);
 
 			// We may need to show the updated empty view
-			UpdateEmptyViewVisibility(ItemsSource?.ItemCount == 0);
+			UpdateEmptyViewVisibility(IsEmptySource());
+		}
+
+		bool IsEmptySource()
+		{
+			if (ItemsSource is null)
+			{
+				return true;
+			}
+
+			return ItemsView is GroupableItemsView { IsGrouped: true }
+				? ItemsSource.GroupCount == 0
+				: ItemsSource.ItemCount == 0;
 		}
 
 		void UpdateEmptyViewVisibility(bool isEmpty)

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		{
 			var wasEmpty = _isEmpty;
 
-			_isEmpty = ItemsSource.ItemCount == 0;
+			_isEmpty = IsEmptySource();
 
 			if (wasEmpty != _isEmpty)
 			{
@@ -546,7 +546,19 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			UpdateView(ItemsView?.EmptyView, ItemsView?.EmptyViewTemplate, ref _emptyUIView, ref _emptyViewFormsElement);
 
 			// We may need to show the updated empty view
-			UpdateEmptyViewVisibility(ItemsSource?.ItemCount == 0);
+			UpdateEmptyViewVisibility(IsEmptySource());
+		}
+
+		bool IsEmptySource()
+		{
+			if (ItemsSource is null)
+			{
+				return true;
+			}
+
+			return ItemsView is GroupableItemsView { IsGrouped: true }
+				? ItemsSource.GroupCount == 0
+				: ItemsSource.ItemCount == 0;
 		}
 
 		void UpdateEmptyViewVisibility(bool isEmpty)

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.Android.cs
@@ -105,6 +105,38 @@ namespace Microsoft.Maui.DeviceTests
 				});
 		}
 
+		[Fact]
+		public async Task GroupedCollectionViewEmptyViewTracksGroups()
+		{
+				SetupBuilder();
+
+				var groups = new ObservableCollection<ObservableCollection<string>>
+				{
+					new()
+				};
+				var collectionView = new CollectionView
+				{
+					IsGrouped = true,
+					ItemsSource = groups,
+					EmptyView = new Label { Text = "Empty" }
+				};
+				var frame = collectionView.Frame;
+
+				await CreateHandlerAndAddToWindow<CollectionViewHandler>(collectionView, async handler =>
+				{
+					await WaitForUIUpdate(frame, collectionView);
+					Assert.IsNotType<EmptyViewAdapter>(handler.PlatformView.GetAdapter());
+
+					groups.Clear();
+					await Task.Delay(100);
+					Assert.IsType<EmptyViewAdapter>(handler.PlatformView.GetAdapter());
+
+					groups.Add(new());
+					await Task.Delay(100);
+					Assert.IsNotType<EmptyViewAdapter>(handler.PlatformView.GetAdapter());
+				});
+		}
+
 		//src/Compatibility/Core/tests/Android/RendererTests.cs
 		[Fact(DisplayName = "EmptySource should have a count of zero")]
 		[Trait("Category", "CollectionView")]

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.Android.cs
@@ -11,6 +11,7 @@ using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using Xunit;
+using static Microsoft.Maui.DeviceTests.AssertHelpers;
 using AInsets = AndroidX.Core.Graphics.Insets;
 using AView = Android.Views.View;
 
@@ -127,13 +128,19 @@ namespace Microsoft.Maui.DeviceTests
 					await WaitForUIUpdate(frame, collectionView);
 					Assert.IsNotType<EmptyViewAdapter>(handler.PlatformView.GetAdapter());
 
-					groups.Clear();
-					await Task.Delay(100);
-					Assert.IsType<EmptyViewAdapter>(handler.PlatformView.GetAdapter());
+					groups.RemoveAt(0);
+					await AssertEventually(() => handler.PlatformView.GetAdapter() is EmptyViewAdapter);
 
 					groups.Add(new());
-					await Task.Delay(100);
-					Assert.IsNotType<EmptyViewAdapter>(handler.PlatformView.GetAdapter());
+					await AssertEventually(() => handler.PlatformView.GetAdapter() is not EmptyViewAdapter);
+
+					groups.Add(new() { "Item 1", "Item 2" });
+					await AssertEventually(() => handler.PlatformView.GetAdapter().ItemCount == 2);
+
+					groups.RemoveAt(1);
+					await AssertEventually(() =>
+						handler.PlatformView.GetAdapter() is not EmptyViewAdapter &&
+						handler.PlatformView.GetAdapter().ItemCount == 0);
 				});
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
@@ -16,6 +16,7 @@ using Microsoft.Maui.Platform;
 using UIKit;
 using Xunit;
 using Xunit.Sdk;
+using static Microsoft.Maui.DeviceTests.AssertHelpers;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -66,12 +67,10 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.Null(emptyViewWrapper.Superview);
 
 				groups.Clear();
-				await Task.Delay(100);
-				Assert.NotNull(emptyViewWrapper.Superview);
+				await AssertEventually(() => emptyViewWrapper.Superview is not null);
 
 				groups.Add(new());
-				await Task.Delay(100);
-				Assert.Null(emptyViewWrapper.Superview);
+				await AssertEventually(() => emptyViewWrapper.Superview is null);
 			});
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
@@ -21,6 +21,60 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class CollectionViewTests
 	{
+		[Fact(DisplayName = "Grouped CollectionView EmptyView Tracks Groups")]
+		public Task GroupedCollectionViewEmptyViewTracksGroups()
+		{
+			return VerifyGroupedCollectionViewEmptyViewTracksGroups<CollectionViewHandler>();
+		}
+
+		[Fact(DisplayName = "CollectionViewHandler2 Grouped EmptyView Tracks Groups")]
+		public Task GroupedCollectionViewEmptyViewTracksGroups2()
+		{
+			return VerifyGroupedCollectionViewEmptyViewTracksGroups<CollectionViewHandler2>();
+		}
+
+		async Task VerifyGroupedCollectionViewEmptyViewTracksGroups<THandler>()
+			where THandler : class, IElementHandler
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler<CollectionView, THandler>();
+					handlers.AddHandler<Label, LabelHandler>();
+				});
+			});
+
+			var groups = new ObservableCollection<ObservableCollection<string>>
+			{
+				new()
+			};
+			var emptyView = new Label { Text = "Empty" };
+			var collectionView = new CollectionView
+			{
+				IsGrouped = true,
+				ItemsSource = groups,
+				EmptyView = emptyView
+			};
+			var frame = collectionView.Frame;
+
+			await CreateHandlerAndAddToWindow<THandler>(collectionView, async _ =>
+			{
+				await WaitForUIUpdate(frame, collectionView);
+				var emptyPlatformView = Assert.IsAssignableFrom<UIView>(emptyView.Handler.PlatformView);
+				var emptyViewWrapper = Assert.IsAssignableFrom<UIView>(emptyPlatformView.Superview);
+				Assert.Null(emptyViewWrapper.Superview);
+
+				groups.Clear();
+				await Task.Delay(100);
+				Assert.NotNull(emptyViewWrapper.Superview);
+
+				groups.Add(new());
+				await Task.Delay(100);
+				Assert.Null(emptyViewWrapper.Superview);
+			});
+		}
+
 		[Fact]
 		public async Task ItemsSourceGroupedClearDoestCrash()
 		{


### PR DESCRIPTION
## Description

Fixes #37429.

Grouped `CollectionView` now determines `EmptyView` visibility from the outer group count instead of the flattened item/cell count:

- iOS no longer overlays `EmptyView` when one or more empty groups still exist. This covers both `CollectionViewHandler` and `CollectionViewHandler2`.
- Android now updates grouped source tracking before notifying `RecyclerView`, so removing the final group immediately displays `EmptyView`.
- Android sends a dataset notification for zero-row group changes only when the outer group count crosses zero, avoiding unnecessary visible-row rebinding.
- Legacy iOS continues tracking leaf-item transitions separately so first-item measurement behavior is preserved.

## Before and after

### iOS 18.4

| Before: EmptyView overlays an existing empty group | After: group header/footer remain without EmptyView |
|---|---|
| ![iOS before](https://github.com/user-attachments/assets/3d0d2b34-d769-49dc-84d4-0f06a3822d63) | ![iOS after final validation](https://github.com/user-attachments/assets/0552ec1c-009e-4cb6-b901-63af611decc1) |

The italic `This group is empty.` text is the reporter project's `GroupFooterTemplate`, whose padding is `10,0,10,10`; it is not the `EmptyView`. The final native accessibility tree contains `Group 1` and no `EMPTY VIEW`.

### Android 16

| Before: blank after removing the final group | After: EmptyView appears immediately |
|---|---|
| ![Android before](https://github.com/user-attachments/assets/e863ea22-bfdc-4b1f-90ef-e5dfa491ab78) | ![Android after final validation](https://github.com/user-attachments/assets/9ca9f347-c6a0-437a-ac71-59017543c229) |

## Validation

- Built the Controls device-test app for `net10.0-ios` and `net10.0-android` with no warnings or errors.
- Added device tests for Android and both iOS CollectionView handlers covering one empty group, zero groups, re-adding an empty group, direct removal of the final empty group, and Android range removal of a populated group.
- Reproduced the original behavior using the issue author's project with Microsoft.Maui.Controls 10.0.90 on iPhone 16 Pro / iOS 18.4 and Pixel 9 Pro / Android 16.
- Linked that project directly to the patched framework and replayed both exact scenarios through Appium, asserting the native accessibility trees.
- Repeated the transitions on both platforms and performed a final fresh-install replay against the review-adjusted implementation.
- Compared independent fix proposals and completed multi-model pre- and post-fix reviews; the final independent reviews reported no actionable issues.
