### PR TITLE
[XAML] CollectionView: Update realized cells on first hot reload

### DIFF
--- a/src/Controls/src/SourceGen/InitializeComponentCodeWriter.cs
+++ b/src/Controls/src/SourceGen/InitializeComponentCodeWriter.cs
@@ -115,6 +115,7 @@ static class InitializeComponentCodeWriter
 					else
 						nodeIds = NodeIdHelper.AssignIds(root);
 				}
+				sgcontext.NodeIds = nodeIds;
 
 				using (newblock())
 				{
@@ -373,7 +374,8 @@ $$"""
 			return null;
 		}
 
-		return UpdateComponentCodeWriter.GeneratePatchBody(diff, fromVersion, toVersion, rootType, compilation, xmlnsCache, typeCache, effectiveNewIds, sourceProductionContext, projectItem, generatedFields);
+		var templateNodeIds = NodeIdHelper.GetTemplateNodeIds(newRoot, effectiveNewIds!);
+		return UpdateComponentCodeWriter.GeneratePatchBody(diff, fromVersion, toVersion, rootType, compilation, xmlnsCache, typeCache, effectiveNewIds, sourceProductionContext, projectItem, generatedFields, templateNodeIds);
 	}
 
 	static void WriteMultiLineString(IndentedTextWriter writer, string text)

--- a/src/Controls/src/SourceGen/NodeIdHelper.cs
+++ b/src/Controls/src/SourceGen/NodeIdHelper.cs
@@ -5,17 +5,18 @@ using Microsoft.Maui.Controls.Xaml;
 namespace Microsoft.Maui.Controls.SourceGen;
 
 /// <summary>
-/// Assigns unique string IDs to every <see cref="ElementNode"/> in a parsed XAML tree via a
-/// depth-first walk. IDs are simple incrementing integers — fast to generate, unique within a tree,
-/// and identity-based (not position-based) so reordering children does not change any node's ID.
+/// Assigns unique string IDs to every <see cref="ElementNode"/> in a parsed XAML tree, including
+/// elements stored as property values such as <c>CollectionView.ItemTemplate</c>. IDs are simple
+/// incrementing integers — fast to generate, unique within a tree, and identity-based
+/// (not position-based) so reordering children does not change any node's ID.
 /// The root always receives <c>""</c> (accessed as <c>this</c> at runtime).
 /// </summary>
 internal static class NodeIdHelper
 {
 	/// <summary>
-	/// Walks <paramref name="root"/> depth-first and returns a dictionary mapping every
-	/// <see cref="ElementNode"/> to its unique ID. The root maps to <c>""</c>; children
-	/// are numbered <c>"0"</c>, <c>"1"</c>, etc. in depth-first order.
+	/// Walks <paramref name="root"/> and returns a dictionary mapping every
+	/// <see cref="ElementNode"/> to its unique ID. The root maps to <c>""</c>; nodes
+	/// are numbered <c>"0"</c>, <c>"1"</c>, etc.
 	/// </summary>
 	public static Dictionary<ElementNode, string> AssignIds(ElementNode root)
 	{
@@ -23,6 +24,7 @@ internal static class NodeIdHelper
 		ids[root] = "";
 		int counter = 0;
 		AssignChildrenRecursive(root, ids, ref counter);
+		AssignPropertyNodesRecursive(root, ids, ref counter);
 		return ids;
 	}
 
@@ -37,6 +39,7 @@ internal static class NodeIdHelper
 		ids[root] = "";
 		int counter = startId;
 		AssignChildrenRecursive(root, ids, ref counter);
+		AssignPropertyNodesRecursive(root, ids, ref counter);
 		nextId = counter;
 		return ids;
 	}
@@ -56,16 +59,56 @@ internal static class NodeIdHelper
 		return result;
 	}
 
+	public static HashSet<string> GetTemplateNodeIds(
+		ElementNode root,
+		IReadOnlyDictionary<ElementNode, string> nodeIds)
+	{
+		var result = new HashSet<string>();
+		CollectTemplateNodeIds(root, nodeIds, result, new HashSet<ElementNode>(), insideTemplate: false);
+		return result;
+	}
+
 	static void AssignChildrenRecursive(ElementNode parent, Dictionary<ElementNode, string> ids, ref int counter)
 	{
 		foreach (var item in parent.CollectionItems)
 		{
-			if (item is ElementNode child)
+			if (item is ElementNode child && !ids.ContainsKey(child))
 			{
 				ids[child] = counter.ToString();
 				counter++;
 				AssignChildrenRecursive(child, ids, ref counter);
 			}
+		}
+	}
+
+	static void AssignPropertyNodesRecursive(ElementNode node, Dictionary<ElementNode, string> ids, ref int counter)
+	{
+		foreach (var property in node.Properties)
+			AssignPropertyValue(property.Value, ids, ref counter);
+
+		foreach (var item in node.CollectionItems)
+		{
+			if (item is ElementNode child)
+				AssignPropertyNodesRecursive(child, ids, ref counter);
+		}
+	}
+
+	static void AssignPropertyValue(INode node, Dictionary<ElementNode, string> ids, ref int counter)
+	{
+		if (node is ElementNode element)
+		{
+			if (!ids.ContainsKey(element))
+			{
+				ids[element] = counter.ToString();
+				counter++;
+				AssignChildrenRecursive(element, ids, ref counter);
+			}
+			AssignPropertyNodesRecursive(element, ids, ref counter);
+		}
+		else if (node is ListNode list)
+		{
+			foreach (var item in list.CollectionItems)
+				AssignPropertyValue(item, ids, ref counter);
 		}
 	}
 
@@ -89,6 +132,75 @@ internal static class NodeIdHelper
 			}
 			ti++;
 			si++;
+		}
+
+		foreach (var property in target.Properties)
+		{
+			if (source.Properties.TryGetValue(property.Key, out var sourceProperty))
+				TransferPropertyValue(property.Value, sourceProperty, sourceIds, result);
+		}
+	}
+
+	static void TransferPropertyValue(
+		INode target,
+		INode source,
+		Dictionary<ElementNode, string> sourceIds,
+		Dictionary<ElementNode, string> result)
+	{
+		if (target is ElementNode targetElement
+			&& source is ElementNode sourceElement
+			&& XmlTypeEquals(targetElement.XmlType, sourceElement.XmlType))
+		{
+			TransferRecursive(targetElement, sourceElement, sourceIds, result);
+		}
+		else if (target is ListNode targetList && source is ListNode sourceList)
+		{
+			var count = System.Math.Min(targetList.CollectionItems.Count, sourceList.CollectionItems.Count);
+			for (int i = 0; i < count; i++)
+				TransferPropertyValue(targetList.CollectionItems[i], sourceList.CollectionItems[i], sourceIds, result);
+		}
+	}
+
+	static void CollectTemplateNodeIds(
+		ElementNode node,
+		IReadOnlyDictionary<ElementNode, string> nodeIds,
+		HashSet<string> result,
+		HashSet<ElementNode> visited,
+		bool insideTemplate)
+	{
+		if (!visited.Add(node))
+			return;
+
+		if (insideTemplate && nodeIds.TryGetValue(node, out var nodeId) && !string.IsNullOrEmpty(nodeId))
+			result.Add(nodeId);
+
+		var childIsInsideTemplate = insideTemplate
+			|| node.XmlType.RepresentsType(XamlParser.MauiUri, "DataTemplate")
+			|| node.XmlType.RepresentsType(XamlParser.MauiUri, "ControlTemplate");
+
+		foreach (var item in node.CollectionItems)
+		{
+			if (item is ElementNode child)
+				CollectTemplateNodeIds(child, nodeIds, result, visited, childIsInsideTemplate);
+		}
+
+		foreach (var property in node.Properties)
+			CollectTemplatePropertyNodeIds(property.Value, nodeIds, result, visited, childIsInsideTemplate);
+	}
+
+	static void CollectTemplatePropertyNodeIds(
+		INode node,
+		IReadOnlyDictionary<ElementNode, string> nodeIds,
+		HashSet<string> result,
+		HashSet<ElementNode> visited,
+		bool insideTemplate)
+	{
+		if (node is ElementNode element)
+			CollectTemplateNodeIds(element, nodeIds, result, visited, insideTemplate);
+		else if (node is ListNode list)
+		{
+			foreach (var item in list.CollectionItems)
+				CollectTemplatePropertyNodeIds(item, nodeIds, result, visited, insideTemplate);
 		}
 	}
 

--- a/src/Controls/src/SourceGen/SourceGenContext.cs
+++ b/src/Controls/src/SourceGen/SourceGenContext.cs
@@ -36,6 +36,7 @@ class SourceGenContext(IndentedTextWriter writer, Compilation compilation, Sourc
 	public IDictionary<XmlType, INamedTypeSymbol> TypeCache => typeCache;
 	public IDictionary<INode, object> Values { get; } = new Dictionary<INode, object>();
 	public IDictionary<INode, ILocalValue> Variables { get; } = new Dictionary<INode, ILocalValue>();
+	public IReadOnlyDictionary<ElementNode, string>? NodeIds { get; set; }
 	public void ReportDiagnostic(Diagnostic diagnostic)
 	{
 		if (ParentContext is not null)
@@ -129,6 +130,18 @@ class SourceGenContext(IndentedTextWriter writer, Compilation compilation, Sourc
 	// redeclaring it. Returns true the first time a name is seen, false afterwards. See dotnet/maui#36682.
 	public bool TryReserveTemplateMethod(string name)
 		=> ParentContext != null ? ParentContext.TryReserveTemplateMethod(name) : _emittedTemplateMethods.Add(name);
+
+	public bool TryGetNodeId(ElementNode node, out string nodeId)
+	{
+		if (ParentContext != null)
+			return ParentContext.TryGetNodeId(node, out nodeId);
+
+		if (NodeIds != null && NodeIds.TryGetValue(node, out nodeId!))
+			return true;
+
+		nodeId = string.Empty;
+		return false;
+	}
 
 	internal Dictionary<ITypeSymbol, (ConverterDelegate, ITypeSymbol)>? knownSGTypeConverters;
 	internal Dictionary<ITypeSymbol, IKnownMarkupValueProvider>? knownSGValueProviders;

--- a/src/Controls/src/SourceGen/UpdateComponentCodeWriter.cs
+++ b/src/Controls/src/SourceGen/UpdateComponentCodeWriter.cs
@@ -73,7 +73,8 @@ static class UpdateComponentCodeWriter
 		Dictionary<ElementNode, string>? newIds = null,
 		SourceProductionContext sourceProductionContext = default,
 		ProjectItem? projectItem = null,
-		Dictionary<string, XmlType>? generatedFields = null)
+		Dictionary<string, XmlType>? generatedFields = null,
+		ISet<string>? templateNodeIds = null)
 	{
 		if (diff.IsEmpty)
 			return null;
@@ -127,7 +128,10 @@ static class UpdateComponentCodeWriter
 				continue;
 			}
 
-			codeWriter.WriteLine($"if (global::Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.TryGet(this, \"{nodeDiff.NodeId}\", out var {varName}))");
+			if (templateNodeIds?.Contains(nodeDiff.NodeId) == true)
+				codeWriter.WriteLine($"foreach (var {varName} in global::Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.GetTemplateComponents(this, \"{nodeDiff.NodeId}\"))");
+			else
+				codeWriter.WriteLine($"if (global::Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.TryGet(this, \"{nodeDiff.NodeId}\", out var {varName}))");
 			using (PrePost.NewBlock(codeWriter))
 			{
 				INamedTypeSymbol? nodeType = null;

--- a/src/Controls/src/SourceGen/UpdateComponentCodeWriter.cs
+++ b/src/Controls/src/SourceGen/UpdateComponentCodeWriter.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Maui.Controls.SourceGen;
 /// <item>IC compile-time converters (Color, Thickness, Enum, GridLength, etc.) — same pipeline as <c>InitializeComponent</c>.</item>
 /// <item>Language primitives (<c>string</c>, <c>bool</c>, <c>int</c>, <c>double</c>, etc.) — inline literal.</item>
 /// <item>Fallback — <c>TypeDescriptor.GetConverter(typeof(T)).ConvertFromInvariantString("value")</c>.</item>
-/// <item>Property not found on type — return (skip patch).</item>
+/// <item>Property not found on type — omit that property assignment.</item>
 /// </list>
 /// </para>
 /// </remarks>

--- a/src/Controls/src/SourceGen/Visitors/SetPropertiesVisitor.cs
+++ b/src/Controls/src/SourceGen/Visitors/SetPropertiesVisitor.cs
@@ -287,6 +287,15 @@ class SetPropertiesVisitor(SourceGenContext context, bool stopOnResourceDictiona
 						node.Accept(new SetNamescopesAndRegisterNamesVisitor(templateContext), null);
 						node.Accept(new SetResourcesVisitor(templateContext), null);
 						node.Accept(new SetPropertiesVisitor(templateContext, stopOnResourceDictionary: true), null);
+						foreach (var entry in templateContext.Variables)
+						{
+							if (entry.Key is ElementNode element
+								&& Context.TryGetNodeId(element, out var nodeId)
+								&& !string.IsNullOrEmpty(nodeId))
+							{
+								Writer.WriteLine($"global::Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.RegisterTemplateComponent(this, \"{nodeId}\", {entry.Value.ValueAccessor});");
+							}
+						}
 						Writer.WriteLine($"return {templateContext.Variables[node].ValueAccessor};");
 					}
 				}

--- a/src/Controls/src/SourceGen/Visitors/SetPropertiesVisitor.cs
+++ b/src/Controls/src/SourceGen/Visitors/SetPropertiesVisitor.cs
@@ -287,15 +287,19 @@ class SetPropertiesVisitor(SourceGenContext context, bool stopOnResourceDictiona
 						node.Accept(new SetNamescopesAndRegisterNamesVisitor(templateContext), null);
 						node.Accept(new SetResourcesVisitor(templateContext), null);
 						node.Accept(new SetPropertiesVisitor(templateContext, stopOnResourceDictionary: true), null);
+						var templateRegistrations = new List<(string NodeId, ILocalValue Value)>();
 						foreach (var entry in templateContext.Variables)
 						{
 							if (entry.Key is ElementNode element
 								&& Context.TryGetNodeId(element, out var nodeId)
 								&& !string.IsNullOrEmpty(nodeId))
 							{
-								Writer.WriteLine($"global::Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.RegisterTemplateComponent(this, \"{nodeId}\", {entry.Value.ValueAccessor});");
+								templateRegistrations.Add((nodeId, entry.Value));
 							}
 						}
+						templateRegistrations.Sort((left, right) => StringComparer.Ordinal.Compare(left.NodeId, right.NodeId));
+						foreach (var registration in templateRegistrations)
+							Writer.WriteLine($"global::Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.RegisterTemplateComponent(this, \"{registration.NodeId}\", {registration.Value.ValueAccessor});");
 						Writer.WriteLine($"return {templateContext.Variables[node].ValueAccessor};");
 					}
 				}

--- a/src/Controls/src/SourceGen/XamlNodeDiff.cs
+++ b/src/Controls/src/SourceGen/XamlNodeDiff.cs
@@ -438,7 +438,7 @@ static class XamlNodeDiff
 					&& newNode.Properties.TryGetValue(property.Key, out var newProperty)
 					&& newProperty is ElementNode newElement
 					&& XmlTypeEquals(oldElement.XmlType, newElement.XmlType)
-					&& ShouldDiffElementProperty(property.Key, oldElement, templateContent))
+					&& ShouldDiffElementProperty(oldNode, property.Key, oldElement, newElement, templateContent))
 				{
 					if (!DiffNode(oldElement, newElement, oldIds, newIds, effective, depth + 1, nodeChanges, childListChanges, childForceRefresh, templateContent))
 						return false;
@@ -829,7 +829,7 @@ static class XamlNodeDiff
 				if (oldPropNode is ElementNode oldElement
 					&& newPropNode is ElementNode newElement
 					&& XmlTypeEquals(oldElement.XmlType, newElement.XmlType)
-					&& ShouldDiffElementProperty(name, oldElement, insideTemplate))
+					&& ShouldDiffElementProperty(oldNode, name, oldElement, newElement, insideTemplate))
 				{
 					continue;
 				}
@@ -946,9 +946,28 @@ static class XamlNodeDiff
 		=> node.XmlType.RepresentsType(XamlParser.MauiUri, "DataTemplate")
 			|| node.XmlType.RepresentsType(XamlParser.MauiUri, "ControlTemplate");
 
-	static bool ShouldDiffElementProperty(XmlName propertyName, ElementNode element, bool insideTemplate)
-		=> insideTemplate
-			|| (propertyName.LocalName == "ItemTemplate" && IsTemplateNode(element));
+	static bool ShouldDiffElementProperty(
+		ElementNode owner,
+		XmlName propertyName,
+		ElementNode oldElement,
+		ElementNode newElement,
+		bool insideTemplate)
+	{
+		// Retyping a template regenerates compiled binding accessors. Keep the owning
+		// property on the conservative complex-property path instead of partially
+		// patching the old realized subtree.
+		if (IsTemplateNode(oldElement) && DetectXDataTypeChange(oldElement, newElement))
+			return false;
+
+		if (insideTemplate)
+			return true;
+
+		// #37890 is intentionally limited to a direct CollectionView.ItemTemplate.
+		// Do not opt unrelated controls with a same-named property into this path.
+		return owner.XmlType.RepresentsType(XamlParser.MauiUri, "CollectionView")
+			&& propertyName.LocalName == "ItemTemplate"
+			&& IsTemplateNode(oldElement);
+	}
 
 	/// <summary>
 	/// Returns <see langword="true"/> when the value of <c>x:DataType</c> on this node

--- a/src/Controls/src/SourceGen/XamlNodeDiff.cs
+++ b/src/Controls/src/SourceGen/XamlNodeDiff.cs
@@ -388,7 +388,8 @@ static class XamlNodeDiff
 		Dictionary<ElementNode, string> oldIds, Dictionary<ElementNode, string> newIds,
 		Dictionary<ElementNode, string> effective, int depth,
 		List<NodeDiff> nodeChanges, List<ChildListChangeDiff> childListChanges,
-		bool forceBindingRefresh = false)
+		bool forceBindingRefresh = false,
+		bool insideTemplate = false)
 	{
 		// Structural check: element type must match
 		if (!XmlTypeEquals(oldNode.XmlType, newNode.XmlType))
@@ -409,12 +410,18 @@ static class XamlNodeDiff
 		// bindings as needing refresh too (not just descendant bindings). Otherwise a binding
 		// whose markup string is unchanged but whose type context shifted would silently keep
 		// its stale compiled binding accessor.
+		bool isTemplateNode = IsTemplateNode(oldNode);
 		bool xDataTypeChangesOnThisNode = DetectXDataTypeChange(oldNode, newNode);
+		// Template retypes are intentionally left on the existing conservative path. They regenerate
+		// compiled binding accessors and are part of the separate successive-edit identity work in #36482.
+		bool skipTemplateContentDiff = xDataTypeChangesOnThisNode
+			&& isTemplateNode;
+		bool templateContent = insideTemplate || isTemplateNode;
 		bool effectiveForce = forceBindingRefresh || xDataTypeChangesOnThisNode;
 
 		// Diff properties (simple value attributes)
 		var propDiffs = new List<PropertyDiff>();
-		if (!DiffProperties(oldNode, newNode, propDiffs, effectiveForce, out var xDataTypeChanged))
+		if (!DiffProperties(oldNode, newNode, propDiffs, effectiveForce, templateContent, out var xDataTypeChanged))
 			return false;
 
 		if (propDiffs.Count > 0)
@@ -423,8 +430,24 @@ static class XamlNodeDiff
 		// If x:DataType changed on this node, propagate to all descendant bindings
 		bool childForceRefresh = forceBindingRefresh || xDataTypeChanged;
 
+		if (!skipTemplateContentDiff)
+		{
+			foreach (var property in oldNode.Properties)
+			{
+				if (property.Value is ElementNode oldElement
+					&& newNode.Properties.TryGetValue(property.Key, out var newProperty)
+					&& newProperty is ElementNode newElement
+					&& XmlTypeEquals(oldElement.XmlType, newElement.XmlType)
+					&& ShouldDiffElementProperty(property.Key, oldElement, templateContent))
+				{
+					if (!DiffNode(oldElement, newElement, oldIds, newIds, effective, depth + 1, nodeChanges, childListChanges, childForceRefresh, templateContent))
+						return false;
+				}
+			}
+		}
+
 		// Diff children
-		return DiffChildren(oldNode, newNode, nodeId, oldIds, newIds, effective, depth, nodeChanges, childListChanges, childForceRefresh);
+		return DiffChildren(oldNode, newNode, nodeId, oldIds, newIds, effective, depth, nodeChanges, childListChanges, childForceRefresh, templateContent);
 	}
 
 	/// <summary>
@@ -437,7 +460,8 @@ static class XamlNodeDiff
 		Dictionary<ElementNode, string> oldIds, Dictionary<ElementNode, string> newIds,
 		Dictionary<ElementNode, string> effective, int depth,
 		List<NodeDiff> nodeChanges, List<ChildListChangeDiff> childListChanges,
-		bool forceBindingRefresh = false)
+		bool forceBindingRefresh = false,
+		bool insideTemplate = false)
 	{
 		int oldCount = oldNode.CollectionItems.Count;
 		int newCount = newNode.CollectionItems.Count;
@@ -464,7 +488,7 @@ static class XamlNodeDiff
 		{
 			if (oldCount != newCount)
 				return false;
-			return DiffChildrenPositional(oldNode, newNode, parentNodeId, oldIds, newIds, effective, depth, nodeChanges, childListChanges, forceBindingRefresh);
+			return DiffChildrenPositional(oldNode, newNode, parentNodeId, oldIds, newIds, effective, depth, nodeChanges, childListChanges, forceBindingRefresh, insideTemplate);
 		}
 
 		// All children are elements. Fast path: same count + same positional types → no child list change
@@ -492,7 +516,7 @@ static class XamlNodeDiff
 			{
 				// If no duplicate types, positional is unambiguous — use fast path
 				if (!hasDuplicateTypes)
-					return DiffChildrenPositional(oldNode, newNode, parentNodeId, oldIds, newIds, effective, depth, nodeChanges, childListChanges, forceBindingRefresh);
+					return DiffChildrenPositional(oldNode, newNode, parentNodeId, oldIds, newIds, effective, depth, nodeChanges, childListChanges, forceBindingRefresh, insideTemplate);
 
 				// Duplicate types exist — use cost-based matching to find optimal assignment.
 				// If the optimal assignment is the identity (same as positional), use fast path.
@@ -538,7 +562,7 @@ static class XamlNodeDiff
 				}
 
 				if (isIdentity)
-					return DiffChildrenPositional(oldNode, newNode, parentNodeId, oldIds, newIds, effective, depth, nodeChanges, childListChanges, forceBindingRefresh);
+					return DiffChildrenPositional(oldNode, newNode, parentNodeId, oldIds, newIds, effective, depth, nodeChanges, childListChanges, forceBindingRefresh, insideTemplate);
 
 				// Optimal matching differs from positional — fall through to general case
 				// which will produce a ChildListChangeDiff with reorder
@@ -546,7 +570,7 @@ static class XamlNodeDiff
 		}
 
 		// General case: type-based matching for reorder/add/remove
-		return DiffChildrenWithMatching(oldNode, newNode, parentNodeId, oldIds, newIds, effective, depth, nodeChanges, childListChanges, forceBindingRefresh);
+		return DiffChildrenWithMatching(oldNode, newNode, parentNodeId, oldIds, newIds, effective, depth, nodeChanges, childListChanges, forceBindingRefresh, insideTemplate);
 	}
 
 	/// <summary>
@@ -559,7 +583,8 @@ static class XamlNodeDiff
 		Dictionary<ElementNode, string> oldIds, Dictionary<ElementNode, string> newIds,
 		Dictionary<ElementNode, string> effective, int depth,
 		List<NodeDiff> nodeChanges, List<ChildListChangeDiff> childListChanges,
-		bool forceBindingRefresh = false)
+		bool forceBindingRefresh = false,
+		bool insideTemplate = false)
 	{
 		int count = oldNode.CollectionItems.Count;
 		for (int i = 0; i < count; i++)
@@ -569,7 +594,7 @@ static class XamlNodeDiff
 
 			if (oldChild is ElementNode oldElem && newChild is ElementNode newElem)
 			{
-				if (!DiffNode(oldElem, newElem, oldIds, newIds, effective, depth + 1, nodeChanges, childListChanges, forceBindingRefresh))
+				if (!DiffNode(oldElem, newElem, oldIds, newIds, effective, depth + 1, nodeChanges, childListChanges, forceBindingRefresh, insideTemplate))
 					return false;
 			}
 			else if (oldChild is ValueNode oldVal && newChild is ValueNode newVal)
@@ -602,7 +627,8 @@ static class XamlNodeDiff
 		Dictionary<ElementNode, string> oldIds, Dictionary<ElementNode, string> newIds,
 		Dictionary<ElementNode, string> effective, int depth,
 		List<NodeDiff> nodeChanges, List<ChildListChangeDiff> childListChanges,
-		bool forceBindingRefresh = false)
+		bool forceBindingRefresh = false,
+		bool insideTemplate = false)
 	{
 		int oldCount = oldNode.CollectionItems.Count;
 		int newCount = newNode.CollectionItems.Count;
@@ -682,7 +708,7 @@ static class XamlNodeDiff
 		// Recursively diff matched pairs (old IDs are transplanted inside DiffNode)
 		foreach (var (oldIdx, newIdx) in matched)
 		{
-			if (!DiffNode(oldChildren[oldIdx], newChildren[newIdx], oldIds, newIds, effective, depth + 1, nodeChanges, childListChanges, forceBindingRefresh))
+			if (!DiffNode(oldChildren[oldIdx], newChildren[newIdx], oldIds, newIds, effective, depth + 1, nodeChanges, childListChanges, forceBindingRefresh, insideTemplate))
 				return false;
 		}
 
@@ -771,7 +797,7 @@ static class XamlNodeDiff
 	/// <c>x:DataType</c> changes from ancestor nodes.
 	/// </summary>
 	static bool DiffProperties(ElementNode oldNode, ElementNode newNode, List<PropertyDiff> diffs,
-		bool forceBindingRefresh, out bool xDataTypeChanged)
+		bool forceBindingRefresh, bool insideTemplate, out bool xDataTypeChanged)
 	{
 		xDataTypeChanged = false;
 
@@ -799,6 +825,14 @@ static class XamlNodeDiff
 				// Both sides have the property — compare values
 				bool valueChanged = !NodeValueEquals(oldPropNode, newPropNode);
 				bool forceThisBinding = forceBindingRefresh && IsBindingMarkup(newPropNode);
+
+				if (oldPropNode is ElementNode oldElement
+					&& newPropNode is ElementNode newElement
+					&& XmlTypeEquals(oldElement.XmlType, newElement.XmlType)
+					&& ShouldDiffElementProperty(name, oldElement, insideTemplate))
+				{
+					continue;
+				}
 
 				if (valueChanged || forceThisBinding)
 				{
@@ -907,6 +941,14 @@ static class XamlNodeDiff
 		=> node is MarkupNode mn
 			&& (mn.MarkupString.StartsWith("{Binding", StringComparison.Ordinal)
 				|| mn.MarkupString.StartsWith("{TemplateBinding", StringComparison.Ordinal));
+
+	static bool IsTemplateNode(ElementNode node)
+		=> node.XmlType.RepresentsType(XamlParser.MauiUri, "DataTemplate")
+			|| node.XmlType.RepresentsType(XamlParser.MauiUri, "ControlTemplate");
+
+	static bool ShouldDiffElementProperty(XmlName propertyName, ElementNode element, bool insideTemplate)
+		=> insideTemplate
+			|| (propertyName.LocalName == "ItemTemplate" && IsTemplateNode(element));
 
 	/// <summary>
 	/// Returns <see langword="true"/> when the value of <c>x:DataType</c> on this node

--- a/src/Controls/src/Xaml/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Xaml/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -12,9 +12,11 @@ static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.FindStaticResource(obj
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.GetComponent(object! page, string! nodeId) -> object?
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.GetInstances(System.Type! pageType) -> System.Collections.Generic.IReadOnlyList<object!>!
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.GetResourceKeys(object! page) -> string![]!
+static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.GetTemplateComponents(object! page, string! nodeId) -> System.Collections.Generic.IReadOnlyList<object!>!
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.Register(object! page, string! nodeId, object! component) -> void
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.RegisterComponent(object! element, string! nodeId) -> void
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.RegisterResourceKeys(object! page, string![]! keys) -> void
+static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.RegisterTemplateComponent(object! page, string! nodeId, object! component) -> void
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.TryGet(object! page, string! nodeId, out object? component) -> bool
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.Unregister(object! page) -> void
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.Unregister(object! page, string! nodeId) -> void

--- a/src/Controls/src/Xaml/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Xaml/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -12,9 +12,11 @@ static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.FindStaticResource(obj
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.GetComponent(object! page, string! nodeId) -> object?
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.GetInstances(System.Type! pageType) -> System.Collections.Generic.IReadOnlyList<object!>!
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.GetResourceKeys(object! page) -> string![]!
+static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.GetTemplateComponents(object! page, string! nodeId) -> System.Collections.Generic.IReadOnlyList<object!>!
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.Register(object! page, string! nodeId, object! component) -> void
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.RegisterComponent(object! element, string! nodeId) -> void
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.RegisterResourceKeys(object! page, string![]! keys) -> void
+static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.RegisterTemplateComponent(object! page, string! nodeId, object! component) -> void
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.TryGet(object! page, string! nodeId, out object? component) -> bool
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.Unregister(object! page) -> void
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.Unregister(object! page, string! nodeId) -> void

--- a/src/Controls/src/Xaml/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Xaml/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -12,9 +12,11 @@ static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.FindStaticResource(obj
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.GetComponent(object! page, string! nodeId) -> object?
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.GetInstances(System.Type! pageType) -> System.Collections.Generic.IReadOnlyList<object!>!
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.GetResourceKeys(object! page) -> string![]!
+static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.GetTemplateComponents(object! page, string! nodeId) -> System.Collections.Generic.IReadOnlyList<object!>!
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.Register(object! page, string! nodeId, object! component) -> void
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.RegisterComponent(object! element, string! nodeId) -> void
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.RegisterResourceKeys(object! page, string![]! keys) -> void
+static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.RegisterTemplateComponent(object! page, string! nodeId, object! component) -> void
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.TryGet(object! page, string! nodeId, out object? component) -> bool
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.Unregister(object! page) -> void
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.Unregister(object! page, string! nodeId) -> void

--- a/src/Controls/src/Xaml/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Xaml/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -12,9 +12,11 @@ static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.FindStaticResource(obj
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.GetComponent(object! page, string! nodeId) -> object?
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.GetInstances(System.Type! pageType) -> System.Collections.Generic.IReadOnlyList<object!>!
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.GetResourceKeys(object! page) -> string![]!
+static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.GetTemplateComponents(object! page, string! nodeId) -> System.Collections.Generic.IReadOnlyList<object!>!
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.Register(object! page, string! nodeId, object! component) -> void
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.RegisterComponent(object! element, string! nodeId) -> void
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.RegisterResourceKeys(object! page, string![]! keys) -> void
+static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.RegisterTemplateComponent(object! page, string! nodeId, object! component) -> void
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.TryGet(object! page, string! nodeId, out object? component) -> bool
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.Unregister(object! page) -> void
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.Unregister(object! page, string! nodeId) -> void

--- a/src/Controls/src/Xaml/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Xaml/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -12,9 +12,11 @@ static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.FindStaticResource(obj
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.GetComponent(object! page, string! nodeId) -> object?
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.GetInstances(System.Type! pageType) -> System.Collections.Generic.IReadOnlyList<object!>!
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.GetResourceKeys(object! page) -> string![]!
+static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.GetTemplateComponents(object! page, string! nodeId) -> System.Collections.Generic.IReadOnlyList<object!>!
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.Register(object! page, string! nodeId, object! component) -> void
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.RegisterComponent(object! element, string! nodeId) -> void
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.RegisterResourceKeys(object! page, string![]! keys) -> void
+static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.RegisterTemplateComponent(object! page, string! nodeId, object! component) -> void
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.TryGet(object! page, string! nodeId, out object? component) -> bool
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.Unregister(object! page) -> void
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.Unregister(object! page, string! nodeId) -> void

--- a/src/Controls/src/Xaml/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Xaml/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -13,9 +13,11 @@ static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.FindStaticResource(obj
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.GetComponent(object! page, string! nodeId) -> object?
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.GetInstances(System.Type! pageType) -> System.Collections.Generic.IReadOnlyList<object!>!
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.GetResourceKeys(object! page) -> string![]!
+static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.GetTemplateComponents(object! page, string! nodeId) -> System.Collections.Generic.IReadOnlyList<object!>!
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.Register(object! page, string! nodeId, object! component) -> void
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.RegisterComponent(object! element, string! nodeId) -> void
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.RegisterResourceKeys(object! page, string![]! keys) -> void
+static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.RegisterTemplateComponent(object! page, string! nodeId, object! component) -> void
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.TryGet(object! page, string! nodeId, out object? component) -> bool
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.Unregister(object! page) -> void
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.Unregister(object! page, string! nodeId) -> void

--- a/src/Controls/src/Xaml/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Xaml/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -12,9 +12,11 @@ static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.FindStaticResource(obj
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.GetComponent(object! page, string! nodeId) -> object?
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.GetInstances(System.Type! pageType) -> System.Collections.Generic.IReadOnlyList<object!>!
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.GetResourceKeys(object! page) -> string![]!
+static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.GetTemplateComponents(object! page, string! nodeId) -> System.Collections.Generic.IReadOnlyList<object!>!
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.Register(object! page, string! nodeId, object! component) -> void
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.RegisterComponent(object! element, string! nodeId) -> void
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.RegisterResourceKeys(object! page, string![]! keys) -> void
+static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.RegisterTemplateComponent(object! page, string! nodeId, object! component) -> void
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.TryGet(object! page, string! nodeId, out object? component) -> bool
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.Unregister(object! page) -> void
 static Microsoft.Maui.Controls.Xaml.XamlComponentRegistry.Unregister(object! page, string! nodeId) -> void

--- a/src/Controls/src/Xaml/XamlComponentRegistry.cs
+++ b/src/Controls/src/Xaml/XamlComponentRegistry.cs
@@ -423,14 +423,6 @@ public static class XamlComponentRegistry
 				_templateEntries[nodeId] = entries;
 			}
 
-			for (int i = entries.Count - 1; i >= 0; i--)
-			{
-				if (!entries[i].TryGetTarget(out var target))
-					entries.RemoveAt(i);
-				else if (ReferenceEquals(target, component))
-					return;
-			}
-
 			entries.Add(new WeakReference<object>(component));
 		}
 

--- a/src/Controls/src/Xaml/XamlComponentRegistry.cs
+++ b/src/Controls/src/Xaml/XamlComponentRegistry.cs
@@ -62,6 +62,32 @@ public static class XamlComponentRegistry
 	}
 
 	/// <summary>
+	/// Registers a realized component created by a data or control template.
+	/// Multiple live components may share the same XAML node ID.
+	/// </summary>
+	public static void RegisterTemplateComponent(object page, string nodeId, object component)
+	{
+		if (page is null)
+			throw new ArgumentNullException(nameof(page));
+		if (nodeId is null)
+			throw new ArgumentNullException(nameof(nodeId));
+		if (component is null)
+			throw new ArgumentNullException(nameof(component));
+
+		var map = s_table.GetOrCreateValue(page);
+		bool firstRegistration;
+		lock (map)
+		{
+			firstRegistration = map.IsNew;
+			map.IsNew = false;
+			map.AddTemplateComponent(nodeId, component);
+		}
+
+		if (firstRegistration)
+			TrackInstance(page);
+	}
+
+	/// <summary>
 	/// Tries to retrieve the live component registered under <paramref name="nodeId"/> for <paramref name="page"/>.
 	/// Called from generated <c>UpdateComponent()</c>.
 	/// </summary>
@@ -83,6 +109,28 @@ public static class XamlComponentRegistry
 
 		component = null;
 		return false;
+	}
+
+	/// <summary>
+	/// Returns a snapshot of the live components realized from the template node identified by
+	/// <paramref name="nodeId"/>.
+	/// </summary>
+	public static IReadOnlyList<object> GetTemplateComponents(object page, string nodeId)
+	{
+		if (page is null)
+			throw new ArgumentNullException(nameof(page));
+		if (nodeId is null)
+			throw new ArgumentNullException(nameof(nodeId));
+
+		if (s_table.TryGetValue(page, out var map))
+		{
+			lock (map)
+			{
+				return map.GetTemplateComponents(nodeId);
+			}
+		}
+
+		return Array.Empty<object>();
 	}
 
 	/// <summary>
@@ -354,6 +402,7 @@ public static class XamlComponentRegistry
 	sealed class ComponentMap
 	{
 		readonly Dictionary<string, WeakReference<object>> _entries = new(StringComparer.Ordinal);
+		readonly Dictionary<string, List<WeakReference<object>>> _templateEntries = new(StringComparer.Ordinal);
 
 		/// <summary>True until the first call to <see cref="Set"/>, used to detect first registration.</summary>
 		public bool IsNew { get; set; } = true;
@@ -364,6 +413,45 @@ public static class XamlComponentRegistry
 				existing.SetTarget(component);
 			else
 				_entries[nodeId] = new WeakReference<object>(component);
+		}
+
+		public void AddTemplateComponent(string nodeId, object component)
+		{
+			if (!_templateEntries.TryGetValue(nodeId, out var entries))
+			{
+				entries = new List<WeakReference<object>>();
+				_templateEntries[nodeId] = entries;
+			}
+
+			for (int i = entries.Count - 1; i >= 0; i--)
+			{
+				if (!entries[i].TryGetTarget(out var target))
+					entries.RemoveAt(i);
+				else if (ReferenceEquals(target, component))
+					return;
+			}
+
+			entries.Add(new WeakReference<object>(component));
+		}
+
+		public IReadOnlyList<object> GetTemplateComponents(string nodeId)
+		{
+			if (!_templateEntries.TryGetValue(nodeId, out var entries))
+				return Array.Empty<object>();
+
+			var result = new List<object>(entries.Count);
+			for (int i = entries.Count - 1; i >= 0; i--)
+			{
+				if (entries[i].TryGetTarget(out var target))
+					result.Add(target);
+				else
+					entries.RemoveAt(i);
+			}
+
+			if (entries.Count == 0)
+				_templateEntries.Remove(nodeId);
+
+			return result;
 		}
 
 		public bool TryGet(string nodeId, out object? component)
@@ -395,11 +483,23 @@ public static class XamlComponentRegistry
 				_entries.Remove(r.OldKey);
 			foreach (var r in renames)
 				_entries[r.NewKey] = r.Value;
+
+			var templateRenames = new List<(string OldKey, string NewKey, List<WeakReference<object>> Value)>();
+			foreach (var key in _templateEntries.Keys)
+			{
+				if (IsNodeOrDescendant(key, oldPrefix))
+					templateRenames.Add((key, newPrefix + key.Substring(oldPrefix.Length), _templateEntries[key]));
+			}
+			foreach (var r in templateRenames)
+				_templateEntries.Remove(r.OldKey);
+			foreach (var r in templateRenames)
+				_templateEntries[r.NewKey] = r.Value;
 		}
 
 		public void Remove(string nodeId)
 		{
 			_entries.Remove(nodeId);
+			_templateEntries.Remove(nodeId);
 		}
 
 		public void RemoveSubtree(string nodeIdPrefix)
@@ -412,6 +512,15 @@ public static class XamlComponentRegistry
 			}
 			foreach (var key in keysToRemove)
 				_entries.Remove(key);
+
+			keysToRemove.Clear();
+			foreach (var key in _templateEntries.Keys)
+			{
+				if (IsNodeOrDescendant(key, nodeIdPrefix))
+					keysToRemove.Add(key);
+			}
+			foreach (var key in keysToRemove)
+				_templateEntries.Remove(key);
 		}
 
 		/// <summary>

--- a/src/Controls/src/Xaml/XamlComponentRegistry.cs
+++ b/src/Controls/src/Xaml/XamlComponentRegistry.cs
@@ -401,6 +401,8 @@ public static class XamlComponentRegistry
 	/// </summary>
 	sealed class ComponentMap
 	{
+		const int TemplateComponentPruneThreshold = 64;
+
 		readonly Dictionary<string, WeakReference<object>> _entries = new(StringComparer.Ordinal);
 		readonly Dictionary<string, List<WeakReference<object>>> _templateEntries = new(StringComparer.Ordinal);
 
@@ -424,6 +426,15 @@ public static class XamlComponentRegistry
 			}
 
 			entries.Add(new WeakReference<object>(component));
+
+			// Compact at geometrically spaced sizes. This keeps registration amortized O(1)
+			// when all realizations are live, while steady virtualization churn cannot grow
+			// dead wrappers past the next doubling (or the initial threshold).
+			if (entries.Count >= TemplateComponentPruneThreshold
+				&& (entries.Count & (entries.Count - 1)) == 0)
+			{
+				PruneDeadEntries(entries);
+			}
 		}
 
 		public IReadOnlyList<object> GetTemplateComponents(string nodeId)
@@ -436,14 +447,22 @@ public static class XamlComponentRegistry
 			{
 				if (entries[i].TryGetTarget(out var target))
 					result.Add(target);
-				else
-					entries.RemoveAt(i);
 			}
 
+			PruneDeadEntries(entries);
 			if (entries.Count == 0)
 				_templateEntries.Remove(nodeId);
 
 			return result;
+		}
+
+		static void PruneDeadEntries(List<WeakReference<object>> entries)
+		{
+			for (int i = entries.Count - 1; i >= 0; i--)
+			{
+				if (!entries[i].TryGetTarget(out _))
+					entries.RemoveAt(i);
+			}
 		}
 
 		public bool TryGet(string nodeId, out object? component)

--- a/src/Controls/tests/Core.UnitTests/XamlComponentRegistryTests.cs
+++ b/src/Controls/tests/Core.UnitTests/XamlComponentRegistryTests.cs
@@ -82,6 +82,35 @@ public class XamlComponentRegistryTests
 	}
 
 	[Fact]
+	public void RegisterTemplateComponent_MultipleInstances_AllRetrievable()
+	{
+		var page = new object();
+		var first = new object();
+		var second = new object();
+
+		XamlComponentRegistry.RegisterTemplateComponent(page, "label_0", first);
+		XamlComponentRegistry.RegisterTemplateComponent(page, "label_0", second);
+
+		var components = XamlComponentRegistry.GetTemplateComponents(page, "label_0");
+
+		Assert.Equal(2, components.Count);
+		Assert.Contains(first, components);
+		Assert.Contains(second, components);
+	}
+
+	[Fact]
+	public void RegisterTemplateComponent_SameInstance_DoesNotDuplicate()
+	{
+		var page = new object();
+		var label = new object();
+
+		XamlComponentRegistry.RegisterTemplateComponent(page, "label_0", label);
+		XamlComponentRegistry.RegisterTemplateComponent(page, "label_0", label);
+
+		Assert.Single(XamlComponentRegistry.GetTemplateComponents(page, "label_0"));
+	}
+
+	[Fact]
 	public void Register_TwoPagesWithSameNodeId_AreIndependent()
 	{
 		var page1 = new object();
@@ -296,6 +325,17 @@ public class XamlComponentRegistryTests
 		// Sibling preserved
 		Assert.True(XamlComponentRegistry.TryGet(page, "VSL_0/Button_1", out var found));
 		Assert.Same(sibling, found);
+	}
+
+	[Fact]
+	public void Unregister_RemovesTemplateComponentsForNode()
+	{
+		var page = new object();
+		XamlComponentRegistry.RegisterTemplateComponent(page, "label_0", new object());
+
+		XamlComponentRegistry.Unregister(page, "label_0");
+
+		Assert.Empty(XamlComponentRegistry.GetTemplateComponents(page, "label_0"));
 	}
 
 	[Fact]

--- a/src/Controls/tests/Core.UnitTests/XamlComponentRegistryTests.cs
+++ b/src/Controls/tests/Core.UnitTests/XamlComponentRegistryTests.cs
@@ -99,18 +99,6 @@ public class XamlComponentRegistryTests
 	}
 
 	[Fact]
-	public void RegisterTemplateComponent_SameInstance_DoesNotDuplicate()
-	{
-		var page = new object();
-		var label = new object();
-
-		XamlComponentRegistry.RegisterTemplateComponent(page, "label_0", label);
-		XamlComponentRegistry.RegisterTemplateComponent(page, "label_0", label);
-
-		Assert.Single(XamlComponentRegistry.GetTemplateComponents(page, "label_0"));
-	}
-
-	[Fact]
 	public void Register_TwoPagesWithSameNodeId_AreIndependent()
 	{
 		var page1 = new object();

--- a/src/Controls/tests/Core.UnitTests/XamlComponentRegistryTests.cs
+++ b/src/Controls/tests/Core.UnitTests/XamlComponentRegistryTests.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 using Microsoft.Maui.Controls.Xaml;
 using Xunit;
 
@@ -96,6 +99,25 @@ public class XamlComponentRegistryTests
 		Assert.Equal(2, components.Count);
 		Assert.Contains(first, components);
 		Assert.Contains(second, components);
+	}
+
+	[Fact]
+	public void RegisterTemplateComponent_PrunesDeadEntriesAtGeometricThreshold()
+	{
+		var page = new object();
+		const string nodeId = "label_0";
+
+		for (int i = 0; i < 63; i++)
+			RegisterEphemeralTemplateComponent(page, nodeId);
+
+		CollectGarbage();
+
+		var live = new object();
+		XamlComponentRegistry.RegisterTemplateComponent(page, nodeId, live);
+
+		Assert.Equal(1, GetTemplateRegistrationCount(page, nodeId));
+		GC.KeepAlive(live);
+		GC.KeepAlive(page);
 	}
 
 	[Fact]
@@ -363,6 +385,38 @@ public class XamlComponentRegistryTests
 
 		Assert.Same(comp, XamlComponentRegistry.GetComponent(page, "Label_0"));
 		Assert.Null(XamlComponentRegistry.GetComponent(page, "NotRegistered"));
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static void RegisterEphemeralTemplateComponent(object page, string nodeId) =>
+		XamlComponentRegistry.RegisterTemplateComponent(page, nodeId, new object());
+
+	static void CollectGarbage()
+	{
+		GC.Collect();
+		GC.WaitForPendingFinalizers();
+		GC.Collect();
+	}
+
+	static int GetTemplateRegistrationCount(object page, string nodeId)
+	{
+		var tableField = typeof(XamlComponentRegistry).GetField("s_table", BindingFlags.NonPublic | BindingFlags.Static);
+		Assert.NotNull(tableField);
+		var table = tableField.GetValue(null);
+		Assert.NotNull(table);
+
+		var tryGetValue = table.GetType().GetMethod("TryGetValue");
+		Assert.NotNull(tryGetValue);
+		var arguments = new object[] { page, null };
+		Assert.True((bool)tryGetValue.Invoke(table, arguments)!);
+		var map = arguments[1];
+		Assert.NotNull(map);
+
+		var entriesField = map.GetType().GetField("_templateEntries", BindingFlags.NonPublic | BindingFlags.Instance);
+		Assert.NotNull(entriesField);
+		var entries = Assert.IsAssignableFrom<IDictionary>(entriesField.GetValue(map));
+		var registrations = Assert.IsAssignableFrom<ICollection>(entries[nodeId]);
+		return registrations.Count;
 	}
 
 	sealed class FakePage { }

--- a/src/Controls/tests/SourceGen.UnitTests/HotReload/AiAssisted/TemplateAndSelectorHotReloadTests.DataTemplates.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/HotReload/AiAssisted/TemplateAndSelectorHotReloadTests.DataTemplates.cs
@@ -44,6 +44,69 @@ public partial class TemplateAndSelectorHotReloadTests
 		});
 	}
 
+	[Fact]
+	public void CollectionViewItemTemplate_RetypeUsesConservativePropertyDiff()
+	{
+		using var harness = CreateHarness(additionalSources: ItemTypesSource);
+		var generation = harness.Generate(
+			CollectionViewCompiledItemTemplateXaml("local:ItemA", "Caption"),
+			CollectionViewCompiledItemTemplateXaml("local:ItemB", "Heading"));
+		var updateComponentSource = generation[1].UpdateComponentSource;
+
+		Assert.NotNull(updateComponentSource);
+		Assert.Contains("Complex property 'ItemTemplate'", updateComponentSource!, StringComparison.Ordinal);
+		Assert.DoesNotContain("GetTemplateComponents", updateComponentSource, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void CollectionViewItemTemplatePatch_EnumeratesWithoutEmittedEarlyExit()
+	{
+		using var harness = CreateHarness();
+		var generation = harness.Generate(
+			CollectionViewItemTemplateXaml("Cell"),
+			CollectionViewItemTemplateXaml("Row"));
+		var updateComponentSource = generation[1].UpdateComponentSource;
+
+		Assert.NotNull(updateComponentSource);
+		Assert.Contains("foreach (var", updateComponentSource!, StringComparison.Ordinal);
+		Assert.Contains("GetTemplateComponents", updateComponentSource, StringComparison.Ordinal);
+		Assert.DoesNotContain("return;", updateComponentSource, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void ItemTemplateFastPath_DoesNotMatchUnrelatedOwner()
+	{
+		using var harness = CreateHarness(additionalSources: CustomItemTemplateHostSource);
+		var generation = harness.Generate(
+			CustomItemTemplateHostXaml("Before"),
+			CustomItemTemplateHostXaml("After"));
+		var updateComponentSource = generation[1].UpdateComponentSource;
+
+		Assert.NotNull(updateComponentSource);
+		Assert.Contains("Complex property 'ItemTemplate'", updateComponentSource!, StringComparison.Ordinal);
+		Assert.DoesNotContain("GetTemplateComponents", updateComponentSource, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void TemplateComponentRegistrations_AreOrderedByStableNodeId()
+	{
+		using var harness = CreateHarness();
+		var generation = harness.Generate(
+			CollectionViewMultiNodeItemTemplateXaml(),
+			CollectionViewMultiNodeItemTemplateXaml());
+		var initializeComponentSource = generation[0].InitializeComponentSource;
+
+		Assert.NotNull(initializeComponentSource);
+		var registrations = initializeComponentSource!
+			.Split('\n')
+			.Where(line => line.Contains("RegisterTemplateComponent", StringComparison.Ordinal))
+			.ToArray();
+		Assert.True(registrations.Length >= 3);
+		Assert.Equal(
+			registrations.OrderBy(line => line, StringComparer.Ordinal),
+			registrations);
+	}
+
 	// Wave-2 · Templates · TS-01 (GREEN anchor)
 	// Provenance: MAUI §hot-reload DataTemplate realization; SetPropertiesVisitor.cs L245-296 (#36482);
 	//             UpdateComponent resource-replacement verified by dumping the generated V2 source.

--- a/src/Controls/tests/SourceGen.UnitTests/HotReload/AiAssisted/TemplateAndSelectorHotReloadTests.DataTemplates.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/HotReload/AiAssisted/TemplateAndSelectorHotReloadTests.DataTemplates.cs
@@ -12,6 +12,38 @@ namespace Microsoft.Maui.Controls.SourceGen.UnitTests.HotReload.AiAssisted;
 
 public partial class TemplateAndSelectorHotReloadTests
 {
+	// Regression for dotnet/maui#37890. Creating template content is the unit-level realization
+	// boundary used by CollectionView handlers; the same instances must receive the first accepted edit.
+	[MetadataUpdateFact]
+	public void CollectionViewItemTemplate_FirstEditUpdatesAlreadyRealizedContent()
+	{
+		using var harness = CreateHarness();
+		var generation = harness.Generate(
+			CollectionViewItemTemplateXaml("Cell"),
+			CollectionViewItemTemplateXaml("Row"));
+		Assert.Contains("RegisterTemplateComponent", generation[0].InitializeComponentSource, StringComparison.Ordinal);
+		Assert.Contains("GetTemplateComponents", generation[1].UpdateComponentSource, StringComparison.Ordinal);
+
+		harness.RunLive(generation, live =>
+		{
+			var page = live.GetInstance<ContentPage>();
+			var collectionView = Assert.IsType<CollectionView>(page.Content);
+			var template = Assert.IsType<DataTemplate>(collectionView.ItemTemplate);
+			var first = Assert.IsType<Label>(template.CreateContent());
+			var second = Assert.IsType<Label>(template.CreateContent());
+			first.BindingContext = "item 00";
+			second.BindingContext = "item 01";
+
+			Assert.Equal("Cell item 00", first.Text);
+			Assert.Equal("Cell item 01", second.Text);
+
+			Assert.Same(page, live.ApplyUpdate<ContentPage>(1));
+			Assert.Same(template, collectionView.ItemTemplate);
+			Assert.Equal("Row item 00", first.Text);
+			Assert.Equal("Row item 01", second.Text);
+		});
+	}
+
 	// Wave-2 · Templates · TS-01 (GREEN anchor)
 	// Provenance: MAUI §hot-reload DataTemplate realization; SetPropertiesVisitor.cs L245-296 (#36482);
 	//             UpdateComponent resource-replacement verified by dumping the generated V2 source.

--- a/src/Controls/tests/SourceGen.UnitTests/HotReload/AiAssisted/TemplateAndSelectorHotReloadTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/HotReload/AiAssisted/TemplateAndSelectorHotReloadTests.cs
@@ -100,6 +100,20 @@ public partial class TemplateAndSelectorHotReloadTests
 		</ContentPage>
 		""";
 
+	static string CollectionViewItemTemplateXaml(string prefix) => $$"""
+		<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+		             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+		             x:Class="TestTemplates.MainPage">
+		  <CollectionView>
+		    <CollectionView.ItemTemplate>
+		      <DataTemplate>
+		        <Label Text="{Binding ., StringFormat='{{prefix}} {0}'}" />
+		      </DataTemplate>
+		    </CollectionView.ItemTemplate>
+		  </CollectionView>
+		</ContentPage>
+		""";
+
 	static string SelectorXaml(string oddText) => $$"""
 		<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 		             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"

--- a/src/Controls/tests/SourceGen.UnitTests/HotReload/AiAssisted/TemplateAndSelectorHotReloadTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/HotReload/AiAssisted/TemplateAndSelectorHotReloadTests.cs
@@ -72,6 +72,15 @@ public partial class TemplateAndSelectorHotReloadTests
 		public sealed class ItemB { public string? Heading { get; set; } }
 		""";
 
+	const string CustomItemTemplateHostSource = """
+		namespace TestTemplates;
+
+		public sealed class CustomItemTemplateHost : global::Microsoft.Maui.Controls.ContentView
+		{
+			public global::Microsoft.Maui.Controls.DataTemplate? ItemTemplate { get; set; }
+		}
+		""";
+
 	static XamlHotReloadTestHarness CreateHarness([CallerMemberName] string scenarioName = "", params string[] additionalSources) =>
 		new(scenarioName, PageClass, PageStub, additionalSources);
 
@@ -111,6 +120,54 @@ public partial class TemplateAndSelectorHotReloadTests
 		      </DataTemplate>
 		    </CollectionView.ItemTemplate>
 		  </CollectionView>
+		</ContentPage>
+		""";
+
+	static string CollectionViewCompiledItemTemplateXaml(string dataType, string property) => $$"""
+		<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+		             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+		             xmlns:local="clr-namespace:TestTemplates"
+		             x:Class="TestTemplates.MainPage">
+		  <CollectionView>
+		    <CollectionView.ItemTemplate>
+		      <DataTemplate x:DataType="{{dataType}}">
+		        <Label Text="{Binding {{property}}}" />
+		      </DataTemplate>
+		    </CollectionView.ItemTemplate>
+		  </CollectionView>
+		</ContentPage>
+		""";
+
+	static string CollectionViewMultiNodeItemTemplateXaml() => """
+		<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+		             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+		             x:Class="TestTemplates.MainPage">
+		  <CollectionView>
+		    <CollectionView.ItemTemplate>
+		      <DataTemplate>
+		        <VerticalStackLayout>
+		          <Label Text="First" />
+		          <Label Text="Second" />
+		          <Button Text="Third" />
+		        </VerticalStackLayout>
+		      </DataTemplate>
+		    </CollectionView.ItemTemplate>
+		  </CollectionView>
+		</ContentPage>
+		""";
+
+	static string CustomItemTemplateHostXaml(string text) => $$"""
+		<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+		             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+		             xmlns:local="clr-namespace:TestTemplates"
+		             x:Class="TestTemplates.MainPage">
+		  <local:CustomItemTemplateHost>
+		    <local:CustomItemTemplateHost.ItemTemplate>
+		      <DataTemplate>
+		        <Label Text="{{text}}" />
+		      </DataTemplate>
+		    </local:CustomItemTemplateHost.ItemTemplate>
+		  </local:CustomItemTemplateHost>
 		</ContentPage>
 		""";
 

--- a/src/Controls/tests/SourceGen.UnitTests/NodeIdHelperTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/NodeIdHelperTests.cs
@@ -136,6 +136,35 @@ public class NodeIdHelperTests
 		Assert.Equal("", ids[root]);
 	}
 
+	[Fact]
+	public void ItemTemplateContent_GetsStableIds()
+	{
+		var xaml = $@"
+			<ContentPage xmlns=""{Ns}"" xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml"">
+				<CollectionView>
+					<CollectionView.ItemTemplate>
+						<DataTemplate>
+							<Label Text=""Hello"" />
+						</DataTemplate>
+					</CollectionView.ItemTemplate>
+				</CollectionView>
+			</ContentPage>";
+
+		var ids = NodeIdHelper.AssignIds(Parse(xaml));
+		var secondIds = NodeIdHelper.AssignIds(Parse(xaml));
+		var template = FindByType(ids, "DataTemplate");
+		var secondTemplate = FindByType(secondIds, "DataTemplate");
+		var label = FindByType(ids, "Label");
+		var secondLabel = FindByType(secondIds, "Label");
+
+		Assert.NotNull(template);
+		Assert.NotNull(secondTemplate);
+		Assert.NotNull(label);
+		Assert.NotNull(secondLabel);
+		Assert.Equal(ids[template!], secondIds[secondTemplate!]);
+		Assert.Equal(ids[label!], secondIds[secondLabel!]);
+	}
+
 	static ElementNode? FindByType(Dictionary<ElementNode, string> ids, string typeName)
 	{
 		foreach (var kvp in ids)


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

- assign stable source-generator node IDs to elements inside a direct `CollectionView.ItemTemplate`
- weakly track every live template realization instead of only the page-level component
- dispatch generated property patches to all realized cells without replacing the `DataTemplate` or refreshing the `CollectionView`
- compact dead template weak references at geometric registration thresholds and during lookup
- emit template registrations in stable node-ID order for deterministic Edit-and-Continue output
- keep template `x:DataType` retypes and unrelated same-named template properties on the conservative whole-property path

## Root cause

The source generator assigned IDs and emitted `XamlComponentRegistry` registrations only for the outer object tree. The `DataTemplate` body is created later by `LoadTemplate`, so realized labels were absent from the registry. The XAML diff therefore collapsed the edit to a complex `CollectionView.ItemTemplate` property change, which `UpdateComponent` skipped. The metadata delta was accepted, but no live cell could receive it.

This change gives element-valued item-template properties stable IDs, registers each realized template component under its page owner, and makes `UpdateComponent` enumerate all live realizations for a changed template node.

## Lifecycle and virtualization

The existing `DataTemplate`, realized view, binding context, handler, selection, focus, and scroll state remain intact. There is no adapter reset, global CollectionView refresh, or identity-destroying re-realization. Template registrations are weak. Dead wrappers are compacted opportunistically at geometrically spaced list sizes, preserving amortized constant-time registration when entries are live, and are also removed when a hot reload patch takes its snapshot. The managed `DataTemplate.CreateContent()` boundary is shared by the Windows, Android, and iOS/MacCatalyst handlers, so a unit-level live metadata-update test covers the cross-platform dispatch mechanism without requiring platform rendering.

## Scope

This PR targets non-structural property edits inside a direct `CollectionView.ItemTemplate`. Structural child-list edits inside template content remain on the existing conservative path because child insertion/removal requires separate per-realization collection reconciliation. Keyed resource replacement, selector-template replacement, other template-bearing properties, and template `x:DataType` retypes are intentionally unchanged. Retypes retain the conservative whole-property diff rather than emitting a partial in-place patch with stale compiled-binding accessors.

## Relation to #36482

This is distinct from #36482. That issue concerns later successive-edit EnC identity/signature failures and is addressed by stable generated template method names. This PR handles the first accepted edit after the delta reaches MAUI. Template registrations are sorted by stable node ID so dictionary insertion history cannot introduce spurious method-body ordering changes. Template `x:DataType` retypes remain on the existing conservative path so this fix does not broaden into the generated-identity/retype problem.

## Test evidence

- Before the fix: `CollectionViewItemTemplate_FirstEditUpdatesAlreadyRealizedContent` failed with `Expected: "Row item 00"; Actual: "Cell item 00"`.
- After the fix: two already-created template instances update in place on the first delta.
- Full verifier: `VERIFICATION PASSED` — affected tests fail without the production changes and pass with them.
- Targeted suites after review fixes:
  - SourceGen diff/writer/node-ID/template selection: 128 passed, 5 metadata-update tests skipped without runtime opt-in
  - metadata-enabled template hot reload suite: 11 passed
  - component registry tests: 29 passed

### Issues Fixed

Fixes #37890
