### PR TITLE
Revert - [iOS & Mac] Fix and Re-enable "Cells Do Not Leak" and "Handler Does Not Leak" Device Tests

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -84,16 +84,31 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		// Deterministically unbind every realized templated cell when this controller's handler
 		// disconnects (e.g. page popped), instead of relying on VisibleCells/recycling heuristics.
-		// The CollectionView is going away here, so it's safe to permanently tear down each cell
-		// via UnbindAndDisconnect() (also used by ClearMeasurementCells()), which detaches the
-		// logical child, clears native subviews, and disconnects the handler tree.
+		//
+		// Also the only place (with ClearMeasurementCells) that calls DetachFromItemsView() and
+		// disconnects each cell's Handler. Not done in TemplatedCell.Unbind() because that also
+		// runs during routine recycling, where removing the view mid-layout can corrupt native
+		// state (e.g. CarouselView). Here the CollectionView is going away, so
+		// it's safe to sever permanently.
 		void UnbindRealizedTemplatedCells()
 		{
 			for (int n = _realizedTemplatedCells.Count - 1; n >= 0; n--)
 			{
 				if (_realizedTemplatedCells[n].TryGetTarget(out var templatedCell))
 				{
-					templatedCell.UnbindAndDisconnect();
+					if (templatedCell.PlatformHandler?.VirtualView is View view)
+					{
+						templatedCell.Unbind();
+						templatedCell.DetachFromItemsView();
+
+						// Recursive DisconnectHandlers() since the bound view (DataTemplate root)
+						// commonly has child views whose handlers also need disconnecting.
+						view.DisconnectHandlers();
+					}
+					else
+					{
+						templatedCell.Unbind();
+					}
 				}
 			}
 
@@ -581,12 +596,16 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			foreach (var measurementCell in _measurementCells.Values)
 			{
 				measurementCell.LayoutAttributesChanged -= CellLayoutAttributesChanged;
+				measurementCell.Unbind();
 
 				// Discarded measurement cells are never reused and have no other strong references,
 				// so they can be GC'd before Disconnect() runs, leaking their handler if not
-				// disconnected here. UnbindAndDisconnect() detaches the logical child, clears
-				// native subviews, and disconnects the handler tree.
-				measurementCell.UnbindAndDisconnect();
+				// disconnected here.
+				if (measurementCell.PlatformHandler?.VirtualView is View measurementView)
+				{
+					measurementCell.DetachFromItemsView();
+					measurementView.DisconnectHandlers();
+				}
 			}
 
 			_measurementCells.Clear();
@@ -973,23 +992,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			// Keep this cell around, we can transfer the contents to the actual cell when the UICollectionView creates it
 			if (_measurementCells != null)
-			{
-				var bindingContext = ItemsSource[indexPath];
-
-				// A layout re-constrain (bounds change, rotation, ConstrainTo) can request a
-				// measurement cell for an index path that already has one cached. Release the
-				// displaced cell's content before overwriting the cache entry, otherwise its
-				// bound view stays orphaned as a logical child of the ItemsView for as long as
-				// the ItemsView is alive - the same leak class this PR fixes.
-				if (_measurementCells.TryGetValue(bindingContext, out var previousMeasurementCell) &&
-					!ReferenceEquals(previousMeasurementCell, templatedCell))
-				{
-					previousMeasurementCell.LayoutAttributesChanged -= CellLayoutAttributesChanged;
-					previousMeasurementCell.UnbindAndDisconnect();
-				}
-
-				_measurementCells[bindingContext] = templatedCell;
-			}
+				_measurementCells[ItemsSource[indexPath]] = templatedCell;
 
 			return templatedCell;
 		}

--- a/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
@@ -42,7 +42,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		// actually changed the size of the cell
 		Size _size;
 		bool _bound;
-		bool _disposed;
 
 		internal CGSize CurrentSize => _size.ToCGSize();
 
@@ -86,17 +85,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			_bound = false;
 
-			// Transient cleanup only: clear the bound view's BindingContext and detach it from
-			// the ItemsView's logical children so it doesn't stay permanently rooted if the cell
-			// is discarded, but deliberately leave the native subtree, PlatformHandler, and
-			// CurrentTemplate intact. CarouselView Loop mode (and
-			// ItemsViewController.CellDisplayingEndedFromDelegate) may call this speculatively on
-			// a cell about to be redisplayed with the same content, and Bind() relies on the
-			// native view still being attached to cheaply reattach the logical child without
-			// re-running SetupPlatformView() (which would otherwise install duplicate Auto Layout
-			// constraints on every reuse cycle).
 			ClearBindingContext();
-			DetachFromItemsView();
 		}
 
 		// Clears the bound view's BindingContext. Called during routine recycling and final teardown.
@@ -108,35 +97,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			}
 		}
 
-		// Permanent teardown for cells/content that are discarded outright and never
-		// reused/rebound: template replacement, deterministic disposal, and measurement-cell
-		// eviction (ItemsViewController.ClearMeasurementCells). Unlike Unbind(), this also
-		// clears the native subtree and disconnects the handler tree so the bound view and
-		// its platform view become collectible.
-		void ReleaseContent()
-		{
-			var view = PlatformHandler?.VirtualView as View;
-
-			ClearBindingContext();
-			DetachFromItemsView();
-			ClearSubviews();
-
-			view?.DisconnectHandlers();
-			PlatformHandler = null;
-			CurrentTemplate = null;
-			_bound = false;
-		}
-
-		internal void UnbindAndDisconnect()
-		{
-			ReleaseContent();
-		}
-
 		// Removes the bound view from the ItemsView's logical children, so it (and its handler) can
-		// be collected. Now also invoked from Unbind() for transient cleanup (previously reserved
-		// only for final teardown paths via ItemsViewController.Disconnect()/ClearMeasurementCells())
-		// as part of fixing the leak where a discarded/reused cell's bound view stayed permanently
-		// rooted as a logical child of the ItemsView.
+		// be collected. Intentionally NOT called from Unbind()/ClearBindingContext() - only from
+		// final teardown paths (ItemsViewController.Disconnect()/ClearMeasurementCells()), since
+		// removing it during routine recycling can corrupt native layout state (e.g. CarouselView
+		// crash).
 		internal void DetachFromItemsView()
 		{
 			if (PlatformHandler?.VirtualView is View view)
@@ -145,47 +110,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			}
 		}
 
-		protected override void Dispose(bool disposing)
-		{
-			// Guard against re-entrancy: Dispose() is a public entry point on this unsealed
-			// type, so it's legal for a caller to invoke it more than once. Without this guard,
-			// a second call would run ReleaseContent() -> ClearSubviews() against a ContentView
-			// whose native handle may already have been released by the first Dispose(true)
-			// call, risking an ObjectDisposedException.
-			if (_disposed)
-			{
-				base.Dispose(disposing);
-				return;
-			}
-
-			// Only run managed/native cleanup on the deterministic disposing path. When
-			// disposing == false (finalizer), touching the managed object graph
-			// (BindingContext, LogicalChildren, events) is unsafe: it can run on the
-			// finalizer thread and reference objects that are themselves being finalized.
-			// ReleaseContent() covers the case where the cell is deallocated without ever
-			// going through PrepareForReuse/Unbind, permanently detaching and disconnecting
-			// the bound view since the cell itself is being torn down for good.
-			if (disposing)
-			{
-				ReleaseContent();
-				_disposed = true;
-			}
-
-			base.Dispose(disposing);
-		}
-
 		public override UICollectionViewLayoutAttributes PreferredLayoutAttributesFittingAttributes(
 			UICollectionViewLayoutAttributes layoutAttributes)
 		{
 			var preferredAttributes = base.PreferredLayoutAttributesFittingAttributes(layoutAttributes);
-
-			// Skip measuring cells that aren't currently bound (e.g. between Unbind() and a
-			// pending Bind() during rapid section restructuring). Measure() unconditionally
-			// dereferences PlatformHandler.VirtualView and would otherwise throw an NRE.
-			if (!_bound || PlatformHandler?.VirtualView is null)
-			{
-				return preferredAttributes;
-			}
 
 			if (_measureInvalidated ||
 				!AttributesConsistentWithConstrainedDimension(preferredAttributes) ||
@@ -271,16 +199,16 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			if (itemTemplate != CurrentTemplate)
 			{
-				// Remove the old view, if it exists. A template change discards oldElement's
-				// renderer for good, so this permanently detaches and disconnects it to avoid
-				// leaking (unlike the same-template branch below, which keeps the native
-				// subtree attached for cheap reuse). ReleaseContent() clears the BindingContext,
-				// removes the logical child, clears native subviews, and disconnects the handler
-				// tree (equivalent to the previous oldElement.DisconnectHandlers() call, since
-				// view == oldElement here).
+				// Remove the old view, if it exists
 				if (oldElement != null)
 				{
-					ReleaseContent();
+					oldElement.BindingContext = null;
+					itemsView.RemoveLogicalChild(oldElement);
+					ClearSubviews();
+
+					// Template change discards oldElement's renderer for good, so its handler tree
+					// must be disconnected explicitly here to avoid a leak.
+					oldElement.DisconnectHandlers();
 				}
 
 				// Create the content and renderer for the view 
@@ -319,11 +247,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				// If the cell is now being reused/rebound with the same template, the view must be
 				// re-attached; otherwise it silently drops out of the logical tree even though it's
 				// visibly bound and displayed again. Mirrors TemplatedCell2.BindVirtualView().
-				//
-				// Note: the native subtree itself never gets detached by Unbind() (only the
-				// logical-child link does), so there's no need to reattach/recreate it here -
-				// doing so would call SetupPlatformView() again and install duplicate Auto
-				// Layout constraints on every reuse cycle.
 				if (oldElement is not null && oldElement.Parent is null)
 				{
 					itemsView.AddLogicalChild(oldElement);
@@ -366,17 +289,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		internal void UseContent(TemplatedCell measurementCell)
 		{
-			// Release any content this cell was already displaying (e.g. left over from being
-			// recycled by the UICollectionView reuse pool) before adopting the donor's content.
-			// Without this, the previous bound view stays orphaned as a logical child of the
-			// ItemsView, and its handler tree stays connected, for as long as the ItemsView is
-			// alive - the same leak class this PR fixes, just reached via the measurement-cell
-			// content-transfer path instead of Bind().
-			if (PlatformHandler is not null)
-			{
-				ReleaseContent();
-			}
-
 			// Copy all the content and values from the measurement cell 
 			ConstrainedDimension = measurementCell.ConstrainedDimension;
 			ConstrainedSize = measurementCell.ConstrainedSize;
@@ -385,14 +297,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			SetRenderer(measurementCell.PlatformHandler);
 			_bound = true;
 			((IPlatformMeasureInvalidationController)this).InvalidateMeasure();
-
-			// Complete the ownership transfer on the donor so it no longer references the handler
-			// it just gave away. Without this, if the donor cell is later disposed directly
-			// (Dispose() is a public entry point on this unsealed type) it would tear down the
-			// handler subtree that now belongs to this cell.
-			measurementCell.PlatformHandler = null;
-			measurementCell.CurrentTemplate = null;
-			measurementCell._bound = false;
 		}
 
 		bool IsUsingVSMForSelectionColor(View view)

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -4,7 +4,6 @@ override Microsoft.Maui.Controls.GraphicsView.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.Handlers.Compatibility.EntryCellRenderer.EntryCellTableViewCell.Dispose(bool disposing) -> void
 override Microsoft.Maui.Controls.Handlers.Compatibility.TableViewModelRenderer.Dispose(bool disposing) -> void
 override Microsoft.Maui.Controls.Handlers.Items.MauiCollectionView.AddSubview(UIKit.UIView! view) -> void
-override Microsoft.Maui.Controls.Handlers.Items.TemplatedCell.Dispose(bool disposing) -> void
 override Microsoft.Maui.Controls.Handlers.Items2.CarouselViewController2.Dispose(bool disposing) -> void
 ~override Microsoft.Maui.Controls.Handlers.Items2.CollectionViewHandler2.DisconnectHandler(UIKit.UIView platformView) -> void
 ~override Microsoft.Maui.Controls.Handlers.Items2.StructuredItemsViewController2<TItemsView>.NumberOfSections(UIKit.UICollectionView collectionView) -> nint

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -5,7 +5,6 @@ override Microsoft.Maui.Controls.Handlers.Compatibility.EntryCellRenderer.EntryC
 override Microsoft.Maui.Controls.Handlers.Compatibility.TableViewModelRenderer.Dispose(bool disposing) -> void
 override Microsoft.Maui.Controls.Handlers.Items.MauiCollectionView.AddSubview(UIKit.UIView! view) -> void
 override Microsoft.Maui.Controls.Handlers.Items.MauiCollectionView.Dispose(bool disposing) -> void
-override Microsoft.Maui.Controls.Handlers.Items.TemplatedCell.Dispose(bool disposing) -> void
 override Microsoft.Maui.Controls.Handlers.Items2.CarouselViewController2.Dispose(bool disposing) -> void
 ~override Microsoft.Maui.Controls.Handlers.Items2.CollectionViewHandler2.DisconnectHandler(UIKit.UIView platformView) -> void
 ~override Microsoft.Maui.Controls.Handlers.Items2.StructuredItemsViewController2<TItemsView>.NumberOfSections(UIKit.UICollectionView collectionView) -> nint

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
@@ -200,6 +200,7 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+#if TESTS_FAILS_ON_IOS // For more information, see: https://github.com/dotnet/maui/issues/35985
 		[Fact("Cells Do Not Leak")]
 		public async Task CellsDoNotLeak()
 		{
@@ -225,34 +226,13 @@ namespace Microsoft.Maui.DeviceTests
 
 			Assert.NotNull(cell);
 
-			// Simulate the cell being discarded outright (e.g. its bound item was removed from
-			// the ItemsSource) while the ItemsView itself stays alive and in use, as it would for
-			// the remainder of the page's lifetime. This is the scenario the production fix
-			// targets: the templated cell's bound view previously stayed registered as a logical
-			// child of the ItemsView even after the cell that displayed it was gone, permanently
-			// rooting the view (and its content) for as long as the ItemsView remained alive.
-			//
-			// Deliberately keep collectionView (and its handler) alive here instead of nulling
-			// them out - the leak only manifests when the ItemsView outlives the discarded cell,
-			// so nulling it out too would mask the very regression this test guards against.
-			await InvokeOnMainThreadAsync(() =>
-			{
-				cell.Unbind();
-			});
-
-			cell = null;
-
 			// HACK: test passes running individually, but fails when running entire suite.
 			// Skip the assertion on Catalyst for now.
 #if !MACCATALYST
 			await AssertionExtensions.WaitForGC([.. labels]);
 #endif
-
-			// Keep the still-alive ItemsView (and its handler) reachable past WaitForGC so the
-			// JIT can't optimize them away as dead stores before the assertion runs above.
-			GC.KeepAlive(collectionView);
-			GC.KeepAlive(handler);
 		}
+#endif
 
 		//src/Compatibility/Core/tests/iOS/ObservableItemsSourceTests.cs
 		[Fact(DisplayName = "IndexPath Range Generation Is Correct")]

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -244,7 +244,9 @@ public class MemoryTests : ControlsHandlerTestBase
 	[InlineData(typeof(Slider))]
 	[InlineData(typeof(Stepper))]
 	[InlineData(typeof(SwipeView))]
+#if TESTS_FAILS_ON_MACCATALYST //For more information, see: https://github.com/dotnet/maui/issues/35985
 	[InlineData(typeof(Switch))]
+#endif
 	[InlineData(typeof(TimePicker))]
 #pragma warning disable CS0618 // Type or member is obsolete
 	[InlineData(typeof(TableView))]


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue details:

PR #36698 aimed to fix and re-enable the "Cells Do Not Leak" and "Handler Does Not Leak" device memory-leak tests on iOS and Mac. To achieve this, it changed `TemplatedCell` and `ItemsViewController` on iOS so that a cell's bound view is detached from the parent's logical children — and the cell's native subviews are cleared — during disposal, ensuring templated views are released deterministically instead of being permanently rooted.

After this change merged, the `NavigateForwardWhenLooped` and `NavigateBackWhenLooped` CarouselView UI tests started failing on iOS. 

### Description of changes:

This reverts the changes introduced in PR #36698, which modified `TemplatedCell.cs` and `ItemsViewController.cs` on iOS/MacCatalyst to detach a cell's bound view from the parent's logical children and clear its native subviews during disposal.

Reverting restores the prior cell disposal behavior, fixing the CarouselView looped-navigation regression (#37571). As a side effect, it also re-introduces the original memory-leak test failures that PR #36698 addressed.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes https://github.com/dotnet/maui/issues/37571

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
