### PR TITLE
Fix to Improve CollectionView2 Resilience During Item Index Resolution

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/CollectionViewHandler2.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items2/CollectionViewHandler2.Windows.cs
@@ -453,10 +453,9 @@ public partial class CollectionViewHandler2 : ReorderableItemsViewHandler2<Reord
 			case ItemsViewSelectionMode.Multiple:
 				PlatformView.DeselectAll();
 
-				// Use safe enumeration to avoid ArgumentOutOfRangeException during collection updates
-				int index = 0;
-				foreach (var nativeItem in itemList)
+				for (int index = 0; index < itemList.Count; index++)
 				{
+					var nativeItem = itemList[index];
 					if (nativeItem is ItemTemplateContext2 itemPair && ItemsView.SelectedItems.Contains(itemPair.Item))
 					{
 						PlatformView.Select(index);
@@ -465,7 +464,6 @@ public partial class CollectionViewHandler2 : ReorderableItemsViewHandler2<Reord
 					{
 						PlatformView.Select(index);
 					}
-					index++;
 				}
 				break;
 			case ItemsViewSelectionMode.None:
@@ -479,20 +477,18 @@ public partial class CollectionViewHandler2 : ReorderableItemsViewHandler2<Reord
 	}
 
 	/// <summary>
-	/// Finds the index of the specified item in the collection view source, using a single-pass
-	/// iteration. Returns -1 if the item is not found.
+	/// Finds the index without enumerating the projected <see cref="ICollectionView"/>. Returns -1 if the item is not found.
 	/// </summary>
 	static int FindItemIndexInSource(ICollectionView itemList, object targetItem)
 	{
-		int index = 0;
-		foreach (var nativeItem in itemList)
+		for (int index = 0; index < itemList.Count; index++)
 		{
+			var nativeItem = itemList[index];
 			var actualItem = nativeItem is ItemTemplateContext2 itc ? itc.Item : nativeItem;
 			if (object.Equals(actualItem, targetItem))
 			{
 				return index;
 			}
-			index++;
 		}
 		return -1;
 	}


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Description

In CollectionView2 , `FindItemIndexInSource` locates an item by iterating through the collection exposed by ICollectionView. On Windows, this collection is not a standard managed List<T> but a WinRT-projected ICollectionView returned by CollectionViewSource.View.

During execution, FindItemIndexInSource calls GetEnumerator() on the ICollectionView and relies on the Windows SDK projection layer (Microsoft.Windows.SDK.NET.Ref) to convert the native WinRT iterator into a managed IEnumerator.

When the project is pinned to WindowsSdkPackageVersion 10.0.19041.41, this conversion fails and GetEnumerator() throws `"Unexpected type for enumerator"` before `FindItemIndexInSource` can begin iterating or comparing items. As a result, FindItemIndexInSource cannot determine the item's index and the operation fails.

### Description of Change
As a defensive fix, we updated FindItemIndexInSource to iterate and compare items directly rather than depending on enumeration of the native ICollectionView. This makes the lookup path more resilient and avoids crashes caused by WinRT projection issues such as the Unexpected type for enumerator exception in older Windows SDK projections.

### Issues Fixed
Fixes #37535 

### Tested the behaviour in the following platforms
- [ ] Android
- [x] Windows
- [ ] iOS
- [ ] Mac

### Note: 
`foreach` is generally preferred when processing every item, especially when indexed access may be inefficient. However, our selection logic requires both the item and its index, and `for` also avoids the faulty WinRT enumerator, making it the more appropriate fix here


### Why is a test not added?

A test was not added because the issue is not reproducible on .NET 11 with the SDK versions currently used in the test environment. The crash occurs only when the project is explicitly pinned to Microsoft.Windows.SDK.NET.Ref 10.0.19041.41, where the WinRT projection layer throws Unexpected type for enumerator.

Since .NET 11 automatically resolves to 10.0.19041.44, the issue no longer reproduces and the test would always pass. As a result, a regression test would not be able to reliably validate the failure scenario or the fix, so no additional test was added.

### Output Screenshot
Before Issue Fix | After Issue Fix |
|----------|----------|
|<video width="100" height="100" alt="Before Fix" src="https://github.com/user-attachments/assets/21cf35b2-747a-4d05-b11b-1870f087163e">|<video width="100" height="100" alt="After Fix" src="https://github.com/user-attachments/assets/1d73c77d-7f5d-429d-a7cb-a709e5c4dc44">|