### PR TITLE
[android] Add failing reproduction for #14305

### DIFF
--- a/src/Controls/tests/Core.UnitTests/Layouts/Issue14305.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/Issue14305.cs
@@ -1,0 +1,80 @@
+using System;
+using Microsoft.Maui.Graphics;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
+{
+	public class Issue14305
+	{
+		const string IssueNumber = "14305";
+
+		[Fact]
+		public void ImageRemainsWithinAssignedStarRow()
+		{
+			if (!string.Equals(
+				Environment.GetEnvironmentVariable("MAUI_REPRODUCTION_ISSUE"),
+				IssueNumber,
+				StringComparison.Ordinal))
+			{
+				return;
+			}
+
+			const double width = 731.43;
+			const double height = 331.43;
+			const double fixedRowHeight = 150;
+
+			var grid = new Grid
+			{
+				RowDefinitions =
+				{
+					new RowDefinition { Height = GridLength.Auto },
+					new RowDefinition { Height = GridLength.Star },
+					new RowDefinition { Height = fixedRowHeight },
+				},
+				ColumnDefinitions =
+				{
+					new ColumnDefinition { Width = GridLength.Auto },
+					new ColumnDefinition { Width = GridLength.Star },
+					new ColumnDefinition { Width = 150 },
+				},
+			};
+
+			var header = new FixedSizeImage
+			{
+				WidthRequest = 200,
+				HeightRequest = 27.05,
+			};
+			Grid.SetColumnSpan(header, 3);
+
+			var image = new FixedSizeImage
+			{
+				WidthRequest = 200,
+				HeightRequest = 200,
+				HorizontalOptions = LayoutOptions.Center,
+			};
+			Grid.SetRow(image, 1);
+			Grid.SetColumn(image, 1);
+
+			grid.Add(header);
+			grid.Add(image);
+
+			grid.CrossPlatformMeasure(width, height);
+			grid.CrossPlatformArrange(new Rect(0, 0, width, height));
+
+			double starRowTop = header.Bounds.Bottom;
+			double starRowBottom = height - fixedRowHeight;
+
+			Assert.True(
+				image.Bounds.Top >= starRowTop && image.Bounds.Bottom <= starRowBottom,
+				"Image bounds must remain within the assigned star row.");
+		}
+
+		sealed class FixedSizeImage : Image
+		{
+			protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
+			{
+				return new Size(WidthRequest, HeightRequest);
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!-- MAUI_COPILOT_REPLICATION issue=14305 platform=android -->

> [!IMPORTANT]
> This is AI-generated **reproduction evidence**, not a merge-ready product fix. The guarded test intentionally fails only when `MAUI_REPRODUCTION_ISSUE=14305` is set. A product fix should remove the guard and make the test pass before this PR is considered for merge.

## Reproduced issue

- Issue: [dotnet/maui#14305 — Grid star (Image?) behaviour inconsistent across platforms](https://github.com/dotnet/maui/issues/14305)
- Platform: **android**
- Baseline commit: `604d9de36e05a40c36ab05cdcd68f2c6286fa260`
- Test type: **unit**
- Targeted filter: `Issue14305`
- Expected failing assertion: `Image bounds must remain within the assigned star row.`
- Pipeline run: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14987025

## Device evidence

[![Reproduction preview](https://raw.githubusercontent.com/dotnet/maui/72d35862e2f341ec4363fe3e34c27856fb994108/pr-14305/replication/android/14987025-1/preview.gif)](https://raw.githubusercontent.com/dotnet/maui/72d35862e2f341ec4363fe3e34c27856fb994108/pr-14305/replication/android/14987025-1/repro.mp4)

[Open the full MP4 recording](https://raw.githubusercontent.com/dotnet/maui/72d35862e2f341ec4363fe3e34c27856fb994108/pr-14305/replication/android/14987025-1/repro.mp4) · [Evidence manifest](https://raw.githubusercontent.com/dotnet/maui/72d35862e2f341ec4363fe3e34c27856fb994108/pr-14305/replication/android/14987025-1/evidence.json)

## Reproduction steps

1. Create a Grid with Auto, star, and 150-unit rows and columns.
1. Place a 200-by-200 Image centered horizontally in the star row and star column.
1. Measure and arrange the grid using the reproduced landscape bounds of 731.43 by 331.43 units.
1. Assert that the arranged image top and bottom remain within the assigned star-row bounds.

## Safety and validation

- The pipeline reconstructed the scenario from issue text, inline snippets, and allowed raster screenshots.
- No linked repository, archive, binary, script, package, or arbitrary external file was downloaded.
- A trusted runner reproduced the behavior on-device and matched the expected targeted test failure.
- The published patch is add-only and restricted to approved MAUI test locations.
