### PR TITLE
[Windows] Enable external file drops in BlazorWebView

### DIFF
--- a/src/BlazorWebView/src/Maui/Windows/BlazorWebViewHandler.Windows.cs
+++ b/src/BlazorWebView/src/Maui/Windows/BlazorWebViewHandler.Windows.cs
@@ -23,7 +23,10 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		/// <inheritdoc />
 		protected override WebView2Control CreatePlatformView()
 		{
-			return new WebView2Control();
+			return new WebView2Control
+			{
+				AllowDrop = true,
+			};
 		}
 
 		/// <inheritdoc />

--- a/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.Behaviors.cs
+++ b/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.Behaviors.cs
@@ -11,6 +11,26 @@ namespace Microsoft.Maui.MauiBlazorWebView.DeviceTests.Elements;
 
 public partial class BlazorWebViewTests
 {
+#if WINDOWS
+	[Fact]
+	public async Task ExternalFileDropIsEnabledByDefault()
+	{
+		EnsureHandlerCreated(additionalCreationActions: appBuilder =>
+		{
+			appBuilder.Services.AddMauiBlazorWebView();
+		});
+
+		var blazorWebView = new BlazorWebView();
+
+		await InvokeOnMainThreadAsync(() =>
+		{
+			var handler = CreateHandler<BlazorWebViewHandler>(blazorWebView);
+
+			Assert.True(handler.PlatformView.AllowDrop);
+		});
+	}
+#endif
+
 #if IOS || MACCATALYST
 	[Fact]
 	public async Task BlazorWebViewScrollBounceDisabledByDefault()


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Enables `AllowDrop` on the Windows BlazorWebView's underlying WinUI `WebView2` so external files dragged from Explorer can reach HTML drop targets.

This addresses the Windows external-file-drop portion of #2205. Native in-page HTML element and image dragging remain unavailable with MAUI's current Windows App SDK 1.8 dependency.

A cross-host repro and compatibility matrix are available at https://github.com/danroth27/BlazorHybridDragDrop.

### Windows App SDK 2.0 follow-up

The plain WinUI reduction was retested with Windows App SDK 2.0.1, WebView2 SDK 1.0.4129.50, and WebView2 Runtime 151.0.4129.107:

| Scenario | `AllowDrop=false` | `AllowDrop=true` |
|---|---|---|
| Native element drag/drop | Fails | Works |
| Image drag preview | Only outside the app | Works inside and outside the WebView |
| External file drop | Fails | Works |

This PR fixes external file drop with the current Windows App SDK 1.8 dependency and also supplies the required `AllowDrop` setting for native in-page drag support when MAUI moves to Windows App SDK 2.0 or later. Repro and results: https://github.com/danroth27/BlazorHybridDragDrop/commit/04810f6

## Testing

- Added a Windows device test that verifies the created platform WebView2 has `AllowDrop` enabled.
- Windows BlazorWebView device tests: 18 passed, 4 skipped, 0 failed.
- Required `maui-pr` and `license/cla` checks passed.

Fixes #37903