### PR TITLE
[Windows] Fix IndicatorView.Background / BackgroundColor is not rendered 

### DIFF
--- a/src/Core/src/Platform/Windows/MauiPageControl.cs
+++ b/src/Core/src/Platform/Windows/MauiPageControl.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Maui.Platform
 			HorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment.Center;
 			VerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment.Center;
 			ItemsPanel = GetItemsPanelTemplate();
+			Template = GetControlTemplate();
 		}
 		public void SetIndicatorView(IIndicatorView indicatorView)
 		{
@@ -93,6 +94,24 @@ namespace Microsoft.Maui.Platform
 			   </ItemsPanelTemplate>";
 
 			return (ItemsPanelTemplate)XamlReader.Load(itemsPanelTemplateXaml);
+		}
+
+		static ControlTemplate GetControlTemplate()
+		{
+			// The default ItemsControl template is just an ItemsPresenter with no Border bound to
+			// Background, so setting IndicatorView.Background has no visual effect on Windows. Wrap
+			// the ItemsPresenter in a Border so Background is actually rendered. IndicatorView does not
+			// expose BorderBrush/BorderThickness, so only Background is bound here.
+			var controlTemplateXaml =
+				$@"<ControlTemplate xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
+                                  xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+                                  TargetType='ItemsControl'>
+                        <Border Background='{{TemplateBinding Background}}'>
+                            <ItemsPresenter/>
+                        </Border>
+			   </ControlTemplate>";
+
+			return (ControlTemplate)XamlReader.Load(controlTemplateXaml);
 		}
 
 		WShape? CreateIndicator(int i, int position)

--- a/src/Core/tests/DeviceTests/Handlers/IndicatorView/IndicatorViewHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/IndicatorView/IndicatorViewHandlerTests.Windows.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Maui.DeviceTests.Stubs;
+﻿using System.Threading.Tasks;
+using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Graphics;
 using Xunit;
 

--- a/src/Core/tests/DeviceTests/Handlers/IndicatorView/IndicatorViewHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/IndicatorView/IndicatorViewHandlerTests.Windows.cs
@@ -1,7 +1,45 @@
-﻿namespace Microsoft.Maui.DeviceTests
+﻿using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Graphics;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
 {
 	public partial class IndicatorViewHandlerTests
 	{
+		[Theory(DisplayName = "IndicatorView Background Color Initializes Correctly on Windows")]
+		[InlineData(0xFFFF0000)]
+		[InlineData(0xFF00FF00)]
+		[InlineData(0xFF0000FF)]
+		public async Task BackgroundColorInitializesCorrectly(uint color)
+		{
+			var expected = Color.FromUint(color);
 
+			var indicatorView = new IndicatorViewStub()
+			{
+				Count = 3,
+				Position = 0,
+				Background = new SolidPaintStub(expected),
+			};
+
+			await ValidateHasColor(indicatorView, expected);
+		}
+
+		[Theory(DisplayName = "IndicatorView Background Color Updates Correctly on Windows")]
+		[InlineData(0xFFFF0000)]
+		[InlineData(0xFF00FF00)]
+		[InlineData(0xFF0000FF)]
+		public async Task BackgroundColorUpdatesCorrectly(uint color)
+		{
+			var expected = Color.FromUint(color);
+
+			var indicatorView = new IndicatorViewStub()
+			{
+				Count = 3,
+				Position = 0,
+				Background = new SolidPaintStub(Colors.Grey),
+			};
+
+			await ValidateHasColor(indicatorView, expected, () => indicatorView.Background = new SolidPaintStub(expected), nameof(indicatorView.Background));
+		}
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details:

- On Windows, setting  IndicatorView.Background  or  BackgroundColor  has no visual effect — the control stays unchanged. On Android, iOS, and MacCatalyst the same property works correctly.

### Root Cause of the issue:

- IndicatorView 's Windows platform view is  MauiPageControl , which derives from WinUI's  ItemsControl.
- IndicatorViewHandler.Windows.cs  creates a  MauiPageControl  as the platform view. 
- The shared cross-platform mapper ( ViewHandler.MapBackground  →  ControlExtensions.UpdateBackground ) correctly sets  MauiPageControl.Background  (a WinUI  Control.BackgroundProperty ) whenever  IndicatorView.Background / BackgroundColor  changes — this part works fine.
- The problem:  MauiPageControl 's constructor only ever set  ItemsPanel ; it never assigned a  Template . Without a custom template that includes an element bound to  Background , the property is set correctly in the object model, but there's nothing in the visual tree to actually paint it.

### Description of Change

**Windows Control Template Improvements:**

* Added a custom control template in `MauiPageControl` that wraps the `ItemsPresenter` in a `Border` bound to the `Background` property, ensuring the `IndicatorView.Background` is visually rendered on Windows. 

**Testing Enhancements:**

* Introduced new tests in `IndicatorViewHandlerTests.Windows.cs` to verify that the background color of `IndicatorView` initializes and updates correctly on Windows.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #37886

### Tested the behavior in the following platforms
 
- [x] Windows
- [ ] Android
- [ ] iOS
- [ ] Mac

### Output
 
| Before | After |
|----------|----------|
| <img src="https://github.com/user-attachments/assets/00564f56-28f3-4326-9aeb-2d2fcaa9afce"> | <img src="https://github.com/user-attachments/assets/67f81d37-082a-4f8d-aa17-ebde96ff9a64"> |



<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
