### PR TITLE
[iOS/MacCatalyst] Fix Editor and CarouselView remaining non-interactive after IsEnabled toggle

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.iOS.cs
@@ -39,6 +39,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		internal static void MapIsEnabled(CarouselViewHandler handler, CarouselView carouselView)
 		{
 			handler.Controller?.CollectionView?.UpdateIsEnabled(carouselView);
+
+			// Also updates the outer Controller.View, which gates touch delivery
+			// but is otherwise left stale by the CollectionView-only update above.
+			ViewHandler.MapIsEnabled(handler, carouselView);
 		}
 
 		public static void MapIsSwipeEnabled(CarouselViewHandler handler, CarouselView carouselView)

--- a/src/Controls/src/Core/Handlers/Items2/CarouselViewHandler2.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items2/CarouselViewHandler2.iOS.cs
@@ -79,6 +79,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		internal static void MapIsEnabled(CarouselViewHandler2 handler, CarouselView carouselView)
 		{
 			handler.Controller?.CollectionView?.UpdateIsEnabled(carouselView);
+
+			// Also updates the outer Controller.View, which gates touch delivery
+			// but is otherwise left stale by the CollectionView-only update above.
+			ViewHandler.MapIsEnabled(handler, carouselView);
 		}
 
 		public static void MapIsSwipeEnabled(CarouselViewHandler2 handler, CarouselView carouselView)

--- a/src/Controls/tests/DeviceTests/Elements/CarouselView/CarouselViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CarouselView/CarouselViewTests.iOS.cs
@@ -50,5 +50,35 @@ namespace Microsoft.Maui.DeviceTests
 			// Verify the handler was collected
 			Assert.False(weakHandler.IsAlive, "CarouselViewHandler2 should have been garbage collected");
 		}
+
+		[Fact(DisplayName = "IsEnabled Updates Native Interaction State On Both Container And CollectionView")]
+		public async Task IsEnabledUpdatesNativeInteractionStateOnBothContainerAndCollectionView()
+		{
+			SetupBuilder();
+
+			var carouselView = new CarouselView
+			{
+				IsEnabled = false,
+				ItemsSource = new List<string> { "Item 1", "Item 2", "Item 3" },
+				ItemTemplate = new DataTemplate(() => new Label())
+			};
+
+			var handler = await CreateHandlerAsync<CarouselViewHandler2>(carouselView);
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				Assert.False(handler.Controller.CollectionView.UserInteractionEnabled);
+				Assert.False(handler.PlatformView.UserInteractionEnabled);
+
+				carouselView.IsEnabled = true;
+				handler.UpdateValue(nameof(IView.IsEnabled));
+
+				// Both the inner CollectionView and the outer Controller.View (handler.PlatformView)
+				// must become interactive - if only the inner one updates, swiping stays blocked
+				// because Controller.View is the outer view that gates touch delivery.
+				Assert.True(handler.Controller.CollectionView.UserInteractionEnabled);
+				Assert.True(handler.PlatformView.UserInteractionEnabled);
+			});
+		}
 	}
 }

--- a/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
@@ -214,8 +214,14 @@ namespace Microsoft.Maui.Handlers
 			handler.PlatformView?.UpdateCharacterSpacing(editor);
 		}
 
-		public static void MapIsEnabled(IEditorHandler handler, IEditor editor) =>
+		public static void MapIsEnabled(IEditorHandler handler, IEditor editor)
+		{
 			handler.PlatformView?.UpdateIsEnabled(editor);
+
+			// MauiTextView is not a UIControl, so UserInteractionEnabled must be
+			// recomputed explicitly here; it is not updated by the call above.
+			ViewHandler.MapIsEnabled(handler, editor);
+		}
 
 		class MauiTextViewEventProxy
 		{

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.iOS.cs
@@ -202,6 +202,29 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(xplatIsEnabled, values.PlatformViewValue);
 		}
 
+		[Fact(DisplayName = "IsEnabled Updates Native Interaction State")]
+		public async Task IsEnabledUpdatesNativeInteractionState()
+		{
+			var editor = new EditorStub
+			{
+				IsEnabled = false
+			};
+
+			var handler = await CreateHandlerAsync(editor);
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				Assert.False(handler.PlatformView.Editable);
+				Assert.False(handler.PlatformView.UserInteractionEnabled);
+
+				editor.IsEnabled = true;
+				handler.UpdateValue(nameof(IEditor.IsEnabled));
+
+				Assert.True(handler.PlatformView.Editable);
+				Assert.True(handler.PlatformView.UserInteractionEnabled);
+			});
+		}
+
 		static MauiTextView GetNativeEditor(EditorHandler editorHandler) =>
 			editorHandler.PlatformView;
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
- On iOS, a CarouselView or Editor that initially has IsEnabled="False"remains non-interactive after being re-enabled. Even though IsEnabledis set to True, the control still cannot be scrolled or typed into.

### Root Cause
- PR #36305 changed iOS interaction handling for non-UIControl views to calculate UserInteractionEnabled from IsEnabled && !InputTransparent; PR #36628 later centralized and extended this behavior. Editor and CarouselView override the inherited IsEnabled mapper without invoking the base mapping, so re-enabling updates only Editable for Editor or the inner UICollectionView for CarouselView, leaving the outer native interaction state disabled.


### Description of Change
- Updated MapIsEnabled in CarouselViewHandler, CarouselViewHandler2, and EditorHandler to invoke ViewHandler.MapIsEnabled after applying their control-specific updates, ensuring the outer native view’s interaction state is recalculated when IsEnabled changes.
- Note: On iOS, a disabled Editor now fully blocks interaction (no scrolling or text selection; touches pass through) instead of only disabling edits.


### Issues Fixed
Fixes #37815


### Validated the behaviour in the following platforms
- [ ] Windows
- [ ] Android
- [x] iOS
- [x] Mac



### Output
| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/0e78b7bf-3d8a-436f-bdb5-2eda8935f561"> | <video src="https://github.com/user-attachments/assets/6eefec85-873f-44ea-b63e-fcd4eb7ed43c"> |