### PR TITLE
[iOS] Fix TimePicker forcing en-US culture on iOS instead of device culture

### DIFF
--- a/src/Core/src/Platform/iOS/Culture.cs
+++ b/src/Core/src/Platform/iOS/Culture.cs
@@ -1,9 +1,38 @@
 ﻿using System.Globalization;
+using Foundation;
 
 namespace Microsoft.Maui.Platform
 {
 	public static class Culture
 	{
-		public static CultureInfo CurrentCulture => CultureInfo.CurrentCulture;
+		static CultureInfo? s_currentCulture;
+		static string? s_localeIdentifier;
+
+		public static CultureInfo CurrentCulture
+		{
+			get
+			{
+				var locale = NSLocale.CurrentLocale;
+				var identifier = locale.LocaleIdentifier;
+
+				if (s_currentCulture == null || s_localeIdentifier != identifier)
+				{
+					s_localeIdentifier = identifier;
+
+					try
+					{
+						// iOS uses identifiers such as en_US, en_GB, ta_IN, etc.
+						var cultureName = identifier.Replace('_', '-');
+						s_currentCulture = CultureInfo.GetCultureInfo(cultureName);
+					}
+					catch (CultureNotFoundException)
+					{
+						s_currentCulture = CultureInfo.InvariantCulture;
+					}
+				}
+
+				return s_currentCulture;
+			}
+		}
 	}
 }

--- a/src/Core/src/Platform/iOS/Culture.cs
+++ b/src/Core/src/Platform/iOS/Culture.cs
@@ -22,11 +22,11 @@ namespace Microsoft.Maui.Platform
 
 					try
 					{
-						// On iOS 26, the locale identifier can contain a Regional Format override
+						// On iOS 17+, the locale identifier can contain a Regional Format override
 						// (e.g. "en_US@rg=inzzzz"), which .NET cannot parse directly. Build the
 						// culture name from LanguageCode/ScriptCode/RegionCode instead, since
 						// RegionCode (unlike the identifier) resolves the "rg" override.
-						if (OperatingSystem.IsIOSVersionAtLeast(26))
+						if (OperatingSystem.IsIOSVersionAtLeast(17))
 						{
 							var languageCode = locale.LanguageCode;
 							var scriptCode = locale.ScriptCode;

--- a/src/Core/src/Platform/iOS/Culture.cs
+++ b/src/Core/src/Platform/iOS/Culture.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Globalization;
 using Foundation;
 
 namespace Microsoft.Maui.Platform
@@ -21,9 +22,28 @@ namespace Microsoft.Maui.Platform
 
 					try
 					{
-						// iOS uses identifiers such as en_US, en_GB, ta_IN, etc.
-						var cultureName = identifier.Replace('_', '-');
-						s_currentCulture = CultureInfo.GetCultureInfo(cultureName);
+						// On iOS 26, the locale identifier can contain a Regional Format override
+						// (e.g. "en_US@rg=inzzzz"), which .NET cannot parse directly. Build the
+						// culture name from LanguageCode/ScriptCode/RegionCode instead, since
+						// RegionCode (unlike the identifier) resolves the "rg" override.
+						if (OperatingSystem.IsIOSVersionAtLeast(26))
+						{
+							var languageCode = locale.LanguageCode;
+							var scriptCode = locale.ScriptCode;
+							var regionCode = locale.RegionCode;
+
+							var cultureName = string.IsNullOrEmpty(scriptCode)
+								? string.IsNullOrEmpty(regionCode) ? languageCode : $"{languageCode}-{regionCode}"
+								: string.IsNullOrEmpty(regionCode) ? $"{languageCode}-{scriptCode}" : $"{languageCode}-{scriptCode}-{regionCode}";
+
+							s_currentCulture = CultureInfo.GetCultureInfo(cultureName);
+						}
+						else
+						{
+							// iOS uses identifiers such as en_US, en_GB, ta_IN, etc.
+							var cultureName = identifier.Replace('_', '-');
+							s_currentCulture = CultureInfo.GetCultureInfo(cultureName);
+						}
 					}
 					catch (CultureNotFoundException)
 					{

--- a/src/Core/src/Platform/iOS/Culture.cs
+++ b/src/Core/src/Platform/iOS/Culture.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Platform
 				var locale = NSLocale.CurrentLocale;
 				var identifier = locale.LocaleIdentifier;
 
-				if (s_currentCulture == null || s_localeIdentifier != identifier)
+				if (s_currentCulture is null || s_localeIdentifier != identifier)
 				{
 					s_localeIdentifier = identifier;
 

--- a/src/Core/src/Platform/iOS/Culture.cs
+++ b/src/Core/src/Platform/iOS/Culture.cs
@@ -1,58 +1,29 @@
-﻿using System;
-using System.Globalization;
+﻿using System.Globalization;
+using System.Linq;
 using Foundation;
 
 namespace Microsoft.Maui.Platform
 {
 	public static class Culture
 	{
+		static NSLocale? s_locale;
 		static CultureInfo? s_currentCulture;
-		static string? s_localeIdentifier;
 
 		public static CultureInfo CurrentCulture
 		{
 			get
 			{
-				var locale = NSLocale.CurrentLocale;
-				var identifier = locale.LocaleIdentifier;
-
-				if (s_currentCulture is null || s_localeIdentifier != identifier)
+				if (s_locale == null || s_currentCulture == null || s_locale != NSLocale.CurrentLocale)
 				{
-					s_localeIdentifier = identifier;
+					s_locale = NSLocale.CurrentLocale;
+					string countryCode = s_locale.CountryCode;
+					var cultureInfo = CultureInfo.GetCultures(CultureTypes.AllCultures)
+						.Where(c => c.Name.EndsWith("-" + countryCode)).FirstOrDefault();
 
-					try
-					{
-						// On iOS 17+, the locale identifier can contain a Regional Format override
-						// (e.g. "en_US@rg=inzzzz"), which .NET cannot parse directly. Build the
-						// culture name from LanguageCode/ScriptCode/RegionCode instead, since
-						// RegionCode (unlike the identifier) resolves the "rg" override.
-						if (OperatingSystem.IsIOSVersionAtLeast(17))
-						{
-							var languageCode = locale.LanguageCode;
-							var scriptCode = locale.ScriptCode;
-							var regionCode = locale.RegionCode;
+					if (cultureInfo == null)
+						cultureInfo = CultureInfo.InvariantCulture;
 
-							var cultureName = string.IsNullOrEmpty(scriptCode)
-								? string.IsNullOrEmpty(regionCode) ? languageCode : $"{languageCode}-{regionCode}"
-								: string.IsNullOrEmpty(regionCode) ? $"{languageCode}-{scriptCode}" : $"{languageCode}-{scriptCode}-{regionCode}";
-
-							s_currentCulture = CultureInfo.GetCultureInfo(cultureName);
-						}
-						else
-						{
-							// Remove ICU keyword suffixes, which are not valid .NET culture names.
-							var keywordIndex = identifier.IndexOf('@', StringComparison.Ordinal);
-							var normalizedIdentifier = keywordIndex >= 0 ? identifier[..keywordIndex] : identifier;
-							var cultureName = normalizedIdentifier.Replace('_', '-');
-
-							s_currentCulture = CultureInfo.GetCultureInfo(cultureName);
-						}
-					}
-					catch (ArgumentException)
-					{
-						// CultureNotFoundException and ArgumentNullException derive from ArgumentException.
-						s_currentCulture = CultureInfo.InvariantCulture;
-					}
+					s_currentCulture = cultureInfo;
 				}
 
 				return s_currentCulture;

--- a/src/Core/src/Platform/iOS/Culture.cs
+++ b/src/Core/src/Platform/iOS/Culture.cs
@@ -40,13 +40,17 @@ namespace Microsoft.Maui.Platform
 						}
 						else
 						{
-							// iOS uses identifiers such as en_US, en_GB, ta_IN, etc.
-							var cultureName = identifier.Replace('_', '-');
+							// Remove ICU keyword suffixes, which are not valid .NET culture names.
+							var keywordIndex = identifier.IndexOf('@', StringComparison.Ordinal);
+							var normalizedIdentifier = keywordIndex >= 0 ? identifier[..keywordIndex] : identifier;
+							var cultureName = normalizedIdentifier.Replace('_', '-');
+
 							s_currentCulture = CultureInfo.GetCultureInfo(cultureName);
 						}
 					}
-					catch (CultureNotFoundException)
+					catch (ArgumentException)
 					{
+						// CultureNotFoundException and ArgumentNullException derive from ArgumentException.
 						s_currentCulture = CultureInfo.InvariantCulture;
 					}
 				}

--- a/src/Core/src/Platform/iOS/Culture.cs
+++ b/src/Core/src/Platform/iOS/Culture.cs
@@ -1,33 +1,9 @@
 ﻿using System.Globalization;
-using System.Linq;
-using Foundation;
 
 namespace Microsoft.Maui.Platform
 {
 	public static class Culture
 	{
-		static NSLocale? s_locale;
-		static CultureInfo? s_currentCulture;
-
-		public static CultureInfo CurrentCulture
-		{
-			get
-			{
-				if (s_locale == null || s_currentCulture == null || s_locale != NSLocale.CurrentLocale)
-				{
-					s_locale = NSLocale.CurrentLocale;
-					string countryCode = s_locale.CountryCode;
-					var cultureInfo = CultureInfo.GetCultures(CultureTypes.AllCultures)
-						.Where(c => c.Name.EndsWith("-" + countryCode)).FirstOrDefault();
-
-					if (cultureInfo == null)
-						cultureInfo = CultureInfo.InvariantCulture;
-
-					s_currentCulture = cultureInfo;
-				}
-
-				return s_currentCulture;
-			}
-		}
+		public static CultureInfo CurrentCulture => CultureInfo.CurrentCulture;
 	}
 }

--- a/src/Core/src/Platform/iOS/TimePickerExtensions.cs
+++ b/src/Core/src/Platform/iOS/TimePickerExtensions.cs
@@ -40,28 +40,20 @@ public static class TimePickerExtensions
 	{
 		picker?.UpdateTime(timePicker);
 
-		var cultureInfo = Culture.CurrentCulture;
 		var time = timePicker.Time;
 		var format = timePicker.Format;
 
-		mauiTimePicker.Text = time?.ToFormattedString(format, cultureInfo);
+		mauiTimePicker.Text = time?.ToFormattedString(format);
 
 		if (picker is not null)
 		{
-			if (string.IsNullOrEmpty(format))
-			{
-				picker.Locale = new NSLocale(cultureInfo.TwoLetterISOLanguageName);
-			}
-			else if (format.Contains('H', StringComparison.Ordinal))
-			{
-				var ci = new CultureInfo("de-DE");
-				picker.Locale = new NSLocale(ci.TwoLetterISOLanguageName);
-			}
-			else if (format.Contains('h', StringComparison.Ordinal))
-			{
-				var ci = new CultureInfo("en-US");
-				picker.Locale = new NSLocale(ci.TwoLetterISOLanguageName);
-			}
+			var localeIdentifier = !string.IsNullOrEmpty(format) && format.Contains('H', StringComparison.Ordinal)
+				? "de"
+				: !string.IsNullOrEmpty(format) && format.Contains('h', StringComparison.Ordinal)
+					? "en"
+					: CultureInfo.CurrentCulture.Name;
+
+			picker.Locale = new NSLocale(localeIdentifier);
 		}
 
 		mauiTimePicker.UpdateCharacterSpacing(timePicker);

--- a/src/Core/src/Platform/iOS/TimePickerExtensions.cs
+++ b/src/Core/src/Platform/iOS/TimePickerExtensions.cs
@@ -55,35 +55,30 @@ public static class TimePickerExtensions
 		var time = timePicker.Time;
 		var format = timePicker.Format;
 
-		// Determine which culture to use for consistent formatting
-		CultureInfo formattingCulture;
-		if (format != null)
-		{
-			if (format.Contains('t', StringComparison.Ordinal) || format.Contains('h', StringComparison.Ordinal))
-			{
-				formattingCulture = new CultureInfo("en-US");
-			}	
-			else if (format.Contains('H', StringComparison.Ordinal))
-			{
-				formattingCulture = new CultureInfo("de-DE");
-			}
-			else
-			{
-				formattingCulture = cultureInfo;
-			}
-				
-		}
-		else
-		{
-			formattingCulture = cultureInfo;
-		}
+		mauiTimePicker.Text = time?.ToFormattedString(format, cultureInfo);
 
-		// Apply the same culture to both the text display and the picker
-		mauiTimePicker.Text = time?.ToFormattedString(format ?? string.Empty, formattingCulture);
-
-		if (picker != null && format != null)
+		if (format is not null)
 		{
-			picker.Locale = new NSLocale(formattingCulture.TwoLetterISOLanguageName);
+			if (format.Contains('H', StringComparison.Ordinal))
+			{
+				var ci = new CultureInfo("de-DE");
+				NSLocale locale = new NSLocale(ci.TwoLetterISOLanguageName);
+
+				if (picker is not null)
+				{
+					picker.Locale = locale;
+				}
+			}
+			else if (format.Contains('h', StringComparison.Ordinal))
+			{
+				var ci = new CultureInfo("en-US");
+				NSLocale locale = new NSLocale(ci.TwoLetterISOLanguageName);
+
+				if (picker is not null)
+				{
+					picker.Locale = locale;
+				}
+			}
 		}
 
 		mauiTimePicker.UpdateCharacterSpacing(timePicker);

--- a/src/Core/src/Platform/iOS/TimePickerExtensions.cs
+++ b/src/Core/src/Platform/iOS/TimePickerExtensions.cs
@@ -41,43 +41,26 @@ public static class TimePickerExtensions
 		picker?.UpdateTime(timePicker);
 
 		var cultureInfo = Culture.CurrentCulture;
-
-		if (string.IsNullOrEmpty(timePicker.Format))
-		{
-			NSLocale locale = new NSLocale(cultureInfo.TwoLetterISOLanguageName);
-
-			if (picker is not null)
-			{
-				picker.Locale = locale;
-			}
-		}
-
 		var time = timePicker.Time;
 		var format = timePicker.Format;
 
 		mauiTimePicker.Text = time?.ToFormattedString(format, cultureInfo);
 
-		if (format is not null)
+		if (picker is not null)
 		{
-			if (format.Contains('H', StringComparison.Ordinal))
+			if (string.IsNullOrEmpty(format))
+			{
+				picker.Locale = new NSLocale(cultureInfo.TwoLetterISOLanguageName);
+			}
+			else if (format.Contains('H', StringComparison.Ordinal))
 			{
 				var ci = new CultureInfo("de-DE");
-				NSLocale locale = new NSLocale(ci.TwoLetterISOLanguageName);
-
-				if (picker is not null)
-				{
-					picker.Locale = locale;
-				}
+				picker.Locale = new NSLocale(ci.TwoLetterISOLanguageName);
 			}
 			else if (format.Contains('h', StringComparison.Ordinal))
 			{
 				var ci = new CultureInfo("en-US");
-				NSLocale locale = new NSLocale(ci.TwoLetterISOLanguageName);
-
-				if (picker is not null)
-				{
-					picker.Locale = locale;
-				}
+				picker.Locale = new NSLocale(ci.TwoLetterISOLanguageName);
 			}
 		}
 

--- a/src/Core/tests/DeviceTests/Handlers/TimePicker/TimePickerHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/TimePicker/TimePickerHandlerTests.iOS.cs
@@ -15,45 +15,38 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class TimePickerHandlerTests
 	{
-		[Fact(DisplayName = "Default Format Uses Current iOS Locale")]
-		public Task DefaultFormatUsesCurrentiOSLocale()
+		[Fact(DisplayName = "Format 't' Uses Current Culture")]
+		public Task FormatTUsesCurrentCulture()
 		{
 			return InvokeOnMainThreadAsync(() =>
 			{
-				var time = new TimeSpan(14, 30, 0);
-				var timePicker = new TimePickerStub
+				var originalCulture = CultureInfo.CurrentCulture;
+				var originalUICulture = CultureInfo.CurrentUICulture;
+
+				try
 				{
-					Format = "t",
-					Time = time
-				};
-				var handler = CreateHandler(timePicker);
+					var culture = CultureInfo.GetCultureInfo("en-GB");
+					CultureInfo.CurrentCulture = culture;
+					CultureInfo.CurrentUICulture = culture;
 
-				var actual = GetNativeTimePicker(handler).Text;
+					var time = new TimeSpan(14, 30, 0);
+					var timePicker = new TimePickerStub
+					{
+						Format = "t",
+						Time = time
+					};
+					var handler = CreateHandler(timePicker);
+					var platformView = GetNativeTimePicker(handler);
+					var expectedLocale = new NSLocale(culture.Name);
 
-				// Use native iOS formatting because LocaleIdentifier can contain
-				// regional overrides that are not valid CultureInfo names.
-				var today = DateTime.Today.Add(time);
-				var components = new NSDateComponents
+					Assert.Equal(time.ToFormattedString("t", culture), platformView.Text);
+					Assert.Equal(expectedLocale.LocaleIdentifier, platformView.Picker.Locale.LocaleIdentifier);
+				}
+				finally
 				{
-					Year = today.Year,
-					Month = today.Month,
-					Day = today.Day,
-					Hour = today.Hour,
-					Minute = today.Minute,
-					Second = today.Second,
-					Calendar = NSCalendar.CurrentCalendar
-				};
-				var referenceDate = NSCalendar.CurrentCalendar.DateFromComponents(components);
-
-				var dateFormatter = new NSDateFormatter
-				{
-					Locale = NSLocale.CurrentLocale,
-					TimeStyle = NSDateFormatterStyle.Short,
-					DateStyle = NSDateFormatterStyle.None
-				};
-				var expected = dateFormatter.StringFor(referenceDate);
-
-				Assert.Equal(expected, actual);
+					CultureInfo.CurrentCulture = originalCulture;
+					CultureInfo.CurrentUICulture = originalUICulture;
+				}
 			});
 		}
 

--- a/src/Core/tests/DeviceTests/Handlers/TimePicker/TimePickerHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/TimePicker/TimePickerHandlerTests.iOS.cs
@@ -1,5 +1,6 @@
 ﻿#if !MACCATALYST
 using System;
+using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.DeviceTests.Stubs;
@@ -13,6 +14,41 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class TimePickerHandlerTests
 	{
+		[Theory(DisplayName = "Default Format Uses Managed Current Culture")]
+		[InlineData("en-US")]
+		[InlineData("fr-FR")]
+		[InlineData("zh-Hant-TW")]
+		public Task DefaultFormatUsesManagedCurrentCulture(string cultureName)
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var originalCulture = CultureInfo.CurrentCulture;
+
+				try
+				{
+					var culture = new CultureInfo(cultureName);
+					culture.DateTimeFormat.ShortTimePattern = $"'managed-{cultureName}-'HH:mm";
+					CultureInfo.CurrentCulture = culture;
+					var time = new TimeSpan(14, 30, 0);
+					var timePicker = new TimePickerStub
+					{
+						Format = "t",
+						Time = time
+					};
+					var handler = CreateHandler(timePicker);
+
+					var actual = GetNativeTimePicker(handler).Text;
+					var expected = DateTime.Today.Add(time).ToString("t", culture);
+
+					Assert.Equal(expected, actual);
+				}
+				finally
+				{
+					CultureInfo.CurrentCulture = originalCulture;
+				}
+			});
+		}
+
 		[Fact(DisplayName = "CharacterSpacing Initializes Correctly")]
 		public async Task CharacterSpacingInitializesCorrectly()
 		{

--- a/src/Core/tests/DeviceTests/Handlers/TimePicker/TimePickerHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/TimePicker/TimePickerHandlerTests.iOS.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Globalization;
 using System.Threading.Tasks;
+using Foundation;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Graphics;
@@ -14,38 +15,34 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class TimePickerHandlerTests
 	{
-		[Theory(DisplayName = "Default Format Uses Managed Current Culture")]
-		[InlineData("en-US")]
-		[InlineData("fr-FR")]
-		[InlineData("zh-Hant-TW")]
-		public Task DefaultFormatUsesManagedCurrentCulture(string cultureName)
+		[Fact(DisplayName = "Default Format Uses Current iOS Locale")]
+		public Task DefaultFormatUsesCurrentiOSLocale()
 		{
 			return InvokeOnMainThreadAsync(() =>
 			{
-				var originalCulture = CultureInfo.CurrentCulture;
-
+				CultureInfo expectedCulture;
 				try
 				{
-					var culture = new CultureInfo(cultureName);
-					culture.DateTimeFormat.ShortTimePattern = $"'managed-{cultureName}-'HH:mm";
-					CultureInfo.CurrentCulture = culture;
-					var time = new TimeSpan(14, 30, 0);
-					var timePicker = new TimePickerStub
-					{
-						Format = "t",
-						Time = time
-					};
-					var handler = CreateHandler(timePicker);
-
-					var actual = GetNativeTimePicker(handler).Text;
-					var expected = DateTime.Today.Add(time).ToString("t", culture);
-
-					Assert.Equal(expected, actual);
+					var cultureName = NSLocale.CurrentLocale.LocaleIdentifier.Replace('_', '-');
+					expectedCulture = CultureInfo.GetCultureInfo(cultureName);
 				}
-				finally
+				catch (CultureNotFoundException)
 				{
-					CultureInfo.CurrentCulture = originalCulture;
+					expectedCulture = CultureInfo.InvariantCulture;
 				}
+
+				var time = new TimeSpan(14, 30, 0);
+				var timePicker = new TimePickerStub
+				{
+					Format = "t",
+					Time = time
+				};
+				var handler = CreateHandler(timePicker);
+
+				var actual = GetNativeTimePicker(handler).Text;
+				var expected = DateTime.Today.Add(time).ToString("t", expectedCulture);
+
+				Assert.Equal(expected, actual);
 			});
 		}
 

--- a/src/Core/tests/DeviceTests/Handlers/TimePicker/TimePickerHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/TimePicker/TimePickerHandlerTests.iOS.cs
@@ -20,17 +20,6 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			return InvokeOnMainThreadAsync(() =>
 			{
-				CultureInfo expectedCulture;
-				try
-				{
-					var cultureName = NSLocale.CurrentLocale.LocaleIdentifier.Replace('_', '-');
-					expectedCulture = CultureInfo.GetCultureInfo(cultureName);
-				}
-				catch (CultureNotFoundException)
-				{
-					expectedCulture = CultureInfo.InvariantCulture;
-				}
-
 				var time = new TimeSpan(14, 30, 0);
 				var timePicker = new TimePickerStub
 				{
@@ -40,7 +29,29 @@ namespace Microsoft.Maui.DeviceTests
 				var handler = CreateHandler(timePicker);
 
 				var actual = GetNativeTimePicker(handler).Text;
-				var expected = DateTime.Today.Add(time).ToString("t", expectedCulture);
+
+				// Use native iOS formatting because LocaleIdentifier can contain
+				// regional overrides that are not valid CultureInfo names.
+				var today = DateTime.Today.Add(time);
+				var components = new NSDateComponents
+				{
+					Year = today.Year,
+					Month = today.Month,
+					Day = today.Day,
+					Hour = today.Hour,
+					Minute = today.Minute,
+					Second = today.Second,
+					Calendar = NSCalendar.CurrentCalendar
+				};
+				var referenceDate = NSCalendar.CurrentCalendar.DateFromComponents(components);
+
+				var dateFormatter = new NSDateFormatter
+				{
+					Locale = NSLocale.CurrentLocale,
+					TimeStyle = NSDateFormatterStyle.Short,
+					DateStyle = NSDateFormatterStyle.None
+				};
+				var expected = dateFormatter.StringFor(referenceDate);
 
 				Assert.Equal(expected, actual);
 			});


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
- On iOS, TimePicker displays time in en-US 12-hour AM/PM format instead of respecting the device's culture and 24-hour time setting — this happens specifically when Format is left at its default value of "t" regardless of what the device's actual region/culture is set to.

### Root Cause
- PR #31066 introduced a regression in TimePickerExtensions.UpdateTime by selecting the formatting culture based on characters in the Format string instead of the device’s actual culture. Formats containing t or h were forced to en-US, while formats containing H were forced to de-DE. Since the default Format is "t", the default TimePicker was always rendered using the 12-hour AM/PM format, ignoring the device’s regional settings.

### Description of Change
- Removed the t-based culture override introduced by #31066, which incorrectly forced en-US when the default Format="t" was used. The displayed time now uses CultureInfo.CurrentCulture, while the existing explicit H and h behavior remains.
- Updated the native UIDatePicker locale on every update. Explicit H and h formats continue to select 24-hour and 12-hour wheels respectively, while other formats use the full current culture name, such as en-GB, to preserve the language and region and prevent a previously assigned locale from remaining stale.



### Issues Fixed
Fixes #37407
Fixes #30837

### Validated the behaviour in the following platforms
- [ ] Windows
- [ ] Android
- [x] iOS
- [ ] Mac

### Output
| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/06a697df-121e-4bff-b5c2-2437ff467b85"> | <video src="https://github.com/user-attachments/assets/1826ffd7-baba-4165-9b84-d1c0e63249c3"> |