### PR TITLE
[catalyst] Add failing reproduction for #35667

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Shell/Issue35667.MacCatalyst.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/Issue35667.MacCatalyst.cs
@@ -1,0 +1,84 @@
+#nullable enable
+using System;
+using System.Threading.Tasks;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.Platform;
+using UIKit;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.Shell)]
+	[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
+	public class Issue35667 : ControlsHandlerTestBase
+	{
+		const string IssueNumber = "35667";
+
+		static string? GetReplicationIssue()
+		{
+#if ANDROID
+			return global::Microsoft.Maui.TestUtils.DeviceTests.Runners.HeadlessRunner
+				.MauiTestInstrumentation.Current?.Arguments?.GetString("MAUI_REPRODUCTION_ISSUE");
+#elif IOS || MACCATALYST
+			return global::Foundation.NSProcessInfo.ProcessInfo.Environment["MAUI_REPRODUCTION_ISSUE"]?.ToString();
+#else
+			return Environment.GetEnvironmentVariable("MAUI_REPRODUCTION_ISSUE");
+#endif
+		}
+
+		[Fact]
+		public async Task UppercaseTextTransformAppliesToEnteredText()
+		{
+			if (!string.Equals(
+				GetReplicationIssue(),
+				IssueNumber,
+				StringComparison.Ordinal))
+			{
+				return;
+			}
+
+			EnsureHandlerCreated(builder => builder.SetupShellHandlers());
+
+			var contentPage = new ContentPage();
+			var searchHandler = new SearchHandler
+			{
+				SearchBoxVisibility = SearchBoxVisibility.Expanded,
+				TextTransform = TextTransform.Uppercase
+			};
+			Shell.SetSearchHandler(contentPage, searchHandler);
+
+			var shell = new Shell
+			{
+				Items =
+				{
+					new ShellContent
+					{
+						Content = contentPage,
+						Title = "Search"
+					}
+				}
+			};
+
+			await CreateHandlerAndAddToWindow<ShellRenderer>(shell, async handler =>
+			{
+				await OnLoadedAsync(contentPage);
+				await OnNavigatedToAsync(contentPage);
+
+				var searchBar = handler.ViewController.View.FindDescendantView<UISearchBar>();
+				Assert.NotNull(searchBar);
+
+				var textField = searchBar.FindDescendantView<UITextField>();
+				Assert.NotNull(textField);
+
+				textField.BecomeFirstResponder();
+				textField.InsertText("Maui");
+
+				Assert.True(
+					string.Equals("MAUI", textField.Text, StringComparison.Ordinal),
+					$"SearchHandler should display 'MAUI' when TextTransform is Uppercase, but displayed '{textField.Text}'.");
+			});
+		}
+	}
+}


### PR DESCRIPTION
<!-- MAUI_COPILOT_REPLICATION issue=35667 platform=catalyst -->

> [!IMPORTANT]
> This is AI-generated **reproduction evidence**, not a merge-ready product fix. The guarded test intentionally fails only when `MAUI_REPRODUCTION_ISSUE=35667` is set. A product fix should remove the guard and make the test pass before this PR is considered for merge.

## Reproduced issue

- Issue: [dotnet/maui#35667 — [Android, iOS, Catalyst] TextTransform.Uppercase does not work on Shell SearchHandler](https://github.com/dotnet/maui/issues/35667)
- Platform: **catalyst**
- Baseline commit: `604d9de36e05a40c36ab05cdcd68f2c6286fa260`
- Test type: **device**
- Targeted filter: `Issue35667`
- Expected failing assertion: `SearchHandler should display 'MAUI' when TextTransform is Uppercase, but displayed 'Maui'.`
- Pipeline run: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14986423

## Device evidence

[![Reproduction preview](https://raw.githubusercontent.com/dotnet/maui/5e4a3bc232062303f514cd949f82062392915e07/pr-35667/replication/catalyst/14986423-1/preview.gif)](https://raw.githubusercontent.com/dotnet/maui/5e4a3bc232062303f514cd949f82062392915e07/pr-35667/replication/catalyst/14986423-1/repro.mp4)

[Open the full MP4 recording](https://raw.githubusercontent.com/dotnet/maui/5e4a3bc232062303f514cd949f82062392915e07/pr-35667/replication/catalyst/14986423-1/repro.mp4) · [Evidence manifest](https://raw.githubusercontent.com/dotnet/maui/5e4a3bc232062303f514cd949f82062392915e07/pr-35667/replication/catalyst/14986423-1/evidence.json)

## Reproduction steps

1. Create a Shell ContentPage with an expanded SearchHandler whose TextTransform is Uppercase.
1. Attach the Shell to a device-test window and wait for the native Mac Catalyst search field to load.
1. Focus the native search field and insert the mixed-case text 'Maui'.
1. Read the text displayed by the native search field and assert that it equals 'MAUI'.

## Safety and validation

- The pipeline reconstructed the scenario from issue text, inline snippets, and allowed raster screenshots.
- No linked repository, archive, binary, script, package, or arbitrary external file was downloaded.
- A trusted runner reproduced the behavior on-device and matched the expected targeted test failure.
- The published patch is add-only and restricted to approved MAUI test locations.
