### PR TITLE
[catalyst] Add failing reproduction for #37187

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Shell/Issue37187.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/Issue37187.iOS.cs
@@ -1,0 +1,121 @@
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers;
+using Microsoft.Maui.Controls.Handlers.Items;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Xunit;
+using NavigationViewHandler = Microsoft.Maui.Controls.Handlers.Compatibility.NavigationRenderer;
+using ShellHandler = Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.Shell)]
+	[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
+	public class Issue37187 : ControlsHandlerTestBase
+	{
+		const string IssueNumber = "37187";
+
+		static string? GetReplicationIssue()
+		{
+#if ANDROID
+			return global::Microsoft.Maui.TestUtils.DeviceTests.Runners.HeadlessRunner
+				.MauiTestInstrumentation.Current?.Arguments?.GetString("MAUI_REPRODUCTION_ISSUE");
+#elif IOS || MACCATALYST
+			return global::Foundation.NSProcessInfo.ProcessInfo.Environment["MAUI_REPRODUCTION_ISSUE"]?.ToString();
+#else
+			return Environment.GetEnvironmentVariable("MAUI_REPRODUCTION_ISSUE");
+#endif
+		}
+
+		[Fact]
+		public async Task ReplacingFlyoutFooterDetachesMeasureInvalidation()
+		{
+			if (!string.Equals(
+				GetReplicationIssue(),
+				IssueNumber,
+				StringComparison.Ordinal))
+			{
+				return;
+			}
+
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					SetupShellHandlers(handlers);
+					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+					handlers.AddHandler(typeof(Button), typeof(ButtonHandler));
+					handlers.AddHandler(typeof(Entry), typeof(EntryHandler));
+					handlers.AddHandler(typeof(ContentView), typeof(ContentViewHandler));
+					handlers.AddHandler(typeof(ScrollView), typeof(ScrollViewHandler));
+					handlers.AddHandler(typeof(CollectionView), typeof(CollectionViewHandler));
+				});
+			});
+
+			var oldFooter = new MeasureProbeView
+			{
+				Content = new Label { Text = "Footer A" }
+			};
+			var currentFooter = new MeasureProbeView
+			{
+				Content = new Label { Text = "Footer B" }
+			};
+			var shell = new Shell
+			{
+				CurrentItem = new ContentPage { Content = new Label { Text = "Shell content" } },
+				FlyoutBehavior = FlyoutBehavior.Flyout,
+				FlyoutFooter = oldFooter
+			};
+
+			await CreateHandlerAndAddToWindow<ShellHandler>(shell, async _ =>
+			{
+				await OnNavigatedToAsync(shell.CurrentPage);
+				shell.FlyoutIsPresented = true;
+				await OnLoadedAsync(oldFooter);
+				shell.FlyoutIsPresented = false;
+
+				shell.FlyoutFooter = currentFooter;
+				currentFooter.ArmMeasureProbe();
+				oldFooter.TriggerMeasureInvalidation();
+
+				Assert.False(
+					currentFooter.WasMeasuredWhileArmed,
+					"Replacing FlyoutFooter must detach the removed footer's measure invalidation callback.");
+			});
+		}
+
+		sealed class MeasureProbeView : ContentView
+		{
+			bool _measureProbeArmed;
+
+			public bool WasMeasuredWhileArmed { get; private set; }
+
+			public void ArmMeasureProbe()
+			{
+				WasMeasuredWhileArmed = false;
+				_measureProbeArmed = true;
+			}
+
+			public void TriggerMeasureInvalidation()
+			{
+				InvalidateMeasure();
+			}
+
+			protected override Microsoft.Maui.Graphics.Size MeasureOverride(double widthConstraint, double heightConstraint)
+			{
+				var size = base.MeasureOverride(widthConstraint, heightConstraint);
+				if (_measureProbeArmed)
+				{
+					_measureProbeArmed = false;
+					WasMeasuredWhileArmed = true;
+				}
+
+				return size;
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!-- MAUI_COPILOT_REPLICATION issue=37187 platform=catalyst -->

> [!IMPORTANT]
> This is AI-generated **reproduction evidence**, not a merge-ready product fix. The guarded test intentionally fails only when `MAUI_REPRODUCTION_ISSUE=37187` is set. A product fix should remove the guard and make the test pass before this PR is considered for merge.

## Reproduced issue

- Issue: [dotnet/maui#37187 — [iOS] Replacing Shell.FlyoutFooter leaves the previous footer active](https://github.com/dotnet/maui/issues/37187)
- Platform: **catalyst**
- Baseline commit: `604d9de36e05a40c36ab05cdcd68f2c6286fa260`
- Test type: **device**
- Targeted filter: `Issue37187`
- Expected failing assertion: `Replacing FlyoutFooter must detach the removed footer's measure invalidation callback.`
- Pipeline run: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14986257

## Device evidence

[![Reproduction preview](https://raw.githubusercontent.com/dotnet/maui/ad4f7b2b7fd496257d524517c95a1ab87e9fcb66/pr-37187/replication/catalyst/14986257-1/preview.gif)](https://raw.githubusercontent.com/dotnet/maui/ad4f7b2b7fd496257d524517c95a1ab87e9fcb66/pr-37187/replication/catalyst/14986257-1/repro.mp4)

[Open the full MP4 recording](https://raw.githubusercontent.com/dotnet/maui/ad4f7b2b7fd496257d524517c95a1ab87e9fcb66/pr-37187/replication/catalyst/14986257-1/repro.mp4) · [Evidence manifest](https://raw.githubusercontent.com/dotnet/maui/ad4f7b2b7fd496257d524517c95a1ab87e9fcb66/pr-37187/replication/catalyst/14986257-1/evidence.json)

## Reproduction steps

1. Create footer A inside a Shell and render the flyout on Mac Catalyst.
1. Close the flyout, replace footer A with footer B, and arm footer B's measure probe.
1. Invalidate the removed footer A.
1. Assert that footer B is not measured by footer A's stale invalidation callback.

## Safety and validation

- The pipeline reconstructed the scenario from issue text, inline snippets, and allowed raster screenshots.
- No linked repository, archive, binary, script, package, or arbitrary external file was downloaded.
- A trusted runner reproduced the behavior on-device and matched the expected targeted test failure.
- The published patch is add-only and restricted to approved MAUI test locations.
