### PR TITLE
[release/10.0.1xx-sr10] Fix Material 3 status bar contrast

### DIFF
--- a/src/Core/src/Platform/Android/WindowExtensions.cs
+++ b/src/Core/src/Platform/Android/WindowExtensions.cs
@@ -59,26 +59,34 @@ namespace Microsoft.Maui
 				var isLightTheme = configuration is null ||
 					(configuration.UiMode & UiMode.NightMask) != UiMode.NightYes;
 
-				// Resolve the actual status bar background color from the current theme and
-				// choose icon/text appearance based on its luminance. If the theme color cannot
-				// be resolved, preserve the previous theme-based behavior.
-				if (TryGetThemeColor(activity, global::Android.Resource.Attribute.ColorPrimary, out var statusBarColor))
-					windowInsetsController.AppearanceLightStatusBars = IsLightColor(statusBarColor);
-				else
-					windowInsetsController.AppearanceLightStatusBars = isLightTheme;
+				windowInsetsController.AppearanceLightStatusBars =
+					GetStatusBarAppearance(activity, isLightTheme, RuntimeFeature.IsMaterial3Enabled);
 
 				windowInsetsController.AppearanceLightNavigationBars = isLightTheme;
 			}
 		}
 
-		static bool TryGetThemeColor(Activity activity, int attribute, out AColor color)
+		internal static bool GetStatusBarAppearance(Context context, bool isLightTheme, bool isMaterial3)
+		{
+			// Material 3 draws its surface behind the transparent edge-to-edge status bar.
+			// The Material 2 app bar uses colorPrimary in the same area.
+			var backgroundAttribute = isMaterial3
+				? Resource.Attribute.colorSurface
+				: global::Android.Resource.Attribute.ColorPrimary;
+
+			return TryGetThemeColor(context, backgroundAttribute, out var backgroundColor)
+				? IsLightColor(backgroundColor)
+				: isLightTheme;
+		}
+
+		static bool TryGetThemeColor(Context context, int attribute, out AColor color)
 		{
 			color = default;
 
-			if (activity.Theme is null)
+			if (context.Theme is null)
 				return false;
 
-			using var ta = activity.Theme.ObtainStyledAttributes([attribute]);
+			using var ta = context.Theme.ObtainStyledAttributes([attribute]);
 
 			if (!ta.HasValue(0))
 				return false;

--- a/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Android.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Maui.DeviceTests
 
 				var appearance = WindowExtensions.GetStatusBarAppearance(
 					themedContext,
-					isLightTheme: !isDarkTheme,
+					isLightTheme: isDarkTheme,
 					isMaterial3: true);
 
 				Assert.Equal(expectedLightAppearance, appearance);

--- a/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Android.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Android.App;
+using Android.Content.Res;
 using AndroidX.AppCompat.App;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Hosting;
 using Xunit;
+using ContextThemeWrapper = Android.Views.ContextThemeWrapper;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -44,6 +46,50 @@ namespace Microsoft.Maui.DeviceTests
 					activity2.CreatePlatformWindow(app, null);
 				});
 
+			});
+		}
+
+		[Theory]
+		[InlineData(false, true)]
+		[InlineData(true, false)]
+		public async Task Material3StatusBarAppearanceUsesSurfaceColor(bool isDarkTheme, bool expectedLightAppearance)
+		{
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var activity = (AppCompatActivity)MauiProgramDefaults.DefaultContext;
+				using var configuration = new Configuration(activity.Resources?.Configuration);
+				configuration.UiMode = (configuration.UiMode & ~UiMode.NightMask) |
+					(isDarkTheme ? UiMode.NightYes : UiMode.NightNo);
+				using var configurationContext = activity.CreateConfigurationContext(configuration);
+				using var themedContext = new ContextThemeWrapper(
+					configurationContext,
+					Resource.Style.Maui_Material3_Theme_NoActionBar);
+
+				var appearance = WindowExtensions.GetStatusBarAppearance(
+					themedContext,
+					isLightTheme: isDarkTheme,
+					isMaterial3: true);
+
+				Assert.Equal(expectedLightAppearance, appearance);
+			});
+		}
+
+		[Fact]
+		public async Task Material2StatusBarAppearanceUsesPrimaryColor()
+		{
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var activity = (AppCompatActivity)MauiProgramDefaults.DefaultContext;
+				using var themedContext = new ContextThemeWrapper(
+					activity,
+					Resource.Style.Maui_MainTheme_NoActionBar);
+
+				var appearance = WindowExtensions.GetStatusBarAppearance(
+					themedContext,
+					isLightTheme: true,
+					isMaterial3: false);
+
+				Assert.False(appearance);
 			});
 		}
 

--- a/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Android.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Maui.DeviceTests
 
 				var appearance = WindowExtensions.GetStatusBarAppearance(
 					themedContext,
-					isLightTheme: isDarkTheme,
+					isLightTheme: !isDarkTheme,
 					isMaterial3: true);
 
 				Assert.Equal(expectedLightAppearance, appearance);


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!-- release-readiness-agent: human-approval-required -->

## Summary

Manual backport of #37710 to `release/10.0.1xx-sr10` for .NET MAUI 10.0.101.

- Addresses #37705.
- Applies only the fix commits from immutable source head `e0c13d71ad8c2ee7b6fd9cb818181aeefe23929a`.
- Preserves the Android device regression coverage from the source PR.
- The source PR merged to `inflight/current` from a `main`-based head and has not flowed to `main`; this manual port excludes all unrelated branch-flow commits and files.

## Validation

- Source and SR10 patches have matching stable patch ID `ac6bf2164fb73841bd05afd9bf714b4fcbd1a68b`.
- `Microsoft.Maui.BuildTasks.slnf` builds successfully.
- `Core.DeviceTests.csproj` builds successfully for `net10.0-android` / `android-arm64` with zero warnings and zero errors.

## Review gate

This agent-authored release PR must remain unmerged until two distinct non-bot MAUI maintainers with write access, other than the PR author, approve the current head SHA.
