### PR TITLE
[android] Add failing reproduction for #15387

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/ScrollView/Issue15387.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ScrollView/Issue15387.cs
@@ -1,0 +1,104 @@
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.ScrollView)]
+	public class Issue15387 : ControlsHandlerTestBase
+	{
+		const string IssueNumber = "15387";
+
+		static string? GetReplicationIssue()
+		{
+#if ANDROID
+			return global::Microsoft.Maui.TestUtils.DeviceTests.Runners.HeadlessRunner
+				.MauiTestInstrumentation.Current?.Arguments?.GetString("MAUI_REPRODUCTION_ISSUE");
+#elif IOS || MACCATALYST
+			return global::Foundation.NSProcessInfo.ProcessInfo.Environment["MAUI_REPRODUCTION_ISSUE"]?.ToString();
+#else
+			return Environment.GetEnvironmentVariable("MAUI_REPRODUCTION_ISSUE");
+#endif
+		}
+
+		[Fact]
+		public async Task ScrollToAsyncCompletesDuringOnAppearing()
+		{
+			if (!string.Equals(
+				GetReplicationIssue(),
+				IssueNumber,
+				StringComparison.Ordinal))
+			{
+				return;
+			}
+
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler<Label, LabelHandler>();
+					handlers.AddHandler<IScrollView, ScrollViewHandler>();
+					handlers.AddHandler<VerticalStackLayout, LayoutHandler>();
+				});
+			});
+
+			var itemsLayout = new VerticalStackLayout();
+			BindableLayout.SetItemTemplate(itemsLayout, new DataTemplate(() => new Label()));
+			BindableLayout.SetItemsSource(itemsLayout, new[]
+			{
+				"Item 1",
+				"Item 2",
+				"Item 3",
+				"Item 4",
+				"Item 5",
+			});
+
+			var scrollView = new ScrollView
+			{
+				Content = itemsLayout,
+			};
+			var page = new ReproductionPage
+			{
+				Content = scrollView,
+				ScrollView = scrollView,
+				ScrollCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously),
+			};
+			bool completed = false;
+
+			await CreateHandlerAndAddToWindow(page, async () =>
+			{
+				try
+				{
+					await page.ScrollCompleted.Task.WaitAsync(TimeSpan.FromSeconds(3));
+					completed = true;
+				}
+				catch (TimeoutException)
+				{
+					completed = false;
+				}
+			});
+
+			Assert.True(completed, "ScrollToAsync should complete when invoked during OnAppearing.");
+		}
+
+		sealed class ReproductionPage : ContentPage
+		{
+			public required ScrollView ScrollView { get; init; }
+
+			public required TaskCompletionSource ScrollCompleted { get; init; }
+
+			protected override async void OnAppearing()
+			{
+				base.OnAppearing();
+
+				await ScrollView.ScrollToAsync(0, 0, false);
+				ScrollCompleted.TrySetResult();
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!-- MAUI_COPILOT_REPLICATION issue=15387 platform=android -->

> [!IMPORTANT]
> This is AI-generated **reproduction evidence**, not a merge-ready product fix. The guarded test intentionally fails only when `MAUI_REPRODUCTION_ISSUE=15387` is set. A product fix should remove the guard and make the test pass before this PR is considered for merge.

## Reproduced issue

- Issue: [dotnet/maui#15387 — Calling ScrollView ScrollToAsync in OnNavigatedTo event or OnAppearing event does not return.](https://github.com/dotnet/maui/issues/15387)
- Platform: **android**
- Baseline commit: `604d9de36e05a40c36ab05cdcd68f2c6286fa260`
- Test type: **device**
- Targeted filter: `Issue15387`
- Expected failing assertion: `ScrollToAsync should complete when invoked during OnAppearing.`
- Pipeline run: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14987017

## Device evidence

[![Reproduction preview](https://raw.githubusercontent.com/dotnet/maui/7f4c1542aad94980c438d77a2978dd1c691e99f2/pr-15387/replication/android/14987017-1/preview.gif)](https://raw.githubusercontent.com/dotnet/maui/7f4c1542aad94980c438d77a2978dd1c691e99f2/pr-15387/replication/android/14987017-1/repro.mp4)

[Open the full MP4 recording](https://raw.githubusercontent.com/dotnet/maui/7f4c1542aad94980c438d77a2978dd1c691e99f2/pr-15387/replication/android/14987017-1/repro.mp4) · [Evidence manifest](https://raw.githubusercontent.com/dotnet/maui/7f4c1542aad94980c438d77a2978dd1c691e99f2/pr-15387/replication/android/14987017-1/evidence.json)

## Reproduction steps

1. Enable only the guarded Issue15387 test on the selected Android device.
1. After the issue guard passes, create a ContentPage containing a ScrollView and a populated BindableLayout.
1. Attach the page to a native window and invoke ScrollToAsync(0, 0, false) from the first OnAppearing callback.
1. Assert that the lifecycle-triggered ScrollToAsync operation completes successfully.

## Safety and validation

- The pipeline reconstructed the scenario from issue text, inline snippets, and allowed raster screenshots.
- No linked repository, archive, binary, script, package, or arbitrary external file was downloaded.
- A trusted runner reproduced the behavior on-device and matched the expected targeted test failure.
- The published patch is add-only and restricted to approved MAUI test locations.
