### PR TITLE
[ios] Add failing reproduction for #31059

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/Issue31059.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/Issue31059.iOS.cs
@@ -1,0 +1,115 @@
+#nullable enable annotations
+
+using System;
+using System.Threading.Tasks;
+using CoreGraphics;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers.Items2;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using UIKit;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
+	[Category(TestCategory.CollectionView)]
+	public class Issue31059 : ControlsHandlerTestBase
+	{
+		const string IssueNumber = "31059";
+		const int LastItemIndex = 4;
+		const string CenterItemChangedMessage = "CollectionView center item changed after portrait-to-landscape resize.";
+
+		static string? GetReplicationIssue()
+		{
+#if ANDROID
+			return global::Microsoft.Maui.TestUtils.DeviceTests.Runners.HeadlessRunner
+				.MauiTestInstrumentation.Current?.Arguments?.GetString("MAUI_REPRODUCTION_ISSUE");
+#elif IOS || MACCATALYST
+			return global::Foundation.NSProcessInfo.ProcessInfo.Environment["MAUI_REPRODUCTION_ISSUE"]?.ToString();
+#else
+			return Environment.GetEnvironmentVariable("MAUI_REPRODUCTION_ISSUE");
+#endif
+		}
+
+		[Fact]
+		public async Task CenterItemRemainsSelectedAfterLandscapeResize()
+		{
+			if (!string.Equals(
+				GetReplicationIssue(),
+				IssueNumber,
+				StringComparison.Ordinal))
+			{
+				return;
+			}
+
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler<CollectionView, CollectionViewHandler2>();
+					handlers.AddHandler<Label, LabelHandler>();
+				});
+			});
+
+			var centeredOnLastItem = new TaskCompletionSource();
+			var centerIndexAfterResize = new TaskCompletionSource<int>();
+			var resizeStarted = false;
+			var currentPosition = 0;
+			var collectionView = new CollectionView
+			{
+				HeightRequest = 260,
+				ItemsSource = new[] { "Item 1", "Item 2", "Item 3", "Item 4", "Item 5" },
+				ItemsLayout = new LinearItemsLayout(ItemsLayoutOrientation.Horizontal)
+				{
+					SnapPointsType = SnapPointsType.MandatorySingle,
+					SnapPointsAlignment = SnapPointsAlignment.Center
+				},
+				ItemTemplate = new DataTemplate(() => new Label
+				{
+					WidthRequest = 240,
+					HeightRequest = 240
+				})
+			};
+
+			collectionView.Scrolled += (_, args) =>
+			{
+				if (args.CenterItemIndex < 0 || args.CenterItemIndex > LastItemIndex)
+					return;
+
+				if (resizeStarted)
+					centerIndexAfterResize.TrySetResult(args.CenterItemIndex);
+
+				if (args.CenterItemIndex != currentPosition)
+				{
+					currentPosition = args.CenterItemIndex;
+					collectionView.ScrollTo(args.CenterItemIndex, position: ScrollToPosition.Center, animate: false);
+				}
+
+				if (args.CenterItemIndex == LastItemIndex)
+					centeredOnLastItem.TrySetResult();
+			};
+
+			await CreateHandlerAndAddToWindow<CollectionViewHandler2>(collectionView, async handler =>
+			{
+				UICollectionView nativeCollectionView = handler.Controller.CollectionView;
+				nativeCollectionView.Frame = new CGRect(0, 0, 390, 260);
+				nativeCollectionView.SetNeedsLayout();
+				nativeCollectionView.LayoutIfNeeded();
+
+				collectionView.ScrollTo(LastItemIndex, position: ScrollToPosition.Center, animate: false);
+				await centeredOnLastItem.Task;
+
+				resizeStarted = true;
+				nativeCollectionView.Frame = new CGRect(0, 0, 844, 260);
+				nativeCollectionView.CollectionViewLayout.InvalidateLayout();
+				nativeCollectionView.SetNeedsLayout();
+				nativeCollectionView.LayoutIfNeeded();
+				await nativeCollectionView.PerformBatchUpdatesAsync(() => { });
+
+				var centerItemIndex = await centerIndexAfterResize.Task;
+				Assert.True(centerItemIndex == LastItemIndex, CenterItemChangedMessage);
+			});
+		}
+	}
+}


### PR DESCRIPTION
<!-- MAUI_COPILOT_REPLICATION issue=31059 platform=ios -->

> [!IMPORTANT]
> This is AI-generated **reproduction evidence**, not a merge-ready product fix. The guarded test intentionally fails only when `MAUI_REPRODUCTION_ISSUE=31059` is set. A product fix should remove the guard and make the test pass before this PR is considered for merge.

## Reproduced issue

- Issue: [dotnet/maui#31059 — MAUI - (IOS) Collectionview Scrolled event called when orientation changes from Portrait to Landscape](https://github.com/dotnet/maui/issues/31059)
- Platform: **ios**
- Baseline commit: `604d9de36e05a40c36ab05cdcd68f2c6286fa260`
- Test type: **device**
- Targeted filter: `Issue31059`
- Expected failing assertion: `CollectionView center item changed after portrait-to-landscape resize.`
- Pipeline run: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14985980

## Device evidence

[![Reproduction preview](https://raw.githubusercontent.com/dotnet/maui/63fbbd98eedba167653855b4fbaa81a333b7a79b/pr-31059/replication/ios/14985980-1/preview.gif)](https://raw.githubusercontent.com/dotnet/maui/63fbbd98eedba167653855b4fbaa81a333b7a79b/pr-31059/replication/ios/14985980-1/repro.mp4)

[Open the full MP4 recording](https://raw.githubusercontent.com/dotnet/maui/63fbbd98eedba167653855b4fbaa81a333b7a79b/pr-31059/replication/ios/14985980-1/repro.mp4) · [Evidence manifest](https://raw.githubusercontent.com/dotnet/maui/63fbbd98eedba167653855b4fbaa81a333b7a79b/pr-31059/replication/ios/14985980-1/evidence.json)

## Reproduction steps

1. Create an iOS CollectionView using CollectionViewHandler2 with five fixed-size items, horizontal mandatory-single center snap points, and a Scrolled handler that scrolls to each newly centered index.
1. Host the CollectionView in a native test window with portrait dimensions and wait for its native layout to complete.
1. Scroll without animation to item index 4 and wait until the Scrolled event reports index 4 as centered.
1. Resize the native viewport to landscape dimensions, force the iOS layout transition, and await the first resulting Scrolled event.
1. Assert with the exact failure message that the center index reported after the resize remains 4.

## Safety and validation

- The pipeline reconstructed the scenario from issue text, inline snippets, and allowed raster screenshots.
- No linked repository, archive, binary, script, package, or arbitrary external file was downloaded.
- A trusted runner reproduced the behavior on-device and matched the expected targeted test failure.
- The published patch is add-only and restricted to approved MAUI test locations.
