### PR TITLE
[catalyst] Add failing reproduction for #35624

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Shell/Issue35624Tests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/Issue35624Tests.iOS.cs
@@ -1,0 +1,84 @@
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.Controls.Platform.Compatibility;
+using Microsoft.Maui.Platform;
+using UIKit;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.Shell)]
+	[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
+	public class Issue35624 : ControlsHandlerTestBase
+	{
+		const string IssueNumber = "35624";
+
+		static string? GetReplicationIssue()
+		{
+#if ANDROID
+			return global::Microsoft.Maui.TestUtils.DeviceTests.Runners.HeadlessRunner
+				.MauiTestInstrumentation.Current?.Arguments?.GetString("MAUI_REPRODUCTION_ISSUE");
+#elif IOS || MACCATALYST
+			return global::Foundation.NSProcessInfo.ProcessInfo.Environment["MAUI_REPRODUCTION_ISSUE"]?.ToString();
+#else
+			return Environment.GetEnvironmentVariable("MAUI_REPRODUCTION_ISSUE");
+#endif
+		}
+
+		[Fact]
+		public async Task SearchHandlerAppliesCharacterSpacing()
+		{
+			if (!string.Equals(
+				GetReplicationIssue(),
+				IssueNumber,
+				StringComparison.Ordinal))
+			{
+				return;
+			}
+
+			EnsureHandlerCreated(builder => builder.SetupShellHandlers());
+
+			const double expected = 8;
+			var page = new ContentPage();
+			var searchHandler = new SearchHandler
+			{
+				CharacterSpacing = expected,
+				Query = "SPACING",
+				SearchBoxVisibility = SearchBoxVisibility.Expanded
+			};
+			Shell.SetSearchHandler(page, searchHandler);
+
+			var shell = new Shell
+			{
+				FlyoutBehavior = FlyoutBehavior.Disabled,
+				CurrentItem = new ShellContent
+				{
+					Content = page
+				}
+			};
+
+			double actual = 0;
+			await CreateHandlerAndAddToWindow<ShellRenderer>(shell, async handler =>
+			{
+				await OnNavigatedToAsync(page);
+
+				var shellContext = (IShellContext)handler;
+				var itemRenderer = (ShellItemRenderer)shellContext.CurrentShellItemRenderer;
+				var sectionRenderer = (ShellSectionRenderer)itemRenderer.CurrentRenderer;
+				var rootRenderer = (ShellSectionRootRenderer)sectionRenderer.ViewControllers[0];
+				UISearchBar searchBar = rootRenderer.NavigationItem.SearchController.SearchBar;
+				UITextField textField = searchBar.FindDescendantView<UITextField>();
+				actual = textField.AttributedText.GetCharacterSpacing();
+			});
+
+			Assert.True(
+				actual == expected,
+				$"SearchHandler CharacterSpacing expected {expected:0} but was {actual:0}.");
+		}
+	}
+}


### PR DESCRIPTION
<!-- MAUI_COPILOT_REPLICATION issue=35624 platform=catalyst -->

> [!IMPORTANT]
> This is AI-generated **reproduction evidence**, not a merge-ready product fix. The guarded test intentionally fails only when `MAUI_REPRODUCTION_ISSUE=35624` is set. A product fix should remove the guard and make the test pass before this PR is considered for merge.

## Reproduced issue

- Issue: [dotnet/maui#35624 — [Android, iOS and Catalyst] SearchHandler CharacterSpacing property is not applied](https://github.com/dotnet/maui/issues/35624)
- Platform: **catalyst**
- Baseline commit: `604d9de36e05a40c36ab05cdcd68f2c6286fa260`
- Test type: **device**
- Targeted filter: `Issue35624`
- Expected failing assertion: `SearchHandler CharacterSpacing expected 8 but was 0.`
- Pipeline run: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14986444

## Device evidence

[![Reproduction preview](https://raw.githubusercontent.com/dotnet/maui/e37adaa4e2b7af55131ae91dd948d3e2cec3f154/pr-35624/replication/catalyst/14986444-1/preview.gif)](https://raw.githubusercontent.com/dotnet/maui/e37adaa4e2b7af55131ae91dd948d3e2cec3f154/pr-35624/replication/catalyst/14986444-1/repro.mp4)

[Open the full MP4 recording](https://raw.githubusercontent.com/dotnet/maui/e37adaa4e2b7af55131ae91dd948d3e2cec3f154/pr-35624/replication/catalyst/14986444-1/repro.mp4) · [Evidence manifest](https://raw.githubusercontent.com/dotnet/maui/e37adaa4e2b7af55131ae91dd948d3e2cec3f154/pr-35624/replication/catalyst/14986444-1/evidence.json)

## Reproduction steps

1. Create a Shell page with an expanded SearchHandler whose CharacterSpacing is 8 and Query is SPACING.
1. Attach the Shell to a Mac Catalyst test window and wait for the current page to finish navigating.
1. Locate the UISearchBar on the native Shell section root and read its text field character spacing.
1. Assert that the native character spacing equals the SearchHandler value of 8.

## Safety and validation

- The pipeline reconstructed the scenario from issue text, inline snippets, and allowed raster screenshots.
- No linked repository, archive, binary, script, package, or arbitrary external file was downloaded.
- A trusted runner reproduced the behavior on-device and matched the expected targeted test failure.
- The published patch is add-only and restricted to approved MAUI test locations.
