### PR TITLE
[ios] Add failing reproduction for #19064

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/Issue19064.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/Issue19064.iOS.cs
@@ -1,0 +1,137 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers.Items2;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Xunit;
+using static Microsoft.Maui.DeviceTests.AssertHelpers;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Collection(RunInNewWindowCollection)]
+	[Category(TestCategory.CollectionView)]
+	public class Issue19064 : ControlsHandlerTestBase
+	{
+		const string IssueNumber = "19064";
+
+		static string? GetReplicationIssue()
+		{
+#if ANDROID
+			return global::Microsoft.Maui.TestUtils.DeviceTests.Runners.HeadlessRunner
+				.MauiTestInstrumentation.Current?.Arguments?.GetString("MAUI_REPRODUCTION_ISSUE");
+#elif IOS || MACCATALYST
+			return global::Foundation.NSProcessInfo.ProcessInfo.Environment["MAUI_REPRODUCTION_ISSUE"]?.ToString();
+#else
+			return Environment.GetEnvironmentVariable("MAUI_REPRODUCTION_ISSUE");
+#endif
+		}
+
+		[Fact]
+		public async Task FirstItemContentSizeRemainsStableAfterRecycling()
+		{
+			if (!string.Equals(
+				GetReplicationIssue(),
+				IssueNumber,
+				StringComparison.Ordinal))
+			{
+				return;
+			}
+
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler<CollectionView, CollectionViewHandler2>();
+					handlers.AddHandler<Border, BorderHandler>();
+				});
+			});
+
+			var realizedItems = new List<Border>();
+			var items = Enumerable.Range(0, 100)
+				.Select(index => new GalleryItem
+				{
+					Index = index,
+					Width = index < 3 ? 100 : 300,
+					Height = index < 3 ? 50 : 150
+				})
+				.ToList();
+
+			var collectionView = new CollectionView
+			{
+				ItemSizingStrategy = ItemSizingStrategy.MeasureFirstItem,
+				ItemsLayout = new GridItemsLayout(2, ItemsLayoutOrientation.Horizontal),
+				ItemsSource = items,
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var border = new Border();
+					border.SetBinding(VisualElement.WidthRequestProperty, nameof(GalleryItem.Width));
+					border.SetBinding(VisualElement.HeightRequestProperty, nameof(GalleryItem.Height));
+					realizedItems.Add(border);
+					return border;
+				})
+			};
+
+			await CreateHandlerAndAddToWindow<CollectionViewHandler2>(collectionView, async handler =>
+			{
+				bool IsRealized(int index) =>
+					realizedItems.Any(item =>
+						item.BindingContext is GalleryItem galleryItem &&
+						galleryItem.Index == index &&
+						item.IsLoaded &&
+						item.Width > 0 &&
+						item.Height > 0);
+
+				await AssertEventually(
+					() => IsRealized(0),
+					timeout: 5000,
+					message: "The first item was not initially arranged.");
+
+				var initialItem = realizedItems.First(item =>
+					item.BindingContext is GalleryItem { Index: 0 } &&
+					item.IsLoaded);
+				var initialWidth = initialItem.Width;
+				var initialHeight = initialItem.Height;
+
+				collectionView.ScrollTo(50, position: ScrollToPosition.Start, animate: false);
+				await AssertEventually(
+					() => handler.Controller.CollectionView.IndexPathsForVisibleItems.All(indexPath => indexPath.Item != 0),
+					timeout: 5000,
+					message: "The first item did not leave the native viewport.");
+				await AssertEventually(
+					() => IsRealized(50),
+					timeout: 5000,
+					message: "The distant item was not realized for cell recycling.");
+
+				collectionView.ScrollTo(0, position: ScrollToPosition.Start, animate: false);
+				await AssertEventually(
+					() => handler.Controller.CollectionView.IndexPathsForVisibleItems.Any(indexPath => indexPath.Item == 0) &&
+						IsRealized(0),
+					timeout: 5000,
+					message: "The first item was not arranged after returning.");
+
+				var returnedItem = realizedItems.First(item =>
+					item.BindingContext is GalleryItem { Index: 0 } &&
+					item.IsLoaded);
+
+				Assert.True(
+					Math.Abs(initialWidth - 100) < 0.5 &&
+					Math.Abs(initialHeight - 50) < 0.5 &&
+					Math.Abs(returnedItem.Width - 100) < 0.5 &&
+					Math.Abs(returnedItem.Height - 50) < 0.5,
+					"The first item's content size must remain 100x50 after recycling.");
+			});
+		}
+
+		sealed class GalleryItem
+		{
+			public int Index { get; set; }
+			public double Width { get; set; }
+			public double Height { get; set; }
+		}
+	}
+}


### PR DESCRIPTION
<!-- MAUI_COPILOT_REPLICATION issue=19064 platform=ios -->

> [!IMPORTANT]
> This is AI-generated **reproduction evidence**, not a merge-ready product fix. The guarded test intentionally fails only when `MAUI_REPRODUCTION_ISSUE=19064` is set. A product fix should remove the guard and make the test pass before this PR is considered for merge.

## Reproduced issue

- Issue: [dotnet/maui#19064 — [iOS] Item Sizing Strategy Gallery currently doesn't display items consistently.](https://github.com/dotnet/maui/issues/19064)
- Platform: **ios**
- Baseline commit: `604d9de36e05a40c36ab05cdcd68f2c6286fa260`
- Test type: **device**
- Targeted filter: `Issue19064`
- Expected failing assertion: `The first item's content size must remain 100x50 after recycling.`
- Pipeline run: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14986304

## Device evidence

[![Reproduction preview](https://raw.githubusercontent.com/dotnet/maui/ab58526ec92d7a864c5a1a3e82f11a64255a6046/pr-19064/replication/ios/14986304-1/preview.gif)](https://raw.githubusercontent.com/dotnet/maui/ab58526ec92d7a864c5a1a3e82f11a64255a6046/pr-19064/replication/ios/14986304-1/repro.mp4)

[Open the full MP4 recording](https://raw.githubusercontent.com/dotnet/maui/ab58526ec92d7a864c5a1a3e82f11a64255a6046/pr-19064/replication/ios/14986304-1/repro.mp4) · [Evidence manifest](https://raw.githubusercontent.com/dotnet/maui/ab58526ec92d7a864c5a1a3e82f11a64255a6046/pr-19064/replication/ios/14986304-1/evidence.json)

## Reproduction steps

1. Create an iOS CollectionView with MeasureFirstItem and a horizontal two-row GridItemsLayout.
1. Populate the collection with three 100x50 items followed by 300x150 items.
1. Attach CollectionViewHandler2 to an iOS device window, wait for the first item to be arranged, and capture its initial size.
1. Scroll to item 50 and wait until item zero leaves the native viewport and item 50 is realized.
1. Scroll back to item zero and wait for it to return to the native viewport.
1. Assert that the first item's arranged content remains 100x50 after recycling.

## Safety and validation

- The pipeline reconstructed the scenario from issue text, inline snippets, and allowed raster screenshots.
- No linked repository, archive, binary, script, package, or arbitrary external file was downloaded.
- A trusted runner reproduced the behavior on-device and matched the expected targeted test failure.
- The published patch is add-only and restricted to approved MAUI test locations.
