### PR TITLE
[Android] Map: Keep the custom pin icon when a pin leaves a cluster

### DIFF
--- a/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/glide/MauiCustomTarget.java
+++ b/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/glide/MauiCustomTarget.java
@@ -70,6 +70,14 @@ public class MauiCustomTarget extends CustomTarget<Drawable> implements MauiTarg
         if (logger.isVerboseLoggable) logger.v("onLoadCleared: " + resourceLogIdentifier);
     }
 
+    // NOTE: the inline branch below runs clear() inside onResourceReady when the caller is already
+    // on the main looper, and Glide rejects a clear() issued from one of its own target callbacks
+    // (SingleRequest.assertNotCallingCallbacks). ImageLoaderCallbackBase completes its
+    // TaskCompletionSource synchronously, so a C# consumer that disposes the result in its await
+    // continuation lands in exactly that state. MapHandler.ReleaseImageResult
+    // (src/Core/maps/src/Handlers/Map/MapHandler.Android.cs) works around it by posting the dispose
+    // itself. Dropping the inline branch here would make disposal safe for every C# caller and make
+    // that workaround redundant - see the TODO in clear() below.
     private void post(Runnable runnable) {
         Looper looper = Looper.getMainLooper();
         if (looper.isCurrentThread()) {

--- a/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/glide/MauiCustomTarget.java
+++ b/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/glide/MauiCustomTarget.java
@@ -70,29 +70,15 @@ public class MauiCustomTarget extends CustomTarget<Drawable> implements MauiTarg
         if (logger.isVerboseLoggable) logger.v("onLoadCleared: " + resourceLogIdentifier);
     }
 
-    // NOTE: the inline branch below runs clear() inside onResourceReady when the caller is already
-    // on the main looper, and Glide rejects a clear() issued from one of its own target callbacks
-    // (SingleRequest.assertNotCallingCallbacks). ImageLoaderCallbackBase completes its
-    // TaskCompletionSource synchronously, so a C# consumer that disposes the result in its await
-    // continuation lands in exactly that state. MapHandler.ReleaseImageResult
-    // (src/Core/maps/src/Handlers/Map/MapHandler.Android.cs) works around it by posting the dispose
-    // itself. Dropping the inline branch here would make disposal safe for every C# caller and make
-    // that workaround redundant - see the TODO in clear() below.
-    private void post(Runnable runnable) {
-        Looper looper = Looper.getMainLooper();
-        if (looper.isCurrentThread()) {
-            runnable.run();
-            return;
-        }
-
-        Handler handler = new Handler(looper);
-        handler.post(runnable);
-    }
-
     private void clear() {
         // TODO: it looks like no one is really disposing the result on C# side
         // we must fix it there to release the Glide cache entry properly
-        post(() -> {
+
+        // Always enqueued, never run inline: clear() is handed to the C# side from inside
+        // onResourceReady, and Glide rejects a clear() issued from one of its own target callbacks
+        // (SingleRequest.assertNotCallingCallbacks). A consumer disposing the result in its await
+        // continuation is still on that callback stack, so running here would throw.
+        new Handler(Looper.getMainLooper()).post(() -> {
             if (PlatformInterop.isContextDestroyed(context)) {
                 if (logger.isVerboseLoggable) {
                     logger.v("clear() skipped - context destroyed: " + resourceLogIdentifier);

--- a/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/glide/MauiCustomTarget.java
+++ b/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/glide/MauiCustomTarget.java
@@ -20,6 +20,7 @@ import com.microsoft.maui.glide.MauiTarget;
 
 public class MauiCustomTarget extends CustomTarget<Drawable> implements MauiTarget {
     private static final PlatformLogger logger = new PlatformLogger("MauiCustomTarget");
+    private static final Handler MAIN_HANDLER = new Handler(Looper.getMainLooper());
 
     private final Context context;
     private final ImageLoaderCallback callback;
@@ -78,16 +79,26 @@ public class MauiCustomTarget extends CustomTarget<Drawable> implements MauiTarg
         // onResourceReady, and Glide rejects a clear() issued from one of its own target callbacks
         // (SingleRequest.assertNotCallingCallbacks). A consumer disposing the result in its await
         // continuation is still on that callback stack, so running here would throw.
-        new Handler(Looper.getMainLooper()).post(() -> {
-            if (PlatformInterop.isContextDestroyed(context)) {
-                if (logger.isVerboseLoggable) {
-                    logger.v("clear() skipped - context destroyed: " + resourceLogIdentifier);
+        MAIN_HANDLER.post(() -> {
+            // Deferring took this body out of the disposer's stack, so nothing catches it any more
+            // and a throw here would reach the looper as an unhandled exception. Releasing a cache
+            // entry must not be able to take the process down: fail as quietly as the inline path
+            // did, where the C# disposer logged and swallowed it.
+            try {
+                if (PlatformInterop.isContextDestroyed(context)) {
+                    if (logger.isVerboseLoggable) {
+                        logger.v("clear() skipped - context destroyed: " + resourceLogIdentifier);
+                    }
+                    return;
                 }
-                return;
+                Glide
+                    .with(context)
+                    .clear(this);
+            } catch (Throwable t) {
+                if (logger.isVerboseLoggable) {
+                    logger.v("clear() failed: " + resourceLogIdentifier);
+                }
             }
-            Glide
-                .with(context)
-                .clear(this);
         });
     }
 }

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -24,7 +24,6 @@ using ABitmapDrawable = Android.Graphics.Drawables.BitmapDrawable;
 using ACanvas = Android.Graphics.Canvas;
 using ACircle = Android.Gms.Maps.Model.Circle;
 using ADrawable = Android.Graphics.Drawables.Drawable;
-using AHandler = Android.OS.Handler;
 using APaint = Android.Graphics.Paint;
 using APolygon = Android.Gms.Maps.Model.Polygon;
 using APolyline = Android.Gms.Maps.Model.Polyline;
@@ -35,11 +34,6 @@ namespace Microsoft.Maui.Maps.Handlers
 {
 	public partial class MapHandler : ViewHandler<IMap, MapView>
 	{
-		// Created on first use rather than in a field initializer: a null MainLooper there would
-		// surface as a TypeInitializationException on every later MapHandler member access, which is
-		// a whole-map failure for a best-effort cleanup path. Same shape as MainThread.android.cs.
-		static volatile AHandler? s_mainHandler;
-
 		bool _init = true;
 
 		MapCallbackHandler? _mapReady;
@@ -1022,13 +1016,7 @@ namespace Microsoft.Maui.Maps.Handlers
 				if (bitmap is null)
 					return null;
 
-				// Every DrawableToBitmap path returns a bitmap this handler owns, and
-				// BitmapDescriptorFactory.FromBitmap copies the pixels into the descriptor, so the
-				// copy has no reader left once the descriptor exists. Recycling here frees it now
-				// instead of leaving one native buffer per load waiting on the GC bridge.
-				var descriptor = BitmapDescriptorFactory.FromBitmap(bitmap);
-				bitmap.Recycle();
-				return descriptor;
+				return BitmapDescriptorFactory.FromBitmap(bitmap);
 			}
 			catch (System.Exception ex)
 			{
@@ -1037,7 +1025,16 @@ namespace Microsoft.Maui.Maps.Handlers
 			}
 			finally
 			{
-				ReleaseImageResult(result, mauiContext);
+				// Guarded: the descriptor is already built by the time this runs, so a failing
+				// release must never be able to replace it with the default marker.
+				try
+				{
+					result?.Dispose();
+				}
+				catch (System.Exception ex)
+				{
+					TryLogWarning(mauiContext, ex, "Failed to release a custom pin icon image result");
+				}
 			}
 		}
 
@@ -1054,53 +1051,6 @@ namespace Microsoft.Maui.Maps.Handlers
 			}
 			catch
 			{
-			}
-		}
-
-		// The drawable is already copied into the descriptor by the time this runs, so releasing the
-		// image result must never be able to take the icon down with it. Glide also refuses a clear()
-		// issued from inside one of its own target callbacks - which is where the load continuation
-		// can resume - so hand the release to the next turn of the main loop: by then the callback
-		// has unwound and the Glide entry is released for real instead of being leaked.
-		static void ReleaseImageResult(IImageSourceServiceResult<ADrawable>? result, IMauiContext mauiContext)
-		{
-			if (result is null)
-				return;
-
-			try
-			{
-				// Resolved here rather than inside the post: the service provider can be gone by the
-				// time the release runs, and an exception raised from a looper callback takes the
-				// process down instead of faulting a task.
-				var logger = mauiContext.Services.GetService<ILogger<MapHandler>>();
-
-				// MainLooper is a process singleton, so one handler serves every release. A race here
-				// just builds a second one and discards it; both post to the same looper.
-				var handler = s_mainHandler;
-				if (handler is null)
-					s_mainHandler = handler = new AHandler(Looper.MainLooper!);
-
-				handler.Post(() =>
-				{
-					try
-					{
-						result.Dispose();
-					}
-					catch (System.Exception ex)
-					{
-						logger?.LogWarning(ex, "Failed to release a custom pin icon image result");
-					}
-				});
-			}
-			catch (System.Exception ex)
-			{
-				// This runs from a finally, so it must not throw under any circumstance - resolving
-				// the logger from a disposed provider included. An exception here would replace the
-				// descriptor that was already built, which is the very failure this method prevents.
-				// Swallowed, but not silently: reaching here means the Glide entry is leaked for the
-				// rest of the process, and a cleanup path that fails invisibly looks like one that
-				// works. TryLogWarning cannot throw back into this catch.
-				TryLogWarning(mauiContext, ex, "Failed to schedule the release of a custom pin icon image result");
 			}
 		}
 

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -1019,7 +1019,16 @@ namespace Microsoft.Maui.Maps.Handlers
 					return null;
 
 				var bitmap = DrawableToBitmap(drawable);
-				return bitmap != null ? BitmapDescriptorFactory.FromBitmap(bitmap) : null;
+				if (bitmap is null)
+					return null;
+
+				// Every DrawableToBitmap path returns a bitmap this handler owns, and
+				// BitmapDescriptorFactory.FromBitmap copies the pixels into the descriptor, so the
+				// copy has no reader left once the descriptor exists. Recycling here frees it now
+				// instead of leaving one native buffer per load waiting on the GC bridge.
+				var descriptor = BitmapDescriptorFactory.FromBitmap(bitmap);
+				bitmap.Recycle();
+				return descriptor;
 			}
 			catch (System.Exception ex)
 			{
@@ -1083,11 +1092,15 @@ namespace Microsoft.Maui.Maps.Handlers
 					}
 				});
 			}
-			catch
+			catch (System.Exception ex)
 			{
 				// This runs from a finally, so it must not throw under any circumstance - resolving
 				// the logger from a disposed provider included. An exception here would replace the
 				// descriptor that was already built, which is the very failure this method prevents.
+				// Swallowed, but not silently: reaching here means the Glide entry is leaked for the
+				// rest of the process, and a cleanup path that fails invisibly looks like one that
+				// works. TryLogWarning cannot throw back into this catch.
+				TryLogWarning(mauiContext, ex, "Failed to schedule the release of a custom pin icon image result");
 			}
 		}
 
@@ -1152,13 +1165,15 @@ namespace Microsoft.Maui.Maps.Handlers
 				// already fits - the size Pin.ImageSource documents for Android - so the descriptor
 				// would be built over pixels the image result owns, and releasing that result lets
 				// them go. Copy instead, and never fall back to the source: a failed copy has to
-				// mean the default marker, not a descriptor over foreign pixels. Hardware bitmaps
-				// are the common immutable case here and cannot be read back, so retarget those.
-				var config = source.GetConfig();
-				if (config is null || (OperatingSystem.IsAndroidVersionAtLeast(26) && config == ABitmap.Config.Hardware))
-					config = ABitmap.Config.Argb8888!;
-
-				return source.Copy(config, false);
+				// mean the default marker, not a descriptor over foreign pixels.
+				//
+				// Always Argb8888 rather than preserving source.GetConfig(): at 64x64 a narrower
+				// config saves a few KB, which is not worth comparing Bitmap.Config values for.
+				// Those compare as JNI peers of a Java enum, and peer identity is not something the
+				// binding guarantees - a comparison that silently went false for a hardware bitmap
+				// would copy it as hardware, and BitmapDescriptorFactory cannot read those pixels
+				// back, which lands on the default marker this PR exists to prevent.
+				return source.Copy(ABitmap.Config.Argb8888!, false);
 			}
 
 			int width = drawable.IntrinsicWidth;

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -1012,7 +1012,11 @@ namespace Microsoft.Maui.Maps.Handlers
 				if (ct.IsCancellationRequested || result?.Value is not ADrawable drawable)
 					return null;
 
-				var bitmap = DrawableToBitmap(drawable);
+				// Every DrawableToBitmap path returns a bitmap this handler owns, so nothing else
+				// reads it once the descriptor exists. Disposed rather than recycled: this drops
+				// the JNI peer and leaves the pixels to the Java GC, which stays correct even if
+				// FromBitmap retained the source rather than copying it. Recycling would not.
+				using var bitmap = DrawableToBitmap(drawable);
 				if (bitmap is null)
 					return null;
 

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -1023,12 +1023,28 @@ namespace Microsoft.Maui.Maps.Handlers
 			}
 			catch (System.Exception ex)
 			{
-				mauiContext.Services.GetService<ILogger<MapHandler>>()?.LogWarning(ex, "Failed to load custom pin icon");
+				TryLogWarning(mauiContext, ex, "Failed to load custom pin icon");
 				return null;
 			}
 			finally
 			{
 				ReleaseImageResult(result, mauiContext);
+			}
+		}
+
+		// Resolving a logger throws once the scoped service provider has been disposed - the window
+		// closing while a pin image load is in flight is enough - and this runs on a path where the
+		// descriptor has often already been built. An exception escaping the catch faults the task,
+		// so AddPinAsync never reaches Map.AddMarker and the pin is missing rather than un-iconed;
+		// under FireAndForget that failure is silent. Failing to log must never cost more than the log.
+		static void TryLogWarning(IMauiContext mauiContext, System.Exception exception, string message)
+		{
+			try
+			{
+				mauiContext.Services.GetService<ILogger<MapHandler>>()?.LogWarning(exception, message);
+			}
+			catch
+			{
 			}
 		}
 
@@ -1049,8 +1065,10 @@ namespace Microsoft.Maui.Maps.Handlers
 				// process down instead of faulting a task.
 				var logger = mauiContext.Services.GetService<ILogger<MapHandler>>();
 
+				// MainLooper is a process singleton, so one handler serves every release. A race here
+				// just builds a second one and discards it; both post to the same looper.
 				var handler = s_mainHandler;
-				if (handler is null || handler.Looper != Looper.MainLooper)
+				if (handler is null)
 					s_mainHandler = handler = new AHandler(Looper.MainLooper!);
 
 				handler.Post(() =>
@@ -1098,7 +1116,7 @@ namespace Microsoft.Maui.Maps.Handlers
 				}
 				catch (System.Exception ex)
 				{
-					mauiContext.Services.GetService<ILogger<MapHandler>>()?.LogWarning(ex, "Cluster image provider threw");
+					TryLogWarning(mauiContext, ex, "Cluster image provider threw");
 				}
 			}
 

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -24,6 +24,7 @@ using ABitmapDrawable = Android.Graphics.Drawables.BitmapDrawable;
 using ACanvas = Android.Graphics.Canvas;
 using ACircle = Android.Gms.Maps.Model.Circle;
 using ADrawable = Android.Graphics.Drawables.Drawable;
+using AHandler = Android.OS.Handler;
 using APaint = Android.Graphics.Paint;
 using APolygon = Android.Gms.Maps.Model.Polygon;
 using APolyline = Android.Gms.Maps.Model.Polyline;
@@ -34,6 +35,11 @@ namespace Microsoft.Maui.Maps.Handlers
 {
 	public partial class MapHandler : ViewHandler<IMap, MapView>
 	{
+		// Created on first use rather than in a field initializer: a null MainLooper there would
+		// surface as a TypeInitializationException on every later MapHandler member access, which is
+		// a whole-map failure for a best-effort cleanup path. Same shape as MainThread.android.cs.
+		static volatile AHandler? s_mainHandler;
+
 		bool _init = true;
 
 		MapCallbackHandler? _mapReady;
@@ -1004,9 +1010,11 @@ namespace Microsoft.Maui.Maps.Handlers
 		// Returns null on cancel/failure/no drawable.
 		static async Task<BitmapDescriptor?> LoadPinIconAsync(IImageSource imageSource, IMauiContext mauiContext, CancellationToken ct)
 		{
+			IImageSourceServiceResult<ADrawable>? result = null;
+
 			try
 			{
-				using var result = await imageSource.GetPlatformImageAsync(mauiContext);
+				result = await imageSource.GetPlatformImageAsync(mauiContext);
 				if (ct.IsCancellationRequested || result?.Value is not ADrawable drawable)
 					return null;
 
@@ -1017,6 +1025,51 @@ namespace Microsoft.Maui.Maps.Handlers
 			{
 				mauiContext.Services.GetService<ILogger<MapHandler>>()?.LogWarning(ex, "Failed to load custom pin icon");
 				return null;
+			}
+			finally
+			{
+				ReleaseImageResult(result, mauiContext);
+			}
+		}
+
+		// The drawable is already copied into the descriptor by the time this runs, so releasing the
+		// image result must never be able to take the icon down with it. Glide also refuses a clear()
+		// issued from inside one of its own target callbacks - which is where the load continuation
+		// can resume - so hand the release to the next turn of the main loop: by then the callback
+		// has unwound and the Glide entry is released for real instead of being leaked.
+		static void ReleaseImageResult(IImageSourceServiceResult<ADrawable>? result, IMauiContext mauiContext)
+		{
+			if (result is null)
+				return;
+
+			try
+			{
+				// Resolved here rather than inside the post: the service provider can be gone by the
+				// time the release runs, and an exception raised from a looper callback takes the
+				// process down instead of faulting a task.
+				var logger = mauiContext.Services.GetService<ILogger<MapHandler>>();
+
+				var handler = s_mainHandler;
+				if (handler is null || handler.Looper != Looper.MainLooper)
+					s_mainHandler = handler = new AHandler(Looper.MainLooper!);
+
+				handler.Post(() =>
+				{
+					try
+					{
+						result.Dispose();
+					}
+					catch (System.Exception ex)
+					{
+						logger?.LogWarning(ex, "Failed to release a custom pin icon image result");
+					}
+				});
+			}
+			catch
+			{
+				// This runs from a finally, so it must not throw under any circumstance - resolving
+				// the logger from a disposed provider included. An exception here would replace the
+				// descriptor that was already built, which is the very failure this method prevents.
 			}
 		}
 
@@ -1071,9 +1124,23 @@ namespace Microsoft.Maui.Maps.Handlers
 
 		static ABitmap? DrawableToBitmap(ADrawable drawable)
 		{
-			if (drawable is ABitmapDrawable bitmapDrawable && bitmapDrawable.Bitmap != null)
+			if (drawable is ABitmapDrawable bitmapDrawable && bitmapDrawable.Bitmap is ABitmap source)
 			{
-				return ScaleBitmap(bitmapDrawable.Bitmap, 64, 64);  // 64x64 pixels
+				var sized = ScaleBitmap(source, 64, 64);  // 64x64 pixels
+				if (!ReferenceEquals(sized, source))
+					return sized;
+
+				// Bitmap.createScaledBitmap hands an immutable source straight back when the image
+				// already fits - the size Pin.ImageSource documents for Android - so the descriptor
+				// would be built over pixels the image result owns, and releasing that result lets
+				// them go. Copy instead, and never fall back to the source: a failed copy has to
+				// mean the default marker, not a descriptor over foreign pixels. Hardware bitmaps
+				// are the common immutable case here and cannot be read back, so retarget those.
+				var config = source.GetConfig();
+				if (config is null || (OperatingSystem.IsAndroidVersionAtLeast(26) && config == ABitmap.Config.Hardware))
+					config = ABitmap.Config.Argb8888!;
+
+				return source.Copy(config, false);
 			}
 
 			int width = drawable.IntrinsicWidth;

--- a/src/Core/src/ImageSources/Android/ImageLoaderCallback.cs
+++ b/src/Core/src/ImageSources/Android/ImageLoaderCallback.cs
@@ -37,12 +37,6 @@ namespace Microsoft.Maui
 					? OnSuccess(drawable, disposeWrapper)
 					: OnFailure(drawable, disposeWrapper);
 
-				// NOTE: completed synchronously, and this runs inside MauiCustomTarget.onResourceReady,
-				// so an awaiting continuation resumes on Glide's own callback stack. A consumer that
-				// disposes the result there reaches MauiCustomTarget.clear(), which Glide rejects from
-				// inside a target callback. MapHandler.ReleaseImageResult posts its dispose to work
-				// around it; switching this to RunContinuationsAsynchronously would remove the need,
-				// but it moves every image-load continuation off the synchronous path.
 				_tcsResult.SetResult(result);
 			}
 			catch (Exception ex)

--- a/src/Core/src/ImageSources/Android/ImageLoaderCallback.cs
+++ b/src/Core/src/ImageSources/Android/ImageLoaderCallback.cs
@@ -37,6 +37,12 @@ namespace Microsoft.Maui
 					? OnSuccess(drawable, disposeWrapper)
 					: OnFailure(drawable, disposeWrapper);
 
+				// NOTE: completed synchronously, and this runs inside MauiCustomTarget.onResourceReady,
+				// so an awaiting continuation resumes on Glide's own callback stack. A consumer that
+				// disposes the result there reaches MauiCustomTarget.clear(), which Glide rejects from
+				// inside a target callback. MapHandler.ReleaseImageResult posts its dispose to work
+				// around it; switching this to RunContinuationsAsynchronously would remove the need,
+				// but it moves every image-load continuation off the synchronous path.
 				_tcsResult.SetResult(result);
 			}
 			catch (Exception ex)

--- a/src/Core/tests/DeviceTests/Services/ImageSource/ImageSourceServiceTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Services/ImageSource/ImageSourceServiceTests.Android.cs
@@ -229,6 +229,53 @@ namespace Microsoft.Maui.DeviceTests
 			result2.Dispose();
 		}
 
+		[Fact]
+		public async Task DisposingTheResultFromInsideTheLoadCallbackDoesNotThrow()
+		{
+			// The dispose Runnable handed to the callback is MauiCustomTarget.clear(), and the
+			// callback itself runs on Glide's own onResourceReady stack. Glide rejects a clear()
+			// issued from inside one of its target callbacks (SingleRequest.assertNotCallingCallbacks),
+			// so running it there threw. That is not an exotic position to be in: ImageLoaderCallbackBase
+			// completes its TaskCompletionSource synchronously, so every consumer that disposes the
+			// result in its await continuation lands on exactly this stack. clear() posts to the main
+			// looper now, so the call has to come back clean.
+			var bitmapFile = CreateBitmapFile(100, 100, Colors.Red);
+			var callback = new DisposeInsideCallbackStub();
+
+			PlatformInterop.LoadImageFromFile(MauiProgram.DefaultContext, bitmapFile, callback);
+
+			var (loaded, disposeError) = await callback.Result;
+
+			// Asserted so a load that quietly failed cannot pass this as "dispose did not throw".
+			Assert.True(loaded);
+			Assert.Null(disposeError);
+		}
+
+		class DisposeInsideCallbackStub : Java.Lang.Object, IImageLoaderCallback
+		{
+			// Asynchronous continuations so awaiting the result does not resume the test body
+			// inside the very callback the test is measuring.
+			readonly TaskCompletionSource<(bool Loaded, Exception DisposeError)> _tcs =
+				new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+			public Task<(bool Loaded, Exception DisposeError)> Result => _tcs.Task;
+
+			public void OnComplete(Java.Lang.Boolean success, Drawable drawable, Java.Lang.IRunnable dispose)
+			{
+				var loaded = success?.BooleanValue() == true;
+
+				try
+				{
+					dispose?.Run();
+					_tcs.TrySetResult((loaded, null));
+				}
+				catch (Exception ex)
+				{
+					_tcs.TrySetResult((loaded, ex));
+				}
+			}
+		}
+
 		async Task<bool> TryCollectFile(string bitmapFile)
 		{
 			var collected = false;


### PR DESCRIPTION
Fixes #37767

### Description of Change

On Android, a `Pin` whose `ImageSource` is a **rooted file path** came back with the default red marker after leaving a cluster, then corrected itself on a later zoom.

That source loads through Glide, and `LoadPinIconAsync` released the image result with a `using`. `ImageLoaderCallbackBase` completes its `TaskCompletionSource` synchronously, so the continuation - and with it the `Dispose` - can run inside Glide's own target callback, where `MauiCustomTarget.clear()` calls `Glide.clear()` and Glide throws `IllegalStateException: You can't start or clear loads in RequestListener or Target callbacks`. Because the throw happened while disposing, it replaced the `BitmapDescriptor` that had already been built: `LoadPinIconAsync` returned `null` and `AddPinAsync` created the marker without an icon.

A `Pin.ImageSource` backed by a MauiImage never hit this - it resolves through the synchronous `Context.GetDrawable` path. The failure looked intermittent because a `MarkerOptions` reused from an earlier successful load masked it; a fresh handler (any change to the `Pins` collection disconnects them) unmasked it.

**Fix:** hand the release to the next turn of the main loop. By then the Glide callback has unwound, so the clear succeeds - the icon survives *and* the Glide entry is genuinely released instead of leaked, which is what the `MauiCustomTarget` TODO asks for. The release is still guarded and logged so that a service whose dispose action fails for another reason cannot discard an icon that was already built; the logger is resolved before the post, because an exception raised from a looper callback takes the process down rather than faulting a task.

**Releasing for real exposes something the leak used to mask.** `Bitmap.createScaledBitmap` hands an *immutable* source straight back when the image already fits - the 64x64 that `Pin.ImageSource` documents for Android - so the descriptor would be built over pixels the image result owns, and releasing that result lets them go. Hardware bitmaps, which Glide emits on API 26+, are the common immutable case here. This PR copies in that branch, retargeting `Config.Hardware` to `Argb8888` since hardware pixels cannot be read back, and never falls back to the source: a failed copy means the default marker rather than a descriptor over foreign pixels. The sibling branch of the same method already guarded against the identity return (`if (scaled != bitmap) bitmap.Dispose();`), so this behaviour of the helper was known - the `BitmapDrawable` branch just never had to account for it while nothing released.

To be explicit about what fixes what: **the deferred release alone restores the icon** - verified on device before the copy existed. The copy is defensive, and belongs with the release because releasing for real is what makes a source-owned bitmap reachable by the descriptor at all.

A tighter fix exists one layer down - `MauiCustomTarget.post()` runs its runnable inline when already on the main looper, which is what puts `clear()` inside the callback in the first place, and Glide's own message suggests posting instead. That would make disposal safe for every C# caller rather than this one. It is deliberately out of scope here because it changes image loading for all of MAUI; happy to open it separately if maintainers prefer that direction.

The redundant-reload half of this work was split into its own PR to keep the bug fix and the caching behaviour separately reviewable.

### Verification

Physical device (Samsung SM-X230, Android 15), clustering gallery using pins whose icon is a PNG written to `FileSystem.CacheDirectory`, handler instrumented at each boundary.

Three zoom-in/zoom-out cycles over 25 clustered custom pins:

| | before | after |
|---|---|---|
| Glide `IllegalStateException` | 29 | 0 |
| icon loads discarded | 29 | 0 |
| markers created without their icon | 0 (masked by a surviving `MarkerOptions`) | 0 |
| recycled-bitmap / canvas errors | - | 0 |

Re-run after the split, both alone and merged with the reload PR: no Glide asserts, no recycled-bitmap errors, no crashes, every de-clustered pin keeps its icon.

### Issues Fixed

Fixes #37767

