### PR TITLE
[net11.0] Use scalable Helix job monitor uploader

### DIFF
--- a/eng/pipelines/arcade/stage-helix-tests.yml
+++ b/eng/pipelines/arcade/stage-helix-tests.yml
@@ -47,6 +47,9 @@ parameters:
   default:
   - Debug
   - Release
+- name: helixJobMonitorVersion
+  type: string
+  default: 11.0.0-beta.26425.2
 - name: helixJobMonitorTimeoutInMinutes
   type: number
   default: 360
@@ -119,9 +122,9 @@ stages:
 
         toolPath="$AGENT_TEMPDIRECTORY/helix-job-monitor"
         bash ./eng/common/dotnet.sh
-        toolVersion=$(bash ./eng/common/dotnet.sh msbuild eng/Versions.props -getProperty:MicrosoftDotNetHelixSdkPackageVersion -nologo | tail -n 1)
+        toolVersion='${{ parameters.helixJobMonitorVersion }}'
         if [[ -z "$toolVersion" || "$toolVersion" =~ [[:space:]] ]]; then
-          echo "Could not read the Helix SDK package version from eng/Versions.props." >&2
+          echo "The Helix Job Monitor package version is invalid." >&2
           exit 1
         fi
 

--- a/eng/pipelines/arcade/stage-helix-tests.yml
+++ b/eng/pipelines/arcade/stage-helix-tests.yml
@@ -124,7 +124,7 @@ stages:
         bash ./eng/common/dotnet.sh
         toolVersion='${{ parameters.helixJobMonitorVersion }}'
         if [[ -z "$toolVersion" || "$toolVersion" =~ [[:space:]] ]]; then
-          echo "The Helix Job Monitor package version is invalid." >&2
+          printf 'The helixJobMonitorVersion parameter must be non-empty and contain no whitespace; received %q.\n' "$toolVersion" >&2
           exit 1
         fi
 

--- a/eng/pipelines/arcade/stage-helix-tests.yml
+++ b/eng/pipelines/arcade/stage-helix-tests.yml
@@ -122,7 +122,7 @@ stages:
 
         toolPath="$AGENT_TEMPDIRECTORY/helix-job-monitor"
         bash ./eng/common/dotnet.sh
-        toolVersion='${{ parameters.helixJobMonitorVersion }}'
+        toolVersion="$HELIX_JOB_MONITOR_VERSION"
         if [[ -z "$toolVersion" || "$toolVersion" =~ [[:space:]] ]]; then
           printf 'The helixJobMonitorVersion parameter must be non-empty and contain no whitespace; received %q.\n' "$toolVersion" >&2
           exit 1
@@ -141,6 +141,8 @@ stages:
 
         echo "##vso[task.setvariable variable=HelixJobMonitorDll]$toolDll"
       displayName: Install Helix Job Monitor
+      env:
+        HELIX_JOB_MONITOR_VERSION: ${{ parameters.helixJobMonitorVersion }}
 
     - bash: |
         set -euo pipefail

--- a/eng/pipelines/arcade/stage-helix-tests.yml
+++ b/eng/pipelines/arcade/stage-helix-tests.yml
@@ -122,7 +122,7 @@ stages:
 
         toolPath="$AGENT_TEMPDIRECTORY/helix-job-monitor"
         bash ./eng/common/dotnet.sh
-        toolVersion="$HELIX_JOB_MONITOR_VERSION"
+        toolVersion="${HELIX_JOB_MONITOR_VERSION:-}"
         if [[ -z "$toolVersion" || "$toolVersion" =~ [[:space:]] ]]; then
           printf 'The helixJobMonitorVersion parameter must be non-empty and contain no whitespace; received %q.\n' "$toolVersion" >&2
           exit 1

--- a/eng/pipelines/arcade/stage-helix-tests.yml
+++ b/eng/pipelines/arcade/stage-helix-tests.yml
@@ -147,16 +147,58 @@ stages:
     - bash: |
         set -euo pipefail
 
-        bash ./eng/common/dotnet.sh exec "$(HelixJobMonitorDll)" \
-          --helix-base-uri 'https://helix.dot.net/' \
-          --polling-interval-seconds 30 \
-          --fail-on-failed-tests true \
-          --max-wait-minutes "$((${{ parameters.helixJobMonitorTimeoutInMinutes }} - 5))" \
-          --stage-name '$(System.StageName)' \
-          --organization dotnet \
-          --repository maui \
-          --build-reason '$(Build.Reason)' \
-          --source-branch '$(Build.SourceBranch)'
+        monitorDeadline=$((SECONDS + (${{ parameters.helixJobMonitorTimeoutInMinutes }} - 5) * 60))
+        monitorAttempt=1
+        monitorResult=0
+
+        # Upload failures do not affect the upstream tool's exit code. Replay untagged jobs until every upload is durable.
+        while true; do
+          remainingSeconds=$((monitorDeadline - SECONDS))
+          if ((remainingSeconds <= 0)); then
+            echo "The Helix Job Monitor exhausted its retry window with untagged uploads remaining." >&2
+            exit 1
+          fi
+
+          remainingMinutes=$(((remainingSeconds + 59) / 60))
+          monitorLog="$AGENT_TEMPDIRECTORY/helix-job-monitor-attempt-$monitorAttempt.log"
+
+          set +e
+          bash ./eng/common/dotnet.sh exec "$(HelixJobMonitorDll)" \
+            --helix-base-uri 'https://helix.dot.net/' \
+            --polling-interval-seconds 30 \
+            --fail-on-failed-tests true \
+            --max-wait-minutes "$remainingMinutes" \
+            --stage-name '$(System.StageName)' \
+            --organization dotnet \
+            --repository maui \
+            --build-reason '$(Build.Reason)' \
+            --source-branch '$(Build.SourceBranch)' 2>&1 | tee "$monitorLog"
+          monitorExitCode=${PIPESTATUS[0]}
+          set -e
+
+          uploadSummary=$(grep -Eo '[0-9]+ job upload\(s\) remain untagged\.' "$monitorLog" | tail -n 1 || true)
+          if [[ ! "$uploadSummary" =~ ^([0-9]+)\ job\ upload\(s\)\ remain\ untagged\.$ ]]; then
+            if ((monitorExitCode != 0)); then
+              exit "$monitorExitCode"
+            fi
+
+            echo "The Helix Job Monitor did not report its durable upload state." >&2
+            exit 1
+          fi
+
+          if ((monitorExitCode != 0 && monitorResult == 0)); then
+            monitorResult=$monitorExitCode
+          fi
+
+          untaggedUploads=${BASH_REMATCH[1]}
+          if ((untaggedUploads == 0)); then
+            exit "$monitorResult"
+          fi
+
+          echo "##vso[task.logissue type=warning]Replaying $untaggedUploads untagged Helix job upload(s)."
+          monitorAttempt=$((monitorAttempt + 1))
+          sleep 30
+        done
       displayName: Monitor Helix Jobs
       env:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Root cause

PR #37852 correctly isolated the Helix Job Monitor from MAUI's root tool manifest, but its exact-head `maui-pr` build [1569038](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1569038) exposed a scalability problem in the branch-pinned monitor version:

- All 4 Helix jobs and all 36 work items completed successfully.
- The monitor discovered and processed all four jobs, then waited 5 hours 41 minutes for four pending Azure DevOps result uploads.
- Azure's Test APIs intermittently returned HTTP 503 or did not respond.
- The old uploader repeatedly left untagged partial runs: 12 `InProgress` runs containing 90,650 uploaded result rows remained when the monitor timed out.
- The monitor was built from `11.0.0-beta.26379.102`, which predates Arcade's transient-write retry fix and scalable result-processing rewrite.

## Fix

Pin the dedicated monitor job to `Microsoft.DotNet.Helix.JobMonitor` `11.0.0-beta.26425.2`, independently from the Helix submission SDK.

That package includes:

- [dotnet/arcade#17256](https://github.com/dotnet/arcade/pull/17256), which retries transient Azure DevOps transport failures and HTTP 5xx/429 result writes.
- [dotnet/arcade#17331](https://github.com/dotnet/arcade/pull/17331), which replaces the blocking upload queue with bounded parallel result processing, coordinated throttling, streaming batches, and idempotent test-run completion retries.

Arcade intentionally excludes upload failures from the monitor's exit code so an interrupted, untagged upload can be replayed by a later invocation. MAUI has only one monitor invocation, so the pipeline now re-invokes the pinned monitor when its final drain reports untagged jobs. Completed tagged uploads are skipped, incomplete jobs are replayed within the original shared timeout, and any real test failure is preserved until result publication is durable. Missing or changed durable-state output fails closed.

The Helix submission SDK remains unchanged at the branch-pinned version, so this only updates centralized result processing. The monitor package targets `net10.0` with `rollForward: Major`, and runs under MAUI's pinned net11 runtime.

No open MAUI PR addresses this follow-up. Increasing the six-hour timeout would only prolong the old uploader's blocked drain, while suppressing result publication would hide real test failures.

## Validation

- Installed `11.0.0-beta.26425.2` from an empty NuGet cache.
- Invoked the exact tool DLL under MAUI's pinned net11 runtime and confirmed source commit `b49c2eb57bbccbbd4a16e535eb1edc2a9604d723`.
- Verified the existing monitor CLI arguments remain supported, including `--max-wait-minutes` and `--fail-on-failed-tests`.
- Verified the package source commit contains both Arcade fixes.
- In follow-up build [1569648](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1569648), all 4 Helix jobs and 36 work items passed while the Test API produced 92 failed request attempts. The scalable uploader processed 12,858 results and drained in 57 minutes instead of hanging for six hours.
- That stress run also proved the upstream tool can exit successfully with incomplete publication: 3 job uploads remained untagged and 3 test runs remained `InProgress`. The new replay guard classifies that exact raw summary as incomplete rather than green.
- Build [1569726](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1569726) empirically exercised the recovery path under sustained Test API degradation. The first monitor invocation encountered 79 failed Azure requests and reported 1 untagged job; the wrapper replayed only that incomplete Windows Release upload, published its 5,461 results, and finished with 0 untagged jobs and all 4 test runs `Completed`.
- Build [1569751](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1569751) validated the clean path: 4 of 4 jobs and 36 of 36 work items succeeded, exactly 21,858 results were published with no retry attempts or failed Azure requests, the final drain completed in 6 minutes 14 seconds, and 0 uploads remained untagged. A later independent AOT workload installation initially failed before tests when its download connection was reset; the in-place retry installed the workloads, passed all 18 AOT tests, and completed the build successfully.
- Required Windows device build [1569753](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1569753) exposed two unrelated `net11.0` test regressions that reproduced on the untouched parent. They are corrected separately by #37877, whose exact-merge build [1570083](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1570083) passed both tests in packaged and unpackaged execution with no failed result rows.
- UI retry build [1569752](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1569752) cleared four of its six failed or canceled shards. Android API 36 SafeArea repeated the untouched-parent height and screenshot failures. Mac Catalyst Shell published 310 passing rows and one `Issue35736` visual failure before the three-hour job limit canceled the next test; its 0.51% SearchHandler snapshot mismatch also reproduced in untouched-parent build [1569531](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1569531). These exact-parent blockers are independent of the Helix monitor change.
- Exercised replay-to-success, preserved-test-failure, missing-summary, and nonzero-exit paths against the pinned output contract.
- Parsed the updated Azure Pipelines template and checked the patch for whitespace errors.
