### PR TITLE
[release/10.0.1xx-sr10] Fix MediaPicker completion from child activities

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue35826.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue35826.cs
@@ -1,0 +1,140 @@
+using Microsoft.Maui.Media;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 35826, "PickPhotosAsync hangs when called from a child activity", PlatformAffected.Android)]
+public class Issue35826 : ContentPage
+{
+	public Issue35826()
+	{
+		var instructions = new Label
+		{
+			AutomationId = "InstructionsLabel",
+			Text = "1. Tap 'Open Child Activity'\n" +
+			       "2. In the child activity, tap 'Pick Photos'\n" +
+			       "3. Press Back to cancel the picker\n" +
+			       "Expected: Status shows 'Cancelled'\n" +
+			       "Bug: Picker hangs indefinitely",
+			FontSize = 14
+		};
+
+		var openButton = new Button
+		{
+			AutomationId = "OpenChildActivityButton",
+			Text = "Open Child Activity",
+			HorizontalOptions = LayoutOptions.Fill
+		};
+		openButton.Clicked += OnOpenChildActivityClicked;
+
+		var statusLabel = new Label
+		{
+			AutomationId = "StatusLabel",
+			Text = "Status: Ready",
+			FontSize = 16,
+			FontAttributes = FontAttributes.Bold
+		};
+
+		Content = new VerticalStackLayout
+		{
+			Padding = 30,
+			Spacing = 25,
+			Children = { instructions, openButton, statusLabel }
+		};
+	}
+
+	void OnOpenChildActivityClicked(object sender, EventArgs e)
+	{
+#if ANDROID
+		var activity = Microsoft.Maui.ApplicationModel.Platform.CurrentActivity;
+		if (activity != null)
+		{
+			var intent = new Android.Content.Intent(activity, typeof(Issue35826ChildActivity));
+			activity.StartActivity(intent);
+		}
+#endif
+	}
+}
+
+#if ANDROID
+// A plain AppCompatActivity that calls MediaPicker.PickPhotosAsync().
+// Before the fix, Platform.Init() on this activity was silently ignored by the guard in
+// ActivityForResultRequest.Register(), so no launcher was registered for it and the
+// picker task never completed. After the fix each activity gets its own launcher entry
+// in the ConditionalWeakTable, so the result is delivered correctly.
+[Android.App.Activity(Label = "Issue35826 Child Activity", Theme = "@style/Maui.SplashTheme")]
+public class Issue35826ChildActivity : AndroidX.AppCompat.App.AppCompatActivity
+{
+	Android.Widget.TextView _resultLabel;
+
+	protected override void OnCreate(Android.OS.Bundle savedInstanceState)
+	{
+		base.OnCreate(savedInstanceState);
+
+		Microsoft.Maui.ApplicationModel.Platform.Init(this, savedInstanceState);
+
+		var layout = new Android.Widget.LinearLayout(this)
+		{
+			Orientation = Android.Widget.Orientation.Vertical
+		};
+		layout.SetPadding(50, 50, 50, 50);
+
+		_resultLabel = new Android.Widget.TextView(this)
+		{
+			Text = "Result: Ready"
+		};
+		_resultLabel.SetPadding(0, 0, 0, 50);
+		SetViewIdResourceName(_resultLabel, "ChildActivityResultLabel");
+
+		var pickButton = new Android.Widget.Button(this)
+		{
+			Text = "Pick Photos"
+		};
+		SetViewIdResourceName(pickButton, "ChildActivityPickButton");
+
+		pickButton.Click += async (_, _) =>
+		{
+			_resultLabel.Text = "Result: Picking...";
+			try
+			{
+				var result = await MediaPicker.PickPhotosAsync();
+				_resultLabel.Text = result?.Count > 0
+					? $"Result: Got {result.Count} photo(s)"
+					: "Result: Cancelled";
+			}
+			catch (OperationCanceledException)
+			{
+				_resultLabel.Text = "Result: Cancelled";
+			}
+			catch (Exception ex)
+			{
+				_resultLabel.Text = $"Result: Error - {ex.Message}";
+			}
+		};
+
+		layout.AddView(_resultLabel);
+		layout.AddView(pickButton);
+		SetContentView(layout);
+	}
+
+	// Sets ViewIdResourceName on a native Android view so Appium can locate it by
+	// resource-id (the same mechanism MAUI uses for AutomationId on Android).
+	void SetViewIdResourceName(Android.Views.View view, string automationId)
+	{
+		var resourceName = $"{PackageName}:id/{automationId}";
+		AndroidX.Core.View.ViewCompat.SetAccessibilityDelegate(view, new AutomationIdDelegate(resourceName));
+	}
+
+	class AutomationIdDelegate : AndroidX.Core.View.AccessibilityDelegateCompat
+	{
+		readonly string _resourceName;
+
+		public AutomationIdDelegate(string resourceName) => _resourceName = resourceName;
+
+		public override void OnInitializeAccessibilityNodeInfo(Android.Views.View host, AndroidX.Core.View.Accessibility.AccessibilityNodeInfoCompat info)
+		{
+			base.OnInitializeAccessibilityNodeInfo(host, info);
+			info.ViewIdResourceName = _resourceName;
+		}
+	}
+}
+#endif

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue35826.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue35826.cs
@@ -5,6 +5,8 @@ namespace Maui.Controls.Sample.Issues;
 [Issue(IssueTracker.Github, 35826, "PickPhotosAsync hangs when called from a child activity", PlatformAffected.Android)]
 public class Issue35826 : ContentPage
 {
+	static WeakReference<Label> s_statusLabel;
+
 	public Issue35826()
 	{
 		var instructions = new Label
@@ -33,6 +35,7 @@ public class Issue35826 : ContentPage
 			FontSize = 16,
 			FontAttributes = FontAttributes.Bold
 		};
+		s_statusLabel = new(statusLabel);
 
 		Content = new VerticalStackLayout
 		{
@@ -40,6 +43,12 @@ public class Issue35826 : ContentPage
 			Spacing = 25,
 			Children = { instructions, openButton, statusLabel }
 		};
+	}
+
+	internal static void UpdateStatus(string text)
+	{
+		if (s_statusLabel?.TryGetTarget(out var statusLabel) == true)
+			statusLabel.Dispatcher.Dispatch(() => statusLabel.Text = text);
 	}
 
 	void OnOpenChildActivityClicked(object sender, EventArgs e)
@@ -85,6 +94,17 @@ public class Issue35826ChildActivity : AndroidX.AppCompat.App.AppCompatActivity
 		_resultLabel.SetPadding(0, 0, 0, 50);
 		SetViewIdResourceName(_resultLabel, "ChildActivityResultLabel");
 
+		var isPhotoPickerAvailable =
+			AndroidX.Activity.Result.Contract.ActivityResultContracts.PickVisualMedia.InvokeIsPhotoPickerAvailable(this);
+		var pickerAvailabilityLabel = new Android.Widget.TextView(this)
+		{
+			Text = isPhotoPickerAvailable
+				? "Photo Picker: Available"
+				: "Photo Picker: Unavailable"
+		};
+		pickerAvailabilityLabel.SetPadding(0, 0, 0, 50);
+		SetViewIdResourceName(pickerAvailabilityLabel, "PhotoPickerAvailabilityLabel");
+
 		var pickButton = new Android.Widget.Button(this)
 		{
 			Text = "Pick Photos"
@@ -111,8 +131,69 @@ public class Issue35826ChildActivity : AndroidX.AppCompat.App.AppCompatActivity
 			}
 		};
 
+		var overlapButton = new Android.Widget.Button(this)
+		{
+			Text = "Start Overlapping Picks"
+		};
+		SetViewIdResourceName(overlapButton, "ChildActivityOverlapButton");
+		overlapButton.Click += async (_, _) =>
+		{
+			_resultLabel.Text = "Result: Starting overlap...";
+			var firstRequest = MediaPicker.PickPhotosAsync();
+			try
+			{
+				await MediaPicker.PickPhotosAsync();
+				_resultLabel.Text = "Result: Overlap Not Rejected";
+			}
+			catch (InvalidOperationException)
+			{
+				_resultLabel.Text = "Result: Overlap Rejected";
+			}
+			catch (Exception ex)
+			{
+				_resultLabel.Text = $"Result: Error - {ex.Message}";
+			}
+
+			try
+			{
+				await firstRequest;
+			}
+			catch (OperationCanceledException)
+			{
+			}
+		};
+
+		var finishWhilePickingButton = new Android.Widget.Button(this)
+		{
+			Text = "Pick Photos And Finish Activity"
+		};
+		SetViewIdResourceName(finishWhilePickingButton, "ChildActivityFinishWhilePickingButton");
+		finishWhilePickingButton.Click += async (_, _) =>
+		{
+			Issue35826.UpdateStatus("Status: Waiting for launch-activity cancellation");
+			var request = MediaPicker.PickPhotosAsync();
+			Finish();
+
+			try
+			{
+				await request;
+				Issue35826.UpdateStatus("Status: Launch activity completed unexpectedly");
+			}
+			catch (OperationCanceledException)
+			{
+				Issue35826.UpdateStatus("Status: Launch activity cancelled");
+			}
+			catch (Exception ex)
+			{
+				Issue35826.UpdateStatus($"Status: Error - {ex.Message}");
+			}
+		};
+
+		layout.AddView(pickerAvailabilityLabel);
 		layout.AddView(_resultLabel);
 		layout.AddView(pickButton);
+		layout.AddView(overlapButton);
+		layout.AddView(finishWhilePickingButton);
 		SetContentView(layout);
 	}
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue35826.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue35826.cs
@@ -64,7 +64,7 @@ public class Issue35826 : ContentPage
 [Android.App.Activity(Label = "Issue35826 Child Activity", Theme = "@style/Maui.SplashTheme")]
 public class Issue35826ChildActivity : AndroidX.AppCompat.App.AppCompatActivity
 {
-	Android.Widget.TextView _resultLabel;
+	Android.Widget.TextView _resultLabel = null!;
 
 	protected override void OnCreate(Android.OS.Bundle savedInstanceState)
 	{

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue35826.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue35826.cs
@@ -5,7 +5,7 @@ namespace Maui.Controls.Sample.Issues;
 [Issue(IssueTracker.Github, 35826, "PickPhotosAsync hangs when called from a child activity", PlatformAffected.Android)]
 public class Issue35826 : ContentPage
 {
-	static WeakReference<Label> s_statusLabel;
+	static WeakReference<Label> s_statusLabel = null!;
 
 	public Issue35826()
 	{

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35826.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35826.cs
@@ -1,0 +1,79 @@
+#if ANDROID
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue35826 : _IssuesUITest
+{
+	public Issue35826(TestDevice device) : base(device) { }
+
+	public override string Issue => "PickPhotosAsync hangs when called from a child activity";
+
+	const string OpenChildActivityButton = "OpenChildActivityButton";
+	const string ChildActivityPickButton = "ChildActivityPickButton";
+	const string ChildActivityResultLabel = "ChildActivityResultLabel";
+
+	[Test]
+	[Category(UITestCategories.Essentials)]
+	public void PickPhotosAsyncShouldReturnFromChildActivity()
+	{
+		// This regression only manifests on Android API 36, where the ActivityResultLauncher
+		// ownership rules are enforced strictly enough that using the wrong activity's launcher
+		// causes the result to never be delivered, hanging the task indefinitely.
+		if (App is AppiumApp appiumApp)
+		{
+			var apiLevel = (long?)appiumApp.Driver.Capabilities.GetCapability("deviceApiLevel") ?? 0;
+			if (apiLevel < 36)
+			{
+				Assert.Ignore($"Issue #35826 only manifests on Android API 36+. Current device API: {apiLevel}.");
+			}
+		}
+
+		// Verify the host page loaded
+		App.WaitForElement(OpenChildActivityButton);
+
+		// Open the child (non-MAUI AppCompatActivity)
+		App.Tap(OpenChildActivityButton);
+
+		// Verify the child activity's UI is visible
+		App.WaitForElement(ChildActivityPickButton);
+		App.WaitForElement(ChildActivityResultLabel);
+
+		// Tap Pick Photos — calls MediaPicker.PickPhotosAsync() from the child activity.
+		// Before the fix the ActivityResultLauncher was never registered for child activities
+		// (the guard in ActivityForResultRequest.Register() blocked it), so the task hung
+		// indefinitely and the result label stayed on "Picking...".
+		App.Tap(ChildActivityPickButton);
+
+		// Cancel the system photo picker by pressing Back.
+		// After the fix each activity has its own launcher entry so the result is delivered.
+		App.Back();
+
+		// If the bug is present WaitForTextToBePresentInElement times out because the
+		// TaskCompletionSource is never resolved. With the fix it updates promptly to
+		// the expected cancellation state. Error indicates a launcher/ownership failure
+		// or another exception path and must fail this regression.
+		var returned = App.WaitForTextToBePresentInElement(ChildActivityResultLabel, "Cancelled",
+			timeout: TimeSpan.FromSeconds(120));
+
+		var resultText = App.FindElement(ChildActivityResultLabel).GetText();
+
+		Assert.That(returned, Is.True,
+			$"PickPhotosAsync must return from a child activity as a cancellation result after backing out of the picker. " +
+			$"Actual result label: '{resultText}'. " +
+			$"If this fails the result label is still showing 'Picking...' after 120 seconds or an exception path was hit.");
+
+		Assert.That(resultText, Does.Not.Contain("Picking"),
+			"PickPhotosAsync must not hang in a child activity.");
+
+		Assert.That(resultText, Does.Not.Contain("Error"),
+			$"PickPhotosAsync should cancel cleanly when backing out of the picker, not surface an exception. Actual result label: '{resultText}'.");
+
+		// Return to the host page
+		App.Back();
+		App.WaitForElement(OpenChildActivityButton);
+	}
+}
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35826.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35826.cs
@@ -22,13 +22,13 @@ public class Issue35826 : _IssuesUITest
 		// This regression only manifests on Android API 36, where the ActivityResultLauncher
 		// ownership rules are enforced strictly enough that using the wrong activity's launcher
 		// causes the result to never be delivered, hanging the task indefinitely.
-		if (App is AppiumApp appiumApp)
+		var appiumApp = App as AppiumApp
+			?? throw new InvalidOperationException("Issue #35826 requires the Appium test driver.");
+		var apiLevel = (long?)appiumApp.Driver.Capabilities.GetCapability("deviceApiLevel")
+			?? throw new InvalidOperationException("deviceApiLevel capability is missing or null.");
+		if (apiLevel < 36)
 		{
-			var apiLevel = (long?)appiumApp.Driver.Capabilities.GetCapability("deviceApiLevel") ?? 0;
-			if (apiLevel < 36)
-			{
-				Assert.Ignore($"Issue #35826 only manifests on Android API 36+. Current device API: {apiLevel}.");
-			}
+			Assert.Ignore($"Issue #35826 only manifests on Android API 36+. Current device API: {apiLevel}.");
 		}
 
 		// Verify the host page loaded

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35826.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35826.cs
@@ -13,25 +13,17 @@ public class Issue35826 : _IssuesUITest
 
 	const string OpenChildActivityButton = "OpenChildActivityButton";
 	const string ChildActivityPickButton = "ChildActivityPickButton";
+	const string ChildActivityOverlapButton = "ChildActivityOverlapButton";
+	const string ChildActivityFinishWhilePickingButton = "ChildActivityFinishWhilePickingButton";
 	const string ChildActivityResultLabel = "ChildActivityResultLabel";
+	const string PhotoPickerAvailabilityLabel = "PhotoPickerAvailabilityLabel";
+	const string StatusLabel = "StatusLabel";
 
 	[Test]
 	[Category(UITestCategories.Essentials)]
 	public void PickPhotosAsyncShouldReturnFromChildActivity()
 	{
-		// API 36 exposed the stricter launcher-ownership regression, but completion from
-		// a child activity is valid on every supported Android version and belongs in the
-		// existing Essentials CI lane.
-
-		// Verify the host page loaded
-		App.WaitForElement(OpenChildActivityButton);
-
-		// Open the child (non-MAUI AppCompatActivity)
-		App.Tap(OpenChildActivityButton);
-
-		// Verify the child activity's UI is visible
-		App.WaitForElement(ChildActivityPickButton);
-		App.WaitForElement(ChildActivityResultLabel);
+		OpenChildActivityAndRequirePhotoPicker();
 
 		// Tap Pick Photos — calls MediaPicker.PickPhotosAsync() from the child activity.
 		// Before the fix the ActivityResultLauncher was never registered for child activities
@@ -41,6 +33,7 @@ public class Issue35826 : _IssuesUITest
 
 		// Cancel the system photo picker by pressing Back.
 		// After the fix each activity has its own launcher entry so the result is delivered.
+		WaitForPhotoPicker();
 		App.Back();
 
 		// If the bug is present WaitForTextToBePresentInElement times out because the
@@ -67,5 +60,70 @@ public class Issue35826 : _IssuesUITest
 		App.Back();
 		App.WaitForElement(OpenChildActivityButton);
 	}
+
+	[Test]
+	[Category(UITestCategories.Essentials)]
+	public void OverlappingPhotoPickerRequestsAreRejected()
+	{
+		OpenChildActivityAndRequirePhotoPicker();
+
+		App.Tap(ChildActivityOverlapButton);
+		WaitForPhotoPicker();
+		App.Back();
+
+		var rejected = App.WaitForTextToBePresentInElement(
+			ChildActivityResultLabel,
+			"Overlap Rejected",
+			timeout: TimeSpan.FromSeconds(120));
+
+		Assert.That(rejected, Is.True,
+			"A second request must be rejected while the first activity-result callback is pending.");
+		Assert.That(App.FindElement(ChildActivityResultLabel).GetText(), Does.Not.Contain("Error"));
+
+		App.Back();
+		App.WaitForElement(OpenChildActivityButton);
+	}
+
+	[Test]
+	[Category(UITestCategories.Essentials)]
+	public void FinishingLaunchingActivityCancelsPendingPhotoPicker()
+	{
+		OpenChildActivityAndRequirePhotoPicker();
+
+		App.Tap(ChildActivityFinishWhilePickingButton);
+		WaitForPhotoPicker();
+		App.Back();
+
+		App.WaitForElement(StatusLabel);
+		var cancelled = App.WaitForTextToBePresentInElement(
+			StatusLabel,
+			"Launch activity cancelled",
+			timeout: TimeSpan.FromSeconds(120));
+
+		var statusText = App.FindElement(StatusLabel).GetText();
+		Assert.That(cancelled, Is.True,
+			$"Destroying the launching activity must cancel its pending picker request. Actual status: '{statusText}'.");
+		Assert.That(statusText, Does.Not.Contain("Error"));
+		Assert.That(statusText, Does.Not.Contain("unexpectedly"));
+	}
+
+	void OpenChildActivityAndRequirePhotoPicker()
+	{
+		App.WaitForElement(OpenChildActivityButton);
+		App.Tap(OpenChildActivityButton);
+
+		App.WaitForElement(ChildActivityPickButton);
+		App.WaitForElement(ChildActivityResultLabel);
+		var availability = App.WaitForElement(PhotoPickerAvailabilityLabel).GetText()
+			?? throw new AssertionException("Photo picker availability label did not expose text.");
+		if (availability.Contains("Unavailable", StringComparison.Ordinal))
+			Assert.Ignore("AndroidX Photo Picker is unavailable on this device; the changed launcher path is not active.");
+
+		Assert.That(availability, Is.EqualTo("Photo Picker: Available"),
+			"The regression test must exercise the AndroidX Photo Picker launcher path changed by this PR.");
+	}
+
+	void WaitForPhotoPicker() =>
+		App.WaitForElement(AppiumQuery.ByXPath("//android.widget.ImageButton[@content-desc='Cancel']"));
 }
 #endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35826.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35826.cs
@@ -19,17 +19,9 @@ public class Issue35826 : _IssuesUITest
 	[Category(UITestCategories.Essentials)]
 	public void PickPhotosAsyncShouldReturnFromChildActivity()
 	{
-		// This regression only manifests on Android API 36, where the ActivityResultLauncher
-		// ownership rules are enforced strictly enough that using the wrong activity's launcher
-		// causes the result to never be delivered, hanging the task indefinitely.
-		var appiumApp = App as AppiumApp
-			?? throw new InvalidOperationException("Issue #35826 requires the Appium test driver.");
-		var apiLevel = (long?)appiumApp.Driver.Capabilities.GetCapability("deviceApiLevel")
-			?? throw new InvalidOperationException("deviceApiLevel capability is missing or null.");
-		if (apiLevel < 36)
-		{
-			Assert.Ignore($"Issue #35826 only manifests on Android API 36+. Current device API: {apiLevel}.");
-		}
+		// API 36 exposed the stricter launcher-ownership regression, but completion from
+		// a child activity is valid on every supported Android version and belongs in the
+		// existing Essentials CI lane.
 
 		// Verify the host page loaded
 		App.WaitForElement(OpenChildActivityButton);

--- a/src/Essentials/src/MediaPicker/MediaPicker.android.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.android.cs
@@ -8,6 +8,7 @@ using Android.Content;
 using Android.Content.PM;
 using Android.Graphics;
 using Android.Provider;
+using AndroidX.Activity;
 using AndroidX.Activity.Result;
 using AndroidX.Activity.Result.Contract;
 using Microsoft.Maui.ApplicationModel;
@@ -177,11 +178,14 @@ namespace Microsoft.Maui.Media
 
 		async Task<FileResult> PickUsingPhotoPicker(MediaPickerOptions options, bool photo)
 		{
+			var launchingActivity = ActivityStateManager.Default.GetCurrentActivity(true) as ComponentActivity
+				?? throw new InvalidOperationException("The current activity must inherit from AndroidX.Activity.ComponentActivity.");
+
 			var pickVisualMediaRequest = new PickVisualMediaRequest.Builder()
 				.SetMediaType(photo ? ActivityResultContracts.PickVisualMedia.ImageOnly.Instance : ActivityResultContracts.PickVisualMedia.VideoOnly.Instance)
 				.Build();
 
-			var androidUri = await PickVisualMediaForResult.Instance.Launch(pickVisualMediaRequest);
+			var androidUri = await PickVisualMediaForResult.Instance.Launch(launchingActivity, pickVisualMediaRequest);
 
 			if (androidUri?.Equals(AndroidUri.Empty) ?? true)
 			{
@@ -208,6 +212,9 @@ namespace Microsoft.Maui.Media
 
 		async Task<List<FileResult>> PickMultipleUsingPhotoPicker(MediaPickerOptions options, bool photo)
 		{
+			var launchingActivity = ActivityStateManager.Default.GetCurrentActivity(true) as ComponentActivity
+				?? throw new InvalidOperationException("The current activity must inherit from AndroidX.Activity.ComponentActivity.");
+
 			// Android has a limitation that you need to use a different request for single and multiple picks.
 			// If the selection limit is 1, we can use the single pick method,
 			// otherwise we need to use the multiple pick method.
@@ -230,7 +237,7 @@ namespace Microsoft.Maui.Media
 
 			var pickVisualMediaRequest = pickVisualMediaRequestBuilder.Build();
 
-			var androidUris = await PickMultipleVisualMediaForResult.Instance.Launch(pickVisualMediaRequest);
+			var androidUris = await PickMultipleVisualMediaForResult.Instance.Launch(launchingActivity, pickVisualMediaRequest);
 
 			if (androidUris?.IsEmpty ?? true)
 			{

--- a/src/Essentials/src/MediaPicker/MediaPicker.android.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.android.cs
@@ -21,6 +21,9 @@ namespace Microsoft.Maui.Media
 {
 	partial class MediaPickerImplementation : IMediaPicker
 	{
+		const string MissingComponentActivityMessage =
+			"The current Activity must inherit from AndroidX.Activity.ComponentActivity (for example, Microsoft.Maui.MauiAppCompatActivity) and call Microsoft.Maui.ApplicationModel.Platform.Init(Activity, Bundle) in OnCreate.";
+
 		public bool IsCaptureSupported
 			=> Application.Context?.PackageManager?.HasSystemFeature(PackageManager.FeatureCameraAny) ?? false;
 
@@ -179,7 +182,7 @@ namespace Microsoft.Maui.Media
 		async Task<FileResult> PickUsingPhotoPicker(MediaPickerOptions options, bool photo)
 		{
 			var launchingActivity = ActivityStateManager.Default.GetCurrentActivity(true) as ComponentActivity
-				?? throw new InvalidOperationException("The current activity must inherit from AndroidX.Activity.ComponentActivity.");
+				?? throw new InvalidOperationException(MissingComponentActivityMessage);
 
 			var pickVisualMediaRequest = new PickVisualMediaRequest.Builder()
 				.SetMediaType(photo ? ActivityResultContracts.PickVisualMedia.ImageOnly.Instance : ActivityResultContracts.PickVisualMedia.VideoOnly.Instance)
@@ -213,7 +216,7 @@ namespace Microsoft.Maui.Media
 		async Task<List<FileResult>> PickMultipleUsingPhotoPicker(MediaPickerOptions options, bool photo)
 		{
 			var launchingActivity = ActivityStateManager.Default.GetCurrentActivity(true) as ComponentActivity
-				?? throw new InvalidOperationException("The current activity must inherit from AndroidX.Activity.ComponentActivity.");
+				?? throw new InvalidOperationException(MissingComponentActivityMessage);
 
 			// Android has a limitation that you need to use a different request for single and multiple picks.
 			// If the selection limit is 1, we can use the single pick method,

--- a/src/Essentials/src/Platform/ActivityForResultRequest.android.cs
+++ b/src/Essentials/src/Platform/ActivityForResultRequest.android.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using AndroidX.Activity;
 using AndroidX.Activity.Result;
@@ -19,40 +20,78 @@ namespace Microsoft.Maui.ApplicationModel;
 /// <para>
 /// <see href="https://developer.android.com/training/basics/intents/result">Google docs</see>
 /// </para>
-/// This must be unconditionally registered every time our activity is created.
+/// <para>
+/// Each <see cref="ComponentActivity"/> instance gets its own registered launcher and its
+/// own pending <see cref="TaskCompletionSource{TResult}"/> entry so that child activities
+/// can use MediaPicker independently of the main activity, and so that two activities with
+/// concurrent in-flight requests cannot clobber each other.
+/// </para>
+/// <para>
+/// The result callback closes over the specific <see cref="ComponentActivity"/> instance
+/// that was passed to <see cref="Register"/> and resolves the pending TCS using THAT
+/// instance as the lookup key. Result delivery therefore does NOT depend on whichever
+/// activity is "current" at delivery time — which is critical because the launching
+/// activity may have been destroyed and recreated (rotation/config change) before the
+/// picker returns.
+/// </para>
 /// </remarks>
 internal abstract class ActivityForResultRequest<TContract, TResult>
 	where TContract : ActivityResultContract, new()
 	where TResult : JavaObject
 {
-	protected ActivityResultLauncher launcher;
-	protected TaskCompletionSource<TResult> tcs = null;
-	protected WeakReference<ComponentActivity> registeredActivity = null;
+	// Tracks one ActivityResultLauncher per ComponentActivity instance.
+	// ConditionalWeakTable holds weak references to keys, so entries are automatically
+	// eligible for collection when the activity is no longer referenced.
+	readonly ConditionalWeakTable<ComponentActivity, ActivityResultLauncher> _activityLaunchers = new();
+
+	// Tracks pending TaskCompletionSource per ComponentActivity to prevent race conditions.
+	// This prevents Activity B from overwriting Activity A's pending request.
+	readonly ConditionalWeakTable<ComponentActivity, TaskCompletionSource<TResult>> _pendingRequests = new();
 
 	/// <summary>
-	/// Gets a value indicating whether the request is registered.
+	/// Gets a value indicating whether the request has a launcher registered for the
+	/// currently focused activity.
 	/// </summary>
-	protected bool IsRegistered => launcher is not null;
+	protected bool HasLauncherForCurrentActivity => GetLauncherForCurrentActivity() is not null;
 
 	/// <summary>
 	/// Registers this request to start an activity for a result.
+	/// Each <see cref="ComponentActivity"/> instance receives its own launcher so child
+	/// activities can use MediaPicker independently of the main activity.
 	/// </summary>
 	/// <param name="componentActivity">The component activity to register the request with.</param>
 	public void Register(ComponentActivity componentActivity)
 	{
-		// Only register if we don't have a valid registration already
-		// This prevents temporary activities from invalidating the launcher registered with the main activity
-		if (registeredActivity?.TryGetTarget(out var existingActivity) == true &&
-			!existingActivity.IsDestroyed && !existingActivity.IsFinishing)
-		{
+		if (componentActivity is null)
+			throw new ArgumentNullException(nameof(componentActivity));
+
+		// Skip if already registered for this specific activity instance (e.g. called again
+		// after a no-op restart). Calling RegisterForActivityResult twice on the same
+		// activity is not legal — must happen once during onCreate.
+		if (_activityLaunchers.TryGetValue(componentActivity, out _))
 			return;
-		}
 
 		var contract = new TContract();
-		var callback = new ActivityResultCallback<TResult>(result => tcs?.SetResult(result));
 
-		launcher = componentActivity.RegisterForActivityResult(contract, callback);
-		registeredActivity = new WeakReference<ComponentActivity>(componentActivity);
+		// CRITICAL: capture the same `componentActivity` instance the launcher is being
+		// registered for. The callback resolves the pending TCS for THIS specific activity,
+		// NOT for whatever ActivityStateManager.Default.GetCurrentActivity() happens to be
+		// at delivery time. That makes delivery invariant under rotation / config changes —
+		// even if the activity is destroyed/recreated, the captured reference remains valid
+		// for the duration of the in-flight callback (Android keeps the registered activity
+		// alive long enough to deliver its own result).
+		var registeredActivity = componentActivity;
+		var callback = new ActivityResultCallback<TResult>(result =>
+		{
+			if (_pendingRequests.TryGetValue(registeredActivity, out var tcs))
+			{
+				_pendingRequests.Remove(registeredActivity);
+				tcs?.TrySetResult(result);
+			}
+		});
+
+		var launcher = componentActivity.RegisterForActivityResult(contract, callback);
+		_activityLaunchers.Add(componentActivity, launcher);
 	}
 
 	/// <summary>
@@ -66,14 +105,57 @@ internal abstract class ActivityForResultRequest<TContract, TResult>
 	public Task<TResult> Launch<T>(T input)
 		where T : JavaObject
 	{
-		tcs = new TaskCompletionSource<TResult>();
-
-		if (!IsRegistered)
+		var launchingActivity = ActivityStateManager.Default.GetCurrentActivity() as ComponentActivity;
+		if (launchingActivity is null)
 		{
 			Trace.WriteLine("""
-			                ActivityForResultRequest is not registered; cancelling the request. 
+			                ActivityForResultRequest.Launch() called but current activity is null or not a ComponentActivity.
 			                Ensure your Activity inherits from ComponentActivity and call Microsoft.Maui.ApplicationModel.Platform.Init(Activity, Bundle) in OnCreate.
 			                """);
+			var canceledTcs = new TaskCompletionSource<TResult>();
+			canceledTcs.SetCanceled();
+			return canceledTcs.Task;
+		}
+
+		return Launch(launchingActivity, input);
+	}
+
+	/// <summary>
+	/// Launches the activity result request for a specific activity instance.
+	/// </summary>
+	/// <typeparam name="T">The type of the input parameter.</typeparam>
+	/// <param name="launchingActivity">The activity that owns the request lifecycle and launcher.</param>
+	/// <param name="input">The input parameter to launch the request with.</param>
+	/// <returns>
+	/// A task that represents the asynchronous operation, containing the result of the activity.
+	/// </returns>
+	public Task<TResult> Launch<T>(ComponentActivity launchingActivity, T input)
+		where T : JavaObject
+	{
+		if (launchingActivity is null)
+			throw new ArgumentNullException(nameof(launchingActivity));
+
+		if (_pendingRequests.TryGetValue(launchingActivity, out var existingTcs))
+		{
+			// Instead of rejecting the new launch, cancel the orphaned previous request and replace it.
+			// This prevents permanent deadlock if a picker result never arrives due to process death or OEM edge cases.
+			// Rejection semantics would block all future launches from this activity forever.
+			Trace.WriteLine("ActivityForResultRequest: canceling overlapping pending request and launching new request.");
+			_pendingRequests.Remove(launchingActivity);
+			existingTcs?.TrySetCanceled();
+		}
+
+		var tcs = new TaskCompletionSource<TResult>();
+		_pendingRequests.Add(launchingActivity, tcs);
+
+		// Get the launcher for this specific activity
+		if (!_activityLaunchers.TryGetValue(launchingActivity, out var launcher))
+		{
+			Trace.WriteLine("""
+			                ActivityForResultRequest is not registered for the launching activity; cancelling the request.
+			                Ensure your Activity inherits from ComponentActivity and call Microsoft.Maui.ApplicationModel.Platform.Init(Activity, Bundle) in OnCreate.
+			                """);
+			_pendingRequests.Remove(launchingActivity);
 			tcs.SetCanceled();
 			return tcs.Task;
 		}
@@ -84,9 +166,36 @@ internal abstract class ActivityForResultRequest<TContract, TResult>
 		}
 		catch (Exception ex)
 		{
-			tcs.SetException(ex);
+			_pendingRequests.Remove(launchingActivity);
+			tcs.TrySetException(ex);
 		}
 
 		return tcs.Task;
+	}
+
+	/// <summary>
+	/// Cancels any pending request for the specified activity.
+	/// This should be called from the activity's OnDestroy() or when the activity is being destroyed
+	/// to ensure the pending task is completed rather than hanging indefinitely.
+	/// </summary>
+	/// <param name="componentActivity">The activity whose pending request should be cancelled.</param>
+	internal void CancelPendingRequest(ComponentActivity componentActivity)
+	{
+		if (_pendingRequests.TryGetValue(componentActivity, out var tcs))
+		{
+			_pendingRequests.Remove(componentActivity);
+			tcs?.TrySetCanceled();
+		}
+	}
+
+	ActivityResultLauncher GetLauncherForCurrentActivity()
+	{
+		if (ActivityStateManager.Default.GetCurrentActivity() is ComponentActivity currentActivity &&
+			_activityLaunchers.TryGetValue(currentActivity, out var launcher))
+		{
+			return launcher;
+		}
+
+		return null;
 	}
 }

--- a/src/Essentials/src/Platform/ActivityForResultRequest.android.cs
+++ b/src/Essentials/src/Platform/ActivityForResultRequest.android.cs
@@ -49,12 +49,6 @@ internal abstract class ActivityForResultRequest<TContract, TResult>
 	readonly ConditionalWeakTable<ComponentActivity, TaskCompletionSource<TResult>> _pendingRequests = new();
 
 	/// <summary>
-	/// Gets a value indicating whether the request has a launcher registered for the
-	/// currently focused activity.
-	/// </summary>
-	protected bool HasLauncherForCurrentActivity => GetLauncherForCurrentActivity() is not null;
-
-	/// <summary>
 	/// Registers this request to start an activity for a result.
 	/// Each <see cref="ComponentActivity"/> instance receives its own launcher so child
 	/// activities can use MediaPicker independently of the main activity.
@@ -188,14 +182,4 @@ internal abstract class ActivityForResultRequest<TContract, TResult>
 		}
 	}
 
-	ActivityResultLauncher GetLauncherForCurrentActivity()
-	{
-		if (ActivityStateManager.Default.GetCurrentActivity() is ComponentActivity currentActivity &&
-			_activityLaunchers.TryGetValue(currentActivity, out var launcher))
-		{
-			return launcher;
-		}
-
-		return null;
-	}
 }

--- a/src/Essentials/src/Platform/ActivityForResultRequest.android.cs
+++ b/src/Essentials/src/Platform/ActivityForResultRequest.android.cs
@@ -1,5 +1,7 @@
-﻿using System;
+﻿#nullable enable annotations
+using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
@@ -10,6 +12,13 @@ using Bundle = Android.OS.Bundle;
 using JavaObject = Java.Lang.Object;
 
 namespace Microsoft.Maui.ApplicationModel;
+
+internal interface IActivityForResultRequest
+{
+	void Register(ComponentActivity componentActivity, Bundle? savedInstanceState);
+	void SaveInstanceState(ComponentActivity componentActivity, Bundle outState);
+	void ActivityDestroyed(ComponentActivity componentActivity);
+}
 
 /// <summary>
 /// Represents a request for an activity result.
@@ -35,9 +44,12 @@ namespace Microsoft.Maui.ApplicationModel;
 /// </para>
 /// </remarks>
 internal abstract class ActivityForResultRequest<TContract, TResult>
+	: IActivityForResultRequest
 	where TContract : ActivityResultContract, new()
 	where TResult : JavaObject
 {
+	static readonly TimeSpan TaskPresencePollInterval = TimeSpan.FromSeconds(2);
+
 	static readonly string RequestOwnerStateKey =
 		$"Microsoft.Maui.ApplicationModel.ActivityForResultRequest.{typeof(TContract).FullName}";
 
@@ -47,6 +59,8 @@ internal abstract class ActivityForResultRequest<TContract, TResult>
 	readonly ConditionalWeakTable<ComponentActivity, ActivityResultLauncher> _activityLaunchers = new();
 
 	readonly ConditionalWeakTable<ComponentActivity, string> _requestOwners = new();
+	readonly ConditionalWeakTable<ComponentActivity, object> _savedRequestOwners = new();
+	readonly ConcurrentDictionary<string, System.Threading.CancellationTokenSource> _taskRemovalMonitors = new();
 	readonly ActivityForResultRequestState<TResult> _requestState = new(RequestOwnerStateKey);
 
 	/// <summary>
@@ -70,15 +84,23 @@ internal abstract class ActivityForResultRequest<TContract, TResult>
 		var contract = new TContract();
 
 		var requestOwner = _requestState.RestoreOrCreateOwner(savedInstanceState);
+		StopTaskRemovalMonitor(requestOwner);
 		var callback = new ActivityResultCallback<TResult>(result =>
 		{
-			_requestState.TrySetResult(requestOwner, result);
+			if (_requestState.TrySetResult(requestOwner, result))
+				StopTaskRemovalMonitor(requestOwner);
 		});
 
-		var launcher = componentActivity.RegisterForActivityResult(contract, callback);
+		var launcher = RegisterForActivityResult(componentActivity, contract, callback);
 		_requestOwners.Add(componentActivity, requestOwner);
 		_activityLaunchers.Add(componentActivity, launcher);
 	}
+
+	protected virtual ActivityResultLauncher RegisterForActivityResult(
+		ComponentActivity componentActivity,
+		TContract contract,
+		ActivityResultCallback<TResult> callback) =>
+		componentActivity.RegisterForActivityResult(contract, callback);
 
 	/// <summary>
 	/// Launches the activity result request for a specific activity instance.
@@ -115,7 +137,8 @@ internal abstract class ActivityForResultRequest<TContract, TResult>
 		}
 		catch (Exception ex)
 		{
-			_requestState.TrySetException(requestOwner, ex);
+			if (_requestState.TrySetException(requestOwner, ex))
+				StopTaskRemovalMonitor(requestOwner);
 		}
 
 		return request;
@@ -124,7 +147,10 @@ internal abstract class ActivityForResultRequest<TContract, TResult>
 	internal void SaveInstanceState(ComponentActivity componentActivity, Bundle outState)
 	{
 		if (_requestOwners.TryGetValue(componentActivity, out var requestOwner))
+		{
 			_requestState.SaveOwner(outState, requestOwner);
+			_savedRequestOwners.GetValue(componentActivity, static _ => new object());
+		}
 	}
 
 	/// <summary>
@@ -136,7 +162,108 @@ internal abstract class ActivityForResultRequest<TContract, TResult>
 	internal void CancelPendingRequest(ComponentActivity componentActivity)
 	{
 		if (_requestOwners.TryGetValue(componentActivity, out var requestOwner))
-			_requestState.TrySetCanceled(requestOwner);
+		{
+			if (_requestState.TrySetCanceled(requestOwner))
+				StopTaskRemovalMonitor(requestOwner);
+		}
+	}
+
+	internal void ActivityDestroyed(ComponentActivity componentActivity)
+	{
+		if (!_requestOwners.TryGetValue(componentActivity, out var requestOwner)
+			|| !_requestState.HasPendingRequest(requestOwner))
+		{
+			return;
+		}
+
+		if (componentActivity.IsFinishing
+			|| !_savedRequestOwners.TryGetValue(componentActivity, out _)
+			|| componentActivity.GetSystemService(global::Android.Content.Context.ActivityService) is not global::Android.App.ActivityManager activityManager
+			|| !IsTaskPresent(activityManager, componentActivity.TaskId))
+		{
+			CancelPendingRequest(componentActivity);
+			return;
+		}
+
+		// A saved owner can be adopted by a replacement activity, but task removal may
+		// happen later without another callback for this already-destroyed instance.
+		StartTaskRemovalMonitor(requestOwner, activityManager, componentActivity.TaskId);
+	}
+
+	void IActivityForResultRequest.SaveInstanceState(ComponentActivity componentActivity, Bundle outState) =>
+		SaveInstanceState(componentActivity, outState);
+
+	void IActivityForResultRequest.ActivityDestroyed(ComponentActivity componentActivity) =>
+		ActivityDestroyed(componentActivity);
+
+	void StartTaskRemovalMonitor(
+		string requestOwner,
+		global::Android.App.ActivityManager activityManager,
+		int taskId)
+	{
+		var cancellation = new System.Threading.CancellationTokenSource();
+		if (!_taskRemovalMonitors.TryAdd(requestOwner, cancellation))
+		{
+			cancellation.Dispose();
+			return;
+		}
+
+		_ = MonitorTaskPresenceAsync(requestOwner, activityManager, taskId, cancellation);
+	}
+
+	async Task MonitorTaskPresenceAsync(
+		string requestOwner,
+		global::Android.App.ActivityManager activityManager,
+		int taskId,
+		System.Threading.CancellationTokenSource cancellation)
+	{
+		try
+		{
+			while (_requestState.HasPendingRequest(requestOwner))
+			{
+				await Task.Delay(TaskPresencePollInterval, cancellation.Token).ConfigureAwait(false);
+				if (!IsTaskPresent(activityManager, taskId))
+				{
+					_requestState.TrySetCanceled(requestOwner);
+					break;
+				}
+			}
+		}
+		catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+		{
+		}
+		catch (global::Java.Lang.SecurityException ex)
+		{
+			_requestState.TrySetException(requestOwner, ex);
+		}
+		finally
+		{
+			if (_taskRemovalMonitors.TryRemove(
+				new KeyValuePair<string, System.Threading.CancellationTokenSource>(requestOwner, cancellation)))
+			{
+				cancellation.Dispose();
+			}
+		}
+	}
+
+	void StopTaskRemovalMonitor(string requestOwner)
+	{
+		if (_taskRemovalMonitors.TryRemove(requestOwner, out var cancellation))
+		{
+			cancellation.Cancel();
+			cancellation.Dispose();
+		}
+	}
+
+	static bool IsTaskPresent(global::Android.App.ActivityManager activityManager, int taskId)
+	{
+		foreach (var appTask in activityManager.AppTasks ?? [])
+		{
+			if (appTask.TaskInfo?.TaskId == taskId)
+				return true;
+		}
+
+		return false;
 	}
 }
 
@@ -158,7 +285,7 @@ internal sealed class ActivityForResultRequestState<TResult>
 
 	internal Task<TResult> BeginRequest(string requestOwner)
 	{
-		var tcs = new TaskCompletionSource<TResult>();
+		var tcs = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
 		if (!_pendingRequests.TryAdd(requestOwner, tcs))
 		{
 			Trace.WriteLine("ActivityForResultRequest: rejecting overlapping request for the same activity.");
@@ -168,6 +295,9 @@ internal sealed class ActivityForResultRequestState<TResult>
 
 		return tcs.Task;
 	}
+
+	internal bool HasPendingRequest(string requestOwner) =>
+		_pendingRequests.ContainsKey(requestOwner);
 
 	internal bool TrySetResult(string requestOwner, TResult result) =>
 		_pendingRequests.TryRemove(requestOwner, out var tcs) && tcs.TrySetResult(result);

--- a/src/Essentials/src/Platform/ActivityForResultRequest.android.cs
+++ b/src/Essentials/src/Platform/ActivityForResultRequest.android.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using AndroidX.Activity;
 using AndroidX.Activity.Result;
 using AndroidX.Activity.Result.Contract;
-using AndroidX.Lifecycle;
+using Bundle = Android.OS.Bundle;
 using JavaObject = Java.Lang.Object;
 
 namespace Microsoft.Maui.ApplicationModel;
@@ -28,23 +29,25 @@ namespace Microsoft.Maui.ApplicationModel;
 /// concurrent in-flight requests cannot clobber each other.
 /// </para>
 /// <para>
-/// Pending requests are keyed by the activity's <see cref="ViewModelStore"/>, whose
-/// identity survives configuration recreation. The callback registered by the recreated
-/// activity can therefore resolve the task started by the previous activity instance.
+/// Pending requests use an owner identifier saved in the activity instance state. A callback
+/// registered by a recreated activity can therefore resolve the task started by the previous
+/// activity instance, including recreation that does not retain the ViewModelStore.
 /// </para>
 /// </remarks>
 internal abstract class ActivityForResultRequest<TContract, TResult>
 	where TContract : ActivityResultContract, new()
 	where TResult : JavaObject
 {
+	static readonly string RequestOwnerStateKey =
+		$"Microsoft.Maui.ApplicationModel.ActivityForResultRequest.{typeof(TContract).FullName}";
+
 	// Tracks one ActivityResultLauncher per ComponentActivity instance.
 	// ConditionalWeakTable holds weak references to keys, so entries are automatically
 	// eligible for collection when the activity is no longer referenced.
 	readonly ConditionalWeakTable<ComponentActivity, ActivityResultLauncher> _activityLaunchers = new();
 
-	// ViewModelStore is stable across configuration recreation but distinct for separate
-	// activity instances, so requests survive rotation without clobbering another activity.
-	readonly ConditionalWeakTable<ViewModelStore, TaskCompletionSource<TResult>> _pendingRequests = new();
+	readonly ConditionalWeakTable<ComponentActivity, string> _requestOwners = new();
+	readonly ActivityForResultRequestState<TResult> _requestState = new(RequestOwnerStateKey);
 
 	/// <summary>
 	/// Registers this request to start an activity for a result.
@@ -52,7 +55,8 @@ internal abstract class ActivityForResultRequest<TContract, TResult>
 	/// activities can use MediaPicker independently of the main activity.
 	/// </summary>
 	/// <param name="componentActivity">The component activity to register the request with.</param>
-	public void Register(ComponentActivity componentActivity)
+	/// <param name="savedInstanceState">State restored for a recreated activity, if available.</param>
+	public void Register(ComponentActivity componentActivity, Bundle savedInstanceState)
 	{
 		if (componentActivity is null)
 			throw new ArgumentNullException(nameof(componentActivity));
@@ -65,17 +69,14 @@ internal abstract class ActivityForResultRequest<TContract, TResult>
 
 		var contract = new TContract();
 
-		var requestOwner = componentActivity.ViewModelStore;
+		var requestOwner = _requestState.RestoreOrCreateOwner(savedInstanceState);
 		var callback = new ActivityResultCallback<TResult>(result =>
 		{
-			if (_pendingRequests.TryGetValue(requestOwner, out var tcs))
-			{
-				_pendingRequests.Remove(requestOwner);
-				tcs?.TrySetResult(result);
-			}
+			_requestState.TrySetResult(requestOwner, result);
 		});
 
 		var launcher = componentActivity.RegisterForActivityResult(contract, callback);
+		_requestOwners.Add(componentActivity, requestOwner);
 		_activityLaunchers.Add(componentActivity, launcher);
 	}
 
@@ -94,28 +95,19 @@ internal abstract class ActivityForResultRequest<TContract, TResult>
 		if (launchingActivity is null)
 			throw new ArgumentNullException(nameof(launchingActivity));
 
-		var requestOwner = launchingActivity.ViewModelStore;
-		if (_pendingRequests.TryGetValue(requestOwner, out _))
-		{
-			Trace.WriteLine("ActivityForResultRequest: rejecting overlapping request for the same activity.");
-			return Task.FromException<TResult>(
-				new InvalidOperationException("An activity result request is already pending for this activity."));
-		}
-
-		var tcs = new TaskCompletionSource<TResult>();
-		_pendingRequests.Add(requestOwner, tcs);
-
-		// Get the launcher for this specific activity
-		if (!_activityLaunchers.TryGetValue(launchingActivity, out var launcher))
+		if (!_requestOwners.TryGetValue(launchingActivity, out var requestOwner)
+			|| !_activityLaunchers.TryGetValue(launchingActivity, out var launcher))
 		{
 			Trace.WriteLine("""
 			                ActivityForResultRequest is not registered for the launching activity; cancelling the request.
 			                Ensure your Activity inherits from ComponentActivity and call Microsoft.Maui.ApplicationModel.Platform.Init(Activity, Bundle) in OnCreate.
 			                """);
-			_pendingRequests.Remove(requestOwner);
-			tcs.SetCanceled();
-			return tcs.Task;
+			return Task.FromCanceled<TResult>(new System.Threading.CancellationToken(true));
 		}
+
+		var request = _requestState.BeginRequest(requestOwner);
+		if (request.IsFaulted)
+			return request;
 
 		try
 		{
@@ -123,11 +115,16 @@ internal abstract class ActivityForResultRequest<TContract, TResult>
 		}
 		catch (Exception ex)
 		{
-			_pendingRequests.Remove(requestOwner);
-			tcs.TrySetException(ex);
+			_requestState.TrySetException(requestOwner, ex);
 		}
 
-		return tcs.Task;
+		return request;
+	}
+
+	internal void SaveInstanceState(ComponentActivity componentActivity, Bundle outState)
+	{
+		if (_requestOwners.TryGetValue(componentActivity, out var requestOwner))
+			_requestState.SaveOwner(outState, requestOwner);
 	}
 
 	/// <summary>
@@ -138,12 +135,46 @@ internal abstract class ActivityForResultRequest<TContract, TResult>
 	/// <param name="componentActivity">The activity whose pending request should be cancelled.</param>
 	internal void CancelPendingRequest(ComponentActivity componentActivity)
 	{
-		var requestOwner = componentActivity.ViewModelStore;
-		if (_pendingRequests.TryGetValue(requestOwner, out var tcs))
-		{
-			_pendingRequests.Remove(requestOwner);
-			tcs?.TrySetCanceled();
-		}
+		if (_requestOwners.TryGetValue(componentActivity, out var requestOwner))
+			_requestState.TrySetCanceled(requestOwner);
+	}
+}
+
+internal sealed class ActivityForResultRequestState<TResult>
+{
+	readonly string _stateKey;
+	readonly ConcurrentDictionary<string, TaskCompletionSource<TResult>> _pendingRequests = new();
+
+	internal ActivityForResultRequestState(string stateKey)
+	{
+		_stateKey = stateKey;
 	}
 
+	internal string RestoreOrCreateOwner(Bundle savedInstanceState) =>
+		savedInstanceState?.GetString(_stateKey) ?? Guid.NewGuid().ToString("N");
+
+	internal void SaveOwner(Bundle outState, string requestOwner) =>
+		outState.PutString(_stateKey, requestOwner);
+
+	internal Task<TResult> BeginRequest(string requestOwner)
+	{
+		var tcs = new TaskCompletionSource<TResult>();
+		if (!_pendingRequests.TryAdd(requestOwner, tcs))
+		{
+			Trace.WriteLine("ActivityForResultRequest: rejecting overlapping request for the same activity.");
+			return Task.FromException<TResult>(
+				new InvalidOperationException("An activity result request is already pending for this activity."));
+		}
+
+		return tcs.Task;
+	}
+
+	internal bool TrySetResult(string requestOwner, TResult result) =>
+		_pendingRequests.TryRemove(requestOwner, out var tcs) && tcs.TrySetResult(result);
+
+	internal bool TrySetException(string requestOwner, Exception exception) =>
+		_pendingRequests.TryRemove(requestOwner, out var tcs) && tcs.TrySetException(exception);
+
+	internal bool TrySetCanceled(string requestOwner) =>
+		_pendingRequests.TryRemove(requestOwner, out var tcs) && tcs.TrySetCanceled();
 }

--- a/src/Essentials/src/Platform/ActivityForResultRequest.android.cs
+++ b/src/Essentials/src/Platform/ActivityForResultRequest.android.cs
@@ -56,7 +56,7 @@ internal abstract class ActivityForResultRequest<TContract, TResult>
 	/// </summary>
 	/// <param name="componentActivity">The component activity to register the request with.</param>
 	/// <param name="savedInstanceState">State restored for a recreated activity, if available.</param>
-	public void Register(ComponentActivity componentActivity, Bundle savedInstanceState)
+	public void Register(ComponentActivity componentActivity, Bundle? savedInstanceState)
 	{
 		if (componentActivity is null)
 			throw new ArgumentNullException(nameof(componentActivity));
@@ -150,7 +150,7 @@ internal sealed class ActivityForResultRequestState<TResult>
 		_stateKey = stateKey;
 	}
 
-	internal string RestoreOrCreateOwner(Bundle savedInstanceState) =>
+	internal string RestoreOrCreateOwner(Bundle? savedInstanceState) =>
 		savedInstanceState?.GetString(_stateKey) ?? Guid.NewGuid().ToString("N");
 
 	internal void SaveOwner(Bundle outState, string requestOwner) =>

--- a/src/Essentials/src/Platform/ActivityForResultRequest.android.cs
+++ b/src/Essentials/src/Platform/ActivityForResultRequest.android.cs
@@ -80,32 +80,6 @@ internal abstract class ActivityForResultRequest<TContract, TResult>
 	}
 
 	/// <summary>
-	/// Launches the activity result request with the specified input.
-	/// </summary>
-	/// <typeparam name="T">The type of the input parameter.</typeparam>
-	/// <param name="input">The input parameter to launch the request with.</param>
-	/// <returns>
-	/// A task that represents the asynchronous operation, containing the result of the activity.
-	/// </returns>
-	public Task<TResult> Launch<T>(T input)
-		where T : JavaObject
-	{
-		var launchingActivity = ActivityStateManager.Default.GetCurrentActivity() as ComponentActivity;
-		if (launchingActivity is null)
-		{
-			Trace.WriteLine("""
-			                ActivityForResultRequest.Launch() called but current activity is null or not a ComponentActivity.
-			                Ensure your Activity inherits from ComponentActivity and call Microsoft.Maui.ApplicationModel.Platform.Init(Activity, Bundle) in OnCreate.
-			                """);
-			var canceledTcs = new TaskCompletionSource<TResult>();
-			canceledTcs.SetCanceled();
-			return canceledTcs.Task;
-		}
-
-		return Launch(launchingActivity, input);
-	}
-
-	/// <summary>
 	/// Launches the activity result request for a specific activity instance.
 	/// </summary>
 	/// <typeparam name="T">The type of the input parameter.</typeparam>
@@ -121,14 +95,11 @@ internal abstract class ActivityForResultRequest<TContract, TResult>
 			throw new ArgumentNullException(nameof(launchingActivity));
 
 		var requestOwner = launchingActivity.ViewModelStore;
-		if (_pendingRequests.TryGetValue(requestOwner, out var existingTcs))
+		if (_pendingRequests.TryGetValue(requestOwner, out _))
 		{
-			// Instead of rejecting the new launch, cancel the orphaned previous request and replace it.
-			// This prevents permanent deadlock if a picker result never arrives due to process death or OEM edge cases.
-			// Rejection semantics would block all future launches from this activity forever.
-			Trace.WriteLine("ActivityForResultRequest: canceling overlapping pending request and launching new request.");
-			_pendingRequests.Remove(requestOwner);
-			existingTcs?.TrySetCanceled();
+			Trace.WriteLine("ActivityForResultRequest: rejecting overlapping request for the same activity.");
+			return Task.FromException<TResult>(
+				new InvalidOperationException("An activity result request is already pending for this activity."));
 		}
 
 		var tcs = new TaskCompletionSource<TResult>();

--- a/src/Essentials/src/Platform/ActivityForResultRequest.android.cs
+++ b/src/Essentials/src/Platform/ActivityForResultRequest.android.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using AndroidX.Activity;
 using AndroidX.Activity.Result;
 using AndroidX.Activity.Result.Contract;
+using AndroidX.Lifecycle;
 using JavaObject = Java.Lang.Object;
 
 namespace Microsoft.Maui.ApplicationModel;
@@ -27,12 +28,9 @@ namespace Microsoft.Maui.ApplicationModel;
 /// concurrent in-flight requests cannot clobber each other.
 /// </para>
 /// <para>
-/// The result callback closes over the specific <see cref="ComponentActivity"/> instance
-/// that was passed to <see cref="Register"/> and resolves the pending TCS using THAT
-/// instance as the lookup key. Result delivery therefore does NOT depend on whichever
-/// activity is "current" at delivery time — which is critical because the launching
-/// activity may have been destroyed and recreated (rotation/config change) before the
-/// picker returns.
+/// Pending requests are keyed by the activity's <see cref="ViewModelStore"/>, whose
+/// identity survives configuration recreation. The callback registered by the recreated
+/// activity can therefore resolve the task started by the previous activity instance.
 /// </para>
 /// </remarks>
 internal abstract class ActivityForResultRequest<TContract, TResult>
@@ -44,9 +42,9 @@ internal abstract class ActivityForResultRequest<TContract, TResult>
 	// eligible for collection when the activity is no longer referenced.
 	readonly ConditionalWeakTable<ComponentActivity, ActivityResultLauncher> _activityLaunchers = new();
 
-	// Tracks pending TaskCompletionSource per ComponentActivity to prevent race conditions.
-	// This prevents Activity B from overwriting Activity A's pending request.
-	readonly ConditionalWeakTable<ComponentActivity, TaskCompletionSource<TResult>> _pendingRequests = new();
+	// ViewModelStore is stable across configuration recreation but distinct for separate
+	// activity instances, so requests survive rotation without clobbering another activity.
+	readonly ConditionalWeakTable<ViewModelStore, TaskCompletionSource<TResult>> _pendingRequests = new();
 
 	/// <summary>
 	/// Registers this request to start an activity for a result.
@@ -67,19 +65,12 @@ internal abstract class ActivityForResultRequest<TContract, TResult>
 
 		var contract = new TContract();
 
-		// CRITICAL: capture the same `componentActivity` instance the launcher is being
-		// registered for. The callback resolves the pending TCS for THIS specific activity,
-		// NOT for whatever ActivityStateManager.Default.GetCurrentActivity() happens to be
-		// at delivery time. That makes delivery invariant under rotation / config changes —
-		// even if the activity is destroyed/recreated, the captured reference remains valid
-		// for the duration of the in-flight callback (Android keeps the registered activity
-		// alive long enough to deliver its own result).
-		var registeredActivity = componentActivity;
+		var requestOwner = componentActivity.ViewModelStore;
 		var callback = new ActivityResultCallback<TResult>(result =>
 		{
-			if (_pendingRequests.TryGetValue(registeredActivity, out var tcs))
+			if (_pendingRequests.TryGetValue(requestOwner, out var tcs))
 			{
-				_pendingRequests.Remove(registeredActivity);
+				_pendingRequests.Remove(requestOwner);
 				tcs?.TrySetResult(result);
 			}
 		});
@@ -129,18 +120,19 @@ internal abstract class ActivityForResultRequest<TContract, TResult>
 		if (launchingActivity is null)
 			throw new ArgumentNullException(nameof(launchingActivity));
 
-		if (_pendingRequests.TryGetValue(launchingActivity, out var existingTcs))
+		var requestOwner = launchingActivity.ViewModelStore;
+		if (_pendingRequests.TryGetValue(requestOwner, out var existingTcs))
 		{
 			// Instead of rejecting the new launch, cancel the orphaned previous request and replace it.
 			// This prevents permanent deadlock if a picker result never arrives due to process death or OEM edge cases.
 			// Rejection semantics would block all future launches from this activity forever.
 			Trace.WriteLine("ActivityForResultRequest: canceling overlapping pending request and launching new request.");
-			_pendingRequests.Remove(launchingActivity);
+			_pendingRequests.Remove(requestOwner);
 			existingTcs?.TrySetCanceled();
 		}
 
 		var tcs = new TaskCompletionSource<TResult>();
-		_pendingRequests.Add(launchingActivity, tcs);
+		_pendingRequests.Add(requestOwner, tcs);
 
 		// Get the launcher for this specific activity
 		if (!_activityLaunchers.TryGetValue(launchingActivity, out var launcher))
@@ -149,7 +141,7 @@ internal abstract class ActivityForResultRequest<TContract, TResult>
 			                ActivityForResultRequest is not registered for the launching activity; cancelling the request.
 			                Ensure your Activity inherits from ComponentActivity and call Microsoft.Maui.ApplicationModel.Platform.Init(Activity, Bundle) in OnCreate.
 			                """);
-			_pendingRequests.Remove(launchingActivity);
+			_pendingRequests.Remove(requestOwner);
 			tcs.SetCanceled();
 			return tcs.Task;
 		}
@@ -160,7 +152,7 @@ internal abstract class ActivityForResultRequest<TContract, TResult>
 		}
 		catch (Exception ex)
 		{
-			_pendingRequests.Remove(launchingActivity);
+			_pendingRequests.Remove(requestOwner);
 			tcs.TrySetException(ex);
 		}
 
@@ -175,9 +167,10 @@ internal abstract class ActivityForResultRequest<TContract, TResult>
 	/// <param name="componentActivity">The activity whose pending request should be cancelled.</param>
 	internal void CancelPendingRequest(ComponentActivity componentActivity)
 	{
-		if (_pendingRequests.TryGetValue(componentActivity, out var tcs))
+		var requestOwner = componentActivity.ViewModelStore;
+		if (_pendingRequests.TryGetValue(requestOwner, out var tcs))
 		{
-			_pendingRequests.Remove(componentActivity);
+			_pendingRequests.Remove(requestOwner);
 			tcs?.TrySetCanceled();
 		}
 	}

--- a/src/Essentials/src/Platform/ActivityStateManager.android.cs
+++ b/src/Essentials/src/Platform/ActivityStateManager.android.cs
@@ -211,8 +211,23 @@ namespace Microsoft.Maui.ApplicationModel
 			_onActivityStateChanged(activity, ActivityState.Created);
 		}
 
-		void Application.IActivityLifecycleCallbacks.OnActivityDestroyed(Activity activity) =>
+		void Application.IActivityLifecycleCallbacks.OnActivityDestroyed(Activity activity)
+		{
+			// Only cancel pending picker requests when the activity is truly finishing
+			// (user pressed Back, or the activity was explicitly finished). On a
+			// configuration-change destroy (e.g. rotation) the system immediately
+			// recreates the activity and the picker result still needs to be delivered
+			// to the original (captured) activity instance — cancelling here would
+			// turn rotation-during-picker into a silent task cancellation.
+			if (activity is ComponentActivity componentActivity && componentActivity.IsFinishing
+				&& MediaPickerImplementation.IsPhotoPickerAvailable)
+			{
+				PickVisualMediaForResult.Instance.CancelPendingRequest(componentActivity);
+				PickMultipleVisualMediaForResult.Instance.CancelPendingRequest(componentActivity);
+			}
+
 			_onActivityStateChanged(activity, ActivityState.Destroyed);
+		}
 
 		void Application.IActivityLifecycleCallbacks.OnActivityPaused(Activity activity)
 		{

--- a/src/Essentials/src/Platform/ActivityStateManager.android.cs
+++ b/src/Essentials/src/Platform/ActivityStateManager.android.cs
@@ -213,11 +213,10 @@ namespace Microsoft.Maui.ApplicationModel
 
 		void Application.IActivityLifecycleCallbacks.OnActivityDestroyed(Activity activity)
 		{
-			// Only cancel pending picker requests when the activity is truly finishing
-			// (user pressed Back, or the activity was explicitly finished). On a
-			// configuration-change destroy (e.g. rotation), the activity's ViewModelStore
-			// and pending request are retained for the recreated activity's callback.
-			if (activity is ComponentActivity componentActivity && componentActivity.IsFinishing
+			// Configuration recreation retains the ViewModelStore and pending request for
+			// the replacement activity. Every other destroy abandons that store, so its
+			// pending callback must be cancelled rather than left incomplete.
+			if (activity is ComponentActivity componentActivity && !componentActivity.IsChangingConfigurations
 				&& MediaPickerImplementation.IsPhotoPickerAvailable)
 			{
 				PickVisualMediaForResult.Instance.CancelPendingRequest(componentActivity);

--- a/src/Essentials/src/Platform/ActivityStateManager.android.cs
+++ b/src/Essentials/src/Platform/ActivityStateManager.android.cs
@@ -65,7 +65,24 @@ namespace Microsoft.Maui.ApplicationModel
 
 	class ActivityStateManagerImplementation : IActivityStateManager
 	{
+		readonly IActivityForResultRequest[] activityResultRequests;
 		ActivityLifecycleContextListener? lifecycleListener;
+		Application? lifecycleApplication;
+
+		public ActivityStateManagerImplementation()
+			: this(CreateDefaultActivityResultRequests())
+		{
+		}
+
+		internal ActivityStateManagerImplementation(params IActivityForResultRequest[] activityResultRequests)
+		{
+			this.activityResultRequests = activityResultRequests;
+		}
+
+		static IActivityForResultRequest[] CreateDefaultActivityResultRequests() =>
+			MediaPickerImplementation.IsPhotoPickerAvailable
+				? [PickVisualMediaForResult.Instance, PickMultipleVisualMediaForResult.Instance]
+				: [];
 
 		public Activity? GetCurrentActivity() => lifecycleListener?.Activity;
 
@@ -78,7 +95,10 @@ namespace Microsoft.Maui.ApplicationModel
 				return;
 			}
 
-			lifecycleListener = new ActivityLifecycleContextListener(OnActivityStateChanged);
+			lifecycleListener = new ActivityLifecycleContextListener(
+				OnActivityStateChanged,
+				activityResultRequests);
+			lifecycleApplication = application;
 			application.RegisterActivityLifecycleCallbacks(lifecycleListener);
 		}
 
@@ -87,10 +107,10 @@ namespace Microsoft.Maui.ApplicationModel
 			if (activity.Application is not Application application)
 				throw new InvalidOperationException("Activity was not attached to an application.");
 
-			if (activity is ComponentActivity componentActivity && MediaPickerImplementation.IsPhotoPickerAvailable)
+			if (activity is ComponentActivity componentActivity)
 			{
-				PickVisualMediaForResult.Instance.Register(componentActivity, bundle);
-				PickMultipleVisualMediaForResult.Instance.Register(componentActivity, bundle);
+				foreach (var activityResultRequest in activityResultRequests)
+					activityResultRequest.Register(componentActivity, bundle);
 			}
 
 			Init(application);
@@ -126,6 +146,16 @@ namespace Microsoft.Maui.ApplicationModel
 
 		void OnActivityStateChanged(Activity activity, ActivityState ev)
 			=> ActivityStateChanged?.Invoke(null, new ActivityStateChangedEventArgs(activity, ev));
+
+		internal void Dispose()
+		{
+			if (lifecycleApplication is not null && lifecycleListener is not null)
+				lifecycleApplication.UnregisterActivityLifecycleCallbacks(lifecycleListener);
+
+			lifecycleListener?.Dispose();
+			lifecycleListener = null;
+			lifecycleApplication = null;
+		}
 	}
 
 	static class ActivityStateManagerExtensions
@@ -189,11 +219,15 @@ namespace Microsoft.Maui.ApplicationModel
 	class ActivityLifecycleContextListener : Java.Lang.Object, Application.IActivityLifecycleCallbacks
 	{
 		readonly Action<Activity, ActivityState> _onActivityStateChanged;
+		readonly IActivityForResultRequest[] _activityResultRequests;
 		readonly WeakReference<Activity?> _currentActivity = new(null);
 
-		public ActivityLifecycleContextListener(Action<Activity, ActivityState> onActivityStateChanged)
+		public ActivityLifecycleContextListener(
+			Action<Activity, ActivityState> onActivityStateChanged,
+			IActivityForResultRequest[] activityResultRequests)
 		{
 			_onActivityStateChanged = onActivityStateChanged;
+			_activityResultRequests = activityResultRequests;
 		}
 
 		public Context Context =>
@@ -213,13 +247,10 @@ namespace Microsoft.Maui.ApplicationModel
 
 		void Application.IActivityLifecycleCallbacks.OnActivityDestroyed(Activity activity)
 		{
-			// Non-finishing activities can be recreated from saved state even when Android
-			// does not classify the teardown as a configuration change.
-			if (activity is ComponentActivity componentActivity && componentActivity.IsFinishing
-				&& MediaPickerImplementation.IsPhotoPickerAvailable)
+			if (activity is ComponentActivity componentActivity)
 			{
-				PickVisualMediaForResult.Instance.CancelPendingRequest(componentActivity);
-				PickMultipleVisualMediaForResult.Instance.CancelPendingRequest(componentActivity);
+				foreach (var activityResultRequest in _activityResultRequests)
+					activityResultRequest.ActivityDestroyed(componentActivity);
 			}
 
 			_onActivityStateChanged(activity, ActivityState.Destroyed);
@@ -239,10 +270,10 @@ namespace Microsoft.Maui.ApplicationModel
 
 		void Application.IActivityLifecycleCallbacks.OnActivitySaveInstanceState(Activity activity, Bundle outState)
 		{
-			if (activity is ComponentActivity componentActivity && MediaPickerImplementation.IsPhotoPickerAvailable)
+			if (activity is ComponentActivity componentActivity)
 			{
-				PickVisualMediaForResult.Instance.SaveInstanceState(componentActivity, outState);
-				PickMultipleVisualMediaForResult.Instance.SaveInstanceState(componentActivity, outState);
+				foreach (var activityResultRequest in _activityResultRequests)
+					activityResultRequest.SaveInstanceState(componentActivity, outState);
 			}
 
 			_onActivityStateChanged(activity, ActivityState.SaveInstanceState);

--- a/src/Essentials/src/Platform/ActivityStateManager.android.cs
+++ b/src/Essentials/src/Platform/ActivityStateManager.android.cs
@@ -89,8 +89,8 @@ namespace Microsoft.Maui.ApplicationModel
 
 			if (activity is ComponentActivity componentActivity && MediaPickerImplementation.IsPhotoPickerAvailable)
 			{
-				PickVisualMediaForResult.Instance.Register(componentActivity);
-				PickMultipleVisualMediaForResult.Instance.Register(componentActivity);
+				PickVisualMediaForResult.Instance.Register(componentActivity, bundle);
+				PickMultipleVisualMediaForResult.Instance.Register(componentActivity, bundle);
 			}
 
 			Init(application);
@@ -213,10 +213,9 @@ namespace Microsoft.Maui.ApplicationModel
 
 		void Application.IActivityLifecycleCallbacks.OnActivityDestroyed(Activity activity)
 		{
-			// Configuration recreation retains the ViewModelStore and pending request for
-			// the replacement activity. Every other destroy abandons that store, so its
-			// pending callback must be cancelled rather than left incomplete.
-			if (activity is ComponentActivity componentActivity && !componentActivity.IsChangingConfigurations
+			// Non-finishing activities can be recreated from saved state even when Android
+			// does not classify the teardown as a configuration change.
+			if (activity is ComponentActivity componentActivity && componentActivity.IsFinishing
 				&& MediaPickerImplementation.IsPhotoPickerAvailable)
 			{
 				PickVisualMediaForResult.Instance.CancelPendingRequest(componentActivity);
@@ -238,8 +237,16 @@ namespace Microsoft.Maui.ApplicationModel
 			_onActivityStateChanged(activity, ActivityState.Resumed);
 		}
 
-		void Application.IActivityLifecycleCallbacks.OnActivitySaveInstanceState(Activity activity, Bundle outState) =>
+		void Application.IActivityLifecycleCallbacks.OnActivitySaveInstanceState(Activity activity, Bundle outState)
+		{
+			if (activity is ComponentActivity componentActivity && MediaPickerImplementation.IsPhotoPickerAvailable)
+			{
+				PickVisualMediaForResult.Instance.SaveInstanceState(componentActivity, outState);
+				PickMultipleVisualMediaForResult.Instance.SaveInstanceState(componentActivity, outState);
+			}
+
 			_onActivityStateChanged(activity, ActivityState.SaveInstanceState);
+		}
 
 		void Application.IActivityLifecycleCallbacks.OnActivityStarted(Activity activity) =>
 			_onActivityStateChanged(activity, ActivityState.Started);

--- a/src/Essentials/src/Platform/ActivityStateManager.android.cs
+++ b/src/Essentials/src/Platform/ActivityStateManager.android.cs
@@ -215,10 +215,8 @@ namespace Microsoft.Maui.ApplicationModel
 		{
 			// Only cancel pending picker requests when the activity is truly finishing
 			// (user pressed Back, or the activity was explicitly finished). On a
-			// configuration-change destroy (e.g. rotation) the system immediately
-			// recreates the activity and the picker result still needs to be delivered
-			// to the original (captured) activity instance — cancelling here would
-			// turn rotation-during-picker into a silent task cancellation.
+			// configuration-change destroy (e.g. rotation), the activity's ViewModelStore
+			// and pending request are retained for the recreated activity's callback.
 			if (activity is ComponentActivity componentActivity && componentActivity.IsFinishing
 				&& MediaPickerImplementation.IsPhotoPickerAvailable)
 			{

--- a/src/Essentials/test/DeviceTests/Tests/ActivityStateManagerRecreation_Tests.Android.cs
+++ b/src/Essentials/test/DeviceTests/Tests/ActivityStateManagerRecreation_Tests.Android.cs
@@ -1,0 +1,287 @@
+#nullable enable
+using System;
+using System.Threading.Tasks;
+using Android.App;
+using Android.Content;
+using Android.OS;
+using AndroidX.Activity;
+using AndroidX.Activity.Result;
+using AndroidX.Activity.Result.Contract;
+using Microsoft.Maui.ApplicationModel;
+using Xunit;
+using ActivityOptionsCompat = AndroidX.Core.App.ActivityOptionsCompat;
+using JavaObject = Java.Lang.Object;
+using JavaString = Java.Lang.String;
+using MauiPlatform = Microsoft.Maui.ApplicationModel.Platform;
+
+namespace Microsoft.Maui.Essentials.DeviceTests;
+
+[Category("ActivityStateManager")]
+public class ActivityStateManagerRecreation_Tests
+{
+	[Fact]
+	public async Task PendingRequest_CompletesThroughRecreatedActivityCallback()
+	{
+		var request = new RecreationActivityForResultRequest();
+		var manager = new ActivityStateManagerImplementation(request);
+		ActivityResultRecreationState.Begin(manager);
+
+		ActivityResultRecreationActivity? originalActivity = null;
+		ActivityResultRecreationActivity? recreatedActivity = null;
+
+		try
+		{
+			var hostActivity = MauiPlatform.CurrentActivity
+				?? throw new InvalidOperationException("The device-test host activity is unavailable.");
+
+			await MainThread.InvokeOnMainThreadAsync(() =>
+				hostActivity.StartActivity(new Intent(hostActivity, typeof(ActivityResultRecreationActivity))));
+
+			originalActivity = await ActivityResultRecreationState.FirstActivity
+				.WaitAsync(TimeSpan.FromSeconds(15));
+
+			Task<JavaString>? pendingResult = null;
+			using var input = new JavaString("recreated-result");
+			await MainThread.InvokeOnMainThreadAsync(() =>
+			{
+				pendingResult = request.Launch(originalActivity, input);
+			});
+			var pending = pendingResult
+				?? throw new InvalidOperationException("The activity-result request was not started.");
+			var requestCode = await ActivityResultRecreationState.RequestCode
+				.WaitAsync(TimeSpan.FromSeconds(15));
+
+			Assert.False(pending.IsCompleted);
+			await MainThread.InvokeOnMainThreadAsync(originalActivity.Recreate);
+
+			await ActivityResultRecreationState.OriginalActivityDestroyed
+				.WaitAsync(TimeSpan.FromSeconds(15));
+			recreatedActivity = await ActivityResultRecreationState.RecreatedActivity
+				.WaitAsync(TimeSpan.FromSeconds(15));
+
+			Assert.NotSame(originalActivity, recreatedActivity);
+			Assert.False(pending.IsCompleted);
+
+			using var callbackResult = new JavaString("recreated-result");
+			await MainThread.InvokeOnMainThreadAsync(() =>
+				recreatedActivity.ResultRegistry.Deliver(requestCode, callbackResult));
+
+			var result = await pending.WaitAsync(TimeSpan.FromSeconds(15));
+			Assert.Same(callbackResult, result);
+			Assert.Equal("recreated-result", result.ToString());
+		}
+		finally
+		{
+			recreatedActivity ??= manager.GetCurrentActivity() as ActivityResultRecreationActivity;
+			await MainThread.InvokeOnMainThreadAsync(() =>
+			{
+				if (recreatedActivity is { IsFinishing: false })
+					recreatedActivity.Finish();
+				if (originalActivity is { IsDestroyed: false, IsFinishing: false })
+					originalActivity.Finish();
+			});
+
+			manager.Dispose();
+			ActivityResultRecreationState.Reset();
+		}
+	}
+
+	[Fact]
+	public async Task PendingRequest_IsCanceledWhenOwningTaskIsRemoved()
+	{
+		var request = new RecreationActivityForResultRequest();
+		var manager = new ActivityStateManagerImplementation(request);
+		ActivityResultRecreationState.Begin(manager);
+
+		ActivityResultRecreationActivity? activity = null;
+
+		try
+		{
+			var hostActivity = MauiPlatform.CurrentActivity
+				?? throw new InvalidOperationException("The device-test host activity is unavailable.");
+			var intent = new Intent(hostActivity, typeof(ActivityResultRecreationActivity))
+				.AddFlags(ActivityFlags.NewDocument | ActivityFlags.MultipleTask);
+
+			await MainThread.InvokeOnMainThreadAsync(() => hostActivity.StartActivity(intent));
+			activity = await ActivityResultRecreationState.FirstActivity
+				.WaitAsync(TimeSpan.FromSeconds(15));
+
+			Task<JavaString>? pendingResult = null;
+			using var input = new JavaString("removed-task");
+			await MainThread.InvokeOnMainThreadAsync(() =>
+			{
+				pendingResult = request.Launch(activity, input);
+			});
+			var pending = pendingResult
+				?? throw new InvalidOperationException("The activity-result request was not started.");
+			await ActivityResultRecreationState.RequestCode.WaitAsync(TimeSpan.FromSeconds(15));
+
+			var activityManager = activity.GetSystemService(Context.ActivityService) as ActivityManager
+				?? throw new InvalidOperationException("The Android activity manager is unavailable.");
+			var appTask = FindTask(activityManager, activity.TaskId)
+				?? throw new InvalidOperationException("The activity's Android task was not found.");
+
+			await MainThread.InvokeOnMainThreadAsync(appTask.FinishAndRemoveTask);
+			await ActivityResultRecreationState.OriginalActivityDestroyed
+				.WaitAsync(TimeSpan.FromSeconds(15));
+
+			await Assert.ThrowsAnyAsync<System.OperationCanceledException>(
+				() => pending.WaitAsync(TimeSpan.FromSeconds(15)));
+		}
+		finally
+		{
+			activity ??= manager.GetCurrentActivity() as ActivityResultRecreationActivity;
+			await MainThread.InvokeOnMainThreadAsync(() =>
+			{
+				if (activity is { IsDestroyed: false, IsFinishing: false })
+					activity.FinishAndRemoveTask();
+			});
+
+			manager.Dispose();
+			ActivityResultRecreationState.Reset();
+		}
+	}
+
+	static ActivityManager.AppTask? FindTask(ActivityManager activityManager, int taskId)
+	{
+		foreach (var appTask in activityManager.AppTasks ?? [])
+		{
+			if (appTask.TaskInfo?.TaskId == taskId)
+				return appTask;
+		}
+
+		return null;
+	}
+}
+
+sealed class RecreationActivityForResultRequest
+	: ActivityForResultRequest<RecreationActivityResultContract, JavaString>
+{
+	protected override ActivityResultLauncher RegisterForActivityResult(
+		ComponentActivity componentActivity,
+		RecreationActivityResultContract contract,
+		ActivityResultCallback<JavaString> callback)
+	{
+		var activity = Assert.IsType<ActivityResultRecreationActivity>(componentActivity);
+		return activity.RegisterForActivityResult(contract, activity.ResultRegistry, callback);
+	}
+}
+
+sealed class RecreationActivityResultContract : ActivityResultContract
+{
+	public override Intent CreateIntent(Context context, JavaObject? input) =>
+		new Intent();
+
+	public override JavaObject ParseResult(int resultCode, Intent? intent) =>
+		new JavaString();
+}
+
+sealed class RecreationActivityResultRegistry : ActivityResultRegistry
+{
+	public override void OnLaunch(
+		int requestCode,
+		ActivityResultContract contract,
+		JavaObject? input,
+		ActivityOptionsCompat? options) =>
+		ActivityResultRecreationState.OnRequestLaunched(requestCode);
+
+	internal void Deliver(int requestCode, JavaString result)
+	{
+		if (!DispatchResult(requestCode, result))
+			throw new InvalidOperationException("The recreated AndroidX activity-result registry rejected the result.");
+	}
+}
+
+[Activity(Theme = "@android:style/Theme.Material.Light.NoActionBar", Exported = false)]
+public sealed class ActivityResultRecreationActivity : ComponentActivity
+{
+	const string RegistryStateKey = "ActivityStateManagerRecreation.Registry";
+
+	internal RecreationActivityResultRegistry ResultRegistry { get; } = new();
+
+	protected override void OnCreate(Bundle? savedInstanceState)
+	{
+		base.OnCreate(savedInstanceState);
+
+		ResultRegistry.OnRestoreInstanceState(savedInstanceState?.GetBundle(RegistryStateKey));
+		MauiPlatform.Init(this, savedInstanceState);
+		ActivityResultRecreationState.Manager?.Init(this, savedInstanceState);
+	}
+
+	protected override void OnResume()
+	{
+		base.OnResume();
+		ActivityResultRecreationState.OnActivityResumed(this);
+	}
+
+	protected override void OnSaveInstanceState(Bundle outState)
+	{
+		var registryState = new Bundle();
+		ResultRegistry.OnSaveInstanceState(registryState);
+		outState.PutBundle(RegistryStateKey, registryState);
+
+		base.OnSaveInstanceState(outState);
+	}
+
+	protected override void OnDestroy()
+	{
+		ActivityResultRecreationState.OnActivityDestroyed(this);
+		base.OnDestroy();
+	}
+}
+
+static class ActivityResultRecreationState
+{
+	static TaskCompletionSource<ActivityResultRecreationActivity> _firstActivity = CreateActivitySource();
+	static TaskCompletionSource<ActivityResultRecreationActivity> _recreatedActivity = CreateActivitySource();
+	static TaskCompletionSource _originalActivityDestroyed = CreateSignalSource();
+	static TaskCompletionSource<int> _requestCode = CreateRequestCodeSource();
+
+	internal static ActivityStateManagerImplementation? Manager { get; private set; }
+	internal static Task<ActivityResultRecreationActivity> FirstActivity => _firstActivity.Task;
+	internal static Task<ActivityResultRecreationActivity> RecreatedActivity => _recreatedActivity.Task;
+	internal static Task OriginalActivityDestroyed => _originalActivityDestroyed.Task;
+	internal static Task<int> RequestCode => _requestCode.Task;
+
+	internal static void Begin(ActivityStateManagerImplementation manager)
+	{
+		Reset();
+		Manager = manager;
+	}
+
+	internal static void OnActivityResumed(ActivityResultRecreationActivity activity)
+	{
+		if (!_firstActivity.TrySetResult(activity))
+			_recreatedActivity.TrySetResult(activity);
+	}
+
+	internal static void OnActivityDestroyed(ActivityResultRecreationActivity activity)
+	{
+		if (_firstActivity.Task.IsCompletedSuccessfully
+			&& ReferenceEquals(_firstActivity.Task.Result, activity))
+		{
+			_originalActivityDestroyed.TrySetResult();
+		}
+	}
+
+	internal static void OnRequestLaunched(int requestCode) =>
+		_requestCode.TrySetResult(requestCode);
+
+	internal static void Reset()
+	{
+		Manager = null;
+		_firstActivity = CreateActivitySource();
+		_recreatedActivity = CreateActivitySource();
+		_originalActivityDestroyed = CreateSignalSource();
+		_requestCode = CreateRequestCodeSource();
+	}
+
+	static TaskCompletionSource<ActivityResultRecreationActivity> CreateActivitySource() =>
+		new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+	static TaskCompletionSource CreateSignalSource() =>
+		new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+	static TaskCompletionSource<int> CreateRequestCodeSource() =>
+		new(TaskCreationOptions.RunContinuationsAsynchronously);
+}

--- a/src/Essentials/test/DeviceTests/Tests/ActivityStateManager_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/ActivityStateManager_Tests.cs
@@ -7,6 +7,8 @@
 #if __ANDROID__
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
+using Android.OS;
 using Microsoft.Maui.ApplicationModel;
 using Xunit;
 
@@ -85,6 +87,26 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 				l?.OnActivityResumed(activity);
 
 			Assert.Equal(1, invocations);
+		}
+
+		[Fact]
+		public async Task PendingRequest_IsAdoptedFromRecreatedActivityState()
+		{
+			const string stateKey = "ActivityStateManager_Tests.RequestOwner";
+			var requestState = new ActivityForResultRequestState<Java.Lang.String>(stateKey);
+			using var savedState = new Bundle();
+			using var result = new Java.Lang.String("selected");
+
+			var originalOwner = requestState.RestoreOrCreateOwner(null);
+			var pendingRequest = requestState.BeginRequest(originalOwner);
+			requestState.SaveOwner(savedState, originalOwner);
+
+			var recreatedOwner = requestState.RestoreOrCreateOwner(savedState);
+
+			Assert.Equal(originalOwner, recreatedOwner);
+			Assert.False(pendingRequest.IsCompleted);
+			Assert.True(requestState.TrySetResult(recreatedOwner, result));
+			Assert.Same(result, await pendingRequest);
 		}
 
 		// Reads the private 'lifecycleListener' field from ActivityStateManagerImplementation


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!-- release-readiness-agent: human-approval-required -->

## Summary

Manual backport of #35944 to `release/10.0.1xx-sr10` for .NET MAUI 10.0.101.

- Addresses #35826.
- Applies the exact net patch from immutable source head `d5a1ae0aa34212a57e04045844bdc96dcc892221`.
- Preserves the Android UI regression coverage from the source PR.
- The source PR merged to `inflight/current` and has not flowed to `main`; this manual port intentionally excludes unrelated inflight branch history.

## Validation

- Source and SR10 patches have matching stable patch ID `c13a33cd90c66ff0cfc43d2833a131cd1e6e6d02`.
- `Essentials.csproj` builds successfully for `net10.0-android36.0` in Release configuration.

## Review gate

This agent-authored release PR must remain unmerged until two distinct non-bot MAUI maintainers with write access, other than the PR author, approve the current head SHA.
