### PR TITLE
[catalyst] Add failing reproduction for #35511

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/Issue35511.MacCatalyst.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/Issue35511.MacCatalyst.cs
@@ -1,0 +1,73 @@
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.NavigationPage)]
+	[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
+	public class Issue35511 : ControlsHandlerTestBase
+	{
+		static string? GetReplicationIssue()
+		{
+#if ANDROID
+			return global::Microsoft.Maui.TestUtils.DeviceTests.Runners.HeadlessRunner
+				.MauiTestInstrumentation.Current?.Arguments?.GetString("MAUI_REPRODUCTION_ISSUE");
+#elif IOS || MACCATALYST
+			return global::Foundation.NSProcessInfo.ProcessInfo.Environment["MAUI_REPRODUCTION_ISSUE"]?.ToString();
+#else
+			return Environment.GetEnvironmentVariable("MAUI_REPRODUCTION_ISSUE");
+#endif
+		}
+
+		[Fact]
+		public async Task BackButtonTitleIsVisibleWithCustomTitleView()
+		{
+			if (!string.Equals(
+				GetReplicationIssue(),
+				"35511",
+				StringComparison.Ordinal))
+			{
+				return;
+			}
+
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationRenderer));
+					handlers.AddHandler<Label, LabelHandler>();
+					handlers.AddHandler<Page, PageHandler>();
+					handlers.AddHandler<Window, WindowHandlerStub>();
+				});
+			});
+
+			var rootPage = new ContentPage { Title = "Root page" };
+			NavigationPage.SetBackButtonTitle(rootPage, "Main");
+
+			var pushedPage = new ContentPage();
+			NavigationPage.SetTitleView(pushedPage, new Label { Text = "Custom title" });
+
+			var navigationPage = new NavigationPage(rootPage);
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(
+				new Window(navigationPage),
+				async handler =>
+				{
+					await navigationPage.PushAsync(pushedPage);
+					await OnNavigatedToAsync(pushedPage);
+
+					var actual = GetBackButtonText(handler);
+					Assert.True(
+						string.Equals("Main", actual, StringComparison.Ordinal),
+						$"Expected the rendered back button title to be 'Main'. Actual: '{actual ?? "<null>"}'.");
+				});
+		}
+	}
+}


### PR DESCRIPTION
<!-- MAUI_COPILOT_REPLICATION issue=35511 platform=catalyst -->

> [!IMPORTANT]
> This is AI-generated **reproduction evidence**, not a merge-ready product fix. The guarded test intentionally fails only when `MAUI_REPRODUCTION_ISSUE=35511` is set. A product fix should remove the guard and make the test pass before this PR is considered for merge.

## Reproduced issue

- Issue: [dotnet/maui#35511 — [MacCatalyst] NavigationPage.BackButtonTitle is not visible when NavigationPage.TitleView is set on the pushed page](https://github.com/dotnet/maui/issues/35511)
- Platform: **catalyst**
- Baseline commit: `604d9de36e05a40c36ab05cdcd68f2c6286fa260`
- Test type: **device**
- Targeted filter: `Issue35511`
- Expected failing assertion: `Expected the rendered back button title to be 'Main'.`
- Pipeline run: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14986306

## Device evidence

[![Reproduction preview](https://raw.githubusercontent.com/dotnet/maui/032967bf11fd681674a22223ed57b9ec39232a28/pr-35511/replication/catalyst/14986306-1/preview.gif)](https://raw.githubusercontent.com/dotnet/maui/032967bf11fd681674a22223ed57b9ec39232a28/pr-35511/replication/catalyst/14986306-1/repro.mp4)

[Open the full MP4 recording](https://raw.githubusercontent.com/dotnet/maui/032967bf11fd681674a22223ed57b9ec39232a28/pr-35511/replication/catalyst/14986306-1/repro.mp4) · [Evidence manifest](https://raw.githubusercontent.com/dotnet/maui/032967bf11fd681674a22223ed57b9ec39232a28/pr-35511/replication/catalyst/14986306-1/evidence.json)

## Reproduction steps

1. Create a NavigationPage whose root page sets its back button title to Main.
1. Present the NavigationPage in the Mac Catalyst device-test window.
1. Push a page with a custom NavigationPage title view.
1. Inspect the native navigation bar and assert that its rendered back button title is Main.

## Safety and validation

- The pipeline reconstructed the scenario from issue text, inline snippets, and allowed raster screenshots.
- No linked repository, archive, binary, script, package, or arbitrary external file was downloaded.
- A trusted runner reproduced the behavior on-device and matched the expected targeted test failure.
- The published patch is add-only and restricted to approved MAUI test locations.
