### PR TITLE
Fixed VisualElement.Resources — shared ResourceDictionary's non-weak ValuesChanged event retains every element

### DIFF
--- a/src/Controls/src/Core/ResourceDictionary.cs
+++ b/src/Controls/src/Core/ResourceDictionary.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Maui.Controls
 			switch (e.Action)
 			{
 				case NotifyCollectionChangedAction.Add:
-					ValuesChanged?.Invoke(this, ResourcesChangedEventArgs.StyleSheets);
+					RaiseValuesChanged(ResourcesChangedEventArgs.StyleSheets);
 					break;
 			}
 		}
@@ -408,7 +408,7 @@ namespace Microsoft.Maui.Controls
 		{
 			StyleSheets = StyleSheets ?? new List<StyleSheets.StyleSheet>(2);
 			StyleSheets.Add(styleSheet);
-			ValuesChanged?.Invoke(this, ResourcesChangedEventArgs.StyleSheets);
+			RaiseValuesChanged(ResourcesChangedEventArgs.StyleSheets);
 		}
 
 		void OnValueChanged(string key, object value)
@@ -420,8 +420,10 @@ namespace Microsoft.Maui.Controls
 		{
 			if (values == null || values.Length == 0)
 				return;
-			ValuesChanged?.Invoke(this, new ResourcesChangedEventArgs(values));
+			RaiseValuesChanged(new ResourcesChangedEventArgs(values));
 		}
+
+		void RaiseValuesChanged(ResourcesChangedEventArgs e) => _weakEventManager.HandleEvent(this, e, nameof(ValuesChanged));
 
 		internal void Reload()
 		{
@@ -429,7 +431,13 @@ namespace Microsoft.Maui.Controls
 				OnValuesChanged(mr);
 		}
 
-		event EventHandler<ResourcesChangedEventArgs> ValuesChanged;
+		readonly WeakEventManager _weakEventManager = new WeakEventManager();
+
+		event EventHandler<ResourcesChangedEventArgs> ValuesChanged
+		{
+			add => _weakEventManager.AddEventHandler(value);
+			remove => _weakEventManager.RemoveEventHandler(value);
+		}
 
 		//only used for unit testing
 		internal static void ClearCache() => s_instances = new ConditionalWeakTable<Type, ResourceDictionary>();

--- a/src/Controls/tests/Core.UnitTests/ResourceDictionaryTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ResourceDictionaryTests.cs
@@ -622,5 +622,40 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			rd0.Add("foo", "Foo");
 			Assert.Equal("Foo", label.Text);
 		}
+
+		// Issue #36389: a shared ResourceDictionary instance assigned to multiple VisualElements should
+		// not root every element for the dictionary's lifetime via the non-weak ValuesChanged subscription.
+		[Fact]
+		public void SharedResourceDictionaryDoesNotLeakSubscribingElements()
+		{
+			const int elementCount = 30;
+			var shared = new ResourceDictionary { { "Accent", "Red" } };
+
+			var references = MakeElements(shared);
+
+			for (int i = 0; i < 6; i++)
+			{
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+				GC.Collect();
+			}
+
+			int alive = references.Count(r => r.IsAlive);
+			GC.KeepAlive(shared);
+
+			Assert.Equal(0, alive);
+
+			[System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+			static List<WeakReference> MakeElements(ResourceDictionary shared)
+			{
+				var refs = new List<WeakReference>(elementCount);
+				for (int i = 0; i < elementCount; i++)
+				{
+					var view = new ContentView { Resources = shared };
+					refs.Add(new WeakReference(view));
+				}
+				return refs;
+			}
+		}
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
 
### Issue Details

 [leak-scan] AnimationExtensions.Insert — disposed non-starting manager leaves callback statically rooted

### Root Cause 

1.  VisualElement.Resources  getter/setter ( VisualElement.cs:1177, 1186, 1190 ) does:
((IResourceDictionary)_resources).ValuesChanged += OnResourcesChanged;
``` `OnResourcesChanged` is an **instance method**, so this delegate captures `this` (the element).
2.  ResourceDictionary.ValuesChanged  ( ResourceDictionary.cs:432 ) was a plain field-like  event  — a standard C# multicast delegate that holds strong references to every subscriber:
event EventHandler<ResourcesChangedEventArgs> ValuesChanged;
3. Teardown ( -= OnResourcesChanged ) only happens when  Resources  is re-assigned on that specific element — never on unload, navigation-away, or handler disconnect.
 
Result: if a single  ResourceDictionary  instance is shared across multiple elements (or a long-lived dictionary like  Application.Current.Resources /a static theme dictionary is assigned to a transient element), that dictionary's subscriber list keeps every one of those elements alive forever, even after all other references to them are gone.

### Description of Change

Route  ResourceDictionary.ValuesChanged  through  Microsoft.Maui.WeakEventManager , which stores only a weak reference to each subscriber's target instead of a strong one — the same pattern already used elsewhere in MAUI for this exact purpose ( Command ,  ImageSource ,  Application ,  GestureElement ,  FormattedString ,  WebViewSource ).
 
// Before
```
event EventHandler<ResourcesChangedEventArgs> ValuesChanged;
...
ValuesChanged?.Invoke(this, new ResourcesChangedEventArgs(values));
 
```
// After
```
readonly WeakEventManager _weakEventManager = new WeakEventManager();
 
event EventHandler<ResourcesChangedEventArgs> ValuesChanged
{
    add => _weakEventManager.AddEventHandler(value);
    remove => _weakEventManager.RemoveEventHandler(value);
}

void RaiseValuesChanged(ResourcesChangedEventArgs e) =>
    _weakEventManager.HandleEvent(this, e, nameof(ValuesChanged));
 ```
 
All three raise sites ( OnValuesChanged ,  StyleSheetsCollectionChanged ,  Add(StyleSheet) ) now call  RaiseValuesChanged(...)  instead of  ValuesChanged?.Invoke(...) .

### Issues Fixed
 
Fixes #36389  
 
**Tested the behavior in the following platforms.**
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
| Before  | After  |
|---------|--------|
| <img src="https://github.com/user-attachments/assets/96cab82f-6fb0-47ed-8816-9518a626ca14" Width="300" Height="600" /> | <img src="https://github.com/user-attachments/assets/8337fef7-5693-4add-bdfd-2ce32469cc94" Width="300" Height="600" /> |