### PR TITLE
[Android] Map: Recluster on a single zoom step

### DIFF
--- a/src/Controls/tests/Core.UnitTests/MapTests.cs
+++ b/src/Controls/tests/Core.UnitTests/MapTests.cs
@@ -813,11 +813,18 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		// One zoom-button press or double-tap moves exactly one level: the case that regressed.
 		[InlineData(11f, 10f, true)]
 		[InlineData(10f, 11f, true)]
-		// A one-level step can land a hair under 1.0f across a binade boundary.
-		[InlineData(16.03f, 15.03f, true)]
+		// A one-level step lands *under* 1.0f when the two values straddle a binade boundary, which
+		// is the only thing ReclusterZoomStep's tolerance is for. This pair is the worst case in
+		// Google Maps' 1-22 zoom range: the delta is 0.9999990463f, exactly 2^-20 short. Keep a pair
+		// that actually falls short - 16.03f/15.03f rounds to 1.0000009537f, which the old strict
+		// "> 1.0f" already passed, so it pins nothing.
+		[InlineData(16.05f, 15.05f, true)]
 		// Anything meaningfully short of a level must not tear down and rebuild every marker.
 		[InlineData(10.5f, 10f, false)]
 		[InlineData(10.9f, 10f, false)]
+		// Just under the threshold (0.9997997284f), so the tolerance is pinned from below too: it
+		// has to stay an epsilon absorbing float noise, not grow into a sub-level recluster policy.
+		[InlineData(10.9998f, 10f, false)]
 		// The -1 seed means the first camera idle always clusters.
 		[InlineData(0f, -1f, true)]
 		[InlineData(11f, -1f, true)]

--- a/src/Controls/tests/Core.UnitTests/MapTests.cs
+++ b/src/Controls/tests/Core.UnitTests/MapTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -807,6 +807,23 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var map = new Map();
 			map.IsClusteringEnabled = true;
 			Assert.True(map.IsClusteringEnabled);
+		}
+
+		[Theory]
+		// One zoom-button press or double-tap moves exactly one level: the case that regressed.
+		[InlineData(11f, 10f, true)]
+		[InlineData(10f, 11f, true)]
+		// A one-level step can land a hair under 1.0f across a binade boundary.
+		[InlineData(16.03f, 15.03f, true)]
+		// Anything meaningfully short of a level must not tear down and rebuild every marker.
+		[InlineData(10.5f, 10f, false)]
+		[InlineData(10.9f, 10f, false)]
+		// The -1 seed means the first camera idle always clusters.
+		[InlineData(0f, -1f, true)]
+		[InlineData(11f, -1f, true)]
+		public void ShouldReclusterOnAFullZoomStep(float currentZoom, float lastClusterZoom, bool expected)
+		{
+			Assert.Equal(expected, MapHandler.ShouldRecluster(currentZoom, lastClusterZoom));
 		}
 
 		[Fact]

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -1376,9 +1376,8 @@ namespace Microsoft.Maui.Maps.Handlers
 			if (_googleMap == null || _handler == null)
 				return;
 
-			// Recalculate clusters when zoom level changes significantly
 			var currentZoom = _googleMap.CameraPosition.Zoom;
-			if (Math.Abs(currentZoom - _lastClusterZoom) > 1.0f)
+			if (MapHandler.ShouldRecluster(currentZoom, _lastClusterZoom))
 			{
 				_lastClusterZoom = currentZoom;
 				_handler.ReclusterPins();

--- a/src/Core/maps/src/Handlers/Map/MapHandler.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.cs
@@ -104,6 +104,15 @@ namespace Microsoft.Maui.Maps.Handlers
 				mapHandler.HideInfoWindow(pin);
 		}
 
+		// Android reclusters once the zoom has moved a full level away from the last clustering pass.
+		// The zoom buttons and double-tap move by exactly one level, so a strict "greater than"
+		// never fires for them; and the delta can land up to 2^-20 under 1.0f when the two values
+		// straddle a binade boundary, which is all the tolerance below is for.
+		internal const float ReclusterZoomStep = 0.9999f;
+
+		internal static bool ShouldRecluster(float currentZoom, float lastClusterZoom) =>
+			Math.Abs(currentZoom - lastClusterZoom) >= ReclusterZoomStep;
+
 		// Builds a stable cache key for a marker icon - cluster or pin - so logically identical images
 		// (same file, URI, or font glyph) share one decoded/rasterized bitmap even when the caller hands
 		// back a fresh ImageSource instance on every recluster. Returns null for sources that can't be


### PR DESCRIPTION
Fixes #37768

### Description of Change

`MapCallbackHandler.OnCameraIdle` only reclustered when the zoom had moved **more than** a full level away from the last clustering pass:

```csharp
if (Math.Abs(currentZoom - _lastClusterZoom) > 1.0f)
```

The Google Maps zoom buttons and double-tap - the ordinary way to zoom on Android - move by exactly one level, so a single press never crossed a strict `> 1.0f`. Clusters only updated after a second press, or after a pan nudged the zoom far enough past the boundary for the comparison to succeed, which reads as clustering being stuck.

Make the comparison inclusive, with just enough tolerance for the one case where a full step lands short: `2^-20` under `1.0f`, when the two zoom values straddle a binade boundary. The threshold is `0.9999f` - about a hundredfold margin on that error, while widening the trigger band by 0.01% of a zoom level rather than 1%. It stays an epsilon rather than becoming a policy change: a genuine sub-level zoom must not trigger a full marker teardown and rebuild.

The comparison moves to `MapHandler.ShouldRecluster` in the shared handler so the boundary is unit-testable - `OnCameraIdle` itself needs a live `GoogleMap` and is out of reach of the test projects, which left nothing pinning `>` against `>=`. `Controls/tests/Core.UnitTests/MapTests.cs` now covers a one-level step in both directions, a one-level step across a binade boundary, sub-level deltas that must not trigger, and the `-1` seed.

### Note on ordering

Worth merging after #37769. Reclustering now runs on every zoom step rather than every other one, and until #37769 lands `AddPinAsync` awaits the image load before `Map.AddMarker`, so pins with a custom `ImageSource` are absent from the map until their image resolves. #37769 adds a per-pin icon cache that skips the load - and therefore the await - for an unchanged source, which removes that flicker.

### Verification

On a physical device (Samsung SM-X230, Android 15) with 80 clustered pins: before the change, logged reclustering fired at zoom 10.72, 12.72 and 14.72 and never in between; after it, a single `-` press visibly merges the clusters.

### Issues Fixed

Fixes #37768

