### PR TITLE
VisualElement: Avoid duplicate initial mappings

### DIFF
--- a/src/Controls/src/Core/VisualElement/VisualElement.Mapper.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.Mapper.cs
@@ -1,7 +1,7 @@
 #nullable disable
 using System;
+using System.Runtime.CompilerServices;
 using Microsoft.Maui.Controls.Compatibility;
-using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 
 namespace Microsoft.Maui.Controls
@@ -11,15 +11,6 @@ namespace Microsoft.Maui.Controls
 	/// </summary>
 	public partial class VisualElement
 	{
-		// Snapshots of the values last observed by RecordBackgroundMapped/RecordSemanticsMapped - see their
-		// doc comments below for how these are used to make the BackgroundColor/BackgroundImageSource/
-		// SemanticProperties.* mapper redirects skip only genuine no-ops.
-		Color _lastMappedBackgroundColor;
-		ImageSource _lastMappedBackgroundImageSource;
-		string _lastMappedSemanticDescription;
-		string _lastMappedSemanticHint;
-		SemanticHeadingLevel _lastMappedSemanticHeadingLevel;
-
 		static VisualElement() => RemapIfNeeded();
 
 		internal static new void RemapIfNeeded()
@@ -50,14 +41,13 @@ namespace Microsoft.Maui.Controls
 			viewMapper.ReplaceMapping<IView, IViewHandler>(SemanticProperties.HintProperty.PropertyName, MapSemanticPropertiesHintProperty);
 			viewMapper.ReplaceMapping<IView, IViewHandler>(SemanticProperties.HeadingLevelProperty.PropertyName, MapSemanticPropertiesHeadingLevelProperty);
 
-			// Record, on the element itself, the exact BackgroundColor/BackgroundImageSource and
-			// SemanticProperties.* values that were current the last time the canonical `Background`/
-			// `Semantics` mapping actually ran (through any path - initial connect, reconnect, or an
-			// explicit `UpdateValue` call). The redirects above compare against these snapshots so they
-			// only skip an invocation that is a genuine no-op, never one that would apply a value that
-			// hasn't been pushed yet. See VisualElementMapperTests for coverage of that invariant.
-			viewMapper.AppendToMapping<VisualElement, IViewHandler>(nameof(IView.Background), RecordBackgroundMapped);
-			viewMapper.AppendToMapping<VisualElement, IViewHandler>(nameof(IView.Semantics), RecordSemanticsMapped);
+			// Record, on the handler, that the canonical `Background`/`Semantics` mapping has just run so
+			// the redirects below can skip only the single, immediately-following redundant invocation of
+			// each key within *this same* bulk mapping pass - never an explicit/reentrant call, a
+			// same-value call, or one that happens before any `Background`/`Semantics` mapping has run at
+			// all. See VisualElementMapperTests for coverage of this invariant.
+			viewMapper.AppendToMapping<IView, IViewHandler>(nameof(IView.Background), RecordBackgroundMapped);
+			viewMapper.AppendToMapping<IView, IViewHandler>(nameof(IView.Semantics), RecordSemanticsMapped);
 
 			viewMapper.AppendToMapping<VisualElement, IViewHandler>(nameof(IViewHandler.ContainerView), MapContainerView);
 
@@ -71,84 +61,169 @@ namespace Microsoft.Maui.Controls
 			handler.UpdateValue(nameof(Background));
 
 		// `nameof(BackgroundColor)`/`nameof(Page.BackgroundImageSource)` are appended (by RemapForControls) after
-		// the Core `nameof(IView.Background)` key in `ViewHandler.ViewMapper`, so whenever the canonical
-		// `Background` mapping has *already* run with the current BackgroundColor/BackgroundImageSource value
-		// (recorded by `RecordBackgroundMapped`), re-running it here would be a pure no-op. We only skip in
-		// that exact case - comparing the live property value against the snapshot taken the last time
-		// `Background` was actually mapped - so this is safe regardless of connect/reconnect/dynamic-update
-		// timing: any call (including an explicit `UpdateValue` from `ConnectHandler` or from another mapper
-		// that runs later in the same pass) whose value hasn't been applied yet still goes through normally.
-		// See VisualElementMapperTests for coverage of this invariant.
+		// the Core `nameof(IView.Background)` key in `ViewHandler.ViewMapper`, so during the single bulk
+		// `UpdateProperties` pass that runs on initial connect or reconnect, the canonical `Background`
+		// mapping already reads the current composite BackgroundColor/BackgroundImageSource/Background
+		// value later in that very same pass, making this redirect redundant. `RecordBackgroundMapped`
+		// marks, on the handler, that a pending redundant invocation of this key exists for the pass that
+		// just ran `Background`'s mapping; this method consumes that one pending mark (skipping only that
+		// single invocation) and applies normally for every other call - whether it happens before
+		// `Background` has ever been mapped (e.g. from `ConnectHandler`), after the pending mark has
+		// already been consumed once (e.g. a mapper that runs later in the same pass and changes the
+		// value), or with an unchanged value. See VisualElementMapperTests for coverage of this invariant.
 		static void MapBackgroundColorForControls(IViewHandler handler, IView view)
 		{
-			if (view is not VisualElement element || element.BackgroundColor != element._lastMappedBackgroundColor)
+			var state = GetMappingPassState(handler);
+
+			if (state.BackgroundColorPendingSkip)
 			{
-				MapBackgroundColor(handler, view);
+				state.BackgroundColorPendingSkip = false;
+			}
+			else
+			{
+				ApplyBackgroundRedirect(state, handler, view, MapBackgroundColor);
 			}
 		}
 
-		// `BackgroundImageSource` is only ever a real, settable property on `Page`, but this key is registered
-		// on the shared `ViewHandler.ViewMapper` used by every view type, so this redirect is invoked for
-		// non-`Page` views too. For those, there is nothing to (re-)apply, so we never invoke the redirect;
-		// for `Page`, apply only when the value differs from the snapshot taken the last time `Background`
-		// was actually mapped, for the same reason as `MapBackgroundColorForControls` above.
+		// Same reasoning as `MapBackgroundColorForControls` above. This key is registered on the shared
+		// `ViewHandler.ViewMapper` used by every view type (even though `BackgroundImageSource` is only a
+		// real, settable property on `Page`), but that's harmless here: for non-`Page` views the pending
+		// mark set by `RecordBackgroundMapped` is still consumed on the natural bulk-pass turn, so no extra
+		// work is ever done for them during a normal pass.
 		static void MapBackgroundImageSourceForControls(IViewHandler handler, IView view)
 		{
-			if (view is Page page && page.BackgroundImageSource != page._lastMappedBackgroundImageSource)
+			var state = GetMappingPassState(handler);
+
+			if (state.BackgroundImageSourcePendingSkip)
 			{
-				MapBackgroundImageSource(handler, view);
+				state.BackgroundImageSourcePendingSkip = false;
+			}
+			else
+			{
+				ApplyBackgroundRedirect(state, handler, view, MapBackgroundImageSource);
 			}
 		}
 
-		// Snapshots the BackgroundColor/BackgroundImageSource values that were just used to compute the
-		// composite `Background` that was mapped, so `MapBackgroundColorForControls`/
-		// `MapBackgroundImageSourceForControls` can tell a genuine no-op apart from a value that has changed
-		// since. Appended to the `Background` key itself, this runs every time that key's mapping executes,
-		// through any path (bulk connect/reconnect pass or an explicit `UpdateValue(nameof(Background))`).
-		static void RecordBackgroundMapped(IViewHandler handler, VisualElement element)
+		// Applying either background redirect re-invokes `nameof(Background)`'s own mapping (through
+		// `MapBackgroundColor`/`MapBackgroundImageSource`), which synchronously re-triggers
+		// `RecordBackgroundMapped`. That particular execution of `Background`'s mapping is a leaf, one-off
+		// call made *by* a redirect, not a step of the top-level bulk-pass enumeration, so it must not
+		// re-arm the pending marks (there is no separate, later redirect turn guaranteed to follow it in
+		// this call chain) - `IsApplyingBackgroundRedirect` flags that to `RecordBackgroundMapped` below.
+		static void ApplyBackgroundRedirect(MappingPassState state, IViewHandler handler, IView view, Action<IViewHandler, IView> map)
 		{
-			element._lastMappedBackgroundColor = element.BackgroundColor;
-
-			if (element is Page page)
+			state.IsApplyingBackgroundRedirect = true;
+			try
 			{
-				page._lastMappedBackgroundImageSource = page.BackgroundImageSource;
+				map(handler, view);
+			}
+			finally
+			{
+				state.IsApplyingBackgroundRedirect = false;
 			}
 		}
 
-		static void MapSemanticPropertiesHeadingLevelProperty(IViewHandler handler, IView element) =>
-			UpdateSemanticsFromMapper(handler, element);
-
-		static void MapSemanticPropertiesHintProperty(IViewHandler handler, IView element) =>
-			UpdateSemanticsFromMapper(handler, element);
-
-		static void MapSemanticPropertiesDescriptionProperty(IViewHandler handler, IView element) =>
-			UpdateSemanticsFromMapper(handler, element);
-
-		// Same reasoning as the background guard above: the three `SemanticProperties` keys are appended
-		// after the Core `nameof(IView.Semantics)` key, so we compare the live SemanticProperties.* values
-		// against the snapshot taken the last time `Semantics` was actually mapped (recorded by
-		// `RecordSemanticsMapped`) and only skip when nothing has changed since. Any explicit `UpdateValue`
-		// call - from `ConnectHandler`, from a later mapper in the same pass, or from a dynamic property
-		// change - whose value hasn't been applied yet still runs normally.
-		static void UpdateSemanticsFromMapper(IViewHandler handler, IView element)
+		// Marks, on the handler, that the very next invocation of `MapBackgroundColorForControls`/
+		// `MapBackgroundImageSourceForControls` (whichever comes first for each) is a redundant no-op -
+		// `Background` was just (re)computed from the current BackgroundColor/BackgroundImageSource, so
+		// immediately re-running either redirect within the same pass would just push the same value
+		// again. Appended to the `Background` key itself, this runs every time that key's mapping executes,
+		// through any path (bulk connect/reconnect pass or an explicit `UpdateValue(nameof(Background))`) -
+		// except when it is itself a leaf call made by one of the redirects above (see
+		// `ApplyBackgroundRedirect`), which must not arm a pending mark for anything.
+		static void RecordBackgroundMapped(IViewHandler handler, IView view)
 		{
-			if (element is not VisualElement ve ||
-				SemanticProperties.GetDescription(ve) != ve._lastMappedSemanticDescription ||
-				SemanticProperties.GetHint(ve) != ve._lastMappedSemanticHint ||
-				SemanticProperties.GetHeadingLevel(ve) != ve._lastMappedSemanticHeadingLevel)
+			var state = GetMappingPassState(handler);
+
+			if (state.IsApplyingBackgroundRedirect)
 			{
-				(element as VisualElement)?.UpdateSemanticsFromMapper();
+				return;
+			}
+
+			state.BackgroundColorPendingSkip = true;
+			state.BackgroundImageSourcePendingSkip = true;
+		}
+
+		// Same reasoning as `MapBackgroundColorForControls` above, but for the `SemanticProperties.Description`
+		// redirect.
+		static void MapSemanticPropertiesDescriptionProperty(IViewHandler handler, IView element)
+		{
+			var state = GetMappingPassState(handler);
+
+			if (state.SemanticDescriptionPendingSkip)
+			{
+				state.SemanticDescriptionPendingSkip = false;
+			}
+			else if (element is VisualElement ve)
+			{
+				ApplySemanticsRedirect(state, ve);
 			}
 		}
 
-		// See RecordBackgroundMapped: runs every time the `Semantics` key's mapping executes, through any
-		// path, so the SemanticProperties.* redirects above can tell a genuine no-op apart from a value that
-		// has changed since.
-		static void RecordSemanticsMapped(IViewHandler handler, VisualElement element)
+		// Same reasoning as `MapBackgroundColorForControls` above, but for the `SemanticProperties.Hint`
+		// redirect.
+		static void MapSemanticPropertiesHintProperty(IViewHandler handler, IView element)
 		{
-			element._lastMappedSemanticDescription = SemanticProperties.GetDescription(element);
-			element._lastMappedSemanticHint = SemanticProperties.GetHint(element);
-			element._lastMappedSemanticHeadingLevel = SemanticProperties.GetHeadingLevel(element);
+			var state = GetMappingPassState(handler);
+
+			if (state.SemanticHintPendingSkip)
+			{
+				state.SemanticHintPendingSkip = false;
+			}
+			else if (element is VisualElement ve)
+			{
+				ApplySemanticsRedirect(state, ve);
+			}
+		}
+
+		// Same reasoning as `MapBackgroundColorForControls` above, but for the
+		// `SemanticProperties.HeadingLevel` redirect.
+		static void MapSemanticPropertiesHeadingLevelProperty(IViewHandler handler, IView element)
+		{
+			var state = GetMappingPassState(handler);
+
+			if (state.SemanticHeadingLevelPendingSkip)
+			{
+				state.SemanticHeadingLevelPendingSkip = false;
+			}
+			else if (element is VisualElement ve)
+			{
+				ApplySemanticsRedirect(state, ve);
+			}
+		}
+
+		// See `ApplyBackgroundRedirect`: applying a semantics redirect re-invokes `nameof(Semantics)`'s own
+		// mapping, synchronously re-triggering `RecordSemanticsMapped` for a leaf, one-off call that must
+		// not re-arm the pending marks.
+		static void ApplySemanticsRedirect(MappingPassState state, VisualElement element)
+		{
+			state.IsApplyingSemanticsRedirect = true;
+			try
+			{
+				element.UpdateSemanticsFromMapper();
+			}
+			finally
+			{
+				state.IsApplyingSemanticsRedirect = false;
+			}
+		}
+
+		// See `RecordBackgroundMapped`: marks, on the handler, that the very next invocation of each of the
+		// three `SemanticProperties.*` redirects above is a redundant no-op, since `Semantics` was just
+		// (re)computed from the current Description/Hint/HeadingLevel values - except when it is itself a
+		// leaf call made by one of those redirects (see `ApplySemanticsRedirect`).
+		static void RecordSemanticsMapped(IViewHandler handler, IView view)
+		{
+			var state = GetMappingPassState(handler);
+
+			if (state.IsApplyingSemanticsRedirect)
+			{
+				return;
+			}
+
+			state.SemanticDescriptionPendingSkip = true;
+			state.SemanticHintPendingSkip = true;
+			state.SemanticHeadingLevelPendingSkip = true;
 		}
 
 		void UpdateSemanticsFromMapper()
@@ -166,6 +241,28 @@ namespace Microsoft.Maui.Controls
 				return;
 
 			view.MapFocus(fr, baseMethod is null ? null : () => baseMethod?.Invoke(handler, view, args));
+		}
+
+		// Per-handler (not per-VisualElement) tracking of which `Background`/`Semantics`-derived redirect
+		// keys still have a pending, provably-redundant invocation outstanding for the bulk mapping pass
+		// that most recently (re-)mapped `Background`/`Semantics`. Keyed on the handler - via a
+		// ConditionalWeakTable so no manual cleanup/disconnect handling is needed - because de-duplication
+		// must be scoped to "has this specific handler's current pass already produced this key's natural,
+		// redundant call", not to any state that outlives a single pass or that lives on the element.
+		static readonly ConditionalWeakTable<IViewHandler, MappingPassState> s_mappingPassState = new();
+
+		static MappingPassState GetMappingPassState(IViewHandler handler) =>
+			s_mappingPassState.GetValue(handler, static _ => new MappingPassState());
+
+		sealed class MappingPassState
+		{
+			public bool BackgroundColorPendingSkip;
+			public bool BackgroundImageSourcePendingSkip;
+			public bool SemanticDescriptionPendingSkip;
+			public bool SemanticHintPendingSkip;
+			public bool SemanticHeadingLevelPendingSkip;
+			public bool IsApplyingBackgroundRedirect;
+			public bool IsApplyingSemanticsRedirect;
 		}
 	}
 }

--- a/src/Controls/src/Core/VisualElement/VisualElement.Mapper.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.Mapper.cs
@@ -1,6 +1,7 @@
 #nullable disable
 using System;
 using Microsoft.Maui.Controls.Compatibility;
+using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 
 namespace Microsoft.Maui.Controls
@@ -10,6 +11,15 @@ namespace Microsoft.Maui.Controls
 	/// </summary>
 	public partial class VisualElement
 	{
+		// Snapshots of the values last observed by RecordBackgroundMapped/RecordSemanticsMapped - see their
+		// doc comments below for how these are used to make the BackgroundColor/BackgroundImageSource/
+		// SemanticProperties.* mapper redirects skip only genuine no-ops.
+		Color _lastMappedBackgroundColor;
+		ImageSource _lastMappedBackgroundImageSource;
+		string _lastMappedSemanticDescription;
+		string _lastMappedSemanticHint;
+		SemanticHeadingLevel _lastMappedSemanticHeadingLevel;
+
 		static VisualElement() => RemapIfNeeded();
 
 		internal static new void RemapIfNeeded()
@@ -40,6 +50,15 @@ namespace Microsoft.Maui.Controls
 			viewMapper.ReplaceMapping<IView, IViewHandler>(SemanticProperties.HintProperty.PropertyName, MapSemanticPropertiesHintProperty);
 			viewMapper.ReplaceMapping<IView, IViewHandler>(SemanticProperties.HeadingLevelProperty.PropertyName, MapSemanticPropertiesHeadingLevelProperty);
 
+			// Record, on the element itself, the exact BackgroundColor/BackgroundImageSource and
+			// SemanticProperties.* values that were current the last time the canonical `Background`/
+			// `Semantics` mapping actually ran (through any path - initial connect, reconnect, or an
+			// explicit `UpdateValue` call). The redirects above compare against these snapshots so they
+			// only skip an invocation that is a genuine no-op, never one that would apply a value that
+			// hasn't been pushed yet. See VisualElementMapperTests for coverage of that invariant.
+			viewMapper.AppendToMapping<VisualElement, IViewHandler>(nameof(IView.Background), RecordBackgroundMapped);
+			viewMapper.AppendToMapping<VisualElement, IViewHandler>(nameof(IView.Semantics), RecordSemanticsMapped);
+
 			viewMapper.AppendToMapping<VisualElement, IViewHandler>(nameof(IViewHandler.ContainerView), MapContainerView);
 
 			commandMapper.ModifyMapping<VisualElement, IViewHandler>(nameof(IView.Focus), MapFocus);
@@ -52,29 +71,47 @@ namespace Microsoft.Maui.Controls
 			handler.UpdateValue(nameof(Background));
 
 		// `nameof(BackgroundColor)`/`nameof(Page.BackgroundImageSource)` are appended (by RemapForControls) after
-		// the Core `nameof(IView.Background)` key in `ViewHandler.ViewMapper`, so during the single bulk
-		// `UpdateProperties` pass that runs on initial connect (and on handler reuse/reconnect - see
-		// `IsMappingProperties`) the canonical `Background` mapping already reads the current composite
-		// BackgroundColor/BackgroundImageSource/Background value later in the very same pass, making this
-		// redirect redundant. We skip it only while that bulk pass is in flight, so any *dynamic* update that
-		// happens once the handler is fully connected still runs through `MapBackgroundColor`/
-		// `MapBackgroundImageSource` normally. This relies on `Background` never being reordered ahead of these
-		// keys and on no handler mutating `BackgroundColor`/`BackgroundImageSource` from within its own
-		// `ConnectHandler` or from a mapper that runs later in the same pass; both invariants are covered by
-		// VisualElementMapperTests.
+		// the Core `nameof(IView.Background)` key in `ViewHandler.ViewMapper`, so whenever the canonical
+		// `Background` mapping has *already* run with the current BackgroundColor/BackgroundImageSource value
+		// (recorded by `RecordBackgroundMapped`), re-running it here would be a pure no-op. We only skip in
+		// that exact case - comparing the live property value against the snapshot taken the last time
+		// `Background` was actually mapped - so this is safe regardless of connect/reconnect/dynamic-update
+		// timing: any call (including an explicit `UpdateValue` from `ConnectHandler` or from another mapper
+		// that runs later in the same pass) whose value hasn't been applied yet still goes through normally.
+		// See VisualElementMapperTests for coverage of this invariant.
 		static void MapBackgroundColorForControls(IViewHandler handler, IView view)
 		{
-			if (!handler.IsMappingProperties())
+			if (view is not VisualElement element || element.BackgroundColor != element._lastMappedBackgroundColor)
 			{
 				MapBackgroundColor(handler, view);
 			}
 		}
 
+		// `BackgroundImageSource` is only ever a real, settable property on `Page`, but this key is registered
+		// on the shared `ViewHandler.ViewMapper` used by every view type, so this redirect is invoked for
+		// non-`Page` views too. For those, there is nothing to (re-)apply, so we never invoke the redirect;
+		// for `Page`, apply only when the value differs from the snapshot taken the last time `Background`
+		// was actually mapped, for the same reason as `MapBackgroundColorForControls` above.
 		static void MapBackgroundImageSourceForControls(IViewHandler handler, IView view)
 		{
-			if (!handler.IsMappingProperties())
+			if (view is Page page && page.BackgroundImageSource != page._lastMappedBackgroundImageSource)
 			{
 				MapBackgroundImageSource(handler, view);
+			}
+		}
+
+		// Snapshots the BackgroundColor/BackgroundImageSource values that were just used to compute the
+		// composite `Background` that was mapped, so `MapBackgroundColorForControls`/
+		// `MapBackgroundImageSourceForControls` can tell a genuine no-op apart from a value that has changed
+		// since. Appended to the `Background` key itself, this runs every time that key's mapping executes,
+		// through any path (bulk connect/reconnect pass or an explicit `UpdateValue(nameof(Background))`).
+		static void RecordBackgroundMapped(IViewHandler handler, VisualElement element)
+		{
+			element._lastMappedBackgroundColor = element.BackgroundColor;
+
+			if (element is Page page)
+			{
+				page._lastMappedBackgroundImageSource = page.BackgroundImageSource;
 			}
 		}
 
@@ -88,16 +125,30 @@ namespace Microsoft.Maui.Controls
 			UpdateSemanticsFromMapper(handler, element);
 
 		// Same reasoning as the background guard above: the three `SemanticProperties` keys are appended
-		// after the Core `nameof(IView.Semantics)` key, so `MapSemantics` already reads the current composite
-		// Semantics value later in the same bulk `UpdateProperties` pass (initial connect or reconnect). We use
-		// `IsMappingProperties` (rather than `IsConnectingHandler`) so the same de-duplication also applies to
-		// handler reuse (e.g. CollectionView/CarouselView cell recycling), not only to the very first connect.
+		// after the Core `nameof(IView.Semantics)` key, so we compare the live SemanticProperties.* values
+		// against the snapshot taken the last time `Semantics` was actually mapped (recorded by
+		// `RecordSemanticsMapped`) and only skip when nothing has changed since. Any explicit `UpdateValue`
+		// call - from `ConnectHandler`, from a later mapper in the same pass, or from a dynamic property
+		// change - whose value hasn't been applied yet still runs normally.
 		static void UpdateSemanticsFromMapper(IViewHandler handler, IView element)
 		{
-			if (!handler.IsMappingProperties())
+			if (element is not VisualElement ve ||
+				SemanticProperties.GetDescription(ve) != ve._lastMappedSemanticDescription ||
+				SemanticProperties.GetHint(ve) != ve._lastMappedSemanticHint ||
+				SemanticProperties.GetHeadingLevel(ve) != ve._lastMappedSemanticHeadingLevel)
 			{
 				(element as VisualElement)?.UpdateSemanticsFromMapper();
 			}
+		}
+
+		// See RecordBackgroundMapped: runs every time the `Semantics` key's mapping executes, through any
+		// path, so the SemanticProperties.* redirects above can tell a genuine no-op apart from a value that
+		// has changed since.
+		static void RecordSemanticsMapped(IViewHandler handler, VisualElement element)
+		{
+			element._lastMappedSemanticDescription = SemanticProperties.GetDescription(element);
+			element._lastMappedSemanticHint = SemanticProperties.GetHint(element);
+			element._lastMappedSemanticHeadingLevel = SemanticProperties.GetHeadingLevel(element);
 		}
 
 		void UpdateSemanticsFromMapper()

--- a/src/Controls/src/Core/VisualElement/VisualElement.Mapper.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.Mapper.cs
@@ -34,8 +34,8 @@ namespace Microsoft.Maui.Controls
 			viewMapper.ReplaceMapping<IView, IViewHandler>(PlatformConfiguration.WindowsSpecific.VisualElement.AccessKeyProperty.PropertyName, MapAccessKey);
 			viewMapper.ReplaceMapping<IView, IViewHandler>(PlatformConfiguration.WindowsSpecific.VisualElement.AccessKeyVerticalOffsetProperty.PropertyName, MapAccessKeyVerticalOffset);
 #endif
-			viewMapper.ReplaceMapping<IView, IViewHandler>(nameof(BackgroundColor), MapBackgroundColor);
-			viewMapper.ReplaceMapping<IView, IViewHandler>(nameof(Page.BackgroundImageSource), MapBackgroundImageSource);
+			viewMapper.ReplaceMapping<IView, IViewHandler>(nameof(BackgroundColor), MapBackgroundColorForControls);
+			viewMapper.ReplaceMapping<IView, IViewHandler>(nameof(Page.BackgroundImageSource), MapBackgroundImageSourceForControls);
 			viewMapper.ReplaceMapping<IView, IViewHandler>(SemanticProperties.DescriptionProperty.PropertyName, MapSemanticPropertiesDescriptionProperty);
 			viewMapper.ReplaceMapping<IView, IViewHandler>(SemanticProperties.HintProperty.PropertyName, MapSemanticPropertiesHintProperty);
 			viewMapper.ReplaceMapping<IView, IViewHandler>(SemanticProperties.HeadingLevelProperty.PropertyName, MapSemanticPropertiesHeadingLevelProperty);
@@ -51,14 +51,38 @@ namespace Microsoft.Maui.Controls
 		public static void MapBackgroundImageSource(IViewHandler handler, IView view) =>
 			handler.UpdateValue(nameof(Background));
 
+		static void MapBackgroundColorForControls(IViewHandler handler, IView view)
+		{
+			if (!handler.IsConnectingHandler())
+			{
+				MapBackgroundColor(handler, view);
+			}
+		}
+
+		static void MapBackgroundImageSourceForControls(IViewHandler handler, IView view)
+		{
+			if (!handler.IsConnectingHandler())
+			{
+				MapBackgroundImageSource(handler, view);
+			}
+		}
+
 		static void MapSemanticPropertiesHeadingLevelProperty(IViewHandler handler, IView element) =>
-			(element as VisualElement)?.UpdateSemanticsFromMapper();
+			UpdateSemanticsFromMapper(handler, element);
 
 		static void MapSemanticPropertiesHintProperty(IViewHandler handler, IView element) =>
-			(element as VisualElement)?.UpdateSemanticsFromMapper();
+			UpdateSemanticsFromMapper(handler, element);
 
 		static void MapSemanticPropertiesDescriptionProperty(IViewHandler handler, IView element) =>
-			(element as VisualElement)?.UpdateSemanticsFromMapper();
+			UpdateSemanticsFromMapper(handler, element);
+
+		static void UpdateSemanticsFromMapper(IViewHandler handler, IView element)
+		{
+			if (!handler.IsConnectingHandler())
+			{
+				(element as VisualElement)?.UpdateSemanticsFromMapper();
+			}
+		}
 
 		void UpdateSemanticsFromMapper()
 		{

--- a/src/Controls/src/Core/VisualElement/VisualElement.Mapper.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.Mapper.cs
@@ -1,6 +1,5 @@
 #nullable disable
 using System;
-using System.Runtime.CompilerServices;
 using Microsoft.Maui.Controls.Compatibility;
 using Microsoft.Maui.Handlers;
 
@@ -35,24 +34,18 @@ namespace Microsoft.Maui.Controls
 			viewMapper.ReplaceMapping<IView, IViewHandler>(PlatformConfiguration.WindowsSpecific.VisualElement.AccessKeyProperty.PropertyName, MapAccessKey);
 			viewMapper.ReplaceMapping<IView, IViewHandler>(PlatformConfiguration.WindowsSpecific.VisualElement.AccessKeyVerticalOffsetProperty.PropertyName, MapAccessKeyVerticalOffset);
 #endif
+			// The five keys below are pure redirects: they re-dispatch into the canonical
+			// `Background`/`Semantics` key, which recomputes the very same composite value they contribute
+			// to. Because they are registered here - after the Core `Background`/`Semantics` keys already
+			// present on ViewHandler.ViewMapper - a bulk `UpdateProperties` pass always maps the canonical
+			// key first, making each redirect's own turn in that pass provably redundant. The wrappers skip
+			// exactly that one turn (see `IsRedundantBulkPassRedirect`) and nothing else; the canonical
+			// mapping itself is left untouched, so a derived handler is free to own/override it.
 			viewMapper.ReplaceMapping<IView, IViewHandler>(nameof(BackgroundColor), MapBackgroundColorForControls);
 			viewMapper.ReplaceMapping<IView, IViewHandler>(nameof(Page.BackgroundImageSource), MapBackgroundImageSourceForControls);
 			viewMapper.ReplaceMapping<IView, IViewHandler>(SemanticProperties.DescriptionProperty.PropertyName, MapSemanticPropertiesDescriptionProperty);
 			viewMapper.ReplaceMapping<IView, IViewHandler>(SemanticProperties.HintProperty.PropertyName, MapSemanticPropertiesHintProperty);
 			viewMapper.ReplaceMapping<IView, IViewHandler>(SemanticProperties.HeadingLevelProperty.PropertyName, MapSemanticPropertiesHeadingLevelProperty);
-
-			// Record, on the handler, that the canonical `Background`/`Semantics` mapping has just run so
-			// the redirects below can skip only the single, immediately-following redundant invocation of
-			// each key within *this same bulk `UpdateProperties` pass* - identified via
-			// PropertyMapperPassScope, not merely "the next time this key happens to run". This never
-			// suppresses an explicit/reentrant call, a same-value call, a call that happens before any
-			// `Background`/`Semantics` mapping has run at all, or a call triggered by `Background`/
-			// `Semantics` running *outside* of a bulk pass (e.g. a platform mapper that reacts to some
-			// other property by directly calling `Handler.UpdateValue(nameof(Background))` /
-			// `nameof(Semantics))` well after connect - see PickerHandler.Windows.MapTitle for a real
-			// example of this shape). See VisualElementMapperTests for coverage of this invariant.
-			viewMapper.AppendToMapping<IView, IViewHandler>(nameof(IView.Background), RecordBackgroundMapped);
-			viewMapper.AppendToMapping<IView, IViewHandler>(nameof(IView.Semantics), RecordSemanticsMapped);
 
 			viewMapper.AppendToMapping<VisualElement, IViewHandler>(nameof(IViewHandler.ContainerView), MapContainerView);
 
@@ -65,213 +58,74 @@ namespace Microsoft.Maui.Controls
 		public static void MapBackgroundImageSource(IViewHandler handler, IView view) =>
 			handler.UpdateValue(nameof(Background));
 
-		// `nameof(BackgroundColor)`/`nameof(Page.BackgroundImageSource)` are appended (by RemapForControls) after
-		// the Core `nameof(IView.Background)` key in `ViewHandler.ViewMapper`, so during the single bulk
-		// `UpdateProperties` pass that runs on initial connect or reconnect, the canonical `Background`
-		// mapping already reads the current composite BackgroundColor/BackgroundImageSource/Background
-		// value later in that very same pass, making this redirect redundant. `RecordBackgroundMapped`
-		// marks, on the handler, that a pending redundant invocation of this key exists for the *specific*
-		// bulk pass that just ran `Background`'s mapping (identified by `PropertyMapperPassScope`'s pass
-		// id); this method consumes that one pending mark only if it is still the current pass (skipping
-		// only that single invocation) and applies normally for every other call - whether it happens
-		// before `Background` has ever been mapped (e.g. from `ConnectHandler`), after the pending mark has
-		// already been consumed once (e.g. a mapper that runs later in the same pass and changes the
-		// value), with an unchanged value, or after the pass that armed the mark has since ended (whether
-		// normally or because a mapper threw) - a stale mark from a pass that is no longer current can never
-		// be consumed. See VisualElementMapperTests for coverage of this invariant.
+		// `nameof(BackgroundColor)`/`nameof(Page.BackgroundImageSource)` are appended (by RemapForControls)
+		// after the Core `nameof(IView.Background)` key, so during a bulk `UpdateProperties` pass - initial
+		// connect, reconnect/handler reuse, or any other full remap - the canonical `Background` mapping
+		// has already read the current composite BackgroundColor/BackgroundImageSource/Background value by
+		// the time this key's own turn comes up, making that one turn a pure no-op.
+		//
+		// `IsRedundantBulkPassRedirect` skips *only* that turn: it returns true exclusively when the
+		// innermost bulk pass on this thread belongs to this handler, is currently executing this very key's
+		// step, and already executed the `Background` key earlier in the same pass. Crucially it asks
+		// nothing about *which* mapping `Background` resolves to, so it works identically when a derived
+		// handler owns/overrides that key (ButtonHandler, PageHandler, LabelHandler, ...) - which is exactly
+		// what re-dispatching through `MapBackgroundColor` would have invoked again anyway.
+		//
+		// Every other invocation still applies normally: a call made before `Background` has ever been
+		// mapped (e.g. from `ConnectHandler`), a re-entrant call raised by a mapper that runs later in the
+		// same pass and legitimately changes the value, an explicit `Handler.UpdateValue(...)` with an
+		// unchanged value, a call arriving while a nested pass for another handler is on top, and any call
+		// made outside of a bulk pass entirely. See VisualElementMapperTests for coverage of this invariant.
 		static void MapBackgroundColorForControls(IViewHandler handler, IView view)
 		{
-			var state = GetMappingPassState(handler);
-			var currentPassId = PropertyMapperPassScope.GetCurrentPassId(handler);
+			if (PropertyMapperPassScope.IsRedundantBulkPassRedirect(handler, nameof(BackgroundColor), nameof(IView.Background)))
+			{
+				return;
+			}
 
-			if (state.BackgroundColorPendingSkipPassId != 0 && state.BackgroundColorPendingSkipPassId == currentPassId)
-			{
-				state.BackgroundColorPendingSkipPassId = 0;
-			}
-			else
-			{
-				state.BackgroundColorPendingSkipPassId = 0;
-				ApplyBackgroundRedirect(state, handler, view, MapBackgroundColor);
-			}
+			MapBackgroundColor(handler, view);
 		}
 
 		// Same reasoning as `MapBackgroundColorForControls` above. This key is registered on the shared
 		// `ViewHandler.ViewMapper` used by every view type (even though `BackgroundImageSource` is only a
-		// real, settable property on `Page`), but that's harmless here: for non-`Page` views the pending
-		// mark set by `RecordBackgroundMapped` is still consumed on the natural bulk-pass turn, so no extra
-		// work is ever done for them during a normal pass.
+		// real, settable property on `Page`), but that's harmless: for non-`Page` views the redirect's
+		// bulk-pass turn is skipped just the same, so no extra work is ever done for them during a pass.
 		static void MapBackgroundImageSourceForControls(IViewHandler handler, IView view)
 		{
-			var state = GetMappingPassState(handler);
-			var currentPassId = PropertyMapperPassScope.GetCurrentPassId(handler);
-
-			if (state.BackgroundImageSourcePendingSkipPassId != 0 && state.BackgroundImageSourcePendingSkipPassId == currentPassId)
-			{
-				state.BackgroundImageSourcePendingSkipPassId = 0;
-			}
-			else
-			{
-				state.BackgroundImageSourcePendingSkipPassId = 0;
-				ApplyBackgroundRedirect(state, handler, view, MapBackgroundImageSource);
-			}
-		}
-
-		// Applying either background redirect re-invokes `nameof(Background)`'s own mapping (through
-		// `MapBackgroundColor`/`MapBackgroundImageSource`), which synchronously re-triggers
-		// `RecordBackgroundMapped`. That particular execution of `Background`'s mapping is a leaf, one-off
-		// call made *by* a redirect, not a step of the top-level bulk-pass enumeration, so it must not
-		// re-arm the pending marks (there is no separate, later redirect turn guaranteed to follow it in
-		// this call chain) - `IsApplyingBackgroundRedirect` flags that to `RecordBackgroundMapped` below.
-		static void ApplyBackgroundRedirect(MappingPassState state, IViewHandler handler, IView view, Action<IViewHandler, IView> map)
-		{
-			state.IsApplyingBackgroundRedirect = true;
-			try
-			{
-				map(handler, view);
-			}
-			finally
-			{
-				state.IsApplyingBackgroundRedirect = false;
-			}
-		}
-
-		// Marks, on the handler, that the very next invocation of `MapBackgroundColorForControls`/
-		// `MapBackgroundImageSourceForControls` (whichever comes first for each) is a redundant no-op for
-		// *this specific* bulk pass - `Background` was just (re)computed from the current
-		// BackgroundColor/BackgroundImageSource, so immediately re-running either redirect within the same
-		// pass would just push the same value again. Appended to the `Background` key itself, this runs
-		// every time that key's mapping executes, through any path - except: (1) when it is itself a leaf
-		// call made by one of the redirects above (see `ApplyBackgroundRedirect`), which must not arm a
-		// pending mark for anything, and (2) when `Background` is being mapped *outside* of a bulk
-		// `UpdateProperties` pass entirely (`PropertyMapperPassScope.GetCurrentPassId` returns 0) - e.g. a
-		// platform mapper reacting to some unrelated property by directly calling
-		// `Handler.UpdateValue(nameof(Background))` well after connect. In that case there is no guarantee
-		// whatsoever that either redirect's turn is still coming, so nothing may be armed.
-		static void RecordBackgroundMapped(IViewHandler handler, IView view)
-		{
-			var state = GetMappingPassState(handler);
-
-			if (state.IsApplyingBackgroundRedirect)
+			if (PropertyMapperPassScope.IsRedundantBulkPassRedirect(handler, nameof(Page.BackgroundImageSource), nameof(IView.Background)))
 			{
 				return;
 			}
 
-			var passId = PropertyMapperPassScope.GetCurrentPassId(handler);
-			if (passId == 0)
+			MapBackgroundImageSource(handler, view);
+		}
+
+		// Same reasoning as `MapBackgroundColorForControls` above, but redirecting into the canonical
+		// `nameof(IView.Semantics)` key instead. Note that `IView.Semantics` recomputes the composite value
+		// on read (see `VisualElement.UpdateSemantics`), so the canonical mapping running earlier in the
+		// pass has already observed the current Description/Hint/HeadingLevel.
+		static void MapSemanticPropertiesDescriptionProperty(IViewHandler handler, IView element) =>
+			MapSemanticPropertyForControls(handler, element, SemanticProperties.DescriptionProperty.PropertyName);
+
+		// Same reasoning as `MapSemanticPropertiesDescriptionProperty` above.
+		static void MapSemanticPropertiesHintProperty(IViewHandler handler, IView element) =>
+			MapSemanticPropertyForControls(handler, element, SemanticProperties.HintProperty.PropertyName);
+
+		// Same reasoning as `MapSemanticPropertiesDescriptionProperty` above.
+		static void MapSemanticPropertiesHeadingLevelProperty(IViewHandler handler, IView element) =>
+			MapSemanticPropertyForControls(handler, element, SemanticProperties.HeadingLevelProperty.PropertyName);
+
+		static void MapSemanticPropertyForControls(IViewHandler handler, IView element, string redirectKey)
+		{
+			if (PropertyMapperPassScope.IsRedundantBulkPassRedirect(handler, redirectKey, nameof(IView.Semantics)))
 			{
 				return;
 			}
 
-			state.BackgroundColorPendingSkipPassId = passId;
-			state.BackgroundImageSourcePendingSkipPassId = passId;
-		}
-
-		// Same reasoning as `MapBackgroundColorForControls` above, but for the `SemanticProperties.Description`
-		// redirect.
-		static void MapSemanticPropertiesDescriptionProperty(IViewHandler handler, IView element)
-		{
-			var state = GetMappingPassState(handler);
-			var currentPassId = PropertyMapperPassScope.GetCurrentPassId(handler);
-
-			if (state.SemanticDescriptionPendingSkipPassId != 0 && state.SemanticDescriptionPendingSkipPassId == currentPassId)
+			if (element is VisualElement ve)
 			{
-				state.SemanticDescriptionPendingSkipPassId = 0;
+				ve.UpdateSemanticsFromMapper();
 			}
-			else
-			{
-				state.SemanticDescriptionPendingSkipPassId = 0;
-				if (element is VisualElement ve)
-				{
-					ApplySemanticsRedirect(state, ve);
-				}
-			}
-		}
-
-		// Same reasoning as `MapBackgroundColorForControls` above, but for the `SemanticProperties.Hint`
-		// redirect.
-		static void MapSemanticPropertiesHintProperty(IViewHandler handler, IView element)
-		{
-			var state = GetMappingPassState(handler);
-			var currentPassId = PropertyMapperPassScope.GetCurrentPassId(handler);
-
-			if (state.SemanticHintPendingSkipPassId != 0 && state.SemanticHintPendingSkipPassId == currentPassId)
-			{
-				state.SemanticHintPendingSkipPassId = 0;
-			}
-			else
-			{
-				state.SemanticHintPendingSkipPassId = 0;
-				if (element is VisualElement ve)
-				{
-					ApplySemanticsRedirect(state, ve);
-				}
-			}
-		}
-
-		// Same reasoning as `MapBackgroundColorForControls` above, but for the
-		// `SemanticProperties.HeadingLevel` redirect.
-		static void MapSemanticPropertiesHeadingLevelProperty(IViewHandler handler, IView element)
-		{
-			var state = GetMappingPassState(handler);
-			var currentPassId = PropertyMapperPassScope.GetCurrentPassId(handler);
-
-			if (state.SemanticHeadingLevelPendingSkipPassId != 0 && state.SemanticHeadingLevelPendingSkipPassId == currentPassId)
-			{
-				state.SemanticHeadingLevelPendingSkipPassId = 0;
-			}
-			else
-			{
-				state.SemanticHeadingLevelPendingSkipPassId = 0;
-				if (element is VisualElement ve)
-				{
-					ApplySemanticsRedirect(state, ve);
-				}
-			}
-		}
-
-		// See `ApplyBackgroundRedirect`: applying a semantics redirect re-invokes `nameof(Semantics)`'s own
-		// mapping, synchronously re-triggering `RecordSemanticsMapped` for a leaf, one-off call that must
-		// not re-arm the pending marks.
-		static void ApplySemanticsRedirect(MappingPassState state, VisualElement element)
-		{
-			state.IsApplyingSemanticsRedirect = true;
-			try
-			{
-				element.UpdateSemanticsFromMapper();
-			}
-			finally
-			{
-				state.IsApplyingSemanticsRedirect = false;
-			}
-		}
-
-		// See `RecordBackgroundMapped`: marks, on the handler, that the very next invocation of each of the
-		// three `SemanticProperties.*` redirects above is a redundant no-op for *this specific* bulk pass,
-		// since `Semantics` was just (re)computed from the current Description/Hint/HeadingLevel values -
-		// except when it is itself a leaf call made by one of those redirects (see
-		// `ApplySemanticsRedirect`), or when `Semantics` is being mapped outside of any bulk
-		// `UpdateProperties` pass entirely (e.g. `PickerHandler.Windows.MapTitle`, which reacts to `Title`
-		// changing - possibly well after connect - by directly calling
-		// `Handler.UpdateValue(nameof(IView.Semantics))`; that call must never be allowed to suppress a
-		// later, unrelated `SemanticProperties.*` update).
-		static void RecordSemanticsMapped(IViewHandler handler, IView view)
-		{
-			var state = GetMappingPassState(handler);
-
-			if (state.IsApplyingSemanticsRedirect)
-			{
-				return;
-			}
-
-			var passId = PropertyMapperPassScope.GetCurrentPassId(handler);
-			if (passId == 0)
-			{
-				return;
-			}
-
-			state.SemanticDescriptionPendingSkipPassId = passId;
-			state.SemanticHintPendingSkipPassId = passId;
-			state.SemanticHeadingLevelPendingSkipPassId = passId;
 		}
 
 		void UpdateSemanticsFromMapper()
@@ -289,35 +143,6 @@ namespace Microsoft.Maui.Controls
 				return;
 
 			view.MapFocus(fr, baseMethod is null ? null : () => baseMethod?.Invoke(handler, view, args));
-		}
-
-		// Per-handler (not per-VisualElement) tracking of which `Background`/`Semantics`-derived redirect
-		// keys still have a pending, provably-redundant invocation outstanding for the *specific* bulk
-		// mapping pass (see `Microsoft.Maui.PropertyMapperPassScope`) that most recently (re-)mapped
-		// `Background`/`Semantics`. Keyed on the handler - via a ConditionalWeakTable so no manual
-		// cleanup/disconnect handling is needed - because de-duplication must be scoped to "has this
-		// specific handler's *current* bulk pass already produced this key's natural, redundant call", not
-		// to any state that outlives a single pass or that lives on the element.
-		static readonly ConditionalWeakTable<IViewHandler, MappingPassState> s_mappingPassState = new();
-
-		static MappingPassState GetMappingPassState(IViewHandler handler) =>
-			s_mappingPassState.GetValue(handler, static _ => new MappingPassState());
-
-		sealed class MappingPassState
-		{
-			// Each field is 0 ("no pending skip") or the id (from PropertyMapperPassScope) of the bulk
-			// pass that armed it. A pending skip is honored only while PropertyMapperPassScope currently
-			// reports that exact same pass id as active for this handler - once the pass that armed a
-			// field has ended (normally, or because a mapper threw and PropertyMapper.UpdateProperties'
-			// finally ran), that id can never again match, so the field is permanently inert even if
-			// never explicitly reset to 0.
-			public int BackgroundColorPendingSkipPassId;
-			public int BackgroundImageSourcePendingSkipPassId;
-			public int SemanticDescriptionPendingSkipPassId;
-			public int SemanticHintPendingSkipPassId;
-			public int SemanticHeadingLevelPendingSkipPassId;
-			public bool IsApplyingBackgroundRedirect;
-			public bool IsApplyingSemanticsRedirect;
 		}
 	}
 }

--- a/src/Controls/src/Core/VisualElement/VisualElement.Mapper.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.Mapper.cs
@@ -51,9 +51,20 @@ namespace Microsoft.Maui.Controls
 		public static void MapBackgroundImageSource(IViewHandler handler, IView view) =>
 			handler.UpdateValue(nameof(Background));
 
+		// `nameof(BackgroundColor)`/`nameof(Page.BackgroundImageSource)` are appended (by RemapForControls) after
+		// the Core `nameof(IView.Background)` key in `ViewHandler.ViewMapper`, so during the single bulk
+		// `UpdateProperties` pass that runs on initial connect (and on handler reuse/reconnect - see
+		// `IsMappingProperties`) the canonical `Background` mapping already reads the current composite
+		// BackgroundColor/BackgroundImageSource/Background value later in the very same pass, making this
+		// redirect redundant. We skip it only while that bulk pass is in flight, so any *dynamic* update that
+		// happens once the handler is fully connected still runs through `MapBackgroundColor`/
+		// `MapBackgroundImageSource` normally. This relies on `Background` never being reordered ahead of these
+		// keys and on no handler mutating `BackgroundColor`/`BackgroundImageSource` from within its own
+		// `ConnectHandler` or from a mapper that runs later in the same pass; both invariants are covered by
+		// VisualElementMapperTests.
 		static void MapBackgroundColorForControls(IViewHandler handler, IView view)
 		{
-			if (!handler.IsConnectingHandler())
+			if (!handler.IsMappingProperties())
 			{
 				MapBackgroundColor(handler, view);
 			}
@@ -61,7 +72,7 @@ namespace Microsoft.Maui.Controls
 
 		static void MapBackgroundImageSourceForControls(IViewHandler handler, IView view)
 		{
-			if (!handler.IsConnectingHandler())
+			if (!handler.IsMappingProperties())
 			{
 				MapBackgroundImageSource(handler, view);
 			}
@@ -76,9 +87,14 @@ namespace Microsoft.Maui.Controls
 		static void MapSemanticPropertiesDescriptionProperty(IViewHandler handler, IView element) =>
 			UpdateSemanticsFromMapper(handler, element);
 
+		// Same reasoning as the background guard above: the three `SemanticProperties` keys are appended
+		// after the Core `nameof(IView.Semantics)` key, so `MapSemantics` already reads the current composite
+		// Semantics value later in the same bulk `UpdateProperties` pass (initial connect or reconnect). We use
+		// `IsMappingProperties` (rather than `IsConnectingHandler`) so the same de-duplication also applies to
+		// handler reuse (e.g. CollectionView/CarouselView cell recycling), not only to the very first connect.
 		static void UpdateSemanticsFromMapper(IViewHandler handler, IView element)
 		{
-			if (!handler.IsConnectingHandler())
+			if (!handler.IsMappingProperties())
 			{
 				(element as VisualElement)?.UpdateSemanticsFromMapper();
 			}

--- a/src/Controls/src/Core/VisualElement/VisualElement.Mapper.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.Mapper.cs
@@ -43,9 +43,14 @@ namespace Microsoft.Maui.Controls
 
 			// Record, on the handler, that the canonical `Background`/`Semantics` mapping has just run so
 			// the redirects below can skip only the single, immediately-following redundant invocation of
-			// each key within *this same* bulk mapping pass - never an explicit/reentrant call, a
-			// same-value call, or one that happens before any `Background`/`Semantics` mapping has run at
-			// all. See VisualElementMapperTests for coverage of this invariant.
+			// each key within *this same bulk `UpdateProperties` pass* - identified via
+			// PropertyMapperPassScope, not merely "the next time this key happens to run". This never
+			// suppresses an explicit/reentrant call, a same-value call, a call that happens before any
+			// `Background`/`Semantics` mapping has run at all, or a call triggered by `Background`/
+			// `Semantics` running *outside* of a bulk pass (e.g. a platform mapper that reacts to some
+			// other property by directly calling `Handler.UpdateValue(nameof(Background))` /
+			// `nameof(Semantics))` well after connect - see PickerHandler.Windows.MapTitle for a real
+			// example of this shape). See VisualElementMapperTests for coverage of this invariant.
 			viewMapper.AppendToMapping<IView, IViewHandler>(nameof(IView.Background), RecordBackgroundMapped);
 			viewMapper.AppendToMapping<IView, IViewHandler>(nameof(IView.Semantics), RecordSemanticsMapped);
 
@@ -65,22 +70,27 @@ namespace Microsoft.Maui.Controls
 		// `UpdateProperties` pass that runs on initial connect or reconnect, the canonical `Background`
 		// mapping already reads the current composite BackgroundColor/BackgroundImageSource/Background
 		// value later in that very same pass, making this redirect redundant. `RecordBackgroundMapped`
-		// marks, on the handler, that a pending redundant invocation of this key exists for the pass that
-		// just ran `Background`'s mapping; this method consumes that one pending mark (skipping only that
-		// single invocation) and applies normally for every other call - whether it happens before
-		// `Background` has ever been mapped (e.g. from `ConnectHandler`), after the pending mark has
+		// marks, on the handler, that a pending redundant invocation of this key exists for the *specific*
+		// bulk pass that just ran `Background`'s mapping (identified by `PropertyMapperPassScope`'s pass
+		// id); this method consumes that one pending mark only if it is still the current pass (skipping
+		// only that single invocation) and applies normally for every other call - whether it happens
+		// before `Background` has ever been mapped (e.g. from `ConnectHandler`), after the pending mark has
 		// already been consumed once (e.g. a mapper that runs later in the same pass and changes the
-		// value), or with an unchanged value. See VisualElementMapperTests for coverage of this invariant.
+		// value), with an unchanged value, or after the pass that armed the mark has since ended (whether
+		// normally or because a mapper threw) - a stale mark from a pass that is no longer current can never
+		// be consumed. See VisualElementMapperTests for coverage of this invariant.
 		static void MapBackgroundColorForControls(IViewHandler handler, IView view)
 		{
 			var state = GetMappingPassState(handler);
+			var currentPassId = PropertyMapperPassScope.GetCurrentPassId(handler);
 
-			if (state.BackgroundColorPendingSkip)
+			if (state.BackgroundColorPendingSkipPassId != 0 && state.BackgroundColorPendingSkipPassId == currentPassId)
 			{
-				state.BackgroundColorPendingSkip = false;
+				state.BackgroundColorPendingSkipPassId = 0;
 			}
 			else
 			{
+				state.BackgroundColorPendingSkipPassId = 0;
 				ApplyBackgroundRedirect(state, handler, view, MapBackgroundColor);
 			}
 		}
@@ -93,13 +103,15 @@ namespace Microsoft.Maui.Controls
 		static void MapBackgroundImageSourceForControls(IViewHandler handler, IView view)
 		{
 			var state = GetMappingPassState(handler);
+			var currentPassId = PropertyMapperPassScope.GetCurrentPassId(handler);
 
-			if (state.BackgroundImageSourcePendingSkip)
+			if (state.BackgroundImageSourcePendingSkipPassId != 0 && state.BackgroundImageSourcePendingSkipPassId == currentPassId)
 			{
-				state.BackgroundImageSourcePendingSkip = false;
+				state.BackgroundImageSourcePendingSkipPassId = 0;
 			}
 			else
 			{
+				state.BackgroundImageSourcePendingSkipPassId = 0;
 				ApplyBackgroundRedirect(state, handler, view, MapBackgroundImageSource);
 			}
 		}
@@ -124,13 +136,17 @@ namespace Microsoft.Maui.Controls
 		}
 
 		// Marks, on the handler, that the very next invocation of `MapBackgroundColorForControls`/
-		// `MapBackgroundImageSourceForControls` (whichever comes first for each) is a redundant no-op -
-		// `Background` was just (re)computed from the current BackgroundColor/BackgroundImageSource, so
-		// immediately re-running either redirect within the same pass would just push the same value
-		// again. Appended to the `Background` key itself, this runs every time that key's mapping executes,
-		// through any path (bulk connect/reconnect pass or an explicit `UpdateValue(nameof(Background))`) -
-		// except when it is itself a leaf call made by one of the redirects above (see
-		// `ApplyBackgroundRedirect`), which must not arm a pending mark for anything.
+		// `MapBackgroundImageSourceForControls` (whichever comes first for each) is a redundant no-op for
+		// *this specific* bulk pass - `Background` was just (re)computed from the current
+		// BackgroundColor/BackgroundImageSource, so immediately re-running either redirect within the same
+		// pass would just push the same value again. Appended to the `Background` key itself, this runs
+		// every time that key's mapping executes, through any path - except: (1) when it is itself a leaf
+		// call made by one of the redirects above (see `ApplyBackgroundRedirect`), which must not arm a
+		// pending mark for anything, and (2) when `Background` is being mapped *outside* of a bulk
+		// `UpdateProperties` pass entirely (`PropertyMapperPassScope.GetCurrentPassId` returns 0) - e.g. a
+		// platform mapper reacting to some unrelated property by directly calling
+		// `Handler.UpdateValue(nameof(Background))` well after connect. In that case there is no guarantee
+		// whatsoever that either redirect's turn is still coming, so nothing may be armed.
 		static void RecordBackgroundMapped(IViewHandler handler, IView view)
 		{
 			var state = GetMappingPassState(handler);
@@ -140,8 +156,14 @@ namespace Microsoft.Maui.Controls
 				return;
 			}
 
-			state.BackgroundColorPendingSkip = true;
-			state.BackgroundImageSourcePendingSkip = true;
+			var passId = PropertyMapperPassScope.GetCurrentPassId(handler);
+			if (passId == 0)
+			{
+				return;
+			}
+
+			state.BackgroundColorPendingSkipPassId = passId;
+			state.BackgroundImageSourcePendingSkipPassId = passId;
 		}
 
 		// Same reasoning as `MapBackgroundColorForControls` above, but for the `SemanticProperties.Description`
@@ -149,14 +171,19 @@ namespace Microsoft.Maui.Controls
 		static void MapSemanticPropertiesDescriptionProperty(IViewHandler handler, IView element)
 		{
 			var state = GetMappingPassState(handler);
+			var currentPassId = PropertyMapperPassScope.GetCurrentPassId(handler);
 
-			if (state.SemanticDescriptionPendingSkip)
+			if (state.SemanticDescriptionPendingSkipPassId != 0 && state.SemanticDescriptionPendingSkipPassId == currentPassId)
 			{
-				state.SemanticDescriptionPendingSkip = false;
+				state.SemanticDescriptionPendingSkipPassId = 0;
 			}
-			else if (element is VisualElement ve)
+			else
 			{
-				ApplySemanticsRedirect(state, ve);
+				state.SemanticDescriptionPendingSkipPassId = 0;
+				if (element is VisualElement ve)
+				{
+					ApplySemanticsRedirect(state, ve);
+				}
 			}
 		}
 
@@ -165,14 +192,19 @@ namespace Microsoft.Maui.Controls
 		static void MapSemanticPropertiesHintProperty(IViewHandler handler, IView element)
 		{
 			var state = GetMappingPassState(handler);
+			var currentPassId = PropertyMapperPassScope.GetCurrentPassId(handler);
 
-			if (state.SemanticHintPendingSkip)
+			if (state.SemanticHintPendingSkipPassId != 0 && state.SemanticHintPendingSkipPassId == currentPassId)
 			{
-				state.SemanticHintPendingSkip = false;
+				state.SemanticHintPendingSkipPassId = 0;
 			}
-			else if (element is VisualElement ve)
+			else
 			{
-				ApplySemanticsRedirect(state, ve);
+				state.SemanticHintPendingSkipPassId = 0;
+				if (element is VisualElement ve)
+				{
+					ApplySemanticsRedirect(state, ve);
+				}
 			}
 		}
 
@@ -181,14 +213,19 @@ namespace Microsoft.Maui.Controls
 		static void MapSemanticPropertiesHeadingLevelProperty(IViewHandler handler, IView element)
 		{
 			var state = GetMappingPassState(handler);
+			var currentPassId = PropertyMapperPassScope.GetCurrentPassId(handler);
 
-			if (state.SemanticHeadingLevelPendingSkip)
+			if (state.SemanticHeadingLevelPendingSkipPassId != 0 && state.SemanticHeadingLevelPendingSkipPassId == currentPassId)
 			{
-				state.SemanticHeadingLevelPendingSkip = false;
+				state.SemanticHeadingLevelPendingSkipPassId = 0;
 			}
-			else if (element is VisualElement ve)
+			else
 			{
-				ApplySemanticsRedirect(state, ve);
+				state.SemanticHeadingLevelPendingSkipPassId = 0;
+				if (element is VisualElement ve)
+				{
+					ApplySemanticsRedirect(state, ve);
+				}
 			}
 		}
 
@@ -209,9 +246,14 @@ namespace Microsoft.Maui.Controls
 		}
 
 		// See `RecordBackgroundMapped`: marks, on the handler, that the very next invocation of each of the
-		// three `SemanticProperties.*` redirects above is a redundant no-op, since `Semantics` was just
-		// (re)computed from the current Description/Hint/HeadingLevel values - except when it is itself a
-		// leaf call made by one of those redirects (see `ApplySemanticsRedirect`).
+		// three `SemanticProperties.*` redirects above is a redundant no-op for *this specific* bulk pass,
+		// since `Semantics` was just (re)computed from the current Description/Hint/HeadingLevel values -
+		// except when it is itself a leaf call made by one of those redirects (see
+		// `ApplySemanticsRedirect`), or when `Semantics` is being mapped outside of any bulk
+		// `UpdateProperties` pass entirely (e.g. `PickerHandler.Windows.MapTitle`, which reacts to `Title`
+		// changing - possibly well after connect - by directly calling
+		// `Handler.UpdateValue(nameof(IView.Semantics))`; that call must never be allowed to suppress a
+		// later, unrelated `SemanticProperties.*` update).
 		static void RecordSemanticsMapped(IViewHandler handler, IView view)
 		{
 			var state = GetMappingPassState(handler);
@@ -221,9 +263,15 @@ namespace Microsoft.Maui.Controls
 				return;
 			}
 
-			state.SemanticDescriptionPendingSkip = true;
-			state.SemanticHintPendingSkip = true;
-			state.SemanticHeadingLevelPendingSkip = true;
+			var passId = PropertyMapperPassScope.GetCurrentPassId(handler);
+			if (passId == 0)
+			{
+				return;
+			}
+
+			state.SemanticDescriptionPendingSkipPassId = passId;
+			state.SemanticHintPendingSkipPassId = passId;
+			state.SemanticHeadingLevelPendingSkipPassId = passId;
 		}
 
 		void UpdateSemanticsFromMapper()
@@ -244,11 +292,12 @@ namespace Microsoft.Maui.Controls
 		}
 
 		// Per-handler (not per-VisualElement) tracking of which `Background`/`Semantics`-derived redirect
-		// keys still have a pending, provably-redundant invocation outstanding for the bulk mapping pass
-		// that most recently (re-)mapped `Background`/`Semantics`. Keyed on the handler - via a
-		// ConditionalWeakTable so no manual cleanup/disconnect handling is needed - because de-duplication
-		// must be scoped to "has this specific handler's current pass already produced this key's natural,
-		// redundant call", not to any state that outlives a single pass or that lives on the element.
+		// keys still have a pending, provably-redundant invocation outstanding for the *specific* bulk
+		// mapping pass (see `Microsoft.Maui.PropertyMapperPassScope`) that most recently (re-)mapped
+		// `Background`/`Semantics`. Keyed on the handler - via a ConditionalWeakTable so no manual
+		// cleanup/disconnect handling is needed - because de-duplication must be scoped to "has this
+		// specific handler's *current* bulk pass already produced this key's natural, redundant call", not
+		// to any state that outlives a single pass or that lives on the element.
 		static readonly ConditionalWeakTable<IViewHandler, MappingPassState> s_mappingPassState = new();
 
 		static MappingPassState GetMappingPassState(IViewHandler handler) =>
@@ -256,11 +305,17 @@ namespace Microsoft.Maui.Controls
 
 		sealed class MappingPassState
 		{
-			public bool BackgroundColorPendingSkip;
-			public bool BackgroundImageSourcePendingSkip;
-			public bool SemanticDescriptionPendingSkip;
-			public bool SemanticHintPendingSkip;
-			public bool SemanticHeadingLevelPendingSkip;
+			// Each field is 0 ("no pending skip") or the id (from PropertyMapperPassScope) of the bulk
+			// pass that armed it. A pending skip is honored only while PropertyMapperPassScope currently
+			// reports that exact same pass id as active for this handler - once the pass that armed a
+			// field has ended (normally, or because a mapper threw and PropertyMapper.UpdateProperties'
+			// finally ran), that id can never again match, so the field is permanently inert even if
+			// never explicitly reset to 0.
+			public int BackgroundColorPendingSkipPassId;
+			public int BackgroundImageSourcePendingSkipPassId;
+			public int SemanticDescriptionPendingSkipPassId;
+			public int SemanticHintPendingSkipPassId;
+			public int SemanticHeadingLevelPendingSkipPassId;
 			public bool IsApplyingBackgroundRedirect;
 			public bool IsApplyingSemanticsRedirect;
 		}

--- a/src/Controls/tests/Core.UnitTests/VisualElementMapperTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualElementMapperTests.cs
@@ -843,40 +843,56 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		// While a nested bulk pass for a *different* handler is on top, a redirect update targeting the
-		// outer handler is not that handler's own pass turn and must therefore still be applied.
+		// outer handler is not that handler's own pass turn and must therefore still be applied - and the
+		// outer pass's own redirect turn, which comes later, must still be skipped.
 		[Fact]
 		public void NestedPassForAnotherHandler_DoesNotSuppressOuterHandlersRedirectUpdate()
 		{
 			int outerBackgroundCalls = 0;
+			HandlerStub outerHandler = null;
 
+			// A non-empty mapper: its single key runs as a genuine step of the other handler's nested pass,
+			// and from there issues an explicit redirect update targeting the *outer* handler.
 			var otherCommandMapper = new CommandMapper<IView, IViewHandler>();
 			var otherMapper = new PropertyMapper<IView, IViewHandler>();
 			var otherHandler = new HandlerStub(otherMapper, otherCommandMapper);
+
+			otherMapper.Add("__OuterHandlerRedirectUpdate", (h, v) =>
+			{
+				if (outerHandler is null)
+				{
+					return;
+				}
+
+				// Guards the premise of this test: the other handler's pass really is the innermost one at
+				// this point, so the update below is issued from *inside* it.
+				Assert.Same(otherHandler, Maui.PropertyMapperPassScope.Current?.Handler);
+
+				outerHandler.UpdateValue(nameof(VisualElement.BackgroundColor));
+			});
+
+			// Connects while `outerHandler` is still null, so this pass is a no-op for the assertion below.
 			otherHandler.SetVirtualView(new Button());
 
+			// "__NestedPassForAnotherHandler" is inserted (via the object initializer, before
+			// RemapForControls runs) between Background and the redirect keys RemapForControls appends, so
+			// the nested pass - and the explicit update it issues - happen after Background has had its
+			// turn but before the outer pass reaches its own BackgroundColor turn.
 			var commandMapper = new CommandMapper<IView, IViewHandler>();
 			var mapper = new PropertyMapper<IView, IViewHandler>
 			{
 				[nameof(IView.Background)] = (h, v) => outerBackgroundCalls++,
+				["__NestedPassForAnotherHandler"] = (h, v) => otherMapper.UpdateProperties(otherHandler, otherHandler.VirtualView),
 			};
 			VisualElement.RemapForControls(mapper, commandMapper);
 
-			// Runs after every key RemapForControls appends, so the outer pass has already skipped its own
-			// BackgroundColor turn by the time this runs.
-			mapper.Add("__NestedPassForAnotherHandler", (h, v) =>
-			{
-				otherMapper.UpdateProperties(otherHandler, otherHandler.VirtualView);
+			outerHandler = new HandlerStub(mapper, commandMapper);
+			outerHandler.SetVirtualView(new Button { BackgroundColor = Colors.Red });
 
-				// An explicit redirect update for *our* handler, issued from a step that is not that
-				// redirect key's own turn, must be honored - the nested pass must not have left anything
-				// behind that makes it look skippable.
-				h.UpdateValue(nameof(VisualElement.BackgroundColor));
-			});
-
-			var handlerStub = new HandlerStub(mapper, commandMapper);
-			handlerStub.SetVirtualView(new Button { BackgroundColor = Colors.Red });
-
-			// Once for the canonical Background key, once for the explicit redirect update above.
+			// Once for the canonical Background key, and once for the explicit BackgroundColor update
+			// issued from inside the nested other-handler pass. The outer pass's own BackgroundColor and
+			// BackgroundImageSource turns, which run after the nested pass has been popped, are still
+			// correctly skipped.
 			Assert.Equal(2, outerBackgroundCalls);
 		}
 

--- a/src/Controls/tests/Core.UnitTests/VisualElementMapperTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualElementMapperTests.cs
@@ -1,0 +1,269 @@
+using System.Linq;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Handlers;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	/// <summary>
+	/// Regression tests for the initial-connect/reconnect de-duplication of the
+	/// <c>BackgroundColor</c>, <c>BackgroundImageSource</c>, and <c>SemanticProperties.*</c> mapper
+	/// entries in <see cref="VisualElement"/>.RemapForControls (see VisualElement.Mapper.cs).
+	/// </summary>
+	public class VisualElementMapperTests : BaseTestFixture
+	{
+		// The Background/Semantics de-duplication relies on the Core `nameof(IView.Background)` and
+		// `nameof(IView.Semantics)` keys always running before the Controls-appended
+		// `BackgroundColor`/`BackgroundImageSource`/`SemanticProperties.*` keys during the same bulk
+		// mapping pass. Guard that invariant so a future mapper reordering fails loudly instead of
+		// silently reintroducing the redundant work (or dropping the redirect entirely).
+		[Fact]
+		public void BackgroundKeyIsMappedBeforeControlsBackgroundColorAndImageSourceKeys()
+		{
+			var keys = ViewHandler.ViewMapper.GetKeys().ToList();
+
+			var backgroundIndex = keys.IndexOf(nameof(IView.Background));
+			var backgroundColorIndex = keys.IndexOf(nameof(VisualElement.BackgroundColor));
+			var backgroundImageSourceIndex = keys.IndexOf(nameof(Page.BackgroundImageSource));
+
+			Assert.True(backgroundIndex >= 0);
+			Assert.True(backgroundColorIndex >= 0);
+			Assert.True(backgroundImageSourceIndex >= 0);
+			Assert.True(backgroundIndex < backgroundColorIndex);
+			Assert.True(backgroundIndex < backgroundImageSourceIndex);
+		}
+
+		[Fact]
+		public void SemanticsKeyIsMappedBeforeControlsSemanticPropertiesKeys()
+		{
+			var keys = ViewHandler.ViewMapper.GetKeys().ToList();
+
+			var semanticsIndex = keys.IndexOf(nameof(IView.Semantics));
+			var descriptionIndex = keys.IndexOf(SemanticProperties.DescriptionProperty.PropertyName);
+			var hintIndex = keys.IndexOf(SemanticProperties.HintProperty.PropertyName);
+			var headingLevelIndex = keys.IndexOf(SemanticProperties.HeadingLevelProperty.PropertyName);
+
+			Assert.True(semanticsIndex >= 0);
+			Assert.True(descriptionIndex >= 0);
+			Assert.True(hintIndex >= 0);
+			Assert.True(headingLevelIndex >= 0);
+			Assert.True(semanticsIndex < descriptionIndex);
+			Assert.True(semanticsIndex < hintIndex);
+			Assert.True(semanticsIndex < headingLevelIndex);
+		}
+
+		[Fact]
+		public void Connect_BackgroundColorOnly_AppliesComposedBackgroundExactlyOnce()
+		{
+			int backgroundCalls = 0;
+			Paint capturedBackground = null;
+
+			var mapper = new PropertyMapper<IView, IViewHandler>(ViewHandler.ViewMapper)
+			{
+				[nameof(IView.Background)] = (h, v) =>
+				{
+					backgroundCalls++;
+					capturedBackground = v.Background;
+				},
+			};
+			var commandMapper = new CommandMapper<IView, IViewHandler>(ViewHandler.ViewCommandMapper);
+			VisualElement.RemapForControls(mapper, commandMapper);
+
+			var handlerStub = new HandlerStub(mapper, commandMapper);
+			var button = new Button { BackgroundColor = Colors.Red };
+
+			handlerStub.SetVirtualView(button);
+
+			Assert.Equal(1, backgroundCalls);
+			// VisualElement's IView.Background implicitly converts the SolidColorBrush composite value
+			// to a Microsoft.Maui.Graphics.SolidPaint (see Brush's implicit Paint conversion operator).
+			var paint = Assert.IsType<SolidPaint>(capturedBackground);
+			Assert.Equal(Colors.Red, paint.Color);
+		}
+
+		[Fact]
+		public void Connect_BackgroundImageSourceOnly_AppliesComposedBackgroundExactlyOnce()
+		{
+			int backgroundCalls = 0;
+			Paint capturedBackground = null;
+
+			var mapper = new PropertyMapper<IView, IViewHandler>(ViewHandler.ViewMapper)
+			{
+				[nameof(IView.Background)] = (h, v) =>
+				{
+					backgroundCalls++;
+					capturedBackground = v.Background;
+				},
+			};
+			var commandMapper = new CommandMapper<IView, IViewHandler>(ViewHandler.ViewCommandMapper);
+			VisualElement.RemapForControls(mapper, commandMapper);
+
+			var handlerStub = new PageHandlerStub(mapper, commandMapper);
+			var page = new ContentPage { BackgroundImageSource = ImageSource.FromFile("some_image.png") };
+
+			handlerStub.SetVirtualView(page);
+
+			Assert.Equal(1, backgroundCalls);
+			Assert.IsType<ImageSourcePaint>(capturedBackground);
+		}
+
+		[Fact]
+		public void Connect_SemanticDescriptionOnly_AppliesSemanticsExactlyOnce()
+		{
+			int semanticsCalls = 0;
+			Semantics capturedSemantics = null;
+
+			var mapper = new PropertyMapper<IView, IViewHandler>(ViewHandler.ViewMapper)
+			{
+				[nameof(IView.Semantics)] = (h, v) =>
+				{
+					semanticsCalls++;
+					capturedSemantics = v.Semantics;
+				},
+			};
+			var commandMapper = new CommandMapper<IView, IViewHandler>(ViewHandler.ViewCommandMapper);
+			VisualElement.RemapForControls(mapper, commandMapper);
+
+			var handlerStub = new HandlerStub(mapper, commandMapper);
+			var button = new Button();
+			SemanticProperties.SetDescription(button, "Submit order");
+
+			handlerStub.SetVirtualView(button);
+
+			Assert.Equal(1, semanticsCalls);
+			Assert.Equal("Submit order", capturedSemantics?.Description);
+		}
+
+		[Fact]
+		public void Connect_UserAppendedBackgroundColorMapping_StillRunsDuringConnect()
+		{
+			bool appendCalled = false;
+
+			var mapper = new PropertyMapper<IView, IViewHandler>(ViewHandler.ViewMapper);
+			var commandMapper = new CommandMapper<IView, IViewHandler>(ViewHandler.ViewCommandMapper);
+			VisualElement.RemapForControls(mapper, commandMapper);
+
+			// Simulate a consumer customization registered on top of the canonical BackgroundColor mapping.
+			mapper.AppendToMapping<IView, IViewHandler>(nameof(VisualElement.BackgroundColor), (h, v) => appendCalled = true);
+
+			var handlerStub = new HandlerStub(mapper, commandMapper);
+			var button = new Button { BackgroundColor = Colors.Blue };
+
+			handlerStub.SetVirtualView(button);
+
+			Assert.True(appendCalled);
+		}
+
+		[Fact]
+		public void HandlerReuse_Reconnect_DoesNotDuplicateBackgroundMapping()
+		{
+			int backgroundCalls = 0;
+
+			var mapper = new PropertyMapper<IView, IViewHandler>(ViewHandler.ViewMapper)
+			{
+				[nameof(IView.Background)] = (h, v) => backgroundCalls++,
+			};
+			var commandMapper = new CommandMapper<IView, IViewHandler>(ViewHandler.ViewCommandMapper);
+			VisualElement.RemapForControls(mapper, commandMapper);
+
+			var handlerStub = new HandlerStub(mapper, commandMapper);
+			var firstView = new Button { BackgroundColor = Colors.Red };
+			handlerStub.SetVirtualView(firstView);
+
+			Assert.Equal(1, backgroundCalls);
+
+			// Simulate handler reuse (e.g. CollectionView/CarouselView cell recycling): the same handler
+			// instance, whose PlatformView already exists, is bound directly to a new virtual view. This
+			// puts the handler in the `Reconnecting` state rather than `Connecting`.
+			backgroundCalls = 0;
+			var secondView = new Button { BackgroundColor = Colors.Green };
+			handlerStub.SetVirtualView(secondView);
+
+			Assert.Equal(1, backgroundCalls);
+		}
+
+		[Fact]
+		public void HandlerReuse_Reconnect_DoesNotDuplicateSemanticsMapping()
+		{
+			int semanticsCalls = 0;
+
+			var mapper = new PropertyMapper<IView, IViewHandler>(ViewHandler.ViewMapper)
+			{
+				[nameof(IView.Semantics)] = (h, v) => semanticsCalls++,
+			};
+			var commandMapper = new CommandMapper<IView, IViewHandler>(ViewHandler.ViewCommandMapper);
+			VisualElement.RemapForControls(mapper, commandMapper);
+
+			var handlerStub = new HandlerStub(mapper, commandMapper);
+			var firstView = new Button();
+			SemanticProperties.SetDescription(firstView, "First");
+			handlerStub.SetVirtualView(firstView);
+
+			Assert.Equal(1, semanticsCalls);
+
+			semanticsCalls = 0;
+			var secondView = new Button();
+			SemanticProperties.SetDescription(secondView, "Second");
+			handlerStub.SetVirtualView(secondView);
+
+			Assert.Equal(1, semanticsCalls);
+		}
+
+		[Fact]
+		public void DynamicUpdateAfterConnect_BackgroundColorChange_StillAppliesBackground()
+		{
+			int backgroundCalls = 0;
+
+			var mapper = new PropertyMapper<IView, IViewHandler>(ViewHandler.ViewMapper)
+			{
+				[nameof(IView.Background)] = (h, v) => backgroundCalls++,
+			};
+			var commandMapper = new CommandMapper<IView, IViewHandler>(ViewHandler.ViewCommandMapper);
+			VisualElement.RemapForControls(mapper, commandMapper);
+
+			var handlerStub = new HandlerStub(mapper, commandMapper);
+			var button = new Button { BackgroundColor = Colors.Red };
+			handlerStub.SetVirtualView(button);
+
+			// The handler is now fully `Connected`, so a dynamic property update must still forward
+			// through to the canonical Background mapping and must not be suppressed by the
+			// connect/reconnect de-duplication guard.
+			backgroundCalls = 0;
+			button.BackgroundColor = Colors.Purple;
+
+			Assert.Equal(1, backgroundCalls);
+		}
+
+		[Fact]
+		public void DynamicUpdateAfterConnect_SemanticDescriptionChange_StillAppliesSemantics()
+		{
+			int semanticsCalls = 0;
+
+			var mapper = new PropertyMapper<IView, IViewHandler>(ViewHandler.ViewMapper)
+			{
+				[nameof(IView.Semantics)] = (h, v) => semanticsCalls++,
+			};
+			var commandMapper = new CommandMapper<IView, IViewHandler>(ViewHandler.ViewCommandMapper);
+			VisualElement.RemapForControls(mapper, commandMapper);
+
+			var handlerStub = new HandlerStub(mapper, commandMapper);
+			var button = new Button();
+			SemanticProperties.SetDescription(button, "Initial");
+			handlerStub.SetVirtualView(button);
+
+			semanticsCalls = 0;
+			SemanticProperties.SetDescription(button, "Updated");
+
+			Assert.Equal(1, semanticsCalls);
+		}
+
+		class PageHandlerStub : ViewHandler<ContentPage, object>
+		{
+			public PageHandlerStub(IPropertyMapper mapper, CommandMapper commandMapper = null) : base(mapper, commandMapper)
+			{
+			}
+
+			protected override object CreatePlatformView() => new object();
+		}
+	}
+}

--- a/src/Controls/tests/Core.UnitTests/VisualElementMapperTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualElementMapperTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
@@ -257,6 +258,194 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal(1, semanticsCalls);
 		}
 
+		// Reproduces a mapper that runs *later* in the same bulk connect pass than BackgroundColor's own
+		// turn and legitimately changes BackgroundColor, forcing a further, explicit re-entrant
+		// UpdateValue call. That call must not be suppressed just because BackgroundColor's own turn
+		// already ran (and was a no-op) earlier in the very same pass.
+		[Fact]
+		public void Connect_LaterMapperChangesBackgroundColor_ReentrantUpdateStillApplies()
+		{
+			int backgroundCalls = 0;
+
+			var mapper = new PropertyMapper<IView, IViewHandler>(ViewHandler.ViewMapper)
+			{
+				[nameof(IView.Background)] = (h, v) => backgroundCalls++,
+			};
+			var commandMapper = new CommandMapper<IView, IViewHandler>(ViewHandler.ViewCommandMapper);
+			VisualElement.RemapForControls(mapper, commandMapper);
+
+			// A brand new key is guaranteed to be enumerated after every key RemapForControls/the real
+			// ViewHandler.ViewMapper already registers (including BackgroundColor), simulating a mapper
+			// that legitimately runs later in the same bulk pass.
+			mapper.Add("__LaterMapperReentry", (h, v) =>
+			{
+				((VisualElement)v).BackgroundColor = Colors.Green;
+				h.UpdateValue(nameof(VisualElement.BackgroundColor));
+			});
+
+			var handlerStub = new HandlerStub(mapper, commandMapper);
+			var button = new Button { BackgroundColor = Colors.Red };
+
+			handlerStub.SetVirtualView(button);
+
+			// Once for the natural Background key entry (BackgroundColor's own turn is then a no-op and
+			// is skipped), once more for the later mapper's explicit re-entrant call after BackgroundColor
+			// legitimately changed.
+			Assert.Equal(2, backgroundCalls);
+			Assert.Equal(Colors.Green, button.BackgroundColor);
+		}
+
+		// Same as above, but for handler reuse/reconnect: the later-mapper re-entrant call must still not
+		// be suppressed on a reused handler.
+		[Fact]
+		public void Reconnect_LaterMapperChangesBackgroundColor_ReentrantUpdateStillApplies()
+		{
+			int backgroundCalls = 0;
+
+			var mapper = new PropertyMapper<IView, IViewHandler>(ViewHandler.ViewMapper)
+			{
+				[nameof(IView.Background)] = (h, v) => backgroundCalls++,
+			};
+			var commandMapper = new CommandMapper<IView, IViewHandler>(ViewHandler.ViewCommandMapper);
+			VisualElement.RemapForControls(mapper, commandMapper);
+
+			mapper.Add("__LaterMapperReentry", (h, v) =>
+			{
+				((VisualElement)v).BackgroundColor = Colors.Purple;
+				h.UpdateValue(nameof(VisualElement.BackgroundColor));
+			});
+
+			var handlerStub = new HandlerStub(mapper, commandMapper);
+			var firstView = new Button { BackgroundColor = Colors.Red };
+			handlerStub.SetVirtualView(firstView);
+
+			Assert.Equal(2, backgroundCalls);
+			Assert.Equal(Colors.Purple, firstView.BackgroundColor);
+
+			backgroundCalls = 0;
+			var secondView = new Button { BackgroundColor = Colors.Blue };
+			handlerStub.SetVirtualView(secondView);
+
+			Assert.Equal(2, backgroundCalls);
+			Assert.Equal(Colors.Purple, secondView.BackgroundColor);
+		}
+
+		// Same reasoning as Connect_LaterMapperChangesBackgroundColor_ReentrantUpdateStillApplies, but for
+		// the SemanticProperties.Description redirect.
+		[Fact]
+		public void Connect_LaterMapperChangesSemanticDescription_ReentrantUpdateStillApplies()
+		{
+			int semanticsCalls = 0;
+
+			var mapper = new PropertyMapper<IView, IViewHandler>(ViewHandler.ViewMapper)
+			{
+				[nameof(IView.Semantics)] = (h, v) => semanticsCalls++,
+			};
+			var commandMapper = new CommandMapper<IView, IViewHandler>(ViewHandler.ViewCommandMapper);
+			VisualElement.RemapForControls(mapper, commandMapper);
+
+			mapper.Add("__LaterMapperReentry", (h, v) =>
+			{
+				SemanticProperties.SetDescription((VisualElement)v, "Changed later");
+				h.UpdateValue(SemanticProperties.DescriptionProperty.PropertyName);
+			});
+
+			var handlerStub = new HandlerStub(mapper, commandMapper);
+			var button = new Button();
+			SemanticProperties.SetDescription(button, "Initial");
+
+			handlerStub.SetVirtualView(button);
+
+			Assert.Equal(2, semanticsCalls);
+			Assert.Equal("Changed later", SemanticProperties.GetDescription(button));
+		}
+
+		// Reproduces a handler that explicitly primes BackgroundColor from within ConnectHandler - i.e.
+		// before the Background key has ever been mapped for this element/handler. That explicit call must
+		// not be suppressed just because the handler is in the Connecting state.
+		[Fact]
+		public void ConnectHandler_ExplicitEarlyBackgroundColorUpdate_IsNotSuppressed()
+		{
+			int backgroundCalls = 0;
+
+			var mapper = new PropertyMapper<IView, IViewHandler>(ViewHandler.ViewMapper)
+			{
+				[nameof(IView.Background)] = (h, v) => backgroundCalls++,
+			};
+			var commandMapper = new CommandMapper<IView, IViewHandler>(ViewHandler.ViewCommandMapper);
+			VisualElement.RemapForControls(mapper, commandMapper);
+
+			var handlerStub = new EarlyBackgroundColorConnectHandlerStub(mapper, commandMapper);
+			var button = new Button { BackgroundColor = Colors.Red };
+
+			handlerStub.SetVirtualView(button);
+
+			// One call from ConnectHandler's explicit early UpdateValue(BackgroundColor) - which must not
+			// be suppressed, since Background has never been mapped for this element yet - and one more
+			// from the bulk pass's own, always-unconditional Background key entry. BackgroundColor's own
+			// turn later in that same bulk pass is then a genuine no-op and is skipped.
+			Assert.Equal(2, backgroundCalls);
+		}
+
+		// A consumer fully replacing the BackgroundColor mapping via ReplaceMapping must run their own
+		// logic instead of MapBackgroundColorForControls; our de-duplication logic must not interfere.
+		[Fact]
+		public void ReplaceMapping_UserReplacesBackgroundColorMapping_UserMappingRunsInstead()
+		{
+			bool userMappingRan = false;
+			int backgroundCalls = 0;
+
+			var mapper = new PropertyMapper<IView, IViewHandler>(ViewHandler.ViewMapper)
+			{
+				[nameof(IView.Background)] = (h, v) => backgroundCalls++,
+			};
+			var commandMapper = new CommandMapper<IView, IViewHandler>(ViewHandler.ViewCommandMapper);
+			VisualElement.RemapForControls(mapper, commandMapper);
+
+			mapper.ReplaceMapping<IView, IViewHandler>(nameof(VisualElement.BackgroundColor), (h, v) => userMappingRan = true);
+
+			var handlerStub = new HandlerStub(mapper, commandMapper);
+			var button = new Button { BackgroundColor = Colors.Red };
+
+			handlerStub.SetVirtualView(button);
+
+			Assert.True(userMappingRan);
+			// Only the natural Background key entry runs; MapBackgroundColorForControls (and our
+			// de-dup logic) isn't reachable anymore since ReplaceMapping fully discarded it.
+			Assert.Equal(1, backgroundCalls);
+		}
+
+		// A consumer using PrependToMapping on the Background key itself must have their mapping run
+		// before the canonical mapping, and our de-duplication must keep working correctly afterward.
+		[Fact]
+		public void PrependToMapping_UserPrependsToBackgroundMapping_RunsBeforeCanonicalMappingAndDedupStillWorks()
+		{
+			var order = new List<string>();
+			int backgroundCalls = 0;
+
+			var mapper = new PropertyMapper<IView, IViewHandler>(ViewHandler.ViewMapper)
+			{
+				[nameof(IView.Background)] = (h, v) =>
+				{
+					order.Add("canonical");
+					backgroundCalls++;
+				},
+			};
+			var commandMapper = new CommandMapper<IView, IViewHandler>(ViewHandler.ViewCommandMapper);
+			VisualElement.RemapForControls(mapper, commandMapper);
+
+			mapper.PrependToMapping<IView, IViewHandler>(nameof(IView.Background), (h, v) => order.Add("prepend"));
+
+			var handlerStub = new HandlerStub(mapper, commandMapper);
+			var button = new Button { BackgroundColor = Colors.Red };
+
+			handlerStub.SetVirtualView(button);
+
+			Assert.Equal(new[] { "prepend", "canonical" }, order);
+			// The redirect is still correctly deduplicated even with the user's prepended mapping.
+			Assert.Equal(1, backgroundCalls);
+		}
+
 		class PageHandlerStub : ViewHandler<ContentPage, object>
 		{
 			public PageHandlerStub(IPropertyMapper mapper, CommandMapper commandMapper = null) : base(mapper, commandMapper)
@@ -264,6 +453,24 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			}
 
 			protected override object CreatePlatformView() => new object();
+		}
+
+		class EarlyBackgroundColorConnectHandlerStub : ViewHandler<Button, object>
+		{
+			public EarlyBackgroundColorConnectHandlerStub(IPropertyMapper mapper, CommandMapper commandMapper = null) : base(mapper, commandMapper)
+			{
+			}
+
+			protected override object CreatePlatformView() => new object();
+
+			protected override void ConnectHandler(object platformView)
+			{
+				base.ConnectHandler(platformView);
+
+				// Simulate a handler that explicitly primes BackgroundColor from within ConnectHandler,
+				// before the Background key has ever been mapped for this element/handler.
+				UpdateValue(nameof(VisualElement.BackgroundColor));
+			}
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/VisualElementMapperTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualElementMapperTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Maui.Graphics;
@@ -10,9 +11,14 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 	/// Regression tests for the initial-connect/reconnect de-duplication of the
 	/// <c>BackgroundColor</c>, <c>BackgroundImageSource</c>, and <c>SemanticProperties.*</c> mapper
 	/// entries in <see cref="VisualElement"/>.RemapForControls (see VisualElement.Mapper.cs). The
-	/// de-duplication is scoped to a single bulk mapping pass (tracked per-handler), so it never
-	/// suppresses an explicit/reentrant call, a same-value call, a call made before the canonical
-	/// `Background`/`Semantics` mapping has ever run, or a call made on a subsequent connect/reconnect.
+	/// de-duplication is scoped to one specific bulk <c>UpdateProperties</c> pass - identified via
+	/// <see cref="Microsoft.Maui.PropertyMapperPassScope"/>'s per-handler pass id, not merely to "the next
+	/// time this key happens to run" - so it never suppresses an explicit/reentrant call, a same-value
+	/// call, a call made before the canonical `Background`/`Semantics` mapping has ever run, a call made on
+	/// a subsequent connect/reconnect, a call triggered by `Background`/`Semantics` running *outside* of any
+	/// bulk pass (e.g. a platform mapper reacting to some unrelated property by directly calling
+	/// `Handler.UpdateValue(nameof(Background))`/`nameof(Semantics))`, mirroring
+	/// `PickerHandler.Windows.MapTitle`), or a call whose armed pass was aborted by an exception.
 	/// </summary>
 	public class VisualElementMapperTests : BaseTestFixture
 	{
@@ -495,6 +501,124 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal(new[] { "prepend", "canonical" }, order);
 			// The redirect is still correctly deduplicated even with the user's prepended mapping.
 			Assert.Equal(1, backgroundCalls);
+		}
+
+		// De-duplication must be scoped to *this specific* bulk UpdateProperties pass, not to "the next
+		// time Background happens to run" regardless of context. If Background is (re)mapped by something
+		// standalone, entirely outside of any bulk pass (e.g. a direct Handler.UpdateValue(nameof(Background))
+		// call made well after connect has finished), that must not arm a pending skip at all - there is no
+		// guarantee whatsoever that BackgroundColor's own redirect turn is still coming, so a later,
+		// completely unrelated BackgroundColor update must still apply.
+		[Fact]
+		public void DirectBackgroundUpdateOutsideBulkPass_DoesNotSuppressLaterUnrelatedBackgroundColorUpdate()
+		{
+			int backgroundCalls = 0;
+
+			var mapper = new PropertyMapper<IView, IViewHandler>(ViewHandler.ViewMapper)
+			{
+				[nameof(IView.Background)] = (h, v) => backgroundCalls++,
+			};
+			var commandMapper = new CommandMapper<IView, IViewHandler>(ViewHandler.ViewCommandMapper);
+			VisualElement.RemapForControls(mapper, commandMapper);
+
+			var handlerStub = new HandlerStub(mapper, commandMapper);
+			var button = new Button { BackgroundColor = Colors.Red };
+			handlerStub.SetVirtualView(button);
+
+			Assert.Equal(1, backgroundCalls);
+
+			// Something remaps Background directly and standalone, well outside of the connect pass and
+			// outside of either redirect (e.g. not through MapBackgroundColor/MapBackgroundImageSource).
+			backgroundCalls = 0;
+			handlerStub.UpdateValue(nameof(IView.Background));
+			Assert.Equal(1, backgroundCalls);
+
+			// A subsequent, unrelated explicit BackgroundColor update must still apply - it must not be
+			// wrongly treated as the "redundant" follow-up to the direct Background update above, since
+			// that update did not happen within any bulk UpdateProperties pass.
+			handlerStub.UpdateValue(nameof(VisualElement.BackgroundColor));
+			Assert.Equal(2, backgroundCalls);
+		}
+
+		// Mirrors PickerHandler.Windows.MapTitle, which reacts to Title changing - including well after
+		// connect, entirely outside of any bulk UpdateProperties pass - by directly calling
+		// handler.UpdateValue(nameof(IView.Semantics)). That call must not be able to suppress a later,
+		// unrelated SemanticProperties.Description update.
+		[Fact]
+		public void HandlerDirectSemanticsUpdateOutsideBulkPass_DoesNotSuppressLaterUnrelatedSemanticDescriptionUpdate()
+		{
+			int semanticsCalls = 0;
+
+			var mapper = new PropertyMapper<IView, IViewHandler>(ViewHandler.ViewMapper)
+			{
+				[nameof(IView.Semantics)] = (h, v) => semanticsCalls++,
+			};
+			var commandMapper = new CommandMapper<IView, IViewHandler>(ViewHandler.ViewCommandMapper);
+			VisualElement.RemapForControls(mapper, commandMapper);
+
+			var handlerStub = new HandlerStub(mapper, commandMapper);
+			var button = new Button();
+			SemanticProperties.SetDescription(button, "Initial");
+			handlerStub.SetVirtualView(button);
+
+			Assert.Equal(1, semanticsCalls);
+
+			// Register the Title mapper only now (after connect has fully finished), so that its own
+			// invocation below happens strictly outside of any bulk UpdateProperties pass - simulating a
+			// platform mapper, like PickerHandler.Windows.MapTitle, that reacts to an unrelated property
+			// (here, a synthetic "Title" key) by directly calling handler.UpdateValue(nameof(IView.Semantics))
+			// well after connect, e.g. because Title changed dynamically.
+			mapper.Add("Title", (h, v) => h.UpdateValue(nameof(IView.Semantics)));
+
+			// "Title" changes well after connect, entirely outside of any bulk pass - mirroring
+			// PickerHandler.Windows.MapTitle firing from a standalone Title property change.
+			semanticsCalls = 0;
+			handlerStub.UpdateValue("Title");
+			Assert.Equal(1, semanticsCalls);
+
+			// A subsequent, unrelated explicit SemanticProperties.Description update must still apply.
+			handlerStub.UpdateValue(SemanticProperties.DescriptionProperty.PropertyName);
+			Assert.Equal(2, semanticsCalls);
+		}
+
+		// If a bulk UpdateProperties pass is aborted by an exception after Background has armed a pending
+		// skip but before BackgroundColor's redirect has had a chance to consume it, that pending mark must
+		// become permanently inert - it must never be honored by a later, unrelated BackgroundColor update
+		// made outside of the (now-ended) pass that armed it.
+		[Fact]
+		public void ExceptionDuringBulkPass_DoesNotLeaveStalePendingSkipForLaterUnrelatedUpdate()
+		{
+			int backgroundCalls = 0;
+
+			// Inserted (via the object initializer, before RemapForControls runs) directly between
+			// Background and BackgroundColor's insertion-order position: RemapForControls only ever
+			// replaces/appends keys, it never reorders or removes ones already present, and
+			// PropertyMapper.GetKeys() yields a mapper's own keys in insertion order. Background is
+			// inserted first (right here), this exploding key second, then RemapForControls appends
+			// BackgroundColor after both.
+			var mapper = new PropertyMapper<IView, IViewHandler>
+			{
+				[nameof(IView.Background)] = (h, v) => backgroundCalls++,
+				["__ExplodingKey"] = (h, v) => throw new InvalidOperationException("Simulated mapper failure mid-pass."),
+			};
+			var commandMapper = new CommandMapper<IView, IViewHandler>();
+			VisualElement.RemapForControls(mapper, commandMapper);
+
+			var handlerStub = new HandlerStub(mapper, commandMapper);
+			var button = new Button { BackgroundColor = Colors.Red };
+
+			// The bulk pass aborts partway through: Background has already mapped (and armed
+			// BackgroundColor/BackgroundImageSource's pending skip for this pass), but the pass ends -
+			// via PropertyMapper.UpdateProperties' finally - before BackgroundColor's own redirect turn is
+			// ever reached.
+			Assert.Throws<InvalidOperationException>(() => handlerStub.SetVirtualView(button));
+			Assert.Equal(1, backgroundCalls);
+
+			// A later, unrelated explicit BackgroundColor update - entirely outside of the aborted pass -
+			// must still apply. The pending mark armed by the aborted pass can never match again, since
+			// PropertyMapperPassScope no longer reports that pass as current for this handler.
+			handlerStub.UpdateValue(nameof(VisualElement.BackgroundColor));
+			Assert.Equal(2, backgroundCalls);
 		}
 
 		class PageHandlerStub : ViewHandler<ContentPage, object>

--- a/src/Controls/tests/Core.UnitTests/VisualElementMapperTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualElementMapperTests.cs
@@ -9,7 +9,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 	/// <summary>
 	/// Regression tests for the initial-connect/reconnect de-duplication of the
 	/// <c>BackgroundColor</c>, <c>BackgroundImageSource</c>, and <c>SemanticProperties.*</c> mapper
-	/// entries in <see cref="VisualElement"/>.RemapForControls (see VisualElement.Mapper.cs).
+	/// entries in <see cref="VisualElement"/>.RemapForControls (see VisualElement.Mapper.cs). The
+	/// de-duplication is scoped to a single bulk mapping pass (tracked per-handler), so it never
+	/// suppresses an explicit/reentrant call, a same-value call, a call made before the canonical
+	/// `Background`/`Semantics` mapping has ever run, or a call made on a subsequent connect/reconnect.
 	/// </summary>
 	public class VisualElementMapperTests : BaseTestFixture
 	{
@@ -258,10 +261,68 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal(1, semanticsCalls);
 		}
 
+		// De-duplication is scoped to a single bulk mapping pass, not to whether the value itself changed.
+		// An explicit call requesting the SAME, unchanged value - made outside of any pass, e.g. well after
+		// connect has completed - must still go through every time it is made.
+		[Fact]
+		public void ExplicitSameValueBackgroundColorUpdateAfterConnect_StillApplies()
+		{
+			int backgroundCalls = 0;
+
+			var mapper = new PropertyMapper<IView, IViewHandler>(ViewHandler.ViewMapper)
+			{
+				[nameof(IView.Background)] = (h, v) => backgroundCalls++,
+			};
+			var commandMapper = new CommandMapper<IView, IViewHandler>(ViewHandler.ViewCommandMapper);
+			VisualElement.RemapForControls(mapper, commandMapper);
+
+			var handlerStub = new HandlerStub(mapper, commandMapper);
+			var button = new Button { BackgroundColor = Colors.Red };
+
+			handlerStub.SetVirtualView(button);
+			Assert.Equal(1, backgroundCalls);
+
+			// Same value as already applied, requested twice in a row, well outside of any bulk pass.
+			handlerStub.UpdateValue(nameof(VisualElement.BackgroundColor));
+			Assert.Equal(2, backgroundCalls);
+
+			handlerStub.UpdateValue(nameof(VisualElement.BackgroundColor));
+			Assert.Equal(3, backgroundCalls);
+		}
+
+		// Same reasoning as ExplicitSameValueBackgroundColorUpdateAfterConnect_StillApplies, but for the
+		// SemanticProperties.Description redirect.
+		[Fact]
+		public void ExplicitSameValueSemanticDescriptionUpdateAfterConnect_StillApplies()
+		{
+			int semanticsCalls = 0;
+
+			var mapper = new PropertyMapper<IView, IViewHandler>(ViewHandler.ViewMapper)
+			{
+				[nameof(IView.Semantics)] = (h, v) => semanticsCalls++,
+			};
+			var commandMapper = new CommandMapper<IView, IViewHandler>(ViewHandler.ViewCommandMapper);
+			VisualElement.RemapForControls(mapper, commandMapper);
+
+			var handlerStub = new HandlerStub(mapper, commandMapper);
+			var button = new Button();
+			SemanticProperties.SetDescription(button, "Same");
+
+			handlerStub.SetVirtualView(button);
+			Assert.Equal(1, semanticsCalls);
+
+			handlerStub.UpdateValue(SemanticProperties.DescriptionProperty.PropertyName);
+			Assert.Equal(2, semanticsCalls);
+
+			handlerStub.UpdateValue(SemanticProperties.DescriptionProperty.PropertyName);
+			Assert.Equal(3, semanticsCalls);
+		}
+
 		// Reproduces a mapper that runs *later* in the same bulk connect pass than BackgroundColor's own
-		// turn and legitimately changes BackgroundColor, forcing a further, explicit re-entrant
-		// UpdateValue call. That call must not be suppressed just because BackgroundColor's own turn
-		// already ran (and was a no-op) earlier in the very same pass.
+		// turn and legitimately changes BackgroundColor, forcing a further, re-entrant handler notification
+		// (property changes on VisualElement route straight to Handler.UpdateValue - see
+		// Element.OnPropertyChanged). That call must not be suppressed just because BackgroundColor's own
+		// turn already ran (and was a no-op) earlier in the very same pass.
 		[Fact]
 		public void Connect_LaterMapperChangesBackgroundColor_ReentrantUpdateStillApplies()
 		{
@@ -276,12 +337,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			// A brand new key is guaranteed to be enumerated after every key RemapForControls/the real
 			// ViewHandler.ViewMapper already registers (including BackgroundColor), simulating a mapper
-			// that legitimately runs later in the same bulk pass.
-			mapper.Add("__LaterMapperReentry", (h, v) =>
-			{
-				((VisualElement)v).BackgroundColor = Colors.Green;
-				h.UpdateValue(nameof(VisualElement.BackgroundColor));
-			});
+			// that legitimately runs later in the same bulk pass. Setting BackgroundColor here
+			// automatically triggers Handler.UpdateValue(nameof(BackgroundColor)) - see
+			// Element.OnPropertyChanged - which is the re-entrant call under test.
+			mapper.Add("__LaterMapperReentry", (h, v) => ((VisualElement)v).BackgroundColor = Colors.Green);
 
 			var handlerStub = new HandlerStub(mapper, commandMapper);
 			var button = new Button { BackgroundColor = Colors.Red };
@@ -289,7 +348,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			handlerStub.SetVirtualView(button);
 
 			// Once for the natural Background key entry (BackgroundColor's own turn is then a no-op and
-			// is skipped), once more for the later mapper's explicit re-entrant call after BackgroundColor
+			// is skipped), once more for the later mapper's re-entrant notification after BackgroundColor
 			// legitimately changed.
 			Assert.Equal(2, backgroundCalls);
 			Assert.Equal(Colors.Green, button.BackgroundColor);
@@ -309,11 +368,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var commandMapper = new CommandMapper<IView, IViewHandler>(ViewHandler.ViewCommandMapper);
 			VisualElement.RemapForControls(mapper, commandMapper);
 
-			mapper.Add("__LaterMapperReentry", (h, v) =>
-			{
-				((VisualElement)v).BackgroundColor = Colors.Purple;
-				h.UpdateValue(nameof(VisualElement.BackgroundColor));
-			});
+			mapper.Add("__LaterMapperReentry", (h, v) => ((VisualElement)v).BackgroundColor = Colors.Purple);
 
 			var handlerStub = new HandlerStub(mapper, commandMapper);
 			var firstView = new Button { BackgroundColor = Colors.Red };
@@ -344,11 +399,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var commandMapper = new CommandMapper<IView, IViewHandler>(ViewHandler.ViewCommandMapper);
 			VisualElement.RemapForControls(mapper, commandMapper);
 
-			mapper.Add("__LaterMapperReentry", (h, v) =>
-			{
-				SemanticProperties.SetDescription((VisualElement)v, "Changed later");
-				h.UpdateValue(SemanticProperties.DescriptionProperty.PropertyName);
-			});
+			mapper.Add("__LaterMapperReentry", (h, v) => SemanticProperties.SetDescription((VisualElement)v, "Changed later"));
 
 			var handlerStub = new HandlerStub(mapper, commandMapper);
 			var button = new Button();

--- a/src/Controls/tests/Core.UnitTests/VisualElementMapperTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualElementMapperTests.cs
@@ -3,22 +3,26 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
 using Xunit;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
 	/// <summary>
-	/// Regression tests for the initial-connect/reconnect de-duplication of the
-	/// <c>BackgroundColor</c>, <c>BackgroundImageSource</c>, and <c>SemanticProperties.*</c> mapper
-	/// entries in <see cref="VisualElement"/>.RemapForControls (see VisualElement.Mapper.cs). The
-	/// de-duplication is scoped to one specific bulk <c>UpdateProperties</c> pass - identified via
-	/// <see cref="Microsoft.Maui.PropertyMapperPassScope"/>'s per-handler pass id, not merely to "the next
-	/// time this key happens to run" - so it never suppresses an explicit/reentrant call, a same-value
-	/// call, a call made before the canonical `Background`/`Semantics` mapping has ever run, a call made on
-	/// a subsequent connect/reconnect, a call triggered by `Background`/`Semantics` running *outside* of any
-	/// bulk pass (e.g. a platform mapper reacting to some unrelated property by directly calling
-	/// `Handler.UpdateValue(nameof(Background))`/`nameof(Semantics))`, mirroring
-	/// `PickerHandler.Windows.MapTitle`), or a call whose armed pass was aborted by an exception.
+	/// Regression tests for the bulk-pass de-duplication of the <c>BackgroundColor</c>,
+	/// <c>BackgroundImageSource</c>, and <c>SemanticProperties.*</c> mapper entries in
+	/// <see cref="VisualElement"/>.RemapForControls (see VisualElement.Mapper.cs). Each of those keys is a
+	/// pure redirect into the canonical <c>Background</c>/<c>Semantics</c> key, and is registered after it,
+	/// so its own step of a bulk <c>UpdateProperties</c> pass is provably redundant. Exactly that one step
+	/// is skipped, via <see cref="Microsoft.Maui.PropertyMapperPassScope"/>.
+	/// <para>
+	/// The de-duplication is deliberately independent of <em>which</em> mapping the canonical key resolves
+	/// to, so it behaves identically when a real derived handler (ButtonHandler, PageHandler, ...) owns and
+	/// overrides that key. And it never suppresses anything else: not an explicit or re-entrant call, a
+	/// same-value call, a call made before the canonical mapping has ever run, a call made while a nested
+	/// pass is on top, a call triggered by `Background`/`Semantics` running outside of any bulk pass (e.g.
+	/// `PickerHandler.Windows.MapTitle`), nor a call made after a pass was aborted by an exception.
+	/// </para>
 	/// </summary>
 	public class VisualElementMapperTests : BaseTestFixture
 	{
@@ -506,9 +510,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		// De-duplication must be scoped to *this specific* bulk UpdateProperties pass, not to "the next
 		// time Background happens to run" regardless of context. If Background is (re)mapped by something
 		// standalone, entirely outside of any bulk pass (e.g. a direct Handler.UpdateValue(nameof(Background))
-		// call made well after connect has finished), that must not arm a pending skip at all - there is no
-		// guarantee whatsoever that BackgroundColor's own redirect turn is still coming, so a later,
-		// completely unrelated BackgroundColor update must still apply.
+		// call made well after connect has finished), nothing becomes skippable - there is no bulk pass in
+		// which BackgroundColor's own redirect turn is still coming, so a later, completely unrelated
+		// BackgroundColor update must still apply.
 		[Fact]
 		public void DirectBackgroundUpdateOutsideBulkPass_DoesNotSuppressLaterUnrelatedBackgroundColorUpdate()
 		{
@@ -581,12 +585,12 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal(2, semanticsCalls);
 		}
 
-		// If a bulk UpdateProperties pass is aborted by an exception after Background has armed a pending
-		// skip but before BackgroundColor's redirect has had a chance to consume it, that pending mark must
-		// become permanently inert - it must never be honored by a later, unrelated BackgroundColor update
-		// made outside of the (now-ended) pass that armed it.
+		// If a bulk UpdateProperties pass is aborted by an exception after Background has been mapped but
+		// before BackgroundColor's redirect turn is ever reached, the pass must be popped on the way out -
+		// so a later, unrelated BackgroundColor update made outside of that (now-ended) pass can never be
+		// mistaken for its skippable turn.
 		[Fact]
-		public void ExceptionDuringBulkPass_DoesNotLeaveStalePendingSkipForLaterUnrelatedUpdate()
+		public void ExceptionDuringBulkPass_DoesNotLeaveAStaleActivePassForLaterUnrelatedUpdate()
 		{
 			int backgroundCalls = 0;
 
@@ -607,18 +611,273 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var handlerStub = new HandlerStub(mapper, commandMapper);
 			var button = new Button { BackgroundColor = Colors.Red };
 
-			// The bulk pass aborts partway through: Background has already mapped (and armed
-			// BackgroundColor/BackgroundImageSource's pending skip for this pass), but the pass ends -
+			// The bulk pass aborts partway through: Background has already been mapped, but the pass ends -
 			// via PropertyMapper.UpdateProperties' finally - before BackgroundColor's own redirect turn is
 			// ever reached.
 			Assert.Throws<InvalidOperationException>(() => handlerStub.SetVirtualView(button));
 			Assert.Equal(1, backgroundCalls);
 
 			// A later, unrelated explicit BackgroundColor update - entirely outside of the aborted pass -
-			// must still apply. The pending mark armed by the aborted pass can never match again, since
-			// PropertyMapperPassScope no longer reports that pass as current for this handler.
+			// must still apply, since PropertyMapperPassScope no longer reports any pass as current for
+			// this handler.
 			handlerStub.UpdateValue(nameof(VisualElement.BackgroundColor));
 			Assert.Equal(2, backgroundCalls);
+		}
+
+		// Most real handlers (ButtonHandler, PageHandler/ContentViewHandler, LabelHandler, EntryHandler,
+		// LayoutHandler, ...) declare their *own* `Background` key, which shadows ViewHandler.ViewMapper's
+		// entry entirely. The de-duplication must therefore never depend on wrapping/observing the
+		// canonical mapping itself - it only depends on the canonical key having already had its turn
+		// earlier in the same bulk pass, whichever mapping that key resolves to.
+		//
+		// Note that VisualElement.RemapForControls is deliberately *not* applied to the mappers built
+		// below: the Controls redirect keys reach them through the chained, globally-remapped
+		// ViewHandler.ViewMapper, exactly as they do for every real handler at runtime.
+
+		[Fact]
+		public void RealDerivedHandlerMappers_MapCanonicalKeysBeforeTheControlsRedirectKeys()
+		{
+			var mappers = new (string Name, IPropertyMapper Mapper)[]
+			{
+				(nameof(ButtonHandler), ButtonHandler.Mapper),
+				(nameof(PageHandler), PageHandler.Mapper),
+				(nameof(ContentViewHandler), ContentViewHandler.Mapper),
+				(nameof(LabelHandler), LabelHandler.Mapper),
+				(nameof(EntryHandler), EntryHandler.Mapper),
+				(nameof(LayoutHandler), LayoutHandler.Mapper),
+				(nameof(ImageHandler), ImageHandler.Mapper),
+			};
+
+			foreach (var (name, mapper) in mappers)
+			{
+				var keys = mapper.GetKeys().Distinct().ToList();
+
+				var backgroundIndex = keys.IndexOf(nameof(IView.Background));
+				var semanticsIndex = keys.IndexOf(nameof(IView.Semantics));
+
+				Assert.True(backgroundIndex >= 0, $"{name} is missing the Background key.");
+				Assert.True(semanticsIndex >= 0, $"{name} is missing the Semantics key.");
+
+				foreach (var redirectKey in new[] { nameof(VisualElement.BackgroundColor), nameof(Page.BackgroundImageSource) })
+				{
+					var redirectIndex = keys.IndexOf(redirectKey);
+					Assert.True(redirectIndex >= 0, $"{name} is missing the {redirectKey} key.");
+					Assert.True(backgroundIndex < redirectIndex, $"{name} maps {redirectKey} before Background.");
+				}
+
+				foreach (var redirectKey in new[]
+				{
+					SemanticProperties.DescriptionProperty.PropertyName,
+					SemanticProperties.HintProperty.PropertyName,
+					SemanticProperties.HeadingLevelProperty.PropertyName,
+				})
+				{
+					var redirectIndex = keys.IndexOf(redirectKey);
+					Assert.True(redirectIndex >= 0, $"{name} is missing the {redirectKey} key.");
+					Assert.True(semanticsIndex < redirectIndex, $"{name} maps {redirectKey} before Semantics.");
+				}
+			}
+		}
+
+		[Fact]
+		public void RealDerivedButtonHandler_OwningBackgroundMapping_MapsBackgroundExactlyOnceOnConnect()
+		{
+			int backgroundCalls = 0;
+			Paint capturedBackground = null;
+
+			var mapper = new PropertyMapper<IButton, IButtonHandler>(ButtonHandler.Mapper)
+			{
+				[nameof(IButton.Background)] = (h, v) =>
+				{
+					backgroundCalls++;
+					capturedBackground = v.Background;
+				},
+			};
+
+			var handler = new DerivedButtonHandlerStub(mapper);
+			var button = new Button { BackgroundColor = Colors.Red };
+
+			handler.SetVirtualView(button);
+
+			Assert.Equal(1, backgroundCalls);
+			var paint = Assert.IsType<SolidPaint>(capturedBackground);
+			Assert.Equal(Colors.Red, paint.Color);
+		}
+
+		[Fact]
+		public void RealDerivedButtonHandler_OwningBackgroundMapping_MapsSemanticsExactlyOnceOnConnect()
+		{
+			int semanticsCalls = 0;
+			Semantics capturedSemantics = null;
+
+			var mapper = new PropertyMapper<IButton, IButtonHandler>(ButtonHandler.Mapper)
+			{
+				[nameof(IButton.Background)] = (h, v) => { },
+				[nameof(IView.Semantics)] = (h, v) =>
+				{
+					semanticsCalls++;
+					capturedSemantics = v.Semantics;
+				},
+			};
+
+			var handler = new DerivedButtonHandlerStub(mapper);
+			var button = new Button();
+			SemanticProperties.SetDescription(button, "Submit order");
+
+			handler.SetVirtualView(button);
+
+			Assert.Equal(1, semanticsCalls);
+			Assert.Equal("Submit order", capturedSemantics?.Description);
+		}
+
+		[Fact]
+		public void RealDerivedPageHandler_OwningBackgroundMapping_MapsBackgroundExactlyOnceOnConnect()
+		{
+			int backgroundCalls = 0;
+			Paint capturedBackground = null;
+
+			// Mirrors PageHandler on iOS/Tizen, where the page handler's own mapper owns Background.
+			var mapper = new PropertyMapper<IContentView, IPageHandler>(PageHandler.Mapper)
+			{
+				[nameof(IContentView.Background)] = (h, v) =>
+				{
+					backgroundCalls++;
+					capturedBackground = v.Background;
+				},
+			};
+
+			var handler = new DerivedPageHandlerStub(mapper);
+
+			// ContentPage.RemapForControls registers a HideSoftInputOnTapped mapping on PageHandler.Mapper
+			// that resolves a service off the handler, so a real page handler needs a MauiContext.
+			handler.SetMauiContext(new MauiContext(MauiApp.CreateBuilder().Build().Services));
+
+			var page = new ContentPage { BackgroundImageSource = ImageSource.FromFile("some_image.png") };
+
+			handler.SetVirtualView(page);
+
+			Assert.Equal(1, backgroundCalls);
+			Assert.IsType<ImageSourcePaint>(capturedBackground);
+		}
+
+		[Fact]
+		public void RealDerivedButtonHandler_Reconnect_MapsBackgroundExactlyOncePerPass()
+		{
+			int backgroundCalls = 0;
+
+			var mapper = new PropertyMapper<IButton, IButtonHandler>(ButtonHandler.Mapper)
+			{
+				[nameof(IButton.Background)] = (h, v) => backgroundCalls++,
+			};
+
+			var handler = new DerivedButtonHandlerStub(mapper);
+			handler.SetVirtualView(new Button { BackgroundColor = Colors.Red });
+			Assert.Equal(1, backgroundCalls);
+
+			// Handler reuse (CollectionView/CarouselView recycling, Shell tab switching): the same handler
+			// instance, whose platform view already exists, is bound to a new virtual view.
+			backgroundCalls = 0;
+			handler.SetVirtualView(new Button { BackgroundColor = Colors.Green });
+			Assert.Equal(1, backgroundCalls);
+		}
+
+		[Fact]
+		public void RealDerivedButtonHandler_DynamicBackgroundColorChangeAfterConnect_StillApplies()
+		{
+			int backgroundCalls = 0;
+
+			var mapper = new PropertyMapper<IButton, IButtonHandler>(ButtonHandler.Mapper)
+			{
+				[nameof(IButton.Background)] = (h, v) => backgroundCalls++,
+			};
+
+			var handler = new DerivedButtonHandlerStub(mapper);
+			var button = new Button { BackgroundColor = Colors.Red };
+			handler.SetVirtualView(button);
+
+			// The handler is fully connected now, so a dynamic change - and an explicit same-value update
+			// after it - must both still reach the derived handler's own Background mapping.
+			backgroundCalls = 0;
+			button.BackgroundColor = Colors.Purple;
+			Assert.Equal(1, backgroundCalls);
+
+			handler.UpdateValue(nameof(VisualElement.BackgroundColor));
+			Assert.Equal(2, backgroundCalls);
+		}
+
+		// A mapper that runs a *nested* bulk pass on the same handler (mid-pass) must not destroy the outer
+		// pass's scope: once the nested pass ends, the outer pass's remaining redirect turns are still
+		// provably redundant and must still be skipped.
+		[Fact]
+		public void NestedSameHandlerPass_RestoresOuterPassScope_AndOuterRedirectsStayDeduplicated()
+		{
+			int outerBackgroundCalls = 0;
+			int nestedBackgroundCalls = 0;
+
+			var nestedCommandMapper = new CommandMapper<IView, IViewHandler>();
+			var nestedMapper = new PropertyMapper<IView, IViewHandler>
+			{
+				[nameof(IView.Background)] = (h, v) => nestedBackgroundCalls++,
+			};
+			VisualElement.RemapForControls(nestedMapper, nestedCommandMapper);
+
+			// "__NestedPass" is inserted (via the object initializer, before RemapForControls runs) between
+			// Background and the redirect keys RemapForControls appends afterwards, so the nested pass runs
+			// *inside* the outer one - after Background has had its turn, but before BackgroundColor gets
+			// its own.
+			var commandMapper = new CommandMapper<IView, IViewHandler>();
+			var mapper = new PropertyMapper<IView, IViewHandler>
+			{
+				[nameof(IView.Background)] = (h, v) => outerBackgroundCalls++,
+				["__NestedPass"] = (h, v) => nestedMapper.UpdateProperties(h, v),
+			};
+			VisualElement.RemapForControls(mapper, commandMapper);
+
+			var handlerStub = new HandlerStub(mapper, commandMapper);
+			handlerStub.SetVirtualView(new Button { BackgroundColor = Colors.Red });
+
+			// The nested pass deduplicates within itself, and the outer pass's own BackgroundColor/
+			// BackgroundImageSource turns are still skipped after it returns.
+			Assert.Equal(1, nestedBackgroundCalls);
+			Assert.Equal(1, outerBackgroundCalls);
+		}
+
+		// While a nested bulk pass for a *different* handler is on top, a redirect update targeting the
+		// outer handler is not that handler's own pass turn and must therefore still be applied.
+		[Fact]
+		public void NestedPassForAnotherHandler_DoesNotSuppressOuterHandlersRedirectUpdate()
+		{
+			int outerBackgroundCalls = 0;
+
+			var otherCommandMapper = new CommandMapper<IView, IViewHandler>();
+			var otherMapper = new PropertyMapper<IView, IViewHandler>();
+			var otherHandler = new HandlerStub(otherMapper, otherCommandMapper);
+			otherHandler.SetVirtualView(new Button());
+
+			var commandMapper = new CommandMapper<IView, IViewHandler>();
+			var mapper = new PropertyMapper<IView, IViewHandler>
+			{
+				[nameof(IView.Background)] = (h, v) => outerBackgroundCalls++,
+			};
+			VisualElement.RemapForControls(mapper, commandMapper);
+
+			// Runs after every key RemapForControls appends, so the outer pass has already skipped its own
+			// BackgroundColor turn by the time this runs.
+			mapper.Add("__NestedPassForAnotherHandler", (h, v) =>
+			{
+				otherMapper.UpdateProperties(otherHandler, otherHandler.VirtualView);
+
+				// An explicit redirect update for *our* handler, issued from a step that is not that
+				// redirect key's own turn, must be honored - the nested pass must not have left anything
+				// behind that makes it look skippable.
+				h.UpdateValue(nameof(VisualElement.BackgroundColor));
+			});
+
+			var handlerStub = new HandlerStub(mapper, commandMapper);
+			handlerStub.SetVirtualView(new Button { BackgroundColor = Colors.Red });
+
+			// Once for the canonical Background key, once for the explicit redirect update above.
+			Assert.Equal(2, outerBackgroundCalls);
 		}
 
 		class PageHandlerStub : ViewHandler<ContentPage, object>
@@ -646,6 +905,24 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				// before the Background key has ever been mapped for this element/handler.
 				UpdateValue(nameof(VisualElement.BackgroundColor));
 			}
+		}
+
+		class DerivedButtonHandlerStub : ButtonHandler
+		{
+			public DerivedButtonHandlerStub(IPropertyMapper mapper) : base(mapper)
+			{
+			}
+
+			protected override object CreatePlatformView() => new object();
+		}
+
+		class DerivedPageHandlerStub : PageHandler
+		{
+			public DerivedPageHandlerStub(IPropertyMapper mapper) : base(mapper)
+			{
+			}
+
+			protected override object CreatePlatformView() => new object();
 		}
 	}
 }

--- a/src/Core/src/PropertyMapper.cs
+++ b/src/Core/src/PropertyMapper.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 
 #if IOS || MACCATALYST
 using PlatformView = UIKit.UIView;
@@ -20,11 +19,15 @@ namespace Microsoft.Maui
 		private protected readonly Dictionary<string, Action<IElementHandler, IElement>> _mapper = new(StringComparer.Ordinal);
 		IPropertyMapper[]? _chained;
 
-		List<string>? _updatePropertiesKeys;
-		List<Action<IElementHandler, IElement>>? _updatePropertiesMappers;
-		Dictionary<string, Action<IElementHandler, IElement>?>? _cachedMappers;
+		// The merged view of this mapper (and its chain) is published as a single reference so that
+		// everything derived from one merge - the keys, the mappings, and the key->mapping cache - is
+		// always read as a matched set. Mutating the mapper (SetPropertyCore/Chained) drops the reference;
+		// the next reader merges again. Readers must therefore snapshot it into a local exactly once.
+		// Volatile so a reader on another thread can never see the reference before the merge it points at
+		// is fully built.
+		volatile MergedMappers? _merged;
 
-		Dictionary<string, Action<IElementHandler, IElement>?> CachedMappers => _cachedMappers ?? SnapshotMappers().CachedMappers;
+		MergedMappers Merged => _merged ?? SnapshotMappers();
 
 		public PropertyMapper()
 		{
@@ -54,7 +57,7 @@ namespace Microsoft.Maui
 
 		internal bool TryUpdatePropertyCore(string key, IElementHandler viewHandler, IElement virtualView)
 		{
-			var cachedMappers = CachedMappers;
+			var cachedMappers = Merged.CachedMappers;
 			if (cachedMappers.TryGetValue(key, out var action))
 			{
 				if (action is not null)
@@ -120,7 +123,12 @@ namespace Microsoft.Maui
 				return;
 			}
 
-			var (keys, mappers) = GetUpdatePropertiesSnapshot();
+			// One read of the merged reference: `keys[i]` is then guaranteed to be the key whose mapping is
+			// `mappers[i]`, even if another thread replaces the merge (with a same-sized one or not) while
+			// this pass is running.
+			var merged = Merged;
+			var keys = merged.Keys;
+			var mappers = merged.Mappers;
 
 			// Scope this bulk enumeration as a single "pass" for viewHandler (see PropertyMapperPassScope)
 			// so mapper implementations can tell a genuine step of *this* bulk pass apart from an unrelated
@@ -142,28 +150,6 @@ namespace Microsoft.Maui
 			}
 		}
 
-		/// <summary>
-		/// Returns the current keys/mappers snapshot as a matched pair. Both lists are produced by the same
-		/// <see cref="SnapshotMappers"/> call, so <c>keys[i]</c> is always the key whose mapping is
-		/// <c>mappers[i]</c> - which is what lets a bulk pass report the key it is currently running.
-		/// </summary>
-		(List<string> Keys, List<Action<IElementHandler, IElement>> Mappers) GetUpdatePropertiesSnapshot()
-		{
-			// Read both fields into locals before validating them: another thread mutating this mapper
-			// (SetPropertyCore/Chained) clears them, and we must not end up with two lists coming from
-			// different snapshots.
-			var keys = _updatePropertiesKeys;
-			var mappers = _updatePropertiesMappers;
-
-			if (keys is null || mappers is null || keys.Count != mappers.Count)
-			{
-				var snapshot = SnapshotMappers();
-				return (snapshot.UpdatePropertiesKeys, snapshot.UpdatePropertiesMappers);
-			}
-
-			return (keys, mappers);
-		}
-
 		public IPropertyMapper[]? Chained
 		{
 			get => _chained;
@@ -174,12 +160,7 @@ namespace Microsoft.Maui
 			}
 		}
 
-		void ClearMergedMappers()
-		{
-			_updatePropertiesMappers = null;
-			_updatePropertiesKeys = null;
-			_cachedMappers = null;
-		}
+		void ClearMergedMappers() => _merged = null;
 
 		public virtual IEnumerable<string> GetKeys()
 		{
@@ -206,24 +187,50 @@ namespace Microsoft.Maui
 			}
 		}
 
-		private (List<string> UpdatePropertiesKeys, List<Action<IElementHandler, IElement>> UpdatePropertiesMappers, Dictionary<string, Action<IElementHandler, IElement>?> CachedMappers) SnapshotMappers()
+		MergedMappers SnapshotMappers()
 		{
-			var updatePropertiesKeys = GetKeys().Distinct().ToList();
-			var updatePropertiesMappers = new List<Action<IElementHandler, IElement>>(updatePropertiesKeys.Count);
-			var cachedMappers = new Dictionary<string, Action<IElementHandler, IElement>?>(updatePropertiesKeys.Count);
+			var keys = GetKeys().Distinct().ToList();
+			var mappers = new List<Action<IElementHandler, IElement>>(keys.Count);
+			var cachedMappers = new Dictionary<string, Action<IElementHandler, IElement>?>(keys.Count);
 
-			foreach (var key in updatePropertiesKeys)
+			foreach (var key in keys)
 			{
 				var mapper = GetProperty(key)!;
-				updatePropertiesMappers.Add(mapper);
+				mappers.Add(mapper);
 				cachedMappers[key] = mapper;
 			}
 
-			_updatePropertiesKeys = updatePropertiesKeys;
-			_updatePropertiesMappers = updatePropertiesMappers;
-			_cachedMappers = cachedMappers;
+			var merged = new MergedMappers(keys, mappers, cachedMappers);
+			_merged = merged;
 
-			return (updatePropertiesKeys, updatePropertiesMappers, cachedMappers);
+			return merged;
+		}
+
+		/// <summary>
+		/// The result of merging a mapper with its chain: the keys to enumerate, their mappings in the very
+		/// same order, and the key-to-mapping lookup used by single-key updates. Published as one reference
+		/// so readers can never observe a mix of two different merges.
+		/// </summary>
+		sealed class MergedMappers
+		{
+			public readonly List<string> Keys;
+
+			public readonly List<Action<IElementHandler, IElement>> Mappers;
+
+			/// <summary>
+			/// Lazily grown by <see cref="TryUpdatePropertyCore"/> for keys outside <see cref="Keys"/>.
+			/// </summary>
+			public readonly Dictionary<string, Action<IElementHandler, IElement>?> CachedMappers;
+
+			public MergedMappers(
+				List<string> keys,
+				List<Action<IElementHandler, IElement>> mappers,
+				Dictionary<string, Action<IElementHandler, IElement>?> cachedMappers)
+			{
+				Keys = keys;
+				Mappers = mappers;
+				CachedMappers = cachedMappers;
+			}
 		}
 	}
 
@@ -253,8 +260,6 @@ namespace Microsoft.Maui
 		[ThreadStatic]
 		static int t_depth;
 
-		static int s_nextPassId;
-
 		/// <summary>
 		/// Marks the start of a new bulk mapping pass for <paramref name="handler"/> over
 		/// <paramref name="keys"/> (the keys of the mapping snapshot being enumerated, in enumeration
@@ -281,9 +286,6 @@ namespace Microsoft.Maui
 			// Frames are reused across passes on this thread, so a steady-state pass allocates nothing.
 			var pass = passes[depth] ??= new PropertyMapperPass();
 
-			// 0 means "no pass", so skip it in the (astronomically unlikely) event the counter wraps.
-			var id = Interlocked.Increment(ref s_nextPassId);
-			pass.Id = id != 0 ? id : Interlocked.Increment(ref s_nextPassId);
 			pass.Depth = depth;
 			pass.Handler = handler;
 			pass.Keys = keys;
@@ -319,17 +321,6 @@ namespace Microsoft.Maui
 				var depth = t_depth;
 				return depth > 0 ? t_passes![depth - 1] : null;
 			}
-		}
-
-		/// <summary>
-		/// Returns the id of the innermost bulk mapping pass currently in progress for
-		/// <paramref name="handler"/> on this thread, or <c>0</c> if the innermost pass is not for that
-		/// handler (or there is no pass in progress at all).
-		/// </summary>
-		public static int GetCurrentPassId(IElementHandler? handler)
-		{
-			var pass = Current;
-			return pass is not null && handler is not null && ReferenceEquals(pass.Handler, handler) ? pass.Id : 0;
 		}
 
 		/// <summary>
@@ -397,9 +388,6 @@ namespace Microsoft.Maui
 	/// </summary>
 	internal sealed class PropertyMapperPass
 	{
-		/// <summary>A process-unique, non-zero id for this pass.</summary>
-		public int Id;
-
 		/// <summary>This pass's index in its thread's pass stack; restored as the depth when it ends.</summary>
 		public int Depth;
 

--- a/src/Core/src/PropertyMapper.cs
+++ b/src/Core/src/PropertyMapper.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
 
 #if IOS || MACCATALYST
 using PlatformView = UIKit.UIView;
@@ -121,9 +123,23 @@ namespace Microsoft.Maui
 				return;
 			}
 
-			foreach (var mapper in UpdatePropertiesMappers)
+			// Scope this bulk enumeration as a single "pass" for viewHandler (see PropertyMapperPassScope)
+			// so mapper implementations can tell a genuine step of *this* bulk pass apart from an unrelated
+			// single-key UpdateProperty call that merely happens to touch the same handler at a different
+			// time. Ended in a finally so the pass is never left open - and any pass-scoped state that a
+			// mapper implementation may have recorded against this pass's id can never again be matched -
+			// even if a mapper throws partway through the enumeration.
+			var passId = PropertyMapperPassScope.BeginPass(viewHandler);
+			try
 			{
-				mapper(viewHandler, virtualView);
+				foreach (var mapper in UpdatePropertiesMappers)
+				{
+					mapper(viewHandler, virtualView);
+				}
+			}
+			finally
+			{
+				PropertyMapperPassScope.EndPass(viewHandler, passId);
 			}
 		}
 
@@ -188,6 +204,70 @@ namespace Microsoft.Maui
 
 			return (updatePropertiesKeys, updatePropertiesMappers, cachedMappers);
 		}
+	}
+
+	/// <summary>
+	/// Tracks, per handler, whether a bulk <see cref="PropertyMapper.UpdateProperties"/> pass is currently
+	/// in progress for it, and a unique id for that specific pass. Mapper implementations that redirect one
+	/// property key's update into another (see VisualElement's BackgroundColor/BackgroundImageSource/
+	/// SemanticProperties redirects) can use this to tell whether two invocations happened within the very
+	/// same bulk pass - as opposed to two unrelated single-key <see cref="PropertyMapper.UpdateProperty"/>
+	/// calls (e.g. <c>Handler.UpdateValue(name)</c>) that merely happen to touch the same handler at
+	/// different times, possibly well after the pass that originally triggered a redirect has ended.
+	/// </summary>
+	internal static class PropertyMapperPassScope
+	{
+		static readonly ConditionalWeakTable<IElementHandler, StrongBox<int>> s_currentPassId = new();
+		static int s_nextPassId;
+
+		/// <summary>
+		/// Marks the start of a new bulk mapping pass for <paramref name="handler"/> and returns its
+		/// unique, non-zero id. Must be paired with a call to <see cref="EndPass"/> in a <c>finally</c>
+		/// block so the pass is considered over - and its id can never again be matched by
+		/// <see cref="GetCurrentPassId"/> - even if a mapper throws partway through the pass.
+		/// </summary>
+		public static int BeginPass(IElementHandler? handler)
+		{
+			var passId = Interlocked.Increment(ref s_nextPassId);
+
+			// A null handler (e.g. some unit tests call UpdateProperties(null!, ...) directly) can never be
+			// looked up again via GetCurrentPassId with that same null reference in a meaningful way, and
+			// ConditionalWeakTable does not accept null keys - so there is nothing to track for it.
+			if (handler is null)
+			{
+				return passId;
+			}
+
+			s_currentPassId.Remove(handler);
+			s_currentPassId.Add(handler, new StrongBox<int>(passId));
+			return passId;
+		}
+
+		/// <summary>
+		/// Marks the end of the bulk mapping pass identified by <paramref name="passId"/> for
+		/// <paramref name="handler"/>. A no-op if a nested/reentrant pass has already begun (and not yet
+		/// ended) for the same handler by the time this runs, so it never clears a more recent pass's id.
+		/// </summary>
+		public static void EndPass(IElementHandler? handler, int passId)
+		{
+			if (handler is null)
+			{
+				return;
+			}
+
+			if (s_currentPassId.TryGetValue(handler, out var box) && box.Value == passId)
+			{
+				s_currentPassId.Remove(handler);
+			}
+		}
+
+		/// <summary>
+		/// Returns the id of the bulk mapping pass currently in progress for <paramref name="handler"/>,
+		/// or <c>0</c> if no bulk mapping pass is currently in progress for it (including when
+		/// <paramref name="handler"/> is <see langword="null"/>).
+		/// </summary>
+		public static int GetCurrentPassId(IElementHandler? handler) =>
+			handler is not null && s_currentPassId.TryGetValue(handler, out var box) ? box.Value : 0;
 	}
 
 	public interface IPropertyMapper

--- a/src/Core/src/PropertyMapper.cs
+++ b/src/Core/src/PropertyMapper.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading;
 
 #if IOS || MACCATALYST
@@ -25,8 +24,6 @@ namespace Microsoft.Maui
 		List<Action<IElementHandler, IElement>>? _updatePropertiesMappers;
 		Dictionary<string, Action<IElementHandler, IElement>?>? _cachedMappers;
 
-		List<string> UpdatePropertiesKeys => _updatePropertiesKeys ?? SnapshotMappers().UpdatePropertiesKeys;
-		List<Action<IElementHandler, IElement>> UpdatePropertiesMappers => _updatePropertiesMappers ?? SnapshotMappers().UpdatePropertiesMappers;
 		Dictionary<string, Action<IElementHandler, IElement>?> CachedMappers => _cachedMappers ?? SnapshotMappers().CachedMappers;
 
 		public PropertyMapper()
@@ -123,24 +120,48 @@ namespace Microsoft.Maui
 				return;
 			}
 
+			var (keys, mappers) = GetUpdatePropertiesSnapshot();
+
 			// Scope this bulk enumeration as a single "pass" for viewHandler (see PropertyMapperPassScope)
 			// so mapper implementations can tell a genuine step of *this* bulk pass apart from an unrelated
 			// single-key UpdateProperty call that merely happens to touch the same handler at a different
-			// time. Ended in a finally so the pass is never left open - and any pass-scoped state that a
-			// mapper implementation may have recorded against this pass's id can never again be matched -
-			// even if a mapper throws partway through the enumeration.
-			var passId = PropertyMapperPassScope.BeginPass(viewHandler);
+			// time. Ended in a finally so the pass is never left open - even if a mapper throws partway
+			// through the enumeration - and so a nested pass always restores the pass that enclosed it.
+			var pass = PropertyMapperPassScope.BeginPass(viewHandler, keys);
 			try
 			{
-				foreach (var mapper in UpdatePropertiesMappers)
+				for (int i = 0; i < mappers.Count; i++)
 				{
-					mapper(viewHandler, virtualView);
+					pass.CurrentKeyIndex = i;
+					mappers[i](viewHandler, virtualView);
 				}
 			}
 			finally
 			{
-				PropertyMapperPassScope.EndPass(viewHandler, passId);
+				PropertyMapperPassScope.EndPass(pass);
 			}
+		}
+
+		/// <summary>
+		/// Returns the current keys/mappers snapshot as a matched pair. Both lists are produced by the same
+		/// <see cref="SnapshotMappers"/> call, so <c>keys[i]</c> is always the key whose mapping is
+		/// <c>mappers[i]</c> - which is what lets a bulk pass report the key it is currently running.
+		/// </summary>
+		(List<string> Keys, List<Action<IElementHandler, IElement>> Mappers) GetUpdatePropertiesSnapshot()
+		{
+			// Read both fields into locals before validating them: another thread mutating this mapper
+			// (SetPropertyCore/Chained) clears them, and we must not end up with two lists coming from
+			// different snapshots.
+			var keys = _updatePropertiesKeys;
+			var mappers = _updatePropertiesMappers;
+
+			if (keys is null || mappers is null || keys.Count != mappers.Count)
+			{
+				var snapshot = SnapshotMappers();
+				return (snapshot.UpdatePropertiesKeys, snapshot.UpdatePropertiesMappers);
+			}
+
+			return (keys, mappers);
 		}
 
 		public IPropertyMapper[]? Chained
@@ -207,67 +228,189 @@ namespace Microsoft.Maui
 	}
 
 	/// <summary>
-	/// Tracks, per handler, whether a bulk <see cref="PropertyMapper.UpdateProperties"/> pass is currently
-	/// in progress for it, and a unique id for that specific pass. Mapper implementations that redirect one
-	/// property key's update into another (see VisualElement's BackgroundColor/BackgroundImageSource/
-	/// SemanticProperties redirects) can use this to tell whether two invocations happened within the very
-	/// same bulk pass - as opposed to two unrelated single-key <see cref="PropertyMapper.UpdateProperty"/>
-	/// calls (e.g. <c>Handler.UpdateValue(name)</c>) that merely happen to touch the same handler at
-	/// different times, possibly well after the pass that originally triggered a redirect has ended.
+	/// Tracks the bulk <see cref="PropertyMapper.UpdateProperties"/> passes currently in progress on the
+	/// calling thread: which handler each one is mapping, and which key of that pass is being mapped right
+	/// now. Mapper implementations that redirect one property key's update into another (see
+	/// VisualElement's BackgroundColor/BackgroundImageSource/SemanticProperties redirects) use this to tell
+	/// their own natural, provably-redundant turn within a bulk pass apart from every other invocation -
+	/// an explicit single-key <see cref="PropertyMapper.UpdateProperty"/> call (e.g.
+	/// <c>Handler.UpdateValue(name)</c>), a re-entrant call raised by a mapper running later in the same
+	/// pass, or a call made when no bulk pass is running at all.
 	/// </summary>
+	/// <remarks>
+	/// Passes are tracked in a per-thread stack of reusable frames rather than in a table keyed by handler.
+	/// A bulk pass is a strictly synchronous, lexically scoped construct (<c>BeginPass</c>/<c>EndPass</c>
+	/// in a <c>try</c>/<c>finally</c>), so a thread-local stack models it exactly: nested passes - whether
+	/// on the same handler or on another one - naturally restore their enclosing pass when they end,
+	/// concurrent passes on different threads cannot interfere with (or race against) each other, and no
+	/// per-pass allocation is needed once a thread's frames have been created.
+	/// </remarks>
 	internal static class PropertyMapperPassScope
 	{
-		static readonly ConditionalWeakTable<IElementHandler, StrongBox<int>> s_currentPassId = new();
+		[ThreadStatic]
+		static PropertyMapperPass[]? t_passes;
+
+		[ThreadStatic]
+		static int t_depth;
+
 		static int s_nextPassId;
 
 		/// <summary>
-		/// Marks the start of a new bulk mapping pass for <paramref name="handler"/> and returns its
-		/// unique, non-zero id. Must be paired with a call to <see cref="EndPass"/> in a <c>finally</c>
-		/// block so the pass is considered over - and its id can never again be matched by
-		/// <see cref="GetCurrentPassId"/> - even if a mapper throws partway through the pass.
+		/// Marks the start of a new bulk mapping pass for <paramref name="handler"/> over
+		/// <paramref name="keys"/> (the keys of the mapping snapshot being enumerated, in enumeration
+		/// order), and returns the frame describing it. The caller must set
+		/// <see cref="PropertyMapperPass.CurrentKeyIndex"/> before invoking each key's mapping, and must
+		/// pair this with a call to <see cref="EndPass"/> in a <c>finally</c> block so the pass is always
+		/// popped - and the enclosing pass, if any, restored - even if a mapping throws.
 		/// </summary>
-		public static int BeginPass(IElementHandler? handler)
+		public static PropertyMapperPass BeginPass(IElementHandler? handler, List<string>? keys)
 		{
-			var passId = Interlocked.Increment(ref s_nextPassId);
+			var passes = t_passes;
+			var depth = t_depth;
 
-			// A null handler (e.g. some unit tests call UpdateProperties(null!, ...) directly) can never be
-			// looked up again via GetCurrentPassId with that same null reference in a meaningful way, and
-			// ConditionalWeakTable does not accept null keys - so there is nothing to track for it.
-			if (handler is null)
+			if (passes is null)
 			{
-				return passId;
+				t_passes = passes = new PropertyMapperPass[4];
+			}
+			else if (depth == passes.Length)
+			{
+				Array.Resize(ref passes, depth * 2);
+				t_passes = passes;
 			}
 
-			s_currentPassId.Remove(handler);
-			s_currentPassId.Add(handler, new StrongBox<int>(passId));
-			return passId;
+			// Frames are reused across passes on this thread, so a steady-state pass allocates nothing.
+			var pass = passes[depth] ??= new PropertyMapperPass();
+
+			// 0 means "no pass", so skip it in the (astronomically unlikely) event the counter wraps.
+			var id = Interlocked.Increment(ref s_nextPassId);
+			pass.Id = id != 0 ? id : Interlocked.Increment(ref s_nextPassId);
+			pass.Depth = depth;
+			pass.Handler = handler;
+			pass.Keys = keys;
+			pass.CurrentKeyIndex = -1;
+
+			t_depth = depth + 1;
+
+			return pass;
 		}
 
 		/// <summary>
-		/// Marks the end of the bulk mapping pass identified by <paramref name="passId"/> for
-		/// <paramref name="handler"/>. A no-op if a nested/reentrant pass has already begun (and not yet
-		/// ended) for the same handler by the time this runs, so it never clears a more recent pass's id.
+		/// Marks the end of <paramref name="pass"/>, restoring whichever pass enclosed it as the current
+		/// one. Clears the frame's references so a finished pass never keeps a handler alive and can never
+		/// be matched again.
 		/// </summary>
-		public static void EndPass(IElementHandler? handler, int passId)
+		public static void EndPass(PropertyMapperPass pass)
 		{
-			if (handler is null)
-			{
-				return;
-			}
+			pass.Handler = null;
+			pass.Keys = null;
+			pass.CurrentKeyIndex = -1;
 
-			if (s_currentPassId.TryGetValue(handler, out var box) && box.Value == passId)
+			t_depth = pass.Depth;
+		}
+
+		/// <summary>
+		/// The innermost bulk mapping pass currently running on this thread, or <see langword="null"/> if
+		/// none is.
+		/// </summary>
+		public static PropertyMapperPass? Current
+		{
+			get
 			{
-				s_currentPassId.Remove(handler);
+				var depth = t_depth;
+				return depth > 0 ? t_passes![depth - 1] : null;
 			}
 		}
 
 		/// <summary>
-		/// Returns the id of the bulk mapping pass currently in progress for <paramref name="handler"/>,
-		/// or <c>0</c> if no bulk mapping pass is currently in progress for it (including when
-		/// <paramref name="handler"/> is <see langword="null"/>).
+		/// Returns the id of the innermost bulk mapping pass currently in progress for
+		/// <paramref name="handler"/> on this thread, or <c>0</c> if the innermost pass is not for that
+		/// handler (or there is no pass in progress at all).
 		/// </summary>
-		public static int GetCurrentPassId(IElementHandler? handler) =>
-			handler is not null && s_currentPassId.TryGetValue(handler, out var box) ? box.Value : 0;
+		public static int GetCurrentPassId(IElementHandler? handler)
+		{
+			var pass = Current;
+			return pass is not null && handler is not null && ReferenceEquals(pass.Handler, handler) ? pass.Id : 0;
+		}
+
+		/// <summary>
+		/// Returns <see langword="true"/> when the caller is running as <paramref name="redirectKey"/>'s
+		/// own natural step of a bulk mapping pass for <paramref name="handler"/>, and
+		/// <paramref name="canonicalKey"/> has already been mapped earlier in that very same pass - i.e.
+		/// when re-dispatching <paramref name="redirectKey"/> into <paramref name="canonicalKey"/> is
+		/// provably redundant.
+		/// </summary>
+		/// <remarks>
+		/// This deliberately says nothing about <em>which</em> mapping is registered for
+		/// <paramref name="canonicalKey"/>: a derived handler is free to own/override it (ButtonHandler,
+		/// PageHandler, ...). All that matters is that the pass already ran whatever mapping that key
+		/// resolves to, because that is exactly what re-dispatching would invoke again.
+		/// Returns <see langword="false"/> for every other shape of invocation - a standalone
+		/// <c>UpdateValue</c>, a re-entrant notification raised by a later mapper in the same pass (the
+		/// current step is then that other key, not <paramref name="redirectKey"/>), a pass belonging to a
+		/// different handler, or a mapper ordering in which <paramref name="canonicalKey"/> does not
+		/// precede <paramref name="redirectKey"/> (or is absent entirely).
+		/// </remarks>
+		public static bool IsRedundantBulkPassRedirect(IElementHandler? handler, string redirectKey, string canonicalKey)
+		{
+			if (handler is null)
+			{
+				return false;
+			}
+
+			var pass = Current;
+			if (pass is null || !ReferenceEquals(pass.Handler, handler))
+			{
+				return false;
+			}
+
+			var keys = pass.Keys;
+			var currentKeyIndex = pass.CurrentKeyIndex;
+
+			// Only the pass's own enumeration step for `redirectKey` is skippable. Anything else reaching
+			// this mapping (a re-entrant `UpdateValue` raised while some other key is being mapped, for
+			// instance) is a genuine request that must be honored.
+			if (keys is null || currentKeyIndex < 0 || currentKeyIndex >= keys.Count ||
+				!string.Equals(keys[currentKeyIndex], redirectKey, StringComparison.Ordinal))
+			{
+				return false;
+			}
+
+			// `canonicalKey` must have already had its turn in this same pass. Scanning is bounded by the
+			// current step and only ever happens on a redirect key's own turn (a handful of times per
+			// pass), so it stays well below the cost of the platform work a redundant redirect would do.
+			for (int i = 0; i < currentKeyIndex; i++)
+			{
+				if (string.Equals(keys[i], canonicalKey, StringComparison.Ordinal))
+				{
+					return true;
+				}
+			}
+
+			return false;
+		}
+	}
+
+	/// <summary>
+	/// A single, in-progress bulk <see cref="PropertyMapper.UpdateProperties"/> pass. Instances are pooled
+	/// and reused per thread by <see cref="PropertyMapperPassScope"/>; they are only meaningful between the
+	/// <c>BeginPass</c> that hands one out and the matching <c>EndPass</c>.
+	/// </summary>
+	internal sealed class PropertyMapperPass
+	{
+		/// <summary>A process-unique, non-zero id for this pass.</summary>
+		public int Id;
+
+		/// <summary>This pass's index in its thread's pass stack; restored as the depth when it ends.</summary>
+		public int Depth;
+
+		/// <summary>The handler whose properties this pass is mapping.</summary>
+		public IElementHandler? Handler;
+
+		/// <summary>The keys being enumerated by this pass, in enumeration order.</summary>
+		public List<string>? Keys;
+
+		/// <summary>The index in <see cref="Keys"/> of the key currently being mapped, or -1 if none.</summary>
+		public int CurrentKeyIndex;
 	}
 
 	public interface IPropertyMapper

--- a/src/Core/tests/UnitTests/PropertyMapperTests.cs
+++ b/src/Core/tests/UnitTests/PropertyMapperTests.cs
@@ -87,10 +87,8 @@ namespace Microsoft.Maui.UnitTests
 			Assert.NotEqual(passIdDuringA, passIdDuringSecondPass);
 		}
 
-		// Even if a mapper throws partway through a bulk pass, the pass must be considered over - so any
-		// pass-scoped state a mapper implementation recorded against that pass's id (e.g. a "skip the next
-		// redundant redirected call" mark) can never again be matched once the pass has ended, whether it
-		// ended normally or via exception.
+		// Even if a mapper throws partway through a bulk pass, the pass must be popped on the way out, so
+		// nothing that ran within it can ever again be mistaken for a step of a still-running pass.
 		[Fact]
 		public void UpdatePropertiesPassScopeIsClearedInFinallyWhenAMapperThrows()
 		{
@@ -110,6 +108,269 @@ namespace Microsoft.Maui.UnitTests
 			Assert.NotEqual(0, passIdBeforeThrow);
 
 			// The aborted pass must not be left "active" - a later caller must see no active pass.
+			Assert.Equal(0, PropertyMapperPassScope.GetCurrentPassId(handler));
+		}
+
+		// The pass scope is a stack: a nested UpdateProperties pass - on the same handler or on another
+		// one - must restore the pass that enclosed it when it ends, so the outer pass keeps running with
+		// its own identity and its own "current key" position.
+		[Fact]
+		public void NestedPassOnTheSameHandlerRestoresTheOuterPassWhenItEnds()
+		{
+			var handler = new HandlerStub();
+			var view = new Button();
+
+			int outerPassId = 0;
+			int innerPassId = 0;
+			int outerPassIdAfterNesting = 0;
+
+			var innerMapper = new PropertyMapper<IView, IViewHandler>
+			{
+				["Inner"] = (h, v) => innerPassId = PropertyMapperPassScope.GetCurrentPassId(h),
+			};
+
+			var outerMapper = new PropertyMapper<IView, IViewHandler>
+			{
+				["BeforeNesting"] = (h, v) => outerPassId = PropertyMapperPassScope.GetCurrentPassId(h),
+				["Nest"] = (h, v) => innerMapper.UpdateProperties(h, v),
+				["AfterNesting"] = (h, v) => outerPassIdAfterNesting = PropertyMapperPassScope.GetCurrentPassId(h),
+			};
+
+			outerMapper.UpdateProperties(handler, view);
+
+			Assert.NotEqual(0, outerPassId);
+			Assert.NotEqual(0, innerPassId);
+			Assert.NotEqual(outerPassId, innerPassId);
+
+			// The outer pass must be exactly the same pass it was before the nested one ran.
+			Assert.Equal(outerPassId, outerPassIdAfterNesting);
+			Assert.Equal(0, PropertyMapperPassScope.GetCurrentPassId(handler));
+		}
+
+		// A nested pass on a *different* handler must not make the outer handler's pass look current while
+		// it runs, and must restore it once it is done.
+		[Fact]
+		public void NestedPassOnAnotherHandlerDoesNotLeakOrClobberTheOuterHandlersPass()
+		{
+			var outerHandler = new HandlerStub();
+			var innerHandler = new HandlerStub();
+			var view = new Button();
+
+			int outerPassId = 0;
+			int outerPassIdSeenFromInnerPass = -1;
+			int outerPassIdAfterNesting = 0;
+
+			var innerMapper = new PropertyMapper<IView, IViewHandler>
+			{
+				["Inner"] = (h, v) => outerPassIdSeenFromInnerPass = PropertyMapperPassScope.GetCurrentPassId(outerHandler),
+			};
+
+			var outerMapper = new PropertyMapper<IView, IViewHandler>
+			{
+				["BeforeNesting"] = (h, v) => outerPassId = PropertyMapperPassScope.GetCurrentPassId(h),
+				["Nest"] = (h, v) => innerMapper.UpdateProperties(innerHandler, v),
+				["AfterNesting"] = (h, v) => outerPassIdAfterNesting = PropertyMapperPassScope.GetCurrentPassId(h),
+			};
+
+			outerMapper.UpdateProperties(outerHandler, view);
+
+			Assert.NotEqual(0, outerPassId);
+			Assert.Equal(0, outerPassIdSeenFromInnerPass);
+			Assert.Equal(outerPassId, outerPassIdAfterNesting);
+		}
+
+		// A nested pass aborted by an exception must still restore the enclosing pass on the way out.
+		[Fact]
+		public void NestedPassThatThrowsStillRestoresTheOuterPass()
+		{
+			var handler = new HandlerStub();
+			var view = new Button();
+
+			int outerPassId = 0;
+			int outerPassIdAfterNesting = 0;
+
+			var innerMapper = new PropertyMapper<IView, IViewHandler>
+			{
+				["Throws"] = (h, v) => throw new InvalidOperationException("Simulated nested mapper failure"),
+			};
+
+			var outerMapper = new PropertyMapper<IView, IViewHandler>
+			{
+				["BeforeNesting"] = (h, v) => outerPassId = PropertyMapperPassScope.GetCurrentPassId(h),
+				["Nest"] = (h, v) =>
+				{
+					Assert.Throws<InvalidOperationException>(() => innerMapper.UpdateProperties(h, v));
+				},
+				["AfterNesting"] = (h, v) => outerPassIdAfterNesting = PropertyMapperPassScope.GetCurrentPassId(h),
+			};
+
+			outerMapper.UpdateProperties(handler, view);
+
+			Assert.NotEqual(0, outerPassId);
+			Assert.Equal(outerPassId, outerPassIdAfterNesting);
+			Assert.Equal(0, PropertyMapperPassScope.GetCurrentPassId(handler));
+		}
+
+		// A bulk pass must report the key it is currently mapping, which is what lets a redirect mapping
+		// recognize its own - provably redundant - turn within the pass.
+		[Fact]
+		public void BulkPassReportsTheKeyCurrentlyBeingMapped()
+		{
+			var handler = new HandlerStub();
+			var view = new Button();
+			var observed = new List<string>();
+
+			var mapper = new PropertyMapper<IView, IViewHandler>();
+			foreach (var key in new[] { "A", "B", "C" })
+			{
+				mapper.Add(key, (h, v) =>
+				{
+					var pass = PropertyMapperPassScope.Current;
+					observed.Add(pass!.Keys![pass.CurrentKeyIndex]);
+				});
+			}
+
+			mapper.UpdateProperties(handler, view);
+
+			Assert.Equal(new[] { "A", "B", "C" }, observed);
+			Assert.Null(PropertyMapperPassScope.Current);
+		}
+
+		// IsRedundantBulkPassRedirect is the primitive the Controls-side redirects are built on: it must be
+		// true *only* on the redirect key's own step of a bulk pass for that same handler, and only when
+		// the canonical key already had its turn earlier in the very same pass.
+		[Fact]
+		public void IsRedundantBulkPassRedirectIsTrueOnlyOnTheRedirectKeysOwnStepAfterTheCanonicalKey()
+		{
+			var handler = new HandlerStub();
+			var otherHandler = new HandlerStub();
+			var view = new Button();
+
+			var results = new List<bool>();
+			bool onRedirectStepForAnotherHandler = true;
+			bool onALaterUnrelatedStep = true;
+
+			PropertyMapper<IView, IViewHandler> mapper = null;
+			mapper = new PropertyMapper<IView, IViewHandler>
+			{
+				["Canonical"] = (h, v) => results.Add(PropertyMapperPassScope.IsRedundantBulkPassRedirect(h, "Redirect", "Canonical")),
+				["Redirect"] = (h, v) =>
+				{
+					results.Add(PropertyMapperPassScope.IsRedundantBulkPassRedirect(h, "Redirect", "Canonical"));
+					onRedirectStepForAnotherHandler = PropertyMapperPassScope.IsRedundantBulkPassRedirect(otherHandler, "Redirect", "Canonical");
+				},
+				["Later"] = (h, v) =>
+				{
+					onALaterUnrelatedStep = PropertyMapperPassScope.IsRedundantBulkPassRedirect(h, "Redirect", "Canonical");
+
+					// A re-entrant single-key update raised by a mapper running later in the same pass is
+					// not the redirect key's own pass step, so it must be honored.
+					mapper.UpdateProperty(h, v, "Redirect");
+				},
+			};
+
+			mapper.UpdateProperties(handler, view);
+
+			// Canonical's own step, Redirect's own step (redundant), and Redirect re-entered from Later.
+			Assert.Equal(new[] { false, true, false }, results);
+			Assert.False(onRedirectStepForAnotherHandler);
+			Assert.False(onALaterUnrelatedStep);
+
+			// Outside of any bulk pass there is nothing redundant to skip.
+			Assert.False(PropertyMapperPassScope.IsRedundantBulkPassRedirect(handler, "Redirect", "Canonical"));
+			Assert.False(PropertyMapperPassScope.IsRedundantBulkPassRedirect(null, "Redirect", "Canonical"));
+		}
+
+		// If the canonical key runs *after* the redirect key (or is missing entirely), the redirect is not
+		// redundant and must be applied - the de-duplication must never be able to drop the only chance a
+		// value had to reach the platform.
+		[Fact]
+		public void IsRedundantBulkPassRedirectIsFalseWhenTheCanonicalKeyDoesNotPrecedeTheRedirectKey()
+		{
+			var handler = new HandlerStub();
+			var view = new Button();
+
+			bool canonicalAfterRedirect = true;
+			bool canonicalMissing = true;
+
+			var reorderedMapper = new PropertyMapper<IView, IViewHandler>
+			{
+				["Redirect"] = (h, v) => canonicalAfterRedirect = PropertyMapperPassScope.IsRedundantBulkPassRedirect(h, "Redirect", "Canonical"),
+				["Canonical"] = (h, v) => { },
+			};
+			reorderedMapper.UpdateProperties(handler, view);
+
+			var mapperWithoutCanonical = new PropertyMapper<IView, IViewHandler>
+			{
+				["Redirect"] = (h, v) => canonicalMissing = PropertyMapperPassScope.IsRedundantBulkPassRedirect(h, "Redirect", "Canonical"),
+			};
+			mapperWithoutCanonical.UpdateProperties(handler, view);
+
+			Assert.False(canonicalAfterRedirect);
+			Assert.False(canonicalMissing);
+		}
+
+		// Pass tracking is per-thread, so concurrent bulk passes - even for the very same handler - can
+		// never corrupt each other's state or throw. (The previous ConditionalWeakTable Remove/Add
+		// implementation could throw when two passes for one handler raced.)
+		[Fact]
+		public void ConcurrentBulkPassesForTheSameHandlerAreIndependentAndDoNotThrow()
+		{
+			var handler = new HandlerStub();
+			const int threadCount = 8;
+			const int iterations = 200;
+
+			var observedPassIds = new System.Collections.Concurrent.ConcurrentBag<int>();
+			var failures = new System.Collections.Concurrent.ConcurrentBag<Exception>();
+
+			var mapper = new PropertyMapper<IView, IViewHandler>
+			{
+				["A"] = (h, v) =>
+				{
+					var passId = PropertyMapperPassScope.GetCurrentPassId(h);
+					if (passId == 0)
+					{
+						throw new InvalidOperationException("A bulk pass must always be current while its own mappers run.");
+					}
+
+					observedPassIds.Add(passId);
+				},
+				["B"] = (h, v) => Assert.NotEqual(0, PropertyMapperPassScope.GetCurrentPassId(h)),
+			};
+
+			var threads = new System.Threading.Thread[threadCount];
+			for (int t = 0; t < threadCount; t++)
+			{
+				threads[t] = new System.Threading.Thread(() =>
+				{
+					try
+					{
+						// Each thread uses its own virtual view; only the handler (and therefore the pass
+						// bookkeeping that used to be keyed on it) is shared.
+						var view = new Button();
+						for (int i = 0; i < iterations; i++)
+						{
+							mapper.UpdateProperties(handler, view);
+						}
+					}
+					catch (Exception ex)
+					{
+						failures.Add(ex);
+					}
+				});
+				threads[t].Start();
+			}
+
+			foreach (var thread in threads)
+			{
+				thread.Join();
+			}
+
+			Assert.Empty(failures);
+
+			// Every pass got its own id, and none of them is left current on this thread.
+			Assert.Equal(threadCount * iterations, observedPassIds.Count);
+			Assert.Equal(threadCount * iterations, observedPassIds.Distinct().Count());
 			Assert.Equal(0, PropertyMapperPassScope.GetCurrentPassId(handler));
 		}
 

--- a/src/Core/tests/UnitTests/PropertyMapperTests.cs
+++ b/src/Core/tests/UnitTests/PropertyMapperTests.cs
@@ -41,50 +41,57 @@ namespace Microsoft.Maui.UnitTests
 			Assert.Equal(insertedProperties, updatedProperties);
 		}
 
-		// Regression test for PropertyMapperPassScope, the pass/generation-scoped tracking used by
-		// VisualElement's BackgroundColor/BackgroundImageSource/SemanticProperties mapper redirects to
-		// distinguish a genuine step of *this* bulk UpdateProperties pass from an unrelated single-key
-		// UpdateProperty call that merely happens to touch the same handler at a different time.
+		// Regression test for PropertyMapperPassScope, the bulk-pass tracking used by VisualElement's
+		// BackgroundColor/BackgroundImageSource/SemanticProperties mapper redirects to distinguish a
+		// genuine step of *this* bulk UpdateProperties pass from an unrelated single-key UpdateProperty
+		// call that merely happens to touch the same handler at a different time.
 		[Fact]
 		public void UpdatePropertiesPassScopeIsActiveDuringBulkPassAndClearedAfterward()
 		{
 			var handler = new HandlerStub();
-			int? passIdDuringA = null;
-			int? passIdDuringB = null;
+			var view = new ViewStub();
 
+			PropertyMapperPass passDuringA = null;
+			PropertyMapperPass passDuringB = null;
+			PropertyMapperPass passDuringStandaloneUpdate = null;
+			IElementHandler handlerDuringA = null;
+			int depthDuringA = -1;
+
+			// Frames are pooled and cleared when a pass ends, so anything other than their identity has to
+			// be read while the pass is still running.
 			var mapper = new PropertyMapper<IView, IViewHandler>
 			{
-				["A"] = (h, v) => passIdDuringA = PropertyMapperPassScope.GetCurrentPassId(h),
-				["B"] = (h, v) => passIdDuringB = PropertyMapperPassScope.GetCurrentPassId(h),
+				["A"] = (h, v) =>
+				{
+					passDuringA = PropertyMapperPassScope.Current;
+					handlerDuringA = passDuringA.Handler;
+					depthDuringA = passDuringA.Depth;
+				},
+				["B"] = (h, v) => passDuringB = PropertyMapperPassScope.Current,
 			};
 
-			Assert.Equal(0, PropertyMapperPassScope.GetCurrentPassId(handler));
+			Assert.Null(PropertyMapperPassScope.Current);
 
-			mapper.UpdateProperties(handler, new Button());
+			mapper.UpdateProperties(handler, view);
 
-			// Both mappers ran as part of the very same bulk pass, so they must have observed the same,
-			// non-zero pass id.
-			Assert.NotNull(passIdDuringA);
-			Assert.NotEqual(0, passIdDuringA);
-			Assert.Equal(passIdDuringA, passIdDuringB);
+			// Both mappers ran as steps of the very same bulk pass, for this handler, at the outermost
+			// depth - so they must have observed one and the same live frame.
+			Assert.NotNull(passDuringA);
+			Assert.Same(passDuringA, passDuringB);
+			Assert.Same(handler, handlerDuringA);
+			Assert.Equal(0, depthDuringA);
 
-			// The pass must be considered over once UpdateProperties has returned.
-			Assert.Equal(0, PropertyMapperPassScope.GetCurrentPassId(handler));
+			// The pass must be over once UpdateProperties has returned, and the frame it used must no
+			// longer reference anything.
+			Assert.Null(PropertyMapperPassScope.Current);
+			Assert.Null(passDuringA.Handler);
+			Assert.Null(passDuringA.Keys);
 
-			// A later, standalone single-key update is not part of a bulk pass, so it must report no
-			// active pass at all - and must get a fresh id from a subsequent bulk pass, never reusing
-			// (or being confused with) the earlier one.
-			mapper.UpdateProperty(handler, new Button(), "A");
-			Assert.Equal(0, PropertyMapperPassScope.GetCurrentPassId(handler));
-
-			int? passIdDuringSecondPass = null;
-			var mapper2 = new PropertyMapper<IView, IViewHandler>
-			{
-				["A"] = (h, v) => passIdDuringSecondPass = PropertyMapperPassScope.GetCurrentPassId(h),
-			};
-			mapper2.UpdateProperties(handler, new Button());
-			Assert.NotNull(passIdDuringSecondPass);
-			Assert.NotEqual(passIdDuringA, passIdDuringSecondPass);
+			// A later, standalone single-key update is not part of a bulk pass at all.
+			mapper.Add("Standalone", (h, v) => passDuringStandaloneUpdate = PropertyMapperPassScope.Current);
+			mapper.UpdateProperty(handler, view, "Standalone");
+			Assert.Null(passDuringStandaloneUpdate);
+			Assert.Null(PropertyMapperPassScope.Current);
 		}
 
 		// Even if a mapper throws partway through a bulk pass, the pass must be popped on the way out, so
@@ -93,58 +100,79 @@ namespace Microsoft.Maui.UnitTests
 		public void UpdatePropertiesPassScopeIsClearedInFinallyWhenAMapperThrows()
 		{
 			var handler = new HandlerStub();
-			int? passIdBeforeThrow = null;
+			PropertyMapperPass passBeforeThrow = null;
 
 			var mapper = new PropertyMapper<IView, IViewHandler>
 			{
-				["A"] = (h, v) => passIdBeforeThrow = PropertyMapperPassScope.GetCurrentPassId(h),
+				["A"] = (h, v) => passBeforeThrow = PropertyMapperPassScope.Current,
 				["Throws"] = (h, v) => throw new InvalidOperationException("Simulated mapper failure"),
 				["C"] = (h, v) => Assert.Fail("Should not run - the pass was aborted by an earlier mapper throwing"),
 			};
 
-			Assert.Throws<InvalidOperationException>(() => mapper.UpdateProperties(handler, new Button()));
+			Assert.Throws<InvalidOperationException>(() => mapper.UpdateProperties(handler, new ViewStub()));
 
-			Assert.NotNull(passIdBeforeThrow);
-			Assert.NotEqual(0, passIdBeforeThrow);
+			Assert.NotNull(passBeforeThrow);
 
-			// The aborted pass must not be left "active" - a later caller must see no active pass.
-			Assert.Equal(0, PropertyMapperPassScope.GetCurrentPassId(handler));
+			// The aborted pass must not be left "active" - a later caller must see no active pass, and the
+			// frame must have been cleared so it cannot keep the handler alive.
+			Assert.Null(PropertyMapperPassScope.Current);
+			Assert.Null(passBeforeThrow.Handler);
 		}
 
 		// The pass scope is a stack: a nested UpdateProperties pass - on the same handler or on another
 		// one - must restore the pass that enclosed it when it ends, so the outer pass keeps running with
-		// its own identity and its own "current key" position.
+		// its own frame and its own "current key" position.
 		[Fact]
 		public void NestedPassOnTheSameHandlerRestoresTheOuterPassWhenItEnds()
 		{
 			var handler = new HandlerStub();
-			var view = new Button();
+			var view = new ViewStub();
 
-			int outerPassId = 0;
-			int innerPassId = 0;
-			int outerPassIdAfterNesting = 0;
+			PropertyMapperPass outerPass = null;
+			PropertyMapperPass innerPass = null;
+			PropertyMapperPass outerPassAfterNesting = null;
+			int outerDepth = -1;
+			int innerDepth = -1;
+			int outerKeyIndexAfterNesting = -1;
 
 			var innerMapper = new PropertyMapper<IView, IViewHandler>
 			{
-				["Inner"] = (h, v) => innerPassId = PropertyMapperPassScope.GetCurrentPassId(h),
+				["Inner"] = (h, v) =>
+				{
+					innerPass = PropertyMapperPassScope.Current;
+					innerDepth = innerPass.Depth;
+				},
 			};
 
 			var outerMapper = new PropertyMapper<IView, IViewHandler>
 			{
-				["BeforeNesting"] = (h, v) => outerPassId = PropertyMapperPassScope.GetCurrentPassId(h),
+				["BeforeNesting"] = (h, v) =>
+				{
+					outerPass = PropertyMapperPassScope.Current;
+					outerDepth = outerPass.Depth;
+				},
 				["Nest"] = (h, v) => innerMapper.UpdateProperties(h, v),
-				["AfterNesting"] = (h, v) => outerPassIdAfterNesting = PropertyMapperPassScope.GetCurrentPassId(h),
+				["AfterNesting"] = (h, v) =>
+				{
+					outerPassAfterNesting = PropertyMapperPassScope.Current;
+					outerKeyIndexAfterNesting = outerPassAfterNesting.CurrentKeyIndex;
+				},
 			};
 
 			outerMapper.UpdateProperties(handler, view);
 
-			Assert.NotEqual(0, outerPassId);
-			Assert.NotEqual(0, innerPassId);
-			Assert.NotEqual(outerPassId, innerPassId);
+			// The nested pass is a distinct frame, one level deeper.
+			Assert.NotNull(outerPass);
+			Assert.NotNull(innerPass);
+			Assert.NotSame(outerPass, innerPass);
+			Assert.Equal(0, outerDepth);
+			Assert.Equal(1, innerDepth);
 
-			// The outer pass must be exactly the same pass it was before the nested one ran.
-			Assert.Equal(outerPassId, outerPassIdAfterNesting);
-			Assert.Equal(0, PropertyMapperPassScope.GetCurrentPassId(handler));
+			// ... and the outer pass is exactly the frame it was before the nested one ran, still tracking
+			// its own position in its own key list.
+			Assert.Same(outerPass, outerPassAfterNesting);
+			Assert.Equal(2, outerKeyIndexAfterNesting);
+			Assert.Null(PropertyMapperPassScope.Current);
 		}
 
 		// A nested pass on a *different* handler must not make the outer handler's pass look current while
@@ -154,29 +182,52 @@ namespace Microsoft.Maui.UnitTests
 		{
 			var outerHandler = new HandlerStub();
 			var innerHandler = new HandlerStub();
-			var view = new Button();
+			var view = new ViewStub();
 
-			int outerPassId = 0;
-			int outerPassIdSeenFromInnerPass = -1;
-			int outerPassIdAfterNesting = 0;
+			PropertyMapperPass outerPass = null;
+			PropertyMapperPass currentPassSeenFromInnerPass = null;
+			PropertyMapperPass outerPassAfterNesting = null;
+			IElementHandler handlerDuringOuterPass = null;
+			IElementHandler handlerSeenFromInnerPass = null;
+			IElementHandler handlerAfterNesting = null;
 
 			var innerMapper = new PropertyMapper<IView, IViewHandler>
 			{
-				["Inner"] = (h, v) => outerPassIdSeenFromInnerPass = PropertyMapperPassScope.GetCurrentPassId(outerHandler),
+				["Inner"] = (h, v) =>
+				{
+					currentPassSeenFromInnerPass = PropertyMapperPassScope.Current;
+					handlerSeenFromInnerPass = currentPassSeenFromInnerPass.Handler;
+				},
 			};
 
 			var outerMapper = new PropertyMapper<IView, IViewHandler>
 			{
-				["BeforeNesting"] = (h, v) => outerPassId = PropertyMapperPassScope.GetCurrentPassId(h),
+				["BeforeNesting"] = (h, v) =>
+				{
+					outerPass = PropertyMapperPassScope.Current;
+					handlerDuringOuterPass = outerPass.Handler;
+				},
 				["Nest"] = (h, v) => innerMapper.UpdateProperties(innerHandler, v),
-				["AfterNesting"] = (h, v) => outerPassIdAfterNesting = PropertyMapperPassScope.GetCurrentPassId(h),
+				["AfterNesting"] = (h, v) =>
+				{
+					outerPassAfterNesting = PropertyMapperPassScope.Current;
+					handlerAfterNesting = outerPassAfterNesting.Handler;
+				},
 			};
 
 			outerMapper.UpdateProperties(outerHandler, view);
 
-			Assert.NotEqual(0, outerPassId);
-			Assert.Equal(0, outerPassIdSeenFromInnerPass);
-			Assert.Equal(outerPassId, outerPassIdAfterNesting);
+			Assert.NotNull(outerPass);
+			Assert.Same(outerHandler, handlerDuringOuterPass);
+
+			// While the nested pass runs, the current pass is the inner handler's - the outer handler's is
+			// no longer the innermost one.
+			Assert.NotNull(currentPassSeenFromInnerPass);
+			Assert.NotSame(outerPass, currentPassSeenFromInnerPass);
+			Assert.Same(innerHandler, handlerSeenFromInnerPass);
+
+			Assert.Same(outerPass, outerPassAfterNesting);
+			Assert.Same(outerHandler, handlerAfterNesting);
 		}
 
 		// A nested pass aborted by an exception must still restore the enclosing pass on the way out.
@@ -184,10 +235,12 @@ namespace Microsoft.Maui.UnitTests
 		public void NestedPassThatThrowsStillRestoresTheOuterPass()
 		{
 			var handler = new HandlerStub();
-			var view = new Button();
+			var view = new ViewStub();
 
-			int outerPassId = 0;
-			int outerPassIdAfterNesting = 0;
+			PropertyMapperPass outerPass = null;
+			PropertyMapperPass outerPassAfterNesting = null;
+			IElementHandler handlerAfterNesting = null;
+			int depthAfterNesting = -1;
 
 			var innerMapper = new PropertyMapper<IView, IViewHandler>
 			{
@@ -196,19 +249,23 @@ namespace Microsoft.Maui.UnitTests
 
 			var outerMapper = new PropertyMapper<IView, IViewHandler>
 			{
-				["BeforeNesting"] = (h, v) => outerPassId = PropertyMapperPassScope.GetCurrentPassId(h),
-				["Nest"] = (h, v) =>
+				["BeforeNesting"] = (h, v) => outerPass = PropertyMapperPassScope.Current,
+				["Nest"] = (h, v) => Assert.Throws<InvalidOperationException>(() => innerMapper.UpdateProperties(h, v)),
+				["AfterNesting"] = (h, v) =>
 				{
-					Assert.Throws<InvalidOperationException>(() => innerMapper.UpdateProperties(h, v));
+					outerPassAfterNesting = PropertyMapperPassScope.Current;
+					handlerAfterNesting = outerPassAfterNesting.Handler;
+					depthAfterNesting = outerPassAfterNesting.Depth;
 				},
-				["AfterNesting"] = (h, v) => outerPassIdAfterNesting = PropertyMapperPassScope.GetCurrentPassId(h),
 			};
 
 			outerMapper.UpdateProperties(handler, view);
 
-			Assert.NotEqual(0, outerPassId);
-			Assert.Equal(outerPassId, outerPassIdAfterNesting);
-			Assert.Equal(0, PropertyMapperPassScope.GetCurrentPassId(handler));
+			Assert.NotNull(outerPass);
+			Assert.Same(outerPass, outerPassAfterNesting);
+			Assert.Same(handler, handlerAfterNesting);
+			Assert.Equal(0, depthAfterNesting);
+			Assert.Null(PropertyMapperPassScope.Current);
 		}
 
 		// A bulk pass must report the key it is currently mapping, which is what lets a redirect mapping
@@ -217,7 +274,7 @@ namespace Microsoft.Maui.UnitTests
 		public void BulkPassReportsTheKeyCurrentlyBeingMapped()
 		{
 			var handler = new HandlerStub();
-			var view = new Button();
+			var view = new ViewStub();
 			var observed = new List<string>();
 
 			var mapper = new PropertyMapper<IView, IViewHandler>();
@@ -236,6 +293,52 @@ namespace Microsoft.Maui.UnitTests
 			Assert.Null(PropertyMapperPassScope.Current);
 		}
 
+		// The merged keys and mappings are published as a single reference, so a running pass can never
+		// observe a mix of two different merges - `keys[i]` is always the key whose mapping is `mappers[i]`,
+		// which is what the redirect de-duplication relies on. A mapper mutating its own mapper mid-pass
+		// exercises exactly that: the pass keeps enumerating - and keeps reporting - the merge it started
+		// with, and the next pass picks the new one up.
+		[Fact]
+		public void MutatingTheMapperDuringABulkPassDoesNotChangeTheRunningPassSnapshot()
+		{
+			var handler = new HandlerStub();
+			var view = new ViewStub();
+			var observed = new List<string>();
+
+			List<string> keysAtFirstStep = null;
+			List<string> keysAtLastStep = null;
+			bool addedKeyRan = false;
+
+			PropertyMapper<IView, IViewHandler> mapper = null;
+			mapper = new PropertyMapper<IView, IViewHandler>
+			{
+				["A"] = (h, v) =>
+				{
+					observed.Add("A");
+					keysAtFirstStep = PropertyMapperPassScope.Current.Keys;
+
+					// Drops the published merge; the running pass must not notice.
+					mapper.Add("AddedMidPass", (h2, v2) => addedKeyRan = true);
+				},
+				["B"] = (h, v) =>
+				{
+					observed.Add("B");
+					keysAtLastStep = PropertyMapperPassScope.Current.Keys;
+				},
+			};
+
+			mapper.UpdateProperties(handler, view);
+
+			Assert.Equal(new[] { "A", "B" }, observed);
+			Assert.Same(keysAtFirstStep, keysAtLastStep);
+			Assert.Equal(new[] { "A", "B" }, keysAtFirstStep);
+			Assert.False(addedKeyRan);
+
+			// The next pass re-merges and does include the key added above.
+			mapper.UpdateProperties(handler, view);
+			Assert.True(addedKeyRan);
+		}
+
 		// IsRedundantBulkPassRedirect is the primitive the Controls-side redirects are built on: it must be
 		// true *only* on the redirect key's own step of a bulk pass for that same handler, and only when
 		// the canonical key already had its turn earlier in the very same pass.
@@ -244,7 +347,7 @@ namespace Microsoft.Maui.UnitTests
 		{
 			var handler = new HandlerStub();
 			var otherHandler = new HandlerStub();
-			var view = new Button();
+			var view = new ViewStub();
 
 			var results = new List<bool>();
 			bool onRedirectStepForAnotherHandler = true;
@@ -288,7 +391,7 @@ namespace Microsoft.Maui.UnitTests
 		public void IsRedundantBulkPassRedirectIsFalseWhenTheCanonicalKeyDoesNotPrecedeTheRedirectKey()
 		{
 			var handler = new HandlerStub();
-			var view = new Button();
+			var view = new ViewStub();
 
 			bool canonicalAfterRedirect = true;
 			bool canonicalMissing = true;
@@ -320,23 +423,34 @@ namespace Microsoft.Maui.UnitTests
 			const int threadCount = 8;
 			const int iterations = 200;
 
-			var observedPassIds = new System.Collections.Concurrent.ConcurrentBag<int>();
+			var passesPerThread = new System.Collections.Concurrent.ConcurrentDictionary<int, PropertyMapperPass>();
 			var failures = new System.Collections.Concurrent.ConcurrentBag<Exception>();
+			var observedSteps = 0;
 
 			var mapper = new PropertyMapper<IView, IViewHandler>
 			{
 				["A"] = (h, v) =>
 				{
-					var passId = PropertyMapperPassScope.GetCurrentPassId(h);
-					if (passId == 0)
+					var pass = PropertyMapperPassScope.Current;
+
+					if (pass is null || !ReferenceEquals(pass.Handler, h) || pass.Depth != 0)
 					{
-						throw new InvalidOperationException("A bulk pass must always be current while its own mappers run.");
+						throw new InvalidOperationException("A bulk pass for this handler must be the current, outermost pass while its own mappers run.");
 					}
 
-					observedPassIds.Add(passId);
+					// Record the frame this thread is using; per-thread pooling means it must be stable
+					// across that thread's passes, and never shared with another thread.
+					passesPerThread[Environment.CurrentManagedThreadId] = pass;
+					System.Threading.Interlocked.Increment(ref observedSteps);
 				},
-				["B"] = (h, v) => Assert.NotEqual(0, PropertyMapperPassScope.GetCurrentPassId(h)),
+				["B"] = (h, v) => Assert.Same(handler, PropertyMapperPassScope.Current?.Handler),
 			};
+
+			// Warm the merged snapshot (and each thread's first frame is allocated on demand) so the
+			// threads below exercise the steady-state, lock-free path rather than racing the first merge.
+			mapper.UpdateProperties(handler, new ViewStub());
+			passesPerThread.Clear();
+			observedSteps = 0;
 
 			var threads = new System.Threading.Thread[threadCount];
 			for (int t = 0; t < threadCount; t++)
@@ -345,9 +459,9 @@ namespace Microsoft.Maui.UnitTests
 				{
 					try
 					{
-						// Each thread uses its own virtual view; only the handler (and therefore the pass
-						// bookkeeping that used to be keyed on it) is shared.
-						var view = new Button();
+						// Each thread uses its own virtual view; only the handler - and therefore the pass
+						// bookkeeping that used to be keyed on it - is shared.
+						var view = new ViewStub();
 						for (int i = 0; i < iterations; i++)
 						{
 							mapper.UpdateProperties(handler, view);
@@ -367,11 +481,13 @@ namespace Microsoft.Maui.UnitTests
 			}
 
 			Assert.Empty(failures);
+			Assert.Equal(threadCount * iterations, observedSteps);
 
-			// Every pass got its own id, and none of them is left current on this thread.
-			Assert.Equal(threadCount * iterations, observedPassIds.Count);
-			Assert.Equal(threadCount * iterations, observedPassIds.Distinct().Count());
-			Assert.Equal(0, PropertyMapperPassScope.GetCurrentPassId(handler));
+			// Every thread ran its passes on its own frame - no two threads ever shared one.
+			Assert.Equal(threadCount, passesPerThread.Count);
+			Assert.Equal(threadCount, passesPerThread.Values.Distinct().Count());
+
+			Assert.Null(PropertyMapperPassScope.Current);
 		}
 
 		[Fact]

--- a/src/Core/tests/UnitTests/PropertyMapperTests.cs
+++ b/src/Core/tests/UnitTests/PropertyMapperTests.cs
@@ -41,6 +41,78 @@ namespace Microsoft.Maui.UnitTests
 			Assert.Equal(insertedProperties, updatedProperties);
 		}
 
+		// Regression test for PropertyMapperPassScope, the pass/generation-scoped tracking used by
+		// VisualElement's BackgroundColor/BackgroundImageSource/SemanticProperties mapper redirects to
+		// distinguish a genuine step of *this* bulk UpdateProperties pass from an unrelated single-key
+		// UpdateProperty call that merely happens to touch the same handler at a different time.
+		[Fact]
+		public void UpdatePropertiesPassScopeIsActiveDuringBulkPassAndClearedAfterward()
+		{
+			var handler = new HandlerStub();
+			int? passIdDuringA = null;
+			int? passIdDuringB = null;
+
+			var mapper = new PropertyMapper<IView, IViewHandler>
+			{
+				["A"] = (h, v) => passIdDuringA = PropertyMapperPassScope.GetCurrentPassId(h),
+				["B"] = (h, v) => passIdDuringB = PropertyMapperPassScope.GetCurrentPassId(h),
+			};
+
+			Assert.Equal(0, PropertyMapperPassScope.GetCurrentPassId(handler));
+
+			mapper.UpdateProperties(handler, new Button());
+
+			// Both mappers ran as part of the very same bulk pass, so they must have observed the same,
+			// non-zero pass id.
+			Assert.NotNull(passIdDuringA);
+			Assert.NotEqual(0, passIdDuringA);
+			Assert.Equal(passIdDuringA, passIdDuringB);
+
+			// The pass must be considered over once UpdateProperties has returned.
+			Assert.Equal(0, PropertyMapperPassScope.GetCurrentPassId(handler));
+
+			// A later, standalone single-key update is not part of a bulk pass, so it must report no
+			// active pass at all - and must get a fresh id from a subsequent bulk pass, never reusing
+			// (or being confused with) the earlier one.
+			mapper.UpdateProperty(handler, new Button(), "A");
+			Assert.Equal(0, PropertyMapperPassScope.GetCurrentPassId(handler));
+
+			int? passIdDuringSecondPass = null;
+			var mapper2 = new PropertyMapper<IView, IViewHandler>
+			{
+				["A"] = (h, v) => passIdDuringSecondPass = PropertyMapperPassScope.GetCurrentPassId(h),
+			};
+			mapper2.UpdateProperties(handler, new Button());
+			Assert.NotNull(passIdDuringSecondPass);
+			Assert.NotEqual(passIdDuringA, passIdDuringSecondPass);
+		}
+
+		// Even if a mapper throws partway through a bulk pass, the pass must be considered over - so any
+		// pass-scoped state a mapper implementation recorded against that pass's id (e.g. a "skip the next
+		// redundant redirected call" mark) can never again be matched once the pass has ended, whether it
+		// ended normally or via exception.
+		[Fact]
+		public void UpdatePropertiesPassScopeIsClearedInFinallyWhenAMapperThrows()
+		{
+			var handler = new HandlerStub();
+			int? passIdBeforeThrow = null;
+
+			var mapper = new PropertyMapper<IView, IViewHandler>
+			{
+				["A"] = (h, v) => passIdBeforeThrow = PropertyMapperPassScope.GetCurrentPassId(h),
+				["Throws"] = (h, v) => throw new InvalidOperationException("Simulated mapper failure"),
+				["C"] = (h, v) => Assert.Fail("Should not run - the pass was aborted by an earlier mapper throwing"),
+			};
+
+			Assert.Throws<InvalidOperationException>(() => mapper.UpdateProperties(handler, new Button()));
+
+			Assert.NotNull(passIdBeforeThrow);
+			Assert.NotEqual(0, passIdBeforeThrow);
+
+			// The aborted pass must not be left "active" - a later caller must see no active pass.
+			Assert.Equal(0, PropertyMapperPassScope.GetCurrentPassId(handler));
+		}
+
 		[Fact]
 		public void MapperExecutesChainedKeysFirst()
 		{


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Avoids redirecting `BackgroundColor`, `BackgroundImageSource`, and the three semantics properties back through their canonical mapper entries during initial handler connection. The canonical `Background` and `Semantics` entries already read the current composite values in that same initialization pass.

Reconnect and dynamic property-update behavior is unchanged.

## Benchmark

The local Sandbox harness is not included in this PR. Release iOS simulator, iPhone 16 Pro / iOS 18.4:

| Fixed-work metric | `net11.0` base | This change | Difference |
|---|---:|---:|---:|
| Heavy tile `ToPlatform` (55 elements) | 11.597 ms | 10.621 ms | **-8.4%** |
| Flat tile `ToPlatform` (14 elements) | 4.524 ms | 4.044 ms | **-10.6%** |
| Mapper calls, 12 heavy tiles | 26,808 | 23,916 | **-2,892 (-10.8%)** |

The optimized run completed all 70 benchmark results with `run-end|ok`.

## Review

Independent GPT, Claude, and Gemini reviews traced initial connection, reconnect, dynamic updates, mapper ordering, and semantics/background composition. The change remains intentionally limited to initial connection rather than changing reconnect semantics.
