### PR TITLE
[release/10.0.1xx-sr10] Fix dynamic ContentPresenter assignment

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue36298.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue36298.cs
@@ -1,0 +1,69 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 36298, "[Windows] ContentPresenter throws ArgumentException when dynamically switching RefreshView or ScrollView content.", PlatformAffected.UWP)]
+public class Issue36298 : ContentPage
+{
+	ContentView _contentHolder;
+	View _view1;
+	View _view2;
+
+	public Issue36298()
+	{
+		_view1 = new ContentView
+		{
+			Content = new RefreshView
+			{
+				Content = new Label { Text = "View 1 - RefreshView" }
+			}
+		};
+
+		_view2 = new ContentView
+		{
+			Content = new ScrollView
+			{
+				Content = new Label { Text = "View 2 - ScrollView" }
+			}
+		};
+
+		_contentHolder = new ContentView
+		{
+			Content = _view1
+		};
+
+		var switchToView2Button = new Button
+		{
+			Text = "Switch to View 2",
+			AutomationId = "SwitchToView2"
+		};
+		switchToView2Button.Clicked += (_, _) => _contentHolder.Content = _view2;
+
+		var switchToView1Button = new Button
+		{
+			Text = "Switch to View 1",
+			AutomationId = "SwitchToView1"
+		};
+		switchToView1Button.Clicked += (_, _) => _contentHolder.Content = _view1;
+
+		var successLabel = new Label
+		{
+			Text = "Waiting",
+			AutomationId = "SuccessLabel"
+		};
+
+		switchToView2Button.Clicked += (_, _) => successLabel.Text = "View2";
+		switchToView1Button.Clicked += (_, _) => successLabel.Text = "Success";
+
+		Content = new VerticalStackLayout
+		{
+			Spacing = 10,
+			Padding = new Thickness(20),
+			Children =
+			{
+				switchToView2Button,
+				switchToView1Button,
+				_contentHolder,
+				successLabel
+			}
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36298.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36298.cs
@@ -1,0 +1,34 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue36298 : _IssuesUITest
+{
+	public Issue36298(TestDevice device) : base(device) { }
+
+	public override string Issue => "[Windows] ContentPresenter throws ArgumentException when dynamically switching RefreshView or ScrollView content.";
+
+	[Test]
+	[Category(UITestCategories.Layout)]
+	public void SwitchingContentPresenterContentShouldNotCrash()
+	{
+		// Wait for the page to load showing View 1
+		App.WaitForElement("SwitchToView2");
+
+		// Switch to View 2
+		App.Tap("SwitchToView2");
+		App.WaitForElement("SwitchToView1");
+
+		// Switch back to View 1 — this triggered the ArgumentException before the fix
+		App.Tap("SwitchToView1");
+		App.Tap("SwitchToView2");
+		App.Tap("SwitchToView1");
+
+		// Label is updated to "Success" only if the switch completed without crashing.
+		// WaitForElement("SuccessLabel") alone is insufficient because the label
+		// is present from page load; we must verify the text was actually updated.
+		Assert.That(App.WaitForTextToBePresentInElement("SuccessLabel", "Success"), Is.True);
+	}
+}

--- a/src/Core/src/Handlers/Border/BorderHandler.Windows.cs
+++ b/src/Core/src/Handlers/Border/BorderHandler.Windows.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.UI.Xaml;
 
 namespace Microsoft.Maui.Handlers
 {
@@ -20,14 +21,38 @@ namespace Microsoft.Maui.Handlers
 			_ = handler.VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 			_ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
-			handler.PlatformView.CachedChildren.Clear();
 			handler.PlatformView.EnsureBorderPath();
 
 			if (handler.VirtualView.PresentedContent is IView view)
 			{
-				// Detach the old handler if it exists (prevents WinUI COM exception on reuse)
-				view.Handler?.DisconnectHandler(); 
-				handler.PlatformView.Content = view.ToPlatform(handler.MauiContext);
+				var platformView = view.ToPlatform(handler.MauiContext);
+
+				// Detach from existing parent — mirrors Android RemoveFromParent / iOS RemoveFromSuperview.
+				// Always remove via CachedChildren directly: Content = null is a no-op when _content
+				// is null (e.g. ScrollViewHandler adds via paddingShim.CachedChildren.Add, not the
+				// Content setter), leaving the element with a live parent and causing a COM exception
+				// when we try to reparent it. Only clear _content when it actually tracks fwElement.
+				if (platformView is FrameworkElement fwElement && fwElement.Parent is not null)
+				{
+					if (fwElement.Parent is ContentPanel existingContentPanel)
+					{
+						existingContentPanel.CachedChildren.Remove(fwElement);
+						if (existingContentPanel.Content == fwElement)
+						{
+							existingContentPanel.Content = null;
+						}
+					}
+					else if (fwElement.Parent is MauiPanel existingPanel)
+					{
+						existingPanel.CachedChildren.Remove(fwElement);
+					}
+				}
+
+				handler.PlatformView.Content = platformView;
+			}
+			else
+			{
+				handler.PlatformView.Content = null;
 			}
 				
 		}

--- a/src/Core/src/Handlers/Border/BorderHandler.Windows.cs
+++ b/src/Core/src/Handlers/Border/BorderHandler.Windows.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.Maui.Handlers
 {
@@ -45,6 +46,12 @@ namespace Microsoft.Maui.Handlers
 					else if (fwElement.Parent is MauiPanel existingPanel)
 					{
 						existingPanel.CachedChildren.Remove(fwElement);
+					}
+					else if (fwElement.Parent is Panel existingParent)
+					{
+#pragma warning disable RS0030 // Do not use banned APIs; MauiPanel is handled above, but not every parent is a MauiPanel.
+						existingParent.Children.Remove(fwElement);
+#pragma warning restore RS0030 // Do not use banned APIs
 					}
 				}
 

--- a/src/Core/src/Handlers/ContentView/ContentViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/ContentView/ContentViewHandler.Windows.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.Maui.Graphics;
+using Microsoft.UI.Xaml;
 
 namespace Microsoft.Maui.Handlers
 {
@@ -21,13 +22,36 @@ namespace Microsoft.Maui.Handlers
 			_ = handler.VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 			_ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
-			handler.PlatformView.CachedChildren.Clear();
-
 			if (handler.VirtualView.PresentedContent is IView view)
 			{
-				// Detach the old handler if it exists (prevents WinUI COM exception on reuse)
-				view.Handler?.DisconnectHandler();
-				handler.PlatformView.CachedChildren.Add(view.ToPlatform(handler.MauiContext));
+				var platformView = view.ToPlatform(handler.MauiContext);
+
+				// Detach from existing parent — mirrors Android RemoveFromParent / iOS RemoveFromSuperview.
+				// Always remove via CachedChildren directly: Content = null is a no-op when _content
+				// is null (e.g. ScrollViewHandler adds via paddingShim.CachedChildren.Add, not the
+				// Content setter), leaving the element with a live parent and causing a COM exception
+				// when we try to reparent it. Only clear _content when it actually tracks fwElement.
+				if (platformView is FrameworkElement fwElement && fwElement.Parent is not null)
+				{
+					if (fwElement.Parent is ContentPanel existingContentPanel)
+					{
+						existingContentPanel.CachedChildren.Remove(fwElement);
+						if (existingContentPanel.Content == fwElement)
+						{
+							existingContentPanel.Content = null;
+						}
+					}
+					else if (fwElement.Parent is MauiPanel existingPanel)
+					{
+						existingPanel.CachedChildren.Remove(fwElement);
+					}
+				}
+
+				handler.PlatformView.Content = platformView;
+			}
+			else
+			{
+				handler.PlatformView.Content = null;
 			}
 		}
 

--- a/src/Core/src/Handlers/ContentView/ContentViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/ContentView/ContentViewHandler.Windows.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Microsoft.Maui.Graphics;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.Maui.Handlers
 {
@@ -44,6 +45,12 @@ namespace Microsoft.Maui.Handlers
 					else if (fwElement.Parent is MauiPanel existingPanel)
 					{
 						existingPanel.CachedChildren.Remove(fwElement);
+					}
+					else if (fwElement.Parent is Panel existingParent)
+					{
+#pragma warning disable RS0030 // Do not use banned APIs; MauiPanel is handled above, but not every parent is a MauiPanel.
+						existingParent.Children.Remove(fwElement);
+#pragma warning restore RS0030 // Do not use banned APIs
 					}
 				}
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!-- release-readiness-agent: human-approval-required -->

## Summary

Manual backport of #36430 to `release/10.0.1xx-sr10` for .NET MAUI 10.0.101.

- Addresses #36298.
- Applies the exact net patch from immutable source head `6aa094eec8163fa3c1bcbf92041366da275b643e`.
- Preserves the Windows UI regression coverage from the source PR.
- The source PR merged to `inflight/current` and has not flowed to `main`; this manual port intentionally excludes unrelated inflight branch history.

## Validation

- Source and SR10 patches have matching stable patch ID `32e617239637aca3c21818f22cc4304afe4bd65d`.
- Local Windows cross-targeting reaches the Windows resource step but cannot execute Windows SDK `MakePri.exe` on macOS. The source PR was validated on Windows; the Windows CI lane is required for this backport.

## Review gate

This agent-authored release PR must remain unmerged until two distinct non-bot MAUI maintainers with write access, other than the PR author, approve the current head SHA.
