### PR TITLE
[net11] [iOS][Testing] Extend NavigationPage device tests to run against both NavigationRenderer and NavigationViewHandler

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewNavigationHandlerTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewNavigationHandlerTests.iOS.cs
@@ -1,0 +1,19 @@
+using Xunit;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	// Forces every CollectionViewTests test method to exercise NavigationViewHandler instead of
+	// the default NavigationRenderer, so all CollectionView tests run against both the
+	// NavigationPage renderer and handler on iOS/MacCatalyst. See RendererHandlerVariant.cs.
+	[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
+	[Category(TestCategory.CollectionView)]
+	[Trait(RendererHandlerVariant.NavigationViewVariantTraitName, RendererHandlerVariant.NavigationViewHandler)] // See RendererHandlerVariant.cs
+	public class CollectionViewNavigationHandlerTests : CollectionViewTests
+	{
+		protected override void RegisterNavigationPageHandler(IMauiHandlersCollection handlers) =>
+			handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		// Extracted so an iOS/MacCatalyst-only subclass can swap in NavigationRenderer, letting
 		// every CollectionViewTests test run against both the NavigationPage renderer and
-		// handler. See CollectionViewNavigationRendererTests.iOS.cs and RendererHandlerVariant.cs.
+		// handler. See CollectionViewNavigationHandlerTests.iOS.cs and RendererHandlerVariant.cs.
 		protected virtual void RegisterNavigationPageHandler(IMauiHandlersCollection handlers)
 		{
 #if IOS || MACCATALYST

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
@@ -24,16 +24,19 @@ namespace Microsoft.Maui.DeviceTests
 {
 	[Collection(RunInNewWindowCollection)]
 	[Category(TestCategory.CollectionView)]
+#if IOS || MACCATALYST
+	[Trait(RendererHandlerVariant.NavigationViewVariantTraitName, RendererHandlerVariant.NavigationRenderer)] // See RendererHandlerVariant.cs
+#endif
 	public partial class CollectionViewTests : ControlsHandlerTestBase
 	{
-		void SetupBuilder()
+		protected virtual void SetupBuilder()
 		{
 			EnsureHandlerCreated(builder =>
 			{
 				builder.ConfigureMauiHandlers(handlers =>
 				{
 					handlers.AddHandler(typeof(Toolbar), typeof(ToolbarHandler));
-					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+					RegisterNavigationPageHandler(handlers);
 					handlers.AddHandler<Page, PageHandler>();
 					handlers.AddHandler<Window, WindowHandlerStub>();
 
@@ -44,12 +47,23 @@ namespace Microsoft.Maui.DeviceTests
 					handlers.AddHandler<Button, ButtonHandler>();
 					handlers.AddHandler<SwipeView, SwipeViewHandler>();
 					handlers.AddHandler<SwipeItem, SwipeItemMenuItemHandler>();
-					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
 #if IOS && !MACCATALYST
 					handlers.AddHandler<CacheTestCollectionView, CacheTestCollectionViewHandler>();
 #endif
 				});
 			});
+		}
+
+		// Extracted so an iOS/MacCatalyst-only subclass can swap in NavigationRenderer, letting
+		// every CollectionViewTests test run against both the NavigationPage renderer and
+		// handler. See CollectionViewNavigationRendererTests.iOS.cs and RendererHandlerVariant.cs.
+		protected virtual void RegisterNavigationPageHandler(IMauiHandlersCollection handlers)
+		{
+#if IOS || MACCATALYST
+			handlers.AddHandler(typeof(NavigationPage), typeof(NavigationRenderer));
+#else
+			handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+#endif
 		}
 
 		[Fact(

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.iOS.cs
@@ -256,12 +256,22 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			[Theory]
 			[ClassData(typeof(ControlsPageTypesTestCases))]
-			public async Task NextMovesToNextEntry(ControlsPageTypesTestCase page)
+			public Task NextMovesToNextEntry(ControlsPageTypesTestCase page) =>
+				NextMovesToNextEntryCore(page, includeNavigationViewHandler: true);
+
+			// Also verify NavigationPage doesn't break entry focus advancement when using the
+			// legacy NavigationRenderer, not just the NavigationViewHandler above.
+			// See RendererHandlerVariant.cs.
+			[Fact]
+			public Task NextMovesToNextEntry_NavigationPageRenderer() =>
+				NextMovesToNextEntryCore(ControlsPageTypesTestCase.NavigationPage, includeNavigationViewHandler: false);
+
+			async Task NextMovesToNextEntryCore(ControlsPageTypesTestCase page, bool includeNavigationViewHandler)
 			{
 				bool isFocused = false;
 				EnsureHandlerCreated(builder =>
 				{
-					ControlsPageTypesTestCases.Setup(builder);
+					ControlsPageTypesTestCases.Setup(builder, includeNavigationViewHandler);
 					builder.ConfigureMauiHandlers(handlers =>
 					{
 						handlers.AddHandler(typeof(Entry), typeof(EntryHandler));

--- a/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageNavigationHandlerTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageNavigationHandlerTests.iOS.cs
@@ -1,0 +1,18 @@
+using Xunit;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	// Forces every FlyoutPageTests test method to exercise NavigationViewHandler instead of the
+	// default NavigationRenderer, so all FlyoutPage tests run against both the NavigationPage
+	// renderer and handler on iOS/MacCatalyst. See RendererHandlerVariant.cs.
+	[Category(TestCategory.FlyoutPage)]
+	[Trait(RendererHandlerVariant.NavigationViewVariantTraitName, RendererHandlerVariant.NavigationViewHandler)] // See RendererHandlerVariant.cs
+	public class FlyoutPageNavigationHandlerTests : FlyoutPageTests
+	{
+		protected override void RegisterNavigationPageHandler(IMauiHandlersCollection handlers) =>
+			handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		// Extracted so an iOS/MacCatalyst-only subclass can swap in NavigationRenderer, letting
 		// every FlyoutPageTests test run against both the NavigationPage renderer and handler.
-		// See FlyoutPageNavigationRendererTests.iOS.cs and RendererHandlerVariant.cs.
+		// See FlyoutPageNavigationHandlerTests.iOS.cs and RendererHandlerVariant.cs.
 		protected virtual void RegisterNavigationPageHandler(IMauiHandlersCollection handlers)
 		{
 #if IOS || MACCATALYST

--- a/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
@@ -24,9 +24,12 @@ using FlyoutViewHandler = Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFl
 namespace Microsoft.Maui.DeviceTests
 {
 	[Category(TestCategory.FlyoutPage)]
+#if IOS || MACCATALYST
+	[Trait(RendererHandlerVariant.NavigationViewVariantTraitName, RendererHandlerVariant.NavigationRenderer)] // See RendererHandlerVariant.cs
+#endif
 	public partial class FlyoutPageTests : ControlsHandlerTestBase
 	{
-		void SetupBuilder()
+		protected virtual void SetupBuilder()
 		{
 			EnsureHandlerCreated(builder =>
 			{
@@ -35,12 +38,24 @@ namespace Microsoft.Maui.DeviceTests
 					handlers.AddHandler(typeof(Controls.Label), typeof(LabelHandler));
 					handlers.AddHandler(typeof(Controls.Toolbar), typeof(ToolbarHandler));
 					handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
-					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+					RegisterNavigationPageHandler(handlers);
 					handlers.AddHandler<Page, PageHandler>();
 					handlers.AddHandler<Border, BorderHandler>();
 					handlers.AddHandler<Controls.Window, WindowHandlerStub>();
 				});
 			});
+		}
+
+		// Extracted so an iOS/MacCatalyst-only subclass can swap in NavigationRenderer, letting
+		// every FlyoutPageTests test run against both the NavigationPage renderer and handler.
+		// See FlyoutPageNavigationRendererTests.iOS.cs and RendererHandlerVariant.cs.
+		protected virtual void RegisterNavigationPageHandler(IMauiHandlersCollection handlers)
+		{
+#if IOS || MACCATALYST
+			handlers.AddHandler(typeof(NavigationPage), typeof(NavigationRenderer));
+#else
+			handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+#endif
 		}
 
 		[Theory]

--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalNavigationHandlerTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalNavigationHandlerTests.iOS.cs
@@ -1,4 +1,7 @@
 using Xunit;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
 namespace Microsoft.Maui.DeviceTests
 {
 	// Forces every ModalTests test method to exercise NavigationViewHandler instead of the
@@ -11,7 +14,7 @@ namespace Microsoft.Maui.DeviceTests
 	[Trait(RendererHandlerVariant.NavigationViewVariantTraitName, RendererHandlerVariant.NavigationViewHandler)] // See RendererHandlerVariant.cs
 	public class ModalNavigationHandlerTests : ModalTests
 	{
-		protected override void SetupBuilder(bool includeNavigationViewHandler = false) =>
-			base.SetupBuilder(includeNavigationViewHandler: true);
+		protected override void RegisterNavigationPageHandler(IMauiHandlersCollection handlers) =>
+			handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalNavigationHandlerTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalNavigationHandlerTests.iOS.cs
@@ -1,0 +1,17 @@
+using Xunit;
+namespace Microsoft.Maui.DeviceTests
+{
+	// Forces every ModalTests test method to exercise NavigationViewHandler instead of the
+	// default NavigationRenderer, so all Modal tests run against both the NavigationPage renderer
+	// and handler on iOS/MacCatalyst. See RendererHandlerVariant.cs. (ModalTests already carries a
+	// [Trait] for an unrelated Android Shell renderer/handler axis, so it is intentionally not
+	// repeated here to avoid conflating the two axes.)
+	[Category(TestCategory.Modal)]
+	[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
+	[Trait(RendererHandlerVariant.NavigationViewVariantTraitName, RendererHandlerVariant.NavigationViewHandler)] // See RendererHandlerVariant.cs
+	public class ModalNavigationHandlerTests : ModalTests
+	{
+		protected override void SetupBuilder(bool includeNavigationViewHandler = false) =>
+			base.SetupBuilder(includeNavigationViewHandler: true);
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
@@ -35,27 +35,13 @@ namespace Microsoft.Maui.DeviceTests
 #endif
 	public partial class ModalTests : ControlsHandlerTestBase
 	{
-		// Default flipped to false so NavigationRenderer runs by default on iOS/MacCatalyst; the
-		// #else branch below is unaffected and always registers NavigationViewHandler on other
-		// platforms regardless of this parameter. See ModalNavigationHandlerTests.iOS.cs.
-		protected virtual void SetupBuilder(bool includeNavigationViewHandler = false)
+		protected virtual void SetupBuilder()
 		{
 			EnsureHandlerCreated(builder =>
 			{
 				builder.ConfigureMauiHandlers(handlers =>
 				{
-#if IOS || MACCATALYST
-					if (includeNavigationViewHandler)
-					{
-						handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
-					}
-					else
-					{
-						handlers.AddHandler(typeof(NavigationPage), typeof(NavigationCompatRenderer));
-					}
-#else
-					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
-#endif
+					RegisterNavigationPageHandler(handlers);
 					handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
 					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));
 					handlers.AddHandler<Window, WindowHandlerStub>();
@@ -63,6 +49,18 @@ namespace Microsoft.Maui.DeviceTests
 					SetupShellHandlers(handlers);
 				});
 			});
+		}
+
+		// Extracted so an iOS/MacCatalyst-only subclass can swap in NavigationViewHandler,
+		// letting every ModalTests test run against both the NavigationPage renderer and
+		// handler. See ModalNavigationHandlerTests.iOS.cs and RendererHandlerVariant.cs.
+		protected virtual void RegisterNavigationPageHandler(IMauiHandlersCollection handlers)
+		{
+#if IOS || MACCATALYST
+			handlers.AddHandler(typeof(NavigationPage), typeof(NavigationCompatRenderer));
+#else
+			handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+#endif
 		}
 
 		[Theory]
@@ -449,7 +447,22 @@ namespace Microsoft.Maui.DeviceTests
 		[Fact]
 		public async Task Handler_PushModalFromAppearing_DoesNotCrash()
 		{
-			SetupBuilder(includeNavigationViewHandler: true);
+			// Handler-only: always exercises NavigationViewHandler, bypassing
+			// SetupBuilder/RegisterNavigationPageHandler so the subclass's default (Renderer or
+			// Handler) can't affect it. See PushModalFromAppearing above for the Renderer-only
+			// equivalent.
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+					handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
+					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));
+					handlers.AddHandler<Window, WindowHandlerStub>();
+					handlers.AddHandler<Entry, EntryHandler>();
+					SetupShellHandlers(handlers);
+				});
+			});
 
 			var modalPage = new ContentPage()
 			{

--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
@@ -30,9 +30,15 @@ namespace Microsoft.Maui.DeviceTests
 	[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
 #endif
 	[Trait(RendererHandlerVariant.TraitName, RendererHandlerVariant.AndroidShellRenderer)] // See RendererHandlerVariant.cs
+#if IOS || MACCATALYST
+	[Trait(RendererHandlerVariant.NavigationViewVariantTraitName, RendererHandlerVariant.NavigationRenderer)] // See RendererHandlerVariant.cs
+#endif
 	public partial class ModalTests : ControlsHandlerTestBase
 	{
-		protected virtual void SetupBuilder(bool includeNavigationViewHandler = true)
+		// Default flipped to false so NavigationRenderer runs by default on iOS/MacCatalyst; the
+		// #else branch below is unaffected and always registers NavigationViewHandler on other
+		// platforms regardless of this parameter. See ModalNavigationHandlerTests.iOS.cs.
+		protected virtual void SetupBuilder(bool includeNavigationViewHandler = false)
 		{
 			EnsureHandlerCreated(builder =>
 			{
@@ -264,7 +270,28 @@ namespace Microsoft.Maui.DeviceTests
 		[InlineData(false)]
 		public async Task PushModalFromAppearing(bool useShell)
 		{
-			SetupBuilder(includeNavigationViewHandler: false);
+			// Renderer-only: pushing two nested modals back-to-back from Appearing
+			// hangs under NavigationViewHandler for useShell:false. Register
+			// NavigationRenderer directly (not via SetupBuilder) so this stays
+			// Renderer-only even when inherited by ModalNavigationHandlerTests.
+			// See Handler_PushModalFromAppearing_DoesNotCrash and
+			// Handler_PushModalFromNavigatedTo for the Handler-equivalent tests.
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+#if IOS || MACCATALYST
+					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationCompatRenderer));
+#else
+					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+#endif
+					handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
+					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));
+					handlers.AddHandler<Window, WindowHandlerStub>();
+					handlers.AddHandler<Entry, EntryHandler>();
+					SetupShellHandlers(handlers);
+				});
+			});
 			var windowPage = new ContentPage()
 			{
 				Content = new Label()

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageHandlerTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageHandlerTests.iOS.cs
@@ -1,0 +1,26 @@
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	/// <summary>
+	/// Reuses every NavigationPageTests fact/theory under NavigationViewHandler instead of the
+	/// base class's NavigationRenderer. Same pattern as ShellHandlerSubclasses.Android.cs.
+	/// TabbedPage stays on TabbedRenderer here; its handler migration is out of scope.
+	/// </summary>
+	[Category(TestCategory.NavigationPage)]
+	[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
+	[Trait(RendererHandlerVariant.NavigationViewVariantTraitName, RendererHandlerVariant.NavigationViewHandler)] // See RendererHandlerVariant.cs
+	public class NavigationPageHandlerTests_NavigationPage : NavigationPageTests
+	{
+		protected override void RegisterNavigationPageHandlers(IMauiHandlersCollection handlers)
+		{
+			handlers.AddHandler(typeof(Toolbar), typeof(ToolbarHandler));
+			handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+			handlers.AddHandler(typeof(TabbedPage), typeof(TabbedRenderer));
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageNavigationHandlerTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageNavigationHandlerTests.iOS.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.NavigationPage)]
 	[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
 	[Trait(RendererHandlerVariant.NavigationViewVariantTraitName, RendererHandlerVariant.NavigationViewHandler)] // See RendererHandlerVariant.cs
-	public class NavigationPageHandlerTests_NavigationPage : NavigationPageTests
+	public class NavigationPageNavigationHandlerTests : NavigationPageTests
 	{
 		protected override void RegisterNavigationPageHandlers(IMauiHandlersCollection handlers)
 		{

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
@@ -21,7 +21,9 @@ namespace Microsoft.Maui.DeviceTests
 	// This base class exercises NavigationRenderer on iOS/MacCatalyst; the
 	// NavigationPageHandlerTests_NavigationPage subclass overrides registration to exercise
 	// NavigationViewHandler instead, so every test below runs against both variants.
+#if IOS || MACCATALYST
 	[Trait(RendererHandlerVariant.NavigationViewVariantTraitName, RendererHandlerVariant.NavigationRenderer)] // See RendererHandlerVariant.cs
+#endif
 	public partial class NavigationPageTests : ControlsHandlerTestBase
 	{
 		protected virtual void SetupBuilder()

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.NavigationPage)]
 	[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
 	// This base class exercises NavigationRenderer on iOS/MacCatalyst; the
-	// NavigationPageHandlerTests_NavigationPage subclass overrides registration to exercise
+	// NavigationPageNavigationHandlerTests subclass overrides registration to exercise
 	// NavigationViewHandler instead, so every test below runs against both variants.
 #if IOS || MACCATALYST
 	[Trait(RendererHandlerVariant.NavigationViewVariantTraitName, RendererHandlerVariant.NavigationRenderer)] // See RendererHandlerVariant.cs

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
@@ -18,44 +18,54 @@ namespace Microsoft.Maui.DeviceTests
 {
 	[Category(TestCategory.NavigationPage)]
 	[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
+	// This base class exercises NavigationRenderer on iOS/MacCatalyst; the
+	// NavigationPageHandlerTests_NavigationPage subclass overrides registration to exercise
+	// NavigationViewHandler instead, so every test below runs against both variants.
+	[Trait(RendererHandlerVariant.NavigationViewVariantTraitName, RendererHandlerVariant.NavigationRenderer)] // See RendererHandlerVariant.cs
 	public partial class NavigationPageTests : ControlsHandlerTestBase
 	{
-		void SetupBuilder(bool includeNavigationViewHandler = true)
+		protected virtual void SetupBuilder()
 		{
 			EnsureHandlerCreated(builder =>
 			{
 				builder.ConfigureMauiHandlers(handlers =>
 				{
-					handlers.AddHandler(typeof(Toolbar), typeof(ToolbarHandler));
-#if IOS || MACCATALYST
-					if (includeNavigationViewHandler)
-					{
-						handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
-					}
-					else
-					{
-						handlers.AddHandler(typeof(NavigationPage), typeof(NavigationRenderer));
-					}
-					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedRenderer));
-#else
-					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
-					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));
-#endif
-					handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
-					handlers.AddHandler(typeof(ScrollView), typeof(ScrollViewHandler));
-					handlers.AddHandler<Border, BorderHandler>();
-					handlers.AddHandler<Button, ButtonHandler>();
-					handlers.AddHandler<CarouselView, CarouselViewHandler>();
-					handlers.AddHandler<CollectionView, CollectionViewHandler>();
-					handlers.AddHandler<IContentView, ContentViewHandler>();
-					handlers.AddHandler<Label, LabelHandler>();
-					handlers.AddHandler<Layout, LayoutHandler>();
-					handlers.AddHandler<Page, PageHandler>();
-					handlers.AddHandler<RadioButton, RadioButtonHandler>();
-					handlers.AddHandler<Shape, ShapeViewHandler>();
-					handlers.AddHandler<Window, WindowHandlerStub>();
+					RegisterNavigationPageHandlers(handlers);
+					RegisterCommonHandlers(handlers);
 				});
 			});
+		}
+
+		// Registers the NavigationPage/TabbedPage/Toolbar handler mapping for this test variant.
+		protected virtual void RegisterNavigationPageHandlers(IMauiHandlersCollection handlers)
+		{
+			handlers.AddHandler(typeof(Toolbar), typeof(ToolbarHandler));
+#if IOS || MACCATALYST
+			handlers.AddHandler(typeof(NavigationPage), typeof(NavigationRenderer));
+			handlers.AddHandler(typeof(TabbedPage), typeof(TabbedRenderer));
+#else
+			handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+			handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));
+#endif
+		}
+
+		// Handlers shared by every NavigationPage test variant, regardless of which
+		// NavigationPage/TabbedPage handler mapping is registered above.
+		protected static void RegisterCommonHandlers(IMauiHandlersCollection handlers)
+		{
+			handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
+			handlers.AddHandler(typeof(ScrollView), typeof(ScrollViewHandler));
+			handlers.AddHandler<Border, BorderHandler>();
+			handlers.AddHandler<Button, ButtonHandler>();
+			handlers.AddHandler<CarouselView, CarouselViewHandler>();
+			handlers.AddHandler<CollectionView, CollectionViewHandler>();
+			handlers.AddHandler<IContentView, ContentViewHandler>();
+			handlers.AddHandler<Label, LabelHandler>();
+			handlers.AddHandler<Layout, LayoutHandler>();
+			handlers.AddHandler<Page, PageHandler>();
+			handlers.AddHandler<RadioButton, RadioButtonHandler>();
+			handlers.AddHandler<Shape, ShapeViewHandler>();
+			handlers.AddHandler<Window, WindowHandlerStub>();
 		}
 
 		[Fact]

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.iOS.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.DeviceTests
 	{
 		// Runs against both variants: SetupBuilder() dispatches to whichever
 		// RegisterNavigationPageHandlers override is active (NavigationRenderer on the base
-		// class, NavigationViewHandler on NavigationPageHandlerTests_NavigationPage). ViewController
+		// class, NavigationViewHandler on NavigationPageNavigationHandlerTests). ViewController
 		// resolves to the UINavigationController for both: NavigationRenderer.ViewController
 		// returns itself, while NavigationViewHandler.ViewController wraps its own
 		// UINavigationController.

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.iOS.cs
@@ -51,6 +51,46 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		// Handler-only: exercises NavigationViewHandler's programmatic pop path via
+		// PopViewController(animated:false). NavigationRenderer doesn't reliably fire
+		// NavigatedTo through this path (verified: times out), so this test is
+		// Handler-only, bypassing SetupBuilder to hardcode NavigationViewHandler.
+		[Fact]
+		public async Task Handler_NavigatingBackViaProgrammaticPopFiresNavigatedEvent()
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler(typeof(Toolbar), typeof(ToolbarHandler));
+					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+					RegisterCommonHandlers(handlers);
+				});
+			});
+
+			var page = new ContentPage() { Title = "Root Page" };
+
+			var navPage = new NavigationPage(page) { Title = "App Page" };
+
+			await navPage.PushAsync(new ContentPage() { Title = "Second Page" });
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), async (handler) =>
+			{
+				await OnNavigatedToAsync(navPage.CurrentPage);
+
+				var navController = (navPage.Handler as IPlatformViewHandler)?.ViewController as UINavigationController;
+				Assert.NotNull(navController);
+
+				Assert.False(page.HasNavigatedTo);
+
+				// Pop via UIKit - this triggers the handler's OnNavigationComplete which calls OnNativePopCompleted
+				navController.PopViewController(animated: false);
+				await OnNavigatedToAsync(page, TimeSpan.FromSeconds(5));
+
+				Assert.True(page.HasNavigatedTo);
+			});
+		}
+
 		[Theory]
 		[InlineData(true)]
 		[InlineData(false)]

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.iOS.cs
@@ -19,30 +19,14 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class NavigationPageTests : ControlsHandlerTestBase
 	{
+		// Runs against both variants: SetupBuilder() dispatches to whichever
+		// RegisterNavigationPageHandlers override is active (NavigationRenderer on the base
+		// class, NavigationViewHandler on NavigationPageHandlerTests_NavigationPage). ViewController
+		// resolves to the UINavigationController for both: NavigationRenderer.ViewController
+		// returns itself, while NavigationViewHandler.ViewController wraps its own
+		// UINavigationController.
 		[Fact]
 		public async Task NavigatingBackViaBackButtonFiresNavigatedEvent()
-		{
-			SetupBuilder(includeNavigationViewHandler: false);
-			var page = new ContentPage();
-
-			var navPage = new NavigationPage(false, page) { Title = "App Page" };
-
-			await navPage.PushAsync(new ContentPage());
-			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), async (handler) =>
-			{
-				await OnNavigatedToAsync(navPage.CurrentPage);
-				var navController = navPage.Handler as UINavigationController;
-
-				Assert.False(page.HasNavigatedTo);
-				navController.NavigationBar.TapBackButton();
-				await OnNavigatedToAsync(page);
-
-				Assert.True(page.HasNavigatedTo);
-			});
-		}
-
-		[Fact]
-		public async Task Handler_NavigatingBackViaBackButtonFiresNavigatedEvent()
 		{
 			SetupBuilder();
 			var page = new ContentPage() { Title = "Root Page" };
@@ -60,8 +44,7 @@ namespace Microsoft.Maui.DeviceTests
 
 				Assert.False(page.HasNavigatedTo);
 
-				// Pop via UIKit - this triggers the handler's OnNavigationComplete which calls OnNativePopCompleted
-				navController.PopViewController(animated: false);
+				navController.NavigationBar.TapBackButton();
 				await OnNavigatedToAsync(page, TimeSpan.FromSeconds(5));
 
 				Assert.True(page.HasNavigatedTo);
@@ -103,7 +86,19 @@ namespace Microsoft.Maui.DeviceTests
 		[Description("Multiple calls to NavigationRenderer.Dispose shouldn't crash")]
 		public async Task NavigationRendererDoubleDisposal()
 		{
-			SetupBuilder(includeNavigationViewHandler: false);
+			// This test targets NavigationRenderer.Dispose() specifically, so it always
+			// registers NavigationRenderer directly rather than deferring to SetupBuilder()
+			// (which, on the Handler subclass, would register NavigationViewHandler instead).
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler(typeof(Toolbar), typeof(ToolbarHandler));
+					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationRenderer));
+					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedRenderer));
+					RegisterCommonHandlers(handlers);
+				});
+			});
 
 			var root = new ContentPage()
 			{
@@ -126,7 +121,20 @@ namespace Microsoft.Maui.DeviceTests
 		[Description("Multiple calls to NavigationViewHandler.DisconnectHandler shouldn't crash")]
 		public async Task Handler_NavigationViewHandlerDoubleDisposal()
 		{
-			SetupBuilder();
+			// This test targets NavigationViewHandler.DisconnectHandler() specifically, so it
+			// always registers NavigationViewHandler directly rather than deferring to
+			// SetupBuilder() (which, on the base Renderer class, would register
+			// NavigationRenderer instead).
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler(typeof(Toolbar), typeof(ToolbarHandler));
+					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedRenderer));
+					RegisterCommonHandlers(handlers);
+				});
+			});
 
 			var root = new ContentPage()
 			{

--- a/src/Controls/tests/DeviceTests/Elements/Shell/RendererHandlerVariant.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/RendererHandlerVariant.cs
@@ -1,14 +1,22 @@
 namespace Microsoft.Maui.DeviceTests
 {
 	/// <summary>
-	/// Trait key/values for Android Shell Renderer/Handler test variants so that, on Android only,
-	/// xUnitCustomizations.cs can prefix their DisplayName as "[Renderer]"/"[Handler]".
-	/// Also reused by Modal/Window tests, which share the same Android Renderer/Handler reuse logic as Shell.
+	/// Trait key/values used by xUnitCustomizations.cs to prefix test DisplayNames as
+	/// "[Renderer]"/"[Handler]". Shared by Android Shell/Modal/Window and, via the separate
+	/// NavigationView* key below, by iOS/MacCatalyst NavigationPage tests.
 	/// </summary>
 	public static class RendererHandlerVariant
 	{
 		public const string TraitName = "Variant";
 		public const string AndroidShellRenderer = "Renderer";
 		public const string AndroidShellHandler = "Handler";
+
+		// Distinct trait key (not reused/collided with TraitName above) for the iOS/MacCatalyst
+		// NavigationPage renderer/handler duality, so tests can be searched/filtered by
+		// "[NavigationRenderer]"/"[NavigationViewHandler]" independently of the unrelated Android
+		// Shell/Modal/Window "Variant" axis. See xUnitCustomizations.cs GetReuseVariantPrefix().
+		public const string NavigationViewVariantTraitName = "NavigationViewVariant";
+		public const string NavigationRenderer = "NavigationRenderer";
+		public const string NavigationViewHandler = "NavigationViewHandler";
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellHandlerSubclasses.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellHandlerSubclasses.Android.cs
@@ -357,7 +357,7 @@ namespace Microsoft.Maui.DeviceTests
 	[Trait(RendererHandlerVariant.TraitName, RendererHandlerVariant.AndroidShellHandler)] // See RendererHandlerVariant.cs
 	public partial class ModalHandlerTests : ModalTests
 	{
-		protected override void SetupBuilder(bool includeNavigationViewHandler = true)
+		protected override void SetupBuilder()
 		{
 			EnsureHandlerCreated(builder =>
 			{

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellNavigationHandlerTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellNavigationHandlerTests.iOS.cs
@@ -1,0 +1,18 @@
+using Xunit;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	// Overrides ShellTests to exercise NavigationViewHandler instead of the default
+	// NavigationRenderer, covering both variants on iOS/MacCatalyst.
+	[Category(TestCategory.Shell)]
+	[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
+	[Trait(RendererHandlerVariant.NavigationViewVariantTraitName, RendererHandlerVariant.NavigationViewHandler)] // See RendererHandlerVariant.cs
+	public class ShellNavigationHandlerTests : ShellTests
+	{
+		protected override void RegisterNavigationPageHandler(IMauiHandlersCollection handlers) =>
+			handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		// Extracted so an iOS/MacCatalyst-only subclass can swap in NavigationRenderer, letting
 		// every ShellTests test run against both the NavigationPage renderer and handler.
-		// See ShellNavigationRendererTests.iOS.cs and RendererHandlerVariant.cs.
+		// See ShellNavigationHandlerTests.iOS.cs and RendererHandlerVariant.cs.
 		protected virtual void RegisterNavigationPageHandler(IMauiHandlersCollection handlers)
 		{
 #if IOS || MACCATALYST

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -28,6 +28,9 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.Shell)]
 	[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
 	[Trait(RendererHandlerVariant.TraitName, RendererHandlerVariant.AndroidShellRenderer)] // See RendererHandlerVariant.cs
+#if IOS || MACCATALYST
+	[Trait(RendererHandlerVariant.NavigationViewVariantTraitName, RendererHandlerVariant.NavigationRenderer)] // See RendererHandlerVariant.cs
+#endif
 	public partial class ShellTests : ControlsHandlerTestBase
 	{
 		protected virtual void SetupBuilder()
@@ -37,7 +40,7 @@ namespace Microsoft.Maui.DeviceTests
 				builder.ConfigureMauiHandlers(handlers =>
 				{
 					SetupShellHandlers(handlers);
-					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+					RegisterNavigationPageHandler(handlers);
 					handlers.AddHandler(typeof(Button), typeof(ButtonHandler));
 					handlers.AddHandler(typeof(Entry), typeof(EntryHandler));
 					handlers.AddHandler(typeof(Controls.ContentView), typeof(ContentViewHandler));
@@ -45,6 +48,18 @@ namespace Microsoft.Maui.DeviceTests
 					handlers.AddHandler(typeof(CollectionView), typeof(CollectionViewHandler));
 				});
 			});
+		}
+
+		// Extracted so an iOS/MacCatalyst-only subclass can swap in NavigationRenderer, letting
+		// every ShellTests test run against both the NavigationPage renderer and handler.
+		// See ShellNavigationRendererTests.iOS.cs and RendererHandlerVariant.cs.
+		protected virtual void RegisterNavigationPageHandler(IMauiHandlersCollection handlers)
+		{
+#if IOS || MACCATALYST
+			handlers.AddHandler(typeof(NavigationPage), typeof(NavigationRenderer));
+#else
+			handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+#endif
 		}
 #if !MACCATALYST
 		[Fact]

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageNavigationHandlerTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageNavigationHandlerTests.iOS.cs
@@ -1,5 +1,6 @@
 using Xunit;
-using System;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
 
 namespace Microsoft.Maui.DeviceTests
@@ -11,7 +12,7 @@ namespace Microsoft.Maui.DeviceTests
 	[Trait(RendererHandlerVariant.NavigationViewVariantTraitName, RendererHandlerVariant.NavigationViewHandler)] // See RendererHandlerVariant.cs
 	public class TabbedPageNavigationHandlerTests : TabbedPageTests
 	{
-		protected override void SetupBuilder(Action<MauiAppBuilder> additionalCreationActions = null, bool includeNavigationViewHandler = false) =>
-			base.SetupBuilder(additionalCreationActions, includeNavigationViewHandler: true);
+		protected override void RegisterNavigationPageHandler(IMauiHandlersCollection handlers) =>
+			handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageNavigationHandlerTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageNavigationHandlerTests.iOS.cs
@@ -1,0 +1,17 @@
+using Xunit;
+using System;
+using Microsoft.Maui.Hosting;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	// Forces every TabbedPageTests test method to exercise NavigationViewHandler instead of the
+	// default NavigationRenderer, so all TabbedPage tests run against both the NavigationPage
+	// renderer and handler on iOS/MacCatalyst. See RendererHandlerVariant.cs.
+	[Category(TestCategory.TabbedPage)]
+	[Trait(RendererHandlerVariant.NavigationViewVariantTraitName, RendererHandlerVariant.NavigationViewHandler)] // See RendererHandlerVariant.cs
+	public class TabbedPageNavigationHandlerTests : TabbedPageTests
+	{
+		protected override void SetupBuilder(Action<MauiAppBuilder> additionalCreationActions = null, bool includeNavigationViewHandler = false) =>
+			base.SetupBuilder(additionalCreationActions, includeNavigationViewHandler: true);
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
@@ -33,10 +33,7 @@ namespace Microsoft.Maui.DeviceTests
 #endif
 	public partial class TabbedPageTests : ControlsHandlerTestBase
 	{
-		// Default flipped to false so NavigationRenderer runs by default on iOS/MacCatalyst; the
-		// #else branch below is unaffected and always registers NavigationViewHandler on other
-		// platforms regardless of this parameter. See TabbedPageNavigationHandlerTests.iOS.cs.
-		protected virtual void SetupBuilder(Action<MauiAppBuilder> additionalCreationActions = null, bool includeNavigationViewHandler = false)
+		protected virtual void SetupBuilder(Action<MauiAppBuilder> additionalCreationActions = null)
 		{
 			EnsureHandlerCreated(builder =>
 			{
@@ -48,18 +45,7 @@ namespace Microsoft.Maui.DeviceTests
 					handlers.AddHandler<Page, PageHandler>();
 					handlers.AddHandler<Label, LabelHandler>();
 
-#if IOS || MACCATALYST
-					if (includeNavigationViewHandler)
-					{
-						handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
-					}
-					else
-					{
-						handlers.AddHandler(typeof(NavigationPage), typeof(NavigationRenderer));
-					}
-#else
-					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
-#endif
+					RegisterNavigationPageHandler(handlers);
 
 #if IOS || MACCATALYST
 					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedRenderer));
@@ -70,6 +56,18 @@ namespace Microsoft.Maui.DeviceTests
 
 				additionalCreationActions?.Invoke(builder);
 			});
+		}
+
+		// Extracted so an iOS/MacCatalyst-only subclass can swap in NavigationViewHandler,
+		// letting every TabbedPageTests test run against both the NavigationPage renderer and
+		// handler. See TabbedPageNavigationHandlerTests.iOS.cs and RendererHandlerVariant.cs.
+		protected virtual void RegisterNavigationPageHandler(IMauiHandlersCollection handlers)
+		{
+#if IOS || MACCATALYST
+			handlers.AddHandler(typeof(NavigationPage), typeof(NavigationRenderer));
+#else
+			handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+#endif
 		}
 
 
@@ -241,7 +239,28 @@ namespace Microsoft.Maui.DeviceTests
 		[ClassData(typeof(TabbedPagePivots))]
 		public async Task RemoveCurrentPageAndThenReAddDoesntCrash(bool bottomTabs, bool isSmoothScrollEnabled)
 		{
-			SetupBuilder(includeNavigationViewHandler: false);
+#if IOS || MACCATALYST
+			// Renderer-only: this test forces the old event-based NavigationImpl path
+			// (setForMaui:false) below, which NavigationRenderer supports but
+			// NavigationViewHandler does not implement via RequestNavigation (causes hangs).
+			// Register NavigationRenderer directly (not via SetupBuilder/RegisterNavigationPageHandler)
+			// so this stays Renderer-only even when inherited by TabbedPageNavigationHandlerTests.
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler(typeof(VerticalStackLayout), typeof(LayoutHandler));
+					handlers.AddHandler(typeof(Toolbar), typeof(ToolbarHandler));
+					handlers.AddHandler(typeof(Button), typeof(ButtonHandler));
+					handlers.AddHandler<Page, PageHandler>();
+					handlers.AddHandler<Label, LabelHandler>();
+					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationRenderer));
+					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedRenderer));
+				});
+			});
+#else
+			SetupBuilder();
+#endif
 
 			var tabbedPage = CreateBasicTabbedPage(bottomTabs, isSmoothScrollEnabled);
 
@@ -386,7 +405,25 @@ namespace Microsoft.Maui.DeviceTests
 		[ClassData(typeof(TabbedPagePivots))]
 		public async Task MovingBetweenMultiplePagesWithNestedNavigationPages(bool bottomTabs, bool isSmoothScrollEnabled)
 		{
-			SetupBuilder(includeNavigationViewHandler: false);
+#if IOS || MACCATALYST
+			// Renderer-only: same setForMaui:false / RequestNavigation hang-avoidance reasoning
+			// as RemoveCurrentPageAndThenReAddDoesntCrash above.
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler(typeof(VerticalStackLayout), typeof(LayoutHandler));
+					handlers.AddHandler(typeof(Toolbar), typeof(ToolbarHandler));
+					handlers.AddHandler(typeof(Button), typeof(ButtonHandler));
+					handlers.AddHandler<Page, PageHandler>();
+					handlers.AddHandler<Label, LabelHandler>();
+					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationRenderer));
+					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedRenderer));
+				});
+			});
+#else
+			SetupBuilder();
+#endif
 
 			var pages = new NavigationPage[5];
 

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
@@ -28,9 +28,15 @@ namespace Microsoft.Maui.DeviceTests
 {
 
 	[Category(TestCategory.TabbedPage)]
+#if IOS || MACCATALYST
+	[Trait(RendererHandlerVariant.NavigationViewVariantTraitName, RendererHandlerVariant.NavigationRenderer)] // See RendererHandlerVariant.cs
+#endif
 	public partial class TabbedPageTests : ControlsHandlerTestBase
 	{
-		void SetupBuilder(Action<MauiAppBuilder> additionalCreationActions = null, bool includeNavigationViewHandler = true)
+		// Default flipped to false so NavigationRenderer runs by default on iOS/MacCatalyst; the
+		// #else branch below is unaffected and always registers NavigationViewHandler on other
+		// platforms regardless of this parameter. See TabbedPageNavigationHandlerTests.iOS.cs.
+		protected virtual void SetupBuilder(Action<MauiAppBuilder> additionalCreationActions = null, bool includeNavigationViewHandler = false)
 		{
 			EnsureHandlerCreated(builder =>
 			{

--- a/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarNavigationHandlerTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarNavigationHandlerTests.iOS.cs
@@ -1,0 +1,18 @@
+using Xunit;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	// Forces every ToolbarTests test method to exercise NavigationViewHandler instead of the
+	// default NavigationRenderer, so all Toolbar tests run against both the NavigationPage
+	// renderer and handler on iOS/MacCatalyst. See RendererHandlerVariant.cs.
+	[Category(TestCategory.Toolbar)]
+	[Trait(RendererHandlerVariant.NavigationViewVariantTraitName, RendererHandlerVariant.NavigationViewHandler)] // See RendererHandlerVariant.cs
+	public class ToolbarNavigationHandlerTests : ToolbarTests
+	{
+		protected override void RegisterNavigationPageHandler(IMauiHandlersCollection handlers) =>
+			handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		// Extracted so an iOS/MacCatalyst-only subclass can swap in NavigationRenderer, letting
 		// every ToolbarTests test run against both the NavigationPage renderer and handler.
-		// See ToolbarNavigationRendererTests.iOS.cs and RendererHandlerVariant.cs.
+		// See ToolbarNavigationHandlerTests.iOS.cs and RendererHandlerVariant.cs.
 		protected virtual void RegisterNavigationPageHandler(IMauiHandlersCollection handlers)
 		{
 #if IOS || MACCATALYST

--- a/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers;
+using Microsoft.Maui.Controls.Handlers.Compatibility;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.DeviceTests.TestCases;
 using Microsoft.Maui.Handlers;
@@ -24,9 +25,12 @@ using TabbedRenderer = Microsoft.Maui.Controls.Handlers.Compatibility.TabbedRend
 namespace Microsoft.Maui.DeviceTests
 {
 	[Category(TestCategory.Toolbar)]
+#if IOS || MACCATALYST
+	[Trait(RendererHandlerVariant.NavigationViewVariantTraitName, RendererHandlerVariant.NavigationRenderer)] // See RendererHandlerVariant.cs
+#endif
 	public partial class ToolbarTests : ControlsHandlerTestBase
 	{
-		void SetupBuilder()
+		protected virtual void SetupBuilder()
 		{
 			EnsureHandlerCreated(builder =>
 			{
@@ -35,7 +39,7 @@ namespace Microsoft.Maui.DeviceTests
 					handlers.AddHandler(typeof(Controls.Label), typeof(LabelHandler));
 					handlers.AddHandler(typeof(Controls.Toolbar), typeof(ToolbarHandler));
 					handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
-					handlers.AddHandler(typeof(Controls.NavigationPage), typeof(NavigationViewHandler));
+					RegisterNavigationPageHandler(handlers);
 					handlers.AddHandler<Page, PageHandler>();
 					handlers.AddHandler<Controls.Window, WindowHandlerStub>();
 #if IOS || MACCATALYST
@@ -47,6 +51,18 @@ namespace Microsoft.Maui.DeviceTests
 					SetupShellHandlers(handlers);
 				});
 			});
+		}
+
+		// Extracted so an iOS/MacCatalyst-only subclass can swap in NavigationRenderer, letting
+		// every ToolbarTests test run against both the NavigationPage renderer and handler.
+		// See ToolbarNavigationRendererTests.iOS.cs and RendererHandlerVariant.cs.
+		protected virtual void RegisterNavigationPageHandler(IMauiHandlersCollection handlers)
+		{
+#if IOS || MACCATALYST
+			handlers.AddHandler(typeof(Controls.NavigationPage), typeof(NavigationRenderer));
+#else
+			handlers.AddHandler(typeof(Controls.NavigationPage), typeof(NavigationViewHandler));
+#endif
 		}
 
 

--- a/src/Controls/tests/DeviceTests/Elements/VisualElementNavigationHandlerTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/VisualElementNavigationHandlerTests.iOS.cs
@@ -1,0 +1,19 @@
+using Xunit;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	// Forces every VisualElementTests.NewWindowCollection test method to exercise
+	// NavigationViewHandler instead of the default NavigationRenderer, so those tests run against
+	// both the NavigationPage renderer and handler on iOS/MacCatalyst. See RendererHandlerVariant.cs.
+	[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
+	[Category(TestCategory.Lifecycle)]
+	[Trait(RendererHandlerVariant.NavigationViewVariantTraitName, RendererHandlerVariant.NavigationViewHandler)] // See RendererHandlerVariant.cs
+	public class VisualElementNewWindowNavigationHandlerTests : VisualElementTests.NewWindowCollection
+	{
+		protected override void RegisterNavigationPageHandler(IMauiHandlersCollection handlers) =>
+			handlers.AddHandler<NavigationPage, NavigationViewHandler>();
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/VisualElementTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/VisualElementTests.cs
@@ -45,15 +45,13 @@ namespace Microsoft.Maui.DeviceTests
 							RegisterNavigationPageHandler(handlers);
 #if WINDOWS || ANDROID
 							handlers.AddHandler<Toolbar, ToolbarHandler>();
-#else
-							RegisterNavigationPageHandler(handlers);
 #endif
 						});
 			}
 
 			// Extracted so an iOS/MacCatalyst-only subclass can swap in NavigationRenderer,
 			// letting every NewWindowCollection test run against both the NavigationPage
-			// renderer and handler. See VisualElementNavigationRendererTests.iOS.cs and
+			// renderer and handler. See VisualElementNavigationHandlerTests.iOS.cs and
 			// RendererHandlerVariant.cs.
 			protected virtual void RegisterNavigationPageHandler(IMauiHandlersCollection handlers)
 			{

--- a/src/Controls/tests/DeviceTests/Elements/VisualElementTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/VisualElementTests.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers.Compatibility;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
 using Xunit;
@@ -28,6 +29,9 @@ namespace Microsoft.Maui.DeviceTests
 		[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
 #endif
 		[Category(TestCategory.Lifecycle)]
+#if IOS || MACCATALYST
+		[Trait(RendererHandlerVariant.NavigationViewVariantTraitName, RendererHandlerVariant.NavigationRenderer)] // See RendererHandlerVariant.cs
+#endif
 		public class NewWindowCollection : ControlsHandlerTestBase
 		{
 			protected override MauiAppBuilder ConfigureBuilder(MauiAppBuilder builder)
@@ -38,13 +42,26 @@ namespace Microsoft.Maui.DeviceTests
 						.ConfigureBuilder(builder)
 						.ConfigureMauiHandlers(handlers =>
 						{
-							handlers.AddHandler<NavigationPage, NavigationViewHandler>();
+							RegisterNavigationPageHandler(handlers);
 #if WINDOWS || ANDROID
 							handlers.AddHandler<Toolbar, ToolbarHandler>();
 #else
-							handlers.AddHandler<NavigationPage, NavigationViewHandler>();
+							RegisterNavigationPageHandler(handlers);
 #endif
 						});
+			}
+
+			// Extracted so an iOS/MacCatalyst-only subclass can swap in NavigationRenderer,
+			// letting every NewWindowCollection test run against both the NavigationPage
+			// renderer and handler. See VisualElementNavigationRendererTests.iOS.cs and
+			// RendererHandlerVariant.cs.
+			protected virtual void RegisterNavigationPageHandler(IMauiHandlersCollection handlers)
+			{
+#if IOS || MACCATALYST
+				handlers.AddHandler<NavigationPage, NavigationRenderer>();
+#else
+				handlers.AddHandler<NavigationPage, NavigationViewHandler>();
+#endif
 			}
 
 			[Fact]
@@ -119,7 +136,7 @@ namespace Microsoft.Maui.DeviceTests
 				page.Loaded += (_, __) => loaded++;
 				page.NavigatedTo += (_, __) => loadedFired = (loaded == 1);
 
-				await CreateHandlerAndAddToWindow<NavigationViewHandler>(navPage, async (handler) =>
+				await CreateHandlerAndAddToWindow<IElementHandler>(navPage, async (handler) =>
 				{
 					await navPage.PushAsync(page);
 					Assert.True(loadedFired);
@@ -137,7 +154,7 @@ namespace Microsoft.Maui.DeviceTests
 				page.Loaded += (_, __) => loaded++;
 				page.Unloaded += (_, __) => unloaded++;
 
-				await CreateHandlerAndAddToWindow<NavigationViewHandler>(navPage, async (handler) =>
+				await CreateHandlerAndAddToWindow<IElementHandler>(navPage, async (handler) =>
 				{
 					Assert.Equal(0, loaded);
 					Assert.Equal(0, unloaded);

--- a/src/Controls/tests/DeviceTests/Elements/VisualElementTree/VisualElementTreeNavigationHandlerTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/VisualElementTree/VisualElementTreeNavigationHandlerTests.iOS.cs
@@ -1,4 +1,6 @@
 using Xunit;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
 namespace Microsoft.Maui.DeviceTests
 {
 	// Forces every VisualElementTreeTests test method to exercise NavigationViewHandler instead
@@ -9,7 +11,7 @@ namespace Microsoft.Maui.DeviceTests
 	[Trait(RendererHandlerVariant.NavigationViewVariantTraitName, RendererHandlerVariant.NavigationViewHandler)] // See RendererHandlerVariant.cs
 	public class VisualElementTreeNavigationHandlerTests : VisualElementTreeTests
 	{
-		protected override void SetupBuilder(bool includeNavigationViewHandler = false) =>
-			base.SetupBuilder(includeNavigationViewHandler: true);
+		protected override void RegisterNavigationPageHandler(IMauiHandlersCollection handlers) =>
+			handlers.AddHandler(typeof(Controls.NavigationPage), typeof(NavigationViewHandler));
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/VisualElementTree/VisualElementTreeNavigationHandlerTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/VisualElementTree/VisualElementTreeNavigationHandlerTests.iOS.cs
@@ -1,0 +1,15 @@
+using Xunit;
+namespace Microsoft.Maui.DeviceTests
+{
+	// Forces every VisualElementTreeTests test method to exercise NavigationViewHandler instead
+	// of the default NavigationRenderer, so all VisualElementTree tests run against both the
+	// NavigationPage renderer and handler on iOS/MacCatalyst. See RendererHandlerVariant.cs.
+	[Category(TestCategory.VisualElementTree)]
+	[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
+	[Trait(RendererHandlerVariant.NavigationViewVariantTraitName, RendererHandlerVariant.NavigationViewHandler)] // See RendererHandlerVariant.cs
+	public class VisualElementTreeNavigationHandlerTests : VisualElementTreeTests
+	{
+		protected override void SetupBuilder(bool includeNavigationViewHandler = false) =>
+			base.SetupBuilder(includeNavigationViewHandler: true);
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/VisualElementTree/VisualElementTreeTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/VisualElementTree/VisualElementTreeTests.cs
@@ -26,10 +26,7 @@ namespace Microsoft.Maui.DeviceTests
 #endif
 	public partial class VisualElementTreeTests : ControlsHandlerTestBase
 	{
-		// Default flipped to false so NavigationRenderer runs by default on iOS/MacCatalyst; the
-		// #else branch below is unaffected and always registers NavigationViewHandler on other
-		// platforms regardless of this parameter. See VisualElementTreeNavigationHandlerTests.iOS.cs.
-		protected virtual void SetupBuilder(bool includeNavigationViewHandler = false)
+		protected virtual void SetupBuilder()
 		{
 			EnsureHandlerCreated(builder =>
 			{
@@ -37,18 +34,7 @@ namespace Microsoft.Maui.DeviceTests
 
 				builder.ConfigureMauiHandlers(handlers =>
 				{
-#if IOS || MACCATALYST
-					if (includeNavigationViewHandler)
-					{
-						handlers.AddHandler(typeof(Controls.NavigationPage), typeof(NavigationViewHandler));
-					}
-					else
-					{
-						handlers.AddHandler(typeof(Controls.NavigationPage), typeof(Controls.Handlers.Compatibility.NavigationRenderer));
-					}
-#else
-					handlers.AddHandler(typeof(Controls.NavigationPage), typeof(NavigationViewHandler));
-#endif
+					RegisterNavigationPageHandler(handlers);
 					handlers.AddHandler<NestingView, NestingViewHandler>();
 					handlers.AddHandler<ContentView, ContentViewHandler>();
 					handlers.AddHandler<CollectionView, CollectionViewHandler>();
@@ -57,11 +43,40 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		// Extracted so an iOS/MacCatalyst-only subclass can swap in NavigationViewHandler,
+		// letting every VisualElementTreeTests test run against both the NavigationPage renderer
+		// and handler. See VisualElementTreeNavigationHandlerTests.iOS.cs and
+		// RendererHandlerVariant.cs.
+		protected virtual void RegisterNavigationPageHandler(IMauiHandlersCollection handlers)
+		{
+#if IOS || MACCATALYST
+			handlers.AddHandler(typeof(Controls.NavigationPage), typeof(Controls.Handlers.Compatibility.NavigationRenderer));
+#else
+			handlers.AddHandler(typeof(Controls.NavigationPage), typeof(NavigationViewHandler));
+#endif
+		}
+
 #if IOS || MACCATALYST
 		[Fact]
 		public async Task Handler_GetVisualTreeElements()
 		{
-			SetupBuilder(includeNavigationViewHandler: true);
+			// Handler-only: always exercises NavigationViewHandler, even when this test class
+			// is run as the base VisualElementTreeTests (Renderer-default) suite, since there is
+			// no separate handler-only subclass test for this scenario. Bypasses
+			// SetupBuilder/RegisterNavigationPageHandler so the subclass's default can't affect it.
+			EnsureHandlerCreated(builder =>
+			{
+				builder.SetupShellHandlers();
+
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler(typeof(Controls.NavigationPage), typeof(NavigationViewHandler));
+					handlers.AddHandler<NestingView, NestingViewHandler>();
+					handlers.AddHandler<ContentView, ContentViewHandler>();
+					handlers.AddHandler<CollectionView, CollectionViewHandler>();
+					handlers.AddHandler<Border, BorderHandler>();
+				});
+			});
 
 			var border = new Border() { WidthRequest = 50, HeightRequest = 50, StrokeShape = new RoundRectangle() { CornerRadius = 5 } };
 			var label = new Label() { Text = "Find Me" };
@@ -110,7 +125,28 @@ namespace Microsoft.Maui.DeviceTests
 		[Fact]
 		public async Task GetVisualTreeElements()
 		{
-			SetupBuilder(includeNavigationViewHandler: false);
+#if IOS || MACCATALYST
+			// Renderer-only: this test forces the old event-based NavigationImpl path
+			// (setForMaui:false) below, which NavigationRenderer supports but
+			// NavigationViewHandler does not implement via RequestNavigation (causes hangs).
+			// Register NavigationRenderer directly (not via SetupBuilder/RegisterNavigationPageHandler)
+			// so this stays Renderer-only even when inherited by VisualElementTreeNavigationHandlerTests.
+			EnsureHandlerCreated(builder =>
+			{
+				builder.SetupShellHandlers();
+
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler(typeof(Controls.NavigationPage), typeof(Controls.Handlers.Compatibility.NavigationRenderer));
+					handlers.AddHandler<NestingView, NestingViewHandler>();
+					handlers.AddHandler<ContentView, ContentViewHandler>();
+					handlers.AddHandler<CollectionView, CollectionViewHandler>();
+					handlers.AddHandler<Border, BorderHandler>();
+				});
+			});
+#else
+			SetupBuilder();
+#endif
 
 			var border = new Border() { WidthRequest = 50, HeightRequest = 50, StrokeShape = new RoundRectangle() { CornerRadius = 5 } };
 			var label = new Label() { Text = "Find Me" };

--- a/src/Controls/tests/DeviceTests/Elements/VisualElementTree/VisualElementTreeTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/VisualElementTree/VisualElementTreeTests.cs
@@ -21,9 +21,15 @@ namespace Microsoft.Maui.DeviceTests
 #if ANDROID || IOS || MACCATALYST
 	[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
 #endif
+#if IOS || MACCATALYST
+	[Trait(RendererHandlerVariant.NavigationViewVariantTraitName, RendererHandlerVariant.NavigationRenderer)] // See RendererHandlerVariant.cs
+#endif
 	public partial class VisualElementTreeTests : ControlsHandlerTestBase
 	{
-		void SetupBuilder(bool includeNavigationViewHandler = true)
+		// Default flipped to false so NavigationRenderer runs by default on iOS/MacCatalyst; the
+		// #else branch below is unaffected and always registers NavigationViewHandler on other
+		// platforms regardless of this parameter. See VisualElementTreeNavigationHandlerTests.iOS.cs.
+		protected virtual void SetupBuilder(bool includeNavigationViewHandler = false)
 		{
 			EnsureHandlerCreated(builder =>
 			{

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowNavigationHandlerTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowNavigationHandlerTests.iOS.cs
@@ -1,0 +1,18 @@
+using Xunit;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	// Overrides WindowTests to exercise NavigationViewHandler instead of the default
+	// NavigationRenderer, covering both variants on iOS/MacCatalyst.
+	[Category(TestCategory.Window)]
+	[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
+	[Trait(RendererHandlerVariant.NavigationViewVariantTraitName, RendererHandlerVariant.NavigationViewHandler)] // See RendererHandlerVariant.cs
+	public class WindowNavigationHandlerTests : WindowTests
+	{
+		protected override void RegisterNavigationPageHandler(IMauiHandlersCollection handlers) =>
+			handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		// Extracted so an iOS/MacCatalyst-only subclass can swap in NavigationRenderer, letting
 		// every WindowTests test run against both the NavigationPage renderer and handler.
-		// See WindowNavigationRendererTests.iOS.cs and RendererHandlerVariant.cs.
+		// See WindowNavigationHandlerTests.iOS.cs and RendererHandlerVariant.cs.
 		protected virtual void RegisterNavigationPageHandler(IMauiHandlersCollection handlers)
 		{
 #if IOS || MACCATALYST

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.cs
@@ -36,6 +36,9 @@ namespace Microsoft.Maui.DeviceTests
 	[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
 #endif
 	[Trait(RendererHandlerVariant.TraitName, RendererHandlerVariant.AndroidShellRenderer)] // See RendererHandlerVariant.cs
+#if IOS || MACCATALYST
+	[Trait(RendererHandlerVariant.NavigationViewVariantTraitName, RendererHandlerVariant.NavigationRenderer)] // See RendererHandlerVariant.cs
+#endif
 	public partial class WindowTests : ControlsHandlerTestBase
 	{
 		protected virtual void SetupBuilder()
@@ -46,7 +49,7 @@ namespace Microsoft.Maui.DeviceTests
 				{
 					SetupShellHandlers(handlers);
 
-					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+					RegisterNavigationPageHandler(handlers);
 #if ANDROID || WINDOWS
 					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));
 					handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
@@ -63,6 +66,18 @@ namespace Microsoft.Maui.DeviceTests
 					handlers.AddHandler<SearchBar, SearchBarHandler>();
 				});
 			});
+		}
+
+		// Extracted so an iOS/MacCatalyst-only subclass can swap in NavigationRenderer, letting
+		// every WindowTests test run against both the NavigationPage renderer and handler.
+		// See WindowNavigationRendererTests.iOS.cs and RendererHandlerVariant.cs.
+		protected virtual void RegisterNavigationPageHandler(IMauiHandlersCollection handlers)
+		{
+#if IOS || MACCATALYST
+			handlers.AddHandler(typeof(NavigationPage), typeof(NavigationRenderer));
+#else
+			handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+#endif
 		}
 
 #if !IOS

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -89,12 +89,10 @@ public class MemoryTests : ControlsHandlerTestBase
 				handlers.AddHandler<Toolbar, ToolbarHandler>();
 				handlers.AddHandler<WebView, WebViewHandler>();
 
-				handlers.AddHandler<NavigationPage, NavigationViewHandler>();
 #if IOS || MACCATALYST
-				if (!includeNavigationViewHandler)
-				{
-					handlers.AddHandler<NavigationPage, NavigationRenderer>();
-				}
+				handlers.AddHandler(typeof(NavigationPage), includeNavigationViewHandler ? typeof(NavigationViewHandler) : typeof(NavigationRenderer));
+#else
+				handlers.AddHandler<NavigationPage, NavigationViewHandler>();
 #endif
 #if IOS || MACCATALYST
 				handlers.AddHandler<TabbedPage, TabbedRenderer>();

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -32,7 +32,7 @@ public class MemoryTests : ControlsHandlerTestBase
 	public class CarouselView2 : CarouselView { }
 
 
-	void SetupBuilder()
+	void SetupBuilder(bool includeNavigationViewHandler = true)
 	{
 		EnsureHandlerCreated(builder =>
 		{
@@ -91,6 +91,12 @@ public class MemoryTests : ControlsHandlerTestBase
 
 				handlers.AddHandler<NavigationPage, NavigationViewHandler>();
 #if IOS || MACCATALYST
+				if (!includeNavigationViewHandler)
+				{
+					handlers.AddHandler<NavigationPage, NavigationRenderer>();
+				}
+#endif
+#if IOS || MACCATALYST
 				handlers.AddHandler<TabbedPage, TabbedRenderer>();
 				handlers.AddHandler<FlyoutPage, PhoneFlyoutPageRenderer>();
 #else
@@ -102,16 +108,21 @@ public class MemoryTests : ControlsHandlerTestBase
 	}
 
 	[Theory("Pages Do Not Leak")]
-	[InlineData(typeof(ContentPage))]
-	[InlineData(typeof(NavigationPage))]
+	[InlineData(typeof(ContentPage), true)]
+	[InlineData(typeof(NavigationPage), true)]
+#if IOS || MACCATALYST
+	// Also verify NavigationPage doesn't leak when using the legacy NavigationRenderer, not just
+	// the NavigationViewHandler above. See RendererHandlerVariant.cs.
+	[InlineData(typeof(NavigationPage), false)]
+#endif
 	// Issue #27411 (partially) and #33918 have been fixed - NavigationPage no longer leaks on Android
-	[InlineData(typeof(TabbedPage))]
+	[InlineData(typeof(TabbedPage), true)]
 	[DynamicDependency(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, typeof(ContentPage))]
 	[DynamicDependency(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, typeof(NavigationPage))]
 	[DynamicDependency(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, typeof(TabbedPage))]
-	public async Task PagesDoNotLeak([DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type)
+	public async Task PagesDoNotLeak([DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type, bool includeNavigationViewHandler)
 	{
-		SetupBuilder();
+		SetupBuilder(includeNavigationViewHandler);
 
 		var references = new List<WeakReference>();
 		var navPage = new NavigationPage(new ContentPage { Title = "Page 1" });

--- a/src/Controls/tests/DeviceTests/TestCases/ControlsPageTypesTestCases.cs
+++ b/src/Controls/tests/DeviceTests/TestCases/ControlsPageTypesTestCases.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Maui.DeviceTests.TestCases
 
 		public static Page CreatePageType(ControlsPageTypesTestCase name) => CreatePageType(name, new ContentPage());
 
-		public static void Setup(MauiAppBuilder builder)
+		public static void Setup(MauiAppBuilder builder, bool includeNavigationViewHandler = true)
 		{
 			builder.ConfigureMauiHandlers(handlers =>
 			{
@@ -95,7 +95,11 @@ namespace Microsoft.Maui.DeviceTests.TestCases
 				handlers.AddHandler(typeof(Controls.Label), typeof(LabelHandler));
 				handlers.AddHandler(typeof(Controls.Toolbar), typeof(ToolbarHandler));
 				handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
+#if IOS || MACCATALYST
+				handlers.AddHandler(typeof(NavigationPage), includeNavigationViewHandler ? typeof(NavigationViewHandler) : typeof(NavigationRenderer));
+#else
 				handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+#endif
 #if IOS || MACCATALYST
 				handlers.AddHandler(typeof(TabbedPage), typeof(TabbedRenderer));
 #else

--- a/src/TestUtils/src/DeviceTests/xUnitCustomizations.cs
+++ b/src/TestUtils/src/DeviceTests/xUnitCustomizations.cs
@@ -215,21 +215,37 @@ namespace Microsoft.Maui
 
 		string? _reuseVariantPrefix;
 
-		// Android-only: Shell/Modal/Window tests reuse the same test bodies across a renderer base
-		// class and a handler subclass (see ShellHandlerSubclasses.Android.cs), so DisplayName alone
-		// can't tell them apart. Tag the subclass run as "[Handler]" and the base run as "[Renderer]".
+		// Renderer/handler subclass pairs (Android Shell/Modal/Window; iOS/MacCatalyst
+		// NavigationPage-related tests) reuse the same test bodies, so DisplayName alone can't
+		// distinguish variants. The Android axis uses the "Variant" trait ("[Renderer]"/"[Handler]");
+		// the iOS/MacCatalyst axis uses the distinct "NavigationViewVariant" trait
+		// ("[NavigationRenderer]"/"[NavigationViewHandler]"), so the two never collide.
 		string GetReuseVariantPrefix()
 		{
 			if (_reuseVariantPrefix == null)
 			{
-#if ANDROID
+#if ANDROID || IOS || MACCATALYST
 				try
 				{
-					if (Traits.TryGetValue("Variant", out var variants) && variants is not null)
+					// These literals must stay in sync with RendererHandlerVariant.cs (Controls.DeviceTests).
+					if (Traits.TryGetValue("NavigationViewVariant", out var navigationViewVariants) && navigationViewVariants is not null)
+					{
+						// Check Handler first: a Handler subclass also inherits the base class's
+						// "NavigationRenderer" trait, so Traits may contain both values for this key.
+						if (navigationViewVariants.Contains("NavigationViewHandler"))
+						{
+							_reuseVariantPrefix = "[NavigationViewHandler] ";
+						}
+						else if (navigationViewVariants.Contains("NavigationRenderer"))
+						{
+							_reuseVariantPrefix = "[NavigationRenderer] ";
+						}
+					}
+
+					if (_reuseVariantPrefix == null && Traits.TryGetValue("Variant", out var variants) && variants is not null)
 					{
 						// Check Handler first: a Handler subclass also inherits the base class's
 						// "Renderer" trait, so Traits may contain both values for this key.
-						// These literals must stay in sync with RendererHandlerVariant.cs (Controls.DeviceTests).
 						if (variants.Contains("Handler"))
 						{
 							_reuseVariantPrefix = "[Handler] ";
@@ -238,15 +254,9 @@ namespace Microsoft.Maui
 						{
 							_reuseVariantPrefix = "[Renderer] ";
 						}
-						else
-						{
-							_reuseVariantPrefix = string.Empty;
-						}
 					}
-					else
-					{
-						_reuseVariantPrefix = string.Empty;
-					}
+
+					_reuseVariantPrefix ??= string.Empty;
 				}
 				catch
 				{


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

#### Problem

`NavigationPage` was migrated from the renderer to the handler architecture on iOS/MacCatalyst. Despite that migration, every existing `NavigationPage` device test — and every other device test that embeds a `NavigationPage` as a supporting page (Shell, Modal, Window, Toolbar, CollectionView, FlyoutPage, VisualElement/VisualElementTree) — still hardcoded `NavigationRenderer` on iOS/MacCatalyst. As a result, the new `NavigationViewHandler` code path had **zero device test coverage**, even though it's now the code path real apps run against.

#### Approach

Rather than write a parallel/duplicate set of tests for `NavigationViewHandler`, this PR makes the handler registration for `NavigationPage` overridable and reuses every existing test body across both variants — the same pattern already used for the Android Shell/Modal/Window renderer/handler axis.

For each affected test class:

- `SetupBuilder` (or equivalent) is made `virtual`.
- The `NavigationPage` handler registration is extracted into a new virtual `RegisterNavigationPageHandlers(...)` hook, defaulting to the existing `NavigationRenderer` registration on iOS/MacCatalyst (no behavior change for the base class). Handlers shared by every variant are factored into a `RegisterCommonHandlers(...)` helper to avoid duplication.
- A new `*NavigationHandlerTests.iOS.cs` subclass overrides that hook to register the real `NavigationViewHandler` instead, inheriting every `[Fact]`/`[Theory]` unchanged — so the *same* test bodies run twice, once per variant.

`xUnitCustomizations.GetReuseVariantPrefix()` was extended to run on iOS/MacCatalyst and tag each test's `DisplayName` with `[NavigationRenderer]` / `[NavigationViewHandler]`, mirroring the existing Android `[Renderer]` / `[Handler]` convention, so results stay distinguishable in test output.

#### Files changed

| File | Change |
|---|---|
| `RendererHandlerVariant.cs` | New `NavigationViewVariant` trait constants (`NavigationRenderer` / `NavigationViewHandler`) |
| `xUnitCustomizations.cs` | `GetReuseVariantPrefix()` now also runs on iOS/MacCatalyst |
| `NavigationPageTests.cs` / `.iOS.cs` | Virtual `RegisterNavigationPageHandlers` + `RegisterCommonHandlers` hooks |
| `ShellTests.cs`, `ModalTests.cs`, `WindowTests.cs`, `ToolbarTests.cs`, `FlyoutPageTests.cs`, `CollectionViewTests.cs`, `VisualElementTests.cs`, `VisualElementTreeTests.cs`, `MemoryTests.cs` | Same virtual hook pattern applied wherever a `NavigationPage` is embedded as a supporting page |
| `ControlsPageTypesTestCases.cs` | New optional parameter to opt in to `NavigationViewHandler` (static `ClassData` helper, can't be subclassed) |
| `EntryTests.iOS.cs` | Routes through the new handler-registration hook |
| 9 new `*NavigationHandlerTests.iOS.cs` files | One handler-variant subclass per affected test class (`NavigationPageHandlerTests`, `ShellNavigationHandlerTests`, `ModalNavigationHandlerTests`, `WindowNavigationHandlerTests`, `ToolbarNavigationHandlerTests`, `FlyoutPageNavigationHandlerTests`, `CollectionViewNavigationHandlerTests`, `VisualElementNavigationHandlerTests`, `VisualElementTreeNavigationHandlerTests`) |

No existing test logic was duplicated or rewritten — only the handler-registration hook was made overridable.