### PR TITLE
[release/10.0.1xx-sr10] Preserve custom iOS button styling

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue36749.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue36749.cs
@@ -67,7 +67,7 @@ public class Issue36749 : ContentPage
 		bool preservedInitialColor = r < 0.01 && g > 0.99 && b > 0.99 && a > 0.99;
 
 		// A later null mapping must clear MAUI-applied state even while the native view is
-		// detached. Window-based initial-map detection incorrectly leaves this color red.
+		// detached. Tracking prior MAUI background application keeps this clear deterministic.
 		_button.Background = new SolidColorBrush(Colors.Red);
 		platformButton.RemoveFromSuperview();
 		_button.Background = null;

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue36749.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue36749.cs
@@ -60,7 +60,7 @@ public class Issue36749 : ContentPage
 
 		// The native UIButton subclass sets BackgroundColor = UIColor.Cyan in its constructor.
 		// With the regression: initial null-Background mapping resets it to UIColor.Clear.
-		// With the fix:        the Window-null check skips the reset, preserving Cyan.
+		// With the fix:        no clear occurs until MAUI has applied a background, preserving Cyan.
 		backgroundColor.GetRGBA(out var r, out var g, out var b, out var a);
 
 		// UIColor.Cyan = R:0, G:1, B:1, A:1

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue36749.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue36749.cs
@@ -64,8 +64,22 @@ public class Issue36749 : ContentPage
 		backgroundColor.GetRGBA(out var r, out var g, out var b, out var a);
 
 		// UIColor.Cyan = R:0, G:1, B:1, A:1
-		bool isCyan = r < 0.01 && g > 0.99 && b > 0.99 && a > 0.99;
-		_resultLabel.Text = isCyan ? "PASS" : "FAIL";
+		bool preservedInitialColor = r < 0.01 && g > 0.99 && b > 0.99 && a > 0.99;
+
+		// A later null mapping must clear MAUI-applied state even while the native view is
+		// detached. Window-based initial-map detection incorrectly leaves this color red.
+		_button.Background = new SolidColorBrush(Colors.Red);
+		platformButton.RemoveFromSuperview();
+		_button.Background = null;
+
+		bool clearedDetachedColor = false;
+		if (platformButton.BackgroundColor is UIColor detachedColor)
+		{
+			detachedColor.GetRGBA(out _, out _, out _, out var detachedAlpha);
+			clearedDetachedColor = detachedAlpha < 0.01;
+		}
+
+		_resultLabel.Text = preservedInitialColor && clearedDetachedColor ? "PASS" : "FAIL";
 #endif
     }
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue36749.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue36749.cs
@@ -17,6 +17,9 @@ public class Issue36749 : ContentPage
 
     readonly Label _resultLabel;
     readonly Button _button;
+#if IOS || MACCATALYST
+    bool _hasRunVerification;
+#endif
 
     public Issue36749()
     {
@@ -49,6 +52,11 @@ public class Issue36749 : ContentPage
         base.OnAppearing();
 
 #if IOS || MACCATALYST
+		if (_hasRunVerification)
+			return;
+
+		_hasRunVerification = true;
+
 		if (_button.Handler?.PlatformView is not UIButton platformButton ||
 			platformButton.BackgroundColor is not UIColor backgroundColor)
 		{

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue36749.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue36749.cs
@@ -1,0 +1,94 @@
+#if IOS || MACCATALYST
+using Microsoft.Maui.Handlers;
+using UIKit;
+#endif
+
+namespace Maui.Controls.Sample.Issues;
+
+// Regression: ButtonHandler.iOS.cs (introduced in 10.0.80 via PR #33346) unconditionally reset
+// BackgroundColor to UIColor.Clear when the cross-platform Background was null. This wiped native
+// colors set by a custom UIButton subclass returned from CreatePlatformView().
+[Issue(IssueTracker.Github, 36749,
+    "ButtonHandler clears native platform-view styling set by custom handlers when Background/TextColor are null",
+    PlatformAffected.iOS | PlatformAffected.macOS)]
+public class Issue36749 : ContentPage
+{
+    public const string ResultLabelId = "Issue36749Result";
+
+    readonly Label _resultLabel;
+    readonly Button _button;
+
+    public Issue36749()
+    {
+        _resultLabel = new Label
+        {
+            AutomationId = ResultLabelId,
+            Text = "Checking...",
+            HorizontalTextAlignment = TextAlignment.Center
+        };
+
+        // Issue36749Button routes to Issue36749ButtonHandler (registered in MauiProgram.cs).
+        // The handler's CreatePlatformView() returns a UIButton subclass that self-styles with
+        // BackgroundColor = UIColor.Cyan. No cross-platform Background is set on this button.
+        _button = new Issue36749Button
+        {
+            Text = "Test Button",
+            AutomationId = "Issue36749Button"
+        };
+
+        Content = new VerticalStackLayout
+        {
+            Padding = 20,
+            Spacing = 20,
+            Children = { _button, _resultLabel }
+        };
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+
+#if IOS || MACCATALYST
+		if (_button.Handler?.PlatformView is UIButton platformButton)
+		{
+			// The native UIButton subclass sets BackgroundColor = UIColor.Cyan in its constructor.
+			// With the regression: initial null-Background mapping resets it to UIColor.Clear.
+			// With the fix:        the Window-null check skips the reset, preserving Cyan.
+			platformButton.BackgroundColor.GetRGBA(out var r, out var g, out var b, out var a);
+
+			// UIColor.Cyan = R:0, G:1, B:1, A:1
+			bool isCyan = r < 0.01 && g > 0.99 && b > 0.99 && a > 0.99;
+			_resultLabel.Text = isCyan ? "PASS" : "FAIL";
+		}
+		else
+		{
+			// Handler or platform view unavailable — mark as FAIL so the test fails
+			// immediately rather than timing out on "Checking...".
+			_resultLabel.Text = "FAIL";
+		}
+#endif
+    }
+}
+
+// Custom Button subtype used purely to route to Issue36749ButtonHandler.
+public class Issue36749Button : Button { }
+
+#if IOS || MACCATALYST
+
+// Simulates a design-system UIButton subclass that self-styles in its constructor.
+// The cross-platform Button intentionally leaves Background and TextColor unset.
+class Issue36749NativeStyledButton : UIButton
+{
+	public Issue36749NativeStyledButton() : base(UIButtonType.System)
+	{
+		BackgroundColor = UIColor.Cyan;
+		SetTitleColor(UIColor.DarkGray, UIControlState.Normal);
+	}
+}
+
+class Issue36749ButtonHandler : ButtonHandler
+{
+	protected override UIButton CreatePlatformView() => new Issue36749NativeStyledButton();
+}
+
+#endif

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue36749.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue36749.cs
@@ -49,23 +49,23 @@ public class Issue36749 : ContentPage
         base.OnAppearing();
 
 #if IOS || MACCATALYST
-		if (_button.Handler?.PlatformView is UIButton platformButton)
+		if (_button.Handler?.PlatformView is not UIButton platformButton ||
+			platformButton.BackgroundColor is not UIColor backgroundColor)
 		{
-			// The native UIButton subclass sets BackgroundColor = UIColor.Cyan in its constructor.
-			// With the regression: initial null-Background mapping resets it to UIColor.Clear.
-			// With the fix:        the Window-null check skips the reset, preserving Cyan.
-			platformButton.BackgroundColor.GetRGBA(out var r, out var g, out var b, out var a);
-
-			// UIColor.Cyan = R:0, G:1, B:1, A:1
-			bool isCyan = r < 0.01 && g > 0.99 && b > 0.99 && a > 0.99;
-			_resultLabel.Text = isCyan ? "PASS" : "FAIL";
-		}
-		else
-		{
-			// Handler or platform view unavailable — mark as FAIL so the test fails
+			// Handler, platform view, or background unavailable — mark as FAIL so the test fails
 			// immediately rather than timing out on "Checking...".
 			_resultLabel.Text = "FAIL";
+			return;
 		}
+
+		// The native UIButton subclass sets BackgroundColor = UIColor.Cyan in its constructor.
+		// With the regression: initial null-Background mapping resets it to UIColor.Clear.
+		// With the fix:        the Window-null check skips the reset, preserving Cyan.
+		backgroundColor.GetRGBA(out var r, out var g, out var b, out var a);
+
+		// UIColor.Cyan = R:0, G:1, B:1, A:1
+		bool isCyan = r < 0.01 && g > 0.99 && b > 0.99 && a > 0.99;
+		_resultLabel.Text = isCyan ? "PASS" : "FAIL";
 #endif
     }
 }

--- a/src/Controls/tests/TestCases.HostApp/MauiProgram.cs
+++ b/src/Controls/tests/TestCases.HostApp/MauiProgram.cs
@@ -57,6 +57,7 @@ namespace Maui.Controls.Sample
 #endif
 #if IOS || MACCATALYST
 				handlers.AddHandler(typeof(Issue11132Control), typeof(Issue11132ControlHandler));
+				handlers.AddHandler(typeof(Issue36749Button), typeof(Issue36749ButtonHandler));
 #endif
 #if IOS || MACCATALYST || ANDROID
 				handlers.AddHandler(typeof(UITestEditor), typeof(UITestEditorHandler));

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36749.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36749.cs
@@ -1,0 +1,29 @@
+#if IOS || MACCATALYST      //This is an iOS-specific issue and can be reproduced by extending UIButton. Therefore, the test was added only for iOS and Mac Catalyst.
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue36749 : _IssuesUITest
+{
+    public Issue36749(TestDevice device) : base(device) { }
+
+    public override string Issue => "ButtonHandler clears native platform-view styling set by custom handlers when Background/TextColor are null";
+
+    [Test]
+    [Category(UITestCategories.Button)]
+    public void NativeStyledButtonShouldPreserveBackgroundColorOnInitialRender()
+    {
+        App.WaitForElement("Issue36749Result");
+
+        var resultText = App.FindElement("Issue36749Result").GetText();
+
+        Assert.That(resultText, Is.EqualTo("PASS"),
+            "Native BackgroundColor set in a UIButton subclass constructor should be preserved " +
+            "when no cross-platform Background is assigned to the Button. " +
+            "Regression: PR #33346 unconditionally reset BackgroundColor to UIColor.Clear " +
+            "on the initial null-paint mapping, wiping native styling.");
+    }
+}
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36749.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36749.cs
@@ -13,7 +13,7 @@ public class Issue36749 : _IssuesUITest
 
     [Test]
     [Category(UITestCategories.Button)]
-    public void NativeStyledButtonShouldPreserveBackgroundColorOnInitialRender()
+    public void NativeStyledButtonPreservesInitialAndClearsDetachedBackground()
     {
         App.WaitForElement("Issue36749Result");
 
@@ -21,7 +21,8 @@ public class Issue36749 : _IssuesUITest
 
         Assert.That(resultText, Is.EqualTo("PASS"),
             "Native BackgroundColor set in a UIButton subclass constructor should be preserved " +
-            "when no cross-platform Background is assigned to the Button. " +
+            "during the initial mapping, while later null Background updates must clear " +
+            "MAUI-applied state even when the native button is detached. " +
             "Regression: PR #33346 unconditionally reset BackgroundColor to UIColor.Clear " +
             "on the initial null-paint mapping, wiping native styling.");
     }

--- a/src/Core/src/Platform/iOS/ButtonExtensions.cs
+++ b/src/Core/src/Platform/iOS/ButtonExtensions.cs
@@ -57,14 +57,24 @@ namespace Microsoft.Maui.Platform
 		// TODO: Make this public in .NET 11
 		internal static void UpdateBackground(this UIButton platformButton, Graphics.Paint? paint)
 		{
-			// Remove previous background gradient layer if any
+			// Remove previous background gradient layer if any.
+			// Safe to call unconditionally even when Window is null (initial-render path): at that
+			// point MAUI has not yet inserted a named gradient layer, so this is a no-op.
+			// Running it before the Window/paint guard ensures any previously-applied gradient is
+			// cleaned up regardless of the new paint value.
 			platformButton.RemoveBackgroundLayer();
 
 			if (paint.IsNullOrEmpty())
 			{
-				// Reset to clear background for buttons when paint is null.
-				// UIColor.Clear ensures proper transparency when VisualState setters are unapplied.
-				platformButton.BackgroundColor = UIColor.Clear;
+				// Only reset to UIColor.Clear when the button is already attached to a window.
+				// During initial property mapping (ConnectHandler), Window is null because the view
+				// hasn't been added to the hierarchy yet — skipping here preserves native BackgroundColor
+				// set by custom UIButton subclasses. Once live on screen, null means a VisualState
+				// transition back to Normal, so we do reset. Mirrors the same guard in UpdateTextColor.
+				if (platformButton.Window is not null)
+				{
+					platformButton.BackgroundColor = UIColor.Clear;
+				}
 				return;
 			}
 

--- a/src/Core/src/Platform/iOS/ButtonExtensions.cs
+++ b/src/Core/src/Platform/iOS/ButtonExtensions.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Maui.Platform
 
 			// Delegate to the standard view background update
 			ViewExtensions.UpdateBackground(platformButton, paint);
-			if (paint is SolidPaint or GradientPaint)
+			if (paint is SolidPaint or LinearGradientPaint or RadialGradientPaint)
 				BackgroundUpdateStates.GetValue(platformButton, static _ => new()).HasMauiBackground = true;
 		}
 

--- a/src/Core/src/Platform/iOS/ButtonExtensions.cs
+++ b/src/Core/src/Platform/iOS/ButtonExtensions.cs
@@ -61,34 +61,33 @@ namespace Microsoft.Maui.Platform
 		internal static void UpdateBackground(this UIButton platformButton, Graphics.Paint? paint)
 		{
 			var updateState = BackgroundUpdateStates.GetValue(platformButton, static _ => new());
-			var isInitialUpdate = updateState.IsInitialUpdate;
-			updateState.IsInitialUpdate = false;
 
 			// Remove previous background gradient layer if any.
-			// Safe to call unconditionally during the initial mapping because MAUI has not yet
-			// inserted a named gradient layer, so this is a no-op.
-			// Running it before the Window/paint guard ensures any previously-applied gradient is
-			// cleaned up regardless of the new paint value.
+			// Safe to call when MAUI has not applied a gradient because this is a no-op.
+			// Running it before the paint guard ensures any previously-applied gradient is cleaned
+			// up regardless of the new paint value.
 			platformButton.RemoveBackgroundLayer();
 
 			if (paint.IsNullOrEmpty())
 			{
-				// Preserve constructor or appearance-proxy styling only during the first property
-				// mapping. Later null updates must clear prior MAUI state even while detached.
-				if (!isInitialUpdate)
+				// Preserve constructor or appearance-proxy styling until MAUI applies a background.
+				// This also covers handlers reconnected to another virtual view with no background.
+				if (updateState.HasMauiBackground)
 				{
 					platformButton.BackgroundColor = UIColor.Clear;
+					updateState.HasMauiBackground = false;
 				}
 				return;
 			}
 
 			// Delegate to the standard view background update
 			ViewExtensions.UpdateBackground(platformButton, paint);
+			updateState.HasMauiBackground = true;
 		}
 
 		sealed class BackgroundUpdateState
 		{
-			public bool IsInitialUpdate { get; set; } = true;
+			public bool HasMauiBackground { get; set; }
 		}
 
 		public static void UpdateCharacterSpacing(this UIButton platformButton, ITextStyle textStyle)

--- a/src/Core/src/Platform/iOS/ButtonExtensions.cs
+++ b/src/Core/src/Platform/iOS/ButtonExtensions.cs
@@ -60,8 +60,6 @@ namespace Microsoft.Maui.Platform
 		// TODO: Make this public in .NET 11
 		internal static void UpdateBackground(this UIButton platformButton, Graphics.Paint? paint)
 		{
-			var updateState = BackgroundUpdateStates.GetValue(platformButton, static _ => new());
-
 			// Remove previous background gradient layer if any.
 			// Safe to call when MAUI has not applied a gradient because this is a no-op.
 			// Running it before the paint guard ensures any previously-applied gradient is cleaned
@@ -72,17 +70,17 @@ namespace Microsoft.Maui.Platform
 			{
 				// Preserve constructor or appearance-proxy styling until MAUI applies a background.
 				// This also covers handlers reconnected to another virtual view with no background.
-				if (updateState.HasMauiBackground)
+				if (BackgroundUpdateStates.TryGetValue(platformButton, out var updateState) && updateState.HasMauiBackground)
 				{
 					platformButton.BackgroundColor = UIColor.Clear;
-					updateState.HasMauiBackground = false;
+					BackgroundUpdateStates.Remove(platformButton);
 				}
 				return;
 			}
 
 			// Delegate to the standard view background update
 			ViewExtensions.UpdateBackground(platformButton, paint);
-			updateState.HasMauiBackground = true;
+			BackgroundUpdateStates.GetValue(platformButton, static _ => new()).HasMauiBackground = true;
 		}
 
 		sealed class BackgroundUpdateState

--- a/src/Core/src/Platform/iOS/ButtonExtensions.cs
+++ b/src/Core/src/Platform/iOS/ButtonExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 using Microsoft.Maui.Graphics;
 using UIKit;
 
@@ -6,6 +7,8 @@ namespace Microsoft.Maui.Platform
 {
 	public static class ButtonExtensions
 	{
+		static readonly ConditionalWeakTable<UIButton, BackgroundUpdateState> BackgroundUpdateStates = new();
+
 		public const double AlmostZero = 0.00001;
 
 		public static void UpdateStrokeColor(this UIButton platformButton, IButtonStroke buttonStroke)
@@ -57,21 +60,22 @@ namespace Microsoft.Maui.Platform
 		// TODO: Make this public in .NET 11
 		internal static void UpdateBackground(this UIButton platformButton, Graphics.Paint? paint)
 		{
+			var updateState = BackgroundUpdateStates.GetValue(platformButton, static _ => new());
+			var isInitialUpdate = updateState.IsInitialUpdate;
+			updateState.IsInitialUpdate = false;
+
 			// Remove previous background gradient layer if any.
-			// Safe to call unconditionally even when Window is null (initial-render path): at that
-			// point MAUI has not yet inserted a named gradient layer, so this is a no-op.
+			// Safe to call unconditionally during the initial mapping because MAUI has not yet
+			// inserted a named gradient layer, so this is a no-op.
 			// Running it before the Window/paint guard ensures any previously-applied gradient is
 			// cleaned up regardless of the new paint value.
 			platformButton.RemoveBackgroundLayer();
 
 			if (paint.IsNullOrEmpty())
 			{
-				// Only reset to UIColor.Clear when the button is already attached to a window.
-				// During initial property mapping (ConnectHandler), Window is null because the view
-				// hasn't been added to the hierarchy yet — skipping here preserves native BackgroundColor
-				// set by custom UIButton subclasses. Once live on screen, null means a VisualState
-				// transition back to Normal, so we do reset. Mirrors the same guard in UpdateTextColor.
-				if (platformButton.Window is not null)
+				// Preserve constructor or appearance-proxy styling only during the first property
+				// mapping. Later null updates must clear prior MAUI state even while detached.
+				if (!isInitialUpdate)
 				{
 					platformButton.BackgroundColor = UIColor.Clear;
 				}
@@ -80,6 +84,11 @@ namespace Microsoft.Maui.Platform
 
 			// Delegate to the standard view background update
 			ViewExtensions.UpdateBackground(platformButton, paint);
+		}
+
+		sealed class BackgroundUpdateState
+		{
+			public bool IsInitialUpdate { get; set; } = true;
 		}
 
 		public static void UpdateCharacterSpacing(this UIButton platformButton, ITextStyle textStyle)

--- a/src/Core/src/Platform/iOS/ButtonExtensions.cs
+++ b/src/Core/src/Platform/iOS/ButtonExtensions.cs
@@ -80,7 +80,8 @@ namespace Microsoft.Maui.Platform
 
 			// Delegate to the standard view background update
 			ViewExtensions.UpdateBackground(platformButton, paint);
-			BackgroundUpdateStates.GetValue(platformButton, static _ => new()).HasMauiBackground = true;
+			if (paint is SolidPaint or GradientPaint)
+				BackgroundUpdateStates.GetValue(platformButton, static _ => new()).HasMauiBackground = true;
 		}
 
 		sealed class BackgroundUpdateState

--- a/src/Core/tests/DeviceTests/Handlers/Button/ButtonHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Button/ButtonHandlerTests.iOS.cs
@@ -166,6 +166,23 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact]
+		public async Task UnsupportedGradientDoesNotClearNativeBackground()
+		{
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var platformButton = new UIButton(UIButtonType.System)
+				{
+					BackgroundColor = UIColor.Cyan
+				};
+
+				platformButton.UpdateBackground(new UnsupportedGradientPaint());
+				platformButton.UpdateBackground(null);
+
+				Assert.Equal(Colors.Cyan, platformButton.BackgroundColor.ToColor());
+			});
+		}
+
 		sealed class NativeStyledButtonHandler : ButtonHandler
 		{
 			protected override UIButton CreatePlatformView()
@@ -186,6 +203,10 @@ namespace Microsoft.Maui.DeviceTests
 			public float StepX => 1;
 			public float StepY => 1;
 			public void Draw(ICanvas canvas) { }
+		}
+
+		sealed class UnsupportedGradientPaint : GradientPaint
+		{
 		}
 
 		bool ImageSourceLoaded(ButtonHandler buttonHandler) =>

--- a/src/Core/tests/DeviceTests/Handlers/Button/ButtonHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Button/ButtonHandlerTests.iOS.cs
@@ -130,6 +130,38 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(UIAccessibilityTrait.Button, trait);
 		}
 
+		[Fact]
+		public async Task NativeBackgroundIsPreservedWhenHandlerIsReused()
+		{
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var handler = new NativeStyledButtonHandler();
+				handler.SetMauiContext(MauiContext);
+				handler.SetVirtualView(new ButtonStub());
+
+				var platformButton = handler.PlatformView;
+				Assert.Equal(Colors.Cyan, platformButton.BackgroundColor.ToColor());
+
+				handler.SetVirtualView(new ButtonStub());
+
+				Assert.Same(platformButton, handler.PlatformView);
+				Assert.Equal(Colors.Cyan, platformButton.BackgroundColor.ToColor());
+			});
+		}
+
+		sealed class NativeStyledButtonHandler : ButtonHandler
+		{
+			protected override UIButton CreatePlatformView()
+			{
+				var button = new UIButton(UIButtonType.System)
+				{
+					BackgroundColor = UIColor.Cyan
+				};
+
+				return button;
+			}
+		}
+
 		bool ImageSourceLoaded(ButtonHandler buttonHandler) =>
 			buttonHandler.PlatformView.ImageView.Image != null;
 

--- a/src/Core/tests/DeviceTests/Handlers/Button/ButtonHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Button/ButtonHandlerTests.iOS.cs
@@ -149,6 +149,23 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact]
+		public async Task UnsupportedPaintDoesNotClearNativeBackground()
+		{
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var platformButton = new UIButton(UIButtonType.System)
+				{
+					BackgroundColor = UIColor.Cyan
+				};
+
+				platformButton.UpdateBackground(new PatternPaint { Pattern = new NoOpPattern() });
+				platformButton.UpdateBackground(null);
+
+				Assert.Equal(Colors.Cyan, platformButton.BackgroundColor.ToColor());
+			});
+		}
+
 		sealed class NativeStyledButtonHandler : ButtonHandler
 		{
 			protected override UIButton CreatePlatformView()
@@ -160,6 +177,15 @@ namespace Microsoft.Maui.DeviceTests
 
 				return button;
 			}
+		}
+
+		sealed class NoOpPattern : IPattern
+		{
+			public float Width => 1;
+			public float Height => 1;
+			public float StepX => 1;
+			public float StepY => 1;
+			public void Draw(ICanvas canvas) { }
 		}
 
 		bool ImageSourceLoaded(ButtonHandler buttonHandler) =>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!-- release-readiness-agent: human-approval-required -->

## Summary

Manual backport of #36769 to `release/10.0.1xx-sr10` for .NET MAUI 10.0.101.

- Addresses #36749.
- Applies the exact net patch from immutable source head `348f69b8e04a72d83b563064404a7c4fd79aef75`.
- Preserves the iOS UI regression coverage from the source PR.
- The source PR merged to `inflight/current` and has not flowed to `main`; this manual port intentionally excludes unrelated inflight branch history.

## Validation

- Source and SR10 patches have matching stable patch ID `f5eb0ffddfe5e87e84c64060fcb73927191d00e1`.
- `Core.csproj` builds successfully for `net10.0-ios26.0` in Release configuration with zero warnings and zero errors.

## Review gate

This agent-authored release PR must remain unmerged until two distinct non-bot MAUI maintainers with write access, other than the PR author, approve the current head SHA.
