### PR TITLE
[net11.0] Make LongPressGestureRecognizer dispatch API public for platform backends

### DIFF
--- a/docs/design/GestureDispatchForPlatformBackends.md
+++ b/docs/design/GestureDispatchForPlatformBackends.md
@@ -1,0 +1,125 @@
+# Gesture dispatch for external platform backends
+
+.NET MAUI ships gesture *recognizers* (`TapGestureRecognizer`, `PointerGestureRecognizer`,
+`LongPressGestureRecognizer`, …) in `Microsoft.Maui.Controls`, and gesture *detection* in the
+per-platform gesture managers under `src/Controls/src/Core/Platform`.
+
+Out-of-tree platform backends — for example [`Maui.Tizen`](https://github.com/Redth/Maui.Tizen) —
+implement their own detection layer and need to raise the recognizer's events. To make that
+possible, each recognizer exposes an infrastructure dispatch surface: `public` methods annotated
+with `[EditorBrowsable(EditorBrowsableState.Never)]` so they are reachable from any assembly but
+stay out of IntelliSense for app authors.
+
+| Recognizer | Dispatch API |
+| ---------- | ------------ |
+| `TapGestureRecognizer` | `SendTapped(View sender, Func<IElement?, Point?>? getPosition = null)` |
+| `PointerGestureRecognizer` | `SendPointerEntered` / `SendPointerExited` / `SendPointerMoved` / `SendPointerPressed` / `SendPointerReleased` |
+| `LongPressGestureRecognizer` | `SendLongPressing(View sender, GestureStatus status, Func<IElement?, Point?>? getPosition = null)` and `SendLongPressed(View sender, Func<IElement?, Point?>? getPosition = null)` |
+| `DragGestureRecognizer` | `SendDragStarting` / `SendDropCompleted` |
+| `DropGestureRecognizer` | `SendDragLeave` / `SendDrop` |
+
+## Rules that apply to every dispatch method
+
+- **`sender` must not be `null`.** Each method throws `ArgumentNullException`; pass the `View` the
+  gesture was detected on.
+- **Call on the UI thread.** Dispatch runs user event handlers and commands synchronously, and it
+  writes bindable properties. Marshal to the dispatcher before calling.
+- **`getPosition` is optional.** Pass `null` when the platform cannot supply a location. Otherwise
+  supply a callback that returns the gesture location *relative to the element passed in*, and the
+  location relative to `sender` when the argument is `null` or is `sender` itself. The callback is
+  invoked lazily by the event args, so keep it cheap and avoid capturing strong references to
+  platform views that may already be disposed.
+- **Only dispatch to recognizers attached to the view.** Enumerate
+  `view.GestureRecognizers.OfType<TRecognizer>()` and honor recognizer configuration such as
+  `NumberOfTouchesRequired`.
+
+## `LongPressGestureRecognizer` contract
+
+`LongPressGestureRecognizer` has two channels:
+
+- `SendLongPressing` sets `LongPressGestureRecognizer.State` and raises `LongPressing` with a
+  `GestureStatus`. It is the state machine.
+- `SendLongPressed` executes `Command` (when `Command.CanExecute(CommandParameter)` is `true`) and
+  raises `LongPressed`. It is the "the long press succeeded" notification and carries
+  `CommandParameter` on the event args.
+
+Backends should follow the same ordering the in-box platforms use:
+
+| Platform signal | Calls |
+| --------------- | ----- |
+| Press recognized | `SendLongPressing(view, GestureStatus.Started, getPosition)` |
+| Press held / moved within `AllowableMovement` | `SendLongPressing(view, GestureStatus.Running, getPosition)` |
+| Press released after the minimum duration | `SendLongPressed(view, getPosition)` **then** `SendLongPressing(view, GestureStatus.Completed, getPosition)` |
+| Press cancelled or failed | `SendLongPressing(view, GestureStatus.Canceled, getPosition)` |
+
+Notes:
+
+- `SendLongPressed` is raised **before** `Completed` so handlers observing `LongPressed` see the
+  gesture result before the terminal state change.
+- A cancelled gesture must **not** raise `LongPressed` and must **not** execute `Command`.
+- `Started`/`Running` are optional for platforms that only surface a single "long press happened"
+  callback. Android and Windows go straight to `SendLongPressed` + `Completed`.
+- `MinimumPressDuration`, `NumberOfTouchesRequired`, and `AllowableMovement` are *inputs* for the
+  backend's detector. MAUI does not enforce them; the backend decides which of them the platform can
+  honor and documents the gaps.
+
+### Example backend
+
+```csharp
+using System;
+using System.Linq;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+
+public sealed class MyPlatformLongPressHandler
+{
+    readonly View _view;
+
+    public MyPlatformLongPressHandler(View view) => _view = view;
+
+    Func<IElement?, Point?> GetPosition(Point origin) =>
+        relativeTo => relativeTo is null || ReferenceEquals(relativeTo, _view)
+            ? origin
+            : TranslateToElement(origin, relativeTo);
+
+    void OnPlatformLongPress(PlatformLongPressArgs e)
+    {
+        var position = GetPosition(new Point(e.X, e.Y));
+
+        foreach (var recognizer in _view.GestureRecognizers
+                     .OfType<LongPressGestureRecognizer>()
+                     .Where(r => r.NumberOfTouchesRequired == e.TouchCount))
+        {
+            switch (e.State)
+            {
+                case PlatformGestureState.Began:
+                    recognizer.SendLongPressing(_view, GestureStatus.Started, position);
+                    break;
+                case PlatformGestureState.Changed:
+                    recognizer.SendLongPressing(_view, GestureStatus.Running, position);
+                    break;
+                case PlatformGestureState.Ended:
+                    recognizer.SendLongPressed(_view, position);
+                    recognizer.SendLongPressing(_view, GestureStatus.Completed, position);
+                    break;
+                case PlatformGestureState.Cancelled:
+                case PlatformGestureState.Failed:
+                    recognizer.SendLongPressing(_view, GestureStatus.Canceled, position);
+                    break;
+            }
+        }
+    }
+}
+```
+
+## Keeping the contract honest
+
+`src/Controls/tests/ExternalGestureBackend` is a test-support assembly that is deliberately **not**
+listed in `Microsoft.Maui.Controls`'s `InternalsVisibleTo` set. It contains a fake backend that
+drives `LongPressGestureRecognizer` purely through the public dispatch API, so demoting any of these
+methods back to `internal` breaks the build. `LongPressGestureRecognizerExternalBackendTests` in
+`Controls.Core.UnitTests` exercises that fake backend across the full
+`Started` → `Running` → `Completed` / `Canceled` lifecycle.
+
+Add the same coverage whenever a new recognizer gains a dispatch API.

--- a/src/Controls/src/Core/LongPressGestureRecognizer.cs
+++ b/src/Controls/src/Core/LongPressGestureRecognizer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.Windows.Input;
 using Microsoft.Maui.Graphics;
 
@@ -120,10 +121,22 @@ namespace Microsoft.Maui.Controls
 		public event EventHandler<LongPressingEventArgs>? LongPressing;
 
 		/// <summary>
-		/// Sends the long pressed event and executes the command.
+		/// Executes the associated <see cref="Command"/> and raises the <see cref="LongPressed"/> event.
 		/// </summary>
-		internal void SendLongPressed(View sender, Func<IElement?, Point?>? getPosition = null)
+		/// <param name="sender">The view on which the long press gesture was recognized.</param>
+		/// <param name="getPosition">A function that returns the long press position relative to a specified element.</param>
+		/// <remarks>
+		/// <para>This infrastructure method is intended for gesture platform managers.</para>
+		/// <para>Platform backends should raise this when the press completes successfully, immediately
+		/// followed by <see cref="SendLongPressing(View, GestureStatus, Func{IElement, Point?})"/> with
+		/// <see cref="GestureStatus.Completed"/>. It must be called on the UI thread.</para>
+		/// </remarks>
+		/// <exception cref="ArgumentNullException"><paramref name="sender"/> is <see langword="null"/>.</exception>
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendLongPressed(View sender, Func<IElement?, Point?>? getPosition = null)
 		{
+			_ = sender ?? throw new ArgumentNullException(nameof(sender));
+
 			var cmd = Command;
 			if (cmd != null && cmd.CanExecute(CommandParameter))
 				cmd.Execute(CommandParameter);
@@ -132,10 +145,24 @@ namespace Microsoft.Maui.Controls
 		}
 
 		/// <summary>
-		/// Sends the long pressing event with state information.
+		/// Updates <see cref="State"/> and raises the <see cref="LongPressing"/> event.
 		/// </summary>
-		internal void SendLongPressing(View sender, GestureStatus status, Func<IElement?, Point?>? getPosition = null)
+		/// <param name="sender">The view on which the long press gesture is being recognized.</param>
+		/// <param name="status">The current status of the gesture.</param>
+		/// <param name="getPosition">A function that returns the long press position relative to a specified element.</param>
+		/// <remarks>
+		/// <para>This infrastructure method is intended for gesture platform managers.</para>
+		/// <para>Platform backends should raise <see cref="GestureStatus.Started"/> once the press is
+		/// recognized, <see cref="GestureStatus.Running"/> while it is held, and finish with either
+		/// <see cref="GestureStatus.Completed"/> or <see cref="GestureStatus.Canceled"/>. It must be
+		/// called on the UI thread.</para>
+		/// </remarks>
+		/// <exception cref="ArgumentNullException"><paramref name="sender"/> is <see langword="null"/>.</exception>
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendLongPressing(View sender, GestureStatus status, Func<IElement?, Point?>? getPosition = null)
 		{
+			_ = sender ?? throw new ArgumentNullException(nameof(sender));
+
 			State = status;
 			LongPressing?.Invoke(sender, new LongPressingEventArgs(status, getPosition));
 		}

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -52,6 +52,8 @@ Microsoft.Maui.Controls.LongPressGestureRecognizer.MinimumPressDuration.get -> i
 Microsoft.Maui.Controls.LongPressGestureRecognizer.MinimumPressDuration.set -> void
 Microsoft.Maui.Controls.LongPressGestureRecognizer.NumberOfTouchesRequired.get -> int
 Microsoft.Maui.Controls.LongPressGestureRecognizer.NumberOfTouchesRequired.set -> void
+Microsoft.Maui.Controls.LongPressGestureRecognizer.SendLongPressed(Microsoft.Maui.Controls.View! sender, System.Func<Microsoft.Maui.IElement?, Microsoft.Maui.Graphics.Point?>? getPosition = null) -> void
+Microsoft.Maui.Controls.LongPressGestureRecognizer.SendLongPressing(Microsoft.Maui.Controls.View! sender, Microsoft.Maui.GestureStatus status, System.Func<Microsoft.Maui.IElement?, Microsoft.Maui.Graphics.Point?>? getPosition = null) -> void
 Microsoft.Maui.Controls.LongPressGestureRecognizer.State.get -> Microsoft.Maui.GestureStatus
 Microsoft.Maui.Controls.LongPressedEventArgs
 Microsoft.Maui.Controls.LongPressedEventArgs.LongPressedEventArgs(object? parameter) -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -32,6 +32,8 @@ Microsoft.Maui.Controls.LongPressGestureRecognizer.MinimumPressDuration.get -> i
 Microsoft.Maui.Controls.LongPressGestureRecognizer.MinimumPressDuration.set -> void
 Microsoft.Maui.Controls.LongPressGestureRecognizer.NumberOfTouchesRequired.get -> int
 Microsoft.Maui.Controls.LongPressGestureRecognizer.NumberOfTouchesRequired.set -> void
+Microsoft.Maui.Controls.LongPressGestureRecognizer.SendLongPressed(Microsoft.Maui.Controls.View! sender, System.Func<Microsoft.Maui.IElement?, Microsoft.Maui.Graphics.Point?>? getPosition = null) -> void
+Microsoft.Maui.Controls.LongPressGestureRecognizer.SendLongPressing(Microsoft.Maui.Controls.View! sender, Microsoft.Maui.GestureStatus status, System.Func<Microsoft.Maui.IElement?, Microsoft.Maui.Graphics.Point?>? getPosition = null) -> void
 Microsoft.Maui.Controls.LongPressGestureRecognizer.State.get -> Microsoft.Maui.GestureStatus
 Microsoft.Maui.Controls.LongPressedEventArgs
 Microsoft.Maui.Controls.LongPressedEventArgs.LongPressedEventArgs(object? parameter) -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -32,6 +32,8 @@ Microsoft.Maui.Controls.LongPressGestureRecognizer.MinimumPressDuration.get -> i
 Microsoft.Maui.Controls.LongPressGestureRecognizer.MinimumPressDuration.set -> void
 Microsoft.Maui.Controls.LongPressGestureRecognizer.NumberOfTouchesRequired.get -> int
 Microsoft.Maui.Controls.LongPressGestureRecognizer.NumberOfTouchesRequired.set -> void
+Microsoft.Maui.Controls.LongPressGestureRecognizer.SendLongPressed(Microsoft.Maui.Controls.View! sender, System.Func<Microsoft.Maui.IElement?, Microsoft.Maui.Graphics.Point?>? getPosition = null) -> void
+Microsoft.Maui.Controls.LongPressGestureRecognizer.SendLongPressing(Microsoft.Maui.Controls.View! sender, Microsoft.Maui.GestureStatus status, System.Func<Microsoft.Maui.IElement?, Microsoft.Maui.Graphics.Point?>? getPosition = null) -> void
 Microsoft.Maui.Controls.LongPressGestureRecognizer.State.get -> Microsoft.Maui.GestureStatus
 Microsoft.Maui.Controls.LongPressedEventArgs
 Microsoft.Maui.Controls.LongPressedEventArgs.LongPressedEventArgs(object? parameter) -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -44,6 +44,8 @@ Microsoft.Maui.Controls.LongPressGestureRecognizer.MinimumPressDuration.get -> i
 Microsoft.Maui.Controls.LongPressGestureRecognizer.MinimumPressDuration.set -> void
 Microsoft.Maui.Controls.LongPressGestureRecognizer.NumberOfTouchesRequired.get -> int
 Microsoft.Maui.Controls.LongPressGestureRecognizer.NumberOfTouchesRequired.set -> void
+Microsoft.Maui.Controls.LongPressGestureRecognizer.SendLongPressed(Microsoft.Maui.Controls.View! sender, System.Func<Microsoft.Maui.IElement?, Microsoft.Maui.Graphics.Point?>? getPosition = null) -> void
+Microsoft.Maui.Controls.LongPressGestureRecognizer.SendLongPressing(Microsoft.Maui.Controls.View! sender, Microsoft.Maui.GestureStatus status, System.Func<Microsoft.Maui.IElement?, Microsoft.Maui.Graphics.Point?>? getPosition = null) -> void
 Microsoft.Maui.Controls.LongPressGestureRecognizer.State.get -> Microsoft.Maui.GestureStatus
 Microsoft.Maui.Controls.LongPressedEventArgs
 Microsoft.Maui.Controls.LongPressedEventArgs.LongPressedEventArgs(object? parameter) -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -40,6 +40,8 @@ Microsoft.Maui.Controls.LongPressGestureRecognizer.MinimumPressDuration.get -> i
 Microsoft.Maui.Controls.LongPressGestureRecognizer.MinimumPressDuration.set -> void
 Microsoft.Maui.Controls.LongPressGestureRecognizer.NumberOfTouchesRequired.get -> int
 Microsoft.Maui.Controls.LongPressGestureRecognizer.NumberOfTouchesRequired.set -> void
+Microsoft.Maui.Controls.LongPressGestureRecognizer.SendLongPressed(Microsoft.Maui.Controls.View! sender, System.Func<Microsoft.Maui.IElement?, Microsoft.Maui.Graphics.Point?>? getPosition = null) -> void
+Microsoft.Maui.Controls.LongPressGestureRecognizer.SendLongPressing(Microsoft.Maui.Controls.View! sender, Microsoft.Maui.GestureStatus status, System.Func<Microsoft.Maui.IElement?, Microsoft.Maui.Graphics.Point?>? getPosition = null) -> void
 Microsoft.Maui.Controls.LongPressGestureRecognizer.State.get -> Microsoft.Maui.GestureStatus
 Microsoft.Maui.Controls.LongPressedEventArgs
 Microsoft.Maui.Controls.LongPressedEventArgs.LongPressedEventArgs(object? parameter) -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -61,6 +61,8 @@ Microsoft.Maui.Controls.LongPressGestureRecognizer.MinimumPressDuration.get -> i
 Microsoft.Maui.Controls.LongPressGestureRecognizer.MinimumPressDuration.set -> void
 Microsoft.Maui.Controls.LongPressGestureRecognizer.NumberOfTouchesRequired.get -> int
 Microsoft.Maui.Controls.LongPressGestureRecognizer.NumberOfTouchesRequired.set -> void
+Microsoft.Maui.Controls.LongPressGestureRecognizer.SendLongPressed(Microsoft.Maui.Controls.View! sender, System.Func<Microsoft.Maui.IElement?, Microsoft.Maui.Graphics.Point?>? getPosition = null) -> void
+Microsoft.Maui.Controls.LongPressGestureRecognizer.SendLongPressing(Microsoft.Maui.Controls.View! sender, Microsoft.Maui.GestureStatus status, System.Func<Microsoft.Maui.IElement?, Microsoft.Maui.Graphics.Point?>? getPosition = null) -> void
 Microsoft.Maui.Controls.LongPressGestureRecognizer.State.get -> Microsoft.Maui.GestureStatus
 Microsoft.Maui.Controls.LongPressedEventArgs
 Microsoft.Maui.Controls.LongPressedEventArgs.LongPressedEventArgs(object? parameter) -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -52,6 +52,8 @@ Microsoft.Maui.Controls.LongPressGestureRecognizer.MinimumPressDuration.get -> i
 Microsoft.Maui.Controls.LongPressGestureRecognizer.MinimumPressDuration.set -> void
 Microsoft.Maui.Controls.LongPressGestureRecognizer.NumberOfTouchesRequired.get -> int
 Microsoft.Maui.Controls.LongPressGestureRecognizer.NumberOfTouchesRequired.set -> void
+Microsoft.Maui.Controls.LongPressGestureRecognizer.SendLongPressed(Microsoft.Maui.Controls.View! sender, System.Func<Microsoft.Maui.IElement?, Microsoft.Maui.Graphics.Point?>? getPosition = null) -> void
+Microsoft.Maui.Controls.LongPressGestureRecognizer.SendLongPressing(Microsoft.Maui.Controls.View! sender, Microsoft.Maui.GestureStatus status, System.Func<Microsoft.Maui.IElement?, Microsoft.Maui.Graphics.Point?>? getPosition = null) -> void
 Microsoft.Maui.Controls.LongPressGestureRecognizer.State.get -> Microsoft.Maui.GestureStatus
 Microsoft.Maui.Controls.LongPressedEventArgs
 Microsoft.Maui.Controls.LongPressedEventArgs.LongPressedEventArgs(object? parameter) -> void

--- a/src/Controls/tests/Core.UnitTests/Controls.Core.UnitTests.csproj
+++ b/src/Controls/tests/Core.UnitTests/Controls.Core.UnitTests.csproj
@@ -19,6 +19,7 @@
     <ProjectReference Include="..\..\..\Controls\Maps\src\Controls.Maps.csproj" />
     <ProjectReference Include="..\..\..\Controls\src\Core\Controls.Core.csproj" />
     <ProjectReference Include="..\..\..\Controls\src\Xaml\Controls.Xaml.csproj" />
+    <ProjectReference Include="..\..\..\Controls\tests\ExternalGestureBackend\Controls.Tests.ExternalGestureBackend.csproj" />
     <ProjectReference Include="..\..\..\Core\maps\src\Maps.csproj" />
     <ProjectReference Include="..\..\..\Core\src\Core.csproj" />
     <ProjectReference Include="..\..\..\Essentials\src\Essentials.csproj" />

--- a/src/Controls/tests/Core.UnitTests/Gestures/LongPressGestureRecognizerExternalBackendTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Gestures/LongPressGestureRecognizerExternalBackendTests.cs
@@ -1,0 +1,221 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Maui.Controls.Tests.ExternalGestureBackend;
+using Microsoft.Maui.Graphics;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	/// <summary>
+	/// Verifies that a platform backend living in a third-party assembly (one that is not on
+	/// <c>Microsoft.Maui.Controls</c>'s <c>InternalsVisibleTo</c> list) can drive
+	/// <see cref="LongPressGestureRecognizer"/> end to end, exactly like the public tap and pointer
+	/// dispatch APIs allow today.
+	/// </summary>
+	/// <remarks>
+	/// <see cref="FakeLongPressGestureBackend"/> is compiled into
+	/// <c>Microsoft.Maui.Controls.Tests.ExternalGestureBackend</c>. The mere fact that it builds proves
+	/// the dispatch contract is reachable from outside the framework; demoting the <c>Send*</c> methods
+	/// back to <see langword="internal"/> breaks that project's compilation.
+	/// </remarks>
+	public class LongPressGestureRecognizerExternalBackendTests : BaseTestFixture
+	{
+		static (View View, LongPressGestureRecognizer Recognizer, FakeLongPressGestureBackend Backend) CreateBackend()
+		{
+			var view = new View();
+			var recognizer = new LongPressGestureRecognizer();
+			view.GestureRecognizers.Add(recognizer);
+
+			return (view, recognizer, new FakeLongPressGestureBackend(view));
+		}
+
+		[Fact]
+		public void DispatchMethodsArePubliclyAccessible()
+		{
+			var type = typeof(LongPressGestureRecognizer);
+
+			foreach (var name in new[] { nameof(LongPressGestureRecognizer.SendLongPressed), nameof(LongPressGestureRecognizer.SendLongPressing) })
+			{
+				var method = type.GetMethod(name, BindingFlags.Public | BindingFlags.Instance);
+
+				Assert.NotNull(method);
+				Assert.True(method!.IsPublic);
+
+				// Infrastructure API: reachable by backends but hidden from IntelliSense, matching
+				// TapGestureRecognizer.SendTapped and PointerGestureRecognizer.Send*.
+				var browsable = method.GetCustomAttribute<EditorBrowsableAttribute>();
+				Assert.NotNull(browsable);
+				Assert.Equal(EditorBrowsableState.Never, browsable!.State);
+			}
+		}
+
+		[Fact]
+		public void ExternalBackendRaisesFullGestureLifecycle()
+		{
+			var (_, recognizer, backend) = CreateBackend();
+			var states = new List<GestureStatus>();
+			var pressedCount = 0;
+
+			recognizer.LongPressing += (_, args) => states.Add(args.Status);
+			recognizer.LongPressed += (_, _) => pressedCount++;
+
+			backend.RaisePressStarted(new Point(5, 5));
+			Assert.Equal(GestureStatus.Started, recognizer.State);
+
+			backend.RaisePressMoved(new Point(6, 6));
+			Assert.Equal(GestureStatus.Running, recognizer.State);
+
+			backend.RaisePressCompleted();
+
+			Assert.Equal(new[] { GestureStatus.Started, GestureStatus.Running, GestureStatus.Completed }, states);
+			Assert.Equal(1, pressedCount);
+			Assert.Equal(GestureStatus.Completed, recognizer.State);
+		}
+
+		[Fact]
+		public void ExternalBackendRaisesLongPressedBeforeCompleted()
+		{
+			var (_, recognizer, backend) = CreateBackend();
+
+			var sequence = new List<string>();
+			recognizer.LongPressed += (_, _) => sequence.Add("pressed");
+			recognizer.LongPressing += (_, args) => sequence.Add(args.Status.ToString());
+
+			backend.RaisePressStarted(Point.Zero);
+			backend.RaisePressCompleted();
+
+			Assert.Equal(new[] { "Started", "pressed", "Completed" }, sequence);
+		}
+
+		[Fact]
+		public void ExternalBackendCancelDoesNotRaiseLongPressedOrCommand()
+		{
+			var (_, recognizer, backend) = CreateBackend();
+
+			var commandInvoked = false;
+			var pressedRaised = false;
+			recognizer.Command = new Command(() => commandInvoked = true);
+			recognizer.LongPressed += (_, _) => pressedRaised = true;
+
+			backend.RaisePressStarted(Point.Zero);
+			backend.RaisePressCanceled();
+
+			Assert.False(pressedRaised);
+			Assert.False(commandInvoked);
+			Assert.Equal(GestureStatus.Canceled, recognizer.State);
+		}
+
+		[Fact]
+		public void ExternalBackendCancelsWhenMovementExceedsAllowableMovement()
+		{
+			var (_, recognizer, backend) = CreateBackend();
+			recognizer.AllowableMovement = 5;
+
+			var states = new List<GestureStatus>();
+			recognizer.LongPressing += (_, args) => states.Add(args.Status);
+
+			backend.RaisePressStarted(Point.Zero);
+			backend.RaisePressMoved(new Point(100, 100));
+
+			Assert.Equal(new[] { GestureStatus.Started, GestureStatus.Canceled }, states);
+			Assert.Empty(backend.ActiveRecognizers);
+		}
+
+		[Fact]
+		public void ExternalBackendExecutesCommandWithParameter()
+		{
+			var (_, recognizer, backend) = CreateBackend();
+
+			object? received = null;
+			recognizer.CommandParameter = "tizen";
+			recognizer.Command = new Command(parameter => received = parameter);
+
+			backend.RaisePressStarted(Point.Zero);
+			backend.RaisePressCompleted();
+
+			Assert.Equal("tizen", received);
+		}
+
+		[Fact]
+		public void ExternalBackendRespectsCanExecute()
+		{
+			var (_, recognizer, backend) = CreateBackend();
+
+			var commandInvoked = false;
+			recognizer.Command = new Command(() => commandInvoked = true, () => false);
+
+			backend.RaisePressStarted(Point.Zero);
+			backend.RaisePressCompleted();
+
+			Assert.False(commandInvoked);
+		}
+
+		[Fact]
+		public void ExternalBackendPassesSenderAndPositionCallback()
+		{
+			var (view, recognizer, backend) = CreateBackend();
+			var relativeElement = new View();
+
+			object? pressedSender = null;
+			Point? positionInView = null;
+			Point? positionRelativeToOther = null;
+
+			recognizer.LongPressed += (sender, args) =>
+			{
+				pressedSender = sender;
+				positionInView = args.GetPosition(view);
+				positionRelativeToOther = args.GetPosition(relativeElement);
+			};
+
+			backend.RaisePressStarted(new Point(12, 34));
+			backend.RaisePressCompleted();
+
+			Assert.Same(view, pressedSender);
+			Assert.Equal(new Point(12, 34), positionInView);
+			Assert.Equal(
+				new Point(12 + FakeLongPressGestureBackend.RelativeElementOffset.X, 34 + FakeLongPressGestureBackend.RelativeElementOffset.Y),
+				positionRelativeToOther);
+		}
+
+		[Fact]
+		public void ExternalBackendOnlyDispatchesToRecognizersMatchingTouchCount()
+		{
+			var view = new View();
+			var oneTouch = new LongPressGestureRecognizer { NumberOfTouchesRequired = 1 };
+			var twoTouch = new LongPressGestureRecognizer { NumberOfTouchesRequired = 2 };
+			view.GestureRecognizers.Add(oneTouch);
+			view.GestureRecognizers.Add(twoTouch);
+
+			var oneTouchPressed = false;
+			var twoTouchPressed = false;
+			oneTouch.LongPressed += (_, _) => oneTouchPressed = true;
+			twoTouch.LongPressed += (_, _) => twoTouchPressed = true;
+
+			var backend = new FakeLongPressGestureBackend(view) { TouchCount = 2 };
+			backend.RaisePressStarted(Point.Zero);
+			backend.RaisePressCompleted();
+
+			Assert.False(oneTouchPressed);
+			Assert.True(twoTouchPressed);
+		}
+
+		[Fact]
+		public void ExternalBackendDispatchesToEveryMatchingRecognizerOnTheView()
+		{
+			var view = new View();
+			var recognizers = Enumerable.Range(0, 3).Select(_ => new LongPressGestureRecognizer()).ToList();
+			foreach (var recognizer in recognizers)
+				view.GestureRecognizers.Add(recognizer);
+
+			var backend = new FakeLongPressGestureBackend(view);
+			backend.RaisePressStarted(Point.Zero);
+			backend.RaisePressCompleted();
+
+			Assert.All(recognizers, recognizer => Assert.Equal(GestureStatus.Completed, recognizer.State));
+		}
+	}
+}

--- a/src/Controls/tests/Core.UnitTests/Gestures/LongPressGestureRecognizerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Gestures/LongPressGestureRecognizerTests.cs
@@ -184,6 +184,22 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public void SendLongPressed_ThrowsForNullSender()
+		{
+			var longPress = new LongPressGestureRecognizer();
+
+			Assert.Throws<ArgumentNullException>(() => longPress.SendLongPressed(null));
+		}
+
+		[Fact]
+		public void SendLongPressing_ThrowsForNullSender()
+		{
+			var longPress = new LongPressGestureRecognizer();
+
+			Assert.Throws<ArgumentNullException>(() => longPress.SendLongPressing(null, GestureStatus.Started));
+		}
+
+		[Fact]
 		public void PropertyChanged_RaisesCorrectly()
 		{
 			var longPress = new LongPressGestureRecognizer();
@@ -242,8 +258,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public void State_IsOneWayToSource()
 		{
 			var longPress = new LongPressGestureRecognizer();
-			
-			// State should only be set internally via SendLongPressing
+
+			// State is only updated through SendLongPressing
 			// Verify it has OneWayToSource binding mode by checking the property
 			var stateProperty = LongPressGestureRecognizer.StateProperty;
 			Assert.Equal(BindingMode.OneWayToSource, stateProperty.DefaultBindingMode);

--- a/src/Controls/tests/ExternalGestureBackend/Controls.Tests.ExternalGestureBackend.csproj
+++ b/src/Controls/tests/ExternalGestureBackend/Controls.Tests.ExternalGestureBackend.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(_MauiDotNetTfm)</TargetFramework>
+    <!--
+      This assembly deliberately does NOT appear in Controls.Core's InternalsVisibleTo list.
+      It stands in for a third-party platform backend (for example Maui.Tizen) and therefore
+      can only compile against the *public* gesture dispatch surface. If a Send* method that
+      backends rely on is demoted back to internal, this project fails to build with CS0122.
+    -->
+    <AssemblyName>Microsoft.Maui.Controls.Tests.ExternalGestureBackend</AssemblyName>
+    <RootNamespace>Microsoft.Maui.Controls.Tests.ExternalGestureBackend</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Controls\src\Core\Controls.Core.csproj" />
+    <ProjectReference Include="..\..\..\Core\src\Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Controls/tests/ExternalGestureBackend/FakeLongPressGestureBackend.cs
+++ b/src/Controls/tests/ExternalGestureBackend/FakeLongPressGestureBackend.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Maui.Graphics;
+
+namespace Microsoft.Maui.Controls.Tests.ExternalGestureBackend
+{
+	/// <summary>
+	/// Stands in for a third-party platform backend (for example <c>Maui.Tizen</c>) that detects long
+	/// presses natively and forwards them to <see cref="LongPressGestureRecognizer"/>.
+	/// </summary>
+	/// <remarks>
+	/// This type lives in an assembly that is intentionally excluded from
+	/// <c>Microsoft.Maui.Controls</c>'s <c>InternalsVisibleTo</c> list, so it can only compile against
+	/// the public gesture dispatch surface. It exists to guarantee that external backends can raise
+	/// long press gestures without reflection or internal access.
+	/// </remarks>
+	public sealed class FakeLongPressGestureBackend
+	{
+		/// <summary>
+		/// Offset applied when a caller asks for a position relative to an element other than the
+		/// pressed view, so tests can distinguish the two code paths.
+		/// </summary>
+		public static readonly Point RelativeElementOffset = new Point(100, 200);
+
+		readonly View _view;
+		readonly List<LongPressGestureRecognizer> _active = new();
+
+		Point _origin;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="FakeLongPressGestureBackend"/> class.
+		/// </summary>
+		/// <param name="view">The view the platform backend is attached to.</param>
+		public FakeLongPressGestureBackend(View view)
+		{
+			_view = view ?? throw new ArgumentNullException(nameof(view));
+		}
+
+		/// <summary>
+		/// Gets or sets the number of touches the simulated platform gesture is tracking.
+		/// Only recognizers whose <see cref="LongPressGestureRecognizer.NumberOfTouchesRequired"/>
+		/// matches this value participate in the gesture.
+		/// </summary>
+		public int TouchCount { get; set; } = 1;
+
+		/// <summary>
+		/// Gets the recognizers that are currently tracking the in-flight gesture.
+		/// </summary>
+		public IReadOnlyList<LongPressGestureRecognizer> ActiveRecognizers => _active;
+
+		/// <summary>
+		/// Raises <see cref="GestureStatus.Started"/> for every matching recognizer on the view.
+		/// </summary>
+		/// <param name="origin">The press location relative to the pressed view.</param>
+		public void RaisePressStarted(Point origin)
+		{
+			_origin = origin;
+			_active.Clear();
+			_active.AddRange(_view.GestureRecognizers
+				.OfType<LongPressGestureRecognizer>()
+				.Where(recognizer => recognizer.NumberOfTouchesRequired == TouchCount));
+
+			foreach (var recognizer in _active)
+				recognizer.SendLongPressing(_view, GestureStatus.Started, GetPosition(origin));
+		}
+
+		/// <summary>
+		/// Raises <see cref="GestureStatus.Running"/> while the press is held, cancelling any
+		/// recognizer whose <see cref="LongPressGestureRecognizer.AllowableMovement"/> was exceeded.
+		/// </summary>
+		/// <param name="location">The current press location relative to the pressed view.</param>
+		public void RaisePressMoved(Point location)
+		{
+			var distance = _origin.Distance(location);
+
+			foreach (var recognizer in _active.ToArray())
+			{
+				if (distance > recognizer.AllowableMovement)
+				{
+					_active.Remove(recognizer);
+					recognizer.SendLongPressing(_view, GestureStatus.Canceled, GetPosition(location));
+					continue;
+				}
+
+				recognizer.SendLongPressing(_view, GestureStatus.Running, GetPosition(location));
+			}
+		}
+
+		/// <summary>
+		/// Completes the gesture, raising the long pressed event followed by
+		/// <see cref="GestureStatus.Completed"/>, mirroring the built-in platform backends.
+		/// </summary>
+		/// <param name="location">The release location relative to the pressed view.</param>
+		public void RaisePressCompleted(Point? location = null)
+		{
+			var position = GetPosition(location ?? _origin);
+
+			foreach (var recognizer in _active)
+			{
+				recognizer.SendLongPressed(_view, position);
+				recognizer.SendLongPressing(_view, GestureStatus.Completed, position);
+			}
+
+			_active.Clear();
+		}
+
+		/// <summary>
+		/// Cancels the gesture, raising <see cref="GestureStatus.Canceled"/> without a long pressed event.
+		/// </summary>
+		/// <param name="location">The location the gesture was cancelled at, relative to the pressed view.</param>
+		public void RaisePressCanceled(Point? location = null)
+		{
+			var position = GetPosition(location ?? _origin);
+
+			foreach (var recognizer in _active)
+				recognizer.SendLongPressing(_view, GestureStatus.Canceled, position);
+
+			_active.Clear();
+		}
+
+		Func<IElement?, Point?> GetPosition(Point origin) => relativeTo =>
+			relativeTo is null || ReferenceEquals(relativeTo, _view)
+				? origin
+				: new Point(origin.X + RelativeElementOffset.X, origin.Y + RelativeElementOffset.Y);
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

External platform backends can already raise tap and pointer gestures, because #37420 / #37671 made `TapGestureRecognizer.SendTapped` and the `PointerGestureRecognizer.Send*` methods public infrastructure APIs. `LongPressGestureRecognizer.SendLongPressing` / `SendLongPressed` were left `internal`, so an out-of-tree backend can detect a long press but has **no supported way to dispatch it**.

Concrete blocker: [Redth/Maui.Tizen#9](https://github.com/Redth/Maui.Tizen/pull/9) has to no-op its long press dispatch.

This PR promotes both methods to `public` with `[EditorBrowsable(EditorBrowsableState.Never)]` and an `ArgumentNullException` guard on `sender` — the smallest additive surface, patterned exactly on the existing tap/pointer dispatch APIs:

```csharp
[EditorBrowsable(EditorBrowsableState.Never)]
public void SendLongPressed(View sender, Func<IElement?, Point?>? getPosition = null);

[EditorBrowsable(EditorBrowsableState.Never)]
public void SendLongPressing(View sender, GestureStatus status, Func<IElement?, Point?>? getPosition = null);
```

A `public ILongPressGestureController` was considered and rejected: no other recognizer added in this wave uses a controller interface, so an interface would be inconsistent with `SendTapped` / `SendPointer*` and would add a second dispatch shape for backend authors to learn.

**Nothing else changes.** Command execution (including `CanExecute`), event raising, `GestureStatus` Started/Running/Completed/Canceled transitions, `State` updates, the lazy `getPosition` callback contract, touch-count filtering, cancellation semantics, threading expectations, and every in-box platform call site (iOS/MacCatalyst, Android, Windows, Tizen) are untouched. Widening accessibility has no trimming impact, and `LongPressGestureRecognizer` is entirely unshipped API in `net11.0`, so this is purely additive.

### Reproducing the failure

Added `src/Controls/tests/ExternalGestureBackend`, a test-support assembly that is **deliberately excluded** from `Microsoft.Maui.Controls`' `InternalsVisibleTo` list. Before the fix it fails to build:

```
error CS1061: 'LongPressGestureRecognizer' does not contain a definition for 'SendLongPressing' ...
error CS1061: 'LongPressGestureRecognizer' does not contain a definition for 'SendLongPressed' ...
```

It now compiles, and its `FakeLongPressGestureBackend` drives the recognizer purely through the public API. Demoting either method back to `internal` breaks that project's build — the contract is enforced by the build, not just by convention.

### Tests

New `LongPressGestureRecognizerExternalBackendTests` (Controls.Core.UnitTests) drives the fake external backend:

- Full `Started` → `Running` → `Completed` lifecycle, and `LongPressed` ordering *before* `Completed`
- `Canceled` raises no `LongPressed` and executes no command
- Cancellation when movement exceeds `AllowableMovement`
- Command dispatch with `CommandParameter`, and `CanExecute == false` suppression
- Sender identity + `getPosition` relative-to-element behavior
- `NumberOfTouchesRequired` filtering, and fan-out to every matching recognizer on the view
- Reflection guard asserting both methods are `public` and `[EditorBrowsable(Never)]`

Also added `SendLongPressed_ThrowsForNullSender` / `SendLongPressing_ThrowsForNullSender` to the existing `LongPressGestureRecognizerTests`, matching `TapGestureRecognizerTests.SendTappedThrowsForNullSender`.

**Results:** `Controls.Core.UnitTests` — 6219 passed, 0 failed, 30 skipped (includes the pre-existing `LongPressGestureRecognizerTests` and `LongPressGestureRecognizerPerformanceTests`). `dotnet build src/Controls/src/Core/Controls.Core.csproj -p:PublicApiType=Validate -f net11.0` succeeds with 0 warnings; removing an entry from `PublicAPI.Unshipped.txt` correctly fails with `RS0016`, confirming the analyzer is enforcing the new signatures.

No device tests exist for `LongPressGestureRecognizer`; platform behavior stays covered by the existing `LongPressGestureInteraction` UI test, which is unaffected.

### Docs

Added `docs/design/GestureDispatchForPlatformBackends.md` for backend authors: the full dispatch table across all recognizers, the shared rules (non-null sender, UI thread, lazy `getPosition` semantics, honoring recognizer configuration), the exact long press call ordering used by each in-box platform, and a complete example backend.

### PublicAPI

Added the two entries to all seven `src/Controls/src/Core/PublicAPI/*` TFM folders (`net`, `net-android`, `net-ios`, `net-maccatalyst`, `net-tizen`, `net-windows`, `netstandard`).

### Issues Fixed

Unblocks external platform backends (e.g. [Redth/Maui.Tizen#9](https://github.com/Redth/Maui.Tizen/pull/9)) from dispatching long press gestures.
