### PR TITLE
[net11] [iOS] [Testing]Extend TabbedPage device tests to run against both TabbedRenderer and TabbedViewHandler

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.iOS.cs
@@ -252,6 +252,11 @@ namespace Microsoft.Maui.DeviceTests
 
 		[Category(TestCategory.Entry)]
 		[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
+		// This base class exercises TabbedRenderer (via ControlsPageTypesTestCases.Setup) on
+		// iOS/MacCatalyst for the TabbedPage/TabbedPageWithNavigationPage cases; the
+		// EntryTestsWithWindow_TabbedViewHandler subclass overrides registration to exercise
+		// TabbedViewHandler instead, so those cases run against both variants.
+		[Trait(RendererHandlerVariant.TabbedViewVariantTraitName, RendererHandlerVariant.TabbedRenderer)] // See RendererHandlerVariant.cs
 		public partial class EntryTestsWithWindow : ControlsHandlerTestBase
 		{
 			[Theory]
@@ -271,7 +276,7 @@ namespace Microsoft.Maui.DeviceTests
 				bool isFocused = false;
 				EnsureHandlerCreated(builder =>
 				{
-					ControlsPageTypesTestCases.Setup(builder, includeNavigationViewHandler);
+					RegisterPageTypeHandlers(builder, includeNavigationViewHandler);
 					builder.ConfigureMauiHandlers(handlers =>
 					{
 						handlers.AddHandler(typeof(Entry), typeof(EntryHandler));
@@ -310,6 +315,21 @@ namespace Microsoft.Maui.DeviceTests
 
 				Assert.True(isFocused, $"{page} failed to focus the second entry DANG");
 			}
+
+			// The base class exercises TabbedRenderer on iOS/MacCatalyst;
+			// EntryTestsWithWindow_TabbedViewHandler overrides this to exercise TabbedViewHandler
+			// instead.
+			protected virtual void RegisterPageTypeHandlers(MauiAppBuilder builder, bool includeNavigationViewHandler) =>
+				ControlsPageTypesTestCases.Setup(builder, includeNavigationViewHandler);
+		}
+
+		[Category(TestCategory.Entry)]
+		[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
+		[Trait(RendererHandlerVariant.TabbedViewVariantTraitName, RendererHandlerVariant.TabbedViewHandler)] // See RendererHandlerVariant.cs
+		public class EntryTestsWithWindow_TabbedViewHandler : EntryTestsWithWindow
+		{
+			protected override void RegisterPageTypeHandlers(MauiAppBuilder builder, bool includeNavigationViewHandler) =>
+				ControlsPageTypesTestCases.Setup(builder, includeNavigationViewHandler, useTabbedViewHandler: true);
 		}
 
 		[Category(TestCategory.Entry)]

--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.TabbedViewHandler.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.TabbedViewHandler.iOS.cs
@@ -1,0 +1,22 @@
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	/// <summary>
+	/// Reuses every ModalTests fact/theory under TabbedViewHandler instead of the base class's
+	/// TabbedRenderer, so tests that embed a TabbedPage exercise both variants on iOS/MacCatalyst.
+	/// </summary>
+	[Category(TestCategory.Modal)]
+	[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
+	[Trait(RendererHandlerVariant.TabbedViewVariantTraitName, RendererHandlerVariant.TabbedViewHandler)] // See RendererHandlerVariant.cs
+	public class ModalTests_TabbedViewHandler : ModalTests
+	{
+		protected override void RegisterTabbedPageHandler(IMauiHandlersCollection handlers)
+		{
+			handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
@@ -19,6 +19,7 @@ using ShellHandler = Microsoft.Maui.Controls.Handlers.Compatibility.ShellRendere
 
 #if IOS || MACCATALYST
 using TabbedViewHandler = Microsoft.Maui.Controls.Handlers.Compatibility.TabbedRenderer;
+using FlyoutViewHandler = Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer;
 using NavigationCompatRenderer = Microsoft.Maui.Controls.Handlers.Compatibility.NavigationRenderer;
 #endif
 
@@ -36,6 +37,10 @@ namespace Microsoft.Maui.DeviceTests
 	// instead, so every test below runs against both variants.
 	[Trait(RendererHandlerVariant.FlyoutViewVariantTraitName, RendererHandlerVariant.PhoneFlyoutPageRenderer)] // See RendererHandlerVariant.cs
 #endif
+	// This base class exercises TabbedRenderer on iOS/MacCatalyst; the
+	// ModalTests_TabbedViewHandler subclass overrides registration to exercise TabbedViewHandler
+	// instead, so every test below runs against both variants.
+	[Trait(RendererHandlerVariant.TabbedViewVariantTraitName, RendererHandlerVariant.TabbedRenderer)] // See RendererHandlerVariant.cs
 	public partial class ModalTests : ControlsHandlerTestBase
 	{
 		protected virtual void SetupBuilder()
@@ -46,7 +51,7 @@ namespace Microsoft.Maui.DeviceTests
 				{
 					RegisterNavigationPageHandler(handlers);
 					RegisterFlyoutPageHandler(handlers);
-					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));
+					RegisterTabbedPageHandler(handlers);
 					handlers.AddHandler<Window, WindowHandlerStub>();
 					handlers.AddHandler<Entry, EntryHandler>();
 					SetupShellHandlers(handlers);
@@ -74,6 +79,17 @@ namespace Microsoft.Maui.DeviceTests
 			handlers.AddHandler(typeof(FlyoutPage), typeof(Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer));
 #else
 			handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
+#endif
+		}
+
+		// The base class exercises TabbedRenderer on iOS/MacCatalyst; ModalTests_TabbedViewHandler
+		// overrides this to exercise TabbedViewHandler instead.
+		protected virtual void RegisterTabbedPageHandler(IMauiHandlersCollection handlers)
+		{
+#if ANDROID || WINDOWS
+			handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));
+#else
+			handlers.AddHandler(typeof(TabbedPage), typeof(Microsoft.Maui.Controls.Handlers.Compatibility.TabbedRenderer));
 #endif
 		}
 
@@ -393,7 +409,7 @@ namespace Microsoft.Maui.DeviceTests
 				{
 					handlers.AddHandler(typeof(NavigationPage), typeof(Microsoft.Maui.Handlers.NavigationViewHandler));
 					RegisterFlyoutPageHandler(handlers);
-					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));
+					RegisterTabbedPageHandler(handlers);
 					handlers.AddHandler<Window, WindowHandlerStub>();
 					handlers.AddHandler<Entry, EntryHandler>();
 					SetupShellHandlers(handlers);

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.TabbedViewHandler.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.TabbedViewHandler.iOS.cs
@@ -1,0 +1,23 @@
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	/// <summary>
+	/// Reuses every NavigationPageTests fact/theory under TabbedViewHandler instead of the base
+	/// class's TabbedRenderer, so tests that embed a TabbedPage exercise both variants on
+	/// iOS/MacCatalyst.
+	/// </summary>
+	[Category(TestCategory.NavigationPage)]
+	[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
+	[Trait(RendererHandlerVariant.TabbedViewVariantTraitName, RendererHandlerVariant.TabbedViewHandler)] // See RendererHandlerVariant.cs
+	public class NavigationPageTests_TabbedViewHandler : NavigationPageTests
+	{
+		protected override void RegisterTabbedPageHandler(IMauiHandlersCollection handlers)
+		{
+			handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
@@ -33,6 +33,10 @@ namespace Microsoft.Maui.DeviceTests
 	// FlyoutViewHandler instead, so every test below runs against both variants.
 	[Trait(RendererHandlerVariant.FlyoutViewVariantTraitName, RendererHandlerVariant.PhoneFlyoutPageRenderer)] // See RendererHandlerVariant.cs
 #endif
+	// This base class exercises TabbedRenderer on iOS/MacCatalyst; the
+	// NavigationPageTests_TabbedViewHandler subclass overrides registration to exercise
+	// TabbedViewHandler instead, so every test below runs against both variants.
+	[Trait(RendererHandlerVariant.TabbedViewVariantTraitName, RendererHandlerVariant.TabbedRenderer)] // See RendererHandlerVariant.cs
 	public partial class NavigationPageTests : ControlsHandlerTestBase
 	{
 		protected virtual void SetupBuilder()
@@ -54,9 +58,19 @@ namespace Microsoft.Maui.DeviceTests
 			handlers.AddHandler(typeof(Toolbar), typeof(ToolbarHandler));
 #if IOS || MACCATALYST
 			handlers.AddHandler(typeof(NavigationPage), typeof(NavigationRenderer));
-			handlers.AddHandler(typeof(TabbedPage), typeof(TabbedRenderer));
 #else
 			handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+#endif
+			RegisterTabbedPageHandler(handlers);
+		}
+
+		// The base class exercises TabbedRenderer on iOS/MacCatalyst;
+		// NavigationPageTests_TabbedViewHandler overrides this to exercise TabbedViewHandler instead.
+		protected virtual void RegisterTabbedPageHandler(IMauiHandlersCollection handlers)
+		{
+#if IOS || MACCATALYST
+			handlers.AddHandler(typeof(TabbedPage), typeof(TabbedRenderer));
+#else
 			handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));
 #endif
 		}
@@ -95,7 +109,6 @@ namespace Microsoft.Maui.DeviceTests
 			handlers.AddHandler<Shape, ShapeViewHandler>();
 			handlers.AddHandler<Window, WindowHandlerStub>();
 		}
-
 		[Fact]
 		public async Task PoppingNavigationPageDoesntCrash()
 		{

--- a/src/Controls/tests/DeviceTests/Elements/Shell/RendererHandlerVariant.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/RendererHandlerVariant.cs
@@ -2,8 +2,8 @@ namespace Microsoft.Maui.DeviceTests
 {
 	/// <summary>
 	/// Trait key/values used by xUnitCustomizations.cs to prefix test DisplayNames as
-	/// "[Renderer]"/"[Handler]". Shared by Android Shell/Modal/Window, with separate keys for
-	/// iOS/MacCatalyst NavigationPage and FlyoutPage variants.
+	/// "[Renderer]"/"[Handler]". Shared by Android Shell/Modal/Window and, via separate keys
+	/// below, by iOS/MacCatalyst NavigationPage, FlyoutPage, and TabbedPage variants.
 	/// </summary>
 	public static class RendererHandlerVariant
 	{
@@ -26,5 +26,12 @@ namespace Microsoft.Maui.DeviceTests
 		public const string FlyoutViewVariantTraitName = "FlyoutViewVariant";
 		public const string PhoneFlyoutPageRenderer = "PhoneFlyoutPageRenderer";
 		public const string FlyoutViewHandler = "FlyoutViewHandler";
+
+		// TabbedPage renderer/handler duality, so tests can be searched/filtered by
+		// "[TabbedRenderer]"/"[TabbedViewHandler]" independently of the unrelated Android
+		// Shell/Modal/Window "Variant" axis. See xUnitCustomizations.cs GetReuseVariantPrefix().
+		public const string TabbedViewVariantTraitName = "TabbedViewVariant";
+		public const string TabbedRenderer = "TabbedRenderer";
+		public const string TabbedViewHandler = "TabbedViewHandler";
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageHandlerTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageHandlerTests.iOS.cs
@@ -1,0 +1,21 @@
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	/// <summary>
+	/// Reuses every TabbedPageTests fact/theory under TabbedViewHandler instead of the base
+	/// class's TabbedRenderer. Same pattern as ShellHandlerSubclasses.Android.cs.
+	/// </summary>
+	[Category(TestCategory.TabbedPage)]
+	[Trait(RendererHandlerVariant.TabbedViewVariantTraitName, RendererHandlerVariant.TabbedViewHandler)] // See RendererHandlerVariant.cs
+	public class TabbedPageHandlerTests_TabbedPage : TabbedPageTests
+	{
+		protected override void RegisterTabbedPageHandler(IMauiHandlersCollection handlers)
+		{
+			handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.TabbedViewHandler.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.TabbedViewHandler.iOS.cs
@@ -13,8 +13,6 @@ namespace Microsoft.Maui.DeviceTests
 	[Trait(RendererHandlerVariant.TabbedViewVariantTraitName, RendererHandlerVariant.TabbedViewHandler)] // See RendererHandlerVariant.cs
 	public class TabbedPageTests_TabbedViewHandler : TabbedPageTests
 	{
-		protected override Type TabbedPageHandlerType => typeof(TabbedViewHandler);
-
 		protected override void RegisterTabbedPageHandler(IMauiHandlersCollection handlers)
 		{
 			handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.TabbedViewHandler.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.TabbedViewHandler.iOS.cs
@@ -11,8 +11,10 @@ namespace Microsoft.Maui.DeviceTests
 	/// </summary>
 	[Category(TestCategory.TabbedPage)]
 	[Trait(RendererHandlerVariant.TabbedViewVariantTraitName, RendererHandlerVariant.TabbedViewHandler)] // See RendererHandlerVariant.cs
-	public class TabbedPageHandlerTests_TabbedPage : TabbedPageTests
+	public class TabbedPageTests_TabbedViewHandler : TabbedPageTests
 	{
+		protected override Type TabbedPageHandlerType => typeof(TabbedViewHandler);
+
 		protected override void RegisterTabbedPageHandler(IMauiHandlersCollection handlers)
 		{
 			handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
@@ -17,9 +17,6 @@ using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Platform;
 using Xunit;
 using static Microsoft.Maui.DeviceTests.AssertHelpers;
-#if IOS
-using TabbedViewHandler = Microsoft.Maui.Controls.Handlers.Compatibility.TabbedRenderer;
-#endif
 #if WINDOWS
 using WSolidColorBrush = Microsoft.UI.Xaml.Media.SolidColorBrush;
 #endif
@@ -31,6 +28,10 @@ namespace Microsoft.Maui.DeviceTests
 #if IOS || MACCATALYST
 	[Trait(RendererHandlerVariant.NavigationViewVariantTraitName, RendererHandlerVariant.NavigationRenderer)] // See RendererHandlerVariant.cs
 #endif
+	// This base class exercises TabbedRenderer on iOS/MacCatalyst; the
+	// TabbedPageTests_TabbedViewHandler subclass overrides registration to exercise
+	// TabbedViewHandler instead, so every test below runs against both variants.
+	[Trait(RendererHandlerVariant.TabbedViewVariantTraitName, RendererHandlerVariant.TabbedRenderer)] // See RendererHandlerVariant.cs
 	public partial class TabbedPageTests : ControlsHandlerTestBase
 	{
 		protected virtual void SetupBuilder(Action<MauiAppBuilder> additionalCreationActions = null)
@@ -47,11 +48,7 @@ namespace Microsoft.Maui.DeviceTests
 
 					RegisterNavigationPageHandler(handlers);
 
-#if IOS || MACCATALYST
-					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedRenderer));
-#else
-					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));
-#endif
+					RegisterTabbedPageHandler(handlers);
 				});
 
 				additionalCreationActions?.Invoke(builder);
@@ -67,6 +64,18 @@ namespace Microsoft.Maui.DeviceTests
 			handlers.AddHandler(typeof(NavigationPage), typeof(NavigationRenderer));
 #else
 			handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+#endif
+		}
+
+		// Registers the TabbedPage handler mapping for this test variant. The base class exercises
+		// TabbedRenderer on iOS/MacCatalyst; TabbedPageTests_TabbedViewHandler overrides this to
+		// exercise TabbedViewHandler instead, so every test below runs against both variants.
+		protected virtual void RegisterTabbedPageHandler(IMauiHandlersCollection handlers)
+		{
+#if IOS || MACCATALYST
+			handlers.AddHandler(typeof(TabbedPage), typeof(TabbedRenderer));
+#else
+			handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));
 #endif
 		}
 
@@ -111,7 +120,7 @@ namespace Microsoft.Maui.DeviceTests
 			});
 
 			tabbedPage.BarTextColor = Colors.Red;
-			await CreateHandlerAndAddToWindow<TabbedViewHandler>(tabbedPage, async handler =>
+			await CreateHandlerAndAddToWindow<IElementHandler>(tabbedPage, async handler =>
 			{
 				// Pre iOS15 you couldn't set the text color of the unselected tab
 				// so only android/windows currently set the color of both
@@ -150,7 +159,7 @@ namespace Microsoft.Maui.DeviceTests
 			tabbedPage.SelectedTabColor = Colors.Red;
 			tabbedPage.UnselectedTabColor = Colors.Purple;
 
-			await CreateHandlerAndAddToWindow<TabbedViewHandler>(tabbedPage, async handler =>
+			await CreateHandlerAndAddToWindow<IElementHandler>(tabbedPage, async handler =>
 			{
 				// Pre iOS15 you couldn't set the text color of the unselected tab
 				// so only android/windows currently set the color of both
@@ -336,7 +345,7 @@ namespace Microsoft.Maui.DeviceTests
 					handlers.AddHandler(typeof(Button), typeof(ButtonHandler));
 					handlers.AddHandler<Page, PageHandler>();
 					handlers.AddHandler<Label, LabelHandler>();
-					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedRenderer));
+					RegisterTabbedPageHandler(handlers);
 					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
 				});
 			});
@@ -511,7 +520,7 @@ namespace Microsoft.Maui.DeviceTests
 					handlers.AddHandler(typeof(Button), typeof(ButtonHandler));
 					handlers.AddHandler<Page, PageHandler>();
 					handlers.AddHandler<Label, LabelHandler>();
-					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedRenderer));
+					RegisterTabbedPageHandler(handlers);
 					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
 				});
 			});

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.iOS.cs
@@ -186,7 +186,7 @@ namespace Microsoft.Maui.DeviceTests
 					handlers.AddHandler(typeof(Button), typeof(ButtonHandler));
 					handlers.AddHandler<Page, PageHandler>();
 					handlers.AddHandler<Label, LabelHandler>();
-					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedRenderer));
+					RegisterTabbedPageHandler(handlers);
 					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
 				});
 			});

--- a/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarTests.TabbedViewHandler.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarTests.TabbedViewHandler.iOS.cs
@@ -1,0 +1,21 @@
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	/// <summary>
+	/// Reuses every ToolbarTests fact/theory under TabbedViewHandler instead of the base class's
+	/// TabbedRenderer, so tests that embed a TabbedPage exercise both variants on iOS/MacCatalyst.
+	/// </summary>
+	[Category(TestCategory.Toolbar)]
+	[Trait(RendererHandlerVariant.TabbedViewVariantTraitName, RendererHandlerVariant.TabbedViewHandler)] // See RendererHandlerVariant.cs
+	public class ToolbarTests_TabbedViewHandler : ToolbarTests
+	{
+		protected override void RegisterTabbedPageHandler(IMauiHandlersCollection handlers)
+		{
+			handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarTests.cs
@@ -31,6 +31,10 @@ namespace Microsoft.Maui.DeviceTests
 	// instead, so every test below runs against both variants.
 	[Trait(RendererHandlerVariant.FlyoutViewVariantTraitName, RendererHandlerVariant.PhoneFlyoutPageRenderer)] // See RendererHandlerVariant.cs
 #endif
+	// This base class exercises TabbedRenderer on iOS/MacCatalyst; the
+	// ToolbarTests_TabbedViewHandler subclass overrides registration to exercise TabbedViewHandler
+	// instead, so every test below runs against both variants.
+	[Trait(RendererHandlerVariant.TabbedViewVariantTraitName, RendererHandlerVariant.TabbedRenderer)] // See RendererHandlerVariant.cs
 	public partial class ToolbarTests : ControlsHandlerTestBase
 	{
 		protected virtual void SetupBuilder()
@@ -45,11 +49,7 @@ namespace Microsoft.Maui.DeviceTests
 					RegisterNavigationPageHandler(handlers);
 					handlers.AddHandler<Page, PageHandler>();
 					handlers.AddHandler<Controls.Window, WindowHandlerStub>();
-#if IOS || MACCATALYST
-					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedRenderer));
-#else
-					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));
-#endif
+					RegisterTabbedPageHandler(handlers);
 
 					SetupShellHandlers(handlers);
 				});
@@ -76,6 +76,17 @@ namespace Microsoft.Maui.DeviceTests
 			handlers.AddHandler(typeof(FlyoutPage), typeof(Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer));
 #else
 			handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
+#endif
+		}
+
+		// The base class exercises TabbedRenderer on iOS/MacCatalyst; ToolbarTests_TabbedViewHandler
+		// overrides this to exercise TabbedViewHandler instead.
+		protected virtual void RegisterTabbedPageHandler(IMauiHandlersCollection handlers)
+		{
+#if IOS || MACCATALYST
+			handlers.AddHandler(typeof(TabbedPage), typeof(TabbedRenderer));
+#else
+			handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));
 #endif
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.TabbedViewHandler.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.TabbedViewHandler.iOS.cs
@@ -1,0 +1,22 @@
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	/// <summary>
+	/// Reuses every WindowTests fact/theory under TabbedViewHandler instead of the base class's
+	/// TabbedRenderer, so tests that embed a TabbedPage exercise both variants on iOS/MacCatalyst.
+	/// </summary>
+	[Category(TestCategory.Window)]
+	[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
+	[Trait(RendererHandlerVariant.TabbedViewVariantTraitName, RendererHandlerVariant.TabbedViewHandler)] // See RendererHandlerVariant.cs
+	public class WindowTests_TabbedViewHandler : WindowTests
+	{
+		protected override void RegisterTabbedPageHandler(IMauiHandlersCollection handlers)
+		{
+			handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.cs
@@ -43,6 +43,10 @@ namespace Microsoft.Maui.DeviceTests
 	// instead, so every test below runs against both variants.
 	[Trait(RendererHandlerVariant.FlyoutViewVariantTraitName, RendererHandlerVariant.PhoneFlyoutPageRenderer)] // See RendererHandlerVariant.cs
 #endif
+	// This base class exercises TabbedRenderer on iOS/MacCatalyst; the
+	// WindowTests_TabbedViewHandler subclass overrides registration to exercise TabbedViewHandler
+	// instead, so every test below runs against both variants.
+	[Trait(RendererHandlerVariant.TabbedViewVariantTraitName, RendererHandlerVariant.TabbedRenderer)] // See RendererHandlerVariant.cs
 	public partial class WindowTests : ControlsHandlerTestBase
 	{
 		protected virtual void SetupBuilder()
@@ -55,11 +59,7 @@ namespace Microsoft.Maui.DeviceTests
 
 					RegisterNavigationPageHandler(handlers);
 					RegisterFlyoutPageHandler(handlers);
-#if ANDROID || WINDOWS
-					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));
-#else
-					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedRenderer));
-#endif
+					RegisterTabbedPageHandler(handlers);
 
 					handlers.AddHandler<IContentView, ContentViewHandler>();
 
@@ -91,6 +91,17 @@ namespace Microsoft.Maui.DeviceTests
 			handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
 #else
 			handlers.AddHandler(typeof(FlyoutPage), typeof(PhoneFlyoutPageRenderer));
+#endif
+		}
+
+		// The base class exercises TabbedRenderer on iOS/MacCatalyst; WindowTests_TabbedViewHandler
+		// overrides this to exercise TabbedViewHandler instead.
+		protected virtual void RegisterTabbedPageHandler(IMauiHandlersCollection handlers)
+		{
+#if ANDROID || WINDOWS
+			handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));
+#else
+			handlers.AddHandler(typeof(TabbedPage), typeof(TabbedRenderer));
 #endif
 		}
 

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.TabbedViewHandler.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.TabbedViewHandler.iOS.cs
@@ -1,0 +1,20 @@
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests.Memory;
+
+/// <summary>
+/// Reuses every MemoryTests fact/theory under TabbedViewHandler instead of the base class's
+/// TabbedRenderer, so PagesDoNotLeak(typeof(TabbedPage)) exercises both variants on iOS/MacCatalyst.
+/// </summary>
+[Category(TestCategory.Memory)]
+[Trait(RendererHandlerVariant.TabbedViewVariantTraitName, RendererHandlerVariant.TabbedViewHandler)] // See RendererHandlerVariant.cs
+public class MemoryTests_TabbedViewHandler : MemoryTests
+{
+	protected override void RegisterTabbedPageHandler(IMauiHandlersCollection handlers)
+	{
+		handlers.AddHandler<TabbedPage, TabbedViewHandler>();
+	}
+}

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -30,8 +30,15 @@ namespace Microsoft.Maui.DeviceTests.Memory;
 // MemoryTests_FlyoutViewHandler subclass overrides registration to exercise FlyoutViewHandler.
 [Trait(RendererHandlerVariant.FlyoutViewVariantTraitName, RendererHandlerVariant.PhoneFlyoutPageRenderer)] // See RendererHandlerVariant.cs
 #endif
+// This base class exercises TabbedRenderer on iOS/MacCatalyst; the
+// MemoryTests_TabbedViewHandler subclass overrides registration to exercise TabbedViewHandler
+// instead, so PagesDoNotLeak(typeof(TabbedPage)) runs against both variants.
+[Trait(RendererHandlerVariant.TabbedViewVariantTraitName, RendererHandlerVariant.TabbedRenderer)] // See RendererHandlerVariant.cs
 public class MemoryTests : ControlsHandlerTestBase
 {
+	// Subclasses used to enable memory tests for CV2 handlers
+	public class CollectionView2 : CollectionView { }
+	public class CarouselView2 : CarouselView { }
 	protected virtual void SetupBuilder(bool includeNavigationViewHandler = true)
 	{
 		EnsureHandlerCreated(builder =>
@@ -102,11 +109,7 @@ public class MemoryTests : ControlsHandlerTestBase
 				handlers.AddHandler<NavigationPage, NavigationViewHandler>();
 #endif
 				RegisterFlyoutPageHandler(handlers);
-#if IOS || MACCATALYST
-				handlers.AddHandler<TabbedPage, TabbedRenderer>();
-#else
-				handlers.AddHandler<TabbedPage, TabbedViewHandler>();
-#endif
+				RegisterTabbedPageHandler(handlers);
 			});
 		});
 	}
@@ -119,6 +122,17 @@ public class MemoryTests : ControlsHandlerTestBase
 		handlers.AddHandler<FlyoutPage, PhoneFlyoutPageRenderer>();
 #else
 		handlers.AddHandler<FlyoutPage, FlyoutViewHandler>();
+#endif
+	}
+
+	// The base class exercises TabbedRenderer on iOS/MacCatalyst; MemoryTests_TabbedViewHandler
+	// overrides this to exercise TabbedViewHandler instead.
+	protected virtual void RegisterTabbedPageHandler(IMauiHandlersCollection handlers)
+	{
+#if IOS || MACCATALYST
+		handlers.AddHandler<TabbedPage, TabbedRenderer>();
+#else
+		handlers.AddHandler<TabbedPage, TabbedViewHandler>();
 #endif
 	}
 

--- a/src/Controls/tests/DeviceTests/TestCases/ControlsPageTypesTestCases.cs
+++ b/src/Controls/tests/DeviceTests/TestCases/ControlsPageTypesTestCases.cs
@@ -82,7 +82,10 @@ namespace Microsoft.Maui.DeviceTests.TestCases
 
 		public static Page CreatePageType(ControlsPageTypesTestCase name) => CreatePageType(name, new ContentPage());
 
-		public static void Setup(MauiAppBuilder builder, bool includeNavigationViewHandler = true)
+		public static void Setup(
+			MauiAppBuilder builder,
+			bool includeNavigationViewHandler = true,
+			bool useTabbedViewHandler = false)
 		{
 			builder.ConfigureMauiHandlers(handlers =>
 			{
@@ -101,7 +104,10 @@ namespace Microsoft.Maui.DeviceTests.TestCases
 				handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
 #endif
 #if IOS || MACCATALYST
-				handlers.AddHandler(typeof(TabbedPage), typeof(TabbedRenderer));
+				// The default (useTabbedViewHandler: false) exercises TabbedRenderer, matching the
+				// legacy iOS/MacCatalyst behavior; callers that want to exercise the migrated
+				// TabbedViewHandler pass useTabbedViewHandler: true. See RendererHandlerVariant.cs.
+				handlers.AddHandler(typeof(TabbedPage), useTabbedViewHandler ? typeof(TabbedViewHandler) : typeof(TabbedRenderer));
 #else
 				handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));
 #endif

--- a/src/TestUtils/src/DeviceTests/xUnitCustomizations.cs
+++ b/src/TestUtils/src/DeviceTests/xUnitCustomizations.cs
@@ -215,9 +215,11 @@ namespace Microsoft.Maui
 
 		string? _reuseVariantPrefix;
 
-		// Renderer/handler subclasses reuse the same test bodies, so DisplayName alone can't
-		// distinguish variants. Android uses the "Variant" trait; iOS/MacCatalyst use distinct
-		// NavigationViewVariant and FlyoutViewVariant traits, which may both be present.
+		// Renderer/handler subclass pairs reuse the same test bodies, so DisplayName alone can't
+		// distinguish variants. Android uses the "Variant" trait ("[Renderer]"/"[Handler]"),
+		// NavigationPage uses "NavigationViewVariant" ("[NavigationRenderer]"/"[NavigationViewHandler]"),
+		// FlyoutPage uses "FlyoutViewVariant" ("[PhoneFlyoutPageRenderer]"/"[FlyoutViewHandler]"),
+		// and TabbedPage uses "TabbedViewVariant" ("[TabbedRenderer]"/"[TabbedViewHandler]").
 		string GetReuseVariantPrefix()
 		{
 			if (_reuseVariantPrefix == null)
@@ -252,6 +254,20 @@ namespace Microsoft.Maui
 						else if (flyoutViewVariants.Contains("PhoneFlyoutPageRenderer"))
 						{
 							_reuseVariantPrefix = (_reuseVariantPrefix ?? string.Empty) + "[PhoneFlyoutPageRenderer] ";
+						}
+					}
+
+					if (Traits.TryGetValue("TabbedViewVariant", out var tabbedViewVariants) && tabbedViewVariants is not null)
+					{
+						// Check Handler first: a Handler subclass also inherits the base class's
+						// "TabbedRenderer" trait, so Traits may contain both values for this key.
+						if (tabbedViewVariants.Contains("TabbedViewHandler"))
+						{
+							_reuseVariantPrefix = (_reuseVariantPrefix ?? string.Empty) + "[TabbedViewHandler] ";
+						}
+						else if (tabbedViewVariants.Contains("TabbedRenderer"))
+						{
+							_reuseVariantPrefix = (_reuseVariantPrefix ?? string.Empty) + "[TabbedRenderer] ";
 						}
 					}
 #endif

--- a/src/TestUtils/src/DeviceTests/xUnitCustomizations.cs
+++ b/src/TestUtils/src/DeviceTests/xUnitCustomizations.cs
@@ -273,7 +273,7 @@ namespace Microsoft.Maui
 #endif
 
 #if ANDROID
-					if (Traits.TryGetValue("Variant", out var variants) && variants is not null)
+					if (_reuseVariantPrefix is null && Traits.TryGetValue("Variant", out var variants) && variants is not null)
 					{
 						// Check Handler first: a Handler subclass also inherits the base class's
 						// "Renderer" trait, so Traits may contain both values for this key.


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

#### Problem

`TabbedPage` was migrated from the renderer to the handler architecture on iOS/MacCatalyst (#36507). Despite that migration, every existing `TabbedPage` device test — and every other device test that embeds a `TabbedPage` as a supporting page — still hardcoded `TabbedRenderer` on iOS/MacCatalyst. As a result, the new `TabbedViewHandler` code path had **zero device test coverage**, even though it's now the code path real apps run against.

#### Approach

Rather than write a parallel/duplicate set of tests for `TabbedViewHandler`, this PR makes the handler registration for `TabbedPage` overridable and reuses every existing test body across both variants — the same pattern already used for the Android Shell/Modal/Window renderer/handler axis.

For each affected test class:

- `SetupBuilder` (or equivalent) is made `virtual`.
- The `TabbedPage` handler registration is extracted into a new virtual `RegisterTabbedPageHandler(...)` hook, defaulting to the existing `TabbedRenderer` registration on iOS/MacCatalyst (no behavior change for the base class).
- A new `*_TabbedViewHandler` subclass (new `.iOS.cs` file) overrides that hook to register the real `TabbedViewHandler` instead, inheriting every `[Fact]`/`[Theory]` unchanged — so the *same* test bodies run twice, once per variant.

`xUnitCustomizations.GetReuseVariantPrefix()` was extended to run on iOS/MacCatalyst and tag each test's `DisplayName` with `[TabbedRenderer]` / `[TabbedViewHandler]`, mirroring the existing Android `[Renderer]` / `[Handler]` convention, so results stay distinguishable in test output.

#### Files changed

| File | Change |
|---|---|
| `RendererHandlerVariant.cs` | New `TabbedViewVariant` trait constants (`TabbedRenderer` / `TabbedViewHandler`) |
| `xUnitCustomizations.cs` | `GetReuseVariantPrefix()` now also runs on iOS/MacCatalyst |
| `TabbedPageTests.cs` / `.iOS.cs` | Virtual `RegisterTabbedPageHandler` hook; fixed 3 `Handler_*` tests and 2 `CreateHandlerAndAddToWindow<T>` call sites that hardcoded a concrete handler type |
| `ModalTests.cs`, `WindowTests.cs`, `NavigationPageTests.cs`, `ToolbarTests.cs`, `MemoryTests.cs` | Same virtual hook pattern; `ModalTests`/`WindowTests` keep their existing Android `Variant` trait alongside the new one |
| `ControlsPageTypesTestCases.cs` | New optional `useTabbedViewHandler` parameter (static `ClassData` helper, can't be subclassed) |
| `EntryTests.iOS.cs` | `EntryTestsWithWindow` routes through a new `RegisterPageTypeHandlers` hook |
| 6 new `*_TabbedViewHandler`/`*.TabbedViewHandler.iOS.cs` files | One handler-variant subclass per affected test class |

No existing test logic was duplicated or rewritten — only the handler-registration hook was made overridable.