### PR TITLE
[Candidate] Fix Build failure in MauiBlazorWebView DeviceTests

### DIFF
--- a/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.Services.cs
+++ b/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.Services.cs
@@ -129,7 +129,7 @@ public partial class BlazorWebViewTests
 		// for the IBlazorWebView service type. The two HostBuilderHandlerTests in Core verify the
 		// underlying ConfigureMauiHandlers replacement mechanism with stub types; this test exercises
 		// the new public API surface end-to-end with the real BlazorWebView/IBlazorWebView types.
-		var builder = MauiApp.CreateBuilder();
+		var builder = MauiApp.CreateBuilder(useDefaults: false);
 		builder.Services.AddMauiBlazorWebView()
 			.UsePlatformHandler<CustomBlazorWebViewHandlerStub>();
 		using var app = builder.Build();
@@ -146,7 +146,7 @@ public partial class BlazorWebViewTests
 		// The factory overload registers a different ServiceDescriptor shape (ImplementationFactory
 		// rather than ImplementationType), so GetHandlerType returns null here; we resolve through
 		// GetHandler instead and assert the produced instance type.
-		var builder = MauiApp.CreateBuilder();
+		var builder = MauiApp.CreateBuilder(useDefaults: false);
 		var factoryWasCalled = false;
 		builder.Services.AddMauiBlazorWebView()
 			.UsePlatformHandler(_ =>

--- a/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.Services.cs
+++ b/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.Services.cs
@@ -129,7 +129,7 @@ public partial class BlazorWebViewTests
 		// for the IBlazorWebView service type. The two HostBuilderHandlerTests in Core verify the
 		// underlying ConfigureMauiHandlers replacement mechanism with stub types; this test exercises
 		// the new public API surface end-to-end with the real BlazorWebView/IBlazorWebView types.
-		var builder = MauiApp.CreateBuilder(useDefaults: false);
+		var builder = MauiApp.CreateBuilder();
 		builder.Services.AddMauiBlazorWebView()
 			.UsePlatformHandler<CustomBlazorWebViewHandlerStub>();
 		using var app = builder.Build();
@@ -146,7 +146,7 @@ public partial class BlazorWebViewTests
 		// The factory overload registers a different ServiceDescriptor shape (ImplementationFactory
 		// rather than ImplementationType), so GetHandlerType returns null here; we resolve through
 		// GetHandler instead and assert the produced instance type.
-		var builder = MauiApp.CreateBuilder(useDefaults: false);
+		var builder = MauiApp.CreateBuilder();
 		var factoryWasCalled = false;
 		builder.Services.AddMauiBlazorWebView()
 			.UsePlatformHandler(_ =>

--- a/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.Startup.cs
+++ b/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.Startup.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;


### PR DESCRIPTION
### Root Cause

BlazorWebViewTests.Startup.cs uses nullable reference annotations (?), but the project does not enable nullable annotations. This caused CS8632 errors, and warnings are treated as errors.
 
### Cause PR
#35053 

### Fix
Added #nullable enable at the top of BlazorWebViewTests.Startup.cs.
This follows the existing per-file convention and avoids enabling nullable annotations for the entire project. The Windows device-test build now passes successfully.