### PR TITLE
[net11.0] Fix Blazor template asset assertion

### DIFF
--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/WindowsTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/WindowsTemplateTest.cs
@@ -132,7 +132,11 @@ public class WindowsTemplateTest : BaseTemplateTests
 		var rid = usesRidGraph ? "win10-x64" : "win-x64";
 		var assetsRoot = Path.Combine(projectDir, $"bin/{config}/{framework}-windows10.0.19041.0/{rid}/publish");
 
-		AssetExists("dotnet_bot.scale-100.png");
+		if (id == "maui")
+		{
+			AssetExists("dotnet_bot.scale-100.png");
+		}
+
 		AssetExists("appiconLogo.scale-100.png");
 		AssetExists("OpenSans-Regular.ttf");
 		AssetExists("splashSplashScreen.scale-100.png");


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

#37785 intentionally removed the unused `dotnet_bot.svg` from the Blazor Hybrid templates. `WindowsTemplateTest.PublishUnpackaged` still required the generated `dotnet_bot.scale-100.png` for both `maui` and `maui-blazor`, so every PR merged against that commit now fails the WindowsTemplates lane after a successful publish.

Only assert the bot output for the `maui` template, which still owns that asset. The remaining shared asset assertions continue to run for both templates.

## Validation

- Built `Microsoft.Maui.IntegrationTests.csproj` on .NET 11 with zero warnings/errors.
- Confirmed the stale assertion fails deterministically in `maui-pr` build 1566052, attempts 1 and 2: 24 passed, 1 failed, with only the removed Blazor bot asset missing.
- The immediately preceding build 1565335 passed the same lane before #37785 entered `net11.0`.