### PR TITLE
Fix workload paths when SDK directory lacks separator

### DIFF
--- a/src/DotNet/DotNet.csproj
+++ b/src/DotNet/DotNet.csproj
@@ -73,7 +73,7 @@
     <CopyWorkloadFiles
         Name="microsoft.net.sdk.maui"
         Files="@(_WorkloadFiles)"
-        WorkloadDirectory="$(MSBuildExtensionsPath)../../sdk-manifests/$(DotNetSdkManifestsFolder)"
+        WorkloadDirectory="$([MSBuild]::EnsureTrailingSlash('$(MSBuildExtensionsPath)'))../../sdk-manifests/$(DotNetSdkManifestsFolder)"
     />
     <RemoveDir Directories="$(_InstallTempDirectory)" />
 
@@ -88,7 +88,7 @@
     </ItemGroup>
     <Copy SourceFiles="$(MauiRootDirectory)NuGet.config" DestinationFolder="$(DotNetTempDirectory)" />
     <Exec Command="dotnet nuget add source &quot;$(NugetArtifactsPath)&quot; --name artifacts --configfile &quot;$(DotNetTempDirectory)NuGet.config&quot;" />
-    <Exec Command="&quot;$(MSBuildExtensionsPath)../../dotnet&quot; workload install %(_LocalWorkloadIds.Identity) --skip-sign-check --skip-manifest-update --verbosity diag --temp-dir &quot;$(DotNetTempDirectory)&quot; --configfile &quot;$(DotNetTempDirectory)NuGet.config&quot;" WorkingDirectory="$(MauiRootDirectory)" />
+    <Exec Command="&quot;$([MSBuild]::EnsureTrailingSlash('$(MSBuildExtensionsPath)'))../../dotnet&quot; workload install %(_LocalWorkloadIds.Identity) --skip-sign-check --skip-manifest-update --verbosity diag --temp-dir &quot;$(DotNetTempDirectory)&quot; --configfile &quot;$(DotNetTempDirectory)NuGet.config&quot;" WorkingDirectory="$(MauiRootDirectory)" />
 
   </Target>
 

--- a/src/DotNet/DotNet.csproj
+++ b/src/DotNet/DotNet.csproj
@@ -13,6 +13,9 @@
     <PrivateSdk Condition=" '$(PrivateSdk)' == ''">false</PrivateSdk>
     <_SkipUpgradeNetAnalyzersNuGetWarning>true</_SkipUpgradeNetAnalyzersNuGetWarning>
     <_SkipUpdateBuildNumber>true</_SkipUpdateBuildNumber>
+    <_NormalizedMSBuildExtensionsPath>$([MSBuild]::EnsureTrailingSlash('$(MSBuildExtensionsPath)'))</_NormalizedMSBuildExtensionsPath>
+    <_WorkloadManifestInstallDirectory>$(_NormalizedMSBuildExtensionsPath)../../sdk-manifests/$(DotNetSdkManifestsFolder)</_WorkloadManifestInstallDirectory>
+    <_WorkloadInstallDotNetPath>$(_NormalizedMSBuildExtensionsPath)../../dotnet</_WorkloadInstallDotNetPath>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('windows'))">
     <DotNetInstallScriptUrl>https://builds.dotnet.microsoft.com/dotnet/scripts/v1/dotnet-install.ps1</DotNetInstallScriptUrl>
@@ -73,7 +76,7 @@
     <CopyWorkloadFiles
         Name="microsoft.net.sdk.maui"
         Files="@(_WorkloadFiles)"
-        WorkloadDirectory="$([MSBuild]::EnsureTrailingSlash('$(MSBuildExtensionsPath)'))../../sdk-manifests/$(DotNetSdkManifestsFolder)"
+        WorkloadDirectory="$(_WorkloadManifestInstallDirectory)"
     />
     <RemoveDir Directories="$(_InstallTempDirectory)" />
 
@@ -88,7 +91,7 @@
     </ItemGroup>
     <Copy SourceFiles="$(MauiRootDirectory)NuGet.config" DestinationFolder="$(DotNetTempDirectory)" />
     <Exec Command="dotnet nuget add source &quot;$(NugetArtifactsPath)&quot; --name artifacts --configfile &quot;$(DotNetTempDirectory)NuGet.config&quot;" />
-    <Exec Command="&quot;$([MSBuild]::EnsureTrailingSlash('$(MSBuildExtensionsPath)'))../../dotnet&quot; workload install %(_LocalWorkloadIds.Identity) --skip-sign-check --skip-manifest-update --verbosity diag --temp-dir &quot;$(DotNetTempDirectory)&quot; --configfile &quot;$(DotNetTempDirectory)NuGet.config&quot;" WorkingDirectory="$(MauiRootDirectory)" />
+    <Exec Command="&quot;$(_WorkloadInstallDotNetPath)&quot; workload install %(_LocalWorkloadIds.Identity) --skip-sign-check --skip-manifest-update --verbosity diag --temp-dir &quot;$(DotNetTempDirectory)&quot; --configfile &quot;$(DotNetTempDirectory)NuGet.config&quot;" WorkingDirectory="$(MauiRootDirectory)" />
 
   </Target>
 

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/DotNetProjectTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/DotNetProjectTests.cs
@@ -1,0 +1,81 @@
+namespace Microsoft.Maui.IntegrationTests;
+
+[Trait("Category", "Build")]
+public class DotNetProjectTests
+{
+	readonly ITestOutputHelper _output;
+
+	public DotNetProjectTests(ITestOutputHelper output)
+	{
+		_output = output;
+	}
+
+	[Fact]
+	public void WorkloadInstallPathsAreIndependentOfTrailingSeparator()
+	{
+		var projectFile = Path.Combine(
+			TestEnvironment.GetMauiDirectory(),
+			"src",
+			"DotNet",
+			"DotNet.csproj");
+		var defaultExtensionsPath = GetProjectProperty(projectFile, "MSBuildExtensionsPath");
+		var extensionsPathWithoutSeparator = defaultExtensionsPath.TrimEnd(
+			Path.DirectorySeparatorChar,
+			Path.AltDirectorySeparatorChar);
+		var extensionsPathWithSeparator = extensionsPathWithoutSeparator + Path.DirectorySeparatorChar;
+
+		var withoutSeparator = GetWorkloadPaths(projectFile, extensionsPathWithoutSeparator);
+		var withSeparator = GetWorkloadPaths(projectFile, extensionsPathWithSeparator);
+
+		Assert.Equal(withSeparator, withoutSeparator);
+		Assert.True(
+			withoutSeparator.ExtensionsPath.EndsWith(
+				Path.DirectorySeparatorChar.ToString(),
+				StringComparison.Ordinal) ||
+			withoutSeparator.ExtensionsPath.EndsWith(
+				Path.AltDirectorySeparatorChar.ToString(),
+				StringComparison.Ordinal));
+		Assert.Equal(
+			$"{withoutSeparator.ExtensionsPath}../../sdk-manifests/{withoutSeparator.ManifestBand}",
+			withoutSeparator.ManifestDirectory);
+		Assert.Equal(
+			$"{withoutSeparator.ExtensionsPath}../../dotnet",
+			withoutSeparator.DotNetPath);
+	}
+
+	(string ExtensionsPath, string ManifestDirectory, string DotNetPath, string ManifestBand) GetWorkloadPaths(
+		string projectFile,
+		string extensionsPath)
+	{
+		return (
+			GetProjectProperty(projectFile, "_NormalizedMSBuildExtensionsPath", extensionsPath),
+			GetProjectProperty(projectFile, "_WorkloadManifestInstallDirectory", extensionsPath),
+			GetProjectProperty(projectFile, "_WorkloadInstallDotNetPath", extensionsPath),
+			GetProjectProperty(projectFile, "DotNetSdkManifestsFolder", extensionsPath));
+	}
+
+	string GetProjectProperty(string projectFile, string propertyName, string? extensionsPath = null)
+	{
+		var propertyArgument = extensionsPath is null
+			? string.Empty
+			: $" -p:MSBuildExtensionsPath=\"{extensionsPath}\"";
+		var output = DotnetInternal.RunForOutput(
+			"msbuild",
+			$"\"{projectFile}\" -nologo -verbosity:quiet -getProperty:{propertyName}{propertyArgument}",
+			out var exitCode,
+			timeoutInSeconds: 60,
+			output: _output);
+
+		Assert.True(exitCode == 0, $"MSBuild property evaluation failed:{Environment.NewLine}{output}");
+
+		var value = output
+			.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+			.LastOrDefault()?
+			.Trim();
+
+		if (string.IsNullOrEmpty(value))
+			throw new XunitException($"MSBuild property '{propertyName}' was empty.");
+
+		return value;
+	}
+}

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/DotNetProjectTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/DotNetProjectTests.cs
@@ -56,12 +56,19 @@ public class DotNetProjectTests
 
 	string GetProjectProperty(string projectFile, string propertyName, string? extensionsPath = null)
 	{
-		var propertyArgument = extensionsPath is null
-			? string.Empty
-			: $" -p:MSBuildExtensionsPath=\"{extensionsPath}\"";
-		var output = DotnetInternal.RunForOutput(
+		var arguments = new List<string>
+		{
 			"msbuild",
-			$"\"{projectFile}\" -nologo -verbosity:quiet -getProperty:{propertyName}{propertyArgument}",
+			projectFile,
+			"-nologo",
+			"-verbosity:quiet",
+			$"-getProperty:{propertyName}",
+		};
+		if (extensionsPath is not null)
+			arguments.Add($"-p:MSBuildExtensionsPath={extensionsPath}");
+
+		var output = DotnetInternal.RunForOutput(
+			arguments,
 			out var exitCode,
 			timeoutInSeconds: 60,
 			output: _output);

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/DotnetInternal.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/DotnetInternal.cs
@@ -179,10 +179,28 @@ namespace Microsoft.Maui.IntegrationTests
 			output?.WriteLine($"Running: '{DotnetTool}' with '{command}'");
 			output?.WriteLine($"Args list: {args}");
 			var pinfo = new ProcessStartInfo(DotnetTool, $"{command} {args}");
-			pinfo.EnvironmentVariables["DOTNET_MULTILEVEL_LOOKUP"] = "0";
-			pinfo.EnvironmentVariables["DOTNET_ROOT"] = DotnetRoot;
+			ConfigureDotnetEnvironment(pinfo);
 
 			return ToolRunner.Run(pinfo, out exitCode, timeoutInSeconds: timeoutInSeconds, output: output);
+		}
+
+		public static string RunForOutput(IReadOnlyList<string> arguments, out int exitCode, int timeoutInSeconds = DEFAULT_TIMEOUT, ITestOutputHelper? output = null)
+		{
+			output?.WriteLine($"Running: '{DotnetTool}'");
+			output?.WriteLine($"Args list: {string.Join(" | ", arguments)}");
+			var pinfo = new ProcessStartInfo(DotnetTool);
+			foreach (var argument in arguments)
+				pinfo.ArgumentList.Add(argument);
+
+			ConfigureDotnetEnvironment(pinfo);
+
+			return ToolRunner.Run(pinfo, out exitCode, timeoutInSeconds: timeoutInSeconds, output: output);
+		}
+
+		static void ConfigureDotnetEnvironment(ProcessStartInfo pinfo)
+		{
+			pinfo.EnvironmentVariables["DOTNET_MULTILEVEL_LOOKUP"] = "0";
+			pinfo.EnvironmentVariables["DOTNET_ROOT"] = DotnetRoot;
 		}
 
 	}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

PR #37688 updates the repository to .NET SDK `11.0.100-rc.1.26420.103`. That SDK includes [dotnet/sdk@bc6956b2](https://github.com/dotnet/sdk/commit/bc6956b2d619b5dbef15dc445813c5c691ee2351), which no longer leaves a directory separator at the end of `MSBuildExtensionsPath`.

`src/DotNet/DotNet.csproj` appended `../../` directly to that property when locating both the SDK manifest directory and the `dotnet` host. With the newer SDK this produced paths such as:

```text
.../sdk/11.0.100-rc.1.26420.103../../dotnet
```

This change calls `EnsureTrailingSlash` before both relative path joins. Existing SDK behavior is preserved, while separator-free values now resolve correctly.

Using `DOTNET_HOST_PATH` was considered for the executable lookup, but it would not address the manifest-directory path. Normalizing the shared base path fixes both lookups consistently. No existing open MAUI PR addressed this path assumption when checked.

## Validation

Reproduced the failure with:

```text
dotnet cake --target=dotnet-local-workloads
```

Applied this patch on top of PR #37688 and reran the same target. The local `maui` workload installed successfully and the build completed with 0 errors.
