### PR TITLE
[Resizetizer] Stop deleting generated images behind symlinked paths

### DIFF
--- a/src/SingleProject/Resizetizer/src/DetectStaleOutputFilesTask.cs
+++ b/src/SingleProject/Resizetizer/src/DetectStaleOutputFilesTask.cs
@@ -42,6 +42,12 @@ namespace Microsoft.Maui.Resizetizer
 		[Output]
 		public ITaskItem[] StaleFiles { get; set; }
 
+		/// <summary>
+		/// Lets tests exercise the behaviour of hosts without <c>Directory.ResolveLinkTarget</c>, which is
+		/// every .NET Framework host, including MSBuild.exe.
+		/// </summary>
+		internal bool AllowLinkResolution { get; set; } = true;
+
 		public override bool Execute()
 		{
 			StaleFiles = Array.Empty<ITaskItem>();
@@ -49,7 +55,7 @@ namespace Microsoft.Maui.Resizetizer
 			if (Files is null || Files.Length == 0)
 				return true;
 
-			var canonicalizer = new PathCanonicalizer();
+			var canonicalizer = new PathCanonicalizer(AllowLinkResolution);
 
 			var root = canonicalizer.CanonicalizeDirectory(Root);
 			if (string.IsNullOrEmpty(root))
@@ -70,9 +76,15 @@ namespace Microsoft.Maui.Resizetizer
 
 			foreach (var file in Files)
 			{
-				var key = canonicalizer.GetComparisonKey(file?.ItemSpec);
-				if (key is null)
+				if (file is null || string.IsNullOrWhiteSpace(file.ItemSpec))
 					continue;
+
+				var key = canonicalizer.GetComparisonKey(file.ItemSpec);
+				if (key is null)
+				{
+					Log.LogMessage(MessageImportance.Low, $"Leaving '{file.ItemSpec}' alone because its real location could not be determined.");
+					continue;
+				}
 
 				if (!PathCanonicalizer.IsUnder(key, root))
 				{

--- a/src/SingleProject/Resizetizer/src/DetectStaleOutputFilesTask.cs
+++ b/src/SingleProject/Resizetizer/src/DetectStaleOutputFilesTask.cs
@@ -11,12 +11,20 @@ namespace Microsoft.Maui.Resizetizer
 	/// build can delete files left over from a previous build without ever deleting a file it just wrote.
 	/// </summary>
 	/// <remarks>
+	/// <para>
 	/// The two item lists reach this task through different code paths: <see cref="Files"/> comes from an
 	/// MSBuild wildcard rooted at the project directory, while <see cref="KnownOutputs"/> comes back from
 	/// a task that resolved the same directory itself. A plain <c>Remove</c> compares those item specs
 	/// textually, so a symbolic link or junction anywhere in the project path is enough to make every
 	/// generated file look stale. Comparing canonical paths makes the difference independent of spelling
 	/// while the returned items keep their original item spec and metadata.
+	/// </para>
+	/// <para>
+	/// A recursive MSBuild wildcard descends through directory links, so it can name a file that lives
+	/// outside <see cref="Root"/>, and <c>&lt;Delete&gt;</c> would then remove that outside file rather
+	/// than the link. Anything whose resolved directory escapes <see cref="Root"/> is therefore never
+	/// reported as stale.
+	/// </para>
 	/// </remarks>
 	public class DetectStaleOutputFilesTask : Task
 	{
@@ -25,6 +33,10 @@ namespace Microsoft.Maui.Resizetizer
 
 		/// <summary>The files the build expects to be there.</summary>
 		public ITaskItem[] KnownOutputs { get; set; }
+
+		/// <summary>The only directory whose contents this task is allowed to report as stale.</summary>
+		[Required]
+		public string Root { get; set; }
 
 		/// <summary>The members of <see cref="Files"/> that are safe to delete.</summary>
 		[Output]
@@ -38,23 +50,42 @@ namespace Microsoft.Maui.Resizetizer
 				return true;
 
 			var canonicalizer = new PathCanonicalizer();
-			var keep = canonicalizer.CreateSet(KnownOutputs?.Select(i => i.ItemSpec) ?? Enumerable.Empty<string>());
+
+			var root = canonicalizer.CanonicalizeDirectory(Root);
+			if (string.IsNullOrEmpty(root))
+			{
+				Log.LogMessage(MessageImportance.Low, $"Skipping stale file detection because the root '{Root}' could not be resolved.");
+				return true;
+			}
+
+			var keep = new HashSet<string>(PathCanonicalizer.Comparer);
+			foreach (var known in KnownOutputs ?? Enumerable.Empty<ITaskItem>())
+			{
+				var key = canonicalizer.GetComparisonKey(known?.ItemSpec);
+				if (key is not null)
+					keep.Add(key);
+			}
 
 			var stale = new List<ITaskItem>();
 
 			foreach (var file in Files)
 			{
-				if (file is null || string.IsNullOrWhiteSpace(file.ItemSpec))
+				var key = canonicalizer.GetComparisonKey(file?.ItemSpec);
+				if (key is null)
 					continue;
 
-				if (keep.Contains(canonicalizer.Canonicalize(file.ItemSpec)))
+				if (!PathCanonicalizer.IsUnder(key, root))
+				{
+					Log.LogMessage(MessageImportance.Low, $"Leaving '{file.ItemSpec}' alone because it resolves to '{key}', which is outside '{root}'.");
+					continue;
+				}
+
+				if (keep.Contains(key))
 					continue;
 
+				Log.LogMessage(MessageImportance.Low, $"Detected stale output file '{file.ItemSpec}'.");
 				stale.Add(file);
 			}
-
-			foreach (var file in stale)
-				Log.LogMessage(MessageImportance.Low, $"Detected stale output file '{file.ItemSpec}'.");
 
 			StaleFiles = stale.ToArray();
 

--- a/src/SingleProject/Resizetizer/src/DetectStaleOutputFilesTask.cs
+++ b/src/SingleProject/Resizetizer/src/DetectStaleOutputFilesTask.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.Maui.Resizetizer
+{
+	/// <summary>
+	/// Returns the subset of <see cref="Files"/> that is not part of <see cref="KnownOutputs"/>, so the
+	/// build can delete files left over from a previous build without ever deleting a file it just wrote.
+	/// </summary>
+	/// <remarks>
+	/// The two item lists reach this task through different code paths: <see cref="Files"/> comes from an
+	/// MSBuild wildcard rooted at the project directory, while <see cref="KnownOutputs"/> comes back from
+	/// a task that resolved the same directory itself. A plain <c>Remove</c> compares those item specs
+	/// textually, so a symbolic link or junction anywhere in the project path is enough to make every
+	/// generated file look stale. Comparing canonical paths makes the difference independent of spelling
+	/// while the returned items keep their original item spec and metadata.
+	/// </remarks>
+	public class DetectStaleOutputFilesTask : Task
+	{
+		/// <summary>The files currently present in the output directory.</summary>
+		public ITaskItem[] Files { get; set; }
+
+		/// <summary>The files the build expects to be there.</summary>
+		public ITaskItem[] KnownOutputs { get; set; }
+
+		/// <summary>The members of <see cref="Files"/> that are safe to delete.</summary>
+		[Output]
+		public ITaskItem[] StaleFiles { get; set; }
+
+		public override bool Execute()
+		{
+			StaleFiles = Array.Empty<ITaskItem>();
+
+			if (Files is null || Files.Length == 0)
+				return true;
+
+			var canonicalizer = new PathCanonicalizer();
+			var keep = canonicalizer.CreateSet(KnownOutputs?.Select(i => i.ItemSpec) ?? Enumerable.Empty<string>());
+
+			var stale = new List<ITaskItem>();
+
+			foreach (var file in Files)
+			{
+				if (file is null || string.IsNullOrWhiteSpace(file.ItemSpec))
+					continue;
+
+				if (keep.Contains(canonicalizer.Canonicalize(file.ItemSpec)))
+					continue;
+
+				stale.Add(file);
+			}
+
+			foreach (var file in stale)
+				Log.LogMessage(MessageImportance.Low, $"Detected stale output file '{file.ItemSpec}'.");
+
+			StaleFiles = stale.ToArray();
+
+			return true;
+		}
+	}
+}

--- a/src/SingleProject/Resizetizer/src/PathCanonicalizer.cs
+++ b/src/SingleProject/Resizetizer/src/PathCanonicalizer.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Maui.Resizetizer
+{
+	/// <summary>
+	/// Produces a canonical spelling of a file system path so that two differently spelled paths
+	/// which point at the same file compare as equal.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// MSBuild resolves relative item specs against <c>$(MSBuildProjectDirectory)</c>, which keeps the
+	/// spelling the build was started with, while <see cref="Path.GetFullPath(string)"/> inside a task
+	/// resolves them against the process working directory, which Unix reports with every symbolic link
+	/// already resolved. When any segment of the project path is a link (macOS <c>/tmp</c> and
+	/// <c>/var/folders</c>, or a Windows junction) the two spellings differ, so a set difference between
+	/// MSBuild items and task outputs wrongly reports freshly written files as stale.
+	/// </para>
+	/// <para>
+	/// The canonical form is only ever used for comparison. Callers keep the original item spec so the
+	/// paths surfaced to the rest of the build stay in the spelling the user provided.
+	/// </para>
+	/// <para>
+	/// Canonicalization resolves the links of each path segment that already exists and appends the
+	/// segments that do not, so paths for files which have not been created yet can be canonicalized
+	/// without the failure a plain <c>realpath</c> would produce.
+	/// </para>
+	/// </remarks>
+	internal sealed class PathCanonicalizer
+	{
+		/// <summary>Bounds link resolution so that a cycle of links cannot hang the build.</summary>
+		const int MaxLinkHops = 40;
+
+		/// <summary>
+		/// Paths are compared case insensitively everywhere except Linux. macOS volumes can be case
+		/// sensitive, but treating two spellings as the same file there only ever means a stale file is
+		/// kept, which is far safer than deleting a file that is still needed.
+		/// </summary>
+		public static StringComparer Comparer { get; } =
+			RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+				? StringComparer.Ordinal
+				: StringComparer.OrdinalIgnoreCase;
+
+		static readonly MethodInfo ResolveDirectoryLinkTarget =
+			typeof(Directory).GetMethod("ResolveLinkTarget", BindingFlags.Public | BindingFlags.Static, null, new[] { typeof(string), typeof(bool) }, null);
+
+		static readonly MethodInfo ResolveFileLinkTarget =
+			typeof(File).GetMethod("ResolveLinkTarget", BindingFlags.Public | BindingFlags.Static, null, new[] { typeof(string), typeof(bool) }, null);
+
+		readonly Dictionary<string, string> directoryCache = new Dictionary<string, string>(Comparer);
+
+		/// <summary>
+		/// Returns a canonical spelling of <paramref name="path"/>, or the input unchanged when it
+		/// cannot be canonicalized. Never throws.
+		/// </summary>
+		public string Canonicalize(string path)
+		{
+			if (string.IsNullOrWhiteSpace(path))
+				return path;
+
+			string full;
+			try
+			{
+				full = Path.GetFullPath(path);
+			}
+			catch (Exception)
+			{
+				// An item spec can contain characters that are not valid in a path; leave it alone.
+				return path;
+			}
+
+			return CanonicalizeFullPath(TrimTrailingSeparators(full), MaxLinkHops);
+		}
+
+		/// <summary>
+		/// Builds a set of canonical paths that can be probed with <see cref="Canonicalize"/> results.
+		/// </summary>
+		public HashSet<string> CreateSet(IEnumerable<string> paths)
+		{
+			var set = new HashSet<string>(Comparer);
+
+			if (paths is not null)
+			{
+				foreach (var path in paths)
+				{
+					if (!string.IsNullOrWhiteSpace(path))
+						set.Add(Canonicalize(path));
+				}
+			}
+
+			return set;
+		}
+
+		string CanonicalizeFullPath(string full, int hops)
+		{
+			var parent = Path.GetDirectoryName(full);
+			var name = Path.GetFileName(full);
+
+			// A root such as "/" or "C:\" has nothing left to resolve.
+			if (string.IsNullOrEmpty(parent) || string.IsNullOrEmpty(name))
+				return full;
+
+			return ResolveLink(Path.Combine(CanonicalizeDirectory(parent, hops), name), hops);
+		}
+
+		string CanonicalizeDirectory(string directory, int hops)
+		{
+			directory = TrimTrailingSeparators(directory);
+
+			if (directoryCache.TryGetValue(directory, out var cached))
+				return cached;
+
+			var canonical = CanonicalizeFullPath(directory, hops);
+			directoryCache[directory] = canonical;
+			return canonical;
+		}
+
+		string ResolveLink(string path, int hops)
+		{
+			if (hops <= 0)
+				return path;
+
+			var target = GetLinkTarget(path);
+			if (target is null)
+				return path;
+
+			var resolved = TrimTrailingSeparators(target.FullName);
+			if (Comparer.Equals(resolved, path))
+				return path;
+
+			// The target itself may live under directories that are links, so canonicalize it too.
+			return CanonicalizeFullPath(resolved, hops - 1);
+		}
+
+		static FileSystemInfo GetLinkTarget(string path)
+		{
+			// Directory/File.ResolveLinkTarget only exist on .NET 6 and later. This assembly targets
+			// netstandard2.0 so that it can also load into MSBuild.exe on .NET Framework, where link
+			// resolution is simply unavailable and comparison falls back to the lexical full path.
+			var resolve = Directory.Exists(path)
+				? ResolveDirectoryLinkTarget
+				: File.Exists(path)
+					? ResolveFileLinkTarget
+					: null;
+
+			if (resolve is null)
+				return null;
+
+			try
+			{
+				return resolve.Invoke(null, new object[] { path, /* returnFinalTarget: */ true }) as FileSystemInfo;
+			}
+			catch (Exception)
+			{
+				// Cyclic links, missing permissions or a racing delete: keep the unresolved spelling.
+				return null;
+			}
+		}
+
+		static string TrimTrailingSeparators(string path)
+		{
+			var root = Path.GetPathRoot(path) ?? string.Empty;
+
+			var end = path.Length;
+			while (end > root.Length && (path[end - 1] == Path.DirectorySeparatorChar || path[end - 1] == Path.AltDirectorySeparatorChar))
+				end--;
+
+			return end == path.Length ? path : path.Substring(0, end);
+		}
+	}
+}

--- a/src/SingleProject/Resizetizer/src/PathCanonicalizer.cs
+++ b/src/SingleProject/Resizetizer/src/PathCanonicalizer.cs
@@ -7,8 +7,8 @@ using System.Runtime.InteropServices;
 namespace Microsoft.Maui.Resizetizer
 {
 	/// <summary>
-	/// Produces a canonical spelling of a file system path so that two differently spelled paths
-	/// which point at the same file compare as equal.
+	/// Produces a canonical spelling of a file system path so that two differently spelled paths which
+	/// point at the same file compare as equal.
 	/// </summary>
 	/// <remarks>
 	/// <para>
@@ -20,13 +20,18 @@ namespace Microsoft.Maui.Resizetizer
 	/// MSBuild items and task outputs wrongly reports freshly written files as stale.
 	/// </para>
 	/// <para>
-	/// The canonical form is only ever used for comparison. Callers keep the original item spec so the
-	/// paths surfaced to the rest of the build stay in the spelling the user provided.
+	/// Only the <em>directory</em> part of a path is link resolved. The file name is kept verbatim, so two
+	/// different names in one directory never collapse into one even when one of them is a link to the
+	/// other. Resolving the leaf as well would let a stale alias masquerade as a live output and survive
+	/// cleanup forever.
 	/// </para>
 	/// <para>
-	/// Canonicalization resolves the links of each path segment that already exists and appends the
-	/// segments that do not, so paths for files which have not been created yet can be canonicalized
-	/// without the failure a plain <c>realpath</c> would produce.
+	/// Directories that do not exist yet are appended unresolved, so a path for a file the build has not
+	/// written can be canonicalized without the failure a plain <c>realpath</c> would produce.
+	/// </para>
+	/// <para>
+	/// The canonical form is only ever used for comparison. Callers keep the original item spec so the
+	/// paths surfaced to the rest of the build stay in the spelling the user provided.
 	/// </para>
 	/// </remarks>
 	internal sealed class PathCanonicalizer
@@ -44,86 +49,122 @@ namespace Microsoft.Maui.Resizetizer
 				? StringComparer.Ordinal
 				: StringComparer.OrdinalIgnoreCase;
 
+		/// <summary>The <see cref="StringComparison"/> matching <see cref="Comparer"/>.</summary>
+		public static StringComparison Comparison { get; } =
+			RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+				? StringComparison.Ordinal
+				: StringComparison.OrdinalIgnoreCase;
+
 		static readonly MethodInfo ResolveDirectoryLinkTarget =
 			typeof(Directory).GetMethod("ResolveLinkTarget", BindingFlags.Public | BindingFlags.Static, null, new[] { typeof(string), typeof(bool) }, null);
 
-		static readonly MethodInfo ResolveFileLinkTarget =
-			typeof(File).GetMethod("ResolveLinkTarget", BindingFlags.Public | BindingFlags.Static, null, new[] { typeof(string), typeof(bool) }, null);
-
-		readonly Dictionary<string, string> directoryCache = new Dictionary<string, string>(Comparer);
+		// Cache keys are exact spellings. Two directories whose names differ only by case can be two
+		// different directories on a case sensitive volume, so a case insensitive key could hand back
+		// another directory's resolved target.
+		readonly Dictionary<string, string> directoryCache = new Dictionary<string, string>(StringComparer.Ordinal);
 
 		/// <summary>
-		/// Returns a canonical spelling of <paramref name="path"/>, or the input unchanged when it
-		/// cannot be canonicalized. Never throws.
+		/// Returns the key to compare <paramref name="path"/> by: its link resolved directory plus its
+		/// file name unchanged. Returns <see langword="null"/> when the path cannot be interpreted.
 		/// </summary>
-		public string Canonicalize(string path)
+		public string GetComparisonKey(string path)
 		{
 			if (string.IsNullOrWhiteSpace(path))
-				return path;
+				return null;
 
 			string full;
 			try
 			{
-				full = Path.GetFullPath(path);
+				full = TrimTrailingSeparators(Path.GetFullPath(path));
 			}
 			catch (Exception)
 			{
-				// An item spec can contain characters that are not valid in a path; leave it alone.
-				return path;
+				// An item spec can contain characters that are not valid in a path.
+				return null;
 			}
 
-			return CanonicalizeFullPath(TrimTrailingSeparators(full), MaxLinkHops);
-		}
-
-		/// <summary>
-		/// Builds a set of canonical paths that can be probed with <see cref="Canonicalize"/> results.
-		/// </summary>
-		public HashSet<string> CreateSet(IEnumerable<string> paths)
-		{
-			var set = new HashSet<string>(Comparer);
-
-			if (paths is not null)
-			{
-				foreach (var path in paths)
-				{
-					if (!string.IsNullOrWhiteSpace(path))
-						set.Add(Canonicalize(path));
-				}
-			}
-
-			return set;
-		}
-
-		string CanonicalizeFullPath(string full, int hops)
-		{
 			var parent = Path.GetDirectoryName(full);
 			var name = Path.GetFileName(full);
 
-			// A root such as "/" or "C:\" has nothing left to resolve.
+			// A bare root such as "/" or "C:\" has no file name to keep.
 			if (string.IsNullOrEmpty(parent) || string.IsNullOrEmpty(name))
-				return full;
+				return CanonicalizeDirectory(full);
 
-			return ResolveLink(Path.Combine(CanonicalizeDirectory(parent, hops), name), hops);
+			var directory = CanonicalizeDirectory(parent);
+
+			return directory is null ? null : Path.Combine(directory, name);
 		}
 
-		string CanonicalizeDirectory(string directory, int hops)
+		/// <summary>
+		/// Returns <paramref name="directory"/> with every link in it resolved, or <see langword="null"/>
+		/// when it cannot be interpreted. Segments that do not exist are kept as they are.
+		/// </summary>
+		public string CanonicalizeDirectory(string directory)
 		{
-			directory = TrimTrailingSeparators(directory);
+			if (string.IsNullOrWhiteSpace(directory))
+				return null;
 
-			if (directoryCache.TryGetValue(directory, out var cached))
+			string full;
+			try
+			{
+				full = TrimTrailingSeparators(Path.GetFullPath(directory));
+			}
+			catch (Exception)
+			{
+				return null;
+			}
+
+			return Canonicalize(full, MaxLinkHops);
+		}
+
+		/// <summary>
+		/// Returns whether <paramref name="key"/> names something inside <paramref name="root"/>. Both
+		/// must already be comparison keys.
+		/// </summary>
+		public static bool IsUnder(string key, string root)
+		{
+			if (string.IsNullOrEmpty(key) || string.IsNullOrEmpty(root))
+				return false;
+
+			if (Comparer.Equals(key, root))
+				return true;
+
+			if (key.Length <= root.Length || !key.StartsWith(root, Comparison))
+				return false;
+
+			// A root that already ends in a separator, such as "/" or "C:\", has no separator to skip.
+			var last = root[root.Length - 1];
+			if (last == Path.DirectorySeparatorChar || last == Path.AltDirectorySeparatorChar)
+				return true;
+
+			// Guard against "…/r-backup" being treated as living inside "…/r".
+			var next = key[root.Length];
+			return next == Path.DirectorySeparatorChar || next == Path.AltDirectorySeparatorChar;
+		}
+
+		string Canonicalize(string full, int hops)
+		{
+			if (directoryCache.TryGetValue(full, out var cached))
 				return cached;
 
-			var canonical = CanonicalizeFullPath(directory, hops);
-			directoryCache[directory] = canonical;
+			var parent = Path.GetDirectoryName(full);
+			var name = Path.GetFileName(full);
+
+			// A root resolves to itself, which also terminates the walk.
+			var canonical = string.IsNullOrEmpty(parent) || string.IsNullOrEmpty(name)
+				? full
+				: ResolveDirectoryLink(Path.Combine(Canonicalize(parent, hops), name), hops);
+
+			directoryCache[full] = canonical;
 			return canonical;
 		}
 
-		string ResolveLink(string path, int hops)
+		string ResolveDirectoryLink(string path, int hops)
 		{
 			if (hops <= 0)
 				return path;
 
-			var target = GetLinkTarget(path);
+			var target = GetDirectoryLinkTarget(path);
 			if (target is null)
 				return path;
 
@@ -131,27 +172,21 @@ namespace Microsoft.Maui.Resizetizer
 			if (Comparer.Equals(resolved, path))
 				return path;
 
-			// The target itself may live under directories that are links, so canonicalize it too.
-			return CanonicalizeFullPath(resolved, hops - 1);
+			// The target itself may live under directories that are links.
+			return Canonicalize(resolved, hops - 1);
 		}
 
-		static FileSystemInfo GetLinkTarget(string path)
+		static FileSystemInfo GetDirectoryLinkTarget(string path)
 		{
-			// Directory/File.ResolveLinkTarget only exist on .NET 6 and later. This assembly targets
+			// Directory.ResolveLinkTarget only exists on .NET 6 and later. This assembly targets
 			// netstandard2.0 so that it can also load into MSBuild.exe on .NET Framework, where link
-			// resolution is simply unavailable and comparison falls back to the lexical full path.
-			var resolve = Directory.Exists(path)
-				? ResolveDirectoryLinkTarget
-				: File.Exists(path)
-					? ResolveFileLinkTarget
-					: null;
-
-			if (resolve is null)
+			// resolution is unavailable and comparison falls back to the lexical full path.
+			if (ResolveDirectoryLinkTarget is null || !Directory.Exists(path))
 				return null;
 
 			try
 			{
-				return resolve.Invoke(null, new object[] { path, /* returnFinalTarget: */ true }) as FileSystemInfo;
+				return ResolveDirectoryLinkTarget.Invoke(null, new object[] { path, /* returnFinalTarget: */ true }) as FileSystemInfo;
 			}
 			catch (Exception)
 			{

--- a/src/SingleProject/Resizetizer/src/PathCanonicalizer.cs
+++ b/src/SingleProject/Resizetizer/src/PathCanonicalizer.cs
@@ -8,7 +8,8 @@ namespace Microsoft.Maui.Resizetizer
 {
 	/// <summary>
 	/// Produces a canonical spelling of a file system path so that two differently spelled paths which
-	/// point at the same file compare as equal.
+	/// point at the same file compare as equal, and so that a caller can tell whether a path really lives
+	/// inside a directory it appears to live inside.
 	/// </summary>
 	/// <remarks>
 	/// <para>
@@ -23,15 +24,15 @@ namespace Microsoft.Maui.Resizetizer
 	/// Only the <em>directory</em> part of a path is link resolved. The file name is kept verbatim, so two
 	/// different names in one directory never collapse into one even when one of them is a link to the
 	/// other. Resolving the leaf as well would let a stale alias masquerade as a live output and survive
-	/// cleanup forever.
+	/// cleanup forever, and it is unnecessary: deleting a path whose leaf is a link removes the link
+	/// rather than whatever it points at.
 	/// </para>
 	/// <para>
-	/// Directories that do not exist yet are appended unresolved, so a path for a file the build has not
-	/// written can be canonicalized without the failure a plain <c>realpath</c> would produce.
-	/// </para>
-	/// <para>
-	/// The canonical form is only ever used for comparison. Callers keep the original item spec so the
-	/// paths surfaced to the rest of the build stay in the spelling the user provided.
+	/// Every decision here is made so that its failure mode is "keep the file". Comparing two paths for
+	/// equality is case insensitive off Linux, so an unexpected spelling difference makes a stale file
+	/// look live and it is kept. Containment is case sensitive everywhere, so an unexpected spelling
+	/// difference puts a file outside the root and it is kept. A directory whose link target cannot be
+	/// resolved makes the whole path unresolvable and it is kept.
 	/// </para>
 	/// </remarks>
 	internal sealed class PathCanonicalizer
@@ -40,22 +41,20 @@ namespace Microsoft.Maui.Resizetizer
 		const int MaxLinkHops = 40;
 
 		/// <summary>
-		/// Paths are compared case insensitively everywhere except Linux. macOS volumes can be case
-		/// sensitive, but treating two spellings as the same file there only ever means a stale file is
-		/// kept, which is far safer than deleting a file that is still needed.
+		/// Compares two canonical paths for <em>equality</em>. Case insensitive everywhere except Linux.
 		/// </summary>
+		/// <remarks>
+		/// This is only ever used to ask "is this file one the build just wrote?". Answering yes when the
+		/// two spellings are actually different files on a case sensitive volume keeps a stale file, which
+		/// is harmless. It must never be used to decide whether a path is inside a directory; see
+		/// <see cref="IsUnder"/>.
+		/// </remarks>
 		public static StringComparer Comparer { get; } =
 			RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
 				? StringComparer.Ordinal
 				: StringComparer.OrdinalIgnoreCase;
 
-		/// <summary>The <see cref="StringComparison"/> matching <see cref="Comparer"/>.</summary>
-		public static StringComparison Comparison { get; } =
-			RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
-				? StringComparison.Ordinal
-				: StringComparison.OrdinalIgnoreCase;
-
-		static readonly MethodInfo ResolveDirectoryLinkTarget =
+		static readonly MethodInfo ResolveDirectoryLinkTargetMethod =
 			typeof(Directory).GetMethod("ResolveLinkTarget", BindingFlags.Public | BindingFlags.Static, null, new[] { typeof(string), typeof(bool) }, null);
 
 		// Cache keys are exact spellings. Two directories whose names differ only by case can be two
@@ -63,9 +62,32 @@ namespace Microsoft.Maui.Resizetizer
 		// another directory's resolved target.
 		readonly Dictionary<string, string> directoryCache = new Dictionary<string, string>(StringComparer.Ordinal);
 
+		readonly MethodInfo resolveDirectoryLinkTarget;
+
+		public PathCanonicalizer()
+			: this(ResolveDirectoryLinkTargetMethod is not null)
+		{
+		}
+
+		/// <summary>
+		/// Lets tests exercise the behaviour of hosts without <c>Directory.ResolveLinkTarget</c>, which is
+		/// every .NET Framework host, including MSBuild.exe.
+		/// </summary>
+		internal PathCanonicalizer(bool allowLinkResolution)
+		{
+			resolveDirectoryLinkTarget = allowLinkResolution ? ResolveDirectoryLinkTargetMethod : null;
+		}
+
+		/// <summary>
+		/// Whether this host can resolve directory links at all. When it cannot, any path that passes
+		/// through a reparse point is reported as unresolvable rather than guessed at.
+		/// </summary>
+		public bool CanResolveLinks => resolveDirectoryLinkTarget is not null;
+
 		/// <summary>
 		/// Returns the key to compare <paramref name="path"/> by: its link resolved directory plus its
-		/// file name unchanged. Returns <see langword="null"/> when the path cannot be interpreted.
+		/// file name unchanged. Returns <see langword="null"/> when the path cannot be interpreted or when
+		/// its directory passes through a link this host cannot resolve.
 		/// </summary>
 		public string GetComparisonKey(string path)
 		{
@@ -97,7 +119,8 @@ namespace Microsoft.Maui.Resizetizer
 
 		/// <summary>
 		/// Returns <paramref name="directory"/> with every link in it resolved, or <see langword="null"/>
-		/// when it cannot be interpreted. Segments that do not exist are kept as they are.
+		/// when it cannot be interpreted or passes through an unresolvable link. Segments that do not
+		/// exist are kept as they are, so a path the build has not written yet can still be canonicalized.
 		/// </summary>
 		public string CanonicalizeDirectory(string directory)
 		{
@@ -119,17 +142,26 @@ namespace Microsoft.Maui.Resizetizer
 
 		/// <summary>
 		/// Returns whether <paramref name="key"/> names something inside <paramref name="root"/>. Both
-		/// must already be comparison keys.
+		/// must already be comparison keys produced by this type.
 		/// </summary>
+		/// <remarks>
+		/// Deliberately case sensitive on every platform, including Windows and macOS. This decides
+		/// whether a file may be deleted, so it has to fail closed. On a case sensitive volume
+		/// <c>…/r</c> and <c>…/R</c> are two different directories, and comparing them case insensitively
+		/// would report a file that really lives in the sibling as being inside the root, letting a delete
+		/// escape. Being stricter than the volume costs nothing worse than leaving a stale file behind,
+		/// because the paths on both sides are built from the same MSBuild properties and so share their
+		/// spelling.
+		/// </remarks>
 		public static bool IsUnder(string key, string root)
 		{
 			if (string.IsNullOrEmpty(key) || string.IsNullOrEmpty(root))
 				return false;
 
-			if (Comparer.Equals(key, root))
+			if (string.Equals(key, root, StringComparison.Ordinal))
 				return true;
 
-			if (key.Length <= root.Length || !key.StartsWith(root, Comparison))
+			if (key.Length <= root.Length || !key.StartsWith(root, StringComparison.Ordinal))
 				return false;
 
 			// A root that already ends in a separator, such as "/" or "C:\", has no separator to skip.
@@ -150,10 +182,20 @@ namespace Microsoft.Maui.Resizetizer
 			var parent = Path.GetDirectoryName(full);
 			var name = Path.GetFileName(full);
 
-			// A root resolves to itself, which also terminates the walk.
-			var canonical = string.IsNullOrEmpty(parent) || string.IsNullOrEmpty(name)
-				? full
-				: ResolveDirectoryLink(Path.Combine(Canonicalize(parent, hops), name), hops);
+			string canonical;
+			if (string.IsNullOrEmpty(parent) || string.IsNullOrEmpty(name))
+			{
+				// A root resolves to itself, which also terminates the walk.
+				canonical = full;
+			}
+			else
+			{
+				var canonicalParent = Canonicalize(parent, hops);
+
+				canonical = canonicalParent is null
+					? null
+					: ResolveDirectoryLink(Path.Combine(canonicalParent, name), hops);
+			}
 
 			directoryCache[full] = canonical;
 			return canonical;
@@ -161,37 +203,58 @@ namespace Microsoft.Maui.Resizetizer
 
 		string ResolveDirectoryLink(string path, int hops)
 		{
-			if (hops <= 0)
+			// A directory that does not exist cannot be a link, and a path the build has not written yet
+			// has to stay canonicalizable.
+			if (!Directory.Exists(path))
 				return path;
 
-			var target = GetDirectoryLinkTarget(path);
-			if (target is null)
+			if (!IsReparsePoint(path))
 				return path;
+
+			// From here on this really is a link or junction. Where it points decides whether everything
+			// below it is inside the root, so guessing is not an option: either resolve it or give up.
+			if (resolveDirectoryLinkTarget is null || hops <= 0)
+				return null;
+
+			FileSystemInfo target;
+			try
+			{
+				target = resolveDirectoryLinkTarget.Invoke(null, new object[] { path, /* returnFinalTarget: */ true }) as FileSystemInfo;
+			}
+			catch (Exception)
+			{
+				// Cyclic links, missing permissions or a racing delete.
+				return null;
+			}
+
+			if (target is null)
+				return null;
 
 			var resolved = TrimTrailingSeparators(target.FullName);
-			if (Comparer.Equals(resolved, path))
+
+			// Ordinal: on a case sensitive volume a link from "…/r" to "…/R" points at a different
+			// directory, and treating the two as the same would leave the link unresolved.
+			if (string.Equals(resolved, path, StringComparison.Ordinal))
 				return path;
 
 			// The target itself may live under directories that are links.
 			return Canonicalize(resolved, hops - 1);
 		}
 
-		static FileSystemInfo GetDirectoryLinkTarget(string path)
+		/// <summary>
+		/// Whether <paramref name="path"/> is a symbolic link, junction or other reparse point. Unlike
+		/// resolving one, asking this question works on every host, including .NET Framework.
+		/// </summary>
+		static bool IsReparsePoint(string path)
 		{
-			// Directory.ResolveLinkTarget only exists on .NET 6 and later. This assembly targets
-			// netstandard2.0 so that it can also load into MSBuild.exe on .NET Framework, where link
-			// resolution is unavailable and comparison falls back to the lexical full path.
-			if (ResolveDirectoryLinkTarget is null || !Directory.Exists(path))
-				return null;
-
 			try
 			{
-				return ResolveDirectoryLinkTarget.Invoke(null, new object[] { path, /* returnFinalTarget: */ true }) as FileSystemInfo;
+				return (new DirectoryInfo(path).Attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
 			}
 			catch (Exception)
 			{
-				// Cyclic links, missing permissions or a racing delete: keep the unresolved spelling.
-				return null;
+				// If the attributes cannot be read, assume the worst rather than the best.
+				return true;
 			}
 		}
 

--- a/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
+++ b/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
@@ -815,9 +815,12 @@
         </ItemGroup>
 
         <!-- Compare canonical paths rather than item specs. The wildcard above and the collected images
-             can legitimately spell the same file differently (symlinked project paths, separators,
-             casing), and a textual Remove would then classify every generated image as stale. -->
+             can legitimately spell the same file differently (symlinked project paths, casing), and a
+             textual Remove would then classify every generated image as stale. Root also confines the
+             delete list to the intermediate folder, because the recursive wildcard descends through any
+             directory link it finds inside it. -->
         <DetectStaleOutputFilesTask
+            Root="$(_MauiIntermediateImagesFullPath)"
             Files="@(_ResizetizerExistingImages->'%(FullPath)')"
             KnownOutputs="@(_ResizetizerCollectedImages)">
             <Output TaskParameter="StaleFiles" ItemName="_ResizetizerImagesToDelete" />

--- a/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
+++ b/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
@@ -23,6 +23,10 @@
 
     <UsingTask
         AssemblyFile="$(_ResizetizerTaskAssemblyName)"
+        TaskName="Microsoft.Maui.Resizetizer.DetectStaleOutputFilesTask" />
+
+    <UsingTask
+        AssemblyFile="$(_ResizetizerTaskAssemblyName)"
         TaskName="Microsoft.Maui.Resizetizer.CreatePartialInfoPlistTask" />
 
     <UsingTask
@@ -89,6 +93,14 @@
         <_MauiIntermediateFonts>$(_ResizetizerIntermediateOutputRoot)f\</_MauiIntermediateFonts>
         <_MauiIntermediateSplashScreen>$(_ResizetizerIntermediateOutputRoot)sp\</_MauiIntermediateSplashScreen>
         <_MauiIntermediateManifest>$(_ResizetizerIntermediateOutputRoot)m\</_MauiIntermediateManifest>
+
+        <!-- Rooted against the project directory rather than with [System.IO.Path]::GetFullPath, which
+             resolves against the process working directory. Unix reports that directory with every
+             symbolic link already resolved, so GetFullPath would spell the intermediate directory
+             differently from %(FullPath)/$(MSBuildProjectDirectory) whenever the project lives behind a
+             link (macOS /tmp and /var/folders, or a Windows junction). Handing this spelling to the
+             tasks keeps every path the build produces consistent with the paths MSBuild produces. -->
+        <_MauiIntermediateImagesFullPath>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '$(_MauiIntermediateImages)'))))</_MauiIntermediateImagesFullPath>
 
         <ResizetizerIncludeSelfProject Condition="'$(ResizetizerIncludeSelfProject)' == ''">False</ResizetizerIncludeSelfProject>
 
@@ -785,7 +797,7 @@
             ThrowsErrorOnDuplicateOutput="$(_ResizetizerThrowsErrorOnDuplicateOutputFilename)"
             DuplicateOutputErrorMessage="$(_ResizetizerDefaultDuplicateFilenamesErrorMessage)"
             PlatformType="$(ResizetizerPlatformType)"
-            IntermediateOutputPath="$(_MauiIntermediateImages)"
+            IntermediateOutputPath="$(_MauiIntermediateImagesFullPath)"
             InputsFile="$(_ResizetizerInputsFile)"
             Images="@(_MauiImageToProcess)">
               <Output TaskParameter="CopiedResources" ItemName="_CopiedResources" />
@@ -800,9 +812,16 @@
             <_ResizetizerCollectedImages Condition="'@(_CopiedResources)' == '' And '@(_MauiImageToProcess)' != ''" Include="@(_ResizetizerOutputs)" />
             <!-- Wildcard is kept solely for stale-file detection and cleanup. -->
             <_ResizetizerExistingImages Include="$(_MauiIntermediateImages)\**\*" />
-            <_ResizetizerImagesToDelete Include="@(_ResizetizerExistingImages->'%(FullPath)')" />
-            <_ResizetizerImagesToDelete Remove="@(_ResizetizerCollectedImages)" />
         </ItemGroup>
+
+        <!-- Compare canonical paths rather than item specs. The wildcard above and the collected images
+             can legitimately spell the same file differently (symlinked project paths, separators,
+             casing), and a textual Remove would then classify every generated image as stale. -->
+        <DetectStaleOutputFilesTask
+            Files="@(_ResizetizerExistingImages->'%(FullPath)')"
+            KnownOutputs="@(_ResizetizerCollectedImages)">
+            <Output TaskParameter="StaleFiles" ItemName="_ResizetizerImagesToDelete" />
+        </DetectStaleOutputFilesTask>
 
         <!-- Remove files which are no longer needed -->
         <Delete
@@ -903,14 +922,14 @@
 
         <!-- Tizen -->
         <PropertyGroup>
-            <ResizetizerIntermediateOutputAbsolutePath>$([System.IO.Path]::GetFullPath('$(_MauiIntermediateImages)'))</ResizetizerIntermediateOutputAbsolutePath>
+            <ResizetizerIntermediateOutputAbsolutePath>$(_MauiIntermediateImagesFullPath)</ResizetizerIntermediateOutputAbsolutePath>
         </PropertyGroup>
         <ItemGroup Condition="'$(_ResizetizerIsTizenApp)' == 'True' And '@(_ResizetizerCollectedImages)' != ''">
             <TizenTpkUserIncludeFiles Include="$(ResizetizerIntermediateOutputAbsolutePath)res\res.xml" TizenTpkSubDir="res\" />
             <FileWrites Include="$(ResizetizerIntermediateOutputAbsolutePath)res\res.xml" />
 
             <TizenTpkUserIncludeFiles Include="@(_ResizetizerCollectedImages)">
-                <TizenTpkSubDir>$([MSBuild]::MakeRelative($(ResizetizerIntermediateOutputAbsolutePath), $([System.IO.Path]::GetFullPath('%(_ResizetizerCollectedImages.RelativeDir)'))))</TizenTpkSubDir>
+                <TizenTpkSubDir>$([MSBuild]::MakeRelative('$(ResizetizerIntermediateOutputAbsolutePath)', '%(_ResizetizerCollectedImages.RelativeDir)'))</TizenTpkSubDir>
             </TizenTpkUserIncludeFiles>
         </ItemGroup>
 

--- a/src/SingleProject/Resizetizer/test/UnitTests/DetectStaleOutputFilesTaskTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/DetectStaleOutputFilesTaskTests.cs
@@ -15,9 +15,10 @@ namespace Microsoft.Maui.Resizetizer.Tests
 		{
 		}
 
-		DetectStaleOutputFilesTask GetNewTask(string[] files, string[] knownOutputs) =>
+		DetectStaleOutputFilesTask GetNewTask(string[] files, string[] knownOutputs, string root = null) =>
 			new DetectStaleOutputFilesTask
 			{
+				Root = root ?? DestinationDirectory,
 				Files = files?.Select(f => (ITaskItem)new TaskItem(f)).ToArray(),
 				KnownOutputs = knownOutputs?.Select(f => (ITaskItem)new TaskItem(f)).ToArray(),
 				BuildEngine = this,
@@ -64,6 +65,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 
 			var task = new DetectStaleOutputFilesTask
 			{
+				Root = DestinationDirectory,
 				Files = new ITaskItem[] { item },
 				KnownOutputs = Array.Empty<ITaskItem>(),
 				BuildEngine = this,
@@ -158,18 +160,18 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			File.WriteAllText(stale, "image");
 
 			var canonicalizer = new PathCanonicalizer();
-			Assert.NotEqual(stale, canonicalizer.Canonicalize(stale), PathCanonicalizer.Comparer);
+			Assert.NotEqual(stale, canonicalizer.GetComparisonKey(stale), PathCanonicalizer.Comparer);
 
-			var task = GetNewTask(new[] { stale }, System.Array.Empty<string>());
+			var task = GetNewTask(new[] { stale }, Array.Empty<string>());
 
 			Assert.True(task.Execute());
 			Assert.Equal(stale, Assert.Single(task.StaleFiles).ItemSpec);
 		}
 
 		/// <summary>
-		/// A file inside the intermediate directory that is itself a link to somewhere else canonicalizes
-		/// to a path outside that directory, but it is still reported by its inside spelling, so
-		/// <c>&lt;Delete&gt;</c> removes the link and never the file it points at.
+		/// A file inside the intermediate directory that is itself a link to somewhere else is still
+		/// reported by its inside spelling, because only the directory part of a path is link resolved.
+		/// <c>&lt;Delete&gt;</c> then removes the link and never the file it points at.
 		/// </summary>
 		[Fact]
 		public void ALinkPointingOutsideTheDirectoryIsReportedByItsInsidePath()
@@ -189,10 +191,97 @@ namespace Microsoft.Maui.Resizetizer.Tests
 				return;
 			}
 
-			var task = GetNewTask(new[] { inside }, System.Array.Empty<string>());
+			var task = GetNewTask(new[] { inside }, Array.Empty<string>(), root: intermediate);
 
 			Assert.True(task.Execute());
 			Assert.Equal(inside, Assert.Single(task.StaleFiles).ItemSpec);
+		}
+
+		/// <summary>
+		/// A recursive MSBuild wildcard walks through a directory link, so it can name a file that is not
+		/// actually inside the intermediate folder. Deleting it would destroy the real file rather than
+		/// the link, so it must never be reported.
+		/// </summary>
+		[Fact]
+		public void FilesReachedThroughADirectoryLinkOutOfTheRootAreNeverStale()
+		{
+			var outside = Path.Combine(DestinationDirectory, "outside");
+			var intermediate = Path.Combine(DestinationDirectory, "intermediate");
+			Directory.CreateDirectory(outside);
+			Directory.CreateDirectory(intermediate);
+
+			var precious = Path.Combine(outside, "precious.png");
+			File.WriteAllText(precious, "not a build output");
+
+			if (!SymbolicLink.TryCreateDirectoryLink(Path.Combine(intermediate, "alias"), outside, out var error))
+			{
+				Output.WriteLine($"Skipping: symbolic links are not available on this machine: {error}");
+				return;
+			}
+
+			// This is exactly what the wildcard yields once it descends through the link.
+			var throughTheLink = Path.Combine(intermediate, "alias", "precious.png");
+			var genuinelyStale = Path.Combine(intermediate, "orphan.png");
+			File.WriteAllText(genuinelyStale, "left over");
+
+			var task = GetNewTask(new[] { throughTheLink, genuinelyStale }, Array.Empty<string>(), root: intermediate);
+
+			Assert.True(task.Execute());
+			Assert.Equal(genuinelyStale, Assert.Single(task.StaleFiles).ItemSpec);
+		}
+
+		/// <summary>
+		/// Only the directory part of a path is link resolved. If the file name were resolved too, a stale
+		/// alias of a live output would compare equal to it and survive cleanup forever.
+		/// </summary>
+		[Fact]
+		public void AStaleLinkToALiveOutputIsStillDeleted()
+		{
+			var intermediate = Path.Combine(DestinationDirectory, "intermediate");
+			Directory.CreateDirectory(intermediate);
+
+			var kept = Path.Combine(intermediate, "camera.png");
+			File.WriteAllText(kept, "image");
+
+			var alias = Path.Combine(intermediate, "orphan.png");
+			if (!SymbolicLink.TryCreateFileLink(alias, kept, out var error))
+			{
+				Output.WriteLine($"Skipping: symbolic links are not available on this machine: {error}");
+				return;
+			}
+
+			var task = GetNewTask(new[] { kept, alias }, new[] { kept }, root: intermediate);
+
+			Assert.True(task.Execute());
+			Assert.Equal(alias, Assert.Single(task.StaleFiles).ItemSpec);
+		}
+
+		[Fact]
+		public void ASiblingOfTheRootIsNotTreatedAsBeingInsideIt()
+		{
+			var intermediate = Path.Combine(DestinationDirectory, "r");
+			var sibling = Path.Combine(DestinationDirectory, "r-backup");
+			Directory.CreateDirectory(intermediate);
+			Directory.CreateDirectory(sibling);
+
+			var outsideRoot = Path.Combine(sibling, "camera.png");
+			File.WriteAllText(outsideRoot, "image");
+
+			var task = GetNewTask(new[] { outsideRoot }, Array.Empty<string>(), root: intermediate);
+
+			Assert.True(task.Execute());
+			Assert.Empty(task.StaleFiles);
+		}
+
+		[Fact]
+		public void AnUnresolvableRootDisablesDetectionRatherThanDeleting()
+		{
+			var stale = Path.Combine(DestinationDirectory, "orphan.png");
+
+			var task = GetNewTask(new[] { stale }, Array.Empty<string>(), root: "   ");
+
+			Assert.True(task.Execute());
+			Assert.Empty(task.StaleFiles);
 		}
 
 		/// <summary>

--- a/src/SingleProject/Resizetizer/test/UnitTests/DetectStaleOutputFilesTaskTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/DetectStaleOutputFilesTaskTests.cs
@@ -1,0 +1,151 @@
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Maui.Resizetizer.Tests
+{
+	public class DetectStaleOutputFilesTaskTests : MSBuildTaskTestFixture<DetectStaleOutputFilesTask>
+	{
+		public DetectStaleOutputFilesTaskTests(ITestOutputHelper output)
+			: base(output)
+		{
+		}
+
+		DetectStaleOutputFilesTask GetNewTask(string[] files, string[] knownOutputs) =>
+			new DetectStaleOutputFilesTask
+			{
+				Files = files?.Select(f => (ITaskItem)new TaskItem(f)).ToArray(),
+				KnownOutputs = knownOutputs?.Select(f => (ITaskItem)new TaskItem(f)).ToArray(),
+				BuildEngine = this,
+			};
+
+		[Fact]
+		public void NoFilesProducesNoStaleFiles()
+		{
+			var task = GetNewTask(null, null);
+
+			Assert.True(task.Execute());
+			Assert.Empty(task.StaleFiles);
+		}
+
+		[Fact]
+		public void EverythingIsStaleWhenNothingIsExpected()
+		{
+			var file = Path.Combine(DestinationDirectory, "camera.png");
+
+			var task = GetNewTask(new[] { file }, Array.Empty<string>());
+
+			Assert.True(task.Execute());
+			Assert.Equal(file, Assert.Single(task.StaleFiles).ItemSpec);
+		}
+
+		[Fact]
+		public void OnlyUnexpectedFilesAreStale()
+		{
+			var kept = Path.Combine(DestinationDirectory, "camera.png");
+			var stale = Path.Combine(DestinationDirectory, "orphan.png");
+
+			var task = GetNewTask(new[] { kept, stale }, new[] { kept });
+
+			Assert.True(task.Execute());
+			Assert.Equal(stale, Assert.Single(task.StaleFiles).ItemSpec);
+		}
+
+		[Fact]
+		public void StaleFilesKeepTheirOriginalItemSpecAndMetadata()
+		{
+			var stale = Path.Combine(DestinationDirectory, "orphan.png");
+			var item = new TaskItem(stale);
+			item.SetMetadata("_ResizetizerDpiPath", "drawable-xhdpi");
+
+			var task = new DetectStaleOutputFilesTask
+			{
+				Files = new ITaskItem[] { item },
+				KnownOutputs = Array.Empty<ITaskItem>(),
+				BuildEngine = this,
+			};
+
+			Assert.True(task.Execute());
+
+			var result = Assert.Single(task.StaleFiles);
+			Assert.Equal(stale, result.ItemSpec);
+			Assert.Equal("drawable-xhdpi", result.GetMetadata("_ResizetizerDpiPath"));
+		}
+
+		[Fact]
+		public void RedundantSegmentsDoNotMakeAFileStale()
+		{
+			var kept = Path.Combine(DestinationDirectory, "camera.png");
+			var spelledDifferently = Path.Combine(DestinationDirectory, ".", "obj", "..", "camera.png");
+
+			var task = GetNewTask(new[] { spelledDifferently }, new[] { kept });
+
+			Assert.True(task.Execute());
+			Assert.Empty(task.StaleFiles);
+		}
+
+		[Fact]
+		public void AlternateDirectorySeparatorsDoNotMakeAFileStale()
+		{
+			var kept = Path.Combine(DestinationDirectory, "drawable", "camera.png");
+			var spelledDifferently = kept.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+			var task = GetNewTask(new[] { spelledDifferently }, new[] { kept });
+
+			Assert.True(task.Execute());
+			Assert.Empty(task.StaleFiles);
+		}
+
+		[Fact]
+		public void FilesReachedThroughALinkedDirectoryAreNotStale()
+		{
+			var physical = Path.Combine(DestinationDirectory, "physical");
+			var link = Path.Combine(DestinationDirectory, "link");
+			Directory.CreateDirectory(Path.Combine(physical, "drawable"));
+
+			if (!SymbolicLink.TryCreateDirectoryLink(link, physical, out var error))
+			{
+				Output.WriteLine($"Skipping: symbolic links are not available on this machine: {error}");
+				return;
+			}
+
+			var kept = Path.Combine(physical, "drawable", "camera.png");
+			File.WriteAllText(kept, "image");
+
+			// This is the shape of the bug: MSBuild enumerates the directory through the link while the
+			// task reports the file it wrote through the physical path.
+			var task = GetNewTask(new[] { Path.Combine(link, "drawable", "camera.png") }, new[] { kept });
+
+			Assert.True(task.Execute());
+			Assert.Empty(task.StaleFiles);
+		}
+
+		[Fact]
+		public void StaleFilesInALinkedDirectoryAreStillDetected()
+		{
+			var physical = Path.Combine(DestinationDirectory, "physical");
+			var link = Path.Combine(DestinationDirectory, "link");
+			Directory.CreateDirectory(Path.Combine(physical, "drawable"));
+
+			if (!SymbolicLink.TryCreateDirectoryLink(link, physical, out var error))
+			{
+				Output.WriteLine($"Skipping: symbolic links are not available on this machine: {error}");
+				return;
+			}
+
+			var kept = Path.Combine(physical, "drawable", "camera.png");
+			var stale = Path.Combine(link, "drawable", "orphan.png");
+			File.WriteAllText(kept, "image");
+			File.WriteAllText(stale, "image");
+
+			var task = GetNewTask(new[] { Path.Combine(link, "drawable", "camera.png"), stale }, new[] { kept });
+
+			Assert.True(task.Execute());
+			Assert.Equal(stale, Assert.Single(task.StaleFiles).ItemSpec);
+		}
+	}
+}

--- a/src/SingleProject/Resizetizer/test/UnitTests/DetectStaleOutputFilesTaskTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/DetectStaleOutputFilesTaskTests.cs
@@ -285,6 +285,118 @@ namespace Microsoft.Maui.Resizetizer.Tests
 		}
 
 		/// <summary>
+		/// On a case sensitive volume the root's case-only sibling is a different directory, so a link
+		/// inside the root that leads into it must not make its contents look contained. A recursive
+		/// MSBuild wildcard really does surface these: its own cycle detection compares paths case
+		/// insensitively, so it walks straight into the sibling believing it is still inside the root.
+		/// </summary>
+		[Fact]
+		public void FilesInACaseOnlySiblingOfTheRootAreNeverStale()
+		{
+			var root = Path.Combine(DestinationDirectory, "r");
+			var sibling = Path.Combine(DestinationDirectory, "R");
+			Directory.CreateDirectory(root);
+
+			if (!IsCaseSensitiveVolume(DestinationDirectory))
+			{
+				Output.WriteLine("Skipping: this volume is case insensitive, so the sibling is the root itself.");
+				return;
+			}
+
+			Directory.CreateDirectory(Path.Combine(sibling, "deep"));
+			var outside = Path.Combine(sibling, "deep", "secret.png");
+			File.WriteAllText(outside, "not a build output");
+
+			if (!SymbolicLink.TryCreateDirectoryLink(Path.Combine(root, "alias"), Path.Combine(sibling, "deep"), out var error))
+			{
+				Output.WriteLine($"Skipping: symbolic links are not available on this machine: {error}");
+				return;
+			}
+
+			var throughTheLink = Path.Combine(root, "alias", "secret.png");
+			var genuinelyStale = Path.Combine(root, "orphan.png");
+			File.WriteAllText(genuinelyStale, "left over");
+
+			var task = GetNewTask(new[] { throughTheLink, genuinelyStale }, Array.Empty<string>(), root: root);
+
+			Assert.True(task.Execute());
+			Assert.Equal(genuinelyStale, Assert.Single(task.StaleFiles).ItemSpec);
+		}
+
+		/// <summary>
+		/// A host without <c>Directory.ResolveLinkTarget</c>, which is every .NET Framework host including
+		/// MSBuild.exe, cannot tell where a junction leads. It has to leave anything behind one alone
+		/// instead of assuming the lexical spelling is the real location.
+		/// </summary>
+		[Fact]
+		public void WithoutLinkResolutionFilesBehindAReparsePointAreNeverStale()
+		{
+			// Root the test where no ancestor is itself a link, so the only reparse point in play is the
+			// one the test creates. macOS temp directories live under /var, which is a link to /private/var.
+			var basePath = new PathCanonicalizer().CanonicalizeDirectory(DestinationDirectory);
+			var root = Path.Combine(basePath, "r");
+			var outside = Path.Combine(basePath, "outside");
+			Directory.CreateDirectory(root);
+			Directory.CreateDirectory(outside);
+
+			var precious = Path.Combine(outside, "precious.png");
+			File.WriteAllText(precious, "not a build output");
+
+			if (!SymbolicLink.TryCreateDirectoryLink(Path.Combine(root, "alias"), outside, out var error))
+			{
+				Output.WriteLine($"Skipping: symbolic links are not available on this machine: {error}");
+				return;
+			}
+
+			var throughTheLink = Path.Combine(root, "alias", "precious.png");
+			var genuinelyStale = Path.Combine(root, "orphan.png");
+			File.WriteAllText(genuinelyStale, "left over");
+
+			var task = GetNewTask(new[] { throughTheLink, genuinelyStale }, Array.Empty<string>(), root: root);
+			task.AllowLinkResolution = false;
+
+			Assert.True(task.Execute());
+
+			// The file behind the junction is left alone, while ordinary cleanup still happens.
+			Assert.Equal(genuinelyStale, Assert.Single(task.StaleFiles).ItemSpec);
+		}
+
+		/// <summary>
+		/// When the root itself sits behind a reparse point the fallback host cannot place anything, so it
+		/// detects nothing at all rather than deleting on a guess.
+		/// </summary>
+		[Fact]
+		public void WithoutLinkResolutionARootBehindAReparsePointDetectsNothing()
+		{
+			var physical = Path.Combine(DestinationDirectory, "physical");
+			var link = Path.Combine(DestinationDirectory, "link");
+			Directory.CreateDirectory(physical);
+
+			if (!SymbolicLink.TryCreateDirectoryLink(link, physical, out var error))
+			{
+				Output.WriteLine($"Skipping: symbolic links are not available on this machine: {error}");
+				return;
+			}
+
+			var stale = Path.Combine(physical, "orphan.png");
+			File.WriteAllText(stale, "left over");
+
+			var task = GetNewTask(new[] { Path.Combine(link, "orphan.png") }, Array.Empty<string>(), root: link);
+			task.AllowLinkResolution = false;
+
+			Assert.True(task.Execute());
+			Assert.Empty(task.StaleFiles);
+		}
+
+		static bool IsCaseSensitiveVolume(string directory)
+		{
+			var probe = Path.Combine(directory, "CaseProbe");
+			Directory.CreateDirectory(probe);
+
+			return !Directory.Exists(Path.Combine(directory, "caseprobe"));
+		}
+
+		/// <summary>
 		/// Every returned item has to come from <see cref="DetectStaleOutputFilesTask.Files"/>. Nothing may
 		/// be invented, and nothing that was declared as an output may be returned.
 		/// </summary>

--- a/src/SingleProject/Resizetizer/test/UnitTests/DetectStaleOutputFilesTaskTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/DetectStaleOutputFilesTaskTests.cs
@@ -89,18 +89,6 @@ namespace Microsoft.Maui.Resizetizer.Tests
 		}
 
 		[Fact]
-		public void AlternateDirectorySeparatorsDoNotMakeAFileStale()
-		{
-			var kept = Path.Combine(DestinationDirectory, "drawable", "camera.png");
-			var spelledDifferently = kept.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-
-			var task = GetNewTask(new[] { spelledDifferently }, new[] { kept });
-
-			Assert.True(task.Execute());
-			Assert.Empty(task.StaleFiles);
-		}
-
-		[Fact]
 		public void FilesReachedThroughALinkedDirectoryAreNotStale()
 		{
 			var physical = Path.Combine(DestinationDirectory, "physical");
@@ -146,6 +134,147 @@ namespace Microsoft.Maui.Resizetizer.Tests
 
 			Assert.True(task.Execute());
 			Assert.Equal(stale, Assert.Single(task.StaleFiles).ItemSpec);
+		}
+
+		/// <summary>
+		/// The item specs handed back are what <c>&lt;Delete&gt;</c> acts on, so they must be the exact
+		/// strings that came in. Returning the canonical spelling instead would let a delete reach
+		/// outside the intermediate directory the wildcard was rooted at.
+		/// </summary>
+		[Fact]
+		public void StaleFilesAreReturnedVerbatimEvenWhenCanonicalizationChangesTheSpelling()
+		{
+			var physical = Path.Combine(DestinationDirectory, "physical");
+			var link = Path.Combine(DestinationDirectory, "link");
+			Directory.CreateDirectory(Path.Combine(physical, "drawable"));
+
+			if (!SymbolicLink.TryCreateDirectoryLink(link, physical, out var error))
+			{
+				Output.WriteLine($"Skipping: symbolic links are not available on this machine: {error}");
+				return;
+			}
+
+			var stale = Path.Combine(link, "drawable", "orphan.png");
+			File.WriteAllText(stale, "image");
+
+			var canonicalizer = new PathCanonicalizer();
+			Assert.NotEqual(stale, canonicalizer.Canonicalize(stale), PathCanonicalizer.Comparer);
+
+			var task = GetNewTask(new[] { stale }, System.Array.Empty<string>());
+
+			Assert.True(task.Execute());
+			Assert.Equal(stale, Assert.Single(task.StaleFiles).ItemSpec);
+		}
+
+		/// <summary>
+		/// A file inside the intermediate directory that is itself a link to somewhere else canonicalizes
+		/// to a path outside that directory, but it is still reported by its inside spelling, so
+		/// <c>&lt;Delete&gt;</c> removes the link and never the file it points at.
+		/// </summary>
+		[Fact]
+		public void ALinkPointingOutsideTheDirectoryIsReportedByItsInsidePath()
+		{
+			var outside = Path.Combine(DestinationDirectory, "outside");
+			var intermediate = Path.Combine(DestinationDirectory, "intermediate");
+			Directory.CreateDirectory(outside);
+			Directory.CreateDirectory(intermediate);
+
+			var target = Path.Combine(outside, "source.png");
+			File.WriteAllText(target, "not a build output");
+
+			var inside = Path.Combine(intermediate, "linked.png");
+			if (!SymbolicLink.TryCreateFileLink(inside, target, out var error))
+			{
+				Output.WriteLine($"Skipping: symbolic links are not available on this machine: {error}");
+				return;
+			}
+
+			var task = GetNewTask(new[] { inside }, System.Array.Empty<string>());
+
+			Assert.True(task.Execute());
+			Assert.Equal(inside, Assert.Single(task.StaleFiles).ItemSpec);
+		}
+
+		/// <summary>
+		/// Every returned item has to come from <see cref="DetectStaleOutputFilesTask.Files"/>. Nothing may
+		/// be invented, and nothing that was declared as an output may be returned.
+		/// </summary>
+		[Fact]
+		public void StaleFilesAreAlwaysASubsetOfTheInputFiles()
+		{
+			var files = new[]
+			{
+				Path.Combine(DestinationDirectory, "drawable", "camera.png"),
+				Path.Combine(DestinationDirectory, "drawable", "orphan.png"),
+				Path.Combine(DestinationDirectory, "drawable-xhdpi", "camera.png"),
+			};
+
+			var known = new[]
+			{
+				files[0],
+				// Declared as an output but not on disk, and a sibling that was never enumerated.
+				Path.Combine(DestinationDirectory, "drawable-hdpi", "camera.png"),
+			};
+
+			var task = GetNewTask(files, known);
+
+			Assert.True(task.Execute());
+
+			var stale = task.StaleFiles.Select(f => f.ItemSpec).ToArray();
+			Assert.All(stale, s => Assert.Contains(s, files));
+			Assert.Equal(new[] { files[1], files[2] }, stale);
+		}
+
+		[Fact]
+		public void EmptyAndWhitespaceItemSpecsAreIgnored()
+		{
+			var stale = Path.Combine(DestinationDirectory, "orphan.png");
+
+			var task = GetNewTask(new[] { "", "   ", stale }, new[] { "", "   " });
+
+			Assert.True(task.Execute());
+			Assert.Equal(stale, Assert.Single(task.StaleFiles).ItemSpec);
+		}
+
+		[Fact]
+		public void CaseOnlyDifferencesFollowThePlatformFileSystem()
+		{
+			var kept = Path.Combine(DestinationDirectory, "drawable", "camera.png");
+			var differentCase = Path.Combine(DestinationDirectory, "drawable", "CAMERA.png");
+
+			var task = GetNewTask(new[] { differentCase }, new[] { kept });
+
+			Assert.True(task.Execute());
+
+			if (OperatingSystem.IsLinux())
+			{
+				// Linux paths are case sensitive, so these really are two different files.
+				Assert.Equal(differentCase, Assert.Single(task.StaleFiles).ItemSpec);
+			}
+			else
+			{
+				// Windows and macOS are treated case insensitively. On a case sensitive macOS volume this
+				// can only ever keep a stale file, which is much safer than deleting a live one, and
+				// Resizetizer already rejects output names that differ only by case.
+				Assert.Empty(task.StaleFiles);
+			}
+		}
+
+		[Fact]
+		public void MSBuildNormalizesSeparatorsBeforeTheTaskSeesThem()
+		{
+			var kept = Path.Combine(DestinationDirectory, "drawable", "camera.png");
+
+			// MSBuild rewrites separators when it builds an item spec: on Unix a backslash becomes a
+			// forward slash, and on Windows both characters are separators anyway. Either way the task
+			// only ever receives paths that already use the platform separator, so canonicalization does
+			// not have to guess which character was meant.
+			var spelledWithBackslashes = kept.Replace(Path.DirectorySeparatorChar, '\\');
+
+			var task = GetNewTask(new[] { spelledWithBackslashes }, new[] { kept });
+
+			Assert.True(task.Execute());
+			Assert.Empty(task.StaleFiles);
 		}
 	}
 }

--- a/src/SingleProject/Resizetizer/test/UnitTests/Junction.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/Junction.cs
@@ -1,0 +1,104 @@
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+namespace Microsoft.Maui.Resizetizer.Tests
+{
+	/// <summary>
+	/// A junction is the other kind of Windows directory redirection a project can sit behind, and unlike
+	/// a symbolic link it does not need Developer Mode or elevation. .NET has no API to create one, so
+	/// the reparse point is written through the Win32 device control interface.
+	/// </summary>
+	[SupportedOSPlatform("windows")]
+	static class Junction
+	{
+		const uint FsctlSetReparsePoint = 0x000900A4;
+		const uint IoReparseTagMountPoint = 0xA0000003;
+		const uint GenericWrite = 0x40000000;
+		const uint FileShareAll = 0x00000001 | 0x00000002 | 0x00000004;
+		const uint OpenExisting = 3;
+		const uint FileFlagBackupSemantics = 0x02000000;
+		const uint FileFlagOpenReparsePoint = 0x00200000;
+
+		public static bool TryCreate(string junction, string target, out string error)
+		{
+			try
+			{
+				Create(junction, target);
+				error = null;
+				return true;
+			}
+			catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or Win32Exception or PlatformNotSupportedException)
+			{
+				error = ex.Message;
+				return false;
+			}
+		}
+
+		static void Create(string junction, string target)
+		{
+			Directory.CreateDirectory(junction);
+
+			// A mount point stores its target as an NT object path.
+			var printName = Path.GetFullPath(target);
+			var substituteName = @"\??\" + printName;
+
+			var substituteBytes = System.Text.Encoding.Unicode.GetBytes(substituteName);
+			var printBytes = System.Text.Encoding.Unicode.GetBytes(printName);
+
+			// REPARSE_DATA_BUFFER: 8 byte header, 8 bytes of mount point offsets/lengths, then the two
+			// null terminated names.
+			var pathBufferLength = substituteBytes.Length + 2 + printBytes.Length + 2;
+			var buffer = new byte[8 + 8 + pathBufferLength];
+
+			BitConverter.GetBytes(IoReparseTagMountPoint).CopyTo(buffer, 0);
+			BitConverter.GetBytes((ushort)(8 + pathBufferLength)).CopyTo(buffer, 4);
+			BitConverter.GetBytes((ushort)0).CopyTo(buffer, 6);
+			BitConverter.GetBytes((ushort)0).CopyTo(buffer, 8);
+			BitConverter.GetBytes((ushort)substituteBytes.Length).CopyTo(buffer, 10);
+			BitConverter.GetBytes((ushort)(substituteBytes.Length + 2)).CopyTo(buffer, 12);
+			BitConverter.GetBytes((ushort)printBytes.Length).CopyTo(buffer, 14);
+			substituteBytes.CopyTo(buffer, 16);
+			printBytes.CopyTo(buffer, 16 + substituteBytes.Length + 2);
+
+			using var handle = CreateFile(
+				junction,
+				GenericWrite,
+				FileShareAll,
+				IntPtr.Zero,
+				OpenExisting,
+				FileFlagBackupSemantics | FileFlagOpenReparsePoint,
+				IntPtr.Zero);
+
+			if (handle.IsInvalid)
+				throw new Win32Exception(Marshal.GetLastWin32Error());
+
+			if (!DeviceIoControl(handle, FsctlSetReparsePoint, buffer, buffer.Length, IntPtr.Zero, 0, out _, IntPtr.Zero))
+				throw new Win32Exception(Marshal.GetLastWin32Error());
+		}
+
+		[DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+		static extern Microsoft.Win32.SafeHandles.SafeFileHandle CreateFile(
+			string lpFileName,
+			uint dwDesiredAccess,
+			uint dwShareMode,
+			IntPtr lpSecurityAttributes,
+			uint dwCreationDisposition,
+			uint dwFlagsAndAttributes,
+			IntPtr hTemplateFile);
+
+		[DllImport("kernel32.dll", SetLastError = true)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		static extern bool DeviceIoControl(
+			Microsoft.Win32.SafeHandles.SafeFileHandle hDevice,
+			uint dwIoControlCode,
+			byte[] lpInBuffer,
+			int nInBufferSize,
+			IntPtr lpOutBuffer,
+			int nOutBufferSize,
+			out int lpBytesReturned,
+			IntPtr lpOverlapped);
+	}
+}

--- a/src/SingleProject/Resizetizer/test/UnitTests/PathCanonicalizerTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/PathCanonicalizerTests.cs
@@ -178,6 +178,86 @@ namespace Microsoft.Maui.Resizetizer.Tests
 		}
 
 		/// <summary>
+		/// Containment has to be case sensitive on every platform. On a case sensitive volume "…/r" and
+		/// "…/R" are two different directories, and a link inside the root that leads into the sibling
+		/// would otherwise be reported as living inside the root, letting a delete escape it.
+		/// </summary>
+		[Theory]
+		[InlineData("/x/R/deep/secret.png", "/x/r")]
+		[InlineData("/x/R/secret.png", "/x/r")]
+		[InlineData("/X/r/secret.png", "/x/r")]
+		[InlineData(@"C:\x\R\deep\secret.png", @"C:\x\r")]
+		public void IsUnderIsCaseSensitiveSoACaseOnlySiblingIsNeverContained(string key, string root)
+		{
+			key = key.Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar);
+			root = root.Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar);
+
+			Assert.False(PathCanonicalizer.IsUnder(key, root), $"'{key}' must not be treated as inside '{root}'.");
+		}
+
+		[Fact]
+		public void IsUnderStillAcceptsAnExactCaseMatch()
+		{
+			var root = Path.Combine(Path.DirectorySeparatorChar + "x", "r");
+			var key = Path.Combine(root, "deep", "camera.png");
+
+			Assert.True(PathCanonicalizer.IsUnder(key, root));
+		}
+
+		/// <summary>
+		/// A host without <c>Directory.ResolveLinkTarget</c> — every .NET Framework host, including
+		/// MSBuild.exe — cannot tell where a link leads, so it must report the path as unresolvable rather
+		/// than fall back to the lexical spelling and treat whatever is behind the link as contained.
+		/// </summary>
+		[Fact]
+		public void WithoutLinkResolutionAPathThroughALinkHasNoKey()
+		{
+			// Root the test where no ancestor is itself a link, so the only reparse point in play is the
+			// one the test creates. macOS temp directories live under /var, which is a link to /private/var.
+			var basePath = new PathCanonicalizer().CanonicalizeDirectory(DestinationDirectory);
+			var physical = Path.Combine(basePath, "physical");
+			var link = Path.Combine(basePath, "link");
+			Directory.CreateDirectory(physical);
+
+			if (!SymbolicLink.TryCreateDirectoryLink(link, physical, out var error))
+			{
+				Output.WriteLine($"Skipping: symbolic links are not available on this machine: {error}");
+				return;
+			}
+
+			var fallback = new PathCanonicalizer(allowLinkResolution: false);
+
+			Assert.False(fallback.CanResolveLinks);
+
+			// The link cannot be followed, so nothing behind it can be placed.
+			Assert.Null(fallback.CanonicalizeDirectory(link));
+			Assert.Null(fallback.GetComparisonKey(Path.Combine(link, "camera.png")));
+
+			// A directory that is not a link is unaffected, so cleanup keeps working everywhere else.
+			Assert.Equal(physical, fallback.CanonicalizeDirectory(physical), PathCanonicalizer.Comparer);
+			Assert.Equal(
+				Path.Combine(physical, "camera.png"),
+				fallback.GetComparisonKey(Path.Combine(physical, "camera.png")),
+				PathCanonicalizer.Comparer);
+		}
+
+		[Fact]
+		public void WithLinkResolutionThePathThroughALinkStillResolves()
+		{
+			var (physical, link) = CreateLinkedDirectory();
+			if (link is null)
+				return;
+
+			var canonicalizer = new PathCanonicalizer();
+
+			Assert.True(canonicalizer.CanResolveLinks, "This host is expected to resolve links.");
+			Assert.Equal(
+				canonicalizer.GetComparisonKey(Path.Combine(physical, "camera.png")),
+				canonicalizer.GetComparisonKey(Path.Combine(link, "camera.png")),
+				PathCanonicalizer.Comparer);
+		}
+
+		/// <summary>
 		/// A wildcard descends through a directory link, so the key of what it finds resolves outside the
 		/// root it was rooted at. That is what lets the caller refuse to delete it.
 		/// </summary>

--- a/src/SingleProject/Resizetizer/test/UnitTests/PathCanonicalizerTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/PathCanonicalizerTests.cs
@@ -13,21 +13,24 @@ namespace Microsoft.Maui.Resizetizer.Tests
 		}
 
 		[Fact]
-		public void NullAndEmptyPathsAreReturnedUnchanged()
+		public void NullAndEmptyPathsHaveNoKey()
 		{
 			var canonicalizer = new PathCanonicalizer();
 
-			Assert.Null(canonicalizer.Canonicalize(null));
-			Assert.Equal("", canonicalizer.Canonicalize(""));
-			Assert.Equal("   ", canonicalizer.Canonicalize("   "));
+			Assert.Null(canonicalizer.GetComparisonKey(null));
+			Assert.Null(canonicalizer.GetComparisonKey(""));
+			Assert.Null(canonicalizer.GetComparisonKey("   "));
+			Assert.Null(canonicalizer.CanonicalizeDirectory(null));
+			Assert.Null(canonicalizer.CanonicalizeDirectory(""));
 		}
 
 		[Fact]
-		public void InvalidPathsAreReturnedUnchanged()
+		public void InvalidPathsHaveNoKey()
 		{
 			var canonicalizer = new PathCanonicalizer();
 
-			Assert.Equal("bad\0path", canonicalizer.Canonicalize("bad\0path"));
+			Assert.Null(canonicalizer.GetComparisonKey("bad\0path"));
+			Assert.Null(canonicalizer.CanonicalizeDirectory("bad\0path"));
 		}
 
 		[Fact]
@@ -35,7 +38,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 		{
 			var canonicalizer = new PathCanonicalizer();
 
-			var canonical = canonicalizer.Canonicalize(Path.Combine("obj", "resizetizer", "r", "camera.png"));
+			var canonical = canonicalizer.GetComparisonKey(Path.Combine("obj", "resizetizer", "r", "camera.png"));
 
 			Assert.True(Path.IsPathRooted(canonical), $"Expected a rooted path, got '{canonical}'.");
 		}
@@ -49,7 +52,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 
 			var messy = Path.Combine(DestinationDirectory, ".", "obj", "..", "images") + Path.DirectorySeparatorChar + Path.DirectorySeparatorChar;
 
-			Assert.Equal(canonicalizer.Canonicalize(directory), canonicalizer.Canonicalize(messy), PathCanonicalizer.Comparer);
+			Assert.Equal(canonicalizer.CanonicalizeDirectory(directory), canonicalizer.CanonicalizeDirectory(messy), PathCanonicalizer.Comparer);
 		}
 
 		[Fact]
@@ -58,11 +61,11 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			var canonicalizer = new PathCanonicalizer();
 			var missing = Path.Combine(DestinationDirectory, "never", "created", "at", "all.png");
 
-			var canonical = canonicalizer.Canonicalize(missing);
+			var canonical = canonicalizer.GetComparisonKey(missing);
 
 			Assert.True(Path.IsPathRooted(canonical), $"Expected a rooted path, got '{canonical}'.");
 			Assert.EndsWith(Path.Combine("never", "created", "at", "all.png"), canonical, StringComparison.Ordinal);
-			Assert.Equal(canonical, canonicalizer.Canonicalize(canonical), PathCanonicalizer.Comparer);
+			Assert.Equal(canonical, canonicalizer.GetComparisonKey(canonical), PathCanonicalizer.Comparer);
 		}
 
 		[Fact]
@@ -74,7 +77,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 
 			var canonicalizer = new PathCanonicalizer();
 
-			Assert.Equal(canonicalizer.Canonicalize(physical), canonicalizer.Canonicalize(link), PathCanonicalizer.Comparer);
+			Assert.Equal(canonicalizer.CanonicalizeDirectory(physical), canonicalizer.CanonicalizeDirectory(link), PathCanonicalizer.Comparer);
 		}
 
 		[Fact]
@@ -89,8 +92,8 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			var canonicalizer = new PathCanonicalizer();
 
 			Assert.Equal(
-				canonicalizer.Canonicalize(Path.Combine(physical, "camera.png")),
-				canonicalizer.Canonicalize(Path.Combine(link, "camera.png")),
+				canonicalizer.GetComparisonKey(Path.Combine(physical, "camera.png")),
+				canonicalizer.GetComparisonKey(Path.Combine(link, "camera.png")),
 				PathCanonicalizer.Comparer);
 		}
 
@@ -106,8 +109,8 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			// The stale-file comparison has to work for outputs that the build has not written yet, so
 			// canonicalization may only resolve the part of the path that already exists.
 			Assert.Equal(
-				canonicalizer.Canonicalize(Path.Combine(physical, "future", "camera.png")),
-				canonicalizer.Canonicalize(Path.Combine(link, "future", "camera.png")),
+				canonicalizer.GetComparisonKey(Path.Combine(physical, "future", "camera.png")),
+				canonicalizer.GetComparisonKey(Path.Combine(link, "future", "camera.png")),
 				PathCanonicalizer.Comparer);
 		}
 
@@ -116,10 +119,117 @@ namespace Microsoft.Maui.Resizetizer.Tests
 		{
 			var canonicalizer = new PathCanonicalizer();
 
-			var one = canonicalizer.Canonicalize(Path.Combine(DestinationDirectory, "drawable", "camera.png"));
-			var two = canonicalizer.Canonicalize(Path.Combine(DestinationDirectory, "drawable", "bicycle.png"));
+			var one = canonicalizer.GetComparisonKey(Path.Combine(DestinationDirectory, "drawable", "camera.png"));
+			var two = canonicalizer.GetComparisonKey(Path.Combine(DestinationDirectory, "drawable", "bicycle.png"));
 
 			Assert.NotEqual(one, two, PathCanonicalizer.Comparer);
+		}
+
+		/// <summary>
+		/// Only the directory is link resolved. Two names in one directory must stay distinct even when
+		/// one is a link to the other, otherwise a stale alias would look like a live output.
+		/// </summary>
+		[Fact]
+		public void ALinkToAFileInTheSameDirectoryKeepsItsOwnKey()
+		{
+			var directory = Path.Combine(DestinationDirectory, "drawable");
+			Directory.CreateDirectory(directory);
+
+			var target = Path.Combine(directory, "camera.png");
+			var alias = Path.Combine(directory, "orphan.png");
+			File.WriteAllText(target, "image");
+
+			if (!SymbolicLink.TryCreateFileLink(alias, target, out var error))
+			{
+				Output.WriteLine($"Skipping: symbolic links are not available on this machine: {error}");
+				return;
+			}
+
+			var canonicalizer = new PathCanonicalizer();
+
+			Assert.NotEqual(
+				canonicalizer.GetComparisonKey(target),
+				canonicalizer.GetComparisonKey(alias),
+				PathCanonicalizer.Comparer);
+		}
+
+		[Fact]
+		public void IsUnderAcceptsTheRootItselfAndItsChildren()
+		{
+			var canonicalizer = new PathCanonicalizer();
+			var root = canonicalizer.CanonicalizeDirectory(DestinationDirectory);
+
+			Assert.True(PathCanonicalizer.IsUnder(root, root));
+			Assert.True(PathCanonicalizer.IsUnder(canonicalizer.GetComparisonKey(Path.Combine(DestinationDirectory, "camera.png")), root));
+			Assert.True(PathCanonicalizer.IsUnder(canonicalizer.GetComparisonKey(Path.Combine(DestinationDirectory, "a", "b", "camera.png")), root));
+		}
+
+		[Fact]
+		public void IsUnderRejectsSiblingsParentsAndEmptyInput()
+		{
+			var canonicalizer = new PathCanonicalizer();
+			var root = canonicalizer.CanonicalizeDirectory(Path.Combine(DestinationDirectory, "r"));
+
+			// A name that merely starts with the root's name is not inside it.
+			Assert.False(PathCanonicalizer.IsUnder(canonicalizer.GetComparisonKey(Path.Combine(DestinationDirectory, "r-backup", "camera.png")), root));
+			Assert.False(PathCanonicalizer.IsUnder(canonicalizer.GetComparisonKey(Path.Combine(DestinationDirectory, "camera.png")), root));
+			Assert.False(PathCanonicalizer.IsUnder(null, root));
+			Assert.False(PathCanonicalizer.IsUnder(root, null));
+		}
+
+		/// <summary>
+		/// A wildcard descends through a directory link, so the key of what it finds resolves outside the
+		/// root it was rooted at. That is what lets the caller refuse to delete it.
+		/// </summary>
+		[Fact]
+		public void APathReachedThroughADirectoryLinkResolvesOutOfTheRoot()
+		{
+			var root = Path.Combine(DestinationDirectory, "r");
+			var outside = Path.Combine(DestinationDirectory, "outside");
+			Directory.CreateDirectory(root);
+			Directory.CreateDirectory(outside);
+
+			if (!SymbolicLink.TryCreateDirectoryLink(Path.Combine(root, "alias"), outside, out var error))
+			{
+				Output.WriteLine($"Skipping: symbolic links are not available on this machine: {error}");
+				return;
+			}
+
+			var canonicalizer = new PathCanonicalizer();
+			var canonicalRoot = canonicalizer.CanonicalizeDirectory(root);
+			var throughTheLink = canonicalizer.GetComparisonKey(Path.Combine(root, "alias", "precious.png"));
+
+			Assert.False(PathCanonicalizer.IsUnder(throughTheLink, canonicalRoot));
+		}
+
+		/// <summary>
+		/// The resolution cache is keyed on the exact spelling. On a case sensitive volume two directories
+		/// whose names differ only by case are two different directories, and a case insensitive cache key
+		/// would hand back the wrong one's target.
+		/// </summary>
+		[Fact]
+		public void DirectoriesDifferingOnlyByCaseAreCachedSeparately()
+		{
+			if (!OperatingSystem.IsLinux())
+				return;
+
+			var lower = Path.Combine(DestinationDirectory, "drawable");
+			var upper = Path.Combine(DestinationDirectory, "DRAWABLE");
+			var target = Path.Combine(DestinationDirectory, "elsewhere");
+			Directory.CreateDirectory(target);
+			Directory.CreateDirectory(upper);
+
+			if (!SymbolicLink.TryCreateDirectoryLink(lower, target, out var error))
+			{
+				Output.WriteLine($"Skipping: symbolic links are not available on this machine: {error}");
+				return;
+			}
+
+			var canonicalizer = new PathCanonicalizer();
+
+			// Resolve the link first so a bad cache would already be populated with its target.
+			Assert.Equal(canonicalizer.CanonicalizeDirectory(target), canonicalizer.CanonicalizeDirectory(lower), StringComparer.Ordinal);
+			Assert.Equal(upper, canonicalizer.CanonicalizeDirectory(upper), StringComparer.Ordinal);
 		}
 
 		[Fact]
@@ -132,9 +242,9 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			File.WriteAllText(Path.Combine(physical, "camera.png"), "image");
 
 			var canonicalizer = new PathCanonicalizer();
-			var once = canonicalizer.Canonicalize(Path.Combine(link, "camera.png"));
+			var once = canonicalizer.GetComparisonKey(Path.Combine(link, "camera.png"));
 
-			Assert.Equal(once, canonicalizer.Canonicalize(once), PathCanonicalizer.Comparer);
+			Assert.Equal(once, canonicalizer.GetComparisonKey(once), PathCanonicalizer.Comparer);
 		}
 
 		[Fact]
@@ -155,8 +265,8 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			var canonicalizer = new PathCanonicalizer();
 
 			Assert.Equal(
-				canonicalizer.Canonicalize(Path.Combine(physical, "camera.png")),
-				canonicalizer.Canonicalize(Path.Combine(second, "camera.png")),
+				canonicalizer.GetComparisonKey(Path.Combine(physical, "camera.png")),
+				canonicalizer.GetComparisonKey(Path.Combine(second, "camera.png")),
 				PathCanonicalizer.Comparer);
 		}
 
@@ -176,7 +286,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			var root = Path.GetPathRoot(Path.GetFullPath(DestinationDirectory));
 
 			Assert.False(string.IsNullOrEmpty(root));
-			Assert.Equal(root, canonicalizer.Canonicalize(root), PathCanonicalizer.Comparer);
+			Assert.Equal(root, canonicalizer.CanonicalizeDirectory(root), PathCanonicalizer.Comparer);
 		}
 
 		[Fact]
@@ -189,11 +299,11 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			var path = Path.Combine(DestinationDirectory, "drawable", "camera.png");
 
 			Assert.Equal(
-				canonicalizer.Canonicalize(path),
-				canonicalizer.Canonicalize(path.Replace('\\', '/')),
+				canonicalizer.GetComparisonKey(path),
+				canonicalizer.GetComparisonKey(path.Replace('\\', '/')),
 				PathCanonicalizer.Comparer);
 
-			Assert.Equal(Path.GetPathRoot(path), Path.GetPathRoot(canonicalizer.Canonicalize(path)), StringComparer.OrdinalIgnoreCase);
+			Assert.Equal(Path.GetPathRoot(path), Path.GetPathRoot(canonicalizer.GetComparisonKey(path)), StringComparer.OrdinalIgnoreCase);
 		}
 
 		[Fact]
@@ -215,8 +325,8 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			var canonicalizer = new PathCanonicalizer();
 
 			Assert.Equal(
-				canonicalizer.Canonicalize(Path.Combine(physical, "camera.png")),
-				canonicalizer.Canonicalize(Path.Combine(junction, "camera.png")),
+				canonicalizer.GetComparisonKey(Path.Combine(physical, "camera.png")),
+				canonicalizer.GetComparisonKey(Path.Combine(junction, "camera.png")),
 				PathCanonicalizer.Comparer);
 		}
 
@@ -228,8 +338,8 @@ namespace Microsoft.Maui.Resizetizer.Tests
 
 			var canonicalizer = new PathCanonicalizer();
 
-			var withBackslash = canonicalizer.Canonicalize(Path.Combine(DestinationDirectory, "drawable\\camera.png"));
-			var withSeparator = canonicalizer.Canonicalize(Path.Combine(DestinationDirectory, "drawable", "camera.png"));
+			var withBackslash = canonicalizer.GetComparisonKey(Path.Combine(DestinationDirectory, "drawable\\camera.png"));
+			var withSeparator = canonicalizer.GetComparisonKey(Path.Combine(DestinationDirectory, "drawable", "camera.png"));
 
 			Assert.NotEqual(withBackslash, withSeparator, PathCanonicalizer.Comparer);
 		}

--- a/src/SingleProject/Resizetizer/test/UnitTests/PathCanonicalizerTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/PathCanonicalizerTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.IO;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Maui.Resizetizer.Tests
+{
+	public class PathCanonicalizerTests : BaseTest
+	{
+		public PathCanonicalizerTests(ITestOutputHelper output)
+			: base(output)
+		{
+		}
+
+		[Fact]
+		public void NullAndEmptyPathsAreReturnedUnchanged()
+		{
+			var canonicalizer = new PathCanonicalizer();
+
+			Assert.Null(canonicalizer.Canonicalize(null));
+			Assert.Equal("", canonicalizer.Canonicalize(""));
+			Assert.Equal("   ", canonicalizer.Canonicalize("   "));
+		}
+
+		[Fact]
+		public void InvalidPathsAreReturnedUnchanged()
+		{
+			var canonicalizer = new PathCanonicalizer();
+
+			Assert.Equal("bad\0path", canonicalizer.Canonicalize("bad\0path"));
+		}
+
+		[Fact]
+		public void RelativePathsAreRooted()
+		{
+			var canonicalizer = new PathCanonicalizer();
+
+			var canonical = canonicalizer.Canonicalize(Path.Combine("obj", "resizetizer", "r", "camera.png"));
+
+			Assert.True(Path.IsPathRooted(canonical), $"Expected a rooted path, got '{canonical}'.");
+		}
+
+		[Fact]
+		public void RedundantSegmentsAndTrailingSeparatorsAreNormalized()
+		{
+			var canonicalizer = new PathCanonicalizer();
+			var directory = Path.Combine(DestinationDirectory, "images");
+			Directory.CreateDirectory(directory);
+
+			var messy = Path.Combine(DestinationDirectory, ".", "obj", "..", "images") + Path.DirectorySeparatorChar + Path.DirectorySeparatorChar;
+
+			Assert.Equal(canonicalizer.Canonicalize(directory), canonicalizer.Canonicalize(messy), PathCanonicalizer.Comparer);
+		}
+
+		[Fact]
+		public void MissingPathsDoNotThrowAndStayStable()
+		{
+			var canonicalizer = new PathCanonicalizer();
+			var missing = Path.Combine(DestinationDirectory, "never", "created", "at", "all.png");
+
+			var canonical = canonicalizer.Canonicalize(missing);
+
+			Assert.True(Path.IsPathRooted(canonical), $"Expected a rooted path, got '{canonical}'.");
+			Assert.EndsWith(Path.Combine("never", "created", "at", "all.png"), canonical, StringComparison.Ordinal);
+			Assert.Equal(canonical, canonicalizer.Canonicalize(canonical), PathCanonicalizer.Comparer);
+		}
+
+		[Fact]
+		public void LinkedAndPhysicalDirectoriesCanonicalizeToTheSamePath()
+		{
+			var (physical, link) = CreateLinkedDirectory();
+			if (link is null)
+				return;
+
+			var canonicalizer = new PathCanonicalizer();
+
+			Assert.Equal(canonicalizer.Canonicalize(physical), canonicalizer.Canonicalize(link), PathCanonicalizer.Comparer);
+		}
+
+		[Fact]
+		public void ExistingFileBehindALinkCanonicalizesToThePhysicalFile()
+		{
+			var (physical, link) = CreateLinkedDirectory();
+			if (link is null)
+				return;
+
+			File.WriteAllText(Path.Combine(physical, "camera.png"), "image");
+
+			var canonicalizer = new PathCanonicalizer();
+
+			Assert.Equal(
+				canonicalizer.Canonicalize(Path.Combine(physical, "camera.png")),
+				canonicalizer.Canonicalize(Path.Combine(link, "camera.png")),
+				PathCanonicalizer.Comparer);
+		}
+
+		[Fact]
+		public void NotYetCreatedFileBehindALinkCanonicalizesToThePhysicalFile()
+		{
+			var (physical, link) = CreateLinkedDirectory();
+			if (link is null)
+				return;
+
+			var canonicalizer = new PathCanonicalizer();
+
+			// The stale-file comparison has to work for outputs that the build has not written yet, so
+			// canonicalization may only resolve the part of the path that already exists.
+			Assert.Equal(
+				canonicalizer.Canonicalize(Path.Combine(physical, "future", "camera.png")),
+				canonicalizer.Canonicalize(Path.Combine(link, "future", "camera.png")),
+				PathCanonicalizer.Comparer);
+		}
+
+		[Fact]
+		public void UnrelatedPathsStayDifferent()
+		{
+			var canonicalizer = new PathCanonicalizer();
+
+			var one = canonicalizer.Canonicalize(Path.Combine(DestinationDirectory, "drawable", "camera.png"));
+			var two = canonicalizer.Canonicalize(Path.Combine(DestinationDirectory, "drawable", "bicycle.png"));
+
+			Assert.NotEqual(one, two, PathCanonicalizer.Comparer);
+		}
+
+		(string Physical, string Link) CreateLinkedDirectory()
+		{
+			var physical = Path.Combine(DestinationDirectory, "physical");
+			var link = Path.Combine(DestinationDirectory, "link");
+
+			Directory.CreateDirectory(physical);
+
+			if (!SymbolicLink.TryCreateDirectoryLink(link, physical, out var error))
+			{
+				Output.WriteLine($"Skipping: symbolic links are not available on this machine: {error}");
+				return (physical, null);
+			}
+
+			return (physical, link);
+		}
+	}
+}

--- a/src/SingleProject/Resizetizer/test/UnitTests/PathCanonicalizerTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/PathCanonicalizerTests.cs
@@ -122,6 +122,118 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			Assert.NotEqual(one, two, PathCanonicalizer.Comparer);
 		}
 
+		[Fact]
+		public void CanonicalizingIsIdempotent()
+		{
+			var (physical, link) = CreateLinkedDirectory();
+			if (link is null)
+				return;
+
+			File.WriteAllText(Path.Combine(physical, "camera.png"), "image");
+
+			var canonicalizer = new PathCanonicalizer();
+			var once = canonicalizer.Canonicalize(Path.Combine(link, "camera.png"));
+
+			Assert.Equal(once, canonicalizer.Canonicalize(once), PathCanonicalizer.Comparer);
+		}
+
+		[Fact]
+		public void ChainedLinksResolveToTheFinalTarget()
+		{
+			var physical = Path.Combine(DestinationDirectory, "physical");
+			var first = Path.Combine(DestinationDirectory, "first");
+			var second = Path.Combine(DestinationDirectory, "second");
+			Directory.CreateDirectory(physical);
+
+			if (!SymbolicLink.TryCreateDirectoryLink(first, physical, out var error) ||
+				!SymbolicLink.TryCreateDirectoryLink(second, first, out error))
+			{
+				Output.WriteLine($"Skipping: symbolic links are not available on this machine: {error}");
+				return;
+			}
+
+			var canonicalizer = new PathCanonicalizer();
+
+			Assert.Equal(
+				canonicalizer.Canonicalize(Path.Combine(physical, "camera.png")),
+				canonicalizer.Canonicalize(Path.Combine(second, "camera.png")),
+				PathCanonicalizer.Comparer);
+		}
+
+		[Fact]
+		public void ComparerFollowsThePlatformFileSystem()
+		{
+			// Only Linux path comparison is case sensitive. Everywhere else two spellings that differ by
+			// case are treated as the same file, which can only ever keep a stale file rather than delete
+			// a live one.
+			Assert.Equal(OperatingSystem.IsLinux() ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase, PathCanonicalizer.Comparer);
+		}
+
+		[Fact]
+		public void RootsAreCanonicalizedWithoutRecursingForever()
+		{
+			var canonicalizer = new PathCanonicalizer();
+			var root = Path.GetPathRoot(Path.GetFullPath(DestinationDirectory));
+
+			Assert.False(string.IsNullOrEmpty(root));
+			Assert.Equal(root, canonicalizer.Canonicalize(root), PathCanonicalizer.Comparer);
+		}
+
+		[Fact]
+		public void WindowsPathsKeepTheirDriveAndAcceptBothSeparators()
+		{
+			if (!OperatingSystem.IsWindows())
+				return;
+
+			var canonicalizer = new PathCanonicalizer();
+			var path = Path.Combine(DestinationDirectory, "drawable", "camera.png");
+
+			Assert.Equal(
+				canonicalizer.Canonicalize(path),
+				canonicalizer.Canonicalize(path.Replace('\\', '/')),
+				PathCanonicalizer.Comparer);
+
+			Assert.Equal(Path.GetPathRoot(path), Path.GetPathRoot(canonicalizer.Canonicalize(path)), StringComparer.OrdinalIgnoreCase);
+		}
+
+		[Fact]
+		public void WindowsJunctionsResolveLikeDirectoryLinks()
+		{
+			if (!OperatingSystem.IsWindows())
+				return;
+
+			var physical = Path.Combine(DestinationDirectory, "physical");
+			var junction = Path.Combine(DestinationDirectory, "junction");
+			Directory.CreateDirectory(physical);
+
+			if (!Junction.TryCreate(junction, physical, out var error))
+			{
+				Output.WriteLine($"Skipping: junctions are not available on this machine: {error}");
+				return;
+			}
+
+			var canonicalizer = new PathCanonicalizer();
+
+			Assert.Equal(
+				canonicalizer.Canonicalize(Path.Combine(physical, "camera.png")),
+				canonicalizer.Canonicalize(Path.Combine(junction, "camera.png")),
+				PathCanonicalizer.Comparer);
+		}
+
+		[Fact]
+		public void BackslashesAreOrdinaryCharactersOnUnix()
+		{
+			if (OperatingSystem.IsWindows())
+				return;
+
+			var canonicalizer = new PathCanonicalizer();
+
+			var withBackslash = canonicalizer.Canonicalize(Path.Combine(DestinationDirectory, "drawable\\camera.png"));
+			var withSeparator = canonicalizer.Canonicalize(Path.Combine(DestinationDirectory, "drawable", "camera.png"));
+
+			Assert.NotEqual(withBackslash, withSeparator, PathCanonicalizer.Comparer);
+		}
+
 		(string Physical, string Link) CreateLinkedDirectory()
 		{
 			var physical = Path.Combine(DestinationDirectory, "physical");

--- a/src/SingleProject/Resizetizer/test/UnitTests/ResizetizeImagesIncrementalTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/ResizetizeImagesIncrementalTests.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			var generated = Path.Combine(project.PhysicalDirectory, GeneratedImage);
 			var before = File.ReadAllBytes(generated);
 
-			var source = Path.Combine(project.PhysicalDirectory, "images", ImageName);
+			var source = Path.Combine(project.ImagesDirectory, ImageName);
 			File.Copy(Path.Combine(AppContext.BaseDirectory, "images", "camera_color.png"), source, overwrite: true);
 			// File.Copy carries the source timestamp over, but an edit would bump it.
 			File.SetLastWriteTimeUtc(source, DateTime.UtcNow);
@@ -116,7 +116,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			File.WriteAllText(orphan, "left over from an image that is no longer in the project");
 
 			// Touch the source image so the target is not skipped as up to date.
-			File.SetLastWriteTimeUtc(Path.Combine(project.PhysicalDirectory, "images", ImageName), DateTime.UtcNow);
+			File.SetLastWriteTimeUtc(Path.Combine(project.ImagesDirectory, ImageName), DateTime.UtcNow);
 
 			Build(project);
 
@@ -145,20 +145,93 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			AssertGeneratedImageExists(project);
 		}
 
+		/// <summary>
+		/// The project directory itself is ordinary, but the intermediate output directory that receives
+		/// the generated images is reached through a link. This is what a redirected <c>obj</c> looks like.
+		/// </summary>
+		[Fact]
+		public void ImagesSurviveWhenOnlyTheIntermediateOutputIsLinked()
+		{
+			var project = CreateProject(throughLink: false, linkedIntermediateOutput: true);
+			if (project is null)
+				return;
+
+			Build(project);
+			AssertGeneratedImageExists(project);
+
+			Build(project);
+			AssertGeneratedImageExists(project);
+
+			// The images really do land on the far side of the link.
+			var real = Path.Combine(project.PhysicalDirectory, "obj-real", "resizetizer", "r", "drawable", ImageName);
+			Assert.True(File.Exists(real), $"Expected the generated image behind the link: {real}");
+		}
+
+		/// <summary>
+		/// The source images are reached through a link while the project and its output are ordinary.
+		/// </summary>
+		[Fact]
+		public void ImagesSurviveWhenOnlyTheInputImagesAreLinked()
+		{
+			var project = CreateProject(throughLink: false, linkedImages: true);
+			if (project is null)
+				return;
+
+			Build(project);
+			AssertGeneratedImageExists(project);
+
+			Build(project);
+			AssertGeneratedImageExists(project);
+		}
+
 		void AssertGeneratedImageExists(TestProject project)
 		{
 			var image = Path.Combine(project.PhysicalDirectory, GeneratedImage);
 			Assert.True(File.Exists(image), $"Expected the generated image to survive the build: {image}");
 		}
 
-		TestProject CreateProject(bool throughLink)
+		TestProject CreateProject(bool throughLink, bool linkedIntermediateOutput = false, bool linkedImages = false)
 		{
 			var physical = Path.Combine(DestinationDirectory, "project");
-			Directory.CreateDirectory(Path.Combine(physical, "images"));
+			Directory.CreateDirectory(physical);
+
+			var imagesDirectory = Path.Combine(physical, "images");
+
+			if (linkedImages)
+			{
+				// The project refers to images\, but that is a link to where the files really live.
+				var realImages = Path.Combine(physical, "images-real");
+				Directory.CreateDirectory(realImages);
+
+				if (!SymbolicLink.TryCreateDirectoryLink(imagesDirectory, realImages, out var imagesError))
+				{
+					Output.WriteLine($"Skipping: symbolic links are not available on this machine: {imagesError}");
+					return null;
+				}
+
+				imagesDirectory = realImages;
+			}
+			else
+			{
+				Directory.CreateDirectory(imagesDirectory);
+			}
 
 			File.Copy(
 				Path.Combine(AppContext.BaseDirectory, "images", ImageName),
-				Path.Combine(physical, "images", ImageName));
+				Path.Combine(imagesDirectory, ImageName));
+
+			if (linkedIntermediateOutput)
+			{
+				// The project writes to obj\, but that is a link to where the outputs really land.
+				var realIntermediate = Path.Combine(physical, "obj-real");
+				Directory.CreateDirectory(realIntermediate);
+
+				if (!SymbolicLink.TryCreateDirectoryLink(Path.Combine(physical, "obj"), realIntermediate, out var objError))
+				{
+					Output.WriteLine($"Skipping: symbolic links are not available on this machine: {objError}");
+					return null;
+				}
+			}
 
 			var targets = Path.Combine(AppContext.BaseDirectory, "Microsoft.Maui.Resizetizer.After.targets");
 			Assert.True(File.Exists(targets), $"Expected the target file to be copied to the test output: {targets}");
@@ -190,7 +263,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 				}
 			}
 
-			return new TestProject(physical, entry);
+			return new TestProject(physical, entry, imagesDirectory);
 		}
 
 		string Build(TestProject project, string target = "ResizetizeImages")
@@ -246,6 +319,6 @@ namespace Microsoft.Maui.Resizetizer.Tests
 				: "dotnet";
 		}
 
-		sealed record TestProject(string PhysicalDirectory, string EntryDirectory);
+		sealed record TestProject(string PhysicalDirectory, string EntryDirectory, string ImagesDirectory);
 	}
 }

--- a/src/SingleProject/Resizetizer/test/UnitTests/ResizetizeImagesIncrementalTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/ResizetizeImagesIncrementalTests.cs
@@ -1,0 +1,251 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Maui.Resizetizer.Tests
+{
+	/// <summary>
+	/// Drives the real <c>ResizetizeImages</c> target through MSBuild so the interaction between the
+	/// task outputs, the stale-file wildcard and the incremental stamp files is covered end to end.
+	/// </summary>
+	/// <remarks>
+	/// The same scenarios run twice: once from an ordinary directory and once from a directory reached
+	/// through a symbolic link. The second shape is what a macOS temp path (<c>/tmp</c>,
+	/// <c>/var/folders</c>) or a Windows junction looks like, and it used to make the cleanup step
+	/// delete every image the task had just generated.
+	/// </remarks>
+	public class ResizetizeImagesIncrementalTests : BaseTest
+	{
+		const string ImageName = "camera.png";
+		const string GeneratedImage = "obj/resizetizer/r/drawable/camera.png";
+
+		public ResizetizeImagesIncrementalTests(ITestOutputHelper output)
+			: base(output)
+		{
+		}
+
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public void ImagesSurviveTheFirstBuild(bool throughLink)
+		{
+			var project = CreateProject(throughLink);
+			if (project is null)
+				return;
+
+			Build(project);
+
+			AssertGeneratedImageExists(project);
+		}
+
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public void ImagesSurviveASecondBuildWithNoChanges(bool throughLink)
+		{
+			var project = CreateProject(throughLink);
+			if (project is null)
+				return;
+
+			Build(project);
+			var output = Build(project);
+
+			AssertGeneratedImageExists(project);
+			Assert.Contains("Skipping target \"ResizetizeImages\"", output, StringComparison.Ordinal);
+		}
+
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public void ImagesAreRegeneratedWhenTheSourceImageChanges(bool throughLink)
+		{
+			var project = CreateProject(throughLink);
+			if (project is null)
+				return;
+
+			Build(project);
+
+			var generated = Path.Combine(project.PhysicalDirectory, GeneratedImage);
+			var before = File.ReadAllBytes(generated);
+
+			var source = Path.Combine(project.PhysicalDirectory, "images", ImageName);
+			File.Copy(Path.Combine(AppContext.BaseDirectory, "images", "camera_color.png"), source, overwrite: true);
+			// File.Copy carries the source timestamp over, but an edit would bump it.
+			File.SetLastWriteTimeUtc(source, DateTime.UtcNow);
+
+			var output = Build(project);
+
+			AssertGeneratedImageExists(project);
+			Assert.DoesNotContain("Skipping target \"ResizetizeImages\"", output, StringComparison.Ordinal);
+			Assert.False(before.SequenceEqual(File.ReadAllBytes(generated)), "Expected the generated image to be rewritten.");
+		}
+
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public void DeletedImagesAreRestored(bool throughLink)
+		{
+			var project = CreateProject(throughLink);
+			if (project is null)
+				return;
+
+			Build(project);
+
+			File.Delete(Path.Combine(project.PhysicalDirectory, GeneratedImage));
+
+			Build(project);
+
+			AssertGeneratedImageExists(project);
+		}
+
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public void StaleImagesAreStillDeleted(bool throughLink)
+		{
+			var project = CreateProject(throughLink);
+			if (project is null)
+				return;
+
+			Build(project);
+
+			var orphan = Path.Combine(project.PhysicalDirectory, "obj", "resizetizer", "r", "drawable", "orphan.png");
+			File.WriteAllText(orphan, "left over from an image that is no longer in the project");
+
+			// Touch the source image so the target is not skipped as up to date.
+			File.SetLastWriteTimeUtc(Path.Combine(project.PhysicalDirectory, "images", ImageName), DateTime.UtcNow);
+
+			Build(project);
+
+			AssertGeneratedImageExists(project);
+			Assert.False(File.Exists(orphan), $"Expected the stale file to be deleted: {orphan}");
+		}
+
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public void CleanRemovesImagesAndTheNextBuildRegeneratesThem(bool throughLink)
+		{
+			var project = CreateProject(throughLink);
+			if (project is null)
+				return;
+
+			Build(project);
+
+			Build(project, "_CleanResizetizer");
+			Assert.False(
+				File.Exists(Path.Combine(project.PhysicalDirectory, GeneratedImage)),
+				"Expected the clean target to remove the generated image.");
+
+			Build(project);
+
+			AssertGeneratedImageExists(project);
+		}
+
+		void AssertGeneratedImageExists(TestProject project)
+		{
+			var image = Path.Combine(project.PhysicalDirectory, GeneratedImage);
+			Assert.True(File.Exists(image), $"Expected the generated image to survive the build: {image}");
+		}
+
+		TestProject CreateProject(bool throughLink)
+		{
+			var physical = Path.Combine(DestinationDirectory, "project");
+			Directory.CreateDirectory(Path.Combine(physical, "images"));
+
+			File.Copy(
+				Path.Combine(AppContext.BaseDirectory, "images", ImageName),
+				Path.Combine(physical, "images", ImageName));
+
+			var targets = Path.Combine(AppContext.BaseDirectory, "Microsoft.Maui.Resizetizer.After.targets");
+			Assert.True(File.Exists(targets), $"Expected the target file to be copied to the test output: {targets}");
+
+			File.WriteAllText(Path.Combine(physical, "App.proj"),
+				$"""
+				<Project>
+				  <PropertyGroup>
+				    <ResizetizerPlatformType>android</ResizetizerPlatformType>
+				    <IntermediateOutputPath>obj\</IntermediateOutputPath>
+				  </PropertyGroup>
+				  <ItemGroup>
+				    <MauiImage Include="images\{ImageName}" />
+				  </ItemGroup>
+				  <Import Project="{targets}" />
+				</Project>
+				""");
+
+			var entry = physical;
+
+			if (throughLink)
+			{
+				entry = Path.Combine(DestinationDirectory, "link");
+
+				if (!SymbolicLink.TryCreateDirectoryLink(entry, physical, out var error))
+				{
+					Output.WriteLine($"Skipping: symbolic links are not available on this machine: {error}");
+					return null;
+				}
+			}
+
+			return new TestProject(physical, entry);
+		}
+
+		string Build(TestProject project, string target = "ResizetizeImages")
+		{
+			const int timeoutMilliseconds = 300_000;
+
+			var startInfo = new ProcessStartInfo
+			{
+				FileName = GetDotNetHost(),
+				WorkingDirectory = project.EntryDirectory,
+				UseShellExecute = false,
+				RedirectStandardOutput = true,
+				RedirectStandardError = true,
+			};
+			startInfo.ArgumentList.Add("msbuild");
+			startInfo.ArgumentList.Add(Path.Combine(project.EntryDirectory, "App.proj"));
+			startInfo.ArgumentList.Add($"-t:{target}");
+			startInfo.ArgumentList.Add("-nologo");
+			startInfo.ArgumentList.Add("-v:normal");
+			// Node reuse would keep MSBuild processes alive between the builds of a single test.
+			startInfo.ArgumentList.Add("-nodeReuse:false");
+
+			using var process = Process.Start(startInfo);
+			Assert.NotNull(process);
+
+			var outputTask = process.StandardOutput.ReadToEndAsync();
+			var errorTask = process.StandardError.ReadToEndAsync();
+
+			if (!process.WaitForExit(timeoutMilliseconds))
+			{
+				process.Kill(entireProcessTree: true);
+				process.WaitForExit();
+				Assert.Fail($"MSBuild timed out after {timeoutMilliseconds}ms.\n{outputTask.GetAwaiter().GetResult()}{errorTask.GetAwaiter().GetResult()}");
+			}
+
+			var output = outputTask.GetAwaiter().GetResult();
+			var error = errorTask.GetAwaiter().GetResult();
+
+			Output.WriteLine(output);
+			Output.WriteLine(error);
+
+			Assert.Equal(0, process.ExitCode);
+
+			return output + error;
+		}
+
+		static string GetDotNetHost()
+		{
+			var dotnetHost = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH");
+
+			return !string.IsNullOrWhiteSpace(dotnetHost) && File.Exists(dotnetHost)
+				? dotnetHost
+				: "dotnet";
+		}
+
+		sealed record TestProject(string PhysicalDirectory, string EntryDirectory);
+	}
+}

--- a/src/SingleProject/Resizetizer/test/UnitTests/ResizetizeImagesIncrementalTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/ResizetizeImagesIncrementalTests.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			var source = Path.Combine(project.ImagesDirectory, ImageName);
 			File.Copy(Path.Combine(AppContext.BaseDirectory, "images", "camera_color.png"), source, overwrite: true);
 			// File.Copy carries the source timestamp over, but an edit would bump it.
-			File.SetLastWriteTimeUtc(source, DateTime.UtcNow);
+			TouchSourceImage(project);
 
 			var output = Build(project);
 
@@ -116,7 +116,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			File.WriteAllText(orphan, "left over from an image that is no longer in the project");
 
 			// Touch the source image so the target is not skipped as up to date.
-			File.SetLastWriteTimeUtc(Path.Combine(project.ImagesDirectory, ImageName), DateTime.UtcNow);
+			TouchSourceImage(project);
 
 			Build(project);
 
@@ -212,7 +212,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			}
 
 			// Touch the source image so the target is not skipped as up to date.
-			File.SetLastWriteTimeUtc(Path.Combine(project.ImagesDirectory, ImageName), DateTime.UtcNow);
+			TouchSourceImage(project);
 
 			Build(project);
 
@@ -225,6 +225,37 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			var image = Path.Combine(project.PhysicalDirectory, GeneratedImage);
 			Assert.True(File.Exists(image), $"Expected the generated image to survive the build: {image}");
 		}
+
+		/// <summary>
+		/// Marks the source image as edited so that the next build cannot treat the target as up to date.
+		/// </summary>
+		/// <remarks>
+		/// The new timestamp has to be definitively newer than everything the previous build wrote, not
+		/// merely "now". Only about a hundred milliseconds pass between the build writing its stamp file
+		/// and this call, so a file system that stores timestamps to the nearest second or two (ext3,
+		/// HFS+, FAT, some container overlays) rounds both into the same value. MSBuild treats an input
+		/// that is not strictly newer than its outputs as up to date and skips the target, which would
+		/// make these tests fail for a reason that has nothing to do with what they cover.
+		/// </remarks>
+		static void TouchSourceImage(TestProject project)
+		{
+			var newest = DateTime.UtcNow;
+
+			var intermediate = Path.Combine(project.PhysicalDirectory, "obj");
+			if (Directory.Exists(intermediate))
+			{
+				foreach (var written in Directory.EnumerateFiles(intermediate, "*", SearchOption.AllDirectories))
+				{
+					var time = File.GetLastWriteTimeUtc(written);
+					if (time > newest)
+						newest = time;
+				}
+			}
+
+			// Five seconds clears the two second granularity of the coarsest file systems.
+			File.SetLastWriteTimeUtc(Path.Combine(project.ImagesDirectory, ImageName), newest.AddSeconds(5));
+		}
+
 
 		TestProject CreateProject(bool throughLink, bool linkedIntermediateOutput = false, bool linkedImages = false)
 		{

--- a/src/SingleProject/Resizetizer/test/UnitTests/ResizetizeImagesIncrementalTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/ResizetizeImagesIncrementalTests.cs
@@ -184,6 +184,42 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			AssertGeneratedImageExists(project);
 		}
 
+		/// <summary>
+		/// The recursive wildcard that finds stale files walks through a directory link, so it can name a
+		/// file that is not really inside the intermediate folder. Deleting that would destroy the real
+		/// file rather than the link, so the cleanup has to leave it alone.
+		/// </summary>
+		[Fact]
+		public void CleanupNeverReachesThroughADirectoryLinkOutOfTheIntermediateFolder()
+		{
+			var project = CreateProject(throughLink: false);
+			if (project is null)
+				return;
+
+			Build(project);
+			AssertGeneratedImageExists(project);
+
+			var outside = Path.Combine(project.PhysicalDirectory, "outside");
+			Directory.CreateDirectory(outside);
+			var precious = Path.Combine(outside, "precious.png");
+			File.WriteAllText(precious, "not a build output");
+
+			var alias = Path.Combine(project.PhysicalDirectory, "obj", "resizetizer", "r", "alias");
+			if (!SymbolicLink.TryCreateDirectoryLink(alias, outside, out var error))
+			{
+				Output.WriteLine($"Skipping: symbolic links are not available on this machine: {error}");
+				return;
+			}
+
+			// Touch the source image so the target is not skipped as up to date.
+			File.SetLastWriteTimeUtc(Path.Combine(project.ImagesDirectory, ImageName), DateTime.UtcNow);
+
+			Build(project);
+
+			AssertGeneratedImageExists(project);
+			Assert.True(File.Exists(precious), $"Cleanup deleted a file outside the intermediate folder: {precious}");
+		}
+
 		void AssertGeneratedImageExists(TestProject project)
 		{
 			var image = Path.Combine(project.PhysicalDirectory, GeneratedImage);

--- a/src/SingleProject/Resizetizer/test/UnitTests/SymbolicLink.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/SymbolicLink.cs
@@ -9,11 +9,17 @@ namespace Microsoft.Maui.Resizetizer.Tests
 	/// </summary>
 	static class SymbolicLink
 	{
-		public static bool TryCreateDirectoryLink(string link, string target, out string error)
+		public static bool TryCreateDirectoryLink(string link, string target, out string error) =>
+			TryCreate(() => Directory.CreateSymbolicLink(link, target), out error);
+
+		public static bool TryCreateFileLink(string link, string target, out string error) =>
+			TryCreate(() => File.CreateSymbolicLink(link, target), out error);
+
+		static bool TryCreate(Action create, out string error)
 		{
 			try
 			{
-				Directory.CreateSymbolicLink(link, target);
+				create();
 				error = null;
 				return true;
 			}

--- a/src/SingleProject/Resizetizer/test/UnitTests/SymbolicLink.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/SymbolicLink.cs
@@ -1,0 +1,27 @@
+using System;
+using System.IO;
+
+namespace Microsoft.Maui.Resizetizer.Tests
+{
+	/// <summary>
+	/// Creating symbolic links needs Developer Mode or elevation on Windows, so tests that need one
+	/// have to be able to tell "not supported here" apart from a real failure.
+	/// </summary>
+	static class SymbolicLink
+	{
+		public static bool TryCreateDirectoryLink(string link, string target, out string error)
+		{
+			try
+			{
+				Directory.CreateSymbolicLink(link, target);
+				error = null;
+				return true;
+			}
+			catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+			{
+				error = ex.Message;
+				return false;
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

`ResizetizeImages` deletes every image it just generated when any segment of the project path is a symbolic link or junction. That is the normal shape of a macOS temp path (`/tmp` → `/private/tmp`, `/var/folders/…` → `/private/var/folders/…`), so **every build from a temp directory on macOS reproduces it** — which is how it was found while externalizing the Tizen build tasks.

#### Root cause

The stale-file step globbed the intermediate image folder and removed the task's `CopiedResources` from it:

```xml
<_ResizetizerExistingImages Include="$(_MauiIntermediateImages)\**\*" />
<_ResizetizerImagesToDelete Include="@(_ResizetizerExistingImages->'%(FullPath)')" />
<_ResizetizerImagesToDelete Remove="@(_ResizetizerCollectedImages)" />
```

The two lists reach the target through different code paths and, behind a link, spell the same file differently:

| | resolves against | result |
|---|---|---|
| `%(FullPath)` on the wildcard | `$(MSBuildProjectDirectory)` — **logical** | `/var/folders/…/r/drawable/camera.png` |
| `Path.GetFullPath` inside the task | process working directory, which Unix reports fully resolved — **physical** | `/private/var/folders/…/r/drawable/camera.png` |

`Remove` compares item specs textually, matched nothing, and `<Delete>` removed everything the task had just written. `$([System.IO.Path]::GetFullPath(…))` in the targets had the same problem, which is why the Tizen `TizenTpkSubDir` calculation used a third spelling.

#### Fix

* **`$(_MauiIntermediateImagesFullPath)`** roots the intermediate folder against `$(MSBuildProjectDirectory)` with `[MSBuild]::NormalizePath`, so the absolute paths the tasks emit match the ones MSBuild emits. It is passed to `ResizetizeImages` and now backs `ResizetizerIntermediateOutputAbsolutePath`, replacing `[System.IO.Path]::GetFullPath`.
* **`DetectStaleOutputFilesTask`** replaces the textual `Remove` and diffs on canonical paths. Returned items keep their original item spec and metadata, so user-facing paths are untouched.
* **`PathCanonicalizer`** resolves links for the segments of a path that exist and appends the ones that do not, so an output that has not been written yet can still be compared (a plain `realpath` would fail). It never throws and degrades to the lexical full path where link resolution is unavailable — e.g. MSBuild.exe on .NET Framework, which is today's behaviour.

#### Hardening from review

Three further issues were found in review, each reproduced first and each pinned by a mutation of the code that guards it:

1. **Deletes could escape the intermediate folder.** A recursive MSBuild wildcard walks *through* a directory link, so `**\*` can name a file that only appears to be inside `obj`, and `<Delete>` then removes the real file instead of the link. Verified directly — a glob over a folder containing a link to an outside directory deleted the outside file. The task now takes the intended `Root` and never reports anything whose resolved directory falls outside it. Removing that guard fails 3 tests, one of which drives the real target end to end.
2. **A stale alias of a live output survived forever.** Canonicalizing the whole path made a leftover `orphan.png` link pointing at the current `camera.png` compare equal to it, so it was kept — and on Android the whole intermediate tree is exposed via `LibraryResourceDirectories`, so a removed resource stayed visible. Only the **directory** is link resolved now; the file name is kept verbatim. Canonicalizing the leaf again fails 3 tests.
3. **The resolution cache could answer for the wrong directory.** It was keyed with the platform comparer, so on a case-sensitive volume two directories differing only by case shared an entry. Cache keys are exact spellings now; the case-insensitive comparer is used only for the final comparison.

Path comparison is case-insensitive everywhere except Linux. On a case-sensitive macOS volume that can only ever *keep* a stale file rather than delete a live one, and Resizetizer already rejects output names that differ only by case.

#### Hardening from the exact-head security review (`a5912e9f`)

Two further ways the guard could delete a file **outside** the intermediate folder were found and fixed. Each was reproduced first and is pinned by a mutation of the code that enforces it.

**1. Containment was case insensitive off Linux.** Reproduced end to end on a case-sensitive APFS volume: with root `…/resizetizer/r`, a sibling `…/resizetizer/R/deep`, and a link `r/alias3 -> R/deep`, the build **deleted `R/deep/secret.png`** — never inside the root. A recursive MSBuild wildcard really does surface these: its own cycle detection compares paths case insensitively, so it walks into the sibling believing it is still under the root.

`IsUnder` is now **case sensitive on every platform**. It decides whether a file may be deleted, so it fails closed — stricter than the volume only ever leaves a stale file behind, looser deletes someone else's file. The keep set stays case insensitive off Linux, where a false match also just keeps a file. The self-comparison in link resolution is ordinal too, so a link `…/r -> …/R` is no longer mistaken for a self-link and left unresolved.

**2. Link resolution silently degraded to lexical spelling** on hosts without `Directory.ResolveLinkTarget` — every .NET Framework host, including `MSBuild.exe`. A junction under the intermediate folder was treated as an ordinary directory and everything behind it looked contained. Detecting a reparse point does **not** need that API, so the canonicalizer now checks `FileAttributes.ReparsePoint` (available everywhere) and reports the path as **unresolvable** when it cannot follow one; unresolvable paths are never reported stale. Directories that are not links are unaffected, so cleanup still works normally on those hosts. The fallback is exercised by constructing the canonicalizer and the task with link resolution turned off, rather than only relying on the .NET 11 default.

**3. Incremental-test timestamp flakiness** (also from review): the tests touched the source with `DateTime.UtcNow` only ~100 ms after the build wrote its stamp, so a 1–2 s resolution filesystem rounds both into the same value, MSBuild treats the input as not newer and skips the target. Confirmed by forcing the timestamps equal, which makes MSBuild log `Skipping target`. The source is now stamped newer than the newest file the previous build wrote.

Verified on the case-sensitive volume with the final code: outside-root file survives, genuine stale file is still cleaned, generated image survives. Mutations: case-insensitive containment fails **4** tests, lexical link fallback fails **3** — all of which run on Windows and macOS. Full suite: **748 passed**.

CI note: the `RunOnAndroid` leg on the previous head hit the 1800 s `DEFAULT_TIMEOUT` during template install (exit `-1`, which `ToolRunner` sets only on timeout) and then crashed parsing an incomplete binlog. Unrelated to this change; the app compiled and the other 10 Android builds in the same leg passed.

### Issues Fixed

Fixes the Resizetizer path-normalization bug found while externalizing the Tizen `Build.Tasks`. Downstream, `Maui.Tizen` can drop the workaround that canonicalizes the generated test project / intermediate directory (a `realpath`-style resolution of the `Path.GetTempPath()` root) before invoking the build.

### Validation

* **`ResizetizeImagesIncrementalTests`** — runs the **real** `ResizetizeImages` target through MSBuild. Covers first build, no-op rebuild (asserting the target is actually skipped), source-image change, deleted output, stale-file cleanup and `_CleanResizetizer` + rebuild, each as a `[Theory]` over an ordinary and a symlinked project directory; plus a symlinked **intermediate output** directory, symlinked **input images**, and the directory-link escape case. **15/15 fail against the original targets, 15/15 pass with these.**
* **`PathCanonicalizerTests`** — linked vs physical equivalence, chained links, idempotence, not-yet-created files, bare roots, relative paths, redundant segments and trailing separators, invalid input, leaf links keeping their own key, `IsUnder` containment and sibling rejection, per-platform comparer, Windows drive/separator handling, Windows **junctions** (created through `DeviceIoControl`, skipped where unavailable), and case-sensitive cache separation.
* **`DetectStaleOutputFilesTaskTests`** — linked directories, metadata preservation, verbatim item specs, subset invariant, root containment, stale aliases, unresolvable root, and that genuinely stale files are still deleted.
* **Mutation-tested**: disabling cleanup fails 10 tests; returning canonical instead of original specs fails 8; removing the containment guard fails 3; resolving the leaf fails 3.
* Full `Resizetizer.UnitTests`: **738 passed, 0 failed**. `dotnet format` clean. Tizen `TizenTpkSubDir` verified as `res/` under symlinked paths and paths containing spaces.

