### PR TITLE
[catalyst] Add failing reproduction for #37229

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Map/Issue37229.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Map/Issue37229.iOS.cs
@@ -1,0 +1,79 @@
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls.Maps;
+using Microsoft.Maui.Devices.Sensors;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.Map)]
+	public class Issue37229 : ControlsHandlerTestBase
+	{
+		const string IssueNumber = "37229";
+
+		static string? GetReplicationIssue()
+		{
+#if ANDROID
+			return global::Microsoft.Maui.TestUtils.DeviceTests.Runners.HeadlessRunner
+				.MauiTestInstrumentation.Current?.Arguments?.GetString("MAUI_REPRODUCTION_ISSUE");
+#elif IOS || MACCATALYST
+			return global::Foundation.NSProcessInfo.ProcessInfo.Environment["MAUI_REPRODUCTION_ISSUE"]?.ToString();
+#else
+			return Environment.GetEnvironmentVariable("MAUI_REPRODUCTION_ISSUE");
+#endif
+		}
+
+		[Fact]
+		public async Task ClearingMapElementsClearsAllNativeIdsAfterElementUpdate()
+		{
+			if (!string.Equals(
+				GetReplicationIssue(),
+				IssueNumber,
+				StringComparison.Ordinal))
+			{
+				return;
+			}
+
+			var map = new Map();
+			await CreateHandlerAsync<Microsoft.Maui.Maps.Handlers.MapHandler>(map);
+
+			var first = CreatePolyline(47.60, -122.33);
+			var second = CreatePolyline(47.62, -122.34);
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				map.MapElements.Add(first);
+				map.MapElements.Add(second);
+			});
+
+			Assert.NotNull(first.MapElementId);
+			Assert.NotNull(second.MapElementId);
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				first.Geopath.Add(new Location(47.62, -122.33));
+				map.MapElements.Clear();
+			});
+
+			Assert.True(
+				first.MapElementId is null && second.MapElementId is null,
+				"All map elements should have their native IDs cleared.");
+		}
+
+		static Polyline CreatePolyline(double latitude, double longitude)
+		{
+			var polyline = new Polyline
+			{
+				Geopath =
+				{
+					new Location(latitude, longitude),
+					new Location(latitude + 0.01, longitude)
+				}
+			};
+
+			return polyline;
+		}
+	}
+}


### PR DESCRIPTION
<!-- MAUI_COPILOT_REPLICATION issue=37229 platform=catalyst -->

> [!IMPORTANT]
> This is AI-generated **reproduction evidence**, not a merge-ready product fix. The guarded test intentionally fails only when `MAUI_REPRODUCTION_ISSUE=37229` is set. A product fix should remove the guard and make the test pass before this PR is considered for merge.

## Reproduced issue

- Issue: [dotnet/maui#37229 — [iOS] MauiMKMapView.AddElements replaces its tracked-element list, so updating one MapElement leaves stale MapElementId on all others](https://github.com/dotnet/maui/issues/37229)
- Platform: **catalyst**
- Baseline commit: `604d9de36e05a40c36ab05cdcd68f2c6286fa260`
- Test type: **device**
- Targeted filter: `Issue37229`
- Expected failing assertion: `All map elements should have their native IDs cleared.`
- Pipeline run: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14986173

## Device evidence

[![Reproduction preview](https://raw.githubusercontent.com/dotnet/maui/1fbb91a3361735907b37b6be9c6e6eb80ac103c7/pr-37229/replication/catalyst/14986173-1/preview.gif)](https://raw.githubusercontent.com/dotnet/maui/1fbb91a3361735907b37b6be9c6e6eb80ac103c7/pr-37229/replication/catalyst/14986173-1/repro.mp4)

[Open the full MP4 recording](https://raw.githubusercontent.com/dotnet/maui/1fbb91a3361735907b37b6be9c6e6eb80ac103c7/pr-37229/replication/catalyst/14986173-1/repro.mp4) · [Evidence manifest](https://raw.githubusercontent.com/dotnet/maui/1fbb91a3361735907b37b6be9c6e6eb80ac103c7/pr-37229/replication/catalyst/14986173-1/evidence.json)

## Reproduction steps

1. Create a Map handler on the main thread for Mac Catalyst.
1. Create two polylines and add both to the map's MapElements collection.
1. Confirm both polylines received non-null native MapElementId values.
1. Append one location to the first polyline's Geopath.
1. Clear the map's MapElements collection on the main thread.
1. Assert that both polylines have null MapElementId values.

## Safety and validation

- The pipeline reconstructed the scenario from issue text, inline snippets, and allowed raster screenshots.
- No linked repository, archive, binary, script, package, or arbitrary external file was downloaded.
- A trusted runner reproduced the behavior on-device and matched the expected targeted test failure.
- The published patch is add-only and restricted to approved MAUI test locations.
