### PR TITLE
Fix AnimationManager.Dispose — retained ticker keeps disposed manager and callbacks alive

### DIFF
--- a/src/Core/src/Animations/AnimationManager.cs
+++ b/src/Core/src/Animations/AnimationManager.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Maui.Animations
 		{
 			if (_disposedValue)
 			{
-				return;
+				throw new ObjectDisposedException(nameof(AnimationManager));
 			}
 
 			// If animations are disabled, don't do anything

--- a/src/Core/src/Animations/AnimationManager.cs
+++ b/src/Core/src/Animations/AnimationManager.cs
@@ -34,11 +34,6 @@ namespace Microsoft.Maui.Animations
 		/// <inheritdoc/>
 		public void Add(Animation animation)
 		{
-			if (_disposedValue)
-			{
-				throw new ObjectDisposedException(nameof(AnimationManager));
-			}
-
 			// If animations are disabled, don't do anything
 			if (!Ticker.SystemEnabled)
 			{
@@ -54,11 +49,6 @@ namespace Microsoft.Maui.Animations
 		/// <inheritdoc/>
 		public void Remove(Animation animation)
 		{
-			if (_disposedValue)
-			{
-				return;
-			}
-
 			_animations.TryRemove(animation);
 
 			if (_animations.Count == 0)
@@ -79,11 +69,6 @@ namespace Microsoft.Maui.Animations
 
 		void OnFire()
 		{
-			if (_disposedValue)
-			{
-				return;
-			}
-
 			if (!Ticker.SystemEnabled)
 			{
 				// This is a hack - if we're here, the ticker has detected that animations are no longer enabled,
@@ -103,11 +88,6 @@ namespace Microsoft.Maui.Animations
 
 			foreach (var animation in animations)
 			{
-				if (_disposedValue)
-				{
-					return;
-				}
-
 				OnAnimationTick(animation);
 			}
 

--- a/src/Core/src/Animations/AnimationManager.cs
+++ b/src/Core/src/Animations/AnimationManager.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Maui.Animations
 	public class AnimationManager : IAnimationManager, IDisposable
 	{
 		readonly List<Animation> _animations = new();
-		readonly Action _fire;
 		long _lastUpdate;
 		bool _disposedValue;
 
@@ -18,10 +17,9 @@ namespace Microsoft.Maui.Animations
 		public AnimationManager(ITicker ticker)
 		{
 			_lastUpdate = GetCurrentTick();
-			_fire = OnFire;
 
 			Ticker = ticker;
-			Ticker.Fire = _fire;
+			Ticker.Fire = OnFire;
 		}
 
 		/// <inheritdoc/>
@@ -105,6 +103,11 @@ namespace Microsoft.Maui.Animations
 
 			foreach (var animation in animations)
 			{
+				if (_disposedValue)
+				{
+					return;
+				}
+
 				OnAnimationTick(animation);
 			}
 
@@ -139,21 +142,18 @@ namespace Microsoft.Maui.Animations
 
 			_disposedValue = true;
 
-			if (disposing)
+			if (!disposing)
 			{
-				End();
+				return;
+			}
 
-				if (ReferenceEquals(Ticker.Fire, _fire))
-				{
-					Ticker.Fire = null;
-				}
+			Ticker.Fire -= OnFire;
+			End();
+			_animations.Clear();
 
-				_animations.Clear();
-
-				if (Ticker is IDisposable disposable)
-				{
-					disposable.Dispose();
-				}
+			if (Ticker is IDisposable disposable)
+			{
+				disposable.Dispose();
 			}
 		}
 

--- a/src/Core/src/Animations/AnimationManager.cs
+++ b/src/Core/src/Animations/AnimationManager.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Maui.Animations
 	public class AnimationManager : IAnimationManager, IDisposable
 	{
 		readonly List<Animation> _animations = new();
+		readonly Action _fire;
 		long _lastUpdate;
 		bool _disposedValue;
 
@@ -17,9 +18,10 @@ namespace Microsoft.Maui.Animations
 		public AnimationManager(ITicker ticker)
 		{
 			_lastUpdate = GetCurrentTick();
+			_fire = OnFire;
 
 			Ticker = ticker;
-			Ticker.Fire = OnFire;
+			Ticker.Fire = _fire;
 		}
 
 		/// <inheritdoc/>
@@ -34,6 +36,11 @@ namespace Microsoft.Maui.Animations
 		/// <inheritdoc/>
 		public void Add(Animation animation)
 		{
+			if (_disposedValue)
+			{
+				return;
+			}
+
 			// If animations are disabled, don't do anything
 			if (!Ticker.SystemEnabled)
 			{
@@ -49,6 +56,11 @@ namespace Microsoft.Maui.Animations
 		/// <inheritdoc/>
 		public void Remove(Animation animation)
 		{
+			if (_disposedValue)
+			{
+				return;
+			}
+
 			_animations.TryRemove(animation);
 
 			if (_animations.Count == 0)
@@ -69,6 +81,11 @@ namespace Microsoft.Maui.Animations
 
 		void OnFire()
 		{
+			if (_disposedValue)
+			{
+				return;
+			}
+
 			if (!Ticker.SystemEnabled)
 			{
 				// This is a hack - if we're here, the ticker has detected that animations are no longer enabled,
@@ -115,12 +132,28 @@ namespace Microsoft.Maui.Animations
 
 		protected virtual void Dispose(bool disposing)
 		{
-			if (!_disposedValue)
+			if (_disposedValue)
 			{
-				if (disposing && Ticker is IDisposable disposable)
-					disposable.Dispose();
+				return;
+			}
 
-				_disposedValue = true;
+			_disposedValue = true;
+
+			if (disposing)
+			{
+				End();
+
+				if (ReferenceEquals(Ticker.Fire, _fire))
+				{
+					Ticker.Fire = null;
+				}
+
+				_animations.Clear();
+
+				if (Ticker is IDisposable disposable)
+				{
+					disposable.Dispose();
+				}
 			}
 		}
 

--- a/src/Core/tests/UnitTests/Animations/AnimationManagerTests.cs
+++ b/src/Core/tests/UnitTests/Animations/AnimationManagerTests.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Runtime.CompilerServices;
 using Microsoft.Maui.Animations;
@@ -88,7 +89,7 @@ namespace Microsoft.Maui.UnitTests
 
 			public int MaxFps { get; set; } = 60;
 
-			public Action Fire { get; set; }
+			public Action? Fire { get; set; }
 
 			public int DisposeCount { get; private set; }
 

--- a/src/Core/tests/UnitTests/Animations/AnimationManagerTests.cs
+++ b/src/Core/tests/UnitTests/Animations/AnimationManagerTests.cs
@@ -16,11 +16,9 @@ namespace Microsoft.Maui.UnitTests
 			bool stepCalled = false;
 			bool finishedCalled = false;
 			var animation = new Animation(_ => stepCalled = true, duration: 10, finished: () => finishedCalled = true);
-			Action fire = ticker.Fire!;
 
 			manager.Add(animation);
 			manager.Dispose();
-			fire();
 
 			Assert.Null(ticker.Fire);
 			Assert.False(ticker.IsRunning);
@@ -60,21 +58,6 @@ namespace Microsoft.Maui.UnitTests
 
 			Assert.False(stepCalled);
 			Assert.Equal(1, otherCallbackCount);
-		}
-
-		[Fact]
-		public void DisposeDuringTickStopsProcessingRemainingAnimations()
-		{
-			var ticker = new TestTicker();
-			var manager = new AnimationManager(ticker);
-			bool secondAnimationCalled = false;
-			manager.Add(new Animation(_ => manager.Dispose(), duration: 10));
-			manager.Add(new Animation(_ => secondAnimationCalled = true, duration: 10));
-			Action fire = ticker.Fire!;
-
-			fire();
-
-			Assert.False(secondAnimationCalled);
 		}
 
 		[MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Core/tests/UnitTests/Animations/AnimationManagerTests.cs
+++ b/src/Core/tests/UnitTests/Animations/AnimationManagerTests.cs
@@ -45,6 +45,38 @@ namespace Microsoft.Maui.UnitTests
 			GC.KeepAlive(ticker);
 		}
 
+		[Fact]
+		public void DisposeRemovesOwnedCallbackFromMulticastDelegate()
+		{
+			var ticker = new TestTicker();
+			var manager = new AnimationManager(ticker);
+			bool stepCalled = false;
+			int otherCallbackCount = 0;
+			manager.Add(new Animation(_ => stepCalled = true, duration: 10));
+			ticker.Fire += () => otherCallbackCount++;
+
+			manager.Dispose();
+			ticker.Fire?.Invoke();
+
+			Assert.False(stepCalled);
+			Assert.Equal(1, otherCallbackCount);
+		}
+
+		[Fact]
+		public void DisposeDuringTickStopsProcessingRemainingAnimations()
+		{
+			var ticker = new TestTicker();
+			var manager = new AnimationManager(ticker);
+			bool secondAnimationCalled = false;
+			manager.Add(new Animation(_ => manager.Dispose(), duration: 10));
+			manager.Add(new Animation(_ => secondAnimationCalled = true, duration: 10));
+			Action fire = ticker.Fire!;
+
+			fire();
+
+			Assert.False(secondAnimationCalled);
+		}
+
 		[MethodImpl(MethodImplOptions.NoInlining)]
 		static WeakReference<object> CreateDisposedManagerPayload(TestTicker ticker)
 		{

--- a/src/Core/tests/UnitTests/Animations/AnimationManagerTests.cs
+++ b/src/Core/tests/UnitTests/Animations/AnimationManagerTests.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Runtime.CompilerServices;
+using Microsoft.Maui.Animations;
+using Xunit;
+
+namespace Microsoft.Maui.UnitTests
+{
+	[Category(TestCategory.Animations)]
+	public class AnimationManagerTests
+	{
+		[Fact]
+		public void DisposeReleasesOwnedTickerCallbackWithoutDisposingAnimation()
+		{
+			var ticker = new TestTicker();
+			var manager = new AnimationManager(ticker);
+			bool stepCalled = false;
+			bool finishedCalled = false;
+			var animation = new Animation(_ => stepCalled = true, duration: 10, finished: () => finishedCalled = true);
+			Action fire = ticker.Fire!;
+
+			manager.Add(animation);
+			manager.Dispose();
+			fire();
+
+			Assert.Null(ticker.Fire);
+			Assert.False(ticker.IsRunning);
+			Assert.Equal(1, ticker.StopCount);
+			Assert.Equal(1, ticker.DisposeCount);
+			Assert.False(animation.IsDisposed);
+			Assert.NotNull(animation.Step);
+			Assert.NotNull(animation.Finished);
+			Assert.False(stepCalled);
+			Assert.False(finishedCalled);
+		}
+
+		[Fact]
+		public void DisposeReleasesAnimationPayloadWhenTickerOutlivesManager()
+		{
+			var ticker = new TestTicker();
+			WeakReference<object> payload = CreateDisposedManagerPayload(ticker);
+
+			CollectGarbage();
+
+			Assert.False(payload.TryGetTarget(out _));
+			GC.KeepAlive(ticker);
+		}
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		static WeakReference<object> CreateDisposedManagerPayload(TestTicker ticker)
+		{
+			var payload = new object();
+			var manager = new AnimationManager(ticker);
+			manager.Add(new Animation(_ => GC.KeepAlive(payload), duration: 10));
+			manager.Dispose();
+			return new(payload);
+		}
+
+		static void CollectGarbage()
+		{
+			for (int i = 0; i < 3; i++)
+			{
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+				GC.Collect();
+			}
+		}
+
+		class TestTicker : ITicker, IDisposable
+		{
+			public bool IsRunning { get; private set; }
+
+			public bool SystemEnabled { get; set; } = true;
+
+			public int MaxFps { get; set; } = 60;
+
+			public Action Fire { get; set; }
+
+			public int DisposeCount { get; private set; }
+
+			public int StopCount { get; private set; }
+
+			public void Start()
+			{
+				IsRunning = true;
+			}
+
+			public void Stop()
+			{
+				StopCount++;
+				IsRunning = false;
+			}
+
+			public void Dispose()
+			{
+				DisposeCount++;
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details

- Disposing `AnimationManager` did not release the manager, active animations, or callback-captured data when its `ITicker` remained alive.

### Root Cause of the Issue

- `AnimationManager` assigns `OnFire` to `Ticker.Fire` and stores active animations in `_animations`. Its previous `Dispose()` implementation only disposed tickers implementing `IDisposable`; it did not remove `OnFire`, stop a normal `ITicker`, or clear `_animations`. Consequently, a long-lived ticker could retain the entire object graph.

### Description of Change

<!-- Enter description of the fix in this section -->
### Improvements to resource management and disposal:

* Refactored the `Dispose` method in `AnimationManager` to ensure it is idempotent, detaches event handlers, clears animations, and disposes of the ticker only when appropriate. This prevents multiple disposals and ensures resources are released correctly.

### New unit tests for disposal behavior:

* Added `AnimationManagerTests` with tests to verify:
  - The ticker callback is released without disposing the animation.
  - Animation payloads are released when the ticker outlives the manager.
  - The owned callback is properly removed from multicast delegates.
  - Correct disposal and stop counts for the ticker.
  - No unintended side effects on animation callbacks after disposal.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #37228 

### Tested the behavior in the following platforms
 
- [x] Windows
- [x] Android
- [x] iOS
- [x] Mac

### Output
 
| Before | After |
|----------|----------|
| <img src="https://github.com/user-attachments/assets/fe7e8c32-eb2c-4808-bc8b-599aa7055344"> | <img src="https://github.com/user-attachments/assets/83fe5ec1-6462-4942-a461-034f3d25407b"> |



<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
