### PR TITLE
[iOS/MacCatalyst] Map bicycling navigation to cycling directions

### DIFF
--- a/.github/scripts/SetupVallyRuntime.sh
+++ b/.github/scripts/SetupVallyRuntime.sh
@@ -82,7 +82,7 @@ if grep -Fqx -- "--experimental" "$probe_output"; then
 	exit 1
 fi
 
-# Vally 0.12 normally creates an empty per-run Copilot home and passes it as the
+# Vally normally creates an empty per-run Copilot home and passes it as the
 # session configDirectory, which takes precedence over COPILOT_HOME. Confirm the
 # pinned executor honors the opt-out before any model credential enters the job.
 copilot_home_module="$install_root/node_modules/@microsoft/vally/dist/executor/copilot-home.js"

--- a/.github/skills/agentic-labeler/tests/eval.vally.yaml
+++ b/.github/skills/agentic-labeler/tests/eval.vally.yaml
@@ -37,7 +37,7 @@
 # Legacy scenarios AND-gated up to ~15 `output_not_contains` assertions
 # (every triage/partner/kind label spelled out) plus, for noop scenarios,
 # a fragile ~10-branch alternation regex matching phrasings of "no labels."
-# With scoring.weights omitted, Vally 0.12 computes the trial score as the
+# With scoring.weights omitted, Vally computes the trial score as the
 # UNWEIGHTED MEAN of
 # grader scores, so piling on 12 floors drowns the judge (1/13 weight) and
 # a single wrong label can't move the aggregate. This port keeps, per
@@ -998,7 +998,7 @@ stimuli:
     constraints: { max_duration: 5m, expect_skills: [agentic-labeler] }
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of grader [0,1] scores; stimulus
   # passes when the mean across runs >= threshold. Invocation is a separate
   # workflow hard veto, while 0.90 preserves the suite's prior semantic bar

--- a/.github/skills/analyze-sessions/SKILL.md
+++ b/.github/skills/analyze-sessions/SKILL.md
@@ -242,7 +242,7 @@ scoring:
 Then validate every emitted file:
 
 ```bash
-npx -y @microsoft/vally-cli@0.12.0 lint --eval-spec <path-to-eval> --strict
+npx -y @microsoft/vally-cli@0.14.0 lint --eval-spec <path-to-eval> --strict
 ```
 
 ## Privacy & safety

--- a/.github/skills/analyze-sessions/references/design-rationale.md
+++ b/.github/skills/analyze-sessions/references/design-rationale.md
@@ -162,7 +162,7 @@ generic `.github/evals/` paths are not valid targets. A different skill's
 Each eval pairs a refutation-proof **structural floor** (`output-matches` on a
 forced token line) with **one LLM judge** (`scale_1_5`, `threshold: 0.6`) so the
 judge carries ~half the weight. Each emitted file must pass
-`npx -y @microsoft/vally-cli@0.12.0 lint --eval-spec <f> --strict`. This is the
+`npx -y @microsoft/vally-cli@0.14.0 lint --eval-spec <f> --strict`. This is the
 mechanism that makes the analysis *iterative*: a failure found today becomes a
 regression test that fails if we regress tomorrow.
 

--- a/.github/skills/analyze-sessions/tests/eval.vally.yaml
+++ b/.github/skills/analyze-sessions/tests/eval.vally.yaml
@@ -19,7 +19,7 @@
 # line — immune to "mentions the word" false-fails) with ONE LLM JUDGE
 # (scale_1_5, threshold 0.6) so the judge carries ~50% of every score.
 #
-# Scoring: this suite deliberately omits scoring.weights, so Vally 0.12 uses the
+# Scoring: this suite deliberately omits scoring.weights, so Vally uses the
 # unweighted mean of grader [0,1] scores; a stimulus passes when the mean across
 # runs >= scoring.threshold (0.6). With a scale_1_5 judge (normalized =
 # (raw-1)/4):
@@ -295,7 +295,7 @@ stimuli:
       reject_skills: [analyze-sessions]
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of each stimulus's two graders
   # (one refutation-proof structural floor + one LLM judge), keeping the judge
   # at ~50% of every score per the house convention.

--- a/.github/skills/code-review/tests/eval.inline-findings.vally.yaml
+++ b/.github/skills/code-review/tests/eval.inline-findings.vally.yaml
@@ -159,7 +159,7 @@ stimuli:
         - code-review
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of the two graders' [0,1] scores;
   # the stimulus passes when the mean across runs >= threshold, and the CI
   # check keys off that mean-vs-threshold `passed` property. Two graders (one

--- a/.github/skills/code-review/tests/eval.vally.yaml
+++ b/.github/skills/code-review/tests/eval.vally.yaml
@@ -440,7 +440,7 @@ stimuli:
       max_duration: 10m
 
 scoring:
-  # Vally 0.12 supports scoring.weights, but this suite deliberately omits
+  # Vally supports scoring.weights, but this suite deliberately omits
   # them so a trial's score is the unweighted mean of its graders' [0,1]
   # scores; the stimulus score is the mean across runs. The deterministic
   # tool-calls grader is the manipulation check: a trial that never reads the

--- a/.github/skills/code-review/tests/hermeticity.vally.yaml
+++ b/.github/skills/code-review/tests/hermeticity.vally.yaml
@@ -101,7 +101,7 @@ stimuli:
       max_turns: 10
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean. Threshold 1.0 means the single stimulus must score a perfect 1.0
   # to "pass" — i.e. the agent's output matched the anonymous rate limit
   # (CORE_LIMIT:60). The hermeticity-gate job reads the verdict directly:

--- a/.github/skills/code-review/tests/soak.capability.vally.yaml
+++ b/.github/skills/code-review/tests/soak.capability.vally.yaml
@@ -474,7 +474,7 @@ stimuli:
         - code-review
 
 scoring:
-  # Vally 0.12 supports scoring.weights, but this suite deliberately omits
+  # Vally supports scoring.weights, but this suite deliberately omits
   # them so a trial's score is the unweighted mean of its graders' [0,1]
   # scores. The `prompt`
   # grader contributes ONE holistic score, so rubric criteria are not

--- a/.github/skills/evaluate-pr-tests/tests/eval.vally.yaml
+++ b/.github/skills/evaluate-pr-tests/tests/eval.vally.yaml
@@ -34,13 +34,13 @@
 # brittle (a correct finding phrased differently fails). Those move into
 # the LLM-judge rubric. Each scenario keeps at most 1–2 structural / crisp-
 # negative floors so the judge stays decisive (this suite omits
-# scoring.weights, so Vally 0.12 scores a trial as the unweighted mean of its
+# scoring.weights, so Vally scores a trial as the unweighted mean of its
 # graders). The two purely-semantic
 # detection scenarios (weak assertions, edge-case gaps) are judge-only — a
 # single prompt grader means the trial score IS the judge's normalized
 # rubric score.
 #
-# Scoring: scoring.weights is deliberately omitted, so Vally 0.12 uses the
+# Scoring: scoring.weights is deliberately omitted, so Vally uses the
 # equal-weight aggregate and the 0.6 threshold remains active.
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -405,7 +405,7 @@ stimuli:
     constraints: { max_duration: 5m, expect_skills: [evaluate-pr-tests] }
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of grader [0,1] scores; skill passes
   # when the mean across runs >= threshold. Structural section-heading floors
   # are kept only where producing the report format IS the capability; the

--- a/.github/skills/pr-review/tests/eval.gh-auth.vally.yaml
+++ b/.github/skills/pr-review/tests/eval.gh-auth.vally.yaml
@@ -160,7 +160,7 @@ stimuli:
       max_duration: 5m
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of the three graders' [0,1] scores. The structural floor
   # and guidance-read check are necessary but insufficient. Threshold 0.8
   # keeps the judge load-bearing: a partial regression (`no`, guidance read,

--- a/.github/skills/try-fix/tests/eval.vally.yaml
+++ b/.github/skills/try-fix/tests/eval.vally.yaml
@@ -28,7 +28,7 @@
 #   structural floors (e.g. "claims PASS when no device was available").
 #
 # Scoring (see scoring block): this suite deliberately omits scoring.weights,
-# so Vally 0.12 uses the unweighted mean of grader [0,1] scores; skill passes
+# so Vally uses the unweighted mean of grader [0,1] scores; skill passes
 # when the mean >= scoring.threshold (0.8), unless any trial has an execution
 # error (a separate hard failure regardless of the numeric aggregate). Every
 # scenario also has a deterministic skill-invocation grader. The workflow
@@ -463,7 +463,7 @@ stimuli:
         - try-fix
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of grader [0,1] scores; skill passes when the mean across runs >=
   # threshold. At 0.6, passing invocation/structural floors could dilute every
   # semantic judge failure to a suite score of 0.607. The 0.8 threshold keeps

--- a/.github/skills/verify-tests-fail-without-fix/tests/eval.vally.yaml
+++ b/.github/skills/verify-tests-fail-without-fix/tests/eval.vally.yaml
@@ -23,7 +23,7 @@
 # whose aggregate threshold is undefined so every grader must pass its own
 # threshold.
 #
-# Scoring: this suite deliberately omits scoring.weights, so Vally 0.12 uses
+# Scoring: this suite deliberately omits scoring.weights, so Vally uses
 # the unweighted mean of grader [0,1] scores. Every scenario also has a
 # deterministic invocation grader, and the workflow applies invocation failures
 # as a hard veto. The threshold preserves the prior semantic-judge floor after
@@ -266,7 +266,7 @@ stimuli:
         - verify-tests-fail-without-fix
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of grader [0,1] scores. At 0.87, a stimulus with invocation
   # plus one structural floor still requires judge >= 0.61, preserving the old
   # 0.60 semantic bar. Stimuli without the extra floor are intentionally

--- a/.github/workflows/skill-evaluation-soak.yml
+++ b/.github/workflows/skill-evaluation-soak.yml
@@ -22,7 +22,7 @@ permissions:
   contents: read
 
 env:
-  VALLY_VERSION: "0.12.0"
+  VALLY_VERSION: "0.14.0"
   NODE_VERSION: "22"
 
 jobs:

--- a/.github/workflows/skill-validation.yml
+++ b/.github/workflows/skill-validation.yml
@@ -94,8 +94,8 @@ permissions:
 
 env:
   # Vally CLI is run via npx from npm. Pinned for reproducibility.
-  # Vally 0.12 requires Node >=22, so we pin Node 22 on the runners.
-  VALLY_VERSION: "0.12.0"
+  # Vally requires Node >=22.12, so we pin Node 22 on the runners.
+  VALLY_VERSION: "0.14.0"
   NODE_VERSION: "22"
 
 jobs:

--- a/src/Essentials/src/Map/Map.ios.watchos.macos.cs
+++ b/src/Essentials/src/Map/Map.ios.watchos.macos.cs
@@ -125,22 +125,26 @@ namespace Microsoft.Maui.ApplicationModel
 
 		internal static MKDirectionsMode GetDirectionsMode(NavigationMode navigationMode)
 		{
-#if __IOS__
-			if (navigationMode == NavigationMode.Bicycling)
-			{
-				return OperatingSystem.IsIOSVersionAtLeast(14)
+#if IOS || MACCATALYST
+			var bicyclingMode =
+				OperatingSystem.IsIOSVersionAtLeast(14) || OperatingSystem.IsMacCatalystVersionAtLeast(14)
 					? MKDirectionsMode.Cycling
 					: MKDirectionsMode.Default;
-			}
+#else
+			var bicyclingMode = MKDirectionsMode.Default;
 #endif
 
-			return navigationMode switch
+			return GetDirectionsMode(navigationMode, bicyclingMode);
+		}
+
+		internal static MKDirectionsMode GetDirectionsMode(NavigationMode navigationMode, MKDirectionsMode bicyclingMode) =>
+			navigationMode switch
 			{
+				NavigationMode.Bicycling => bicyclingMode,
 				NavigationMode.Driving => MKDirectionsMode.Driving,
 				NavigationMode.Transit => MKDirectionsMode.Transit,
 				NavigationMode.Walking => MKDirectionsMode.Walking,
 				_ => MKDirectionsMode.Default,
 			};
-		}
 	}
 }

--- a/src/Essentials/src/Map/Map.ios.watchos.macos.cs
+++ b/src/Essentials/src/Map/Map.ios.watchos.macos.cs
@@ -113,31 +113,34 @@ namespace Microsoft.Maui.ApplicationModel
 			MKLaunchOptions launchOptions = null;
 			if (options.NavigationMode != NavigationMode.None)
 			{
-				var mode = MKDirectionsMode.Default;
-
-				switch (options.NavigationMode)
-				{
-					case NavigationMode.Driving:
-						mode = MKDirectionsMode.Driving;
-						break;
-					case NavigationMode.Transit:
-						mode = MKDirectionsMode.Transit;
-						break;
-					case NavigationMode.Walking:
-						mode = MKDirectionsMode.Walking;
-						break;
-					case NavigationMode.Default:
-						mode = MKDirectionsMode.Default;
-						break;
-				}
 				launchOptions = new MKLaunchOptions
 				{
-					DirectionsMode = mode
+					DirectionsMode = GetDirectionsMode(options.NavigationMode)
 				};
 			}
 
 			var mapItems = new[] { mapItem };
 			return Task.FromResult(MKMapItem.OpenMaps(mapItems, launchOptions));
+		}
+
+		internal static MKDirectionsMode GetDirectionsMode(NavigationMode navigationMode)
+		{
+#if __IOS__
+			if (navigationMode == NavigationMode.Bicycling)
+			{
+				return OperatingSystem.IsIOSVersionAtLeast(14)
+					? MKDirectionsMode.Cycling
+					: MKDirectionsMode.Default;
+			}
+#endif
+
+			return navigationMode switch
+			{
+				NavigationMode.Driving => MKDirectionsMode.Driving,
+				NavigationMode.Transit => MKDirectionsMode.Transit,
+				NavigationMode.Walking => MKDirectionsMode.Walking,
+				_ => MKDirectionsMode.Default,
+			};
 		}
 	}
 }

--- a/src/Essentials/src/Map/Map.ios.watchos.macos.cs
+++ b/src/Essentials/src/Map/Map.ios.watchos.macos.cs
@@ -126,21 +126,19 @@ namespace Microsoft.Maui.ApplicationModel
 		internal static MKDirectionsMode GetDirectionsMode(NavigationMode navigationMode)
 		{
 #if IOS || MACCATALYST
-			var bicyclingMode =
-				OperatingSystem.IsIOSVersionAtLeast(14) || OperatingSystem.IsMacCatalystVersionAtLeast(14)
-					? MKDirectionsMode.Cycling
-					: MKDirectionsMode.Default;
+			var isCyclingAvailable =
+				OperatingSystem.IsIOSVersionAtLeast(14) || OperatingSystem.IsMacCatalystVersionAtLeast(14);
 #else
-			var bicyclingMode = MKDirectionsMode.Default;
+			const bool isCyclingAvailable = false;
 #endif
 
-			return GetDirectionsMode(navigationMode, bicyclingMode);
+			return GetDirectionsMode(navigationMode, isCyclingAvailable);
 		}
 
-		internal static MKDirectionsMode GetDirectionsMode(NavigationMode navigationMode, MKDirectionsMode bicyclingMode) =>
+		internal static MKDirectionsMode GetDirectionsMode(NavigationMode navigationMode, bool isCyclingAvailable) =>
 			navigationMode switch
 			{
-				NavigationMode.Bicycling => bicyclingMode,
+				NavigationMode.Bicycling when isCyclingAvailable => MKDirectionsMode.Cycling,
 				NavigationMode.Driving => MKDirectionsMode.Driving,
 				NavigationMode.Transit => MKDirectionsMode.Transit,
 				NavigationMode.Walking => MKDirectionsMode.Walking,

--- a/src/Essentials/test/DeviceTests/Tests/Maps_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Maps_Tests.cs
@@ -3,6 +3,9 @@ using System.Threading.Tasks;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Devices.Sensors;
 using Xunit;
+#if __IOS__
+using MapKit;
+#endif
 
 namespace Microsoft.Maui.Essentials.DeviceTests
 {
@@ -33,6 +36,12 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 			};
 			await Map.OpenAsync(placemark, new MapLaunchOptions { Name = mapName }).ConfigureAwait(false);
 		}
+
+#if __IOS__
+		[Fact]
+		public void BicyclingNavigationModeUsesCyclingDirections() =>
+			Assert.Equal(MKDirectionsMode.Cycling, MapImplementation.GetDirectionsMode(NavigationMode.Bicycling));
+#endif
 
 		[Fact]
 		public async Task LaunchMap_NullLocation()

--- a/src/Essentials/test/DeviceTests/Tests/Maps_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Maps_Tests.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Devices.Sensors;
 using Xunit;
-#if __IOS__
+#if IOS || MACCATALYST
 using MapKit;
 #endif
 
@@ -37,10 +37,22 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 			await Map.OpenAsync(placemark, new MapLaunchOptions { Name = mapName }).ConfigureAwait(false);
 		}
 
-#if __IOS__
+#if IOS || MACCATALYST
+		[Theory]
+		[InlineData(NavigationMode.None, MKDirectionsMode.Default)]
+		[InlineData(NavigationMode.Default, MKDirectionsMode.Default)]
+		[InlineData(NavigationMode.Bicycling, MKDirectionsMode.Cycling)]
+		[InlineData(NavigationMode.Driving, MKDirectionsMode.Driving)]
+		[InlineData(NavigationMode.Transit, MKDirectionsMode.Transit)]
+		[InlineData(NavigationMode.Walking, MKDirectionsMode.Walking)]
+		public void NavigationModeUsesExpectedDirectionsMode(NavigationMode navigationMode, MKDirectionsMode expected) =>
+			Assert.Equal(expected, MapImplementation.GetDirectionsMode(navigationMode, MKDirectionsMode.Cycling));
+
 		[Fact]
-		public void BicyclingNavigationModeUsesCyclingDirections() =>
-			Assert.Equal(MKDirectionsMode.Cycling, MapImplementation.GetDirectionsMode(NavigationMode.Bicycling));
+		public void BicyclingNavigationModeFallsBackWhenCyclingIsUnavailable() =>
+			Assert.Equal(
+				MKDirectionsMode.Default,
+				MapImplementation.GetDirectionsMode(NavigationMode.Bicycling, MKDirectionsMode.Default));
 #endif
 
 		[Fact]

--- a/src/Essentials/test/DeviceTests/Tests/Maps_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Maps_Tests.cs
@@ -49,8 +49,14 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 			Assert.Equal(expected, MapImplementation.GetDirectionsMode(navigationMode, isCyclingAvailable: true));
 
 		[Fact]
-		public void BicyclingNavigationModeUsesCyclingDirections() =>
-			Assert.Equal(MKDirectionsMode.Cycling, MapImplementation.GetDirectionsMode(NavigationMode.Bicycling));
+		public void BicyclingNavigationModeUsesExpectedDirectionsMode()
+		{
+			var expected = OperatingSystem.IsIOSVersionAtLeast(14) || OperatingSystem.IsMacCatalystVersionAtLeast(14)
+				? MKDirectionsMode.Cycling
+				: MKDirectionsMode.Default;
+
+			Assert.Equal(expected, MapImplementation.GetDirectionsMode(NavigationMode.Bicycling));
+		}
 
 		[Fact]
 		public void BicyclingNavigationModeFallsBackWhenCyclingIsUnavailable() =>

--- a/src/Essentials/test/DeviceTests/Tests/Maps_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Maps_Tests.cs
@@ -46,13 +46,15 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		[InlineData(NavigationMode.Transit, MKDirectionsMode.Transit)]
 		[InlineData(NavigationMode.Walking, MKDirectionsMode.Walking)]
 		public void NavigationModeUsesExpectedDirectionsMode(NavigationMode navigationMode, MKDirectionsMode expected) =>
-			Assert.Equal(expected, MapImplementation.GetDirectionsMode(navigationMode, MKDirectionsMode.Cycling));
+			Assert.Equal(expected, MapImplementation.GetDirectionsMode(navigationMode, isCyclingAvailable: true));
+
+		[Fact]
+		public void BicyclingNavigationModeUsesCyclingDirections() =>
+			Assert.Equal(MKDirectionsMode.Cycling, MapImplementation.GetDirectionsMode(NavigationMode.Bicycling));
 
 		[Fact]
 		public void BicyclingNavigationModeFallsBackWhenCyclingIsUnavailable() =>
-			Assert.Equal(
-				MKDirectionsMode.Default,
-				MapImplementation.GetDirectionsMode(NavigationMode.Bicycling, MKDirectionsMode.Default));
+			Assert.Equal(MKDirectionsMode.Default, MapImplementation.GetDirectionsMode(NavigationMode.Bicycling, isCyclingAvailable: false));
 #endif
 
 		[Fact]


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Maps `NavigationMode.Bicycling` to MapKit's `MKDirectionsMode.Cycling` on iOS 14 and later and on supported Mac Catalyst versions. Previously, the shared Apple implementation omitted bicycling from its direction-mode mapping, so Apple Maps fell back to its default driving mode.

On iOS 13, where MapKit does not provide the cycling launch mode, bicycling gracefully falls back to `MKDirectionsMode.Default`. Device tests cover every navigation-mode mapping and the unavailable-cycling fallback.

### Issues Fixed

Fixes #37937