### PR TITLE
[net11.0] Fix Windows build: add missing 'using static AssertHelpers' to TabbedPageTests.Windows.cs

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Windows.cs
@@ -13,6 +13,7 @@ using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Platform;
 using Xunit;
+using static Microsoft.Maui.DeviceTests.AssertHelpers;
 using WContentPresenter = Microsoft.UI.Xaml.Controls.ContentPresenter;
 using WFrame = Microsoft.UI.Xaml.Controls.Frame;
 using WFrameworkElement = Microsoft.UI.Xaml.FrameworkElement;


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

PR #37755 added Windows TabbedPage badge tests that call `AssertEventually`, but `TabbedPageTests.Windows.cs` was missing the static import for `Microsoft.Maui.DeviceTests.AssertHelpers`. This causes CS0103 in both net11.0 Windows TFMs and blocks the Debug and Release Windows builds for every PR targeting `net11.0`.

This adds the same `using static Microsoft.Maui.DeviceTests.AssertHelpers;` directive already present in every sibling `TabbedPageTests` partial. No test logic or runtime behavior changes.

## Verification

Verified by code inspection that the sibling partials use the same static import and that `AssertHelpers.AssertEventually(Func<bool>, ...)` exists. Windows compile verification is deferred to CI because the local host is macOS and cannot build the `net11.0-windows` TFMs.
