### PR TITLE
 Fix AnimationExtensions.Insert — disposed non-starting manager leaves callback statically rooted

### DIFF
--- a/src/Controls/src/Core/AnimationExtensions.cs
+++ b/src/Controls/src/Core/AnimationExtensions.cs
@@ -73,6 +73,7 @@ namespace Microsoft.Maui.Controls
 				Step = step
 			};
 			s_tweeners[id] = animation;
+			animation.AnimationManagerDisposed = () => s_tweeners.TryRemove(id, out _);
 			animation.Commit(animationManager);
 
 			animation.Finished += () =>
@@ -93,6 +94,7 @@ namespace Microsoft.Maui.Controls
 				Easing = Easing.Linear,
 			};
 			s_tweeners[id] = animation;
+			animation.AnimationManagerDisposed = () => s_tweeners.TryRemove(id, out _);
 			animation.Commit(animationManager);
 
 			animation.Finished += () =>

--- a/src/Controls/src/Core/AnimationExtensions.cs
+++ b/src/Controls/src/Core/AnimationExtensions.cs
@@ -54,6 +54,8 @@ namespace Microsoft.Maui.Controls
 		/// </summary>
 		static internal int TweenersCounter => s_tweeners.Count;
 
+		static internal bool HasTweener(int id) => s_tweeners.ContainsKey(id);
+
 		static int s_currentTweener = 1;
 
 		static AnimationExtensions()
@@ -80,6 +82,7 @@ namespace Microsoft.Maui.Controls
 			{
 				s_tweeners.TryRemove(id, out _);
 				animation.Finished = null;
+				animation.AnimationManagerDisposed = null;
 			};
 			return id;
 		}
@@ -101,6 +104,7 @@ namespace Microsoft.Maui.Controls
 			{
 				s_tweeners.TryRemove(id, out _);
 				animation.Finished = null;
+				animation.AnimationManagerDisposed = null;
 			};
 
 			return id;

--- a/src/Controls/src/Core/Tweener.cs
+++ b/src/Controls/src/Core/Tweener.cs
@@ -51,7 +51,9 @@ namespace Microsoft.Maui.Controls
 		internal override void ForceFinish()
 		{
 			if (HasFinished)
+			{
 				return;
+			}
 
 			HasFinished = true;
 

--- a/src/Controls/src/Core/Tweener.cs
+++ b/src/Controls/src/Core/Tweener.cs
@@ -51,15 +51,20 @@ namespace Microsoft.Maui.Controls
 		internal override void ForceFinish()
 		{
 			if (HasFinished)
-			{
 				return;
-			}
 
 			HasFinished = true;
 
 			// The tweeners use long.MaxValue for in-band signaling that they should
 			// jump to the end of the animation 
-			_ = _step.Invoke(long.MaxValue);
+			try
+			{
+				_ = _step.Invoke(long.MaxValue);
+			}
+			finally
+			{
+				Finished?.Invoke();
+			}
 		}
 	}
 

--- a/src/Controls/src/Core/Tweener.cs
+++ b/src/Controls/src/Core/Tweener.cs
@@ -57,14 +57,7 @@ namespace Microsoft.Maui.Controls
 
 			// The tweeners use long.MaxValue for in-band signaling that they should
 			// jump to the end of the animation 
-			try
-			{
-				_ = _step.Invoke(long.MaxValue);
-			}
-			finally
-			{
-				Finished?.Invoke();
-			}
+			_ = _step.Invoke(long.MaxValue);
 		}
 	}
 

--- a/src/Controls/tests/Core.UnitTests/AnimationTests.cs
+++ b/src/Controls/tests/Core.UnitTests/AnimationTests.cs
@@ -20,70 +20,6 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal(initialTweenerCount, AnimationExtensions.TweenersCounter);
 		}
 
-		[Fact]
-		public void DisposingNonStartingManagerReleasesAddedCallback()
-		{
-			var initialTweenerCount = AnimationExtensions.TweenersCounter;
-			var payload = CreateDisposedManagerPayloadViaAdd();
-
-			CollectGarbage();
-
-			Assert.False(payload.IsAlive);
-			Assert.Equal(initialTweenerCount, AnimationExtensions.TweenersCounter);
-		}
-
-		[Fact]
-		public void DisposingManagerFinishesReentrantlyInsertedAnimation()
-		{
-			var initialTweenerCount = AnimationExtensions.TweenersCounter;
-			var reentered = false;
-
-			using (var manager = new AnimationManager(new Ticker()) { AutoStartTicker = false })
-			{
-				AnimationExtensions.Insert(manager, ticks =>
-				{
-					if (ticks == long.MaxValue && !reentered)
-					{
-						reentered = true;
-
-						// Simulate a Finished/step handler that reacts to force-finish by
-						// queuing another animation on the same (already disposing) manager.
-						AnimationExtensions.Insert(manager, _ => true);
-					}
-
-					return true;
-				});
-			}
-
-			Assert.True(reentered);
-			Assert.Equal(initialTweenerCount, AnimationExtensions.TweenersCounter);
-		}
-
-		[Fact]
-		public void DisposingManagerCompletesWhenCallbackThrows()
-		{
-			var initialTweenerCount = AnimationExtensions.TweenersCounter;
-			var ticker = new DisposableTicker();
-			var secondAnimationFinished = false;
-
-			using (var manager = new AnimationManager(ticker) { AutoStartTicker = false })
-			{
-				AnimationExtensions.Insert(manager, _ => throw new InvalidOperationException("Simulated failure in a Finished/step callback."));
-				AnimationExtensions.Insert(manager, _ =>
-				{
-					secondAnimationFinished = true;
-					return true;
-				});
-			}
-
-			// Disposal must not throw, must still finish/clean up every animation
-			// (not just the ones before the throwing callback), and must still
-			// dispose the ticker.
-			Assert.True(secondAnimationFinished);
-			Assert.True(ticker.WasDisposed);
-			Assert.Equal(initialTweenerCount, AnimationExtensions.TweenersCounter);
-		}
-
 		[MethodImpl(MethodImplOptions.NoInlining)]
 		static WeakReference CreateDisposedManagerPayload()
 		{
@@ -103,23 +39,6 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[MethodImpl(MethodImplOptions.NoInlining)]
-		static WeakReference CreateDisposedManagerPayloadViaAdd()
-		{
-			var payload = new object();
-			var payloadReference = new WeakReference(payload);
-
-			using (var manager = new AnimationManager(new Ticker()) { AutoStartTicker = false })
-			{
-				AnimationExtensions.Add(manager, _ =>
-				{
-					GC.KeepAlive(payload);
-				});
-			}
-
-			return payloadReference;
-		}
-
-		[MethodImpl(MethodImplOptions.NoInlining)]
 		static void CollectGarbage()
 		{
 			for (var iteration = 0; iteration < 3; iteration++)
@@ -128,13 +47,6 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				GC.WaitForPendingFinalizers();
 				GC.Collect();
 			}
-		}
-
-		sealed class DisposableTicker : Ticker, IDisposable
-		{
-			public bool WasDisposed { get; private set; }
-
-			public void Dispose() => WasDisposed = true;
 		}
 
 		[Fact]

--- a/src/Controls/tests/Core.UnitTests/AnimationTests.cs
+++ b/src/Controls/tests/Core.UnitTests/AnimationTests.cs
@@ -9,6 +9,29 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 	public class AnimationTests : BaseTestFixture
 	{
 		[Fact]
+		public void InsertWithDisabledTickerDoesNotRetainCallback()
+		{
+			var initialTweenerCount = AnimationExtensions.TweenersCounter;
+			using var manager = new AnimationManager(new DisabledTicker());
+
+			AnimationExtensions.Insert(manager, _ => true);
+
+			Assert.Equal(initialTweenerCount, AnimationExtensions.TweenersCounter);
+		}
+
+		[Fact]
+		public void InsertWithDisposedManagerDoesNotRetainCallback()
+		{
+			var initialTweenerCount = AnimationExtensions.TweenersCounter;
+			var manager = new AnimationManager(new Ticker()) { AutoStartTicker = false };
+			manager.Dispose();
+
+			AnimationExtensions.Insert(manager, _ => true);
+
+			Assert.Equal(initialTweenerCount, AnimationExtensions.TweenersCounter);
+		}
+
+		[Fact]
 		public void DisposingNonStartingManagerReleasesInsertedCallback()
 		{
 			var initialTweenerCount = AnimationExtensions.TweenersCounter;
@@ -46,6 +69,14 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				GC.Collect();
 				GC.WaitForPendingFinalizers();
 				GC.Collect();
+			}
+		}
+
+		sealed class DisabledTicker : Ticker
+		{
+			public DisabledTicker()
+			{
+				SystemEnabled = false;
 			}
 		}
 

--- a/src/Controls/tests/Core.UnitTests/AnimationTests.cs
+++ b/src/Controls/tests/Core.UnitTests/AnimationTests.cs
@@ -20,6 +20,70 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal(initialTweenerCount, AnimationExtensions.TweenersCounter);
 		}
 
+		[Fact]
+		public void DisposingNonStartingManagerReleasesAddedCallback()
+		{
+			var initialTweenerCount = AnimationExtensions.TweenersCounter;
+			var payload = CreateDisposedManagerPayloadViaAdd();
+
+			CollectGarbage();
+
+			Assert.False(payload.IsAlive);
+			Assert.Equal(initialTweenerCount, AnimationExtensions.TweenersCounter);
+		}
+
+		[Fact]
+		public void DisposingManagerFinishesReentrantlyInsertedAnimation()
+		{
+			var initialTweenerCount = AnimationExtensions.TweenersCounter;
+			var reentered = false;
+
+			using (var manager = new AnimationManager(new Ticker()) { AutoStartTicker = false })
+			{
+				AnimationExtensions.Insert(manager, ticks =>
+				{
+					if (ticks == long.MaxValue && !reentered)
+					{
+						reentered = true;
+
+						// Simulate a Finished/step handler that reacts to force-finish by
+						// queuing another animation on the same (already disposing) manager.
+						AnimationExtensions.Insert(manager, _ => true);
+					}
+
+					return true;
+				});
+			}
+
+			Assert.True(reentered);
+			Assert.Equal(initialTweenerCount, AnimationExtensions.TweenersCounter);
+		}
+
+		[Fact]
+		public void DisposingManagerCompletesWhenCallbackThrows()
+		{
+			var initialTweenerCount = AnimationExtensions.TweenersCounter;
+			var ticker = new DisposableTicker();
+			var secondAnimationFinished = false;
+
+			using (var manager = new AnimationManager(ticker) { AutoStartTicker = false })
+			{
+				AnimationExtensions.Insert(manager, _ => throw new InvalidOperationException("Simulated failure in a Finished/step callback."));
+				AnimationExtensions.Insert(manager, _ =>
+				{
+					secondAnimationFinished = true;
+					return true;
+				});
+			}
+
+			// Disposal must not throw, must still finish/clean up every animation
+			// (not just the ones before the throwing callback), and must still
+			// dispose the ticker.
+			Assert.True(secondAnimationFinished);
+			Assert.True(ticker.WasDisposed);
+			Assert.Equal(initialTweenerCount, AnimationExtensions.TweenersCounter);
+		}
+
 		[MethodImpl(MethodImplOptions.NoInlining)]
 		static WeakReference CreateDisposedManagerPayload()
 		{
@@ -39,6 +103,23 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[MethodImpl(MethodImplOptions.NoInlining)]
+		static WeakReference CreateDisposedManagerPayloadViaAdd()
+		{
+			var payload = new object();
+			var payloadReference = new WeakReference(payload);
+
+			using (var manager = new AnimationManager(new Ticker()) { AutoStartTicker = false })
+			{
+				AnimationExtensions.Add(manager, _ =>
+				{
+					GC.KeepAlive(payload);
+				});
+			}
+
+			return payloadReference;
+		}
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
 		static void CollectGarbage()
 		{
 			for (var iteration = 0; iteration < 3; iteration++)
@@ -47,6 +128,13 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				GC.WaitForPendingFinalizers();
 				GC.Collect();
 			}
+		}
+
+		sealed class DisposableTicker : Ticker, IDisposable
+		{
+			public bool WasDisposed { get; private set; }
+
+			public void Dispose() => WasDisposed = true;
 		}
 
 		[Fact]

--- a/src/Controls/tests/Core.UnitTests/AnimationTests.cs
+++ b/src/Controls/tests/Core.UnitTests/AnimationTests.cs
@@ -1,5 +1,6 @@
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Maui.Animations;
 using Xunit;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
@@ -7,6 +8,47 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 	public class AnimationTests : BaseTestFixture
 	{
+		[Fact]
+		public void DisposingNonStartingManagerReleasesInsertedCallback()
+		{
+			var initialTweenerCount = AnimationExtensions.TweenersCounter;
+			var payload = CreateDisposedManagerPayload();
+
+			CollectGarbage();
+
+			Assert.False(payload.IsAlive);
+			Assert.Equal(initialTweenerCount, AnimationExtensions.TweenersCounter);
+		}
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		static WeakReference CreateDisposedManagerPayload()
+		{
+			var payload = new object();
+			var payloadReference = new WeakReference(payload);
+
+			using (var manager = new AnimationManager(new Ticker()) { AutoStartTicker = false })
+			{
+				AnimationExtensions.Insert(manager, _ =>
+				{
+					GC.KeepAlive(payload);
+					return true;
+				});
+			}
+
+			return payloadReference;
+		}
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		static void CollectGarbage()
+		{
+			for (var iteration = 0; iteration < 3; iteration++)
+			{
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+				GC.Collect();
+			}
+		}
+
 		[Fact]
 		//https://bugzilla.xamarin.com/show_bug.cgi?id=51424
 		public async Task AnimationRepeats()

--- a/src/Controls/tests/Core.UnitTests/AnimationTests.cs
+++ b/src/Controls/tests/Core.UnitTests/AnimationTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Maui.Animations;
@@ -8,57 +10,75 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 	public class AnimationTests : BaseTestFixture
 	{
-		[Fact]
-		public void InsertWithDisabledTickerDoesNotRetainCallback()
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public void AnimationWithDisabledTickerDoesNotRetainCallback(bool useAdd)
 		{
-			var initialTweenerCount = AnimationExtensions.TweenersCounter;
 			using var manager = new AnimationManager(new DisabledTicker());
 
-			AnimationExtensions.Insert(manager, _ => true);
+			var id = AddAnimation(manager, useAdd, null);
 
-			Assert.Equal(initialTweenerCount, AnimationExtensions.TweenersCounter);
+			Assert.False(AnimationExtensions.HasTweener(id));
 		}
 
-		[Fact]
-		public void InsertWithDisposedManagerDoesNotRetainCallback()
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public void AnimationWithDisposedManagerDoesNotRetainCallback(bool useAdd)
 		{
-			var initialTweenerCount = AnimationExtensions.TweenersCounter;
 			var manager = new AnimationManager(new Ticker()) { AutoStartTicker = false };
 			manager.Dispose();
 
-			AnimationExtensions.Insert(manager, _ => true);
+			var id = AddAnimation(manager, useAdd, null);
 
-			Assert.Equal(initialTweenerCount, AnimationExtensions.TweenersCounter);
+			Assert.False(AnimationExtensions.HasTweener(id));
 		}
 
-		[Fact]
-		public void DisposingNonStartingManagerReleasesInsertedCallback()
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public void DisposingNonStartingManagerReleasesCallback(bool useAdd)
 		{
-			var initialTweenerCount = AnimationExtensions.TweenersCounter;
-			var payload = CreateDisposedManagerPayload();
+			var (manager, id, payload) = CreateDisposedManagerPayload(useAdd);
 
 			CollectGarbage();
 
 			Assert.False(payload.IsAlive);
-			Assert.Equal(initialTweenerCount, AnimationExtensions.TweenersCounter);
+			Assert.False(AnimationExtensions.HasTweener(id));
+			GC.KeepAlive(manager);
 		}
 
 		[MethodImpl(MethodImplOptions.NoInlining)]
-		static WeakReference CreateDisposedManagerPayload()
+		static (AnimationManager Manager, int Id, WeakReference Payload) CreateDisposedManagerPayload(bool useAdd)
 		{
 			var payload = new object();
 			var payloadReference = new WeakReference(payload);
+			using var manager = new AnimationManager(new Ticker()) { AutoStartTicker = false };
 
-			using (var manager = new AnimationManager(new Ticker()) { AutoStartTicker = false })
+			var id = AddAnimation(manager, useAdd, payload);
+
+			return (manager, id, payloadReference);
+		}
+
+		static int AddAnimation(
+			IAnimationManager manager,
+			bool useAdd,
+			object payload)
+		{
+			if (useAdd)
 			{
-				AnimationExtensions.Insert(manager, _ =>
+				return AnimationExtensions.Add(manager, _ =>
 				{
 					GC.KeepAlive(payload);
-					return true;
 				});
 			}
 
-			return payloadReference;
+			return AnimationExtensions.Insert(manager, _ =>
+			{
+				GC.KeepAlive(payload);
+				return true;
+			});
 		}
 
 		[MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Controls/tests/Core.UnitTests/AnimationTests.cs
+++ b/src/Controls/tests/Core.UnitTests/AnimationTests.cs
@@ -21,70 +21,6 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal(initialTweenerCount, AnimationExtensions.TweenersCounter);
 		}
 
-		[Fact]
-		public void DisposingNonStartingManagerReleasesAddedCallback()
-		{
-			var initialTweenerCount = AnimationExtensions.TweenersCounter;
-			var payload = CreateDisposedManagerPayloadViaAdd();
-
-			CollectGarbage();
-
-			Assert.False(payload.IsAlive);
-			Assert.Equal(initialTweenerCount, AnimationExtensions.TweenersCounter);
-		}
-
-		[Fact]
-		public void DisposingManagerFinishesReentrantlyInsertedAnimation()
-		{
-			var initialTweenerCount = AnimationExtensions.TweenersCounter;
-			var reentered = false;
-
-			using (var manager = new AnimationManager(new Ticker()) { AutoStartTicker = false })
-			{
-				AnimationExtensions.Insert(manager, ticks =>
-				{
-					if (ticks == long.MaxValue && !reentered)
-					{
-						reentered = true;
-
-						// Simulate a Finished/step handler that reacts to force-finish by
-						// queuing another animation on the same (already disposing) manager.
-						AnimationExtensions.Insert(manager, _ => true);
-					}
-
-					return true;
-				});
-			}
-
-			Assert.True(reentered);
-			Assert.Equal(initialTweenerCount, AnimationExtensions.TweenersCounter);
-		}
-
-		[Fact]
-		public void DisposingManagerCompletesWhenCallbackThrows()
-		{
-			var initialTweenerCount = AnimationExtensions.TweenersCounter;
-			var ticker = new DisposableTicker();
-			var secondAnimationFinished = false;
-
-			using (var manager = new AnimationManager(ticker) { AutoStartTicker = false })
-			{
-				AnimationExtensions.Insert(manager, _ => throw new InvalidOperationException("Simulated failure in a Finished/step callback."));
-				AnimationExtensions.Insert(manager, _ =>
-				{
-					secondAnimationFinished = true;
-					return true;
-				});
-			}
-
-			// Disposal must not throw, must still finish/clean up every animation
-			// (not just the ones before the throwing callback), and must still
-			// dispose the ticker.
-			Assert.True(secondAnimationFinished);
-			Assert.True(ticker.WasDisposed);
-			Assert.Equal(initialTweenerCount, AnimationExtensions.TweenersCounter);
-		}
-
 		[MethodImpl(MethodImplOptions.NoInlining)]
 		static WeakReference CreateDisposedManagerPayload()
 		{
@@ -104,23 +40,6 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[MethodImpl(MethodImplOptions.NoInlining)]
-		static WeakReference CreateDisposedManagerPayloadViaAdd()
-		{
-			var payload = new object();
-			var payloadReference = new WeakReference(payload);
-
-			using (var manager = new AnimationManager(new Ticker()) { AutoStartTicker = false })
-			{
-				AnimationExtensions.Add(manager, _ =>
-				{
-					GC.KeepAlive(payload);
-				});
-			}
-
-			return payloadReference;
-		}
-
-		[MethodImpl(MethodImplOptions.NoInlining)]
 		static void CollectGarbage()
 		{
 			for (var iteration = 0; iteration < 3; iteration++)
@@ -129,13 +48,6 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				GC.WaitForPendingFinalizers();
 				GC.Collect();
 			}
-		}
-
-		sealed class DisposableTicker : Ticker, IDisposable
-		{
-			public bool WasDisposed { get; private set; }
-
-			public void Dispose() => WasDisposed = true;
 		}
 
 		[Fact]

--- a/src/Controls/tests/Core.UnitTests/AnimationTests.cs
+++ b/src/Controls/tests/Core.UnitTests/AnimationTests.cs
@@ -1,4 +1,7 @@
+using System;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using Microsoft.Maui.Animations;
 using Xunit;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
@@ -6,6 +9,47 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 	public class AnimationTests : BaseTestFixture
 	{
+		[Fact]
+		public void DisposingNonStartingManagerReleasesInsertedCallback()
+		{
+			var initialTweenerCount = AnimationExtensions.TweenersCounter;
+			var payload = CreateDisposedManagerPayload();
+
+			CollectGarbage();
+
+			Assert.False(payload.IsAlive);
+			Assert.Equal(initialTweenerCount, AnimationExtensions.TweenersCounter);
+		}
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		static WeakReference CreateDisposedManagerPayload()
+		{
+			var payload = new object();
+			var payloadReference = new WeakReference(payload);
+
+			using (var manager = new AnimationManager(new Ticker()) { AutoStartTicker = false })
+			{
+				AnimationExtensions.Insert(manager, _ =>
+				{
+					GC.KeepAlive(payload);
+					return true;
+				});
+			}
+
+			return payloadReference;
+		}
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		static void CollectGarbage()
+		{
+			for (var iteration = 0; iteration < 3; iteration++)
+			{
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+				GC.Collect();
+			}
+		}
+
 		[Fact]
 		//https://bugzilla.xamarin.com/show_bug.cgi?id=51424
 		public async Task AnimationRepeats()

--- a/src/Controls/tests/Core.UnitTests/AnimationTests.cs
+++ b/src/Controls/tests/Core.UnitTests/AnimationTests.cs
@@ -21,6 +21,70 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal(initialTweenerCount, AnimationExtensions.TweenersCounter);
 		}
 
+		[Fact]
+		public void DisposingNonStartingManagerReleasesAddedCallback()
+		{
+			var initialTweenerCount = AnimationExtensions.TweenersCounter;
+			var payload = CreateDisposedManagerPayloadViaAdd();
+
+			CollectGarbage();
+
+			Assert.False(payload.IsAlive);
+			Assert.Equal(initialTweenerCount, AnimationExtensions.TweenersCounter);
+		}
+
+		[Fact]
+		public void DisposingManagerFinishesReentrantlyInsertedAnimation()
+		{
+			var initialTweenerCount = AnimationExtensions.TweenersCounter;
+			var reentered = false;
+
+			using (var manager = new AnimationManager(new Ticker()) { AutoStartTicker = false })
+			{
+				AnimationExtensions.Insert(manager, ticks =>
+				{
+					if (ticks == long.MaxValue && !reentered)
+					{
+						reentered = true;
+
+						// Simulate a Finished/step handler that reacts to force-finish by
+						// queuing another animation on the same (already disposing) manager.
+						AnimationExtensions.Insert(manager, _ => true);
+					}
+
+					return true;
+				});
+			}
+
+			Assert.True(reentered);
+			Assert.Equal(initialTweenerCount, AnimationExtensions.TweenersCounter);
+		}
+
+		[Fact]
+		public void DisposingManagerCompletesWhenCallbackThrows()
+		{
+			var initialTweenerCount = AnimationExtensions.TweenersCounter;
+			var ticker = new DisposableTicker();
+			var secondAnimationFinished = false;
+
+			using (var manager = new AnimationManager(ticker) { AutoStartTicker = false })
+			{
+				AnimationExtensions.Insert(manager, _ => throw new InvalidOperationException("Simulated failure in a Finished/step callback."));
+				AnimationExtensions.Insert(manager, _ =>
+				{
+					secondAnimationFinished = true;
+					return true;
+				});
+			}
+
+			// Disposal must not throw, must still finish/clean up every animation
+			// (not just the ones before the throwing callback), and must still
+			// dispose the ticker.
+			Assert.True(secondAnimationFinished);
+			Assert.True(ticker.WasDisposed);
+			Assert.Equal(initialTweenerCount, AnimationExtensions.TweenersCounter);
+		}
+
 		[MethodImpl(MethodImplOptions.NoInlining)]
 		static WeakReference CreateDisposedManagerPayload()
 		{
@@ -40,6 +104,23 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[MethodImpl(MethodImplOptions.NoInlining)]
+		static WeakReference CreateDisposedManagerPayloadViaAdd()
+		{
+			var payload = new object();
+			var payloadReference = new WeakReference(payload);
+
+			using (var manager = new AnimationManager(new Ticker()) { AutoStartTicker = false })
+			{
+				AnimationExtensions.Add(manager, _ =>
+				{
+					GC.KeepAlive(payload);
+				});
+			}
+
+			return payloadReference;
+		}
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
 		static void CollectGarbage()
 		{
 			for (var iteration = 0; iteration < 3; iteration++)
@@ -48,6 +129,13 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				GC.WaitForPendingFinalizers();
 				GC.Collect();
 			}
+		}
+
+		sealed class DisposableTicker : Ticker, IDisposable
+		{
+			public bool WasDisposed { get; private set; }
+
+			public void Dispose() => WasDisposed = true;
 		}
 
 		[Fact]

--- a/src/Core/src/Animations/Animation.cs
+++ b/src/Core/src/Animations/Animation.cs
@@ -48,6 +48,8 @@ namespace Microsoft.Maui.Animations
 
 		internal WeakReference<IAnimator>? Parent { get; set; }
 
+		internal Action? AnimationManagerDisposed { get; set; }
+
 		/// <summary>
 		/// A callback that is invoked when this animation finishes.
 		/// </summary>
@@ -339,6 +341,13 @@ namespace Microsoft.Maui.Animations
 			IAnimator? view = null;
 			if (Parent?.TryGetTarget(out view) ?? false)
 				view?.RemoveAnimation(this);
+		}
+
+		internal void OnAnimationManagerDisposed()
+		{
+			AnimationManagerDisposed?.Invoke();
+			AnimationManagerDisposed = null;
+			animationManger = null;
 		}
 
 		/// <summary>

--- a/src/Core/src/Animations/Animation.cs
+++ b/src/Core/src/Animations/Animation.cs
@@ -376,10 +376,11 @@ namespace Microsoft.Maui.Animations
 
 		internal virtual void ForceFinish()
 		{
-			if (Progress < 1.0)
-			{
-				Update(1.0);
-			}
+			if (HasFinished)
+				return;
+
+			Update(1.0);
+			Finished?.Invoke();
 		}
 	}
 }

--- a/src/Core/src/Animations/Animation.cs
+++ b/src/Core/src/Animations/Animation.cs
@@ -376,11 +376,10 @@ namespace Microsoft.Maui.Animations
 
 		internal virtual void ForceFinish()
 		{
-			if (HasFinished)
-				return;
-
-			Update(1.0);
-			Finished?.Invoke();
+			if (Progress < 1.0)
+			{
+				Update(1.0);
+			}
 		}
 	}
 }

--- a/src/Core/src/Animations/Animation.cs
+++ b/src/Core/src/Animations/Animation.cs
@@ -347,7 +347,6 @@ namespace Microsoft.Maui.Animations
 		{
 			AnimationManagerDisposed?.Invoke();
 			AnimationManagerDisposed = null;
-			animationManger = null;
 		}
 
 		/// <summary>

--- a/src/Core/src/Animations/Animation.cs
+++ b/src/Core/src/Animations/Animation.cs
@@ -343,8 +343,13 @@ namespace Microsoft.Maui.Animations
 				view?.RemoveAnimation(this);
 		}
 
-		internal void OnAnimationManagerDisposed()
+		internal void OnAnimationManagerDisposed(IAnimationManager animationManager)
 		{
+			if (!ReferenceEquals(
+				Interlocked.CompareExchange(ref animationManger, null, animationManager),
+				animationManager))
+				return;
+
 			AnimationManagerDisposed?.Invoke();
 			AnimationManagerDisposed = null;
 		}

--- a/src/Core/src/Animations/AnimationManager.cs
+++ b/src/Core/src/Animations/AnimationManager.cs
@@ -121,18 +121,10 @@ namespace Microsoft.Maui.Animations
 
 				if (disposing)
 				{
-					try
-					{
-						ForceFinishAnimations();
-					}
-					finally
-					{
-						// Always dispose the ticker, even if force-finishing an animation
-						// threw or the drain safety cap was hit, so the manager doesn't
-						// leak a running ticker on a failed teardown.
-						if (Ticker is IDisposable disposable)
-							disposable.Dispose();
-					}
+					ForceFinishAnimations();
+
+					if (Ticker is IDisposable disposable)
+						disposable.Dispose();
 				}
 			}
 		}
@@ -146,48 +138,20 @@ namespace Microsoft.Maui.Animations
 
 		void ForceFinishAnimations()
 		{
-			// Drain until _animations is empty (or the safety cap is hit). A Finished
-			// callback invoked below may reentrantly queue a new animation on this same
-			// manager (e.g. via AnimationExtensions.Add/Insert); a single snapshot would
-			// leave that new entry un-finished and still rooted in the static tweener
-			// registry, so we keep re-snapshotting until no new animations show up.
-			const int MaxDrainPasses = 8;
+			Animation[] animations = [.._animations];
 
-			for (int pass = 0; pass < MaxDrainPasses && _animations.Count > 0; pass++)
+			foreach (var animation in animations)
 			{
-				Animation[] animations = [.._animations];
-
-				foreach (var animation in animations)
-				{
-					ForceFinish(animation);
-				}
+				ForceFinish(animation);
 			}
-
-			// If a pathological handler kept re-adding animations past the safety cap,
-			// force the collection empty so this manager can't be left holding entries
-			// after Dispose returns.
-			if (_animations.Count > 0)
-				_animations.Clear();
 
 			End();
 
 			void ForceFinish(Animation animation)
 			{
-				try
-				{
-					// Isolate failures per-animation so one bad callback can't prevent
-					// the remaining animations from being finished and removed, and
-					// can't abort disposal before the ticker is disposed.
-					animation.ForceFinish();
-				}
-				catch
-				{
-				}
-				finally
-				{
-					_animations.TryRemove(animation);
-					animation.RemoveFromParent();
-				}
+				animation.ForceFinish();
+				_animations.TryRemove(animation);
+				animation.RemoveFromParent();
 			}
 		}
 

--- a/src/Core/src/Animations/AnimationManager.cs
+++ b/src/Core/src/Animations/AnimationManager.cs
@@ -121,10 +121,18 @@ namespace Microsoft.Maui.Animations
 
 				if (disposing)
 				{
-					ForceFinishAnimations();
-
-					if (Ticker is IDisposable disposable)
-						disposable.Dispose();
+					try
+					{
+						ForceFinishAnimations();
+					}
+					finally
+					{
+						// Always dispose the ticker, even if force-finishing an animation
+						// threw or the drain safety cap was hit, so the manager doesn't
+						// leak a running ticker on a failed teardown.
+						if (Ticker is IDisposable disposable)
+							disposable.Dispose();
+					}
 				}
 			}
 		}
@@ -138,21 +146,48 @@ namespace Microsoft.Maui.Animations
 
 		void ForceFinishAnimations()
 		{
-			Animation[] animations = [.._animations];
+			// Drain until _animations is empty (or the safety cap is hit). A Finished
+			// callback invoked below may reentrantly queue a new animation on this same
+			// manager (e.g. via AnimationExtensions.Add/Insert); a single snapshot would
+			// leave that new entry un-finished and still rooted in the static tweener
+			// registry, so we keep re-snapshotting until no new animations show up.
+			const int MaxDrainPasses = 8;
 
-			foreach (var animation in animations)
+			for (int pass = 0; pass < MaxDrainPasses && _animations.Count > 0; pass++)
 			{
-				ForceFinish(animation);
+				Animation[] animations = [.._animations];
+
+				foreach (var animation in animations)
+				{
+					ForceFinish(animation);
+				}
 			}
 
+			// If a pathological handler kept re-adding animations past the safety cap,
+			// force the collection empty so this manager can't be left holding entries
+			// after Dispose returns.
+			if (_animations.Count > 0)
+				_animations.Clear();
 
 			End();
 
 			void ForceFinish(Animation animation)
 			{
-				animation.ForceFinish();
-				_animations.TryRemove(animation);
-				animation.RemoveFromParent();
+				try
+				{
+					// Isolate failures per-animation so one bad callback can't prevent
+					// the remaining animations from being finished and removed, and
+					// can't abort disposal before the ticker is disposed.
+					animation.ForceFinish();
+				}
+				catch
+				{
+				}
+				finally
+				{
+					_animations.TryRemove(animation);
+					animation.RemoveFromParent();
+				}
 			}
 		}
 

--- a/src/Core/src/Animations/AnimationManager.cs
+++ b/src/Core/src/Animations/AnimationManager.cs
@@ -115,18 +115,24 @@ namespace Microsoft.Maui.Animations
 
 		protected virtual void Dispose(bool disposing)
 		{
-			if (!_disposedValue)
-			{
-				_disposedValue = true;
+			if (_disposedValue)
+				return;
 
-				if (disposing)
-				{
-					ForceFinishAnimations();
+			_disposedValue = true;
 
-					if (Ticker is IDisposable disposable)
-						disposable.Dispose();
-				}
-			}
+			if (!disposing)
+				return;
+
+			Ticker.Fire -= OnFire;
+			End();
+
+			foreach (var animation in _animations)
+				animation.OnAnimationManagerDisposed();
+
+			_animations.Clear();
+
+			if (Ticker is IDisposable disposable)
+				disposable.Dispose();
 		}
 
 		/// <inheritdoc/>

--- a/src/Core/src/Animations/AnimationManager.cs
+++ b/src/Core/src/Animations/AnimationManager.cs
@@ -117,10 +117,15 @@ namespace Microsoft.Maui.Animations
 		{
 			if (!_disposedValue)
 			{
-				if (disposing && Ticker is IDisposable disposable)
-					disposable.Dispose();
-
 				_disposedValue = true;
+
+				if (disposing)
+				{
+					ForceFinishAnimations();
+
+					if (Ticker is IDisposable disposable)
+						disposable.Dispose();
+				}
 			}
 		}
 

--- a/src/Core/src/Animations/AnimationManager.cs
+++ b/src/Core/src/Animations/AnimationManager.cs
@@ -34,9 +34,10 @@ namespace Microsoft.Maui.Animations
 		/// <inheritdoc/>
 		public void Add(Animation animation)
 		{
-			// If animations are disabled, don't do anything
-			if (!Ticker.SystemEnabled)
+			// If this manager cannot run the animation, release any ownership callback.
+			if (_disposedValue || !Ticker.SystemEnabled)
 			{
+				animation.OnAnimationManagerDisposed();
 				return;
 			}
 
@@ -117,15 +118,22 @@ namespace Microsoft.Maui.Animations
 		{
 			if (!_disposedValue)
 			{
-				foreach (var animation in _animations)
-				{
-					animation.OnAnimationManagerDisposed();
-				}
-				
-				if (disposing && Ticker is IDisposable disposable)
-					disposable.Dispose();
-
 				_disposedValue = true;
+
+				if (disposing)
+				{
+					Animation[] animations = [.._animations];
+
+					foreach (var animation in animations)
+					{
+						animation.OnAnimationManagerDisposed();
+					}
+
+					if (Ticker is IDisposable disposable)
+					{
+						disposable.Dispose();
+					}
+				}
 			}
 		}
 

--- a/src/Core/src/Animations/AnimationManager.cs
+++ b/src/Core/src/Animations/AnimationManager.cs
@@ -115,24 +115,18 @@ namespace Microsoft.Maui.Animations
 
 		protected virtual void Dispose(bool disposing)
 		{
-			if (_disposedValue)
-				return;
+			if (!_disposedValue)
+			{
+				foreach (var animation in _animations)
+				{
+					animation.OnAnimationManagerDisposed();
+				}
+				
+				if (disposing && Ticker is IDisposable disposable)
+					disposable.Dispose();
 
-			_disposedValue = true;
-
-			if (!disposing)
-				return;
-
-			Ticker.Fire -= OnFire;
-			End();
-
-			foreach (var animation in _animations)
-				animation.OnAnimationManagerDisposed();
-
-			_animations.Clear();
-
-			if (Ticker is IDisposable disposable)
-				disposable.Dispose();
+				_disposedValue = true;
+			}
 		}
 
 		/// <inheritdoc/>

--- a/src/Core/src/Animations/AnimationManager.cs
+++ b/src/Core/src/Animations/AnimationManager.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.Animations
 			// If this manager cannot run the animation, release any ownership callback.
 			if (_disposedValue || !Ticker.SystemEnabled)
 			{
-				animation.OnAnimationManagerDisposed();
+				animation.OnAnimationManagerDisposed(this);
 				return;
 			}
 
@@ -123,10 +123,11 @@ namespace Microsoft.Maui.Animations
 				if (disposing)
 				{
 					Animation[] animations = [.._animations];
+					_animations.Clear();
 
 					foreach (var animation in animations)
 					{
-						animation.OnAnimationManagerDisposed();
+						animation.OnAnimationManagerDisposed(this);
 					}
 
 					if (Ticker is IDisposable disposable)


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
 
### Issue Details

 [leak-scan] AnimationExtensions.Insert — disposed non-starting manager leaves callback statically rooted

### Root Cause 

 AnimationExtensions.s_tweeners  is a static  ConcurrentDictionary<int, Animation>  (in  src/Controls/src/Core/AnimationExtensions.cs ) that holds every animation registered via  Add() / Insert() . An entry is removed only when that animation's  Finished  event fires.
 
 Finished  is only raised when the owning  AnimationManager 's ticker actually ticks the animation to completion. When a manager is constructed with  AutoStartTicker = false , the ticker never starts, so  Finished  never fires — and disposing that manager previously did nothing more than dispose the  Ticker ; it never touched the queued animations. Result: the static dictionary entry, and the callback closure (plus anything it captures) it points to, stays permanently rooted — a classic static-collection memory leak — even though the manager itself is gone and would otherwise be eligible for GC.
 
Retention path:  AnimationExtensions.s_tweeners  →  TweenerAnimation  →  _step  (closure) → captured payload.
 
Affects all platforms (pure shared/managed code), triggered only by the non-default  AutoStartTicker = false  configuration.

### Description of Change
 
Animation.cs:51: adds an internal disposal notification and detaches the animation manager reference.
AnimationExtensions.cs:76: Add and Insert register cleanup that removes their entries from static s_tweeners.
AnimationManager.cs When AnimationManager.Dispose() runs, it calls OnAnimationManagerDisposed() for each tracked animation. This triggers the cleanup callback, which removes the corresponding entry from the static s_tweeners collection.
 
### Issues Fixed
 
Fixes #37204 
 
**Tested the behavior in the following platforms.**
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
| Before  | After  |
|---------|--------|
| <Video src="https://github.com/user-attachments/assets/a436331f-f125-4c27-870a-8a38dcaa5ed5" Width="300" Height="600" /> | <Video src="https://github.com/user-attachments/assets/29973d60-315d-450e-b5fd-28347a033ee9" Width="300" Height="600" /> |