### PR TITLE
Remove Publish-Build-Assets variable group from release/10.0.1xx-sr7

### DIFF
--- a/eng/common/core-templates/job/publish-build-assets.yml
+++ b/eng/common/core-templates/job/publish-build-assets.yml
@@ -58,7 +58,6 @@ jobs:
     parameters:
       is1ESPipeline: ${{ parameters.is1ESPipeline }}
   - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - group: Publish-Build-Assets
     - group: AzureDevOps-Artifact-Feeds-Pats
     - name: runCodesignValidationInjection
       value: false

--- a/eng/common/core-templates/jobs/codeql-build.yml
+++ b/eng/common/core-templates/jobs/codeql-build.yml
@@ -18,7 +18,6 @@ jobs:
     enableTelemetry: true
 
     variables:
-      - group: Publish-Build-Assets
       # The Guardian version specified in 'eng/common/sdl/packages.config'. This value must be kept in
       # sync with the packages.config file.
       - name: DefaultGuardianVersion

--- a/eng/common/core-templates/post-build/common-variables.yml
+++ b/eng/common/core-templates/post-build/common-variables.yml
@@ -1,6 +1,4 @@
 variables:
-  - group: Publish-Build-Assets
-
   # Whether the build is internal or not
   - name: IsInternalBuild
     value: ${{ and(ne(variables['System.TeamProject'], 'public'), contains(variables['Build.SourceBranch'], 'internal')) }}

--- a/eng/common/core-templates/steps/publish-logs.yml
+++ b/eng/common/core-templates/steps/publish-logs.yml
@@ -30,10 +30,7 @@ steps:
       -TokensFilePath '$(System.DefaultWorkingDirectory)/eng/BinlogSecretsRedactionFile.txt'
       -runtimeSourceFeed https://ci.dot.net/internal 
       -runtimeSourceFeedKey '$(dotnetbuilds-internal-container-read-token-base64)'
-      '$(publishing-dnceng-devdiv-code-r-build-re)'
-      '$(MaestroAccessToken)'
       '$(dn-bot-all-orgs-artifact-feeds-rw)'
-      '$(akams-client-id)'
       '$(microsoft-symbol-server-pat)'
       '$(symweb-symbol-server-pat)'
       '$(dnceng-symbol-server-pat)'

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -70,7 +70,5 @@ variables:
     - group: SDL_Settings
     - group: AzureDevOps-Artifact-Feeds-Pats
     - ${{ if eq(variables['Build.DefinitionName'], 'dotnet-maui') }}:
-      - group: Publish-Build-Assets # This variable group contains secrets to publis to BAR
-
 
 


### PR DESCRIPTION
Removes the repository-owned VG20 import and synchronizes the relevant Arcade credential-removal changes on `release/10.0.1xx-sr7`.

Tracked by https://dev.azure.com/dnceng/internal/_workitems/edit/12131