### PR TITLE
[Resizetizer] Never place a path through an unstatable directory

### DIFF
--- a/src/SingleProject/Resizetizer/src/PathCanonicalizer.cs
+++ b/src/SingleProject/Resizetizer/src/PathCanonicalizer.cs
@@ -203,13 +203,22 @@ namespace Microsoft.Maui.Resizetizer
 
 		string ResolveDirectoryLink(string path, int hops)
 		{
-			// A directory that does not exist cannot be a link, and a path the build has not written yet
-			// has to stay canonicalizable.
-			if (!Directory.Exists(path))
-				return path;
+			switch (Probe(path))
+			{
+				case DirectoryKind.Missing:
+					// Nothing is there at all, so nothing can be reached through it either and the lexical
+					// spelling is the whole truth. This is also the case for an output the build has not
+					// written yet, which still has to be canonicalizable.
+					return path;
 
-			if (!IsReparsePoint(path))
-				return path;
+				case DirectoryKind.Ordinary:
+					return path;
+
+				case DirectoryKind.Unknown:
+					// Something is there but it cannot be identified, so it cannot be ruled out as a link.
+					// Refuse to place anything under it rather than assume the lexical spelling is real.
+					return null;
+			}
 
 			// From here on this really is a link or junction. Where it points decides whether everything
 			// below it is inside the root, so guessing is not an option: either resolve it or give up.
@@ -223,7 +232,8 @@ namespace Microsoft.Maui.Resizetizer
 			}
 			catch (Exception)
 			{
-				// Cyclic links, missing permissions or a racing delete.
+				// A cycle of links, missing permissions or a racing delete. A dangling link still resolves,
+				// to its absent target, and that target decides containment as usual.
 				return null;
 			}
 
@@ -241,20 +251,68 @@ namespace Microsoft.Maui.Resizetizer
 			return Canonicalize(resolved, hops - 1);
 		}
 
+		/// <summary>What a path turned out to be, as far as it can be determined.</summary>
+		enum DirectoryKind
+		{
+			/// <summary>Nothing exists at this path.</summary>
+			Missing,
+
+			/// <summary>An ordinary entry that is not a link and can be trusted lexically.</summary>
+			Ordinary,
+
+			/// <summary>A symbolic link, junction or other reparse point.</summary>
+			Link,
+
+			/// <summary>Something is there, but it could not be identified.</summary>
+			Unknown,
+		}
+
 		/// <summary>
-		/// Whether <paramref name="path"/> is a symbolic link, junction or other reparse point. Unlike
-		/// resolving one, asking this question works on every host, including .NET Framework.
+		/// Classifies <paramref name="path"/> without following it.
 		/// </summary>
-		static bool IsReparsePoint(string path)
+		/// <remarks>
+		/// <para>
+		/// <see cref="Directory.Exists(string)"/> cannot be used for this. It answers "can I open a
+		/// directory here", so it reports <see langword="false"/> for a link whose target is missing, for
+		/// a cycle of links, and for an entry it lacks permission to inspect. Treating those as "not a
+		/// link" would hand back the lexical spelling and let everything apparently beneath them look
+		/// contained.
+		/// </para>
+		/// <para>
+		/// <see cref="FileSystemInfo.Attributes"/> cannot be used either: for a path that does not exist
+		/// it yields <c>(FileAttributes)(-1)</c> rather than throwing, which has every bit set and so
+		/// claims to be a reparse point.
+		/// </para>
+		/// <para>
+		/// <see cref="File.GetAttributes(string)"/> does distinguish all of these, and works on every host
+		/// including .NET Framework: it reports the attributes of the entry itself rather than of whatever
+		/// it points at, throws for a path that is genuinely absent, and throws something else when the
+		/// entry cannot be inspected.
+		/// </para>
+		/// </remarks>
+		static DirectoryKind Probe(string path)
 		{
 			try
 			{
-				return (new DirectoryInfo(path).Attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
+				var attributes = File.GetAttributes(path);
+
+				return (attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint
+					? DirectoryKind.Link
+					: DirectoryKind.Ordinary;
+			}
+			catch (FileNotFoundException)
+			{
+				return DirectoryKind.Missing;
+			}
+			catch (DirectoryNotFoundException)
+			{
+				return DirectoryKind.Missing;
 			}
 			catch (Exception)
 			{
-				// If the attributes cannot be read, assume the worst rather than the best.
-				return true;
+				// Denied permission, a path the platform rejects, or a racing change. Anything that is not
+				// a definite "nothing is here" has to count as unsafe.
+				return DirectoryKind.Unknown;
 			}
 		}
 

--- a/src/SingleProject/Resizetizer/test/UnitTests/DetectStaleOutputFilesTaskTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/DetectStaleOutputFilesTaskTests.cs
@@ -388,6 +388,170 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			Assert.Empty(task.StaleFiles);
 		}
 
+		/// <summary>
+		/// A link whose target no longer exists, a cycle of links, and an entry that cannot be inspected
+		/// all make <see cref="Directory.Exists(string)"/> report <see langword="false"/>, exactly like an
+		/// ordinary absent directory. Anything reached through one of them must still be left alone: the
+		/// wildcard enumerated it while the link was intact, and by the time <c>&lt;Delete&gt;</c> runs the
+		/// link may point somewhere real again.
+		/// </summary>
+		[Theory]
+		[InlineData(BrokenLinkKind.Dangling)]
+		[InlineData(BrokenLinkKind.Cyclic)]
+		[InlineData(BrokenLinkKind.Inaccessible)]
+		public void FilesBehindABrokenOrUnreadableLinkAreNeverStale(BrokenLinkKind kind)
+		{
+			AssertOnlyTheOrdinaryStaleFileIsReported(kind, allowLinkResolution: true);
+		}
+
+		/// <summary>
+		/// The same three states on a host that cannot resolve links at all, which is every .NET Framework
+		/// host including MSBuild.exe.
+		/// </summary>
+		[Theory]
+		[InlineData(BrokenLinkKind.Dangling)]
+		[InlineData(BrokenLinkKind.Cyclic)]
+		[InlineData(BrokenLinkKind.Inaccessible)]
+		public void WithoutLinkResolutionFilesBehindABrokenOrUnreadableLinkAreNeverStale(BrokenLinkKind kind)
+		{
+			AssertOnlyTheOrdinaryStaleFileIsReported(kind, allowLinkResolution: false);
+		}
+
+		void AssertOnlyTheOrdinaryStaleFileIsReported(BrokenLinkKind kind, bool allowLinkResolution)
+		{
+			// Root the test where no ancestor is itself a link, so the only unusual entry in play is the
+			// one the test creates. macOS temp directories live under /var, which is a link to /private/var,
+			// and a host that cannot resolve links could not place the root itself.
+			var basePath = new PathCanonicalizer().CanonicalizeDirectory(DestinationDirectory);
+			var root = Path.Combine(basePath, "r");
+			Directory.CreateDirectory(root);
+
+			if (!TryCreateBrokenEntry(kind, root, basePath, out var traversed, out var skip))
+			{
+				Output.WriteLine(skip);
+				return;
+			}
+
+			try
+			{
+				var throughTheBrokenEntry = Path.Combine(traversed, "precious.png");
+				var genuinelyStale = Path.Combine(root, "orphan.png");
+				File.WriteAllText(genuinelyStale, "left over");
+
+				var task = GetNewTask(new[] { throughTheBrokenEntry, genuinelyStale }, Array.Empty<string>(), root: root);
+				task.AllowLinkResolution = allowLinkResolution;
+
+				Assert.True(task.Execute());
+
+				// Ordinary cleanup still happens; only the path through the broken entry is spared.
+				Assert.Equal(genuinelyStale, Assert.Single(task.StaleFiles).ItemSpec);
+			}
+			finally
+			{
+				Unlock(kind, root);
+			}
+		}
+
+		/// <summary>
+		/// A directory that is genuinely absent is not ambiguous, so it must not disable cleanup. Without
+		/// this, the guard would be indistinguishable from refusing to delete anything.
+		/// </summary>
+		[Fact]
+		public void AGenuinelyAbsentDirectoryStillAllowsCleanup()
+		{
+			var root = Path.Combine(DestinationDirectory, "r");
+			Directory.CreateDirectory(root);
+
+			var stale = Path.Combine(root, "drawable", "orphan.png");
+			Directory.CreateDirectory(Path.GetDirectoryName(stale));
+			File.WriteAllText(stale, "left over");
+
+			// A sibling directory that was never created at all.
+			var neverCreated = Path.Combine(root, "drawable-xhdpi", "orphan.png");
+
+			var task = GetNewTask(new[] { stale, neverCreated }, Array.Empty<string>(), root: root);
+
+			Assert.True(task.Execute());
+			Assert.Equal(new[] { stale, neverCreated }, task.StaleFiles.Select(f => f.ItemSpec).ToArray());
+		}
+
+		public enum BrokenLinkKind
+		{
+			/// <summary>A link whose target does not exist.</summary>
+			Dangling,
+
+			/// <summary>A link that eventually points back at itself.</summary>
+			Cyclic,
+
+			/// <summary>A real directory that cannot be inspected because its parent denies access.</summary>
+			Inaccessible,
+		}
+
+		static bool TryCreateBrokenEntry(BrokenLinkKind kind, string root, string outside, out string traversed, out string skip)
+		{
+			skip = null;
+			traversed = Path.Combine(root, "alias");
+
+			switch (kind)
+			{
+				case BrokenLinkKind.Dangling:
+					// The target has to be outside the root: a dangling link that pointed back inside it
+					// would resolve to an inside path and be legitimately stale.
+					if (!SymbolicLink.TryCreateDirectoryLink(traversed, Path.Combine(outside, "gone"), out var danglingError))
+					{
+						skip = $"Skipping: symbolic links are not available on this machine: {danglingError}";
+						return false;
+					}
+
+					return true;
+
+				case BrokenLinkKind.Cyclic:
+					var other = Path.Combine(root, "alias-other");
+					if (!SymbolicLink.TryCreateDirectoryLink(traversed, other, out var cyclicError) ||
+						!SymbolicLink.TryCreateDirectoryLink(other, traversed, out cyclicError))
+					{
+						skip = $"Skipping: symbolic links are not available on this machine: {cyclicError}";
+						return false;
+					}
+
+					return true;
+
+				default:
+					if (OperatingSystem.IsWindows())
+					{
+						// Denying read access needs ACL work that does not model the Unix case this covers,
+						// and the unidentifiable branch is already exercised by the other two states.
+						skip = "Skipping: denying directory access is not modelled on Windows.";
+						return false;
+					}
+
+					// A directory can only be inspected through a parent that grants access, so the parent
+					// is what gets locked.
+					var locked = Path.Combine(root, "locked");
+					traversed = Path.Combine(locked, "inner");
+					Directory.CreateDirectory(traversed);
+					File.WriteAllText(Path.Combine(traversed, "precious.png"), "not a build output");
+
+					if (Chmod(locked, 0) != 0)
+					{
+						skip = "Skipping: could not remove access from the directory.";
+						return false;
+					}
+
+					return true;
+			}
+		}
+
+		static void Unlock(BrokenLinkKind kind, string root)
+		{
+			// Leave the directory removable so the test's own cleanup can run.
+			if (kind == BrokenLinkKind.Inaccessible && !OperatingSystem.IsWindows())
+				Chmod(Path.Combine(root, "locked"), Convert.ToInt32("755", 8));
+		}
+
+		[System.Runtime.InteropServices.DllImport("libc", EntryPoint = "chmod", SetLastError = true)]
+		static extern int Chmod(string path, int mode);
+
 		static bool IsCaseSensitiveVolume(string directory)
 		{
 			var probe = Path.Combine(directory, "CaseProbe");

--- a/src/SingleProject/Resizetizer/test/UnitTests/PathCanonicalizerTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/PathCanonicalizerTests.cs
@@ -258,6 +258,76 @@ namespace Microsoft.Maui.Resizetizer.Tests
 		}
 
 		/// <summary>
+		/// A link whose target is gone still reports where it was pointing, so containment is decided by
+		/// that target rather than by the link's own location inside the root.
+		/// </summary>
+		[Fact]
+		public void ADanglingLinkResolvesToItsAbsentTargetRatherThanItself()
+		{
+			var basePath = new PathCanonicalizer().CanonicalizeDirectory(DestinationDirectory);
+			var root = Path.Combine(basePath, "r");
+			var absent = Path.Combine(basePath, "gone");
+			Directory.CreateDirectory(root);
+
+			var alias = Path.Combine(root, "alias");
+			if (!SymbolicLink.TryCreateDirectoryLink(alias, absent, out var error))
+			{
+				Output.WriteLine($"Skipping: symbolic links are not available on this machine: {error}");
+				return;
+			}
+
+			var canonicalizer = new PathCanonicalizer();
+			var key = canonicalizer.GetComparisonKey(Path.Combine(alias, "precious.png"));
+
+			// Either it resolves to the absent target, which is outside the root, or it is refused
+			// outright. What it must never be is the lexical spelling inside the root.
+			Assert.NotEqual(Path.Combine(alias, "precious.png"), key ?? string.Empty, PathCanonicalizer.Comparer);
+			Assert.False(PathCanonicalizer.IsUnder(key, canonicalizer.CanonicalizeDirectory(root)));
+		}
+
+		/// <summary>
+		/// A cycle of links cannot be followed, so nothing beneath it can be placed.
+		/// </summary>
+		[Fact]
+		public void ACyclicLinkHasNoKey()
+		{
+			var basePath = new PathCanonicalizer().CanonicalizeDirectory(DestinationDirectory);
+			var first = Path.Combine(basePath, "first");
+			var second = Path.Combine(basePath, "second");
+
+			if (!SymbolicLink.TryCreateDirectoryLink(first, second, out var error) ||
+				!SymbolicLink.TryCreateDirectoryLink(second, first, out error))
+			{
+				Output.WriteLine($"Skipping: symbolic links are not available on this machine: {error}");
+				return;
+			}
+
+			var canonicalizer = new PathCanonicalizer();
+
+			Assert.Null(canonicalizer.GetComparisonKey(Path.Combine(first, "precious.png")));
+		}
+
+		/// <summary>
+		/// A genuinely absent directory is not ambiguous. It has to keep canonicalizing lexically, because
+		/// an output the build has not written yet must still be comparable against the wildcard's result.
+		/// </summary>
+		[Fact]
+		public void AnAbsentDirectoryIsNotTreatedAsAmbiguous()
+		{
+			var basePath = new PathCanonicalizer().CanonicalizeDirectory(DestinationDirectory);
+			var neverCreated = Path.Combine(basePath, "never", "created");
+
+			var canonicalizer = new PathCanonicalizer();
+
+			Assert.Equal(neverCreated, canonicalizer.CanonicalizeDirectory(neverCreated), PathCanonicalizer.Comparer);
+			Assert.Equal(
+				Path.Combine(neverCreated, "camera.png"),
+				canonicalizer.GetComparisonKey(Path.Combine(neverCreated, "camera.png")),
+				PathCanonicalizer.Comparer);
+			Assert.True(PathCanonicalizer.IsUnder(canonicalizer.GetComparisonKey(Path.Combine(neverCreated, "camera.png")), basePath));
+		}
+
+		/// <summary>
 		/// A wildcard descends through a directory link, so the key of what it finds resolves outside the
 		/// root it was rooted at. That is what lets the caller refuse to delete it.
 		/// </summary>

--- a/src/SingleProject/Resizetizer/test/UnitTests/ResizetizeImagesIncrementalTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/ResizetizeImagesIncrementalTests.cs
@@ -185,6 +185,47 @@ namespace Microsoft.Maui.Resizetizer.Tests
 		}
 
 		/// <summary>
+		/// A link that has gone dangling between enumeration and cleanup must not be followed either. The
+		/// wildcard still names what it found, and by the time <c>&lt;Delete&gt;</c> runs the link may point
+		/// at something real again, so a path through it can never be treated as living inside the folder.
+		/// </summary>
+		[Fact]
+		public void CleanupNeverReachesThroughADanglingDirectoryLink()
+		{
+			var project = CreateProject(throughLink: false);
+			if (project is null)
+				return;
+
+			Build(project);
+			AssertGeneratedImageExists(project);
+
+			var outside = Path.Combine(project.PhysicalDirectory, "outside");
+			Directory.CreateDirectory(outside);
+			var precious = Path.Combine(outside, "precious.png");
+			File.WriteAllText(precious, "not a build output");
+
+			// Points at a directory that does not exist yet, so the link is dangling right now.
+			var future = Path.Combine(project.PhysicalDirectory, "outside-later");
+			var alias = Path.Combine(project.PhysicalDirectory, "obj", "resizetizer", "r", "alias");
+			if (!SymbolicLink.TryCreateDirectoryLink(alias, future, out var error))
+			{
+				Output.WriteLine($"Skipping: symbolic links are not available on this machine: {error}");
+				return;
+			}
+
+			TouchSourceImage(project);
+
+			Build(project);
+
+			AssertGeneratedImageExists(project);
+			Assert.True(File.Exists(precious), $"Cleanup deleted a file outside the intermediate folder: {precious}");
+
+			// The link itself is still inside the folder, so removing it is fine; what must not happen is
+			// anything being deleted through it.
+			Assert.False(Directory.Exists(future), "The dangling link's target should never have been created.");
+		}
+
+		/// <summary>
 		/// The recursive wildcard that finds stale files walks through a directory link, so it can name a
 		/// file that is not really inside the intermediate folder. Deleting that would destroy the real
 		/// file rather than the link, so the cleanup has to leave it alone.


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Follow-up to #37859, which merged before this last review finding could be folded into it.

That PR added a guard so Resizetizer's stale-file cleanup can never delete something outside the intermediate folder. The guard decided a path was *not* a link by asking `Directory.Exists`, and returned the lexical spelling when the answer was no.

`Directory.Exists` answers *"can I open a directory here"*, not *"is there an entry here"*. Measured on macOS:

| state | `Directory.Exists` | `File.GetAttributes` |
|---|---|---|
| ordinary missing | `False` | throws `FileNotFoundException` |
| **dangling link** | `False` | **OK, `ReparsePoint`** |
| **cycle of links** | `False` | **OK, `ReparsePoint`** |
| **inaccessible parent** | `False` | throws `UnauthorizedAccessException` |
| ordinary directory | `True` | OK, no `ReparsePoint` |
| valid link to directory | `True` | OK, `ReparsePoint` |

So the last three **skipped resolution entirely** and were handed back lexically — everything apparently beneath them looked contained and could be deleted. The wildcard enumerates such an entry while the link is intact; by the time `<Delete>` runs the link may point somewhere real again.

#### Fix

Resolution now classifies a path with `File.GetAttributes`, which reports the entry *itself* rather than what it points at, and is available on every host including .NET Framework:

- **Missing** — nothing is there, so nothing can be reached through it and the lexical spelling is the whole truth. An output that has not been written yet still has to canonicalize, so this must stay allowed.
- **Ordinary** — not a link, trusted lexically.
- **Link** — resolved, or refused when it cannot be.
- **Unknown** — anything else, including denied access: refused.

This also removes `IsReparsePoint`, which used `FileSystemInfo.Attributes`. That returns `(FileAttributes)(-1)` for a path that does not exist rather than throwing, so **every bit is set and it claimed to be a reparse point** — a latent bug the `Directory.Exists` shortcut happened to mask.

### Issues Fixed

Completes the hardening started in #37859.

### Validation

- **Regressions for dangling, cyclic, and inaccessible entries** at three levels: the canonicalizer, through `DetectStaleOutputFilesTask`, and **end to end through the real target and its `<Delete>`** — each on both a modern host and one without `Directory.ResolveLinkTarget` (via the injectable `AllowLinkResolution` seam, since a real `MSBuild.exe` host is not reachable from macOS).
- **A genuinely absent directory is asserted to still allow cleanup**, so the guard cannot quietly degrade into deleting nothing.
- **Mutation**: restoring the `Directory.Exists` shortcut fails **7** tests.
- Full `Resizetizer.UnitTests`: **759 passed, 0 failed**. `dotnet format` clean.

Note: the inaccessible-directory case is Unix-only (denying read access on Windows needs ACL work that doesn't model the same thing); it self-skips there, and the `Unknown` branch is still covered on Windows by the cyclic and dangling cases.
