### PR TITLE
[ios] Add failing reproduction for #37407

### DIFF
--- a/src/Core/tests/DeviceTests/Handlers/TimePicker/Issue37407.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/TimePicker/Issue37407.iOS.cs
@@ -1,0 +1,79 @@
+#if !MACCATALYST
+#nullable enable
+using System;
+using System.Globalization;
+using System.Threading.Tasks;
+using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Handlers;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.TimePicker)]
+	public class Issue37407 : CoreHandlerTestBase<TimePickerHandler, TimePickerStub>
+	{
+		const string IssueNumber = "37407";
+
+		static string? GetReplicationIssue()
+		{
+#if ANDROID
+			return global::Microsoft.Maui.TestUtils.DeviceTests.Runners.HeadlessRunner
+				.MauiTestInstrumentation.Current?.Arguments?.GetString("MAUI_REPRODUCTION_ISSUE");
+#elif IOS || MACCATALYST
+			return global::Foundation.NSProcessInfo.ProcessInfo.Environment["MAUI_REPRODUCTION_ISSUE"]?.ToString();
+#else
+			return Environment.GetEnvironmentVariable("MAUI_REPRODUCTION_ISSUE");
+#endif
+		}
+
+		[Fact]
+		public async Task DefaultShortTimeFormatUsesCurrentCulture()
+		{
+			if (!string.Equals(
+				GetReplicationIssue(),
+				IssueNumber,
+				StringComparison.Ordinal))
+			{
+				return;
+			}
+
+			var actual = await InvokeOnMainThreadAsync(() =>
+			{
+				var originalCulture = CultureInfo.CurrentCulture;
+				var originalUICulture = CultureInfo.CurrentUICulture;
+				var originalDefaultCulture = CultureInfo.DefaultThreadCurrentCulture;
+				var originalDefaultUICulture = CultureInfo.DefaultThreadCurrentUICulture;
+
+				try
+				{
+					var frenchCulture = CultureInfo.GetCultureInfo("fr-FR");
+					CultureInfo.DefaultThreadCurrentCulture = frenchCulture;
+					CultureInfo.DefaultThreadCurrentUICulture = frenchCulture;
+					CultureInfo.CurrentCulture = frenchCulture;
+					CultureInfo.CurrentUICulture = frenchCulture;
+
+					var timePicker = new TimePickerStub
+					{
+						Format = "t",
+						Time = new TimeSpan(7, 30, 0)
+					};
+					var handler = CreateHandler(timePicker);
+
+					return handler.PlatformView.Text;
+				}
+				finally
+				{
+					CultureInfo.CurrentCulture = originalCulture;
+					CultureInfo.CurrentUICulture = originalUICulture;
+					CultureInfo.DefaultThreadCurrentCulture = originalDefaultCulture;
+					CultureInfo.DefaultThreadCurrentUICulture = originalDefaultUICulture;
+				}
+			});
+
+			Assert.True(
+				string.Equals("07:30", actual, StringComparison.Ordinal),
+				"Issue 37407 expected French short time '07:30' instead of an en-US 12-hour value.");
+		}
+	}
+}
+#endif


### PR DESCRIPTION
<!-- MAUI_COPILOT_REPLICATION issue=37407 platform=ios -->

> [!IMPORTANT]
> This is AI-generated **reproduction evidence**, not a merge-ready product fix. The guarded test intentionally fails only when `MAUI_REPRODUCTION_ISSUE=37407` is set. A product fix should remove the guard and make the test pass before this PR is considered for merge.

## Reproduced issue

- Issue: [dotnet/maui#37407 — [iOS] TimePicker forces en-US (12-hour AM/PM) when Format is left at its default "t", ignoring the device culture](https://github.com/dotnet/maui/issues/37407)
- Platform: **ios**
- Baseline commit: `604d9de36e05a40c36ab05cdcd68f2c6286fa260`
- Test type: **device**
- Targeted filter: `Issue37407`
- Expected failing assertion: `Issue 37407 expected French short time '07:30' instead of an en-US 12-hour value.`
- Pipeline run: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14986307

## Device evidence

[![Reproduction preview](https://raw.githubusercontent.com/dotnet/maui/b6cba21414431abb7d59f12b3bfa6c2127226fb8/pr-37407/replication/ios/14986307-1/preview.gif)](https://raw.githubusercontent.com/dotnet/maui/b6cba21414431abb7d59f12b3bfa6c2127226fb8/pr-37407/replication/ios/14986307-1/repro.mp4)

[Open the full MP4 recording](https://raw.githubusercontent.com/dotnet/maui/b6cba21414431abb7d59f12b3bfa6c2127226fb8/pr-37407/replication/ios/14986307-1/repro.mp4) · [Evidence manifest](https://raw.githubusercontent.com/dotnet/maui/b6cba21414431abb7d59f12b3bfa6c2127226fb8/pr-37407/replication/ios/14986307-1/evidence.json)

## Reproduction steps

1. Set the device-test process culture to fr-FR and create a TimePickerStub for 07:30 with Format set to t, matching the TimePicker control default.
1. Create its iOS TimePickerHandler and read the resulting MauiTimePicker text on the UI thread.
1. Assert that the native text exactly equals the French short-time value 07:30 with a deterministic failure message.

## Safety and validation

- The pipeline reconstructed the scenario from issue text, inline snippets, and allowed raster screenshots.
- No linked repository, archive, binary, script, package, or arbitrary external file was downloaded.
- A trusted runner reproduced the behavior on-device and matched the expected targeted test failure.
- The published patch is add-only and restricted to approved MAUI test locations.
