### PR TITLE
[iOS] Label: Reduce initial attributed-text formatting work

### DIFF
--- a/src/Controls/src/Core/Label/Label.iOS.cs
+++ b/src/Controls/src/Core/Label/Label.iOS.cs
@@ -23,7 +23,10 @@ namespace Microsoft.Maui.Controls
 		{
 			Platform.LabelExtensions.UpdateText(handler.PlatformView, label);
 
-			MapFormatting(handler, label);
+			if (!handler.IsConnectingHandler())
+			{
+				MapFormatting(handler, label);
+			}
 		}
 
 		public static void MapLineBreakMode(ILabelHandler handler, Label label)

--- a/src/Core/src/Handlers/Label/LabelHandler.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.cs
@@ -28,13 +28,22 @@ namespace Microsoft.Maui.Handlers
 #if TIZEN
 			[nameof(ILabel.Shadow)] = MapShadow,
 #endif
+#if IOS || MACCATALYST
+			// Attributed-text formatting must run after Text creates the native attributed string.
+			[nameof(ILabel.Text)] = MapText,
+			[nameof(ITextStyle.Font)] = MapFont,
+			[nameof(ITextStyle.CharacterSpacing)] = MapCharacterSpacing,
+#else
 			[nameof(ITextStyle.CharacterSpacing)] = MapCharacterSpacing,
 			[nameof(ITextStyle.Font)] = MapFont,
+#endif
 			[nameof(ITextAlignment.HorizontalTextAlignment)] = MapHorizontalTextAlignment,
 			[nameof(ITextAlignment.VerticalTextAlignment)] = MapVerticalTextAlignment,
 			[nameof(ILabel.LineHeight)] = MapLineHeight,
 			[nameof(ILabel.Padding)] = MapPadding,
+#if !IOS && !MACCATALYST
 			[nameof(ILabel.Text)] = MapText,
+#endif
 			[nameof(ITextStyle.TextColor)] = MapTextColor,
 			[nameof(ILabel.TextDecorations)] = MapTextDecorations,
 #if ANDROID

--- a/src/Core/src/Handlers/Label/LabelHandler.iOS.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.iOS.cs
@@ -48,8 +48,11 @@ namespace Microsoft.Maui.Handlers
 		{
 			handler.PlatformView?.UpdateTextPlainText(label);
 
-			// Any text update requires that we update any attributed string formatting
-			MapFormatting(handler, label);
+			if (!handler.IsConnectingHandler())
+			{
+				// Text changes can replace the attributed string, so reapply its formatting.
+				MapFormatting(handler, label);
+			}
 		}
 
 		public static void MapTextColor(ILabelHandler handler, ILabel label)


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Reorders iOS and Mac Catalyst Label initialization so native text and font are established before attributed-text formatting. During initial connection, the individual formatting mapper entries then apply character spacing, line height, decorations, and alignment once instead of `MapText` recursively applying them and the initialization loop applying them again.

Dynamic text changes still reapply formatting. Other platforms retain their existing mapper order.

## Benchmark

The local Sandbox harness is not included in this PR. Release iOS simulator, iPhone 16 Pro / iOS 18.4:

| Fixed-work metric | `net11.0` base | This change | Difference |
|---|---:|---:|---:|
| Heavy tile `ToPlatform` (55 elements) | 11.597 ms | 10.905 ms | **-6.0%** |
| Flat tile `ToPlatform` (14 elements) | 4.524 ms | 4.114 ms | **-9.1%** |
| Mapper calls, 12 heavy tiles | 26,808 | 25,824 | **-984 (-3.7%)** |

A native `UILabel` probe verified that underline, character spacing, and line height all survived initialization: `label-formatting|PASS`. The revised run completed all 70 benchmark results with `run-end|ok`.

## Review

Independent GPT, Claude, and Gemini reviews covered initialization, reconnect, formatted spans, HTML text, alignment, and the prior #35892 / #37087 regression history. Review identified that `Font` must precede `CharacterSpacing`; the mapper order was corrected and the native formatting probe was rerun successfully.
