### PR TITLE
[iOS] Fix MediaPicker throwing UIKitThreadAccessException when picking 2+ items

### DIFF
--- a/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
@@ -269,22 +269,44 @@ namespace Microsoft.Maui.Media
 			if (results == null || results.Length == 0)
 				return [];
 
-			var fileResults = new List<FileResult>(results.Length);
-			PHPickerFileResult fileResult = null;
+			// PHPickerResult.ItemProvider is a UIKit call and must be read on the main thread.
+			// This method is invoked from the picker delegate, so we are on the main thread here,
+			// but awaiting below resumes on the thread pool. Read every ItemProvider up front,
+			// before the first await, so no read is left straddling a continuation.
+			var pickerResults = new List<PHPickerFileResult>(results.Length);
 			try
 			{
 				foreach (var file in results)
 				{
-					fileResult = new PHPickerFileResult(file.ItemProvider);
-					await fileResult.LoadFileRepresentationAsync().ConfigureAwait(false);
-					fileResults.Add(fileResult);
-					fileResult = null;
+					pickerResults.Add(new PHPickerFileResult(file.ItemProvider));
 				}
 			}
 			catch
 			{
-				fileResult?.Dispose();
+				foreach (var pickerResult in pickerResults)
+				{
+					pickerResult.Dispose();
+				}
+				throw;
+			}
+
+			var fileResults = new List<FileResult>(pickerResults.Count);
+			try
+			{
+				foreach (var pickerResult in pickerResults)
+				{
+					await pickerResult.LoadFileRepresentationAsync().ConfigureAwait(false);
+					fileResults.Add(pickerResult);
+				}
+			}
+			catch
+			{
+				// Dispose the loaded results, then the ones left unloaded by the failure.
 				DisposeFileResults(fileResults);
+				for (var i = fileResults.Count; i < pickerResults.Count; i++)
+				{
+					pickerResults[i].Dispose();
+				}
 				throw;
 			}
 


### PR DESCRIPTION
### Description of Change

`PickerResultsToMediaFiles` reads `PHPickerResult.ItemProvider` — a UIKit call guarded by `UIApplication.EnsureUIThread()` — inside a loop that awaits with `ConfigureAwait(false)`:

```csharp
foreach (var file in results)
{
    fileResult = new PHPickerFileResult(file.ItemProvider);   // UIKit call
    await fileResult.LoadFileRepresentationAsync().ConfigureAwait(false);
    fileResults.Add(fileResult);
    fileResult = null;
}
```

The first iteration runs on the main thread, because the picker delegate invokes it from the dismissal completion. But `LoadFileRepresentationAsync` completes through a `TaskCompletionSource<bool>` created with `TaskCreationOptions.RunContinuationsAsynchronously`, so the continuation never runs inline. From the second iteration onwards the read happens on the thread pool and throws `UIKitThreadAccessException`. This makes it deterministic rather than a race — picking 2 or more items always fails, picking 1 always works.

This is a regression from #35805, which replaced the previous `Select(...).ToList()` materialization — where every `ItemProvider` was read before the first await — with the loop above.

**Change:** read every `ItemProvider` up front, before the first await, then load the file representations in a second loop. `NSItemProvider` is a Foundation type with no UI-thread guard, so holding the providers across the awaits is safe.

This preserves what #35805 set out to fix: `FullPath` is assigned in the `PHPickerFileResult` constructor via `CreateTemporaryFilePath`, not by the load, so it still points at a real temp-backed file. Ordering, image processing and video handling are untouched.

It also fixes a leak in the error path: previously, when a load threw, results already constructed by earlier iterations were disposed, but ones constructed later were not. Results are now only added to the returned list once loaded, and any left unloaded by a failure are disposed separately.

### Verification

- `dotnet format src/Essentials/src/Essentials.csproj --no-restore --include src/Essentials/src/MediaPicker/MediaPicker.ios.cs --verify-no-changes` — clean
- `dotnet build src/Essentials/src/Essentials.csproj -f net10.0-ios26.0 --no-restore /p:BuildIpa=false /p:EnableSourceLink=false /p:UseSharedCompilation=false` — 0 warnings, 0 errors
- `dotnet build src/Essentials/src/Essentials.csproj -f net10.0-maccatalyst26.0 --no-restore /p:EnableSourceLink=false /p:UseSharedCompilation=false` — 0 warnings, 0 errors
- Ran on the iOS 26.4 simulator (iPhone 17) by dropping the built `Microsoft.Maui.Essentials.dll` into the repro app from the issue, so the real fixed code was exercised through `MediaPicker.Default.PickPhotosAsync`:
  - picking 3 photos no longer throws
  - every returned `FileResult.FullPath` exists, is non-empty, and `File.Copy(result.FullPath, ...)` succeeds — i.e. the #32832 scenario that #35805 fixed still works

No unit test is included: the affected path needs a real `PHPickerResult`, which cannot be constructed in `Essentials.UnitTests`. Happy to add coverage if you can point me at a suitable seam.

### Issues Fixed

Fixes #37878