### PR TITLE
[Tests] Remove obsolete Apple NativeAOT warning workaround

### DIFF
--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
@@ -120,7 +120,6 @@ namespace Microsoft.Maui.IntegrationTests
 				buildProps.Add("PublishAot=true");
 				buildProps.Add("PublishAotUsingRuntimePack=true"); // TODO: This parameter will become obsolete https://github.com/dotnet/runtime/issues/87060
 				buildProps.Add("_IsPublishing=true"); // using dotnet build with -p:_IsPublishing=true enables targeting simulators
-				buildProps.Add("IlcTreatWarningsAsErrors=false"); // TODO: Remove this once all warnings are fixed https://github.com/dotnet/maui/issues/19397
 				// Restrict to iOS-only to avoid restoring NativeAOT packages for other platforms (e.g., Android)
 				// which may not be available in the configured NuGet sources
 				buildProps.Add($"TargetFrameworks={framework}-ios");


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Removes the `IlcTreatWarningsAsErrors=false` workaround and its TODO from the Apple NativeAOT simulator integration test.

The linked tracking issue, #19397, was closed after all template trimming warnings were resolved. The dedicated `AOTTemplateTest.PublishNativeAOT` suite also maintains an empty expected-warning baseline for Apple NativeAOT builds, so the simulator run should enforce the default ILC warning policy again.

## Validation

- The exact `AppleTemplateTests.RunOniOS_MauiNativeAOT` test compiled and started on Windows, but Windows could not complete the Apple ILC phase because the iOS-simulator NativeAOT runtime pack was unavailable (`MSB3030` for `System.Runtime.InteropServices.RuntimeInformation.dll`).
- The Windows `AOTTemplateTest.PublishNativeAOT(... win-arm64)` proxy passed, including its assertion that the complete NativeAOT binlog warning list is empty.

Apple-specific ILC/codegen and simulator execution require the macOS CI lanes and will be monitored on this draft PR.