### PR TITLE
[catalyst] Add failing reproduction for #17210

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/MenuFlyoutItem/Issue17210.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/MenuFlyoutItem/Issue17210.iOS.cs
@@ -1,0 +1,103 @@
+#if MACCATALYST
+#nullable enable
+using System;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using UIKit;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.MenuFlyout)]
+	public class Issue17210 : ControlsHandlerTestBase
+	{
+		const string IssueNumber = "17210";
+
+		static string? GetReplicationIssue()
+		{
+#if ANDROID
+			return global::Microsoft.Maui.TestUtils.DeviceTests.Runners.HeadlessRunner
+				.MauiTestInstrumentation.Current?.Arguments?.GetString("MAUI_REPRODUCTION_ISSUE");
+#elif IOS || MACCATALYST
+			return global::Foundation.NSProcessInfo.ProcessInfo.Environment["MAUI_REPRODUCTION_ISSUE"]?.ToString();
+#else
+			return Environment.GetEnvironmentVariable("MAUI_REPRODUCTION_ISSUE");
+#endif
+		}
+
+		[Fact]
+		public async Task BoundIconImageSourceUpdatesNativeMenuIcon()
+		{
+			if (!string.Equals(
+				GetReplicationIssue(),
+				IssueNumber,
+				StringComparison.Ordinal))
+			{
+				return;
+			}
+
+			try
+			{
+				await InvokeOnMainThreadAsync(() =>
+				{
+					var model = new MenuItemModel();
+					var item = new MenuFlyoutItem { Text = "Bound menu icon" };
+					item.SetBinding(MenuFlyoutItem.IconImageSourceProperty, nameof(MenuItemModel.Icon));
+					item.BindingContext = model;
+
+					var handler = CreateHandler<MenuFlyoutItemHandler>(item);
+					try
+					{
+						var nativeItem = Assert.IsType<UICommand>(handler.PlatformView);
+						var initialImage = Assert.IsType<UIImage>(nativeItem.Image);
+
+						model.Icon = new FontImageSource
+						{
+							Glyph = "B",
+							Size = 16
+						};
+
+						var updatedSource = Assert.IsType<FontImageSource>(item.IconImageSource);
+						var updatedImage = Assert.IsType<UIImage>(nativeItem.Image);
+						Assert.Equal("B", updatedSource.Glyph);
+						Assert.False(
+							initialImage.Handle == updatedImage.Handle,
+							"The native menu icon should update when its bound IconImageSource changes.");
+					}
+					finally
+					{
+						((IElementHandler)handler).DisconnectHandler();
+					}
+				});
+			}
+			finally
+			{
+				MenuFlyoutItemHandler.Reset();
+			}
+		}
+
+		sealed class MenuItemModel : BindableObject
+		{
+			ImageSource _icon = new FontImageSource
+			{
+				Glyph = "A",
+				Size = 16
+			};
+
+			public ImageSource Icon
+			{
+				get => _icon;
+				set
+				{
+					if (_icon == value)
+						return;
+
+					_icon = value;
+					OnPropertyChanged();
+				}
+			}
+		}
+	}
+}
+#endif


### PR DESCRIPTION
<!-- MAUI_COPILOT_REPLICATION issue=17210 platform=catalyst -->

> [!IMPORTANT]
> This is AI-generated **reproduction evidence**, not a merge-ready product fix. The guarded test intentionally fails only when `MAUI_REPRODUCTION_ISSUE=17210` is set. A product fix should remove the guard and make the test pass before this PR is considered for merge.

## Reproduced issue

- Issue: [dotnet/maui#17210 — Binding IconImageSource on MenuFlyoutItem does not update on runtime.](https://github.com/dotnet/maui/issues/17210)
- Platform: **catalyst**
- Baseline commit: `604d9de36e05a40c36ab05cdcd68f2c6286fa260`
- Test type: **device**
- Targeted filter: `Issue17210`
- Expected failing assertion: `The native menu icon should update when its bound IconImageSource changes.`
- Pipeline run: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14986056

## Device evidence

[![Reproduction preview](https://raw.githubusercontent.com/dotnet/maui/c48553df4ac813560808610e7a6abafad7ff6840/pr-17210/replication/catalyst/14986056-1/preview.gif)](https://raw.githubusercontent.com/dotnet/maui/c48553df4ac813560808610e7a6abafad7ff6840/pr-17210/replication/catalyst/14986056-1/repro.mp4)

[Open the full MP4 recording](https://raw.githubusercontent.com/dotnet/maui/c48553df4ac813560808610e7a6abafad7ff6840/pr-17210/replication/catalyst/14986056-1/repro.mp4) · [Evidence manifest](https://raw.githubusercontent.com/dotnet/maui/c48553df4ac813560808610e7a6abafad7ff6840/pr-17210/replication/catalyst/14986056-1/evidence.json)

## Reproduction steps

1. Create a MenuFlyoutItem whose IconImageSource is bound to a model initialized with an in-memory font glyph.
1. Create its Mac Catalyst handler and capture the native menu element image.
1. Change the bound model value to a different in-memory font glyph and confirm the managed IconImageSource changes.
1. Assert that the native menu element image is replaced after the binding update.

## Safety and validation

- The pipeline reconstructed the scenario from issue text, inline snippets, and allowed raster screenshots.
- No linked repository, archive, binary, script, package, or arbitrary external file was downloaded.
- A trusted runner reproduced the behavior on-device and matched the expected targeted test failure.
- The published patch is add-only and restricted to approved MAUI test locations.
