### PR TITLE
[net11.0] Make remaining platform APIs public

### DIFF
--- a/src/Controls/src/Core/Editor/Editor.iOS.cs
+++ b/src/Controls/src/Core/Editor/Editor.iOS.cs
@@ -3,8 +3,12 @@ namespace Microsoft.Maui.Controls
 {
 	public partial class Editor
 	{
-		// TODO: Make this public in .NET 11
-		internal static void MapAutoSize(IEditorHandler handler, Editor editor)
+		/// <summary>
+		/// Maps the <see cref="AutoSize"/> property to the iOS or Mac Catalyst platform view.
+		/// </summary>
+		/// <param name="handler">The handler associated with the editor.</param>
+		/// <param name="editor">The editor whose automatic sizing behavior is being mapped.</param>
+		public static void MapAutoSize(IEditorHandler handler, Editor editor)
 		{
 			if (handler.PlatformView is Microsoft.Maui.Platform.MauiTextView textView)
 			{

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -241,4 +241,5 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.Editor.MapAutoSize(Microsoft.Maui.Handlers.IEditorHandler handler, Microsoft.Maui.Controls.Editor editor) -> void
 static Microsoft.Maui.Controls.Shell.ResolveFlyoutItemTemplate(Microsoft.Maui.Controls.Shell? shell, Microsoft.Maui.Controls.BindableObject! flyoutItem) -> Microsoft.Maui.Controls.DataTemplate?

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -233,4 +233,5 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TabbedPage.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.Editor.MapAutoSize(Microsoft.Maui.Handlers.IEditorHandler handler, Microsoft.Maui.Controls.Editor editor) -> void
 static Microsoft.Maui.Controls.Shell.ResolveFlyoutItemTemplate(Microsoft.Maui.Controls.Shell? shell, Microsoft.Maui.Controls.BindableObject! flyoutItem) -> Microsoft.Maui.Controls.DataTemplate?

--- a/src/Core/src/Platform/Android/WindowExtensions.cs
+++ b/src/Core/src/Platform/Android/WindowExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.CompilerServices;
 using Android.App;
 using Android.Content;
@@ -55,8 +56,11 @@ namespace Microsoft.Maui
 		/// <param name="window">The Android window to configure.</param>
 		/// <param name="activity">The activity that owns the window.</param>
 		/// <remarks>This method must be called on the UI thread.</remarks>
+		/// <exception cref="ArgumentNullException"><paramref name="activity"/> is <see langword="null"/>.</exception>
 		public static void ConfigureTranslucentSystemBars(this Window? window, Activity activity)
 		{
+			ArgumentNullException.ThrowIfNull(activity);
+
 			if (!RuntimeFeature.UseMauiAndroidSystemBarBackgrounds)
 			{
 				ConfigureLegacyTranslucentSystemBars(window, activity);

--- a/src/Core/src/Platform/Android/WindowExtensions.cs
+++ b/src/Core/src/Platform/Android/WindowExtensions.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Maui
 		/// <summary>
 		/// Configures translucent system bars for the specified Android window.
 		/// </summary>
-		/// <param name="window">The Android window to configure.</param>
+		/// <param name="window">The Android window to configure, or <see langword="null"/> to skip configuration.</param>
 		/// <param name="activity">The activity that owns the window.</param>
 		/// <remarks>This method must be called on the UI thread.</remarks>
 		/// <exception cref="ArgumentNullException"><paramref name="activity"/> is <see langword="null"/>.</exception>

--- a/src/Core/src/Platform/Android/WindowExtensions.cs
+++ b/src/Core/src/Platform/Android/WindowExtensions.cs
@@ -49,8 +49,13 @@ namespace Microsoft.Maui
 				.SetSoftInputMode(inputMode);
 		}
 
-		//TODO : Make it public in NET 11.
-		internal static void ConfigureTranslucentSystemBars(this Window? window, Activity activity)
+		/// <summary>
+		/// Configures translucent system bars for the specified Android window.
+		/// </summary>
+		/// <param name="window">The Android window to configure.</param>
+		/// <param name="activity">The activity that owns the window.</param>
+		/// <remarks>This method must be called on the UI thread.</remarks>
+		public static void ConfigureTranslucentSystemBars(this Window? window, Activity activity)
 		{
 			if (!RuntimeFeature.UseMauiAndroidSystemBarBackgrounds)
 			{

--- a/src/Core/src/Platform/Windows/MauiBorderAutomationPeer.cs
+++ b/src/Core/src/Platform/Windows/MauiBorderAutomationPeer.cs
@@ -4,10 +4,16 @@ using Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.Maui.Platform
 {
-	// TODO: Make this class public in .NET11.0. Issue Link: https://github.com/dotnet/maui/issues/30205
-	internal partial class MauiBorderAutomationPeer : FrameworkElementAutomationPeer
+	/// <summary>
+	/// Provides automation peer behavior for a .NET MAUI border on Windows.
+	/// </summary>
+	public partial class MauiBorderAutomationPeer : FrameworkElementAutomationPeer
 	{
-		internal MauiBorderAutomationPeer(ContentPanel owner) : base(owner) { }
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MauiBorderAutomationPeer"/> class.
+		/// </summary>
+		/// <param name="owner">The content panel associated with the border.</param>
+		public MauiBorderAutomationPeer(ContentPanel owner) : base(owner) { }
 
 		protected override AutomationControlType GetAutomationControlTypeCore()
 		{

--- a/src/Core/src/Platform/iOS/SemanticExtensions.cs
+++ b/src/Core/src/Platform/iOS/SemanticExtensions.cs
@@ -39,8 +39,11 @@ namespace Microsoft.Maui.Platform
 		/// </summary>
 		/// <param name="platformView">The platform view that should receive focus.</param>
 		/// <remarks>This method must be called on the UI thread.</remarks>
+		/// <exception cref="ArgumentNullException"><paramref name="platformView"/> is <see langword="null"/>.</exception>
 		public static void PostAccessibilityFocusNotification(this UIView platformView)
 		{
+			ArgumentNullException.ThrowIfNull(platformView);
+
 			UIAccessibility.PostNotification(UIAccessibilityPostNotification.ScreenChanged, platformView);
 		}
 

--- a/src/Core/src/Platform/iOS/SemanticExtensions.cs
+++ b/src/Core/src/Platform/iOS/SemanticExtensions.cs
@@ -51,9 +51,12 @@ namespace Microsoft.Maui.Platform
 		/// Posts a VoiceOver screen changed notification for an input view when it becomes visible.
 		/// This ensures VoiceOver shifts focus to the input view (e.g., UIPickerView, UIDatePicker) when it appears.
 		/// </summary>
-		/// <param name="platformView">The platform view that hosts the input view.</param>
+		/// <param name="platformView">The platform view that hosts the input view. This receiver is not the notification target.</param>
 		/// <param name="inputView">The input view that should receive focus, or <see langword="null"/> if no notification should be posted.</param>
-		/// <remarks>This method must be called on the UI thread.</remarks>
+		/// <remarks>
+		/// This method must be called on the UI thread. The notification targets <paramref name="inputView"/>;
+		/// passing <see langword="null"/> for <paramref name="inputView"/> is a no-op.
+		/// </remarks>
 		/// <exception cref="ArgumentNullException"><paramref name="platformView"/> is <see langword="null"/>.</exception>
 		public static void PostAccessibilityFocusNotification(this UIView platformView, UIView? inputView)
 		{

--- a/src/Core/src/Platform/iOS/SemanticExtensions.cs
+++ b/src/Core/src/Platform/iOS/SemanticExtensions.cs
@@ -36,10 +36,10 @@ namespace Microsoft.Maui.Platform
 		/// Posts a VoiceOver screen changed notification to return focus to the specified view.
 		/// This is typically used when an input view is dismissed and focus should return to the original control.
 		/// </summary>
-		/// <param name="platformView">The platform view that should receive focus</param>
-		internal static void PostAccessibilityFocusNotification(this UIView platformView)
+		/// <param name="platformView">The platform view that should receive focus.</param>
+		/// <remarks>This method must be called on the UI thread.</remarks>
+		public static void PostAccessibilityFocusNotification(this UIView platformView)
 		{
-			// TODO: Make public for .NET 11.
 			UIAccessibility.PostNotification(UIAccessibilityPostNotification.ScreenChanged, platformView);
 		}
 
@@ -47,12 +47,11 @@ namespace Microsoft.Maui.Platform
 		/// Posts a VoiceOver screen changed notification for an input view when it becomes visible.
 		/// This ensures VoiceOver shifts focus to the input view (e.g., UIPickerView, UIDatePicker) when it appears.
 		/// </summary>
-		/// <param name="platformView">The platform view that hosts the input view</param>
-		/// <param name="inputView">The input view that should receive focus</param>
-		internal static void PostAccessibilityFocusNotification(this UIView platformView, UIView? inputView)
+		/// <param name="platformView">The platform view that hosts the input view.</param>
+		/// <param name="inputView">The input view that should receive focus, or <see langword="null"/> if no notification should be posted.</param>
+		/// <remarks>This method must be called on the UI thread.</remarks>
+		public static void PostAccessibilityFocusNotification(this UIView platformView, UIView? inputView)
 		{
-			// TODO: Make public for .NET 11.
-
 			if (inputView is null)
 			{
 				return;

--- a/src/Core/src/Platform/iOS/SemanticExtensions.cs
+++ b/src/Core/src/Platform/iOS/SemanticExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System;
+using System.Text;
 using UIKit;
 
 namespace Microsoft.Maui.Platform
@@ -50,8 +51,11 @@ namespace Microsoft.Maui.Platform
 		/// <param name="platformView">The platform view that hosts the input view.</param>
 		/// <param name="inputView">The input view that should receive focus, or <see langword="null"/> if no notification should be posted.</param>
 		/// <remarks>This method must be called on the UI thread.</remarks>
+		/// <exception cref="ArgumentNullException"><paramref name="platformView"/> is <see langword="null"/>.</exception>
 		public static void PostAccessibilityFocusNotification(this UIView platformView, UIView? inputView)
 		{
+			ArgumentNullException.ThrowIfNull(platformView);
+
 			if (inputView is null)
 			{
 				return;

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -352,8 +352,8 @@ static Microsoft.Maui.Platform.TimePickerExtensions.UpdateFormat(this Microsoft.
 static Microsoft.Maui.Platform.TimePickerExtensions.UpdateTextAlignment(this Microsoft.Maui.Platform.MauiTimePicker! mauiTimePicker, Microsoft.Maui.ITimePicker! timePicker) -> void
 static Microsoft.Maui.Platform.TimePickerExtensions.UpdateTextColor(this Microsoft.Maui.Platform.MauiMaterialTimePicker! platformTimePicker, Microsoft.Maui.ITimePicker! timePicker) -> void
 static Microsoft.Maui.Platform.TimePickerExtensions.UpdateTime(this Microsoft.Maui.Platform.MauiMaterialTimePicker! mauiTimePicker, Microsoft.Maui.ITimePicker! timePicker) -> void
-static Microsoft.Maui.WindowExtensions.ConfigureTranslucentSystemBars(this Android.Views.Window? window, Android.App.Activity! activity) -> void
 static Microsoft.Maui.SafeAreaEdges.Container.get -> Microsoft.Maui.SafeAreaEdges
+static Microsoft.Maui.WindowExtensions.ConfigureTranslucentSystemBars(this Android.Views.Window? window, Android.App.Activity! activity) -> void
 virtual Microsoft.Maui.Handlers.DatePickerHandler2.CreateDatePickerDialog(int year, int month, int day) -> Google.Android.Material.DatePicker.MaterialDatePicker?
 virtual Microsoft.Maui.Handlers.TimePickerHandler2.CreateTimePickerDialog(int hour, int minute) -> Google.Android.Material.TimePicker.MaterialTimePicker?
 virtual Microsoft.Maui.Platform.MauiDrawerLayout.Disconnect() -> void

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -352,6 +352,7 @@ static Microsoft.Maui.Platform.TimePickerExtensions.UpdateFormat(this Microsoft.
 static Microsoft.Maui.Platform.TimePickerExtensions.UpdateTextAlignment(this Microsoft.Maui.Platform.MauiTimePicker! mauiTimePicker, Microsoft.Maui.ITimePicker! timePicker) -> void
 static Microsoft.Maui.Platform.TimePickerExtensions.UpdateTextColor(this Microsoft.Maui.Platform.MauiMaterialTimePicker! platformTimePicker, Microsoft.Maui.ITimePicker! timePicker) -> void
 static Microsoft.Maui.Platform.TimePickerExtensions.UpdateTime(this Microsoft.Maui.Platform.MauiMaterialTimePicker! mauiTimePicker, Microsoft.Maui.ITimePicker! timePicker) -> void
+static Microsoft.Maui.WindowExtensions.ConfigureTranslucentSystemBars(this Android.Views.Window? window, Android.App.Activity! activity) -> void
 static Microsoft.Maui.SafeAreaEdges.Container.get -> Microsoft.Maui.SafeAreaEdges
 virtual Microsoft.Maui.Handlers.DatePickerHandler2.CreateDatePickerDialog(int year, int month, int day) -> Google.Android.Material.DatePicker.MaterialDatePicker?
 virtual Microsoft.Maui.Handlers.TimePickerHandler2.CreateTimePickerDialog(int hour, int minute) -> Google.Android.Material.TimePicker.MaterialTimePicker?

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -56,6 +56,8 @@ static Microsoft.Maui.Handlers.TimePickerHandler.MapFlowDirection(Microsoft.Maui
 static Microsoft.Maui.Handlers.WindowHandler.MapStatusBarTheme(Microsoft.Maui.Handlers.IWindowHandler! handler, Microsoft.Maui.IWindow! window) -> void
 static Microsoft.Maui.Platform.ButtonExtensions.UpdateBackground(this UIKit.UIButton! platformButton, Microsoft.Maui.Graphics.Paint? paint) -> void
 static Microsoft.Maui.Platform.CollectionViewExtensions.UpdateIsEnabled(this UIKit.UICollectionView! collectionView, Microsoft.Maui.IView! view) -> void
+static Microsoft.Maui.Platform.SemanticExtensions.PostAccessibilityFocusNotification(this UIKit.UIView! platformView) -> void
+static Microsoft.Maui.Platform.SemanticExtensions.PostAccessibilityFocusNotification(this UIKit.UIView! platformView, UIKit.UIView? inputView) -> void
 static Microsoft.Maui.SafeAreaEdges.Container.get -> Microsoft.Maui.SafeAreaEdges
 virtual Microsoft.Maui.Animations.PlatformTicker.Dispose(bool disposing) -> void
 ~override Microsoft.Maui.Handlers.TabbedViewHandler.ConnectHandler(UIKit.UIView platformView) -> void

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -53,6 +53,8 @@ static Microsoft.Maui.Handlers.StepperHandler.MapFlowDirection(Microsoft.Maui.Ha
 static Microsoft.Maui.Handlers.WindowHandler.MapStatusBarTheme(Microsoft.Maui.Handlers.IWindowHandler! handler, Microsoft.Maui.IWindow! window) -> void
 static Microsoft.Maui.Platform.ButtonExtensions.UpdateBackground(this UIKit.UIButton! platformButton, Microsoft.Maui.Graphics.Paint? paint) -> void
 static Microsoft.Maui.Platform.CollectionViewExtensions.UpdateIsEnabled(this UIKit.UICollectionView! collectionView, Microsoft.Maui.IView! view) -> void
+static Microsoft.Maui.Platform.SemanticExtensions.PostAccessibilityFocusNotification(this UIKit.UIView! platformView) -> void
+static Microsoft.Maui.Platform.SemanticExtensions.PostAccessibilityFocusNotification(this UIKit.UIView! platformView, UIKit.UIView? inputView) -> void
 static Microsoft.Maui.SafeAreaEdges.Container.get -> Microsoft.Maui.SafeAreaEdges
 virtual Microsoft.Maui.Animations.PlatformTicker.Dispose(bool disposing) -> void
 ~override Microsoft.Maui.Handlers.TabbedViewHandler.ConnectHandler(UIKit.UIView platformView) -> void

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -11,6 +11,8 @@ Microsoft.Maui.ITab.IsEnabled.get -> bool
 Microsoft.Maui.ITab.Title.get -> string!
 Microsoft.Maui.IWindow.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
 Microsoft.Maui.LifecycleEvents.WindowsLifecycle.OnAppInstanceActivated
+Microsoft.Maui.Platform.MauiBorderAutomationPeer
+Microsoft.Maui.Platform.MauiBorderAutomationPeer.MauiBorderAutomationPeer(Microsoft.Maui.Platform.ContentPanel! owner) -> void
 Microsoft.Maui.Platform.MauiLayoutAutomationPeer
 Microsoft.Maui.Platform.MauiLayoutAutomationPeer.MauiLayoutAutomationPeer(Microsoft.Maui.Platform.LayoutPanel! owner) -> void
 Microsoft.Maui.Platform.MauiPasswordTextBoxAutomationPeer
@@ -27,6 +29,10 @@ override Microsoft.Maui.Animations.PlatformTicker.IsRunning.get -> bool
 override Microsoft.Maui.Platform.ContentPanel.MeasureOverride(Windows.Foundation.Size availableSize) -> Windows.Foundation.Size
 override Microsoft.Maui.Platform.ContentPanel.OnCreateAutomationPeer() -> Microsoft.UI.Xaml.Automation.Peers.AutomationPeer!
 override Microsoft.Maui.Platform.LayoutPanel.OnCreateAutomationPeer() -> Microsoft.UI.Xaml.Automation.Peers.AutomationPeer!
+override Microsoft.Maui.Platform.MauiBorderAutomationPeer.GetAutomationControlTypeCore() -> Microsoft.UI.Xaml.Automation.Peers.AutomationControlType
+override Microsoft.Maui.Platform.MauiBorderAutomationPeer.GetClassNameCore() -> string!
+override Microsoft.Maui.Platform.MauiBorderAutomationPeer.IsContentElementCore() -> bool
+override Microsoft.Maui.Platform.MauiBorderAutomationPeer.IsControlElementCore() -> bool
 override Microsoft.Maui.Platform.MauiLayoutAutomationPeer.GetAutomationControlTypeCore() -> Microsoft.UI.Xaml.Automation.Peers.AutomationControlType
 override Microsoft.Maui.Platform.MauiLayoutAutomationPeer.GetClassNameCore() -> string!
 override Microsoft.Maui.Platform.MauiLayoutAutomationPeer.GetLocalizedControlTypeCore() -> string!


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

Promotes the remaining explicit .NET 11 platform API TODOs to public:

- `Editor.MapAutoSize` on iOS and Mac Catalyst
- `WindowExtensions.ConfigureTranslucentSystemBars` on Android
- `MauiBorderAutomationPeer` and its constructor on Windows
- Both `SemanticExtensions.PostAccessibilityFocusNotification` overloads on iOS and Mac Catalyst

Adds XML documentation and the corresponding platform-specific `PublicAPI.Unshipped.txt` entries. All exposed signatures use types that were already public.

Closes #30205

## Validation

- `Controls.Core.csproj` / `Core.csproj` — `net11.0-windows10.0.19041.0`
- `Controls.Core.csproj` / `Core.csproj` — `net11.0-android37.0`
- `Controls.Core.csproj` / `Core.csproj` — `net11.0-ios26.5`
- `Controls.Core.csproj` / `Core.csproj` — `net11.0-maccatalyst26.5`