### PR TITLE
[net11.0] Temporarily disable Helix Job Monitor

### DIFF
--- a/eng/pipelines/arcade/stage-helix-tests.yml
+++ b/eng/pipelines/arcade/stage-helix-tests.yml
@@ -57,6 +57,9 @@ stages:
 - stage: HelixTests
   displayName: Run Helix Unit Tests
   dependsOn: []
+  variables:
+  - name: enableHelixJobMonitor
+    value: false
   jobs:
   - ${{ each BuildConfiguration in parameters.buildConfigurations }}:
     - template: ${{ iif(eq(parameters.runAsPublic, 'true'), '/eng/common/templates/jobs/jobs.yml@self', '/eng/common/templates-official/jobs/jobs.yml@self') }}
@@ -94,7 +97,7 @@ stages:
               DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
               PRIVATE_BUILD: $(PrivateBuild)
 
-          - script: $(_msbuildCommand) "${{ parameters.helixProject }}" -warnAsError 0 -restore /p:Configuration=${{ BuildConfiguration }} /p:EnableHelixJobMonitor=true /p:HelixInternal="${{ parameters.helixInternal }}" /p:TestRunNameSuffix="_${{ BuildConfiguration }}" /p:SkipInitInternalTooling=true /bl:$(Build.Arcade.LogsPath)${{ BuildConfiguration }}/helix_tests.binlog ${{ parameters.extraHelixArguments }}
+          - script: $(_msbuildCommand) "${{ parameters.helixProject }}" -warnAsError 0 -restore /p:Configuration=${{ BuildConfiguration }} /p:EnableHelixJobMonitor=$(enableHelixJobMonitor) /p:HelixInternal="${{ parameters.helixInternal }}" /p:TestRunNameSuffix="_${{ BuildConfiguration }}" /p:SkipInitInternalTooling=true /bl:$(Build.Arcade.LogsPath)${{ BuildConfiguration }}/helix_tests.binlog ${{ parameters.extraHelixArguments }}
             displayName: Run Helix Tests
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
@@ -102,6 +105,7 @@ stages:
 
   - job: HelixJobMonitor
     displayName: Monitor Helix Jobs
+    condition: eq(variables['enableHelixJobMonitor'], 'true')
     timeoutInMinutes: ${{ parameters.helixJobMonitorTimeoutInMinutes }}
     pool:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

Temporarily disabling JobMonitor to reduce ADO load.

Tracking: https://dev.azure.com/dnceng/internal/_workitems/edit/12380