### PR TITLE
[net11.0] Make Resizetizer SVG test cleanup resilient

### DIFF
--- a/src/SingleProject/Resizetizer/test/UnitTests/SkiaSharpSvgToolsTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/SkiaSharpSvgToolsTests.cs
@@ -2,27 +2,30 @@ using System;
 using System.IO;
 using SkiaSharp;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Maui.Resizetizer.Tests
 {
 	public class SkiaSharpSvgToolsTests
 	{
-		public class Resize : IDisposable
+		public class Resize : BaseTest
 		{
 			readonly string DestinationFilename;
 			readonly TestLogger Logger;
 
-			public Resize()
+			public Resize(ITestOutputHelper outputHelper)
+				: base(outputHelper)
 			{
-				DestinationFilename = Path.GetTempFileName();
+				Directory.CreateDirectory(DestinationDirectory);
+				DestinationFilename = Path.Combine(DestinationDirectory, Path.GetRandomFileName());
 				Logger = new TestLogger();
 			}
 
-			public void Dispose()
+			public override void Dispose()
 			{
 				//Logger.Persist();
 				File.Copy(DestinationFilename, "output.png", true);
-				File.Delete(DestinationFilename);
+				base.Dispose();
 			}
 
 			[Fact]

--- a/src/SingleProject/Resizetizer/test/UnitTests/SkiaSharpSvgToolsTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/SkiaSharpSvgToolsTests.cs
@@ -21,13 +21,6 @@ namespace Microsoft.Maui.Resizetizer.Tests
 				Logger = new TestLogger();
 			}
 
-			public override void Dispose()
-			{
-				//Logger.Persist();
-				File.Copy(DestinationFilename, "output.png", true);
-				base.Dispose();
-			}
-
 			[Fact]
 			public void BasicNoScaleReturnsOriginalSize()
 			{


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Root cause

The Windows Release Resizetizer work item in `maui-pr` build [1570082](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1570082) ran all 688 tests but failed while xUnit disposed `SkiaSharpSvgToolsTests.Resize`. Windows still held the test's temporary image when the fixture called `File.Delete`, producing:

```text
System.IO.IOException: The process cannot access the file because it is being used by another process.
```

The fixture used a global temporary file and attempted one immediate deletion. The neighboring Resizetizer fixtures already use `BaseTest`, whose per-test directory cleanup retries transient `IOException` and `UnauthorizedAccessException` failures after collecting and draining pending finalizers.

## Fix

Store the SVG fixture's destination image in its own `BaseTest` directory and delegate disposal to the existing bounded cleanup implementation. Remove the unused shared `output.png` debug copy so parallel tests cannot interfere and cleanup cannot mask the primary test failure. This keeps each test isolated and gives Windows native image handles time to release without swallowing a persistent cleanup failure.

This changes test infrastructure only; production Resizetizer behavior is unchanged.

## Existing work

No open or recently closed MAUI PR or issue matched `SkiaSharpSvgToolsTests`, `ColorizedWithAlphaReturnsColored`, or this file-sharing failure. The fix follows the cleanup pattern already used by `SkiaSharpAppIconToolsTests` rather than introducing another retry implementation.

## Validation

- All 29 cases in `SkiaSharpSvgToolsTests.Resize`, including the exact `ColorizedWithAlphaReturnsColored` failure, pass with the branch-pinned .NET 11 SDK and leave no shared `output.png` artifact.
- The complete local Resizetizer project passes: 685 passed, two platform-specific tests skipped, and zero failed.
- Exact-merge build [1570212](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1570212) validated merge commit `979b131e332e368a9200c6c91c916c0851eecc37`. Its raw Helix monitor processed all four jobs and 36 work items with zero failed work items.
- The Windows Release Resizetizer work item ran all 688 tests with zero errors, zero failures, and two platform skips. All 14 `SkiaSharpSvgToolsTests.Resize` cases passed in both Windows Release and Debug, including `ColorizedWithAlphaReturnsColored`.
- Azure published 5,461 Windows Release rows (5,403 passed, 58 intentionally not executed) and 5,468 Windows Debug rows (5,414 passed, 54 intentionally not executed), with no failed or synthetic failed-work-item rows. This run did not emit a cleanup-retry diagnostic, so it validates successful Windows isolation and cleanup without claiming that the retry branch itself executed.
- The same exact-merge build completed successfully with all unit, build, pack, and integration stages green.
