### PR TITLE
[android] Add failing reproduction for #11740

### DIFF
--- a/src/Controls/tests/Core.UnitTests/Issue11740.cs
+++ b/src/Controls/tests/Core.UnitTests/Issue11740.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Globalization;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	public class Issue11740
+	{
+		const string IssueNumber = "11740";
+
+		[Fact]
+		public void DoNothingConverterLeavesTargetUnchanged()
+		{
+			if (!string.Equals(
+				Environment.GetEnvironmentVariable("MAUI_REPRODUCTION_ISSUE"),
+				IssueNumber,
+				StringComparison.Ordinal))
+			{
+				return;
+			}
+
+			var entry = new Entry();
+			entry.SetBinding(
+				Entry.TextProperty,
+				new Binding(nameof(BindingSource.SourceText), converter: new DoNothingValueConverter()));
+			entry.BindingContext = new BindingSource();
+
+			Assert.True(
+				string.IsNullOrEmpty(entry.Text),
+				"Binding.DoNothing should leave the target value unchanged.");
+		}
+
+		sealed class BindingSource
+		{
+			public string SourceText => "Source value";
+		}
+
+		sealed class DoNothingValueConverter : IValueConverter
+		{
+			public object Convert(object value, Type targetType, object parameter, CultureInfo culture) =>
+				Binding.DoNothing;
+
+			public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
+				Binding.DoNothing;
+		}
+	}
+}


### PR DESCRIPTION
<!-- MAUI_COPILOT_REPLICATION issue=11740 platform=android -->

> [!IMPORTANT]
> This is AI-generated **reproduction evidence**, not a merge-ready product fix. The guarded test intentionally fails only when `MAUI_REPRODUCTION_ISSUE=11740` is set. A product fix should remove the guard and make the test pass before this PR is considered for merge.

## Reproduced issue

- Issue: [dotnet/maui#11740 — Maui Binding does not respect Binding.DoNothing returned from IValueConverter](https://github.com/dotnet/maui/issues/11740)
- Platform: **android**
- Baseline commit: `604d9de36e05a40c36ab05cdcd68f2c6286fa260`
- Test type: **unit**
- Targeted filter: `Issue11740`
- Expected failing assertion: `Binding.DoNothing should leave the target value unchanged.`
- Pipeline run: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14986058

## Device evidence

[![Reproduction preview](https://raw.githubusercontent.com/dotnet/maui/d320ec89560c5c0b7b7d754a3ebac3266bcdf537/pr-11740/replication/android/14986058-1/preview.gif)](https://raw.githubusercontent.com/dotnet/maui/d320ec89560c5c0b7b7d754a3ebac3266bcdf537/pr-11740/replication/android/14986058-1/repro.mp4)

[Open the full MP4 recording](https://raw.githubusercontent.com/dotnet/maui/d320ec89560c5c0b7b7d754a3ebac3266bcdf537/pr-11740/replication/android/14986058-1/repro.mp4) · [Evidence manifest](https://raw.githubusercontent.com/dotnet/maui/d320ec89560c5c0b7b7d754a3ebac3266bcdf537/pr-11740/replication/android/14986058-1/evidence.json)

## Reproduction steps

1. Create an Entry whose Text is initially empty.
1. Bind Entry.Text to a non-empty source through an IValueConverter that returns Binding.DoNothing.
1. Apply the source as the Entry binding context.
1. Assert that Entry.Text remains empty.

## Safety and validation

- The pipeline reconstructed the scenario from issue text, inline snippets, and allowed raster screenshots.
- No linked repository, archive, binary, script, package, or arbitrary external file was downloaded.
- A trusted runner reproduced the behavior on-device and matched the expected targeted test failure.
- The published patch is add-only and restricted to approved MAUI test locations.
