### PR TITLE
[net11.0] Update Helix Job Monitor to 11.0.0-beta.26427.10

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -195,6 +195,10 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.DotNet.Helix.JobMonitor" Version="11.0.0-beta.26427.10">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>2cdfe99944d984749c8bdfc7d8d6a2589ed15d6d</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="11.0.0-beta.26379.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -153,6 +153,7 @@
     <MicrosoftDotNetBuildTasksFeedVersion>11.0.0-beta.26379.102</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetBuildTasksInstallersPackageVersion>11.0.0-beta.26379.102</MicrosoftDotNetBuildTasksInstallersPackageVersion>
     <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>11.0.0-beta.26379.102</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
+    <MicrosoftDotNetHelixJobMonitorPackageVersion>11.0.0-beta.26427.10</MicrosoftDotNetHelixJobMonitorPackageVersion>
     <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26379.102</MicrosoftDotNetHelixSdkPackageVersion>
     <MicroBuildPluginsSwixBuildDotnetPackageVersion>1.1.87-gba258badda</MicroBuildPluginsSwixBuildDotnetPackageVersion>
     <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.26379.102</MicrosoftDotNetRemoteExecutorPackageVersion>

--- a/eng/pipelines/arcade/stage-helix-tests.yml
+++ b/eng/pipelines/arcade/stage-helix-tests.yml
@@ -57,9 +57,6 @@ stages:
 - stage: HelixTests
   displayName: Run Helix Unit Tests
   dependsOn: []
-  variables:
-  - name: enableHelixJobMonitor
-    value: false
   jobs:
   - ${{ each BuildConfiguration in parameters.buildConfigurations }}:
     - template: ${{ iif(eq(parameters.runAsPublic, 'true'), '/eng/common/templates/jobs/jobs.yml@self', '/eng/common/templates-official/jobs/jobs.yml@self') }}
@@ -97,7 +94,7 @@ stages:
               DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
               PRIVATE_BUILD: $(PrivateBuild)
 
-          - script: $(_msbuildCommand) "${{ parameters.helixProject }}" -warnAsError 0 -restore /p:Configuration=${{ BuildConfiguration }} /p:EnableHelixJobMonitor=$(enableHelixJobMonitor) /p:HelixInternal="${{ parameters.helixInternal }}" /p:TestRunNameSuffix="_${{ BuildConfiguration }}" /p:SkipInitInternalTooling=true /bl:$(Build.Arcade.LogsPath)${{ BuildConfiguration }}/helix_tests.binlog ${{ parameters.extraHelixArguments }}
+          - script: $(_msbuildCommand) "${{ parameters.helixProject }}" -warnAsError 0 -restore /p:Configuration=${{ BuildConfiguration }} /p:EnableHelixJobMonitor=true /p:HelixInternal="${{ parameters.helixInternal }}" /p:TestRunNameSuffix="_${{ BuildConfiguration }}" /p:SkipInitInternalTooling=true /bl:$(Build.Arcade.LogsPath)${{ BuildConfiguration }}/helix_tests.binlog ${{ parameters.extraHelixArguments }}
             displayName: Run Helix Tests
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
@@ -105,7 +102,6 @@ stages:
 
   - job: HelixJobMonitor
     displayName: Monitor Helix Jobs
-    condition: eq(variables['enableHelixJobMonitor'], 'true')
     timeoutInMinutes: ${{ parameters.helixJobMonitorTimeoutInMinutes }}
     pool:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
@@ -123,9 +119,9 @@ stages:
 
         toolPath="$AGENT_TEMPDIRECTORY/helix-job-monitor"
         bash ./eng/common/dotnet.sh
-        toolVersion=$(bash ./eng/common/dotnet.sh msbuild eng/Versions.props -getProperty:MicrosoftDotNetHelixSdkPackageVersion -nologo | tail -n 1)
+        toolVersion=$(bash ./eng/common/dotnet.sh msbuild eng/Versions.props -getProperty:MicrosoftDotNetHelixJobMonitorPackageVersion -nologo | tail -n 1)
         if [[ -z "$toolVersion" || "$toolVersion" =~ [[:space:]] ]]; then
-          echo "Could not read the Helix SDK package version from eng/Versions.props." >&2
+          echo "Could not read the Helix Job Monitor package version from eng/Versions.props." >&2
           exit 1
         fi
 


### PR DESCRIPTION
Updates Microsoft.DotNet.Helix.JobMonitor to the fixed 11.0.0-beta.26427.10 build and restores the Helix Job Monitor after #37917.

Build: https://dev.azure.com/dnceng/internal/_build/results?buildId=3059358