### PR TITLE
[iOS] ScrollView: Complete every superseded or dropped scroll request's task

### DIFF
--- a/src/Controls/src/Core/ScrollView/ScrollView.cs
+++ b/src/Controls/src/Core/ScrollView/ScrollView.cs
@@ -43,19 +43,22 @@ namespace Microsoft.Maui.Controls
 		ScrollToRequestedEventArgs _pendingScrollToRequested;
 		bool _replayPendingScrollToRequestedEvent;
 
-		// A parked element request lives exactly as long as the task the caller is awaiting.
-		// It leaves the park in one of two ways, and no other: the arrange arrives and the
-		// request is replayed against real geometry (the task completes with the scroll),
-		// or there is nothing left that could ever satisfy it and the request is dropped
-		// (the task completes without a scroll). The latter happens when the view's
-		// lifecycle ends — its handler goes away or it is removed from the tree — and when
-		// the target is orphaned from this ScrollView's content (see IsElementTargetOrphaned).
-		// Nothing releases the task while the request is still parked, so a completed await
-		// never scrolls later; and nothing but one of those terminal conditions drops the
-		// request, so a view that is merely hidden (a collapsed branch, an unselected tab)
-		// still scrolls to the element when it is eventually arranged. A view that stays
-		// attached and is never arranged keeps the task pending — that is the contract, not
-		// a leak: the task completes when the scroll happens or nothing can make it happen.
+		// A parked request lives exactly as long as the task the caller is awaiting, and the
+		// task completes exactly when the request ends. A parked request ends in one of
+		// three ways, and no other: the arrange arrives and it is replayed against real
+		// geometry (the task completes with the scroll); a newer ScrollToAsync supersedes it
+		// (latest wins — the task completes without a scroll); or there is nothing left that
+		// could ever satisfy it and it is dropped (the task completes without a scroll) —
+		// when the view's lifecycle ends (its handler goes away or it is removed from the
+		// tree) or the target is orphaned from this ScrollView's content (see
+		// IsElementTargetOrphaned). Nothing releases the task while the request is still
+		// parked, so a completed await never scrolls later; and nothing but one of those
+		// conditions ends the request, so a view that is merely hidden (a collapsed branch,
+		// an unselected tab) still scrolls to the element when it is eventually arranged. A
+		// view that stays attached and is never arranged keeps the task pending — that is the
+		// contract, not a leak: the task completes when the scroll happens, is superseded, or
+		// nothing can make it happen. Completions for a request ending without its scroll go
+		// through CompleteWithoutScroll.
 		private protected override void OnHandlerChangedCore()
 		{
 			base.OnHandlerChangedCore();
@@ -102,14 +105,28 @@ namespace Microsoft.Maui.Controls
 			// A stale replay flag from a pre-handler park must not carry over to a later request
 			_replayPendingScrollToRequestedEvent = false;
 
-			// Complete inline, at the moment the request is dropped. Deferring the completion
-			// would open a window in which a newer ScrollToAsync could swap the completion
-			// source, so a deferred completion would release the wrong task and orphan this
-			// one. Completing here binds the release to the request being dropped by
-			// construction. This is also the convention already in place: the handler-detach
-			// drop and Core's own DisconnectHandler both complete the task inline from their
-			// lifecycle hooks.
-			SendScrollFinished();
+			CompleteWithoutScroll(_scrollCompletionSource);
+		}
+
+		// Completes a task whose request has ended without a scroll (dropped, or superseded
+		// by a newer request). Two things must hold at once, and both are satisfied by
+		// capturing the completion source as a value and posting the completion:
+		//  - the caller's continuation must not run on the stack of the lifecycle mutation
+		//    that ended the request (OnParentChangedCore fires from inside Element.SetParent,
+		//    before the Parent change has finished propagating), so it is posted; and
+		//  - the completion must release exactly this task — a newer ScrollToAsync in the
+		//    window before the post runs replaces the field, so the post must not read the
+		//    field when it fires. Nothing else reads it here.
+		// The ordinary platform-callback completion is untouched (SendScrollFinished), so
+		// `await ScrollToAsync(...)` keeps its existing timing when the scroll happens.
+		void CompleteWithoutScroll(TaskCompletionSource<bool> completion)
+		{
+			if (completion is null)
+			{
+				return;
+			}
+
+			Dispatcher.Dispatch(() => completion.TrySetResult(true));
 		}
 
 		void DispatchPendingScrollToRequest()
@@ -199,11 +216,15 @@ namespace Microsoft.Maui.Controls
 				// compatibility renderer scrolling, say). That newer request wins: it has
 				// already been sent, and sending the stale replay after it would land the
 				// scroll on the old target. Every request creates a fresh completion source,
-				// so a changed source is the exact signal that one was made.
+				// so a changed source is the exact signal that one was made — and the
+				// superseded caller's task must then be completed, not abandoned: nothing
+				// else will ever complete it (a superseding request does not touch it), and
+				// the contract is that a request ends with its task completed.
 				var replayed = _scrollCompletionSource;
 				ScrollToRequested?.Invoke(this, pending);
 				if (!ReferenceEquals(_scrollCompletionSource, replayed))
 				{
+					CompleteWithoutScroll(replayed);
 					return;
 				}
 			}
@@ -609,6 +630,11 @@ namespace Microsoft.Maui.Controls
 
 		void OnScrollToRequested(ScrollToRequestedEventArgs e)
 		{
+			// A request still parked when this one arrives is about to be superseded. Its
+			// caller's task must be completed, not abandoned (see CompleteWithoutScroll);
+			// capture it before CheckTaskCompletionSource replaces the source for this request.
+			var supersededParked = _pendingScrollToRequested is not null ? _scrollCompletionSource : null;
+
 			CheckTaskCompletionSource();
 			ScrollToRequested?.Invoke(this, e);
 
@@ -637,6 +663,11 @@ namespace Microsoft.Maui.Controls
 
 				Handler.Invoke(nameof(IScrollView.RequestScrollTo), ConvertRequestMode(e).ToRequest());
 			}
+
+			// Whichever branch ran, a request that was parked when this one arrived has been
+			// displaced — overwritten by this one parking in its place, or cleared by the
+			// direct send — and has ended without its scroll: release its caller.
+			CompleteWithoutScroll(supersededParked);
 		}
 
 		ScrollToRequestedEventArgs ConvertRequestMode(ScrollToRequestedEventArgs args)

--- a/src/Controls/tests/Core.UnitTests/ScrollViewUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ScrollViewUnitTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using Microsoft.Maui.UnitTests;
 using NSubstitute;
 using Xunit;
 
@@ -913,7 +914,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var scrollView = new ScrollView { Content = layout };
 
 			// Parked before the handler exists, so the attach replays ScrollToRequested
-			_ = scrollView.ScrollToAsync(0, 100, false);
+			var original = scrollView.ScrollToAsync(0, 100, false);
 
 			// A subscriber (as a compatibility renderer would be) that issues a new request
 			// from inside the replayed event. The replay has already cleared the pending
@@ -935,6 +936,104 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			// Latest request wins; exactly what was sent, in order: the re-entrant one first
 			// (sent immediately, handler present) — the stale replay must not follow it
 			Assert.Equal(new[] { 250d }, handler.ScrollToRequests.ConvertAll(r => r.VerticalOffset));
+
+			// The superseded caller must not be stranded: nothing else will ever complete
+			// its task (the superseding request does not touch it), so yielding the replay
+			// completes it — without a scroll — instead of abandoning it
+			Assert.True(original.IsCompleted);
+			Assert.False(reentrant.IsCompleted);
+		}
+
+		[Fact]
+		public void DropCompletionIsPostedNotRunOnTheMutationStack()
+		{
+			// Capture dispatcher posts instead of running them, so the test can see when
+			// the completion happens relative to the mutation. The option is thread-static
+			// and this capture swallows posts, so it is restored in finally.
+			var posted = new System.Collections.Generic.List<Action>();
+			DispatcherProviderStubOptions.InvokeOnMainThread = posted.Add;
+			try
+			{
+				var item = new View();
+				var scrollView = new ScrollView { Content = new StackLayout { Children = { item } } };
+				var parent = new StackLayout { Children = { scrollView } };
+				scrollView.Handler = new ViewportProviderHandlerStub();
+
+				var task = scrollView.ScrollToAsync(item, ScrollToPosition.Start, false);
+
+				// The drop runs from inside Element.SetParent, before the Parent change has
+				// finished propagating. The caller's continuation must not run there, so
+				// after Remove returns the task is still pending and one post is queued
+				parent.Children.Remove(scrollView);
+				Assert.False(task.IsCompleted);
+				var completion = Assert.Single(posted);
+
+				completion();
+				Assert.True(task.IsCompleted);
+			}
+			finally
+			{
+				DispatcherProviderStubOptions.InvokeOnMainThread = null;
+			}
+		}
+
+		[Fact]
+		public void PostedDropCompletionReleasesOnlyTheDroppedTaskEvenIfANewRequestArrivesFirst()
+		{
+			var posted = new System.Collections.Generic.List<Action>();
+			DispatcherProviderStubOptions.InvokeOnMainThread = posted.Add;
+			try
+			{
+				var item = new View();
+				var scrollView = new ScrollView { Content = new StackLayout { Children = { item } } };
+				var parent = new StackLayout { Children = { scrollView } };
+				scrollView.Handler = new ViewportProviderHandlerStub();
+
+				var task1 = scrollView.ScrollToAsync(item, ScrollToPosition.Start, false);
+				parent.Children.Remove(scrollView);
+				var completion = Assert.Single(posted);
+				Assert.False(task1.IsCompleted);
+
+				// Before the post runs, the view is re-attached and a new request T2 parks,
+				// replacing the completion source. The post must be bound to T1's source,
+				// not read the field when it fires: T1 completes, T2 is untouched.
+				parent.Children.Add(scrollView);
+				var task2 = scrollView.ScrollToAsync(item, ScrollToPosition.End, false);
+
+				completion();
+				Assert.True(task1.IsCompleted);
+				Assert.False(task2.IsCompleted);
+			}
+			finally
+			{
+				DispatcherProviderStubOptions.InvokeOnMainThread = null;
+			}
+		}
+
+		[Fact]
+		public void SupersedingAParkedRequestCompletesTheSupersededCallersTask()
+		{
+			var item = new View();
+			var layout = new StackLayout { Children = { item } };
+			var scrollView = new ScrollView { Content = layout };
+			var handler = new ViewportProviderHandlerStub();
+			scrollView.Handler = handler;
+
+			// T1 parks for geometry. A direct request T2 then displaces it (latest wins).
+			// T1's request is over — nothing will ever scroll it — so T1's caller must be
+			// released rather than left awaiting forever, and T2 must be untouched
+			var task1 = scrollView.ScrollToAsync(item, ScrollToPosition.Start, false);
+			var task2 = scrollView.ScrollToAsync(0, 100, false);
+			Assert.True(task1.IsCompleted);
+			Assert.False(task2.IsCompleted);
+			Assert.Equal(100, Assert.Single(handler.ScrollToRequests).VerticalOffset);
+
+			// Same when the displacing request parks in T1's place instead of sending
+			var task3 = scrollView.ScrollToAsync(item, ScrollToPosition.End, false);
+			Assert.False(task3.IsCompleted);
+			var task4 = scrollView.ScrollToAsync(item, ScrollToPosition.Center, false);
+			Assert.True(task3.IsCompleted);
+			Assert.False(task4.IsCompleted);
 		}
 
 		[Fact]


### PR DESCRIPTION
### Description of Change

Follow-up to #37409 (itself a follow-up to #37060), closing three holes of the same species in the deferred element-scroll machinery: **a request that ends without its task completing, or whose completion runs on the wrong stack.** Two are permanent hangs of `await ScrollToAsync(...)`; one is reachable by entirely ordinary code.

1. **A parked request displaced by any newer `ScrollToAsync` orphaned the first caller's task** — two calls in a row (say, both from `OnAppearing` before the first layout) and the first `await` never returns. Nothing else ever completes it: the superseding request creates a fresh completion source, and the `TaskStatus.Running` check in `CheckTaskCompletionSource` is dead code (a TCS-backed task reports `WaitingForActivation`, never `Running`, so the `TrySetCanceled` there is unreachable). This is the headline fix.
2. **Yielding the replay to a re-entrant `ScrollToRequested` subscriber abandoned the superseded caller's task** — same mechanism, narrower trigger (a legacy renderer issuing its own `ScrollToAsync` from inside the replayed event): permanent hang.
3. **The lifecycle-drop completion ran the caller's continuation from inside `Element.SetParent`**, before `OnPropertyChanged(nameof(Parent))` fires — caller code observing/mutating a half-propagated parent change.

**One primitive fixes all three.** `CompleteWithoutScroll(completion)` captures the completion source **as a value** and posts `TrySetResult(true)` through the dispatcher:

- **off the mutation stack** (fixes 3) — the continuation never runs inside `SetParent`/handler-change;
- **bound by identity** (preserves the invariant from #37409's review rounds) — the post cannot read the field at fire time, so a newer request swapping `_scrollCompletionSource` in the window can never be released in the old request's place;
- **applied at every point a request ends without its scroll** — the drop paths (detach, tree-removal, orphaned target), the yielded replay (fixes 2), and the supersede in `OnScrollToRequested` (fixes 1).

The ordinary platform-callback completion (`SendScrollFinished` when a scroll actually happens) is untouched, so `await ScrollToAsync(...)` timing on the normal path is unchanged. Completing (rather than cancelling) a superseded task matches the existing drop semantics — no `await` in this API's history has thrown on supersede, and introducing `TaskCanceledException` would be a new public behavior.

The contract comment now names all three exits from the park — replayed, superseded, dropped — so the stated contract and the code have no gap.

No new public API.

### Issues Fixed

Follow-up to #37409 / #37060 (fixes for #36801).

### Tests

Every fix is pinned by a test **proven to fail with that fix reverted**:

- `SupersedingAParkedRequestCompletesTheSupersededCallersTask` — both supersede shapes (direct send, and park-in-place)
- `ReentrantRequestFromTheReplayedEventSupersedesTheReplay` — extended to assert the superseded caller is released
- `DropCompletionIsPostedNotRunOnTheMutationStack` — dispatcher-capture harness: task pending after `Remove` returns, exactly one post queued, completes when it runs
- `PostedDropCompletionReleasesOnlyTheDroppedTaskEvenIfANewRequestArrivesFirst` — the identity property: a new request arriving before the post runs is untouched; the dropped task completes (this test fails against a field-reading post, the bug shape from #37409's review)

Verified on the merged `inflight/current` base: `ScrollViewUnitTests` 42/42 (10 consecutive runs), `Issue36801` + `Issue36801DeferredElement` + `ShellFlyoutHeaderScrollViewContent` iOS UI suites 12/12 on the simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
