### PR TITLE
[ci] Enable dotnet/skiasharp non-workload releases

### DIFF
--- a/.github/workflows/powershell-script-tests.yml
+++ b/.github/workflows/powershell-script-tests.yml
@@ -22,6 +22,7 @@ on:
       - 'eng/pipelines/ci-official-release.Tests.ps1'
       - 'eng/scripts/nuget_release_packages.ps1'
       - 'eng/scripts/nuget_release_packages.Tests.ps1'
+      - 'eng/pipelines/common/non-workload-publish.yml'
       - '.github/workflows/powershell-script-tests.yml'
   workflow_dispatch:
 

--- a/docs/ReleaseProcess.md
+++ b/docs/ReleaseProcess.md
@@ -23,7 +23,7 @@ The pipeline accepts:
 - `pushWorkloadSet`: adds the resolved BAR build to the matching .NET workload release channel.
 - `pushNugetOrg`: enables the NuGet.org release stages.
 - `pushPackages`: when `false`, gathers and publishes release artifacts without promoting a workload build, running approvals, or requesting the production NuGet service connection.
-- `nugetIncludeFilters` and `nugetExcludeFilters`: workload-only, semicolon-separated wildcard filters applied to package file names. Include filters select workload packs; workload manifests remain selected unless an exclude filter removes them, preserving the previous release behavior. Non-workload releases reject these parameters rather than silently ignoring them.
+- `nugetIncludeFilters` and `nugetExcludeFilters`: semicolon-separated wildcard filters applied to package file names. For workload releases, include filters select packs while manifests remain selected unless excluded, preserving the previous behavior. For non-workload releases, the filters select packages for the single release set.
 - `nugetAlreadyAttemptedPackFilters` and `nugetAlreadyAttemptedManifestFilters`: workload-only recovery filters for pack or manifest files that a previous task invocation already submitted to NuGet.org. These packages stay in the expected verification set but are withheld from another push while NuGet.org validation is still pending. Use only the parameter for the affected publish stage; non-workload releases reject them.
 
 ### Non-workload NuGet packages
@@ -31,8 +31,9 @@ The pipeline accepts:
 For repositories outside the inferred workload set, the generic non-workload path validates the
 BAR build against the requested GitHub repository, runs one fail-fast
 `darc gather-drop --id <BAR ID>`, gathers only shipping NuGet packages, rejects
-malformed or duplicate packages, and filters exact ID/version pairs already on
-NuGet.org. All remaining `.nupkg` files form one release set. Workload manifests
+malformed or duplicate packages, applies the package filters, and filters exact
+ID/version pairs already on NuGet.org. All selected `.nupkg` files form one
+release set. Workload manifests
 are rejected so a workload build cannot accidentally bypass MAUI's pack-before-
 manifest ordering.
 

--- a/docs/ReleaseProcess.md
+++ b/docs/ReleaseProcess.md
@@ -12,25 +12,67 @@ The .NET MAUI release process uses Arcade and 1ES to build, sign, gather, and pu
 
 The pipeline accepts:
 
-- `commitHash`: the source commit registered in BAR. The default value, `skip`, prevents all preparation, approval, workload-channel, and NuGet publishing jobs.
+- `ghOwner` and `ghRepo`: the GitHub owner and repository name used to resolve
+  the BAR build. Keep `ghOwner: dotnet` and enter `ghRepo: android-libraries`
+  for an Android libraries release.
+- Workload behavior is inferred for `dotnet/android`, `dotnet/macios`, and
+  `dotnet/maui`. Other enabled repositories use the ordinary NuGet package path.
+- `commitHash`: the source commit registered in BAR. It must resolve to exactly
+  one build for the requested repository. The default value, `skip`, prevents
+  all preparation, approval, workload-channel, and NuGet publishing jobs.
 - `pushWorkloadSet`: adds the resolved BAR build to the matching .NET workload release channel.
 - `pushNugetOrg`: enables the NuGet.org release stages.
-- `pushPackages`: when `false`, gathers and publishes release artifacts without running approvals or requesting the production NuGet service connection.
-- `nugetIncludeFilters` and `nugetExcludeFilters`: semicolon-separated wildcard filters applied to package file names. Include filters select workload packs; workload manifests remain selected unless an exclude filter removes them, preserving the previous release behavior.
-- `nugetAlreadyAttemptedPackFilters` and `nugetAlreadyAttemptedManifestFilters`: recovery-only wildcard filters for pack or manifest files that a previous task invocation already submitted to NuGet.org. These packages stay in the expected verification set but are withheld from another push while NuGet.org validation is still pending. Use only the parameter for the affected publish stage.
+- `pushPackages`: when `false`, gathers and publishes release artifacts without promoting a workload build, running approvals, or requesting the production NuGet service connection.
+- `nugetIncludeFilters` and `nugetExcludeFilters`: workload-only, semicolon-separated wildcard filters applied to package file names. Include filters select workload packs; workload manifests remain selected unless an exclude filter removes them, preserving the previous release behavior. Non-workload releases reject these parameters rather than silently ignoring them.
+- `nugetAlreadyAttemptedPackFilters` and `nugetAlreadyAttemptedManifestFilters`: workload-only recovery filters for pack or manifest files that a previous task invocation already submitted to NuGet.org. These packages stay in the expected verification set but are withheld from another push while NuGet.org validation is still pending. Use only the parameter for the affected publish stage; non-workload releases reject them.
+
+### Non-workload NuGet packages
+
+For repositories outside the inferred workload set, the generic non-workload path validates the
+BAR build against the requested GitHub repository, runs one fail-fast
+`darc gather-drop --id <BAR ID>`, gathers only shipping NuGet packages, rejects
+malformed or duplicate packages, and filters exact ID/version pairs already on
+NuGet.org. All remaining `.nupkg` files form one release set. Workload manifests
+are rejected so a workload build cannot accidentally bypass MAUI's pack-before-
+manifest ordering.
+
+The `NuGetReleaseAudit` artifact records the selected and exact staged package
+lists before manual approval. `pushPackages: false` performs the
+same resolution, gather, validation, filtering, and audit without promotion or
+publishing. A real release uses `1ES.PublishNuget@1` and verifies every selected
+package on NuGet.org afterward.
+
+Repository-specific policy remains at the pipeline boundary. For example,
+`dotnet/android-libraries` must match the public `.NET 10` channel exactly (ID
+`5172`). Its BAR builds contain per-build deltas, not the union of channel
+assets, so release each pending build in commit order.
+Before the first push for any repository, verify that the existing
+`nuget.org (dotnetframework)` service connection owns every package ID in the
+audit artifact.
+
+Example dry-run inputs:
+
+```yaml
+ghOwner: dotnet
+ghRepo: android-libraries
+commitHash: <FULL_COMMIT_SHA>
+pushWorkloadSet: false
+pushNugetOrg: true
+pushPackages: false
+```
 
 ### Preparation
 
-The preparation stage resolves the BAR build once and runs one fail-fast `darc gather-drop`, filtered to BAR NuGet package assets. Symbol and other path-based blob assets are not NuGet.org release inputs and are not downloaded. The stage rejects a failed or incomplete package gather, applies the include and exclude filters, and requires non-empty workload-pack and workload-manifest sets.
+The preparation stage resolves the BAR build once and runs one fail-fast `darc gather-drop`, filtered to BAR NuGet package assets. Symbol and other path-based blob assets are not NuGet.org release inputs and are not downloaded. The stage rejects a failed or incomplete package gather. Workload releases apply the include and exclude filters and require non-empty pack and manifest sets; non-workload releases use the single package set described above.
 
-For every selected package, the stage reads the package ID and version from its nuspec and reports the selected identities and counts. It publishes two 1ES pipeline outputs:
+For every selected package, the stage reads the package ID and version from its nuspec and reports the selected identities and counts. Workload releases publish two 1ES pipeline outputs:
 
 - `MauiPacksForNuGet`
 - `MauiManifestsForNuGet`
 
 These outputs include `expected-packages.json` and the package-availability helper used by the release jobs. They are SBOM-backed by the 1ES pipeline template and are the immutable inputs for publishing and recovery. The preparation stage records the helper's SHA-256 hash, and each production step verifies that hash before executing the artifact copy. A dry run (`pushPackages: false`) produces these artifacts but does not validate service-connection authorization, external NuGet.org authentication, or egress.
 
-### Publishing and ordering
+### Workload publishing and ordering
 
 Workload packs and manifests have separate manual approval points. Their production jobs:
 
@@ -45,7 +87,7 @@ NuGet.org may reserve a package version and return HTTP 409 before that package 
 
 After each publish, the pipeline polls NuGet.org for every expected package ID and normalized version with a 30-minute deadline, then fails with the missing identities if indexing does not complete. The manifest stage depends on successful pack publication and verification, so manifest approval is unavailable until every selected pack is resolvable.
 
-The production service connection must be protected by Azure DevOps Environment and/or service-connection approval checks outside repository YAML. Before production use, release owners must confirm that it owns every selected MAUI package ID and has enough quota for the maximum release payload. If one identity cannot cover the payload, publishing must be split into deterministic sequential batches rather than reintroducing repository API keys.
+The production service connection must be protected by Azure DevOps Environment and/or service-connection approval checks outside repository YAML. Before production use, release owners must confirm that it owns every selected package ID and has enough quota for the maximum release payload. If one identity cannot cover the payload, publishing must be split into deterministic sequential batches rather than reintroducing repository API keys.
 
 ## Required internal validation
 
@@ -66,7 +108,7 @@ An internal Azure Artifacts feed proves task mechanics but not the exact externa
 
 ## Recovery
 
-If publishing partially succeeds, rerun with the same commit and selection filters. The availability step removes packages that are already visible on NuGet.org. For packages accepted by the previous invocation but still undergoing NuGet.org validation, set the affected stage's `nugetAlreadyAttemptedPackFilters` or `nugetAlreadyAttemptedManifestFilters` from the package names in the prior task log, leaving the other recovery parameter at `skip`. The task receives only the remaining packages, and post-publish verification checks the complete expected set. Do not release from a different BAR drop.
+If publishing partially succeeds, rerun with the same commit and selection filters. The availability step removes packages that are already visible on NuGet.org. For workload packages accepted by the previous invocation but still undergoing NuGet.org validation, set the affected stage's `nugetAlreadyAttemptedPackFilters` or `nugetAlreadyAttemptedManifestFilters` from the package names in the prior task log, leaving the other recovery parameter at `skip`. Non-workload releases have no recovery filter; rerun after accepted packages become visible. Post-publish verification checks the complete expected set. Do not release from a different BAR drop.
 
 Published package contents cannot be replaced. If an incorrect version is published, follow NuGet.org's process to remove it from package search results.
 

--- a/docs/ReleaseProcess.md
+++ b/docs/ReleaseProcess.md
@@ -44,9 +44,7 @@ publishing. Immediately before a real release, the pipeline filters the staged
 set again so packages published since preparation do not cause conflicts. It
 then uses `1ES.PublishNuget@1` and verifies every selected package on NuGet.org.
 
-Repository-specific policy remains at the pipeline boundary. For example,
-`dotnet/android-libraries` must match the public `.NET 10` channel exactly (ID
-`5172`). Its BAR builds contain per-build deltas, not the union of channel
+Android-libraries BAR builds contain per-build deltas, not the union of channel
 assets, so release each pending build in commit order.
 Before the first push for any repository, verify that the existing
 `nuget.org (dotnetframework)` service connection owns every package ID in the

--- a/docs/ReleaseProcess.md
+++ b/docs/ReleaseProcess.md
@@ -15,6 +15,12 @@ The pipeline accepts:
 - `ghOwner` and `ghRepo`: the GitHub owner and repository name used to resolve
   the BAR build. Keep `ghOwner: dotnet` and enter `ghRepo: android-libraries`
   for an Android libraries release.
+- `barBuildId`: optional. BAR records a build's GitHub URL only when Arcade
+  could verify the AzDO-to-GitHub mapping when the build was published. A build
+  without that URL cannot be found by repository and commit, so supply its BAR
+  ID to resolve it directly. The requested commit is still verified against the
+  resolved build, and the repository is verified against the AzDO mirror naming
+  convention (`<owner>-<name>`). Leave it at `skip` otherwise.
 - Workload behavior is inferred for `dotnet/android`, `dotnet/macios`, and
   `dotnet/maui`. Other enabled repositories use the ordinary NuGet package path.
 - `commitHash`: the source commit registered in BAR. It must resolve to exactly

--- a/docs/ReleaseProcess.md
+++ b/docs/ReleaseProcess.md
@@ -39,8 +39,9 @@ manifest ordering.
 The `NuGetReleaseAudit` artifact records the selected and exact staged package
 lists before manual approval. `pushPackages: false` performs the
 same resolution, gather, validation, filtering, and audit without promotion or
-publishing. A real release uses `1ES.PublishNuget@1` and verifies every selected
-package on NuGet.org afterward.
+publishing. Immediately before a real release, the pipeline filters the staged
+set again so packages published since preparation do not cause conflicts. It
+then uses `1ES.PublishNuget@1` and verifies every selected package on NuGet.org.
 
 Repository-specific policy remains at the pipeline boundary. For example,
 `dotnet/android-libraries` must match the public `.NET 10` channel exactly (ID

--- a/docs/ReleaseProcess.md
+++ b/docs/ReleaseProcess.md
@@ -29,11 +29,15 @@ The pipeline accepts:
 ### Non-workload NuGet packages
 
 For repositories outside the inferred workload set, the generic non-workload path validates the
-BAR build against the requested GitHub repository, runs one fail-fast
-`darc gather-drop --id <BAR ID>`, gathers only shipping NuGet packages, rejects
-malformed or duplicate packages, applies the package filters, and filters exact
-ID/version pairs already on NuGet.org. All selected `.nupkg` files form one
-release set. Workload manifests
+BAR build against the requested GitHub repository and gathers its shipping
+NuGet packages with `darc gather-drop --id <BAR ID>`. Repeated releases of the
+same BAR build may encounter packages whose downloadable BAR location was
+replaced by NuGet.org after an earlier partial release. The gather continues in
+that case, but every selected package that was not downloaded must be confirmed
+at its exact ID/version on NuGet.org; an unavailable unpublished package fails
+the release. The pipeline also rejects malformed or duplicate packages, applies
+the package filters, and filters exact ID/version pairs already on NuGet.org.
+All selected `.nupkg` files form one release set. Workload manifests
 are rejected so a workload build cannot accidentally bypass MAUI's pack-before-
 manifest ordering.
 

--- a/eng/pipelines/ci-official-release.Tests.ps1
+++ b/eng/pipelines/ci-official-release.Tests.ps1
@@ -23,13 +23,14 @@ Describe 'ci-official-release.yml' {
       Should -Not -Match $packageAssetFilter
   }
 
-  It 'keeps the filtered gather fail-fast' {
-    $gatherCommands = [regex]::Matches($pipeline, '(?m)^\s*& \$darc gather-drop.*$')
+  It 'keeps workload gathering fail-fast and validates non-workload misses' {
+    $gatherCommands = [regex]::Matches($pipeline, '(?m)^\s*& \$darc @gatherArguments.*$')
 
     $gatherCommands.Count | Should -Be 1
-    $gatherCommands[0].Value | Should -Match '--asset-filter \$packageAssetFilter'
-    $gatherCommands[0].Value | Should -Not -Match '--continue-on-error'
-    $pipeline | Should -Match '(?s)& \$darc gather-drop.*?if \(\$LASTEXITCODE -ne 0\) \{\s*throw'
+    $pipeline | Should -Match ([regex]::Escape("'--asset-filter', `$packageAssetFilter"))
+    $pipeline | Should -Match '(?s)if \(!\$releaseWorkload\) \{\s*\$gatherArguments \+= ''--continue-on-error'''
+    $pipeline | Should -Match '(?s)& \$darc @gatherArguments.*?if \(\$gatherFailed -and \$releaseWorkload\) \{\s*throw'
+    $pipeline | Should -Match 'missing selected packages must already exist on NuGet\.org'
   }
 
   It 'rejects duplicate package file names before copying release artifacts' {
@@ -79,9 +80,11 @@ Describe 'ci-official-release.yml' {
     $pipeline | Should -Match 'https://github\.com/dotnet/android'
     $pipeline | Should -Match 'https://github\.com/dotnet/macios'
     $pipeline | Should -Match 'non-workload release cannot contain workload manifest'
-    $pipeline | Should -Match 'Name = ''NuGet packages''; Packages = \$selectedPackages'
+    $pipeline | Should -Match '(?s)Name = ''NuGet packages''.*?Packages = \$selectedPackages.*?Identities = \$selectedIdentities'
     $pipeline | Should -Match '(?s)-Action FilterExisting.*?selectedPackages.*?stagedPackages'
     $pipeline | Should -Match 'belongs to ''\$repository'', not ''\$sourceRepository'''
+    $pipeline | Should -Match '(?s)\$barPackageAssets = @\(\$build\.assets.*?\$selectedBarAssets = @\(\$barPackageAssets'
+    $pipeline | Should -Match 'Gathered packages are absent from the selected BAR assets'
   }
 
   It 'supports package selection and rejects workload recovery filters for non-workload releases' {

--- a/eng/pipelines/ci-official-release.Tests.ps1
+++ b/eng/pipelines/ci-official-release.Tests.ps1
@@ -56,7 +56,7 @@ Describe 'ci-official-release.yml' {
     $pipeline | Should -Not -Match '(?m)^- name: barBuildId$'
     $pipeline | Should -Match '--repo \$sourceRepository --commit'
     $pipeline | Should -Match 'Expected exactly one BAR build'
-    $pipeline | Should -Match '\$requiredChannelId = if \(\$requiredChannelName\) \{ 5172 \}'
+    $pipeline | Should -Not -Match 'requiredChannel(Name|Id)|build\.channels|5172'
   }
 
   It 'publishes a generic audit before approval and supports dry runs' {

--- a/eng/pipelines/ci-official-release.Tests.ps1
+++ b/eng/pipelines/ci-official-release.Tests.ps1
@@ -83,9 +83,10 @@ Describe 'ci-official-release.yml' {
   }
 
   It 'rejects workload-only filters for non-workload releases' {
-    $pipeline | Should -Match '(?s)else \{.*?\$unsupportedFilters = @\(.*?' +
+    $pipeline | Should -Match '(?s)else \{.*?\$unsupportedFilters = @\(@\(.*?' +
       'nugetIncludeFilters.*?nugetExcludeFilters.*?' +
       'nugetAlreadyAttemptedPackFilters.*?nugetAlreadyAttemptedManifestFilters.*?' +
+      '\) \| Where-Object \{ \$_.Values.Count -gt 0 \}\).*?' +
       'Non-workload releases do not support workload package filters'
     $pipeline | Should -Match 'NUGET_ALREADY_ATTEMPTED_PACK_FILTERS: \$\{\{ parameters\.nugetAlreadyAttemptedPackFilters \}\}'
     $pipeline | Should -Match 'NUGET_ALREADY_ATTEMPTED_MANIFEST_FILTERS: \$\{\{ parameters\.nugetAlreadyAttemptedManifestFilters \}\}'

--- a/eng/pipelines/ci-official-release.Tests.ps1
+++ b/eng/pipelines/ci-official-release.Tests.ps1
@@ -79,17 +79,20 @@ Describe 'ci-official-release.yml' {
     $pipeline | Should -Match 'https://github\.com/dotnet/android'
     $pipeline | Should -Match 'https://github\.com/dotnet/macios'
     $pipeline | Should -Match 'non-workload release cannot contain workload manifest'
-    $pipeline | Should -Match 'Name = ''NuGet packages''; Packages = \$allPackages'
+    $pipeline | Should -Match 'Name = ''NuGet packages''; Packages = \$selectedPackages'
     $pipeline | Should -Match '(?s)-Action FilterExisting.*?selectedPackages.*?stagedPackages'
     $pipeline | Should -Match 'belongs to ''\$repository'', not ''\$sourceRepository'''
   }
 
-  It 'rejects workload-only filters for non-workload releases' {
+  It 'supports package selection and rejects workload recovery filters for non-workload releases' {
+    $pipeline | Should -Match '(?s)\$selectedPackages = @\(\$allPackages \| Where-Object \{.*?' +
+      'Test-AnyFilter \$_.Name \$includeFilters.*?' +
+      'Test-AnyFilter \$_.Name \$excludeFilters.*?' +
+      'Package filtering selected no non-workload NuGet packages'
     $pipeline | Should -Match '(?s)else \{.*?\$unsupportedFilters = @\(@\(.*?' +
-      'nugetIncludeFilters.*?nugetExcludeFilters.*?' +
       'nugetAlreadyAttemptedPackFilters.*?nugetAlreadyAttemptedManifestFilters.*?' +
       '\) \| Where-Object \{ \$_.Values.Count -gt 0 \}\).*?' +
-      'Non-workload releases do not support workload package filters'
+      'Non-workload releases do not support workload recovery filters'
     $pipeline | Should -Match 'NUGET_ALREADY_ATTEMPTED_PACK_FILTERS: \$\{\{ parameters\.nugetAlreadyAttemptedPackFilters \}\}'
     $pipeline | Should -Match 'NUGET_ALREADY_ATTEMPTED_MANIFEST_FILTERS: \$\{\{ parameters\.nugetAlreadyAttemptedManifestFilters \}\}'
   }

--- a/eng/pipelines/ci-official-release.Tests.ps1
+++ b/eng/pipelines/ci-official-release.Tests.ps1
@@ -54,10 +54,46 @@ Describe 'ci-official-release.yml' {
   }
 
   It 'requires commit resolution to return one BAR build for the repository' {
-    $pipeline | Should -Not -Match '(?m)^- name: barBuildId$'
     $pipeline | Should -Match '--repo \$sourceRepository --commit'
     $pipeline | Should -Match 'Expected exactly one BAR build'
+    # Repository-specific channel policy was deliberately removed; identity is
+    # established by repository and commit alone.
     $pipeline | Should -Not -Match 'requiredChannel(Name|Id)|build\.channels|5172'
+  }
+
+  It 'enables dotnet/skiasharp as a non-workload repository' {
+    $allowed = [regex]::Match(
+      $pipeline,
+      '(?s)\$allowedRepositories = @\((?<entries>.*?)\r?\n\s*\)').Groups['entries'].Value
+    $allowed | Should -Match 'dotnet/skiasharp'
+
+    # skiasharp must not be inferred as a workload repository.
+    $isWorkload = [regex]::Match(
+      $pipeline,
+      "(?s)- name: isWorkload.*?value: \\\$\{\{(?<expr>.*?)\}\}").Groups['expr'].Value
+    $isWorkload | Should -Not -Match 'skiasharp'
+  }
+
+  It 'resolves a build by BAR ID when the GitHub URL is unavailable' {
+    $pipeline | Should -Match '(?m)^- name: barBuildId$'
+    $pipeline | Should -Match 'get-build --ci --id \$barBuildId --extended'
+    $pipeline | Should -Match 'BAR_BUILD_ID: \$\{\{ parameters\.barBuildId \}\}'
+    # A build found by ID was never matched against the request, so the commit
+    # must still be verified.
+    $pipeline | Should -Match 'not the requested'
+    # Darc reports failures on stdout; losing them makes the run undiagnosable.
+    $pipeline | Should -Match 'Darc failed to resolve the BAR build: \$\(\$buildJson \| Out-String\)'
+  }
+
+  It 'falls back to the AzDO mirror convention when BAR has no GitHub URL' {
+    # Anchored: a substring match would still pass if the field were renamed.
+    $pipeline | Should -Match '(?m)\$buildRepository = \$build\.gitHubRepository\s*$'
+    $pipeline | Should -Match '\[string\]::IsNullOrWhiteSpace\(\$buildRepository\)'
+    $pipeline | Should -Match "\`$separator = \`$azdoName\.IndexOf\('-'\)"
+    $pipeline | Should -Match 'mirror convention'
+    # The verified identity must come from the fallback, never the raw field.
+    $pipeline | Should -Match '\[Uri\] \$buildRepository'
+    $pipeline | Should -Not -Match '\[Uri\] \$build\.gitHubRepository'
   }
 
   It 'publishes a generic audit before approval and supports dry runs' {

--- a/eng/pipelines/ci-official-release.Tests.ps1
+++ b/eng/pipelines/ci-official-release.Tests.ps1
@@ -63,6 +63,8 @@ Describe 'ci-official-release.yml' {
     $pipeline | Should -Match 'artifactName: NuGetReleaseAudit'
     $nonWorkloadTemplate | Should -Match '(?s)dependsOn: prepare_release.*ManualValidation@0'
     $pipeline | Should -Match "(?s)eq\(parameters\.pushPackages, true\).*non-workload-publish\.yml"
+    $nonWorkloadTemplate | Should -Match '(?s)-Action FilterExisting.*?1ES\.PublishNuget@1'
+    $nonWorkloadTemplate | Should -Match "eq\(variables\['NuGetPackagesToPublish'\], 'true'\)"
     $nonWorkloadTemplate | Should -Match '1ES\.PublishNuget@1'
     $nonWorkloadTemplate | Should -Match "publishFeedCredentials: 'nuget\.org \(dotnetframework\)'"
     $pipeline | Should -Not -Match '(?m)^- name: nugetPublishServiceConnection$'

--- a/eng/pipelines/ci-official-release.Tests.ps1
+++ b/eng/pipelines/ci-official-release.Tests.ps1
@@ -4,6 +4,8 @@ Describe 'ci-official-release.yml' {
   BeforeAll {
     $pipelinePath = Join-Path $PSScriptRoot 'ci-official-release.yml'
     $pipeline = Get-Content -LiteralPath $pipelinePath -Raw
+    $nonWorkloadTemplate = Get-Content -LiteralPath (
+      Join-Path $PSScriptRoot 'common/non-workload-publish.yml') -Raw
   }
 
   It 'gathers NuGet package assets without downloading symbol blobs' {
@@ -38,5 +40,54 @@ Describe 'ci-official-release.yml' {
       '\$packageSet\.Packages \| Copy-Item')
 
     $duplicateCheck.Success | Should -BeTrue
+  }
+
+  It 'infers workload releases from the workload repositories' {
+    $pipeline | Should -Not -Match '(?m)^- name: releaseWorkload$'
+    @([regex]::Matches($pipeline, "in\(parameters\.ghRepo, 'android', 'macios', 'maui'\)")).Count |
+      Should -Be 1
+    $pipeline | Should -Match '(?s)- name: isWorkload.*?value: \$\{\{ and'
+    $pipeline | Should -Match '\$releaseWorkload = \[bool\]::Parse\(\$env:IS_WORKLOAD\)'
+    $pipeline | Should -Match '--skip-assets-publishing'
+    $nonWorkloadTemplate | Should -Not -Match 'skip-assets-publishing|add-build-to-channel'
+  }
+
+  It 'requires commit resolution to return one BAR build for the repository' {
+    $pipeline | Should -Not -Match '(?m)^- name: barBuildId$'
+    $pipeline | Should -Match '--repo \$sourceRepository --commit'
+    $pipeline | Should -Match 'Expected exactly one BAR build'
+    $pipeline | Should -Match '\$requiredChannelId = if \(\$requiredChannelName\) \{ 5172 \}'
+  }
+
+  It 'publishes a generic audit before approval and supports dry runs' {
+    $pipeline | Should -Match 'artifactName: NuGetReleaseAudit'
+    $nonWorkloadTemplate | Should -Match '(?s)dependsOn: prepare_release.*ManualValidation@0'
+    $pipeline | Should -Match "(?s)eq\(parameters\.pushPackages, true\).*non-workload-publish\.yml"
+    $nonWorkloadTemplate | Should -Match '1ES\.PublishNuget@1'
+    $nonWorkloadTemplate | Should -Match "publishFeedCredentials: 'nuget\.org \(dotnetframework\)'"
+    $pipeline | Should -Not -Match '(?m)^- name: nugetPublishServiceConnection$'
+    $pipeline | Should -Not -Match '(?m)^- name: nugetAlreadyAttemptedNonWorkloadFilters$'
+  }
+
+  It 'uses the original repository text inputs and rejects workload manifests on the inferred non-workload path' {
+    $pipeline | Should -Match '(?s)- name: ghRepo.*?default: maui'
+    $pipeline | Should -Match '(?s)- name: ghOwner.*?default: dotnet'
+    $pipeline | Should -Not -Match '(?s)- name: ghRepo.*?values:'
+    $pipeline | Should -Match 'Repository.*is not enabled for this release pipeline'
+    $pipeline | Should -Match 'https://github\.com/dotnet/android'
+    $pipeline | Should -Match 'https://github\.com/dotnet/macios'
+    $pipeline | Should -Match 'non-workload release cannot contain workload manifest'
+    $pipeline | Should -Match 'Name = ''NuGet packages''; Packages = \$allPackages'
+    $pipeline | Should -Match '(?s)-Action FilterExisting.*?selectedPackages.*?stagedPackages'
+    $pipeline | Should -Match 'belongs to ''\$repository'', not ''\$sourceRepository'''
+  }
+
+  It 'rejects workload-only filters for non-workload releases' {
+    $pipeline | Should -Match '(?s)else \{.*?\$unsupportedFilters = @\(.*?' +
+      'nugetIncludeFilters.*?nugetExcludeFilters.*?' +
+      'nugetAlreadyAttemptedPackFilters.*?nugetAlreadyAttemptedManifestFilters.*?' +
+      'Non-workload releases do not support workload package filters'
+    $pipeline | Should -Match 'NUGET_ALREADY_ATTEMPTED_PACK_FILTERS: \$\{\{ parameters\.nugetAlreadyAttemptedPackFilters \}\}'
+    $pipeline | Should -Match 'NUGET_ALREADY_ATTEMPTED_MANIFEST_FILTERS: \$\{\{ parameters\.nugetAlreadyAttemptedManifestFilters \}\}'
   }
 }

--- a/eng/pipelines/ci-official-release.yml
+++ b/eng/pipelines/ci-official-release.yml
@@ -17,6 +17,11 @@ parameters:
   type: string
   default: skip
 
+- name: barBuildId
+  displayName: "[OPTIONAL] BAR build ID, when the commit cannot be resolved from GitHub"
+  type: string
+  default: skip
+
 - name: pushWorkloadSet
   displayName: Push workload set channel stage
   type: boolean
@@ -157,7 +162,8 @@ extends:
                   'https://github.com/dotnet/maui',
                   'https://github.com/dotnet/android',
                   'https://github.com/dotnet/macios',
-                  'https://github.com/dotnet/android-libraries'
+                  'https://github.com/dotnet/android-libraries',
+                  'https://github.com/dotnet/skiasharp'
                 )
                 if ($sourceRepository -notin $allowedRepositories) {
                   throw "Repository '$sourceRepository' is not enabled for this release pipeline."
@@ -229,9 +235,23 @@ extends:
                 Add-Type -AssemblyName System.IO.Compression.FileSystem
                 . $(Build.SourcesDirectory)\eng\common\tools.ps1
                 $darc = Get-Darc
-                $buildJson = & $darc get-build --ci --repo $sourceRepository --commit "$env:COMMIT_HASH" --extended --output-format json --azdev-pat $(System.AccessToken)
+                # Darc can only resolve a build from a repository URL that BAR recorded. When
+                # Arcade could not verify the AzDO -> GitHub mapping at publish time the build
+                # has no GitHub URL and is reachable only by its BAR ID.
+                if ("$env:BAR_BUILD_ID" -ne 'skip' -and ![string]::IsNullOrWhiteSpace($env:BAR_BUILD_ID)) {
+                  $barBuildId = 0
+                  if (![int]::TryParse($env:BAR_BUILD_ID.Trim(), [ref] $barBuildId) -or $barBuildId -le 0) {
+                    throw "BAR build ID '$env:BAR_BUILD_ID' is not a positive integer."
+                  }
+                  $buildJson = & $darc get-build --ci --id $barBuildId --extended --output-format json --azdev-pat $(System.AccessToken)
+                }
+                else {
+                  $buildJson = & $darc get-build --ci --repo $sourceRepository --commit "$env:COMMIT_HASH" --extended --output-format json --azdev-pat $(System.AccessToken)
+                }
                 if ($LASTEXITCODE -ne 0) {
-                  throw "Darc failed to resolve the BAR build."
+                  # Darc reports "Could not any builds matching the given criteria" on stdout,
+                  # so include the captured output or the reason is lost.
+                  throw "Darc failed to resolve the BAR build: $($buildJson | Out-String)"
                 }
 
                 $builds = @($buildJson | ConvertFrom-Json)
@@ -239,7 +259,24 @@ extends:
                   throw "Expected exactly one BAR build for '$sourceRepository', found $($builds.Count)."
                 }
                 $build = $builds[0]
-                $repository = ([Uri] $build.gitHubRepository).GetLeftPart([UriPartial]::Path).TrimEnd('/').ToLowerInvariant()
+                # A build resolved by ID has not been matched against the requested repository
+                # or commit yet, so both are verified below for every resolution path.
+                if (([string] $build.commit).Trim() -ne "$env:COMMIT_HASH".Trim()) {
+                  throw "BAR build '$($build.id)' is for commit '$($build.commit)', not the requested '$env:COMMIT_HASH'."
+                }
+                $buildRepository = $build.gitHubRepository
+                if ([string]::IsNullOrWhiteSpace($buildRepository)) {
+                  # Reproduce Arcade's AzDO -> GitHub convention (lowercase the repository name,
+                  # then turn its first '-' into '/') so a build that predates a working mapping
+                  # is still bound to a verifiable GitHub identity.
+                  $azdoName = (("$($build.azureDevOpsRepository)".TrimEnd('/') -split '/')[-1]).ToLowerInvariant()
+                  $separator = $azdoName.IndexOf('-')
+                  if ($separator -le 0) {
+                    throw "BAR build '$($build.id)' has no GitHub repository and '$azdoName' does not follow the '<owner>-<name>' mirror convention."
+                  }
+                  $buildRepository = "https://github.com/$($azdoName.Substring(0, $separator))/$($azdoName.Substring($separator + 1))"
+                }
+                $repository = ([Uri] $buildRepository).GetLeftPart([UriPartial]::Path).TrimEnd('/').ToLowerInvariant()
                 if ($repository.EndsWith('.git')) {
                   $repository = $repository.Substring(0, $repository.Length - 4)
                 }
@@ -482,6 +519,7 @@ extends:
                 Write-Host "##vso[task.setvariable variable=PackageStatusScriptHash;isOutput=true]$packageStatusScriptHash"
             env:
               COMMIT_HASH: ${{ parameters.commitHash }}
+              BAR_BUILD_ID: ${{ parameters.barBuildId }}
               GH_OWNER: ${{ parameters.ghOwner }}
               GH_REPO: ${{ parameters.ghRepo }}
               IS_WORKLOAD: $(isWorkload)

--- a/eng/pipelines/ci-official-release.yml
+++ b/eng/pipelines/ci-official-release.yml
@@ -63,6 +63,8 @@ parameters:
 variables:
 - template: /eng/common/templates/variables/pool-providers.yml@self
 - group: AzureDevOps-Artifact-Feeds-Pats
+- name: isWorkload
+  value: ${{ and(eq(parameters.ghOwner, 'dotnet'), in(parameters.ghRepo, 'android', 'macios', 'maui')) }}
 
 resources:
   repositories:
@@ -93,7 +95,7 @@ extends:
       suppression:
         suppressionFile: $(Build.SourcesDirectory)\eng\automation\guardian\source.gdnsuppress
     stages:
-    - ${{ if or(eq(parameters.commitHash, 'skip'), and(eq(parameters.pushWorkloadSet, false), eq(parameters.pushNugetOrg, false))) }}:
+    - ${{ if or(eq(parameters.commitHash, 'skip'), and(eq(parameters.pushNugetOrg, false), or(eq(variables.isWorkload, 'false'), eq(parameters.pushWorkloadSet, false)))) }}:
       - stage: skip_release
         displayName: Skip release
         dependsOn: []
@@ -105,7 +107,7 @@ extends:
           - script: echo No release operations were requested.
             displayName: Skip release
 
-    - ${{ if and(ne(parameters.commitHash, 'skip'), or(eq(parameters.pushWorkloadSet, true), eq(parameters.pushNugetOrg, true))) }}:
+    - ${{ if and(ne(parameters.commitHash, 'skip'), or(and(eq(variables.isWorkload, 'true'), eq(parameters.pushWorkloadSet, true)), eq(parameters.pushNugetOrg, true))) }}:
       - stage: prepare_release
         displayName: Prepare release artifacts
         dependsOn: []
@@ -117,14 +119,24 @@ extends:
             clean: all
           templateContext:
             outputs:
-            - output: pipelineArtifact
-              displayName: Publish workload packs
-              targetPath: '$(Build.ArtifactStagingDirectory)\MauiPacksForNuGet'
-              artifactName: MauiPacksForNuGet
-            - output: pipelineArtifact
-              displayName: Publish workload manifests
-              targetPath: '$(Build.ArtifactStagingDirectory)\MauiManifestsForNuGet'
-              artifactName: MauiManifestsForNuGet
+            - ${{ if eq(variables.isWorkload, 'true') }}:
+              - output: pipelineArtifact
+                displayName: Publish workload packs
+                targetPath: '$(Build.ArtifactStagingDirectory)\MauiPacksForNuGet'
+                artifactName: MauiPacksForNuGet
+              - output: pipelineArtifact
+                displayName: Publish workload manifests
+                targetPath: '$(Build.ArtifactStagingDirectory)\MauiManifestsForNuGet'
+                artifactName: MauiManifestsForNuGet
+            - ${{ else }}:
+              - output: pipelineArtifact
+                displayName: Publish NuGet packages
+                targetPath: '$(Build.ArtifactStagingDirectory)\NuGetPackagesForRelease'
+                artifactName: NuGetPackagesForRelease
+              - output: pipelineArtifact
+                displayName: Publish NuGet release audit
+                targetPath: '$(Build.ArtifactStagingDirectory)\NuGetReleaseAudit'
+                artifactName: NuGetReleaseAudit
           steps:
           - checkout: self
             clean: true
@@ -139,6 +151,19 @@ extends:
               scriptLocation: inlineScript
               inlineScript: |
                 $ErrorActionPreference = 'Stop'
+                $releaseWorkload = [bool]::Parse($env:IS_WORKLOAD)
+                $sourceRepository = "https://github.com/$env:GH_OWNER/$env:GH_REPO".ToLowerInvariant()
+                $allowedRepositories = @(
+                  'https://github.com/dotnet/maui',
+                  'https://github.com/dotnet/android',
+                  'https://github.com/dotnet/macios',
+                  'https://github.com/dotnet/android-libraries'
+                )
+                if ($sourceRepository -notin $allowedRepositories) {
+                  throw "Repository '$sourceRepository' is not enabled for this release pipeline."
+                }
+                $requiredChannelName = if ($sourceRepository -eq 'https://github.com/dotnet/android-libraries') { '.NET 10' } else { '' }
+                $requiredChannelId = if ($requiredChannelName) { 5172 } else { 0 }
 
                 function Get-Filters([string] $value) {
                   if ([string]::IsNullOrWhiteSpace($value) -or $value -eq 'skip') {
@@ -204,18 +229,36 @@ extends:
                 }
 
                 Add-Type -AssemblyName System.IO.Compression.FileSystem
-                Write-Host "Getting BAR ID for commit: $env:COMMIT_HASH"
                 . $(Build.SourcesDirectory)\eng\common\tools.ps1
                 $darc = Get-Darc
-                $buildJson = & $darc get-build --ci --repo "$env:GH_REPO" --commit "$env:COMMIT_HASH" --output-format json --azdev-pat $(System.AccessToken)
+                $buildJson = & $darc get-build --ci --repo $sourceRepository --commit "$env:COMMIT_HASH" --extended --output-format json --azdev-pat $(System.AccessToken)
                 if ($LASTEXITCODE -ne 0) {
-                  throw "Darc failed to resolve the BAR build for commit '$env:COMMIT_HASH'."
+                  throw "Darc failed to resolve the BAR build."
                 }
 
-                $barId = $buildJson | ConvertFrom-Json | Select-Object -ExpandProperty id -First 1
-                if (!$barId) {
-                  throw "Could not find a BAR build for commit '$env:COMMIT_HASH' on repo '$env:GH_REPO'."
+                $builds = @($buildJson | ConvertFrom-Json)
+                if ($builds.Count -ne 1) {
+                  throw "Expected exactly one BAR build for '$sourceRepository', found $($builds.Count)."
                 }
+                $build = $builds[0]
+                $repository = ([Uri] $build.gitHubRepository).GetLeftPart([UriPartial]::Path).TrimEnd('/').ToLowerInvariant()
+                if ($repository.EndsWith('.git')) {
+                  $repository = $repository.Substring(0, $repository.Length - 4)
+                }
+                $repository = $repository.Replace('://www.github.com/', '://github.com/')
+                if ($repository -ne $sourceRepository) {
+                  throw "BAR build '$($build.id)' belongs to '$repository', not '$sourceRepository'."
+                }
+                if ($requiredChannelId -gt 0) {
+                  $channelMatches = @($build.channels | Where-Object {
+                    $_.name -ceq $requiredChannelName -and
+                    [int] $_.id -eq $requiredChannelId
+                  })
+                  if ($channelMatches.Count -ne 1) {
+                    throw "BAR build '$($build.id)' must be assigned to '$requiredChannelName' (channel $requiredChannelId)."
+                  }
+                }
+                $barId = $build.id
 
                 $dropPath = "$(Build.StagingDirectory)\nupkgs"
                 # Darc represents NuGet packages as slash-free asset names. Symbol and other blob
@@ -237,37 +280,55 @@ extends:
                   throw "Darc gather-drop produced no shipping NuGet packages."
                 }
 
-                $includeFilters = @(Get-Filters $env:NUGET_INCLUDE_FILTERS)
-                $excludeFilters = @(Get-Filters $env:NUGET_EXCLUDE_FILTERS)
-                $packPackages = @($allPackages | Where-Object {
-                  $_.Name -notlike '*Manifest*.nupkg' -and
-                  ($includeFilters.Count -eq 0 -or (Test-AnyFilter $_.Name $includeFilters)) -and
-                  !($excludeFilters.Count -gt 0 -and (Test-AnyFilter $_.Name $excludeFilters))
-                })
-                $manifestPackages = @($allPackages | Where-Object {
-                  $_.Name -like '*Manifest*.nupkg' -and
-                  !($excludeFilters.Count -gt 0 -and (Test-AnyFilter $_.Name $excludeFilters))
-                })
-                if ($packPackages.Count -eq 0) {
-                  throw "Package filtering selected no workload packs."
-                }
-                if ($manifestPackages.Count -eq 0) {
-                  throw "Package filtering selected no workload manifests."
-                }
-
-                $packsPath = '$(Build.ArtifactStagingDirectory)\MauiPacksForNuGet'
-                $manifestsPath = '$(Build.ArtifactStagingDirectory)\MauiManifestsForNuGet'
                 $packageStatusScript = '$(Build.SourcesDirectory)\eng\scripts\nuget_release_packages.ps1'
                 if (!(Test-Path -LiteralPath $packageStatusScript -PathType Leaf)) {
                   throw "Package status script '$packageStatusScript' was not found."
                 }
                 $packageStatusScriptHash = (Get-FileHash -LiteralPath $packageStatusScript -Algorithm SHA256).Hash
-                New-Item -ItemType Directory -Force -Path $packsPath, $manifestsPath | Out-Null
 
-                foreach ($packageSet in @(
-                  @{ Name = 'Workload packs'; Packages = $packPackages; Path = $packsPath },
-                  @{ Name = 'Workload manifests'; Packages = $manifestPackages; Path = $manifestsPath }
-                )) {
+                if ($releaseWorkload) {
+                  $includeFilters = @(Get-Filters $env:NUGET_INCLUDE_FILTERS)
+                  $excludeFilters = @(Get-Filters $env:NUGET_EXCLUDE_FILTERS)
+                  $packPackages = @($allPackages | Where-Object {
+                    $_.Name -notlike '*Manifest*.nupkg' -and
+                    ($includeFilters.Count -eq 0 -or (Test-AnyFilter $_.Name $includeFilters)) -and
+                    !($excludeFilters.Count -gt 0 -and (Test-AnyFilter $_.Name $excludeFilters))
+                  })
+                  $manifestPackages = @($allPackages | Where-Object {
+                    $_.Name -like '*Manifest*.nupkg' -and
+                    !($excludeFilters.Count -gt 0 -and (Test-AnyFilter $_.Name $excludeFilters))
+                  })
+                  if ($packPackages.Count -eq 0 -or $manifestPackages.Count -eq 0) {
+                    throw "Package filtering must select workload packs and manifests."
+                  }
+
+                  $packageSets = @(
+                    @{ Name = 'Workload packs'; Packages = $packPackages; Path = '$(Build.ArtifactStagingDirectory)\MauiPacksForNuGet' },
+                    @{ Name = 'Workload manifests'; Packages = $manifestPackages; Path = '$(Build.ArtifactStagingDirectory)\MauiManifestsForNuGet' }
+                  )
+                }
+                else {
+                  $unsupportedFilters = @(
+                    @{ Name = 'nugetIncludeFilters'; Values = @(Get-Filters $env:NUGET_INCLUDE_FILTERS) },
+                    @{ Name = 'nugetExcludeFilters'; Values = @(Get-Filters $env:NUGET_EXCLUDE_FILTERS) },
+                    @{ Name = 'nugetAlreadyAttemptedPackFilters'; Values = @(Get-Filters $env:NUGET_ALREADY_ATTEMPTED_PACK_FILTERS) },
+                    @{ Name = 'nugetAlreadyAttemptedManifestFilters'; Values = @(Get-Filters $env:NUGET_ALREADY_ATTEMPTED_MANIFEST_FILTERS) }
+                  ) | Where-Object { $_.Values.Count -gt 0 }
+                  if ($unsupportedFilters.Count -gt 0) {
+                    throw "Non-workload releases do not support workload package filters: $($unsupportedFilters.Name -join ', ')."
+                  }
+
+                  if (@($allPackages | Where-Object Name -like '*Manifest*.nupkg').Count -gt 0) {
+                    throw "A non-workload release cannot contain workload manifest packages."
+                  }
+                  $packageSets = @(
+                    @{ Name = 'NuGet packages'; Packages = $allPackages; Path = '$(Build.ArtifactStagingDirectory)\NuGetPackagesForRelease' }
+                  )
+                }
+
+                $releaseIdentities = @()
+                foreach ($packageSet in $packageSets) {
+                  New-Item -ItemType Directory -Force -Path $packageSet.Path | Out-Null
                   $identities = @($packageSet.Packages | ForEach-Object { Get-PackageIdentity $_ })
                   $fileNameDuplicates = @($identities | Group-Object fileName | Where-Object Count -gt 1)
                   if ($fileNameDuplicates.Count -gt 0) {
@@ -285,38 +346,66 @@ extends:
                   Copy-Item -LiteralPath $packageStatusScript -Destination $packageSet.Path
                   ConvertTo-Json -InputObject @($identities | Sort-Object id, version) -Depth 3 |
                     Set-Content -Path (Join-Path $packageSet.Path 'expected-packages.json') -Encoding utf8
-                }
-
-                $manifestMajors = @($manifestPackages | ForEach-Object {
-                  if ($_.Name -notmatch '\.Manifest-(?<major>\d+)\.') {
-                    throw "Could not determine the workload band from manifest '$($_.Name)'."
+                  if (!$releaseWorkload) {
+                    $releaseIdentities = $identities
                   }
-                  $Matches.major
-                } | Sort-Object -Unique)
-                if ($manifestMajors.Count -ne 1) {
-                  throw "Expected one workload major version, found: $($manifestMajors -join ', ')."
                 }
 
                 $workloadSetsChannel = ''
                 $workloadSetsFeed = ''
-                if ($manifestMajors[0] -eq '8') {
-                  $workloadSetsChannel = '.NET 8 Workload Release'
-                  $workloadSetsFeed = 'dotnet8-workloads'
+                if ($releaseWorkload) {
+                  $manifestMajors = @($manifestPackages | ForEach-Object {
+                    if ($_.Name -notmatch '\.Manifest-(?<major>\d+)\.') {
+                      throw "Could not determine the workload band from manifest '$($_.Name)'."
+                    }
+                    $Matches.major
+                  } | Sort-Object -Unique)
+                  if ($manifestMajors.Count -ne 1) {
+                    throw "Expected one workload major version, found: $($manifestMajors -join ', ')."
+                  }
+
+                  if ($manifestMajors[0] -eq '8') {
+                    $workloadSetsChannel = '.NET 8 Workload Release'
+                    $workloadSetsFeed = 'dotnet8-workloads'
+                  }
+                  elseif ($manifestMajors[0] -eq '9') {
+                    $workloadSetsChannel = '.NET 9 Workload Release'
+                    $workloadSetsFeed = 'dotnet9-workloads'
+                  }
+                  elseif ($manifestMajors[0] -eq '10') {
+                    $workloadSetsChannel = '.NET 10 Workload Release'
+                    $workloadSetsFeed = 'dotnet10-workloads'
+                  }
+                  elseif ($manifestMajors[0] -eq '11') {
+                    $workloadSetsChannel = '.NET 11 Workload Release'
+                    $workloadSetsFeed = 'dotnet11-workloads'
+                  }
+                  if (!$workloadSetsChannel -or !$workloadSetsFeed) {
+                    throw "No workload set channel is configured for .NET $($manifestMajors[0])."
+                  }
                 }
-                elseif ($manifestMajors[0] -eq '9') {
-                  $workloadSetsChannel = '.NET 9 Workload Release'
-                  $workloadSetsFeed = 'dotnet9-workloads'
-                }
-                elseif ($manifestMajors[0] -eq '10') {
-                  $workloadSetsChannel = '.NET 10 Workload Release'
-                  $workloadSetsFeed = 'dotnet10-workloads'
-                }
-                elseif ($manifestMajors[0] -eq '11') {
-                  $workloadSetsChannel = '.NET 11 Workload Release'
-                  $workloadSetsFeed = 'dotnet11-workloads'
-                }
-                if (!$workloadSetsChannel -or !$workloadSetsFeed) {
-                  throw "No workload set channel is configured for .NET $($manifestMajors[0])."
+                else {
+                  $packagesPath = '$(Build.ArtifactStagingDirectory)\NuGetPackagesForRelease'
+                  & $packageStatusScript `
+                    -Action FilterExisting `
+                    -PackagesPath $packagesPath
+
+                  $staged = @($releaseIdentities | Where-Object {
+                    Test-Path -LiteralPath (Join-Path $packagesPath $_.fileName) -PathType Leaf
+                  })
+                  $auditPath = '$(Build.ArtifactStagingDirectory)\NuGetReleaseAudit'
+                  New-Item -ItemType Directory -Force -Path $auditPath | Out-Null
+                  [ordered]@{
+                    barBuildId = [int] $barId
+                    commit = [string] $build.commit
+                    repository = $repository
+                    selectedPackages = @($releaseIdentities | Sort-Object id, version)
+                    stagedPackages = @($staged | Sort-Object id, version)
+                  } | ConvertTo-Json -Depth 5 |
+                    Set-Content -LiteralPath (Join-Path $auditPath 'release-audit.json') -Encoding utf8
+
+                  $hasPackages = ($staged.Count -gt 0).ToString().ToLowerInvariant()
+                  Write-Host "##vso[task.setvariable variable=HasPackages;isOutput=true]$hasPackages"
                 }
 
                 Write-Host "##vso[task.setvariable variable=BarId;isOutput=true]$barId"
@@ -325,11 +414,15 @@ extends:
                 Write-Host "##vso[task.setvariable variable=PackageStatusScriptHash;isOutput=true]$packageStatusScriptHash"
             env:
               COMMIT_HASH: ${{ parameters.commitHash }}
+              GH_OWNER: ${{ parameters.ghOwner }}
               GH_REPO: ${{ parameters.ghRepo }}
+              IS_WORKLOAD: $(isWorkload)
               NUGET_INCLUDE_FILTERS: ${{ parameters.nugetIncludeFilters }}
               NUGET_EXCLUDE_FILTERS: ${{ parameters.nugetExcludeFilters }}
+              NUGET_ALREADY_ATTEMPTED_PACK_FILTERS: ${{ parameters.nugetAlreadyAttemptedPackFilters }}
+              NUGET_ALREADY_ATTEMPTED_MANIFEST_FILTERS: ${{ parameters.nugetAlreadyAttemptedManifestFilters }}
 
-      - ${{ if eq(parameters.pushWorkloadSet, true) }}:
+      - ${{ if and(eq(variables.isWorkload, 'true'), eq(parameters.pushWorkloadSet, true), eq(parameters.pushPackages, true)) }}:
         - stage: publish_maestro
           displayName: Publish to Workload Set channel
           dependsOn: prepare_release
@@ -364,7 +457,7 @@ extends:
                     throw "Darc failed to add BAR build '$(BarId)' to workload set channel '$(WorkloadSetsChannel)'."
                   }
 
-      - ${{ if and(eq(parameters.pushNugetOrg, true), eq(parameters.pushPackages, true)) }}:
+      - ${{ if and(eq(variables.isWorkload, 'true'), eq(parameters.pushNugetOrg, true), eq(parameters.pushPackages, true)) }}:
         - stage: stage_push_packs
           displayName: Release packs
           dependsOn: prepare_release
@@ -517,3 +610,6 @@ extends:
               displayName: Verify workload manifests on NuGet.org
               env:
                 EXPECTED_SCRIPT_HASH: $(PackageStatusScriptHash)
+
+    - ${{ if and(eq(variables.isWorkload, 'false'), eq(parameters.pushNugetOrg, true), eq(parameters.pushPackages, true), ne(parameters.commitHash, 'skip')) }}:
+      - template: /eng/pipelines/common/non-workload-publish.yml@self

--- a/eng/pipelines/ci-official-release.yml
+++ b/eng/pipelines/ci-official-release.yml
@@ -162,8 +162,6 @@ extends:
                 if ($sourceRepository -notin $allowedRepositories) {
                   throw "Repository '$sourceRepository' is not enabled for this release pipeline."
                 }
-                $requiredChannelName = if ($sourceRepository -eq 'https://github.com/dotnet/android-libraries') { '.NET 10' } else { '' }
-                $requiredChannelId = if ($requiredChannelName) { 5172 } else { 0 }
 
                 function Get-Filters([string] $value) {
                   if ([string]::IsNullOrWhiteSpace($value) -or $value -eq 'skip') {
@@ -248,15 +246,6 @@ extends:
                 $repository = $repository.Replace('://www.github.com/', '://github.com/')
                 if ($repository -ne $sourceRepository) {
                   throw "BAR build '$($build.id)' belongs to '$repository', not '$sourceRepository'."
-                }
-                if ($requiredChannelId -gt 0) {
-                  $channelMatches = @($build.channels | Where-Object {
-                    $_.name -ceq $requiredChannelName -and
-                    [int] $_.id -eq $requiredChannelId
-                  })
-                  if ($channelMatches.Count -ne 1) {
-                    throw "BAR build '$($build.id)' must be assigned to '$requiredChannelName' (channel $requiredChannelId)."
-                  }
                 }
                 $barId = $build.id
 

--- a/eng/pipelines/ci-official-release.yml
+++ b/eng/pipelines/ci-official-release.yml
@@ -285,10 +285,10 @@ extends:
                   throw "Package status script '$packageStatusScript' was not found."
                 }
                 $packageStatusScriptHash = (Get-FileHash -LiteralPath $packageStatusScript -Algorithm SHA256).Hash
+                $includeFilters = @(Get-Filters $env:NUGET_INCLUDE_FILTERS)
+                $excludeFilters = @(Get-Filters $env:NUGET_EXCLUDE_FILTERS)
 
                 if ($releaseWorkload) {
-                  $includeFilters = @(Get-Filters $env:NUGET_INCLUDE_FILTERS)
-                  $excludeFilters = @(Get-Filters $env:NUGET_EXCLUDE_FILTERS)
                   $packPackages = @($allPackages | Where-Object {
                     $_.Name -notlike '*Manifest*.nupkg' -and
                     ($includeFilters.Count -eq 0 -or (Test-AnyFilter $_.Name $includeFilters)) -and
@@ -309,20 +309,25 @@ extends:
                 }
                 else {
                   $unsupportedFilters = @(@(
-                    @{ Name = 'nugetIncludeFilters'; Values = @(Get-Filters $env:NUGET_INCLUDE_FILTERS) },
-                    @{ Name = 'nugetExcludeFilters'; Values = @(Get-Filters $env:NUGET_EXCLUDE_FILTERS) },
                     @{ Name = 'nugetAlreadyAttemptedPackFilters'; Values = @(Get-Filters $env:NUGET_ALREADY_ATTEMPTED_PACK_FILTERS) },
                     @{ Name = 'nugetAlreadyAttemptedManifestFilters'; Values = @(Get-Filters $env:NUGET_ALREADY_ATTEMPTED_MANIFEST_FILTERS) }
                   ) | Where-Object { $_.Values.Count -gt 0 })
                   if ($unsupportedFilters.Count -gt 0) {
-                    throw "Non-workload releases do not support workload package filters: $($unsupportedFilters.Name -join ', ')."
+                    throw "Non-workload releases do not support workload recovery filters: $($unsupportedFilters.Name -join ', ')."
                   }
 
                   if (@($allPackages | Where-Object Name -like '*Manifest*.nupkg').Count -gt 0) {
                     throw "A non-workload release cannot contain workload manifest packages."
                   }
+                  $selectedPackages = @($allPackages | Where-Object {
+                    ($includeFilters.Count -eq 0 -or (Test-AnyFilter $_.Name $includeFilters)) -and
+                    !($excludeFilters.Count -gt 0 -and (Test-AnyFilter $_.Name $excludeFilters))
+                  })
+                  if ($selectedPackages.Count -eq 0) {
+                    throw "Package filtering selected no non-workload NuGet packages."
+                  }
                   $packageSets = @(
-                    @{ Name = 'NuGet packages'; Packages = $allPackages; Path = '$(Build.ArtifactStagingDirectory)\NuGetPackagesForRelease' }
+                    @{ Name = 'NuGet packages'; Packages = $selectedPackages; Path = '$(Build.ArtifactStagingDirectory)\NuGetPackagesForRelease' }
                   )
                 }
 

--- a/eng/pipelines/ci-official-release.yml
+++ b/eng/pipelines/ci-official-release.yml
@@ -253,19 +253,47 @@ extends:
                 # Darc represents NuGet packages as slash-free asset names. Symbol and other blob
                 # assets use paths and are not inputs to this NuGet.org release.
                 $packageAssetFilter = '^[^/]+$'
+                $barPackageAssets = @($build.assets | Where-Object {
+                  !$_.nonShipping -and $_.name -match $packageAssetFilter
+                })
+                if (!$releaseWorkload -and $barPackageAssets.Count -eq 0) {
+                  throw "BAR build '$barId' contains no shipping NuGet package assets."
+                }
+
+                $gatherArguments = @(
+                  'gather-drop',
+                  '--ci',
+                  '--id', $barId,
+                  '-o', $dropPath,
+                  '--azdev-pat', '$(System.AccessToken)',
+                  '--include-released',
+                  '--asset-filter', $packageAssetFilter,
+                  '--verbose'
+                )
+                if (!$releaseWorkload) {
+                  $gatherArguments += '--continue-on-error'
+                }
                 Write-Host "Gathering BAR build '$barId' into '$dropPath'."
-                & $darc gather-drop --ci --id $barId -o "$dropPath" --azdev-pat $(System.AccessToken) --include-released --asset-filter $packageAssetFilter --verbose
-                if ($LASTEXITCODE -ne 0) {
+                & $darc @gatherArguments
+                $gatherExitCode = $LASTEXITCODE
+                $gatherFailed = $gatherExitCode -ne 0
+                if ($gatherFailed -and $releaseWorkload) {
                   throw "Darc gather-drop failed for BAR build '$barId'."
+                }
+                if ($gatherFailed) {
+                  Write-Warning "Darc exited with code $gatherExitCode for BAR build '$barId'; missing selected packages must already exist on NuGet.org."
                 }
 
                 $shippingPath = Join-Path $dropPath 'shipping\packages'
                 if (!(Test-Path $shippingPath -PathType Container)) {
-                  throw "Darc gather-drop did not create the expected package directory '$shippingPath'."
+                  if ($releaseWorkload) {
+                    throw "Darc gather-drop did not create the expected package directory '$shippingPath'."
+                  }
+                  New-Item -ItemType Directory -Force -Path $shippingPath | Out-Null
                 }
 
                 $allPackages = @(Get-ChildItem -Path $shippingPath -Filter '*.nupkg' -File -Recurse)
-                if ($allPackages.Count -eq 0) {
+                if ($releaseWorkload -and $allPackages.Count -eq 0) {
                   throw "Darc gather-drop produced no shipping NuGet packages."
                 }
 
@@ -305,25 +333,71 @@ extends:
                     throw "Non-workload releases do not support workload recovery filters: $($unsupportedFilters.Name -join ', ')."
                   }
 
-                  if (@($allPackages | Where-Object Name -like '*Manifest*.nupkg').Count -gt 0) {
+                  if (@($barPackageAssets | Where-Object Name -like '*Manifest*').Count -gt 0) {
                     throw "A non-workload release cannot contain workload manifest packages."
                   }
+                  $selectedBarAssets = @($barPackageAssets | Where-Object {
+                    $fileName = "$($_.name).$($_.version).nupkg"
+                    ($includeFilters.Count -eq 0 -or (Test-AnyFilter $fileName $includeFilters)) -and
+                    !($excludeFilters.Count -gt 0 -and (Test-AnyFilter $fileName $excludeFilters))
+                  })
+                  if ($selectedBarAssets.Count -eq 0) {
+                    throw "Package filtering selected no non-workload NuGet packages."
+                  }
+
                   $selectedPackages = @($allPackages | Where-Object {
                     ($includeFilters.Count -eq 0 -or (Test-AnyFilter $_.Name $includeFilters)) -and
                     !($excludeFilters.Count -gt 0 -and (Test-AnyFilter $_.Name $excludeFilters))
                   })
-                  if ($selectedPackages.Count -eq 0) {
-                    throw "Package filtering selected no non-workload NuGet packages."
+                  $downloadedIdentities = @($selectedPackages | ForEach-Object { Get-PackageIdentity $_ })
+                  $selectedIdentities = @($selectedBarAssets | ForEach-Object {
+                    $asset = $_
+                    $downloadedIdentity = @($downloadedIdentities | Where-Object {
+                      $_.id -ieq $asset.name -and $_.version -ieq $asset.version
+                    })
+                    if ($downloadedIdentity.Count -gt 1) {
+                      throw "Downloaded packages contain duplicate BAR identity '$($asset.name) $($asset.version)'."
+                    }
+                    if ($downloadedIdentity.Count -eq 1) {
+                      $downloadedIdentity[0]
+                    }
+                    else {
+                      [pscustomobject]@{
+                        id = [string] $asset.name
+                        version = [string] $asset.version
+                        normalizedVersion = [string] $asset.version
+                        fileName = "$($asset.name).$($asset.version).nupkg"
+                      }
+                    }
+                  })
+                  $unexpectedDownloadedPackages = @($downloadedIdentities | Where-Object {
+                    $downloadedIdentity = $_
+                    !@($selectedIdentities | Where-Object {
+                      $_.id -ieq $downloadedIdentity.id -and $_.version -ieq $downloadedIdentity.version
+                    })
+                  })
+                  if ($unexpectedDownloadedPackages.Count -gt 0) {
+                    throw "Gathered packages are absent from the selected BAR assets: $($unexpectedDownloadedPackages.fileName -join ', ')."
                   }
                   $packageSets = @(
-                    @{ Name = 'NuGet packages'; Packages = $selectedPackages; Path = '$(Build.ArtifactStagingDirectory)\NuGetPackagesForRelease' }
+                    @{
+                      Name = 'NuGet packages'
+                      Packages = $selectedPackages
+                      Identities = $selectedIdentities
+                      Path = '$(Build.ArtifactStagingDirectory)\NuGetPackagesForRelease'
+                    }
                   )
                 }
 
                 $releaseIdentities = @()
                 foreach ($packageSet in $packageSets) {
                   New-Item -ItemType Directory -Force -Path $packageSet.Path | Out-Null
-                  $identities = @($packageSet.Packages | ForEach-Object { Get-PackageIdentity $_ })
+                  $identities = if ($packageSet.ContainsKey('Identities')) {
+                    @($packageSet.Identities)
+                  }
+                  else {
+                    @($packageSet.Packages | ForEach-Object { Get-PackageIdentity $_ })
+                  }
                   $fileNameDuplicates = @($identities | Group-Object fileName | Where-Object Count -gt 1)
                   if ($fileNameDuplicates.Count -gt 0) {
                     throw "$($packageSet.Name) contains duplicate package file names: $($fileNameDuplicates.Name -join ', ')."

--- a/eng/pipelines/ci-official-release.yml
+++ b/eng/pipelines/ci-official-release.yml
@@ -308,12 +308,12 @@ extends:
                   )
                 }
                 else {
-                  $unsupportedFilters = @(
+                  $unsupportedFilters = @(@(
                     @{ Name = 'nugetIncludeFilters'; Values = @(Get-Filters $env:NUGET_INCLUDE_FILTERS) },
                     @{ Name = 'nugetExcludeFilters'; Values = @(Get-Filters $env:NUGET_EXCLUDE_FILTERS) },
                     @{ Name = 'nugetAlreadyAttemptedPackFilters'; Values = @(Get-Filters $env:NUGET_ALREADY_ATTEMPTED_PACK_FILTERS) },
                     @{ Name = 'nugetAlreadyAttemptedManifestFilters'; Values = @(Get-Filters $env:NUGET_ALREADY_ATTEMPTED_MANIFEST_FILTERS) }
-                  ) | Where-Object { $_.Values.Count -gt 0 }
+                  ) | Where-Object { $_.Values.Count -gt 0 })
                   if ($unsupportedFilters.Count -gt 0) {
                     throw "Non-workload releases do not support workload package filters: $($unsupportedFilters.Name -join ', ')."
                   }

--- a/eng/pipelines/common/non-workload-publish.yml
+++ b/eng/pipelines/common/non-workload-publish.yml
@@ -32,9 +32,23 @@ stages:
     steps:
     - checkout: none
 
+    - pwsh: |
+        $scriptPath = '$(Pipeline.Workspace)\NuGetPackagesForRelease\nuget_release_packages.ps1'
+        $actualHash = (Get-FileHash -LiteralPath $scriptPath -Algorithm SHA256).Hash
+        if ($actualHash -ne $env:EXPECTED_SCRIPT_HASH) {
+          throw "Package status script hash '$actualHash' does not match the prepared hash."
+        }
+
+        & $scriptPath `
+          -Action FilterExisting `
+          -PackagesPath '$(Pipeline.Workspace)\NuGetPackagesForRelease'
+      displayName: Filter already-published NuGet packages
+      env:
+        EXPECTED_SCRIPT_HASH: $(PackageStatusScriptHash)
+
     - task: 1ES.PublishNuget@1
       displayName: Push NuGet packages to NuGet.org
-      condition: and(succeeded(), eq(variables['HasPackages'], 'true'))
+      condition: and(succeeded(), eq(variables['NuGetPackagesToPublish'], 'true'))
       inputs:
         useDotNetTask: false
         packagesToPush: '$(Pipeline.Workspace)\NuGetPackagesForRelease\*.nupkg'

--- a/eng/pipelines/common/non-workload-publish.yml
+++ b/eng/pipelines/common/non-workload-publish.yml
@@ -1,0 +1,58 @@
+stages:
+- stage: publish_non_workload
+  displayName: Release NuGet packages
+  dependsOn: prepare_release
+  jobs:
+  - job: approval
+    displayName: Wait to push NuGet packages
+    timeoutInMinutes: 240
+    pool: server
+    steps:
+    - task: ManualValidation@0
+      timeoutInMinutes: 120
+      inputs:
+        instructions: 'Review NuGetReleaseAudit, then press "Resume" to publish its exact staged package list.'
+        onTimeout: reject
+
+  - job: publish
+    displayName: Push NuGet packages to NuGet.org
+    timeoutInMinutes: 90
+    dependsOn: approval
+    condition: eq(dependencies.approval.result, 'Succeeded')
+    variables:
+      HasPackages: $[ stageDependencies.prepare_release.prepare_release.outputs['prepareRelease.HasPackages'] ]
+      PackageStatusScriptHash: $[ stageDependencies.prepare_release.prepare_release.outputs['prepareRelease.PackageStatusScriptHash'] ]
+    templateContext:
+      type: releaseJob
+      isProduction: true
+      inputs:
+      - input: pipelineArtifact
+        artifactName: NuGetPackagesForRelease
+        targetPath: '$(Pipeline.Workspace)\NuGetPackagesForRelease'
+    steps:
+    - checkout: none
+
+    - task: 1ES.PublishNuget@1
+      displayName: Push NuGet packages to NuGet.org
+      condition: and(succeeded(), eq(variables['HasPackages'], 'true'))
+      inputs:
+        useDotNetTask: false
+        packagesToPush: '$(Pipeline.Workspace)\NuGetPackagesForRelease\*.nupkg'
+        packageParentPath: '$(Pipeline.Workspace)\NuGetPackagesForRelease'
+        nuGetFeedType: external
+        publishFeedCredentials: 'nuget.org (dotnetframework)'
+
+    - pwsh: |
+        $scriptPath = '$(Pipeline.Workspace)\NuGetPackagesForRelease\nuget_release_packages.ps1'
+        if ((Get-FileHash -LiteralPath $scriptPath -Algorithm SHA256).Hash -ne $env:EXPECTED_SCRIPT_HASH) {
+          throw 'Package status script hash does not match the prepared hash.'
+        }
+        & $scriptPath `
+          -Action Verify `
+          -PackagesPath '$(Pipeline.Workspace)\NuGetPackagesForRelease' `
+          -MaxAttempts 90 `
+          -DelaySeconds 20 `
+          -MaxDurationMinutes 30
+      displayName: Verify NuGet packages on NuGet.org
+      env:
+        EXPECTED_SCRIPT_HASH: $(PackageStatusScriptHash)

--- a/eng/scripts/nuget_release_packages.Tests.ps1
+++ b/eng/scripts/nuget_release_packages.Tests.ps1
@@ -37,6 +37,27 @@ Describe 'nuget_release_packages.ps1' {
     $output -join "`n" | Should -Match 'NuGetPackagesToPublish]false'
   }
 
+  It 'accepts an already-published package removed during preparation' {
+    @(
+      [pscustomobject]@{ id = 'Existing.Package'; version = '1.0.0'; normalizedVersion = '1.0.0'; fileName = 'Existing.Package.1.0.0.nupkg' }
+    ) | ConvertTo-Json | Set-Content (Join-Path $packagesPath 'expected-packages.json')
+    Mock Invoke-WebRequest { [pscustomobject]@{ StatusCode = 200 } }
+
+    $output = & $scriptPath -Action FilterExisting -PackagesPath $packagesPath 6>&1
+
+    $output -join "`n" | Should -Match 'NuGetPackagesToPublish]false'
+  }
+
+  It 'rejects an unpublished package missing from the artifact' {
+    @(
+      [pscustomobject]@{ id = 'Missing.Package'; version = '1.0.0'; normalizedVersion = '1.0.0'; fileName = 'Missing.Package.1.0.0.nupkg' }
+    ) | ConvertTo-Json | Set-Content (Join-Path $packagesPath 'expected-packages.json')
+    Mock Invoke-WebRequest { [pscustomobject]@{ StatusCode = 404 } }
+
+    { & $scriptPath -Action FilterExisting -PackagesPath $packagesPath } |
+      Should -Throw '*Unpublished package*was not found*'
+  }
+
   It 'fails closed on an unexpected NuGet response' {
     @(
       [pscustomobject]@{ id = 'Unknown.Package'; version = '1.0.0'; normalizedVersion = '1.0.0'; fileName = 'Unknown.Package.1.0.0.nupkg' }

--- a/eng/scripts/nuget_release_packages.ps1
+++ b/eng/scripts/nuget_release_packages.ps1
@@ -153,22 +153,27 @@ if ($Action -eq 'FilterExisting') {
   $remaining = 0
   foreach ($package in $expected) {
     $packagePath = Join-Path $PackagesPath $package.fileName
-    if (!(Test-Path -LiteralPath $packagePath -PathType Leaf)) {
-      throw "Expected package '$packagePath' was not found."
-    }
+    $packageExists = Test-Path -LiteralPath $packagePath -PathType Leaf
 
     if ($skipPatterns.Count -gt 0 -and (Test-AnyFilter -Name $package.fileName -Filters $skipPatterns)) {
       Write-Host "Skipping previously attempted package $($package.id) $($package.version)."
-      Remove-Item -LiteralPath $packagePath
+      if ($packageExists) {
+        Remove-Item -LiteralPath $packagePath
+      }
       continue
     }
 
     $status = Get-NuGetPackageStatus -Package $package
     if ($status.StatusCode -eq 200) {
       Write-Host "Skipping already-published package $($package.id) $($package.version)."
-      Remove-Item -LiteralPath $packagePath
+      if ($packageExists) {
+        Remove-Item -LiteralPath $packagePath
+      }
     }
     elseif ($status.StatusCode -eq 404) {
+      if (!$packageExists) {
+        throw "Unpublished package '$packagePath' was not found."
+      }
       $remaining++
     }
     else {


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

> [!IMPORTANT]
> **This PR is stacked on #37658 and must merge after it.**
> It targets `jonathanpeppers-release-android-libraries` rather than `main`, so the diff shown here is only the SkiaSharp delta on top of that branch. It is rebased onto `adec5b8d72` ("[ci] Support repeated non-workload releases") and contains **no channel policy**, in line with `3013cd846f` ("[ci] Remove repository-specific channel policy").

### Description of Change

Adds SkiaSharp to the non-workload NuGet release flow introduced in #37658.

Three files, +85/-5:

- **`eng/pipelines/ci-official-release.yml`** — adds `https://github.com/dotnet/skiasharp` to the allowed repositories, adds an optional `barBuildId` parameter, verifies the requested commit on every resolution path, and falls back to the AzDO mirror naming convention when BAR has no GitHub URL.
- **`eng/pipelines/ci-official-release.Tests.ps1`** — three new contract tests.
- **`docs/ReleaseProcess.md`** — documents `barBuildId`.

#### Why `barBuildId` is needed

SkiaSharp cannot be resolved by repository and commit at all. Arcade's `PublishBuildToMaestro` derives a build's GitHub identity from the AzDO mirror name and then *verifies* it:

```
dotnet-SkiaSharp  ->  dotnet/skiasharp  ->  GET api.github.com/repos/dotnet/skiasharp/commits/{sha}
```

While the sources live at `mono/SkiaSharp` that request returns 404, and Arcade **silently leaves `gitHubRepository` null** — it is a `LogMessage`, not an error. BAR build `328857` has `gitHubRepository: null` in production today.

Two consequences for the current pipeline:

1. `darc get-build --repo <url> --commit <sha>` cannot find the build. Verified empirically against `mono/SkiaSharp`, `dotnet/skiasharp`, and both AzDO URL forms — all exit 42.
2. `([Uri] $build.gitHubRepository)` dereferences null.

So `barBuildId` resolves the build directly by ID. Because a build found by ID was never matched against the request, **the commit is now verified on every resolution path**, and the repository is verified against the mirror convention rather than being trusted. This self-heals once the repository moves to `dotnet/SkiaSharp`, at which point the existing mirror name becomes correct — but the null-URL handling remains valid for any repository in the same position.

Darc reports resolution failures on **stdout**, so its output is now included in the thrown error; the first dry run failed with no usable diagnostic because of this.

#### Nothing else was changed

`isWorkload` is `and(eq(ghOwner, 'dotnet'), in(ghRepo, 'android', 'macios', 'maui'))`, so SkiaSharp already evaluates non-workload — no expression change was needed. The workload path, the `pushPackages: false` dry-run behavior, and every manual validation and release-job gate from #37658 are untouched. `barBuildId` defaults to `skip`, so all existing repositories keep the exact resolution path they have today.

### Validation

Local, plus real pipeline runs from this branch.

- All 11 pipeline contract tests pass; YAML parses; `git diff --check` clean; cSpell reports **exactly** the same words as the base commit (no new findings).
- **Mutation-checked.** Removing the SkiaSharp allow-list entry, removing the `barBuildId` parameter, renaming the `gitHubRepository` read, bypassing the fallback for identity, or dropping the `IsNullOrWhiteSpace` guard each fail a test. The fallback assertion is anchored specifically so a renamed field cannot pass on a substring match.

#### Verified against the real pipeline

| Build | Parameters | Result |
|---|---|---|
| [3059057](https://dev.azure.com/dnceng/internal/_build/results?buildId=3059057) | repo + commit, no `barBuildId` | Failed at `darc get-build` — the problem this PR fixes |
| [3059201](https://dev.azure.com/dnceng/internal/_build/results?buildId=3059201) | `pushPackages: false` | Succeeded — 41 packages gathered, artifacts published, nothing pushed |
| [3059242](https://dev.azure.com/dnceng/internal/_build/results?buildId=3059242) | `pushPackages: true` | **Succeeded — 41/41 published and verified on NuGet.org** |

Build 3059242 shipped SkiaSharp `4.152.0-rc.1` for real using this code. It reports `partiallySucceeded` **only** because it ran from this feature branch: 1ES emits two *non-blocking* `Branch Validation` errors requiring a production branch (`main`, `release/*`, …). Both packs pushed and `Verified all 41 packages on NuGet.org`. That warning disappears once this merges to `main`.

### Release inputs

**No packages are published when `pushPackages: false`** — the publication stages are excluded at template-expansion time.

```yaml
ghOwner: dotnet
ghRepo: skiasharp
commitHash: <FULL_COMMIT_SHA>
barBuildId: <BAR_BUILD_ID>   # required while BAR has no GitHub URL for the build
pushWorkloadSet: false
pushNugetOrg: true
pushPackages: false          # true to publish
```

### Before releasing a new repository

Release owners must confirm the existing `nuget.org (dotnetframework)` service connection owns every package ID being pushed. Adding an allow-list entry here does not grant that. *(For SkiaSharp this is now confirmed by build 3059242 — all 41 IDs were accepted.)*

### Issues Fixed

N/A

