### PR TITLE
[ios] Add failing reproduction for #36826

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue36826.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue36826.cs
@@ -1,0 +1,124 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 36826, "ScrollView SoftInput safe area should keep bottom content above the keyboard", PlatformAffected.iOS)]
+public class Issue36826 : ContentPage
+{
+	double _scrollPositionWithKeyboard;
+	bool _keyboardInputReceived;
+
+	public Issue36826()
+	{
+		var modeLabel = new Label
+		{
+			Text = "Select SoftInput mode",
+			AutomationId = "ModeLabel"
+		};
+		var resultLabel = new Label
+		{
+			Text = "NOT EVALUATED",
+			AutomationId = "ResultLabel",
+			FontAttributes = FontAttributes.Bold
+		};
+		var scrollView = new ScrollView
+		{
+			AutomationId = "ReproScrollView"
+		};
+		var content = new VerticalStackLayout
+		{
+			Spacing = 10
+		};
+
+		for (var i = 1; i <= 11; i++)
+		{
+			content.Children.Add(new Label
+			{
+				Text = $"Test Item {i}",
+				HeightRequest = 64,
+				BackgroundColor = Colors.LightGray,
+				Padding = 12
+			});
+		}
+
+		var entry = new Entry
+		{
+			Placeholder = "Tap to raise keyboard",
+			AutomationId = "ReproEntry"
+		};
+		entry.TextChanged += (sender, args) =>
+		{
+			if (string.IsNullOrEmpty(args.NewTextValue))
+				return;
+
+			_scrollPositionWithKeyboard = scrollView.ScrollY;
+			_keyboardInputReceived = true;
+			resultLabel.Text = "READY: Swipe toward bottom, then evaluate";
+		};
+		content.Children.Add(entry);
+		content.Children.Add(new Label
+		{
+			Text = "Bottom marker",
+			AutomationId = "BottomMarker",
+			HeightRequest = 64,
+			BackgroundColor = Colors.LightGray,
+			Padding = 12
+		});
+		scrollView.Content = content;
+
+		var setSoftInputButton = new Button
+		{
+			Text = "Use SoftInput safe area",
+			AutomationId = "SetSoftInputButton"
+		};
+		setSoftInputButton.Clicked += (sender, args) =>
+		{
+			scrollView.SafeAreaEdges = new SafeAreaEdges(SafeAreaRegions.SoftInput);
+			_keyboardInputReceived = false;
+			modeLabel.Text = "READY: SoftInput safe area enabled";
+			resultLabel.Text = "NOT EVALUATED";
+		};
+
+		var evaluateButton = new Button
+		{
+			Text = "Evaluate keyboard scrolling",
+			AutomationId = "EvaluateButton"
+		};
+		evaluateButton.Clicked += (sender, args) =>
+		{
+			if (!_keyboardInputReceived)
+			{
+				resultLabel.Text = "NOT EVALUATED";
+				return;
+			}
+
+			var additionalScrollRange = scrollView.ScrollY - _scrollPositionWithKeyboard;
+			resultLabel.Text = additionalScrollRange < 80
+				? "BUG REPRODUCED: Bottom marker remains behind keyboard"
+				: "PASS: Bottom marker can scroll above keyboard";
+		};
+
+		var controls = new VerticalStackLayout
+		{
+			Spacing = 8,
+			Children =
+			{
+				setSoftInputButton,
+				evaluateButton,
+				modeLabel,
+				resultLabel
+			}
+		};
+		var grid = new Grid
+		{
+			Padding = 16,
+			RowSpacing = 12,
+			RowDefinitions =
+			{
+				new RowDefinition(GridLength.Auto),
+				new RowDefinition(GridLength.Star)
+			}
+		};
+		grid.Add(controls);
+		grid.Add(scrollView, 0, 1);
+		Content = grid;
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36826.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36826.cs
@@ -1,0 +1,46 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue36826 : _IssuesUITest
+{
+	public override string Issue => "ScrollView SoftInput safe area should keep bottom content above the keyboard";
+
+	public Issue36826 /* NUnit provides the selected test device. */ (TestDevice device) : base(device)
+	{
+	}
+
+	[Test]
+	[Category(UITestCategories.ScrollView)]
+	public void BottomMarkerShouldScrollAboveSoftwareKeyboard()
+	{
+		if (!string.Equals(
+			Environment.GetEnvironmentVariable("MAUI_REPRODUCTION_ISSUE"),
+			"36826",
+			StringComparison.Ordinal))
+		{
+			return;
+		}
+
+		App.WaitForElement("SetSoftInputButton");
+		App.Tap("SetSoftInputButton");
+		App.WaitForTextToBePresentInElement("ModeLabel", "READY: SoftInput safe area enabled");
+
+		App.ScrollDown("ReproScrollView", ScrollStrategy.Gesture, 0.75);
+		App.ScrollDown("ReproScrollView", ScrollStrategy.Gesture, 0.75);
+		App.ScrollDown("ReproScrollView", ScrollStrategy.Gesture, 0.75);
+		App.WaitForElement("ReproEntry");
+		App.Tap("ReproEntry");
+		App.EnterText("ReproEntry", "keyboard visible");
+		App.WaitForTextToBePresentInElement("ResultLabel", "READY: Swipe toward bottom, then evaluate");
+
+		App.ScrollDown("ReproScrollView", ScrollStrategy.Gesture, 0.75);
+		App.Tap("EvaluateButton");
+
+		var result = App.FindElement("ResultLabel").GetText();
+		Assert.That(result, Is.EqualTo("PASS: Bottom marker can scroll above keyboard"),
+			"Bottom marker should scroll above the software keyboard when SoftInput safe area is enabled.");
+	}
+}


### PR DESCRIPTION
<!-- MAUI_COPILOT_REPLICATION issue=36826 platform=ios -->

> [!IMPORTANT]
> This is AI-generated **reproduction evidence**, not a merge-ready product fix. The guarded test intentionally fails only when `MAUI_REPRODUCTION_ISSUE=36826` is set. A product fix should remove the guard and make the test pass before this PR is considered for merge.

## Reproduced issue

- Issue: [dotnet/maui#36826 — [Android, iOS] In ScrollView, when SafeArea is set to ALL or SoftInput, the bottom labels do not move above the keyboard](https://github.com/dotnet/maui/issues/36826)
- Platform: **ios**
- Baseline commit: `604d9de36e05a40c36ab05cdcd68f2c6286fa260`
- Test type: **ui**
- Targeted filter: `Issue36826`
- Expected failing assertion: `Bottom marker should scroll above the software keyboard when SoftInput safe area is enabled.`
- Pipeline run: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14986617

## Device evidence

[![Reproduction preview](https://raw.githubusercontent.com/dotnet/maui/5f9b70b72673f424e82c84aa4dae19939a46d8e1/pr-36826/replication/ios/14986617-1/preview.gif)](https://raw.githubusercontent.com/dotnet/maui/5f9b70b72673f424e82c84aa4dae19939a46d8e1/pr-36826/replication/ios/14986617-1/repro.mp4)

[Open the full MP4 recording](https://raw.githubusercontent.com/dotnet/maui/5f9b70b72673f424e82c84aa4dae19939a46d8e1/pr-36826/replication/ios/14986617-1/repro.mp4) · [Evidence manifest](https://raw.githubusercontent.com/dotnet/maui/5f9b70b72673f424e82c84aa4dae19939a46d8e1/pr-36826/replication/ios/14986617-1/evidence.json)

## Reproduction steps

1. Open the Issue36826 host page on the selected iOS device.
1. Enable SoftInput safe-area handling on the ScrollView.
1. Scroll to the Entry near the bottom of the content.
1. Tap the Entry to display the software keyboard, then enter text.
1. Swipe toward the bottom while the keyboard remains visible, then evaluate the additional ScrollView range.
1. Assert that the bottom marker can scroll above the software keyboard.

## Safety and validation

- The pipeline reconstructed the scenario from issue text, inline snippets, and allowed raster screenshots.
- No linked repository, archive, binary, script, package, or arbitrary external file was downloaded.
- A trusted runner reproduced the behavior on-device and matched the expected targeted test failure.
- The published patch is add-only and restricted to approved MAUI test locations.
