### PR TITLE
[android] Add failing reproduction for #10792

### DIFF
--- a/src/Controls/tests/Core.UnitTests/Issue10792.cs
+++ b/src/Controls/tests/Core.UnitTests/Issue10792.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Globalization;
+using Microsoft.Maui.Controls;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	public class Issue10792
+	{
+		[Fact]
+		public void MultiBindingEvaluatesWhenAppliedToBindingContext()
+		{
+			if (!string.Equals(
+				Environment.GetEnvironmentVariable("MAUI_REPRODUCTION_ISSUE"),
+				"10792",
+				StringComparison.Ordinal))
+			{
+				return;
+			}
+
+			var source = new BindingSource();
+			var parent = new StackLayout
+			{
+				BindingContext = source
+			};
+			var label = new Label();
+			label.SetBinding(BindableObject.BindingContextProperty, new MultiBinding
+			{
+				Bindings =
+				{
+					new Binding(nameof(BindingSource.Property1), mode: BindingMode.OneTime),
+					new Binding(nameof(BindingSource.Property2), mode: BindingMode.OneTime)
+				},
+				Converter = new JoinValuesConverter(),
+				FallbackValue = "FallbackValue"
+			});
+
+			parent.Children.Add(label);
+
+			Assert.Equal("Alpha + Beta", label.BindingContext as string);
+		}
+
+		sealed class BindingSource
+		{
+			public string Property1 => "Alpha";
+
+			public string Property2 => "Beta";
+		}
+
+		sealed class JoinValuesConverter : IMultiValueConverter
+		{
+			public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+			{
+				if (values.Length != 2 || values[0] is not string first || values[1] is not string second)
+					return BindableProperty.UnsetValue;
+
+				return $"{first} + {second}";
+			}
+
+			public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture) =>
+				throw new NotSupportedException();
+		}
+	}
+}


### PR DESCRIPTION
<!-- MAUI_COPILOT_REPLICATION issue=10792 platform=android -->

> [!IMPORTANT]
> This is AI-generated **reproduction evidence**, not a merge-ready product fix. The guarded test intentionally fails only when `MAUI_REPRODUCTION_ISSUE=10792` is set. A product fix should remove the guard and make the test pass before this PR is considered for merge.

## Reproduced issue

- Issue: [dotnet/maui#10792 — Multibindings applied to BindableObject.BindingContext property do not work.](https://github.com/dotnet/maui/issues/10792)
- Platform: **android**
- Baseline commit: `604d9de36e05a40c36ab05cdcd68f2c6286fa260`
- Test type: **unit**
- Targeted filter: `Issue10792`
- Expected failing assertion: `Expected: "Alpha + Beta"`
- Pipeline run: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14985778

## Device evidence

[![Reproduction preview](https://raw.githubusercontent.com/dotnet/maui/cc6b00e3179f6020684cf523c96e32210eeff529/pr-10792/replication/android/14985778-1/preview.gif)](https://raw.githubusercontent.com/dotnet/maui/cc6b00e3179f6020684cf523c96e32210eeff529/pr-10792/replication/android/14985778-1/repro.mp4)

[Open the full MP4 recording](https://raw.githubusercontent.com/dotnet/maui/cc6b00e3179f6020684cf523c96e32210eeff529/pr-10792/replication/android/14985778-1/repro.mp4) · [Evidence manifest](https://raw.githubusercontent.com/dotnet/maui/cc6b00e3179f6020684cf523c96e32210eeff529/pr-10792/replication/android/14985778-1/evidence.json)

## Reproduction steps

1. Create a managed source object whose Property1 and Property2 values are Alpha and Beta.
1. Set the source object as the BindingContext of a parent layout.
1. Attach a Label whose BindingContextProperty uses a MultiBinding over Property1 and Property2 with a converter returning Alpha + Beta and FallbackValue set to FallbackValue.
1. Add the Label to the parent layout and assert that the Label BindingContext is Alpha + Beta.

## Safety and validation

- The pipeline reconstructed the scenario from issue text, inline snippets, and allowed raster screenshots.
- No linked repository, archive, binary, script, package, or arbitrary external file was downloaded.
- A trusted runner reproduced the behavior on-device and matched the expected targeted test failure.
- The published patch is add-only and restricted to approved MAUI test locations.
