### PR TITLE
ViewHandler: Skip null ToolTip initialization

### DIFF
--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -655,7 +655,14 @@ namespace Microsoft.Maui.Handlers
 		{
 #if PLATFORM
 			if (view is IToolTipElement tooltipContainer)
+			{
+				if (handler.IsConnectingHandler() && tooltipContainer.ToolTip is null)
+				{
+					return;
+				}
+
 				handler.ToPlatform().UpdateToolTip(tooltipContainer.ToolTip);
+			}
 #endif
 		}
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Skips the platform ToolTip update while a new handler is connecting when the virtual view has the default `null` ToolTip.

Reconnects still execute the update so a reused platform view can clear stale state. Dynamic non-null and null updates are unchanged.

## Benchmark

The local Sandbox harness is not included in this PR. Release iOS simulator, iPhone 16 Pro / iOS 18.4:

| Metric | Result |
|---|---:|
| Heavy tile `ToPlatform` (55 elements) | 12.771 ms |
| Flat tile `ToPlatform` (14 elements) | 4.844 ms |
| ToolTip mapper activity, 480 initial handlers | 0.236 ms |

The mapper activity count remains 480 because attribution wraps the mapper entry even when the new guard returns immediately. This micro-optimization is below end-to-end simulator noise and no aggregate speedup is claimed. The run completed all 70 benchmark results with `run-end|ok`.

## Review

Independent GPT, Claude, and Gemini reviews traced connection, reconnect, null/default values, dynamic updates, custom implementations, and all platform paths. All three found the guard safe and consistent with existing connect-time mapper guards.
