### PR TITLE
[ios] Add failing reproduction for #37264

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/ScrollView/Issue37264.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ScrollView/Issue37264.iOS.cs
@@ -1,0 +1,97 @@
+#nullable enable annotations
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Microsoft.Maui.Platform;
+using UIKit;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.ScrollView)]
+	public class Issue37264 : ControlsHandlerTestBase
+	{
+		const string IssueNumber = "37264";
+
+		static string? GetReplicationIssue()
+		{
+#if ANDROID
+			return global::Microsoft.Maui.TestUtils.DeviceTests.Runners.HeadlessRunner
+				.MauiTestInstrumentation.Current?.Arguments?.GetString("MAUI_REPRODUCTION_ISSUE");
+#elif IOS || MACCATALYST
+			return global::Foundation.NSProcessInfo.ProcessInfo.Environment["MAUI_REPRODUCTION_ISSUE"]?.ToString();
+#else
+			return Environment.GetEnvironmentVariable("MAUI_REPRODUCTION_ISSUE");
+#endif
+		}
+
+		[Fact]
+		public async Task SoftInputDoesNotHorizontallyInsetContent()
+		{
+			if (!string.Equals(
+				GetReplicationIssue(),
+				IssueNumber,
+				StringComparison.Ordinal))
+			{
+				return;
+			}
+
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler<Label, LabelHandler>();
+					handlers.AddHandler<ScrollView, ScrollViewHandler>();
+					handlers.AddHandler<VerticalStackLayout, LayoutHandler>();
+					handlers.AddHandler<Grid, LayoutHandler>();
+				});
+			});
+
+			var topLabel = new Label { Text = "Top", HorizontalOptions = LayoutOptions.Fill };
+			var bottomLabel = new Label { Text = "Bottom", HorizontalOptions = LayoutOptions.Fill };
+			var content = new VerticalStackLayout
+			{
+				topLabel,
+				new Label { Text = "ScrollView content", HeightRequest = 180 },
+				bottomLabel
+			};
+			var scrollView = new ScrollView
+			{
+				SafeAreaEdges = SafeAreaEdges.None,
+				Content = content
+			};
+			var page = new ContentPage
+			{
+				SafeAreaEdges = SafeAreaEdges.None,
+				Content = new Grid
+				{
+					SafeAreaEdges = SafeAreaEdges.None,
+					Children = { scrollView }
+				}
+			};
+
+			await CreateHandlerAndAddToWindow(page, () =>
+			{
+				var viewController = ((IPlatformViewHandler)page.Handler).ViewController;
+				viewController.AdditionalSafeAreaInsets = new UIEdgeInsets(0, 20, 0, 20);
+				viewController.View.SetNeedsLayout();
+				viewController.View.LayoutIfNeeded();
+
+				scrollView.SafeAreaEdges = new SafeAreaEdges(SafeAreaRegions.SoftInput);
+				scrollView.InvalidateMeasure();
+				viewController.View.SetNeedsLayout();
+				viewController.View.LayoutIfNeeded();
+
+				bool contentIsFullWidth =
+					Math.Abs(topLabel.Width - scrollView.Width) <= 1 &&
+					Math.Abs(bottomLabel.Width - scrollView.Width) <= 1;
+
+				Assert.True(contentIsFullWidth,
+					"SoftInput safe area must not horizontally inset ScrollView content.");
+			});
+		}
+	}
+}


### PR DESCRIPTION
<!-- MAUI_COPILOT_REPLICATION issue=37264 platform=ios -->

> [!IMPORTANT]
> This is AI-generated **reproduction evidence**, not a merge-ready product fix. The guarded test intentionally fails only when `MAUI_REPRODUCTION_ISSUE=37264` is set. A product fix should remove the guard and make the test pass before this PR is considered for merge.

## Reproduced issue

- Issue: [dotnet/maui#37264 — [iOS] In ScrollView, when SafeArea is set to SoftInput, the top and bottom labels are not aligned properly](https://github.com/dotnet/maui/issues/37264)
- Platform: **ios**
- Baseline commit: `604d9de36e05a40c36ab05cdcd68f2c6286fa260`
- Test type: **device**
- Targeted filter: `Issue37264`
- Expected failing assertion: `SoftInput safe area must not horizontally inset ScrollView content.`
- Pipeline run: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14986391

## Device evidence

[![Reproduction preview](https://raw.githubusercontent.com/dotnet/maui/3371f38605eed882c64520fcf7da11dd3da0b36b/pr-37264/replication/ios/14986391-1/preview.gif)](https://raw.githubusercontent.com/dotnet/maui/3371f38605eed882c64520fcf7da11dd3da0b36b/pr-37264/replication/ios/14986391-1/repro.mp4)

[Open the full MP4 recording](https://raw.githubusercontent.com/dotnet/maui/3371f38605eed882c64520fcf7da11dd3da0b36b/pr-37264/replication/ios/14986391-1/repro.mp4) · [Evidence manifest](https://raw.githubusercontent.com/dotnet/maui/3371f38605eed882c64520fcf7da11dd3da0b36b/pr-37264/replication/ios/14986391-1/evidence.json)

## Reproduction steps

1. Create a vertical ScrollView whose content contains top and bottom labels configured to fill horizontally.
1. Attach the ScrollView to an iOS test window with nonzero left and right safe-area insets.
1. Set every ScrollView safe-area edge to SafeAreaRegions.SoftInput and synchronously complete native layout.
1. Assert that both label widths remain equal to the ScrollView width within a one-point tolerance.

## Safety and validation

- The pipeline reconstructed the scenario from issue text, inline snippets, and allowed raster screenshots.
- No linked repository, archive, binary, script, package, or arbitrary external file was downloaded.
- A trusted runner reproduced the behavior on-device and matched the expected targeted test failure.
- The published patch is add-only and restricted to approved MAUI test locations.
