### PR TITLE
[release-readiness] Add RC release support

### DIFF
--- a/.github/agents/release-readiness-agent.agent.md
+++ b/.github/agents/release-readiness-agent.agent.md
@@ -82,6 +82,7 @@ If the user wants the raw deterministic report with no judgment layer (e.g. for 
 
 - `release/<major>.0.1xx-sr<N>` → **SR lane** → `Get-ReleaseReadiness.ps1` (`-Candidate` if the branch doesn't exist yet; `-Shipped` if that SR cycle has a stable tag)
 - `release/<major>.0.1xx-preview<N>` → **Preview lane** → `Get-PreviewReadiness.ps1` (`-Mode candidate -SurveyRef net<major>.0` if the preview branch doesn't exist yet)
+- `release/<major>.0.1xx-rc<N>` → **RC lane** → `Get-PreviewReadiness.ps1` (`-Mode candidate -SurveyRef net<major>.0` if the RC branch doesn't exist yet)
 
 **If the user asked a portfolio / cross-release question** (plural "releases", "status overview", "what needs attention across releases", "what's next" — no single branch named) → **Portfolio path (§0a)**. Do NOT ask "which release?" — the whole point is they may not know which releases exist.
 

--- a/.github/skills/release-readiness/SKILL.md
+++ b/.github/skills/release-readiness/SKILL.md
@@ -33,11 +33,11 @@ This skill has **four** PowerShell entry points, one Preview helper, and one wor
 
 | Script | Branch type | Purpose |
 |--------|-------------|---------|
-| [`Find-ReleaseReadinessTrackers.ps1`](scripts/Find-ReleaseReadinessTrackers.ps1) | both | Detects active in-flight & candidate trackers (SR and Preview) across all active majors using a four-lane algorithm and the **tag-existence rule** ("a release is in flight unless its tag already exists"). Emits a single tracker JSON consumed by the workflow. |
+| [`Find-ReleaseReadinessTrackers.ps1`](scripts/Find-ReleaseReadinessTrackers.ps1) | all | Detects active in-flight & candidate trackers (SR, Preview, and RC) across all active majors using a five-lane algorithm and the **tag-existence rule** ("a release is in flight unless its tag already exists"). Emits a single tracker JSON consumed by the workflow. |
 | [`Get-ReleaseReadiness.ps1`](scripts/Get-ReleaseReadiness.ps1) | SR | Full readiness report for a single SR branch (in-flight, `-Candidate`, or `-Shipped`). `-Shipped` surveys the same branch with post-ship verdict, carry-forward, and hotfix-vs-next-SR guidance semantics. |
-| [`Get-PreviewReadiness.ps1`](scripts/Get-PreviewReadiness.ps1) | Preview | Full readiness report for a single Preview branch (in-flight or candidate via `-Mode candidate -SurveyRef net<major>.0`), including consumer-installability evidence. |
+| [`Get-PreviewReadiness.ps1`](scripts/Get-PreviewReadiness.ps1) | Preview / RC | Full readiness report for a single prerelease branch (in-flight or candidate via `-Mode candidate -SurveyRef net<major>.0`). Preview reports include consumer-installability evidence; RC reports retain that check as `UNKNOWN` until RC workload-set package resolution is supported. |
 | [`PreviewInstallability.ps1`](scripts/PreviewInstallability.ps1) | Preview helper | Resolves the workload-set package, validates branch-pin coherence, probes manifest and representative pack availability, extracts platform prerequisites, and emits an isolated NuGet configuration for local validation. |
-| [`New-ReleaseHandoff.ps1`](scripts/New-ReleaseHandoff.ps1) | both | Projects existing readiness JSON plus separately verified public release evidence into copy-ready Markdown and normalized JSON. Missing facts remain `TBD`; it never selects builds or mutates release state. |
+| [`New-ReleaseHandoff.ps1`](scripts/New-ReleaseHandoff.ps1) | all | Projects existing readiness JSON plus separately verified public release evidence into copy-ready Markdown and normalized JSON. Missing facts remain `TBD`; it never selects builds or mutates release state. |
 | [`release-readiness.yml`](../../workflows/release-readiness.yml) | both | Three-hourly daytime UTC schedule + event-driven refreshes + manual dispatch + PR validation. Non-PR triggers run `Find-Trackers -AllActiveMajors`, fan out a matrix job per tracker, and write idempotent `[Release Readiness]` issues; PR triggers validate outputs only. |
 
 Shared support code lives in [`PublicReportSanitizer.ps1`](scripts/PublicReportSanitizer.ps1) for public Markdown/JSON redaction and [`TrackerIssueLifecycle.sh`](scripts/TrackerIssueLifecycle.sh) for tested issue-selection and race-compensation primitives.
@@ -48,6 +48,7 @@ The trackers detector is grounded in **tag existence as the source of truth for 
 
 - SR shipped tag pattern: `<major>.0.<patch>` (e.g. `10.0.71` shipped → SR7 retired, no longer produces a tracker)
 - Preview shipped tag pattern: `<major>.0.0-preview.<N>.<date>[.<build>]` (e.g. `11.0.0-preview.5.26304.4` shipped → preview5 no longer produces a tracker)
+- RC shipped tag pattern: `<major>.0.0-rc.<N>.<date>[.<build>]` (e.g. `11.0.0-rc.1.26425.128` shipped → RC1 no longer produces a tracker)
 
 **Post-ship lifecycle (`shipped` mode).** Most shipped SRs are retired the moment their tag exists. The **one exception** is the *most-recently-shipped* SR (highest shipped patch), which keeps emitting as `mode='shipped'` so its tracker issue stays useful through post-ship follow-up — adding the new build to the GitHub issue version dropdown, publishing release notes, closing out the milestone. Shipped reports never retroactively return `Not Ready`: unresolved work is split into urgent hotfix-vs-next-SR follow-ups and structured carry-forward items. Each immutable shipped tag is **create-once**: if it was never tracked (for example, the tag appeared before a scheduled updater ran), the workflow creates it; once a human closes that exact tagged generation, scheduled runs do not resurrect it. An untagged hotfix is explicitly marked `hotfixInProgress=true`, forces a yellow follow-up verdict, and is likewise create-once. Hotfix closure is scoped to the live version **and branch commit**: the same generation stays closed, while new commits or a new version can create fresh evidence. Workflow decisions use the generated report markers, not detector-time hotfix fields, so tag/commit changes between detection and reporting cannot apply stale lifecycle state. Older shipped SRs remain retired.
 
@@ -67,14 +68,14 @@ pwsh .github/skills/release-readiness/scripts/Find-ReleaseReadinessTrackers.ps1 
   -OutputJson trackers.json
 
 # Emits a JSON envelope with one tracker per active branch, each carrying:
-#   branchType:    'sr' | 'preview'
+#   branchType:    'sr' | 'preview' | 'rc'
 #   branchName:    canonical proposed branch slug (always populated)
 #   branchExists:  true if the branch is on origin, false for candidates
 #   mode:          'in-flight' | 'candidate' | 'shipped'
 #   hotfixInProgress: true only when the latest shipped SR branch is ahead of its stable tag
 #   hotfixVersion/hotfixCommit: mutable hotfix generation used for close/recreate idempotency
 #   surveyRef:     ref to actually survey (branch itself, or net<major>.0 for candidates)
-#   canonicalKey:  stable join key (e.g. net10-sr8, net11-preview6)
+#   canonicalKey:  stable join key (e.g. net10-sr8, net11-preview6, net11-rc1)
 #   issueTitle:    title for the maintained tracker issue
 #   regressionLabels: list of regressed-in-* labels relevant to this branch
 ```
@@ -117,6 +118,17 @@ pwsh .github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1 \
   '-PublicSafe:$false' \
   -TrackerKey net11-preview6 \
   -OutputDir CustomAgentLogsTmp/release-readiness/preview6-candidate
+```
+
+### Release Candidate
+
+```bash
+pwsh .github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1 \
+  -Branch release/11.0.1xx-rc1 \
+  -Mode in-flight \
+  '-PublicSafe:$false' \
+  -TrackerKey net11-rc1 \
+  -OutputDir CustomAgentLogsTmp/release-readiness/rc1
 ```
 
 The unattended public survey does not know the release-owner-confirmed workload-set
@@ -335,19 +347,19 @@ inferred ✅ but the sub points at the wrong channel, or inferred ⚠️/❌ con
 real gap with the missing source repos named. When the local check simply agrees with
 the inferred signal, report it conversationally and leave the tracker to the CI body.
 
-### Preview action ordering (newly cut branch)
+### Prerelease action ordering (newly cut Preview or RC branch)
 
 When the preview branch exists but its plumbing is incomplete, present the remediation
 as a dependency-ordered sequence. Do **not** sort unrelated `BLOCKED`/`WATCH` rows ahead
 of these prerequisites:
 
-1. Add the Preview N default-channel mapping.
+1. Add the matching Preview/RC default-channel mapping for MAUI's outward build flow.
 2. Add the baseline Android and macOS/iOS subscriptions. Wait for the
    `maestro-configuration` PR to merge into `production`, then verify BAR ingestion
    with `darc get-subscriptions --target-repo https://github.com/dotnet/maui --target-branch <preview-branch>`.
-3. Reconcile MAUI's SDK/VMR pin **locally** with the official Preview N build and
+3. Reconcile MAUI's SDK/VMR pin **locally** with the official Preview/RC build and
    open the resulting focused component-bump PR. Do not add a VMR subscription.
-4. Build branch HEAD and promote the resulting MAUI build to the Preview N channel.
+4. Build branch HEAD and promote the resulting MAUI build to the matching Preview/RC channel.
 5. Clear current-preview CI/device/UI failures and finish release validation.
 
 Keep the report scoped to Preview N. Do **not** mention the `netN.0` Preview N+1
@@ -393,15 +405,15 @@ work. Those belong only in the Preview N+1 candidate/in-flight readiness report.
 | `-IncludeInternal` | No | off | Release-captain only — augments the local survey with internal pipeline status when AzDO auth is available. |
 | `-PublicSafe` | No | `$true` | Sanitizes private/internal coordinates from SR Markdown and JSON. Set false only for local artifacts that will not be posted publicly. |
 
-### `Get-PreviewReadiness.ps1` (Preview)
+### `Get-PreviewReadiness.ps1` (Preview / RC)
 
 | Parameter | Required | Default | Description |
 |-----------|----------|---------|-------------|
-| `-Branch` | Yes | — | Preview branch name (e.g. `release/11.0.1xx-preview6`). Required even for candidate runs — used to derive milestone, tracker key, and regression labels. |
+| `-Branch` | Yes | — | Preview or RC branch name (e.g. `release/11.0.1xx-preview6` or `release/11.0.1xx-rc1`). Required even for candidate runs — used to derive milestone, tracker key, and regression labels. |
 | `-Mode` | No | `in-flight` | `in-flight` (survey the preview branch itself) or `candidate` (survey `-SurveyRef` instead — typically `net<major>.0`). |
 | `-SurveyRef` | No | computed | Ref to actually survey. Defaults to `$Branch` for in-flight; `net<major>.0` for candidate. |
 | `-Repository` | No | `dotnet/maui` | Repository in `owner/name` form. |
-| `-TrackerKey` | No | derived | Canonical key (default: `net<major>-preview<N>`) embedded for idempotent issue lookup. |
+| `-TrackerKey` | No | derived | Canonical key (default: `net<major>-preview<N>` or `net<major>-rc<N>`) embedded for idempotent issue lookup. |
 | `-OutputDir` | No | — | If set, writes `preview-readiness.{json,md}`. |
 | `-OutputFormat` | No | `markdown` | `markdown`, `json`, or `both`. |
 | `-IncludeInternal` | No | off | Compatibility override that requests sanitized internal classification even with `-PublicSafe`; enriched local skill/agent runs pass `'-PublicSafe:$false'`. GitHub Actions still skips. |
@@ -418,7 +430,7 @@ work. Those belong only in the Preview N+1 candidate/in-flight readiness report.
 | `release-readiness.{json,md}` | Get-ReleaseReadiness | Full SR readiness report |
 | `sr-source-prs.txt` | Get-ReleaseReadiness | Flat newline-delimited source PR list; use `grep -qxF NNNNN file` for instant cherry-pick verification |
 | `sr-commits.json` | Get-ReleaseReadiness | Raw SR-only commit metadata |
-| `preview-readiness.{json,md}` | Get-PreviewReadiness | Full Preview readiness report. Local non-public-safe net11 JSON includes `InternalOfficialBuilds`; public-safe JSON omits that property. |
+| `preview-readiness.{json,md}` | Get-PreviewReadiness | Full Preview/RC readiness report. Local non-public-safe net11 JSON includes `InternalOfficialBuilds`; public-safe JSON omits that property. |
 
 ## Tracker refresh workflow
 
@@ -426,7 +438,7 @@ work. Those belong only in the Preview N+1 candidate/in-flight readiness report.
 
 1. **`detect-trackers`** — runs `Find-Trackers -AllActiveMajors`, emits a matrix of tracker descriptors.
 2. **`per-tracker-report`** — matrix-expanded job per tracker:
-   - Dispatches to `Get-ReleaseReadiness.ps1` (SR) or `Get-PreviewReadiness.ps1` (Preview) based on `branchType`.
+   - Dispatches to `Get-ReleaseReadiness.ps1` (SR) or `Get-PreviewReadiness.ps1` (Preview/RC) based on `branchType`.
    - Looks for an open tracker issue by the canonical marker `<!-- release-readiness-tracker: <key> -->`.
      - **Refresh path**: in shipped mode, prefer an open issue carrying the exact current shipped/hotfix generation marker; otherwise refresh the oldest labeled tracker in place so Release Captain Notes and subscriptions survive commit-to-commit generation changes. If the exact generation was intentionally closed, retire any stale generic opens and do not recreate it. For non-shipped trackers, adopt the oldest labeled tracker issue and close remaining duplicates.
      - **Create path**: open a new issue with the mandatory `area-infrastructure` ownership label (creation fails rather than producing a tracker the lifecycle lookup cannot recognize); attach `report` / `s/triaged` best-effort.
@@ -565,7 +577,7 @@ Two consequences the report must get right:
 1. **Roll-forward milestone.** The cycle after `preview7` is `.NET <major>.0-rc1`, *not* `.NET <major>.0-preview8`. `Get-PreviewTrainMilestoneTitle` in [`Get-ReleaseReadiness.ps1`](scripts/Get-ReleaseReadiness.ps1) owns this mapping (ordinals `1..7` → previews, `8` → rc1, `9` → rc2, `10+` → `$null`); `$script:FinalPreviewNumber` is the single constant to change if the cadence ever moves. (.NET 5 shipped 8 previews; the 7-preview cadence has held for every major since .NET 6.)
 2. **`preview7` is the feature/API-lock gate.** Because no eighth preview exists, work that misses the `preview7` cut does **not** roll into "the next preview" — RC is normally API-locked and go-live-licensed, so in practice it slips to the **next major**. When reporting on a `preview7` branch or candidate, say so explicitly: public-API PRs still open at the `preview7` cut are a *decide-now* item, not a defer-later one.
 
-> **Where the `rc` mapping actually fires (and where it doesn't).** `Get-MilestoneHygieneChecks` lives only in the **SR lane** (`Get-ReleaseReadiness.ps1`); the automated preview lane (`Get-PreviewReadiness.ps1` → `Test-PreviewMilestoneExists`) validates only the *current* preview's own milestone and never derives a next-cycle title. So an `rc`-shaped milestone title is produced **only** when the SR-lane hygiene check is driven with a preview-shaped branch — an ad-hoc `Get-ReleaseReadiness.ps1 -SrBranch release/<major>.0.1xx-preview7` run, or candidate mode off `preview7`. An **in-flight survey of an actual `release/*-rc1` branch produces no milestone checks at all**: rc-shaped branches match neither the SR nor the preview shape, so the parser skips them (scenario M15). Treat the `preview→rc` mapping as defensive normalization for preview-lane inputs, **not** a live milestone gate on cut `rc` branches.
+> **RC is a first-class tracker lane.** `Find-ReleaseReadinessTrackers.ps1` discovers strict `release/<major>.0.<band>xx-rc<N>` branches and RC tags independently of Preview. `Get-PreviewReadiness.ps1` validates the current `.NET <major>.0-rc<N>` milestone, expected `rc/N` version metadata, the outward MAUI default-channel mapping, Android/macOS-iOS inbound subscriptions, and the no-VMR-subscription reconciliation model.
 
 ### Maestro / BAR check gating
 

--- a/.github/skills/release-readiness/scripts/Find-ReleaseReadinessTrackers.ps1
+++ b/.github/skills/release-readiness/scripts/Find-ReleaseReadinessTrackers.ps1
@@ -4,11 +4,11 @@
 .SYNOPSIS
     Determines which .NET MAUI Release Readiness tracker issues should
     exist right now based on shipped tags + current release branches.
-    Covers both Servicing Releases (SR) AND Previews.
+    Covers Servicing Releases (SR), Previews, and Release Candidates (RC).
 
 .DESCRIPTION
     Deterministic auto-detection used by the daily release-readiness workflow.
-    Implements a four-lane algorithm documented in the release-readiness
+    Implements a five-lane algorithm documented in the release-readiness
     SKILL.md:
 
       Lane 1 — in-flight SR branches
@@ -46,6 +46,13 @@
         iteration number has no matching tag AND no matching branch, propose
         a candidate preview tracker. Skipped for majors that are in SR phase
         (PreReleaseVersionLabel is not 'preview').
+
+      Lane 5 — RC branches and candidates
+        Applies the same immutable-tag lifecycle as Preview, using strict
+        `release/<major>.0.<band>xx-rc<N>` branches and
+        `<major>.0.0-rc.<N>.<date>[.<build>]` tags. A survey ref whose
+        Versions.props advertises rc/N creates an RC candidate when the branch
+        has not been cut.
 
         Tag existence is the authoritative ship signal (the release-notes
         publish job creates the tag). This is more robust than comparing
@@ -123,8 +130,8 @@
         regressionLabels, hasRecentActivity, recentCommitCount,
         priorShippedPatch, priorShippedTag }
 
-    Each tracker (preview):
-      { branchType: 'preview', previewNumber, majorVersion, mode, branchName,
+    Each tracker (preview or RC):
+      { branchType: 'preview'|'rc', previewNumber|rcNumber, majorVersion, mode, branchName,
         surveyRef, canonicalKey, issueTitle, expectedTagPrefix, milestoneName,
         regressionLabels, hasRecentActivity, recentCommitCount }
 #>
@@ -153,23 +160,31 @@ $Script:StrictSrBranchRegex = '^release/(\d+)\.0\.\d+xx-sr(\d+)$'
 #   Preview branch: must end in `-preview<digits>` with no further qualifiers.
 #     rejects: preview-next, preview6.1 (sub-preview), preview7-test
 $Script:StrictPreviewBranchRegex = '^release/(\d+)\.0\.\d+xx-preview(\d+)$'
+#   RC branch: must end in `-rc<digits>` with no further qualifiers.
+$Script:StrictRcBranchRegex = '^release/(\d+)\.0\.\d+xx-rc(\d+)$'
 #   Stable tag: exactly `<major>.0.<patch>`, no prerelease suffix.
 $Script:StrictStableTagRegex = '^(\d+)\.0\.(\d+)$'
 #   Preview tag: `<major>.0.0-preview.<N>.<YYYYMMDD>[.<build>]`
 #     e.g., 11.0.0-preview.5.26304.4
 $Script:StrictPreviewTagRegex = '^(\d+)\.0\.0-preview\.(\d+)\.\d+(?:\.\d+)?$'
+#   RC tag: `<major>.0.0-rc.<N>.<YYYYMMDD>[.<build>]`
+$Script:StrictRcTagRegex = '^(\d+)\.0\.0-rc\.(\d+)\.\d+(?:\.\d+)?$'
 # .NET 6 through the currently active majors use seven previews before RC1.
 # This is release policy, not a pointer to the current preview. If a future
 # major changes cadence, update this explicit invariant (and its RC tests)
 # rather than silently inferring a stage from branch/tag names.
 $Script:FinalPreviewNumber = 7
+# .NET release trains currently use two RCs before GA.
+$Script:FinalRcNumber = 2
 
 # Backwards-compatible exports for tests that dot-source this script.
 # Tests assert against the same regex strings the algorithm uses.
 $Global:FindReleaseReadinessTrackers_StrictSrBranchRegex = $Script:StrictSrBranchRegex
 $Global:FindReleaseReadinessTrackers_StrictPreviewBranchRegex = $Script:StrictPreviewBranchRegex
+$Global:FindReleaseReadinessTrackers_StrictRcBranchRegex = $Script:StrictRcBranchRegex
 $Global:FindReleaseReadinessTrackers_StrictStableTagRegex = $Script:StrictStableTagRegex
 $Global:FindReleaseReadinessTrackers_StrictPreviewTagRegex = $Script:StrictPreviewTagRegex
+$Global:FindReleaseReadinessTrackers_StrictRcTagRegex = $Script:StrictRcTagRegex
 
 function Invoke-GitOrFail {
     <#
@@ -225,6 +240,18 @@ function Get-PreviewTagsForMajor {
     ,$tags
 }
 
+function Get-RcTagsForMajor {
+    param([int]$Major)
+
+    $allTags = Invoke-GitOrFail @('--no-pager', 'tag', '-l') "Could not list tags"
+    $tags = @($allTags | Where-Object {
+        $_ -and ($_ -match $Script:StrictRcTagRegex) -and ([int]$Matches[1] -eq $Major)
+    } | Sort-Object {
+        if ($_ -match $Script:StrictRcTagRegex) { [int]$Matches[2] } else { 0 }
+    }, { $_ })
+    ,$tags
+}
+
 function Get-ShippedPatchSet {
     <#
     .SYNOPSIS
@@ -266,6 +293,19 @@ function Get-ShippedPreviewSet {
     if ($null -eq $PreviewTags) { return ,$set }
     foreach ($tag in $PreviewTags) {
         if ($tag -and ($tag -match $Script:StrictPreviewTagRegex)) {
+            [void]$set.Add([int]$Matches[2])
+        }
+    }
+    ,$set
+}
+
+function Get-ShippedRcSet {
+    param([AllowEmptyCollection()][string[]]$RcTags)
+
+    $set = [System.Collections.Generic.HashSet[int]]::new()
+    if ($null -eq $RcTags) { return ,$set }
+    foreach ($tag in $RcTags) {
+        if ($tag -and ($tag -match $Script:StrictRcTagRegex)) {
             [void]$set.Add([int]$Matches[2])
         }
     }
@@ -522,6 +562,37 @@ function Get-RemotePreviewBranchesForMajor {
     ,$branches
 }
 
+function Get-RemoteRcBranchesForMajor {
+    param([int]$Major)
+
+    $lines = Invoke-GitOrFail @('ls-remote', '--heads', 'origin', "release/$Major.0.*xx-rc*") `
+        "Could not list remote RC branches for major $Major"
+    $branches = @()
+    foreach ($line in $lines) {
+        if (-not $line) { continue }
+        if ($line -match '^[0-9a-f]{40}\s+refs/heads/(.+)$') {
+            $branch = $Matches[1]
+            if ($branch -match $Script:StrictRcBranchRegex) {
+                $branchMajor = [int]$Matches[1]
+                $rcN = [int]$Matches[2]
+                if ($branchMajor -eq $Major) {
+                    $branches += [pscustomobject]@{
+                        branch   = $branch
+                        rcNumber = $rcN
+                    }
+                }
+            } else {
+                Write-Verbose "Skipping non-strict RC branch '$branch'"
+            }
+        }
+    }
+    $branches = @($branches | Sort-Object rcNumber)
+    if ($branches.Count -gt $MaxBranches) {
+        throw "Fail-closed: matched $($branches.Count) RC branches for major $Major (> MaxBranches=$MaxBranches)."
+    }
+    ,$branches
+}
+
 function Get-RecentCommitCount {
     <#
     .SYNOPSIS
@@ -710,6 +781,55 @@ function New-PreviewTracker {
     }
 }
 
+function New-RcRegressionLabelList {
+    param([int]$Major, [int]$RcNumber)
+
+    $labels = New-Object System.Collections.Generic.List[string]
+    if ($RcNumber -gt 1) {
+        $labels.Add("regressed-in-$Major.0.0-rc$($RcNumber - 1)")
+    }
+    $labels.Add("regressed-in-$Major.0.0-rc$RcNumber")
+    return $labels
+}
+
+function New-RcTracker {
+    param(
+        [int]$Major,
+        [int]$RcNumber,
+        [string]$Mode,
+        [string]$BranchName,
+        [string]$SurveyRef,
+        [int]$HasRecentActivityCount
+    )
+
+    $canonical = "net$Major-rc$RcNumber"
+    $branchExists = [bool]$BranchName
+    $effectiveBranchName = if ($BranchName) { $BranchName } else { "release/$Major.0.1xx-rc$RcNumber" }
+    $title = if ($Mode -eq 'candidate') {
+        "[Release Readiness] .NET $Major.0 RC $RcNumber — candidate from $SurveyRef"
+    } else {
+        "[Release Readiness] .NET $Major.0 RC $RcNumber — $effectiveBranchName"
+    }
+
+    return [pscustomobject]@{
+        branchType           = 'rc'
+        rcNumber             = $RcNumber
+        majorVersion         = $Major
+        mode                 = $Mode
+        branchName           = $effectiveBranchName
+        branchExists         = $branchExists
+        surveyRef            = $SurveyRef
+        canonicalKey         = $canonical
+        issueTitle           = $title
+        milestoneName        = ".NET $Major.0-rc$RcNumber"
+        expectedChannelName  = ".NET $Major.0.1xx SDK RC $RcNumber"
+        expectedTagPrefix    = "$Major.0.0-rc.$RcNumber."
+        regressionLabels     = @(New-RcRegressionLabelList -Major $Major -RcNumber $RcNumber)
+        hasRecentActivity    = ($HasRecentActivityCount -gt 0)
+        recentCommitCount    = $HasRecentActivityCount
+    }
+}
+
 function Invoke-DetectionForMajor {
     <#
     .SYNOPSIS
@@ -723,7 +843,7 @@ function Invoke-DetectionForMajor {
 
     $mainBranchForMajor = Get-MainBranchForVersion -Major $Major -Repo $Repo
 
-    # ── Step 1: Inventory all shipped stable + preview tags for this major.
+    # ── Step 1: Inventory all shipped stable + prerelease tags for this major.
     # All helpers below use unary-comma return + plain assignment here. DON'T
     # wrap in @(...) — that combination doubles up (returns a 1-elem array
     # whose only entry is the inner array). PS unrolling is the gotcha.
@@ -731,6 +851,8 @@ function Invoke-DetectionForMajor {
     $shippedPatches  = Get-ShippedPatchSet      -StableTags  $stableTags
     $previewTags     = Get-PreviewTagsForMajor  -Major $Major
     $shippedPreviews = Get-ShippedPreviewSet    -PreviewTags $previewTags
+    $rcTags          = Get-RcTagsForMajor       -Major $Major
+    $shippedRcs      = Get-ShippedRcSet          -RcTags $rcTags
 
     $highestShippedPatch = 0
     $highestShippedTag   = $null
@@ -752,6 +874,7 @@ function Invoke-DetectionForMajor {
     Write-Host "[major $Major] Shipped previews: $(if ($shippedPreviews.Count -gt 0) { ($shippedPreviews | Sort-Object) -join ', ' } else { '(none)' })" -ForegroundColor Cyan
     Write-Host "[major $Major] Highest stable tag:  $(if ($highestShippedTag) { $highestShippedTag } else { '(none)' })" -ForegroundColor Cyan
     Write-Host "[major $Major] Highest preview tag: $(if ($highestShippedPreviewTag) { $highestShippedPreviewTag } else { '(none)' })" -ForegroundColor Cyan
+    Write-Host "[major $Major] Shipped RCs:      $(if ($shippedRcs.Count -gt 0) { ($shippedRcs | Sort-Object) -join ', ' } else { '(none)' })" -ForegroundColor Cyan
 
     $trackers = New-Object System.Collections.Generic.List[object]
 
@@ -924,6 +1047,7 @@ function Invoke-DetectionForMajor {
 
     # ── Lane 3: in-flight preview branches.
     $previewBranches = Get-RemotePreviewBranchesForMajor -Major $Major
+    $rcBranches = Get-RemoteRcBranchesForMajor -Major $Major
     Write-Host "[major $Major] Found $($previewBranches.Count) strict release/$Major.0.*xx-preview* branches on origin" -ForegroundColor Cyan
     $highestBranchPreview = 0
     $inflightPreviewsByNum = @{}
@@ -1001,11 +1125,22 @@ function Invoke-DetectionForMajor {
                     $trackers.Add($tracker)
                     Write-Host "  -> cut-before-bump candidate preview tracker: preview$nextPreviewN (surveyRef=$previewCandidateRef still advertises preview$candidatePreviewN, recent=$recent)" -ForegroundColor Yellow
                 }
-            } else {
-                # Preview 7 is the final preview; its next cycle is rc1, not
-                # preview8. Keep the current Preview 7 tracker scoped to its branch
-                # and warn until the dedicated RC lane exists.
-                Write-Warning "[major $Major] preview$candidatePreviewN is cut while $previewCandidateRef still advertises preview$candidatePreviewN. The next cycle is rc1, but RC tracking is not yet implemented; no preview8 tracker will be invented."
+            } elseif ($candidatePreviewN -eq $Script:FinalPreviewNumber) {
+                # The cycle after the final Preview is RC1. Cover the source
+                # branch immediately after Preview 7 is cut/tagged, even before
+                # Versions.props is bumped from preview/7 to rc/1.
+                $rc1AlreadyShipped = $shippedRcs.Contains(1)
+                $rc1BranchExists = $rcBranches | Where-Object { [int]$_.rcNumber -eq 1 }
+                $nextRcN = if ($rc1AlreadyShipped -or $rc1BranchExists) { 2 } else { 1 }
+                $nextRcAlreadyShipped = $shippedRcs.Contains($nextRcN)
+                $nextRcBranchExists = $rcBranches | Where-Object { [int]$_.rcNumber -eq $nextRcN }
+                if ($nextRcN -le $Script:FinalRcNumber -and
+                    -not $nextRcAlreadyShipped -and -not $nextRcBranchExists) {
+                    $recent = Get-RecentCommitCount -Ref $previewCandidateRef -Days $ActivityWindowDays
+                    $trackers.Add((New-RcTracker -Major $Major -RcNumber $nextRcN -Mode 'candidate' `
+                        -BranchName $null -SurveyRef $previewCandidateRef -HasRecentActivityCount $recent))
+                    Write-Host "  -> cut-before-bump candidate RC tracker: rc$nextRcN (surveyRef=$previewCandidateRef still advertises preview$candidatePreviewN, recent=$recent)" -ForegroundColor Yellow
+                }
             }
             if ($previewAlreadyShipped) {
                 Write-Host "[major $Major] preview$candidatePreviewN (from $previewCandidateRef) already shipped; next-cycle transition handled separately" -ForegroundColor DarkGray
@@ -1018,45 +1153,50 @@ function Invoke-DetectionForMajor {
             $trackers.Add($tracker)
             Write-Host "  -> candidate preview tracker: preview$candidatePreviewN (surveyRef=$previewCandidateRef, recent=$recent)" -ForegroundColor Green
         }
-    } elseif ($candidatePreviewVersionInfo -and $candidatePreviewVersionInfo.PreLabel -eq 'rc') {
-        # The pre-release train does NOT end at the last preview: .NET ships
-        # preview1..preview7, then rc1, rc2, then GA (the same discontinuity
-        # Get-ReleaseReadiness.ps1's Get-PreviewTrainMilestoneTitle exists to
-        # handle). Once the survey ref is bumped past the final preview it flips
-        # to label=rc/iteration=1 rather than preview8 — verified against this
-        # repo: release/10.0.1xx-rc1's Versions.props carries rc/1, and the rc
-        # branches and tags use naming exactly parallel to previews
-        # (release/<major>.0.1xx-rc<N>, <major>.0.0-rc.<N>.<build>).
-        #
-        # The `PreLabel -eq 'preview'` guard above therefore stops matching for
-        # the whole rc window, and this lane produces no tracker for rc1 or rc2.
-        # Emitting one here is NOT the fix: the rest of the preview lane is still
-        # preview-only, so an rc tracker would break downstream rather than help.
-        # Closing the gap requires, together:
-        #   1. Get-PreviewReadiness.ps1 — its branch parser hard-`throw`s on any
-        #      ref that isn't `release/<major>.0.1xx-preview<N>`, so an rc tracker
-        #      would fail the workflow's report job outright.
-        #   2. Lane 3 + Get-RemotePreviewBranchesForMajor / Get-PreviewTagsForMajor
-        #      — rc branches and tags don't match the strict preview regexes, so
-        #      in-flight detection and the "already shipped / already has a branch"
-        #      dedup would never fire and this lane would re-propose the same rc
-        #      candidate forever, even after it was cut and shipped.
-        #   3. New-PreviewTracker / New-PreviewRegressionLabelList — canonicalKey,
-        #      milestoneName, expectedTagPrefix and labels are all preview-shaped.
-        #
-        # Until that lands, WARN loudly. The bug that matters most here is not the
-        # missing tracker but the silence: this case previously fell into the
-        # generic DarkGray "No active preview cycle" line below, which is also what
-        # a major legitimately in SR phase prints. A release captain had no way to
-        # tell "nothing to do" apart from "rc1 needs a tracker and you won't get one".
-        $rcIter = $candidatePreviewVersionInfo.PreIter
-        Write-Warning ("[major $Major] $previewCandidateRef is in the rc phase (label=rc, iteration=$rcIter) but this lane only emits preview trackers, " +
-                       "so no rc$rcIter tracker will be created. Track rc$rcIter manually until rc support is added to the preview lane.")
     } else {
         $labelDisplay = if ($candidatePreviewVersionInfo) { ($candidatePreviewVersionInfo.PreLabel) } else { '<n/a>' }
         $iterDisplay  = if ($candidatePreviewVersionInfo) { ($candidatePreviewVersionInfo.PreIter)  } else { '<n/a>' }
         $refDisplay   = if ($previewCandidateRef) { $previewCandidateRef } else { '<none>' }
         Write-Host "[major $Major] No active preview cycle (surveyRef=$refDisplay, label=$labelDisplay, iter=$iterDisplay)" -ForegroundColor DarkGray
+    }
+
+    # ── Lane 5: RC branches and candidates.
+    Write-Host "[major $Major] Found $($rcBranches.Count) strict release/$Major.0.*xx-rc* branches on origin" -ForegroundColor Cyan
+    foreach ($entry in $rcBranches) {
+        $rcN = [int]$entry.rcNumber
+        if ($shippedRcs.Contains($rcN)) {
+            Write-Host "  -> rc$rcN branch '$($entry.branch)' already shipped (tag $Major.0.0-rc.$rcN.* exists)" -ForegroundColor DarkGray
+            continue
+        }
+
+        $recent = Get-RecentCommitCount -Ref $entry.branch -Days $ActivityWindowDays
+        $trackers.Add((New-RcTracker -Major $Major -RcNumber $rcN -Mode 'in-flight' `
+            -BranchName $entry.branch -SurveyRef $entry.branch -HasRecentActivityCount $recent))
+        Write-Host "  -> in-flight RC tracker: rc$rcN (no $Major.0.0-rc.$rcN.* tag yet, recent=$recent)" -ForegroundColor Green
+    }
+
+    if ($candidatePreviewVersionInfo -and $candidatePreviewVersionInfo.PreLabel -eq 'rc' -and $candidatePreviewVersionInfo.PreIter -gt 0) {
+        $candidateRcN = [int]$candidatePreviewVersionInfo.PreIter
+        $rcBranchAlreadyExists = $rcBranches | Where-Object { [int]$_.rcNumber -eq $candidateRcN }
+        $rcAlreadyShipped = $shippedRcs.Contains($candidateRcN)
+        if (-not $rcBranchAlreadyExists -and -not $rcAlreadyShipped) {
+            $recent = Get-RecentCommitCount -Ref $previewCandidateRef -Days $ActivityWindowDays
+            $trackers.Add((New-RcTracker -Major $Major -RcNumber $candidateRcN -Mode 'candidate' `
+                -BranchName $null -SurveyRef $previewCandidateRef -HasRecentActivityCount $recent))
+            Write-Host "  -> candidate RC tracker: rc$candidateRcN (surveyRef=$previewCandidateRef, recent=$recent)" -ForegroundColor Green
+        } elseif ($candidateRcN -lt $Script:FinalRcNumber) {
+            # Keep source-branch work visible after RC N is cut/tagged but before
+            # the source advances to RC N+1 metadata.
+            $nextRcN = $candidateRcN + 1
+            $nextRcAlreadyShipped = $shippedRcs.Contains($nextRcN)
+            $nextRcBranchExists = $rcBranches | Where-Object { [int]$_.rcNumber -eq $nextRcN }
+            if (-not $nextRcAlreadyShipped -and -not $nextRcBranchExists) {
+                $recent = Get-RecentCommitCount -Ref $previewCandidateRef -Days $ActivityWindowDays
+                $trackers.Add((New-RcTracker -Major $Major -RcNumber $nextRcN -Mode 'candidate' `
+                    -BranchName $null -SurveyRef $previewCandidateRef -HasRecentActivityCount $recent))
+                Write-Host "  -> cut-before-bump candidate RC tracker: rc$nextRcN (surveyRef=$previewCandidateRef still advertises rc$candidateRcN, recent=$recent)" -ForegroundColor Yellow
+            }
+        }
     }
 
     return [pscustomobject]@{

--- a/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
+++ b/.github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1
@@ -193,13 +193,19 @@ if (Test-Path $internalOfficialBuildHelperPath) {
 # ===================================================================
 # BRANCH PARSING
 # ===================================================================
-# Preview branch contract: release/<major>.0.1xx-preview<N>
-# (Find-Trackers emits exactly this format for branchType='preview'.)
-if ($Branch -notmatch '^release/(\d+)\.0\.1xx-preview(\d+)$') {
-    throw "Branch '$Branch' does not match expected preview format 'release/<major>.0.1xx-preview<N>'."
+# Prerelease branch contract: release/<major>.0.1xx-<preview|rc><N>.
+if ($Branch -notmatch '^release/(\d+)\.0\.1xx-(preview|rc)(\d+)$') {
+    throw "Branch '$Branch' does not match expected prerelease format 'release/<major>.0.1xx-<preview|rc><N>'."
 }
 $majorVersion = [int]$Matches[1]
-$previewNumber = [int]$Matches[2]
+$releaseStage = $Matches[2].ToLowerInvariant()
+$releaseNumber = [int]$Matches[3]
+# Retain the legacy variable for Preview-specific helpers while the shared
+# report engine supports both prerelease lanes.
+$previewNumber = $releaseNumber
+$releaseStageDisplay = if ($releaseStage -eq 'rc') { 'RC' } else { 'Preview' }
+$releaseDisplayName = "$releaseStageDisplay $releaseNumber"
+$expectedChannelName = ".NET $majorVersion.0.1xx SDK $releaseStageDisplay $releaseNumber"
 $mainBranch = "net$majorVersion.0"
 $isGitHubActions = if (Get-Command Test-IsGitHubActions -ErrorAction SilentlyContinue) {
     Test-IsGitHubActions
@@ -208,7 +214,7 @@ $isGitHubActions = if (Get-Command Test-IsGitHubActions -ErrorAction SilentlyCon
 }
 $effectivePublicSafe = $PublicSafe
 
-# In candidate mode, the preview branch hasn't been cut yet — survey the
+# In candidate mode, the prerelease branch hasn't been cut yet — survey the
 # source instead (caller passes net<major>.0 via -SurveyRef). In in-flight
 # mode, the source IS the branch itself.
 if ([string]::IsNullOrWhiteSpace($SurveyRef)) {
@@ -222,9 +228,9 @@ if ([string]::IsNullOrWhiteSpace($SurveyRef)) {
 # the Preview N report.
 $mergeUpChainLabel = if ($Mode -eq 'candidate') { "main → $SurveyRef" } else { "$mainBranch → $SurveyRef" }
 
-# Canonical tracker key. Default matches Find-Trackers' New-PreviewTracker.
+# Canonical tracker key. Default matches tracker discovery.
 if ([string]::IsNullOrWhiteSpace($TrackerKey)) {
-    $TrackerKey = "net$majorVersion-preview$previewNumber"
+    $TrackerKey = "net$majorVersion-$releaseStage$releaseNumber"
 }
 
 # ===================================================================
@@ -493,6 +499,25 @@ function Get-PreReleaseVersionIteration {
     }
 
     return $null
+}
+
+function Get-PreReleaseVersionMetadata {
+    param([string]$BranchName)
+
+    $versions = Get-ContentFromRepo -Path "eng/Versions.props" -Ref $BranchName
+    $label = $null
+    $iteration = $null
+    if ($versions -match "<PreReleaseVersionLabel>\s*([^<]*)\s*</PreReleaseVersionLabel>") {
+        $label = $Matches[1].Trim()
+    }
+    if ($versions -match "<PreReleaseVersionIteration>\s*([^<]*)\s*</PreReleaseVersionIteration>") {
+        $iteration = $Matches[1].Trim()
+    }
+
+    return [PSCustomObject]@{
+        Label     = $label
+        Iteration = $iteration
+    }
 }
 
 function Get-XcodeRequirements {
@@ -856,7 +881,7 @@ function Get-AllMilestones {
     }
 }
 
-function Test-PreviewMilestoneExists {
+function Test-PrereleaseMilestoneExists {
     <#
     .SYNOPSIS
         Checks whether the GitHub milestone for THIS preview
@@ -880,18 +905,20 @@ function Test-PreviewMilestoneExists {
     #>
     param(
         [int]$Major,
-        [int]$Preview
+        [ValidateSet('preview', 'rc')]
+        [string]$Stage,
+        [int]$Number
     )
 
-    $expected = ".NET $Major.0-preview$Preview"
+    $expected = ".NET $Major.0-$Stage$Number"
     $ms = Get-AllMilestones
     if (-not $ms.Success) {
         return @{ QueryFailed = $true; Exists = $false; ExpectedTitle = $expected; MatchedTitle = $null }
     }
 
     $acceptable = @(
-        ".net $Major.0-preview$Preview",
-        "$Major.0-preview$Preview"
+        ".net $Major.0-$Stage$Number",
+        "$Major.0-$Stage$Number"
     )
     $match = $null
     foreach ($m in $ms.Data) {
@@ -903,6 +930,12 @@ function Test-PreviewMilestoneExists {
         return @{ QueryFailed = $false; Exists = $true; ExpectedTitle = $expected; MatchedTitle = $match.title }
     }
     return @{ QueryFailed = $false; Exists = $false; ExpectedTitle = $expected; MatchedTitle = $null }
+}
+
+function Test-PreviewMilestoneExists {
+    param([int]$Major, [int]$Preview)
+
+    Test-PrereleaseMilestoneExists -Major $Major -Stage 'preview' -Number $Preview
 }
 
 function Get-CiScanLabelForBranch {
@@ -1037,37 +1070,58 @@ function Test-IssueReleaseRelevant {
     <#
     .SYNOPSIS
         Returns $true if a labelled issue is plausibly relevant to the
-        active major / preview number based on its title, milestone, or
+        active major / prerelease stage based on its title, milestone, or
         labels.
     .NOTES
         Uses a wide net on purpose — false negatives are worse than false
         positives for release-readiness triage. The one exception is a
-        *cross-major* collision: the bare "previewN" phrase matches every
-        major's previewN, so it is only honored when the issue carries no
+        Explicit Preview/RC markers must match the active stage and number.
+        A matching marker is only honored when the issue carries no
         contradicting foreign-major signal (see Test-IssueHasForeignMajor).
     #>
     param(
         $Issue,
         [int]$Major,
-        [int]$Preview
+        [ValidateSet('preview', 'rc')]
+        [string]$Stage = 'preview',
+        [Alias('Preview')]
+        [int]$Number
     )
 
     $labels = @($Issue.labels | ForEach-Object { $_.name })
     $milestone = if ($Issue.milestone -and $Issue.milestone.title) { $Issue.milestone.title } else { "" }
     $haystack = "$($Issue.title) $milestone $($labels -join ' ')"
 
+    $prereleaseMarkerRx = '(?i)(?:preview|rc)[\s.-]*\d+'
+    $activeMarkerRx = "(?i)$Stage[\s.-]*$Number(?!\d)"
+    $releaseContext = "$milestone $($labels -join ' ')"
+    if ($Issue.title -match '(?i)(?:\.net\s*\d+|regressed-in-\d+)') {
+        $releaseContext += " $($Issue.title)"
+    }
+
+    if ($releaseContext -match $prereleaseMarkerRx) {
+        if ($releaseContext -notmatch $activeMarkerRx) {
+            return $false
+        }
+
+        # A stage marker is major-ambiguous; reject it when the issue
+        # explicitly names a different major.
+        if (-not (Test-IssueHasForeignMajor -Haystack $releaseContext -Major $Major)) {
+            return $true
+        }
+        return $false
+    }
+
     $majorRx = "(?i)net\s*$Major|net$Major|$Major\.0|$Major\.0\.1xx|xcode"
     if ($haystack -match $majorRx) {
         return $true
     }
 
-    if ($haystack -match "(?i)preview\s*$Preview|preview$Preview") {
-        # "previewN" alone is major-ambiguous; reject it when the issue
-        # explicitly names a different major (e.g. regressed-in-10-preview7
-        # surveyed against major 11).
-        if (-not (Test-IssueHasForeignMajor -Haystack $haystack -Major $Major)) {
-            return $true
-        }
+    # Preserve the wide net for a bare current-stage mention when no explicit
+    # release context or contradictory major is present.
+    if ($haystack -match $activeMarkerRx -and
+        -not (Test-IssueHasForeignMajor -Haystack $haystack -Major $Major)) {
+        return $true
     }
 
     return $false
@@ -1077,7 +1131,10 @@ function Get-ReleaseRelevantIssuesByLabel {
     param(
         [string[]]$Labels,
         [int]$Major,
-        [int]$Preview
+        [ValidateSet('preview', 'rc')]
+        [string]$Stage = 'preview',
+        [Alias('Preview')]
+        [int]$Number
     )
 
     $issues = @()
@@ -1087,7 +1144,7 @@ function Get-ReleaseRelevantIssuesByLabel {
 
     $deduped = $issues |
         Sort-Object number -Unique |
-        Where-Object { Test-IssueReleaseRelevant -Issue $_ -Major $Major -Preview $Preview }
+        Where-Object { Test-IssueReleaseRelevant -Issue $_ -Major $Major -Stage $Stage -Number $Number }
 
     # PowerShell unwraps single-element arrays on function return, so a
     # naked `return @($deduped)` with a $null/empty pipeline result yields
@@ -1630,12 +1687,14 @@ function Format-PreviewComponentSourceCell {
         [AllowNull()][AllowEmptyString()][string]$Version,
         [int]$Major,
         [int]$Preview,
+        [ValidateSet('preview', 'rc')]
+        [string]$Stage = 'preview',
         [Parameter(Mandatory)]$Drift,
         [switch]$Vmr
     )
 
     if ($Repo -eq 'dotnet/macios') {
-        $expectedStamp = "-net$Major-p$Preview"
+        $expectedStamp = if ($Stage -eq 'rc') { "-net$Major-rc.$Preview" } else { "-net$Major-p$Preview" }
         if ([string]::IsNullOrWhiteSpace($Version) -or
             $Version -notmatch "$([regex]::Escape($expectedStamp))(?!\d)") {
             $actual = if ([string]::IsNullOrWhiteSpace($Version)) { '<empty>' } else { $Version }
@@ -1998,17 +2057,223 @@ function Get-PreviewIterationCheck {
         [AllowNull()][AllowEmptyString()][string]$Iteration
     )
 
-    $area = if ($Mode -eq 'candidate') { "$SurveyRef preview iteration (candidate source)" } else { "Preview iteration" }
-    if ($Iteration -eq [string]$PreviewNumber) {
+    return Get-PrereleaseVersionCheck -Mode $Mode -SurveyRef $SurveyRef `
+        -Stage 'preview' -Number $PreviewNumber -Label 'preview' -Iteration $Iteration
+}
+
+function Get-PrereleaseVersionCheck {
+    param(
+        [ValidateSet('candidate', 'in-flight')]
+        [string]$Mode,
+        [string]$SurveyRef,
+        [ValidateSet('preview', 'rc')]
+        [string]$Stage,
+        [int]$Number,
+        [AllowNull()][AllowEmptyString()][string]$Label,
+        [AllowNull()][AllowEmptyString()][string]$Iteration
+    )
+
+    $stageDisplay = if ($Stage -eq 'rc') { 'RC' } else { 'Preview' }
+    $area = if ($Mode -eq 'candidate') {
+        "$SurveyRef $Stage version (candidate source)"
+    } else {
+        "$stageDisplay version"
+    }
+    if ($Label -eq $Stage -and $Iteration -eq [string]$Number) {
         return New-Check -Area $area -Status "READY" `
-            -Details "``$SurveyRef`` has PreReleaseVersionIteration=$Iteration." `
-            -NextAction "No version-iteration action needed."
+            -Details "``$SurveyRef`` has PreReleaseVersionLabel=$Label and PreReleaseVersionIteration=$Iteration." `
+            -NextAction "No prerelease-version action needed."
     }
 
-    $displayValue = if ($Iteration) { $Iteration } else { "<empty>" }
+    $displayLabel = if ($Label) { $Label } else { "<empty>" }
+    $displayIteration = if ($Iteration) { $Iteration } else { "<empty>" }
     return New-Check -Area $area -Status "BLOCKED" `
-        -Details "``$SurveyRef`` has PreReleaseVersionIteration=$displayValue; expected $PreviewNumber." `
-        -NextAction "Bump ``$SurveyRef`` to match the preview number before cutting."
+        -Details "``$SurveyRef`` has PreReleaseVersionLabel=$displayLabel and PreReleaseVersionIteration=$displayIteration; expected $Stage/$Number." `
+        -NextAction "Set ``$SurveyRef`` to PreReleaseVersionLabel=$Stage and PreReleaseVersionIteration=$Number before cutting."
+}
+
+function Get-PrereleaseChannelName {
+    param(
+        [int]$Major,
+        [ValidateSet('preview', 'rc')]
+        [string]$Stage,
+        [int]$Number
+    )
+
+    $stageDisplay = if ($Stage -eq 'rc') { 'RC' } else { 'Preview' }
+    return ".NET $Major.0.1xx SDK $stageDisplay $Number"
+}
+
+function Test-PrereleaseDarcAvailable {
+    return $null -ne (Get-Command darc -ErrorAction SilentlyContinue)
+}
+
+function Invoke-PrereleaseDarcJson {
+    param([string[]]$DarcArgs)
+
+    try {
+        $rawOutput = @(& darc @DarcArgs --output-format json 2>$null)
+        $exitCode = $LASTEXITCODE
+        $joined = ($rawOutput -join "`n").Trim()
+        if ($exitCode -ne 0) {
+            # darc uses its generic exit code for a legitimate empty
+            # get-subscriptions result. Normalize only this exact command and
+            # message; all other exit-42 failures remain unknown.
+            if ($DarcArgs[0] -eq 'get-subscriptions' -and
+                $exitCode -eq 42 -and
+                $joined -eq 'No subscriptions found matching the specified criteria.') {
+                return [PSCustomObject]@{ Success = $true; Data = @(); ExitCode = $exitCode }
+            }
+            return [PSCustomObject]@{ Success = $false; Data = @(); ExitCode = $exitCode }
+        }
+
+        if ([string]::IsNullOrWhiteSpace($joined)) {
+            return [PSCustomObject]@{ Success = $true; Data = @(); ExitCode = 0 }
+        }
+
+        # Some successful empty queries emit a human-readable preamble before
+        # the JSON array. Discard only lines before the first JSON delimiter.
+        $jsonStart = $joined.IndexOf('[')
+        if ($jsonStart -lt 0) { $jsonStart = $joined.IndexOf('{') }
+        if ($jsonStart -lt 0) {
+            return [PSCustomObject]@{ Success = $false; Data = @(); ExitCode = 0 }
+        }
+        $parsed = $joined.Substring($jsonStart) | ConvertFrom-Json -ErrorAction Stop
+        return [PSCustomObject]@{ Success = $true; Data = @($parsed); ExitCode = 0 }
+    } catch {
+        return [PSCustomObject]@{ Success = $false; Data = @(); ExitCode = $null }
+    }
+}
+
+function Get-PrereleaseDependencyFlowChecks {
+    param(
+        [string]$Branch,
+        [string]$ExpectedChannelName,
+        [ValidateSet('preview', 'rc')]
+        [string]$Stage = 'preview',
+        [string]$RepositoryUrl = 'https://github.com/dotnet/maui',
+        [AllowNull()][object]$DefaultChannelsResult,
+        [AllowNull()][object]$SubscriptionsResult
+    )
+
+        $checks = [System.Collections.Generic.List[object]]::new()
+        $mappingCommand = "darc get-default-channels --source-repo $RepositoryUrl --branch $Branch"
+        $subscriptionCommand = "darc get-subscriptions --target-repo $RepositoryUrl --target-branch $Branch"
+
+        if ($null -eq $DefaultChannelsResult -or $null -eq $SubscriptionsResult) {
+            if (-not (Test-PrereleaseDarcAvailable)) {
+                if ($null -eq $DefaultChannelsResult) {
+                    $DefaultChannelsResult = [PSCustomObject]@{ Success = $false; Data = @() }
+                }
+                if ($null -eq $SubscriptionsResult) {
+                    $SubscriptionsResult = [PSCustomObject]@{ Success = $false; Data = @() }
+                }
+            } else {
+                if ($null -eq $DefaultChannelsResult) {
+                    $DefaultChannelsResult = Invoke-PrereleaseDarcJson -DarcArgs @(
+                        'get-default-channels', '--source-repo', $RepositoryUrl, '--branch', $Branch
+                    )
+                }
+                if ($null -eq $SubscriptionsResult) {
+                    $SubscriptionsResult = Invoke-PrereleaseDarcJson -DarcArgs @(
+                        'get-subscriptions', '--target-repo', $RepositoryUrl, '--target-branch', $Branch
+                    )
+                }
+            }
+        }
+
+        if (-not $DefaultChannelsResult.Success) {
+            $checks.Add((New-Check -Area 'MAUI outward default-channel mapping' -Status 'UNKNOWN' `
+                -Details "Could not query the outward MAUI build mapping for ``$Branch`` → ``$ExpectedChannelName``." `
+                -NextAction "Authenticate darc and run ``$mappingCommand``."))
+        } else {
+            $mappings = @($DefaultChannelsResult.Data | Where-Object {
+                "$($_.repository)".TrimEnd('/') -ieq $RepositoryUrl.TrimEnd('/') -and
+                "$($_.branch)" -eq $Branch
+            })
+            $matching = @($mappings | Where-Object { "$($_.channel.name)" -eq $ExpectedChannelName })
+            $enabled = @($matching | Where-Object { $_.enabled -eq $true })
+            if ($enabled.Count -gt 0) {
+                $checks.Add((New-Check -Area 'MAUI outward default-channel mapping' -Status 'READY' `
+                    -Details "Enabled default-channel mapping exists: ``$Branch`` → ``$ExpectedChannelName``. This controls where MAUI's own builds flow outward." `
+                    -NextAction 'No outward-mapping action needed.'))
+            } elseif ($matching.Count -gt 0) {
+                $checks.Add((New-Check -Area 'MAUI outward default-channel mapping' -Status 'BLOCKED' `
+                    -Details "Default-channel mapping exists but is disabled: ``$Branch`` → ``$ExpectedChannelName``." `
+                    -NextAction "Enable the mapping, then verify with ``$mappingCommand``."))
+            } elseif ($mappings.Count -gt 0) {
+                $actualChannels = @($mappings | ForEach-Object { "$($_.channel.name)" } | Sort-Object -Unique) -join ', '
+                $checks.Add((New-Check -Area 'MAUI outward default-channel mapping' -Status 'BLOCKED' `
+                    -Details "Missing matching default-channel mapping: expected ``$Branch`` → ``$ExpectedChannelName``; branch currently maps to: $actualChannels." `
+                    -NextAction "Add and enable the expected mapping, then verify with ``$mappingCommand``."))
+            } else {
+                $checks.Add((New-Check -Area 'MAUI outward default-channel mapping' -Status 'BLOCKED' `
+                    -Details "Missing default-channel mapping: ``$Branch`` → ``$ExpectedChannelName``. Without it, MAUI's own branch builds do not enter the RC/Preview SDK channel." `
+                    -NextAction "Add and enable the expected mapping, then verify with ``$mappingCommand``."))
+            }
+        }
+
+        if (-not $SubscriptionsResult.Success) {
+            foreach ($name in @('Android', 'macOS/iOS')) {
+                $checks.Add((New-Check -Area "$name inbound subscription" -Status 'UNKNOWN' `
+                    -Details "Could not query the inbound $name dependency flow into ``$Branch`` on ``$ExpectedChannelName``." `
+                    -NextAction "Authenticate darc and run ``$subscriptionCommand``."))
+            }
+            $checks.Add((New-Check -Area 'VMR reconciliation model' -Status 'UNKNOWN' `
+                -Details 'Could not verify that no dotnet/dotnet subscription is configured. VMR remains a local reconciliation against the authoritative official build.' `
+                -NextAction "Authenticate darc and run ``$subscriptionCommand``."))
+            return @($checks)
+        }
+
+        $subscriptions = @($SubscriptionsResult.Data | Where-Object {
+            "$($_.targetRepository)".TrimEnd('/') -ieq $RepositoryUrl.TrimEnd('/') -and
+            "$($_.targetBranch)" -eq $Branch
+        })
+        $required = @(
+            [PSCustomObject]@{ Name = 'Android'; Source = 'https://github.com/dotnet/android' },
+            [PSCustomObject]@{ Name = 'macOS/iOS'; Source = 'https://github.com/dotnet/macios' }
+        )
+        $missingSubscriptionStatus = if ($Stage -eq 'rc') { 'BLOCKED' } else { 'WATCH' }
+        foreach ($component in $required) {
+            $componentSubscriptions = @($subscriptions | Where-Object {
+                "$($_.sourceRepository)".TrimEnd('/') -ieq $component.Source
+            })
+            $matching = @($componentSubscriptions | Where-Object {
+                $_.enabled -eq $true -and "$($_.channel.name)" -eq $ExpectedChannelName
+            })
+            if ($matching.Count -gt 0) {
+                $checks.Add((New-Check -Area "$($component.Name) inbound subscription" -Status 'READY' `
+                    -Details "Enabled inbound subscription exists: ``$($component.Source)`` → ``$Branch`` on ``$ExpectedChannelName``." `
+                    -NextAction 'No inbound-subscription action needed.'))
+            } elseif ($componentSubscriptions.Count -eq 0) {
+                $checks.Add((New-Check -Area "$($component.Name) inbound subscription" -Status $missingSubscriptionStatus `
+                    -Details "Missing inbound subscription: ``$($component.Source)`` → ``$Branch`` on ``$ExpectedChannelName``." `
+                    -NextAction "Create and enable the matching subscription, then verify with ``$subscriptionCommand``."))
+            } else {
+                $actual = @($componentSubscriptions | ForEach-Object {
+                    "channel=$($_.channel.name), enabled=$($_.enabled)"
+                }) -join '; '
+                $checks.Add((New-Check -Area "$($component.Name) inbound subscription" -Status $missingSubscriptionStatus `
+                    -Details "Inbound subscription does not match the required enabled channel ``$ExpectedChannelName``: $actual." `
+                    -NextAction "Correct the subscription channel/state, then verify with ``$subscriptionCommand``."))
+            }
+        }
+
+        $enabledVmrSubscriptions = @($subscriptions | Where-Object {
+            "$($_.sourceRepository)".TrimEnd('/') -ieq 'https://github.com/dotnet/dotnet' -and
+            $_.enabled -eq $true
+        })
+        if ($enabledVmrSubscriptions.Count -eq 0) {
+            $checks.Add((New-Check -Area 'VMR reconciliation model' -Status 'READY' `
+                -Details 'No enabled dotnet/dotnet subscription is configured or required. VMR is reconciled locally against the authoritative official build.' `
+                -NextAction 'Keep VMR reconciliation local; do not add a dotnet/dotnet subscription.'))
+        } else {
+            $checks.Add((New-Check -Area 'VMR reconciliation model' -Status 'BLOCKED' `
+                -Details 'An unexpected dotnet/dotnet subscription targets this prerelease branch. VMR must remain locally reconciled against the authoritative official build.' `
+                -NextAction 'Remove or disable the unexpected VMR subscription after release-infrastructure review.'))
+        }
+
+        return @($checks)
 }
 
 function Get-OverallStatus {
@@ -2266,7 +2531,7 @@ if ($Mode -eq 'candidate') {
     if ($targetBranchExists) {
         # Branch already exists; if Find-Trackers ran today it would have
         # classified this as in-flight. Inform the operator but don't fail.
-        $checks += New-Check -Area "Target branch" -Status "WATCH" -Details "``$Branch`` already exists — preview was cut. Re-run Find-Trackers to switch this tracker to in-flight mode." -NextAction "Re-run Find-ReleaseReadinessTrackers and update the workflow input."
+        $checks += New-Check -Area "Target branch" -Status "WATCH" -Details "``$Branch`` already exists — $releaseDisplayName was cut. Re-run Find-Trackers to switch this tracker to in-flight mode." -NextAction "Re-run Find-ReleaseReadinessTrackers and update the workflow input."
     } else {
         $checks += New-Check -Area "Target branch (candidate)" -Status "READY" -Details "``$Branch`` does not exist yet — surveying source ``$SurveyRef`` (candidate mode)." -NextAction "Cut ``$Branch`` from ``$SurveyRef`` when ready."
     }
@@ -2278,21 +2543,28 @@ if ($Mode -eq 'candidate') {
     }
 }
 
-# --- Iteration check ---
+# --- Prerelease dependency-flow wiring ---
+if ($Mode -eq 'in-flight' -and $targetBranchExists) {
+    $checks += @(Get-PrereleaseDependencyFlowChecks -Branch $Branch `
+        -ExpectedChannelName $expectedChannelName -Stage $releaseStage)
+}
+
+# --- Version label + iteration check ---
 # In-flight: surveyRef == Branch, so we check that the branch itself declares
 # PreReleaseVersionIteration == previewNumber.
 # Candidate: surveyRef == net<major>.0, so we check that the source branch
 # is bumped to match THIS preview (the one about to be cut).
-$surveyIteration = $null
+$surveyVersion = $null
 $xcodeRequirements = [PSCustomObject]@{ RequiredXcode = $null; DeviceTestsRequiredXcode = $null }
 $surveyExists = if ($SurveyRef -eq $Branch) { $targetBranchExists } else { Test-BranchExists -BranchName $SurveyRef }
 if ($surveyExists) {
     try {
-        $surveyIteration = Get-PreReleaseVersionIteration -BranchName $SurveyRef
-        $checks += Get-PreviewIterationCheck -Mode $Mode -SurveyRef $SurveyRef `
-            -PreviewNumber $previewNumber -Iteration $surveyIteration
+        $surveyVersion = Get-PreReleaseVersionMetadata -BranchName $SurveyRef
+        $checks += Get-PrereleaseVersionCheck -Mode $Mode -SurveyRef $SurveyRef `
+            -Stage $releaseStage -Number $releaseNumber `
+            -Label $surveyVersion.Label -Iteration $surveyVersion.Iteration
     } catch {
-        $checks += New-Check -Area "Preview iteration" -Status "UNKNOWN" -Details "Could not read version iteration from ``$SurveyRef``." -NextAction "Run locally and inspect eng/Versions.props."
+        $checks += New-Check -Area "$releaseStageDisplay version" -Status "UNKNOWN" -Details "Could not read prerelease version metadata from ``$SurveyRef``." -NextAction "Run locally and inspect eng/Versions.props."
     }
 
     try {
@@ -2307,7 +2579,7 @@ if ($surveyExists) {
     # against it. Read the template from main (issue templates are global per repo)
     # and verify the dropdown contains an entry matching this preview.
     try {
-        $expectedVersion = "$majorVersion.0.0-preview.$previewNumber"
+        $expectedVersion = "$majorVersion.0.0-$releaseStage.$releaseNumber"
         $templateBranch = if ($mainBranch) { $mainBranch } else { 'main' }
         $templateVersions = Get-BugTemplateVersions -BranchName $templateBranch
         if ($templateVersions.Count -eq 0) {
@@ -2323,8 +2595,8 @@ if ($surveyExists) {
     }
 }
 
-# --- Preview milestone existence check ---
-# Policy: a preview release-readiness tracker and its GitHub milestone are
+# --- Prerelease milestone existence check ---
+# Policy: a prerelease readiness tracker and its GitHub milestone are
 # coupled. If this tracker exists, the ".NET <major>.0-preview<N>" milestone
 # must exist RIGHT AWAY — not deferred to cut time — otherwise fixed issues have
 # no milestone to land on and the release-notes generator has nothing to query.
@@ -2333,24 +2605,24 @@ if ($surveyExists) {
 # candidate tracker's OWN milestone as blocking. Repo-global, so it runs
 # independent of branch/survey state (candidate and in-flight alike).
 try {
-    $msCheck = Test-PreviewMilestoneExists -Major $majorVersion -Preview $previewNumber
-    $msArea = "Milestone for preview$previewNumber ($($msCheck.ExpectedTitle))"
+    $msCheck = Test-PrereleaseMilestoneExists -Major $majorVersion -Stage $releaseStage -Number $releaseNumber
+    $msArea = "Milestone for $releaseStage$releaseNumber ($($msCheck.ExpectedTitle))"
     if ($msCheck.QueryFailed) {
         $checks += New-Check -Area $msArea -Status "UNKNOWN" `
             -Details "Could not query milestones from the GitHub API for ``$Repository`` (gh exited non-zero after retries). Treating as unknown so a gh outage does not silently pass — or falsely block — the milestone check." `
             -NextAction "Verify ``gh auth status`` and rerun, or check manually: ``gh api repos/$Repository/milestones``."
     } elseif ($msCheck.Exists) {
         $checks += New-Check -Area $msArea -Status "READY" `
-            -Details "Milestone ``$($msCheck.MatchedTitle)`` exists — fixed preview$previewNumber issues have a milestone to land on." `
+            -Details "Milestone ``$($msCheck.MatchedTitle)`` exists — fixed $releaseStage$releaseNumber issues have a milestone to land on." `
             -NextAction "No action needed."
     } else {
         $checks += New-Check -Area $msArea -Status "BLOCKED" `
-            -Details "No milestone matching ``$($msCheck.ExpectedTitle)`` exists in ``$Repository``. A preview$previewNumber release-readiness tracker exists, so its milestone must exist right away — without it, fixed issues have nowhere to land and the release-notes generator has nothing to query." `
+            -Details "No milestone matching ``$($msCheck.ExpectedTitle)`` exists in ``$Repository``. A $releaseStage$releaseNumber release-readiness tracker exists, so its milestone must exist right away — without it, fixed issues have nowhere to land and the release-notes generator has nothing to query." `
             -NextAction "Create it now: ``gh api repos/$Repository/milestones -f title=""$($msCheck.ExpectedTitle)"" -f state=open``"
     }
 } catch {
-    $checks += New-Check -Area "Milestone for preview$previewNumber" -Status "UNKNOWN" `
-        -Details "Failed to evaluate the preview milestone: $($_.Exception.Message)" `
+    $checks += New-Check -Area "Milestone for $releaseStage$releaseNumber" -Status "UNKNOWN" `
+        -Details "Failed to evaluate the prerelease milestone: $($_.Exception.Message)" `
         -NextAction "Check milestones manually: ``gh api repos/$Repository/milestones``."
 }
 
@@ -2468,8 +2740,10 @@ if ($p0Prs.Count -gt 0) {
 }
 
 # --- Release-relevant issues ---
-$priorityIssues = Get-ReleaseRelevantIssuesByLabel -Labels @("p/0", "p/1") -Major $majorVersion -Preview $previewNumber
-$kbeIssues = Get-ReleaseRelevantIssuesByLabel -Labels @("Known Build Error") -Major $majorVersion -Preview $previewNumber
+$priorityIssues = Get-ReleaseRelevantIssuesByLabel -Labels @("p/0", "p/1") `
+    -Major $majorVersion -Stage $releaseStage -Number $releaseNumber
+$kbeIssues = Get-ReleaseRelevantIssuesByLabel -Labels @("Known Build Error") `
+    -Major $majorVersion -Stage $releaseStage -Number $releaseNumber
 
 # Carve out P/0 issues separately — these are surfaced in the hoisted
 # "🔴 High-priority items" section at the top of the report so the release
@@ -2564,7 +2838,7 @@ $consumerInstallability = New-PreviewInstallabilityFallback `
     -Summary 'Consumer installability could not be evaluated.' `
     -CliVersion $ConfirmedWorkloadSetVersion `
     -PublicSafe $effectivePublicSafe
-if ($Script:PreviewInstallabilityHelperLoaded) {
+if ($Script:PreviewInstallabilityHelperLoaded -and $releaseStage -eq 'preview') {
     try {
         $consumerInstallability = Get-PreviewConsumerInstallability `
             -Major $majorVersion `
@@ -2583,8 +2857,12 @@ if ($Script:PreviewInstallabilityHelperLoaded) {
     }
 }
 
-if ($Script:PreviewInstallabilityHelperLoaded) {
+if ($Script:PreviewInstallabilityHelperLoaded -and $releaseStage -eq 'preview') {
     $checks += ConvertTo-PreviewInstallabilityCheck -Result $consumerInstallability
+} elseif ($releaseStage -eq 'rc') {
+    $checks += New-Check -Area 'Consumer installability' -Status 'UNKNOWN' `
+        -Details 'The existing package-level installability probe is Preview-specific and does not yet resolve RC workload-set package IDs.' `
+        -NextAction 'Validate RC consumer installability against the authoritative official RC workload-set package.'
 } else {
     $checks += New-Check -Area 'Consumer installability' -Status 'UNKNOWN' `
         -Details $consumerInstallability.Summary `
@@ -2649,7 +2927,7 @@ if ($Script:InternalOfficialBuildHelperLoaded) {
 # transient file/API failure must not silently remove that guidance or let the
 # report look fully verified. $componentPins was already resolved above for
 # the consumer-installability gate; reuse it here instead of re-querying.
-$isCutPreview = $Mode -eq 'in-flight'
+$isCutPrerelease = $Mode -eq 'in-flight'
 $componentPinsCheck = Get-ComponentPinsReadinessCheck -Pins $componentPins -SurveyRef $SurveyRef
 if ($componentPinsCheck) {
     $checks += $componentPinsCheck
@@ -2668,9 +2946,13 @@ $report = [PSCustomObject]@{
     Branch                = $Branch
     Mode                  = $Mode
     SurveyRef             = $SurveyRef
-    BranchType            = "preview"
+    BranchType            = $releaseStage
+    ReleaseStage          = $releaseStage
+    ReleaseNumber         = $releaseNumber
     MajorVersion          = $majorVersion
-    PreviewNumber         = $previewNumber
+    PreviewNumber         = if ($releaseStage -eq 'preview') { $releaseNumber } else { $null }
+    RcNumber              = if ($releaseStage -eq 'rc') { $releaseNumber } else { $null }
+    ExpectedChannelName   = $expectedChannelName
     InflightBranch        = $mainBranch
     TrackerKey            = $TrackerKey
     OverallStatus         = $overallStatus
@@ -2707,16 +2989,17 @@ if ($Script:NightlyFeedHelperLoaded -and
     try {
         $nfFeed = "dotnet$majorVersion"
         $nfFeedUrl = "https://dev.azure.com/dnceng/public/_artifacts/feed/$nfFeed"
-        $nfIteration = Get-PreReleaseVersionIteration -BranchName $SurveyRef
-        if ([string]::IsNullOrWhiteSpace($nfIteration)) { $nfIteration = "$previewNumber" }
-        $nfBand = "$majorVersion.0.0-preview.$nfIteration"
+        $nfVersion = Get-PreReleaseVersionMetadata -BranchName $SurveyRef
+        $nfLabel = if ([string]::IsNullOrWhiteSpace($nfVersion.Label)) { $releaseStage } else { $nfVersion.Label }
+        $nfIteration = if ([string]::IsNullOrWhiteSpace($nfVersion.Iteration)) { "$releaseNumber" } else { $nfVersion.Iteration }
+        $nfBand = "$majorVersion.0.0-$nfLabel.$nfIteration"
         $nfBandPrefix = '^' + [regex]::Escape("$nfBand.")
 
         $nfFresh = Resolve-NightlyDogfoodFreshness -Feed $nfFeed -BandPrefixRegex $nfBandPrefix
         if ($null -eq $nfFresh) { $nfFresh = @{ unknown = $true } }
 
         $nfBuildType = [string](Get-NightlyFeedProp $nfFresh 'buildType')
-        $nfLaneLabel = Format-NightlyFeedLaneLabel -Feed $nfFeed -FeedUrl $nfFeedUrl -BuildType $nfBuildType -BandNote "``$nfBand`` (preview.$nfIteration)"
+        $nfLaneLabel = Format-NightlyFeedLaneLabel -Feed $nfFeed -FeedUrl $nfFeedUrl -BuildType $nfBuildType -BandNote "``$nfBand`` ($nfLabel.$nfIteration)"
         $nfFresh['laneLabel'] = $nfLaneLabel
         $nfFresh['feedUrl'] = $nfFeedUrl
         $nfFresh['versionPrefix'] = $nfBandPrefix
@@ -2733,12 +3016,12 @@ if ($Script:NightlyFeedHelperLoaded -and
 
 $md = [System.Text.StringBuilder]::new()
 [void]$md.AppendLine("<!-- release-readiness-tracker: $TrackerKey -->")
-[void]$md.AppendLine("<!-- release-readiness-flavor: preview -->")
+[void]$md.AppendLine("<!-- release-readiness-flavor: $releaseStage -->")
 [void]$md.AppendLine("<!-- release-readiness-mode: $Mode -->")
 if ($Mode -eq 'candidate') {
-    [void]$md.AppendLine("# Release Readiness — .NET $majorVersion.0 preview $previewNumber (CANDIDATE from $SurveyRef) — $((Get-Date).ToString("yyyy-MM-dd"))")
+    [void]$md.AppendLine("# Release Readiness — .NET $majorVersion.0 $releaseDisplayName (CANDIDATE from $SurveyRef) — $((Get-Date).ToString("yyyy-MM-dd"))")
 } else {
-    [void]$md.AppendLine("# Release Readiness — .NET $majorVersion.0 preview $previewNumber — $((Get-Date).ToString("yyyy-MM-dd"))")
+    [void]$md.AppendLine("# Release Readiness — .NET $majorVersion.0 $releaseDisplayName — $((Get-Date).ToString("yyyy-MM-dd"))")
 }
 [void]$md.AppendLine("")
 [void]$md.AppendLine("**Ship verdict:** **$readinessVerdict** (check state: ``$overallStatus``)")
@@ -2752,7 +3035,7 @@ if ($nightlyFeedBanner) {
 [void]$md.AppendLine("**Tracker:** ``$TrackerKey`` · mode=``$Mode`` · branch=``$Branch`` · survey=``$SurveyRef``")
 [void]$md.AppendLine("")
 if ($Mode -eq 'candidate') {
-    [void]$md.AppendLine("> 🛫 **Pre-flight (candidate) mode.** Branch ``$Branch`` has not been cut yet. This report surveys ``$SurveyRef`` and shows what WOULD ship if the preview were cut today.")
+    [void]$md.AppendLine("> 🛫 **Pre-flight (candidate) mode.** Branch ``$Branch`` has not been cut yet. This report surveys ``$SurveyRef`` and shows what WOULD ship if $releaseDisplayName were cut today.")
     [void]$md.AppendLine("")
 }
 
@@ -2876,21 +3159,21 @@ $notesBlockText = $notesSb.ToString()
 # mandatory policy in a reusable block so the body cap can reserve and re-append it.
 $componentPolicySb = [System.Text.StringBuilder]::new()
 [void]$componentPolicySb.AppendLine("<!-- release-readiness:component-policy:begin -->")
-[void]$componentPolicySb.AppendLine("## 🏷️ Preview $previewNumber component build — branch pins + update paths")
+[void]$componentPolicySb.AppendLine("## 🏷️ $releaseDisplayName component build — branch pins + update paths")
 [void]$componentPolicySb.AppendLine("")
 [void]$componentPolicySb.AppendLine("> [!IMPORTANT]")
-$vmrPolicyText = if ($isCutPreview) {
-    "VMR is intentionally different: there is **no dotnet/dotnet subscription** on a cut preview branch because the Maestro preview feed can differ from the official release source of truth; reconcile that pin locally against the official SDK/runtime build."
+$vmrPolicyText = if ($isCutPrerelease) {
+    "VMR is intentionally different: there is **no dotnet/dotnet subscription** on a cut prerelease branch because the Maestro channel can differ from the official release source of truth; reconcile that pin locally against the official SDK/runtime build."
 } else {
-    "Candidate mode surveys ``$SurveyRef``: its VMR flow signal describes the inflight branch subscription only and does **not** select or validate the official Preview $previewNumber SDK/runtime pin. After cut, use only Android/macOS-iOS subscriptions and reconcile VMR locally."
+    "Candidate mode surveys ``$SurveyRef``: its VMR flow signal describes the inflight branch subscription only and does **not** select or validate the official $releaseDisplayName SDK/runtime pin. After cut, use only Android/macOS-iOS subscriptions and reconcile VMR locally."
 }
 [void]$componentPolicySb.AppendLine("> **Branch pins** are read from ``$SurveyRef`` (``eng/Version.Details.xml`` — public git). **This is NOT a confirmed official build**; this public workflow cannot resolve the authoritative release designation. $vmrPolicyText")
 [void]$componentPolicySb.AppendLine(">")
 [void]$componentPolicySb.AppendLine("> ``````")
-$localVerificationPrompt = if ($isCutPreview) {
-    "Run release readiness for ${Branch}: resolve the official Preview $previewNumber SDK/runtime build from the authorized release source of truth, reconcile the MAUI SDK/VMR pin locally to that build, and verify only the dotnet/android + dotnet/macios preview subscriptions are wired to the .NET $majorVersion.0.1xx SDK Preview $previewNumber channel."
+$localVerificationPrompt = if ($isCutPrerelease) {
+    "Run release readiness for ${Branch}: resolve the official $releaseDisplayName SDK/runtime build from the authorized release source of truth, reconcile the MAUI SDK/VMR pin locally to that build, and verify only the dotnet/android + dotnet/macios inbound subscriptions are wired to the $expectedChannelName channel."
 } else {
-    "Run release readiness for ${Branch}: resolve the official Preview $previewNumber SDK/runtime build from the authorized release source of truth. Treat ``$SurveyRef`` VMR flow as inflight evidence only; after cut, add only dotnet/android + dotnet/macios subscriptions and reconcile MAUI's SDK/VMR pin locally."
+    "Run release readiness for ${Branch}: resolve the official $releaseDisplayName SDK/runtime build from the authorized release source of truth. Treat ``$SurveyRef`` VMR flow as inflight evidence only; after cut, add only dotnet/android + dotnet/macios subscriptions and reconcile MAUI's SDK/VMR pin locally."
 }
 [void]$componentPolicySb.AppendLine("> $localVerificationPrompt")
 [void]$componentPolicySb.AppendLine("> ``````")
@@ -2929,7 +3212,7 @@ if ($componentPins) {
     $allPRsForFlow   = @($targetPRs) + @($mergedPRsForFlow)
     $depFlowPRs      = @($allPRsForFlow | Where-Object { Test-IsDependencyFlowPr $_ })
 
-    [void]$md.AppendLine("> The **Upstream** column is a hard git fact (not an inference): it compares our pinned SHA against the tip of each component's same-named branch (``$SurveyRef`` — derived, never hardcoded) via the public compare API. ⬆️ *N ahead* means the source moved past what we bundle — an FYI you *may* want to pull in, **not** a required bump (maui pins blessed builds deliberately, so those commits may be post-preview churn or not yet blessed).")
+    [void]$md.AppendLine("> The **Upstream** column is a hard git fact (not an inference): it compares our pinned SHA against the tip of each component's same-named branch (``$SurveyRef`` — derived, never hardcoded) via the public compare API. ⬆️ *N ahead* means the source moved past what we bundle — an FYI you *may* want to pull in, **not** a required bump (maui pins blessed builds deliberately, so those commits may be post-release churn or not yet blessed).")
     [void]$md.AppendLine("")
     [void]$md.AppendLine("| Component | Branch pin (bundled) | Commit | Update path / flow signal | Upstream (vs our pin) |")
     [void]$md.AppendLine("|-----------|----------------------|--------|---------------------------|-----------------------|")
@@ -2942,7 +3225,7 @@ if ($componentPins) {
     foreach ($r in $pinRows) {
         $flowCell = Format-PreviewComponentUpdatePathCell -Repo $r.Repo `
             -DepFlowPRs $depFlowPRs -Now $flowNow -StaleDays $flowStaleDays `
-            -LocalVmr:($isCutPreview) `
+            -LocalVmr:($isCutPrerelease) `
             -HistoryUnavailable:$mergedHistoryUnavailable
         $pin = $r.Pin
         if (-not $pin) {
@@ -2957,6 +3240,7 @@ if ($componentPins) {
         $drift = Get-UpstreamDriftSignal -Repo $r.Repo -Sha $pin.Sha -BranchName $SurveyRef
         $driftCell = Format-PreviewComponentSourceCell -Repo $r.Repo `
             -Version $pin.Version -Major $majorVersion -Preview $previewNumber `
+            -Stage $releaseStage `
             -Drift $drift -Vmr:$r.Vmr
 
         $commitCell = '—'
@@ -2967,14 +3251,14 @@ if ($componentPins) {
         [void]$md.AppendLine("| $(Format-MarkdownCell $r.Label) | ``$($pin.Version)`` | $commitCell | $flowCell | $driftCell |")
     }
     [void]$md.AppendLine("")
-    $updatePathLegend = if ($isCutPreview) {
+    $updatePathLegend = if ($isCutPrerelease) {
         "_Update-path legend: Android/macOS-iOS — 🔄 open dep-flow PR · ✅ merged ≤ $flowStaleDays d · ⚠️ newest merge > $flowStaleDays d · ❌ no PR trail (subscription may be missing). Confirm those two subscriptions with ``darc get-subscriptions --target-repo https://github.com/dotnet/maui --target-branch $SurveyRef``. VMR — 🛠️ no subscription by design; reconcile locally against the official SDK/runtime build._"
     } else {
-        "_Update-path legend: candidate mode reports the existing ``$SurveyRef`` subscription PR trail. Its VMR signal is inflight evidence only, not proof of the official Preview $previewNumber SDK/runtime selection._"
+        "_Update-path legend: candidate mode reports the existing ``$SurveyRef`` subscription PR trail. Its VMR signal is inflight evidence only, not proof of the official $releaseDisplayName SDK/runtime selection._"
     }
     [void]$md.AppendLine($updatePathLegend)
     [void]$md.AppendLine("")
-    [void]$md.AppendLine("_Upstream legend: ✅ current = our pin **is** the tip of the component's ``$SurveyRef`` branch · ⬆️ N ahead = that branch has N newer commit(s) than we bundle (**FYI** — may be post-preview churn or not-yet-blessed work; not necessarily a bump you need) · ⚠️ diverged = our pin isn't a clean ancestor of the branch tip (build tag / different line) — compare manually · — = couldn't determine (no same-named upstream branch, or the compare API was unavailable). Branch is **derived** from the survey ref, never hardcoded. dotnet/dotnet (VMR) advances constantly; its upstream drift is informational because the official SDK/runtime build, not branch tip or Maestro feed, selects the release pin._")
+    [void]$md.AppendLine("_Upstream legend: ✅ current = our pin **is** the tip of the component's ``$SurveyRef`` branch · ⬆️ N ahead = that branch has N newer commit(s) than we bundle (**FYI** — may be post-release churn or not-yet-blessed work; not necessarily a bump you need) · ⚠️ diverged = our pin isn't a clean ancestor of the branch tip (build tag / different line) — compare manually · — = couldn't determine (no same-named upstream branch, or the compare API was unavailable). Branch is **derived** from the survey ref, never hardcoded. dotnet/dotnet (VMR) advances constantly; its upstream drift is informational because the official SDK/runtime build, not branch tip or Maestro feed, selects the release pin._")
 
     # If a manual/darc component-bump PR is open against the branch, it names the
     # pending target BAR builds in its title — surface it so readers see the pins
@@ -3051,7 +3335,7 @@ if ($cleanupChecks.Count -gt 0) {
 [void]$md.AppendLine("## Recent CI Failure Scanner signals (``ci-scan``)")
 [void]$md.AppendLine("")
 if (-not $ciScanLabel) {
-    [void]$md.AppendLine("_No CI Failure Scanner runs against ``$SurveyRef``. This section has no continuous-scan evidence for the cut preview branch._")
+    [void]$md.AppendLine("_No CI Failure Scanner runs against ``$SurveyRef``. This section has no continuous-scan evidence for the cut prerelease branch._")
     [void]$md.AppendLine("")
 } else {
     $ciScanBlurb = "_Filtered to issues whose ``**Branch**: <name>`` body marker matches ``$SurveyRef`` (auto-filed by the CI Failure Scanner workflow every 12h). Fresh issues (<24h) are flagged 🆕._"
@@ -3085,9 +3369,11 @@ if ($generatedAt -and (Get-Command Format-ReportFreshnessBanner -ErrorAction Sil
 [void]$md.AppendLine("|-------|-------|")
 [void]$md.AppendLine("| Branch | ``$Branch`` |")
 [void]$md.AppendLine("| Inflight branch | ``$mainBranch`` |")
-[void]$md.AppendLine("| Expected SDK channel | ``.NET $majorVersion.0.1xx SDK Preview $previewNumber`` |")
+[void]$md.AppendLine("| Release lane | ``$releaseStage`` |")
+[void]$md.AppendLine("| Expected SDK channel | ``$expectedChannelName`` |")
 [void]$md.AppendLine("| Workload release channel | ``.NET $majorVersion Workload Release`` |")
-[void]$md.AppendLine("| Expected PreReleaseVersionIteration | ``$previewNumber`` |")
+[void]$md.AppendLine("| Expected PreReleaseVersionLabel | ``$releaseStage`` |")
+[void]$md.AppendLine("| Expected PreReleaseVersionIteration | ``$releaseNumber`` |")
 [void]$md.AppendLine("")
 
 [void]$md.AppendLine("## Readiness checklist")
@@ -3111,7 +3397,7 @@ $sdkBumpPrs = @($maestroPRs | Where-Object { Test-IsSdkBumpPr $_ })
 if ($sdkBumpPrs.Count -gt 0) {
     $sdkBumpLinks = ($sdkBumpPrs | ForEach-Object { "[#$($_.number)]($($_.url))" }) -join ', '
     [void]$md.AppendLine("> [!WARNING]")
-    [void]$md.AppendLine("> $($sdkBumpPrs.Count) open PR(s) bump the **SDK/VMR** ($sdkBumpLinks). The new SDK pin they land is only a **candidate**; this public workflow cannot resolve the authoritative release designation. **Confirm the official SDK/runtime build locally** (see 🏷️ Preview $previewNumber component build above) before treating the bumped pin as final.")
+    [void]$md.AppendLine("> $($sdkBumpPrs.Count) open PR(s) bump the **SDK/VMR** ($sdkBumpLinks). The new SDK pin they land is only a **candidate**; this public workflow cannot resolve the authoritative release designation. **Confirm the official SDK/runtime build locally** (see 🏷️ $releaseDisplayName component build above) before treating the bumped pin as final.")
     [void]$md.AppendLine("")
 }
 Add-PRTable -Builder $md -PRs $maestroPRs

--- a/.github/skills/release-readiness/scripts/New-ReleaseHandoff.ps1
+++ b/.github/skills/release-readiness/scripts/New-ReleaseHandoff.ps1
@@ -5,7 +5,7 @@
     Renders a copy-ready public release handoff from release-readiness JSON.
 
 .DESCRIPTION
-    Projects an existing Preview or SR readiness report plus separately verified
+    Projects an existing Preview, RC, or SR readiness report plus separately verified
     release evidence into Markdown and normalized JSON. It does not survey a
     branch, select a build, query private release systems, or publish content.
     Missing evidence is rendered as a literal TBD instead of being inferred.
@@ -312,20 +312,21 @@ function Get-HandoffReleaseType {
 
     $branchType = [string](Get-HandoffProperty -Object $Readiness -Name 'BranchType')
     if ($branchType -ieq 'preview') { return 'preview' }
+    if ($branchType -ieq 'rc') { return 'rc' }
     if ($branchType -ieq 'sr') { return 'sr' }
     if (Get-HandoffProperty -Object $Readiness -Name 'metadata') { return 'sr' }
-    throw 'Readiness JSON is not recognized as a Preview or SR report.'
+    throw 'Readiness JSON is not recognized as a Preview, RC, or SR report.'
 }
 
 function Get-HandoffReadinessSummary {
     param(
         [Parameter(Mandatory)]$Readiness,
-        [Parameter(Mandatory)][ValidateSet('preview', 'sr')][string]$ReleaseType,
+        [Parameter(Mandatory)][ValidateSet('preview', 'rc', 'sr')][string]$ReleaseType,
         [bool]$PublicSafe = $true
     )
 
     $rows = [Collections.Generic.List[object]]::new()
-    if ($ReleaseType -eq 'preview') {
+    if ($ReleaseType -in @('preview', 'rc')) {
         $checks = @(Get-HandoffProperty -Object $Readiness -Name 'Checks' -Default @())
     } else {
         $checks = @(Get-HandoffProperty -Object $Readiness -Name 'shipChecks' -Default @())
@@ -578,15 +579,20 @@ function New-ReleaseHandoffModel {
     $useEvidence = -not $PublicSafe -or $evidenceIsPublic
     $effectiveEvidence = if ($useEvidence) { $Evidence } else { [PSCustomObject]@{} }
     $releaseType = Get-HandoffReleaseType -Readiness $Readiness
-    if ($releaseType -eq 'preview') {
+    if ($releaseType -in @('preview', 'rc')) {
         $major = Get-HandoffProperty -Object $Readiness -Name 'MajorVersion'
-        $iteration = Get-HandoffProperty -Object $Readiness -Name 'PreviewNumber'
+        $iteration = if ($releaseType -eq 'rc') {
+            Get-HandoffProperty -Object $Readiness -Name 'RcNumber'
+        } else {
+            Get-HandoffProperty -Object $Readiness -Name 'PreviewNumber'
+        }
         $branch = Get-HandoffProperty -Object $Readiness -Name 'Branch'
         $mode = Get-HandoffProperty -Object $Readiness -Name 'Mode'
         $verdict = Get-HandoffProperty -Object $Readiness -Name 'Verdict'
         $checkState = Get-HandoffProperty -Object $Readiness -Name 'OverallStatus'
         $generatedAt = Get-HandoffProperty -Object $Readiness -Name 'GeneratedAt'
-        $defaultName = ".NET MAUI $major.0.0 Preview $iteration"
+        $stageName = if ($releaseType -eq 'rc') { 'RC' } else { 'Preview' }
+        $defaultName = ".NET MAUI $major.0.0 $stageName $iteration"
         $installability = Get-HandoffProperty -Object $Readiness -Name 'ConsumerInstallability'
     } else {
         $metadata = Get-HandoffProperty -Object $Readiness -Name 'metadata'
@@ -665,7 +671,7 @@ function New-ReleaseHandoffModel {
         $rollbackUrl = $null
     }
     if ($PublicSafe) {
-        if ($branch -notmatch '^release/\d+\.\d+\.\d+xx-(?:preview\d+|sr\d+)$') { $branch = $null }
+        if ($branch -notmatch '^release/\d+\.\d+\.\d+xx-(?:preview\d+|rc\d+|sr\d+)$') { $branch = $null }
         if ($mode -notin @('in-flight', 'candidate', 'shipped')) { $mode = $null }
         $verdict = ConvertTo-HandoffStructuredText -Value $verdict -Kind status -PublicSafe $true
         $checkStateText = [string]$checkState

--- a/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
+++ b/.github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1
@@ -726,6 +726,43 @@ if (-not (Test-Path $detectScriptPath)) {
             Assert-Eq -Label "  -> major=$($case.Major)"       -Expected $case.Major    -Actual ([int]$m.Groups[1].Value)
             Assert-Eq -Label "  -> previewN=$($case.PreviewN)" -Expected $case.PreviewN -Actual ([int]$m.Groups[2].Value)
         }
+
+        Write-Host "`n[Unit] RC branch/tag contracts" -ForegroundColor Cyan
+        foreach ($case in @(
+            @{ Branch = 'release/11.0.1xx-rc1'; Match = $true; Major = 11; RcN = 1 }
+            @{ Branch = 'release/11.0.1xx-rc2'; Match = $true; Major = 11; RcN = 2 }
+            @{ Branch = 'release/11.0.1xx-rc1-test'; Match = $false }
+            @{ Branch = 'release/11.0.1xx-preview7'; Match = $false }
+        )) {
+            $m = [regex]::Match($case.Branch, $Script:StrictRcBranchRegex)
+            Assert-Eq -Label "RC branch '$($case.Branch)' match=$($case.Match)" -Expected $case.Match -Actual $m.Success
+            if ($case.Match) {
+                Assert-Eq -Label "  -> RC major=$($case.Major)" -Expected $case.Major -Actual ([int]$m.Groups[1].Value)
+                Assert-Eq -Label "  -> rcN=$($case.RcN)" -Expected $case.RcN -Actual ([int]$m.Groups[2].Value)
+            }
+        }
+        foreach ($case in @(
+            @{ Tag = '11.0.0-rc.1.26425.128'; Match = $true; Major = 11; RcN = 1 }
+            @{ Tag = '11.0.0-rc.2.26450'; Match = $true; Major = 11; RcN = 2 }
+            @{ Tag = '11.0.0-rc.1'; Match = $false }
+            @{ Tag = '11.0.0-preview.7.26420.5'; Match = $false }
+        )) {
+            $m = [regex]::Match($case.Tag, $Script:StrictRcTagRegex)
+            Assert-Eq -Label "RC tag '$($case.Tag)' match=$($case.Match)" -Expected $case.Match -Actual $m.Success
+            if ($case.Match) {
+                Assert-Eq -Label "  -> RC tag major=$($case.Major)" -Expected $case.Major -Actual ([int]$m.Groups[1].Value)
+                Assert-Eq -Label "  -> RC tag number=$($case.RcN)" -Expected $case.RcN -Actual ([int]$m.Groups[2].Value)
+            }
+        }
+        $rcSet = Get-ShippedRcSet -RcTags @('11.0.0-rc.1.26425.128', '11.0.0-rc.1.26425.129')
+        Assert-Eq -Label 'RC shipped set collapses duplicate RC1 tags' -Expected 1 -Actual $rcSet.Count
+        Assert-Eq -Label 'RC shipped set contains RC1' -Expected $true -Actual $rcSet.Contains(1)
+        $rcTracker = New-RcTracker -Major 11 -RcNumber 1 -Mode 'in-flight' `
+            -BranchName 'release/11.0.1xx-rc1' -SurveyRef 'release/11.0.1xx-rc1' `
+            -HasRecentActivityCount 1
+        Assert-Eq -Label 'RC tracker canonical key' -Expected 'net11-rc1' -Actual $rcTracker.canonicalKey
+        Assert-Eq -Label 'RC tracker expected channel' -Expected '.NET 11.0.1xx SDK RC 1' -Actual $rcTracker.expectedChannelName
+        Assert-Eq -Label 'RC tracker milestone' -Expected '.NET 11.0-rc1' -Actual $rcTracker.milestoneName
     }
 
     # ─────────── Preview regression label inference ───────────
@@ -1254,8 +1291,10 @@ if (-not $SkipE2E) {
     $origGetMainBranchForVersion = (Get-Item function:Get-MainBranchForVersion).ScriptBlock
     $origGetStableTagsForMajor = (Get-Item function:Get-StableTagsForMajor).ScriptBlock
     $origGetPreviewTagsForMajor = (Get-Item function:Get-PreviewTagsForMajor).ScriptBlock
+    $origGetRcTagsForMajor = (Get-Item function:Get-RcTagsForMajor).ScriptBlock
     $origGetRemoteSrBranchesForMajor = (Get-Item function:Get-RemoteSrBranchesForMajor).ScriptBlock
     $origGetRemotePreviewBranchesForMajor = (Get-Item function:Get-RemotePreviewBranchesForMajor).ScriptBlock
+    $origGetRemoteRcBranchesForMajor = (Get-Item function:Get-RemoteRcBranchesForMajor).ScriptBlock
     $origGetVersionFromGitRef = (Get-Item function:Get-VersionFromGitRef).ScriptBlock
     $origGetRecentCommitCount = (Get-Item function:Get-RecentCommitCount).ScriptBlock
     $origInvokeGitOrFail = (Get-Item function:Invoke-GitOrFail).ScriptBlock
@@ -1266,6 +1305,7 @@ if (-not $SkipE2E) {
         function Get-MainBranchForVersion { param([int]$Major, [string]$Repo) 'main' }
         function Get-StableTagsForMajor { param([int]$Major) ,@('10.0.0', '10.0.90') }
         function Get-PreviewTagsForMajor { param([int]$Major) ,@() }
+        function Get-RcTagsForMajor { param([int]$Major) ,@() }
         function Get-RemoteSrBranchesForMajor {
             param([int]$Major)
             ,@([pscustomobject]@{
@@ -1274,6 +1314,7 @@ if (-not $SkipE2E) {
             })
         }
         function Get-RemotePreviewBranchesForMajor { param([int]$Major) ,@() }
+        function Get-RemoteRcBranchesForMajor { param([int]$Major) ,@() }
         function Get-VersionFromGitRef {
             param([string]$GitRef, [string]$Repo)
             if ($GitRef -eq "origin/$($script:SyntheticSrBranchName)") {
@@ -1360,8 +1401,10 @@ if (-not $SkipE2E) {
         Set-Item function:Get-MainBranchForVersion $origGetMainBranchForVersion
         Set-Item function:Get-StableTagsForMajor $origGetStableTagsForMajor
         Set-Item function:Get-PreviewTagsForMajor $origGetPreviewTagsForMajor
+        Set-Item function:Get-RcTagsForMajor $origGetRcTagsForMajor
         Set-Item function:Get-RemoteSrBranchesForMajor $origGetRemoteSrBranchesForMajor
         Set-Item function:Get-RemotePreviewBranchesForMajor $origGetRemotePreviewBranchesForMajor
+        Set-Item function:Get-RemoteRcBranchesForMajor $origGetRemoteRcBranchesForMajor
         Set-Item function:Get-VersionFromGitRef $origGetVersionFromGitRef
         Set-Item function:Get-RecentCommitCount $origGetRecentCommitCount
         Set-Item function:Invoke-GitOrFail $origInvokeGitOrFail
@@ -1379,8 +1422,10 @@ if (-not $SkipE2E) {
     $origGetMainBranchForVersion = (Get-Item function:Get-MainBranchForVersion).ScriptBlock
     $origGetStableTagsForMajor = (Get-Item function:Get-StableTagsForMajor).ScriptBlock
     $origGetPreviewTagsForMajor = (Get-Item function:Get-PreviewTagsForMajor).ScriptBlock
+    $origGetRcTagsForMajor = (Get-Item function:Get-RcTagsForMajor).ScriptBlock
     $origGetRemoteSrBranchesForMajor = (Get-Item function:Get-RemoteSrBranchesForMajor).ScriptBlock
     $origGetRemotePreviewBranchesForMajor = (Get-Item function:Get-RemotePreviewBranchesForMajor).ScriptBlock
+    $origGetRemoteRcBranchesForMajor = (Get-Item function:Get-RemoteRcBranchesForMajor).ScriptBlock
     $origGetVersionFromGitRef = (Get-Item function:Get-VersionFromGitRef).ScriptBlock
     $origGetRecentCommitCount = (Get-Item function:Get-RecentCommitCount).ScriptBlock
     $origInvokeGitOrFail = (Get-Item function:Invoke-GitOrFail).ScriptBlock
@@ -1389,11 +1434,13 @@ if (-not $SkipE2E) {
         function Get-StableTagsForMajor { param([int]$Major) ,@() }
         $script:SyntheticPreviewTags = @('11.0.0-preview.5.26000.1')
         function Get-PreviewTagsForMajor { param([int]$Major) ,@($script:SyntheticPreviewTags) }
+        function Get-RcTagsForMajor { param([int]$Major) ,@() }
         function Get-RemoteSrBranchesForMajor { param([int]$Major) ,@() }
         function Get-RemotePreviewBranchesForMajor {
             param([int]$Major)
             ,@([pscustomobject]@{ branch = 'release/11.0.1xx-preview6'; previewNumber = 6 })
         }
+        function Get-RemoteRcBranchesForMajor { param([int]$Major) ,@() }
         $script:SyntheticPreviewIteration = 7
         function Get-VersionFromGitRef {
             param([string]$GitRef, [string]$Repo)
@@ -1449,42 +1496,45 @@ if (-not $SkipE2E) {
         Set-Item function:Get-MainBranchForVersion $origGetMainBranchForVersion
         Set-Item function:Get-StableTagsForMajor $origGetStableTagsForMajor
         Set-Item function:Get-PreviewTagsForMajor $origGetPreviewTagsForMajor
+        Set-Item function:Get-RcTagsForMajor $origGetRcTagsForMajor
         Set-Item function:Get-RemoteSrBranchesForMajor $origGetRemoteSrBranchesForMajor
         Set-Item function:Get-RemotePreviewBranchesForMajor $origGetRemotePreviewBranchesForMajor
+        Set-Item function:Get-RemoteRcBranchesForMajor $origGetRemoteRcBranchesForMajor
         Set-Item function:Get-VersionFromGitRef $origGetVersionFromGitRef
         Set-Item function:Get-RecentCommitCount $origGetRecentCommitCount
         Set-Item function:Invoke-GitOrFail $origInvokeGitOrFail
         Remove-Variable -Name SyntheticPreviewIteration,SyntheticPreviewTags -Scope Script -ErrorAction SilentlyContinue
     }
 
-    # Synthetic rc window: the pre-release train continues past the final preview
-    # into rc1/rc2, so the survey ref eventually reads label=rc rather than an
-    # eighth preview. Lane 4 only emits preview trackers, and this case used to
-    # fall into the same DarkGray "No active preview cycle" line that a major
-    # legitimately in SR phase prints — so the missing rc tracker was completely
-    # silent. Pin the warning, and pin that it does NOT fire for a genuinely
-    # inactive cycle (otherwise "always warn" would satisfy the first assertion).
+    # Synthetic RC window: RC1 is cut without a shipped tag. It must be emitted
+    # as its own lane, never invented as Preview 8.
     Write-Host "`n[Unit] Tracker detection synthetic rc window" -ForegroundColor Cyan
     $origGetMainBranchForVersion = (Get-Item function:Get-MainBranchForVersion).ScriptBlock
     $origGetStableTagsForMajor = (Get-Item function:Get-StableTagsForMajor).ScriptBlock
     $origGetPreviewTagsForMajor = (Get-Item function:Get-PreviewTagsForMajor).ScriptBlock
+    $origGetRcTagsForMajor = (Get-Item function:Get-RcTagsForMajor).ScriptBlock
     $origGetRemoteSrBranchesForMajor = (Get-Item function:Get-RemoteSrBranchesForMajor).ScriptBlock
     $origGetRemotePreviewBranchesForMajor = (Get-Item function:Get-RemotePreviewBranchesForMajor).ScriptBlock
+    $origGetRemoteRcBranchesForMajor = (Get-Item function:Get-RemoteRcBranchesForMajor).ScriptBlock
     $origGetVersionFromGitRef = (Get-Item function:Get-VersionFromGitRef).ScriptBlock
     $origGetRecentCommitCount = (Get-Item function:Get-RecentCommitCount).ScriptBlock
     $origInvokeGitOrFail = (Get-Item function:Invoke-GitOrFail).ScriptBlock
-    $origWriteWarning = (Get-Item function:Write-Warning -ErrorAction SilentlyContinue)
-    $script:rcWarnings = New-Object System.Collections.Generic.List[string]
     try {
         function Get-MainBranchForVersion { param([int]$Major, [string]$Repo) 'net11.0' }
         function Get-StableTagsForMajor { param([int]$Major) ,@() }
         # preview7 has shipped — the final preview of the major.
         function Get-PreviewTagsForMajor { param([int]$Major) ,@('11.0.0-preview.7.26000.1') }
+        $script:SyntheticRcTags = @()
+        function Get-RcTagsForMajor { param([int]$Major) ,@($script:SyntheticRcTags) }
         function Get-RemoteSrBranchesForMajor { param([int]$Major) ,@() }
         function Get-RemotePreviewBranchesForMajor {
             param([int]$Major)
             ,@([pscustomobject]@{ branch = 'release/11.0.1xx-preview7'; previewNumber = 7 })
         }
+        $script:SyntheticRcBranches = @()
+        $script:SyntheticPrereleaseLabel = 'preview'
+        $script:SyntheticPrereleaseIteration = 7
+        function Get-RemoteRcBranchesForMajor { param([int]$Major) ,@($script:SyntheticRcBranches) }
         function Get-RecentCommitCount { param([string]$Ref, [int]$Days) 1 }
         function Invoke-GitOrFail {
             param([string[]]$ArgList, [string]$FailureMessage)
@@ -1493,41 +1543,71 @@ if (-not $SkipE2E) {
             }
             return @()
         }
-        function Write-Warning { param([Parameter(ValueFromPipeline)][string]$Message) $script:rcWarnings.Add($Message) }
-
-        # net11.0 has been bumped past preview7 → rc1.
         function Get-VersionFromGitRef {
             param([string]$GitRef, [string]$Repo)
-            [pscustomobject]@{ Tag = '11.0.0'; PreLabel = 'rc'; PreIter = 1 }
+            [pscustomobject]@{
+                Tag = '11.0.0'
+                PreLabel = $script:SyntheticPrereleaseLabel
+                PreIter = $script:SyntheticPrereleaseIteration
+            }
         }
+        $preview7CutBeforeRcBump = Invoke-DetectionForMajor -Major 11
+        $rc1Candidate = @($preview7CutBeforeRcBump.trackers | Where-Object {
+            $_.branchType -eq 'rc' -and [int]$_.rcNumber -eq 1
+        })
+        Assert-Eq -Label "Preview 7 cut-before-bump emits one RC1 candidate" -Expected 1 -Actual $rc1Candidate.Count
+        Assert-Eq -Label "Preview 7 cut-before-bump RC1 surveys net11.0" -Expected 'net11.0' -Actual $rc1Candidate[0].surveyRef
+
+        $script:SyntheticRcBranches = @(
+            [pscustomobject]@{ branch = 'release/11.0.1xx-rc1'; rcNumber = 1 }
+        )
+        $preview7AfterRc1Cut = Invoke-DetectionForMajor -Major 11
+        $preview7Rc2Candidate = @($preview7AfterRc1Cut.trackers | Where-Object {
+            $_.branchType -eq 'rc' -and [int]$_.rcNumber -eq 2
+        })
+        Assert-Eq -Label "Preview 7 metadata after RC1 cut emits one RC2 candidate" `
+            -Expected 1 -Actual $preview7Rc2Candidate.Count
+        Assert-Eq -Label "Preview 7 metadata after RC1 cut keeps net11.0 covered" `
+            -Expected 'net11.0' -Actual $preview7Rc2Candidate[0].surveyRef
+
+        $script:SyntheticPrereleaseLabel = 'rc'
+        $script:SyntheticPrereleaseIteration = 1
         $rcSynthetic = Invoke-DetectionForMajor -Major 11
-        $rcCandidates = @($rcSynthetic.trackers | Where-Object { $_.branchType -eq 'preview' -and $_.mode -eq 'candidate' })
+        $preview8Candidates = @($rcSynthetic.trackers | Where-Object {
+            $_.branchType -eq 'preview' -and [int]$_.previewNumber -eq 8
+        })
+        $rc1Trackers = @($rcSynthetic.trackers | Where-Object {
+            $_.branchType -eq 'rc' -and [int]$_.rcNumber -eq 1
+        })
+        $rc2Candidates = @($rcSynthetic.trackers | Where-Object {
+            $_.branchType -eq 'rc' -and [int]$_.rcNumber -eq 2
+        })
 
-        Assert-Eq -Label "rc window emits no preview candidate tracker" -Expected 0 -Actual $rcCandidates.Count
-        Assert-Eq -Label "rc window warns instead of silently skipping" `
-                  -Expected $true -Actual ($script:rcWarnings.Count -gt 0)
-        Assert-Eq -Label "rc window warning names the missing rc tracker" `
-                  -Expected $true -Actual ([bool](@($script:rcWarnings) -match 'rc1'))
+        Assert-Eq -Label "RC window emits no Preview 8 tracker" -Expected 0 -Actual $preview8Candidates.Count
+        Assert-Eq -Label "RC1 discovery emits exactly one tracker" -Expected 1 -Actual $rc1Trackers.Count
+        Assert-Eq -Label "RC1 discovery uses in-flight mode for cut branch" -Expected 'in-flight' -Actual $rc1Trackers[0].mode
+        Assert-Eq -Label "RC1 discovery names expected channel" -Expected '.NET 11.0.1xx SDK RC 1' -Actual $rc1Trackers[0].expectedChannelName
+        Assert-Eq -Label "RC1 discovery uses RC milestone" -Expected '.NET 11.0-rc1' -Actual $rc1Trackers[0].milestoneName
+        Assert-Eq -Label "RC1 cut-before-bump emits one RC2 candidate" -Expected 1 -Actual $rc2Candidates.Count
+        Assert-Eq -Label "RC2 candidate surveys net11.0" -Expected 'net11.0' -Actual $rc2Candidates[0].surveyRef
 
-        # Negative control: an inactive pre-release cycle (SR phase) must stay quiet.
-        $script:rcWarnings.Clear()
-        function Get-VersionFromGitRef {
-            param([string]$GitRef, [string]$Repo)
-            [pscustomobject]@{ Tag = '11.0.100'; PreLabel = 'ci.main'; PreIter = 0 }
-        }
-        $null = Invoke-DetectionForMajor -Major 11
-        Assert-Eq -Label "inactive cycle does not emit the rc warning" -Expected 0 -Actual $script:rcWarnings.Count
+        $script:SyntheticRcTags = @('11.0.0-rc.1.26425.128')
+        $rcShipped = Invoke-DetectionForMajor -Major 11
+        Assert-Eq -Label "tagged RC1 tracker retires" -Expected 0 -Actual @(
+            $rcShipped.trackers | Where-Object { $_.branchType -eq 'rc' -and [int]$_.rcNumber -eq 1 }
+        ).Count
     } finally {
         Set-Item function:Get-MainBranchForVersion $origGetMainBranchForVersion
         Set-Item function:Get-StableTagsForMajor $origGetStableTagsForMajor
         Set-Item function:Get-PreviewTagsForMajor $origGetPreviewTagsForMajor
+        Set-Item function:Get-RcTagsForMajor $origGetRcTagsForMajor
         Set-Item function:Get-RemoteSrBranchesForMajor $origGetRemoteSrBranchesForMajor
         Set-Item function:Get-RemotePreviewBranchesForMajor $origGetRemotePreviewBranchesForMajor
+        Set-Item function:Get-RemoteRcBranchesForMajor $origGetRemoteRcBranchesForMajor
         Set-Item function:Get-VersionFromGitRef $origGetVersionFromGitRef
         Set-Item function:Get-RecentCommitCount $origGetRecentCommitCount
         Set-Item function:Invoke-GitOrFail $origInvokeGitOrFail
-        if ($origWriteWarning) { Set-Item function:Write-Warning $origWriteWarning.ScriptBlock }
-        else { Remove-Item function:Write-Warning -ErrorAction SilentlyContinue }
+        Remove-Variable -Name SyntheticRcTags,SyntheticRcBranches,SyntheticPrereleaseLabel,SyntheticPrereleaseIteration -Scope Script -ErrorAction SilentlyContinue
     }
 
     Write-Host "`n[Unit] Workflow preserves active hotfix tracker creation" -ForegroundColor Cyan
@@ -7495,6 +7575,7 @@ try {
     Assert-Eq -Label "Invoke-DarcJson: darc exit 42 → raw ExitCode surfaced (42)" -Expected 42 -Actual $darc42.ExitCode
     Assert-Eq -Label "Invoke-DarcJson: darc exit 42 → NO truthy NoMatch flag (generic error, not no-match)" -Expected $false `
         -Actual ([bool](Get-AzdoProp $darc42 'NoMatch'))
+
 } finally {
     if ($null -ne $script:OrigDarcForExitTest) { Set-Item function:darc $script:OrigDarcForExitTest }
     else { Remove-Item function:darc -ErrorAction SilentlyContinue }
@@ -8398,6 +8479,143 @@ $prevScript = Join-Path $PSScriptRoot '..' 'scripts' 'Get-PreviewReadiness.ps1'
 . $prevScript -Branch 'release/11.0.1xx-preview6'
 Assert-PublicSanitizerEdgeCases -Lane 'Preview'
 
+Write-Host "`n[Unit] Prerelease dependency-flow wiring" -ForegroundColor Cyan
+Assert-Eq -Label 'RC1 channel derivation' -Expected '.NET 11.0.1xx SDK RC 1' `
+    -Actual (Get-PrereleaseChannelName -Major 11 -Stage rc -Number 1)
+Assert-Eq -Label 'Preview channel derivation remains unchanged' -Expected '.NET 11.0.1xx SDK Preview 7' `
+    -Actual (Get-PrereleaseChannelName -Major 11 -Stage preview -Number 7)
+
+$originalPrereleaseDarc = ${function:darc}
+function darc {
+    'No subscriptions found matching the specified criteria.'
+    $global:LASTEXITCODE = 42
+}
+try {
+    $emptySubscriptions = Invoke-PrereleaseDarcJson -DarcArgs @(
+        'get-subscriptions', '--target-repo', 'https://github.com/dotnet/maui',
+        '--target-branch', 'release/11.0.1xx-rc999'
+    )
+    Assert-Eq -Label "prerelease darc: exact empty-subscriptions exit 42 is successful" `
+        -Expected $true -Actual $emptySubscriptions.Success
+    Assert-Eq -Label "prerelease darc: exact empty-subscriptions result has zero rows" `
+        -Expected 0 -Actual @($emptySubscriptions.Data).Count
+
+    $sameTextForOtherCommand = Invoke-PrereleaseDarcJson -DarcArgs @(
+        'get-build', '--repo', 'https://github.com/dotnet/maui', '--commit', 'deadbeef'
+    )
+    Assert-Eq -Label "prerelease darc: empty-subscriptions text does not normalize other commands" `
+        -Expected $false -Actual $sameTextForOtherCommand.Success
+} finally {
+    if ($null -ne $originalPrereleaseDarc) { Set-Item function:darc $originalPrereleaseDarc }
+    else { Remove-Item function:darc -ErrorAction SilentlyContinue }
+}
+
+$rcBranch = 'release/11.0.1xx-rc1'
+$rcChannel = '.NET 11.0.1xx SDK RC 1'
+$rcSubscriptions = @(
+    [pscustomobject]@{
+        sourceRepository = 'https://github.com/dotnet/android'
+        targetRepository = 'https://github.com/dotnet/maui'
+        targetBranch = $rcBranch
+        channel = [pscustomobject]@{ name = $rcChannel }
+        enabled = $true
+    },
+    [pscustomobject]@{
+        sourceRepository = 'https://github.com/dotnet/macios'
+        targetRepository = 'https://github.com/dotnet/maui'
+        targetBranch = $rcBranch
+        channel = [pscustomobject]@{ name = $rcChannel }
+        enabled = $true
+    }
+)
+$successfulSubscriptions = [pscustomobject]@{ Success = $true; Data = $rcSubscriptions }
+$missingMappingChecks = @(Get-PrereleaseDependencyFlowChecks -Branch $rcBranch `
+    -ExpectedChannelName $rcChannel -Stage rc `
+    -DefaultChannelsResult ([pscustomobject]@{ Success = $true; Data = @() }) `
+    -SubscriptionsResult $successfulSubscriptions)
+$missingMapping = $missingMappingChecks | Where-Object Area -eq 'MAUI outward default-channel mapping'
+Assert-Eq -Label 'missing RC default-channel mapping is blocking' -Expected 'BLOCKED' -Actual $missingMapping.Status
+Assert-Eq -Label 'missing mapping names expected branch and channel' -Expected $true `
+    -Actual ([bool]($missingMapping.Details -match [regex]::Escape($rcBranch) -and
+        $missingMapping.Details -match [regex]::Escape($rcChannel)))
+Assert-Eq -Label 'Android inbound subscription is separate and ready' -Expected 'READY' `
+    -Actual (($missingMappingChecks | Where-Object Area -eq 'Android inbound subscription').Status)
+Assert-Eq -Label 'macOS/iOS inbound subscription is separate and ready' -Expected 'READY' `
+    -Actual (($missingMappingChecks | Where-Object Area -eq 'macOS/iOS inbound subscription').Status)
+Assert-Eq -Label 'no VMR subscription is required' -Expected 'READY' `
+    -Actual (($missingMappingChecks | Where-Object Area -eq 'VMR reconciliation model').Status)
+
+$disabledVmrSubscription = [pscustomobject]@{
+    sourceRepository = 'https://github.com/dotnet/dotnet'
+    targetRepository = 'https://github.com/dotnet/maui'
+    targetBranch = $rcBranch
+    channel = [pscustomobject]@{ name = $rcChannel }
+    enabled = $false
+}
+$disabledVmrChecks = @(Get-PrereleaseDependencyFlowChecks -Branch $rcBranch `
+    -ExpectedChannelName $rcChannel -Stage rc `
+    -DefaultChannelsResult ([pscustomobject]@{ Success = $true; Data = @() }) `
+    -SubscriptionsResult ([pscustomobject]@{
+        Success = $true
+        Data = @($rcSubscriptions) + @($disabledVmrSubscription)
+    }))
+Assert-Eq -Label 'disabled VMR subscription does not block local reconciliation model' -Expected 'READY' `
+    -Actual (($disabledVmrChecks | Where-Object Area -eq 'VMR reconciliation model').Status)
+
+$enabledVmrSubscription = $disabledVmrSubscription.PSObject.Copy()
+$enabledVmrSubscription.enabled = $true
+$enabledVmrChecks = @(Get-PrereleaseDependencyFlowChecks -Branch $rcBranch `
+    -ExpectedChannelName $rcChannel -Stage rc `
+    -DefaultChannelsResult ([pscustomobject]@{ Success = $true; Data = @() }) `
+    -SubscriptionsResult ([pscustomobject]@{
+        Success = $true
+        Data = @($rcSubscriptions) + @($enabledVmrSubscription)
+    }))
+Assert-Eq -Label 'enabled VMR subscription blocks local reconciliation model' -Expected 'BLOCKED' `
+    -Actual (($enabledVmrChecks | Where-Object Area -eq 'VMR reconciliation model').Status)
+
+$presentMappingChecks = @(Get-PrereleaseDependencyFlowChecks -Branch $rcBranch `
+    -ExpectedChannelName $rcChannel -Stage rc `
+    -DefaultChannelsResult ([pscustomobject]@{
+        Success = $true
+        Data = @([pscustomobject]@{
+            repository = 'https://github.com/dotnet/maui'
+            branch = $rcBranch
+            channel = [pscustomobject]@{ name = $rcChannel }
+            enabled = $true
+        })
+    }) `
+    -SubscriptionsResult $successfulSubscriptions)
+Assert-Eq -Label 'present enabled RC default-channel mapping is ready' -Expected 'READY' `
+    -Actual (($presentMappingChecks | Where-Object Area -eq 'MAUI outward default-channel mapping').Status)
+
+$singleRcSubscriptionResult = [pscustomobject]@{ Success = $true; Data = @($rcSubscriptions[0]) }
+$missingRcSubscriptionChecks = @(Get-PrereleaseDependencyFlowChecks -Branch $rcBranch `
+    -ExpectedChannelName $rcChannel -Stage rc `
+    -DefaultChannelsResult ([pscustomobject]@{ Success = $true; Data = @() }) `
+    -SubscriptionsResult $singleRcSubscriptionResult)
+Assert-Eq -Label 'missing RC inbound subscription is blocking' -Expected 'BLOCKED' `
+    -Actual (($missingRcSubscriptionChecks | Where-Object Area -eq 'macOS/iOS inbound subscription').Status)
+
+$previewBranch = 'release/11.0.1xx-preview7'
+$previewChannel = '.NET 11.0.1xx SDK Preview 7'
+$previewAndroidSubscription = $rcSubscriptions[0].PSObject.Copy()
+$previewAndroidSubscription.targetBranch = $previewBranch
+$previewAndroidSubscription.channel = [pscustomobject]@{ name = $previewChannel }
+$missingPreviewSubscriptionChecks = @(Get-PrereleaseDependencyFlowChecks -Branch $previewBranch `
+    -ExpectedChannelName $previewChannel -Stage preview `
+    -DefaultChannelsResult ([pscustomobject]@{ Success = $true; Data = @() }) `
+    -SubscriptionsResult ([pscustomobject]@{ Success = $true; Data = @($previewAndroidSubscription) }))
+Assert-Eq -Label 'missing Preview inbound subscription remains non-blocking' -Expected 'WATCH' `
+    -Actual (($missingPreviewSubscriptionChecks | Where-Object Area -eq 'macOS/iOS inbound subscription').Status)
+
+$rcVersionReady = Get-PrereleaseVersionCheck -Mode in-flight -SurveyRef $rcBranch `
+    -Stage rc -Number 1 -Label rc -Iteration 1
+$rcVersionWrong = Get-PrereleaseVersionCheck -Mode in-flight -SurveyRef $rcBranch `
+    -Stage rc -Number 1 -Label preview -Iteration 7
+Assert-Eq -Label 'RC version metadata accepts rc/1' -Expected 'READY' -Actual $rcVersionReady.Status
+Assert-Eq -Label 'RC version metadata rejects preview/7' -Expected 'BLOCKED' -Actual $rcVersionWrong.Status
+
 $previewNotesBlock = @"
 <!-- release-readiness:human-notes:begin -->
 _Captain notes._
@@ -8597,8 +8815,8 @@ $preview8Iteration = Get-PreviewIterationCheck -Mode 'candidate' `
     -SurveyRef 'net11.0' -PreviewNumber 8 -Iteration '7'
 Assert-Eq -Label "preview iteration: Preview 8 candidate blocks until net11.0 is bumped" `
     -Expected 'BLOCKED' -Actual $preview8Iteration.Status
-Assert-Eq -Label "preview iteration: Preview 8 candidate expects iteration 8" `
-    -Expected $true -Actual ([bool]($preview8Iteration.Details -match 'expected 8'))
+Assert-Eq -Label "preview iteration: Preview 8 candidate expects preview/8 metadata" `
+    -Expected $true -Actual ([bool]($preview8Iteration.Details -match 'expected preview/8'))
 
 # =========================================================================
 # Internal official build health — definition 1095, offline fixtures only
@@ -11176,6 +11394,25 @@ Assert-Eq -Label "OS version 'iOS 18.0' does not drop a preview7 p/0 (M11/P7)" `
 $net10Preview6 = New-RelevanceIssue -Title 'Z' -Milestone '.NET 10' -Labels @('regressed-in-10-preview6')
 Assert-Eq -Label "regressed-in-10-preview6 NOT relevant for M11/P6" `
     -Expected $false -Actual (Test-IssueReleaseRelevant -Issue $net10Preview6 -Major 11 -Preview 6)
+
+# RC reports must use RC markers rather than treating RC1 as Preview 1.
+$net11Rc1 = New-RelevanceIssue -Title 'RC regression' -Milestone $null -Labels @('regressed-in-11-rc1')
+$net11Preview1 = New-RelevanceIssue -Title 'Preview regression' -Milestone $null -Labels @('regressed-in-11-preview1')
+$net11RcMilestone = New-RelevanceIssue -Title 'RC blocker' -Milestone '.NET 11.0-rc1' -Labels @('p/0')
+$net11PreviewMilestone = New-RelevanceIssue -Title 'Preview blocker' -Milestone '.NET 11.0-preview1' -Labels @('p/0')
+Assert-Eq -Label "regressed-in-11-rc1 relevant for M11/RC1" `
+    -Expected $true -Actual (Test-IssueReleaseRelevant -Issue $net11Rc1 -Major 11 -Stage rc -Number 1)
+Assert-Eq -Label "regressed-in-11-preview1 NOT relevant for M11/RC1" `
+    -Expected $false -Actual (Test-IssueReleaseRelevant -Issue $net11Preview1 -Major 11 -Stage rc -Number 1)
+Assert-Eq -Label ".NET 11.0-rc1 milestone relevant for M11/RC1" `
+    -Expected $true -Actual (Test-IssueReleaseRelevant -Issue $net11RcMilestone -Major 11 -Stage rc -Number 1)
+Assert-Eq -Label ".NET 11.0-preview1 milestone NOT relevant for M11/RC1" `
+    -Expected $false -Actual (Test-IssueReleaseRelevant -Issue $net11PreviewMilestone -Major 11 -Stage rc -Number 1)
+Assert-Eq -Label "RC1 marker NOT relevant for M11/Preview1" `
+    -Expected $false -Actual (Test-IssueReleaseRelevant -Issue $net11Rc1 -Major 11 -Stage preview -Number 1)
+$xcodeRcTitle = New-RelevanceIssue -Title 'Xcode 26 RC 1 crash' -Milestone '.NET 11.0' -Labels @('p/0')
+Assert-Eq -Label "tool RC marker does not hide a release-relevant Xcode issue" `
+    -Expected $true -Actual (Test-IssueReleaseRelevant -Issue $xcodeRcTitle -Major 11 -Stage rc -Number 2)
 
 # Direct unit coverage of the foreign-major detector.
 Assert-Eq -Label "foreign-major: 'regressed-in-10-*' is foreign to major 11" `

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -2,10 +2,10 @@ name: Release Readiness
 
 # Unified release-readiness workflow. Each day:
 #  1. detect-trackers: invoke Find-ReleaseReadinessTrackers -AllActiveMajors to enumerate every
-#     active in-flight/candidate branch across all active majors (SR + preview).
+#     active in-flight/candidate branch across all active majors (SR + Preview + RC).
 #  2. matrix expansion: emit one matrix job per tracker (≤ a handful per day).
 #  3. per-tracker readiness: dispatch the right report script based on branchType
-#     ('sr' -> Get-ReleaseReadiness.ps1; 'preview' -> Get-PreviewReadiness.ps1)
+#     ('sr' -> Get-ReleaseReadiness.ps1; 'preview'/'rc' -> Get-PreviewReadiness.ps1)
 #     and write a daily "[Release Readiness]" issue idempotently:
 #       - reuse open tracker issue by canonicalKey marker if it already exists
 #       - otherwise close any older daily issues for the same tracker and create a new one
@@ -241,11 +241,12 @@ jobs:
                   recentCommitCount: .recentCommitCount,
                   hasRecentActivity: .hasRecentActivity,
                   expectedTag: (.expectedTag // ""),
-                  # SR-only fields (null for preview trackers)
+                  # SR-only fields (null for prerelease trackers)
                   priorSrBranch:    (.priorSrBranch // ""),
                   regressionLabels: (.regressionLabels // []),
-                  # Preview-only fields (null for SR trackers)
-                  previewNumber: (.previewNumber // null)
+                  # Prerelease-only fields (null for SR trackers)
+                  previewNumber: (.previewNumber // null),
+                  rcNumber: (.rcNumber // null)
                 }
             ]
           ' trackers.json > matrix.json
@@ -380,9 +381,9 @@ jobs:
               -OutputDir readiness-out
             BODY_FILE="readiness-out/release-readiness.md"
 
-          elif [ "$BRANCH_TYPE" = "preview" ]; then
-            # Preview readiness — Get-PreviewReadiness.ps1 always takes the
-            # canonical preview branch name (whether it exists yet or not);
+          elif [ "$BRANCH_TYPE" = "preview" ] || [ "$BRANCH_TYPE" = "rc" ]; then
+            # Prerelease readiness — Get-PreviewReadiness.ps1 takes the
+            # canonical Preview/RC branch name (whether it exists yet or not);
             # candidate mode flips -SurveyRef to net<major>.0.
             pwsh -NoProfile -File .github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1 \
               -Branch "$BRANCH_NAME" \
@@ -971,7 +972,7 @@ jobs:
                 "${REG_LABEL_ARG[@]}" \
                 -TrackerKey "$CANONICAL" \
                 -OutputDir "$OUT_DIR"
-            elif [ "$BRANCH_TYPE" = "preview" ]; then
+            elif [ "$BRANCH_TYPE" = "preview" ] || [ "$BRANCH_TYPE" = "rc" ]; then
               pwsh -NoProfile -File .github/skills/release-readiness/scripts/Get-PreviewReadiness.ps1 \
                 -Branch "$BRANCH_NAME" \
                 -Mode "$MODE" \


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Adds first-class Release Candidate support to the .NET MAUI release-readiness workflow.

The workflow now:

- discovers strict `release/<major>.0.<band>xx-rc<N>` branches and RC tags;
- tracks RC candidate, in-flight, shipped, and cut-before-bump transitions without inventing Preview 8;
- derives the matching SDK channel, such as `.NET 11.0.1xx SDK RC 1`;
- validates the outward MAUI default-channel mapping independently from inbound Android and macOS/iOS subscriptions;
- requires RC subscriptions to be enabled and on the matching channel while preserving Preview's existing non-blocking subscription severity;
- keeps VMR reconciliation local and blocks only an enabled `dotnet/dotnet` subscription;
- emits missing mappings as explicit blockers in JSON and Markdown;
- routes RC trackers through workflow reporting and release-handoff generation;
- filters release-relevant issues by the active Preview/RC stage.

### Root Cause

Tracker discovery and the prerelease report engine only understood Preview branches. RC branches were ignored or rejected, so the normal report could not expose a missing mapping such as:

`release/11.0.1xx-rc1` → `.NET 11.0.1xx SDK RC 1`

The existing dependency-flow presentation also did not deterministically separate MAUI's outward default-channel mapping from Android/macOS-iOS inbound subscriptions and local VMR reconciliation.

### Key Technical Details

- **Outward flow:** MAUI branch builds require an enabled default-channel mapping to the matching Preview/RC SDK channel.
- **Inbound flow:** Android and macOS/iOS subscriptions are checked separately for target branch, channel, and enabled state.
- **VMR:** no enabled `dotnet/dotnet` subscription is expected; the official SDK/runtime pin is reconciled locally.
- **CLI behavior:** the exact `darc get-subscriptions` empty-result response (exit 42 plus `No subscriptions found matching the specified criteria.`) is normalized to an empty successful query so missing RC subscriptions become deterministic blockers rather than `UNKNOWN`.
- **Public safety:** environments without authenticated `darc` continue to report dependency-flow evidence as `UNKNOWN` instead of guessing.

### Tests

- `pwsh -NoProfile -File .github/skills/release-readiness/tests/Test-ReleaseReadiness.ps1`
  - **2,466 passed, 0 failed**
- Live RC1 report validation confirmed the generated JSON and Markdown identify the missing default-channel mapping as `BLOCKED` while reporting the Android/macOS-iOS subscriptions and local VMR model separately.
- Live enabled Preview mapping validation confirmed existing Preview mapping detection remains `READY`.
- Focused fixtures cover RC branch/tag discovery, RC1/RC2 transitions, channel derivation, mapping missing/present, subscription state and severity, VMR enabled/disabled behavior, stage-aware issue filtering, and exact `darc` empty-result handling.

### Limitations

RC package-level consumer installability remains `UNKNOWN` until the workload-set package resolver supports RC package identities.

### Issues Fixed

N/A — release tooling enhancement.