### PR TITLE
[catalyst] Add failing reproduction for #35512

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Button/Issue35512Tests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Button/Issue35512Tests.iOS.cs
@@ -1,0 +1,64 @@
+#nullable enable
+using System;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Handlers;
+using UIKit;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.Button)]
+	public class Issue35512 : ControlsHandlerTestBase
+	{
+		const string IssueNumber = "35512";
+
+		static string? GetReplicationIssue()
+		{
+#if ANDROID
+			return global::Microsoft.Maui.TestUtils.DeviceTests.Runners.HeadlessRunner
+				.MauiTestInstrumentation.Current?.Arguments?.GetString("MAUI_REPRODUCTION_ISSUE");
+#elif IOS || MACCATALYST
+			return global::Foundation.NSProcessInfo.ProcessInfo.Environment["MAUI_REPRODUCTION_ISSUE"]?.ToString();
+#else
+			return Environment.GetEnvironmentVariable("MAUI_REPRODUCTION_ISSUE");
+#endif
+		}
+
+		[Fact]
+		public async Task ResettingBackgroundColorRestoresPlatformDefault()
+		{
+			if (!string.Equals(
+				GetReplicationIssue(),
+				IssueNumber,
+				StringComparison.Ordinal))
+			{
+				return;
+			}
+
+			var platformDefaults = await InvokeOnMainThreadAsync(() =>
+			{
+				using var defaultButton = new UIButton(UIButtonType.System);
+				return (defaultButton.BackgroundColor, defaultButton.Configuration?.BaseBackgroundColor);
+			});
+
+			var button = new Button();
+			var handler = await CreateHandlerAsync<ButtonHandler>(button);
+
+			await InvokeOnMainThreadAsync(() => button.BackgroundColor = Colors.Red);
+			var redBackgroundColor = await InvokeOnMainThreadAsync(
+				() => handler.PlatformView.Configuration?.BaseBackgroundColor ?? handler.PlatformView.BackgroundColor);
+			Assert.Equal(UIColor.Red, redBackgroundColor);
+
+			await InvokeOnMainThreadAsync(() => button.BackgroundColor = null);
+			var resetBackgroundColors = await InvokeOnMainThreadAsync(
+				() => (handler.PlatformView.BackgroundColor, handler.PlatformView.Configuration?.BaseBackgroundColor));
+
+			Assert.True(
+				Equals(platformDefaults.BackgroundColor, resetBackgroundColors.BackgroundColor) &&
+				Equals(platformDefaults.BaseBackgroundColor, resetBackgroundColors.BaseBackgroundColor),
+				"Button native background should restore its platform default after BackgroundColor is reset to null.");
+		}
+	}
+}


### PR DESCRIPTION
<!-- MAUI_COPILOT_REPLICATION issue=35512 platform=catalyst -->

> [!IMPORTANT]
> This is AI-generated **reproduction evidence**, not a merge-ready product fix. The guarded test intentionally fails only when `MAUI_REPRODUCTION_ISSUE=35512` is set. A product fix should remove the guard and make the test pass before this PR is considered for merge.

## Reproduced issue

- Issue: [dotnet/maui#35512 — [iOS, Mac & Windows]Button BackgroundColor does not restore to default when reset to null after dynamic update](https://github.com/dotnet/maui/issues/35512)
- Platform: **catalyst**
- Baseline commit: `604d9de36e05a40c36ab05cdcd68f2c6286fa260`
- Test type: **device**
- Targeted filter: `Issue35512`
- Expected failing assertion: `Button native background should restore its platform default after BackgroundColor is reset to null.`
- Pipeline run: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14986351

## Device evidence

[![Reproduction preview](https://raw.githubusercontent.com/dotnet/maui/b52199c3f4d64941c1e994817dc09c802924cca8/pr-35512/replication/catalyst/14986351-1/preview.gif)](https://raw.githubusercontent.com/dotnet/maui/b52199c3f4d64941c1e994817dc09c802924cca8/pr-35512/replication/catalyst/14986351-1/repro.mp4)

[Open the full MP4 recording](https://raw.githubusercontent.com/dotnet/maui/b52199c3f4d64941c1e994817dc09c802924cca8/pr-35512/replication/catalyst/14986351-1/repro.mp4) · [Evidence manifest](https://raw.githubusercontent.com/dotnet/maui/b52199c3f4d64941c1e994817dc09c802924cca8/pr-35512/replication/catalyst/14986351-1/evidence.json)

## Reproduction steps

1. Create a system UIButton and record its native BackgroundColor and configuration BaseBackgroundColor defaults.
1. Create a Button without an explicit BackgroundColor and create its Mac Catalyst ButtonHandler.
1. Set Button.BackgroundColor to Colors.Red and verify the active native background channel becomes red.
1. Set Button.BackgroundColor to null and compare both native background channels with the system UIButton defaults.

## Safety and validation

- The pipeline reconstructed the scenario from issue text, inline snippets, and allowed raster screenshots.
- No linked repository, archive, binary, script, package, or arbitrary external file was downloaded.
- A trusted runner reproduced the behavior on-device and matched the expected targeted test failure.
- The published patch is add-only and restricted to approved MAUI test locations.
