### PR TITLE
Fix SourceGen hot reload for application resources

### DIFF
--- a/src/Controls/src/SourceGen/UpdateComponentCodeWriter.cs
+++ b/src/Controls/src/SourceGen/UpdateComponentCodeWriter.cs
@@ -111,6 +111,21 @@ static class UpdateComponentCodeWriter
 			}
 
 			var varName = $"__uc_{compIdx++}";
+			if (TryEmitResourceDictionaryItemChange(
+				codeWriter,
+				nodeDiff,
+				varName,
+				compilation,
+				xmlnsCache,
+				typeCache,
+				rootType,
+				sourceProductionContext,
+				projectItem))
+			{
+				codeWriter.WriteLine();
+				continue;
+			}
+
 			codeWriter.WriteLine($"if (global::Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.TryGet(this, \"{nodeDiff.NodeId}\", out var {varName}))");
 			using (PrePost.NewBlock(codeWriter))
 			{
@@ -984,6 +999,57 @@ static class UpdateComponentCodeWriter
 		var keysArrayExpr = string.Join(", ", emittableResources.Select(kr => $"\"{EscapeString(kr.key)}\""));
 		codeWriter.WriteLine($"global::Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.RegisterResourceKeys(this, new string[] {{ {keysArrayExpr} }});");
 
+		return true;
+	}
+
+	static bool TryEmitResourceDictionaryItemChange(
+		IndentedTextWriter codeWriter,
+		NodeDiff nodeDiff,
+		string varName,
+		Compilation compilation,
+		AssemblyAttributes xmlnsCache,
+		IDictionary<XmlType, INamedTypeSymbol> typeCache,
+		INamedTypeSymbol rootType,
+		SourceProductionContext sourceProductionContext,
+		ProjectItem? projectItem)
+	{
+		if (!InheritsFrom(rootType, "global::Microsoft.Maui.Controls.ResourceDictionary")
+			&& rootType.ToFQDisplayString() != "global::Microsoft.Maui.Controls.ResourceDictionary")
+		{
+			return false;
+		}
+
+		var element = nodeDiff.NewNode;
+		if (element is null
+			|| nodeDiff.PropertyChanges.Count != 1
+			|| nodeDiff.PropertyChanges[0].Kind != PropertyDiffKind.Set
+			|| nodeDiff.PropertyChanges[0].PropertyName.LocalName != "__MAUI_Content__"
+			|| element.CollectionItems.Count != 1
+			|| element.CollectionItems[0] is not ValueNode
+			|| !element.Properties.TryGetValue(XmlName.xKey, out var keyNode)
+			|| keyNode is not ValueNode { Value: string key })
+		{
+			return false;
+		}
+
+		var parent = element.Parent is ListNode list ? list.Parent : element.Parent;
+		if (parent is not SGRootNode)
+			return false;
+
+		var valueExpression = BuildResourceValueExpression(
+			element,
+			compilation,
+			xmlnsCache,
+			typeCache,
+			rootType,
+			sourceProductionContext,
+			projectItem);
+		if (valueExpression is null)
+			return false;
+
+		codeWriter.WriteLine($"var {varName} = {valueExpression};");
+		codeWriter.WriteLine($"this[\"{EscapeString(key)}\"] = {varName};");
+		codeWriter.WriteLine($"global::Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.Register(this, \"{nodeDiff.NodeId}\", {varName});");
 		return true;
 	}
 

--- a/src/Controls/src/SourceGen/UpdateComponentCodeWriter.cs
+++ b/src/Controls/src/SourceGen/UpdateComponentCodeWriter.cs
@@ -1049,7 +1049,10 @@ static class UpdateComponentCodeWriter
 
 		codeWriter.WriteLine($"var {varName} = {valueExpression};");
 		codeWriter.WriteLine($"this[\"{EscapeString(key)}\"] = {varName};");
+		codeWriter.WriteLine($"if ({varName} is not null)");
+		codeWriter.Indent++;
 		codeWriter.WriteLine($"global::Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.Register(this, \"{nodeDiff.NodeId}\", {varName});");
+		codeWriter.Indent--;
 		return true;
 	}
 

--- a/src/Controls/src/SourceGen/XamlNodeDiff.cs
+++ b/src/Controls/src/SourceGen/XamlNodeDiff.cs
@@ -53,7 +53,11 @@ readonly struct PropertyDiff(XmlName propertyName, PropertyDiffKind kind, string
 /// <summary>
 /// Describes all property changes on a single element node, identified by its stable path within the tree.
 /// </summary>
-readonly struct NodeDiff(string nodeId, IReadOnlyList<PropertyDiff> propertyChanges, XmlType? nodeXmlType = null)
+readonly struct NodeDiff(
+	string nodeId,
+	IReadOnlyList<PropertyDiff> propertyChanges,
+	XmlType? nodeXmlType = null,
+	ElementNode? newNode = null)
 {
 	/// <summary>
 	/// Stable ID for this node. <c>""</c> for root, <c>"0"</c>, <c>"1"</c>, etc. for children
@@ -69,6 +73,12 @@ readonly struct NodeDiff(string nodeId, IReadOnlyList<PropertyDiff> propertyChan
 	/// May be <see langword="null"/> when not available (e.g. in tests).
 	/// </summary>
 	public XmlType? NodeXmlType { get; } = nodeXmlType;
+
+	/// <summary>
+	/// The complete new element, used when a property change must be applied through its owner
+	/// rather than by mutating the registered value object.
+	/// </summary>
+	public ElementNode? NewNode { get; } = newNode;
 }
 
 /// <summary>
@@ -344,7 +354,7 @@ static class XamlNodeDiff
 			return false;
 
 		if (propDiffs.Count > 0)
-			nodeChanges.Add(new NodeDiff(nodeId, propDiffs, newNode.XmlType));
+			nodeChanges.Add(new NodeDiff(nodeId, propDiffs, newNode.XmlType, newNode));
 
 		// If x:DataType changed on this node, propagate to all descendant bindings
 		bool childForceRefresh = forceBindingRefresh || xDataTypeChanged;
@@ -505,7 +515,7 @@ static class XamlNodeDiff
 				{
 					var contentName = new XmlName("", "__MAUI_Content__");
 					var contentDiff = new PropertyDiff(contentName, PropertyDiffKind.Set, newVal.Value?.ToString());
-					nodeChanges.Add(new NodeDiff(parentNodeId, new[] { contentDiff }, newNode.XmlType));
+					nodeChanges.Add(new NodeDiff(parentNodeId, new[] { contentDiff }, newNode.XmlType, newNode));
 				}
 			}
 			else

--- a/src/Controls/src/SourceGen/XamlNodeDiff.cs
+++ b/src/Controls/src/SourceGen/XamlNodeDiff.cs
@@ -693,7 +693,7 @@ static class XamlNodeDiff
 	/// Diffs the <see cref="ElementNode.Properties"/> dictionaries of two nodes.
 	/// All property changes are recorded — simple <see cref="ValueNode"/> values, markup extensions,
 	/// and nested elements alike. Only changes to codegen-sensitive <c>x:</c> properties
-	/// (e.g. <c>x:Name</c>, <c>x:Class</c>) trigger structural fallback.
+	/// (e.g. <c>x:Name</c>, <c>x:Class</c>, <c>x:Key</c>) trigger structural fallback.
 	/// When <paramref name="forceBindingRefresh"/> is <see langword="true"/>, all binding MarkupNode
 	/// properties are treated as changed even if the markup string is identical — this propagates
 	/// <c>x:DataType</c> changes from ancestor nodes.
@@ -813,6 +813,7 @@ static class XamlNodeDiff
 			case "FieldModifier":
 			case "TypeArguments":
 			case "FactoryMethod":
+			case "Key":
 				return true;
 			default:
 				return false;

--- a/src/Controls/src/Xaml/HotReload/XamlIncrementalHotReloadHandler.cs
+++ b/src/Controls/src/Xaml/HotReload/XamlIncrementalHotReloadHandler.cs
@@ -28,11 +28,9 @@ namespace Microsoft.Maui.Controls.Xaml;
 public static class XamlIncrementalHotReloadHandler
 {
 	/// <summary>
-	/// Generator-only entry point retained for backward compatibility with previously
-	/// compiled <c>InitializeComponent()</c> bodies. <see cref="XamlComponentRegistry.Register"/>
-	/// already records every page instance, so live-instance enumeration is sourced from
-	/// <see cref="XamlComponentRegistry.GetInstances"/>. This method only validates its
-	/// argument and respects the <c>IsIncrementalHotReloadEnabled</c> feature switch.
+	/// Generator-only entry point that registers every XAML root for live-instance enumeration.
+	/// Roots such as <see cref="Application"/> and <see cref="ResourceDictionary"/> may not contain
+	/// child components, so they cannot rely on component registration to be tracked.
 	/// </summary>
 	public static void Track(object instance)
 	{
@@ -42,8 +40,7 @@ public static class XamlIncrementalHotReloadHandler
 		if (!global::Microsoft.Maui.RuntimeFeature.IsIncrementalHotReloadEnabled)
 			return;
 
-		// No-op: XamlComponentRegistry.Register has already tracked this instance via
-		// its secondary type-indexed weak-reference list.
+		XamlComponentRegistry.RegisterComponent(instance, string.Empty);
 	}
 
 	/// <summary>

--- a/src/Controls/tests/SourceGen.UnitTests/HotReload/Maui37888Tests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/HotReload/Maui37888Tests.cs
@@ -40,6 +40,62 @@ public class Maui37888Tests
 		}
 	}
 
+	[Fact]
+	public void NullConvertedResource_GuardsComponentRegistration()
+	{
+		const string rootClass = "TestMaui37888.NullResources";
+		const string codeBehind = """
+			using System;
+			using System.ComponentModel;
+			using System.Globalization;
+
+			namespace TestMaui37888;
+
+			[TypeConverter(typeof(NullResourceConverter))]
+			public sealed class NullResource
+			{
+			}
+
+			public sealed class NullResourceConverter : TypeConverter
+			{
+				public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType) =>
+					sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+
+				public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value) =>
+					null;
+			}
+
+			public partial class NullResources : global::Microsoft.Maui.Controls.ResourceDictionary
+			{
+				private partial void InitializeComponent();
+
+				public NullResources() => InitializeComponent();
+			}
+			""";
+
+		string Xaml(string value) => $$"""
+			<ResourceDictionary xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			                    xmlns:local="clr-namespace:TestMaui37888"
+			                    x:Class="{{rootClass}}">
+			  <local:NullResource x:Key="NullResource">{{value}}</local:NullResource>
+			  <x:String x:Key="FollowingResource">{{value}}</x:String>
+			</ResourceDictionary>
+			""";
+
+		using var harness = new XamlHotReloadTestHarness(
+			nameof(NullConvertedResource_GuardsComponentRegistration),
+			rootClass,
+			codeBehind);
+		var generation = harness.Generate(Xaml("V0"), Xaml("V1"));
+		var updateComponentSource = generation[1].UpdateComponentSource;
+
+		Assert.NotNull(updateComponentSource);
+		Assert.Contains("if (__uc_0 is not null)", updateComponentSource, StringComparison.Ordinal);
+		Assert.Contains("this[\"FollowingResource\"] = __uc_1;", updateComponentSource, StringComparison.Ordinal);
+		harness.Compile(generation[1]);
+	}
+
 	static void VerifyInlineApplicationResourceUpdate()
 	{
 		const string rootClass = "TestMaui37888.App";

--- a/src/Controls/tests/SourceGen.UnitTests/HotReload/Maui37888Tests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/HotReload/Maui37888Tests.cs
@@ -1,0 +1,161 @@
+#nullable enable
+
+using System;
+using System.Reflection;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls.SourceGen.UnitTests.HotReload;
+using Microsoft.Maui.Controls.Xaml;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.SourceGen.UnitTests;
+
+[Collection("XamlHotReloadTests")]
+public class Maui37888Tests
+{
+	const string IncrementalHotReloadSwitch = "Microsoft.Maui.RuntimeFeature.IsIncrementalHotReloadEnabled";
+	const string ResourceKey = "ExploratoryCaption";
+
+	[MetadataUpdateTheory]
+	[InlineData(false)]
+	[InlineData(true)]
+	public void ApplicationResourceUpdate_ReachesExistingAndNewConsumers(bool useMergedDictionary)
+	{
+		AppContext.TryGetSwitch(IncrementalHotReloadSwitch, out var previousSwitch);
+		var previousApplication = Application.Current;
+		AppContext.SetSwitch(IncrementalHotReloadSwitch, true);
+		SetMainThreadImplementation();
+
+		try
+		{
+			if (useMergedDictionary)
+				VerifyMergedDictionaryUpdate();
+			else
+				VerifyInlineApplicationResourceUpdate();
+		}
+		finally
+		{
+			Application.Current = previousApplication;
+			AppContext.SetSwitch(IncrementalHotReloadSwitch, previousSwitch);
+			ClearMainThreadImplementation();
+		}
+	}
+
+	static void VerifyInlineApplicationResourceUpdate()
+	{
+		const string rootClass = "TestMaui37888.App";
+		const string codeBehind = """
+			namespace TestMaui37888;
+
+			public partial class App : global::Microsoft.Maui.Controls.Application
+			{
+				private partial void InitializeComponent();
+
+				public App() => InitializeComponent();
+			}
+			""";
+
+		string Xaml(string value) => $$"""
+			<Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			             x:Class="{{rootClass}}">
+			  <Application.Resources>
+			    <x:String x:Key="{{ResourceKey}}">{{value}}</x:String>
+			  </Application.Resources>
+			</Application>
+			""";
+
+		using var harness = new XamlHotReloadTestHarness(
+			nameof(ApplicationResourceUpdate_ReachesExistingAndNewConsumers) + "_Inline",
+			rootClass,
+			codeBehind);
+		var generation = harness.Generate(Xaml("App resource V0"), Xaml("App resource V1"));
+
+		harness.RunLive(generation, live =>
+		{
+			var application = live.GetInstance<Application>();
+			Application.Current = application;
+			VerifyConsumers(application, () => live.ApplyUpdateThroughRuntimeHandler<Application>(1));
+		});
+	}
+
+	static void VerifyMergedDictionaryUpdate()
+	{
+		const string rootClass = "TestMaui37888.AppResources";
+		const string codeBehind = """
+			namespace TestMaui37888;
+
+			public partial class AppResources : global::Microsoft.Maui.Controls.ResourceDictionary
+			{
+				private partial void InitializeComponent();
+
+				public AppResources() => InitializeComponent();
+			}
+			""";
+
+		string Xaml(string value) => $$"""
+			<ResourceDictionary xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			                    x:Class="{{rootClass}}">
+			  <x:String x:Key="{{ResourceKey}}">{{value}}</x:String>
+			</ResourceDictionary>
+			""";
+
+		using var harness = new XamlHotReloadTestHarness(
+			nameof(ApplicationResourceUpdate_ReachesExistingAndNewConsumers) + "_Merged",
+			rootClass,
+			codeBehind);
+		var generation = harness.Generate(Xaml("App resource V0"), Xaml("App resource V1"));
+
+		harness.RunLive(generation, live =>
+		{
+			var application = new Application();
+			var dictionary = live.GetInstance<global::Microsoft.Maui.Controls.ResourceDictionary>();
+			application.Resources.MergedDictionaries.Add(dictionary);
+			Application.Current = application;
+			VerifyConsumers(application, () => live.ApplyUpdateThroughRuntimeHandler<global::Microsoft.Maui.Controls.ResourceDictionary>(1));
+		});
+	}
+
+	static void VerifyConsumers(Application application, Action applyUpdate)
+	{
+		var existingConsumer = CreateConsumer();
+#pragma warning disable CS0618
+		application.MainPage = new ContentPage { Content = existingConsumer };
+#pragma warning restore CS0618
+		Assert.Equal("App resource V0", existingConsumer.Text);
+
+		applyUpdate();
+
+		Assert.Equal("App resource V1", existingConsumer.Text);
+		Assert.Equal("App resource V1", CreateConsumer().Text);
+		Assert.Equal("App resource V1", application.Resources[ResourceKey]);
+	}
+
+	static Label CreateConsumer()
+	{
+		var label = new Label();
+		label.SetDynamicResource(Label.TextProperty, ResourceKey);
+		return label;
+	}
+
+	static void SetMainThreadImplementation()
+	{
+		var method = typeof(MainThread).GetMethod(
+			"SetCustomImplementation",
+			BindingFlags.Static | BindingFlags.NonPublic,
+			binder: null,
+			[typeof(Func<bool>), typeof(Action<Action>)],
+			modifiers: null);
+		Assert.NotNull(method);
+		method!.Invoke(null, [() => true, (Action<Action>)(action => action())]);
+	}
+
+	static void ClearMainThreadImplementation()
+	{
+		var method = typeof(MainThread).GetMethod(
+			"ClearCustomImplementation",
+			BindingFlags.Static | BindingFlags.NonPublic);
+		Assert.NotNull(method);
+		method!.Invoke(null, null);
+	}
+}

--- a/src/Controls/tests/SourceGen.UnitTests/HotReload/XamlHotReloadTestHarness.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/HotReload/XamlHotReloadTestHarness.cs
@@ -504,19 +504,22 @@ internal sealed class XamlHotReloadLiveSession : IDisposable
 	{
 		ObjectDisposedException.ThrowIf(_disposed, this);
 
-		if (versionIndex != _versionIndex + 1)
-			throw new ArgumentOutOfRangeException(nameof(versionIndex), "Updates must be applied sequentially.");
-
-		var nextVersion = _harness.Compile(_generation[versionIndex]);
-		var semanticEdits = CreateSemanticEdits(
-			_compiledVersion!.Compilation,
-			nextVersion.Compilation,
-			_compiledVersion.GeneratedVersion,
-			nextVersion.GeneratedVersion);
+		var (nextVersion, semanticEdits) = PrepareUpdate(versionIndex);
 
 		_harness.ApplicationHost?.Dispatch(() => ApplyUpdate(nextVersion, semanticEdits));
 		if (_harness.ApplicationHost is null)
 			ApplyUpdate(nextVersion, semanticEdits);
+
+		return Assert.IsAssignableFrom<T>(Instance);
+	}
+
+	public T ApplyUpdateThroughRuntimeHandler<T>(int versionIndex) where T : class
+	{
+		ObjectDisposedException.ThrowIf(_disposed, this);
+
+		var (nextVersion, semanticEdits) = PrepareUpdate(versionIndex);
+		ApplyMetadataUpdate(nextVersion, semanticEdits);
+		global::Microsoft.Maui.Controls.Xaml.XamlIncrementalHotReloadHandler.UpdateApplication([_pageType!]);
 
 		return Assert.IsAssignableFrom<T>(Instance);
 	}
@@ -562,6 +565,39 @@ internal sealed class XamlHotReloadLiveSession : IDisposable
 		XamlHotReloadCompiledVersion nextVersion,
 		XamlHotReloadSemanticEdits semanticEdits)
 	{
+		ApplyMetadataUpdate(nextVersion, semanticEdits);
+
+		foreach (var instance in _instances)
+		{
+			if (!semanticEdits.AffectedTypes.Contains(instance.GetType().FullName!, StringComparer.Ordinal))
+				continue;
+
+			var updateMethod = instance.GetType().GetMethod(
+				"UpdateComponent",
+				BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+			Assert.NotNull(updateMethod);
+			updateMethod!.Invoke(instance, null);
+		}
+	}
+
+	(XamlHotReloadCompiledVersion NextVersion, XamlHotReloadSemanticEdits SemanticEdits) PrepareUpdate(int versionIndex)
+	{
+		if (versionIndex != _versionIndex + 1)
+			throw new ArgumentOutOfRangeException(nameof(versionIndex), "Updates must be applied sequentially.");
+
+		var nextVersion = _harness.Compile(_generation[versionIndex]);
+		var semanticEdits = CreateSemanticEdits(
+			_compiledVersion!.Compilation,
+			nextVersion.Compilation,
+			_compiledVersion.GeneratedVersion,
+			nextVersion.GeneratedVersion);
+		return (nextVersion, semanticEdits);
+	}
+
+	void ApplyMetadataUpdate(
+		XamlHotReloadCompiledVersion nextVersion,
+		XamlHotReloadSemanticEdits semanticEdits)
+	{
 		Assert.NotEmpty(semanticEdits.Edits);
 
 		using var metadataDelta = new MemoryStream();
@@ -584,18 +620,6 @@ internal sealed class XamlHotReloadLiveSession : IDisposable
 			metadataDelta.ToArray(),
 			ilDelta.ToArray(),
 			pdbDelta.ToArray());
-
-		foreach (var instance in _instances)
-		{
-			if (!semanticEdits.AffectedTypes.Contains(instance.GetType().FullName!, StringComparer.Ordinal))
-				continue;
-
-			var updateMethod = instance.GetType().GetMethod(
-				"UpdateComponent",
-				BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
-			Assert.NotNull(updateMethod);
-			updateMethod!.Invoke(instance, null);
-		}
 
 		_baseline = difference.Baseline;
 		_compiledVersion = nextVersion;

--- a/src/Controls/tests/SourceGen.UnitTests/XamlNodeDiffTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/XamlNodeDiffTests.cs
@@ -969,6 +969,25 @@ public class XamlNodeDiffTests
 	}
 
 	[Fact]
+	public void XKey_Changed_ReturnsNull()
+	{
+		var old = Parse($"""
+			<ResourceDictionary {MauiXmlns} x:Class="Test.Resources">
+				<Color x:Key="OldKey">Red</Color>
+			</ResourceDictionary>
+			""");
+		var @new = Parse($"""
+			<ResourceDictionary {MauiXmlns} x:Class="Test.Resources">
+				<Color x:Key="NewKey">Red</Color>
+			</ResourceDictionary>
+			""");
+
+		var diff = XamlNodeDiff.ComputeDiff(old, @new);
+
+		Assert.Null(diff);
+	}
+
+	[Fact]
 	public void XDataType_Changed_NoBindings_EmptyDiff()
 	{
 		// x:DataType changed but no bindings → no property diffs needed (incremental, not structural)
@@ -1366,7 +1385,7 @@ public class XamlNodeDiffTests
 		var prop = diff.NodeChanges[0].PropertyChanges[0];
 		Assert.Equal("Text", prop.PropertyName.LocalName);
 		Assert.NotNull(prop.NewNode); // complex markup
-		// Child list change: Entry added
+									  // Child list change: Entry added
 		Assert.Single(diff.ChildListChanges);
 		Assert.Equal(1, diff.ChildListChanges[0].NewChildren.Count(e => e.Kind == ChildChangeKind.Added));
 	}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

Fixes SourceGen XAML Hot Reload propagation for application-level resources so edits reach both existing `DynamicResource` consumers and consumers created after the update.

## Root cause

- Generated `InitializeComponent` calls `XamlIncrementalHotReloadHandler.Track(this)`, but `Track` was a no-op and assumed every root had already registered a child component. Resource-only `Application` roots can have no registered child, so the runtime handler found no live application instance to patch.
- A scalar value in a generated merged `ResourceDictionary` was treated as an independently mutable registered object. Immutable values such as `x:String` must instead replace their keyed entry on the owning dictionary.

## Changes

- Track every SourceGen XAML root, including resource-only `Application` and `ResourceDictionary` roots.
- Carry the changed element through the XAML diff and replace direct keyed scalar entries on generated resource dictionary roots.
- Treat `x:Key` edits as structural changes so the incremental scalar path cannot leave the old and new keys in the live dictionary.
- Guard component registration when runtime conversion returns `null`, allowing subsequent generated updates to continue.
- Add end-to-end metadata-update coverage for inline `App.xaml` resources and merged dictionaries, plus focused regression tests for `x:Key` edits and nullable converter results.
- Extend the SourceGen Hot Reload test harness with a runtime-handler update path so the test exercises production dispatch rather than invoking `UpdateComponent` directly.

## Validation

- Broken baseline: `Maui37888Tests` failed both inline and merged cases; consumers remained at `App resource V0`.
- Fixed in the original validation environment: `Maui37888Tests` passed both cases (2/2).
- Review follow-up: targeted SourceGen resource, diff, and Hot Reload tests passed with 110 passed and 3 metadata-update tests skipped on this host.
- Targeted runtime handler and component registry tests passed (33/33).
- Targeted `dotnet format` completed successfully; the solution workspace reported existing load warnings.

## Risk

The dictionary emitter remains intentionally limited to direct, stable-key scalar resource value edits. `x:Key` edits now fall back to structural handling rather than risking stale entries; general merged-dictionary structural reconciliation remains out of scope (#36732).

Fixes #37888
