### PR TITLE
[ci-fix-net11] Fix Windows device test synchronization

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Windows.cs
@@ -127,15 +127,8 @@ namespace Microsoft.Maui.DeviceTests
 				var navItem = Assert.Single(GetNavigationViewItems(navView));
 				var infoBadge = navItem.InfoBadge;
 				Assert.NotNull(infoBadge);
-				await AssertEventually(() =>
-					infoBadge.Background is WSolidColorBrush &&
-					infoBadge.Foreground is WSolidColorBrush,
-					timeout: 5000,
-					message: "Timed out waiting for the InfoBadge default brushes to be applied.");
-				var defaultBackgroundColor = Assert.IsType<WSolidColorBrush>(infoBadge.Background).Color;
-				var defaultForegroundColor = Assert.IsType<WSolidColorBrush>(infoBadge.Foreground).Color;
-				Assert.NotEqual(Colors.Blue.ToWindowsColor(), defaultBackgroundColor);
-				Assert.NotEqual(Colors.Yellow.ToWindowsColor(), defaultForegroundColor);
+				Assert.Null(infoBadge.Background);
+				Assert.Null(infoBadge.Foreground);
 
 				TabbedPage.SetBadgeColor(firstPage, Colors.Blue);
 				TabbedPage.SetBadgeTextColor(firstPage, Colors.Yellow);
@@ -159,10 +152,8 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.Null(item.BadgeBackground);
 				Assert.Null(item.BadgeForeground);
 				await AssertEventually(() =>
-					infoBadge.Background is WSolidColorBrush background &&
-					infoBadge.Foreground is WSolidColorBrush foreground &&
-					background.Color == defaultBackgroundColor &&
-					foreground.Color == defaultForegroundColor);
+					infoBadge.Background is null &&
+					infoBadge.Foreground is null);
 
 				var converter = new Microsoft.Maui.Controls.Platform.NullToUnsetValueConverter();
 				Assert.Same(

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Windows.cs
@@ -128,13 +128,26 @@ namespace Microsoft.Maui.DeviceTests
 				var infoBadge = navItem.InfoBadge;
 				Assert.NotNull(infoBadge);
 				Assert.Null(infoBadge.Background);
-				Assert.Null(infoBadge.Foreground);
+
+				Assert.Equal("New", item.BadgeText);
+				Assert.Equal(-1, item.BadgeValue);
+
+				TabbedPage.SetBadgeText(firstPage, "42");
+
+				Assert.Equal("42", item.BadgeText);
+				Assert.Equal(42, item.BadgeValue);
+				await AssertEventually(() =>
+					infoBadge.Value == 42 &&
+					infoBadge.Background is null &&
+					infoBadge.Foreground is WSolidColorBrush,
+					timeout: 5000,
+					message: "Timed out waiting for the InfoBadge numeric value and native default brushes.");
+				var defaultForegroundColor = Assert.IsType<WSolidColorBrush>(infoBadge.Foreground).Color;
+				Assert.NotEqual(Colors.Yellow.ToWindowsColor(), defaultForegroundColor);
 
 				TabbedPage.SetBadgeColor(firstPage, Colors.Blue);
 				TabbedPage.SetBadgeTextColor(firstPage, Colors.Yellow);
 
-				Assert.Equal("New", item.BadgeText);
-				Assert.Equal(-1, item.BadgeValue);
 				Assert.Equal(Colors.Blue.ToWindowsColor(), Assert.IsType<WSolidColorBrush>(item.BadgeBackground).Color);
 				Assert.Equal(Colors.Yellow.ToWindowsColor(), Assert.IsType<WSolidColorBrush>(item.BadgeForeground).Color);
 				await AssertEventually(() =>
@@ -145,7 +158,6 @@ namespace Microsoft.Maui.DeviceTests
 					timeout: 5000,
 					message: "Timed out waiting for the InfoBadge custom brushes to be applied.");
 
-				TabbedPage.SetBadgeText(firstPage, "42");
 				TabbedPage.SetBadgeColor(firstPage, null);
 				TabbedPage.SetBadgeTextColor(firstPage, null);
 
@@ -155,9 +167,10 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.Null(item.BadgeForeground);
 				await AssertEventually(() =>
 					infoBadge.Background is null &&
-					infoBadge.Foreground is null,
+					infoBadge.Foreground is WSolidColorBrush foreground &&
+					foreground.Color == defaultForegroundColor,
 					timeout: 5000,
-					message: "Timed out waiting for the InfoBadge custom brushes to be cleared.");
+					message: "Timed out waiting for the InfoBadge native default brushes to be restored.");
 
 				var converter = new Microsoft.Maui.Controls.Platform.NullToUnsetValueConverter();
 				Assert.Same(

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Windows.cs
@@ -127,6 +127,9 @@ namespace Microsoft.Maui.DeviceTests
 				var navItem = Assert.Single(GetNavigationViewItems(navView));
 				var infoBadge = navItem.InfoBadge;
 				Assert.NotNull(infoBadge);
+				await AssertEventually(() =>
+					infoBadge.Background is WSolidColorBrush &&
+					infoBadge.Foreground is WSolidColorBrush);
 				var defaultBackgroundColor = Assert.IsType<WSolidColorBrush>(infoBadge.Background).Color;
 				var defaultForegroundColor = Assert.IsType<WSolidColorBrush>(infoBadge.Foreground).Color;
 				Assert.NotEqual(Colors.Blue.ToWindowsColor(), defaultBackgroundColor);

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Windows.cs
@@ -141,7 +141,9 @@ namespace Microsoft.Maui.DeviceTests
 					infoBadge.Background is WSolidColorBrush background &&
 					infoBadge.Foreground is WSolidColorBrush foreground &&
 					background.Color == Colors.Blue.ToWindowsColor() &&
-					foreground.Color == Colors.Yellow.ToWindowsColor());
+					foreground.Color == Colors.Yellow.ToWindowsColor(),
+					timeout: 5000,
+					message: "Timed out waiting for the InfoBadge custom brushes to be applied.");
 
 				TabbedPage.SetBadgeText(firstPage, "42");
 				TabbedPage.SetBadgeColor(firstPage, null);
@@ -153,7 +155,9 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.Null(item.BadgeForeground);
 				await AssertEventually(() =>
 					infoBadge.Background is null &&
-					infoBadge.Foreground is null);
+					infoBadge.Foreground is null,
+					timeout: 5000,
+					message: "Timed out waiting for the InfoBadge custom brushes to be cleared.");
 
 				var converter = new Microsoft.Maui.Controls.Platform.NullToUnsetValueConverter();
 				Assert.Same(

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Windows.cs
@@ -129,7 +129,9 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.NotNull(infoBadge);
 				await AssertEventually(() =>
 					infoBadge.Background is WSolidColorBrush &&
-					infoBadge.Foreground is WSolidColorBrush);
+					infoBadge.Foreground is WSolidColorBrush,
+					timeout: 5000,
+					message: "Timed out waiting for the InfoBadge default brushes to be applied.");
 				var defaultBackgroundColor = Assert.IsType<WSolidColorBrush>(infoBadge.Background).Color;
 				var defaultForegroundColor = Assert.IsType<WSolidColorBrush>(infoBadge.Foreground).Color;
 				Assert.NotEqual(Colors.Blue.ToWindowsColor(), defaultBackgroundColor);

--- a/src/Core/tests/DeviceTests/Services/EssentialsDIBridgeTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Services/EssentialsDIBridgeTests.Windows.cs
@@ -341,7 +341,12 @@ public class EssentialsDIBridgeTests
 		{
 			releaseFirstTokenSetter.TrySetResult(true);
 			if (firstBuild is not null && firstApp is null)
-				firstApp = await firstBuild.WaitAsync(timeout);
+			{
+				await Record.ExceptionAsync(async () =>
+				{
+					firstApp = await firstBuild.WaitAsync(timeout);
+				});
+			}
 
 			secondApp?.Dispose();
 			firstApp?.Dispose();

--- a/src/Core/tests/DeviceTests/Services/EssentialsDIBridgeTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Services/EssentialsDIBridgeTests.Windows.cs
@@ -295,9 +295,18 @@ public class EssentialsDIBridgeTests
 		var timeout = TimeSpan.FromSeconds(30);
 		var field = GetGeocodingBackingField();
 		var original = field.GetValue(null);
-		var cleanupResolutionEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-		var releaseCleanupResolution = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-		var first = new StubPlatformGeocoding();
+		var firstTokenSetterEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+		var releaseFirstTokenSetter = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+		var first = new CallbackPlatformGeocoding(value =>
+		{
+			if (!string.Equals(value, token, StringComparison.Ordinal))
+				return;
+
+			firstTokenSetterEntered.TrySetResult(true);
+			Assert.True(
+				releaseFirstTokenSetter.Task.Wait(timeout),
+				"Timed out waiting to release the first map-token setter.");
+		});
 		var second = new StubPlatformGeocoding();
 		Task<MauiApp>? firstBuild = null;
 		MauiApp? firstApp = null;
@@ -310,14 +319,9 @@ public class EssentialsDIBridgeTests
 			var firstBuilder = MauiApp.CreateBuilder(useDefaults: false);
 			firstBuilder.Services.AddSingleton<IGeocoding>(first);
 			firstBuilder.ConfigureEssentials(essentials => essentials.UseMapServiceToken(token));
-			BlockEssentialsCleanupResolution(
-				firstBuilder,
-				cleanupResolutionEntered,
-				releaseCleanupResolution,
-				timeout);
 
 			firstBuild = Task.Run(firstBuilder.Build);
-			await cleanupResolutionEntered.Task.WaitAsync(timeout);
+			await firstTokenSetterEntered.Task.WaitAsync(timeout);
 			Assert.Same(first, Geocoding.Default);
 
 			var secondBuilder = MauiApp.CreateBuilder(useDefaults: false);
@@ -326,7 +330,7 @@ public class EssentialsDIBridgeTests
 			secondApp = secondBuilder.Build();
 			Assert.Same(second, Geocoding.Default);
 
-			releaseCleanupResolution.TrySetResult(true);
+			releaseFirstTokenSetter.TrySetResult(true);
 			firstApp = await firstBuild.WaitAsync(timeout);
 
 			Assert.Equal(token, first.MapServiceToken);
@@ -335,7 +339,7 @@ public class EssentialsDIBridgeTests
 		}
 		finally
 		{
-			releaseCleanupResolution.TrySetResult(true);
+			releaseFirstTokenSetter.TrySetResult(true);
 			if (firstBuild is not null && firstApp is null)
 				firstApp = await firstBuild.WaitAsync(timeout);
 
@@ -880,29 +884,6 @@ public class EssentialsDIBridgeTests
 		var builder = MauiApp.CreateBuilder();
 		builder.Services.AddSingleton(service);
 		return builder.Build();
-	}
-
-	static void BlockEssentialsCleanupResolution(
-		MauiAppBuilder builder,
-		TaskCompletionSource<bool> entered,
-		TaskCompletionSource<bool> release,
-		TimeSpan timeout)
-	{
-		var descriptor = Assert.Single(
-			builder.Services,
-			service => service.ServiceType.Name == "EssentialsCleanup");
-		Assert.True(builder.Services.Remove(descriptor));
-		builder.Services.Add(
-			ServiceDescriptor.Singleton(
-				descriptor.ServiceType,
-				_ =>
-				{
-					entered.TrySetResult(true);
-					Assert.True(
-						release.Task.Wait(timeout),
-						"Timed out waiting to release Essentials cleanup resolution.");
-					return Activator.CreateInstance(descriptor.ServiceType, nonPublic: true)!;
-				}));
 	}
 
 	class StubWebAuthenticator : IWebAuthenticator


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Root cause

The required `maui-pr-devicetests` pipeline is deterministically failing two newly added Windows tests in both packaged and unpackaged execution:

- `Badge Properties Update NavigationView Item` expects both native `InfoBadge.Background` and `Foreground` properties to expose default brushes. MAUI's bindings intentionally convert null badge colors to `DependencyProperty.UnsetValue`; WinUI's effective defaults are asymmetric here: `Background` remains null while `Foreground` is supplied by the native style.
- `ConcurrentBuildAppliesMapServiceTokenToOwningGeocoder` blocks construction while resolving `EssentialsCleanup`, which is the first step of Essentials initialization. It then assumes `Geocoding.Default` was already bridged, although facade bridging necessarily occurs after that blocked resolution.

The untouched `net11.0` parent commit reproduced both failures in build [1569389](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1569389). Build [1569753](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1569753) reproduced the same two XML failures in both its original run and an in-place retry.

## Fix

- Assert the native `InfoBadge.Background` is null and capture the styled default `Foreground` after the badge enters its numeric value state. The test then verifies custom blue/yellow brushes propagate and clearing the MAUI colors restores that same null-background/styled-foreground state.
- Block the first geocoder inside its `MapServiceToken` setter instead. The setter runs after `Geocoding.Default` has been bridged to that instance and outside the global bookkeeping locks, so the existing test now pauses at the state it intended to exercise: a second app build taking facade ownership while the first token assignment is in progress.
- Remove the obsolete cleanup-resolution hook.

These are test-only synchronization corrections; the production InfoBadge binding and Essentials initialization/rollback ordering remain unchanged.

## Existing work

No open MAUI PR addresses either failure or test mechanism. PR #37803 changes only iOS TabbedPage coverage, while PR #37818 only restored compilation of the Windows TabbedPage test file. Changing product initialization order to satisfy the geocoder test would weaken its rollback invariant, and changing the badge implementation would mask the native InfoBadge template-default contract.

## Validation

- Inspected the raw Azure job logs and uploaded xUnit XML for the exact-parent build and both PR build attempts; all three runs failed the same assertions in packaged and unpackaged execution.
- Targeted build [1569887](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1569887) passed the corrected geocoder test in both packaged and unpackaged execution. Its two Controls XML files then isolated the remaining badge assumption: waiting for both default properties to become brushes timed out because `Background` correctly remains null.
- Exact-merge build [1570003](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1570003) again passed the geocoder test packaged and unpackaged. Both badge executions proved the other half of the native contract: the null `Background` assertion passed, while `Foreground` was a styled `#E4000000` brush rather than null.
- Built `Microsoft.Maui.BuildTasks.slnf` with the branch-pinned net11 SDK in task-only mode with 0 warnings and 0 errors.
- Checked the patch for whitespace errors and completed a focused concurrency/lifecycle review with no significant findings.
- Exact-merge targeted build [1570083](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1570083) succeeded at merge commit `29d3069371ca4e30738c429a62c52bbc139e4c06`. Its complete Windows Azure Test run contained 1,913 rows: 1,787 passed and 126 intentionally not executed, with no failed or synthetic failed-work-item rows. `Badge Properties Update NavigationView Item` and `ConcurrentBuildAppliesMapServiceTokenToOwningGeocoder` both passed in packaged and unpackaged execution.
