### PR TITLE
Update Aspire branding and links in MAUI template

### DIFF
--- a/src/Templates/src/templates/maui-aspire-servicedefaults/.template.config/localize/templatestrings.en.json
+++ b/src/Templates/src/templates/maui-aspire-servicedefaults/.template.config/localize/templatestrings.en.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
-  "name": ".NET MAUI for .NET Aspire Service Defaults",
-  "description": "A project template for creating a .NET Aspire service defaults project for .NET MAUI.",
+  "name": ".NET MAUI for Aspire Service Defaults",
+  "description": "A project template for creating an Aspire service defaults project for .NET MAUI.",
   "symbols/Framework/description": "The target framework for the project.",
   "symbols/Framework/choices/DOTNET_TFM_VALUE/description": "Target DOTNET_TFM_VALUE",
   "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",

--- a/src/Templates/src/templates/maui-aspire-servicedefaults/.template.config/template.json
+++ b/src/Templates/src/templates/maui-aspire-servicedefaults/.template.config/template.json
@@ -22,7 +22,7 @@
     },
     "precedence": "9000",
     "identity": "MauiAspire.ServiceDefaults.CSharp.8.0",
-    "thirdPartyNotices": "https://aka.ms/dotnet/aspire/third-party-notices",
+    "thirdPartyNotices": "https://github.com/microsoft/aspire/blob/main/THIRD-PARTY-NOTICES.TXT",
     "groupIdentity": "MauiAspire.ServiceDefaults",
     "symbols": {
       "Framework": {

--- a/src/Templates/src/templates/maui-aspire-servicedefaults/Extensions.cs
+++ b/src/Templates/src/templates/maui-aspire-servicedefaults/Extensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Extensions.Hosting;
 
 // Adds common Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
 // This project should be referenced by each service project in your solution.
-// To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
+// To learn more about using this project, see https://aspire.dev/get-started/csharp-service-defaults/
 public static class Extensions
 {
     public static TBuilder AddServiceDefaults<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

This updates the MAUI Aspire Service Defaults template to:

- use the current `Aspire` product name in the editable English localization source;
- link Service Defaults documentation directly to `aspire.dev`;
- link third-party notices directly to the current `microsoft/aspire` repository.

PR #32626 corrected the main template manifest but intentionally reverted localization files. This follow-up updates `templatestrings.en.json`, the editable source of the English localization metadata. Generated `templatestrings.json`, translated JSON files, and `loc/**.lcl` files remain unchanged so the repository's OneLocBuild workflow can generate the localization follow-up.

### Issues Fixed

Follow-up to #32624 and #32626.

### Validation

- Built and packed `Microsoft.Maui.Templates.csproj`.
- Verified the packaged English template metadata uses `Aspire`.
- Verified both replacement links resolve.
- Verified no editable `.NET Aspire` references or legacy Aspire links remain.