### PR TITLE
[Android] Map: Stop pin icons and cluster icons evicting each other

### DIFF
--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -49,7 +49,12 @@ namespace Microsoft.Maui.Maps.Handlers
 		List<MapCluster>? _clusters;
 		Dictionary<string, MapCluster>? _clusterMarkers;
 		const int MaxIconCacheSize = 64;
-		readonly IconCache<BitmapDescriptor> _iconCache = new(MaxIconCacheSize);
+
+		// Two caches, not one: a ClusterImageVersion bump must not drop the pin icons, and pin
+		// traffic past the capacity must not evict the cluster entries on every pass. The cost is
+		// that a pin and a cluster naming the same image decode twice.
+		readonly IconCache<BitmapDescriptor> _pinIconCache = new(MaxIconCacheSize);
+		readonly IconCache<BitmapDescriptor> _clusterIconCache = new(MaxIconCacheSize);
 		WeakReference<IMap>? _clusterImageOwner;
 		int _clusterImageVersion = int.MinValue;
 
@@ -135,7 +140,8 @@ namespace Microsoft.Maui.Maps.Handlers
 			_circles = null;
 			_clusters?.Clear();
 			_clusterMarkers?.Clear();
-			_iconCache.Clear();
+			_pinIconCache.Clear();
+			_clusterIconCache.Clear();
 			_clusterImageOwner = null;
 			_clusterImageVersion = int.MinValue;
 			_init = true;
@@ -414,7 +420,8 @@ namespace Microsoft.Maui.Maps.Handlers
 
 			_clusterImageOwner = new WeakReference<IMap>(map);
 			_clusterImageVersion = version;
-			_iconCache.Clear();
+			// Cluster entries only: a version bump says nothing about the pins' own ImageSources.
+			_clusterIconCache.Clear();
 		}
 
 		/// <summary>
@@ -921,7 +928,7 @@ namespace Microsoft.Maui.Maps.Handlers
 			{
 				// Clustering re-runs AddPins on every zoom change, so without the cache the icon of
 				// every un-clustered pin is decoded and rescaled again on each pass.
-				var icon = await GetIconAsync(requestedSource, MauiContext, ct);
+				var icon = await GetIconAsync(_pinIconCache, requestedSource, MauiContext, ct);
 
 				// Re-checked after the await: UpdatePinImageSourceAsync can have applied a newer
 				// source in the meantime, and it guards its own write the same way. Without this
@@ -961,7 +968,11 @@ namespace Microsoft.Maui.Maps.Handlers
 
 			if (requestedSource != null)
 			{
-				icon = await LoadPinIconAsync(requestedSource, mauiContext, ct);
+				// Through the cache like AddPinAsync: switching many pins to one image coalesces
+				// into a single load, and the next recluster pass finds the entry. Note GetIconAsync
+				// drops ct for a keyable load, so this can outlive a pins reset - the guards below
+				// still discard the result.
+				icon = await GetIconAsync(_pinIconCache, requestedSource, mauiContext, ct);
 				// null means load failed/cancelled - leave the marker's current icon untouched.
 				if (icon == null)
 					return;
@@ -984,17 +995,17 @@ namespace Microsoft.Maui.Maps.Handlers
 			}
 		}
 
-		// Shared by pin and cluster markers: one decoded descriptor backs every marker naming the same
-		// image, so a recluster pass reuses it instead of decoding per marker. GetIconCacheKey returns
-		// null for a source that can't be keyed stably, or that opted out of caching - those load fresh
-		// every time, which is also why they keep this caller's ct: nobody else is waiting on them.
-		// A keyable load is shared, so it must not be cancelled by whichever caller happened to start it.
-		Task<BitmapDescriptor?> GetIconAsync(IImageSource imageSource, IMauiContext mauiContext, CancellationToken ct)
+		// One decoded descriptor backs every marker naming the same image, so a recluster pass reuses
+		// it instead of decoding per marker. GetIconCacheKey returns null for a source that can't be
+		// keyed stably, or that opted out of caching - those load fresh every time, which is also why
+		// they keep this caller's ct: nobody else is waiting on them. A keyable load is shared, so it
+		// must not be cancelled by whichever caller happened to start it.
+		static Task<BitmapDescriptor?> GetIconAsync(IconCache<BitmapDescriptor> cache, IImageSource imageSource, IMauiContext mauiContext, CancellationToken ct)
 		{
 			var cacheKey = GetIconCacheKey(imageSource);
 			var loadToken = cacheKey is null ? ct : CancellationToken.None;
 
-			return _iconCache.GetOrCreateAsync(
+			return cache.GetOrCreateAsync(
 				cacheKey,
 				() => LoadPinIconAsync(imageSource, mauiContext, loadToken),
 				() => GetIconCacheExpiry(imageSource));
@@ -1089,7 +1100,7 @@ namespace Microsoft.Maui.Maps.Handlers
 
 			BitmapDescriptor? icon = null;
 			if (image != null)
-				icon = await GetIconAsync(image, mauiContext, ct);
+				icon = await GetIconAsync(_clusterIconCache, image, mauiContext, ct);
 
 			if (ct.IsCancellationRequested || !ReferenceEquals(Map, map))
 				return;


### PR DESCRIPTION
### Description of Change

Fixes #37943.

#37774 added a bounded LRU of decoded marker icons, and during review I merged the per-pin cache into the cluster one so a single instance served both. That sharing is the bug — I introduced it, so this is a self-report.

Pin icons and cluster icons compete for the same 64 entries and evict each other in both directions:

- **Pin traffic evicts the cluster icon.** Un-clustered pins decode on every recluster pass, so with more distinct pin images than the capacity they keep the cluster entry least recently used. It is evicted and re-decoded each pass — the exact work the cache was added to avoid. Past the capacity the cache degenerates to a 0% hit rate, leaving such a map worse off than before it existed.
- **A cluster image change discards the pin icons.** `UpdateClusterImageVersion` calls `Clear()` on the shared instance, so a `ClusterImageSource` change throws away every decoded pin icon even though no pin `ImageSource` changed.

Two instances, and the version bump now clears only the cluster one. The cost is that a pin and a cluster naming the same image decode twice, which is rarer than either eviction path.

`UpdatePinImageSourceAsync` also goes through the pin cache now, so the two pin-icon paths agree — previously `AddPinAsync` used the cache and the property-change path did not. This makes switching many live pins to one image coalesce into a single load instead of one per pin, and leaves the entry there for the following recluster pass. Note it hands a keyable load `CancellationToken.None`, so such a load can outlive a pins reset; the guards after the await still discard the result, and it is the trade `AddPinAsync` already made.

Nothing here is a correctness change — icons rendered correctly before and after. This is decode and rescale churn on zoom.

### Issues Fixed

Fixes #37943

### Validation

The repro page is on a branch rather than in this PR: [`repro/issue-37943`](https://github.com/kevin68/maui/blob/repro/issue-37943/src/Controls/tests/TestCases.HostApp/Issues/Issue37943.cs), matching what was done for #37775. It is not merged here because the symptom is decode churn with no UI-observable effect, so there is no `TestCases.Shared.Tests` case to drive it — a page nothing runs in CI is maintenance surface, not coverage.

The page drives three scenarios and emits `PROBE` phase markers. Counting decodes needs one line inside `LoadPinIconAsync`, which its header comment gives.

Measured on a Samsung SM-X230, Android 16, running that page on both arms with the line in place. Counts are decodes of the named image:

| phase | image counted | before | after |
|---|---|---|---|
| 1 — 6 recluster passes, 100 distinct pin images | cluster image | **1 per pass** (7 total) | **1 total** |
| 2 — `ClusterImageSource` changed | pin icons | **5 re-decoded** | **0** |
| 3 — 12 live pins switched to one image | that image | **12** | **1** |
| 3 — the recluster pass that follows | that image | **1 more** | **0** |

The 100 distinct pin images in phase 1 are re-decoded identically in both arms (700 each) — more distinct images than the capacity is ordinary bounded-LRU behaviour, not the regression. They are there to create the eviction pressure the measurement needs.

`Microsoft.Maui.Controls.Core.UnitTests` MapTests: 108/108.
