### PR TITLE
[Mac] Fix VoiceOver announcement for actionable CollectionView items

### DIFF
--- a/src/Controls/src/Core/Platform/iOS/Extensions/AcessibilityExtensions.cs
+++ b/src/Controls/src/Core/Platform/iOS/Extensions/AcessibilityExtensions.cs
@@ -4,6 +4,8 @@ namespace Microsoft.Maui.Controls.Platform;
 
 internal static class AcessibilityExtensions
 {
+	const int MaxAccessibilityElementDepth = 10;
+
 	internal static void UpdateAccessibilityTraits(this UICollectionView collectionView, SelectableItemsView itemsView)
 	{
 		foreach (var subview in collectionView.Subviews)
@@ -30,14 +32,45 @@ internal static class AcessibilityExtensions
 				return;
 			}
 
+			var accessibilityElement = FindAccessibilityElement(firstChild, 0) ?? firstChild;
+
 			if (selectionMode != SelectionMode.None)
 			{
-				firstChild.AccessibilityTraits |= UIAccessibilityTrait.Button;
+				accessibilityElement.AccessibilityTraits |= UIAccessibilityTrait.Button;
 			}
 			else
 			{
-				firstChild.AccessibilityTraits &= ~UIAccessibilityTrait.Button;
+				accessibilityElement.AccessibilityTraits &= ~UIAccessibilityTrait.Button;
 			}
 		}
+	}
+
+	static UIView? FindAccessibilityElement(UIView view, int depth)
+	{
+		if (view is UIControl)
+		{
+			return null;
+		}
+
+		if (view.IsAccessibilityElement)
+		{
+			return view;
+		}
+
+		if (depth >= MaxAccessibilityElementDepth)
+		{
+			return null;
+		}
+
+		var subviews = view.Subviews;
+		for (var index = 0; index < subviews.Length; index++)
+		{
+			if (FindAccessibilityElement(subviews[index], depth + 1) is UIView accessibilityElement)
+			{
+				return accessibilityElement;
+			}
+		}
+
+		return null;
 	}
 }

--- a/src/Controls/src/Core/Platform/iOS/Extensions/AcessibilityExtensions.cs
+++ b/src/Controls/src/Core/Platform/iOS/Extensions/AcessibilityExtensions.cs
@@ -1,94 +1,73 @@
-using System.Runtime.CompilerServices;
 using UIKit;
 
 namespace Microsoft.Maui.Controls.Platform;
 
 internal static class AcessibilityExtensions
 {
-	// Defensive cap on recursion depth, not a UIKit limit; real item templates rarely nest this deep.
-	const int MaxAccessibilityElementDepth = 10;
+    internal static void UpdateAccessibilityTraits(this UICollectionView collectionView, SelectableItemsView itemsView)
+    {
+        foreach (var subview in collectionView.Subviews)
+        {
+            if (subview is UICollectionViewCell cell)
+            {
+                cell.UpdateAccessibilityTraits(itemsView);
+            }
+        }
+    }
 
-	internal static void UpdateAccessibilityTraits(this UICollectionView collectionView, SelectableItemsView itemsView)
-	{
-		foreach (var subview in collectionView.Subviews)
-		{
-			if (subview is UICollectionViewCell cell)
-			{
-				cell.UpdateAccessibilityTraits(itemsView);
-			}
-		}
-	}
+    internal static void UpdateAccessibilityTraits(this UICollectionViewCell cell, ItemsView itemsView)
+    {
+        var selectionMode = (itemsView as CollectionView)?.SelectionMode;
 
-	internal static void UpdateAccessibilityTraits(this UICollectionViewCell cell, ItemsView itemsView)
-	{
-		var selectionMode = (itemsView as CollectionView)?.SelectionMode;
-		if (cell.ContentView is null
-			|| cell.ContentView.Subviews.Length == 0
-			|| selectionMode is null)
-		{
-			return;
-		}
+        if (selectionMode is null || cell.ContentView is null || cell.ContentView.Subviews.Length == 0)
+        {
+            return;
+        }
 
-		if (selectionMode == SelectionMode.None)
-		{
-			// Nothing to apply. Only clear a previously-applied trait (e.g. the cell is being
-			// reused after a prior bind with Single/Multiple selection); avoid re-running the
-			// accessibility-element search when this cell never had the trait applied.
-			if (s_appliedAccessibilityElements.TryGetValue(cell, out var previouslyAppliedElement))
-			{
-				previouslyAppliedElement.AccessibilityTraits &= ~UIAccessibilityTrait.Button;
-				s_appliedAccessibilityElements.Remove(cell);
-			}
+        var accessibilityTarget = FindAccessibilityElement(cell.ContentView.Subviews[0], 0);
 
-			return;
-		}
+        // Preserve the accessibility role of native controls.
+        if (accessibilityTarget is null || accessibilityTarget is UIControl)
+        {
+            return;
+        }
 
-		var firstChild = cell.ContentView.Subviews[0];
+        if (selectionMode != SelectionMode.None)
+        {
+            accessibilityTarget.AccessibilityTraits |= UIAccessibilityTrait.Button;
+        }
+        else
+        {
+            accessibilityTarget.AccessibilityTraits &= ~UIAccessibilityTrait.Button;
+        }
+    }
 
-		// if the first child is a control, changing the accessibility traits from an entry to a button could be confusing.
-		if (firstChild is UIControl)
-		{
-			return;
-		}
+    static UIView? FindAccessibilityElement(UIView view, int depth)
+    {
+        // Do not change the role of native controls such as
+        // UIButton, UITextField, UISwitch, etc.
+        if (view is UIControl)
+        {
+            return null;
+        }
 
-		var accessibilityElement = FindAccessibilityElement(firstChild, 0) ?? firstChild;
+        // This is the native view that MAUI has exposed to
+        // VoiceOver as the accessibility element.
+        if (view.IsAccessibilityElement)
+        {
+            return view;
+        }
 
-		accessibilityElement.AccessibilityTraits |= UIAccessibilityTrait.Button;
-		s_appliedAccessibilityElements.Remove(cell);
-		s_appliedAccessibilityElements.Add(cell, accessibilityElement);
-	}
+        foreach (var subview in view.Subviews)
+        {
+            var accessibilityElement = FindAccessibilityElement(subview, depth + 1);
 
-	// Tracks which descendant view (if any) last received the Button trait for a given cell,
-	// so that switching to SelectionMode.None can clear the trait from that exact element
-	// without re-running the recursive accessibility-element search on every bind/rebind.
-	static readonly ConditionalWeakTable<UICollectionViewCell, UIView> s_appliedAccessibilityElements = new();
+            if (accessibilityElement is not null)
+            {
+                return accessibilityElement;
+            }
+        }
 
-	static UIView? FindAccessibilityElement(UIView view, int depth)
-	{
-		if (view is UIControl)
-		{
-			return null;
-		}
-
-		if (view.IsAccessibilityElement)
-		{
-			return view;
-		}
-
-		if (depth >= MaxAccessibilityElementDepth)
-		{
-			return null;
-		}
-
-		var subviews = view.Subviews;
-		for (var index = 0; index < subviews.Length; index++)
-		{
-			if (FindAccessibilityElement(subviews[index], depth + 1) is UIView accessibilityElement)
-			{
-				return accessibilityElement;
-			}
-		}
-
-		return null;
-	}
+        return null;
+    }
 }

--- a/src/Controls/src/Core/Platform/iOS/Extensions/AcessibilityExtensions.cs
+++ b/src/Controls/src/Core/Platform/iOS/Extensions/AcessibilityExtensions.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Maui.Controls.Platform;
 
 internal static class AcessibilityExtensions
 {
+	// Defensive cap on recursion depth, not a UIKit limit; real item templates rarely nest this deep.
 	const int MaxAccessibilityElementDepth = 10;
 
 	internal static void UpdateAccessibilityTraits(this UICollectionView collectionView, SelectableItemsView itemsView)

--- a/src/Controls/src/Core/Platform/iOS/Extensions/AcessibilityExtensions.cs
+++ b/src/Controls/src/Core/Platform/iOS/Extensions/AcessibilityExtensions.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using UIKit;
 
 namespace Microsoft.Maui.Controls.Platform;
@@ -20,30 +21,46 @@ internal static class AcessibilityExtensions
 	internal static void UpdateAccessibilityTraits(this UICollectionViewCell cell, ItemsView itemsView)
 	{
 		var selectionMode = (itemsView as CollectionView)?.SelectionMode;
-		if (cell.ContentView is not null
-			&& cell.ContentView.Subviews.Length > 0
-			&& selectionMode is not null)
+		if (cell.ContentView is null
+			|| cell.ContentView.Subviews.Length == 0
+			|| selectionMode is null)
 		{
-			var firstChild = cell.ContentView.Subviews[0];
-
-			// if the first child is a control, changing the accessibility traits from an entry to a button could be confusing.
-			if (firstChild is UIControl)
-			{
-				return;
-			}
-
-			var accessibilityElement = FindAccessibilityElement(firstChild, 0) ?? firstChild;
-
-			if (selectionMode != SelectionMode.None)
-			{
-				accessibilityElement.AccessibilityTraits |= UIAccessibilityTrait.Button;
-			}
-			else
-			{
-				accessibilityElement.AccessibilityTraits &= ~UIAccessibilityTrait.Button;
-			}
+			return;
 		}
+
+		if (selectionMode == SelectionMode.None)
+		{
+			// Nothing to apply. Only clear a previously-applied trait (e.g. the cell is being
+			// reused after a prior bind with Single/Multiple selection); avoid re-running the
+			// accessibility-element search when this cell never had the trait applied.
+			if (s_appliedAccessibilityElements.TryGetValue(cell, out var previouslyAppliedElement))
+			{
+				previouslyAppliedElement.AccessibilityTraits &= ~UIAccessibilityTrait.Button;
+				s_appliedAccessibilityElements.Remove(cell);
+			}
+
+			return;
+		}
+
+		var firstChild = cell.ContentView.Subviews[0];
+
+		// if the first child is a control, changing the accessibility traits from an entry to a button could be confusing.
+		if (firstChild is UIControl)
+		{
+			return;
+		}
+
+		var accessibilityElement = FindAccessibilityElement(firstChild, 0) ?? firstChild;
+
+		accessibilityElement.AccessibilityTraits |= UIAccessibilityTrait.Button;
+		s_appliedAccessibilityElements.Remove(cell);
+		s_appliedAccessibilityElements.Add(cell, accessibilityElement);
 	}
+
+	// Tracks which descendant view (if any) last received the Button trait for a given cell,
+	// so that switching to SelectionMode.None can clear the trait from that exact element
+	// without re-running the recursive accessibility-element search on every bind/rebind.
+	static readonly ConditionalWeakTable<UICollectionViewCell, UIView> s_appliedAccessibilityElements = new();
 
 	static UIView? FindAccessibilityElement(UIView view, int depth)
 	{

--- a/src/Controls/src/Core/Platform/iOS/Extensions/AcessibilityExtensions.cs
+++ b/src/Controls/src/Core/Platform/iOS/Extensions/AcessibilityExtensions.cs
@@ -24,7 +24,7 @@ internal static class AcessibilityExtensions
             return;
         }
 
-        var accessibilityTarget = FindAccessibilityElement(cell.ContentView.Subviews[0], 0);
+        var accessibilityTarget = FindAccessibilityElement(cell.ContentView.Subviews[0]);
 
         // Preserve the accessibility role of native controls.
         if (accessibilityTarget is null || accessibilityTarget is UIControl)
@@ -42,7 +42,7 @@ internal static class AcessibilityExtensions
         }
     }
 
-    static UIView? FindAccessibilityElement(UIView view, int depth)
+    static UIView? FindAccessibilityElement(UIView view)
     {
         // Do not change the role of native controls such as
         // UIButton, UITextField, UISwitch, etc.
@@ -60,7 +60,7 @@ internal static class AcessibilityExtensions
 
         foreach (var subview in view.Subviews)
         {
-            var accessibilityElement = FindAccessibilityElement(subview, depth + 1);
+            var accessibilityElement = FindAccessibilityElement(subview);
 
             if (accessibilityElement is not null)
             {

--- a/src/Controls/src/Core/Platform/iOS/Extensions/AcessibilityExtensions.cs
+++ b/src/Controls/src/Core/Platform/iOS/Extensions/AcessibilityExtensions.cs
@@ -1,9 +1,12 @@
+using System.Runtime.CompilerServices;
 using UIKit;
 
 namespace Microsoft.Maui.Controls.Platform;
 
-internal static class AcessibilityExtensions
+internal static class AccessibilityExtensions
 {
+    static readonly ConditionalWeakTable<UICollectionViewCell, AccessibilityTraitState> AccessibilityTraitStates = new();
+
     internal static void UpdateAccessibilityTraits(this UICollectionView collectionView, SelectableItemsView itemsView)
     {
         foreach (var subview in collectionView.Subviews)
@@ -15,31 +18,76 @@ internal static class AcessibilityExtensions
         }
     }
 
-    internal static void UpdateAccessibilityTraits(this UICollectionViewCell cell, ItemsView itemsView)
+    internal static void UpdateAccessibilityTraits(this UICollectionViewCell cell, ItemsView itemsView, bool invalidateAccessibilityTarget = false)
     {
         var selectionMode = (itemsView as CollectionView)?.SelectionMode;
+        var traitState = AccessibilityTraitStates.GetValue(cell, static _ => new AccessibilityTraitState());
 
         if (selectionMode is null || cell.ContentView is null || cell.ContentView.Subviews.Length == 0)
         {
+            ResetAccessibilityTraitState(traitState);
             return;
         }
 
-        var accessibilityTarget = FindAccessibilityElement(cell.ContentView.Subviews[0]);
+        var accessibilityRoot = cell.ContentView.Subviews[0];
+        if (!ReferenceEquals(traitState.AccessibilityRoot, accessibilityRoot))
+        {
+            ResetAccessibilityTraitState(traitState);
+            traitState.AccessibilityRoot = accessibilityRoot;
+        }
 
-        // Preserve the accessibility role of native controls.
-        if (accessibilityTarget is null || accessibilityTarget is UIControl)
+        if (selectionMode == SelectionMode.None)
+        {
+            ClearButtonTrait(traitState);
+            return;
+        }
+
+        if (!traitState.HasResolvedAccessibilityTarget)
+        {
+            traitState.AccessibilityTarget = FindAccessibilityElement(accessibilityRoot);
+            traitState.HasResolvedAccessibilityTarget = true;
+        }
+
+        var accessibilityTarget = traitState.AccessibilityTarget;
+
+        // The exposed accessibility element can change when semantic properties are updated.
+        // Always remove the trait from the view where we added it before targeting another view.
+        if (!ReferenceEquals(traitState.Target, accessibilityTarget))
+        {
+            ClearButtonTrait(traitState);
+        }
+
+        if (accessibilityTarget is null)
         {
             return;
         }
 
-        if (selectionMode != SelectionMode.None)
+        // Only track traits added here so developer-assigned Button traits are preserved.
+        if ((accessibilityTarget.AccessibilityTraits & UIAccessibilityTrait.Button) == 0)
         {
             accessibilityTarget.AccessibilityTraits |= UIAccessibilityTrait.Button;
+            traitState.Target = accessibilityTarget;
+            traitState.AddedButtonTrait = true;
         }
-        else
+    }
+
+    static void ClearButtonTrait(AccessibilityTraitState traitState)
+    {
+        if (traitState.AddedButtonTrait && traitState.Target is not null)
         {
-            accessibilityTarget.AccessibilityTraits &= ~UIAccessibilityTrait.Button;
+            traitState.Target.AccessibilityTraits &= ~UIAccessibilityTrait.Button;
         }
+
+        traitState.Target = null;
+        traitState.AddedButtonTrait = false;
+    }
+
+    static void ResetAccessibilityTraitState(AccessibilityTraitState traitState)
+    {
+        ClearButtonTrait(traitState);
+        traitState.AccessibilityRoot = null;
+        traitState.AccessibilityTarget = null;
+        traitState.HasResolvedAccessibilityTarget = false;
     }
 
     static UIView? FindAccessibilityElement(UIView view)
@@ -69,5 +117,18 @@ internal static class AcessibilityExtensions
         }
 
         return null;
+    }
+
+    sealed class AccessibilityTraitState
+    {
+        public UIView? AccessibilityRoot { get; set; }
+
+        public UIView? AccessibilityTarget { get; set; }
+
+        public bool HasResolvedAccessibilityTarget { get; set; }
+
+        public UIView? Target { get; set; }
+
+        public bool AddedButtonTrait { get; set; }
     }
 }

--- a/src/Controls/src/Core/VisualElement/VisualElement.Mapper.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.Mapper.cs
@@ -2,6 +2,10 @@
 using System;
 using Microsoft.Maui.Controls.Compatibility;
 using Microsoft.Maui.Handlers;
+#if IOS || MACCATALYST
+using Microsoft.Maui.Controls.Platform;
+using UIKit;
+#endif
 
 namespace Microsoft.Maui.Controls
 {
@@ -64,7 +68,33 @@ namespace Microsoft.Maui.Controls
 		{
 			UpdateSemantics();
 			Handler?.UpdateValue(nameof(IView.Semantics));
+
+#if IOS || MACCATALYST
+			UpdateCollectionViewAccessibilityTraits();
+#endif
 		}
+
+#if IOS || MACCATALYST
+		void UpdateCollectionViewAccessibilityTraits()
+		{
+			if (this.FindParentOfType<CollectionView>() is not CollectionView collectionView ||
+				Handler?.PlatformView is not UIView platformView)
+			{
+				return;
+			}
+
+			UIView current = platformView;
+			while (current is not null && current is not UICollectionViewCell)
+			{
+				current = current.Superview;
+			}
+
+			if (current is UICollectionViewCell cell)
+			{
+				cell.UpdateAccessibilityTraits(collectionView, invalidateAccessibilityTarget: true);
+			}
+		}
+#endif
 
 		static void MapContainerView(IViewHandler handler, VisualElement element) =>
 			element._platformContainerViewChanged?.Invoke(element, EventArgs.Empty);

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
@@ -160,6 +160,61 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact]
+		public async Task ChangingSelectionModeToNoneClearsButtonTraitFromNestedAccessibilityElement()
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler<CollectionView, CollectionViewHandler2>();
+					handlers.AddHandler<Grid, LayoutHandler>();
+					handlers.AddHandler<Border, BorderHandler>();
+					handlers.AddHandler<Label, LabelHandler>();
+					handlers.AddHandler<CheckBox, CheckBoxHandler>();
+				});
+			});
+
+			Grid taskAccessibilityElement = null;
+			var collectionView = new CollectionView
+			{
+				ItemsSource = new[] { "Survey Employees" },
+				SelectionMode = SelectionMode.Single,
+				ItemTemplate = new DataTemplate(() =>
+				{
+					taskAccessibilityElement = new Grid();
+					SemanticProperties.SetDescription(taskAccessibilityElement, "Survey Employees");
+					taskAccessibilityElement.Add(new Label { Text = "Survey Employees" });
+
+					var content = new Grid();
+					content.Add(taskAccessibilityElement);
+					content.Add(new CheckBox());
+
+					return new Border { Content = content };
+				})
+			};
+
+			await CreateHandlerAndAddToWindow<CollectionViewHandler2>(collectionView, async handler =>
+			{
+				await Task.Delay(100);
+
+				// Sanity check: the trait was applied while the item was selectable.
+				var platformAccessibilityElement = Assert.IsAssignableFrom<MauiView>(taskAccessibilityElement?.Handler?.PlatformView);
+
+				Assert.Equal(UIAccessibilityTrait.Button,
+					platformAccessibilityElement.AccessibilityTraits & UIAccessibilityTrait.Button);
+
+				// Switching to SelectionMode.None should clear the previously-applied trait
+				// from that exact tracked descendant, without needing a full rebind.
+				collectionView.SelectionMode = SelectionMode.None;
+
+				await Task.Delay(100);
+
+				Assert.Equal((UIAccessibilityTrait)0,
+					platformAccessibilityElement.AccessibilityTraits & UIAccessibilityTrait.Button);
+			});
+		}
+
+		[Fact]
 		public async Task CollectionViewContentRespectsMargin()
 		{
 			SetupBuilder();

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
@@ -114,6 +114,52 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact]
+		public async Task SelectableItemAppliesButtonTraitToNestedAccessibilityElement()
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler<CollectionView, CollectionViewHandler2>();
+					handlers.AddHandler<Grid, LayoutHandler>();
+					handlers.AddHandler<Border, BorderHandler>();
+					handlers.AddHandler<Label, LabelHandler>();
+					handlers.AddHandler<CheckBox, CheckBoxHandler>();
+				});
+			});
+
+			Grid taskAccessibilityElement = null;
+			var collectionView = new CollectionView
+			{
+				ItemsSource = new[] { "Survey Employees" },
+				SelectionMode = SelectionMode.Single,
+				ItemTemplate = new DataTemplate(() =>
+				{
+					taskAccessibilityElement = new Grid();
+					SemanticProperties.SetDescription(taskAccessibilityElement, "Survey Employees");
+					taskAccessibilityElement.Add(new Label { Text = "Survey Employees" });
+
+					var content = new Grid();
+					content.Add(taskAccessibilityElement);
+					content.Add(new CheckBox());
+
+					return new Border { Content = content };
+				})
+			};
+
+			await CreateHandlerAndAddToWindow<CollectionViewHandler2>(collectionView, async handler =>
+			{
+				await Task.Delay(100);
+
+				var platformAccessibilityElement = Assert.IsAssignableFrom<MauiView>(taskAccessibilityElement?.Handler?.PlatformView);
+
+				Assert.True(platformAccessibilityElement.IsAccessibilityElement);
+				Assert.Equal(UIAccessibilityTrait.Button,
+					platformAccessibilityElement.AccessibilityTraits & UIAccessibilityTrait.Button);
+			});
+		}
+
+		[Fact]
 		public async Task CollectionViewContentRespectsMargin()
 		{
 			SetupBuilder();

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
@@ -149,13 +149,58 @@ namespace Microsoft.Maui.DeviceTests
 
 			await CreateHandlerAndAddToWindow<CollectionViewHandler2>(collectionView, async handler =>
 			{
-				await Task.Delay(100);
+				await AssertHelpers.AssertEventually(() =>
+					taskAccessibilityElement?.Handler?.PlatformView is MauiView platformView &&
+					platformView.IsAccessibilityElement &&
+					(platformView.AccessibilityTraits & UIAccessibilityTrait.Button) == UIAccessibilityTrait.Button,
+					message: "The nested accessibility element was not assigned the Button trait.");
 
+				Assert.NotNull(taskAccessibilityElement);
+				Assert.NotNull(taskAccessibilityElement.Handler);
 				var platformAccessibilityElement = Assert.IsAssignableFrom<MauiView>(taskAccessibilityElement?.Handler?.PlatformView);
 
 				Assert.True(platformAccessibilityElement.IsAccessibilityElement);
 				Assert.Equal(UIAccessibilityTrait.Button,
 					platformAccessibilityElement.AccessibilityTraits & UIAccessibilityTrait.Button);
+			});
+		}
+
+		[Fact]
+		public async Task SelectableItemPreservesNativeControlAccessibilityTraits()
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler<CollectionView, CollectionViewHandler2>();
+					handlers.AddHandler<CheckBox, CheckBoxHandler>();
+				});
+			});
+
+			CheckBox checkBox = null;
+			var collectionView = new CollectionView
+			{
+				ItemsSource = new[] { "Survey Employees" },
+				SelectionMode = SelectionMode.None,
+				ItemTemplate = new DataTemplate(() => checkBox = new CheckBox())
+			};
+
+			await CreateHandlerAndAddToWindow<CollectionViewHandler2>(collectionView, async handler =>
+			{
+				await AssertHelpers.AssertEventually(() => checkBox?.Handler?.PlatformView is MauiCheckBox,
+					message: "The CheckBox item template did not create its native control.");
+
+				var platformCheckBox = Assert.IsAssignableFrom<MauiCheckBox>(checkBox.Handler.PlatformView);
+				var originalTraits = platformCheckBox.AccessibilityTraits;
+
+				collectionView.SelectionMode = SelectionMode.Single;
+
+				Assert.Equal(originalTraits, platformCheckBox.AccessibilityTraits);
+				Assert.IsAssignableFrom<UIControl>(platformCheckBox);
+
+				collectionView.SelectionMode = SelectionMode.None;
+
+				Assert.Equal(originalTraits, platformCheckBox.AccessibilityTraits);
 			});
 		}
 
@@ -195,7 +240,10 @@ namespace Microsoft.Maui.DeviceTests
 
 			await CreateHandlerAndAddToWindow<CollectionViewHandler2>(collectionView, async handler =>
 			{
-				await Task.Delay(100);
+				await AssertHelpers.AssertEventually(() =>
+					taskAccessibilityElement?.Handler?.PlatformView is MauiView platformView &&
+					(platformView.AccessibilityTraits & UIAccessibilityTrait.Button) == UIAccessibilityTrait.Button,
+					message: "The nested accessibility element was not assigned the Button trait.");
 
 				// Sanity check: the trait was applied while the item was selectable.
 				var platformAccessibilityElement = Assert.IsAssignableFrom<MauiView>(taskAccessibilityElement?.Handler?.PlatformView);
@@ -207,8 +255,70 @@ namespace Microsoft.Maui.DeviceTests
 				// from that exact tracked descendant, without needing a full rebind.
 				collectionView.SelectionMode = SelectionMode.None;
 
-				await Task.Delay(100);
+				await AssertHelpers.AssertEventually(() =>
+					(platformAccessibilityElement.AccessibilityTraits & UIAccessibilityTrait.Button) == 0,
+					message: "The Button trait was not cleared after selection was disabled.");
 
+				Assert.Equal((UIAccessibilityTrait)0,
+					platformAccessibilityElement.AccessibilityTraits & UIAccessibilityTrait.Button);
+			});
+		}
+
+		[Fact]
+		public async Task ChangingAccessibilityTargetClearsButtonTraitFromPreviouslyTargetedElement()
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler<CollectionView, CollectionViewHandler2>();
+					handlers.AddHandler<Grid, LayoutHandler>();
+					handlers.AddHandler<Label, LabelHandler>();
+				});
+			});
+
+			Grid taskAccessibilityElement = null;
+			var collectionView = new CollectionView
+			{
+				ItemsSource = new[] { "Survey Employees" },
+				SelectionMode = SelectionMode.Single,
+				ItemTemplate = new DataTemplate(() =>
+				{
+					taskAccessibilityElement = new Grid();
+					SemanticProperties.SetDescription(taskAccessibilityElement, "Survey Employees");
+					taskAccessibilityElement.Add(new Label { Text = "Survey Employees" });
+
+					return taskAccessibilityElement;
+				})
+			};
+
+			await CreateHandlerAndAddToWindow<CollectionViewHandler2>(collectionView, async handler =>
+			{
+				await AssertHelpers.AssertEventually(() =>
+					taskAccessibilityElement?.Handler?.PlatformView is MauiView platformView &&
+					platformView.IsAccessibilityElement &&
+					(platformView.AccessibilityTraits & UIAccessibilityTrait.Button) == UIAccessibilityTrait.Button,
+					message: "The initial accessibility target was not assigned the Button trait.");
+
+				var platformAccessibilityElement = Assert.IsAssignableFrom<MauiView>(taskAccessibilityElement?.Handler?.PlatformView);
+				Assert.True(platformAccessibilityElement.IsAccessibilityElement);
+				Assert.Equal(UIAccessibilityTrait.Button,
+					platformAccessibilityElement.AccessibilityTraits & UIAccessibilityTrait.Button);
+
+				// Demote the layout so target discovery moves to its child label, then clear
+				// selection before promoting the original layout again.
+				SemanticProperties.SetDescription(taskAccessibilityElement, null);
+				Assert.False(platformAccessibilityElement.IsAccessibilityElement);
+
+				collectionView.SelectionMode = SelectionMode.None;
+				SemanticProperties.SetDescription(taskAccessibilityElement, "Survey Employees");
+
+				await AssertHelpers.AssertEventually(() =>
+					platformAccessibilityElement.IsAccessibilityElement &&
+					(platformAccessibilityElement.AccessibilityTraits & UIAccessibilityTrait.Button) == 0,
+					message: "The promoted non-selectable element retained the Button trait.");
+
+				Assert.True(platformAccessibilityElement.IsAccessibilityElement);
 				Assert.Equal((UIAccessibilityTrait)0,
 					platformAccessibilityElement.AccessibilityTraits & UIAccessibilityTrait.Button);
 			});

--- a/src/TestUtils/src/DeviceTests.Runners/VisualRunner/Pages/TestResultPage.xaml
+++ b/src/TestUtils/src/DeviceTests.Runners/VisualRunner/Pages/TestResultPage.xaml
@@ -6,30 +6,40 @@
              Title="Test Result">
 
     <ScrollView>
-        <StackLayout Spacing="10" Padding="20">
-            <Label Text="{Binding TestCase.DisplayName}" FontAttributes="Bold" />
+        <StackLayout Spacing="10"
+                Padding="20">
+            <Label Text="{Binding TestCase.DisplayName}"
+                    FontAttributes="Bold"/>
 
-            <Label Text="{Binding TestCase.Message}" TextColor="{Binding TestCase.RunStatus, Converter={StaticResource RunStatusToColorConverter}}" />
+            <Label Text="{Binding TestCase.Message}"
+                    TextColor="{Binding TestCase.RunStatus, Converter={StaticResource RunStatusToColorConverter}}"/>
 
-            <Frame IsVisible="{Binding HasOutput}" Padding="10" HasShadow="False" BorderColor="DarkGray" CornerRadius="5" Margin="0,10">
+            <Border IsVisible="{Binding HasOutput}"
+                    Padding="10"
+                    Stroke="DarkGray"
+                    StrokeShape="RoundRectangle 5"
+                    Margin="0,10">
                 <StackLayout Spacing="5">
-                    <Label Text="Test Output" FontAttributes="Bold" />
-                    <Label Text="{Binding Output}" />
+                    <Label Text="Test Output"
+                            FontAttributes="Bold"/>
+                    <Label Text="{Binding Output}"/>
                 </StackLayout>
-            </Frame>
+            </Border>
 
             <Image Source="{Binding ErrorImage}"></Image>
-            
-            <Label Text="{Binding ErrorMessage}" FontAttributes="Bold" x:Name="ErrorMessage" />
+
+            <Label Text="{Binding ErrorMessage}"
+                    FontAttributes="Bold"
+                    x:Name="ErrorMessage"/>
             <Label Text="{Binding ErrorStackTrace}"
-                   x:Name="ErrorTrace" />
+                   x:Name="ErrorTrace"/>
 
             <HorizontalStackLayout Spacing="5">
                 <Button Text="Copy Message"
-                        x:Name="CopyMessage" />
+                        x:Name="CopyMessage"/>
 
                 <Button Text="Copy StackTrace"
-                        x:Name="CopyTrace" />
+                        x:Name="CopyTrace"/>
             </HorizontalStackLayout>
         </StackLayout>
     </ScrollView>

--- a/src/TestUtils/src/DeviceTests.Runners/VisualRunner/Pages/TestResultPage.xaml
+++ b/src/TestUtils/src/DeviceTests.Runners/VisualRunner/Pages/TestResultPage.xaml
@@ -6,40 +6,30 @@
              Title="Test Result">
 
     <ScrollView>
-        <StackLayout Spacing="10"
-                Padding="20">
-            <Label Text="{Binding TestCase.DisplayName}"
-                    FontAttributes="Bold"/>
+        <StackLayout Spacing="10" Padding="20">
+            <Label Text="{Binding TestCase.DisplayName}" FontAttributes="Bold" />
 
-            <Label Text="{Binding TestCase.Message}"
-                    TextColor="{Binding TestCase.RunStatus, Converter={StaticResource RunStatusToColorConverter}}"/>
+            <Label Text="{Binding TestCase.Message}" TextColor="{Binding TestCase.RunStatus, Converter={StaticResource RunStatusToColorConverter}}" />
 
-            <Border IsVisible="{Binding HasOutput}"
-                    Padding="10"
-                    Stroke="DarkGray"
-                    StrokeShape="RoundRectangle 5"
-                    Margin="0,10">
+            <Frame IsVisible="{Binding HasOutput}" Padding="10" HasShadow="False" BorderColor="DarkGray" CornerRadius="5" Margin="0,10">
                 <StackLayout Spacing="5">
-                    <Label Text="Test Output"
-                            FontAttributes="Bold"/>
-                    <Label Text="{Binding Output}"/>
+                    <Label Text="Test Output" FontAttributes="Bold" />
+                    <Label Text="{Binding Output}" />
                 </StackLayout>
-            </Border>
+            </Frame>
 
             <Image Source="{Binding ErrorImage}"></Image>
-
-            <Label Text="{Binding ErrorMessage}"
-                    FontAttributes="Bold"
-                    x:Name="ErrorMessage"/>
+            
+            <Label Text="{Binding ErrorMessage}" FontAttributes="Bold" x:Name="ErrorMessage" />
             <Label Text="{Binding ErrorStackTrace}"
-                   x:Name="ErrorTrace"/>
+                   x:Name="ErrorTrace" />
 
             <HorizontalStackLayout Spacing="5">
                 <Button Text="Copy Message"
-                        x:Name="CopyMessage"/>
+                        x:Name="CopyMessage" />
 
                 <Button Text="Copy StackTrace"
-                        x:Name="CopyTrace"/>
+                        x:Name="CopyTrace" />
             </HorizontalStackLayout>
         </StackLayout>
     </ScrollView>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Detail
On Mac Catalyst, VoiceOver announces selectable task items in a CollectionView only by name, without an actionable role. Although users can activate the item with Control + Option + Space, they are not informed that it is interactive. VoiceOver should announce an appropriate role, such as “button,” for selectable items.


### Root Cause

- On iOS/MacCatalyst, VoiceOver announced only a CollectionView item's text and did not announce its role/interactivity (for example, "Button"), even when SelectionMode made the item selectable.
- UpdateAccessibilityTraits unconditionally applied UIAccessibilityTrait.Button to the cell's first templated child view. When that child was a non-accessible container, such as a Grid or Border wrapping a Label, the trait was applied to a view that VoiceOver did not use as the accessibility element. 
- The nested descendant that was actually exposed to VoiceOver (IsAccessibilityElement == true) never received the trait, so VoiceOver announced only the item's text without indicating that it was selectable/interactable.

### Description of Change

- The fix changes the trait assignment to recursively search the first templated child’s view hierarchy for the first view with IsAccessibilityElement == true. The UIAccessibilityTrait.Button trait is then applied directly to that accessibility element.
- The search intentionally does not descend into UIControl subtrees. This preserves the native accessibility roles of controls such as UIButton, UITextField, and UISwitch, rather than overriding their existing accessibility behavior.
- For selectable items, the button trait is added to the discovered accessibility element. When SelectionMode.None is used, the trait is removed.
- This ensures that the trait is applied to the same native view that VoiceOver uses as the accessibility target. Consequently, VoiceOver correctly announces both the item's content and its interactive role, for example, “Survey Employees, Button.”

### Validated the behaviour in the following platforms
- [ ] Android
- [ ] Windows
- [ ] iOS
- [x] Mac

### Issues Fixed:
Fixes #37140 

### Screenshots
| Before  | After |
|---------|--------|
| <video src="https://github.com/user-attachments/assets/9b00bcc3-bb31-49f6-9f97-1fd0f3891d5a"> | <video src="https://github.com/user-attachments/assets/93426da3-564b-46dd-b5f8-60adfedb195d"> |