### PR TITLE
[android] Add failing reproduction for #37418

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Issue37418.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Issue37418.Android.cs
@@ -1,0 +1,100 @@
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+using AndroidX.Core.View;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers;
+using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Microsoft.Maui.Platform;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.Layout)]
+	public class Issue37418 : ControlsHandlerTestBase
+	{
+		const string IssueNumber = "37418";
+
+		static string? GetReplicationIssue()
+		{
+#if ANDROID
+			return global::Microsoft.Maui.TestUtils.DeviceTests.Runners.HeadlessRunner
+				.MauiTestInstrumentation.Current?.Arguments?.GetString("MAUI_REPRODUCTION_ISSUE");
+#elif IOS || MACCATALYST
+			return global::Foundation.NSProcessInfo.ProcessInfo.Environment["MAUI_REPRODUCTION_ISSUE"]?.ToString();
+#else
+			return Environment.GetEnvironmentVariable("MAUI_REPRODUCTION_ISSUE");
+#endif
+		}
+
+		[Fact]
+		public async Task ResettingOffscreenTranslationDoesNotAddTopGap()
+		{
+			if (!string.Equals(
+				GetReplicationIssue(),
+				IssueNumber,
+				StringComparison.Ordinal))
+			{
+				return;
+			}
+
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler<Page, PageHandler>();
+					handlers.AddHandler<Window, WindowHandlerStub>();
+					handlers.AddHandler<Layout, LayoutHandler>();
+					handlers.AddHandler<BoxView, BoxViewHandler>();
+				});
+			});
+
+			var firstChild = new BoxView
+			{
+				HeightRequest = 40,
+				VerticalOptions = LayoutOptions.Start
+			};
+			var bottomSheet = new Grid
+			{
+				HeightRequest = 320,
+				Padding = 0,
+				VerticalOptions = LayoutOptions.End,
+				TranslationY = 2000,
+				SafeAreaEdges = SafeAreaEdges.Container,
+				Children = { firstChild }
+			};
+			var root = new Grid
+			{
+				Children = { bottomSheet }
+			};
+			var page = new ContentPage
+			{
+				SafeAreaEdges = SafeAreaEdges.None,
+				Content = root
+			};
+
+			await CreateHandlerAndAddToWindow(page, async () =>
+			{
+				var platformSheet = bottomSheet.ToPlatform();
+				await platformSheet.WaitForLayoutOrNonZeroSize();
+
+				var windowInsets = ViewCompat.GetRootWindowInsets(platformSheet);
+				Assert.NotNull(windowInsets);
+				((IHandleWindowInsets)platformSheet).HandleWindowInsets(platformSheet, windowInsets);
+
+				await InvokeOnMainThreadAsync(() => bottomSheet.TranslationY = 0);
+
+				var nativeUpdate = new TaskCompletionSource();
+				platformSheet.Post(nativeUpdate.SetResult);
+				await nativeUpdate.Task;
+
+				Assert.True(
+					platformSheet.PaddingTop == 0,
+					"The bottom sheet must not retain a top gap after TranslationY is reset to zero.");
+			});
+		}
+	}
+}


### PR DESCRIPTION
<!-- MAUI_COPILOT_REPLICATION issue=37418 platform=android -->

> [!IMPORTANT]
> This is AI-generated **reproduction evidence**, not a merge-ready product fix. The guarded test intentionally fails only when `MAUI_REPRODUCTION_ISSUE=37418` is set. A product fix should remove the guard and make the test pass before this PR is considered for merge.

## Reproduced issue

- Issue: [dotnet/maui#37418 — [Android] TranslationY out of screen creates broken layout padding](https://github.com/dotnet/maui/issues/37418)
- Platform: **android**
- Baseline commit: `604d9de36e05a40c36ab05cdcd68f2c6286fa260`
- Test type: **device**
- Targeted filter: `Issue37418`
- Expected failing assertion: `The bottom sheet must not retain a top gap after TranslationY is reset to zero.`
- Pipeline run: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14986305

## Device evidence

[![Reproduction preview](https://raw.githubusercontent.com/dotnet/maui/39cad8c54f3e0f147543ea494f497fb48f89cb4f/pr-37418/replication/android/14986305-1/preview.gif)](https://raw.githubusercontent.com/dotnet/maui/39cad8c54f3e0f147543ea494f497fb48f89cb4f/pr-37418/replication/android/14986305-1/repro.mp4)

[Open the full MP4 recording](https://raw.githubusercontent.com/dotnet/maui/39cad8c54f3e0f147543ea494f497fb48f89cb4f/pr-37418/replication/android/14986305-1/repro.mp4) · [Evidence manifest](https://raw.githubusercontent.com/dotnet/maui/39cad8c54f3e0f147543ea494f497fb48f89cb4f/pr-37418/replication/android/14986305-1/evidence.json)

## Reproduction steps

1. Register the existing page, window, layout, and Controls BoxView handlers used by the Controls device-test host.
1. Create a zero-padding bottom-aligned Grid with SafeAreaEdges set to Container and a fixed height.
1. Set the Grid TranslationY beyond the bottom of the Android window before attaching it to a handler.
1. Add the layout to a device-test window, wait for native layout, and apply its real Android window insets while the Grid is off-screen.
1. Reset TranslationY to zero on the UI thread and await the queued Android native-view update.
1. Read the Grid's Android native top padding, which directly controls the unexpected content offset.
1. Assert that the native top padding is zero.

## Safety and validation

- The pipeline reconstructed the scenario from issue text, inline snippets, and allowed raster screenshots.
- No linked repository, archive, binary, script, package, or arbitrary external file was downloaded.
- A trusted runner reproduced the behavior on-device and matched the expected targeted test failure.
- The published patch is add-only and restricted to approved MAUI test locations.
