### PR TITLE
[catalyst] Add failing reproduction for #36230

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/CarouselView/Issue36230.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CarouselView/Issue36230.iOS.cs
@@ -1,0 +1,82 @@
+#nullable enable
+using System;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers.Items2;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.CarouselView)]
+	public class Issue36230 : ControlsHandlerTestBase
+	{
+		const string IssueNumber = "36230";
+
+		static string? GetReplicationIssue()
+		{
+#if ANDROID
+			return global::Microsoft.Maui.TestUtils.DeviceTests.Runners.HeadlessRunner
+				.MauiTestInstrumentation.Current?.Arguments?.GetString("MAUI_REPRODUCTION_ISSUE");
+#elif IOS || MACCATALYST
+			return global::Foundation.NSProcessInfo.ProcessInfo.Environment["MAUI_REPRODUCTION_ISSUE"]?.ToString();
+#else
+			return Environment.GetEnvironmentVariable("MAUI_REPRODUCTION_ISSUE");
+#endif
+		}
+
+		[Fact]
+		public async Task CurrentItemRemainsReplacementAfterReplacingSelectedItem()
+		{
+			if (!string.Equals(
+				GetReplicationIssue(),
+				IssueNumber,
+				StringComparison.Ordinal))
+			{
+				return;
+			}
+
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler<CarouselView, CarouselViewHandler2>();
+					handlers.AddHandler<Label, LabelHandler>();
+				});
+			});
+
+			var items = new ObservableCollection<string>
+			{
+				"1",
+				"2",
+				"3"
+			};
+			const string replacement = "2b";
+			var carouselView = new CarouselView
+			{
+				CurrentItem = items[1],
+				IsScrollAnimated = false,
+				ItemTemplate = new DataTemplate(() => new Label()),
+				ItemsSource = items,
+				Loop = false
+			};
+
+			items.CollectionChanged += (_, _) => carouselView.CurrentItem = replacement;
+
+			await CreateHandlerAndAddToWindow<CarouselViewHandler2>(carouselView, async handler =>
+			{
+				await handler.Controller.CollectionView.PerformBatchUpdatesAsync(() => { });
+
+				items[1] = replacement;
+
+				await handler.Controller.CollectionView.PerformBatchUpdatesAsync(() => { });
+
+				Assert.True(
+					ReferenceEquals(replacement, carouselView.CurrentItem),
+					"CarouselView.CurrentItem should remain the replacement item after replacing the selected item.");
+			});
+		}
+	}
+}


### PR DESCRIPTION
<!-- MAUI_COPILOT_REPLICATION issue=36230 platform=catalyst -->

> [!IMPORTANT]
> This is AI-generated **reproduction evidence**, not a merge-ready product fix. The guarded test intentionally fails only when `MAUI_REPRODUCTION_ISSUE=36230` is set. A product fix should remove the guard and make the test pass before this PR is considered for merge.

## Reproduced issue

- Issue: [dotnet/maui#36230 — CurrentItem is updated incorrectly on Windows and Mac when CarouselView is bound to an ObservableCollection with Loop = false](https://github.com/dotnet/maui/issues/36230)
- Platform: **catalyst**
- Baseline commit: `604d9de36e05a40c36ab05cdcd68f2c6286fa260`
- Test type: **device**
- Targeted filter: `Issue36230`
- Expected failing assertion: `CarouselView.CurrentItem should remain the replacement item after replacing the selected item.`
- Pipeline run: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14986524

## Device evidence

[![Reproduction preview](https://raw.githubusercontent.com/dotnet/maui/954bd3869b7dcca97f7a673a6d4fc52d07b12517/pr-36230/replication/catalyst/14986524-1/preview.gif)](https://raw.githubusercontent.com/dotnet/maui/954bd3869b7dcca97f7a673a6d4fc52d07b12517/pr-36230/replication/catalyst/14986524-1/repro.mp4)

[Open the full MP4 recording](https://raw.githubusercontent.com/dotnet/maui/954bd3869b7dcca97f7a673a6d4fc52d07b12517/pr-36230/replication/catalyst/14986524-1/repro.mp4) · [Evidence manifest](https://raw.githubusercontent.com/dotnet/maui/954bd3869b7dcca97f7a673a6d4fc52d07b12517/pr-36230/replication/catalyst/14986524-1/evidence.json)

## Reproduction steps

1. Create a non-looping, non-animated CarouselView backed by an ObservableCollection containing items 1, 2, and 3, with item 2 selected.
1. Host the CarouselView in a Mac Catalyst window using CarouselViewHandler2.
1. Replace item 2 with item 2b and assign item 2b to CurrentItem from the collection change callback.
1. Flush the native collection updates and assert that CurrentItem remains item 2b.

## Safety and validation

- The pipeline reconstructed the scenario from issue text, inline snippets, and allowed raster screenshots.
- No linked repository, archive, binary, script, package, or arbitrary external file was downloaded.
- A trusted runner reproduced the behavior on-device and matched the expected targeted test failure.
- The published patch is add-only and restricted to approved MAUI test locations.
