### PR TITLE
[ios] Add failing reproduction for #37013

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Label/Issue37013.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Label/Issue37013.iOS.cs
@@ -1,0 +1,107 @@
+#nullable enable
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using UIKit;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.Label)]
+	public class Issue37013 : ControlsHandlerTestBase
+	{
+		const string IssueNumber = "37013";
+
+		static string? GetReplicationIssue()
+		{
+#if ANDROID
+			return global::Microsoft.Maui.TestUtils.DeviceTests.Runners.HeadlessRunner
+				.MauiTestInstrumentation.Current?.Arguments?.GetString("MAUI_REPRODUCTION_ISSUE");
+#elif IOS || MACCATALYST
+			return global::Foundation.NSProcessInfo.ProcessInfo.Environment["MAUI_REPRODUCTION_ISSUE"]?.ToString();
+#else
+			return Environment.GetEnvironmentVariable("MAUI_REPRODUCTION_ISSUE");
+#endif
+		}
+
+		void SetupBuilder()
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler<Label, LabelHandler>();
+				});
+			});
+		}
+
+		[Fact]
+		public async Task VisibleSpanCenterResolvesToTapGesture()
+		{
+			if (!string.Equals(
+				GetReplicationIssue(),
+				IssueNumber,
+				StringComparison.Ordinal))
+			{
+				return;
+			}
+
+			SetupBuilder();
+
+			var tapGesture = new TapGestureRecognizer();
+			var linkSpan = new Span
+			{
+				Text = "TAP THIS VISIBLE LINK",
+				TextColor = Colors.Blue,
+				TextDecorations = TextDecorations.Underline,
+				GestureRecognizers = { tapGesture }
+			};
+
+			var label = new Label
+			{
+				FontSize = 16,
+				HorizontalOptions = LayoutOptions.Center,
+				LineHeight = 1.1,
+				WidthRequest = 300,
+				FormattedText = new FormattedString
+				{
+					Spans =
+					{
+						new Span
+						{
+							Text = "This is the first naturally wrapping paragraph used to create many rendered lines at a constrained width. The repeated prose keeps the layout deterministic while allowing the native label to choose every line break. Additional words extend the paragraph so vertical metric differences accumulate before the interactive span. This section continues with ordinary sentence text and enough content to occupy several more wrapped lines before the visible link appears.\n\nA second paragraph adds more naturally wrapped content before the link. It deliberately avoids manual line breaks within the paragraph because the reproduction depends on native wrapping metrics. More words complete this balanced section near the middle of the label.\n\n"
+						},
+						linkSpan,
+						new Span
+						{
+							Text = "\n\nA matching paragraph follows the visible link and preserves its position near the center of the complete label. It also uses naturally wrapped prose so the rendered text height remains governed by the native text engine. More words complete this balanced section after the interactive span.\n\nThis final naturally wrapping paragraph supplies several additional lines below the link. The repeated prose keeps the layout deterministic while allowing the native label to choose every line break. Additional words extend the paragraph to balance the content above the link. This section continues with ordinary sentence text and enough content to occupy several more wrapped lines after the visible link."
+						}
+					}
+				}
+			};
+
+			var labelHandler = await CreateHandlerAsync<LabelHandler>(label);
+			bool resolvesToTapGesture = false;
+
+			await CreateHandlerAndAddToWindow(label, () =>
+			{
+				var platformLabel = (UILabel)labelHandler.PlatformView;
+				var visibleCenter = new Point(
+					platformLabel.Bounds.Width / 2,
+					platformLabel.Bounds.Height / 2);
+
+				resolvesToTapGesture = label.GetChildElements(visibleCenter)?
+					.Any(element => element.GestureRecognizers.Contains(tapGesture)) == true;
+			});
+
+			Assert.True(
+				resolvesToTapGesture,
+				"The visible span center must resolve to the span tap gesture.");
+		}
+	}
+}


### PR DESCRIPTION
<!-- MAUI_COPILOT_REPLICATION issue=37013 platform=ios -->

> [!IMPORTANT]
> This is AI-generated **reproduction evidence**, not a merge-ready product fix. The guarded test intentionally fails only when `MAUI_REPRODUCTION_ISSUE=37013` is set. A product fix should remove the guard and make the test pass before this PR is considered for merge.

## Reproduced issue

- Issue: [dotnet/maui#37013 — [iOS] RecalculateSpanPositions uses TextKit 1 but UILabel renders with TextKit 2, causing vertically offset Span tap targets on iOS](https://github.com/dotnet/maui/issues/37013)
- Platform: **ios**
- Baseline commit: `604d9de36e05a40c36ab05cdcd68f2c6286fa260`
- Test type: **device**
- Targeted filter: `Issue37013`
- Expected failing assertion: `The visible span center must resolve to the span tap gesture.`
- Pipeline run: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14986331

## Device evidence

[![Reproduction preview](https://raw.githubusercontent.com/dotnet/maui/24f0508489805e03df225abc72759fab5d5bea2e/pr-37013/replication/ios/14986331-1/preview.gif)](https://raw.githubusercontent.com/dotnet/maui/24f0508489805e03df225abc72759fab5d5bea2e/pr-37013/replication/ios/14986331-1/repro.mp4)

[Open the full MP4 recording](https://raw.githubusercontent.com/dotnet/maui/24f0508489805e03df225abc72759fab5d5bea2e/pr-37013/replication/ios/14986331-1/repro.mp4) · [Evidence manifest](https://raw.githubusercontent.com/dotnet/maui/24f0508489805e03df225abc72759fab5d5bea2e/pr-37013/replication/ios/14986331-1/evidence.json)

## Reproduction steps

1. Create a 300-point-wide Label with naturally wrapping formatted text and a tappable span centered between balanced paragraphs.
1. Register and explicitly create the existing LabelHandler, then attach the Label to an iOS test window so its native UILabel is measured and laid out.
1. Query the Label child elements at the center point of the laid-out UILabel, matching the Sandbox tap coordinate.
1. Assert that the centered tappable span is returned for that visible point.

## Safety and validation

- The pipeline reconstructed the scenario from issue text, inline snippets, and allowed raster screenshots.
- No linked repository, archive, binary, script, package, or arbitrary external file was downloaded.
- A trusted runner reproduced the behavior on-device and matched the expected targeted test failure.
- The published patch is add-only and restricted to approved MAUI test locations.
