### PR TITLE
[net 11] [Windows] Fix failing Windows geocoding concurrency test

### DIFF
--- a/src/Core/tests/DeviceTests/Services/EssentialsDIBridgeTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Services/EssentialsDIBridgeTests.Windows.cs
@@ -295,9 +295,18 @@ public class EssentialsDIBridgeTests
 		var timeout = TimeSpan.FromSeconds(30);
 		var field = GetGeocodingBackingField();
 		var original = field.GetValue(null);
-		var cleanupResolutionEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-		var releaseCleanupResolution = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-		var first = new StubPlatformGeocoding();
+		var firstTokenSetterEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+		var releaseFirstTokenSetter = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+		var first = new CallbackPlatformGeocoding(value =>
+		{
+			if (!string.Equals(value, token, StringComparison.Ordinal))
+				return;
+
+			firstTokenSetterEntered.TrySetResult(true);
+			Assert.True(
+				releaseFirstTokenSetter.Task.Wait(timeout),
+				"Timed out waiting to release the map-token setter.");
+		});
 		var second = new StubPlatformGeocoding();
 		Task<MauiApp>? firstBuild = null;
 		MauiApp? firstApp = null;
@@ -310,14 +319,13 @@ public class EssentialsDIBridgeTests
 			var firstBuilder = MauiApp.CreateBuilder(useDefaults: false);
 			firstBuilder.Services.AddSingleton<IGeocoding>(first);
 			firstBuilder.ConfigureEssentials(essentials => essentials.UseMapServiceToken(token));
-			BlockEssentialsCleanupResolution(
-				firstBuilder,
-				cleanupResolutionEntered,
-				releaseCleanupResolution,
-				timeout);
 
+			// The map-token setter (rather than EssentialsCleanup resolution) is the right
+			// place to stall the first build: it runs after Geocoding.Default has already
+			// been bridged to `first`, so the assertion below observes the state the real
+			// initialization pipeline produces instead of racing ahead of it.
 			firstBuild = Task.Run(firstBuilder.Build);
-			await cleanupResolutionEntered.Task.WaitAsync(timeout);
+			await firstTokenSetterEntered.Task.WaitAsync(timeout);
 			Assert.Same(first, Geocoding.Default);
 
 			var secondBuilder = MauiApp.CreateBuilder(useDefaults: false);
@@ -326,7 +334,7 @@ public class EssentialsDIBridgeTests
 			secondApp = secondBuilder.Build();
 			Assert.Same(second, Geocoding.Default);
 
-			releaseCleanupResolution.TrySetResult(true);
+			releaseFirstTokenSetter.TrySetResult(true);
 			firstApp = await firstBuild.WaitAsync(timeout);
 
 			Assert.Equal(token, first.MapServiceToken);
@@ -335,7 +343,7 @@ public class EssentialsDIBridgeTests
 		}
 		finally
 		{
-			releaseCleanupResolution.TrySetResult(true);
+			releaseFirstTokenSetter.TrySetResult(true);
 			if (firstBuild is not null && firstApp is null)
 				firstApp = await firstBuild.WaitAsync(timeout);
 
@@ -880,29 +888,6 @@ public class EssentialsDIBridgeTests
 		var builder = MauiApp.CreateBuilder();
 		builder.Services.AddSingleton(service);
 		return builder.Build();
-	}
-
-	static void BlockEssentialsCleanupResolution(
-		MauiAppBuilder builder,
-		TaskCompletionSource<bool> entered,
-		TaskCompletionSource<bool> release,
-		TimeSpan timeout)
-	{
-		var descriptor = Assert.Single(
-			builder.Services,
-			service => service.ServiceType.Name == "EssentialsCleanup");
-		Assert.True(builder.Services.Remove(descriptor));
-		builder.Services.Add(
-			ServiceDescriptor.Singleton(
-				descriptor.ServiceType,
-				_ =>
-				{
-					entered.TrySetResult(true);
-					Assert.True(
-						release.Task.Wait(timeout),
-						"Timed out waiting to release Essentials cleanup resolution.");
-					return Activator.CreateInstance(descriptor.ServiceType, nonPublic: true)!;
-				}));
 	}
 
 	class StubWebAuthenticator : IWebAuthenticator


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

This test case was introduced in PR [#36657](https://github.com/dotnet/maui/pull/36657), and it failed during the PR’s CI run.

### Root Cause
The test paused the first `MauiApp.Build()` while resolving `EssentialsCleanup`. However, cleanup is now resolved before the first app's geocoder is assigned to `Geocoding.Default`.

Consequently, the test checked `Geocoding.Default` too early and failed consistently. The failure was caused by the test's assumption about initialization order, not by incorrect map-token ownership in the production code.

### Description of Change
The test now pauses when the map-service token is being assigned to the first app's geocoder. At this point, the geocoder has already been assigned to `Geocoding.Default`.

This directly synchronizes on the behavior under test and follows the callback-based approach already used by a neighboring map-token concurrency [test](https://github.com/dotnet/maui/blob/ec79089f659b4964710d59d4dc4a4e5fb59c7091/src/Core/tests/DeviceTests/Services/EssentialsDIBridgeTests.Windows.cs#L358).

The obsolete `EssentialsCleanup` synchronization helper was also removed because it was used only by this test.

### Test case
Device Test
ConcurrentBuildAppliesMapServiceTokenToOwningGeocoder 

### Snapshot

| Before | After |
|---|---|
| <img width="1958" height="984" alt="image" src="https://github.com/user-attachments/assets/111799b5-1d56-48a8-8dfe-3d9f0f603b5a" /> | <img width="1958" height="984" alt="After" src="https://github.com/user-attachments/assets/eb1039dc-7102-447f-9910-699abcdb2851" /> |