### PR TITLE
[Android] Fix Screenshot.CaptureAsync deadlock for synchronous UI-thread callers

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue37638.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue37638.cs
@@ -1,0 +1,68 @@
+using Microsoft.Maui.Media;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 37638, "Screenshot.CaptureAsync deadlocks when awaited synchronously from the UI thread", PlatformAffected.Android)]
+public class Issue37638 : ContentPage
+{
+	readonly Label _statusLabel;
+
+	public Issue37638()
+	{
+		_statusLabel = new Label
+		{
+			Text = "Ready",
+			AutomationId = "StatusLabel",
+		};
+
+		var captureButton = new Button
+		{
+			Text = "Generate error",
+			AutomationId = "GenerateErrorButton",
+		};
+		captureButton.Clicked += OnGenerateErrorClicked;
+
+		Content = new VerticalStackLayout
+		{
+			Padding = 30,
+			Spacing = 20,
+			Children =
+			{
+				captureButton,
+				_statusLabel,
+				new Editor
+				{
+					Placeholder = "Check if app still responds",
+					AutomationId = "ResponsivenessEditor",
+				},
+			},
+		};
+	}
+
+	void OnGenerateErrorClicked(object sender, EventArgs e)
+	{
+		CaptureTestException();
+	}
+
+	void CaptureTestException()
+	{
+		try
+		{
+			throw new InvalidOperationException("Screenshot deadlock test");
+		}
+		catch (Exception ex)
+		{
+			_statusLabel.Text = $"Capturing error: {ex.Message}";
+			string eventId = CaptureException(ex);
+			_statusLabel.Text = $"Error captured: {eventId}";
+		}
+	}
+
+	static string CaptureException(Exception exception)
+	{
+		_ = exception ?? throw new ArgumentNullException(nameof(exception));
+
+		var screenshot = Screenshot.Default.CaptureAsync().GetAwaiter().GetResult();
+		return screenshot is null ? string.Empty : Guid.NewGuid().ToString("N");
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue37638.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue37638.cs
@@ -1,0 +1,29 @@
+#if ANDROID
+// Reproduces the Android only PixelCopy deadlock triggered by Sentry's synchronous screenshot attachment without adding the third-party SDK to the shared HostApp.
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue37638 : _IssuesUITest
+{
+	public Issue37638(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue =>
+		"Screenshot.CaptureAsync deadlocks when awaited synchronously from the UI thread";
+
+	[Test]
+	[Category(UITestCategories.Essentials)]
+	public void GenerateErrorIsCapturedWithoutDeadlockingUIThread()
+	{
+		App.WaitForElement("GenerateErrorButton");
+		App.Tap("GenerateErrorButton");
+		Assert.That(
+			App.WaitForTextToBePresentInElement("StatusLabel", "Error captured"),
+			Is.True);
+	}
+}
+#endif

--- a/src/Essentials/src/Screenshot/Screenshot.android.cs
+++ b/src/Essentials/src/Screenshot/Screenshot.android.cs
@@ -3,6 +3,7 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Android.App;
 using Android.Content;
@@ -16,6 +17,9 @@ namespace Microsoft.Maui.Media
 {
 	partial class ScreenshotImplementation : IPlatformScreenshot, IScreenshot
 	{
+		static readonly Lazy<Handler> PixelCopyCallbackHandler =
+			new(CreatePixelCopyCallbackHandler, LazyThreadSafetyMode.ExecutionAndPublication);
+
 		static IWindowManager? WindowManager =>
 			Application.Context.GetSystemService(Context.WindowService) as IWindowManager;
 
@@ -60,10 +64,14 @@ namespace Microsoft.Maui.Media
 		{
 			if (OperatingSystem.IsAndroidVersionAtLeast(26))
 			{
-				var bitmap = await RenderUsingPixelCopyAsync(view, window);
+				var bitmap = await RenderUsingPixelCopyAsync(view, window).ConfigureAwait(false);
 				if (bitmap is not null)
 					return bitmap;
 			}
+
+			// View fallbacks require the UI thread; dispatching could deadlock if a synchronous caller is blocking it.
+			if (!MainThread.IsMainThread)
+				return null;
 
 			return RenderUsingCanvasDrawing(view) ?? RenderUsingDrawingCache(view);
 		}
@@ -93,13 +101,11 @@ namespace Microsoft.Maui.Media
 			try
 			{
 				var listener = new PixelCopyFinishedListener(tcs, bitmap);
-				PixelCopy.Request(window, rect, bitmap,
-					listener,
-					new Handler(Looper.MainLooper!));
+				PixelCopy.Request(window, rect, bitmap, listener, PixelCopyCallbackHandler.Value);
 
 				try
 				{
-					return await tcs.Task.ConfigureAwait(true);
+					return await tcs.Task.ConfigureAwait(false);
 				}
 				finally
 				{
@@ -111,6 +117,17 @@ namespace Microsoft.Maui.Media
 				bitmap.Dispose();
 				return null;
 			}
+		}
+
+		static Handler CreatePixelCopyCallbackHandler()
+		{
+			var thread = new HandlerThread("Microsoft.Maui.Screenshot.PixelCopy");
+			thread.Start();
+
+			var looper = thread.Looper
+				?? throw new InvalidOperationException("Unable to create the PixelCopy callback looper.");
+
+			return new Handler(looper);
 		}
 
 		static Activity? GetActivity(Context? context)

--- a/src/Essentials/src/Screenshot/Screenshot.android.cs
+++ b/src/Essentials/src/Screenshot/Screenshot.android.cs
@@ -67,11 +67,11 @@ namespace Microsoft.Maui.Media
 				var bitmap = await RenderUsingPixelCopyAsync(view, window).ConfigureAwait(false);
 				if (bitmap is not null)
 					return bitmap;
-			}
 
-			// View fallbacks require the UI thread; dispatching could deadlock if a synchronous caller is blocking it.
-			if (!MainThread.IsMainThread)
-				return null;
+				// PixelCopy may complete off the UI thread, where view-based fallbacks are unsafe.
+				if (!MainThread.IsMainThread)
+					return null;
+			}
 
 			return RenderUsingCanvasDrawing(view) ?? RenderUsingDrawingCache(view);
 		}


### PR DESCRIPTION
 <!-- Please let the below note in for people that find this PR -->
   > [!NOTE]
   > Are you waiting for the changes in this PR to be merged?
   > It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue.

### Root Cause

The regression was introduced when Android screenshot capture switched from synchronous Canvas rendering to asynchronous `PixelCopy` to support hardware-rendered content such as WebView.  #35384 

`PixelCopy` delivered its completion callback on `Looper.MainLooper`, while Sentry synchronously waited for `Screenshot.Default.CaptureAsync().GetAwaiter().GetResult()` on the UI thread. This created a circular dependency: the UI thread blocked waiting for the screenshot task, and the `PixelCopy` callback could not execute because it also required the UI thread, resulting in a deadlock.

### Description of Change

The fix retains `PixelCopy` but moves its completion callback from `Looper.MainLooper` to a shared, process-wide `HandlerThread`, allowing the screenshot task to complete even when the UI thread is synchronously blocked.

Additionally, the internal await chain now uses `ConfigureAwait(false)` to avoid resuming on the UI thread. The legacy Canvas/DrawingCache fallback is guarded to run only on the main thread; if `PixelCopy` fails asynchronously on a worker thread, screenshot capture safely returns failure instead of risking off-thread Android View access or recreating the deadlock.

### Regressed By
#35384 

### Issues Fixed

Fixes #37638 

### Platforms Tested

- [ ] iOS
- [ ] MacCatalyst
- [x] Android
- [ ] Windows 

### Note
The regression test is **Android-only** because the deadlock originates in Android’s PixelCopy callback and main-looper implementation. Other platforms use different screenshot implementations and cannot exercise this code path. The test models Sentry’s relevant synchronous behavior directly to avoid adding a third-party dependency to the shared HostApp.

### Screenshots

| Before Issue Fix | After Issue Fix |
|------------------|-----------------|
| <video width="350" alt="withoutfix" src="https://github.com/user-attachments/assets/72e74130-9f1b-4751-8d36-a777f3fc256c" /> | <video width="350" alt="withfix" src="https://github.com/user-attachments/assets/d4e9c8d2-cfa5-4f03-a8cc-f67fd5fa004f" /> |