### PR TITLE
[ci] Fix empty conditional block breaking internal pipeline YAML

### DIFF
--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -78,6 +78,3 @@ variables:
     - group: DotNet-HelixApi-Access
     - group: SDL_Settings
     - group: AzureDevOps-Artifact-Feeds-Pats
-    - ${{ if eq(variables['Build.DefinitionName'], 'dotnet-maui') }}:
-
-


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Problem

The internal `dotnet-maui` official build currently fails to compile the pipeline YAML, before any stage runs:

```
/eng/pipelines/common/variables.yml (Line: 81, Col: 7): Expected at least one key-value pair in the mapping
```

### Cause

#37589 removed `- group: Publish-Build-Assets`, but that group was the only child of the conditional that enclosed it, leaving an empty block behind:

```yaml
    - group: AzureDevOps-Artifact-Feeds-Pats
    - ${{ if eq(variables['Build.DefinitionName'], 'dotnet-maui') }}:   # <- nothing under it
```

Azure DevOps requires a conditional insertion block to contain at least one entry, so template expansion fails outright.

### Why PR validation stayed green

The empty block is nested inside an outer guard:

```yaml
- ${{ if or(eq(variables['Build.DefinitionName'], 'dotnet-maui'), eq(variables['Build.DefinitionName'], 'dotnet-maui-build')) }}:
  - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
```

For the public `maui-pr` definition that outer condition is false, so Azure DevOps short-circuits and never expands the inner block. The breakage is therefore invisible to PR CI and only manifests on the internal official build.

### Fix

Remove the empty conditional. No file in the repository references the `Publish-Build-Assets` variable group any more, so it is deleted outright rather than repopulated.

### Validation

- `eng/pipelines/common/variables.yml` parses as valid YAML.
- Swept all 39 YAML files under `eng/pipelines/` for conditional blocks with no body — this was the only one.
- `grep` for `Publish-Build-Assets` across `eng/` and `.github/` returns no remaining references.

This blocks the internal build entirely, so it is worth merging ahead of larger infra work such as #36257 (which carries the same one-line fix, but cannot be validated on the internal pipeline until this is on `main`).
