### PR TITLE
Fix memory leak in BindingDiagnostics.BindingFailed by backing the static event with WeakEventManager

### DIFF
--- a/src/Controls/src/Core/Xaml/Diagnostics/BindingDiagnostics.cs
+++ b/src/Controls/src/Core/Xaml/Diagnostics/BindingDiagnostics.cs
@@ -16,12 +16,12 @@ namespace Microsoft.Maui.Controls.Xaml.Diagnostics
 		// Backed by WeakEventManager so instance subscribers that forget to
 		// unsubscribe are not pinned by the multicast delegate for the process
 		// lifetime. See https://github.com/dotnet/maui/issues/37245.
-		static readonly WeakEventManager s_weakEventManager = new WeakEventManager();
+		static readonly WeakEventManager _weakEventManager = new WeakEventManager();
 
 		public static event EventHandler<BindingBaseErrorEventArgs> BindingFailed
 		{
-			add => s_weakEventManager.AddEventHandler(value);
-			remove => s_weakEventManager.RemoveEventHandler(value);
+			add => _weakEventManager.AddEventHandler(value);
+			remove => _weakEventManager.RemoveEventHandler(value);
 		}
 
 		internal static void SendBindingFailure(BindingBase binding, string errorCode, string message, params object[] messageArgs)
@@ -31,7 +31,7 @@ namespace Microsoft.Maui.Controls.Xaml.Diagnostics
 				return;
 			}
 			Application.Current?.FindMauiContext()?.CreateLogger<BindingDiagnostics>()?.LogWarning(message, messageArgs);
-			s_weakEventManager.HandleEvent(null, new BindingBaseErrorEventArgs(VisualDiagnostics.GetSourceInfo(binding), binding, errorCode, message, messageArgs), nameof(BindingFailed));
+			_weakEventManager.HandleEvent(null, new BindingBaseErrorEventArgs(VisualDiagnostics.GetSourceInfo(binding), binding, errorCode, message, messageArgs), nameof(BindingFailed));
 		}
 
 		internal static void SendBindingFailure(BindingBase binding, object source, BindableObject bo, BindableProperty bp, string errorCode, string message, params object[] messageArgs)
@@ -41,7 +41,7 @@ namespace Microsoft.Maui.Controls.Xaml.Diagnostics
 				return;
 			}
 			Application.Current?.FindMauiContext()?.CreateLogger<BindingDiagnostics>()?.LogWarning(message, messageArgs);
-			s_weakEventManager.HandleEvent(null, new BindingErrorEventArgs(VisualDiagnostics.GetSourceInfo(binding), binding, source, bo, bp, errorCode, message, messageArgs), nameof(BindingFailed));
+			_weakEventManager.HandleEvent(null, new BindingErrorEventArgs(VisualDiagnostics.GetSourceInfo(binding), binding, source, bo, bp, errorCode, message, messageArgs), nameof(BindingFailed));
 		}
 	}
 }

--- a/src/Controls/src/Core/Xaml/Diagnostics/BindingDiagnostics.cs
+++ b/src/Controls/src/Core/Xaml/Diagnostics/BindingDiagnostics.cs
@@ -13,7 +13,16 @@ namespace Microsoft.Maui.Controls.Xaml.Diagnostics
 	/// </summary>
 	public class BindingDiagnostics
 	{
-		public static event EventHandler<BindingBaseErrorEventArgs> BindingFailed;
+		// Backed by WeakEventManager so instance subscribers that forget to
+		// unsubscribe are not pinned by the multicast delegate for the process
+		// lifetime. See https://github.com/dotnet/maui/issues/37245.
+		static readonly WeakEventManager s_weakEventManager = new WeakEventManager();
+
+		public static event EventHandler<BindingBaseErrorEventArgs> BindingFailed
+		{
+			add => s_weakEventManager.AddEventHandler(value);
+			remove => s_weakEventManager.RemoveEventHandler(value);
+		}
 
 		internal static void SendBindingFailure(BindingBase binding, string errorCode, string message, params object[] messageArgs)
 		{
@@ -22,7 +31,7 @@ namespace Microsoft.Maui.Controls.Xaml.Diagnostics
 				return;
 			}
 			Application.Current?.FindMauiContext()?.CreateLogger<BindingDiagnostics>()?.LogWarning(message, messageArgs);
-			BindingFailed?.Invoke(null, new BindingBaseErrorEventArgs(VisualDiagnostics.GetSourceInfo(binding), binding, errorCode, message, messageArgs));
+			s_weakEventManager.HandleEvent(null, new BindingBaseErrorEventArgs(VisualDiagnostics.GetSourceInfo(binding), binding, errorCode, message, messageArgs), nameof(BindingFailed));
 		}
 
 		internal static void SendBindingFailure(BindingBase binding, object source, BindableObject bo, BindableProperty bp, string errorCode, string message, params object[] messageArgs)
@@ -32,7 +41,7 @@ namespace Microsoft.Maui.Controls.Xaml.Diagnostics
 				return;
 			}
 			Application.Current?.FindMauiContext()?.CreateLogger<BindingDiagnostics>()?.LogWarning(message, messageArgs);
-			BindingFailed?.Invoke(null, new BindingErrorEventArgs(VisualDiagnostics.GetSourceInfo(binding), binding, source, bo, bp, errorCode, message, messageArgs));
+			s_weakEventManager.HandleEvent(null, new BindingErrorEventArgs(VisualDiagnostics.GetSourceInfo(binding), binding, source, bo, bp, errorCode, message, messageArgs), nameof(BindingFailed));
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/BindingUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindingUnitTests.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Maui.Controls.Xaml.Diagnostics;
 using Microsoft.Maui.Graphics;
 using Xunit;
 
@@ -2531,6 +2532,62 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			}
 
 			public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
+		}
+
+		// Regression tests for https://github.com/dotnet/maui/issues/37245.
+		// BindingDiagnostics.BindingFailed is a plain static event; instance
+		// subscribers that never unsubscribe are pinned by the multicast
+		// delegate for the process lifetime.
+
+		[Fact, Category(TestCategory.Memory)]
+		public async Task BindingDiagnosticsBindingFailed_Control_NeverSubscribed_IsCollected()
+		{
+			var reference = CreateBindingFailedSubscriber(subscribe: false, unsubscribe: false);
+
+			Assert.False(await reference.WaitForCollect(),
+				"Subject that never subscribed to BindingDiagnostics.BindingFailed should be collected.");
+		}
+
+		[Fact, Category(TestCategory.Memory)]
+		public async Task BindingDiagnosticsBindingFailed_Mitigation_SubscribedAndUnsubscribed_IsCollected()
+		{
+			var reference = CreateBindingFailedSubscriber(subscribe: true, unsubscribe: true);
+
+			Assert.False(await reference.WaitForCollect(),
+				"Subject that unsubscribed from BindingDiagnostics.BindingFailed should be collected.");
+		}
+
+		// Regression: FAILS on current code (issue #37245); passes once
+		// BindingFailed is backed by WeakEventManager or a weak-subscription API.
+		[Fact, Category(TestCategory.Memory)]
+		public async Task BindingDiagnosticsBindingFailed_Leaky_SubscribedButNotUnsubscribed_IsCollected()
+		{
+			var reference = CreateBindingFailedSubscriber(subscribe: true, unsubscribe: false);
+
+			Assert.False(await reference.WaitForCollect(),
+				"BindingDiagnostics.BindingFailed leaks subscribers (issue #37245). " +
+				"Back the event with WeakEventManager (or expose a disposable subscription API) to fix.");
+		}
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		static WeakReference CreateBindingFailedSubscriber(bool subscribe, bool unsubscribe)
+		{
+			var subject = new BindingFailedSubscriber();
+
+			if (subscribe)
+				BindingDiagnostics.BindingFailed += subject.OnBindingFailed;
+
+			if (unsubscribe)
+				BindingDiagnostics.BindingFailed -= subject.OnBindingFailed;
+
+			return new WeakReference(subject);
+		}
+
+		sealed class BindingFailedSubscriber
+		{
+			public void OnBindingFailed(object sender, BindingBaseErrorEventArgs args)
+			{
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->


### Issue Details
When a page or view model subscribes to BindingDiagnostics.BindingFailed (a helpful event that tells you when a data binding fails) and forgets to unsubscribe, that page never gets cleaned up from memory. Every page it holds — plus its images, view models, and data — stays alive until the app closes. Over time, the app uses more and more memory.

### Root Cause
BindingFailed is a static event, which means it lives for the whole life of the app. Normal C# events keep a strong reference to whoever subscribed, so as long as the event is alive, its subscribers stay alive too. Since this event never goes away, any subscriber that doesn't call -= is stuck in memory forever.

### Description of Change
Switched BindingFailed from a normal event to one backed by WeakEventManager, which keeps only a weak reference to subscribers — so the garbage collector can clean them up even if someone forgets to unsubscribe.
 

Validated the behavior in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
### Issues Fixed
  
Fixes #37245 

### Fix reference 
[maui/src/Controls/src/Core/Application/Application.cs at bf62313db2cecf3215f10c353720b341aba0a4ee · …](https://github.com/dotnet/maui/blob/bf62313db2cecf3215f10c353720b341aba0a4ee/src/Controls/src/Core/Application/Application.cs#L263)
[maui/src/Controls/src/Core/Command.cs at bf62313db2cecf3215f10c353720b341aba0a4ee · dotnet/maui](https://github.com/dotnet/maui/blob/bf62313db2cecf3215f10c353720b341aba0a4ee/src/Controls/src/Core/Command.cs#L128)
[maui/src/Controls/src/Core/ImageSource.cs at bf62313db2cecf3215f10c353720b341aba0a4ee · dotnet/maui](https://github.com/dotnet/maui/blob/bf62313db2cecf3215f10c353720b341aba0a4ee/src/Controls/src/Core/ImageSource.cs#L175)

### Output  ScreenShot

|Before|After|
|--|--|
| <video src="https://github.com/user-attachments/assets/86c6d76d-a051-458b-beb3-6c254545f87a" >| <video src="https://github.com/user-attachments/assets/e3b02ce7-71a7-4e90-94e0-dd6587c8e3cf">|








