### PR TITLE
[release/10.0.1xx-sr10] Align Android SwipeItem content

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/SwipeView/SwipeViewTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/SwipeView/SwipeViewTests.Android.cs
@@ -288,8 +288,8 @@ namespace Microsoft.Maui.DeviceTests
 				await AssertEventually(() => swipeButton.Height > 0);
 
 				// The button's MeasuredHeight should be LESS than its layout height.
-				// This proves it was measured with AtMost (self-sizing) rather than
-				// Exactly (forced to fill).
+				// In this scenario, that is the expected result of AtMost measurement;
+				// Exactly would always force the measured height to fill the available space.
 				Assert.True(
 					swipeButton.MeasuredHeight < swipeButton.Height,
 					$"SwipeItem button should self-size (MeasuredHeight={swipeButton.MeasuredHeight}) " +

--- a/src/Controls/tests/DeviceTests/Elements/SwipeView/SwipeViewTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/SwipeView/SwipeViewTests.Android.cs
@@ -229,13 +229,13 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact]
-		[Description("SwipeItem icon and text should be vertically aligned when SwipeView has large content")]
-		public async Task SwipeItemIconAndTextVerticallyAligned()
+		[Description("SwipeItem button should self-size when SwipeView has large content")]
+		public async Task SwipeItemButtonSelfSizesWithLargeContent()
 		{
 			// Regression test for https://github.com/dotnet/maui/issues/36736
 			// When SwipeView wraps tall content (e.g., CollectionView), the SwipeItem button
 			// should self-size its content (AtMost height) rather than being forced to fill
-			// the entire content area (Exactly height), which would misalign icon and text.
+			// the entire content area (Exactly height).
 			SetupBuilder();
 
 			var content = new VerticalStackLayout
@@ -289,13 +289,12 @@ namespace Microsoft.Maui.DeviceTests
 
 				// The button's MeasuredHeight should be LESS than its layout height.
 				// This proves it was measured with AtMost (self-sizing) rather than
-				// Exactly (forced to fill), which keeps icon+text vertically aligned.
+				// Exactly (forced to fill).
 				Assert.True(
 					swipeButton.MeasuredHeight < swipeButton.Height,
 					$"SwipeItem button should self-size (MeasuredHeight={swipeButton.MeasuredHeight}) " +
 					$"rather than fill entire area (Height={swipeButton.Height}). " +
-					$"If MeasuredHeight equals Height, the button is forced to fill, " +
-					$"causing icon and text to misalign.");
+					$"If MeasuredHeight equals Height, the button is forced to fill.");
 			});
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/SwipeView/SwipeViewTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/SwipeView/SwipeViewTests.Android.cs
@@ -9,6 +9,7 @@ using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using Xunit;
 using static Microsoft.Maui.DeviceTests.AssertHelpers;
+using ALinearLayoutCompat = AndroidX.AppCompat.Widget.LinearLayoutCompat;
 using ATextView = Android.Widget.TextView;
 
 namespace Microsoft.Maui.DeviceTests
@@ -287,13 +288,17 @@ namespace Microsoft.Maui.DeviceTests
 				var platformView = Assert.IsType<SwipeViewHandler>(swipeView.Handler).PlatformView;
 				swipeView.Open(OpenSwipeItem.LeftItems, false);
 
-				await AssertEventually(() => platformView.ChildCount > 1);
+				await AssertEventually(() =>
+					Enumerable.Range(0, platformView.ChildCount)
+						.Select(platformView.GetChildAt)
+						.OfType<ALinearLayoutCompat>()
+						.Any(view => view.ChildCount > 0));
 
-				var actionView = platformView.GetChildAt(1) as ViewGroup;
-				Assert.NotNull(actionView);
-
-				await AssertEventually(() => actionView.ChildCount > 0);
-
+				var actionView = Assert.Single(
+					Enumerable.Range(0, platformView.ChildCount)
+						.Select(platformView.GetChildAt)
+						.OfType<ALinearLayoutCompat>()
+						.Where(view => view.ChildCount > 0));
 				var swipeButton = Assert.IsAssignableFrom<ATextView>(actionView.GetChildAt(0));
 
 				await AssertEventually(() =>
@@ -313,7 +318,7 @@ namespace Microsoft.Maui.DeviceTests
 					swipeButton.CompoundDrawablePadding + tolerance,
 					swipeButton.LineHeight / 2);
 
-				Assert.InRange(textTop - iconBottom, 0, maxAlignmentGap);
+				Assert.InRange(textTop - iconBottom, -tolerance, maxAlignmentGap);
 			});
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/SwipeView/SwipeViewTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/SwipeView/SwipeViewTests.Android.cs
@@ -227,5 +227,76 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.Equal(expectedValue, isEnabled);
 			});
 		}
+
+		[Fact]
+		[Description("SwipeItem icon and text should be vertically aligned when SwipeView has large content")]
+		public async Task SwipeItemIconAndTextVerticallyAligned()
+		{
+			// Regression test for https://github.com/dotnet/maui/issues/36736
+			// When SwipeView wraps tall content (e.g., CollectionView), the SwipeItem button
+			// should self-size its content (AtMost height) rather than being forced to fill
+			// the entire content area (Exactly height), which would misalign icon and text.
+			SetupBuilder();
+
+			var content = new VerticalStackLayout
+			{
+				HeightRequest = 300,
+				Background = new SolidColorBrush(Colors.White)
+			};
+
+			var swipeItem = new SwipeItem
+			{
+				Text = "Delete",
+				BackgroundColor = Colors.Red,
+				IconImageSource = new FontImageSource
+				{
+					Glyph = "X",
+					FontFamily = "Arial",
+					Size = 20
+				}
+			};
+
+			var swipeItems = new SwipeItems
+			{
+				swipeItem
+			};
+
+			var swipeView = new SwipeView()
+			{
+				HeightRequest = 300,
+				LeftItems = swipeItems,
+				Content = content
+			};
+
+			await AttachAndRun(swipeView, async (handler) =>
+			{
+				var platformView = ((SwipeViewHandler)handler).PlatformView;
+				swipeView.Open(OpenSwipeItem.LeftItems, false);
+
+				// Wait for SwipeView to create action view with children
+				await AssertEventually(() => platformView.ChildCount > 1);
+
+				var actionView = platformView.GetChildAt(1) as ViewGroup;
+				Assert.NotNull(actionView);
+
+				await AssertEventually(() => actionView.ChildCount > 0);
+
+				var swipeButton = actionView.GetChildAt(0);
+				Assert.NotNull(swipeButton);
+
+				// Wait for button to be laid out
+				await AssertEventually(() => swipeButton.Height > 0);
+
+				// The button's MeasuredHeight should be LESS than its layout height.
+				// This proves it was measured with AtMost (self-sizing) rather than
+				// Exactly (forced to fill), which keeps icon+text vertically aligned.
+				Assert.True(
+					swipeButton.MeasuredHeight < swipeButton.Height,
+					$"SwipeItem button should self-size (MeasuredHeight={swipeButton.MeasuredHeight}) " +
+					$"rather than fill entire area (Height={swipeButton.Height}). " +
+					$"If MeasuredHeight equals Height, the button is forced to fill, " +
+					$"causing icon and text to misalign.");
+			});
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/SwipeView/SwipeViewTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/SwipeView/SwipeViewTests.Android.cs
@@ -1,4 +1,6 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
 using System.Threading.Tasks;
 using Android.Views;
 using Microsoft.Maui.Controls;
@@ -7,6 +9,7 @@ using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using Xunit;
 using static Microsoft.Maui.DeviceTests.AssertHelpers;
+using ATextView = Android.Widget.TextView;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -228,32 +231,31 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Fact]
-		[Description("SwipeItem button should self-size when SwipeView has large content")]
-		public async Task SwipeItemButtonSelfSizesWithLargeContent()
+		[Theory]
+		[InlineData(1)]
+		[InlineData(5)]
+		[InlineData(20)]
+		[Description("SwipeItem icon and text should remain centered together when wrapping a CollectionView")]
+		public async Task SwipeItemIconAndTextRemainAlignedWithCollectionView(int itemCount)
 		{
-			// Regression test for https://github.com/dotnet/maui/issues/36736
-			// When SwipeView wraps tall content (e.g., CollectionView), the SwipeItem button
-			// should self-size its content (AtMost height) rather than being forced to fill
-			// the entire content area (Exactly height).
 			SetupBuilder();
 
-			var content = new VerticalStackLayout
+			var collectionView = new CollectionView
 			{
-				HeightRequest = 300,
-				Background = new SolidColorBrush(Colors.White)
+				ItemsSource = Enumerable.Range(1, itemCount).Select(index => $"{index} record").ToArray(),
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var label = new Label { Padding = 10 };
+					label.SetBinding(Label.TextProperty, ".");
+					return label;
+				})
 			};
 
 			var swipeItem = new SwipeItem
 			{
-				Text = "Delete",
-				BackgroundColor = Colors.Red,
-				IconImageSource = new FontImageSource
-				{
-					Glyph = "X",
-					FontFamily = "Arial",
-					Size = 20
-				}
+				Text = "Back",
+				BackgroundColor = Colors.White,
+				IconImageSource = new FileImageSource { File = "red.png" }
 			};
 
 			var swipeItems = new SwipeItems
@@ -263,17 +265,28 @@ namespace Microsoft.Maui.DeviceTests
 
 			var swipeView = new SwipeView()
 			{
-				HeightRequest = 300,
 				LeftItems = swipeItems,
-				Content = content
+				Content = collectionView
 			};
 
-			await AttachAndRun(swipeView, async (handler) =>
+			var root = new Grid
 			{
-				var platformView = ((SwipeViewHandler)handler).PlatformView;
+				HeightRequest = 500,
+				WidthRequest = 300,
+				RowDefinitions =
+				{
+					new RowDefinition { Height = 40 },
+					new RowDefinition { Height = GridLength.Star }
+				}
+			};
+			root.Add(new Label { Text = "Records" });
+			root.Add(swipeView, row: 1);
+
+			await AttachAndRun(root, async (_) =>
+			{
+				var platformView = Assert.IsType<SwipeViewHandler>(swipeView.Handler).PlatformView;
 				swipeView.Open(OpenSwipeItem.LeftItems, false);
 
-				// Wait for SwipeView to create action view with children
 				await AssertEventually(() => platformView.ChildCount > 1);
 
 				var actionView = platformView.GetChildAt(1) as ViewGroup;
@@ -281,20 +294,26 @@ namespace Microsoft.Maui.DeviceTests
 
 				await AssertEventually(() => actionView.ChildCount > 0);
 
-				var swipeButton = actionView.GetChildAt(0);
-				Assert.NotNull(swipeButton);
+				var swipeButton = Assert.IsAssignableFrom<ATextView>(actionView.GetChildAt(0));
 
-				// Wait for button to be laid out
-				await AssertEventually(() => swipeButton.Height > 0);
+				await AssertEventually(() =>
+					swipeButton.Height > 0 &&
+					swipeButton.Baseline > 0 &&
+					swipeButton.GetCompoundDrawables()[1] is not null);
 
-				// The button's MeasuredHeight should be LESS than its layout height.
-				// In this scenario, that is the expected result of AtMost measurement;
-				// Exactly would always force the measured height to fill the available space.
-				Assert.True(
-					swipeButton.MeasuredHeight < swipeButton.Height,
-					$"SwipeItem button should self-size (MeasuredHeight={swipeButton.MeasuredHeight}) " +
-					$"rather than fill entire area (Height={swipeButton.Height}). " +
-					$"If MeasuredHeight equals Height, the button is forced to fill.");
+				var icon = swipeButton.GetCompoundDrawables()[1];
+				var fontMetrics = new global::Android.Graphics.Paint.FontMetricsInt();
+				swipeButton.Paint.GetFontMetricsInt(fontMetrics);
+				var iconTop = swipeButton.PaddingTop;
+				var iconBottom = iconTop + icon.Bounds.Height();
+				var textTop = swipeButton.Baseline + fontMetrics.Top;
+				var density = swipeButton.Context.GetDisplayDensity();
+				var tolerance = (int)Math.Ceiling(density);
+				var maxAlignmentGap = Math.Max(
+					swipeButton.CompoundDrawablePadding + tolerance,
+					swipeButton.LineHeight / 2);
+
+				Assert.InRange(textTop - iconBottom, 0, maxAlignmentGap);
 			});
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/SwipeView/SwipeViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/SwipeView/SwipeViewTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers.Items;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
@@ -20,6 +21,8 @@ namespace Microsoft.Maui.DeviceTests
 					handlers.AddHandler(typeof(VerticalStackLayout), typeof(LayoutHandler));
 					handlers.AddHandler(typeof(Grid), typeof(LayoutHandler));
 					handlers.AddHandler(typeof(Button), typeof(ButtonHandler));
+					handlers.AddHandler(typeof(Label), typeof(LabelHandler));
+					handlers.AddHandler(typeof(CollectionView), typeof(CollectionViewHandler));
 					handlers.AddHandler<SwipeView, SwipeViewHandler>();
 					handlers.AddHandler<SwipeItem, SwipeItemMenuItemHandler>();
 					handlers.AddHandler<SwipeItemView, SwipeItemViewHandler>();

--- a/src/Core/src/Platform/Android/MauiSwipeView.cs
+++ b/src/Core/src/Platform/Android/MauiSwipeView.cs
@@ -680,12 +680,13 @@ namespace Microsoft.Maui.Platform
 							break;
 					}
 
-					// AtMost lets custom SwipeItemView content size itself; Exactly forces precise dimensions for default SwipeItems.
-					var measureMode = item is ISwipeItemView ? MeasureSpecMode.AtMost : MeasureSpecMode.Exactly;
+					// Width: Exactly for default SwipeItems (ensures text is visible), AtMost for custom SwipeItemView.
+					// Height: Always AtMost so the button can self-size and keep icon+text vertically centered.
+					var widthMode = item is ISwipeItemView ? MeasureSpecMode.AtMost : MeasureSpecMode.Exactly;
 
 					child.Measure(
-						MeasureSpec.MakeMeasureSpec(swipeItemWidth, measureMode),
-						MeasureSpec.MakeMeasureSpec(swipeItemHeight, measureMode));
+						MeasureSpec.MakeMeasureSpec(swipeItemWidth, widthMode),
+						MeasureSpec.MakeMeasureSpec(swipeItemHeight, MeasureSpecMode.AtMost));
 
 					child.Layout(l, t, r, b);
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!-- release-readiness-agent: human-approval-required -->

## Summary

Manual backport of #36820 to `release/10.0.1xx-sr10` for .NET MAUI 10.0.101.

- Addresses #36736.
- Backports the Android SwipeItem measurement change from immutable source head `afab3f6df793d8a563030669e39fb48e8537c050`.
- Expands the Android device regression coverage to exercise the original CollectionView scenarios with 1, 5, and 20 items and verify the rendered icon/text alignment.
- The source PR merged to `inflight/current` and has not flowed to `main`; this manual port intentionally excludes unrelated inflight branch history.

## Validation

- `Microsoft.Maui.BuildTasks.slnf` builds successfully.
- `Controls.DeviceTests.csproj` builds successfully for `net10.0-android` / `android-arm64`.
- Android SwipeView device tests pass for all three CollectionView item-count scenarios.

## Review gate

This agent-authored release PR must remain unmerged until two distinct non-bot MAUI maintainers with write access, other than the PR author, approve the current head SHA.
