### PR TITLE
[XAML] Reconcile x:Name after structural Hot Reload updates

### DIFF
--- a/src/Controls/src/SourceGen/InitializeComponentCodeWriter.cs
+++ b/src/Controls/src/SourceGen/InitializeComponentCodeWriter.cs
@@ -303,7 +303,7 @@ $$"""
 		IDictionary<XmlType, INamedTypeSymbol> typeCache,
 		SourceProductionContext sourceProductionContext,
 		ProjectItem projectItem,
-		HashSet<string>? generatedFieldNames,
+		Dictionary<string, XmlType>? generatedFields,
 		out SGRootNode? parsedNewRoot,
 		out Dictionary<ElementNode, string>? effectiveNewIds,
 		out int newNextNodeId,
@@ -373,7 +373,7 @@ $$"""
 			return null;
 		}
 
-		return UpdateComponentCodeWriter.GeneratePatchBody(diff, fromVersion, toVersion, rootType, compilation, xmlnsCache, typeCache, effectiveNewIds, sourceProductionContext, projectItem, generatedFieldNames);
+		return UpdateComponentCodeWriter.GeneratePatchBody(diff, fromVersion, toVersion, rootType, compilation, xmlnsCache, typeCache, effectiveNewIds, sourceProductionContext, projectItem, generatedFields);
 	}
 
 	static void WriteMultiLineString(IndentedTextWriter writer, string text)

--- a/src/Controls/src/SourceGen/InitializeComponentCodeWriter.cs
+++ b/src/Controls/src/SourceGen/InitializeComponentCodeWriter.cs
@@ -303,6 +303,7 @@ $$"""
 		IDictionary<XmlType, INamedTypeSymbol> typeCache,
 		SourceProductionContext sourceProductionContext,
 		ProjectItem projectItem,
+		HashSet<string>? generatedFieldNames,
 		out SGRootNode? parsedNewRoot,
 		out Dictionary<ElementNode, string>? effectiveNewIds,
 		out int newNextNodeId,
@@ -372,7 +373,7 @@ $$"""
 			return null;
 		}
 
-		return UpdateComponentCodeWriter.GeneratePatchBody(diff, fromVersion, toVersion, rootType, compilation, xmlnsCache, typeCache, effectiveNewIds, sourceProductionContext, projectItem, oldRoot);
+		return UpdateComponentCodeWriter.GeneratePatchBody(diff, fromVersion, toVersion, rootType, compilation, xmlnsCache, typeCache, effectiveNewIds, sourceProductionContext, projectItem, generatedFieldNames);
 	}
 
 	static void WriteMultiLineString(IndentedTextWriter writer, string text)

--- a/src/Controls/src/SourceGen/InitializeComponentCodeWriter.cs
+++ b/src/Controls/src/SourceGen/InitializeComponentCodeWriter.cs
@@ -372,7 +372,7 @@ $$"""
 			return null;
 		}
 
-		return UpdateComponentCodeWriter.GeneratePatchBody(diff, fromVersion, toVersion, rootType, compilation, xmlnsCache, typeCache, effectiveNewIds, sourceProductionContext, projectItem);
+		return UpdateComponentCodeWriter.GeneratePatchBody(diff, fromVersion, toVersion, rootType, compilation, xmlnsCache, typeCache, effectiveNewIds, sourceProductionContext, projectItem, oldRoot);
 	}
 
 	static void WriteMultiLineString(IndentedTextWriter writer, string text)

--- a/src/Controls/src/SourceGen/UpdateComponentCodeWriter.cs
+++ b/src/Controls/src/SourceGen/UpdateComponentCodeWriter.cs
@@ -72,12 +72,14 @@ static class UpdateComponentCodeWriter
 		IDictionary<XmlType, INamedTypeSymbol> typeCache,
 		Dictionary<ElementNode, string>? newIds = null,
 		SourceProductionContext sourceProductionContext = default,
-		ProjectItem? projectItem = null)
+		ProjectItem? projectItem = null,
+		ElementNode? oldRoot = null)
 	{
 		if (diff.IsEmpty)
 			return null;
 
 		using var codeWriter = new IndentedTextWriter(new StringWriter(CultureInfo.InvariantCulture), "\t") { NewLine = NewLine };
+		var existingNamedFields = oldRoot is null ? null : CollectRootScopeNames(oldRoot);
 
 		// Emit diff summary as a comment for diagnostics
 		EmitDiffSummary(codeWriter, diff);
@@ -87,7 +89,7 @@ static class UpdateComponentCodeWriter
 		int addedCounter = 0;
 		foreach (var change in diff.ChildListChanges)
 		{
-			EmitChildListChange(codeWriter, change, changeIdx++, ref addedCounter, newIds, compilation, xmlnsCache, typeCache, rootType, sourceProductionContext, projectItem);
+			EmitChildListChange(codeWriter, change, changeIdx++, ref addedCounter, newIds, existingNamedFields, compilation, xmlnsCache, typeCache, rootType, sourceProductionContext, projectItem);
 			codeWriter.WriteLine();
 		}
 
@@ -237,6 +239,7 @@ static class UpdateComponentCodeWriter
 		int changeIdx,
 		ref int addedCounter,
 		Dictionary<ElementNode, string>? newIds,
+		HashSet<string>? existingNamedFields,
 		Compilation compilation,
 		AssemblyAttributes xmlnsCache,
 		IDictionary<XmlType, INamedTypeSymbol> typeCache,
@@ -369,7 +372,7 @@ static class UpdateComponentCodeWriter
 						else // Added
 						{
 							var newElement = entry.NewElement!;
-							EmitNewElement(codeWriter, newElement, layoutVar, entry.NewNodeId, newIds, ref addedCounter, compilation, xmlnsCache, typeCache, rootType, sourceProductionContext, projectItem);
+							EmitNewElement(codeWriter, newElement, layoutVar, entry.NewNodeId, newIds, existingNamedFields, ref addedCounter, compilation, xmlnsCache, typeCache, rootType, sourceProductionContext, projectItem);
 						}
 					}
 				}
@@ -379,7 +382,7 @@ static class UpdateComponentCodeWriter
 		{
 			// Content property container (ContentPage, ContentView, ScrollView, Border, etc.)
 			// These have a single content property — set directly instead of using Children.Add()
-			EmitContentPropertyChange(codeWriter, change, changeIdx, parentVar, parentType, isRoot, contentPropertyName!, ref addedCounter, newIds, compilation, xmlnsCache, typeCache, rootType, sourceProductionContext, projectItem);
+			EmitContentPropertyChange(codeWriter, change, changeIdx, parentVar, parentType, isRoot, contentPropertyName!, ref addedCounter, newIds, existingNamedFields, compilation, xmlnsCache, typeCache, rootType, sourceProductionContext, projectItem);
 		}
 
 		// Unregister removed children and their entire subtrees.
@@ -413,6 +416,7 @@ static class UpdateComponentCodeWriter
 		string contentPropertyName,
 		ref int addedCounter,
 		Dictionary<ElementNode, string>? newIds,
+		HashSet<string>? existingNamedFields,
 		Compilation compilation,
 		AssemblyAttributes xmlnsCache,
 		IDictionary<XmlType, INamedTypeSymbol> typeCache,
@@ -464,11 +468,13 @@ static class UpdateComponentCodeWriter
 		var fqName = childType.ToFQDisplayString();
 		codeWriter.WriteLine($"var {childVar} = new {fqName}();");
 
+		EmitNewElementNameScope(codeWriter, newElement, childVar, childType, rootType, existingNamedFields);
+
 		// Set properties on the new child
 		EmitNewElementProperties(codeWriter, newElement, childVar, childType, compilation, xmlnsCache, typeCache, rootType, sourceProductionContext, projectItem);
 
 		// Recursively create grandchildren
-		EmitNewElementChildren(codeWriter, newElement, childVar, entry.NewNodeId, newIds, ref addedCounter, childType, compilation, xmlnsCache, typeCache, rootType, sourceProductionContext, projectItem);
+		EmitNewElementChildren(codeWriter, newElement, childVar, entry.NewNodeId, newIds, existingNamedFields, ref addedCounter, childType, compilation, xmlnsCache, typeCache, rootType, sourceProductionContext, projectItem);
 
 		// Set as content. Assign the concrete child directly: a single content property (e.g.
 		// ContentPage.Content, typed View) is not IView-typed, so casting up to IView would fail
@@ -491,6 +497,7 @@ static class UpdateComponentCodeWriter
 		string parentLayoutVar,
 		string nodeId,
 		Dictionary<ElementNode, string>? newIds,
+		HashSet<string>? existingNamedFields,
 		ref int addedCounter,
 		Compilation compilation,
 		AssemblyAttributes xmlnsCache,
@@ -515,17 +522,102 @@ static class UpdateComponentCodeWriter
 		// Create instance
 		codeWriter.WriteLine($"var {varName} = new {fqName}();");
 
+		EmitNewElementNameScope(codeWriter, element, varName, typeSymbol, rootType, existingNamedFields);
+
 		// Set properties
 		EmitNewElementProperties(codeWriter, element, varName, typeSymbol, compilation, xmlnsCache, typeCache, rootType, sourceProductionContext, projectItem);
 
 		// Recursively create children
-		EmitNewElementChildren(codeWriter, element, varName, nodeId, newIds, ref addedCounter, typeSymbol, compilation, xmlnsCache, typeCache, rootType, sourceProductionContext, projectItem);
+		EmitNewElementChildren(codeWriter, element, varName, nodeId, newIds, existingNamedFields, ref addedCounter, typeSymbol, compilation, xmlnsCache, typeCache, rootType, sourceProductionContext, projectItem);
 
 		// Add to parent layout
 		codeWriter.WriteLine($"{parentLayoutVar}.Add((global::Microsoft.Maui.IView){varName});");
 
 		// Register in component registry
 		codeWriter.WriteLine($"global::Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.Register(this, \"{nodeId}\", {varName});");
+	}
+
+	static void EmitNewElementNameScope(
+		IndentedTextWriter codeWriter,
+		ElementNode element,
+		string varName,
+		INamedTypeSymbol typeSymbol,
+		INamedTypeSymbol rootType,
+		HashSet<string>? existingNamedFields)
+	{
+		if (!InheritsFrom(typeSymbol, "global::Microsoft.Maui.Controls.Element")
+			|| !InheritsFrom(rootType, "global::Microsoft.Maui.Controls.BindableObject"))
+		{
+			return;
+		}
+
+		var nameScopeVar = $"__ns_{varName}";
+		using (PrePost.NewConditional(codeWriter, "!_MAUIXAML_SG_NAMESCOPE_DISABLE"))
+		{
+			codeWriter.WriteLine($"var {nameScopeVar} = global::Microsoft.Maui.Controls.Internals.NameScope.GetNameScope(this);");
+			codeWriter.WriteLine($"if ({nameScopeVar} != null)");
+			using (PrePost.NewBlock(codeWriter))
+			{
+				codeWriter.WriteLine($"{varName}.transientNamescope = {nameScopeVar};");
+
+				if (element.Properties.TryGetValue(XmlName.xName, out var nameNode)
+					&& nameNode is ValueNode { Value: string name })
+				{
+					var escapedName = EscapeString(name);
+					var previousVar = $"__previous_{varName}";
+					codeWriter.WriteLine($"var {previousVar} = {nameScopeVar}.FindByName(\"{escapedName}\");");
+					codeWriter.WriteLine($"if (!global::System.Object.ReferenceEquals({previousVar}, {varName}))");
+					using (PrePost.NewBlock(codeWriter))
+					{
+						codeWriter.WriteLine($"if ({previousVar} != null)");
+						codeWriter.Indent++;
+						codeWriter.WriteLine($"{nameScopeVar}.UnregisterName(\"{escapedName}\");");
+						codeWriter.Indent--;
+						codeWriter.WriteLine($"{nameScopeVar}.RegisterName(\"{escapedName}\", {varName});");
+					}
+				}
+			}
+		}
+
+		if (element.Properties.TryGetValue(XmlName.xName, out var fieldNameNode)
+			&& fieldNameNode is ValueNode { Value: string fieldName }
+			&& existingNamedFields?.Contains(fieldName) == true)
+		{
+			codeWriter.WriteLine($"this.{GeneratorHelpers.EscapeIdentifier(fieldName)} = {varName};");
+			codeWriter.WriteLine($"{varName}.StyleId ??= \"{EscapeString(fieldName)}\";");
+		}
+	}
+
+	static HashSet<string> CollectRootScopeNames(ElementNode root)
+	{
+		var names = new HashSet<string>(StringComparer.Ordinal);
+		Collect(root, names, isRoot: true);
+		return names;
+
+		static void Collect(INode node, HashSet<string> names, bool isRoot = false)
+		{
+			if (node is ElementNode element)
+			{
+				if (!isRoot && element.XmlType.Name is "DataTemplate" or "ControlTemplate" or "Style" or "VisualStateGroup")
+					return;
+
+				if (element.Properties.TryGetValue(XmlName.xName, out var nameNode)
+					&& nameNode is ValueNode { Value: string name })
+				{
+					names.Add(name);
+				}
+
+				foreach (var property in element.Properties.Values)
+					Collect(property, names);
+				foreach (var child in element.CollectionItems)
+					Collect(child, names);
+			}
+			else if (node is ListNode list)
+			{
+				foreach (var child in list.CollectionItems)
+					Collect(child, names);
+			}
+		}
 	}
 
 	/// <summary>
@@ -798,6 +890,7 @@ static class UpdateComponentCodeWriter
 		string varName,
 		string nodeId,
 		Dictionary<ElementNode, string>? newIds,
+		HashSet<string>? existingNamedFields,
 		ref int addedCounter,
 		INamedTypeSymbol typeSymbol,
 		Compilation compilation,
@@ -838,7 +931,7 @@ static class UpdateComponentCodeWriter
 						childNodeId = childId;
 					else
 						childNodeId = $"{nodeId}_{i}"; // fallback
-					EmitNewElement(codeWriter, childElement, childLayoutVar, childNodeId, newIds, ref addedCounter, compilation, xmlnsCache, typeCache, rootType, sourceProductionContext, projectItem);
+					EmitNewElement(codeWriter, childElement, childLayoutVar, childNodeId, newIds, existingNamedFields, ref addedCounter, compilation, xmlnsCache, typeCache, rootType, sourceProductionContext, projectItem);
 				}
 			}
 		}
@@ -875,8 +968,9 @@ static class UpdateComponentCodeWriter
 					var childIdx = addedCounter++;
 					var childVar = $"__na_{childIdx}";
 					codeWriter.WriteLine($"var {childVar} = new {childType.ToFQDisplayString()}();");
+					EmitNewElementNameScope(codeWriter, childElement, childVar, childType, rootType, existingNamedFields);
 					EmitNewElementProperties(codeWriter, childElement, childVar, childType, compilation, xmlnsCache, typeCache, rootType, sourceProductionContext, projectItem);
-					EmitNewElementChildren(codeWriter, childElement, childVar, childNodeId, newIds, ref addedCounter, childType, compilation, xmlnsCache, typeCache, rootType, sourceProductionContext, projectItem);
+					EmitNewElementChildren(codeWriter, childElement, childVar, childNodeId, newIds, existingNamedFields, ref addedCounter, childType, compilation, xmlnsCache, typeCache, rootType, sourceProductionContext, projectItem);
 					// Assign the concrete child directly (not cast to IView): a content property is not
 					// IView-typed, so an IView -> View cast would fail with CS0266. See EmitContentPropertyChange.
 					codeWriter.WriteLine($"{varName}.{contentProp} = {childVar};");

--- a/src/Controls/src/SourceGen/UpdateComponentCodeWriter.cs
+++ b/src/Controls/src/SourceGen/UpdateComponentCodeWriter.cs
@@ -73,13 +73,12 @@ static class UpdateComponentCodeWriter
 		Dictionary<ElementNode, string>? newIds = null,
 		SourceProductionContext sourceProductionContext = default,
 		ProjectItem? projectItem = null,
-		ElementNode? oldRoot = null)
+		HashSet<string>? generatedFieldNames = null)
 	{
 		if (diff.IsEmpty)
 			return null;
 
 		using var codeWriter = new IndentedTextWriter(new StringWriter(CultureInfo.InvariantCulture), "\t") { NewLine = NewLine };
-		var existingNamedFields = oldRoot is null ? null : CollectRootScopeNames(oldRoot);
 
 		// Emit diff summary as a comment for diagnostics
 		EmitDiffSummary(codeWriter, diff);
@@ -89,7 +88,7 @@ static class UpdateComponentCodeWriter
 		int addedCounter = 0;
 		foreach (var change in diff.ChildListChanges)
 		{
-			EmitChildListChange(codeWriter, change, changeIdx++, ref addedCounter, newIds, existingNamedFields, compilation, xmlnsCache, typeCache, rootType, sourceProductionContext, projectItem);
+			EmitChildListChange(codeWriter, change, changeIdx++, ref addedCounter, newIds, generatedFieldNames, compilation, xmlnsCache, typeCache, rootType, sourceProductionContext, projectItem);
 			codeWriter.WriteLine();
 		}
 
@@ -248,6 +247,27 @@ static class UpdateComponentCodeWriter
 		ProjectItem? projectItem)
 	{
 		bool isRoot = string.IsNullOrEmpty(change.ParentNodeId);
+
+		if (change.RemovedNames.Count > 0)
+		{
+			var removedNameScopeVar = $"__removedNameScope_{changeIdx}";
+			using (PrePost.NewConditional(codeWriter, "!_MAUIXAML_SG_NAMESCOPE_DISABLE"))
+			{
+				codeWriter.WriteLine($"var {removedNameScopeVar} = global::Microsoft.Maui.Controls.Internals.NameScope.GetNameScope(this);");
+				codeWriter.WriteLine($"if ({removedNameScopeVar} != null)");
+				using (PrePost.NewBlock(codeWriter))
+				{
+					foreach (var removedName in change.RemovedNames)
+					{
+						var escapedName = EscapeString(removedName);
+						codeWriter.WriteLine($"if ({removedNameScopeVar}.FindByName(\"{escapedName}\") != null)");
+						codeWriter.Indent++;
+						codeWriter.WriteLine($"{removedNameScopeVar}.UnregisterName(\"{escapedName}\");");
+						codeWriter.Indent--;
+					}
+				}
+			}
+		}
 
 		// Resolve the parent variable and type
 		string parentVar;
@@ -588,7 +608,7 @@ static class UpdateComponentCodeWriter
 		}
 	}
 
-	static HashSet<string> CollectRootScopeNames(ElementNode root)
+	internal static HashSet<string> CollectRootScopeNames(ElementNode root)
 	{
 		var names = new HashSet<string>(StringComparer.Ordinal);
 		Collect(root, names, isRoot: true);

--- a/src/Controls/src/SourceGen/UpdateComponentCodeWriter.cs
+++ b/src/Controls/src/SourceGen/UpdateComponentCodeWriter.cs
@@ -73,7 +73,7 @@ static class UpdateComponentCodeWriter
 		Dictionary<ElementNode, string>? newIds = null,
 		SourceProductionContext sourceProductionContext = default,
 		ProjectItem? projectItem = null,
-		HashSet<string>? generatedFieldNames = null)
+		Dictionary<string, XmlType>? generatedFields = null)
 	{
 		if (diff.IsEmpty)
 			return null;
@@ -88,7 +88,7 @@ static class UpdateComponentCodeWriter
 		int addedCounter = 0;
 		foreach (var change in diff.ChildListChanges)
 		{
-			EmitChildListChange(codeWriter, change, changeIdx++, ref addedCounter, newIds, generatedFieldNames, compilation, xmlnsCache, typeCache, rootType, sourceProductionContext, projectItem);
+			EmitChildListChange(codeWriter, change, changeIdx++, ref addedCounter, newIds, generatedFields, compilation, xmlnsCache, typeCache, rootType, sourceProductionContext, projectItem);
 			codeWriter.WriteLine();
 		}
 
@@ -238,7 +238,7 @@ static class UpdateComponentCodeWriter
 		int changeIdx,
 		ref int addedCounter,
 		Dictionary<ElementNode, string>? newIds,
-		HashSet<string>? existingNamedFields,
+		Dictionary<string, XmlType>? existingNamedFields,
 		Compilation compilation,
 		AssemblyAttributes xmlnsCache,
 		IDictionary<XmlType, INamedTypeSymbol> typeCache,
@@ -248,7 +248,8 @@ static class UpdateComponentCodeWriter
 	{
 		bool isRoot = string.IsNullOrEmpty(change.ParentNodeId);
 
-		if (change.RemovedNames.Count > 0)
+		if (change.RemovedNames.Count > 0
+			&& InheritsFrom(rootType, "global::Microsoft.Maui.Controls.BindableObject"))
 		{
 			var removedNameScopeVar = $"__removedNameScope_{changeIdx}";
 			using (PrePost.NewConditional(codeWriter, "!_MAUIXAML_SG_NAMESCOPE_DISABLE"))
@@ -257,13 +258,17 @@ static class UpdateComponentCodeWriter
 				codeWriter.WriteLine($"if ({removedNameScopeVar} != null)");
 				using (PrePost.NewBlock(codeWriter))
 				{
-					foreach (var removedName in change.RemovedNames)
+					for (int removedNameIdx = 0; removedNameIdx < change.RemovedNames.Count; removedNameIdx++)
 					{
-						var escapedName = EscapeString(removedName);
-						codeWriter.WriteLine($"if ({removedNameScopeVar}.FindByName(\"{escapedName}\") != null)");
+						var removedName = change.RemovedNames[removedNameIdx];
+						var escapedName = EscapeString(removedName.Name);
+						var removedElementVar = $"__removedNamedElement_{changeIdx}_{removedNameIdx}";
+						codeWriter.WriteLine($"if (global::Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.TryGet(this, \"{EscapeString(removedName.NodeId)}\", out var {removedElementVar})");
 						codeWriter.Indent++;
-						codeWriter.WriteLine($"{removedNameScopeVar}.UnregisterName(\"{escapedName}\");");
+						codeWriter.WriteLine($"&& global::System.Object.ReferenceEquals({removedNameScopeVar}.FindByName(\"{escapedName}\"), {removedElementVar}))");
 						codeWriter.Indent--;
+						using (PrePost.NewBlock(codeWriter))
+							codeWriter.WriteLine($"{removedNameScopeVar}.UnregisterName(\"{escapedName}\");");
 					}
 				}
 			}
@@ -436,7 +441,7 @@ static class UpdateComponentCodeWriter
 		string contentPropertyName,
 		ref int addedCounter,
 		Dictionary<ElementNode, string>? newIds,
-		HashSet<string>? existingNamedFields,
+		Dictionary<string, XmlType>? existingNamedFields,
 		Compilation compilation,
 		AssemblyAttributes xmlnsCache,
 		IDictionary<XmlType, INamedTypeSymbol> typeCache,
@@ -488,7 +493,7 @@ static class UpdateComponentCodeWriter
 		var fqName = childType.ToFQDisplayString();
 		codeWriter.WriteLine($"var {childVar} = new {fqName}();");
 
-		EmitNewElementNameScope(codeWriter, newElement, childVar, childType, rootType, existingNamedFields);
+		EmitNewElementNameScope(codeWriter, newElement, childVar, childType, rootType, existingNamedFields, compilation, xmlnsCache, typeCache);
 
 		// Set properties on the new child
 		EmitNewElementProperties(codeWriter, newElement, childVar, childType, compilation, xmlnsCache, typeCache, rootType, sourceProductionContext, projectItem);
@@ -517,7 +522,7 @@ static class UpdateComponentCodeWriter
 		string parentLayoutVar,
 		string nodeId,
 		Dictionary<ElementNode, string>? newIds,
-		HashSet<string>? existingNamedFields,
+		Dictionary<string, XmlType>? existingNamedFields,
 		ref int addedCounter,
 		Compilation compilation,
 		AssemblyAttributes xmlnsCache,
@@ -542,7 +547,7 @@ static class UpdateComponentCodeWriter
 		// Create instance
 		codeWriter.WriteLine($"var {varName} = new {fqName}();");
 
-		EmitNewElementNameScope(codeWriter, element, varName, typeSymbol, rootType, existingNamedFields);
+		EmitNewElementNameScope(codeWriter, element, varName, typeSymbol, rootType, existingNamedFields, compilation, xmlnsCache, typeCache);
 
 		// Set properties
 		EmitNewElementProperties(codeWriter, element, varName, typeSymbol, compilation, xmlnsCache, typeCache, rootType, sourceProductionContext, projectItem);
@@ -563,7 +568,10 @@ static class UpdateComponentCodeWriter
 		string varName,
 		INamedTypeSymbol typeSymbol,
 		INamedTypeSymbol rootType,
-		HashSet<string>? existingNamedFields)
+		Dictionary<string, XmlType>? existingNamedFields,
+		Compilation compilation,
+		AssemblyAttributes xmlnsCache,
+		IDictionary<XmlType, INamedTypeSymbol> typeCache)
 	{
 		if (!InheritsFrom(typeSymbol, "global::Microsoft.Maui.Controls.Element")
 			|| !InheritsFrom(rootType, "global::Microsoft.Maui.Controls.BindableObject"))
@@ -602,42 +610,27 @@ static class UpdateComponentCodeWriter
 		if (element.Properties.TryGetValue(XmlName.xName, out var fieldNameNode)
 			&& fieldNameNode is ValueNode { Value: string fieldName })
 		{
-			if (existingNamedFields?.Contains(fieldName) == true)
+			if (existingNamedFields?.TryGetValue(fieldName, out var existingFieldXmlType) == true
+				&& existingFieldXmlType.TryResolveTypeSymbol(null, compilation, xmlnsCache, typeCache, out var existingFieldType)
+				&& existingFieldType is not null
+				&& IsAssignableTo(typeSymbol, existingFieldType))
+			{
 				codeWriter.WriteLine($"this.{GeneratorHelpers.EscapeIdentifier(fieldName)} = {varName};");
+			}
 			codeWriter.WriteLine($"{varName}.StyleId ??= \"{EscapeString(fieldName)}\";");
 		}
 	}
 
-	internal static HashSet<string> CollectRootScopeNames(ElementNode root)
+	static bool IsAssignableTo(INamedTypeSymbol sourceType, INamedTypeSymbol targetType)
 	{
-		var names = new HashSet<string>(StringComparer.Ordinal);
-		Collect(root, names, isRoot: true);
-		return names;
-
-		static void Collect(INode node, HashSet<string> names, bool isRoot = false)
+		for (var current = sourceType; current is not null; current = current.BaseType)
 		{
-			if (node is ElementNode element)
-			{
-				if (!isRoot && element.XmlType.Name is "DataTemplate" or "ControlTemplate" or "Style" or "VisualStateGroup")
-					return;
-
-				if (element.Properties.TryGetValue(XmlName.xName, out var nameNode)
-					&& nameNode is ValueNode { Value: string name })
-				{
-					names.Add(name);
-				}
-
-				foreach (var property in element.Properties.Values)
-					Collect(property, names);
-				foreach (var child in element.CollectionItems)
-					Collect(child, names);
-			}
-			else if (node is ListNode list)
-			{
-				foreach (var child in list.CollectionItems)
-					Collect(child, names);
-			}
+			if (SymbolEqualityComparer.Default.Equals(current, targetType))
+				return true;
 		}
+
+		return sourceType.AllInterfaces.Any(interfaceType =>
+			SymbolEqualityComparer.Default.Equals(interfaceType, targetType));
 	}
 
 	/// <summary>
@@ -910,7 +903,7 @@ static class UpdateComponentCodeWriter
 		string varName,
 		string nodeId,
 		Dictionary<ElementNode, string>? newIds,
-		HashSet<string>? existingNamedFields,
+		Dictionary<string, XmlType>? existingNamedFields,
 		ref int addedCounter,
 		INamedTypeSymbol typeSymbol,
 		Compilation compilation,
@@ -988,7 +981,7 @@ static class UpdateComponentCodeWriter
 					var childIdx = addedCounter++;
 					var childVar = $"__na_{childIdx}";
 					codeWriter.WriteLine($"var {childVar} = new {childType.ToFQDisplayString()}();");
-					EmitNewElementNameScope(codeWriter, childElement, childVar, childType, rootType, existingNamedFields);
+					EmitNewElementNameScope(codeWriter, childElement, childVar, childType, rootType, existingNamedFields, compilation, xmlnsCache, typeCache);
 					EmitNewElementProperties(codeWriter, childElement, childVar, childType, compilation, xmlnsCache, typeCache, rootType, sourceProductionContext, projectItem);
 					EmitNewElementChildren(codeWriter, childElement, childVar, childNodeId, newIds, existingNamedFields, ref addedCounter, childType, compilation, xmlnsCache, typeCache, rootType, sourceProductionContext, projectItem);
 					// Assign the concrete child directly (not cast to IView): a content property is not

--- a/src/Controls/src/SourceGen/UpdateComponentCodeWriter.cs
+++ b/src/Controls/src/SourceGen/UpdateComponentCodeWriter.cs
@@ -580,10 +580,10 @@ static class UpdateComponentCodeWriter
 		}
 
 		if (element.Properties.TryGetValue(XmlName.xName, out var fieldNameNode)
-			&& fieldNameNode is ValueNode { Value: string fieldName }
-			&& existingNamedFields?.Contains(fieldName) == true)
+			&& fieldNameNode is ValueNode { Value: string fieldName })
 		{
-			codeWriter.WriteLine($"this.{GeneratorHelpers.EscapeIdentifier(fieldName)} = {varName};");
+			if (existingNamedFields?.Contains(fieldName) == true)
+				codeWriter.WriteLine($"this.{GeneratorHelpers.EscapeIdentifier(fieldName)} = {varName};");
 			codeWriter.WriteLine($"{varName}.StyleId ??= \"{EscapeString(fieldName)}\";");
 		}
 	}

--- a/src/Controls/src/SourceGen/XamlGenerator.cs
+++ b/src/Controls/src/SourceGen/XamlGenerator.cs
@@ -225,6 +225,7 @@ public class XamlGenerator : IIncrementalGenerator
 				{
 					var rootType = ucRootType!;
 					var accessModifier = ucAccessModifier;
+					var generatedFieldNames = XamlHotReloadState.GetGeneratedFieldNames(assemblyName, targetFramework, stateKey);
 					var patchBody = InitializeComponentCodeWriter.TryGeneratePatchBody(
 						previousRoot,
 						previousNodeIds,
@@ -239,6 +240,7 @@ public class XamlGenerator : IIncrementalGenerator
 						typeCache,
 						sourceProductionContext,
 						xamlItem.ProjectItem,
+						generatedFieldNames,
 						out var parsedNewRoot,
 						out var effectiveNewIds,
 						out var newNextNodeId,

--- a/src/Controls/src/SourceGen/XamlGenerator.cs
+++ b/src/Controls/src/SourceGen/XamlGenerator.cs
@@ -225,7 +225,7 @@ public class XamlGenerator : IIncrementalGenerator
 				{
 					var rootType = ucRootType!;
 					var accessModifier = ucAccessModifier;
-					var generatedFieldNames = XamlHotReloadState.GetGeneratedFieldNames(assemblyName, targetFramework, stateKey);
+					var generatedFields = XamlHotReloadState.GetGeneratedFields(assemblyName, targetFramework, stateKey);
 					var patchBody = InitializeComponentCodeWriter.TryGeneratePatchBody(
 						previousRoot,
 						previousNodeIds,
@@ -240,7 +240,7 @@ public class XamlGenerator : IIncrementalGenerator
 						typeCache,
 						sourceProductionContext,
 						xamlItem.ProjectItem,
-						generatedFieldNames,
+						generatedFields,
 						out var parsedNewRoot,
 						out var effectiveNewIds,
 						out var newNextNodeId,

--- a/src/Controls/src/SourceGen/XamlHotReloadState.cs
+++ b/src/Controls/src/SourceGen/XamlHotReloadState.cs
@@ -70,6 +70,11 @@ internal static class XamlHotReloadState
 		/// can tell how many times a file has been regenerated in the current build session.
 		/// </summary>
 		public int Version { get; set; }
+		/// <summary>
+		/// Names whose generated fields exist on the originally loaded type. This seed set remains
+		/// stable across edits because metadata updates cannot add or remove instance fields.
+		/// </summary>
+		public HashSet<string>? GeneratedFieldNames { get; set; }
 	}
 
 	/// <summary>
@@ -110,7 +115,12 @@ internal static class XamlHotReloadState
 		{
 			if (!_cache.TryGetValue((assemblyName, targetFramework, relativePath), out var entry))
 			{
-				entry = new CacheEntry();
+				entry = new CacheEntry
+				{
+					GeneratedFieldNames = parsedRoot is null
+						? null
+						: UpdateComponentCodeWriter.CollectRootScopeNames(parsedRoot),
+				};
 				_cache[(assemblyName, targetFramework, relativePath)] = entry;
 			}
 			entry.XamlText = xamlText;
@@ -118,6 +128,20 @@ internal static class XamlHotReloadState
 			entry.NodeIds = nodeIds;
 			entry.NextNodeId = nextNodeId;
 			entry.Version = version;
+		}
+	}
+
+	public static HashSet<string>? GetGeneratedFieldNames(string assemblyName, string targetFramework, string relativePath)
+	{
+		lock (_lock)
+		{
+			if (_cache.TryGetValue((assemblyName, targetFramework, relativePath), out var entry)
+				&& entry.GeneratedFieldNames is not null)
+			{
+				return new HashSet<string>(entry.GeneratedFieldNames, System.StringComparer.Ordinal);
+			}
+
+			return null;
 		}
 	}
 

--- a/src/Controls/src/SourceGen/XamlHotReloadState.cs
+++ b/src/Controls/src/SourceGen/XamlHotReloadState.cs
@@ -71,10 +71,10 @@ internal static class XamlHotReloadState
 		/// </summary>
 		public int Version { get; set; }
 		/// <summary>
-		/// Names whose generated fields exist on the originally loaded type. This seed set remains
-		/// stable across edits because metadata updates cannot add or remove instance fields.
+		/// Names and declared XAML types of fields generated on the originally loaded type. This seed
+		/// remains stable across edits because metadata updates cannot add or remove instance fields.
 		/// </summary>
-		public HashSet<string>? GeneratedFieldNames { get; set; }
+		public Dictionary<string, XmlType>? GeneratedFields { get; set; }
 	}
 
 	/// <summary>
@@ -117,11 +117,15 @@ internal static class XamlHotReloadState
 			{
 				entry = new CacheEntry
 				{
-					GeneratedFieldNames = parsedRoot is null
+					GeneratedFields = parsedRoot is null
 						? null
-						: UpdateComponentCodeWriter.CollectRootScopeNames(parsedRoot),
+						: XamlGeneratedFieldCollector.Collect(parsedRoot),
 				};
 				_cache[(assemblyName, targetFramework, relativePath)] = entry;
+			}
+			else if (entry.GeneratedFields is null && parsedRoot is not null)
+			{
+				entry.GeneratedFields = XamlGeneratedFieldCollector.Collect(parsedRoot);
 			}
 			entry.XamlText = xamlText;
 			entry.ParsedRoot = parsedRoot;
@@ -131,14 +135,14 @@ internal static class XamlHotReloadState
 		}
 	}
 
-	public static HashSet<string>? GetGeneratedFieldNames(string assemblyName, string targetFramework, string relativePath)
+	public static Dictionary<string, XmlType>? GetGeneratedFields(string assemblyName, string targetFramework, string relativePath)
 	{
 		lock (_lock)
 		{
 			if (_cache.TryGetValue((assemblyName, targetFramework, relativePath), out var entry)
-				&& entry.GeneratedFieldNames is not null)
+				&& entry.GeneratedFields is not null)
 			{
-				return new HashSet<string>(entry.GeneratedFieldNames, System.StringComparer.Ordinal);
+				return new Dictionary<string, XmlType>(entry.GeneratedFields, System.StringComparer.Ordinal);
 			}
 
 			return null;

--- a/src/Controls/src/SourceGen/XamlNodeDiff.cs
+++ b/src/Controls/src/SourceGen/XamlNodeDiff.cs
@@ -133,7 +133,7 @@ readonly struct ChildListChangeDiff(
 	XmlType? parentXmlType,
 	IReadOnlyList<ChildChangeEntry> newChildren,
 	IReadOnlyList<string> removedNodeIds,
-	IReadOnlyList<string> removedNames)
+	IReadOnlyList<RemovedNameEntry> removedNames)
 {
 	/// <summary>Stable path of the parent node whose children changed.</summary>
 	public string ParentNodeId { get; } = parentNodeId;
@@ -154,7 +154,68 @@ readonly struct ChildListChangeDiff(
 	/// </summary>
 	public IReadOnlyList<string> RemovedNodeIds { get; } = removedNodeIds;
 
-	public IReadOnlyList<string> RemovedNames { get; } = removedNames;
+	public IReadOnlyList<RemovedNameEntry> RemovedNames { get; } = removedNames;
+}
+
+readonly struct RemovedNameEntry(string name, string nodeId)
+{
+	public string Name { get; } = name;
+
+	public string NodeId { get; } = nodeId;
+}
+
+static class XamlGeneratedFieldCollector
+{
+	public static Dictionary<string, XmlType> Collect(ElementNode root)
+	{
+		var fields = new Dictionary<string, XmlType>(StringComparer.Ordinal);
+		Visit(root, (element, name) => fields[name] = element.XmlType);
+		return fields;
+	}
+
+	public static void Visit(ElementNode root, Action<ElementNode, string> visitor)
+		=> Visit(root, parent: null, visitor);
+
+	static void Visit(INode node, INode? parent, Action<ElementNode, string> visitor)
+	{
+		if (node is ElementNode element)
+		{
+			if (!IsVisualStateFieldExcluded(element, parent)
+				&& element.Properties.TryGetValue(XmlName.xName, out var nameNode)
+				&& nameNode is ValueNode { Value: string name })
+			{
+				visitor(element, name);
+			}
+
+			if (IsFieldBoundary(element.XmlType))
+				return;
+
+			foreach (var property in element.Properties)
+			{
+				if (!IsFieldBoundary(property.Key))
+					Visit(property.Value, element, visitor);
+			}
+
+			foreach (var child in element.CollectionItems)
+				Visit(child, element, visitor);
+		}
+		else if (node is ListNode list)
+		{
+			foreach (var child in list.CollectionItems)
+				Visit(child, list, visitor);
+		}
+	}
+
+	static bool IsFieldBoundary(XmlType type)
+		=> type.IsOfAnyType("DataTemplate", "ControlTemplate", "Style");
+
+	static bool IsFieldBoundary(XmlName property)
+		=> (property.NamespaceURI == XamlParser.MauiUri || property.NamespaceURI == XamlParser.MauiGlobalUri)
+			&& property.LocalName == "VisualStateManager.VisualStateGroups";
+
+	static bool IsVisualStateFieldExcluded(ElementNode element, INode? parent)
+		=> parent is IListNode
+			&& element.XmlType.Name is "VisualStateGroup" or "VisualState";
 }
 
 /// <summary>
@@ -660,11 +721,15 @@ static class XamlNodeDiff
 		}
 
 		var removedIds = new List<string>();
-		var removedNames = new List<string>();
+		var removedNames = new List<RemovedNameEntry>();
 		foreach (var oldIdx in removedOldIndices)
 		{
 			CollectSubtreeIds(oldChildren[oldIdx], oldIds, removedIds);
-			CollectRootScopeNames(oldChildren[oldIdx], removedNames);
+			XamlGeneratedFieldCollector.Visit(oldChildren[oldIdx], (element, name) =>
+			{
+				if (oldIds.TryGetValue(element, out var id))
+					removedNames.Add(new RemovedNameEntry(name, id));
+			});
 		}
 
 		childListChanges.Add(new ChildListChangeDiff(parentNodeId, oldNode.XmlType, entries, removedIds, removedNames));
@@ -684,34 +749,6 @@ static class XamlNodeDiff
 			if (item is ElementNode child)
 				CollectSubtreeIds(child, ids, result);
 		}
-	}
-
-	static void CollectRootScopeNames(ElementNode node, List<string> result)
-	{
-		if (node.XmlType.Name is "DataTemplate" or "ControlTemplate" or "Style" or "VisualStateGroup")
-			return;
-
-		if (node.Properties.TryGetValue(XmlName.xName, out var nameNode)
-			&& nameNode is ValueNode { Value: string name })
-		{
-			result.Add(name);
-		}
-
-		foreach (var property in node.Properties.Values)
-		{
-			if (property is ElementNode propertyElement)
-				CollectRootScopeNames(propertyElement, result);
-			else if (property is ListNode propertyList)
-			{
-				foreach (var item in propertyList.CollectionItems)
-					if (item is ElementNode itemElement)
-						CollectRootScopeNames(itemElement, result);
-			}
-		}
-
-		foreach (var child in node.CollectionItems)
-			if (child is ElementNode childElement)
-				CollectRootScopeNames(childElement, result);
 	}
 
 	/// <summary>

--- a/src/Controls/src/SourceGen/XamlNodeDiff.cs
+++ b/src/Controls/src/SourceGen/XamlNodeDiff.cs
@@ -132,7 +132,8 @@ readonly struct ChildListChangeDiff(
 	string parentNodeId,
 	XmlType? parentXmlType,
 	IReadOnlyList<ChildChangeEntry> newChildren,
-	IReadOnlyList<string> removedNodeIds)
+	IReadOnlyList<string> removedNodeIds,
+	IReadOnlyList<string> removedNames)
 {
 	/// <summary>Stable path of the parent node whose children changed.</summary>
 	public string ParentNodeId { get; } = parentNodeId;
@@ -152,6 +153,8 @@ readonly struct ChildListChangeDiff(
 	/// these (and their subtrees) from the component registry.
 	/// </summary>
 	public IReadOnlyList<string> RemovedNodeIds { get; } = removedNodeIds;
+
+	public IReadOnlyList<string> RemovedNames { get; } = removedNames;
 }
 
 /// <summary>
@@ -657,10 +660,14 @@ static class XamlNodeDiff
 		}
 
 		var removedIds = new List<string>();
+		var removedNames = new List<string>();
 		foreach (var oldIdx in removedOldIndices)
+		{
 			CollectSubtreeIds(oldChildren[oldIdx], oldIds, removedIds);
+			CollectRootScopeNames(oldChildren[oldIdx], removedNames);
+		}
 
-		childListChanges.Add(new ChildListChangeDiff(parentNodeId, oldNode.XmlType, entries, removedIds));
+		childListChanges.Add(new ChildListChangeDiff(parentNodeId, oldNode.XmlType, entries, removedIds, removedNames));
 		return true;
 	}
 
@@ -677,6 +684,34 @@ static class XamlNodeDiff
 			if (item is ElementNode child)
 				CollectSubtreeIds(child, ids, result);
 		}
+	}
+
+	static void CollectRootScopeNames(ElementNode node, List<string> result)
+	{
+		if (node.XmlType.Name is "DataTemplate" or "ControlTemplate" or "Style" or "VisualStateGroup")
+			return;
+
+		if (node.Properties.TryGetValue(XmlName.xName, out var nameNode)
+			&& nameNode is ValueNode { Value: string name })
+		{
+			result.Add(name);
+		}
+
+		foreach (var property in node.Properties.Values)
+		{
+			if (property is ElementNode propertyElement)
+				CollectRootScopeNames(propertyElement, result);
+			else if (property is ListNode propertyList)
+			{
+				foreach (var item in propertyList.CollectionItems)
+					if (item is ElementNode itemElement)
+						CollectRootScopeNames(itemElement, result);
+			}
+		}
+
+		foreach (var child in node.CollectionItems)
+			if (child is ElementNode childElement)
+				CollectRootScopeNames(childElement, result);
 	}
 
 	/// <summary>

--- a/src/Controls/tests/SourceGen.UnitTests/HotReload/AiAssisted/StructuralHotReloadTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/HotReload/AiAssisted/StructuralHotReloadTests.cs
@@ -44,6 +44,34 @@ public class StructuralHotReloadTests
 	static XamlHotReloadTestHarness CreateHarness([CallerMemberName] string scenarioName = "") =>
 		new(scenarioName, PageClass, PageStub);
 
+	static (string Before, string After) GetMoveBetweenContainersXaml() =>
+		(
+			"""
+			<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			             x:Class="TestAiAssisted.MainPage">
+				<Grid>
+					<VerticalStackLayout x:Name="EarlierContainer" />
+					<VerticalStackLayout x:Name="LaterContainer">
+						<Label x:Name="MovedLabel" Text="Moved" />
+					</VerticalStackLayout>
+				</Grid>
+			</ContentPage>
+			""",
+			"""
+			<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			             x:Class="TestAiAssisted.MainPage">
+				<Grid>
+					<VerticalStackLayout x:Name="EarlierContainer">
+						<Label x:Name="MovedLabel" Text="Moved" />
+					</VerticalStackLayout>
+					<VerticalStackLayout x:Name="LaterContainer" />
+				</Grid>
+			</ContentPage>
+			"""
+		);
+
 	[MetadataUpdateFact]
 	public void AncestorLayoutTypeReplacement_ReconcilesNamedFieldWithVisibleElement()
 	{
@@ -195,6 +223,108 @@ public class StructuralHotReloadTests
 			Assert.Same(visibleLabel, page.FindByName<Label>("StructureCounterLabel"));
 		});
 	}
+
+	[Fact]
+	public void IncompatibleNamedElementReplacement_DoesNotAssignGeneratedField()
+	{
+		const string currentPageStub = """
+			namespace TestAiAssisted;
+
+			public partial class MainPage : global::Microsoft.Maui.Controls.ContentPage
+			{
+				private partial void InitializeComponent();
+				private global::Microsoft.Maui.Controls.Button NamedElement = default!;
+
+				public void InitializeComponentRuntime() { }
+				public MainPage() => InitializeComponent();
+			}
+			""";
+		const string xamlV1 = """
+			<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			             x:Class="TestAiAssisted.MainPage">
+				<HorizontalStackLayout>
+					<Label x:Name="NamedElement" />
+				</HorizontalStackLayout>
+			</ContentPage>
+			""";
+		const string xamlV2 = """
+			<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			             x:Class="TestAiAssisted.MainPage">
+				<VerticalStackLayout>
+					<Button x:Name="NamedElement" />
+				</VerticalStackLayout>
+			</ContentPage>
+			""";
+
+		using var harness = new XamlHotReloadTestHarness(
+			nameof(IncompatibleNamedElementReplacement_DoesNotAssignGeneratedField),
+			PageClass,
+			currentPageStub);
+		var generation = harness.Generate(xamlV1, xamlV2);
+		var updateComponentSource = generation[1].UpdateComponentSource;
+
+		Assert.NotNull(updateComponentSource);
+		Assert.DoesNotContain("this.NamedElement =", updateComponentSource!, StringComparison.Ordinal);
+		Assert.True(harness.Compile(generation[1]).PeImage.Length > 0);
+	}
+
+	[MetadataUpdateFact]
+	public void MovingNameFromLaterToEarlierContainer_KeepsNewRegistration()
+	{
+		var (xamlV1, xamlV2) = GetMoveBetweenContainersXaml();
+
+		using var harness = CreateMoveBetweenContainersHarness();
+		var generation = harness.Generate(xamlV1, xamlV2);
+
+		harness.RunLive(generation, live =>
+		{
+			var page = live.GetInstance<ContentPage>();
+
+			live.ApplyUpdate<ContentPage>(1);
+
+			var grid = Assert.IsType<Grid>(page.Content);
+			var earlier = Assert.IsType<VerticalStackLayout>(grid[0]);
+			var movedLabel = Assert.IsType<Label>(Assert.Single(earlier));
+			Assert.Same(movedLabel, page.FindByName<Label>("MovedLabel"));
+		});
+	}
+
+	[Fact]
+	public void MovingNameFromLaterToEarlierContainer_EmitsIdentitySafeUnregister()
+	{
+		var (xamlV1, xamlV2) = GetMoveBetweenContainersXaml();
+
+		using var harness = CreateMoveBetweenContainersHarness();
+		var generation = harness.Generate(xamlV1, xamlV2);
+		var updateComponentSource = generation[1].UpdateComponentSource;
+
+		Assert.NotNull(updateComponentSource);
+		Assert.Contains("XamlComponentRegistry.TryGet(this", updateComponentSource!, StringComparison.Ordinal);
+		Assert.Contains("ReferenceEquals(__removedNameScope_", updateComponentSource!, StringComparison.Ordinal);
+		Assert.Contains("__removedNamedElement_", updateComponentSource!, StringComparison.Ordinal);
+		Assert.True(harness.Compile(generation[1]).PeImage.Length > 0);
+	}
+
+	static XamlHotReloadTestHarness CreateMoveBetweenContainersHarness([CallerMemberName] string scenarioName = "") =>
+		new(
+			scenarioName,
+			PageClass,
+			"""
+			namespace TestAiAssisted;
+
+			public partial class MainPage : global::Microsoft.Maui.Controls.ContentPage
+			{
+				private partial void InitializeComponent();
+				private global::Microsoft.Maui.Controls.VerticalStackLayout EarlierContainer = default!;
+				private global::Microsoft.Maui.Controls.VerticalStackLayout LaterContainer = default!;
+				private global::Microsoft.Maui.Controls.Label MovedLabel = default!;
+
+				public void InitializeComponentRuntime() { }
+				public MainPage() => InitializeComponent();
+			}
+			""");
 
 	[Fact]
 	public void RootComplexElementProperty_IsNotSilentlyDropped()

--- a/src/Controls/tests/SourceGen.UnitTests/HotReload/AiAssisted/StructuralHotReloadTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/HotReload/AiAssisted/StructuralHotReloadTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using Microsoft.Maui.Controls.SourceGen.UnitTests.HotReload;
 using Xunit;
@@ -42,6 +43,87 @@ public class StructuralHotReloadTests
 
 	static XamlHotReloadTestHarness CreateHarness([CallerMemberName] string scenarioName = "") =>
 		new(scenarioName, PageClass, PageStub);
+
+	[MetadataUpdateFact]
+	public void AncestorLayoutTypeReplacement_ReconcilesNamedFieldWithVisibleElement()
+	{
+		const string pageStub = """
+			namespace TestAiAssisted;
+
+			public partial class MainPage : global::Microsoft.Maui.Controls.ContentPage
+			{
+				private partial void InitializeComponent();
+
+				private global::Microsoft.Maui.Controls.Label StructureCounterLabel = default!;
+				private int _structureCount;
+
+				public void InitializeComponentRuntime() { }
+
+				public MainPage()
+				{
+					InitializeComponent();
+				}
+
+				public void IncrementStructureCounter()
+				{
+					_structureCount++;
+					StructureCounterLabel.Text = $"Structure count {_structureCount}";
+				}
+
+				public global::Microsoft.Maui.Controls.Label GetStructureCounterLabel() => StructureCounterLabel;
+			}
+			""";
+		const string xamlV1 = """
+			<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			             x:Class="TestAiAssisted.MainPage">
+			  <HorizontalStackLayout>
+			    <Label x:Name="StructureCounterLabel" Text="Structure count 0" />
+			  </HorizontalStackLayout>
+			</ContentPage>
+			""";
+		const string xamlV2 = """
+			<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			             x:Class="TestAiAssisted.MainPage">
+			  <VerticalStackLayout>
+			    <Label x:Name="StructureCounterLabel" Text="Structure count 0" />
+			  </VerticalStackLayout>
+			</ContentPage>
+			""";
+
+		using var harness = new XamlHotReloadTestHarness(
+			nameof(AncestorLayoutTypeReplacement_ReconcilesNamedFieldWithVisibleElement),
+			PageClass,
+			pageStub);
+		var generation = harness.Generate(xamlV1, xamlV2);
+
+		harness.RunLive(generation, live =>
+		{
+			var page = live.GetInstance<ContentPage>();
+			var originalLabel = Assert.IsType<Label>(Assert.IsType<HorizontalStackLayout>(page.Content)[0]);
+
+			Invoke(page, "IncrementStructureCounter");
+			Assert.Equal("Structure count 1", originalLabel.Text);
+
+			Assert.Same(page, live.ApplyUpdate<ContentPage>(1));
+			var visibleLabel = Assert.IsType<Label>(Assert.IsType<VerticalStackLayout>(page.Content)[0]);
+			Assert.NotSame(originalLabel, visibleLabel);
+
+			Invoke(page, "IncrementStructureCounter");
+
+			Assert.Equal("Structure count 2", visibleLabel.Text);
+			Assert.Equal("Structure count 1", originalLabel.Text);
+			Assert.Same(visibleLabel, Invoke<Label>(page, "GetStructureCounterLabel"));
+			Assert.Same(visibleLabel, page.FindByName<Label>("StructureCounterLabel"));
+		});
+	}
+
+	static object? Invoke(object instance, string methodName) =>
+		instance.GetType().GetMethod(methodName, BindingFlags.Instance | BindingFlags.Public)!.Invoke(instance, null);
+
+	static T Invoke<T>(object instance, string methodName) where T : class =>
+		Assert.IsType<T>(Invoke(instance, methodName));
 
 	[Fact]
 	public void RootComplexElementProperty_IsNotSilentlyDropped()

--- a/src/Controls/tests/SourceGen.UnitTests/HotReload/AiAssisted/StructuralHotReloadTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/HotReload/AiAssisted/StructuralHotReloadTests.cs
@@ -125,6 +125,77 @@ public class StructuralHotReloadTests
 	static T Invoke<T>(object instance, string methodName) where T : class =>
 		Assert.IsType<T>(Invoke(instance, methodName));
 
+	[MetadataUpdateFact]
+	public void RemovedThenReaddedName_ReconcilesOriginalGeneratedField()
+	{
+		const string pageStub = """
+			namespace TestAiAssisted;
+
+			public partial class MainPage : global::Microsoft.Maui.Controls.ContentPage
+			{
+				private partial void InitializeComponent();
+				private global::Microsoft.Maui.Controls.Label StructureCounterLabel = default!;
+
+				public void InitializeComponentRuntime() { }
+				public MainPage() => InitializeComponent();
+				public void SetCounterText(string text) => StructureCounterLabel.Text = text;
+				public global::Microsoft.Maui.Controls.Label GetStructureCounterLabel() => StructureCounterLabel;
+			}
+			""";
+		const string xamlV1 = """
+			<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			             x:Class="TestAiAssisted.MainPage">
+			  <HorizontalStackLayout>
+			    <Label x:Name="StructureCounterLabel" Text="Original" />
+			  </HorizontalStackLayout>
+			</ContentPage>
+			""";
+		const string xamlV2 = """
+			<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			             x:Class="TestAiAssisted.MainPage">
+			  <HorizontalStackLayout />
+			</ContentPage>
+			""";
+		const string xamlV3 = """
+			<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			             x:Class="TestAiAssisted.MainPage">
+			  <VerticalStackLayout>
+			    <Label x:Name="StructureCounterLabel" Text="Readded" />
+			  </VerticalStackLayout>
+			</ContentPage>
+			""";
+
+		using var harness = new XamlHotReloadTestHarness(
+			nameof(RemovedThenReaddedName_ReconcilesOriginalGeneratedField),
+			PageClass,
+			pageStub);
+		var generation = harness.Generate(xamlV1, xamlV2, xamlV3);
+
+		harness.RunLive(generation, live =>
+		{
+			var page = live.GetInstance<ContentPage>();
+			var originalLabel = Assert.IsType<Label>(Assert.IsType<HorizontalStackLayout>(page.Content)[0]);
+
+			live.ApplyUpdate<ContentPage>(1);
+			Assert.Empty(Assert.IsType<HorizontalStackLayout>(page.Content));
+			Assert.Null(page.FindByName<Label>("StructureCounterLabel"));
+
+			live.ApplyUpdate<ContentPage>(2);
+			var visibleLabel = Assert.IsType<Label>(Assert.IsType<VerticalStackLayout>(page.Content)[0]);
+			Assert.NotSame(originalLabel, visibleLabel);
+
+			page.GetType().GetMethod("SetCounterText")!.Invoke(page, ["Updated"]);
+
+			Assert.Equal("Updated", visibleLabel.Text);
+			Assert.Equal("Original", originalLabel.Text);
+			Assert.Same(visibleLabel, Invoke<Label>(page, "GetStructureCounterLabel"));
+			Assert.Same(visibleLabel, page.FindByName<Label>("StructureCounterLabel"));
+		});
+	}
+
 	[Fact]
 	public void RootComplexElementProperty_IsNotSilentlyDropped()
 	{

--- a/src/Controls/tests/SourceGen.UnitTests/UpdateComponentCodeWriterTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/UpdateComponentCodeWriterTests.cs
@@ -121,6 +121,28 @@ $"""
 	}
 
 	[Fact]
+	public void RemovedName_NonBindableObjectRoot_DoesNotEmitNameScopeLookup()
+	{
+		var v1 =
+$"""
+<ResourceDictionary {MauiXmlns} x:Class="Test.TestResources">
+	<Label x:Name="RemovedLabel" />
+</ResourceDictionary>
+""";
+		var v2 =
+$"""
+<ResourceDictionary {MauiXmlns} x:Class="Test.TestResources" />
+""";
+		var compilation = CreateMauiCompilation();
+		var rootType = compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.ResourceDictionary")!;
+
+		var result = Generate(v1, v2, rootType: rootType);
+
+		Assert.NotNull(result);
+		Assert.DoesNotContain("NameScope.GetNameScope(this)", result!, StringComparison.Ordinal);
+	}
+
+	[Fact]
 	public void SinglePropertyChange_GeneratesMethodHeader()
 	{
 		var v1 = $"<ContentPage {MauiXmlns} x:Class=\"Test.TestPage\"><Label Text=\"Hello\" /></ContentPage>";

--- a/src/Controls/tests/SourceGen.UnitTests/XamlIncrementalHotReloadPipelineTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/XamlIncrementalHotReloadPipelineTests.cs
@@ -1896,6 +1896,44 @@ public class XamlIncrementalHotReloadPipelineTests : IDisposable
 	}
 
 	[Fact]
+	public void AddedNamedElement_RemainsFieldlessAfterLaterStructuralReplacement()
+	{
+		XamlHotReloadState.Reset();
+
+		const string xamlV1 = """
+			<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			             x:Class="TestApp.MainPage">
+			    <HorizontalStackLayout />
+			</ContentPage>
+			""";
+		const string xamlV2 = """
+			<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			             x:Class="TestApp.MainPage">
+			    <HorizontalStackLayout>
+			        <Button x:Name="Foo" Text="Added" />
+			    </HorizontalStackLayout>
+			</ContentPage>
+			""";
+		const string xamlV3 = """
+			<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			             x:Class="TestApp.MainPage">
+			    <VerticalStackLayout>
+			        <Button x:Name="Foo" Text="Recreated" />
+			    </VerticalStackLayout>
+			</ContentPage>
+			""";
+
+		var (_, _, run3) = ThreeRuns(xamlV1, xamlV2, xamlV3);
+		var uc = FindUCSource(run3, "uc.xsg");
+		Assert.NotNull(uc);
+		Assert.Contains("new global::Microsoft.Maui.Controls.Button()", uc!, StringComparison.Ordinal);
+		Assert.DoesNotContain("this.Foo =", uc!, StringComparison.Ordinal);
+	}
+
+	[Fact]
 	public void ContentTransitions_StringToMarkupToElementAndBack_Compile()
 	{
 		// jonathanpeppers review: verify a content/property value transitioning through

--- a/src/Controls/tests/SourceGen.UnitTests/XamlIncrementalHotReloadPipelineTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/XamlIncrementalHotReloadPipelineTests.cs
@@ -1112,6 +1112,29 @@ public class XamlIncrementalHotReloadPipelineTests : IDisposable
 		Assert.Equal(1, storedVer);
 	}
 
+	[Fact]
+	public void HotReloadState_LazilySeedsGeneratedFieldsAfterNullRoot()
+	{
+		const string xaml = """
+			<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			             x:Class="TestApp.MainPage">
+				<Label x:Name="NamedLabel" />
+			</ContentPage>
+			""";
+		var parsedRoot = GeneratorHelpers.ParseXaml(xaml, AssemblyAttributes.Empty);
+		Assert.NotNull(parsedRoot);
+
+		XamlHotReloadState.Update("TestApp", "net11.0", PageRelativePath, xaml, null, null, 0, 0);
+		Assert.Null(XamlHotReloadState.GetGeneratedFields("TestApp", "net11.0", PageRelativePath));
+
+		XamlHotReloadState.Update("TestApp", "net11.0", PageRelativePath, xaml, parsedRoot, null, 0, 1);
+
+		var generatedFields = XamlHotReloadState.GetGeneratedFields("TestApp", "net11.0", PageRelativePath);
+		Assert.NotNull(generatedFields);
+		Assert.Equal("Label", generatedFields["NamedLabel"].Name);
+	}
+
 	// -----------------------------------------------------------------------
 	// Type converter tests — verify UC uses compile-time converters from IC
 	// -----------------------------------------------------------------------

--- a/src/Controls/tests/SourceGen.UnitTests/XamlNodeDiffTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/XamlNodeDiffTests.cs
@@ -287,6 +287,71 @@ public class XamlNodeDiffTests
 	}
 
 	[Fact]
+	public void RemovedBoundary_IncludesOwnNameButExcludesNestedNames()
+	{
+		var old = Parse(Page("""
+			<DataTemplate x:Name="NamedTemplate">
+				<Label x:Name="TemplateLabel" />
+			</DataTemplate>
+			"""));
+		var @new = Parse(Page(""));
+
+		var diff = XamlNodeDiff.ComputeDiff(old, @new);
+
+		var removedName = Assert.Single(Assert.Single(diff!.ChildListChanges).RemovedNames);
+		Assert.Equal("NamedTemplate", removedName.Name);
+	}
+
+	[Fact]
+	public void GeneratedFields_UseNamespaceAwareBoundaries()
+	{
+		var root = Parse($"""
+			<ContentPage {MauiXmlns} xmlns:local="clr-namespace:Test">
+				<local:Style x:Name="CustomStyle">
+					<Label x:Name="NestedLabel" />
+				</local:Style>
+			</ContentPage>
+			""");
+
+		var fields = XamlGeneratedFieldCollector.Collect(root);
+
+		Assert.Contains("CustomStyle", fields);
+		Assert.Contains("NestedLabel", fields);
+	}
+
+	[Fact]
+	public void GeneratedFields_IncludeBoundaryAndExcludeItsDescendants()
+	{
+		var root = Parse(Page("""
+			<Style x:Name="NamedStyle">
+				<Label x:Name="NestedLabel" />
+			</Style>
+			"""));
+
+		var fields = XamlGeneratedFieldCollector.Collect(root);
+
+		Assert.Contains("NamedStyle", fields);
+		Assert.DoesNotContain("NestedLabel", fields);
+	}
+
+	[Fact]
+	public void GeneratedFields_ExcludeVisualStateNames()
+	{
+		var root = Parse(Page("""
+			<VisualStateManager.VisualStateGroups>
+				<VisualStateGroup x:Name="CommonStates">
+					<VisualState x:Name="Normal" />
+				</VisualStateGroup>
+			</VisualStateManager.VisualStateGroups>
+			"""));
+
+		var fields = XamlGeneratedFieldCollector.Collect(root);
+
+		Assert.DoesNotContain("CommonStates", fields);
+		Assert.DoesNotContain("Normal", fields);
+	}
+
+	[Fact]
 	public void ChangedChildElementType_ProducesChildListChange()
 	{
 		var old = Parse(Page("<Label Text=\"Hello\" />"));


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause

Source-generated incremental XAML Hot Reload rebuilt structurally replaced subtrees and updated the component registry, but skipped the namescope and generated-field work performed by `InitializeComponent`. The visible named descendant was replaced while its `x:Name` field and root namescope entry continued to reference the detached instance.

Generated-field availability is fixed when the type is originally loaded: metadata updates cannot add or remove instance fields. Therefore chained edits must use the original XAML field set, not the immediately previous XAML.

### Description of Change

- Reconcile newly created structural-patch elements with the root namescope before applying properties and event handlers.
- Replace stale registrations, restore `StyleId`, and reassign a field only when that name existed on the originally loaded type.
- Persist the original root-scope generated-field set across incremental edits.
- Unregister removed root-scope names before reconstruction so `FindByName` never returns a detached object during removal-only edits.

Retained elements keep their identity, handlers, bindings, and lifecycle. Namescope operations remain behind `_MAUIXAML_SG_NAMESCOPE_DISABLE`.

### What NOT to Do

- Do not assign fields for names introduced by Hot Reload: EnC cannot add their instance fields to the loaded type.
- Do not derive field availability from the previous edit: an added name stays fieldless, while an original name's field survives removal and can be reused if re-added.
- Do not use reflection to locate fields; the compile-time seed set remains trimming/NativeAOT safe.
- Do not rebuild retained elements merely to repair name state.

### Test Evidence

- Direct `HorizontalStackLayout` → `VerticalStackLayout` replacement invokes code-behind through the generated field and distinguishes visible and detached label identities.
- Original name removal and later structural re-add reassigns the surviving generated field; removal immediately clears `FindByName`.
- A name introduced by Hot Reload remains fieldless across a later structural replacement.
- Baseline direct reproduction fails with visible text `Structure count 0` instead of `Structure count 2`; fixed test passes.
- `DOTNET_MODIFIABLE_ASSEMBLIES=debug dotnet test src/Controls/tests/SourceGen.UnitTests/SourceGen.UnitTests.csproj --no-restore -v minimal` — 514 passed.
- The repository verification script was attempted but could not auto-detect the SourceGen test project; explicit manual before/after runs established failure/pass evidence.

### Structural and Lifecycle Risks

The change is limited to structural patch creation/removal. Root-scope field collection excludes DataTemplate, ControlTemplate, Style, and VisualStateGroup scopes. Runtime reconciliation is per page instance; no runtime global state is added.

### Issues Fixed

Fixes #37891
