### PR TITLE
[Net12] Shell: Add static query parameters to ShellContent

### DIFF
--- a/docs/specs/shell-content-query-parameters.md
+++ b/docs/specs/shell-content-query-parameters.md
@@ -52,16 +52,24 @@ or uniqueness.
   again reapplies its declarative parameters.
 - `QueryString` values are URI-decoded once. Both declarative forms use invariant
   conversion when assigned through `QueryPropertyAttribute`; structured values retain
-  their original CLR type when no conversion is required.
+  their original CLR type when no conversion is required. Existing `Shell.GoToAsync`
+  navigation keeps its historical decoding and current-culture conversion behavior for
+  compatibility, so moving identical encoded text into `QueryString` can produce a
+  different result.
 - When names are duplicated, the last parameter in collection order wins. Removing or
   replacing it reveals the preceding value, if one exists.
 - Parameters are applied on initial selection and whenever the user switches back to the
   content. Created pages are reused according to normal `ShellContent` lifecycle behavior.
 - Changes to the collection, a parameter name, or a parameter value update the selected
   content immediately. Changes to inactive content are applied when it is next selected.
-- Parameter objects inherit the `ShellContent` binding context, so `Name` and `Value` can use
-  bindings. Removed and replaced objects are detached from that inherited context and no
-  longer observed.
+- Parameter objects are logical children of `ShellContent`. `Name` and `Value` support
+  inherited binding contexts, dynamic resources, relative-source ancestor bindings, and
+  parent-scoped XAML references. Removed and replaced objects leave the logical tree and
+  are no longer observed.
+- The same parameter instance can appear more than once within one collection and remains
+  attached until its final occurrence is removed. It cannot be shared across different
+  `ShellContent` owners; adding an already-parented instance to another owner's collection
+  throws before that collection changes.
 - Parameters passed explicitly to `Shell.GoToAsync` take precedence over declarative parameters
   with the same name for that navigation. Content parameters supply values for keys not present
   in the navigation data, and are reapplied when the content is selected again.

--- a/docs/specs/shell-content-query-parameters.md
+++ b/docs/specs/shell-content-query-parameters.md
@@ -47,9 +47,10 @@ or uniqueness.
 
 - Names are case-sensitive. Parameters with null or empty names are ignored.
 - Null values are delivered as values rather than treated as removal.
-- Parameters supplied to `Shell.GoToAsync` take precedence over structured parameters,
-  which take precedence over `QueryString`.
-- `QueryString` values use URI query decoding. Both declarative forms use invariant
+- During a navigation, parameters supplied to `Shell.GoToAsync` take precedence over
+  structured parameters, which take precedence over `QueryString`. Selecting the content
+  again reapplies its declarative parameters.
+- `QueryString` values are URI-decoded once. Both declarative forms use invariant
   conversion when assigned through `QueryPropertyAttribute`; structured values retain
   their original CLR type when no conversion is required.
 - When names are duplicated, the last parameter in collection order wins. Removing or
@@ -61,7 +62,7 @@ or uniqueness.
 - Parameter objects inherit the `ShellContent` binding context, so `Name` and `Value` can use
   bindings. Removed and replaced objects are detached from that inherited context and no
   longer observed.
-- Parameters passed explicitly to `Shell.GoToAsync` take precedence over content parameters
-  with the same name. Content parameters supply values for keys not present in the navigation
-  data.
+- Parameters passed explicitly to `Shell.GoToAsync` take precedence over declarative parameters
+  with the same name for that navigation. Content parameters supply values for keys not present
+  in the navigation data, and are reapplied when the content is selected again.
 - Exceptions raised by the target's query handling are propagated unchanged.

--- a/docs/specs/shell-content-query-parameters.md
+++ b/docs/specs/shell-content-query-parameters.md
@@ -1,0 +1,47 @@
+# ShellContent query parameters
+
+`ShellContent.QueryParameters` supplies instance-specific data to the page created by a
+`ShellContent`, including when users select tabs or flyout items without calling
+`Shell.GoToAsync`.
+
+```xaml
+<Tab Title="Reminders">
+    <ShellContent Title="Yesterday"
+                  ContentTemplate="{DataTemplate pages:ReminderPage}">
+        <ShellContent.QueryParameters>
+            <ShellContentQueryParameter Name="date"
+                                        Value="{Binding Yesterday}" />
+        </ShellContent.QueryParameters>
+    </ShellContent>
+    <ShellContent Title="Today"
+                  ContentTemplate="{DataTemplate pages:ReminderPage}">
+        <ShellContent.QueryParameters>
+            <ShellContentQueryParameter Name="date"
+                                        Value="{Binding Today}" />
+        </ShellContent.QueryParameters>
+    </ShellContent>
+</Tab>
+```
+
+The page receives these values through the existing `IQueryAttributable` and
+`QueryPropertyAttribute` mechanisms. The route continues to identify the navigation
+destination; query parameters are instance data and don't participate in route registration
+or uniqueness.
+
+## Behavior
+
+- Names are case-sensitive. Parameters with null or empty names are ignored.
+- Null values are delivered as values rather than treated as removal.
+- When names are duplicated, the last parameter in collection order wins. Removing or
+  replacing it reveals the preceding value, if one exists.
+- Parameters are applied on initial selection and whenever the user switches back to the
+  content. Created pages are reused according to normal `ShellContent` lifecycle behavior.
+- Changes to the collection, a parameter name, or a parameter value update the selected
+  content immediately. Changes to inactive content are applied when it is next selected.
+- Parameter objects inherit the `ShellContent` binding context, so `Name` and `Value` can use
+  bindings. Removed and replaced objects are detached from that inherited context and no
+  longer observed.
+- Parameters passed explicitly to `Shell.GoToAsync` take precedence over content parameters
+  with the same name. Content parameters supply values for keys not present in the navigation
+  data.
+- Exceptions raised by the target's query handling are propagated unchanged.

--- a/docs/specs/shell-content-query-parameters.md
+++ b/docs/specs/shell-content-query-parameters.md
@@ -4,6 +4,21 @@
 `ShellContent`, including when users select tabs or flyout items without calling
 `Shell.GoToAsync`.
 
+For string-only parameters, `QueryString` provides compact URI query syntax:
+
+```xaml
+<ShellContent Title="Yesterday"
+              Route="reminders-yesterday"
+              QueryString="date=2021-12-13"
+              ContentTemplate="{DataTemplate pages:ReminderPage}" />
+```
+
+The leading `?` is optional. Standard URI query escaping applies, so `&` must be written
+as `&amp;` when multiple parameters are declared in an XML attribute.
+
+Use the structured collection when values need individual bindings, non-string objects,
+or explicit nulls:
+
 ```xaml
 <Tab Title="Reminders">
     <ShellContent Title="Yesterday"
@@ -32,6 +47,11 @@ or uniqueness.
 
 - Names are case-sensitive. Parameters with null or empty names are ignored.
 - Null values are delivered as values rather than treated as removal.
+- Parameters supplied to `Shell.GoToAsync` take precedence over structured parameters,
+  which take precedence over `QueryString`.
+- `QueryString` values use URI query decoding. Both declarative forms use invariant
+  conversion when assigned through `QueryPropertyAttribute`; structured values retain
+  their original CLR type when no conversion is required.
 - When names are duplicated, the last parameter in collection order wins. Removing or
   replacing it reveals the preceding value, if one exists.
 - Parameters are applied on initial selection and whenever the user switches back to the

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -256,6 +256,8 @@ virtual Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutTemplatedConte
 ~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(string key, System.Func<object> factory, bool shared = true) -> void
 ~Microsoft.Maui.Controls.ShellAppearance.Background.get -> Microsoft.Maui.Controls.Brush
 ~Microsoft.Maui.Controls.ShellContent.QueryParameters.get -> System.Collections.Generic.IList<Microsoft.Maui.Controls.ShellContentQueryParameter>
+Microsoft.Maui.Controls.ShellContent.QueryString.get -> string?
+Microsoft.Maui.Controls.ShellContent.QueryString.set -> void
 Microsoft.Maui.Controls.ShellContentQueryParameter
 Microsoft.Maui.Controls.ShellContentQueryParameter.Name.get -> string?
 Microsoft.Maui.Controls.ShellContentQueryParameter.Name.set -> void
@@ -308,6 +310,7 @@ Microsoft.Maui.Controls.ShellContentQueryParameter.Value.set -> void
 ~static readonly Microsoft.Maui.Controls.Shell.BackgroundProperty -> Microsoft.Maui.Controls.BindableProperty
 static readonly Microsoft.Maui.Controls.ShellContentQueryParameter.NameProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.ShellContentQueryParameter.ValueProperty -> Microsoft.Maui.Controls.BindableProperty!
+~static readonly Microsoft.Maui.Controls.ShellContent.QueryStringProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -255,6 +255,13 @@ virtual Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutTemplatedConte
 ~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(System.Type targetType, System.Func<Microsoft.Maui.Controls.Style> factory, bool shared = true) -> void
 ~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(string key, System.Func<object> factory, bool shared = true) -> void
 ~Microsoft.Maui.Controls.ShellAppearance.Background.get -> Microsoft.Maui.Controls.Brush
+~Microsoft.Maui.Controls.ShellContent.QueryParameters.get -> System.Collections.Generic.IList<Microsoft.Maui.Controls.ShellContentQueryParameter>
+Microsoft.Maui.Controls.ShellContentQueryParameter
+Microsoft.Maui.Controls.ShellContentQueryParameter.Name.get -> string?
+Microsoft.Maui.Controls.ShellContentQueryParameter.Name.set -> void
+Microsoft.Maui.Controls.ShellContentQueryParameter.ShellContentQueryParameter() -> void
+Microsoft.Maui.Controls.ShellContentQueryParameter.Value.get -> object?
+Microsoft.Maui.Controls.ShellContentQueryParameter.Value.set -> void
 ~Microsoft.Maui.Controls.Toolbar.BackButtonAccessibilityLabel.get -> string
 ~Microsoft.Maui.Controls.Toolbar.BackButtonAccessibilityLabel.set -> void
 ~Microsoft.Maui.Controls.ToolbarItem.BadgeColor.get -> Microsoft.Maui.Graphics.Color
@@ -299,6 +306,8 @@ virtual Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutTemplatedConte
 ~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.NavigationPage.BackButtonAccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.Shell.BackgroundProperty -> Microsoft.Maui.Controls.BindableProperty
+static readonly Microsoft.Maui.Controls.ShellContentQueryParameter.NameProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.ShellContentQueryParameter.ValueProperty -> Microsoft.Maui.Controls.BindableProperty!
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -180,6 +180,8 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(string key, System.Func<object> factory, bool shared = true) -> void
 ~Microsoft.Maui.Controls.ShellAppearance.Background.get -> Microsoft.Maui.Controls.Brush
 ~Microsoft.Maui.Controls.ShellContent.QueryParameters.get -> System.Collections.Generic.IList<Microsoft.Maui.Controls.ShellContentQueryParameter>
+Microsoft.Maui.Controls.ShellContent.QueryString.get -> string?
+Microsoft.Maui.Controls.ShellContent.QueryString.set -> void
 Microsoft.Maui.Controls.ShellContentQueryParameter
 Microsoft.Maui.Controls.ShellContentQueryParameter.Name.get -> string?
 Microsoft.Maui.Controls.ShellContentQueryParameter.Name.set -> void
@@ -230,6 +232,7 @@ Microsoft.Maui.Controls.ShellContentQueryParameter.Value.set -> void
 ~static readonly Microsoft.Maui.Controls.Shell.BackgroundProperty -> Microsoft.Maui.Controls.BindableProperty
 static readonly Microsoft.Maui.Controls.ShellContentQueryParameter.NameProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.ShellContentQueryParameter.ValueProperty -> Microsoft.Maui.Controls.BindableProperty!
+~static readonly Microsoft.Maui.Controls.ShellContent.QueryStringProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -179,6 +179,13 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(System.Type targetType, System.Func<Microsoft.Maui.Controls.Style> factory, bool shared = true) -> void
 ~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(string key, System.Func<object> factory, bool shared = true) -> void
 ~Microsoft.Maui.Controls.ShellAppearance.Background.get -> Microsoft.Maui.Controls.Brush
+~Microsoft.Maui.Controls.ShellContent.QueryParameters.get -> System.Collections.Generic.IList<Microsoft.Maui.Controls.ShellContentQueryParameter>
+Microsoft.Maui.Controls.ShellContentQueryParameter
+Microsoft.Maui.Controls.ShellContentQueryParameter.Name.get -> string?
+Microsoft.Maui.Controls.ShellContentQueryParameter.Name.set -> void
+Microsoft.Maui.Controls.ShellContentQueryParameter.ShellContentQueryParameter() -> void
+Microsoft.Maui.Controls.ShellContentQueryParameter.Value.get -> object?
+Microsoft.Maui.Controls.ShellContentQueryParameter.Value.set -> void
 ~Microsoft.Maui.Controls.Toolbar.BackButtonAccessibilityLabel.get -> string
 ~Microsoft.Maui.Controls.Toolbar.BackButtonAccessibilityLabel.set -> void
 ~Microsoft.Maui.Controls.ToolbarItem.BadgeColor.get -> Microsoft.Maui.Graphics.Color
@@ -221,6 +228,8 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.NavigationPage.BackButtonAccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.Shell.BackgroundProperty -> Microsoft.Maui.Controls.BindableProperty
+static readonly Microsoft.Maui.Controls.ShellContentQueryParameter.NameProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.ShellContentQueryParameter.ValueProperty -> Microsoft.Maui.Controls.BindableProperty!
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -179,6 +179,8 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(string key, System.Func<object> factory, bool shared = true) -> void
 ~Microsoft.Maui.Controls.ShellAppearance.Background.get -> Microsoft.Maui.Controls.Brush
 ~Microsoft.Maui.Controls.ShellContent.QueryParameters.get -> System.Collections.Generic.IList<Microsoft.Maui.Controls.ShellContentQueryParameter>
+Microsoft.Maui.Controls.ShellContent.QueryString.get -> string?
+Microsoft.Maui.Controls.ShellContent.QueryString.set -> void
 Microsoft.Maui.Controls.ShellContentQueryParameter
 Microsoft.Maui.Controls.ShellContentQueryParameter.Name.get -> string?
 Microsoft.Maui.Controls.ShellContentQueryParameter.Name.set -> void
@@ -222,6 +224,7 @@ Microsoft.Maui.Controls.ShellContentQueryParameter.Value.set -> void
 ~static readonly Microsoft.Maui.Controls.Shell.BackgroundProperty -> Microsoft.Maui.Controls.BindableProperty
 static readonly Microsoft.Maui.Controls.ShellContentQueryParameter.NameProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.ShellContentQueryParameter.ValueProperty -> Microsoft.Maui.Controls.BindableProperty!
+~static readonly Microsoft.Maui.Controls.ShellContent.QueryStringProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -178,6 +178,13 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(System.Type targetType, System.Func<Microsoft.Maui.Controls.Style> factory, bool shared = true) -> void
 ~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(string key, System.Func<object> factory, bool shared = true) -> void
 ~Microsoft.Maui.Controls.ShellAppearance.Background.get -> Microsoft.Maui.Controls.Brush
+~Microsoft.Maui.Controls.ShellContent.QueryParameters.get -> System.Collections.Generic.IList<Microsoft.Maui.Controls.ShellContentQueryParameter>
+Microsoft.Maui.Controls.ShellContentQueryParameter
+Microsoft.Maui.Controls.ShellContentQueryParameter.Name.get -> string?
+Microsoft.Maui.Controls.ShellContentQueryParameter.Name.set -> void
+Microsoft.Maui.Controls.ShellContentQueryParameter.ShellContentQueryParameter() -> void
+Microsoft.Maui.Controls.ShellContentQueryParameter.Value.get -> object?
+Microsoft.Maui.Controls.ShellContentQueryParameter.Value.set -> void
 ~Microsoft.Maui.Controls.Toolbar.BackButtonAccessibilityLabel.get -> string
 ~Microsoft.Maui.Controls.Toolbar.BackButtonAccessibilityLabel.set -> void
 ~Microsoft.Maui.Controls.ToolbarItem.BadgeColor.get -> Microsoft.Maui.Graphics.Color
@@ -213,6 +220,8 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.NavigationPage.BackButtonAccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.Shell.BackgroundProperty -> Microsoft.Maui.Controls.BindableProperty
+static readonly Microsoft.Maui.Controls.ShellContentQueryParameter.NameProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.ShellContentQueryParameter.ValueProperty -> Microsoft.Maui.Controls.BindableProperty!
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -128,9 +128,18 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
 ~Microsoft.Maui.Controls.ShellAppearance.Background.get -> Microsoft.Maui.Controls.Brush
+~Microsoft.Maui.Controls.ShellContent.QueryParameters.get -> System.Collections.Generic.IList<Microsoft.Maui.Controls.ShellContentQueryParameter>
+Microsoft.Maui.Controls.ShellContentQueryParameter
+Microsoft.Maui.Controls.ShellContentQueryParameter.Name.get -> string?
+Microsoft.Maui.Controls.ShellContentQueryParameter.Name.set -> void
+Microsoft.Maui.Controls.ShellContentQueryParameter.ShellContentQueryParameter() -> void
+Microsoft.Maui.Controls.ShellContentQueryParameter.Value.get -> object?
+Microsoft.Maui.Controls.ShellContentQueryParameter.Value.set -> void
 ~static Microsoft.Maui.Controls.Shell.GetBackground(Microsoft.Maui.Controls.BindableObject obj) -> Microsoft.Maui.Controls.Brush
 ~static Microsoft.Maui.Controls.Shell.SetBackground(Microsoft.Maui.Controls.BindableObject obj, Microsoft.Maui.Controls.Brush value) -> void
 ~static readonly Microsoft.Maui.Controls.Shell.BackgroundProperty -> Microsoft.Maui.Controls.BindableProperty
+static readonly Microsoft.Maui.Controls.ShellContentQueryParameter.NameProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.ShellContentQueryParameter.ValueProperty -> Microsoft.Maui.Controls.BindableProperty!
 override Microsoft.Maui.Controls.BindablePropertyConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
 override Microsoft.Maui.Controls.BindablePropertyConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type? destinationType) -> bool
 override Microsoft.Maui.Controls.BindablePropertyConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object?

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -129,6 +129,8 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
 ~Microsoft.Maui.Controls.ShellAppearance.Background.get -> Microsoft.Maui.Controls.Brush
 ~Microsoft.Maui.Controls.ShellContent.QueryParameters.get -> System.Collections.Generic.IList<Microsoft.Maui.Controls.ShellContentQueryParameter>
+Microsoft.Maui.Controls.ShellContent.QueryString.get -> string?
+Microsoft.Maui.Controls.ShellContent.QueryString.set -> void
 Microsoft.Maui.Controls.ShellContentQueryParameter
 Microsoft.Maui.Controls.ShellContentQueryParameter.Name.get -> string?
 Microsoft.Maui.Controls.ShellContentQueryParameter.Name.set -> void
@@ -140,6 +142,7 @@ Microsoft.Maui.Controls.ShellContentQueryParameter.Value.set -> void
 ~static readonly Microsoft.Maui.Controls.Shell.BackgroundProperty -> Microsoft.Maui.Controls.BindableProperty
 static readonly Microsoft.Maui.Controls.ShellContentQueryParameter.NameProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.ShellContentQueryParameter.ValueProperty -> Microsoft.Maui.Controls.BindableProperty!
+~static readonly Microsoft.Maui.Controls.ShellContent.QueryStringProperty -> Microsoft.Maui.Controls.BindableProperty
 override Microsoft.Maui.Controls.BindablePropertyConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
 override Microsoft.Maui.Controls.BindablePropertyConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type? destinationType) -> bool
 override Microsoft.Maui.Controls.BindablePropertyConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object?

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -175,9 +175,18 @@ virtual Microsoft.Maui.Controls.Handlers.Items2.ItemsViewHandler2<TItemsView>.Up
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
 ~Microsoft.Maui.Controls.ShellAppearance.Background.get -> Microsoft.Maui.Controls.Brush
+~Microsoft.Maui.Controls.ShellContent.QueryParameters.get -> System.Collections.Generic.IList<Microsoft.Maui.Controls.ShellContentQueryParameter>
+Microsoft.Maui.Controls.ShellContentQueryParameter
+Microsoft.Maui.Controls.ShellContentQueryParameter.Name.get -> string?
+Microsoft.Maui.Controls.ShellContentQueryParameter.Name.set -> void
+Microsoft.Maui.Controls.ShellContentQueryParameter.ShellContentQueryParameter() -> void
+Microsoft.Maui.Controls.ShellContentQueryParameter.Value.get -> object?
+Microsoft.Maui.Controls.ShellContentQueryParameter.Value.set -> void
 ~static Microsoft.Maui.Controls.Shell.GetBackground(Microsoft.Maui.Controls.BindableObject obj) -> Microsoft.Maui.Controls.Brush
 ~static Microsoft.Maui.Controls.Shell.SetBackground(Microsoft.Maui.Controls.BindableObject obj, Microsoft.Maui.Controls.Brush value) -> void
 ~static readonly Microsoft.Maui.Controls.Shell.BackgroundProperty -> Microsoft.Maui.Controls.BindableProperty
+static readonly Microsoft.Maui.Controls.ShellContentQueryParameter.NameProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.ShellContentQueryParameter.ValueProperty -> Microsoft.Maui.Controls.BindableProperty!
 override Microsoft.Maui.Controls.BindablePropertyConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
 override Microsoft.Maui.Controls.BindablePropertyConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type? destinationType) -> bool
 override Microsoft.Maui.Controls.BindablePropertyConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object?

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -176,6 +176,8 @@ virtual Microsoft.Maui.Controls.Handlers.Items2.ItemsViewHandler2<TItemsView>.Up
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
 ~Microsoft.Maui.Controls.ShellAppearance.Background.get -> Microsoft.Maui.Controls.Brush
 ~Microsoft.Maui.Controls.ShellContent.QueryParameters.get -> System.Collections.Generic.IList<Microsoft.Maui.Controls.ShellContentQueryParameter>
+Microsoft.Maui.Controls.ShellContent.QueryString.get -> string?
+Microsoft.Maui.Controls.ShellContent.QueryString.set -> void
 Microsoft.Maui.Controls.ShellContentQueryParameter
 Microsoft.Maui.Controls.ShellContentQueryParameter.Name.get -> string?
 Microsoft.Maui.Controls.ShellContentQueryParameter.Name.set -> void
@@ -187,6 +189,7 @@ Microsoft.Maui.Controls.ShellContentQueryParameter.Value.set -> void
 ~static readonly Microsoft.Maui.Controls.Shell.BackgroundProperty -> Microsoft.Maui.Controls.BindableProperty
 static readonly Microsoft.Maui.Controls.ShellContentQueryParameter.NameProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.ShellContentQueryParameter.ValueProperty -> Microsoft.Maui.Controls.BindableProperty!
+~static readonly Microsoft.Maui.Controls.ShellContent.QueryStringProperty -> Microsoft.Maui.Controls.BindableProperty
 override Microsoft.Maui.Controls.BindablePropertyConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
 override Microsoft.Maui.Controls.BindablePropertyConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type? destinationType) -> bool
 override Microsoft.Maui.Controls.BindablePropertyConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object?

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -151,9 +151,18 @@ static readonly Microsoft.Maui.Controls.TitleBar.TitleFontAttributesProperty -> 
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
 ~Microsoft.Maui.Controls.ShellAppearance.Background.get -> Microsoft.Maui.Controls.Brush
+~Microsoft.Maui.Controls.ShellContent.QueryParameters.get -> System.Collections.Generic.IList<Microsoft.Maui.Controls.ShellContentQueryParameter>
+Microsoft.Maui.Controls.ShellContentQueryParameter
+Microsoft.Maui.Controls.ShellContentQueryParameter.Name.get -> string?
+Microsoft.Maui.Controls.ShellContentQueryParameter.Name.set -> void
+Microsoft.Maui.Controls.ShellContentQueryParameter.ShellContentQueryParameter() -> void
+Microsoft.Maui.Controls.ShellContentQueryParameter.Value.get -> object?
+Microsoft.Maui.Controls.ShellContentQueryParameter.Value.set -> void
 ~static Microsoft.Maui.Controls.Shell.GetBackground(Microsoft.Maui.Controls.BindableObject obj) -> Microsoft.Maui.Controls.Brush
 ~static Microsoft.Maui.Controls.Shell.SetBackground(Microsoft.Maui.Controls.BindableObject obj, Microsoft.Maui.Controls.Brush value) -> void
 ~static readonly Microsoft.Maui.Controls.Shell.BackgroundProperty -> Microsoft.Maui.Controls.BindableProperty
+static readonly Microsoft.Maui.Controls.ShellContentQueryParameter.NameProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.ShellContentQueryParameter.ValueProperty -> Microsoft.Maui.Controls.BindableProperty!
 override Microsoft.Maui.Controls.BindablePropertyConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
 override Microsoft.Maui.Controls.BindablePropertyConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type? destinationType) -> bool
 override Microsoft.Maui.Controls.BindablePropertyConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object?

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -152,6 +152,8 @@ static readonly Microsoft.Maui.Controls.TitleBar.TitleFontAttributesProperty -> 
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
 ~Microsoft.Maui.Controls.ShellAppearance.Background.get -> Microsoft.Maui.Controls.Brush
 ~Microsoft.Maui.Controls.ShellContent.QueryParameters.get -> System.Collections.Generic.IList<Microsoft.Maui.Controls.ShellContentQueryParameter>
+Microsoft.Maui.Controls.ShellContent.QueryString.get -> string?
+Microsoft.Maui.Controls.ShellContent.QueryString.set -> void
 Microsoft.Maui.Controls.ShellContentQueryParameter
 Microsoft.Maui.Controls.ShellContentQueryParameter.Name.get -> string?
 Microsoft.Maui.Controls.ShellContentQueryParameter.Name.set -> void
@@ -163,6 +165,7 @@ Microsoft.Maui.Controls.ShellContentQueryParameter.Value.set -> void
 ~static readonly Microsoft.Maui.Controls.Shell.BackgroundProperty -> Microsoft.Maui.Controls.BindableProperty
 static readonly Microsoft.Maui.Controls.ShellContentQueryParameter.NameProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.ShellContentQueryParameter.ValueProperty -> Microsoft.Maui.Controls.BindableProperty!
+~static readonly Microsoft.Maui.Controls.ShellContent.QueryStringProperty -> Microsoft.Maui.Controls.BindableProperty
 override Microsoft.Maui.Controls.BindablePropertyConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
 override Microsoft.Maui.Controls.BindablePropertyConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type? destinationType) -> bool
 override Microsoft.Maui.Controls.BindablePropertyConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object?

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -143,6 +143,8 @@ static readonly Microsoft.Maui.Controls.TitleBar.TitleFontAttributesProperty -> 
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
 ~Microsoft.Maui.Controls.ShellAppearance.Background.get -> Microsoft.Maui.Controls.Brush
 ~Microsoft.Maui.Controls.ShellContent.QueryParameters.get -> System.Collections.Generic.IList<Microsoft.Maui.Controls.ShellContentQueryParameter>
+Microsoft.Maui.Controls.ShellContent.QueryString.get -> string?
+Microsoft.Maui.Controls.ShellContent.QueryString.set -> void
 Microsoft.Maui.Controls.ShellContentQueryParameter
 Microsoft.Maui.Controls.ShellContentQueryParameter.Name.get -> string?
 Microsoft.Maui.Controls.ShellContentQueryParameter.Name.set -> void
@@ -154,6 +156,7 @@ Microsoft.Maui.Controls.ShellContentQueryParameter.Value.set -> void
 ~static readonly Microsoft.Maui.Controls.Shell.BackgroundProperty -> Microsoft.Maui.Controls.BindableProperty
 static readonly Microsoft.Maui.Controls.ShellContentQueryParameter.NameProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.ShellContentQueryParameter.ValueProperty -> Microsoft.Maui.Controls.BindableProperty!
+~static readonly Microsoft.Maui.Controls.ShellContent.QueryStringProperty -> Microsoft.Maui.Controls.BindableProperty
 override Microsoft.Maui.Controls.BindablePropertyConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
 override Microsoft.Maui.Controls.BindablePropertyConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type? destinationType) -> bool
 override Microsoft.Maui.Controls.BindablePropertyConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object?

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -142,9 +142,18 @@ static readonly Microsoft.Maui.Controls.TitleBar.TitleFontAttributesProperty -> 
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
 ~Microsoft.Maui.Controls.ShellAppearance.Background.get -> Microsoft.Maui.Controls.Brush
+~Microsoft.Maui.Controls.ShellContent.QueryParameters.get -> System.Collections.Generic.IList<Microsoft.Maui.Controls.ShellContentQueryParameter>
+Microsoft.Maui.Controls.ShellContentQueryParameter
+Microsoft.Maui.Controls.ShellContentQueryParameter.Name.get -> string?
+Microsoft.Maui.Controls.ShellContentQueryParameter.Name.set -> void
+Microsoft.Maui.Controls.ShellContentQueryParameter.ShellContentQueryParameter() -> void
+Microsoft.Maui.Controls.ShellContentQueryParameter.Value.get -> object?
+Microsoft.Maui.Controls.ShellContentQueryParameter.Value.set -> void
 ~static Microsoft.Maui.Controls.Shell.GetBackground(Microsoft.Maui.Controls.BindableObject obj) -> Microsoft.Maui.Controls.Brush
 ~static Microsoft.Maui.Controls.Shell.SetBackground(Microsoft.Maui.Controls.BindableObject obj, Microsoft.Maui.Controls.Brush value) -> void
 ~static readonly Microsoft.Maui.Controls.Shell.BackgroundProperty -> Microsoft.Maui.Controls.BindableProperty
+static readonly Microsoft.Maui.Controls.ShellContentQueryParameter.NameProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.ShellContentQueryParameter.ValueProperty -> Microsoft.Maui.Controls.BindableProperty!
 override Microsoft.Maui.Controls.BindablePropertyConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
 override Microsoft.Maui.Controls.BindablePropertyConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type? destinationType) -> bool
 override Microsoft.Maui.Controls.BindablePropertyConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object?

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -1909,6 +1909,7 @@ namespace Microsoft.Maui.Controls
 				ShellContent currentShellContent = shell.CurrentItem.CurrentItem?.CurrentItem;
 				currentShellContent?.SetValue(ShellContent.QueryAttributesProperty, new ShellRouteParameters());
 			}
+			shell.CurrentContent?.ApplyQueryAttributesFromSelection();
 
 			if (shell.CurrentItem?.CurrentItem != null)
 				shell.ShellController.AppearanceChanged(shell.CurrentItem.CurrentItem, false);

--- a/src/Controls/src/Core/Shell/ShellContent.cs
+++ b/src/Controls/src/Core/Shell/ShellContent.cs
@@ -65,8 +65,10 @@ namespace Microsoft.Maui.Controls
 		/// Gets or sets an encoded query string supplied to this content's page when the content is selected.
 		/// </summary>
 		/// <remarks>
-		/// The leading <c>?</c> is optional. Values from <see cref="QueryParameters"/> take precedence over
-		/// values in this query string, while parameters supplied to Shell navigation take precedence over both.
+		/// The leading <c>?</c> is optional. The query string is URI-decoded once. Values from
+		/// <see cref="QueryParameters"/> take precedence over values in this query string. Parameters supplied
+		/// to Shell navigation take precedence for that navigation; selecting the content again reapplies its
+		/// declarative parameters.
 		/// </remarks>
 #nullable enable
 		public string? QueryString
@@ -81,7 +83,9 @@ namespace Microsoft.Maui.Controls
 		/// </summary>
 		/// <remarks>
 		/// Changes to this collection or its parameters are applied immediately when this content is selected,
-		/// or the next time it is selected otherwise.
+		/// or the next time it is selected otherwise. Values in this collection take precedence over
+		/// <see cref="QueryString"/>. Parameters supplied to Shell navigation take precedence for that
+		/// navigation; selecting the content again reapplies its declarative parameters.
 		/// </remarks>
 		public IList<ShellContentQueryParameter> QueryParameters { get; }
 

--- a/src/Controls/src/Core/Shell/ShellContent.cs
+++ b/src/Controls/src/Core/Shell/ShellContent.cs
@@ -628,8 +628,12 @@ namespace Microsoft.Maui.Controls
 						{
 							if (prop.PropertyType == typeof(string))
 							{
-								if (value != null && !query.IsShellContentQueryParameter(attrib.QueryId))
-									value = global::System.Net.WebUtility.UrlDecode((string)value);
+								if (value != null)
+								{
+									value = query.IsShellContentQueryParameter(attrib.QueryId)
+										? Convert.ToString(value, global::System.Globalization.CultureInfo.InvariantCulture)
+										: global::System.Net.WebUtility.UrlDecode((string)value);
+								}
 
 								prop.SetValue(content, value);
 							}
@@ -644,7 +648,10 @@ namespace Microsoft.Maui.Controls
 								}
 								else
 								{
-									var castValue = Convert.ChangeType(value, targetType);
+									var culture = query.IsShellContentQueryParameter(attrib.QueryId)
+										? global::System.Globalization.CultureInfo.InvariantCulture
+										: global::System.Globalization.CultureInfo.CurrentCulture;
+									var castValue = Convert.ChangeType(value, targetType, culture);
 									prop.SetValue(content, castValue);
 								}
 							}

--- a/src/Controls/src/Core/Shell/ShellContent.cs
+++ b/src/Controls/src/Core/Shell/ShellContent.cs
@@ -57,6 +57,15 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(ContentTemplateProperty, value);
 		}
 
+		/// <summary>
+		/// Gets the query parameters supplied to this content's page when the content is selected.
+		/// </summary>
+		/// <remarks>
+		/// Changes to this collection or its parameters are applied immediately when this content is selected,
+		/// or the next time it is selected otherwise.
+		/// </remarks>
+		public IList<ShellContentQueryParameter> QueryParameters { get; }
+
 		Page IShellContentController.Page => ContentCache;
 
 		EventHandler _isPageVisibleChanged;
@@ -126,6 +135,9 @@ namespace Microsoft.Maui.Controls
 		}
 
 		Page _contentCache;
+		readonly HashSet<ShellContentQueryParameter> _trackedQueryParameters = new();
+		readonly HashSet<string> _lastAppliedContentParameterNames = new(StringComparer.Ordinal);
+		bool _hasAppliedQueryParameters;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="ShellContent"/> class.
@@ -133,16 +145,22 @@ namespace Microsoft.Maui.Controls
 		public ShellContent()
 		{
 			((INotifyCollectionChanged)MenuItems).CollectionChanged += MenuItemsCollectionChanged;
+			QueryParameters = new ObservableCollection<ShellContentQueryParameter>();
+			((INotifyCollectionChanged)QueryParameters).CollectionChanged += QueryParametersCollectionChanged;
+			BindingContextChanged += OnShellContentBindingContextChanged;
 		}
 
 		internal bool IsVisibleContent =>
-			Parent is ShellSection shellSection &&
-			shellSection.IsVisibleSection &&
-			shellSection.CurrentItem == this &&
+			IsSelectedContent &&
 			(
 				Navigation?.ModalStack is null ||
 				Navigation?.ModalStack?.Count == 0
 			);
+
+		bool IsSelectedContent =>
+			Parent is ShellSection shellSection &&
+			shellSection.IsVisibleSection &&
+			shellSection.CurrentItem == this;
 
 		internal override void SendDisappearing()
 		{
@@ -367,10 +385,103 @@ namespace Microsoft.Maui.Controls
 				}
 		}
 
+		void QueryParametersCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+		{
+			if (e.Action == NotifyCollectionChangedAction.Reset)
+			{
+				foreach (var parameter in new List<ShellContentQueryParameter>(_trackedQueryParameters))
+					UntrackQueryParameter(parameter);
+			}
+			else if (e.OldItems is not null)
+			{
+				foreach (ShellContentQueryParameter parameter in e.OldItems)
+					if (parameter is not null && !QueryParameters.Contains(parameter))
+						UntrackQueryParameter(parameter);
+			}
+
+			if (e.Action == NotifyCollectionChangedAction.Reset)
+			{
+				foreach (var parameter in QueryParameters)
+					TrackQueryParameterIfNeeded(parameter);
+			}
+			else if (e.NewItems is not null)
+				foreach (ShellContentQueryParameter parameter in e.NewItems)
+					TrackQueryParameterIfNeeded(parameter);
+
+			ApplyQueryParametersIfVisible();
+		}
+
+		void TrackQueryParameterIfNeeded(ShellContentQueryParameter parameter)
+		{
+			if (parameter is not null && _trackedQueryParameters.Add(parameter))
+				TrackQueryParameter(parameter);
+		}
+
+		void TrackQueryParameter(ShellContentQueryParameter parameter)
+		{
+			parameter.PropertyChanged += OnQueryParameterPropertyChanged;
+			SetInheritedBindingContext(parameter, BindingContext);
+		}
+
+		void UntrackQueryParameter(ShellContentQueryParameter parameter)
+		{
+			_trackedQueryParameters.Remove(parameter);
+			parameter.PropertyChanged -= OnQueryParameterPropertyChanged;
+			SetInheritedBindingContext(parameter, null);
+		}
+
+		void OnQueryParameterPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName == ShellContentQueryParameter.NameProperty.PropertyName ||
+				e.PropertyName == ShellContentQueryParameter.ValueProperty.PropertyName)
+			{
+				ApplyQueryParametersIfVisible();
+			}
+		}
+
+		void ApplyQueryParametersIfVisible()
+		{
+			if (IsSelectedContent)
+				ApplyQueryAttributesFromParameterChange();
+		}
+
+		internal void ApplyQueryAttributesFromSelection()
+		{
+			if (this.FindParentOfType<Shell>()?.NavigationManager.AccumulateNavigatedEvents == true)
+				return;
+
+			if (!IsSelectedContent)
+				return;
+
+			var query = CreateSelectionQueryParameters(out bool hasQueryParameters);
+			if (!hasQueryParameters && !_hasAppliedQueryParameters)
+				return;
+
+			ApplyQueryAttributesCore(query);
+			_hasAppliedQueryParameters = hasQueryParameters;
+		}
+
+		void ApplyQueryAttributesFromParameterChange()
+		{
+			var query = CreateParameterChangeQueryParameters(out bool hasQueryParameters);
+			if (!hasQueryParameters && !_hasAppliedQueryParameters)
+				return;
+
+			ApplyQueryAttributesCore(query);
+			_hasAppliedQueryParameters = hasQueryParameters;
+		}
+
 		internal override void ApplyQueryAttributes(ShellRouteParameters query)
 		{
 			base.ApplyQueryAttributes(query);
 
+			var mergedQuery = CreateMergedQueryParameters(query, out bool hasQueryParameters);
+			ApplyQueryAttributesCore(mergedQuery);
+			_hasAppliedQueryParameters = hasQueryParameters;
+		}
+
+		void ApplyQueryAttributesCore(ShellRouteParameters query)
+		{
 			// If the query parameters are empty and this attribute wasn't previously set
 			// That means there's no work to be done here.
 			// An empty query is only valid if we've previously propagated
@@ -382,6 +493,100 @@ namespace Microsoft.Maui.Controls
 
 			if (ContentCache is BindableObject bindable)
 				bindable.SetValue(QueryAttributesProperty, query);
+		}
+
+		ShellRouteParameters CreateMergedQueryParameters(ShellRouteParameters navigationQuery, out bool hasQueryParameters)
+		{
+			var contentQuery = GetContentQueryParameters();
+			hasQueryParameters = contentQuery.Count > 0;
+
+			if (!hasQueryParameters)
+			{
+				_lastAppliedContentParameterNames.Clear();
+				return navigationQuery;
+			}
+
+			var query = new ShellRouteParameters(navigationQuery);
+			var appliedNames = new HashSet<string>(StringComparer.Ordinal);
+
+			foreach (var parameter in contentQuery)
+			{
+				if (!query.ContainsKey(parameter.Key) || query.IsShellContentQueryParameter(parameter.Key))
+				{
+					query.SetShellContentQueryParameter(parameter.Key, parameter.Value);
+					appliedNames.Add(parameter.Key);
+				}
+			}
+
+			UpdateLastAppliedContentParameterNames(appliedNames);
+			return query;
+		}
+
+		ShellRouteParameters CreateSelectionQueryParameters(out bool hasQueryParameters)
+		{
+			var existing = GetValue(QueryAttributesProperty) as ShellRouteParameters;
+			var query = existing is null ? new ShellRouteParameters() : new ShellRouteParameters(existing);
+			var contentQuery = GetContentQueryParameters();
+
+			foreach (var name in _lastAppliedContentParameterNames)
+				query.RemoveShellContentQueryParameter(name);
+
+			foreach (var parameter in contentQuery)
+				query.SetShellContentQueryParameter(parameter.Key, parameter.Value);
+
+			hasQueryParameters = contentQuery.Count > 0;
+			UpdateLastAppliedContentParameterNames(contentQuery.Keys);
+			return query;
+		}
+
+		ShellRouteParameters CreateParameterChangeQueryParameters(out bool hasQueryParameters)
+		{
+			var existing = GetValue(QueryAttributesProperty) as ShellRouteParameters;
+			var query = existing is null ? new ShellRouteParameters() : new ShellRouteParameters(existing);
+			var contentQuery = GetContentQueryParameters();
+			var previouslyAppliedNames = new HashSet<string>(_lastAppliedContentParameterNames, StringComparer.Ordinal);
+			var appliedNames = new HashSet<string>(StringComparer.Ordinal);
+
+			foreach (var name in previouslyAppliedNames)
+				query.RemoveShellContentQueryParameter(name);
+
+			foreach (var parameter in contentQuery)
+			{
+				if (previouslyAppliedNames.Contains(parameter.Key) || !query.ContainsKey(parameter.Key))
+				{
+					query.SetShellContentQueryParameter(parameter.Key, parameter.Value);
+					appliedNames.Add(parameter.Key);
+				}
+			}
+
+			hasQueryParameters = contentQuery.Count > 0;
+			UpdateLastAppliedContentParameterNames(appliedNames);
+			return query;
+		}
+
+		Dictionary<string, object> GetContentQueryParameters()
+		{
+			var contentQuery = new Dictionary<string, object>(StringComparer.Ordinal);
+			foreach (var parameter in QueryParameters)
+			{
+				if (!string.IsNullOrEmpty(parameter?.Name))
+					contentQuery[parameter.Name] = parameter.Value;
+			}
+
+			return contentQuery;
+		}
+
+		void UpdateLastAppliedContentParameterNames(IEnumerable<string> names)
+		{
+			_lastAppliedContentParameterNames.Clear();
+			foreach (var name in names)
+				_lastAppliedContentParameterNames.Add(name);
+		}
+
+		void OnShellContentBindingContextChanged(object sender, EventArgs e)
+		{
+			foreach (var parameter in _trackedQueryParameters)
+				SetInheritedBindingContext(parameter, BindingContext);
 		}
 
 		static void OnQueryAttributesPropertyChanged(BindableObject bindable, object oldValue, object newValue)
@@ -423,7 +628,7 @@ namespace Microsoft.Maui.Controls
 						{
 							if (prop.PropertyType == typeof(string))
 							{
-								if (value != null)
+								if (value != null && !query.IsShellContentQueryParameter(attrib.QueryId))
 									value = global::System.Net.WebUtility.UrlDecode((string)value);
 
 								prop.SetValue(content, value);

--- a/src/Controls/src/Core/Shell/ShellContent.cs
+++ b/src/Controls/src/Core/Shell/ShellContent.cs
@@ -68,7 +68,9 @@ namespace Microsoft.Maui.Controls
 		/// The leading <c>?</c> is optional. The query string is URI-decoded once. Values from
 		/// <see cref="QueryParameters"/> take precedence over values in this query string. Parameters supplied
 		/// to Shell navigation take precedence for that navigation; selecting the content again reapplies its
-		/// declarative parameters.
+		/// declarative parameters. For compatibility, existing Shell navigation retains its historical decoding
+		/// and culture behavior, so moving the same encoded text from navigation to this property can produce
+		/// a different result.
 		/// </remarks>
 #nullable enable
 		public string? QueryString
@@ -85,7 +87,10 @@ namespace Microsoft.Maui.Controls
 		/// Changes to this collection or its parameters are applied immediately when this content is selected,
 		/// or the next time it is selected otherwise. Values in this collection take precedence over
 		/// <see cref="QueryString"/>. Parameters supplied to Shell navigation take precedence for that
-		/// navigation; selecting the content again reapplies its declarative parameters.
+		/// navigation; selecting the content again reapplies its declarative parameters. Parameters are logical
+		/// children of this content, so they support inherited binding contexts, dynamic resources, relative-source
+		/// ancestor bindings, and parent-scoped XAML references. A parameter instance can occur more than once in
+		/// this collection, but it cannot be shared with another <see cref="ShellContent"/>.
 		/// </remarks>
 		public IList<ShellContentQueryParameter> QueryParameters { get; }
 
@@ -162,15 +167,42 @@ namespace Microsoft.Maui.Controls
 		readonly HashSet<string> _lastAppliedContentParameterNames = new(StringComparer.Ordinal);
 		bool _hasAppliedQueryParameters;
 
+		sealed class ShellContentQueryParameterCollection : ObservableCollection<ShellContentQueryParameter>
+		{
+			readonly ShellContent _owner;
+
+			public ShellContentQueryParameterCollection(ShellContent owner)
+			{
+				_owner = owner;
+			}
+
+			protected override void InsertItem(int index, ShellContentQueryParameter item)
+			{
+				ValidateOwner(item);
+				base.InsertItem(index, item);
+			}
+
+			protected override void SetItem(int index, ShellContentQueryParameter item)
+			{
+				ValidateOwner(item);
+				base.SetItem(index, item);
+			}
+
+			void ValidateOwner(ShellContentQueryParameter parameter)
+			{
+				if (parameter?.Parent is Element parent && parent != _owner)
+					throw new InvalidOperationException($"{nameof(ShellContentQueryParameter)} instances cannot be shared across {nameof(ShellContent)} objects.");
+			}
+		}
+
 		/// <summary>
 		/// Initializes a new instance of the <see cref="ShellContent"/> class.
 		/// </summary>
 		public ShellContent()
 		{
 			((INotifyCollectionChanged)MenuItems).CollectionChanged += MenuItemsCollectionChanged;
-			QueryParameters = new ObservableCollection<ShellContentQueryParameter>();
+			QueryParameters = new ShellContentQueryParameterCollection(this);
 			((INotifyCollectionChanged)QueryParameters).CollectionChanged += QueryParametersCollectionChanged;
-			BindingContextChanged += OnShellContentBindingContextChanged;
 		}
 
 		internal bool IsVisibleContent =>
@@ -274,6 +306,9 @@ namespace Microsoft.Maui.Controls
 						value.Unloaded += OnPageUnloaded;
 					}
 				}
+
+				if (value is not null && GetValue(QueryAttributesProperty) is ShellRouteParameters query)
+					value.SetValue(QueryAttributesProperty, query);
 
 				if (Parent is not null)
 				{
@@ -417,8 +452,10 @@ namespace Microsoft.Maui.Controls
 			}
 			else if (e.OldItems is not null)
 			{
+				// An instance can appear more than once or be moved. Only detach it once it is absent.
+				var currentParameters = new HashSet<ShellContentQueryParameter>(QueryParameters);
 				foreach (ShellContentQueryParameter parameter in e.OldItems)
-					if (parameter is not null && !QueryParameters.Contains(parameter))
+					if (parameter is not null && !currentParameters.Contains(parameter))
 						UntrackQueryParameter(parameter);
 			}
 
@@ -443,14 +480,14 @@ namespace Microsoft.Maui.Controls
 		void TrackQueryParameter(ShellContentQueryParameter parameter)
 		{
 			parameter.PropertyChanged += OnQueryParameterPropertyChanged;
-			SetInheritedBindingContext(parameter, BindingContext);
+			AddLogicalChild(parameter);
 		}
 
 		void UntrackQueryParameter(ShellContentQueryParameter parameter)
 		{
 			_trackedQueryParameters.Remove(parameter);
 			parameter.PropertyChanged -= OnQueryParameterPropertyChanged;
-			SetInheritedBindingContext(parameter, null);
+			RemoveLogicalChild(parameter);
 		}
 
 		void OnQueryParameterPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -478,7 +515,17 @@ namespace Microsoft.Maui.Controls
 			if (this.FindParentOfType<Shell>()?.NavigationManager.AccumulateNavigatedEvents == true)
 				return;
 
-			if (!IsSelectedContent)
+			ApplyQueryAttributesFromSelectionCore(requireSelected: true);
+		}
+
+		internal void ApplyQueryAttributesFromIntermediateNavigation()
+		{
+			ApplyQueryAttributesFromSelectionCore(requireSelected: false);
+		}
+
+		void ApplyQueryAttributesFromSelectionCore(bool requireSelected)
+		{
+			if (requireSelected && !IsSelectedContent)
 				return;
 
 			var query = CreateSelectionQueryParameters(out bool hasQueryParameters);
@@ -494,6 +541,14 @@ namespace Microsoft.Maui.Controls
 			var query = CreateParameterChangeQueryParameters(out bool hasQueryParameters);
 			if (!hasQueryParameters && !_hasAppliedQueryParameters)
 				return;
+
+			var currentQuery = GetValue(QueryAttributesProperty) as ShellRouteParameters;
+			var currentContentQuery = (ContentCache as BindableObject)?.GetValue(QueryAttributesProperty) as ShellRouteParameters;
+			if (query.IsEquivalentTo(currentQuery) &&
+				(ContentCache is null || query.IsEquivalentTo(currentContentQuery)))
+			{
+				return;
+			}
 
 			ApplyQueryAttributesCore(query);
 			_hasAppliedQueryParameters = hasQueryParameters;
@@ -626,12 +681,6 @@ namespace Microsoft.Maui.Controls
 			_lastAppliedContentParameterNames.Clear();
 			foreach (var name in names)
 				_lastAppliedContentParameterNames.Add(name);
-		}
-
-		void OnShellContentBindingContextChanged(object sender, EventArgs e)
-		{
-			foreach (var parameter in _trackedQueryParameters)
-				SetInheritedBindingContext(parameter, BindingContext);
 		}
 
 		readonly struct ContentQueryParameter

--- a/src/Controls/src/Core/Shell/ShellContent.cs
+++ b/src/Controls/src/Core/Shell/ShellContent.cs
@@ -31,6 +31,10 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty ContentTemplateProperty =
 			BindableProperty.Create(nameof(ContentTemplate), typeof(DataTemplate), typeof(ShellContent), null, BindingMode.OneTime);
 
+		/// <summary>Bindable property for <see cref="QueryString"/>.</summary>
+		public static readonly BindableProperty QueryStringProperty =
+			BindableProperty.Create(nameof(QueryString), typeof(string), typeof(ShellContent), default(string), propertyChanged: OnQueryStringChanged);
+
 		internal static readonly BindableProperty QueryAttributesProperty =
 			BindableProperty.CreateAttached("QueryAttributes", typeof(ShellRouteParameters), typeof(ShellContent), defaultValue: null, propertyChanged: OnQueryAttributesPropertyChanged);
 
@@ -56,6 +60,21 @@ namespace Microsoft.Maui.Controls
 			get => (DataTemplate)GetValue(ContentTemplateProperty);
 			set => SetValue(ContentTemplateProperty, value);
 		}
+
+		/// <summary>
+		/// Gets or sets an encoded query string supplied to this content's page when the content is selected.
+		/// </summary>
+		/// <remarks>
+		/// The leading <c>?</c> is optional. Values from <see cref="QueryParameters"/> take precedence over
+		/// values in this query string, while parameters supplied to Shell navigation take precedence over both.
+		/// </remarks>
+#nullable enable
+		public string? QueryString
+		{
+			get => (string?)GetValue(QueryStringProperty);
+			set => SetValue(QueryStringProperty, value);
+		}
+#nullable disable
 
 		/// <summary>
 		/// Gets the query parameters supplied to this content's page when the content is selected.
@@ -445,6 +464,11 @@ namespace Microsoft.Maui.Controls
 				ApplyQueryAttributesFromParameterChange();
 		}
 
+		static void OnQueryStringChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			((ShellContent)bindable).ApplyQueryParametersIfVisible();
+		}
+
 		internal void ApplyQueryAttributesFromSelection()
 		{
 			if (this.FindParentOfType<Shell>()?.NavigationManager.AccumulateNavigatedEvents == true)
@@ -511,9 +535,9 @@ namespace Microsoft.Maui.Controls
 
 			foreach (var parameter in contentQuery)
 			{
-				if (!query.ContainsKey(parameter.Key) || query.IsShellContentQueryParameter(parameter.Key))
+				if (!query.ContainsKey(parameter.Key) || query.IsShellContentParameter(parameter.Key))
 				{
-					query.SetShellContentQueryParameter(parameter.Key, parameter.Value);
+					SetContentQueryParameter(query, parameter.Key, parameter.Value);
 					appliedNames.Add(parameter.Key);
 				}
 			}
@@ -532,7 +556,7 @@ namespace Microsoft.Maui.Controls
 				query.RemoveShellContentQueryParameter(name);
 
 			foreach (var parameter in contentQuery)
-				query.SetShellContentQueryParameter(parameter.Key, parameter.Value);
+				SetContentQueryParameter(query, parameter.Key, parameter.Value);
 
 			hasQueryParameters = contentQuery.Count > 0;
 			UpdateLastAppliedContentParameterNames(contentQuery.Keys);
@@ -554,7 +578,7 @@ namespace Microsoft.Maui.Controls
 			{
 				if (previouslyAppliedNames.Contains(parameter.Key) || !query.ContainsKey(parameter.Key))
 				{
-					query.SetShellContentQueryParameter(parameter.Key, parameter.Value);
+					SetContentQueryParameter(query, parameter.Key, parameter.Value);
 					appliedNames.Add(parameter.Key);
 				}
 			}
@@ -564,16 +588,33 @@ namespace Microsoft.Maui.Controls
 			return query;
 		}
 
-		Dictionary<string, object> GetContentQueryParameters()
+		Dictionary<string, ContentQueryParameter> GetContentQueryParameters()
 		{
-			var contentQuery = new Dictionary<string, object>(StringComparer.Ordinal);
+			var contentQuery = new Dictionary<string, ContentQueryParameter>(StringComparer.Ordinal);
+			var queryStringParameters = new ShellRouteParameters();
+			queryStringParameters.SetQueryStringParameters(QueryString);
+
+			foreach (var parameter in queryStringParameters)
+			{
+				if (!string.IsNullOrEmpty(parameter.Key))
+					contentQuery[parameter.Key] = new ContentQueryParameter(parameter.Value, isQueryString: true);
+			}
+
 			foreach (var parameter in QueryParameters)
 			{
 				if (!string.IsNullOrEmpty(parameter?.Name))
-					contentQuery[parameter.Name] = parameter.Value;
+					contentQuery[parameter.Name] = new ContentQueryParameter(parameter.Value, isQueryString: false);
 			}
 
 			return contentQuery;
+		}
+
+		static void SetContentQueryParameter(ShellRouteParameters query, string name, ContentQueryParameter parameter)
+		{
+			if (parameter.IsQueryString)
+				query.SetShellContentQueryStringParameter(name, parameter.Value);
+			else
+				query.SetShellContentQueryParameter(name, parameter.Value);
 		}
 
 		void UpdateLastAppliedContentParameterNames(IEnumerable<string> names)
@@ -587,6 +628,18 @@ namespace Microsoft.Maui.Controls
 		{
 			foreach (var parameter in _trackedQueryParameters)
 				SetInheritedBindingContext(parameter, BindingContext);
+		}
+
+		readonly struct ContentQueryParameter
+		{
+			public ContentQueryParameter(object value, bool isQueryString)
+			{
+				Value = value;
+				IsQueryString = isQueryString;
+			}
+
+			public object Value { get; }
+			public bool IsQueryString { get; }
 		}
 
 		static void OnQueryAttributesPropertyChanged(BindableObject bindable, object oldValue, object newValue)
@@ -630,9 +683,10 @@ namespace Microsoft.Maui.Controls
 							{
 								if (value != null)
 								{
-									value = query.IsShellContentQueryParameter(attrib.QueryId)
-										? Convert.ToString(value, global::System.Globalization.CultureInfo.InvariantCulture)
-										: global::System.Net.WebUtility.UrlDecode((string)value);
+									if (query.IsShellContentQueryParameter(attrib.QueryId))
+										value = Convert.ToString(value, global::System.Globalization.CultureInfo.InvariantCulture);
+									else if (!query.IsShellContentQueryStringParameter(attrib.QueryId))
+										value = global::System.Net.WebUtility.UrlDecode((string)value);
 								}
 
 								prop.SetValue(content, value);
@@ -648,7 +702,7 @@ namespace Microsoft.Maui.Controls
 								}
 								else
 								{
-									var culture = query.IsShellContentQueryParameter(attrib.QueryId)
+									var culture = query.IsShellContentParameter(attrib.QueryId)
 										? global::System.Globalization.CultureInfo.InvariantCulture
 										: global::System.Globalization.CultureInfo.CurrentCulture;
 									var castValue = Convert.ChangeType(value, targetType, culture);
@@ -662,7 +716,13 @@ namespace Microsoft.Maui.Controls
 						PropertyInfo prop = type.GetRuntimeProperty(attrib.Name);
 
 						if (prop != null && prop.CanWrite && prop.SetMethod.IsPublic)
-							prop.SetValue(content, null);
+						{
+							object defaultValue = prop.PropertyType.IsValueType &&
+								Nullable.GetUnderlyingType(prop.PropertyType) is null
+									? Activator.CreateInstance(prop.PropertyType)
+									: null;
+							prop.SetValue(content, defaultValue);
+						}
 					}
 				}
 			}

--- a/src/Controls/src/Core/Shell/ShellContentQueryParameter.cs
+++ b/src/Controls/src/Core/Shell/ShellContentQueryParameter.cs
@@ -1,0 +1,44 @@
+#nullable enable
+
+namespace Microsoft.Maui.Controls
+{
+	/// <summary>
+	/// Defines a named value that a <see cref="ShellContent"/> supplies to its page through Shell query parameter handling.
+	/// </summary>
+	/// <remarks>
+	/// Parameter names are case-sensitive. When a <see cref="ShellContent"/> contains duplicate names, the last parameter
+	/// in the collection supplies the value. A navigation parameter supplied to <c>GoToAsync</c> takes precedence over a
+	/// content parameter with the same name.
+	/// </remarks>
+	[ContentProperty(nameof(Value))]
+	public sealed class ShellContentQueryParameter : BindableObject
+	{
+		/// <summary>Bindable property for <see cref="Name"/>.</summary>
+		public static readonly BindableProperty NameProperty =
+			BindableProperty.Create(nameof(Name), typeof(string), typeof(ShellContentQueryParameter), default(string));
+
+		/// <summary>Bindable property for <see cref="Value"/>.</summary>
+		public static readonly BindableProperty ValueProperty =
+			BindableProperty.Create(nameof(Value), typeof(object), typeof(ShellContentQueryParameter));
+
+		/// <summary>
+		/// Gets or sets the query parameter name.
+		/// </summary>
+		/// <remarks>A parameter with a <see langword="null"/> or empty name is ignored.</remarks>
+		public string? Name
+		{
+			get => (string?)GetValue(NameProperty);
+			set => SetValue(NameProperty, value);
+		}
+
+		/// <summary>
+		/// Gets or sets the query parameter value.
+		/// </summary>
+		/// <remarks>A <see langword="null"/> value is delivered to the target.</remarks>
+		public object? Value
+		{
+			get => GetValue(ValueProperty);
+			set => SetValue(ValueProperty, value);
+		}
+	}
+}

--- a/src/Controls/src/Core/Shell/ShellContentQueryParameter.cs
+++ b/src/Controls/src/Core/Shell/ShellContentQueryParameter.cs
@@ -7,8 +7,8 @@ namespace Microsoft.Maui.Controls
 	/// </summary>
 	/// <remarks>
 	/// Parameter names are case-sensitive. When a <see cref="ShellContent"/> contains duplicate names, the last parameter
-	/// in the collection supplies the value. A navigation parameter supplied to <c>GoToAsync</c> takes precedence over a
-	/// content parameter with the same name.
+	/// in the collection supplies the value. A navigation parameter supplied to <c>GoToAsync</c> takes precedence for
+	/// that navigation; selecting the content again reapplies its declarative parameters.
 	/// </remarks>
 	[ContentProperty(nameof(Value))]
 	public sealed class ShellContentQueryParameter : BindableObject

--- a/src/Controls/src/Core/Shell/ShellContentQueryParameter.cs
+++ b/src/Controls/src/Core/Shell/ShellContentQueryParameter.cs
@@ -8,10 +8,11 @@ namespace Microsoft.Maui.Controls
 	/// <remarks>
 	/// Parameter names are case-sensitive. When a <see cref="ShellContent"/> contains duplicate names, the last parameter
 	/// in the collection supplies the value. A navigation parameter supplied to <c>GoToAsync</c> takes precedence for
-	/// that navigation; selecting the content again reapplies its declarative parameters.
+	/// that navigation; selecting the content again reapplies its declarative parameters. Instances are logical children
+	/// of their owning <see cref="ShellContent"/> and cannot be shared across different owners.
 	/// </remarks>
 	[ContentProperty(nameof(Value))]
-	public sealed class ShellContentQueryParameter : BindableObject
+	public sealed class ShellContentQueryParameter : Element
 	{
 		/// <summary>Bindable property for <see cref="Name"/>.</summary>
 		public static readonly BindableProperty NameProperty =

--- a/src/Controls/src/Core/Shell/ShellItem.cs
+++ b/src/Controls/src/Core/Shell/ShellItem.cs
@@ -332,6 +332,7 @@ namespace Microsoft.Maui.Controls
 			{
 				currentShellContent?.SetValue(ShellContent.QueryAttributesProperty, new ShellRouteParameters());
 			}
+			currentShellContent?.ApplyQueryAttributesFromSelection();
 
 			shellItem.SendStructureChanged();
 

--- a/src/Controls/src/Core/Shell/ShellNavigationManager.cs
+++ b/src/Controls/src/Core/Shell/ShellNavigationManager.cs
@@ -357,11 +357,14 @@ namespace Microsoft.Maui.Controls
 			// For non-destination items (isLastItem=false), skip entirely when there are no
 			// matching prefix params. This prevents stale QueryAttributesProperty stored from
 			// a prior cycle from propagating to pages that are not the navigation target.
-			if (!isLastItem &&
-				filteredQuery.Count == 0 &&
-				(baseShellItem is not ShellContent shellContent ||
-					(shellContent.QueryParameters.Count == 0 && string.IsNullOrEmpty(shellContent.QueryString))))
+			if (!isLastItem && filteredQuery.Count == 0)
 			{
+				if (baseShellItem is ShellContent shellContent &&
+					(shellContent.QueryParameters.Count > 0 || !string.IsNullOrEmpty(shellContent.QueryString)))
+				{
+					shellContent.ApplyQueryAttributes(new ShellRouteParameters());
+				}
+
 				return;
 			}
 

--- a/src/Controls/src/Core/Shell/ShellNavigationManager.cs
+++ b/src/Controls/src/Core/Shell/ShellNavigationManager.cs
@@ -357,7 +357,9 @@ namespace Microsoft.Maui.Controls
 			// For non-destination items (isLastItem=false), skip entirely when there are no
 			// matching prefix params. This prevents stale QueryAttributesProperty stored from
 			// a prior cycle from propagating to pages that are not the navigation target.
-			if (!isLastItem && filteredQuery.Count == 0)
+			if (!isLastItem &&
+				filteredQuery.Count == 0 &&
+				(baseShellItem is not ShellContent shellContent || shellContent.QueryParameters.Count == 0))
 			{
 				return;
 			}

--- a/src/Controls/src/Core/Shell/ShellNavigationManager.cs
+++ b/src/Controls/src/Core/Shell/ShellNavigationManager.cs
@@ -419,7 +419,12 @@ namespace Microsoft.Maui.Controls
 				foreach (var datum in existing)
 				{
 					if (!returnValue.ContainsKey(datum.Key))
-						returnValue[datum.Key] = datum.Value;
+					{
+						if (existing.IsShellContentQueryParameter(datum.Key))
+							returnValue.SetShellContentQueryParameter(datum.Key, datum.Value);
+						else
+							returnValue[datum.Key] = datum.Value;
+					}
 				}
 
 				return returnValue;

--- a/src/Controls/src/Core/Shell/ShellNavigationManager.cs
+++ b/src/Controls/src/Core/Shell/ShellNavigationManager.cs
@@ -131,11 +131,11 @@ namespace Microsoft.Maui.Controls
 							if (!seg.IsParameter)
 								continue;
 							if (pathParameters.TryGetValue(seg.Value, out var val))
-						{
-							var prefixedKey = $"{routeKey}.{seg.Value}";
-							if (!parameters.ContainsKey(prefixedKey))
-								parameters[prefixedKey] = val;
-						}
+							{
+								var prefixedKey = $"{routeKey}.{seg.Value}";
+								if (!parameters.ContainsKey(prefixedKey))
+									parameters[prefixedKey] = val;
+							}
 						}
 					}
 				}
@@ -359,11 +359,8 @@ namespace Microsoft.Maui.Controls
 			// a prior cycle from propagating to pages that are not the navigation target.
 			if (!isLastItem && filteredQuery.Count == 0)
 			{
-				if (baseShellItem is ShellContent shellContent &&
-					(shellContent.QueryParameters.Count > 0 || !string.IsNullOrEmpty(shellContent.QueryString)))
-				{
-					shellContent.ApplyQueryAttributes(new ShellRouteParameters());
-				}
+				if (baseShellItem is ShellContent shellContent)
+					shellContent.ApplyQueryAttributesFromIntermediateNavigation();
 
 				return;
 			}

--- a/src/Controls/src/Core/Shell/ShellNavigationManager.cs
+++ b/src/Controls/src/Core/Shell/ShellNavigationManager.cs
@@ -359,7 +359,8 @@ namespace Microsoft.Maui.Controls
 			// a prior cycle from propagating to pages that are not the navigation target.
 			if (!isLastItem &&
 				filteredQuery.Count == 0 &&
-				(baseShellItem is not ShellContent shellContent || shellContent.QueryParameters.Count == 0))
+				(baseShellItem is not ShellContent shellContent ||
+					(shellContent.QueryParameters.Count == 0 && string.IsNullOrEmpty(shellContent.QueryString))))
 			{
 				return;
 			}
@@ -424,6 +425,8 @@ namespace Microsoft.Maui.Controls
 					{
 						if (existing.IsShellContentQueryParameter(datum.Key))
 							returnValue.SetShellContentQueryParameter(datum.Key, datum.Value);
+						else if (existing.IsShellContentQueryStringParameter(datum.Key))
+							returnValue.SetShellContentQueryStringParameter(datum.Key, datum.Value);
 						else
 							returnValue[datum.Key] = datum.Value;
 					}

--- a/src/Controls/src/Core/Shell/ShellRouteParameters.cs
+++ b/src/Controls/src/Core/Shell/ShellRouteParameters.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Maui.Controls
 			new ShellNavigationQueryParameters();
 		readonly HashSet<string> _shellContentQueryParameterNames =
 			new HashSet<string>(StringComparer.Ordinal);
+		readonly HashSet<string> _shellContentQueryStringParameterNames =
+			new HashSet<string>(StringComparer.Ordinal);
 
 		public ShellRouteParameters()
 		{
@@ -24,6 +26,9 @@ namespace Microsoft.Maui.Controls
 
 			foreach (var item in shellRouteParams._shellContentQueryParameterNames)
 				_shellContentQueryParameterNames.Add(item);
+
+			foreach (var item in shellRouteParams._shellContentQueryStringParameterNames)
+				_shellContentQueryStringParameterNames.Add(item);
 		}
 
 		internal IDictionary<string, object> ToReadOnlyIfUsingShellNavigationQueryParameters()
@@ -71,9 +76,24 @@ namespace Microsoft.Maui.Controls
 
 			foreach (var item in query._shellContentQueryParameterNames)
 			{
-				if (item.StartsWith(prefix, StringComparison.Ordinal))
-					_shellContentQueryParameterNames.Add(item.Substring(prefix.Length));
+				if (!item.StartsWith(prefix, StringComparison.Ordinal))
+					continue;
+
+				var key = item.Substring(prefix.Length);
+				if (key.IndexOf(".", StringComparison.Ordinal) == -1)
+					_shellContentQueryParameterNames.Add(key);
 			}
+
+			foreach (var item in query._shellContentQueryStringParameterNames)
+			{
+				if (!item.StartsWith(prefix, StringComparison.Ordinal))
+					continue;
+
+				var key = item.Substring(prefix.Length);
+				if (key.IndexOf(".", StringComparison.Ordinal) == -1)
+					_shellContentQueryStringParameterNames.Add(key);
+			}
+
 		}
 
 		internal ShellRouteParameters(IDictionary<string, object> shellRouteParams) : base(shellRouteParams)
@@ -87,6 +107,7 @@ namespace Microsoft.Maui.Controls
 
 			foreach (var item in shellNavigationQueryParameterss)
 				_shellNavigationQueryParameters[item.Key] = item.Value;
+
 		}
 
 		internal void ResetToQueryParameters()
@@ -122,7 +143,16 @@ namespace Microsoft.Maui.Controls
 		{
 			this[name] = value;
 			_shellNavigationQueryParameters.Remove(name);
+			_shellContentQueryStringParameterNames.Remove(name);
 			_shellContentQueryParameterNames.Add(name);
+		}
+
+		internal void SetShellContentQueryStringParameter(string name, object value)
+		{
+			this[name] = value;
+			_shellNavigationQueryParameters.Remove(name);
+			_shellContentQueryParameterNames.Remove(name);
+			_shellContentQueryStringParameterNames.Add(name);
 		}
 
 		internal void RemoveShellContentQueryParameter(string name)
@@ -130,10 +160,17 @@ namespace Microsoft.Maui.Controls
 			Remove(name);
 			_shellNavigationQueryParameters.Remove(name);
 			_shellContentQueryParameterNames.Remove(name);
+			_shellContentQueryStringParameterNames.Remove(name);
 		}
 
 		internal bool IsShellContentQueryParameter(string name) =>
 			_shellContentQueryParameterNames.Contains(name);
+
+		internal bool IsShellContentQueryStringParameter(string name) =>
+			_shellContentQueryStringParameterNames.Contains(name);
+
+		internal bool IsShellContentParameter(string name) =>
+			IsShellContentQueryParameter(name) || IsShellContentQueryStringParameter(name);
 
 		static Dictionary<string, string> ParseQueryString(ReadOnlySpan<char> query)
 		{

--- a/src/Controls/src/Core/Shell/ShellRouteParameters.cs
+++ b/src/Controls/src/Core/Shell/ShellRouteParameters.cs
@@ -63,16 +63,7 @@ namespace Microsoft.Maui.Controls
 			}
 
 			foreach (var item in query._shellNavigationQueryParameters)
-			{
-				if (!item.Key.StartsWith(prefix, StringComparison.Ordinal))
-					continue;
-
-				var key = item.Key.Substring(prefix.Length);
-				if (key.IndexOf(".", StringComparison.Ordinal) != -1)
-					continue;
-
-				_shellNavigationQueryParameters[key] = item.Value;
-			}
+				_shellNavigationQueryParameters[item.Key] = item.Value;
 
 			foreach (var item in query._shellContentQueryParameterNames)
 			{

--- a/src/Controls/src/Core/Shell/ShellRouteParameters.cs
+++ b/src/Controls/src/Core/Shell/ShellRouteParameters.cs
@@ -58,7 +58,16 @@ namespace Microsoft.Maui.Controls
 			}
 
 			foreach (var item in query._shellNavigationQueryParameters)
-				_shellNavigationQueryParameters[item.Key] = item.Value;
+			{
+				if (!item.Key.StartsWith(prefix, StringComparison.Ordinal))
+					continue;
+
+				var key = item.Key.Substring(prefix.Length);
+				if (key.IndexOf(".", StringComparison.Ordinal) != -1)
+					continue;
+
+				_shellNavigationQueryParameters[key] = item.Value;
+			}
 
 			foreach (var item in query._shellContentQueryParameterNames)
 			{

--- a/src/Controls/src/Core/Shell/ShellRouteParameters.cs
+++ b/src/Controls/src/Core/Shell/ShellRouteParameters.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Maui.Controls
 	{
 		readonly ShellNavigationQueryParameters _shellNavigationQueryParameters =
 			new ShellNavigationQueryParameters();
+		readonly HashSet<string> _shellContentQueryParameterNames =
+			new HashSet<string>(StringComparer.Ordinal);
 
 		public ShellRouteParameters()
 		{
@@ -19,6 +21,9 @@ namespace Microsoft.Maui.Controls
 		{
 			foreach (var item in shellRouteParams._shellNavigationQueryParameters)
 				_shellNavigationQueryParameters[item.Key] = item.Value;
+
+			foreach (var item in shellRouteParams._shellContentQueryParameterNames)
+				_shellContentQueryParameterNames.Add(item);
 		}
 
 		internal IDictionary<string, object> ToReadOnlyIfUsingShellNavigationQueryParameters()
@@ -54,6 +59,12 @@ namespace Microsoft.Maui.Controls
 
 			foreach (var item in query._shellNavigationQueryParameters)
 				_shellNavigationQueryParameters[item.Key] = item.Value;
+
+			foreach (var item in query._shellContentQueryParameterNames)
+			{
+				if (item.StartsWith(prefix, StringComparison.Ordinal))
+					_shellContentQueryParameterNames.Add(item.Substring(prefix.Length));
+			}
 		}
 
 		internal ShellRouteParameters(IDictionary<string, object> shellRouteParams) : base(shellRouteParams)
@@ -97,6 +108,23 @@ namespace Microsoft.Maui.Controls
 					this[item.Key] = item.Value;
 			}
 		}
+
+		internal void SetShellContentQueryParameter(string name, object value)
+		{
+			this[name] = value;
+			_shellNavigationQueryParameters.Remove(name);
+			_shellContentQueryParameterNames.Add(name);
+		}
+
+		internal void RemoveShellContentQueryParameter(string name)
+		{
+			Remove(name);
+			_shellNavigationQueryParameters.Remove(name);
+			_shellContentQueryParameterNames.Remove(name);
+		}
+
+		internal bool IsShellContentQueryParameter(string name) =>
+			_shellContentQueryParameterNames.Contains(name);
 
 		static Dictionary<string, string> ParseQueryString(ReadOnlySpan<char> query)
 		{

--- a/src/Controls/src/Core/Shell/ShellRouteParameters.cs
+++ b/src/Controls/src/Core/Shell/ShellRouteParameters.cs
@@ -163,6 +163,34 @@ namespace Microsoft.Maui.Controls
 		internal bool IsShellContentParameter(string name) =>
 			IsShellContentQueryParameter(name) || IsShellContentQueryStringParameter(name);
 
+		internal bool IsEquivalentTo(ShellRouteParameters other)
+		{
+			if (ReferenceEquals(this, other))
+				return true;
+
+			return other is not null &&
+				DictionaryEquals(this, other) &&
+				DictionaryEquals(_shellNavigationQueryParameters, other._shellNavigationQueryParameters) &&
+				_shellContentQueryParameterNames.SetEquals(other._shellContentQueryParameterNames) &&
+				_shellContentQueryStringParameterNames.SetEquals(other._shellContentQueryStringParameterNames);
+		}
+
+		static bool DictionaryEquals(
+			IDictionary<string, object> first,
+			IDictionary<string, object> second)
+		{
+			if (first.Count != second.Count)
+				return false;
+
+			foreach (var item in first)
+			{
+				if (!second.TryGetValue(item.Key, out var value) || !Equals(item.Value, value))
+					return false;
+			}
+
+			return true;
+		}
+
 		static Dictionary<string, string> ParseQueryString(ReadOnlySpan<char> query)
 		{
 			if (query.Length > 0 && query[0] == '?')

--- a/src/Controls/src/Core/Shell/ShellSection.cs
+++ b/src/Controls/src/Core/Shell/ShellSection.cs
@@ -1078,6 +1078,7 @@ namespace Microsoft.Maui.Controls
 			if (newValue == null)
 				return;
 
+			((ShellContent)newValue).ApplyQueryAttributesFromSelection();
 			shellSection.PresentedPageAppearing();
 
 			if (shellSection.Parent?.Parent is IShellController shell && shellSection.IsVisibleSection)

--- a/src/Controls/tests/Core.UnitTests/ShellContentQueryParameterTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellContentQueryParameterTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Globalization;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -307,6 +308,51 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public void QueryPropertyConvertsStaticValueToString()
+		{
+			var content = new ShellContent
+			{
+				Route = "content",
+				ContentTemplate = new DataTemplate(() => new QueryPropertyPage()),
+			};
+			content.QueryParameters.Add(new ShellContentQueryParameter
+			{
+				Name = "value",
+				Value = 42,
+			});
+			CreateShell(content);
+
+			Assert.Equal("42", GetPage<QueryPropertyPage>(content).Value);
+		}
+
+		[Fact]
+		public void QueryPropertyConvertsStaticStringUsingInvariantCulture()
+		{
+			var originalCulture = CultureInfo.CurrentCulture;
+			try
+			{
+				CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+				var content = new ShellContent
+				{
+					Route = "content",
+					ContentTemplate = new DataTemplate(() => new NumericQueryPropertyPage()),
+				};
+				content.QueryParameters.Add(new ShellContentQueryParameter
+				{
+					Name = "value",
+					Value = "3.5",
+				});
+				CreateShell(content);
+
+				Assert.Equal(3.5, GetPage<NumericQueryPropertyPage>(content).Value);
+			}
+			finally
+			{
+				CultureInfo.CurrentCulture = originalCulture;
+			}
+		}
+
+		[Fact]
 		public async Task QueryPropertyPreservesLiteralStaticStringAfterRelativePop()
 		{
 			Routing.RegisterRoute("details", typeof(ContentPage));
@@ -446,6 +492,47 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.Equal("navigation", page.Value);
 			Assert.Equal(1, page.ApplyCount);
+		}
+
+		[Fact]
+		public async Task DeepLinkAppliesStaticParametersToSelectedRootContent()
+		{
+			Routing.RegisterRoute("details", typeof(ContentPage));
+			var first = CreateContent("first");
+			first.Route = "first";
+			var second = CreateContent("static");
+			second.Route = "second";
+			var (shell, _) = CreateShell(first, second);
+
+			await shell.GoToAsync("//second/details");
+
+			var page = GetPage<QueryAttributablePage>(second);
+			Assert.Equal("static", page.Value);
+			Assert.Equal(1, page.ApplyCount);
+		}
+
+		[Fact]
+		public async Task DeepLinkDoesNotApplyDetailNavigationParametersToRootContent()
+		{
+			Routing.RegisterRoute("details", typeof(QueryAttributablePage));
+			var first = CreateContent("first");
+			first.Route = "first";
+			var second = CreateContent("static");
+			second.Route = "second";
+			var (shell, _) = CreateShell(first, second);
+			var navigationParameters = new ShellNavigationQueryParameters
+			{
+				["detailId"] = 42,
+			};
+
+			await shell.GoToAsync(new ShellNavigationState("//second/details"), navigationParameters);
+
+			var rootPage = GetPage<QueryAttributablePage>(second);
+			Assert.Equal("static", rootPage.Value);
+			Assert.DoesNotContain("detailId", rootPage.LastQuery);
+
+			var detailPage = Assert.IsType<QueryAttributablePage>(shell.CurrentPage);
+			Assert.Equal(42, detailPage.LastQuery["detailId"]);
 		}
 
 		[Fact]
@@ -652,6 +739,12 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		sealed class QueryPropertyPage : ContentPage
 		{
 			public string Value { get; set; }
+		}
+
+		[QueryProperty(nameof(Value), "value")]
+		sealed class NumericQueryPropertyPage : ContentPage
+		{
+			public double Value { get; set; }
 		}
 
 		[QueryProperty(nameof(First), "first")]

--- a/src/Controls/tests/Core.UnitTests/ShellContentQueryParameterTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellContentQueryParameterTests.cs
@@ -62,6 +62,157 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public void QueryStringSelectionDeliversDistinctParametersToSharedPageTemplate()
+		{
+			var pageTemplate = new DataTemplate(() => new ReminderPage());
+			var yesterday = CreateContent("Yesterday", "date=2021-12-13");
+			var today = CreateContent("Today", "date=2021-12-14");
+			var tomorrow = CreateContent("Tomorrow", "date=2021-12-15");
+			var (_, tab) = CreateShell(yesterday, today, tomorrow);
+
+			Assert.Equal("2021-12-13", GetPage<ReminderPage>(yesterday).Date);
+
+			tab.CurrentItem = today;
+			Assert.Equal("2021-12-14", GetPage<ReminderPage>(today).Date);
+
+			tab.CurrentItem = tomorrow;
+			Assert.Equal("2021-12-15", GetPage<ReminderPage>(tomorrow).Date);
+
+			ShellContent CreateContent(string title, string queryString) =>
+				new()
+				{
+					Title = title,
+					QueryString = queryString,
+					ContentTemplate = pageTemplate,
+				};
+		}
+
+		[Fact]
+		public void QueryStringDeliversParametersViaIQueryAttributable()
+		{
+			var content = CreateQueryStringContent("value=first&other=second");
+			CreateShell(content);
+
+			var page = GetPage<QueryAttributablePage>(content);
+
+			Assert.Equal("first", page.Value);
+			Assert.Equal("second", page.LastQuery["other"]);
+		}
+
+		[Fact]
+		public void QueryStringDecodesQueryProperty()
+		{
+			var content = CreateQueryStringContent(
+				"value=A%2BB",
+				() => new QueryPropertyPage());
+			CreateShell(content);
+
+			Assert.Equal("A+B", GetPage<QueryPropertyPage>(content).Value);
+		}
+
+		[Fact]
+		public void QueryStringConvertsUsingInvariantCulture()
+		{
+			var originalCulture = CultureInfo.CurrentCulture;
+			try
+			{
+				CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+				var content = CreateQueryStringContent(
+					"value=3.5",
+					() => new NumericQueryPropertyPage());
+				CreateShell(content);
+
+				Assert.Equal(3.5, GetPage<NumericQueryPropertyPage>(content).Value);
+			}
+			finally
+			{
+				CultureInfo.CurrentCulture = originalCulture;
+			}
+		}
+
+		[Fact]
+		public void ClearingQueryStringResetsNonNullableQueryProperty()
+		{
+			var content = CreateQueryStringContent(
+				"value=42",
+				() => new IntegerQueryPropertyPage());
+			CreateShell(content);
+			var page = GetPage<IntegerQueryPropertyPage>(content);
+
+			Assert.Equal(42, page.Value);
+
+			content.QueryString = null;
+			Assert.Equal(0, page.Value);
+		}
+
+		[Fact]
+		public void QueryStringChangeUpdatesCurrentPageAndClearRemovesValue()
+		{
+			var content = CreateQueryStringContent("value=first");
+			CreateShell(content);
+			var page = GetPage<QueryAttributablePage>(content);
+
+			content.QueryString = "value=updated";
+			Assert.Equal("updated", page.Value);
+
+			content.QueryString = null;
+			Assert.Null(page.Value);
+		}
+
+		[Fact]
+		public void QueryStringIgnoresEmptyParameterName()
+		{
+			var content = CreateQueryStringContent("=ignored&value=valid");
+			CreateShell(content);
+
+			var page = GetPage<QueryAttributablePage>(content);
+
+			Assert.Equal("valid", page.Value);
+			Assert.DoesNotContain("", page.LastQuery);
+		}
+
+		[Fact]
+		public void BoundQueryStringInheritsBindingContext()
+		{
+			var viewModel = new TestViewModel { Value = "value=first" };
+			var content = CreateQueryStringContent(null);
+			content.SetBinding(ShellContent.QueryStringProperty, nameof(TestViewModel.Value));
+			var (shell, _) = CreateShell(content);
+			shell.BindingContext = viewModel;
+			var page = GetPage<QueryAttributablePage>(content);
+
+			Assert.Equal("first", page.Value);
+
+			viewModel.Value = "value=updated";
+			Assert.Equal("updated", page.Value);
+		}
+
+		[Fact]
+		public void StructuredParameterOverridesQueryString()
+		{
+			var content = CreateQueryStringContent("value=query-string");
+			content.QueryParameters.Add(new ShellContentQueryParameter
+			{
+				Name = "value",
+				Value = "structured",
+			});
+			CreateShell(content);
+
+			Assert.Equal("structured", GetPage<QueryAttributablePage>(content).Value);
+		}
+
+		[Fact]
+		public async Task NavigationParameterOverridesQueryString()
+		{
+			var content = CreateQueryStringContent("value=query-string");
+			var (shell, _) = CreateShell(content);
+
+			await shell.GoToAsync("//content?value=navigation");
+
+			Assert.Equal("navigation", GetPage<QueryAttributablePage>(content).Value);
+		}
+
+		[Fact]
 		public void SwitchingBackReappliesParametersToReusedPage()
 		{
 			var first = CreateContent("first");
@@ -376,6 +527,25 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public async Task QueryStringRemainsSingleDecodedAndUpdatesAfterRelativePop()
+		{
+			Routing.RegisterRoute("details", typeof(ContentPage));
+			var content = CreateQueryStringContent(
+				"value=A%2BB",
+				() => new QueryPropertyPage());
+			var (shell, _) = CreateShell(content);
+			var page = GetPage<QueryPropertyPage>(content);
+
+			await shell.GoToAsync("details");
+			await shell.GoToAsync("..");
+
+			Assert.Equal("A+B", page.Value);
+
+			content.QueryString = "value=updated";
+			Assert.Equal("updated", page.Value);
+		}
+
+		[Fact]
 		public async Task StaticParameterCanUpdateAndBeRemovedAfterRelativePop()
 		{
 			Routing.RegisterRoute("details", typeof(ContentPage));
@@ -508,6 +678,23 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			var page = GetPage<QueryAttributablePage>(second);
 			Assert.Equal("static", page.Value);
+			Assert.Equal(1, page.ApplyCount);
+		}
+
+		[Fact]
+		public async Task DeepLinkAppliesQueryStringToSelectedRootContent()
+		{
+			Routing.RegisterRoute("details", typeof(ContentPage));
+			var first = CreateQueryStringContent("value=first");
+			first.Route = "first";
+			var second = CreateQueryStringContent("value=query-string");
+			second.Route = "second";
+			var (shell, _) = CreateShell(first, second);
+
+			await shell.GoToAsync("//second/details");
+
+			var page = GetPage<QueryAttributablePage>(second);
+			Assert.Equal("query-string", page.Value);
 			Assert.Equal(1, page.ApplyCount);
 		}
 
@@ -706,6 +893,14 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			return content;
 		}
 
+		static ShellContent CreateQueryStringContent(string queryString, Func<Page> factory = null) =>
+			new()
+			{
+				Route = "content",
+				QueryString = queryString,
+				ContentTemplate = new DataTemplate(factory ?? (() => new QueryAttributablePage())),
+			};
+
 		static (Shell Shell, Tab Tab) CreateShell(params ShellContent[] contents)
 		{
 			var tab = new Tab { Route = "tab" };
@@ -745,6 +940,12 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		sealed class NumericQueryPropertyPage : ContentPage
 		{
 			public double Value { get; set; }
+		}
+
+		[QueryProperty(nameof(Value), "value")]
+		sealed class IntegerQueryPropertyPage : ContentPage
+		{
+			public int Value { get; set; }
 		}
 
 		[QueryProperty(nameof(First), "first")]

--- a/src/Controls/tests/Core.UnitTests/ShellContentQueryParameterTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellContentQueryParameterTests.cs
@@ -546,6 +546,22 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public async Task RelativePopDoesNotReapplyStaleNavigationParametersToRootContent()
+		{
+			Routing.RegisterRoute("details", typeof(ContentPage));
+			var content = CreateQueryStringContent("value=query-string");
+			var (shell, _) = CreateShell(content);
+			var page = GetPage<QueryAttributablePage>(content);
+
+			await shell.GoToAsync("//content/details?stale=previous");
+			Assert.DoesNotContain("stale", page.LastQuery);
+			await shell.GoToAsync("..");
+
+			Assert.Equal("query-string", page.Value);
+			Assert.DoesNotContain("stale", page.LastQuery);
+		}
+
+		[Fact]
 		public async Task StaticParameterCanUpdateAndBeRemovedAfterRelativePop()
 		{
 			Routing.RegisterRoute("details", typeof(ContentPage));

--- a/src/Controls/tests/Core.UnitTests/ShellContentQueryParameterTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellContentQueryParameterTests.cs
@@ -111,6 +111,22 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public async Task QueryStringUsesStandardDecodeWhileNavigationKeepsLegacyDecode()
+		{
+			var content = CreateQueryStringContent(
+				"value=a%252Bb",
+				() => new QueryPropertyPage());
+			var (shell, _) = CreateShell(content);
+			var page = GetPage<QueryPropertyPage>(content);
+
+			Assert.Equal("a%2Bb", page.Value);
+
+			await shell.GoToAsync("//content?value=a%252Bb");
+
+			Assert.Equal("a+b", page.Value);
+		}
+
+		[Fact]
 		public void QueryStringConvertsUsingInvariantCulture()
 		{
 			var originalCulture = CultureInfo.CurrentCulture;
@@ -256,6 +272,25 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			GetPage<QueryAttributablePage>(second);
 			Assert.Equal(2, createdPages);
 			Assert.Equal("second", GetPage<QueryAttributablePage>(second).Value);
+		}
+
+		[Fact]
+		public void ReplacingCurrentContentAppliesExistingParametersToNewPage()
+		{
+			var firstPage = new QueryAttributablePage();
+			var content = new ShellContent
+			{
+				Route = "content",
+				Content = firstPage,
+			};
+			content.QueryParameters.Add(new ShellContentQueryParameter { Name = "value", Value = "static" });
+			CreateShell(content);
+			var replacementPage = new QueryAttributablePage();
+
+			content.Content = replacementPage;
+
+			Assert.Equal("static", replacementPage.Value);
+			Assert.Equal(1, replacementPage.ApplyCount);
 		}
 
 		[Fact]
@@ -562,6 +597,62 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public async Task NavigationRemovalResetsNonNullableQueryPropertyToDefault()
+		{
+			var content = new ShellContent
+			{
+				Route = "content",
+				ContentTemplate = new DataTemplate(() => new IntegerQueryPropertyPage()),
+			};
+			var (shell, _) = CreateShell(content);
+
+			await shell.GoToAsync("//content?value=42");
+
+			await shell.GoToAsync("//content");
+
+			Assert.Equal(0, GetPage<IntegerQueryPropertyPage>(content).Value);
+		}
+
+		[Fact]
+		public void QueryParameterResolvesDynamicResourceFromShell()
+		{
+			var parameter = new ShellContentQueryParameter { Name = "value" };
+			parameter.SetDynamicResource(ShellContentQueryParameter.ValueProperty, "parameter-value");
+			var content = CreateContent(parameter);
+			var (shell, _) = CreateShell(content);
+
+			shell.Resources["parameter-value"] = "resolved";
+
+			Assert.Equal("resolved", GetPage<QueryAttributablePage>(content).Value);
+		}
+
+		[Fact]
+		public void RemovedQueryParameterLeavesLogicalTree()
+		{
+			var parameter = new ShellContentQueryParameter { Name = "value", Value = "first" };
+			var content = CreateContent(parameter);
+			var element = Assert.IsAssignableFrom<Element>(parameter);
+
+			Assert.Same(content, element.Parent);
+
+			content.QueryParameters.Remove(parameter);
+
+			Assert.Null(element.Parent);
+		}
+
+		[Fact]
+		public void QueryParameterCannotBeSharedAcrossShellContentOwners()
+		{
+			var parameter = new ShellContentQueryParameter { Name = "value", Value = "first" };
+			var first = CreateContent(parameter);
+			var second = new ShellContent();
+
+			Assert.Throws<InvalidOperationException>(() => second.QueryParameters.Add(parameter));
+			Assert.Same(first, parameter.Parent);
+			Assert.DoesNotContain(parameter, second.QueryParameters);
+		}
+
+		[Fact]
 		public async Task StaticParameterCanUpdateAndBeRemovedAfterRelativePop()
 		{
 			Routing.RegisterRoute("details", typeof(ContentPage));
@@ -624,9 +715,62 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			await shell.GoToAsync("//content?value=navigation");
 			var page = GetPage<QueryAttributablePage>(content);
+			int applyCount = page.ApplyCount;
 			parameter.Value = "updated";
 
 			Assert.Equal("navigation", page.Value);
+			Assert.Equal(applyCount, page.ApplyCount);
+		}
+
+		[Fact]
+		public async Task IntermediateNavigationPreservesExistingUnrelatedRootParameter()
+		{
+			Routing.RegisterRoute("details", typeof(ContentPage));
+			var content = CreateQueryStringContent("value=query-string");
+			var (shell, _) = CreateShell(content);
+			var page = GetPage<QueryAttributablePage>(content);
+
+			await shell.GoToAsync("//content?filter=retained");
+			await shell.GoToAsync("details");
+
+			Assert.Equal("query-string", page.Value);
+			Assert.Equal("retained", page.LastQuery["filter"]);
+		}
+
+		[Fact]
+		public async Task AbsoluteIntermediateNavigationPreservesExistingUnrelatedRootParameter()
+		{
+			Routing.RegisterRoute("details", typeof(ContentPage));
+			var content = CreateQueryStringContent("value=query-string");
+			var (shell, _) = CreateShell(content);
+			var page = GetPage<QueryAttributablePage>(content);
+
+			await shell.GoToAsync("//content?filter=retained");
+			await shell.GoToAsync("//content/details");
+
+			Assert.Equal("query-string", page.Value);
+			Assert.Equal("retained", page.LastQuery["filter"]);
+		}
+
+		[Fact]
+		public async Task IneffectiveDeclarativeParameterDoesNotClearRootQuery()
+		{
+			Routing.RegisterRoute("details", typeof(ContentPage));
+			var content = new ShellContent
+			{
+				Route = "content",
+				ContentTemplate = new DataTemplate(() => new QueryAttributablePage()),
+			};
+			content.QueryParameters.Add(new ShellContentQueryParameter { Value = "ignored" });
+			var (shell, _) = CreateShell(content);
+			var page = GetPage<QueryAttributablePage>(content);
+
+			await shell.GoToAsync("//content?filter=retained");
+			int applyCount = page.ApplyCount;
+			await shell.GoToAsync("//content/details");
+
+			Assert.Equal("retained", page.LastQuery["filter"]);
+			Assert.Equal(applyCount, page.ApplyCount);
 		}
 
 		[Fact]

--- a/src/Controls/tests/Core.UnitTests/ShellContentQueryParameterTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellContentQueryParameterTests.cs
@@ -1,0 +1,701 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	public class ShellContentQueryParameterTests : ShellTestBase
+	{
+		[Fact]
+		public void StaticSelectionDeliversDistinctParametersToSharedPageTemplate()
+		{
+			var pageTemplate = new DataTemplate(() => new ReminderPage());
+			var yesterday = CreateContent("Yesterday", "2021-12-13");
+			var today = CreateContent("Today", "2021-12-14");
+			var tomorrow = CreateContent("Tomorrow", "2021-12-15");
+			var tab = new Tab
+			{
+				Items =
+				{
+					yesterday,
+					today,
+					tomorrow,
+				}
+			};
+			var tabBar = new TabBar
+			{
+				Items = { tab }
+			};
+			var shell = new Shell
+			{
+				Items = { tabBar }
+			};
+
+			Assert.Equal("2021-12-13", GetPage(yesterday).Date);
+
+			tab.CurrentItem = today;
+			Assert.Equal("2021-12-14", GetPage(today).Date);
+
+			tab.CurrentItem = tomorrow;
+			Assert.Equal("2021-12-15", GetPage(tomorrow).Date);
+
+			ShellContent CreateContent(string title, string date)
+			{
+				var content = new ShellContent
+				{
+					Title = title,
+					ContentTemplate = pageTemplate,
+				};
+				content.QueryParameters.Add(new ShellContentQueryParameter
+				{
+					Name = "date",
+					Value = date,
+				});
+				return content;
+			}
+
+			static ReminderPage GetPage(ShellContent content) =>
+				(ReminderPage)((IShellContentController)content).GetOrCreateContent();
+		}
+
+		[Fact]
+		public void SwitchingBackReappliesParametersToReusedPage()
+		{
+			var first = CreateContent("first");
+			var second = CreateContent("second");
+			var (_, tab) = CreateShell(first, second);
+			var firstPage = GetPage<QueryAttributablePage>(first);
+
+			tab.CurrentItem = second;
+			var secondPage = GetPage<QueryAttributablePage>(second);
+			tab.CurrentItem = first;
+
+			Assert.Same(firstPage, GetPage<QueryAttributablePage>(first));
+			Assert.Equal(2, firstPage.ApplyCount);
+			Assert.Equal("first", firstPage.Value);
+			Assert.Equal(1, secondPage.ApplyCount);
+			Assert.Equal("second", secondPage.Value);
+		}
+
+		[Fact]
+		public void ContentPagesRemainLazyUntilSelected()
+		{
+			var createdPages = 0;
+			var first = CreateContent("first", () =>
+			{
+				createdPages++;
+				return new QueryAttributablePage();
+			});
+			var second = CreateContent("second", () =>
+			{
+				createdPages++;
+				return new QueryAttributablePage();
+			});
+			var (_, tab) = CreateShell(first, second);
+
+			Assert.Equal(0, createdPages);
+
+			GetPage<QueryAttributablePage>(first);
+			Assert.Equal(1, createdPages);
+
+			tab.CurrentItem = second;
+			GetPage<QueryAttributablePage>(second);
+			Assert.Equal(2, createdPages);
+			Assert.Equal("second", GetPage<QueryAttributablePage>(second).Value);
+		}
+
+		[Fact]
+		public void ParameterChangesUpdateCurrentCreatedPage()
+		{
+			var parameter = new ShellContentQueryParameter { Name = "value", Value = "first" };
+			var content = CreateContent(parameter);
+			CreateShell(content);
+			var page = GetPage<QueryAttributablePage>(content);
+
+			parameter.Value = "updated";
+
+			Assert.Equal("updated", page.Value);
+			Assert.Equal(2, page.ApplyCount);
+		}
+
+		[Fact]
+		public void AddingParameterUpdatesCurrentCreatedPage()
+		{
+			var content = new ShellContent
+			{
+				Route = "content",
+				ContentTemplate = new DataTemplate(() => new QueryAttributablePage()),
+			};
+			CreateShell(content);
+			var page = GetPage<QueryAttributablePage>(content);
+
+			content.QueryParameters.Add(new ShellContentQueryParameter { Name = "value", Value = "added" });
+
+			Assert.Equal("added", page.Value);
+			Assert.Equal(1, page.ApplyCount);
+		}
+
+		[Fact]
+		public void InactiveParameterChangesApplyOnNextSelection()
+		{
+			var first = CreateContent("first");
+			var parameter = new ShellContentQueryParameter { Name = "value", Value = "second" };
+			var second = CreateContent(parameter);
+			var (_, tab) = CreateShell(first, second);
+			var secondPage = GetPage<QueryAttributablePage>(second);
+
+			parameter.Value = "updated";
+
+			Assert.Equal(0, secondPage.ApplyCount);
+			tab.CurrentItem = second;
+			Assert.Equal("updated", secondPage.Value);
+			Assert.Equal(1, secondPage.ApplyCount);
+		}
+
+		[Fact]
+		public void InactiveParentItemParameterChangesApplyOnNextSelection()
+		{
+			var firstContent = CreateContent("first");
+			firstContent.Route = "first-content";
+			var firstSection = new Tab { Route = "first-tab", Items = { firstContent } };
+			var firstItem = new FlyoutItem { Route = "first-item", Items = { firstSection } };
+			var parameter = new ShellContentQueryParameter { Name = "value", Value = "second" };
+			var secondContent = CreateContent(parameter);
+			secondContent.Route = "second-content";
+			var secondSection = new Tab { Route = "second-tab", Items = { secondContent } };
+			var secondItem = new FlyoutItem { Route = "second-item", Items = { secondSection } };
+			var shell = new Shell { Items = { firstItem, secondItem } };
+
+			parameter.Value = "updated";
+			shell.CurrentItem = secondItem;
+
+			Assert.Equal("updated", GetPage<QueryAttributablePage>(secondContent).Value);
+		}
+
+		[Fact]
+		public void BoundParameterInheritsBindingContextAndUpdatesCurrentPage()
+		{
+			var viewModel = new TestViewModel { Value = "first" };
+			var parameter = new ShellContentQueryParameter { Name = "value" };
+			parameter.SetBinding(ShellContentQueryParameter.ValueProperty, nameof(TestViewModel.Value));
+			var content = CreateContent(parameter);
+			content.BindingContext = viewModel;
+			CreateShell(content);
+			var page = GetPage<QueryAttributablePage>(content);
+
+			Assert.Equal("first", page.Value);
+
+			viewModel.Value = "updated";
+
+			Assert.Equal("updated", page.Value);
+		}
+
+		[Fact]
+		public void BoundParameterInheritsBindingContextFromParentShell()
+		{
+			var viewModel = new TestViewModel { Value = "first" };
+			var parameter = new ShellContentQueryParameter { Name = "value" };
+			parameter.SetBinding(ShellContentQueryParameter.ValueProperty, nameof(TestViewModel.Value));
+			var content = CreateContent(parameter);
+			var (shell, _) = CreateShell(content);
+
+			shell.BindingContext = viewModel;
+			var page = GetPage<QueryAttributablePage>(content);
+
+			Assert.Equal("first", page.Value);
+
+			viewModel.Value = "updated";
+			Assert.Equal("updated", page.Value);
+		}
+
+		[Fact]
+		public void ReplacingParameterUnsubscribesOldParameter()
+		{
+			var oldParameter = new ShellContentQueryParameter { Name = "value", Value = "first" };
+			var content = CreateContent(oldParameter);
+			CreateShell(content);
+			var page = GetPage<QueryAttributablePage>(content);
+			var newParameter = new ShellContentQueryParameter { Name = "value", Value = "replacement" };
+
+			content.QueryParameters[0] = newParameter;
+			int applyCountAfterReplacement = page.ApplyCount;
+			oldParameter.Value = "ignored";
+
+			Assert.Equal("replacement", page.Value);
+			Assert.Equal(applyCountAfterReplacement, page.ApplyCount);
+		}
+
+		[Fact]
+		public void DuplicateNamesUseLastValueAndRevealPreviousValueOnRemoval()
+		{
+			var first = new ShellContentQueryParameter { Name = "value", Value = "first" };
+			var second = new ShellContentQueryParameter { Name = "value", Value = "second" };
+			var content = CreateContent(first, second);
+			CreateShell(content);
+			var page = GetPage<QueryAttributablePage>(content);
+
+			Assert.Equal("second", page.Value);
+
+			content.QueryParameters.Remove(second);
+
+			Assert.Equal("first", page.Value);
+		}
+
+		[Fact]
+		public void NullValueIsDeliveredAndRemovalClearsQueryProperty()
+		{
+			var parameter = new ShellContentQueryParameter { Name = "value", Value = "first" };
+			var content = new ShellContent
+			{
+				Route = "content",
+				ContentTemplate = new DataTemplate(() => new QueryPropertyPage()),
+			};
+			content.QueryParameters.Add(parameter);
+			CreateShell(content);
+			var page = GetPage<QueryPropertyPage>(content);
+
+			parameter.Value = null;
+			Assert.Null(page.Value);
+
+			parameter.Value = "second";
+			Assert.Equal("second", page.Value);
+
+			content.QueryParameters.Remove(parameter);
+			Assert.Null(page.Value);
+		}
+
+		[Fact]
+		public void RenamingParameterClearsOldQueryPropertyAndSetsNewQueryProperty()
+		{
+			var parameter = new ShellContentQueryParameter { Name = "first", Value = "value" };
+			var content = new ShellContent
+			{
+				Route = "content",
+				ContentTemplate = new DataTemplate(() => new TwoQueryPropertyPage()),
+			};
+			content.QueryParameters.Add(parameter);
+			CreateShell(content);
+			var page = GetPage<TwoQueryPropertyPage>(content);
+
+			Assert.Equal("value", page.First);
+			Assert.Null(page.Second);
+
+			parameter.Name = "second";
+
+			Assert.Null(page.First);
+			Assert.Equal("value", page.Second);
+		}
+
+		[Fact]
+		public void QueryPropertyPreservesLiteralStaticString()
+		{
+			var content = new ShellContent
+			{
+				Route = "content",
+				ContentTemplate = new DataTemplate(() => new QueryPropertyPage()),
+			};
+			content.QueryParameters.Add(new ShellContentQueryParameter
+			{
+				Name = "value",
+				Value = "A+B%2B",
+			});
+			CreateShell(content);
+
+			Assert.Equal("A+B%2B", GetPage<QueryPropertyPage>(content).Value);
+		}
+
+		[Fact]
+		public async Task QueryPropertyPreservesLiteralStaticStringAfterRelativePop()
+		{
+			Routing.RegisterRoute("details", typeof(ContentPage));
+			var content = new ShellContent
+			{
+				Route = "content",
+				ContentTemplate = new DataTemplate(() => new QueryPropertyPage()),
+			};
+			content.QueryParameters.Add(new ShellContentQueryParameter
+			{
+				Name = "value",
+				Value = "A+B%2B",
+			});
+			var (shell, _) = CreateShell(content);
+			var page = GetPage<QueryPropertyPage>(content);
+
+			await shell.GoToAsync("details");
+			await shell.GoToAsync("..");
+
+			Assert.Equal("A+B%2B", page.Value);
+		}
+
+		[Fact]
+		public async Task StaticParameterCanUpdateAndBeRemovedAfterRelativePop()
+		{
+			Routing.RegisterRoute("details", typeof(ContentPage));
+			var parameter = new ShellContentQueryParameter
+			{
+				Name = "value",
+				Value = "first",
+			};
+			var content = new ShellContent
+			{
+				Route = "content",
+				ContentTemplate = new DataTemplate(() => new QueryPropertyPage()),
+			};
+			content.QueryParameters.Add(parameter);
+			var (shell, _) = CreateShell(content);
+			var page = GetPage<QueryPropertyPage>(content);
+
+			await shell.GoToAsync("details");
+			await shell.GoToAsync("..");
+			parameter.Value = "updated";
+
+			Assert.Equal("updated", page.Value);
+
+			content.QueryParameters.Remove(parameter);
+			Assert.Null(page.Value);
+		}
+
+		[Fact]
+		public void EmptyAndNullNamesAreIgnored()
+		{
+			var content = CreateContent(
+				new ShellContentQueryParameter { Name = null, Value = "null" },
+				new ShellContentQueryParameter { Name = "", Value = "empty" },
+				new ShellContentQueryParameter { Name = "value", Value = "valid" });
+			CreateShell(content);
+
+			var page = GetPage<QueryAttributablePage>(content);
+
+			Assert.Equal("valid", page.Value);
+			Assert.Single(page.LastQuery);
+		}
+
+		[Fact]
+		public async Task NavigationParametersOverrideContentParameters()
+		{
+			var content = CreateContent("static");
+			var (shell, _) = CreateShell(content);
+
+			await shell.GoToAsync("//content?value=navigation");
+
+			Assert.Equal("navigation", GetPage<QueryAttributablePage>(content).Value);
+		}
+
+		[Fact]
+		public async Task ParameterChangeDoesNotReplaceCurrentNavigationOverride()
+		{
+			var parameter = new ShellContentQueryParameter { Name = "value", Value = "static" };
+			var content = CreateContent(parameter);
+			var (shell, _) = CreateShell(content);
+
+			await shell.GoToAsync("//content?value=navigation");
+			var page = GetPage<QueryAttributablePage>(content);
+			parameter.Value = "updated";
+
+			Assert.Equal("navigation", page.Value);
+		}
+
+		[Fact]
+		public async Task DirectSelectionReclaimsShellNavigationQueryParameterKey()
+		{
+			var first = CreateContent("first");
+			first.Route = "first";
+			var second = CreateContent("static");
+			second.Route = "second";
+			var (shell, tab) = CreateShell(first, second);
+			var navigationParameters = new ShellNavigationQueryParameters
+			{
+				["value"] = "navigation",
+			};
+
+			await shell.GoToAsync(new ShellNavigationState("//second"), navigationParameters);
+			var page = GetPage<QueryAttributablePage>(second);
+			tab.CurrentItem = first;
+			tab.CurrentItem = second;
+
+			Assert.Equal("static", page.Value);
+		}
+
+		[Fact]
+		public async Task ParameterRemovalDoesNotRemoveCurrentNavigationOverride()
+		{
+			var parameter = new ShellContentQueryParameter { Name = "value", Value = "static" };
+			var content = CreateContent(parameter);
+			var (shell, _) = CreateShell(content);
+
+			await shell.GoToAsync("//content?value=navigation");
+			var page = GetPage<QueryAttributablePage>(content);
+			content.QueryParameters.Remove(parameter);
+
+			Assert.Equal("navigation", page.Value);
+		}
+
+		[Fact]
+		public async Task NavigationThatChangesContentAppliesQueryOnce()
+		{
+			var first = CreateContent("first");
+			first.Route = "first";
+			var second = CreateContent("static");
+			second.Route = "second";
+			var (shell, _) = CreateShell(first, second);
+
+			await shell.GoToAsync("//second?value=navigation");
+			var page = GetPage<QueryAttributablePage>(second);
+
+			Assert.Equal("navigation", page.Value);
+			Assert.Equal(1, page.ApplyCount);
+		}
+
+		[Fact]
+		public async Task NavigationThatChangesShellItemAppliesQueryOnce()
+		{
+			var firstContent = CreateContent("first");
+			firstContent.Route = "first-content";
+			var firstSection = new Tab { Route = "first-tab", Items = { firstContent } };
+			var firstItem = new FlyoutItem { Route = "first-item", Items = { firstSection } };
+			var secondContent = CreateContent("static");
+			secondContent.Route = "second-content";
+			var secondSection = new Tab { Route = "second-tab", Items = { secondContent } };
+			var secondItem = new FlyoutItem { Route = "second-item", Items = { secondSection } };
+			var shell = new Shell { Items = { firstItem, secondItem } };
+
+			await shell.GoToAsync("//second-item/second-tab/second-content?value=navigation");
+			var page = GetPage<QueryAttributablePage>(secondContent);
+
+			Assert.Equal("navigation", page.Value);
+			Assert.Equal(1, page.ApplyCount);
+		}
+
+		[Fact]
+		public async Task DirectSelectionAfterNavigationRestoresContentParameter()
+		{
+			var first = CreateContent("first");
+			first.Route = "first";
+			var second = CreateContent("static");
+			second.Route = "second";
+			var (shell, tab) = CreateShell(first, second);
+
+			await shell.GoToAsync("//second?value=navigation");
+			var page = GetPage<QueryAttributablePage>(second);
+			tab.CurrentItem = first;
+			tab.CurrentItem = second;
+
+			Assert.Equal("static", page.Value);
+			Assert.Equal(2, page.ApplyCount);
+		}
+
+		[Fact]
+		public async Task ContentParametersApplyWhenNavigationDoesNotSupplySameKey()
+		{
+			var content = CreateContent("static");
+			content.QueryParameters.Add(new ShellContentQueryParameter { Name = "other", Value = "content" });
+			var (shell, _) = CreateShell(content);
+
+			await shell.GoToAsync("//content?navigation=value");
+
+			var query = GetPage<QueryAttributablePage>(content).LastQuery;
+			Assert.Equal("static", query["value"]);
+			Assert.Equal("content", query["other"]);
+			Assert.Equal("value", query["navigation"]);
+		}
+
+		[Fact]
+		public async Task DirectSelectionRetainsUnrelatedNavigationParameter()
+		{
+			var first = CreateContent("first");
+			first.Route = "first";
+			var second = CreateContent("static");
+			second.Route = "second";
+			second.QueryParameters.Add(new ShellContentQueryParameter { Name = "other", Value = "content" });
+			var (shell, tab) = CreateShell(first, second);
+
+			await shell.GoToAsync("//second?navigation=value");
+			var page = GetPage<QueryAttributablePage>(second);
+			tab.CurrentItem = first;
+			tab.CurrentItem = second;
+
+			Assert.Equal("static", page.LastQuery["value"]);
+			Assert.Equal("content", page.LastQuery["other"]);
+			Assert.Equal("value", page.LastQuery["navigation"]);
+		}
+
+		[Fact]
+		public async Task NavigationWithoutParameterRestoresContentParameter()
+		{
+			var content = CreateContent("static");
+			var (shell, _) = CreateShell(content);
+
+			await shell.GoToAsync("//content?value=navigation");
+			await shell.GoToAsync("//content");
+
+			Assert.Equal("static", GetPage<QueryAttributablePage>(content).Value);
+		}
+
+		[Fact]
+		public void QueryExceptionsAreNotSwallowed()
+		{
+			var content = new ShellContent
+			{
+				ContentTemplate = new DataTemplate(() => new ThrowingQueryPage()),
+			};
+			content.QueryParameters.Add(new ShellContentQueryParameter { Name = "value", Value = "test" });
+			CreateShell(content);
+
+			Assert.Throws<InvalidOperationException>(() =>
+				((IShellContentController)content).GetOrCreateContent());
+		}
+
+		[Fact]
+		public void InactiveSectionCurrentItemDoesNotApplyUntilParentIsSelected()
+		{
+			var first = CreateContent("first");
+			first.Route = "first";
+			var second = CreateContent("second");
+			second.Route = "second";
+			var inactiveSection = new Tab { Route = "inactive", Items = { first, second } };
+			var activeContent = CreateContent("active");
+			activeContent.Route = "active-content";
+			var activeSection = new Tab { Route = "active", Items = { activeContent } };
+			var item = new TabBar { Items = { activeSection, inactiveSection } };
+			var shell = new Shell { Items = { item } };
+			var secondPage = GetPage<QueryAttributablePage>(second);
+
+			inactiveSection.CurrentItem = second;
+
+			Assert.Equal(0, secondPage.ApplyCount);
+			item.CurrentItem = inactiveSection;
+			Assert.Equal("second", secondPage.Value);
+			Assert.Equal(1, secondPage.ApplyCount);
+		}
+
+		[Fact]
+		public async Task ParameterChangeWhileModalIsVisibleUpdatesSelectedContent()
+		{
+			var parameter = new ShellContentQueryParameter { Name = "value", Value = "first" };
+			var content = CreateContent(parameter);
+			var (shell, _) = CreateShell(content);
+			var page = GetPage<QueryAttributablePage>(content);
+
+			await shell.Navigation.PushModalAsync(new ContentPage(), false);
+			parameter.Value = "updated";
+
+			Assert.Equal("updated", page.Value);
+
+			await shell.Navigation.PopModalAsync(false);
+			Assert.Equal("updated", page.Value);
+		}
+
+		static ShellContent CreateContent(string value, Func<Page> factory = null) =>
+			CreateContent(
+				new ShellContentQueryParameter { Name = "value", Value = value },
+				factory);
+
+		static ShellContent CreateContent(params ShellContentQueryParameter[] parameters) =>
+			CreateContent(parameters, null);
+
+		static ShellContent CreateContent(ShellContentQueryParameter parameter) =>
+			CreateContent(new[] { parameter }, null);
+
+		static ShellContent CreateContent(
+			ShellContentQueryParameter parameter,
+			Func<Page> factory) =>
+			CreateContent(new[] { parameter }, factory);
+
+		static ShellContent CreateContent(
+			ShellContentQueryParameter[] parameters,
+			Func<Page> factory)
+		{
+			var content = new ShellContent
+			{
+				Route = "content",
+				ContentTemplate = new DataTemplate(factory ?? (() => new QueryAttributablePage())),
+			};
+
+			foreach (var parameter in parameters)
+				content.QueryParameters.Add(parameter);
+
+			return content;
+		}
+
+		static (Shell Shell, Tab Tab) CreateShell(params ShellContent[] contents)
+		{
+			var tab = new Tab { Route = "tab" };
+			foreach (var content in contents)
+				tab.Items.Add(content);
+
+			var tabBar = new TabBar { Route = "root", Items = { tab } };
+			var shell = new Shell { Items = { tabBar } };
+			return (shell, tab);
+		}
+
+		static T GetPage<T>(ShellContent content)
+			where T : Page =>
+			(T)((IShellContentController)content).GetOrCreateContent();
+
+		sealed class QueryAttributablePage : ContentPage, IQueryAttributable
+		{
+			public int ApplyCount { get; private set; }
+			public IDictionary<string, object> LastQuery { get; private set; }
+			public string Value { get; private set; }
+
+			public void ApplyQueryAttributes(IDictionary<string, object> query)
+			{
+				ApplyCount++;
+				LastQuery = new Dictionary<string, object>(query);
+				Value = query.TryGetValue("value", out var value) ? (string)value : null;
+			}
+		}
+
+		[QueryProperty(nameof(Value), "value")]
+		sealed class QueryPropertyPage : ContentPage
+		{
+			public string Value { get; set; }
+		}
+
+		[QueryProperty(nameof(First), "first")]
+		[QueryProperty(nameof(Second), "second")]
+		sealed class TwoQueryPropertyPage : ContentPage
+		{
+			public string First { get; set; }
+			public string Second { get; set; }
+		}
+
+		sealed class ThrowingQueryPage : ContentPage, IQueryAttributable
+		{
+			public void ApplyQueryAttributes(IDictionary<string, object> query) =>
+				throw new InvalidOperationException("Query failure");
+		}
+
+		sealed class TestViewModel : INotifyPropertyChanged
+		{
+			string _value;
+
+			public event PropertyChangedEventHandler PropertyChanged;
+
+			public string Value
+			{
+				get => _value;
+				set
+				{
+					if (_value == value)
+						return;
+
+					_value = value;
+					PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Value)));
+				}
+			}
+		}
+
+		sealed class ReminderPage : ContentPage, IQueryAttributable
+		{
+			public string Date { get; private set; }
+
+			public void ApplyQueryAttributes(IDictionary<string, object> query)
+			{
+				Date = (string)query["date"];
+			}
+		}
+	}
+}

--- a/src/Controls/tests/Core.UnitTests/ShellParameterPassingTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellParameterPassingTests.cs
@@ -807,6 +807,32 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public async Task IntermediatePagePreservesLegacyShellNavigationQueryParametersPayload()
+		{
+			var shell = new TestShell();
+			var item = CreateShellItem(shellSectionRoute: "section", shellContentRoute: "content");
+			shell.Items.Add(item);
+
+			var intermediatePage = new ShellTestPage();
+			shell.RegisterPage("product", intermediatePage);
+			Routing.RegisterRoute("review", typeof(ShellTestPage));
+			var parameters = new ShellNavigationQueryParameters
+			{
+				["product.id"] = 42,
+				["stars"] = 5,
+			};
+
+			await shell.GoToAsync(new ShellNavigationState("product/review"), parameters);
+
+			var query = Assert.IsType<ShellNavigationQueryParameters>(
+				Assert.Single(intermediatePage.AppliedQueryAttributes));
+			Assert.True(query.IsReadOnly);
+			Assert.Equal(42, query["product.id"]);
+			Assert.Equal(42, query["id"]);
+			Assert.Equal(5, query["stars"]);
+		}
+
+		[Fact]
 		public async Task IntermediatePageReceivesQueryPropertyAttributes()
 		{
 			var shell = new TestShell();

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui3868.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui3868.xaml
@@ -13,17 +13,11 @@
 				</ShellContent.QueryParameters>
 			</ShellContent>
 			<ShellContent x:Name="Today" Title="Today"
-				ContentTemplate="{DataTemplate local:Maui3868ReminderPage}">
-				<ShellContent.QueryParameters>
-					<ShellContentQueryParameter Name="date" Value="2021-12-14" />
-				</ShellContent.QueryParameters>
-			</ShellContent>
+				ContentTemplate="{DataTemplate local:Maui3868ReminderPage}"
+				QueryString="date=2021-12-14&amp;source=xaml" />
 			<ShellContent x:Name="Tomorrow" Title="Tomorrow"
-				ContentTemplate="{DataTemplate local:Maui3868ReminderPage}">
-				<ShellContent.QueryParameters>
-					<ShellContentQueryParameter Name="date" Value="2021-12-15" />
-				</ShellContent.QueryParameters>
-			</ShellContent>
+				ContentTemplate="{DataTemplate local:Maui3868ReminderPage}"
+				QueryString="?date=2021-12-15" />
 		</Tab>
 	</TabBar>
 </Shell>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui3868.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui3868.xaml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Shell
+	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+	x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui3868">
+	<TabBar>
+		<Tab x:Name="ReminderTab">
+			<ShellContent x:Name="Yesterday" Title="Yesterday"
+				ContentTemplate="{DataTemplate local:Maui3868ReminderPage}">
+				<ShellContent.QueryParameters>
+					<ShellContentQueryParameter Name="date" Value="2021-12-13" />
+				</ShellContent.QueryParameters>
+			</ShellContent>
+			<ShellContent x:Name="Today" Title="Today"
+				ContentTemplate="{DataTemplate local:Maui3868ReminderPage}">
+				<ShellContent.QueryParameters>
+					<ShellContentQueryParameter Name="date" Value="2021-12-14" />
+				</ShellContent.QueryParameters>
+			</ShellContent>
+			<ShellContent x:Name="Tomorrow" Title="Tomorrow"
+				ContentTemplate="{DataTemplate local:Maui3868ReminderPage}">
+				<ShellContent.QueryParameters>
+					<ShellContentQueryParameter Name="date" Value="2021-12-15" />
+				</ShellContent.QueryParameters>
+			</ShellContent>
+		</Tab>
+	</TabBar>
+</Shell>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui3868.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui3868.xaml.cs
@@ -23,6 +23,7 @@ public partial class Maui3868 : Shell
 
 			shell.ReminderTab.CurrentItem = shell.Today;
 			Assert.Equal("2021-12-14", GetPage(shell.Today).Date);
+			Assert.Equal("xaml", GetPage(shell.Today).ReceivedQuery["source"]);
 
 			shell.ReminderTab.CurrentItem = shell.Tomorrow;
 			Assert.Equal("2021-12-15", GetPage(shell.Tomorrow).Date);
@@ -39,9 +40,11 @@ public partial class Maui3868 : Shell
 public class Maui3868ReminderPage : ContentPage, IQueryAttributable
 {
 	public string Date { get; private set; }
+	public IDictionary<string, object> ReceivedQuery { get; private set; }
 
 	public void ApplyQueryAttributes(IDictionary<string, object> query)
 	{
+		ReceivedQuery = new Dictionary<string, object>(query);
 		Date = (string)query["date"];
 	}
 }

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui3868.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui3868.xaml.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui3868 : Shell
+{
+	public Maui3868() => InitializeComponent();
+
+	[Collection("Xaml Inflation")]
+	public class Tests
+	{
+		[Theory]
+		[XamlInflatorData]
+		internal void StaticShellContentParametersLoadAndApply(XamlInflator inflator)
+		{
+			var shell = new Maui3868(inflator);
+			shell.Yesterday.ContentTemplate = CreateTemplate();
+			shell.Today.ContentTemplate = CreateTemplate();
+			shell.Tomorrow.ContentTemplate = CreateTemplate();
+
+			Assert.Equal("2021-12-13", GetPage(shell.Yesterday).Date);
+
+			shell.ReminderTab.CurrentItem = shell.Today;
+			Assert.Equal("2021-12-14", GetPage(shell.Today).Date);
+
+			shell.ReminderTab.CurrentItem = shell.Tomorrow;
+			Assert.Equal("2021-12-15", GetPage(shell.Tomorrow).Date);
+		}
+
+		static Maui3868ReminderPage GetPage(ShellContent content) =>
+			(Maui3868ReminderPage)((IShellContentController)content).GetOrCreateContent();
+
+		static Microsoft.Maui.Controls.DataTemplate CreateTemplate() =>
+			new(() => new Maui3868ReminderPage());
+	}
+}
+
+public class Maui3868ReminderPage : ContentPage, IQueryAttributable
+{
+	public string Date { get; private set; }
+
+	public void ApplyQueryAttributes(IDictionary<string, object> query)
+	{
+		Date = (string)query["date"];
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Adds two XAML-friendly, per-`ShellContent` APIs so multiple statically declared Shell entries can reuse the same page template while supplying different instance data. Parameters are delivered through the existing `IQueryAttributable` and `[QueryProperty]` mechanisms when users select tabs or flyout items; no `GoToAsync` call is required.

- `QueryString` provides the compact string syntax requested by the original issue.
- `QueryParameters` provides structured, individually bindable values, including objects and explicit nulls.

#### Root cause

Direct Shell selection runs through the `Shell`, `ShellItem`, and `ShellSection` current-item callbacks rather than `ShellNavigationManager.GoToAsync`, where URI/path/query extraction normally happens. Route-template support therefore cannot provide instance data for direct tab or flyout selection.

#### Public API

```csharp
public class ShellContent
{
    public string? QueryString { get; set; }
    public IList<ShellContentQueryParameter> QueryParameters { get; }
}

public sealed class ShellContentQueryParameter : Element
{
    public static readonly BindableProperty NameProperty;
    public static readonly BindableProperty ValueProperty;

    public string? Name { get; set; }
    public object? Value { get; set; }
}
```

Compact syntax:

```xaml
<ShellContent Title="Today"
              Route="reminders-today"
              QueryString="date=2021-12-14"
              ContentTemplate="{StaticResource ReminderPageTemplate}" />
```

The leading `?` is optional. Multiple XML-attribute parameters use `&amp;`.

Structured syntax:

```xaml
<ShellContent Title="Today"
              Route="reminders-today"
              ContentTemplate="{StaticResource ReminderPageTemplate}">
    <ShellContent.QueryParameters>
        <ShellContentQueryParameter Name="date"
                                    Value="{Binding Today}" />
    </ShellContent.QueryParameters>
</ShellContent>
```

Routes remain navigation identity; both APIs are instance data and do not participate in route registration or uniqueness.

#### Defined behavior

- Applies on initial selection, tab/flyout switching, re-selection, deep links, and relative pop.
- Both APIs are bindable. Structured parameter items are logical children of their `ShellContent`, enabling inherited bindings, dynamic resources, relative-source ancestors, and parent-scoped XAML references.
- Selected pages update immediately; inactive content updates on its next selection. Replacing an already-created `Content` receives the current payload.
- During navigation, precedence is explicit `GoToAsync` parameters > structured `QueryParameters` > `QueryString`. Selecting the content again reapplies its declarative parameters.
- No-op parameter/property notifications do not re-run receivers, while explicit re-selection still does.
- Duplicate structured names are deterministic: the last collection item wins; removal reveals the preceding value. The same instance may occur repeatedly in one collection, but cannot be shared across different `ShellContent` owners.
- Null structured values are delivered; removal/clearing resets prior `[QueryProperty]` values, including non-nullable value types to their default.
- Unrelated retained root parameters survive intermediate navigation, and detail-only parameters do not leak into root content.
- `QueryString` performs standard URI query decoding exactly once. Declarative conversion uses invariant culture; legacy `GoToAsync` decoding/current-culture behavior remains unchanged for compatibility.
- Collection reset, replacement, and removal detach logical parents and subscriptions without repeated collection scans.
- Exceptions from query receivers propagate unchanged.

### What NOT to Do

- Do not encode instance data into `Route`; use `QueryString` for compact syntax. Route identity remains stable.
- Do not retain `ShellNavigationQueryParameters` ownership when declarative data takes over the same key; those parameters are intentionally single-use.
- Do not apply inactive content parameters until their containing Shell hierarchy becomes selected.
- Do not reuse one `ShellContentQueryParameter` instance across different `ShellContent` owners; use distinct instances so each has one logical parent.

### Tests

**Before/after proof:** the focused regression initially failed with `Expected: "2021-12-13"; Actual: null`. It now passes for both structured parameters and compact query strings while selecting three `ShellContent` instances through `Tab.CurrentItem`, all sharing one `DataTemplate`/page type.

- Focused query/parameter/template suites: **180 passed**
- Full Shell-filtered `Controls.Core.UnitTests`: **491 passed**
- `Maui3868` XAML loading: **3 passed** (Runtime, XamlC, SourceGen)
- `Controls.Core` API builds: `net11.0` and `netstandard2.0`, **0 warnings / 0 errors**
- Full `Controls.Core.UnitTests`: **6,234 passed, 30 skipped, 1 unrelated locale-sensitive failure**, reproduced alone (`3.14` expected vs `3,14` actual)

Coverage includes initial selection, switching/re-selection, lazy/reused/replaced pages, inherited bindings and dynamic resources, active/inactive updates, collection replacement/unsubscription, cross-owner protection, compact parsing, optional `?`, XML-escaped multi-parameters, empty keys, precedence, `IQueryAttributable`, `[QueryProperty]`, duplicate keys/instances, null/removal/clear, modal overlays, absolute and relative deep links, relative pop, retained root state, exactly-once decoding, legacy decode compatibility, invariant conversion, value-type reset, single-use parameters, prefix filtering, and exception propagation.

### Runtime validation

MAUI DevFlow from `dotnet/maui-labs` was installed and configured:

```powershell
.\.dotnet\dotnet.exe tool install -g Microsoft.Maui.Cli --prerelease
maui devflow broker start --no-json
maui devflow wait --platform windows --no-json
```

The current DevFlow agent package targets released MAUI 10 and could not initialize against this in-tree .NET 11 RC build on the ARM64 host after diagnosing transitive MAUI targets and runtime architecture. The runtime proof therefore used the same real in-tree Windows Sandbox with Windows UI Automation as the interaction fallback:

```powershell
.\.dotnet\dotnet.exe restore src\Controls\samples\Controls.Sample.Sandbox\Maui.Controls.Sample.Sandbox.csproj -r win-x64 -p:MauiSamplePlatforms=net11.0-windows10.0.19041.0 -p:MauiPlatforms=net11.0-windows10.0.19041.0 -p:AppendRuntimeIdentifierToOutputPath=false -p:DisableTransitiveFrameworkReferenceDownloads=false
.\.dotnet\dotnet.exe build src\Controls\samples\Controls.Sample.Sandbox\Maui.Controls.Sample.Sandbox.csproj -f net11.0-windows10.0.19041.0 -r win-x64 --self-contained true -p:MauiSamplePlatforms=net11.0-windows10.0.19041.0 -p:MauiPlatforms=net11.0-windows10.0.19041.0 -p:AppendRuntimeIdentifierToOutputPath=false -p:DisableTransitiveFrameworkReferenceDownloads=false --no-restore
```

Three `ShellContent` entries shared one `DataTemplate`/page. Windows UI Automation changed the real parent `Tab.CurrentItem`; the page displayed `2021-12-13`, `2021-12-14`, and `2021-12-15`, each with `Apply count: 1`. Temporary Sandbox instrumentation was removed from this PR.

Structured parameter proof:

![Windows runtime proof showing structured ShellContent parameters](https://github.com/user-attachments/assets/b5066dc0-4309-4530-aad0-1dfb343d4d98)

Compact `QueryString` proof:

![Windows runtime proof showing compact ShellContent QueryString values](https://github.com/user-attachments/assets/f49fc2e4-5225-4a8a-ad69-716fa4ad2bf8)

### Review

The complete functional/API diff and feedback fixes were independently reviewed with four distinct models:

- MAUI expert review (Claude Sonnet 5) found the absolute intermediate-navigation root-state loss; a discriminating red test was added and the merge path fixed.
- Code-review specialist (Claude Opus 5) found deep-link selection ordering in the first fix; three existing deep-link tests reproduced it and the intermediate entry point was corrected.
- Rubber-duck/API review (GPT-5.4) found cross-owner logical parenting and selected `Content` replacement gaps; both were reproduced red and fixed with regression tests.
- Independent final API/pipeline review (Gemini 3.1 Pro) reported no remaining actionable findings.

Earlier MauiBot feedback was resolved with regression coverage for stale pop handling, preservation of shipped intermediate `ShellNavigationQueryParameters` payload behavior, and corrected public precedence/decoding documentation. This round also adds explicit coverage for scoped intermediate navigation, no-op updates, logical ownership/resources, value-type reset compatibility, removal complexity, and the intentionally different legacy `GoToAsync` decode behavior.

### CI investigation

The prior PR runs were investigated through Azure DevOps Build Analysis and individual AzDO/Helix logs. The reported failures were outside the changed Shell code: a Resizetizer temporary-file lock, existing Android gesture memory tests, an Essentials geocoder concurrency test, and broad UI snapshot/missing-baseline failures. Current `net11.0` base builds for `maui-pr`, `maui-pr-devicetests`, and `maui-pr-uitests` are also red. A fresh `maui-pr` run is required for this head.

### Issues Fixed

Fixes #3868

### Breaking Changes

None. These are additive public APIs; `ShellContent` instances using neither API retain existing behavior.