### PR TITLE
[Flaky] Fixed the Issue34975 flaky issue

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34975.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34975.cs
@@ -20,9 +20,9 @@ public class Issue34975 : _IssuesUITest
 		App.WaitForElement("CheckMemoryButton");
 		App.Tap("CheckMemoryButton");
 
-		// GarbageCollectionHelper.WaitForGC runs for up to 10 s inside the app,
-		// so allow 2s total for the status label to reflect the final result.
-		App.WaitForTextToBePresentInElement("StatusLabel", "Still alive:", timeout: TimeSpan.FromSeconds(2));
+		// GarbageCollectionHelper.WaitForGC runs for up to 5 seconds inside the app.
+		var memoryCheckCompleted = App.WaitForTextToBePresentInElement("StatusLabel", "Still alive:");
+		Assert.That(memoryCheckCompleted, Is.True, "Memory check did not complete within the expected time.");
 		Assert.That(App.FindElement("StatusLabel").GetText(), Is.EqualTo("Still alive: 0"),
 			"Memory leak detected: SecondPage instances were not garbage collected.");
 	}


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Issue

The test read **StatusLabel** immediately after tapping Check Memory. The in-app `GarbageCollectionHelper.WaitForGC `operation can take up to five seconds, during which the label displays "**Checking**...". This race condition caused the test to fail before the memory check completed, even when no memory leak existed.

**Build link :** https://dev.azure.com/dnceng-public/public/_build/results?buildId=1565488&view=ms.vss-test-web.build-test-results-tab&runId=43115338&resultId=100235&paneView=debug

<img width="1336" height="1034" alt="image" src="https://github.com/user-attachments/assets/82c71f7b-4cc4-48da-931d-14d6e0f70bbd" />

### Description of Change

Updated the UI test to wait until StatusLabel contains "**Still alive:**", indicating that the garbage-collection check has completed, before asserting the final result. The wait uses the helper’s default 15-second timeout, which is sufficient for the five-second operation. The test then verifies that the final text is "Still alive: 0".


### Issues Fixed

Fixes #36418
