### PR TITLE
[catalyst] Add failing reproduction for #35516

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Shell/Issue35516.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/Issue35516.iOS.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.Controls.Platform.Compatibility;
+using Microsoft.Maui.Hosting;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.Shell)]
+	[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
+	public class Issue35516 : ControlsHandlerTestBase
+	{
+		const string IssueNumber = "35516";
+
+		static string? GetReplicationIssue()
+		{
+#if ANDROID
+			return global::Microsoft.Maui.TestUtils.DeviceTests.Runners.HeadlessRunner
+				.MauiTestInstrumentation.Current?.Arguments?.GetString("MAUI_REPRODUCTION_ISSUE");
+#elif IOS || MACCATALYST
+			return global::Foundation.NSProcessInfo.ProcessInfo.Environment["MAUI_REPRODUCTION_ISSUE"]?.ToString();
+#else
+			return Environment.GetEnvironmentVariable("MAUI_REPRODUCTION_ISSUE");
+#endif
+		}
+
+		[Fact]
+		public async Task SettingQueryUpdatesNativeSearchBar()
+		{
+			if (!string.Equals(
+				GetReplicationIssue(),
+				IssueNumber,
+				StringComparison.Ordinal))
+			{
+				return;
+			}
+
+#if !MACCATALYST
+			return;
+#else
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers => SetupShellHandlers(handlers));
+			});
+
+			var searchHandler = new SearchHandler
+			{
+				Placeholder = "Search query",
+				SearchBoxVisibility = SearchBoxVisibility.Expanded
+			};
+			var page = new ContentPage();
+			Shell.SetSearchHandler(page, searchHandler);
+
+			var shell = new Shell
+			{
+				CurrentItem = page,
+				FlyoutBehavior = FlyoutBehavior.Disabled
+			};
+
+			await CreateHandlerAndAddToWindow<ShellRenderer>(shell, async handler =>
+			{
+				await OnLoadedAsync(page);
+
+				var shellContext = (IShellContext)handler;
+				var itemRenderer = Assert.IsType<ShellItemRenderer>(shellContext.CurrentShellItemRenderer);
+				var sectionRenderer = Assert.IsType<ShellSectionRenderer>(itemRenderer.CurrentRenderer);
+				var nativeSearchBar = sectionRenderer.TopViewController?.NavigationItem.SearchController?.SearchBar;
+				Assert.NotNull(nativeSearchBar);
+
+				searchHandler.Query = "Hello World";
+
+				Assert.True(
+					string.Equals("Hello World", nativeSearchBar.Text, StringComparison.Ordinal),
+					"Native SearchHandler text should update to 'Hello World'.");
+			});
+#endif
+		}
+	}
+}


### PR DESCRIPTION
<!-- MAUI_COPILOT_REPLICATION issue=35516 platform=catalyst -->

> [!IMPORTANT]
> This is AI-generated **reproduction evidence**, not a merge-ready product fix. The guarded test intentionally fails only when `MAUI_REPRODUCTION_ISSUE=35516` is set. A product fix should remove the guard and make the test pass before this PR is considered for merge.

## Reproduced issue

- Issue: [dotnet/maui#35516 — [Shell] Dynamically setting SearchHandler Query property does not update text in the search box on Mac Catalyst](https://github.com/dotnet/maui/issues/35516)
- Platform: **catalyst**
- Baseline commit: `604d9de36e05a40c36ab05cdcd68f2c6286fa260`
- Test type: **device**
- Targeted filter: `Issue35516`
- Expected failing assertion: `Native SearchHandler text should update to 'Hello World'.`
- Pipeline run: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14985805

## Device evidence

[![Reproduction preview](https://raw.githubusercontent.com/dotnet/maui/d15c3c8885646ec15297489701ad92c74e4bf890/pr-35516/replication/catalyst/14985805-1/preview.gif)](https://raw.githubusercontent.com/dotnet/maui/d15c3c8885646ec15297489701ad92c74e4bf890/pr-35516/replication/catalyst/14985805-1/repro.mp4)

[Open the full MP4 recording](https://raw.githubusercontent.com/dotnet/maui/d15c3c8885646ec15297489701ad92c74e4bf890/pr-35516/replication/catalyst/14985805-1/repro.mp4) · [Evidence manifest](https://raw.githubusercontent.com/dotnet/maui/d15c3c8885646ec15297489701ad92c74e4bf890/pr-35516/replication/catalyst/14985805-1/evidence.json)

## Reproduction steps

1. Create a Shell page with an expanded SearchHandler whose placeholder is 'Search query'.
1. Attach the Shell to a native window and wait for its Mac Catalyst search controller to load.
1. Set SearchHandler.Query programmatically to 'Hello World'.
1. Read the text from the native UISearchBar and assert that it equals 'Hello World'.

## Safety and validation

- The pipeline reconstructed the scenario from issue text, inline snippets, and allowed raster screenshots.
- No linked repository, archive, binary, script, package, or arbitrary external file was downloaded.
- A trusted runner reproduced the behavior on-device and matched the expected targeted test failure.
- The published patch is add-only and restricted to approved MAUI test locations.
