### PR TITLE
[release/11.0.1xx-rc1] Use WIF for OneLocBuild feed access

### DIFF
--- a/eng/pipelines/common/localization.yml
+++ b/eng/pipelines/common/localization.yml
@@ -1,5 +1,5 @@
 parameters:
-  CeapexPat: $(dn-bot-ceapex-package-r) # PAT for the loc AzDO instance https://dev.azure.com/ceapex
+  CeapexServiceConnection: dnceng-onelocbuild-ceapex
   GithubPat: $(BotAccount-dotnet-bot-repo-PAT)
 
 stages:
@@ -14,9 +14,14 @@ stages:
         pool:  $(1ESPTPool)
 
         variables:
-          - group: OneLocBuildVariables # Contains the CeapexPat and GithubPat
+          - group: OneLocBuildVariables # Contains the GithubPat
 
         steps:
+          - template: /eng/common/templates/steps/get-federated-access-token.yml
+            parameters:
+              federatedServiceConnection: ${{ parameters.CeapexServiceConnection }}
+              outputVariableName: CeapexEntraToken
+
           - task: OneLocBuild@2
             displayName: 'Localization Build'
             env:
@@ -25,7 +30,7 @@ stages:
               locProj: 'eng/automation/LocProject.json'
               outDir: '$(Build.ArtifactStagingDirectory)'
               packageSourceAuth: patAuth
-              patVariable: ${{ parameters.CeapexPat }}
+              patVariable: $(CeapexEntraToken)
               isCreatePrSelected: true                            # Create the PR with the Localization changes if there are any
               isShouldReusePrSelected: true                       # Make sure to not keep creating new PRs if one is already open
               isAutoCompletePrSelected: false                     # Allow us to review the created PR instead of auto-merging it


### PR DESCRIPTION
### Description of Change

Backport of #37607 to `release/11.0.1xx-rc1`.

Replace MAUI's long-lived `dn-bot-ceapex-package-r` dependency with a short-lived Entra token for OneLocBuild package restores. The pipeline acquires the token through the existing DevDiv `dnceng-onelocbuild-ceapex` workload-identity service connection and Arcade's shared federated-token helper. GitHub PR authentication is unchanged.

The DevDiv service connection is configured for workload identity federation and MAUI pipeline 13330 is authorized to use it.

### Validation

- Parsed the updated pipeline as YAML.
- Verified the shared federated-token helper exists on this release branch.
- Verified the legacy ceapex PAT is no longer referenced by MAUI's repo-owned localization pipeline.

### Issues Fixed

Tracks [dnceng work item 10151](https://dev.azure.com/dnceng/internal/_workitems/edit/10151).