### PR TITLE
Fix race in WeakEventProxy field access

### DIFF
--- a/src/Controls/src/Core/Internals/WeakEventProxy.cs
+++ b/src/Controls/src/Core/Internals/WeakEventProxy.cs
@@ -24,7 +24,8 @@ namespace Microsoft.Maui.Controls
 
 		public bool TryGetSource([MaybeNullWhen(false)] out TSource source)
 		{
-			if (_source is not null && _source.TryGetTarget(out source))
+			var sourceReference = _source;
+			if (sourceReference is not null && sourceReference.TryGetTarget(out source))
 			{
 				return source is not null;
 			}
@@ -35,7 +36,8 @@ namespace Microsoft.Maui.Controls
 
 		public bool TryGetHandler([MaybeNullWhen(false)] out TEventHandler handler)
 		{
-			if (_handler is not null && _handler.TryGetTarget(out handler))
+			var handlerReference = _handler;
+			if (handlerReference is not null && handlerReference.TryGetTarget(out handler))
 			{
 				return handler is not null;
 			}


### PR DESCRIPTION
### Description of Change

Captures the weak-reference fields in local variables before testing and dereferencing them. This closes the time-of-check/time-of-use race with `Unsubscribe()`, which clears the fields concurrently.

The race has been observed as an unhandled Android `NullReferenceException` from both `TryGetSource` during binding finalization and `TryGetHandler` while processing property changes.

### Issues Fixed

Fixes #32602

### Validation

- `dotnet build src/Controls/src/Core/Controls.Core.csproj --no-restore --verbosity minimal -p:TargetFramework=netstandard2.0`