### PR TITLE
[net11.0] Fix Aspire ServiceDefaults template selection

### DIFF
--- a/src/Templates/src/templates/maui-aspire-servicedefaults/.template.config/template.json
+++ b/src/Templates/src/templates/maui-aspire-servicedefaults/.template.config/template.json
@@ -20,8 +20,8 @@
       "language": "C#",
       "type": "project"
     },
-    "precedence": "9000",
-    "identity": "MauiAspire.ServiceDefaults.CSharp.8.0",
+    "precedence": "DOTNET_TFM_VERSION_MAJOR_VALUE",
+    "identity": "MauiAspire.ServiceDefaults.CSharp.DOTNET_TFM_VERSION_VALUE",
     "thirdPartyNotices": "https://github.com/microsoft/aspire/blob/main/THIRD-PARTY-NOTICES.TXT",
     "groupIdentity": "MauiAspire.ServiceDefaults",
     "symbols": {

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Xml.Linq;
 
 namespace Microsoft.Maui.IntegrationTests;
@@ -376,7 +377,7 @@ public class SimpleTemplateTest : BaseTemplateTests
 		var projectDir = Path.Combine(TestDirectory, projectName);
 		var expectedProjectFile = Path.Combine(projectDir, $"{projectName}.csproj");
 
-		Assert.True(DotnetInternal.New("maui-aspire-servicedefaults", projectDir, additionalDotNetNewParams: $"-n \"{projectName}\"", output: _output),
+		Assert.True(DotnetInternal.New("maui-aspire-servicedefaults", projectDir, additionalDotNetNewParams: $"-n \"{projectName}\" --skipRestore", output: _output),
 			$"Unable to create template maui-aspire-servicedefaults. Check test output for errors.");
 
 		// Verify the project file was created with the correct name (this was the bug)
@@ -395,12 +396,31 @@ public class SimpleTemplateTest : BaseTemplateTests
 		Assert.True(File.Exists(Path.Combine(projectDir, "Extensions.cs")),
 			"Expected Extensions.cs file was not created.");
 
-		// Verify the project file contains required properties
-		var projectContent = File.ReadAllText(expectedProjectFile);
-		Assert.True(projectContent.Contains("<IsAspireSharedProject>true</IsAspireSharedProject>", StringComparison.Ordinal),
-			"Project file should contain Aspire-specific properties.");
-		Assert.True(projectContent.Contains("<UseMauiCore>true</UseMauiCore>", StringComparison.Ordinal),
-			"Project file should contain UseMauiCore property.");
+		// Verify the current template was selected and contains the required MAUI properties.
+		var project = XDocument.Load(expectedProjectFile);
+		var targetFramework = project.Descendants("TargetFramework").Single().Value;
+		Assert.Equal(DotNetCurrent, targetFramework);
+		Assert.Equal("true", project.Descendants("IsAspireSharedProject").Single().Value);
+		Assert.Equal("true", project.Descendants("UseMauiCore").Single().Value);
+
+		var mauiCoreReference = project.Descendants("PackageReference")
+			.Single(element => string.Equals((string?)element.Attribute("Include"), "Microsoft.Maui.Core", StringComparison.Ordinal));
+		Assert.Equal("$(MauiVersion)", (string?)mauiCoreReference.Attribute("Version"));
+
+		Assert.True(DotnetInternal.Build(expectedProjectFile, "Debug", target: "Restore", properties: BuildProps, msbuildWarningsAsErrors: true, output: _output),
+			$"Project {Path.GetFileName(expectedProjectFile)} failed to restore. Check test output/attachments for errors.");
+
+		using var assets = JsonDocument.Parse(File.ReadAllText(Path.Combine(projectDir, "obj", "project.assets.json")));
+		var mauiCoreVersion = assets.RootElement
+			.GetProperty("project")
+			.GetProperty("frameworks")
+			.GetProperty(DotNetCurrent)
+			.GetProperty("dependencies")
+			.GetProperty("Microsoft.Maui.Core")
+			.GetProperty("version")
+			.GetString();
+		Assert.NotNull(mauiCoreVersion);
+		Assert.Contains(MauiPackageVersion, mauiCoreVersion, StringComparison.Ordinal);
 
 		// Verify the project actually builds
 		Assert.True(DotnetInternal.Build(expectedProjectFile, "Debug", properties: BuildProps, msbuildWarningsAsErrors: true, output: _output),


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

A merge into `net11.0` retained the Aspire branding/link updates from #37850, but unintentionally reverted the version-specific template identity and precedence from commit `120af7a6bb`. With both the .NET 10 and .NET 11 MAUI template packs installed, both ServiceDefaults templates then advertised the same `8.0` identity and `9000` precedence. `dotnet new maui-aspire-servicedefaults` selected the stale .NET 10 template, which generated a project without `UseMauiCore`; that left `$(MauiVersion)` empty and restore failed with `NU1015` for `Microsoft.Maui.Core`.

This restores the pack-time target-framework tokens so the .NET 11 package emits identity `MauiAspire.ServiceDefaults.CSharp.11.0` and precedence `11000`. The existing integration test remains end-to-end and now explicitly verifies the generated project name, `net11.0` target, `UseMauiCore`, the `Microsoft.Maui.Core` version expression, successful restore, the resolved package version in `project.assets.json`, and a successful build.

### Issues Fixed

Fixes the `net11.0` base CI regression reproduced in `maui-pr` builds 1570902, 1570903, 1570904, and 1570953.

### Validation

- Reproduced all 3 test parameterizations failing locally with the stale .NET 10 template, missing `UseMauiCore`, and `NU1015`.
- Built and packed the product, installed the local workload, and verified the packed template emits identity `11.0` / precedence `11000`.
- Re-ran all 3 `SimpleTemplateTest.AspireServiceDefaultsTemplateUsesCorrectProjectName` parameterizations on macOS: 3 passed, 0 failed.
- Verified restore resolves `Microsoft.Maui.Core` to `11.0.0-dev` before the generated project build.
- Ran the full macOS `Build` integration category: 61 passed, 2 skipped, 0 failed.