### PR TITLE
[net11.0] Add public Shell flyout item template contract for external backends

### DIFF
--- a/src/Controls/src/Core/Handlers/Shell/Tizen/ShellFlyoutItemAdaptor.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Tizen/ShellFlyoutItemAdaptor.cs
@@ -53,15 +53,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 			if (item != null && item is BindableObject bo)
 			{
-				BindableProperty? bp = null;
-				var bindableObjectWithTemplate = Shell.GetBindableObjectWithFlyoutItemTemplate(bo);
-
-				if (bo is IMenuItemController)
-					bp = Shell.MenuItemTemplateProperty;
-				else
-					bp = Shell.ItemTemplateProperty;
-
-				if (bindableObjectWithTemplate.IsSet(bp) || container.IsSet(bp))
+				if (Shell.IsFlyoutItemTemplateSet(container as Shell, bo))
 				{
 					DataTemplate? dataTemplate = (container as IShellController)?.GetFlyoutItemDataTemplate(bo);
 					template = dataTemplate.SelectDataTemplate(item, container);

--- a/src/Controls/src/Core/Handlers/Shell/Tizen/ShellFlyoutItemAdaptor.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Tizen/ShellFlyoutItemAdaptor.cs
@@ -49,17 +49,15 @@ namespace Microsoft.Maui.Controls.Platform
 
 		protected override DataTemplate? OnSelectTemplate(object item, BindableObject container)
 		{
-			DataTemplate template = DefaultItemTemplate;
-
-			if (item != null && item is BindableObject bo)
+			if (item is BindableObject bo)
 			{
-				if (Shell.IsFlyoutItemTemplateSet(container as Shell, bo))
-				{
-					DataTemplate? dataTemplate = (container as IShellController)?.GetFlyoutItemDataTemplate(bo);
-					template = dataTemplate.SelectDataTemplate(item, container);
-				}
+				var dataTemplate = Shell.ResolveFlyoutItemTemplate(container as Shell, bo);
+
+				if (dataTemplate is not null)
+					return dataTemplate.SelectDataTemplate(item, container);
 			}
-			return template;
+
+			return DefaultItemTemplate;
 		}
 	}
 }

--- a/src/Controls/src/Core/Handlers/Shell/Windows/ShellFlyoutItemView.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ShellFlyoutItemView.cs
@@ -66,7 +66,13 @@ namespace Microsoft.Maui.Controls.Platform
 
 			var element = bo as Element;
 			_shell = element?.FindParentOfType<Shell>();
-			DataTemplate dataTemplate = (_shell as IShellController)?.GetFlyoutItemDataTemplate(bo);
+
+			// Resolve the application supplied template through the same public contract external backends use.
+			// A null result means the application did not supply one, so fall back to the default flyout item cell.
+			DataTemplate dataTemplate = null;
+
+			if (bo != null && _shell != null)
+				dataTemplate = Shell.ResolveFlyoutItemTemplate(_shell, bo) ?? BaseShellItem.CreateDefaultFlyoutItemCell(bo);
 
 			if (bo != null)
 				bo.PropertyChanged += ShellElementPropertyChanged;

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -319,6 +319,4 @@ virtual Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutTemplatedConte
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
-~static Microsoft.Maui.Controls.Shell.GetFlyoutItemTemplateProperty(Microsoft.Maui.Controls.BindableObject flyoutItem) -> Microsoft.Maui.Controls.BindableProperty
-~static Microsoft.Maui.Controls.Shell.GetFlyoutItemTemplateSource(Microsoft.Maui.Controls.BindableObject flyoutItem) -> Microsoft.Maui.Controls.BindableObject
-~static Microsoft.Maui.Controls.Shell.IsFlyoutItemTemplateSet(Microsoft.Maui.Controls.Shell shell, Microsoft.Maui.Controls.BindableObject flyoutItem) -> bool
+static Microsoft.Maui.Controls.Shell.ResolveFlyoutItemTemplate(Microsoft.Maui.Controls.Shell? shell, Microsoft.Maui.Controls.BindableObject! flyoutItem) -> Microsoft.Maui.Controls.DataTemplate?

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -319,3 +319,6 @@ virtual Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutTemplatedConte
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.Shell.GetFlyoutItemTemplateProperty(Microsoft.Maui.Controls.BindableObject flyoutItem) -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.Shell.GetFlyoutItemTemplateSource(Microsoft.Maui.Controls.BindableObject flyoutItem) -> Microsoft.Maui.Controls.BindableObject
+~static Microsoft.Maui.Controls.Shell.IsFlyoutItemTemplateSet(Microsoft.Maui.Controls.Shell shell, Microsoft.Maui.Controls.BindableObject flyoutItem) -> bool

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -239,6 +239,4 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
-~static Microsoft.Maui.Controls.Shell.GetFlyoutItemTemplateProperty(Microsoft.Maui.Controls.BindableObject flyoutItem) -> Microsoft.Maui.Controls.BindableProperty
-~static Microsoft.Maui.Controls.Shell.GetFlyoutItemTemplateSource(Microsoft.Maui.Controls.BindableObject flyoutItem) -> Microsoft.Maui.Controls.BindableObject
-~static Microsoft.Maui.Controls.Shell.IsFlyoutItemTemplateSet(Microsoft.Maui.Controls.Shell shell, Microsoft.Maui.Controls.BindableObject flyoutItem) -> bool
+static Microsoft.Maui.Controls.Shell.ResolveFlyoutItemTemplate(Microsoft.Maui.Controls.Shell? shell, Microsoft.Maui.Controls.BindableObject! flyoutItem) -> Microsoft.Maui.Controls.DataTemplate?

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -239,3 +239,6 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.Shell.GetFlyoutItemTemplateProperty(Microsoft.Maui.Controls.BindableObject flyoutItem) -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.Shell.GetFlyoutItemTemplateSource(Microsoft.Maui.Controls.BindableObject flyoutItem) -> Microsoft.Maui.Controls.BindableObject
+~static Microsoft.Maui.Controls.Shell.IsFlyoutItemTemplateSet(Microsoft.Maui.Controls.Shell shell, Microsoft.Maui.Controls.BindableObject flyoutItem) -> bool

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -231,3 +231,6 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.Shell.GetFlyoutItemTemplateProperty(Microsoft.Maui.Controls.BindableObject flyoutItem) -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.Shell.GetFlyoutItemTemplateSource(Microsoft.Maui.Controls.BindableObject flyoutItem) -> Microsoft.Maui.Controls.BindableObject
+~static Microsoft.Maui.Controls.Shell.IsFlyoutItemTemplateSet(Microsoft.Maui.Controls.Shell shell, Microsoft.Maui.Controls.BindableObject flyoutItem) -> bool

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -231,6 +231,4 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
-~static Microsoft.Maui.Controls.Shell.GetFlyoutItemTemplateProperty(Microsoft.Maui.Controls.BindableObject flyoutItem) -> Microsoft.Maui.Controls.BindableProperty
-~static Microsoft.Maui.Controls.Shell.GetFlyoutItemTemplateSource(Microsoft.Maui.Controls.BindableObject flyoutItem) -> Microsoft.Maui.Controls.BindableObject
-~static Microsoft.Maui.Controls.Shell.IsFlyoutItemTemplateSet(Microsoft.Maui.Controls.Shell shell, Microsoft.Maui.Controls.BindableObject flyoutItem) -> bool
+static Microsoft.Maui.Controls.Shell.ResolveFlyoutItemTemplate(Microsoft.Maui.Controls.Shell? shell, Microsoft.Maui.Controls.BindableObject! flyoutItem) -> Microsoft.Maui.Controls.DataTemplate?

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -223,6 +223,4 @@ Microsoft.Maui.Controls.Label.~Label() -> void
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
-~static Microsoft.Maui.Controls.Shell.GetFlyoutItemTemplateProperty(Microsoft.Maui.Controls.BindableObject flyoutItem) -> Microsoft.Maui.Controls.BindableProperty
-~static Microsoft.Maui.Controls.Shell.GetFlyoutItemTemplateSource(Microsoft.Maui.Controls.BindableObject flyoutItem) -> Microsoft.Maui.Controls.BindableObject
-~static Microsoft.Maui.Controls.Shell.IsFlyoutItemTemplateSet(Microsoft.Maui.Controls.Shell shell, Microsoft.Maui.Controls.BindableObject flyoutItem) -> bool
+static Microsoft.Maui.Controls.Shell.ResolveFlyoutItemTemplate(Microsoft.Maui.Controls.Shell? shell, Microsoft.Maui.Controls.BindableObject! flyoutItem) -> Microsoft.Maui.Controls.DataTemplate?

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -223,3 +223,6 @@ Microsoft.Maui.Controls.Label.~Label() -> void
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.Shell.GetFlyoutItemTemplateProperty(Microsoft.Maui.Controls.BindableObject flyoutItem) -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.Shell.GetFlyoutItemTemplateSource(Microsoft.Maui.Controls.BindableObject flyoutItem) -> Microsoft.Maui.Controls.BindableObject
+~static Microsoft.Maui.Controls.Shell.IsFlyoutItemTemplateSet(Microsoft.Maui.Controls.Shell shell, Microsoft.Maui.Controls.BindableObject flyoutItem) -> bool

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -274,6 +274,4 @@ static Microsoft.Maui.Controls.Platform.FormattedStringExtensions.ToRunAndColors
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
-~static Microsoft.Maui.Controls.Shell.GetFlyoutItemTemplateProperty(Microsoft.Maui.Controls.BindableObject flyoutItem) -> Microsoft.Maui.Controls.BindableProperty
-~static Microsoft.Maui.Controls.Shell.GetFlyoutItemTemplateSource(Microsoft.Maui.Controls.BindableObject flyoutItem) -> Microsoft.Maui.Controls.BindableObject
-~static Microsoft.Maui.Controls.Shell.IsFlyoutItemTemplateSet(Microsoft.Maui.Controls.Shell shell, Microsoft.Maui.Controls.BindableObject flyoutItem) -> bool
+static Microsoft.Maui.Controls.Shell.ResolveFlyoutItemTemplate(Microsoft.Maui.Controls.Shell? shell, Microsoft.Maui.Controls.BindableObject! flyoutItem) -> Microsoft.Maui.Controls.DataTemplate?

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -274,3 +274,6 @@ static Microsoft.Maui.Controls.Platform.FormattedStringExtensions.ToRunAndColors
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.Shell.GetFlyoutItemTemplateProperty(Microsoft.Maui.Controls.BindableObject flyoutItem) -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.Shell.GetFlyoutItemTemplateSource(Microsoft.Maui.Controls.BindableObject flyoutItem) -> Microsoft.Maui.Controls.BindableObject
+~static Microsoft.Maui.Controls.Shell.IsFlyoutItemTemplateSet(Microsoft.Maui.Controls.Shell shell, Microsoft.Maui.Controls.BindableObject flyoutItem) -> bool

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -218,6 +218,4 @@ Microsoft.Maui.Controls.Label.~Label() -> void
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
-~static Microsoft.Maui.Controls.Shell.GetFlyoutItemTemplateProperty(Microsoft.Maui.Controls.BindableObject flyoutItem) -> Microsoft.Maui.Controls.BindableProperty
-~static Microsoft.Maui.Controls.Shell.GetFlyoutItemTemplateSource(Microsoft.Maui.Controls.BindableObject flyoutItem) -> Microsoft.Maui.Controls.BindableObject
-~static Microsoft.Maui.Controls.Shell.IsFlyoutItemTemplateSet(Microsoft.Maui.Controls.Shell shell, Microsoft.Maui.Controls.BindableObject flyoutItem) -> bool
+static Microsoft.Maui.Controls.Shell.ResolveFlyoutItemTemplate(Microsoft.Maui.Controls.Shell? shell, Microsoft.Maui.Controls.BindableObject! flyoutItem) -> Microsoft.Maui.Controls.DataTemplate?

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -218,3 +218,6 @@ Microsoft.Maui.Controls.Label.~Label() -> void
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.Shell.GetFlyoutItemTemplateProperty(Microsoft.Maui.Controls.BindableObject flyoutItem) -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.Shell.GetFlyoutItemTemplateSource(Microsoft.Maui.Controls.BindableObject flyoutItem) -> Microsoft.Maui.Controls.BindableObject
+~static Microsoft.Maui.Controls.Shell.IsFlyoutItemTemplateSet(Microsoft.Maui.Controls.Shell shell, Microsoft.Maui.Controls.BindableObject flyoutItem) -> bool

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -209,3 +209,6 @@ Microsoft.Maui.Controls.Label.~Label() -> void
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.Shell.GetFlyoutItemTemplateProperty(Microsoft.Maui.Controls.BindableObject flyoutItem) -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.Shell.GetFlyoutItemTemplateSource(Microsoft.Maui.Controls.BindableObject flyoutItem) -> Microsoft.Maui.Controls.BindableObject
+~static Microsoft.Maui.Controls.Shell.IsFlyoutItemTemplateSet(Microsoft.Maui.Controls.Shell shell, Microsoft.Maui.Controls.BindableObject flyoutItem) -> bool

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -209,6 +209,4 @@ Microsoft.Maui.Controls.Label.~Label() -> void
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
-~static Microsoft.Maui.Controls.Shell.GetFlyoutItemTemplateProperty(Microsoft.Maui.Controls.BindableObject flyoutItem) -> Microsoft.Maui.Controls.BindableProperty
-~static Microsoft.Maui.Controls.Shell.GetFlyoutItemTemplateSource(Microsoft.Maui.Controls.BindableObject flyoutItem) -> Microsoft.Maui.Controls.BindableObject
-~static Microsoft.Maui.Controls.Shell.IsFlyoutItemTemplateSet(Microsoft.Maui.Controls.Shell shell, Microsoft.Maui.Controls.BindableObject flyoutItem) -> bool
+static Microsoft.Maui.Controls.Shell.ResolveFlyoutItemTemplate(Microsoft.Maui.Controls.Shell? shell, Microsoft.Maui.Controls.BindableObject! flyoutItem) -> Microsoft.Maui.Controls.DataTemplate?

--- a/src/Controls/src/Core/Shell/BaseShellItem.cs
+++ b/src/Controls/src/Core/Shell/BaseShellItem.cs
@@ -615,7 +615,7 @@ namespace Microsoft.Maui.Controls
 					if (sender is Grid g)
 					{
 						var bo = g.BindingContext as BindableObject;
-						var styleClassSource = (bo is null ? null : Shell.GetBindableObjectWithFlyoutItemTemplate(bo)) as IStyleSelectable;
+						var styleClassSource = Shell.GetBindableObjectWithFlyoutItemTemplate(bo) as IStyleSelectable;
 						UpdateFlyoutItemStyles(g, styleClassSource);
 
 						// this means they haven't changed the BaseShellItemContext so we are

--- a/src/Controls/src/Core/Shell/BaseShellItem.cs
+++ b/src/Controls/src/Core/Shell/BaseShellItem.cs
@@ -615,7 +615,7 @@ namespace Microsoft.Maui.Controls
 					if (sender is Grid g)
 					{
 						var bo = g.BindingContext as BindableObject;
-						var styleClassSource = (bo is null ? null : Shell.GetFlyoutItemTemplateSource(bo)) as IStyleSelectable;
+						var styleClassSource = (bo is null ? null : Shell.GetBindableObjectWithFlyoutItemTemplate(bo)) as IStyleSelectable;
 						UpdateFlyoutItemStyles(g, styleClassSource);
 
 						// this means they haven't changed the BaseShellItemContext so we are

--- a/src/Controls/src/Core/Shell/BaseShellItem.cs
+++ b/src/Controls/src/Core/Shell/BaseShellItem.cs
@@ -615,7 +615,7 @@ namespace Microsoft.Maui.Controls
 					if (sender is Grid g)
 					{
 						var bo = g.BindingContext as BindableObject;
-						var styleClassSource = Shell.GetBindableObjectWithFlyoutItemTemplate(bo) as IStyleSelectable;
+						var styleClassSource = (bo is null ? null : Shell.GetFlyoutItemTemplateSource(bo)) as IStyleSelectable;
 						UpdateFlyoutItemStyles(g, styleClassSource);
 
 						// this means they haven't changed the BaseShellItemContext so we are

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -731,119 +731,95 @@ namespace Microsoft.Maui.Controls
 		List<IFlyoutBehaviorObserver> _flyoutBehaviorObservers = new List<IFlyoutBehaviorObserver>();
 
 
+#nullable enable
 		/// <summary>
-		/// Gets the <see cref="BindableProperty"/> that Shell uses to look up the flyout <see cref="DataTemplate"/>
-		/// for <paramref name="flyoutItem"/>.
+		/// Resolves the application-defined flyout <see cref="DataTemplate"/> for a flyout item.
 		/// </summary>
+		/// <param name="shell">
+		/// The <see cref="Shell"/> that owns <paramref name="flyoutItem"/>. When <see langword="null"/>, the owning Shell is
+		/// resolved from <paramref name="flyoutItem"/>; if it cannot be resolved, only templates set on the item itself are considered.
+		/// </param>
 		/// <param name="flyoutItem">A flyout item produced by <see cref="IShellController.GenerateFlyoutGrouping"/>.</param>
 		/// <returns>
-		/// <see cref="MenuItemTemplateProperty"/> for menu items, otherwise <see cref="ItemTemplateProperty"/>.
-		/// </returns>
-		/// <exception cref="ArgumentNullException"><paramref name="flyoutItem"/> is <see langword="null"/>.</exception>
-		public static BindableProperty GetFlyoutItemTemplateProperty(BindableObject flyoutItem)
-		{
-			if (flyoutItem is null)
-				throw new ArgumentNullException(nameof(flyoutItem));
-
-			return flyoutItem is IMenuItemController ? MenuItemTemplateProperty : ItemTemplateProperty;
-		}
-
-		/// <summary>
-		/// Gets the <see cref="BindableObject"/> that carries the flyout <see cref="DataTemplate"/> for
-		/// <paramref name="flyoutItem"/>.
-		/// </summary>
-		/// <param name="flyoutItem">A flyout item produced by <see cref="IShellController.GenerateFlyoutGrouping"/>.</param>
-		/// <returns>
-		/// The object whose <see cref="MenuItemTemplateProperty"/> or <see cref="ItemTemplateProperty"/> value should be
-		/// inspected. This is usually <paramref name="flyoutItem"/> itself, but menu items are backed by a pair of objects
-		/// and the template may be set on either one, so the object that actually holds the template is returned.
+		/// The application-defined <see cref="DataTemplate"/> for <paramref name="flyoutItem"/>, or <see langword="null"/> when the
+		/// application has not supplied one and the caller should use its own platform-native default flyout item presentation.
 		/// </returns>
 		/// <exception cref="ArgumentNullException"><paramref name="flyoutItem"/> is <see langword="null"/>.</exception>
 		/// <remarks>
-		/// Custom Shell backends should use this method (rather than <paramref name="flyoutItem"/> directly) when resolving
-		/// the template, the <c>StyleClass</c> source, or the binding context for a flyout item, so that menu items behave
-		/// the same way they do on the built-in platform backends.
-		/// </remarks>
-		public static BindableObject GetFlyoutItemTemplateSource(BindableObject flyoutItem)
-		{
-			if (flyoutItem is null)
-				throw new ArgumentNullException(nameof(flyoutItem));
-
-			if (flyoutItem is IMenuItemController)
-			{
-				if (flyoutItem is MenuItem mi && mi.Parent != null && mi.Parent.IsSet(MenuItemTemplateProperty))
-					return mi.Parent;
-				else if (flyoutItem is MenuShellItem msi && msi.MenuItem != null && msi.MenuItem.IsSet(MenuItemTemplateProperty))
-					return msi.MenuItem;
-			}
-
-			return flyoutItem;
-		}
-
-		/// <summary>
-		/// Gets a value indicating whether an application-defined flyout <see cref="DataTemplate"/> applies to
-		/// <paramref name="flyoutItem"/>.
-		/// </summary>
-		/// <param name="shell">The Shell that owns <paramref name="flyoutItem"/>, or <see langword="null"/> to only consider templates set on the item itself.</param>
-		/// <param name="flyoutItem">A flyout item produced by <see cref="IShellController.GenerateFlyoutGrouping"/>.</param>
-		/// <returns>
-		/// <see langword="true"/> when <see cref="IShellController.GetFlyoutItemDataTemplate(BindableObject)"/> returns an
-		/// application-defined template; <see langword="false"/> when it falls back to the default flyout item template.
-		/// </returns>
-		/// <exception cref="ArgumentNullException"><paramref name="flyoutItem"/> is <see langword="null"/>.</exception>
-		/// <remarks>
-		/// Custom Shell backends call this to decide whether to use their own platform-specific default flyout item view
-		/// instead of the template returned by <see cref="IShellController.GetFlyoutItemDataTemplate(BindableObject)"/>.
+		/// <para>
+		/// This is the supported entry point for custom Shell backends. It applies the same precedence the built-in backends use:
+		/// a template set on the item wins over a template set on the Shell, <see cref="MenuItemTemplateProperty"/> is used for menu
+		/// items and <see cref="ItemTemplateProperty"/> for everything else, and the pair of objects that backs a menu item is
+		/// resolved internally so a template set on either one is found.
+		/// </para>
+		/// <para>
+		/// The returned value may be a <see cref="DataTemplateSelector"/>. Call
+		/// <see cref="Internals.DataTemplateExtensions.SelectDataTemplate(DataTemplate, object, BindableObject)"/> before creating
+		/// content. Bind the created content to <paramref name="flyoutItem"/>, which is what the built-in Android, iOS, and Windows
+		/// backends do.
+		/// </para>
 		/// </remarks>
 		/// <example>
 		/// <code><![CDATA[
-		/// DataTemplate SelectFlyoutItemTemplate(Shell shell, BindableObject flyoutItem)
-		/// {
-		///     if (!Shell.IsFlyoutItemTemplateSet(shell, flyoutItem))
-		///         return _platformDefaultTemplate;
-		///
-		///     return ((IShellController)shell).GetFlyoutItemDataTemplate(flyoutItem);
-		/// }
-		///
 		/// View CreateFlyoutItemView(Shell shell, BindableObject flyoutItem)
 		/// {
-		///     var template = SelectFlyoutItemTemplate(shell, flyoutItem);
-		///     var view = (View)template.SelectDataTemplate(flyoutItem, shell).CreateContent();
+		///     var template = Shell.ResolveFlyoutItemTemplate(shell, flyoutItem);
 		///
-		///     // Menu items are backed by a pair of objects, so the binding context has to come from the
-		///     // same object that supplied the template.
-		///     view.BindingContext = Shell.GetFlyoutItemTemplateSource(flyoutItem);
+		///     if (template is null)
+		///         return CreatePlatformDefaultFlyoutItemView(flyoutItem);
+		///
+		///     var view = (View)template.SelectDataTemplate(flyoutItem, shell).CreateContent();
+		///     view.BindingContext = flyoutItem;
 		///     return view;
 		/// }
 		/// ]]></code>
 		/// </example>
-		public static bool IsFlyoutItemTemplateSet(Shell shell, BindableObject flyoutItem)
+		public static DataTemplate? ResolveFlyoutItemTemplate(Shell? shell, BindableObject flyoutItem)
 		{
-			BindableProperty bp = GetFlyoutItemTemplateProperty(flyoutItem);
+			if (flyoutItem is null)
+				throw new ArgumentNullException(nameof(flyoutItem));
 
-			if (GetFlyoutItemTemplateSource(flyoutItem).IsSet(bp))
-				return true;
+			shell ??= (flyoutItem as Element)?.FindParentOfType<Shell>();
 
-			return shell is not null && shell.IsSet(bp);
+			BindableProperty bp = flyoutItem is IMenuItemController ? MenuItemTemplateProperty : ItemTemplateProperty;
+
+			// An explicitly set template wins even when its value is null, which lets an application opt a single item
+			// out of a Shell level template. A null value is reported as "no template" so callers fall back safely.
+			BindableObject templateSource = GetBindableObjectWithFlyoutItemTemplate(flyoutItem);
+
+			if (templateSource.IsSet(bp))
+				return templateSource.GetValue(bp) as DataTemplate;
+
+			if (shell is not null && shell.IsSet(bp))
+				return shell.GetValue(bp) as DataTemplate;
+
+			return null;
 		}
+
+		/// <summary>
+		/// Gets the object that carries the flyout template for <paramref name="bo"/>.
+		/// </summary>
+		/// <remarks>
+		/// A menu item in the flyout is backed by a pair of objects: the public <see cref="MenuItem"/> and the internal
+		/// <c>MenuShellItem</c> wrapper (or the item's parent for <c>ShellContent.MenuItems</c>). The template may be set on
+		/// either one, so this resolves whichever object actually holds it.
+		/// </remarks>
+		internal static BindableObject GetBindableObjectWithFlyoutItemTemplate(BindableObject bo)
+		{
+			if (bo is IMenuItemController)
+			{
+				if (bo is MenuItem mi && mi.Parent != null && mi.Parent.IsSet(MenuItemTemplateProperty))
+					return mi.Parent;
+				else if (bo is MenuShellItem msi && msi.MenuItem != null && msi.MenuItem.IsSet(MenuItemTemplateProperty))
+					return msi.MenuItem;
+			}
+
+			return bo;
+		}
+#nullable disable
 
 		DataTemplate IShellController.GetFlyoutItemDataTemplate(BindableObject bo)
-		{
-			BindableProperty bp = GetFlyoutItemTemplateProperty(bo);
-			var bindableObjectWithTemplate = GetFlyoutItemTemplateSource(bo);
-
-			if (bindableObjectWithTemplate.IsSet(bp))
-			{
-				return (DataTemplate)bindableObjectWithTemplate.GetValue(bp);
-			}
-
-			if (IsSet(bp))
-			{
-				return (DataTemplate)GetValue(bp);
-			}
-
-			return BaseShellItem.CreateDefaultFlyoutItemCell(bo);
-		}
+			=> ResolveFlyoutItemTemplate(this, bo) ?? BaseShellItem.CreateDefaultFlyoutItemCell(bo);
 
 		event EventHandler IShellController.StructureChanged
 		{

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -731,23 +731,106 @@ namespace Microsoft.Maui.Controls
 		List<IFlyoutBehaviorObserver> _flyoutBehaviorObservers = new List<IFlyoutBehaviorObserver>();
 
 
-		internal static BindableObject GetBindableObjectWithFlyoutItemTemplate(BindableObject bo)
+		/// <summary>
+		/// Gets the <see cref="BindableProperty"/> that Shell uses to look up the flyout <see cref="DataTemplate"/>
+		/// for <paramref name="flyoutItem"/>.
+		/// </summary>
+		/// <param name="flyoutItem">A flyout item produced by <see cref="IShellController.GenerateFlyoutGrouping"/>.</param>
+		/// <returns>
+		/// <see cref="MenuItemTemplateProperty"/> for menu items, otherwise <see cref="ItemTemplateProperty"/>.
+		/// </returns>
+		/// <exception cref="ArgumentNullException"><paramref name="flyoutItem"/> is <see langword="null"/>.</exception>
+		public static BindableProperty GetFlyoutItemTemplateProperty(BindableObject flyoutItem)
 		{
-			if (bo is IMenuItemController)
+			if (flyoutItem is null)
+				throw new ArgumentNullException(nameof(flyoutItem));
+
+			return flyoutItem is IMenuItemController ? MenuItemTemplateProperty : ItemTemplateProperty;
+		}
+
+		/// <summary>
+		/// Gets the <see cref="BindableObject"/> that carries the flyout <see cref="DataTemplate"/> for
+		/// <paramref name="flyoutItem"/>.
+		/// </summary>
+		/// <param name="flyoutItem">A flyout item produced by <see cref="IShellController.GenerateFlyoutGrouping"/>.</param>
+		/// <returns>
+		/// The object whose <see cref="MenuItemTemplateProperty"/> or <see cref="ItemTemplateProperty"/> value should be
+		/// inspected. This is usually <paramref name="flyoutItem"/> itself, but menu items are backed by a pair of objects
+		/// and the template may be set on either one, so the object that actually holds the template is returned.
+		/// </returns>
+		/// <exception cref="ArgumentNullException"><paramref name="flyoutItem"/> is <see langword="null"/>.</exception>
+		/// <remarks>
+		/// Custom Shell backends should use this method (rather than <paramref name="flyoutItem"/> directly) when resolving
+		/// the template, the <c>StyleClass</c> source, or the binding context for a flyout item, so that menu items behave
+		/// the same way they do on the built-in platform backends.
+		/// </remarks>
+		public static BindableObject GetFlyoutItemTemplateSource(BindableObject flyoutItem)
+		{
+			if (flyoutItem is null)
+				throw new ArgumentNullException(nameof(flyoutItem));
+
+			if (flyoutItem is IMenuItemController)
 			{
-				if (bo is MenuItem mi && mi.Parent != null && mi.Parent.IsSet(MenuItemTemplateProperty))
+				if (flyoutItem is MenuItem mi && mi.Parent != null && mi.Parent.IsSet(MenuItemTemplateProperty))
 					return mi.Parent;
-				else if (bo is MenuShellItem msi && msi.MenuItem != null && msi.MenuItem.IsSet(MenuItemTemplateProperty))
+				else if (flyoutItem is MenuShellItem msi && msi.MenuItem != null && msi.MenuItem.IsSet(MenuItemTemplateProperty))
 					return msi.MenuItem;
 			}
 
-			return bo;
+			return flyoutItem;
+		}
+
+		/// <summary>
+		/// Gets a value indicating whether an application-defined flyout <see cref="DataTemplate"/> applies to
+		/// <paramref name="flyoutItem"/>.
+		/// </summary>
+		/// <param name="shell">The Shell that owns <paramref name="flyoutItem"/>, or <see langword="null"/> to only consider templates set on the item itself.</param>
+		/// <param name="flyoutItem">A flyout item produced by <see cref="IShellController.GenerateFlyoutGrouping"/>.</param>
+		/// <returns>
+		/// <see langword="true"/> when <see cref="IShellController.GetFlyoutItemDataTemplate(BindableObject)"/> returns an
+		/// application-defined template; <see langword="false"/> when it falls back to the default flyout item template.
+		/// </returns>
+		/// <exception cref="ArgumentNullException"><paramref name="flyoutItem"/> is <see langword="null"/>.</exception>
+		/// <remarks>
+		/// Custom Shell backends call this to decide whether to use their own platform-specific default flyout item view
+		/// instead of the template returned by <see cref="IShellController.GetFlyoutItemDataTemplate(BindableObject)"/>.
+		/// </remarks>
+		/// <example>
+		/// <code><![CDATA[
+		/// DataTemplate SelectFlyoutItemTemplate(Shell shell, BindableObject flyoutItem)
+		/// {
+		///     if (!Shell.IsFlyoutItemTemplateSet(shell, flyoutItem))
+		///         return _platformDefaultTemplate;
+		///
+		///     return ((IShellController)shell).GetFlyoutItemDataTemplate(flyoutItem);
+		/// }
+		///
+		/// View CreateFlyoutItemView(Shell shell, BindableObject flyoutItem)
+		/// {
+		///     var template = SelectFlyoutItemTemplate(shell, flyoutItem);
+		///     var view = (View)template.SelectDataTemplate(flyoutItem, shell).CreateContent();
+		///
+		///     // Menu items are backed by a pair of objects, so the binding context has to come from the
+		///     // same object that supplied the template.
+		///     view.BindingContext = Shell.GetFlyoutItemTemplateSource(flyoutItem);
+		///     return view;
+		/// }
+		/// ]]></code>
+		/// </example>
+		public static bool IsFlyoutItemTemplateSet(Shell shell, BindableObject flyoutItem)
+		{
+			BindableProperty bp = GetFlyoutItemTemplateProperty(flyoutItem);
+
+			if (GetFlyoutItemTemplateSource(flyoutItem).IsSet(bp))
+				return true;
+
+			return shell is not null && shell.IsSet(bp);
 		}
 
 		DataTemplate IShellController.GetFlyoutItemDataTemplate(BindableObject bo)
 		{
-			BindableProperty bp = bo is IMenuItemController ? MenuItemTemplateProperty : ItemTemplateProperty;
-			var bindableObjectWithTemplate = GetBindableObjectWithFlyoutItemTemplate(bo);
+			BindableProperty bp = GetFlyoutItemTemplateProperty(bo);
+			var bindableObjectWithTemplate = GetFlyoutItemTemplateSource(bo);
 
 			if (bindableObjectWithTemplate.IsSet(bp))
 			{

--- a/src/Controls/tests/Core.UnitTests/ShellExternalFlyoutBackendTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellExternalFlyoutBackendTests.cs
@@ -194,6 +194,42 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public void BareMenuItemResolvesTemplateSetOnItsWrapper()
+		{
+			var shell = new Shell();
+			shell.Items.Add(CreateShellItem());
+
+			var menuItem = new MenuItem { Text = "Menu" };
+			AddMenuShellItem(shell, menuItem);
+
+			// The wrapper is internal, but it is reachable as the MenuItem's parent, and a template set there
+			// has to be found when the backend is handed the bare MenuItem.
+			var template = new DataTemplate(() => new Label { Text = "OnWrapper" });
+			Shell.SetMenuItemTemplate(menuItem.Parent, template);
+
+			var backend = new FakeExternalShellFlyoutBackend(shell);
+
+			Assert.False(menuItem.IsSet(Shell.MenuItemTemplateProperty));
+			Assert.Same(template, Shell.ResolveFlyoutItemTemplate(shell, menuItem));
+			Assert.Equal("OnWrapper", ((Label)backend.CreateFlyoutItemView(menuItem)).Text);
+		}
+
+		[Fact]
+		public void BareMenuItemWithoutTemplateResolvesToNull()
+		{
+			var shell = new Shell();
+			shell.Items.Add(CreateShellItem());
+
+			var menuItem = new MenuItem { Text = "Menu" };
+			AddMenuShellItem(shell, menuItem);
+
+			var backend = new FakeExternalShellFlyoutBackend(shell);
+
+			Assert.Null(Shell.ResolveFlyoutItemTemplate(shell, menuItem));
+			Assert.Equal(FakeExternalShellFlyoutBackend.PlatformDefaultText, ((Label)backend.CreateFlyoutItemView(menuItem)).Text);
+		}
+
+		[Fact]
 		public void MenuItemTemplateBindsTextAndCommandForShellContentMenuItems()
 		{
 			bool invoked = false;

--- a/src/Controls/tests/Core.UnitTests/ShellExternalFlyoutBackendTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellExternalFlyoutBackendTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Windows.Input;
 using Microsoft.Maui.Controls.Internals;
 using Xunit;
 
@@ -15,7 +16,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		/// <summary>
 		/// Stand-in for a platform flyout adaptor living outside of this repository. It mirrors what the in-box
 		/// backends do: use the application supplied template when there is one, otherwise use the backend's own
-		/// platform default view.
+		/// platform-native flyout item presentation.
 		/// </summary>
 		class FakeExternalShellFlyoutBackend
 		{
@@ -31,35 +32,33 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			public IEnumerable<Element> GetFlyoutItems() => GetFlyoutGroups().SelectMany(g => g);
 
-			public DataTemplate SelectTemplate(BindableObject flyoutItem)
-			{
-				if (!Shell.IsFlyoutItemTemplateSet(_shell, flyoutItem))
-					return PlatformDefaultTemplate;
-
-				return ((IShellController)_shell).GetFlyoutItemDataTemplate(flyoutItem);
-			}
+			public bool UsesPlatformDefault(BindableObject flyoutItem) =>
+				Shell.ResolveFlyoutItemTemplate(_shell, flyoutItem) is null;
 
 			public View CreateFlyoutItemView(BindableObject flyoutItem)
 			{
-				var template = SelectTemplate(flyoutItem).SelectDataTemplate(flyoutItem, _shell);
-				var view = (View)template.CreateContent();
+				var template = Shell.ResolveFlyoutItemTemplate(_shell, flyoutItem);
 
-				// Menu items are backed by two objects; the binding context has to come from the same object
-				// that supplies the template, otherwise bindings inside the template resolve against the wrong item.
-				view.BindingContext = Shell.GetFlyoutItemTemplateSource(flyoutItem);
+				if (template is null)
+					return CreatePlatformDefaultView(flyoutItem);
+
+				var view = (View)template.SelectDataTemplate(flyoutItem, _shell).CreateContent();
+
+				// Matches what the built-in Android, iOS, and Windows backends do.
+				view.BindingContext = flyoutItem;
 				view.Parent = _shell;
 				return view;
 			}
 
-			public static DataTemplate PlatformDefaultTemplate { get; } =
-				new DataTemplate(() => new Label { Text = PlatformDefaultText });
+			static View CreatePlatformDefaultView(BindableObject flyoutItem) =>
+				new Label { Text = PlatformDefaultText, BindingContext = flyoutItem };
 
 			public const string PlatformDefaultText = "PlatformDefault";
 		}
 
 		static MenuItem AddMenuShellItem(Shell shell, MenuItem menuItem)
 		{
-			// This is the only public way to get at the internal MenuShellItem wrapper.
+			// Adding a MenuItem to Shell.Items wraps it in the internal MenuShellItem.
 			shell.Items.Add(menuItem);
 			return menuItem;
 		}
@@ -68,7 +67,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			backend.GetFlyoutItems().Single(e => e == menuItem || e == menuItem.Parent);
 
 		[Fact]
-		public void ShellItemWithoutTemplateFallsBackToBackendDefault()
+		public void ShellItemWithoutTemplateResolvesToNull()
 		{
 			var shell = new Shell();
 			var shellItem = CreateShellItem();
@@ -76,8 +75,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			var backend = new FakeExternalShellFlyoutBackend(shell);
 
-			Assert.False(Shell.IsFlyoutItemTemplateSet(shell, shellItem));
-			Assert.Same(FakeExternalShellFlyoutBackend.PlatformDefaultTemplate, backend.SelectTemplate(shellItem));
+			Assert.Null(Shell.ResolveFlyoutItemTemplate(shell, shellItem));
+			Assert.Equal(FakeExternalShellFlyoutBackend.PlatformDefaultText, ((Label)backend.CreateFlyoutItemView(shellItem)).Text);
 		}
 
 		[Fact]
@@ -93,26 +92,29 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			var backend = new FakeExternalShellFlyoutBackend(shell);
 
-			Assert.True(Shell.IsFlyoutItemTemplateSet(shell, shellItem));
+			Assert.Same(shell.ItemTemplate, Shell.ResolveFlyoutItemTemplate(shell, shellItem));
 			Assert.Equal("ItemTemplate", ((Label)backend.CreateFlyoutItemView(shellItem)).Text);
 		}
 
 		[Fact]
-		public void ItemLevelItemTemplateIsUsedForShellItems()
+		public void ItemLevelItemTemplateWinsOverShellLevelItemTemplate()
 		{
-			var shell = new Shell();
+			var shell = new Shell
+			{
+				ItemTemplate = new DataTemplate(() => new Label { Text = "ShellLevel" })
+			};
+
 			var shellItem = CreateShellItem();
 			Shell.SetItemTemplate(shellItem, new DataTemplate(() => new Label { Text = "ItemLevel" }));
 			shell.Items.Add(shellItem);
 
 			var backend = new FakeExternalShellFlyoutBackend(shell);
 
-			Assert.True(Shell.IsFlyoutItemTemplateSet(shell, shellItem));
 			Assert.Equal("ItemLevel", ((Label)backend.CreateFlyoutItemView(shellItem)).Text);
 		}
 
 		[Fact]
-		public void MenuItemWithoutTemplateFallsBackToBackendDefault()
+		public void MenuItemWithoutTemplateResolvesToNull()
 		{
 			var shell = new Shell();
 			shell.Items.Add(CreateShellItem());
@@ -121,7 +123,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var backend = new FakeExternalShellFlyoutBackend(shell);
 			var flyoutItem = FindFlyoutItem(backend, menuItem);
 
-			Assert.False(Shell.IsFlyoutItemTemplateSet(shell, flyoutItem));
+			Assert.Null(Shell.ResolveFlyoutItemTemplate(shell, flyoutItem));
 			Assert.Equal(FakeExternalShellFlyoutBackend.PlatformDefaultText, ((Label)backend.CreateFlyoutItemView(flyoutItem)).Text);
 		}
 
@@ -145,9 +147,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal("ItemTemplate", ((Label)backend.CreateFlyoutItemView(shellItem)).Text);
 		}
 
-		// This is the branch an external backend cannot reproduce without GetFlyoutItemTemplateSource:
-		// the template is set on the MenuItem, but the flyout item handed to the backend is the internal
-		// MenuShellItem wrapper, which does not have the property set.
+		// This is the branch an external backend cannot reproduce on its own: the template is set on the
+		// MenuItem, but the flyout item handed to the backend is the internal MenuShellItem wrapper, which does
+		// not have the property set.
 		[Fact]
 		public void MenuItemTemplateSetOnMenuItemIsFoundThroughMenuShellItem()
 		{
@@ -155,15 +157,15 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			shell.Items.Add(CreateShellItem());
 
 			var menuItem = new MenuItem { Text = "Menu" };
-			Shell.SetMenuItemTemplate(menuItem, new DataTemplate(() => new Label { Text = "OnMenuItem" }));
+			var template = new DataTemplate(() => new Label { Text = "OnMenuItem" });
+			Shell.SetMenuItemTemplate(menuItem, template);
 			AddMenuShellItem(shell, menuItem);
 
 			var backend = new FakeExternalShellFlyoutBackend(shell);
 			var flyoutItem = FindFlyoutItem(backend, menuItem);
 
 			Assert.NotSame(menuItem, flyoutItem);
-			Assert.Same(menuItem, Shell.GetFlyoutItemTemplateSource(flyoutItem));
-			Assert.True(Shell.IsFlyoutItemTemplateSet(shell, flyoutItem));
+			Assert.Same(template, Shell.ResolveFlyoutItemTemplate(shell, flyoutItem));
 			Assert.Equal("OnMenuItem", ((Label)backend.CreateFlyoutItemView(flyoutItem)).Text);
 		}
 
@@ -177,75 +179,243 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			var menuItem = new MenuItem { Text = "Menu" };
 			shellContent.MenuItems.Add(menuItem);
-			Shell.SetMenuItemTemplate(shellContent, new DataTemplate(() => new Label { Text = "OnParent" }));
+
+			var template = new DataTemplate(() => new Label { Text = "OnParent" });
+			Shell.SetMenuItemTemplate(shellContent, template);
 
 			shell.Items.Add(shellContent);
 
 			var backend = new FakeExternalShellFlyoutBackend(shell);
 
 			Assert.Contains(menuItem, backend.GetFlyoutItems());
-			Assert.Same(shellContent, Shell.GetFlyoutItemTemplateSource(menuItem));
-			Assert.True(Shell.IsFlyoutItemTemplateSet(shell, menuItem));
+			Assert.False(menuItem.IsSet(Shell.MenuItemTemplateProperty));
+			Assert.Same(template, Shell.ResolveFlyoutItemTemplate(shell, menuItem));
 			Assert.Equal("OnParent", ((Label)backend.CreateFlyoutItemView(menuItem)).Text);
 		}
 
-		// Documents the failure mode this API exists to fix: an external backend that only inspects the flyout
-		// item itself concludes that no template is set and incorrectly falls back to its own default view.
 		[Fact]
-		public void InspectingTheFlyoutItemDirectlyMissesMenuItemTemplates()
+		public void MenuItemTemplateBindsTextAndCommandForShellContentMenuItems()
 		{
+			bool invoked = false;
+
 			var shell = new Shell();
-			shell.Items.Add(CreateShellItem());
+			var shellContent = CreateShellContent();
 
-			var menuItem = new MenuItem { Text = "Menu" };
-			Shell.SetMenuItemTemplate(menuItem, new DataTemplate(() => new Label { Text = "OnMenuItem" }));
-			AddMenuShellItem(shell, menuItem);
-
-			var backend = new FakeExternalShellFlyoutBackend(shell);
-			var flyoutItem = FindFlyoutItem(backend, menuItem);
-
-			Assert.False(flyoutItem.IsSet(Shell.MenuItemTemplateProperty));
-			Assert.True(Shell.IsFlyoutItemTemplateSet(shell, flyoutItem));
-		}
-
-		[Fact]
-		public void MenuItemTemplateSourceProvidesBindingContextForTemplate()
-		{
-			var shell = new Shell();
-			shell.Items.Add(CreateShellItem());
-
-			var menuItem = new MenuItem { Text = "Menu" };
-			Shell.SetMenuItemTemplate(menuItem, new DataTemplate(() =>
+			var menuItem = new MenuItem
 			{
-				var label = new Label();
-				label.SetBinding(Label.TextProperty, static (MenuItem item) => item.Text);
-				return label;
+				Text = "Menu",
+				Command = new Command(() => invoked = true)
+			};
+
+			shellContent.MenuItems.Add(menuItem);
+
+			Shell.SetMenuItemTemplate(shellContent, new DataTemplate(() =>
+			{
+				var button = new Button();
+				button.SetBinding(Button.TextProperty, static (MenuItem item) => item.Text);
+				button.SetBinding(Button.CommandProperty, static (MenuItem item) => item.Command);
+				return button;
 			}));
 
-			AddMenuShellItem(shell, menuItem);
+			shell.Items.Add(shellContent);
 
 			var backend = new FakeExternalShellFlyoutBackend(shell);
-			var flyoutItem = FindFlyoutItem(backend, menuItem);
+			var button = Assert.IsType<Button>(backend.CreateFlyoutItemView(menuItem));
 
-			Assert.Equal("Menu", ((Label)backend.CreateFlyoutItemView(flyoutItem)).Text);
+			Assert.Equal("Menu", button.Text);
+
+			Assert.NotNull(button.Command);
+			button.Command.Execute(null);
+			Assert.True(invoked);
 		}
 
 		[Fact]
-		public void TemplateSourceCarriesStyleClassForMenuItems()
+		public void MenuItemTemplateBindsTextAndCommandForShellLevelMenuItems()
 		{
+			bool invoked = false;
+
+			var shell = new Shell
+			{
+				MenuItemTemplate = new DataTemplate(() =>
+				{
+					var button = new Button();
+					button.SetBinding(Button.TextProperty, "Text");
+					button.SetBinding(Button.CommandProperty, "Command");
+					return button;
+				})
+			};
+
+			shell.Items.Add(CreateShellItem());
+
+			var menuItem = new MenuItem
+			{
+				Text = "Menu",
+				Command = new Command(() => invoked = true)
+			};
+
+			AddMenuShellItem(shell, menuItem);
+
+			var backend = new FakeExternalShellFlyoutBackend(shell);
+			var flyoutItem = FindFlyoutItem(backend, menuItem);
+			var button = Assert.IsType<Button>(backend.CreateFlyoutItemView(flyoutItem));
+
+			// The MenuShellItem wrapper mirrors Text from its MenuItem, so binding the created content to the
+			// flyout item works the same way it does on the built-in backends.
+			Assert.Equal("Menu", button.Text);
+		}
+
+		[Fact]
+		public void MenuItemFlyoutSelectionInvokesTheCommand()
+		{
+			bool invoked = false;
+
 			var shell = new Shell();
 			shell.Items.Add(CreateShellItem());
 
-			var menuItem = new MenuItem { Text = "Menu", StyleClass = new[] { "fooClass" } };
-			Shell.SetMenuItemTemplate(menuItem, new DataTemplate(() => new Label()));
+			var menuItem = new MenuItem
+			{
+				Text = "Menu",
+				Command = new Command(() => invoked = true)
+			};
+
 			AddMenuShellItem(shell, menuItem);
 
 			var backend = new FakeExternalShellFlyoutBackend(shell);
 			var flyoutItem = FindFlyoutItem(backend, menuItem);
 
-			var styleSource = Assert.IsType<MenuItem>(Shell.GetFlyoutItemTemplateSource(flyoutItem));
+			((IShellController)shell).OnFlyoutItemSelected(flyoutItem);
 
-			Assert.Contains("fooClass", styleSource.StyleClass);
+			Assert.True(invoked);
+		}
+
+		[Fact]
+		public void ItemTemplateBindsTitleForShellItems()
+		{
+			var shell = new Shell
+			{
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var label = new Label();
+					label.SetBinding(Label.TextProperty, static (BaseShellItem item) => item.Title);
+					return label;
+				})
+			};
+
+			var shellItem = CreateShellItem();
+			shellItem.Title = "Cat";
+			shell.Items.Add(shellItem);
+
+			var backend = new FakeExternalShellFlyoutBackend(shell);
+
+			Assert.Equal("Cat", ((Label)backend.CreateFlyoutItemView(shellItem)).Text);
+		}
+
+		[Fact]
+		public void ExplicitNullItemTemplateOnItemOptsOutOfShellTemplate()
+		{
+			var shell = new Shell
+			{
+				ItemTemplate = new DataTemplate(() => new Label { Text = "ShellLevel" })
+			};
+
+			var shellItem = CreateShellItem();
+			Shell.SetItemTemplate(shellItem, null);
+			shell.Items.Add(shellItem);
+
+			var backend = new FakeExternalShellFlyoutBackend(shell);
+
+			Assert.True(shellItem.IsSet(Shell.ItemTemplateProperty));
+			Assert.Null(Shell.ResolveFlyoutItemTemplate(shell, shellItem));
+			Assert.True(backend.UsesPlatformDefault(shellItem));
+			Assert.Equal(FakeExternalShellFlyoutBackend.PlatformDefaultText, ((Label)backend.CreateFlyoutItemView(shellItem)).Text);
+		}
+
+		[Fact]
+		public void ExplicitNullTemplateStillProducesDefaultCellForBuiltInBackends()
+		{
+			var shell = new Shell
+			{
+				ItemTemplate = new DataTemplate(() => new Label { Text = "ShellLevel" })
+			};
+
+			var shellItem = CreateShellItem();
+			Shell.SetItemTemplate(shellItem, null);
+			shell.Items.Add(shellItem);
+
+			// The in-box path must never hand a null template to platform code.
+			Assert.NotNull(((IShellController)shell).GetFlyoutItemDataTemplate(shellItem));
+		}
+
+		[Fact]
+		public void ExplicitNullMenuItemTemplateOptsOutOfShellTemplate()
+		{
+			var shell = new Shell
+			{
+				MenuItemTemplate = new DataTemplate(() => new Label { Text = "ShellLevel" })
+			};
+
+			shell.Items.Add(CreateShellItem());
+
+			var menuItem = new MenuItem { Text = "Menu" };
+			Shell.SetMenuItemTemplate(menuItem, null);
+			AddMenuShellItem(shell, menuItem);
+
+			var backend = new FakeExternalShellFlyoutBackend(shell);
+			var flyoutItem = FindFlyoutItem(backend, menuItem);
+
+			Assert.Null(Shell.ResolveFlyoutItemTemplate(shell, flyoutItem));
+			Assert.Equal(FakeExternalShellFlyoutBackend.PlatformDefaultText, ((Label)backend.CreateFlyoutItemView(flyoutItem)).Text);
+		}
+
+		[Fact]
+		public void NullBoundTemplateResolvesToNull()
+		{
+			var shell = new Shell();
+			var shellItem = CreateShellItem();
+
+			// A binding that resolves to null must behave like no template rather than throwing.
+			shellItem.BindingContext = new object();
+			shellItem.SetBinding(Shell.ItemTemplateProperty, "MissingTemplate");
+
+			shell.Items.Add(shellItem);
+
+			var backend = new FakeExternalShellFlyoutBackend(shell);
+
+			Assert.Null(Shell.ResolveFlyoutItemTemplate(shell, shellItem));
+			Assert.Equal(FakeExternalShellFlyoutBackend.PlatformDefaultText, ((Label)backend.CreateFlyoutItemView(shellItem)).Text);
+		}
+
+		[Fact]
+		public void DataTemplateSelectorIsReturnedAndResolvedByTheCaller()
+		{
+			var shell = new Shell
+			{
+				ItemTemplate = new TestFlyoutItemTemplateSelector()
+			};
+
+			var withTitle = CreateShellItem();
+			withTitle.Title = "Cat";
+
+			var withoutTitle = CreateShellItem();
+			withoutTitle.Title = null;
+
+			shell.Items.Add(withTitle);
+			shell.Items.Add(withoutTitle);
+
+			var backend = new FakeExternalShellFlyoutBackend(shell);
+
+			Assert.IsType<TestFlyoutItemTemplateSelector>(Shell.ResolveFlyoutItemTemplate(shell, withTitle));
+			Assert.Equal("HasTitle", ((Label)backend.CreateFlyoutItemView(withTitle)).Text);
+			Assert.Equal("NoTitle", ((Label)backend.CreateFlyoutItemView(withoutTitle)).Text);
+		}
+
+		class TestFlyoutItemTemplateSelector : DataTemplateSelector
+		{
+			readonly DataTemplate _hasTitle = new DataTemplate(() => new Label { Text = "HasTitle" });
+			readonly DataTemplate _noTitle = new DataTemplate(() => new Label { Text = "NoTitle" });
+
+			protected override DataTemplate OnSelectTemplate(object item, BindableObject container) =>
+				item is BaseShellItem bsi && !string.IsNullOrEmpty(bsi.Title) ? _hasTitle : _noTitle;
 		}
 
 		[Fact]
@@ -269,11 +439,12 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
-		public void FlyoutHeaderTemplateIsAvailableToExternalBackends()
+		public void FlyoutHeaderAndFooterTemplatesAreAvailableToExternalBackends()
 		{
 			var shell = new Shell
 			{
-				FlyoutHeaderTemplate = new DataTemplate(() => new Label { Text = "HeaderTemplate" })
+				FlyoutHeaderTemplate = new DataTemplate(() => new Label { Text = "HeaderTemplate" }),
+				FlyoutFooterTemplate = new DataTemplate(() => new Label { Text = "FooterTemplate" })
 			};
 
 			shell.Items.Add(CreateShellItem());
@@ -281,49 +452,27 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var backend = new FakeExternalShellFlyoutBackend(shell);
 
 			Assert.Equal("HeaderTemplate", Assert.IsType<Label>(backend.Header).Text);
+			Assert.Equal("FooterTemplate", Assert.IsType<Label>(backend.Footer).Text);
 		}
 
 		[Fact]
-		public void TemplatePropertyMatchesItemKind()
+		public void HeadersAreNotFlyoutItems()
 		{
-			var shell = new Shell();
-			var shellItem = CreateShellItem();
-			shell.Items.Add(shellItem);
-			var menuItem = AddMenuShellItem(shell, new MenuItem { Text = "Menu" });
+			var shell = new Shell
+			{
+				FlyoutHeader = new Label { Text = "Header" },
+				ItemTemplate = new DataTemplate(() => new Label { Text = "ItemTemplate" })
+			};
+
+			shell.Items.Add(CreateShellItem());
 
 			var backend = new FakeExternalShellFlyoutBackend(shell);
-			var flyoutItem = FindFlyoutItem(backend, menuItem);
 
-			Assert.Same(Shell.ItemTemplateProperty, Shell.GetFlyoutItemTemplateProperty(shellItem));
-			Assert.Same(Shell.MenuItemTemplateProperty, Shell.GetFlyoutItemTemplateProperty(flyoutItem));
-			Assert.Same(Shell.MenuItemTemplateProperty, Shell.GetFlyoutItemTemplateProperty(menuItem));
+			Assert.DoesNotContain(backend.Header, backend.GetFlyoutItems());
 		}
 
 		[Fact]
-		public void TemplateSourceReturnsItemWhenNoTemplateIsSet()
-		{
-			var shell = new Shell();
-			var shellItem = CreateShellItem();
-			shell.Items.Add(shellItem);
-			var menuItem = AddMenuShellItem(shell, new MenuItem { Text = "Menu" });
-
-			var backend = new FakeExternalShellFlyoutBackend(shell);
-			var flyoutItem = FindFlyoutItem(backend, menuItem);
-
-			Assert.Same(shellItem, Shell.GetFlyoutItemTemplateSource(shellItem));
-			Assert.Same(flyoutItem, Shell.GetFlyoutItemTemplateSource(flyoutItem));
-		}
-
-		[Fact]
-		public void NullFlyoutItemThrows()
-		{
-			Assert.Throws<System.ArgumentNullException>(() => Shell.GetFlyoutItemTemplateSource(null));
-			Assert.Throws<System.ArgumentNullException>(() => Shell.GetFlyoutItemTemplateProperty(null));
-			Assert.Throws<System.ArgumentNullException>(() => Shell.IsFlyoutItemTemplateSet(new Shell(), null));
-		}
-
-		[Fact]
-		public void NullShellOnlyConsidersTemplatesSetOnTheItem()
+		public void OmittingShellResolvesItThroughTheFlyoutItem()
 		{
 			var shell = new Shell
 			{
@@ -333,8 +482,32 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var shellItem = CreateShellItem();
 			shell.Items.Add(shellItem);
 
-			Assert.True(Shell.IsFlyoutItemTemplateSet(shell, shellItem));
-			Assert.False(Shell.IsFlyoutItemTemplateSet(null, shellItem));
+			Assert.Same(shell.ItemTemplate, Shell.ResolveFlyoutItemTemplate(null, shellItem));
+		}
+
+		[Fact]
+		public void UnparentedItemWithoutTemplateResolvesToNull()
+		{
+			var shellItem = CreateShellItem();
+
+			Assert.Null(Shell.ResolveFlyoutItemTemplate(null, shellItem));
+		}
+
+		[Fact]
+		public void UnparentedItemWithItemTemplateStillResolves()
+		{
+			var shellItem = CreateShellItem();
+			var template = new DataTemplate(() => new Label { Text = "ItemLevel" });
+			Shell.SetItemTemplate(shellItem, template);
+
+			Assert.Same(template, Shell.ResolveFlyoutItemTemplate(null, shellItem));
+		}
+
+		[Fact]
+		public void NullFlyoutItemThrows()
+		{
+			Assert.Throws<System.ArgumentNullException>(() => Shell.ResolveFlyoutItemTemplate(new Shell(), null));
+			Assert.Throws<System.ArgumentNullException>(() => Shell.ResolveFlyoutItemTemplate(null, null));
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/ShellExternalFlyoutBackendTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellExternalFlyoutBackendTests.cs
@@ -193,8 +193,11 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal("OnParent", ((Label)backend.CreateFlyoutItemView(menuItem)).Text);
 		}
 
+		// Direct parent-resolution unit coverage. GenerateFlyoutGrouping hands a backend the MenuShellItem
+		// wrapper for items added to Shell.Items, not the bare MenuItem, so this exercises the resolver's
+		// parent lookup directly rather than a shape a backend receives from grouping.
 		[Fact]
-		public void BareMenuItemResolvesTemplateSetOnItsWrapper()
+		public void ResolverFindsTemplateOnTheParentOfAMenuItem()
 		{
 			var shell = new Shell();
 			shell.Items.Add(CreateShellItem());
@@ -202,20 +205,16 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var menuItem = new MenuItem { Text = "Menu" };
 			AddMenuShellItem(shell, menuItem);
 
-			// The wrapper is internal, but it is reachable as the MenuItem's parent, and a template set there
-			// has to be found when the backend is handed the bare MenuItem.
-			var template = new DataTemplate(() => new Label { Text = "OnWrapper" });
+			var template = new DataTemplate(() => new Label { Text = "OnParent" });
 			Shell.SetMenuItemTemplate(menuItem.Parent, template);
-
-			var backend = new FakeExternalShellFlyoutBackend(shell);
 
 			Assert.False(menuItem.IsSet(Shell.MenuItemTemplateProperty));
 			Assert.Same(template, Shell.ResolveFlyoutItemTemplate(shell, menuItem));
-			Assert.Equal("OnWrapper", ((Label)backend.CreateFlyoutItemView(menuItem)).Text);
 		}
 
+		// Direct resolver coverage, same caveat as above.
 		[Fact]
-		public void BareMenuItemWithoutTemplateResolvesToNull()
+		public void ResolverReturnsNullForAMenuItemWithNoTemplateAnywhere()
 		{
 			var shell = new Shell();
 			shell.Items.Add(CreateShellItem());
@@ -223,10 +222,52 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var menuItem = new MenuItem { Text = "Menu" };
 			AddMenuShellItem(shell, menuItem);
 
+			Assert.Null(Shell.ResolveFlyoutItemTemplate(shell, menuItem));
+		}
+
+		// Unlike Shell.Items, ShellContent.MenuItems puts the bare MenuItem in the flyout grouping, so a
+		// template set directly on the MenuItem is a shape backends really do receive.
+		[Fact]
+		public void MenuItemTemplateSetOnTheMenuItemIsUsedForShellContentMenuItems()
+		{
+			var shell = new Shell();
+			var shellContent = CreateShellContent();
+
+			var menuItem = new MenuItem { Text = "Menu" };
+			var template = new DataTemplate(() => new Label { Text = "OnMenuItem" });
+			Shell.SetMenuItemTemplate(menuItem, template);
+
+			shellContent.MenuItems.Add(menuItem);
+			shell.Items.Add(shellContent);
+
 			var backend = new FakeExternalShellFlyoutBackend(shell);
 
-			Assert.Null(Shell.ResolveFlyoutItemTemplate(shell, menuItem));
-			Assert.Equal(FakeExternalShellFlyoutBackend.PlatformDefaultText, ((Label)backend.CreateFlyoutItemView(menuItem)).Text);
+			Assert.Contains(menuItem, backend.GetFlyoutItems());
+			Assert.Same(template, Shell.ResolveFlyoutItemTemplate(shell, menuItem));
+			Assert.Equal("OnMenuItem", ((Label)backend.CreateFlyoutItemView(menuItem)).Text);
+		}
+
+		// Pins pre-existing behavior: when both the MenuItem and its parent set a template, the parent wins.
+		// This is long-standing Shell behavior that the public resolver preserves verbatim.
+		[Fact]
+		public void ParentTemplateWinsOverMenuItemTemplateForShellContentMenuItems()
+		{
+			var shell = new Shell();
+			var shellContent = CreateShellContent();
+
+			var menuItem = new MenuItem { Text = "Menu" };
+			Shell.SetMenuItemTemplate(menuItem, new DataTemplate(() => new Label { Text = "OnMenuItem" }));
+
+			var parentTemplate = new DataTemplate(() => new Label { Text = "OnParent" });
+			Shell.SetMenuItemTemplate(shellContent, parentTemplate);
+
+			shellContent.MenuItems.Add(menuItem);
+			shell.Items.Add(shellContent);
+
+			var backend = new FakeExternalShellFlyoutBackend(shell);
+
+			Assert.Same(parentTemplate, Shell.ResolveFlyoutItemTemplate(shell, menuItem));
+			Assert.Equal("OnParent", ((Label)backend.CreateFlyoutItemView(menuItem)).Text);
 		}
 
 		[Fact]
@@ -265,39 +306,32 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.True(invoked);
 		}
 
+		// Shell level MenuItemTemplate is applied to the MenuShellItem wrapper, which mirrors Text/Title from
+		// its MenuItem but does not surface Command. Selection is what activates the command; see
+		// MenuItemFlyoutSelectionInvokesTheCommand.
 		[Fact]
-		public void MenuItemTemplateBindsTextAndCommandForShellLevelMenuItems()
+		public void MenuItemTemplateBindsTextForShellLevelMenuItems()
 		{
-			bool invoked = false;
-
 			var shell = new Shell
 			{
 				MenuItemTemplate = new DataTemplate(() =>
 				{
-					var button = new Button();
-					button.SetBinding(Button.TextProperty, "Text");
-					button.SetBinding(Button.CommandProperty, "Command");
-					return button;
+					var label = new Label();
+					label.SetBinding(Label.TextProperty, "Text");
+					return label;
 				})
 			};
 
 			shell.Items.Add(CreateShellItem());
 
-			var menuItem = new MenuItem
-			{
-				Text = "Menu",
-				Command = new Command(() => invoked = true)
-			};
-
+			var menuItem = new MenuItem { Text = "Menu" };
 			AddMenuShellItem(shell, menuItem);
 
 			var backend = new FakeExternalShellFlyoutBackend(shell);
 			var flyoutItem = FindFlyoutItem(backend, menuItem);
-			var button = Assert.IsType<Button>(backend.CreateFlyoutItemView(flyoutItem));
+			var label = Assert.IsType<Label>(backend.CreateFlyoutItemView(flyoutItem));
 
-			// The MenuShellItem wrapper mirrors Text from its MenuItem, so binding the created content to the
-			// flyout item works the same way it does on the built-in backends.
-			Assert.Equal("Menu", button.Text);
+			Assert.Equal("Menu", label.Text);
 		}
 
 		[Fact]

--- a/src/Controls/tests/Core.UnitTests/ShellExternalFlyoutBackendTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellExternalFlyoutBackendTests.cs
@@ -1,0 +1,340 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Maui.Controls.Internals;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	/// <summary>
+	/// Covers the public contract an out-of-tree Shell backend needs in order to resolve the flyout item
+	/// <see cref="DataTemplate"/> exactly like the in-box backends do.
+	/// Everything in <see cref="FakeExternalShellFlyoutBackend"/> must be expressible with public API only.
+	/// </summary>
+	public class ShellExternalFlyoutBackendTests : ShellTestBase
+	{
+		/// <summary>
+		/// Stand-in for a platform flyout adaptor living outside of this repository. It mirrors what the in-box
+		/// backends do: use the application supplied template when there is one, otherwise use the backend's own
+		/// platform default view.
+		/// </summary>
+		class FakeExternalShellFlyoutBackend
+		{
+			readonly Shell _shell;
+
+			public FakeExternalShellFlyoutBackend(Shell shell) => _shell = shell;
+
+			public View Header => ((IShellController)_shell).FlyoutHeader;
+
+			public View Footer => ((IShellController)_shell).FlyoutFooter;
+
+			public List<List<Element>> GetFlyoutGroups() => ((IShellController)_shell).GenerateFlyoutGrouping();
+
+			public IEnumerable<Element> GetFlyoutItems() => GetFlyoutGroups().SelectMany(g => g);
+
+			public DataTemplate SelectTemplate(BindableObject flyoutItem)
+			{
+				if (!Shell.IsFlyoutItemTemplateSet(_shell, flyoutItem))
+					return PlatformDefaultTemplate;
+
+				return ((IShellController)_shell).GetFlyoutItemDataTemplate(flyoutItem);
+			}
+
+			public View CreateFlyoutItemView(BindableObject flyoutItem)
+			{
+				var template = SelectTemplate(flyoutItem).SelectDataTemplate(flyoutItem, _shell);
+				var view = (View)template.CreateContent();
+
+				// Menu items are backed by two objects; the binding context has to come from the same object
+				// that supplies the template, otherwise bindings inside the template resolve against the wrong item.
+				view.BindingContext = Shell.GetFlyoutItemTemplateSource(flyoutItem);
+				view.Parent = _shell;
+				return view;
+			}
+
+			public static DataTemplate PlatformDefaultTemplate { get; } =
+				new DataTemplate(() => new Label { Text = PlatformDefaultText });
+
+			public const string PlatformDefaultText = "PlatformDefault";
+		}
+
+		static MenuItem AddMenuShellItem(Shell shell, MenuItem menuItem)
+		{
+			// This is the only public way to get at the internal MenuShellItem wrapper.
+			shell.Items.Add(menuItem);
+			return menuItem;
+		}
+
+		static Element FindFlyoutItem(FakeExternalShellFlyoutBackend backend, MenuItem menuItem) =>
+			backend.GetFlyoutItems().Single(e => e == menuItem || e == menuItem.Parent);
+
+		[Fact]
+		public void ShellItemWithoutTemplateFallsBackToBackendDefault()
+		{
+			var shell = new Shell();
+			var shellItem = CreateShellItem();
+			shell.Items.Add(shellItem);
+
+			var backend = new FakeExternalShellFlyoutBackend(shell);
+
+			Assert.False(Shell.IsFlyoutItemTemplateSet(shell, shellItem));
+			Assert.Same(FakeExternalShellFlyoutBackend.PlatformDefaultTemplate, backend.SelectTemplate(shellItem));
+		}
+
+		[Fact]
+		public void ShellLevelItemTemplateIsUsedForShellItems()
+		{
+			var shell = new Shell
+			{
+				ItemTemplate = new DataTemplate(() => new Label { Text = "ItemTemplate" })
+			};
+
+			var shellItem = CreateShellItem();
+			shell.Items.Add(shellItem);
+
+			var backend = new FakeExternalShellFlyoutBackend(shell);
+
+			Assert.True(Shell.IsFlyoutItemTemplateSet(shell, shellItem));
+			Assert.Equal("ItemTemplate", ((Label)backend.CreateFlyoutItemView(shellItem)).Text);
+		}
+
+		[Fact]
+		public void ItemLevelItemTemplateIsUsedForShellItems()
+		{
+			var shell = new Shell();
+			var shellItem = CreateShellItem();
+			Shell.SetItemTemplate(shellItem, new DataTemplate(() => new Label { Text = "ItemLevel" }));
+			shell.Items.Add(shellItem);
+
+			var backend = new FakeExternalShellFlyoutBackend(shell);
+
+			Assert.True(Shell.IsFlyoutItemTemplateSet(shell, shellItem));
+			Assert.Equal("ItemLevel", ((Label)backend.CreateFlyoutItemView(shellItem)).Text);
+		}
+
+		[Fact]
+		public void MenuItemWithoutTemplateFallsBackToBackendDefault()
+		{
+			var shell = new Shell();
+			shell.Items.Add(CreateShellItem());
+			var menuItem = AddMenuShellItem(shell, new MenuItem { Text = "Menu" });
+
+			var backend = new FakeExternalShellFlyoutBackend(shell);
+			var flyoutItem = FindFlyoutItem(backend, menuItem);
+
+			Assert.False(Shell.IsFlyoutItemTemplateSet(shell, flyoutItem));
+			Assert.Equal(FakeExternalShellFlyoutBackend.PlatformDefaultText, ((Label)backend.CreateFlyoutItemView(flyoutItem)).Text);
+		}
+
+		[Fact]
+		public void ShellLevelMenuItemTemplateIsUsedForMenuItems()
+		{
+			var shell = new Shell
+			{
+				MenuItemTemplate = new DataTemplate(() => new Label { Text = "MenuItemTemplate" }),
+				ItemTemplate = new DataTemplate(() => new Label { Text = "ItemTemplate" })
+			};
+
+			var shellItem = CreateShellItem();
+			shell.Items.Add(shellItem);
+			var menuItem = AddMenuShellItem(shell, new MenuItem { Text = "Menu" });
+
+			var backend = new FakeExternalShellFlyoutBackend(shell);
+			var flyoutItem = FindFlyoutItem(backend, menuItem);
+
+			Assert.Equal("MenuItemTemplate", ((Label)backend.CreateFlyoutItemView(flyoutItem)).Text);
+			Assert.Equal("ItemTemplate", ((Label)backend.CreateFlyoutItemView(shellItem)).Text);
+		}
+
+		// This is the branch an external backend cannot reproduce without GetFlyoutItemTemplateSource:
+		// the template is set on the MenuItem, but the flyout item handed to the backend is the internal
+		// MenuShellItem wrapper, which does not have the property set.
+		[Fact]
+		public void MenuItemTemplateSetOnMenuItemIsFoundThroughMenuShellItem()
+		{
+			var shell = new Shell();
+			shell.Items.Add(CreateShellItem());
+
+			var menuItem = new MenuItem { Text = "Menu" };
+			Shell.SetMenuItemTemplate(menuItem, new DataTemplate(() => new Label { Text = "OnMenuItem" }));
+			AddMenuShellItem(shell, menuItem);
+
+			var backend = new FakeExternalShellFlyoutBackend(shell);
+			var flyoutItem = FindFlyoutItem(backend, menuItem);
+
+			Assert.NotSame(menuItem, flyoutItem);
+			Assert.Same(menuItem, Shell.GetFlyoutItemTemplateSource(flyoutItem));
+			Assert.True(Shell.IsFlyoutItemTemplateSet(shell, flyoutItem));
+			Assert.Equal("OnMenuItem", ((Label)backend.CreateFlyoutItemView(flyoutItem)).Text);
+		}
+
+		// Same gap seen from the other side: the flyout item is the MenuItem itself and the template lives on
+		// its parent.
+		[Fact]
+		public void MenuItemTemplateSetOnParentIsFoundThroughMenuItem()
+		{
+			var shell = new Shell();
+			var shellContent = CreateShellContent();
+
+			var menuItem = new MenuItem { Text = "Menu" };
+			shellContent.MenuItems.Add(menuItem);
+			Shell.SetMenuItemTemplate(shellContent, new DataTemplate(() => new Label { Text = "OnParent" }));
+
+			shell.Items.Add(shellContent);
+
+			var backend = new FakeExternalShellFlyoutBackend(shell);
+
+			Assert.Contains(menuItem, backend.GetFlyoutItems());
+			Assert.Same(shellContent, Shell.GetFlyoutItemTemplateSource(menuItem));
+			Assert.True(Shell.IsFlyoutItemTemplateSet(shell, menuItem));
+			Assert.Equal("OnParent", ((Label)backend.CreateFlyoutItemView(menuItem)).Text);
+		}
+
+		// Documents the failure mode this API exists to fix: an external backend that only inspects the flyout
+		// item itself concludes that no template is set and incorrectly falls back to its own default view.
+		[Fact]
+		public void InspectingTheFlyoutItemDirectlyMissesMenuItemTemplates()
+		{
+			var shell = new Shell();
+			shell.Items.Add(CreateShellItem());
+
+			var menuItem = new MenuItem { Text = "Menu" };
+			Shell.SetMenuItemTemplate(menuItem, new DataTemplate(() => new Label { Text = "OnMenuItem" }));
+			AddMenuShellItem(shell, menuItem);
+
+			var backend = new FakeExternalShellFlyoutBackend(shell);
+			var flyoutItem = FindFlyoutItem(backend, menuItem);
+
+			Assert.False(flyoutItem.IsSet(Shell.MenuItemTemplateProperty));
+			Assert.True(Shell.IsFlyoutItemTemplateSet(shell, flyoutItem));
+		}
+
+		[Fact]
+		public void MenuItemTemplateSourceProvidesBindingContextForTemplate()
+		{
+			var shell = new Shell();
+			shell.Items.Add(CreateShellItem());
+
+			var menuItem = new MenuItem { Text = "Menu" };
+			Shell.SetMenuItemTemplate(menuItem, new DataTemplate(() =>
+			{
+				var label = new Label();
+				label.SetBinding(Label.TextProperty, static (MenuItem item) => item.Text);
+				return label;
+			}));
+
+			AddMenuShellItem(shell, menuItem);
+
+			var backend = new FakeExternalShellFlyoutBackend(shell);
+			var flyoutItem = FindFlyoutItem(backend, menuItem);
+
+			Assert.Equal("Menu", ((Label)backend.CreateFlyoutItemView(flyoutItem)).Text);
+		}
+
+		[Fact]
+		public void TemplateSourceCarriesStyleClassForMenuItems()
+		{
+			var shell = new Shell();
+			shell.Items.Add(CreateShellItem());
+
+			var menuItem = new MenuItem { Text = "Menu", StyleClass = new[] { "fooClass" } };
+			Shell.SetMenuItemTemplate(menuItem, new DataTemplate(() => new Label()));
+			AddMenuShellItem(shell, menuItem);
+
+			var backend = new FakeExternalShellFlyoutBackend(shell);
+			var flyoutItem = FindFlyoutItem(backend, menuItem);
+
+			var styleSource = Assert.IsType<MenuItem>(Shell.GetFlyoutItemTemplateSource(flyoutItem));
+
+			Assert.Contains("fooClass", styleSource.StyleClass);
+		}
+
+		[Fact]
+		public void FlyoutHeaderAndFooterAreAvailableToExternalBackends()
+		{
+			var header = new Label { Text = "Header" };
+			var footer = new Label { Text = "Footer" };
+
+			var shell = new Shell
+			{
+				FlyoutHeader = header,
+				FlyoutFooter = footer
+			};
+
+			shell.Items.Add(CreateShellItem());
+
+			var backend = new FakeExternalShellFlyoutBackend(shell);
+
+			Assert.Same(header, backend.Header);
+			Assert.Same(footer, backend.Footer);
+		}
+
+		[Fact]
+		public void FlyoutHeaderTemplateIsAvailableToExternalBackends()
+		{
+			var shell = new Shell
+			{
+				FlyoutHeaderTemplate = new DataTemplate(() => new Label { Text = "HeaderTemplate" })
+			};
+
+			shell.Items.Add(CreateShellItem());
+
+			var backend = new FakeExternalShellFlyoutBackend(shell);
+
+			Assert.Equal("HeaderTemplate", Assert.IsType<Label>(backend.Header).Text);
+		}
+
+		[Fact]
+		public void TemplatePropertyMatchesItemKind()
+		{
+			var shell = new Shell();
+			var shellItem = CreateShellItem();
+			shell.Items.Add(shellItem);
+			var menuItem = AddMenuShellItem(shell, new MenuItem { Text = "Menu" });
+
+			var backend = new FakeExternalShellFlyoutBackend(shell);
+			var flyoutItem = FindFlyoutItem(backend, menuItem);
+
+			Assert.Same(Shell.ItemTemplateProperty, Shell.GetFlyoutItemTemplateProperty(shellItem));
+			Assert.Same(Shell.MenuItemTemplateProperty, Shell.GetFlyoutItemTemplateProperty(flyoutItem));
+			Assert.Same(Shell.MenuItemTemplateProperty, Shell.GetFlyoutItemTemplateProperty(menuItem));
+		}
+
+		[Fact]
+		public void TemplateSourceReturnsItemWhenNoTemplateIsSet()
+		{
+			var shell = new Shell();
+			var shellItem = CreateShellItem();
+			shell.Items.Add(shellItem);
+			var menuItem = AddMenuShellItem(shell, new MenuItem { Text = "Menu" });
+
+			var backend = new FakeExternalShellFlyoutBackend(shell);
+			var flyoutItem = FindFlyoutItem(backend, menuItem);
+
+			Assert.Same(shellItem, Shell.GetFlyoutItemTemplateSource(shellItem));
+			Assert.Same(flyoutItem, Shell.GetFlyoutItemTemplateSource(flyoutItem));
+		}
+
+		[Fact]
+		public void NullFlyoutItemThrows()
+		{
+			Assert.Throws<System.ArgumentNullException>(() => Shell.GetFlyoutItemTemplateSource(null));
+			Assert.Throws<System.ArgumentNullException>(() => Shell.GetFlyoutItemTemplateProperty(null));
+			Assert.Throws<System.ArgumentNullException>(() => Shell.IsFlyoutItemTemplateSet(new Shell(), null));
+		}
+
+		[Fact]
+		public void NullShellOnlyConsidersTemplatesSetOnTheItem()
+		{
+			var shell = new Shell
+			{
+				ItemTemplate = new DataTemplate(() => new Label { Text = "ItemTemplate" })
+			};
+
+			var shellItem = CreateShellItem();
+			shell.Items.Add(shellItem);
+
+			Assert.True(Shell.IsFlyoutItemTemplateSet(shell, shellItem));
+			Assert.False(Shell.IsFlyoutItemTemplateSet(null, shellItem));
+		}
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Out-of-tree Shell backends need to decide whether a flyout item uses an application-supplied `DataTemplate` or the backend's own platform-native presentation. That decision requires resolving the object that actually *carries* the template, which is not always the flyout item itself:

- A `MenuItem` added to `Shell.Items` is wrapped in the **internal** `MenuShellItem`. When `Shell.MenuItemTemplate` is set on the `MenuItem`, the wrapper never has the property set — the template lives on `MenuShellItem.MenuItem`.
- A `MenuItem` in `ShellContent.MenuItems` appears in the flyout grouping directly, while the template may be set on its parent `ShellContent`.

Both branches lived in the internal `Shell.GetBindableObjectWithFlyoutItemTemplate`. An external backend can only inspect the flyout item it is handed, so it concludes no template is set and incorrectly falls back to its platform default. This is a concrete blocker for the Tizen backend now maintained out-of-tree ([Redth/Maui.Tizen](https://github.com/Redth/Maui.Tizen), Wave C).

#### New API

One result-oriented, nullable-annotated method:

```csharp
public static DataTemplate? ResolveFlyoutItemTemplate(Shell? shell, BindableObject flyoutItem)
```

Returns the final application-defined template, or `null` meaning **use your own platform-native default**. `MenuShellItem` and the paired-object lookup stay internal, and `IShellController` is unchanged (no breaking interface addition).

Precedence matches the built-in backends exactly: a template set on the item wins over one set on the Shell; `MenuItemTemplateProperty` is used for menu items and `ItemTemplateProperty` for everything else.

```csharp
View CreateFlyoutItemView(Shell shell, BindableObject flyoutItem)
{
    var template = Shell.ResolveFlyoutItemTemplate(shell, flyoutItem);

    if (template is null)
        return CreatePlatformDefaultFlyoutItemView(flyoutItem);

    var view = (View)template.SelectDataTemplate(flyoutItem, shell).CreateContent();
    view.BindingContext = flyoutItem;
    return view;
}
```

Binding the created content to **`flyoutItem`** is what all three built-in backends do — iOS `UIContainerCell.BindingContext = context`, Android `View.BindingContext = value`, Windows `_content.BindingContext = bo`.

#### Null semantics

An item that explicitly sets the template property wins **even when the value is null**, so an app can opt a single item out of a Shell-level template. A null or null-bound value is reported as "no template" rather than producing a `true` + `null` mismatch or an NRE in platform code.

`IShellController.GetFlyoutItemDataTemplate` is now `ResolveFlyoutItemTemplate(this, bo) ?? BaseShellItem.CreateDefaultFlyoutItemCell(bo)`, so the in-box path never hands `null` to platform code. Previously an explicitly-null template returned `null` here, which produced a blank Windows item and an NRE on Tizen.

#### Dogfooding

The **Windows** backend (`ShellFlyoutItemView`) now goes through the public API and falls back to the default cell. The in-box **Tizen** adaptor resolves and null-checks in one step. `BaseShellItem.CreateDefaultFlyoutItemCell` continues to use the internal helper for its style-class source.

> [!IMPORTANT]
> **Intentional Windows behavior change.** When a flyout item explicitly sets its template property to `null` (e.g. `Shell.SetItemTemplate(item, null)` to opt one item out of a Shell-level template), Windows previously rendered a **blank flyout item** — `GetFlyoutItemDataTemplate` returned `null` and `ShellFlyoutItemView` skipped content creation entirely. It now renders the **default flyout item cell**, matching Android and iOS. This is a deliberate consistency fix, not a regression.

### Changes since the first revision

Addressing review feedback, the original three methods (`GetFlyoutItemTemplateProperty`, `GetFlyoutItemTemplateSource`, `IsFlyoutItemTemplateSet`) were removed in favor of the single method above, because:

1. `Get*` on `Shell` reads as an attached-property accessor, which these were not.
2. Exposing the property / source / is-set trio froze the internal lookup levels as public contract.
3. The documented binding context was **wrong** — it pointed callers at the template source (the parent `ShellContent` for `ShellContent.MenuItems`) instead of the flyout item.

### Issues Fixed

Unblocks external Shell backends (Tizen) from replicating in-box flyout item template selection.

### Tests

`ShellExternalFlyoutBackendTests` (27 tests) drives a `FakeExternalShellFlyoutBackend` restricted to public API only, mirroring an out-of-tree adaptor:

- **Template resolution** — no template → `null`; Shell-level `ItemTemplate`/`MenuItemTemplate`; item-level template winning over Shell-level; `MenuItemTemplate` set on the `MenuItem` and found through the `MenuShellItem` wrapper; set on the parent `ShellContent` and found through the `MenuItem`; set on the `MenuItem` itself for `ShellContent.MenuItems`; and the pre-existing parent-wins precedence when both are set
- **Binding** — `Text` and `Command` bound through `ShellContent.MenuItems`, `Text`/`Command` bound through Shell-level `MenuItemTemplate`, `Title` bound for shell items, and flyout selection actually invoking the `MenuItem.Command`
- **Null handling** — explicit-null item template opting out of the Shell template (item and menu item), null-bound template, and a test asserting the in-box path still yields a non-null template
- **Selector** — `DataTemplateSelector` returned as-is and resolved by the caller
- **Headers/footers** — `FlyoutHeader`, `FlyoutFooter`, `FlyoutHeaderTemplate`, `FlyoutFooterTemplate`, and headers not appearing as flyout items
- **Argument/ownership semantics** — omitting the Shell resolves it from the item, unparented items, `null` argument validation

Results:

| Suite | Result |
| --- | --- |
| `Controls.Core.UnitTests` | **6234 passed, 0 failed** (30 skipped) |
| `Controls.Xaml.UnitTests` | **2115 passed, 0 failed** (8 skipped) |
| `Controls.Core` `net11.0` + `netstandard2.0` build | clean, PublicAPI analyzer clean |

`net11.0-windows*` and `net11.0-tizen*` cannot be compiled on this macOS box (`MakePri.exe` / unrecognized tizen platform identifier), so those two backend edits are review-validated only; CI covers them.


