### PR TITLE
[ios] Add failing reproduction for #19340

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/ContentView/Issue19340.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ContentView/Issue19340.iOS.cs
@@ -1,0 +1,99 @@
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+using CoreGraphics;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using UIKit;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.ContentView)]
+	public class Issue19340 : ControlsHandlerTestBase
+	{
+		const string IssueNumber = "19340";
+
+		static string? GetReplicationIssue()
+		{
+#if ANDROID
+			return global::Microsoft.Maui.TestUtils.DeviceTests.Runners.HeadlessRunner
+				.MauiTestInstrumentation.Current?.Arguments?.GetString("MAUI_REPRODUCTION_ISSUE");
+#elif IOS || MACCATALYST
+			return global::Foundation.NSProcessInfo.ProcessInfo.Environment["MAUI_REPRODUCTION_ISSUE"]?.ToString();
+#else
+			return Environment.GetEnvironmentVariable("MAUI_REPRODUCTION_ISSUE");
+#endif
+		}
+
+		[Fact]
+		public async Task EmbeddedContentViewHasPositiveFittedHeight()
+		{
+			if (!string.Equals(
+				GetReplicationIssue(),
+				IssueNumber,
+				StringComparison.Ordinal))
+			{
+				return;
+			}
+
+			var heights = await InvokeOnMainThreadAsync(() =>
+			{
+				var button = new Button
+				{
+					Text = "Reference Button"
+				};
+				var label = new Label
+				{
+					Text = "ContentView child"
+				};
+				var entry = new Entry
+				{
+					Placeholder = "Embedded entry"
+				};
+				var layout = new VerticalStackLayout
+				{
+					Children =
+					{
+						label,
+						entry
+					}
+				};
+				var contentView = new ContentView
+				{
+					Content = layout
+				};
+
+				CreateHandler<LabelHandler>(label);
+				CreateHandler<EntryHandler>(entry);
+				CreateHandler<LayoutHandler>(layout);
+				var buttonHandler = CreateHandler<ButtonHandler>(button);
+				var contentViewHandler = CreateHandler<ContentViewHandler>(contentView);
+
+				var nativeStack = new UIStackView(new UIView[]
+				{
+					buttonHandler.PlatformView,
+					contentViewHandler.PlatformView
+				})
+				{
+					Axis = UILayoutConstraintAxis.Vertical,
+					Alignment = UIStackViewAlignment.Fill,
+					Distribution = UIStackViewDistribution.Fill,
+					Spacing = 8
+				};
+
+				var fittedSize = nativeStack.SystemLayoutSizeFittingSize(UIView.UILayoutFittingCompressedSize);
+				nativeStack.Frame = new CGRect(0, 0, fittedSize.Width, fittedSize.Height);
+				nativeStack.LayoutIfNeeded();
+
+				return (
+					Button: buttonHandler.PlatformView.Frame.Height,
+					ContentView: contentViewHandler.PlatformView.Frame.Height);
+			});
+
+			Assert.True(heights.Button > 0, "Expected reference Button to have a positive height.");
+			Assert.True(heights.ContentView > 0, "Expected embedded ContentView to have a positive height.");
+		}
+	}
+}


### PR DESCRIPTION
<!-- MAUI_COPILOT_REPLICATION issue=19340 platform=ios -->

> [!IMPORTANT]
> This is AI-generated **reproduction evidence**, not a merge-ready product fix. The guarded test intentionally fails only when `MAUI_REPRODUCTION_ISSUE=19340` is set. A product fix should remove the guard and make the test pass before this PR is considered for merge.

## Reproduced issue

- Issue: [dotnet/maui#19340 — Embedding an iOS ContentView or Layout does not get a size](https://github.com/dotnet/maui/issues/19340)
- Platform: **ios**
- Baseline commit: `604d9de36e05a40c36ab05cdcd68f2c6286fa260`
- Test type: **device**
- Targeted filter: `Issue19340`
- Expected failing assertion: `Expected embedded ContentView to have a positive height.`
- Pipeline run: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14987029

## Device evidence

[![Reproduction preview](https://raw.githubusercontent.com/dotnet/maui/faf5f2f69121d2f068e9636cf154edbf5e2aa0ee/pr-19340/replication/ios/14987029-1/preview.gif)](https://raw.githubusercontent.com/dotnet/maui/faf5f2f69121d2f068e9636cf154edbf5e2aa0ee/pr-19340/replication/ios/14987029-1/repro.mp4)

[Open the full MP4 recording](https://raw.githubusercontent.com/dotnet/maui/faf5f2f69121d2f068e9636cf154edbf5e2aa0ee/pr-19340/replication/ios/14987029-1/repro.mp4) · [Evidence manifest](https://raw.githubusercontent.com/dotnet/maui/faf5f2f69121d2f068e9636cf154edbf5e2aa0ee/pr-19340/replication/ios/14987029-1/evidence.json)

## Reproduction steps

1. On the iOS main thread, create handled Button and ContentView controls, with the ContentView containing a VerticalStackLayout with a Label and Entry.
1. Add both platform views to a vertical UIStackView and size it with SystemLayoutSizeFittingSize using the compressed fitting size.
1. Lay out the native stack and verify the reference Button has positive height.
1. Assert that the embedded ContentView platform view also has positive height.

## Safety and validation

- The pipeline reconstructed the scenario from issue text, inline snippets, and allowed raster screenshots.
- No linked repository, archive, binary, script, package, or arbitrary external file was downloaded.
- A trusted runner reproduced the behavior on-device and matched the expected targeted test failure.
- The published patch is add-only and restricted to approved MAUI test locations.
