### PR TITLE
[net11] [iOS] [Testing] Extend FlyoutPage device tests to run against both PhoneFlyoutPageRenderer and FlyoutViewHandler

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageHandlerTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageHandlerTests.iOS.cs
@@ -1,0 +1,28 @@
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Microsoft.Maui.Platform;
+using UIKit;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	/// <summary>
+	/// Reuses every FlyoutPageTests fact/theory under FlyoutViewHandler instead of the base
+	/// class's PhoneFlyoutPageRenderer, so all FlyoutPage tests run against both variants on
+	/// iOS/MacCatalyst.
+	/// </summary>
+	[Category(TestCategory.FlyoutPage)]
+	[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
+	[Trait(RendererHandlerVariant.FlyoutViewVariantTraitName, RendererHandlerVariant.FlyoutViewHandler)] // See RendererHandlerVariant.cs
+	public class FlyoutPageHandlerTests : FlyoutPageTests
+	{
+		protected override void RegisterFlyoutPageHandler(IMauiHandlersCollection handlers)
+		{
+			handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
+		}
+
+		protected override UIView FindPlatformFlyoutView(UIView uiView) =>
+			uiView.FindResponder<FlyoutContainerViewController>()?.View;
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
@@ -16,16 +16,16 @@ using Microsoft.Maui.Platform;
 using Xunit;
 using static Microsoft.Maui.DeviceTests.AssertHelpers;
 
-#if IOS || MACCATALYST
-using FlyoutViewHandler = Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer;
-#endif
-
 
 namespace Microsoft.Maui.DeviceTests
 {
 	[Category(TestCategory.FlyoutPage)]
 #if IOS || MACCATALYST
 	[Trait(RendererHandlerVariant.NavigationViewVariantTraitName, RendererHandlerVariant.NavigationRenderer)] // See RendererHandlerVariant.cs
+	// This base class exercises PhoneFlyoutPageRenderer on iOS/MacCatalyst; the
+	// FlyoutPageHandlerTests subclass overrides registration to exercise FlyoutViewHandler
+	// instead, so every test below runs against both variants.
+	[Trait(RendererHandlerVariant.FlyoutViewVariantTraitName, RendererHandlerVariant.PhoneFlyoutPageRenderer)] // See RendererHandlerVariant.cs
 #endif
 	public partial class FlyoutPageTests : ControlsHandlerTestBase
 	{
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.DeviceTests
 				{
 					handlers.AddHandler(typeof(Controls.Label), typeof(LabelHandler));
 					handlers.AddHandler(typeof(Controls.Toolbar), typeof(ToolbarHandler));
-					handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
+					RegisterFlyoutPageHandler(handlers);
 					RegisterNavigationPageHandler(handlers);
 					handlers.AddHandler<Page, PageHandler>();
 					handlers.AddHandler<Border, BorderHandler>();
@@ -55,6 +55,17 @@ namespace Microsoft.Maui.DeviceTests
 			handlers.AddHandler(typeof(NavigationPage), typeof(NavigationRenderer));
 #else
 			handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+#endif
+		}
+
+		// The base class exercises PhoneFlyoutPageRenderer on iOS/MacCatalyst;
+		// FlyoutPageHandlerTests overrides this to exercise FlyoutViewHandler instead.
+		protected virtual void RegisterFlyoutPageHandler(IMauiHandlersCollection handlers)
+		{
+#if IOS || MACCATALYST
+			handlers.AddHandler(typeof(FlyoutPage), typeof(Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer));
+#else
+			handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
 #endif
 		}
 
@@ -112,7 +123,7 @@ namespace Microsoft.Maui.DeviceTests
 					new NavigationPage(new ContentPage() { Title = "Detail" }),
 					new ContentPage() { Title = "Flyout" });
 
-			await CreateHandlerAndAddToWindow<FlyoutViewHandler>(flyoutPage, (handler) =>
+			await CreateHandlerAndAddToWindow<IElementHandler>(flyoutPage, (handler) =>
 			{
 				// validate that nothing crashes
 
@@ -132,7 +143,7 @@ namespace Microsoft.Maui.DeviceTests
 					new NavigationPage(new ContentPage() { Title = "Detail" }),
 					new ContentPage() { Title = "Flyout" });
 
-			await CreateHandlerAndAddToWindow<FlyoutViewHandler>(flyoutPage, async (handler) =>
+			await CreateHandlerAndAddToWindow<IElementHandler>(flyoutPage, async (handler) =>
 			{
 				var details2 = new NavigationPage(new ContentPage() { Title = "Detail" });
 
@@ -158,7 +169,7 @@ namespace Microsoft.Maui.DeviceTests
 					new ContentPage() { Title = "Detail" },
 					new ContentPage() { Title = "Flyout" });
 
-			await CreateHandlerAndAddToWindow<FlyoutViewHandler>(flyoutPage, async (handler) =>
+			await CreateHandlerAndAddToWindow<IElementHandler>(flyoutPage, async (handler) =>
 			{
 				var details2 = new ContentPage() { Title = "Detail" };
 				var flyoutView = flyoutPage.ToPlatform();
@@ -211,7 +222,7 @@ namespace Microsoft.Maui.DeviceTests
 				FlowDirection = (isRtl) ? FlowDirection.RightToLeft : FlowDirection.LeftToRight
 			});
 
-			await CreateHandlerAndAddToWindow<FlyoutViewHandler>(flyoutPage, async (handler) =>
+			await CreateHandlerAndAddToWindow<IElementHandler>(flyoutPage, async (handler) =>
 			{
 				if (!CanDeviceDoSplitMode(flyoutPage))
 					return;
@@ -259,7 +270,7 @@ namespace Microsoft.Maui.DeviceTests
 
 			flyoutPage.Detail = first;
 
-			await CreateHandlerAndAddToWindow<FlyoutViewHandler>(flyoutPage, async (handler) =>
+			await CreateHandlerAndAddToWindow<IElementHandler>(flyoutPage, async (handler) =>
 			{
 				Assert.False(IsBackButtonVisible(handler));
 

--- a/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.iOS.cs
@@ -9,10 +9,6 @@ using UIKit;
 using Xunit;
 using static Microsoft.Maui.DeviceTests.AssertHelpers;
 
-#if IOS || MACCATALYST
-using FlyoutViewHandler = Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer;
-#endif
-
 namespace Microsoft.Maui.DeviceTests
 {
 	[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
@@ -45,7 +41,7 @@ namespace Microsoft.Maui.DeviceTests
 				}
 			});
 
-			await CreateHandlerAndAddToWindow<PhoneFlyoutPageRenderer>(flyoutPage, async (handler) =>
+			await CreateHandlerAndAddToWindow<IElementHandler>(flyoutPage, async (handler) =>
 			{
 				var offset = (float)UIApplication.SharedApplication.GetSafeAreaInsetsForWindow().Top;
 				await AssertEventually(() => flyoutLabel.ToPlatform().GetLocationOnScreen().Y > 1);
@@ -82,7 +78,7 @@ namespace Microsoft.Maui.DeviceTests
 				FlowDirection = isRtl ? FlowDirection.RightToLeft : FlowDirection.LeftToRight
 			});
 
-			await CreateHandlerAndAddToWindow<FlyoutViewHandler>(flyoutPage, async (handler) =>
+			await CreateHandlerAndAddToWindow<IElementHandler>(flyoutPage, async (handler) =>
 			{
 				await AssertEventually(() => flyoutPage.Flyout.GetBoundingBox().Width > 0);
 				var screenBounds = flyoutPage.GetBoundingBox();
@@ -129,7 +125,9 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		UIView FindPlatformFlyoutView(UIView uiView) =>
+		// The base class exercises PhoneFlyoutPageRenderer on iOS/MacCatalyst;
+		// FlyoutPageHandlerTests overrides this to look for FlyoutContainerViewController instead.
+		protected virtual UIView FindPlatformFlyoutView(UIView uiView) =>
 			uiView.FindResponder<PhoneFlyoutPageRenderer>()?.View;
 
 		async Task CloseFlyout(FlyoutPage flyoutPage)

--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.FlyoutViewHandler.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.FlyoutViewHandler.iOS.cs
@@ -1,0 +1,23 @@
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	/// <summary>
+	/// Reuses every ModalTests fact/theory under FlyoutViewHandler instead of the base class's
+	/// PhoneFlyoutPageRenderer, so tests that embed a FlyoutPage exercise both variants on
+	/// iOS/MacCatalyst.
+	/// </summary>
+	[Category(TestCategory.Modal)]
+	[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
+	[Trait(RendererHandlerVariant.FlyoutViewVariantTraitName, RendererHandlerVariant.FlyoutViewHandler)] // See RendererHandlerVariant.cs
+	public class ModalTests_FlyoutViewHandler : ModalTests
+	{
+		protected override void RegisterFlyoutPageHandler(IMauiHandlersCollection handlers)
+		{
+			handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
@@ -18,7 +18,6 @@ using ShellHandler = Microsoft.Maui.Controls.Handlers.Compatibility.ShellRendere
 #endif
 
 #if IOS || MACCATALYST
-using FlyoutViewHandler = Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer;
 using TabbedViewHandler = Microsoft.Maui.Controls.Handlers.Compatibility.TabbedRenderer;
 using NavigationCompatRenderer = Microsoft.Maui.Controls.Handlers.Compatibility.NavigationRenderer;
 #endif
@@ -32,6 +31,10 @@ namespace Microsoft.Maui.DeviceTests
 	[Trait(RendererHandlerVariant.TraitName, RendererHandlerVariant.AndroidShellRenderer)] // See RendererHandlerVariant.cs
 #if IOS || MACCATALYST
 	[Trait(RendererHandlerVariant.NavigationViewVariantTraitName, RendererHandlerVariant.NavigationRenderer)] // See RendererHandlerVariant.cs
+	// This base class exercises PhoneFlyoutPageRenderer on iOS/MacCatalyst; the
+	// ModalTests_FlyoutViewHandler subclass overrides registration to exercise FlyoutViewHandler
+	// instead, so every test below runs against both variants.
+	[Trait(RendererHandlerVariant.FlyoutViewVariantTraitName, RendererHandlerVariant.PhoneFlyoutPageRenderer)] // See RendererHandlerVariant.cs
 #endif
 	public partial class ModalTests : ControlsHandlerTestBase
 	{
@@ -42,7 +45,7 @@ namespace Microsoft.Maui.DeviceTests
 				builder.ConfigureMauiHandlers(handlers =>
 				{
 					RegisterNavigationPageHandler(handlers);
-					handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
+					RegisterFlyoutPageHandler(handlers);
 					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));
 					handlers.AddHandler<Window, WindowHandlerStub>();
 					handlers.AddHandler<Entry, EntryHandler>();
@@ -60,6 +63,17 @@ namespace Microsoft.Maui.DeviceTests
 			handlers.AddHandler(typeof(NavigationPage), typeof(NavigationCompatRenderer));
 #else
 			handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+#endif
+		}
+
+		// The base class exercises PhoneFlyoutPageRenderer on iOS/MacCatalyst;
+		// ModalTests_FlyoutViewHandler overrides this to exercise FlyoutViewHandler instead.
+		protected virtual void RegisterFlyoutPageHandler(IMauiHandlersCollection handlers)
+		{
+#if IOS || MACCATALYST
+			handlers.AddHandler(typeof(FlyoutPage), typeof(Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer));
+#else
+			handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
 #endif
 		}
 
@@ -378,7 +392,7 @@ namespace Microsoft.Maui.DeviceTests
 				builder.ConfigureMauiHandlers(handlers =>
 				{
 					handlers.AddHandler(typeof(NavigationPage), typeof(Microsoft.Maui.Handlers.NavigationViewHandler));
-					handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
+					RegisterFlyoutPageHandler(handlers);
 					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));
 					handlers.AddHandler<Window, WindowHandlerStub>();
 					handlers.AddHandler<Entry, EntryHandler>();

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.FlyoutViewHandler.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.FlyoutViewHandler.iOS.cs
@@ -1,0 +1,23 @@
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	/// <summary>
+	/// Reuses every NavigationPageTests fact/theory under FlyoutViewHandler instead of the base
+	/// class's PhoneFlyoutPageRenderer, so tests that embed a FlyoutPage exercise both variants on
+	/// iOS/MacCatalyst.
+	/// </summary>
+	[Category(TestCategory.NavigationPage)]
+	[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
+	[Trait(RendererHandlerVariant.FlyoutViewVariantTraitName, RendererHandlerVariant.FlyoutViewHandler)] // See RendererHandlerVariant.cs
+	public class NavigationPageTests_FlyoutViewHandler : NavigationPageTests
+	{
+		protected override void RegisterFlyoutPageHandler(IMauiHandlersCollection handlers)
+		{
+			handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
@@ -23,6 +23,10 @@ namespace Microsoft.Maui.DeviceTests
 	// NavigationViewHandler instead, so every test below runs against both variants.
 #if IOS || MACCATALYST
 	[Trait(RendererHandlerVariant.NavigationViewVariantTraitName, RendererHandlerVariant.NavigationRenderer)] // See RendererHandlerVariant.cs
+	// This base class exercises PhoneFlyoutPageRenderer on iOS/MacCatalyst; the
+	// NavigationPageTests_FlyoutViewHandler subclass overrides registration to exercise
+	// FlyoutViewHandler instead, so every test below runs against both variants.
+	[Trait(RendererHandlerVariant.FlyoutViewVariantTraitName, RendererHandlerVariant.PhoneFlyoutPageRenderer)] // See RendererHandlerVariant.cs
 #endif
 	public partial class NavigationPageTests : ControlsHandlerTestBase
 	{
@@ -33,6 +37,7 @@ namespace Microsoft.Maui.DeviceTests
 				builder.ConfigureMauiHandlers(handlers =>
 				{
 					RegisterNavigationPageHandlers(handlers);
+					RegisterFlyoutPageHandler(handlers);
 					RegisterCommonHandlers(handlers);
 				});
 			});
@@ -51,11 +56,21 @@ namespace Microsoft.Maui.DeviceTests
 #endif
 		}
 
+		// The base class exercises PhoneFlyoutPageRenderer on iOS/MacCatalyst;
+		// NavigationPageTests_FlyoutViewHandler overrides this to exercise FlyoutViewHandler instead.
+		protected virtual void RegisterFlyoutPageHandler(IMauiHandlersCollection handlers)
+		{
+#if IOS || MACCATALYST
+			handlers.AddHandler(typeof(FlyoutPage), typeof(PhoneFlyoutPageRenderer));
+#else
+			handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
+#endif
+		}
+
 		// Handlers shared by every NavigationPage test variant, regardless of which
-		// NavigationPage/TabbedPage handler mapping is registered above.
+		// NavigationPage/TabbedPage or FlyoutPage handler mapping is registered above.
 		protected static void RegisterCommonHandlers(IMauiHandlersCollection handlers)
 		{
-			handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
 			handlers.AddHandler(typeof(ScrollView), typeof(ScrollViewHandler));
 			handlers.AddHandler<Border, BorderHandler>();
 			handlers.AddHandler<Button, ButtonHandler>();

--- a/src/Controls/tests/DeviceTests/Elements/Shell/RendererHandlerVariant.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/RendererHandlerVariant.cs
@@ -2,8 +2,8 @@ namespace Microsoft.Maui.DeviceTests
 {
 	/// <summary>
 	/// Trait key/values used by xUnitCustomizations.cs to prefix test DisplayNames as
-	/// "[Renderer]"/"[Handler]". Shared by Android Shell/Modal/Window and, via the separate
-	/// NavigationView* key below, by iOS/MacCatalyst NavigationPage tests.
+	/// "[Renderer]"/"[Handler]". Shared by Android Shell/Modal/Window, with separate keys for
+	/// iOS/MacCatalyst NavigationPage and FlyoutPage variants.
 	/// </summary>
 	public static class RendererHandlerVariant
 	{
@@ -11,12 +11,20 @@ namespace Microsoft.Maui.DeviceTests
 		public const string AndroidShellRenderer = "Renderer";
 		public const string AndroidShellHandler = "Handler";
 
-		// Distinct trait key (not reused/collided with TraitName above) for the iOS/MacCatalyst
+		// Distinct trait key for the iOS/MacCatalyst
 		// NavigationPage renderer/handler duality, so tests can be searched/filtered by
 		// "[NavigationRenderer]"/"[NavigationViewHandler]" independently of the unrelated Android
 		// Shell/Modal/Window "Variant" axis. See xUnitCustomizations.cs GetReuseVariantPrefix().
 		public const string NavigationViewVariantTraitName = "NavigationViewVariant";
 		public const string NavigationRenderer = "NavigationRenderer";
 		public const string NavigationViewHandler = "NavigationViewHandler";
+
+		// Distinct trait key for the iOS/MacCatalyst
+		// FlyoutPage renderer/handler duality, so tests can be searched/filtered by
+		// "[PhoneFlyoutPageRenderer]"/"[FlyoutViewHandler]" independently of the unrelated Android
+		// Shell/Modal/Window "Variant" axis. See xUnitCustomizations.cs GetReuseVariantPrefix().
+		public const string FlyoutViewVariantTraitName = "FlyoutViewVariant";
+		public const string PhoneFlyoutPageRenderer = "PhoneFlyoutPageRenderer";
+		public const string FlyoutViewHandler = "FlyoutViewHandler";
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarTests.FlyoutViewHandler.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarTests.FlyoutViewHandler.iOS.cs
@@ -1,0 +1,22 @@
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	/// <summary>
+	/// Reuses every ToolbarTests fact/theory under FlyoutViewHandler instead of the base class's
+	/// PhoneFlyoutPageRenderer, so tests that embed a FlyoutPage exercise both variants on
+	/// iOS/MacCatalyst.
+	/// </summary>
+	[Category(TestCategory.Toolbar)]
+	[Trait(RendererHandlerVariant.FlyoutViewVariantTraitName, RendererHandlerVariant.FlyoutViewHandler)] // See RendererHandlerVariant.cs
+	public class ToolbarTests_FlyoutViewHandler : ToolbarTests
+	{
+		protected override void RegisterFlyoutPageHandler(IMauiHandlersCollection handlers)
+		{
+			handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarTests.cs
@@ -18,7 +18,6 @@ using Xunit.Sdk;
 using static Microsoft.Maui.DeviceTests.AssertHelpers;
 
 #if IOS || MACCATALYST
-using FlyoutViewHandler = Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer;
 using TabbedRenderer = Microsoft.Maui.Controls.Handlers.Compatibility.TabbedRenderer;
 #endif
 
@@ -27,6 +26,10 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.Toolbar)]
 #if IOS || MACCATALYST
 	[Trait(RendererHandlerVariant.NavigationViewVariantTraitName, RendererHandlerVariant.NavigationRenderer)] // See RendererHandlerVariant.cs
+	// This base class exercises PhoneFlyoutPageRenderer on iOS/MacCatalyst; the
+	// ToolbarTests_FlyoutViewHandler subclass overrides registration to exercise FlyoutViewHandler
+	// instead, so every test below runs against both variants.
+	[Trait(RendererHandlerVariant.FlyoutViewVariantTraitName, RendererHandlerVariant.PhoneFlyoutPageRenderer)] // See RendererHandlerVariant.cs
 #endif
 	public partial class ToolbarTests : ControlsHandlerTestBase
 	{
@@ -38,7 +41,7 @@ namespace Microsoft.Maui.DeviceTests
 				{
 					handlers.AddHandler(typeof(Controls.Label), typeof(LabelHandler));
 					handlers.AddHandler(typeof(Controls.Toolbar), typeof(ToolbarHandler));
-					handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
+					RegisterFlyoutPageHandler(handlers);
 					RegisterNavigationPageHandler(handlers);
 					handlers.AddHandler<Page, PageHandler>();
 					handlers.AddHandler<Controls.Window, WindowHandlerStub>();
@@ -62,6 +65,17 @@ namespace Microsoft.Maui.DeviceTests
 			handlers.AddHandler(typeof(Controls.NavigationPage), typeof(NavigationRenderer));
 #else
 			handlers.AddHandler(typeof(Controls.NavigationPage), typeof(NavigationViewHandler));
+#endif
+		}
+
+		// The base class exercises PhoneFlyoutPageRenderer on iOS/MacCatalyst;
+		// ToolbarTests_FlyoutViewHandler overrides this to exercise FlyoutViewHandler instead.
+		protected virtual void RegisterFlyoutPageHandler(IMauiHandlersCollection handlers)
+		{
+#if IOS || MACCATALYST
+			handlers.AddHandler(typeof(FlyoutPage), typeof(Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer));
+#else
+			handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
 #endif
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.FlyoutViewHandler.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.FlyoutViewHandler.iOS.cs
@@ -1,0 +1,24 @@
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	/// <summary>
+	/// Reuses every WindowTests fact/theory under FlyoutViewHandler instead of the base class's
+	/// PhoneFlyoutPageRenderer, so tests that embed a FlyoutPage exercise both variants on
+	/// iOS/MacCatalyst.
+	/// </summary>
+	[Category(TestCategory.Window)]
+	[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
+	[Trait(RendererHandlerVariant.FlyoutViewVariantTraitName, RendererHandlerVariant.FlyoutViewHandler)] // See RendererHandlerVariant.cs
+	public class WindowTests_FlyoutViewHandler : WindowTests
+	{
+		protected override void RegisterFlyoutPageHandler(IMauiHandlersCollection handlers)
+		{
+			handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.cs
@@ -38,6 +38,10 @@ namespace Microsoft.Maui.DeviceTests
 	[Trait(RendererHandlerVariant.TraitName, RendererHandlerVariant.AndroidShellRenderer)] // See RendererHandlerVariant.cs
 #if IOS || MACCATALYST
 	[Trait(RendererHandlerVariant.NavigationViewVariantTraitName, RendererHandlerVariant.NavigationRenderer)] // See RendererHandlerVariant.cs
+	// This base class exercises PhoneFlyoutPageRenderer on iOS/MacCatalyst; the
+	// WindowTests_FlyoutViewHandler subclass overrides registration to exercise FlyoutViewHandler
+	// instead, so every test below runs against both variants.
+	[Trait(RendererHandlerVariant.FlyoutViewVariantTraitName, RendererHandlerVariant.PhoneFlyoutPageRenderer)] // See RendererHandlerVariant.cs
 #endif
 	public partial class WindowTests : ControlsHandlerTestBase
 	{
@@ -50,12 +54,11 @@ namespace Microsoft.Maui.DeviceTests
 					SetupShellHandlers(handlers);
 
 					RegisterNavigationPageHandler(handlers);
+					RegisterFlyoutPageHandler(handlers);
 #if ANDROID || WINDOWS
 					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));
-					handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
 #else
 					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedRenderer));
-					handlers.AddHandler(typeof(FlyoutPage), typeof(PhoneFlyoutPageRenderer));
 #endif
 
 					handlers.AddHandler<IContentView, ContentViewHandler>();
@@ -77,6 +80,17 @@ namespace Microsoft.Maui.DeviceTests
 			handlers.AddHandler(typeof(NavigationPage), typeof(NavigationRenderer));
 #else
 			handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+#endif
+		}
+
+		// The base class exercises PhoneFlyoutPageRenderer on iOS/MacCatalyst;
+		// WindowTests_FlyoutViewHandler overrides this to exercise FlyoutViewHandler instead.
+		protected virtual void RegisterFlyoutPageHandler(IMauiHandlersCollection handlers)
+		{
+#if ANDROID || WINDOWS
+			handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
+#else
+			handlers.AddHandler(typeof(FlyoutPage), typeof(PhoneFlyoutPageRenderer));
 #endif
 		}
 

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.FlyoutViewHandler.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.FlyoutViewHandler.iOS.cs
@@ -1,0 +1,21 @@
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests.Memory;
+
+/// <summary>
+/// Reuses every MemoryTests fact/theory under FlyoutViewHandler instead of the base class's
+/// PhoneFlyoutPageRenderer, so PagesDoNotLeak(typeof(FlyoutPage)) exercises both variants on
+/// iOS/MacCatalyst.
+/// </summary>
+[Category(TestCategory.Memory)]
+[Trait(RendererHandlerVariant.FlyoutViewVariantTraitName, RendererHandlerVariant.FlyoutViewHandler)] // See RendererHandlerVariant.cs
+public class MemoryTests_FlyoutViewHandler : MemoryTests
+{
+	protected override void RegisterFlyoutPageHandler(IMauiHandlersCollection handlers)
+	{
+		handlers.AddHandler<FlyoutPage, FlyoutViewHandler>();
+	}
+}

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -25,6 +25,11 @@ using Xunit.Sdk;
 namespace Microsoft.Maui.DeviceTests.Memory;
 
 [Category(TestCategory.Memory)]
+#if IOS || MACCATALYST
+// This base class exercises PhoneFlyoutPageRenderer on iOS/MacCatalyst; the
+// MemoryTests_FlyoutViewHandler subclass overrides registration to exercise FlyoutViewHandler.
+[Trait(RendererHandlerVariant.FlyoutViewVariantTraitName, RendererHandlerVariant.PhoneFlyoutPageRenderer)] // See RendererHandlerVariant.cs
+#endif
 public class MemoryTests : ControlsHandlerTestBase
 {
 	// Subclasses used to enable memory tests for CV2 handlers
@@ -32,7 +37,7 @@ public class MemoryTests : ControlsHandlerTestBase
 	public class CarouselView2 : CarouselView { }
 
 
-	void SetupBuilder(bool includeNavigationViewHandler = true)
+	protected virtual void SetupBuilder(bool includeNavigationViewHandler = true)
 	{
 		EnsureHandlerCreated(builder =>
 		{
@@ -94,15 +99,25 @@ public class MemoryTests : ControlsHandlerTestBase
 #else
 				handlers.AddHandler<NavigationPage, NavigationViewHandler>();
 #endif
+				RegisterFlyoutPageHandler(handlers);
 #if IOS || MACCATALYST
 				handlers.AddHandler<TabbedPage, TabbedRenderer>();
-				handlers.AddHandler<FlyoutPage, PhoneFlyoutPageRenderer>();
 #else
 				handlers.AddHandler<TabbedPage, TabbedViewHandler>();
-				handlers.AddHandler<FlyoutPage, FlyoutViewHandler>();
 #endif
 			});
 		});
+	}
+
+	// The base class exercises PhoneFlyoutPageRenderer on iOS/MacCatalyst; MemoryTests_FlyoutViewHandler
+	// overrides this to exercise FlyoutViewHandler instead.
+	protected virtual void RegisterFlyoutPageHandler(IMauiHandlersCollection handlers)
+	{
+#if IOS || MACCATALYST
+		handlers.AddHandler<FlyoutPage, PhoneFlyoutPageRenderer>();
+#else
+		handlers.AddHandler<FlyoutPage, FlyoutViewHandler>();
+#endif
 	}
 
 	[Theory("Pages Do Not Leak")]

--- a/src/Controls/tests/DeviceTests/TestCases/ControlsPageTypesTestCases.cs
+++ b/src/Controls/tests/DeviceTests/TestCases/ControlsPageTypesTestCases.cs
@@ -11,10 +11,6 @@ using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
 
-#if IOS || MACCATALYST
-using FlyoutViewHandler = Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer;
-#endif
-
 namespace Microsoft.Maui.DeviceTests.TestCases
 {
 	public enum ControlsPageTypesTestCase
@@ -94,7 +90,11 @@ namespace Microsoft.Maui.DeviceTests.TestCases
 
 				handlers.AddHandler(typeof(Controls.Label), typeof(LabelHandler));
 				handlers.AddHandler(typeof(Controls.Toolbar), typeof(ToolbarHandler));
+#if IOS || MACCATALYST
+				handlers.AddHandler(typeof(FlyoutPage), typeof(Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer));
+#else
 				handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
+#endif
 #if IOS || MACCATALYST
 				handlers.AddHandler(typeof(NavigationPage), includeNavigationViewHandler ? typeof(NavigationViewHandler) : typeof(NavigationRenderer));
 #else

--- a/src/TestUtils/src/DeviceTests/xUnitCustomizations.cs
+++ b/src/TestUtils/src/DeviceTests/xUnitCustomizations.cs
@@ -215,11 +215,9 @@ namespace Microsoft.Maui
 
 		string? _reuseVariantPrefix;
 
-		// Renderer/handler subclass pairs (Android Shell/Modal/Window; iOS/MacCatalyst
-		// NavigationPage-related tests) reuse the same test bodies, so DisplayName alone can't
-		// distinguish variants. The Android axis uses the "Variant" trait ("[Renderer]"/"[Handler]");
-		// the iOS/MacCatalyst axis uses the distinct "NavigationViewVariant" trait
-		// ("[NavigationRenderer]"/"[NavigationViewHandler]"), so the two never collide.
+		// Renderer/handler subclasses reuse the same test bodies, so DisplayName alone can't
+		// distinguish variants. Android uses the "Variant" trait; iOS/MacCatalyst use distinct
+		// NavigationViewVariant and FlyoutViewVariant traits, which may both be present.
 		string GetReuseVariantPrefix()
 		{
 			if (_reuseVariantPrefix == null)
@@ -228,6 +226,7 @@ namespace Microsoft.Maui
 				try
 				{
 					// These literals must stay in sync with RendererHandlerVariant.cs (Controls.DeviceTests).
+#if IOS || MACCATALYST
 					if (Traits.TryGetValue("NavigationViewVariant", out var navigationViewVariants) && navigationViewVariants is not null)
 					{
 						// Check Handler first: a Handler subclass also inherits the base class's
@@ -242,7 +241,23 @@ namespace Microsoft.Maui
 						}
 					}
 
-					if (_reuseVariantPrefix == null && Traits.TryGetValue("Variant", out var variants) && variants is not null)
+					if (Traits.TryGetValue("FlyoutViewVariant", out var flyoutViewVariants) && flyoutViewVariants is not null)
+					{
+						// Check Handler first: a Handler subclass also inherits the base class's
+						// "PhoneFlyoutPageRenderer" trait, so Traits may contain both values for this key.
+						if (flyoutViewVariants.Contains("FlyoutViewHandler"))
+						{
+							_reuseVariantPrefix = (_reuseVariantPrefix ?? string.Empty) + "[FlyoutViewHandler] ";
+						}
+						else if (flyoutViewVariants.Contains("PhoneFlyoutPageRenderer"))
+						{
+							_reuseVariantPrefix = (_reuseVariantPrefix ?? string.Empty) + "[PhoneFlyoutPageRenderer] ";
+						}
+					}
+#endif
+
+#if ANDROID
+					if (Traits.TryGetValue("Variant", out var variants) && variants is not null)
 					{
 						// Check Handler first: a Handler subclass also inherits the base class's
 						// "Renderer" trait, so Traits may contain both values for this key.
@@ -255,6 +270,7 @@ namespace Microsoft.Maui
 							_reuseVariantPrefix = "[Renderer] ";
 						}
 					}
+#endif
 
 					_reuseVariantPrefix ??= string.Empty;
 				}


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

#### Problem

`FlyoutPage` was migrated from the renderer to the handler architecture on iOS/MacCatalyst (dotnet/maui#36676). Despite that migration, every existing `FlyoutPage` device test — and every other device test that embeds a `FlyoutPage` as a supporting page (Modal, Window, NavigationPage, Toolbar, Memory) — still hardcoded `PhoneFlyoutPageRenderer` on iOS/MacCatalyst. As a result, the new `FlyoutViewHandler` code path had zero device test coverage, even though it's now the code path real apps run against.

#### Approach

Rather than write a parallel/duplicate set of tests for `FlyoutViewHandler`, this PR makes the handler registration for `FlyoutPage` overridable and reuses every existing test body across both variants — the same pattern already used for the Android Shell/Modal/Window renderer/handler axis.

For each affected test class:

- `SetupBuilder` (or equivalent) is made `virtual`.
- The `FlyoutPage` handler registration is extracted into a new virtual `RegisterFlyoutPageHandler(...)` hook, defaulting to the existing `PhoneFlyoutPageRenderer` registration on iOS/MacCatalyst (no behavior change for the base class).
- A new `*_FlyoutViewHandler`/`FlyoutPageHandlerTests` subclass (new `.iOS.cs` file) overrides that hook to register the real `FlyoutViewHandler` instead, inheriting every `[Fact]`/`[Theory]` unchanged — so the *same* test bodies run twice, once per variant.
- `FlyoutPageTests.iOS.cs`'s `FindPlatformFlyoutView` helper is made virtual, so the handler subclass can locate `FlyoutContainerViewController` (the real handler's `UIViewController`) instead of `PhoneFlyoutPageRenderer`.

`xUnitCustomizations.GetReuseVariantPrefix()` was extended with a new `FlyoutViewVariant` trait so each test's `DisplayName` is tagged `[PhoneFlyoutPageRenderer]` / `[FlyoutViewHandler]`, mirroring the existing Android `[Renderer]` / `[Handler]` convention, so results stay distinguishable in test output.

Also fixes `NavigationPageTests` to register `PhoneFlyoutPageRenderer` by default on iOS/MacCatalyst (it previously hardcoded `FlyoutViewHandler` unconditionally), matching the default used by every other affected test class.

#### Files changed

| File | Change |
|---|---|
| `RendererHandlerVariant.cs` | New `FlyoutViewVariant` trait constants (`PhoneFlyoutPageRenderer` / `FlyoutViewHandler`) |
| `xUnitCustomizations.cs` | `GetReuseVariantPrefix()` now also checks the new `FlyoutViewVariant` trait |
| `FlyoutPageTests.cs` / `.iOS.cs` | Virtual `RegisterFlyoutPageHandler` hook; virtual `FindPlatformFlyoutView`; test bodies switched to `CreateHandlerAndAddToWindow<IElementHandler>` so they work under either variant |
| `ModalTests.cs`, `ToolbarTests.cs`, `WindowTests.cs`, `MemoryTests.cs`, `NavigationPageTests.cs` | Same virtual hook pattern applied wherever a `FlyoutPage` is embedded as a supporting page |
| `ControlsPageTypesTestCases.cs` | Routes through the new handler-registration hook |
| 6 new `*_FlyoutViewHandler`/`*.FlyoutViewHandler.iOS.cs` files (`FlyoutPageHandlerTests`, `ModalTests.FlyoutViewHandler`, `ToolbarTests.FlyoutViewHandler`, `WindowTests.FlyoutViewHandler`, `MemoryTests.FlyoutViewHandler`, `NavigationPageTests.FlyoutViewHandler`) | One handler-variant subclass per affected test class |

No existing test logic was duplicated or rewritten — only the handler-registration hook was made overridable.