### PR TITLE
[iOS] Fix custom cluster icons never being applied on Map

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Map/MapTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Map/MapTests.iOS.cs
@@ -189,5 +189,93 @@ namespace Microsoft.Maui.DeviceTests
 					message: "Timed out waiting for the pin's annotation view to revert to the default marker view.");
 			});
 		}
+
+		[Fact(DisplayName = "Cluster Marshalled As A Protocol Wrapper Gets The Cluster View")]
+		public async Task ClusterMarshalledAsProtocolWrapperGetsClusterView()
+		{
+			// Regression test for https://github.com/dotnet/maui/issues/37806
+			// MapKit invokes the GetViewForAnnotation block with the annotation marshalled as
+			// MKAnnotationWrapper - an INativeObject that is not an NSObject - so managed type
+			// checks never recognised the cluster and every cluster fell through to the ordinary
+			// pin path, silently ignoring ClusterImageSource/ClusterImageProvider.
+			SetupBuilder();
+
+			var map = new Map { IsClusteringEnabled = true };
+
+			await AttachAndRun<MapHandler>(map, async handler =>
+			{
+				await Task.Yield();
+
+				var platformView = handler.PlatformView;
+				Assert.NotNull(platformView);
+
+				using var member = new MKPointAnnotation
+				{
+					Coordinate = new CoreLocation.CLLocationCoordinate2D(47.6062, -122.3321),
+				};
+				using var cluster = new MKClusterAnnotation(new IMKAnnotation[] { member });
+
+				var view = InvokeGetViewForAnnotation(platformView, WrapAsProtocolWrapper(cluster));
+
+				Assert.NotNull(view);
+				Assert.Equal("clusterPin", view.ReuseIdentifier);
+			});
+		}
+
+		[Fact(DisplayName = "Disposed Cluster Annotation Is Not Treated As A Cluster")]
+		public void DisposedClusterAnnotationIsNotTreatedAsACluster()
+		{
+			// A cluster whose managed peer was disposed while a MapKit callback was in flight has a
+			// zero handle; treating it as a cluster throws ObjectDisposedException from
+			// MemberAnnotations inside the callback.
+			var member = new MKPointAnnotation
+			{
+				Coordinate = new CoreLocation.CLLocationCoordinate2D(47.6062, -122.3321),
+			};
+			var cluster = new MKClusterAnnotation(new IMKAnnotation[] { member });
+			cluster.Dispose();
+			member.Dispose();
+
+			Assert.Null(InvokeResolveAnnotationPeer(cluster));
+		}
+
+		// MapKit marshals the annotation into the GetViewForAnnotation block as the generated
+		// protocol wrapper for IMKAnnotation. It cannot be produced by the public runtime helpers
+		// (Runtime.GetINativeObject resolves the typed peer instead), so build the same wrapper the
+		// runtime hands us.
+		static IMKAnnotation WrapAsProtocolWrapper(MKClusterAnnotation cluster)
+		{
+			var wrapperType = typeof(IMKAnnotation).Assembly.GetType("MapKit.MKAnnotationWrapper");
+			Assert.NotNull(wrapperType);
+
+			var wrapper = Activator.CreateInstance(wrapperType, cluster.Handle, false) as IMKAnnotation;
+			Assert.NotNull(wrapper);
+			Assert.IsNotType<MKClusterAnnotation>(wrapper);
+
+			return wrapper;
+		}
+
+		static MKAnnotationView InvokeGetViewForAnnotation(MauiMKMapView mapView, IMKAnnotation annotation)
+		{
+			var method = typeof(MauiMKMapView).GetMethod(
+				"GetViewForAnnotation",
+				BindingFlags.Instance | BindingFlags.NonPublic,
+				new[] { typeof(MKMapView), typeof(IMKAnnotation) });
+
+			Assert.NotNull(method);
+
+			return (MKAnnotationView)method.Invoke(mapView, new object[] { mapView, annotation });
+		}
+
+		static Foundation.NSObject InvokeResolveAnnotationPeer(IMKAnnotation annotation)
+		{
+			var method = typeof(MauiMKMapView).GetMethod(
+				"ResolveAnnotationPeer",
+				BindingFlags.Static | BindingFlags.NonPublic);
+
+			Assert.NotNull(method);
+
+			return (Foundation.NSObject)method.Invoke(null, new object[] { annotation });
+		}
 	}
 }

--- a/src/Core/maps/src/Platform/iOS/MauiMKMapView.cs
+++ b/src/Core/maps/src/Platform/iOS/MauiMKMapView.cs
@@ -181,22 +181,21 @@ namespace Microsoft.Maui.Maps.Platform
 			return mapPin;
 		}
 
-		// Native class of MKClusterAnnotation, used to detect clusters by their real ObjC class
-		// rather than the managed peer type (which binding skew can report as a generic wrapper).
-		static readonly ObjCRuntime.Class s_clusterAnnotationClass = new(typeof(MKClusterAnnotation));
-
-		// Resolves a cluster annotation, isolating the binding-skew workaround in one place so a
-		// better native check can be swapped in later. Checking the native class (not the managed
-		// type name) also avoids using exceptions for the common non-cluster case.
+		// Resolves a cluster annotation. MapKit hands the GetViewForAnnotation block its annotation as a
+		// marshalled protocol wrapper (MKAnnotationWrapper), which is an INativeObject but *not* an
+		// NSObject - so neither a managed `is MKClusterAnnotation` check nor an NSObject-based
+		// IsKindOfClass sees the cluster, and every cluster fell through to the default marker.
+		// Resolving the peer from the handle picks the managed type from the native class, which works
+		// for the wrapper and for an already-typed annotation (the selection callbacks pass the latter).
 		static MKClusterAnnotation? TryGetClusterAnnotation(IMKAnnotation annotation)
 		{
 			if (annotation is MKClusterAnnotation clusterAnnotation)
 				return clusterAnnotation;
 
-			if (annotation is Foundation.NSObject nsObject && nsObject.IsKindOfClass(s_clusterAnnotationClass))
-				return Runtime.GetNSObject<MKClusterAnnotation>(annotation.Handle);
+			if (annotation.Handle == IntPtr.Zero)
+				return null;
 
-			return null;
+			return Runtime.GetNSObject(annotation.Handle) as MKClusterAnnotation;
 		}
 
 		MKAnnotationView GetViewForClusterAnnotation(MKMapView mapView, MKClusterAnnotation clusterAnnotation)

--- a/src/Core/maps/src/Platform/iOS/MauiMKMapView.cs
+++ b/src/Core/maps/src/Platform/iOS/MauiMKMapView.cs
@@ -99,16 +99,15 @@ namespace Microsoft.Maui.Maps.Platform
 		{
 			MKAnnotationView? mapPin;
 
+			// Resolved once: this block runs for every annotation entering the viewport and again
+			// on every pan/zoom, and both checks below need the concrete annotation type.
+			var annotationPeer = ResolveAnnotationPeer(annotation);
+
 			// https://bugzilla.xamarin.com/show_bug.cgi?id=26416
-			var userLocationAnnotation = Runtime.GetNSObject(annotation.Handle) as MKUserLocation;
-			if (userLocationAnnotation != null)
+			if (annotationPeer is MKUserLocation)
 				return null!;
 
-			// Handle cluster annotations. Binding skew (observed with the iOS 26.5/net11 preview.5
-			// bindings) sometimes hands us a cluster as a generic managed wrapper rather than the
-			// concrete MKClusterAnnotation, so a plain `is` check can miss a real cluster.
-			var clusterAnnotation = TryGetClusterAnnotation(annotation);
-			if (clusterAnnotation != null)
+			if (annotationPeer is MKClusterAnnotation clusterAnnotation)
 			{
 				return GetViewForClusterAnnotation(mapView, clusterAnnotation);
 			}
@@ -181,22 +180,18 @@ namespace Microsoft.Maui.Maps.Platform
 			return mapPin;
 		}
 
-		// Resolves a cluster annotation. MapKit hands the GetViewForAnnotation block its annotation as a
-		// marshalled protocol wrapper (MKAnnotationWrapper), which is an INativeObject but *not* an
-		// NSObject - so neither a managed `is MKClusterAnnotation` check nor an NSObject-based
-		// IsKindOfClass sees the cluster, and every cluster fell through to the default marker.
-		// Resolving the peer from the handle picks the managed type from the native class, which works
-		// for the wrapper and for an already-typed annotation (the selection callbacks pass the latter).
-		static MKClusterAnnotation? TryGetClusterAnnotation(IMKAnnotation annotation)
-		{
-			if (annotation is MKClusterAnnotation clusterAnnotation)
-				return clusterAnnotation;
-
-			if (annotation.Handle == IntPtr.Zero)
-				return null;
-
-			return Runtime.GetNSObject(annotation.Handle) as MKClusterAnnotation;
-		}
+		// Resolves the managed peer for an annotation MapKit handed us. The GetViewForAnnotation block
+		// receives its annotation as a marshalled protocol wrapper (MKAnnotationWrapper), which is an
+		// INativeObject but *not* an NSObject - so neither a managed `is MKClusterAnnotation` check nor
+		// an NSObject-based IsKindOfClass sees the cluster, and every cluster fell through to the
+		// default marker. Going through the handle picks the managed type from the native class, and
+		// works for an already-typed annotation too (the selection callbacks pass the latter).
+		// A zero handle means the peer is already gone - a disposed annotation reaching a MapKit
+		// callback still in flight - so callers take the no-cluster path instead of throwing on it.
+		static Foundation.NSObject? ResolveAnnotationPeer(IMKAnnotation? annotation) =>
+			annotation is null || annotation.Handle == IntPtr.Zero
+				? null
+				: Runtime.GetNSObject(annotation.Handle);
 
 		MKAnnotationView GetViewForClusterAnnotation(MKMapView mapView, MKClusterAnnotation clusterAnnotation)
 		{
@@ -710,7 +705,7 @@ namespace Microsoft.Maui.Maps.Platform
 			}
 
 			// Handle cluster annotation selection
-			if (annotation is not null && TryGetClusterAnnotation(annotation) is MKClusterAnnotation clusterAnnotation)
+			if (ResolveAnnotationPeer(annotation) is MKClusterAnnotation clusterAnnotation)
 			{
 				OnClusterClicked(clusterAnnotation);
 				// Deselect the cluster annotation to allow re-selection


### PR DESCRIPTION
### Description of Change

On iOS and MacCatalyst, `Map.ClusterImageSource` and `Map.ClusterImageProvider` had no effect: every cluster was drawn with MapKit's default marker and the requested image was never loaded.

MapKit calls the `GetViewForAnnotation` block with the annotation marshalled as `MKAnnotationWrapper`, the generated wrapper for the `IMKAnnotation` protocol. That wrapper is an `INativeObject` but **not** an `NSObject`, so both branches of `TryGetClusterAnnotation` failed — `is MKClusterAnnotation` because it is the wrapper, and the `IsKindOfClass` guard because `annotation as NSObject` is itself `null`. `GetViewForClusterAnnotation` was therefore never reached: the cluster fell through to the single-pin branch and was handed an `MKMarkerAnnotationView` from the `"defaultPin"` reuse pool, which is why the result looked like ordinary default cluster styling rather than something broken.

This resolves the managed peer from the handle instead, so the type comes from the native class. That covers both the marshalled wrapper and an already-typed annotation — the selection callbacks pass the latter, which is why cluster **taps** worked all along while the icons did not. That asymmetry is what hid the bug.

The resolution happens once per callback, in `ResolveAnnotationPeer`. The `MKUserLocation` check at the top of `GetViewForAnnotation` was already resolving that same handle, so the cluster check reuses its result — one peer lookup where the previous code did two. A zero handle short-circuits to `null` before any type check, so a disposed annotation reaching a MapKit callback in flight takes the no-cluster path instead of throwing from `MemberAnnotations`.

`TryGetClusterAnnotation` and the now-unused `s_clusterAnnotationClass` probe are both removed.

**Targeting `net11.0`, not `main`:** the cluster icon API (#36336) exists only on `net11.0`, so this cannot be applied to `main` — `MauiMKMapView` there has no `TryGetClusterAnnotation` and `Map` has no `ClusterImageSource`. Same base branch as the PR that introduced the API.

### Verification

Simulator (iPhone 17 Pro, iOS 26.5 bindings) via **Controls.Sample → Controls → Maps → Pin Clustering**:

- "Static Cluster Icon" and "Custom Cluster Icon (provider)" now render their images, including the provider's `Count >= 10` branch when zoomed out
- Default clustering (no cluster image) and per-pin `Pin.ImageSource` are unchanged

Confirmed on an iPad (A16, iOS 26) with the reproduction page from #37806, which inspects the native cluster annotation views and reports, per cluster, whether MapKit's default marker or the handler's custom view was used: every cluster uses the default marker before this change and the custom icon after it, stable across repeated recluster passes.

### Tests

Two device tests in `MapTests.iOS.cs` (`Category=Map`):

- **`Cluster Marshalled As A Protocol Wrapper Gets The Cluster View`** — the regression test for this bug. MapKit does not run its clustering pass inside the `Controls.DeviceTests` harness (closely-spaced pins with a shared `ClusteringIdentifier`, the region set directly on the platform view, a world-sized `MKMapRect` and a 20 s wait all yield the point annotations and never an `MKClusterAnnotation`), and the wrapper cannot be obtained from the public helpers — `Runtime.GetINativeObject<IMKAnnotation>(handle, forced_type: true, owns: false)` resolves the typed peer. So the test supplies the failing input directly: it builds the same generated wrapper the runtime marshals, over a real `MKClusterAnnotation`, and invokes `GetViewForAnnotation` through the reflection seam the existing `TappingMapWithNoOverlaysDoesNotThrow` test in this file already uses. It asserts on `ReuseIdentifier`, not the view type, because the ordinary-pin fallback also produced an `MKMarkerAnnotationView`.
- **`Disposed Cluster Annotation Is Not Treated As A Cluster`** — pins the zero-handle guard.

Verified in both directions on an iPhone 17 Pro simulator, iOS 26.5: 8/8 pass with the fix, and with the pre-fix predicate restored the first test fails with `Expected: "clusterPin" / Actual: "defaultPin"` — the exact reported symptom.

An end-to-end check that drives real MapKit clustering (a HostApp page running 10 recluster passes and self-reporting `REPRODUCED` / `OK`) lives on [`repro/issue-37806`](https://github.com/kevin68/maui/tree/repro/issue-37806). It needs a rendered, windowed map, so it is not part of this PR; happy to bring it over as a UITest if that is wanted.

### Issues Fixed

Fixes #37806

