### PR TITLE
[catalyst] Add failing reproduction for #17673

### DIFF
--- a/src/Core/tests/UnitTests/Layouts/Issue17673.cs
+++ b/src/Core/tests/UnitTests/Layouts/Issue17673.cs
@@ -1,0 +1,48 @@
+using System;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Layouts;
+using Microsoft.Maui.Primitives;
+using NSubstitute;
+using Xunit;
+using static Microsoft.Maui.UnitTests.Layouts.LayoutTestHelpers;
+
+namespace Microsoft.Maui.UnitTests.Layouts
+{
+	[Category(TestCategory.Core, TestCategory.Layout)]
+	public class Issue17673
+	{
+		const string IssueNumber = "17673";
+
+		[Fact]
+		public void ProportionalChildPreservesIntrinsicHeightWithUnboundedConstraint()
+		{
+			if (!string.Equals(
+				Environment.GetEnvironmentVariable("MAUI_REPRODUCTION_ISSUE"),
+				IssueNumber,
+				StringComparison.Ordinal))
+			{
+				return;
+			}
+
+			var layout = Substitute.For<IAbsoluteLayout>();
+			layout.Height.Returns(Dimension.Unset);
+			layout.Width.Returns(Dimension.Unset);
+			layout.MinimumHeight.Returns(Dimension.Minimum);
+			layout.MinimumWidth.Returns(Dimension.Minimum);
+			layout.MaximumHeight.Returns(Dimension.Maximum);
+			layout.MaximumWidth.Returns(Dimension.Maximum);
+
+			var intrinsicSize = new Size(100, 40);
+			var child = CreateTestView(intrinsicSize);
+			SubstituteChildren(layout, child);
+			layout.GetLayoutBounds(child).Returns(new Rect(0, 0, 1, 1));
+			layout.GetLayoutFlags(child).Returns(AbsoluteLayoutFlags.All);
+
+			var measuredSize = new AbsoluteLayoutManager(layout).Measure(300, double.PositiveInfinity);
+
+			Assert.True(
+				measuredSize.Height >= intrinsicSize.Height,
+				"AbsoluteLayout should preserve the child's intrinsic height when proportional sizing is measured without a finite height constraint.");
+		}
+	}
+}


### PR DESCRIPTION
<!-- MAUI_COPILOT_REPLICATION issue=17673 platform=catalyst -->

> [!IMPORTANT]
> This is AI-generated **reproduction evidence**, not a merge-ready product fix. The guarded test intentionally fails only when `MAUI_REPRODUCTION_ISSUE=17673` is set. A product fix should remove the guard and make the test pass before this PR is considered for merge.

## Reproduced issue

- Issue: [dotnet/maui#17673 — AbsoluteLayout has slightly different behavior in Maui (than in Forms)](https://github.com/dotnet/maui/issues/17673)
- Platform: **catalyst**
- Baseline commit: `604d9de36e05a40c36ab05cdcd68f2c6286fa260`
- Test type: **unit**
- Targeted filter: `Issue17673`
- Expected failing assertion: `AbsoluteLayout should preserve the child's intrinsic height when proportional sizing is measured without a finite height constraint.`
- Pipeline run: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14987031

## Device evidence

[![Reproduction preview](https://raw.githubusercontent.com/dotnet/maui/91b9f83bee53c07399bbaabc892636405ab0c7de/pr-17673/replication/catalyst/14987031-1/preview.gif)](https://raw.githubusercontent.com/dotnet/maui/91b9f83bee53c07399bbaabc892636405ab0c7de/pr-17673/replication/catalyst/14987031-1/repro.mp4)

[Open the full MP4 recording](https://raw.githubusercontent.com/dotnet/maui/91b9f83bee53c07399bbaabc892636405ab0c7de/pr-17673/replication/catalyst/14987031-1/repro.mp4) · [Evidence manifest](https://raw.githubusercontent.com/dotnet/maui/91b9f83bee53c07399bbaabc892636405ab0c7de/pr-17673/replication/catalyst/14987031-1/evidence.json)

## Reproduction steps

1. Create an in-memory absolute layout with unset dimensions and a child whose intrinsic height is greater than one.
1. Set the child layout bounds to 0,0,1,1 and enable all proportional layout flags.
1. Measure the layout with a finite width constraint and an infinite height constraint, matching an auto-sized vertical parent.
1. Assert that the measured height preserves the child's intrinsic height instead of collapsing to one.

## Safety and validation

- The pipeline reconstructed the scenario from issue text, inline snippets, and allowed raster screenshots.
- No linked repository, archive, binary, script, package, or arbitrary external file was downloaded.
- A trusted runner reproduced the behavior on-device and matched the expected targeted test failure.
- The published patch is add-only and restricted to approved MAUI test locations.
