### PR TITLE
[release/10.0.1xx-sr10] Fix Android root-page back handling

### DIFF
--- a/src/Controls/src/Core/Page/Page.cs
+++ b/src/Controls/src/Core/Page/Page.cs
@@ -514,6 +514,13 @@ namespace Microsoft.Maui.Controls
 			return OnBackButtonPressed();
 		}
 
+		bool? _hasBackButtonPressedOverride;
+
+		internal bool HasBackButtonPressedOverride =>
+			_hasBackButtonPressedOverride ??=
+				new Func<bool>(OnBackButtonPressed).Method.DeclaringType is Type declaringType &&
+				declaringType.Assembly != typeof(Page).Assembly;
+
 		/// <summary>
 		/// Lays out the child elements when the layout is invalidated.
 		/// </summary>

--- a/src/Controls/src/Core/Window/Window.cs
+++ b/src/Controls/src/Core/Window/Window.cs
@@ -826,6 +826,12 @@ namespace Microsoft.Maui.Controls
 			if (page is null)
 				return false;
 
+			// Framework containers are handled below based on their current navigation state.
+			// App and third-party overrides must always receive the back press because only
+			// invoking the override can determine whether it consumes the navigation.
+			if (page.HasBackButtonPressedOverride)
+				return true;
+
 			switch (page)
 			{
 				case Shell shell:
@@ -862,8 +868,8 @@ namespace Microsoft.Maui.Controls
 
 				default:
 					// Conservative default: return false for unknown page types.
-					// We cannot know whether a custom container's OnBackButtonPressed() returns true,
-					// so we avoid suppressing the back-to-home animation speculatively.
+					// Custom overrides were handled above, so the system can safely provide
+					// the back-to-home animation for pages with framework behavior.
 					return false;
 			}
 		}

--- a/src/Controls/tests/Core.UnitTests/WindowsTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WindowsTests.cs
@@ -969,6 +969,25 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public void DerivedContentPageWithoutOverride_ReturnsFalse()
+		{
+			Assert.False(Window.CanConsumeBackNavigation(new DerivedContentPage()));
+		}
+
+		[Fact]
+		public void ContentPageWithBackButtonOverride_ReturnsTrue()
+		{
+			Assert.True(Window.CanConsumeBackNavigation(new ContentPageWithBackButtonOverride()));
+		}
+
+		[Fact]
+		public void NavigationPageWithBackButtonOverride_ReturnsTrue()
+		{
+			var nav = new NavigationPageWithBackButtonOverride(new ContentPage());
+			Assert.True(Window.CanConsumeBackNavigation(nav));
+		}
+
+		[Fact]
 		public void NavigationPage_SinglePage_ReturnsFalse()
 		{
 			// NavigationPage with only the root page — nothing to pop.
@@ -1119,6 +1138,24 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			item.Items.Add(section);
 			shell.Items.Add(item);
 			return shell;
+		}
+
+		class DerivedContentPage : ContentPage
+		{
+		}
+
+		class ContentPageWithBackButtonOverride : ContentPage
+		{
+			protected override bool OnBackButtonPressed() => true;
+		}
+
+		class NavigationPageWithBackButtonOverride : NavigationPage
+		{
+			public NavigationPageWithBackButtonOverride(Page root) : base(root)
+			{
+			}
+
+			protected override bool OnBackButtonPressed() => true;
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue37706.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue37706.cs
@@ -1,0 +1,39 @@
+[Issue(
+	IssueTracker.Github,
+	37706,
+	"Page.OnBackButtonPressed is not invoked on a root page",
+	PlatformAffected.Android)]
+public class Issue37706 : ContentPage
+{
+	int _backPressCount;
+	readonly Label _statusLabel;
+
+	public Issue37706()
+	{
+		_statusLabel = new Label
+		{
+			AutomationId = "BackButtonPressedStatus",
+			Text = "OnBackButtonPressed not called",
+		};
+
+		Content = new VerticalStackLayout
+		{
+			Children =
+			{
+				new Label
+				{
+					AutomationId = "RootPageLabel",
+					Text = "Root page",
+				},
+				_statusLabel,
+			},
+		};
+	}
+
+	protected override bool OnBackButtonPressed()
+	{
+		_backPressCount++;
+		_statusLabel.Text = $"OnBackButtonPressed called {_backPressCount} time";
+		return true;
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue37706.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue37706.cs
@@ -1,0 +1,31 @@
+#if ANDROID
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue37706 : _IssuesUITest
+{
+	public Issue37706(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue => "Page.OnBackButtonPressed is not invoked on a root page";
+
+	[Test]
+	[Category(UITestCategories.Navigation)]
+	public void RootPageBackButtonOverrideIsInvokedOnce()
+	{
+		App.WaitForElement("RootPageLabel");
+
+		App.Back();
+
+		Assert.That(
+			App.WaitForTextToBePresentInElement("BackButtonPressedStatus", "OnBackButtonPressed called 1 time"),
+			Is.True,
+			"OnBackButtonPressed should be called exactly once.");
+		App.WaitForElement("RootPageLabel");
+	}
+}
+#endif


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!-- release-readiness-agent: human-approval-required -->

## Summary

Manual backport of #37709 to `release/10.0.1xx-sr10` for .NET MAUI 10.0.101.

- Addresses #37706.
- Applies only the two fix commits from immutable source head `270c68781cde6a407da439b3f550c4f3c0a07e55`.
- Preserves the unit and Android UI regression coverage from the source PR.
- The source PR merged to `inflight/current` from a `main`-based head and has not flowed to `main`; this manual port excludes all unrelated branch-flow commits and files.

## Validation

- Source and SR10 patches have matching stable patch ID `3cf2fd29cb41073887e5ab06f21ad3774a0a177f`.
- All 58 `WindowsTests` Controls unit tests pass.

## Review gate

This agent-authored release PR must remain unmerged until two distinct non-bot MAUI maintainers with write access, other than the PR author, approve the current head SHA.
