### PR TITLE
[.NET 11] Make overdue handler mapper APIs public

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.Android.cs
+++ b/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.Android.cs
@@ -43,8 +43,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			(handler.PlatformView as IMauiRecyclerView<CarouselView>).UpdateAdapter();
 		}
 
-		// TODO: Change the modifier to public in .NET 10.
-		internal static void MapLoop(CarouselViewHandler handler, CarouselView carouselView)
+		public static void MapLoop(CarouselViewHandler handler, CarouselView carouselView)
 		{
 			if (handler.PlatformView is MauiCarouselRecyclerView cv)
 			{
@@ -66,8 +65,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			(handler.PlatformView as IMauiCarouselRecyclerView).UpdateFromCurrentItem();
 		}
 
-		// TODO: Change the modifier to public in .NET 10.
-		internal static void MapItemsLayout(CarouselViewHandler handler, CarouselView carouselView)
+		public static void MapItemsLayout(CarouselViewHandler handler, CarouselView carouselView)
 		{
 			if (handler.PlatformView is IMauiRecyclerView<CarouselView> recyclerView)
 			{

--- a/src/Controls/src/Core/Handlers/Items2/CarouselViewHandler2.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items2/CarouselViewHandler2.iOS.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 		public static void MapItemsLayout(CarouselViewHandler2 handler, CarouselView carouselView)
 		{
-			handler?.UpdateLayout();
+			handler.UpdateLayout();
 			(handler.Controller as CarouselViewController2)?.UpdateScrollingConstraints();
 		}
 

--- a/src/Controls/src/Core/Handlers/Items2/CarouselViewHandler2.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items2/CarouselViewHandler2.iOS.cs
@@ -97,8 +97,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			handler.Controller.CollectionView.Bounces = carouselView.IsBounceEnabled;
 		}
 
-		// TODO: Change the modifier to public in .NET 10.
-		internal static void MapItemsLayout(CarouselViewHandler2 handler, CarouselView carouselView)
+		public static void MapItemsLayout(CarouselViewHandler2 handler, CarouselView carouselView)
 		{
 			handler?.UpdateLayout();
 			(handler.Controller as CarouselViewController2)?.UpdateScrollingConstraints();

--- a/src/Controls/src/Core/Handlers/Shell/ShellHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellHandler.Windows.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Maui.Controls.Handlers
 				return;
 
 			var provider = handler.GetRequiredService<IImageSourceServiceProvider>();
-			handler.PlatformView.UpdateBackgroundImageSourceAsync(view.FlyoutBackgroundImage, provider, view.FlyoutBackgroundImageAspect).FireAndForget();
+			handler.PlatformView.UpdateBackgroundImageSourceAsync(view.FlyoutBackgroundImage, provider, view.FlyoutBackgroundImageAspect).FireAndForget(handler);
 		}
 
 		public static void MapFlyoutIcon(ShellHandler handler, Shell view)

--- a/src/Controls/src/Core/Handlers/Shell/ShellHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellHandler.Windows.cs
@@ -140,8 +140,7 @@ namespace Microsoft.Maui.Controls.Handlers
 					view.FlyoutBackgroundColor?.AsPaint());
 		}
 
-		//TODO: Make it public in .NET 10.
-		internal static void MapFlyoutBackgroundImage(ShellHandler handler, Shell view)
+		public static void MapFlyoutBackgroundImage(ShellHandler handler, Shell view)
 		{
 			var provider = handler.GetRequiredService<IImageSourceServiceProvider>();
 			if (handler?.PlatformView is not null && provider is not null)

--- a/src/Controls/src/Core/Handlers/Shell/ShellHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellHandler.Windows.cs
@@ -142,11 +142,11 @@ namespace Microsoft.Maui.Controls.Handlers
 
 		public static void MapFlyoutBackgroundImage(ShellHandler handler, Shell view)
 		{
+			if (handler.PlatformView is null)
+				return;
+
 			var provider = handler.GetRequiredService<IImageSourceServiceProvider>();
-			if (handler?.PlatformView is not null && provider is not null)
-			{
-				handler.PlatformView.UpdateBackgroundImageSourceAsync(view.FlyoutBackgroundImage, provider, view.FlyoutBackgroundImageAspect).FireAndForget();
-			}
+			handler.PlatformView.UpdateBackgroundImageSourceAsync(view.FlyoutBackgroundImage, provider, view.FlyoutBackgroundImageAspect).FireAndForget();
 		}
 
 		public static void MapFlyoutIcon(ShellHandler handler, Shell view)

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -164,6 +164,8 @@ override Microsoft.Maui.Controls.TextAlignmentConverter.CanConvertTo(System.Comp
 override Microsoft.Maui.Controls.TextAlignmentConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object?
 override Microsoft.Maui.Controls.TextAlignmentConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type! destinationType) -> object?
 override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
+~static Microsoft.Maui.Controls.Handlers.Items.CarouselViewHandler.MapItemsLayout(Microsoft.Maui.Controls.Handlers.Items.CarouselViewHandler handler, Microsoft.Maui.Controls.CarouselView carouselView) -> void
+~static Microsoft.Maui.Controls.Handlers.Items.CarouselViewHandler.MapLoop(Microsoft.Maui.Controls.Handlers.Items.CarouselViewHandler handler, Microsoft.Maui.Controls.CarouselView carouselView) -> void
 static Microsoft.Maui.Controls.Handlers.ShellHandler.MapCurrentItem(Microsoft.Maui.Controls.Handlers.ShellHandler! handler, Microsoft.Maui.Controls.Shell! shell) -> void
 static Microsoft.Maui.Controls.Handlers.ShellHandler.MapFlowDirection(Microsoft.Maui.Controls.Handlers.ShellHandler! handler, Microsoft.Maui.Controls.Shell! shell) -> void
 static Microsoft.Maui.Controls.Handlers.ShellHandler.MapFlyout(Microsoft.Maui.Controls.Handlers.ShellHandler! handler, Microsoft.Maui.Controls.Shell! shell) -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -208,6 +208,7 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static Microsoft.Maui.Controls.Brush.HasTransparency(Microsoft.Maui.Controls.Brush background) -> bool
 ~static Microsoft.Maui.Controls.Handlers.Items.CarouselViewHandler.MapIsEnabled(Microsoft.Maui.Controls.Handlers.Items.CarouselViewHandler handler, Microsoft.Maui.Controls.CarouselView carouselView) -> void
 ~static Microsoft.Maui.Controls.Handlers.Items2.CarouselViewHandler2.MapIsEnabled(Microsoft.Maui.Controls.Handlers.Items2.CarouselViewHandler2 handler, Microsoft.Maui.Controls.CarouselView carouselView) -> void
+~static Microsoft.Maui.Controls.Handlers.Items2.CarouselViewHandler2.MapItemsLayout(Microsoft.Maui.Controls.Handlers.Items2.CarouselViewHandler2 handler, Microsoft.Maui.Controls.CarouselView carouselView) -> void
 ~static Microsoft.Maui.Controls.NavigationPage.GetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page) -> string
 ~static Microsoft.Maui.Controls.NavigationPage.SetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page, string value) -> void
 ~static Microsoft.Maui.Controls.Shell.GetBackground(Microsoft.Maui.Controls.BindableObject obj) -> Microsoft.Maui.Controls.Brush

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -200,6 +200,7 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static Microsoft.Maui.Controls.Brush.HasTransparency(Microsoft.Maui.Controls.Brush background) -> bool
 ~static Microsoft.Maui.Controls.Handlers.Items.CarouselViewHandler.MapIsEnabled(Microsoft.Maui.Controls.Handlers.Items.CarouselViewHandler handler, Microsoft.Maui.Controls.CarouselView carouselView) -> void
 ~static Microsoft.Maui.Controls.Handlers.Items2.CarouselViewHandler2.MapIsEnabled(Microsoft.Maui.Controls.Handlers.Items2.CarouselViewHandler2 handler, Microsoft.Maui.Controls.CarouselView carouselView) -> void
+~static Microsoft.Maui.Controls.Handlers.Items2.CarouselViewHandler2.MapItemsLayout(Microsoft.Maui.Controls.Handlers.Items2.CarouselViewHandler2 handler, Microsoft.Maui.Controls.CarouselView carouselView) -> void
 ~static Microsoft.Maui.Controls.NavigationPage.GetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page) -> string
 ~static Microsoft.Maui.Controls.NavigationPage.SetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page, string value) -> void
 ~static Microsoft.Maui.Controls.Shell.GetBackground(Microsoft.Maui.Controls.BindableObject obj) -> Microsoft.Maui.Controls.Brush

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -164,6 +164,7 @@ static Microsoft.Maui.Controls.Handlers.Items2.ItemsViewHandler2<TItemsView>.Map
 static Microsoft.Maui.Controls.Handlers.Items2.ItemsViewHandler2<TItemsView>.MapFooter(Microsoft.Maui.Controls.Handlers.Items2.ItemsViewHandler2<TItemsView!>! handler, Microsoft.Maui.Controls.ItemsView! itemsView) -> void
 static Microsoft.Maui.Controls.Handlers.Items2.ItemsViewHandler2<TItemsView>.MapFooterTemplate(Microsoft.Maui.Controls.Handlers.Items2.ItemsViewHandler2<TItemsView!>! handler, Microsoft.Maui.Controls.ItemsView! itemsView) -> void
 virtual Microsoft.Maui.Controls.Handlers.Items2.ItemsViewHandler2<TItemsView>.UpdateItemsSource() -> void
+~static Microsoft.Maui.Controls.Handlers.ShellHandler.MapFlyoutBackgroundImage(Microsoft.Maui.Controls.Handlers.ShellHandler handler, Microsoft.Maui.Controls.Shell view) -> void
 ~static Microsoft.Maui.Controls.VisualStateManager.InvalidateVisualStates(Microsoft.Maui.Controls.VisualElement visualElement) -> void
 ~static readonly Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.BaseShellItem.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Core/src/Handlers/Switch/SwitchHandler.Windows.cs
+++ b/src/Core/src/Handlers/Switch/SwitchHandler.Windows.cs
@@ -62,8 +62,7 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 
-		// TODO: Make it public in .NET 10.0
-		internal static void MapSwitchMinimumWidth(IViewHandler handler, IView view)
+		public static void MapSwitchMinimumWidth(IViewHandler handler, IView view)
 		{
 			// Update the native ToggleSwitch MinWidth to reflect the MAUI view's MinimumWidth,
 			// overriding the default WinUI MinWidth (154) since we're not supporting OnContent and OffContent.

--- a/src/Core/src/Handlers/Switch/SwitchHandler.Windows.cs
+++ b/src/Core/src/Handlers/Switch/SwitchHandler.Windows.cs
@@ -62,15 +62,12 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 
-		public static void MapSwitchMinimumWidth(IViewHandler handler, IView view)
+		public static void MapSwitchMinimumWidth(ISwitchHandler handler, ISwitch view)
 		{
 			// Update the native ToggleSwitch MinWidth to reflect the MAUI view's MinimumWidth,
 			// overriding the default WinUI MinWidth (154) since we're not supporting OnContent and OffContent.
 			// This ensures the control does not reserve unnecessary space for labels.
-			if (view is ISwitch switchView && handler is SwitchHandler switchHandler)
-			{
-				switchHandler.PlatformView?.UpdateMinWidth(switchView);
-			}
+			handler.PlatformView?.UpdateMinWidth(view);
 		}
 
 		void OnToggled(object sender, UI.Xaml.RoutedEventArgs e)

--- a/src/Core/src/Handlers/Switch/SwitchHandler.Windows.cs
+++ b/src/Core/src/Handlers/Switch/SwitchHandler.Windows.cs
@@ -67,7 +67,10 @@ namespace Microsoft.Maui.Handlers
 			// Update the native ToggleSwitch MinWidth to reflect the MAUI view's MinimumWidth,
 			// overriding the default WinUI MinWidth (154) since we're not supporting OnContent and OffContent.
 			// This ensures the control does not reserve unnecessary space for labels.
-			handler.PlatformView?.UpdateMinWidth(view);
+			if (handler is SwitchHandler switchHandler)
+			{
+				switchHandler.PlatformView?.UpdateMinWidth(view);
+			}
 		}
 
 		void OnToggled(object sender, UI.Xaml.RoutedEventArgs e)

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -39,7 +39,7 @@ static Microsoft.Maui.GridLength.implicit operator Microsoft.Maui.GridLength(str
 static Microsoft.Maui.Handlers.SearchBarHandler.MapCursorPosition(Microsoft.Maui.Handlers.ISearchBarHandler! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
 static Microsoft.Maui.Handlers.SearchBarHandler.MapSelectionLength(Microsoft.Maui.Handlers.ISearchBarHandler! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
 static Microsoft.Maui.Handlers.ShapeViewHandler.MapFlowDirection(Microsoft.Maui.Handlers.IShapeViewHandler! handler, Microsoft.Maui.IShapeView! shapeView) -> void
-static Microsoft.Maui.Handlers.SwitchHandler.MapSwitchMinimumWidth(Microsoft.Maui.IViewHandler! handler, Microsoft.Maui.IView! view) -> void
+static Microsoft.Maui.Handlers.SwitchHandler.MapSwitchMinimumWidth(Microsoft.Maui.Handlers.ISwitchHandler! handler, Microsoft.Maui.ISwitch! view) -> void
 static Microsoft.Maui.Handlers.WebViewHandler.MapBackground(Microsoft.Maui.Handlers.IWebViewHandler! handler, Microsoft.Maui.IWebView! webView) -> void
 static Microsoft.Maui.LifecycleEvents.WindowsLifecycleBuilderExtensions.OnAppInstanceActivated(this Microsoft.Maui.LifecycleEvents.IWindowsLifecycleBuilder! lifecycle, Microsoft.Maui.LifecycleEvents.WindowsLifecycle.OnAppInstanceActivated! del) -> Microsoft.Maui.LifecycleEvents.IWindowsLifecycleBuilder!
 static Microsoft.Maui.SafeAreaEdges.Container.get -> Microsoft.Maui.SafeAreaEdges

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -39,6 +39,7 @@ static Microsoft.Maui.GridLength.implicit operator Microsoft.Maui.GridLength(str
 static Microsoft.Maui.Handlers.SearchBarHandler.MapCursorPosition(Microsoft.Maui.Handlers.ISearchBarHandler! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
 static Microsoft.Maui.Handlers.SearchBarHandler.MapSelectionLength(Microsoft.Maui.Handlers.ISearchBarHandler! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
 static Microsoft.Maui.Handlers.ShapeViewHandler.MapFlowDirection(Microsoft.Maui.Handlers.IShapeViewHandler! handler, Microsoft.Maui.IShapeView! shapeView) -> void
+static Microsoft.Maui.Handlers.SwitchHandler.MapSwitchMinimumWidth(Microsoft.Maui.IViewHandler! handler, Microsoft.Maui.IView! view) -> void
 static Microsoft.Maui.Handlers.WebViewHandler.MapBackground(Microsoft.Maui.Handlers.IWebViewHandler! handler, Microsoft.Maui.IWebView! webView) -> void
 static Microsoft.Maui.LifecycleEvents.WindowsLifecycleBuilderExtensions.OnAppInstanceActivated(this Microsoft.Maui.LifecycleEvents.IWindowsLifecycleBuilder! lifecycle, Microsoft.Maui.LifecycleEvents.WindowsLifecycle.OnAppInstanceActivated! del) -> Microsoft.Maui.LifecycleEvents.IWindowsLifecycleBuilder!
 static Microsoft.Maui.SafeAreaEdges.Container.get -> Microsoft.Maui.SafeAreaEdges


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Promotes five implemented platform handler mapper methods that were scheduled to become public in .NET 10 but remained internal:

- Android `CarouselViewHandler.MapLoop`
- Android `CarouselViewHandler.MapItemsLayout`
- iOS/MacCatalyst `CarouselViewHandler2.MapItemsLayout`
- Windows `ShellHandler.MapFlyoutBackgroundImage`
- Windows `SwitchHandler.MapSwitchMinimumWidth`

These mapper entry points have clear handler-customization value and match the visibility of equivalent mapper methods on other handlers and platforms. `MapSwitchMinimumWidth` uses the strongly typed `(ISwitchHandler, ISwitch)` mapper contract while retaining the existing concrete `SwitchHandler` behavior gate; the other methods retain their existing signatures. Control behavior is unchanged. `MapFlyoutBackgroundImage` now uses the handler-aware `FireAndForget` overload so unexpected asynchronous failures are logged through the handler's service provider. The applicable Android, iOS, Mac Catalyst, and Windows `PublicAPI.Unshipped.txt` baselines are updated.

Tizen's `ShellHandler.MapFlyoutBackgroundImage` remains internal because it is an unimplemented no-op.

### Issues Fixed

N/A

### Validation

- `Controls.Core.csproj` — `net11.0-android37.0`
- `Controls.Core.csproj` — `net11.0-ios26.5`
- `Controls.Core.csproj` — `net11.0-maccatalyst26.5`
- `Controls.Core.csproj` — `net11.0-windows10.0.19041.0`