### PR TITLE
[android] Add failing reproduction for #37440

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Editor/Issue37440Tests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Editor/Issue37440Tests.Android.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Microsoft.Maui.Platform;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.Editor)]
+	[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
+	public class Issue37440 : ControlsHandlerTestBase
+	{
+		const string IssueNumber = "37440";
+
+		static string? GetReplicationIssue()
+		{
+#if ANDROID
+			return global::Microsoft.Maui.TestUtils.DeviceTests.Runners.HeadlessRunner
+				.MauiTestInstrumentation.Current?.Arguments?.GetString("MAUI_REPRODUCTION_ISSUE");
+#elif IOS || MACCATALYST
+			return global::Foundation.NSProcessInfo.ProcessInfo.Environment["MAUI_REPRODUCTION_ISSUE"]?.ToString();
+#else
+			return Environment.GetEnvironmentVariable("MAUI_REPRODUCTION_ISSUE");
+#endif
+		}
+
+		void SetupBuilder()
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler<Border, BorderHandler>();
+				});
+			});
+		}
+
+		[Fact]
+		public async Task EmptyAutoSizeEditorStartsBelowMaximumHeight()
+		{
+			if (!string.Equals(
+				GetReplicationIssue(),
+				IssueNumber,
+				StringComparison.Ordinal))
+			{
+				return;
+			}
+
+			SetupBuilder();
+
+			const double maximumEditorHeight = 150;
+			const double heightTolerance = 2;
+			var editor = new Editor
+			{
+				MinimumHeightRequest = 50,
+				MaximumHeightRequest = maximumEditorHeight,
+				AutoSize = EditorAutoSizeOption.TextChanges,
+			};
+			var layout = new VerticalStackLayout
+			{
+				Children =
+				{
+					new Border
+					{
+						HeightRequest = 200,
+						Content = new Border
+						{
+							HeightRequest = 150,
+							Content = editor,
+						},
+					},
+				},
+			};
+
+			await AttachAndRun<LayoutHandler>(layout, async _ =>
+			{
+				var editorHandler = Assert.IsType<EditorHandler>(editor.Handler);
+				await editorHandler.PlatformView.WaitForLayoutOrNonZeroSize();
+
+				Assert.True(
+					editor.Height < maximumEditorHeight - heightTolerance,
+					"Editor should start below MaximumHeightRequest when empty and AutoSize is TextChanges.");
+			});
+		}
+	}
+}


### PR DESCRIPTION
<!-- MAUI_COPILOT_REPLICATION issue=37440 platform=android -->

> [!IMPORTANT]
> This is AI-generated **reproduction evidence**, not a merge-ready product fix. The guarded test intentionally fails only when `MAUI_REPRODUCTION_ISSUE=37440` is set. A product fix should remove the guard and make the test pass before this PR is considered for merge.

## Reproduced issue

- Issue: [dotnet/maui#37440 — [android] Editor auto expands wrongly to MaximumHeightRequest](https://github.com/dotnet/maui/issues/37440)
- Platform: **android**
- Baseline commit: `604d9de36e05a40c36ab05cdcd68f2c6286fa260`
- Test type: **device**
- Targeted filter: `Issue37440`
- Expected failing assertion: `Editor should start below MaximumHeightRequest when empty and AutoSize is TextChanges.`
- Pipeline run: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14985825

## Device evidence

[![Reproduction preview](https://raw.githubusercontent.com/dotnet/maui/a83146fc53e5a3f08d27bfeb58ee0d0bace9630d/pr-37440/replication/android/14985825-1/preview.gif)](https://raw.githubusercontent.com/dotnet/maui/a83146fc53e5a3f08d27bfeb58ee0d0bace9630d/pr-37440/replication/android/14985825-1/repro.mp4)

[Open the full MP4 recording](https://raw.githubusercontent.com/dotnet/maui/a83146fc53e5a3f08d27bfeb58ee0d0bace9630d/pr-37440/replication/android/14985825-1/repro.mp4) · [Evidence manifest](https://raw.githubusercontent.com/dotnet/maui/a83146fc53e5a3f08d27bfeb58ee0d0bace9630d/pr-37440/replication/android/14985825-1/evidence.json)

## Reproduction steps

1. Create an empty Editor with MinimumHeightRequest 50, MaximumHeightRequest 150, and AutoSize TextChanges inside the same nested fixed-height Borders.
1. Register the Border handler in the isolated test context and attach the layout to an Android window.
1. Wait for the native Editor to complete a layout pass using the existing layout wait helper.
1. Assert that the Editor height is less than MaximumHeightRequest minus the two-point layout tolerance.

## Safety and validation

- The pipeline reconstructed the scenario from issue text, inline snippets, and allowed raster screenshots.
- No linked repository, archive, binary, script, package, or arbitrary external file was downloaded.
- A trusted runner reproduced the behavior on-device and matched the expected targeted test failure.
- The published patch is add-only and restricted to approved MAUI test locations.
