### PR TITLE
Fix x:Reference binding updates during XAML Hot Reload

### DIFF
--- a/src/Controls/src/SourceGen/UpdateComponentCodeWriter.cs
+++ b/src/Controls/src/SourceGen/UpdateComponentCodeWriter.cs
@@ -1574,6 +1574,7 @@ static class UpdateComponentCodeWriter
 		var captureStringWriter = new StringWriter(CultureInfo.InvariantCulture);
 		var captureWriter = new IndentedTextWriter(captureStringWriter, "\t") { NewLine = NewLine };
 		var ctx = CreateConversionContext(compilation, sourceProductionContext, xmlnsCache, typeCache, rootType, projectItem, captureWriter);
+		var referenceLookups = new List<(string VariableName, string ElementAccessor, string Name)>();
 
 		// Create a synthetic parent variable so SetPropertyValue can emit "parent.SetValue(...)"
 		var parentAccessor = isRoot ? "this" : $"(({ownerType.ToFQDisplayString()}){targetAccessor}!)";
@@ -1602,6 +1603,9 @@ static class UpdateComponentCodeWriter
 			// BEFORE TryProvideValue creates the TypedBinding (which reads extension.Converter).
 			if (ctx.Variables.TryGetValue(elementNode, out var extVar))
 			{
+				var elementType = compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.Element");
+				var referenceExtensionType = compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.Xaml.ReferenceExtension");
+
 				foreach (var kvp in elementNode.Properties)
 				{
 					if (kvp.Value is ElementNode propElement
@@ -1622,19 +1626,35 @@ static class UpdateComponentCodeWriter
 						}
 					}
 					else if (kvp.Value is ElementNode referenceElement
-						&& referenceElement.XmlType.Name is "ReferenceExtension" or "Reference"
+						&& referenceExtensionType is not null
+						&& referenceElement.XmlType.TryResolveTypeSymbol(null, compilation, xmlnsCache, typeCache, out var resolvedReferenceType)
+						&& SymbolEqualityComparer.Default.Equals(resolvedReferenceType, referenceExtensionType)
 						&& TryGetReferenceName(referenceElement, out var referenceName)
-						&& compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.Element") is { } elementType
-						&& ownerType.InheritsFrom(elementType, ctx))
+						&& elementType is not null)
 					{
 						var propLocalName = kvp.Key.LocalName;
 						var propSymbol = extVar.Type.GetAllProperties(propLocalName, ctx).FirstOrDefault();
-						if (propSymbol != null)
+						if (propSymbol is null)
 						{
-							var castType = propSymbol.Type.ToFQDisplayString();
-							var referenceLiteral = Microsoft.CodeAnalysis.CSharp.SymbolDisplay.FormatLiteral(referenceName, quote: true);
-							captureWriter.WriteLine($"{extVar.ValueAccessor}.{propLocalName} = ({castType})((global::Microsoft.Maui.Controls.Element){parentAccessor}).FindByName({referenceLiteral});");
+							codeWriter.WriteLine($"// Markup extension '{elementNode.XmlType.Name}' skipped: property '{propLocalName}' required for x:Reference resolution was not found.");
+							return false;
 						}
+
+						var elementAccessor = ownerType.InheritsFrom(elementType, ctx)
+							? parentAccessor
+							: rootType.InheritsFrom(elementType, ctx)
+								? "this"
+								: null;
+						if (elementAccessor is null)
+						{
+							codeWriter.WriteLine($"// Markup extension '{elementNode.XmlType.Name}' skipped: no Element namescope anchor was available for x:Reference '{referenceName}'.");
+							return false;
+						}
+
+						var referenceVariable = $"__xReference{referenceLookups.Count}";
+						referenceLookups.Add((referenceVariable, elementAccessor, referenceName));
+						var castType = propSymbol.Type.ToFQDisplayString();
+						captureWriter.WriteLine($"{extVar.ValueAccessor}.{propLocalName} = ({castType}){referenceVariable};");
 					}
 				}
 			}
@@ -1667,6 +1687,32 @@ static class UpdateComponentCodeWriter
 		codeWriter.WriteLine("{");
 		codeWriter.Indent++;
 
+		foreach (var lookup in referenceLookups)
+		{
+			var referenceLiteral = Microsoft.CodeAnalysis.CSharp.SymbolDisplay.FormatLiteral(lookup.Name, quote: true);
+			codeWriter.WriteLine($"global::System.Object? {lookup.VariableName} = null;");
+			codeWriter.WriteLine("try");
+			using (PrePost.NewBlock(codeWriter))
+			{
+				codeWriter.WriteLine($"{lookup.VariableName} = ((global::Microsoft.Maui.Controls.Element){lookup.ElementAccessor}).FindByName({referenceLiteral});");
+			}
+			codeWriter.WriteLine("catch (global::System.InvalidOperationException)");
+			using (PrePost.NewBlock(codeWriter))
+			{
+			}
+			codeWriter.WriteLine("catch (global::System.NotSupportedException)");
+			using (PrePost.NewBlock(codeWriter))
+			{
+			}
+		}
+
+		if (referenceLookups.Count > 0)
+		{
+			codeWriter.WriteLine($"if ({string.Join(" && ", referenceLookups.Select(static lookup => $"{lookup.VariableName} != null"))})");
+			codeWriter.WriteLine("{");
+			codeWriter.Indent++;
+		}
+
 		foreach (var line in capturedCode.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None))
 		{
 			if (!string.IsNullOrEmpty(line))
@@ -1685,6 +1731,12 @@ static class UpdateComponentCodeWriter
 				else
 					codeWriter.WriteLine(mline);
 			}
+		}
+
+		if (referenceLookups.Count > 0)
+		{
+			codeWriter.Indent--;
+			codeWriter.WriteLine("}");
 		}
 
 		codeWriter.Indent--;

--- a/src/Controls/src/SourceGen/UpdateComponentCodeWriter.cs
+++ b/src/Controls/src/SourceGen/UpdateComponentCodeWriter.cs
@@ -1586,6 +1586,16 @@ static class UpdateComponentCodeWriter
 			// Step 1: CreateValue — resolves type, handles early extensions (DynamicResource, x:Static, etc.)
 			CreateValuesVisitor.CreateValue(elementNode, captureWriter, ctx.Variables, compilation, xmlnsCache, ctx);
 
+			var referenceExtensionType = compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.Xaml.ReferenceExtension");
+			foreach (var propertyNode in elementNode.Properties.Values.OfType<ElementNode>())
+			{
+				var isReferenceExtension = referenceExtensionType is not null
+					&& propertyNode.XmlType.TryResolveTypeSymbol(null, compilation, xmlnsCache, typeCache, out var propertyType)
+					&& SymbolEqualityComparer.Default.Equals(propertyType, referenceExtensionType);
+				if (!isReferenceExtension)
+					CreateValuesVisitor.CreateValue(propertyNode, captureWriter, ctx.Variables, compilation, xmlnsCache, ctx);
+			}
+
 			// Step 2: SetPropertiesVisitor — sets properties on the extension object
 			var setPropsVisitor = new SetPropertiesVisitor(ctx);
 			foreach (var kvp in elementNode.Properties)
@@ -1604,7 +1614,6 @@ static class UpdateComponentCodeWriter
 			if (ctx.Variables.TryGetValue(elementNode, out var extVar))
 			{
 				var elementType = compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.Element");
-				var referenceExtensionType = compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.Xaml.ReferenceExtension");
 
 				foreach (var kvp in elementNode.Properties)
 				{
@@ -1747,14 +1756,12 @@ static class UpdateComponentCodeWriter
 
 	static bool TryGetReferenceName(ElementNode referenceElement, out string referenceName)
 	{
-		foreach (var property in referenceElement.Properties)
+		if ((referenceElement.Properties.TryGetValue(new XmlName("", "Name"), out var nameNode)
+				|| referenceElement.Properties.TryGetValue(new XmlName(null, "Name"), out nameNode))
+			&& nameNode is ValueNode { Value: string name })
 		{
-			if (property.Key.LocalName == "Name"
-				&& property.Value is ValueNode { Value: string name })
-			{
-				referenceName = name;
-				return true;
-			}
+			referenceName = name;
+			return true;
 		}
 
 		if (referenceElement.CollectionItems.Count == 1

--- a/src/Controls/src/SourceGen/UpdateComponentCodeWriter.cs
+++ b/src/Controls/src/SourceGen/UpdateComponentCodeWriter.cs
@@ -1624,7 +1624,8 @@ static class UpdateComponentCodeWriter
 					else if (kvp.Value is ElementNode referenceElement
 						&& referenceElement.XmlType.Name is "ReferenceExtension" or "Reference"
 						&& TryGetReferenceName(referenceElement, out var referenceName)
-						&& ownerType.InheritsFrom(compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.Element")!, ctx))
+						&& compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.Element") is { } elementType
+						&& ownerType.InheritsFrom(elementType, ctx))
 					{
 						var propLocalName = kvp.Key.LocalName;
 						var propSymbol = extVar.Type.GetAllProperties(propLocalName, ctx).FirstOrDefault();

--- a/src/Controls/src/SourceGen/UpdateComponentCodeWriter.cs
+++ b/src/Controls/src/SourceGen/UpdateComponentCodeWriter.cs
@@ -1621,6 +1621,15 @@ static class UpdateComponentCodeWriter
 							captureWriter.WriteLine($"{extVar.ValueAccessor}.{propLocalName} = ({castType})global::Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.FindStaticResource({parentAccessor}, {Microsoft.CodeAnalysis.CSharp.SymbolDisplay.FormatLiteral(resourceKey, quote: true)})!;");
 						}
 					}
+					else if (kvp.Value is ElementNode referenceElement
+						&& referenceElement.XmlType.Name is "ReferenceExtension" or "Reference"
+						&& TryGetReferenceName(referenceElement, out var referenceName)
+						&& ownerType.InheritsFrom(compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.Element")!, ctx))
+					{
+						var propLocalName = kvp.Key.LocalName;
+						var referenceLiteral = Microsoft.CodeAnalysis.CSharp.SymbolDisplay.FormatLiteral(referenceName, quote: true);
+						captureWriter.WriteLine($"{extVar.ValueAccessor}.{propLocalName} = ((global::Microsoft.Maui.Controls.Element){parentAccessor}).FindByName({referenceLiteral});");
+					}
 				}
 			}
 
@@ -1676,6 +1685,29 @@ static class UpdateComponentCodeWriter
 		codeWriter.WriteLine("}");
 
 		return true;
+	}
+
+	static bool TryGetReferenceName(ElementNode referenceElement, out string referenceName)
+	{
+		foreach (var property in referenceElement.Properties)
+		{
+			if (property.Key.LocalName == "Name"
+				&& property.Value is ValueNode { Value: string name })
+			{
+				referenceName = name;
+				return true;
+			}
+		}
+
+		if (referenceElement.CollectionItems.Count == 1
+			&& referenceElement.CollectionItems[0] is ValueNode { Value: string contentName })
+		{
+			referenceName = contentName;
+			return true;
+		}
+
+		referenceName = string.Empty;
+		return false;
 	}
 
 	/// <summary>Simple IXmlLineInfoProvider for UC's ExpandMarkupForUC.</summary>

--- a/src/Controls/src/SourceGen/UpdateComponentCodeWriter.cs
+++ b/src/Controls/src/SourceGen/UpdateComponentCodeWriter.cs
@@ -1627,8 +1627,13 @@ static class UpdateComponentCodeWriter
 						&& ownerType.InheritsFrom(compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.Element")!, ctx))
 					{
 						var propLocalName = kvp.Key.LocalName;
-						var referenceLiteral = Microsoft.CodeAnalysis.CSharp.SymbolDisplay.FormatLiteral(referenceName, quote: true);
-						captureWriter.WriteLine($"{extVar.ValueAccessor}.{propLocalName} = ((global::Microsoft.Maui.Controls.Element){parentAccessor}).FindByName({referenceLiteral});");
+						var propSymbol = extVar.Type.GetAllProperties(propLocalName, ctx).FirstOrDefault();
+						if (propSymbol != null)
+						{
+							var castType = propSymbol.Type.ToFQDisplayString();
+							var referenceLiteral = Microsoft.CodeAnalysis.CSharp.SymbolDisplay.FormatLiteral(referenceName, quote: true);
+							captureWriter.WriteLine($"{extVar.ValueAccessor}.{propLocalName} = ({castType})((global::Microsoft.Maui.Controls.Element){parentAccessor}).FindByName({referenceLiteral});");
+						}
 					}
 				}
 			}

--- a/src/Controls/tests/SourceGen.UnitTests/HotReload/AiAssisted/BindingAndMarkupHotReloadTests.Bindings.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/HotReload/AiAssisted/BindingAndMarkupHotReloadTests.Bindings.cs
@@ -85,6 +85,114 @@ public partial class BindingAndMarkupHotReloadTests
 	}
 
 	[MetadataUpdateFact]
+	public void XReferenceBinding_RetargetsToAnotherLiveName()
+	{
+		const string pageStub = """
+			namespace TestAiAssisted;
+
+			public partial class MainPage : global::Microsoft.Maui.Controls.ContentPage
+			{
+				internal global::Microsoft.Maui.Controls.Label CaptionLabel = null!;
+				internal global::Microsoft.Maui.Controls.Label SubtitleLabel = null!;
+
+				private partial void InitializeComponent();
+
+				public MainPage()
+				{
+					InitializeComponent();
+				}
+			}
+			""";
+		const string xamlV0 = """
+			<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			             x:Class="TestAiAssisted.MainPage">
+			  <VerticalStackLayout>
+			    <Label x:Name="CaptionLabel" Text="Caption" />
+			    <Label x:Name="SubtitleLabel" Text="Subtitle" />
+			    <Label Text="{Binding Source={x:Reference Name=CaptionLabel}, Path=Text, StringFormat='echo {0}'}" />
+			  </VerticalStackLayout>
+			</ContentPage>
+			""";
+		const string xamlV1 = """
+			<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			             x:Class="TestAiAssisted.MainPage">
+			  <VerticalStackLayout>
+			    <Label x:Name="CaptionLabel" Text="Caption" />
+			    <Label x:Name="SubtitleLabel" Text="Subtitle" />
+			    <Label Text="{Binding Source={x:Reference Name=SubtitleLabel}, Path=Text, StringFormat='mirror {0}'}" />
+			  </VerticalStackLayout>
+			</ContentPage>
+			""";
+
+		using var harness = new XamlHotReloadTestHarness(
+			nameof(XReferenceBinding_RetargetsToAnotherLiveName),
+			PageClass,
+			pageStub,
+			BindingAndMarkupSource);
+		var generation = harness.Generate(xamlV0, xamlV1);
+
+		harness.RunLive(generation, live =>
+		{
+			var page = live.GetInstance<ContentPage>();
+			var layout = Assert.IsType<VerticalStackLayout>(page.Content);
+			var caption = Assert.IsType<Label>(layout.Children[0]);
+			var subtitle = Assert.IsType<Label>(layout.Children[1]);
+			var formatted = Assert.IsType<Label>(layout.Children[2]);
+
+			Assert.Equal("echo Caption", formatted.Text);
+
+			Assert.Same(page, live.ApplyUpdate<ContentPage>(1));
+			Assert.Same(caption, layout.Children[0]);
+			Assert.Same(subtitle, layout.Children[1]);
+			Assert.Same(formatted, layout.Children[2]);
+			Assert.Equal("mirror Subtitle", formatted.Text);
+
+			var registration = GetTextRegistration(formatted);
+			var binding = Assert.IsAssignableFrom<BindingBase>(registration.Binding);
+			Assert.Same(subtitle, binding.GetType().GetProperty("Source")!.GetValue(binding));
+
+			subtitle.Text = "Subtitle V1";
+			Assert.Equal("mirror Subtitle V1", formatted.Text);
+		});
+	}
+
+	[Fact]
+	public void XReferenceBinding_NamespacedNameDoesNotOverrideReferenceName()
+	{
+		const string xamlV0 = """
+			<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			             x:Class="TestAiAssisted.MainPage">
+			  <VerticalStackLayout>
+			    <Label x:Name="CaptionLabel" Text="Caption" />
+			    <Label x:Name="SubtitleLabel" Text="Subtitle" />
+			    <Label Text="{Binding Source={x:Reference CaptionLabel}, Path=Text}" />
+			  </VerticalStackLayout>
+			</ContentPage>
+			""";
+		const string xamlV1 = """
+			<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			             x:Class="TestAiAssisted.MainPage">
+			  <VerticalStackLayout>
+			    <Label x:Name="CaptionLabel" Text="Caption" />
+			    <Label x:Name="SubtitleLabel" Text="Subtitle" />
+			    <Label Text="{Binding Source={x:Reference x:Name=CaptionLabel, Name=SubtitleLabel}, Path=Text}" />
+			  </VerticalStackLayout>
+			</ContentPage>
+			""";
+
+		using var harness = CreateHarness();
+		var generation = harness.Generate(xamlV0, xamlV1);
+		var updateSource = Assert.IsType<string>(generation[1].UpdateComponentSource);
+
+		Assert.Contains("FindByName(\"SubtitleLabel\")", updateSource, StringComparison.Ordinal);
+		Assert.DoesNotContain("FindByName(\"CaptionLabel\")", updateSource, StringComparison.Ordinal);
+	}
+
+	[MetadataUpdateFact]
 	public void XReferenceBinding_RenamedUnregisteredName_DoesNotClearExistingSource()
 	{
 		const string pageStub = """
@@ -175,6 +283,17 @@ public partial class BindingAndMarkupHotReloadTests
 			"FindByName(\"Custom\")",
 			Assert.IsType<string>(generation[1].UpdateComponentSource),
 			StringComparison.Ordinal);
+
+		harness.RunLive(generation, live =>
+		{
+			var page = live.GetInstance<ContentPage>();
+			var label = Assert.IsType<Label>(page.Content);
+			Assert.Equal("echo Custom", label.Text);
+
+			Assert.Same(page, live.ApplyUpdate<ContentPage>(1));
+			Assert.Same(label, page.Content);
+			Assert.Equal("mirror Custom", label.Text);
+		});
 	}
 
 	[MetadataUpdateFact]

--- a/src/Controls/tests/SourceGen.UnitTests/HotReload/AiAssisted/BindingAndMarkupHotReloadTests.Bindings.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/HotReload/AiAssisted/BindingAndMarkupHotReloadTests.Bindings.cs
@@ -17,6 +17,167 @@ namespace Microsoft.Maui.Controls.SourceGen.UnitTests.HotReload.AiAssisted;
 public partial class BindingAndMarkupHotReloadTests
 {
 	[MetadataUpdateFact]
+	public void XReferenceBinding_MissingLiveNameScope_RetainsExistingBinding()
+	{
+		const string pageStub = """
+			namespace TestAiAssisted;
+
+			public partial class MainPage : global::Microsoft.Maui.Controls.ContentPage
+			{
+				internal global::Microsoft.Maui.Controls.Label CaptionLabel = null!;
+
+				private partial void InitializeComponent();
+
+				public MainPage()
+				{
+					InitializeComponent();
+				}
+			}
+			""";
+		const string xamlV0 = """
+			<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			             x:Class="TestAiAssisted.MainPage">
+			  <VerticalStackLayout>
+			    <Label x:Name="CaptionLabel" Text="Caption V0" />
+			    <Label Text="{Binding Source={x:Reference CaptionLabel}, Path=Text, StringFormat='echo {0}'}" />
+			  </VerticalStackLayout>
+			</ContentPage>
+			""";
+		const string xamlV1 = """
+			<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			             x:Class="TestAiAssisted.MainPage">
+			  <VerticalStackLayout>
+			    <Label x:Name="CaptionLabel" Text="Caption V0" />
+			    <Label Text="{Binding Source={x:Reference CaptionLabel}, Path=Text, StringFormat='mirror {0}'}" />
+			  </VerticalStackLayout>
+			</ContentPage>
+			""";
+
+		using var harness = new XamlHotReloadTestHarness(
+			nameof(XReferenceBinding_MissingLiveNameScope_RetainsExistingBinding),
+			PageClass,
+			pageStub,
+			BindingAndMarkupSource);
+		var generation = harness.Generate(xamlV0, xamlV1);
+
+		harness.RunLive(generation, live =>
+		{
+			var page = live.GetInstance<ContentPage>();
+			var layout = Assert.IsType<VerticalStackLayout>(page.Content);
+			var caption = Assert.IsType<Label>(layout.Children[0]);
+			var formatted = Assert.IsType<Label>(layout.Children[1]);
+
+			Assert.True(layout.Children.Remove(formatted));
+			formatted.transientNamescope = null;
+
+			Assert.Same(page, live.ApplyUpdate<ContentPage>(1));
+
+			var registration = GetTextRegistration(formatted);
+			var binding = Assert.IsAssignableFrom<BindingBase>(registration.Binding);
+			Assert.Same(caption, binding.GetType().GetProperty("Source")!.GetValue(binding));
+			Assert.Equal("echo Caption V0", formatted.Text);
+
+			caption.Text = "Caption V1";
+			Assert.Equal("echo Caption V1", formatted.Text);
+		});
+	}
+
+	[MetadataUpdateFact]
+	public void XReferenceBinding_RenamedUnregisteredName_DoesNotClearExistingSource()
+	{
+		const string pageStub = """
+			namespace TestAiAssisted;
+
+			public partial class MainPage : global::Microsoft.Maui.Controls.ContentPage
+			{
+				internal global::Microsoft.Maui.Controls.Label CaptionLabel = null!;
+				internal global::Microsoft.Maui.Controls.Label HeaderLabel = null!;
+
+				private partial void InitializeComponent();
+
+				public MainPage()
+				{
+					InitializeComponent();
+				}
+			}
+			""";
+		const string xamlV0 = """
+			<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			             x:Class="TestAiAssisted.MainPage">
+			  <VerticalStackLayout>
+			    <Label x:Name="CaptionLabel" Text="Caption V0" />
+			    <Label Text="{Binding Source={x:Reference CaptionLabel}, Path=Text, StringFormat='echo {0}'}" />
+			  </VerticalStackLayout>
+			</ContentPage>
+			""";
+		const string xamlV1 = """
+			<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			             x:Class="TestAiAssisted.MainPage">
+			  <VerticalStackLayout>
+			    <Label x:Name="HeaderLabel" Text="Caption V1" />
+			    <Label Text="{Binding Source={x:Reference HeaderLabel}, Path=Text, StringFormat='mirror {0}'}" />
+			  </VerticalStackLayout>
+			</ContentPage>
+			""";
+
+		using var harness = new XamlHotReloadTestHarness(
+			nameof(XReferenceBinding_RenamedUnregisteredName_DoesNotClearExistingSource),
+			PageClass,
+			pageStub,
+			BindingAndMarkupSource);
+		var generation = harness.Generate(xamlV0, xamlV1);
+
+		harness.RunLive(generation, live =>
+		{
+			var page = live.GetInstance<ContentPage>();
+			var layout = Assert.IsType<VerticalStackLayout>(page.Content);
+			var caption = Assert.IsType<Label>(layout.Children[0]);
+			var formatted = Assert.IsType<Label>(layout.Children[1]);
+
+			Assert.Same(page, live.ApplyUpdate<ContentPage>(1));
+			Assert.Equal("Caption V0", caption.Text);
+			Assert.Equal("echo Caption V0", formatted.Text);
+
+			var registration = GetTextRegistration(formatted);
+			var binding = Assert.IsAssignableFrom<BindingBase>(registration.Binding);
+			Assert.Same(caption, binding.GetType().GetProperty("Source")!.GetValue(binding));
+		});
+	}
+
+	[MetadataUpdateFact]
+	public void UserReferenceExtension_IsNotRewrittenAsMauiXReference()
+	{
+		const string xamlV0 = """
+			<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			             xmlns:local="clr-namespace:TestAiAssisted"
+			             x:Class="TestAiAssisted.MainPage">
+			  <Label Text="{Binding Source={local:Reference Name=Custom}, Path=Text, StringFormat='echo {0}'}" />
+			</ContentPage>
+			""";
+		const string xamlV1 = """
+			<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			             xmlns:local="clr-namespace:TestAiAssisted"
+			             x:Class="TestAiAssisted.MainPage">
+			  <Label Text="{Binding Source={local:Reference Name=Custom}, Path=Text, StringFormat='mirror {0}'}" />
+			</ContentPage>
+			""";
+
+		using var harness = CreateHarness();
+		var generation = harness.Generate(xamlV0, xamlV1);
+
+		Assert.DoesNotContain(
+			"FindByName(\"Custom\")",
+			Assert.IsType<string>(generation[1].UpdateComponentSource),
+			StringComparison.Ordinal);
+	}
+
+	[MetadataUpdateFact]
 	public void XReferenceBinding_StringFormatEdit_RetainsSourceAcrossUpdates()
 	{
 		const string pageStub = """

--- a/src/Controls/tests/SourceGen.UnitTests/HotReload/AiAssisted/BindingAndMarkupHotReloadTests.Bindings.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/HotReload/AiAssisted/BindingAndMarkupHotReloadTests.Bindings.cs
@@ -16,6 +16,108 @@ namespace Microsoft.Maui.Controls.SourceGen.UnitTests.HotReload.AiAssisted;
 
 public partial class BindingAndMarkupHotReloadTests
 {
+	[MetadataUpdateFact]
+	public void XReferenceBinding_StringFormatEdit_RetainsSourceAcrossUpdates()
+	{
+		const string pageStub = """
+			namespace TestAiAssisted;
+
+			public partial class MainPage : global::Microsoft.Maui.Controls.ContentPage
+			{
+				internal global::Microsoft.Maui.Controls.Label CaptionLabel = null!;
+
+				private partial void InitializeComponent();
+
+				public MainPage()
+				{
+					InitializeComponent();
+				}
+			}
+			""";
+		const string xamlV0 = """
+			<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			             x:Class="TestAiAssisted.MainPage">
+			  <VerticalStackLayout>
+			    <Label x:Name="CaptionLabel" Text="Instance caption V0" />
+			    <Label Text="{Binding Source={x:Reference CaptionLabel}, Path=Text, StringFormat='echo {0}'}" />
+			  </VerticalStackLayout>
+			</ContentPage>
+			""";
+		const string xamlV1 = """
+			<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			             x:Class="TestAiAssisted.MainPage">
+			  <VerticalStackLayout>
+			    <Label x:Name="CaptionLabel" Text="Instance caption V1" />
+			    <Label Text="{Binding Source={x:Reference CaptionLabel}, Path=Text, StringFormat='echo {0}'}" />
+			  </VerticalStackLayout>
+			</ContentPage>
+			""";
+		const string xamlV2 = """
+			<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			             x:Class="TestAiAssisted.MainPage">
+			  <VerticalStackLayout>
+			    <Label x:Name="CaptionLabel" Text="Instance caption V1" />
+			    <Label Text="{Binding Source={x:Reference CaptionLabel}, Path=Text, StringFormat='mirror {0}'}" />
+			  </VerticalStackLayout>
+			</ContentPage>
+			""";
+
+		using var harness = new XamlHotReloadTestHarness(
+			nameof(XReferenceBinding_StringFormatEdit_RetainsSourceAcrossUpdates),
+			PageClass,
+			pageStub,
+			BindingAndMarkupSource);
+		var generation = harness.Generate(xamlV0, xamlV1, xamlV2);
+
+		harness.RunLive(generation, live =>
+		{
+			var firstPage = live.GetInstance<ContentPage>();
+			var secondPage = live.CreateInstance<ContentPage>();
+
+			AssertPage(firstPage, "Instance caption V0", "echo Instance caption V0");
+			AssertPage(secondPage, "Instance caption V0", "echo Instance caption V0");
+
+			Assert.Same(firstPage, live.ApplyUpdate<ContentPage>(1));
+			AssertPage(firstPage, "Instance caption V1", "echo Instance caption V1");
+			AssertPage(secondPage, "Instance caption V1", "echo Instance caption V1");
+
+			Assert.Same(firstPage, live.ApplyUpdate<ContentPage>(2));
+			AssertPage(firstPage, "Instance caption V1", "mirror Instance caption V1");
+			AssertPage(secondPage, "Instance caption V1", "mirror Instance caption V1");
+
+			SetCaption(firstPage, "Instance caption V2", "mirror Instance caption V2");
+			SetCaption(secondPage, "Instance caption V2", "mirror Instance caption V2");
+		});
+
+		static void AssertPage(ContentPage page, string expectedCaption, string expectedFormattedText)
+		{
+			var layout = Assert.IsType<VerticalStackLayout>(page.Content);
+			var caption = Assert.IsType<Label>(layout.Children[0]);
+			var formatted = Assert.IsType<Label>(layout.Children[1]);
+
+			Assert.Equal(expectedCaption, caption.Text);
+			Assert.Equal(expectedFormattedText, formatted.Text);
+
+			var registration = GetTextRegistration(formatted);
+			var binding = Assert.IsAssignableFrom<BindingBase>(registration.Binding);
+			var source = binding.GetType().GetProperty("Source")!.GetValue(binding);
+			Assert.Same(caption, source);
+		}
+
+		static void SetCaption(ContentPage page, string captionText, string expectedFormattedText)
+		{
+			var layout = Assert.IsType<VerticalStackLayout>(page.Content);
+			var caption = Assert.IsType<Label>(layout.Children[0]);
+			var formatted = Assert.IsType<Label>(layout.Children[1]);
+
+			caption.Text = captionText;
+			Assert.Equal(expectedFormattedText, formatted.Text);
+		}
+	}
+
 	// Wave2 · Binding & Markup · P0-01 · BM-01
 	// Provenance: MAUI §3.4 | portfolio P0-01
 	// Faithfulness: reaches writer L1548 for DynamicResource and Binding markup nodes; fails-for-bug: markup swap does not replace the prior value source.

--- a/src/Controls/tests/SourceGen.UnitTests/HotReload/AiAssisted/BindingAndMarkupHotReloadTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/HotReload/AiAssisted/BindingAndMarkupHotReloadTests.cs
@@ -114,6 +114,13 @@ public partial class BindingAndMarkupHotReloadTests : IDisposable
 
 			object IMarkupExtension.ProvideValue(IServiceProvider serviceProvider) => ProvideValue(serviceProvider);
 		}
+
+		public sealed class ReferenceExtension : IMarkupExtension
+		{
+			public string Name { get; set; } = string.Empty;
+
+			public object ProvideValue(IServiceProvider serviceProvider) => new TestViewModel { Text = Name };
+		}
 		""";
 
 	static XamlHotReloadTestHarness CreateHarness([CallerMemberName] string scenarioName = "") =>

--- a/src/Controls/tests/SourceGen.UnitTests/HotReload/AiAssisted/BindingAndMarkupHotReloadTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/HotReload/AiAssisted/BindingAndMarkupHotReloadTests.cs
@@ -7,16 +7,22 @@ using System;
 using System.Collections;
 using System.ComponentModel;
 using System.Globalization;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Microsoft.Maui.Controls.SourceGen.UnitTests.HotReload;
+using Microsoft.Maui.Dispatching;
 using Xunit;
 
 namespace Microsoft.Maui.Controls.SourceGen.UnitTests.HotReload.AiAssisted;
 
 [Collection("XamlHotReloadTests")]
-public partial class BindingAndMarkupHotReloadTests
+public partial class BindingAndMarkupHotReloadTests : IDisposable
 {
+	public BindingAndMarkupHotReloadTests() => DispatcherProvider.SetCurrent(new StubDispatcherProvider());
+
+	public void Dispose() => DispatcherProvider.SetCurrent(null);
+
 	const string PageClass = "TestAiAssisted.MainPage";
 
 	const string PageStub = """
@@ -135,7 +141,9 @@ public partial class BindingAndMarkupHotReloadTests
 			Assert.NotNull(bindings);
 
 			var bindingCount = (int)bindings!.GetType().GetProperty("Count")!.GetValue(bindings)!;
-			var binding = bindings.GetType().GetMethod("GetValue")!.Invoke(bindings, null) as BindingBase;
+			var getValue = bindings.GetType().GetMethods()
+				.Single(method => method.Name == "GetValue" && !method.IsGenericMethod && method.GetParameters().Length == 0);
+			var binding = getValue.Invoke(bindings, null) as BindingBase;
 			return new TextRegistration(binding, bindingCount, attributes.Contains("IsDynamicResource", StringComparison.Ordinal));
 		}
 
@@ -143,4 +151,28 @@ public partial class BindingAndMarkupHotReloadTests
 	}
 
 	readonly record struct TextRegistration(BindingBase? Binding, int BindingCount, bool IsDynamicResource);
+
+	sealed class StubDispatcher : IDispatcher
+	{
+		public bool IsDispatchRequired => false;
+
+		public bool Dispatch(Action action)
+		{
+			action();
+			return true;
+		}
+
+		public bool DispatchDelayed(TimeSpan delay, Action action)
+		{
+			action();
+			return true;
+		}
+
+		public IDispatcherTimer CreateTimer() => throw new NotSupportedException();
+	}
+
+	sealed class StubDispatcherProvider : IDispatcherProvider
+	{
+		public IDispatcher GetForCurrentThread() => new StubDispatcher();
+	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Fixes #37889.

Source-generated incremental Hot Reload rebuilds a binding when only `StringFormat` changes. The update writer expands the binding in a synthetic generator context that has no live XAML namescope, so nested `{x:Reference ...}` resolution loses its source. The replacement binding keeps its path and format but receives a null source, clearing the target value.

This change recognizes the actual `Microsoft.Maui.Controls.Xaml.ReferenceExtension` symbol while regenerating markup extensions and resolves it from the live target element's namescope. Resolution is performed before replacing the existing property value: if the element is detached, namescopes are disabled, or a renamed/new name has not yet been reconciled, the update is skipped and the existing binding is retained rather than cleared or throwing. Non-`Element` property owners use the root `Element` as the namescope anchor when available.

The change intentionally does not duplicate the broad structural namescope registration work in #37897. Child-list changes already run before property changes, so once #37897 reconciles a structurally introduced name, this guarded lookup can consume it; without that reconciliation, it fails safely.

## Tests

Added source-generator Hot Reload coverage that:

- creates two live page instances and verifies a `StringFormat`-only edit retains each instance's referenced source;
- detaches the updated element and removes its transient namescope, proving the update does not throw or replace the existing binding;
- renames an `x:Name` without live namescope reconciliation, proving the unresolved reference does not clear the existing source;
- defines a user markup extension named `ReferenceExtension`, proving it is not mistaken for MAUI's `x:Reference`.

Baseline result for the original reproduction: failed with `Expected: \"mirror Instance caption V1\"; Actual: null`.

Validation:

```text
Targeted: Passed 20, Failed 0, Skipped 0
Full SourceGen suite: Passed 515, Failed 0, Skipped 0
```

Commands:

```bash
DOTNET_MODIFIABLE_ASSEMBLIES=debug dotnet test src/Controls/tests/SourceGen.UnitTests/SourceGen.UnitTests.csproj --no-restore --filter "FullyQualifiedName~BindingAndMarkupHotReloadTests|FullyQualifiedName~UpdateComponentCodeWriterTests"
DOTNET_MODIFIABLE_ASSEMBLIES=debug dotnet test src/Controls/tests/SourceGen.UnitTests/SourceGen.UnitTests.csproj --no-restore
```

Formatting:

```bash
dotnet format src/Controls/src/SourceGen/Controls.SourceGen.csproj --no-restore --include src/Controls/src/SourceGen/UpdateComponentCodeWriter.cs --exclude-diagnostics CA1822
dotnet format src/Controls/tests/SourceGen.UnitTests/SourceGen.UnitTests.csproj --no-restore --include src/Controls/tests/SourceGen.UnitTests/HotReload/AiAssisted/BindingAndMarkupHotReloadTests.Bindings.cs src/Controls/tests/SourceGen.UnitTests/HotReload/AiAssisted/BindingAndMarkupHotReloadTests.cs --exclude-diagnostics CA1822
```

## Risk

Low and limited to source-generated incremental Hot Reload markup-extension regeneration. Normal XAML inflation and runtime binding behavior are unchanged. Template realization remains outside this patch's scope; existing DataTemplate/ControlTemplate namescope isolation behavior is unchanged.
