### PR TITLE
[android] Add failing reproduction for #36834

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Picker/Issue36834.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Picker/Issue36834.Android.cs
@@ -1,0 +1,90 @@
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+using Android.Views;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Microsoft.Maui.Platform;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.Picker)]
+	public class Issue36834 : ControlsHandlerTestBase
+	{
+		const string IssueNumber = "36834";
+
+		static string? GetReplicationIssue()
+		{
+#if ANDROID
+			return global::Microsoft.Maui.TestUtils.DeviceTests.Runners.HeadlessRunner
+				.MauiTestInstrumentation.Current?.Arguments?.GetString("MAUI_REPRODUCTION_ISSUE");
+#elif IOS || MACCATALYST
+			return global::Foundation.NSProcessInfo.ProcessInfo.Environment["MAUI_REPRODUCTION_ISSUE"]?.ToString();
+#else
+			return Environment.GetEnvironmentVariable("MAUI_REPRODUCTION_ISSUE");
+#endif
+		}
+
+		[Fact]
+		public async Task LongSelectedValueScrollsHorizontally()
+		{
+			if (!string.Equals(
+				GetReplicationIssue(),
+				IssueNumber,
+				StringComparison.Ordinal))
+			{
+				return;
+			}
+
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler<Picker, PickerHandler>();
+				});
+			});
+
+			var picker = new Picker
+			{
+				ItemsSource = new[] { "This is a very long selected Picker value that should scroll horizontally" },
+				SelectedIndex = 0,
+				WidthRequest = 180
+			};
+
+			await CreateHandlerAndAddToWindow<PickerHandler>(picker, async handler =>
+			{
+				var platformPicker = handler.PlatformView;
+				await platformPicker.WaitForLayoutOrNonZeroSize();
+
+				SwipeLeft(platformPicker);
+
+				Assert.True(
+					platformPicker.ScrollX > 0,
+					"Picker should horizontally scroll a selected value that is wider than its viewport after a left swipe.");
+			});
+		}
+
+		static void SwipeLeft(MauiPicker picker)
+		{
+			float startX = picker.Width * 0.75f;
+			float endX = picker.Width * 0.25f;
+			float y = picker.Height * 0.5f;
+			long downTime = global::Android.OS.SystemClock.UptimeMillis();
+
+			var down = MotionEvent.Obtain(downTime, downTime, MotionEventActions.Down, startX, y, 0);
+			picker.DispatchTouchEvent(down);
+			down.Recycle();
+
+			var move = MotionEvent.Obtain(downTime, downTime + 16, MotionEventActions.Move, endX, y, 0);
+			picker.DispatchTouchEvent(move);
+			move.Recycle();
+
+			var up = MotionEvent.Obtain(downTime, downTime + 32, MotionEventActions.Up, endX, y, 0);
+			picker.DispatchTouchEvent(up);
+			up.Recycle();
+		}
+	}
+}


### PR DESCRIPTION
<!-- MAUI_COPILOT_REPLICATION issue=36834 platform=android -->

> [!IMPORTANT]
> This is AI-generated **reproduction evidence**, not a merge-ready product fix. The guarded test intentionally fails only when `MAUI_REPRODUCTION_ISSUE=36834` is set. A product fix should remove the guard and make the test pass before this PR is considered for merge.

## Reproduced issue

- Issue: [dotnet/maui#36834 — [Android] Can not scroll horizontally long text into Picker's title placeholder](https://github.com/dotnet/maui/issues/36834)
- Platform: **android**
- Baseline commit: `604d9de36e05a40c36ab05cdcd68f2c6286fa260`
- Test type: **device**
- Targeted filter: `Issue36834`
- Expected failing assertion: `Picker should horizontally scroll a selected value that is wider than its viewport after a left swipe.`
- Pipeline run: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14986530

## Device evidence

[![Reproduction preview](https://raw.githubusercontent.com/dotnet/maui/9a594022a6a2ba939980f550371e5bf2cbf77ee5/pr-36834/replication/android/14986530-1/preview.gif)](https://raw.githubusercontent.com/dotnet/maui/9a594022a6a2ba939980f550371e5bf2cbf77ee5/pr-36834/replication/android/14986530-1/repro.mp4)

[Open the full MP4 recording](https://raw.githubusercontent.com/dotnet/maui/9a594022a6a2ba939980f550371e5bf2cbf77ee5/pr-36834/replication/android/14986530-1/repro.mp4) · [Evidence manifest](https://raw.githubusercontent.com/dotnet/maui/9a594022a6a2ba939980f550371e5bf2cbf77ee5/pr-36834/replication/android/14986530-1/evidence.json)

## Reproduction steps

1. Create a fixed-width Picker with a selected value wider than its viewport.
1. Register PickerHandler, attach the Picker to an Android test window, and obtain its native view.
1. Dispatch a leftward down, move, and up touch sequence across the native Picker.
1. Assert that the native Picker horizontal scroll offset is greater than zero.

## Safety and validation

- The pipeline reconstructed the scenario from issue text, inline snippets, and allowed raster screenshots.
- No linked repository, archive, binary, script, package, or arbitrary external file was downloaded.
- A trusted runner reproduced the behavior on-device and matched the expected targeted test failure.
- The published patch is add-only and restricted to approved MAUI test locations.
