### PR TITLE
[Android] Remove ImageButton shapeable image shim

### DIFF
--- a/src/Core/src/Handlers/ImageButton/ImageButtonHandler.Android.cs
+++ b/src/Core/src/Handlers/ImageButton/ImageButtonHandler.Android.cs
@@ -9,11 +9,7 @@ namespace Microsoft.Maui.Handlers
 	{
 		protected override ShapeableImageView CreatePlatformView()
 		{
-			// TODO: net11 - Remove MaterialShapeableImageView and always use MauiShapeableImageView
-			// once MauiShapeableImageView has public API changes that support Material3.
-			ShapeableImageView platformView = RuntimeFeature.IsMaterial3Enabled
-				? new MaterialShapeableImageView(Context)
-				: new MauiShapeableImageView(Context);
+			var platformView = new MauiShapeableImageView(Context);
 
 			// These set the defaults so visually it matches up with other platforms
 			platformView.SetPadding(0, 0, 0, 0);

--- a/src/Core/src/Handlers/ImageButton/ImageButtonHandler.Android.cs
+++ b/src/Core/src/Handlers/ImageButton/ImageButtonHandler.Android.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Handlers
 	{
 		protected override ShapeableImageView CreatePlatformView()
 		{
-			var platformView = new MauiShapeableImageView(Context);
+			var platformView = new MauiShapeableImageView(Context, RuntimeFeature.IsMaterial3Enabled);
 
 			// These set the defaults so visually it matches up with other platforms
 			platformView.SetPadding(0, 0, 0, 0);

--- a/src/Core/src/Platform/Android/MauiMaterialContextThemeWrapper.cs
+++ b/src/Core/src/Platform/Android/MauiMaterialContextThemeWrapper.cs
@@ -7,14 +7,14 @@ public class MauiMaterialContextThemeWrapper : ContextThemeWrapper
 {
 	// IsMaterial3Enabled Flag needed for Control Level theming. App Level theming is handled in MauiAppCompatActivity
 	public MauiMaterialContextThemeWrapper(Context context)
-		: this(context, RuntimeFeature.IsMaterial3Enabled)
+		: this(context, GetThemeResourceId(RuntimeFeature.IsMaterial3Enabled))
 	{
 	}
 
-	MauiMaterialContextThemeWrapper(Context context, bool useMaterial3)
-		: base(context, useMaterial3 ? Resource.Style.Maui_Material3_Theme_Base : Resource.Style.Maui_MainTheme_Base)
+	MauiMaterialContextThemeWrapper(Context context, int themeResId)
+		: base(context, themeResId)
 	{
-		UseMaterial3 = useMaterial3;
+		UseMaterial3 = themeResId == Resource.Style.Maui_Material3_Theme_Base;
 	}
 
 	internal bool UseMaterial3 { get; }
@@ -41,6 +41,9 @@ public class MauiMaterialContextThemeWrapper : ContextThemeWrapper
 			context = materialContext.BaseContext ?? context;
 		}
 
-		return new MauiMaterialContextThemeWrapper(context, useMaterial3);
+		return new MauiMaterialContextThemeWrapper(context, GetThemeResourceId(useMaterial3));
 	}
+
+	static int GetThemeResourceId(bool useMaterial3) =>
+		useMaterial3 ? Resource.Style.Maui_Material3_Theme_Base : Resource.Style.Maui_MainTheme_Base;
 }

--- a/src/Core/src/Platform/Android/MauiMaterialContextThemeWrapper.cs
+++ b/src/Core/src/Platform/Android/MauiMaterialContextThemeWrapper.cs
@@ -5,26 +5,38 @@ namespace Microsoft.Maui.Platform;
 
 public class MauiMaterialContextThemeWrapper : ContextThemeWrapper
 {
-    // IsMaterial3Enabled Flag needed for Control Level theming. App Level theming is handled in MauiAppCompatActivity
-    public MauiMaterialContextThemeWrapper(Context context)
-        : this(context, RuntimeFeature.IsMaterial3Enabled
-            ? Resource.Style.Maui_Material3_Theme_Base
-            : Resource.Style.Maui_MainTheme_Base)
-    {
-    }
+	// IsMaterial3Enabled Flag needed for Control Level theming. App Level theming is handled in MauiAppCompatActivity
+	public MauiMaterialContextThemeWrapper(Context context)
+		: this(context, RuntimeFeature.IsMaterial3Enabled
+			? Resource.Style.Maui_Material3_Theme_Base
+			: Resource.Style.Maui_MainTheme_Base)
+	{
+	}
 
-    MauiMaterialContextThemeWrapper(Context context, int themeResId) : base(context, themeResId)
-    {
+	MauiMaterialContextThemeWrapper(Context context, int themeResId) : base(context, themeResId)
+	{
 
-    }
+	}
 
-    public static MauiMaterialContextThemeWrapper Create(Context context)
-    {
-        if (context is MauiMaterialContextThemeWrapper materialContext)
-        {
-            return materialContext;
-        }
+	public static MauiMaterialContextThemeWrapper Create(Context context)
+	{
+		if (context is MauiMaterialContextThemeWrapper materialContext)
+		{
+			return materialContext;
+		}
 
-        return new MauiMaterialContextThemeWrapper(context);
-    }
+		return new MauiMaterialContextThemeWrapper(context);
+	}
+
+	internal static MauiMaterialContextThemeWrapper Create(Context context, bool useMaterial3)
+	{
+		if (context is MauiMaterialContextThemeWrapper materialContext)
+		{
+			return materialContext;
+		}
+
+		return new MauiMaterialContextThemeWrapper(
+			context,
+			useMaterial3 ? Resource.Style.Maui_Material3_Theme_Base : Resource.Style.Maui_MainTheme_Base);
+	}
 }

--- a/src/Core/src/Platform/Android/MauiMaterialContextThemeWrapper.cs
+++ b/src/Core/src/Platform/Android/MauiMaterialContextThemeWrapper.cs
@@ -7,16 +7,17 @@ public class MauiMaterialContextThemeWrapper : ContextThemeWrapper
 {
 	// IsMaterial3Enabled Flag needed for Control Level theming. App Level theming is handled in MauiAppCompatActivity
 	public MauiMaterialContextThemeWrapper(Context context)
-		: this(context, RuntimeFeature.IsMaterial3Enabled
-			? Resource.Style.Maui_Material3_Theme_Base
-			: Resource.Style.Maui_MainTheme_Base)
+		: this(context, RuntimeFeature.IsMaterial3Enabled)
 	{
 	}
 
-	MauiMaterialContextThemeWrapper(Context context, int themeResId) : base(context, themeResId)
+	MauiMaterialContextThemeWrapper(Context context, bool useMaterial3)
+		: base(context, useMaterial3 ? Resource.Style.Maui_Material3_Theme_Base : Resource.Style.Maui_MainTheme_Base)
 	{
-
+		UseMaterial3 = useMaterial3;
 	}
+
+	internal bool UseMaterial3 { get; }
 
 	public static MauiMaterialContextThemeWrapper Create(Context context)
 	{
@@ -32,11 +33,14 @@ public class MauiMaterialContextThemeWrapper : ContextThemeWrapper
 	{
 		if (context is MauiMaterialContextThemeWrapper materialContext)
 		{
-			return materialContext;
+			if (materialContext.UseMaterial3 == useMaterial3)
+			{
+				return materialContext;
+			}
+
+			context = materialContext.BaseContext ?? context;
 		}
 
-		return new MauiMaterialContextThemeWrapper(
-			context,
-			useMaterial3 ? Resource.Style.Maui_Material3_Theme_Base : Resource.Style.Maui_MainTheme_Base);
+		return new MauiMaterialContextThemeWrapper(context, useMaterial3);
 	}
 }

--- a/src/Core/src/Platform/Android/MauiShapeableImageView.cs
+++ b/src/Core/src/Platform/Android/MauiShapeableImageView.cs
@@ -6,7 +6,7 @@ using Google.Android.Material.ImageView;
 namespace Microsoft.Maui.Platform
 {
 	/// <summary>
-	/// A <see cref="ShapeableImageView"/> that applies the .NET MAUI Material theme and normalizes padding during measurement.
+	/// A <see cref="ShapeableImageView"/> that applies the .NET MAUI Material 3 theme when enabled and normalizes padding during measurement.
 	/// </summary>
 	public class MauiShapeableImageView : ShapeableImageView
 	{
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Platform
 		/// Initializes a new instance of the <see cref="MauiShapeableImageView"/> class.
 		/// </summary>
 		/// <param name="context">The Android context for the view.</param>
-		public MauiShapeableImageView(Context context) : base(MauiMaterialContextThemeWrapper.Create(context))
+		public MauiShapeableImageView(Context? context) : base(GetThemedContext(context))
 		{
 		}
 
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.Platform
 		/// </summary>
 		/// <param name="context">The Android context for the view.</param>
 		/// <param name="attrs">The attributes for the view.</param>
-		public MauiShapeableImageView(Context context, IAttributeSet? attrs) : base(MauiMaterialContextThemeWrapper.Create(context), attrs)
+		public MauiShapeableImageView(Context? context, IAttributeSet? attrs) : base(GetThemedContext(context), attrs)
 		{
 		}
 
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Platform
 		/// <param name="context">The Android context for the view.</param>
 		/// <param name="attrs">The attributes for the view.</param>
 		/// <param name="defStyle">The default style attribute for the view.</param>
-		public MauiShapeableImageView(Context context, IAttributeSet? attrs, int defStyle) : base(MauiMaterialContextThemeWrapper.Create(context), attrs, defStyle)
+		public MauiShapeableImageView(Context? context, IAttributeSet? attrs, int defStyle) : base(GetThemedContext(context), attrs, defStyle)
 		{
 		}
 
@@ -44,6 +44,14 @@ namespace Microsoft.Maui.Platform
 		/// <param name="transfer">The ownership transfer behavior for the JNI reference.</param>
 		protected MauiShapeableImageView(nint javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
 		{
+		}
+
+		static Context? GetThemedContext(Context? context)
+		{
+			if (!RuntimeFeature.IsMaterial3Enabled || context is null)
+				return context;
+
+			return MauiMaterialContextThemeWrapper.Create(context);
 		}
 
 		/// <inheritdoc />

--- a/src/Core/src/Platform/Android/MauiShapeableImageView.cs
+++ b/src/Core/src/Platform/Android/MauiShapeableImageView.cs
@@ -42,7 +42,10 @@ namespace Microsoft.Maui.Platform
 		/// optionally applying the .NET MAUI Material 3 theme to the context.
 		/// </summary>
 		/// <param name="context">The Android context for the view.</param>
-		/// <param name="useMaterial3">Whether to apply the .NET MAUI Material 3 theme.</param>
+		/// <param name="useMaterial3">
+		/// <see langword="true"/> to use the .NET MAUI Material 3 theme; otherwise, to use the Material 2 theme
+		/// when <paramref name="context"/> is already wrapped in a .NET MAUI Material theme.
+		/// </param>
 		public MauiShapeableImageView(Context? context, bool useMaterial3)
 			: base(GetThemedContext(context, useMaterial3))
 		{

--- a/src/Core/src/Platform/Android/MauiShapeableImageView.cs
+++ b/src/Core/src/Platform/Android/MauiShapeableImageView.cs
@@ -37,7 +37,13 @@ namespace Microsoft.Maui.Platform
 		{
 		}
 
-		internal MauiShapeableImageView(Context? context, bool useMaterial3)
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MauiShapeableImageView"/> class,
+		/// optionally applying the .NET MAUI Material 3 theme to the context.
+		/// </summary>
+		/// <param name="context">The Android context for the view.</param>
+		/// <param name="useMaterial3">Whether to apply the .NET MAUI Material 3 theme.</param>
+		public MauiShapeableImageView(Context? context, bool useMaterial3)
 			: base(GetThemedContext(context, useMaterial3))
 		{
 		}
@@ -56,7 +62,7 @@ namespace Microsoft.Maui.Platform
 			if (!useMaterial3 || context is null)
 				return context;
 
-			return MauiMaterialContextThemeWrapper.Create(context);
+			return MauiMaterialContextThemeWrapper.Create(context, useMaterial3);
 		}
 
 		/// <inheritdoc />

--- a/src/Core/src/Platform/Android/MauiShapeableImageView.cs
+++ b/src/Core/src/Platform/Android/MauiShapeableImageView.cs
@@ -6,7 +6,7 @@ using Google.Android.Material.ImageView;
 namespace Microsoft.Maui.Platform
 {
 	/// <summary>
-	/// A <see cref="ShapeableImageView"/> that applies the .NET MAUI Material 3 theme when enabled and normalizes padding during measurement.
+	/// A <see cref="ShapeableImageView"/> that normalizes padding during measurement.
 	/// </summary>
 	public class MauiShapeableImageView : ShapeableImageView
 	{
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Platform
 		/// Initializes a new instance of the <see cref="MauiShapeableImageView"/> class.
 		/// </summary>
 		/// <param name="context">The Android context for the view.</param>
-		public MauiShapeableImageView(Context? context) : base(GetThemedContext(context))
+		public MauiShapeableImageView(Context? context) : base(context)
 		{
 		}
 
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.Platform
 		/// </summary>
 		/// <param name="context">The Android context for the view.</param>
 		/// <param name="attrs">The attributes for the view.</param>
-		public MauiShapeableImageView(Context? context, IAttributeSet? attrs) : base(GetThemedContext(context), attrs)
+		public MauiShapeableImageView(Context? context, IAttributeSet? attrs) : base(context, attrs)
 		{
 		}
 
@@ -33,7 +33,12 @@ namespace Microsoft.Maui.Platform
 		/// <param name="context">The Android context for the view.</param>
 		/// <param name="attrs">The attributes for the view.</param>
 		/// <param name="defStyle">The default style attribute for the view.</param>
-		public MauiShapeableImageView(Context? context, IAttributeSet? attrs, int defStyle) : base(GetThemedContext(context), attrs, defStyle)
+		public MauiShapeableImageView(Context? context, IAttributeSet? attrs, int defStyle) : base(context, attrs, defStyle)
+		{
+		}
+
+		internal MauiShapeableImageView(Context? context, bool useMaterial3)
+			: base(GetThemedContext(context, useMaterial3))
 		{
 		}
 
@@ -46,9 +51,9 @@ namespace Microsoft.Maui.Platform
 		{
 		}
 
-		static Context? GetThemedContext(Context? context)
+		static Context? GetThemedContext(Context? context, bool useMaterial3)
 		{
-			if (!RuntimeFeature.IsMaterial3Enabled || context is null)
+			if (!useMaterial3 || context is null)
 				return context;
 
 			return MauiMaterialContextThemeWrapper.Create(context);

--- a/src/Core/src/Platform/Android/MauiShapeableImageView.cs
+++ b/src/Core/src/Platform/Android/MauiShapeableImageView.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Maui.Platform
 
 		static Context? GetThemedContext(Context? context, bool useMaterial3)
 		{
-			if (!useMaterial3 || context is null)
+			if (context is null || (!useMaterial3 && context is not MauiMaterialContextThemeWrapper))
 				return context;
 
 			return MauiMaterialContextThemeWrapper.Create(context, useMaterial3);

--- a/src/Core/src/Platform/Android/MauiShapeableImageView.cs
+++ b/src/Core/src/Platform/Android/MauiShapeableImageView.cs
@@ -5,57 +5,48 @@ using Google.Android.Material.ImageView;
 
 namespace Microsoft.Maui.Platform
 {
+	/// <summary>
+	/// A <see cref="ShapeableImageView"/> that applies the .NET MAUI Material theme and normalizes padding during measurement.
+	/// </summary>
 	public class MauiShapeableImageView : ShapeableImageView
 	{
-		public MauiShapeableImageView(Context? context) : base(context)
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MauiShapeableImageView"/> class.
+		/// </summary>
+		/// <param name="context">The Android context for the view.</param>
+		public MauiShapeableImageView(Context context) : base(MauiMaterialContextThemeWrapper.Create(context))
 		{
 		}
 
-		public MauiShapeableImageView(Context? context, IAttributeSet? attrs) : base(context, attrs)
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MauiShapeableImageView"/> class.
+		/// </summary>
+		/// <param name="context">The Android context for the view.</param>
+		/// <param name="attrs">The attributes for the view.</param>
+		public MauiShapeableImageView(Context context, IAttributeSet? attrs) : base(MauiMaterialContextThemeWrapper.Create(context), attrs)
 		{
 		}
 
-		public MauiShapeableImageView(Context? context, IAttributeSet? attrs, int defStyle) : base(context, attrs, defStyle)
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MauiShapeableImageView"/> class.
+		/// </summary>
+		/// <param name="context">The Android context for the view.</param>
+		/// <param name="attrs">The attributes for the view.</param>
+		/// <param name="defStyle">The default style attribute for the view.</param>
+		public MauiShapeableImageView(Context context, IAttributeSet? attrs, int defStyle) : base(MauiMaterialContextThemeWrapper.Create(context), attrs, defStyle)
 		{
 		}
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MauiShapeableImageView"/> class from a JNI reference.
+		/// </summary>
+		/// <param name="javaReference">The JNI reference.</param>
+		/// <param name="transfer">The ownership transfer behavior for the JNI reference.</param>
 		protected MauiShapeableImageView(nint javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
 		{
 		}
 
-		protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)
-		{
-			// The padding has a few issues. This is a workaround for the following issue:
-			// https://github.com/material-components/material-components-android/issues/2063
-
-			// ShapeableImageView combines ContentPadding with Padding and updates
-			// Padding with the result.
-			base.OnMeasure(widthMeasureSpec, heightMeasureSpec);
-
-			// We need to reset the padding to 0 to avoid a double padding.
-			SetPadding(0, 0, 0, 0);
-		}
-	}
-
-	// TODO: net11 - Remove this class and update MauiShapeableImageView to public API with the same changes.
-	internal class MaterialShapeableImageView : ShapeableImageView
-	{
-		public MaterialShapeableImageView(Context context) : base(MauiMaterialContextThemeWrapper.Create(context))
-		{
-		}
-
-		public MaterialShapeableImageView(Context context, IAttributeSet? attrs) : base(MauiMaterialContextThemeWrapper.Create(context), attrs)
-		{
-		}
-
-		public MaterialShapeableImageView(Context context, IAttributeSet? attrs, int defStyle) : base(MauiMaterialContextThemeWrapper.Create(context), attrs, defStyle)
-		{
-		}
-
-		protected MaterialShapeableImageView(nint javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
-		{
-		}
-
+		/// <inheritdoc />
 		protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)
 		{
 			// The padding has a few issues. This is a workaround for the following issue:

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -135,6 +135,7 @@ Microsoft.Maui.Platform.MauiMaterialTimePicker.MauiMaterialTimePicker(nint javaR
 Microsoft.Maui.Platform.MauiMaterialTimePicker.OnClick(Android.Views.View? v) -> void
 Microsoft.Maui.Platform.MauiMaterialTimePicker.ShowPicker.get -> System.Action?
 Microsoft.Maui.Platform.MauiMaterialTimePicker.ShowPicker.set -> void
+Microsoft.Maui.Platform.MauiShapeableImageView.MauiShapeableImageView(Android.Content.Context? context, bool useMaterial3) -> void
 Microsoft.Maui.PlatformDrawable
 Microsoft.Maui.PlatformDrawable.PlatformDrawable(Android.Content.Context? context) -> void
 Microsoft.Maui.PlatformDrawable.PlatformDrawable(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -7,6 +7,9 @@
 *REMOVED*override Microsoft.Maui.Handlers.FlyoutViewHandler.DisconnectHandler(Android.Views.View! platformView) -> void
 *REMOVED*static Microsoft.Maui.Handlers.WebViewHandler.MapWebChromeClient(Microsoft.Maui.Handlers.IWebViewHandler! handler, Microsoft.Maui.IWebView! webView) -> void
 *REMOVED*static Microsoft.Maui.Handlers.WebViewHandler.MapWebViewClient(Microsoft.Maui.Handlers.IWebViewHandler! handler, Microsoft.Maui.IWebView! webView) -> void
+*REMOVED*Microsoft.Maui.Platform.MauiShapeableImageView.MauiShapeableImageView(Android.Content.Context? context) -> void
+*REMOVED*Microsoft.Maui.Platform.MauiShapeableImageView.MauiShapeableImageView(Android.Content.Context? context, Android.Util.IAttributeSet? attrs) -> void
+*REMOVED*Microsoft.Maui.Platform.MauiShapeableImageView.MauiShapeableImageView(Android.Content.Context? context, Android.Util.IAttributeSet? attrs, int defStyle) -> void
 Microsoft.Maui.Handlers.ActivityIndicatorHandler2
 Microsoft.Maui.Handlers.ActivityIndicatorHandler2.ActivityIndicatorHandler2() -> void
 Microsoft.Maui.Handlers.DatePickerHandler2
@@ -135,6 +138,9 @@ Microsoft.Maui.Platform.MauiMaterialTimePicker.MauiMaterialTimePicker(nint javaR
 Microsoft.Maui.Platform.MauiMaterialTimePicker.OnClick(Android.Views.View? v) -> void
 Microsoft.Maui.Platform.MauiMaterialTimePicker.ShowPicker.get -> System.Action?
 Microsoft.Maui.Platform.MauiMaterialTimePicker.ShowPicker.set -> void
+Microsoft.Maui.Platform.MauiShapeableImageView.MauiShapeableImageView(Android.Content.Context! context) -> void
+Microsoft.Maui.Platform.MauiShapeableImageView.MauiShapeableImageView(Android.Content.Context! context, Android.Util.IAttributeSet? attrs) -> void
+Microsoft.Maui.Platform.MauiShapeableImageView.MauiShapeableImageView(Android.Content.Context! context, Android.Util.IAttributeSet? attrs, int defStyle) -> void
 Microsoft.Maui.PlatformDrawable
 Microsoft.Maui.PlatformDrawable.PlatformDrawable(Android.Content.Context? context) -> void
 Microsoft.Maui.PlatformDrawable.PlatformDrawable(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -7,9 +7,6 @@
 *REMOVED*override Microsoft.Maui.Handlers.FlyoutViewHandler.DisconnectHandler(Android.Views.View! platformView) -> void
 *REMOVED*static Microsoft.Maui.Handlers.WebViewHandler.MapWebChromeClient(Microsoft.Maui.Handlers.IWebViewHandler! handler, Microsoft.Maui.IWebView! webView) -> void
 *REMOVED*static Microsoft.Maui.Handlers.WebViewHandler.MapWebViewClient(Microsoft.Maui.Handlers.IWebViewHandler! handler, Microsoft.Maui.IWebView! webView) -> void
-*REMOVED*Microsoft.Maui.Platform.MauiShapeableImageView.MauiShapeableImageView(Android.Content.Context? context) -> void
-*REMOVED*Microsoft.Maui.Platform.MauiShapeableImageView.MauiShapeableImageView(Android.Content.Context? context, Android.Util.IAttributeSet? attrs) -> void
-*REMOVED*Microsoft.Maui.Platform.MauiShapeableImageView.MauiShapeableImageView(Android.Content.Context? context, Android.Util.IAttributeSet? attrs, int defStyle) -> void
 Microsoft.Maui.Handlers.ActivityIndicatorHandler2
 Microsoft.Maui.Handlers.ActivityIndicatorHandler2.ActivityIndicatorHandler2() -> void
 Microsoft.Maui.Handlers.DatePickerHandler2
@@ -138,9 +135,6 @@ Microsoft.Maui.Platform.MauiMaterialTimePicker.MauiMaterialTimePicker(nint javaR
 Microsoft.Maui.Platform.MauiMaterialTimePicker.OnClick(Android.Views.View? v) -> void
 Microsoft.Maui.Platform.MauiMaterialTimePicker.ShowPicker.get -> System.Action?
 Microsoft.Maui.Platform.MauiMaterialTimePicker.ShowPicker.set -> void
-Microsoft.Maui.Platform.MauiShapeableImageView.MauiShapeableImageView(Android.Content.Context! context) -> void
-Microsoft.Maui.Platform.MauiShapeableImageView.MauiShapeableImageView(Android.Content.Context! context, Android.Util.IAttributeSet? attrs) -> void
-Microsoft.Maui.Platform.MauiShapeableImageView.MauiShapeableImageView(Android.Content.Context! context, Android.Util.IAttributeSet? attrs, int defStyle) -> void
 Microsoft.Maui.PlatformDrawable
 Microsoft.Maui.PlatformDrawable.PlatformDrawable(Android.Content.Context? context) -> void
 Microsoft.Maui.PlatformDrawable.PlatformDrawable(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void

--- a/src/Core/tests/DeviceTests/Handlers/ImageButton/ImageButtonHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ImageButton/ImageButtonHandlerTests.Android.cs
@@ -7,8 +7,11 @@ using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
 {
+	[Collection(Material3FeatureSwitchTestCollection.Name)]
 	public partial class ImageButtonHandlerTests
 	{
+		const string Material3FeatureSwitch = "Microsoft.Maui.RuntimeFeature.IsMaterial3Enabled";
+
 		[Fact(DisplayName = "ImageButton uses MauiShapeableImageView with expected activity context")]
 		public Task ImageButtonUsesMauiShapeableImageViewWithExpectedActivityContext()
 		{
@@ -33,15 +36,25 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Fact(DisplayName = "MauiShapeableImageView applies Material 3 theme when requested")]
-		public Task MauiShapeableImageViewAppliesMaterial3ThemeWhenRequested()
+		[Fact(DisplayName = "ImageButton applies Material 3 theme when enabled")]
+		public Task ImageButtonAppliesMaterial3ThemeWhenEnabled()
 		{
 			return InvokeOnMainThreadAsync(() =>
 			{
-				var platformView = new MauiShapeableImageView(MauiContext.Context, useMaterial3: true);
+				AppContext.TryGetSwitch(Material3FeatureSwitch, out bool wasMaterial3Enabled);
+				AppContext.SetSwitch(Material3FeatureSwitch, true);
+				try
+				{
+					var handler = CreateHandler(new ImageButtonStub());
+					var platformView = Assert.IsType<MauiShapeableImageView>(handler.PlatformView);
 
-				Assert.IsType<MauiMaterialContextThemeWrapper>(platformView.Context);
-				Assert.Same(MauiContext.Context.GetActivity(), platformView.Context.GetActivity());
+					Assert.IsType<MauiMaterialContextThemeWrapper>(platformView.Context);
+					Assert.Same(MauiContext.Context.GetActivity(), platformView.Context.GetActivity());
+				}
+				finally
+				{
+					AppContext.SetSwitch(Material3FeatureSwitch, wasMaterial3Enabled);
+				}
 			});
 		}
 
@@ -93,5 +106,11 @@ namespace Microsoft.Maui.DeviceTests
 
 		bool ImageSourceLoaded(ImageButtonHandler imageButtonHandler) =>
 			imageButtonHandler.PlatformView.Drawable != null;
+	}
+
+	[CollectionDefinition(Name, DisableParallelization = true)]
+	public sealed class Material3FeatureSwitchTestCollection
+	{
+		public const string Name = "Material3FeatureSwitch";
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/ImageButton/ImageButtonHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ImageButton/ImageButtonHandlerTests.Android.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using Android.Views;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Platform;
 using Xunit;
@@ -8,15 +9,38 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class ImageButtonHandlerTests
 	{
-		[Fact(DisplayName = "ImageButton uses MauiShapeableImageView")]
-		public Task ImageButtonUsesMauiShapeableImageView()
+		[Fact(DisplayName = "ImageButton uses MauiShapeableImageView with expected theme context")]
+		public Task ImageButtonUsesMauiShapeableImageViewWithExpectedThemeContext()
 		{
 			return InvokeOnMainThreadAsync(() =>
 			{
 				var handler = CreateHandler(new ImageButtonStub());
 
 				var platformView = Assert.IsType<MauiShapeableImageView>(handler.PlatformView);
-				Assert.IsType<MauiMaterialContextThemeWrapper>(platformView.Context);
+
+				if (RuntimeFeature.IsMaterial3Enabled)
+					Assert.IsType<MauiMaterialContextThemeWrapper>(platformView.Context);
+				else
+					Assert.Same(MauiContext.Context, platformView.Context);
+			});
+		}
+
+		[Fact(DisplayName = "MauiShapeableImageView clears combined padding after measure")]
+		public Task MauiShapeableImageViewClearsCombinedPaddingAfterMeasure()
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var platformView = new MauiShapeableImageView(MauiContext.Context);
+				platformView.SetContentPadding(1, 2, 3, 4);
+				platformView.SetPadding(5, 6, 7, 8);
+
+				var measureSpec = View.MeasureSpec.MakeMeasureSpec(100, MeasureSpecMode.Exactly);
+				platformView.Measure(measureSpec, measureSpec);
+
+				Assert.Equal(0, platformView.PaddingLeft);
+				Assert.Equal(0, platformView.PaddingTop);
+				Assert.Equal(0, platformView.PaddingRight);
+				Assert.Equal(0, platformView.PaddingBottom);
 			});
 		}
 

--- a/src/Core/tests/DeviceTests/Handlers/ImageButton/ImageButtonHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ImageButton/ImageButtonHandlerTests.Android.cs
@@ -71,9 +71,10 @@ namespace Microsoft.Maui.DeviceTests
 				{
 					var handler = CreateHandler(new ImageButtonStub());
 					var platformView = Assert.IsType<MauiShapeableImageView>(handler.PlatformView);
+					var themedContext = Assert.IsType<MauiMaterialContextThemeWrapper>(platformView.Context);
 
-					Assert.IsType<MauiMaterialContextThemeWrapper>(platformView.Context);
-					Assert.Same(MauiContext.Context.GetActivity(), platformView.Context.GetActivity());
+					Assert.True(themedContext.UseMaterial3);
+					Assert.Same(MauiContext.Context.GetActivity(), themedContext.GetActivity());
 				}
 				finally
 				{

--- a/src/Core/tests/DeviceTests/Handlers/ImageButton/ImageButtonHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ImageButton/ImageButtonHandlerTests.Android.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Maui.DeviceTests
 				var handler = CreateHandler(new ImageButtonStub());
 
 				var platformView = Assert.IsType<MauiShapeableImageView>(handler.PlatformView);
+				Assert.IsNotType<MauiMaterialContextThemeWrapper>(platformView.Context);
 				Assert.Same(MauiContext.Context.GetActivity(), platformView.Context.GetActivity());
 			});
 		}

--- a/src/Core/tests/DeviceTests/Handlers/ImageButton/ImageButtonHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ImageButton/ImageButtonHandlerTests.Android.cs
@@ -1,11 +1,25 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Platform;
+using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
 {
 	public partial class ImageButtonHandlerTests
 	{
+		[Fact(DisplayName = "ImageButton uses MauiShapeableImageView")]
+		public Task ImageButtonUsesMauiShapeableImageView()
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var handler = CreateHandler(new ImageButtonStub());
+
+				var platformView = Assert.IsType<MauiShapeableImageView>(handler.PlatformView);
+				Assert.IsType<MauiMaterialContextThemeWrapper>(platformView.Context);
+			});
+		}
+
 		[Fact(DisplayName = "Clip ImageButton with Background works Correctly")]
 		public async Task ClipImageButtonWithBackgroundWorks()
 		{

--- a/src/Core/tests/DeviceTests/Handlers/ImageButton/ImageButtonHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ImageButton/ImageButtonHandlerTests.Android.cs
@@ -37,6 +37,29 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Theory(DisplayName = "MauiShapeableImageView uses the requested Material theme")]
+		[InlineData(false, false)]
+		[InlineData(false, true)]
+		[InlineData(true, false)]
+		[InlineData(true, true)]
+		public Task MauiShapeableImageViewUsesRequestedMaterialTheme(bool currentMaterial3, bool requestedMaterial3)
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var currentContext = MauiMaterialContextThemeWrapper.Create(MauiContext.Context, currentMaterial3);
+				var platformView = new MauiShapeableImageView(currentContext, requestedMaterial3);
+				var actualContext = Assert.IsType<MauiMaterialContextThemeWrapper>(platformView.Context);
+
+				Assert.Equal(requestedMaterial3, actualContext.UseMaterial3);
+				Assert.Same(MauiContext.Context.GetActivity(), actualContext.GetActivity());
+
+				if (currentMaterial3 == requestedMaterial3)
+					Assert.Same(currentContext, actualContext);
+				else
+					Assert.NotSame(currentContext, actualContext);
+			});
+		}
+
 		[Fact(DisplayName = "ImageButton applies Material 3 theme when enabled")]
 		public Task ImageButtonAppliesMaterial3ThemeWhenEnabled()
 		{

--- a/src/Core/tests/DeviceTests/Handlers/ImageButton/ImageButtonHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ImageButton/ImageButtonHandlerTests.Android.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.DeviceTests
 	[Collection(Material3FeatureSwitchTestCollection.Name)]
 	public partial class ImageButtonHandlerTests
 	{
-		const string Material3FeatureSwitch = "Microsoft.Maui.RuntimeFeature.IsMaterial3Enabled";
+		const string Material3FeatureSwitch = "Microsoft.Maui.RuntimeFeature." + nameof(RuntimeFeature.IsMaterial3Enabled);
 
 		[Fact(DisplayName = "ImageButton uses MauiShapeableImageView with expected activity context")]
 		public Task ImageButtonUsesMauiShapeableImageViewWithExpectedActivityContext()
@@ -65,7 +65,7 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			return InvokeOnMainThreadAsync(() =>
 			{
-				AppContext.TryGetSwitch(Material3FeatureSwitch, out bool wasMaterial3Enabled);
+				bool wasMaterial3Enabled = RuntimeFeature.IsMaterial3Enabled;
 				AppContext.SetSwitch(Material3FeatureSwitch, true);
 				try
 				{

--- a/src/Core/tests/DeviceTests/Handlers/ImageButton/ImageButtonHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ImageButton/ImageButtonHandlerTests.Android.cs
@@ -9,19 +9,39 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class ImageButtonHandlerTests
 	{
-		[Fact(DisplayName = "ImageButton uses MauiShapeableImageView with expected theme context")]
-		public Task ImageButtonUsesMauiShapeableImageViewWithExpectedThemeContext()
+		[Fact(DisplayName = "ImageButton uses MauiShapeableImageView with expected activity context")]
+		public Task ImageButtonUsesMauiShapeableImageViewWithExpectedActivityContext()
 		{
 			return InvokeOnMainThreadAsync(() =>
 			{
 				var handler = CreateHandler(new ImageButtonStub());
 
 				var platformView = Assert.IsType<MauiShapeableImageView>(handler.PlatformView);
+				Assert.Same(MauiContext.Context.GetActivity(), platformView.Context.GetActivity());
+			});
+		}
 
-				if (RuntimeFeature.IsMaterial3Enabled)
-					Assert.IsType<MauiMaterialContextThemeWrapper>(platformView.Context);
-				else
-					Assert.Same(MauiContext.Context, platformView.Context);
+		[Fact(DisplayName = "MauiShapeableImageView preserves public constructor context behavior")]
+		public Task MauiShapeableImageViewPreservesPublicConstructorContextBehavior()
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var platformView = new MauiShapeableImageView(MauiContext.Context);
+
+				Assert.Same(MauiContext.Context.GetActivity(), platformView.Context.GetActivity());
+				Assert.IsNotType<MauiMaterialContextThemeWrapper>(platformView.Context);
+			});
+		}
+
+		[Fact(DisplayName = "MauiShapeableImageView applies Material 3 theme when requested")]
+		public Task MauiShapeableImageViewAppliesMaterial3ThemeWhenRequested()
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var platformView = new MauiShapeableImageView(MauiContext.Context, useMaterial3: true);
+
+				Assert.IsType<MauiMaterialContextThemeWrapper>(platformView.Context);
+				Assert.Same(MauiContext.Context.GetActivity(), platformView.Context.GetActivity());
 			});
 		}
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Completes the .NET 11 follow-up from the Android Material 3 ImageButton work by removing the temporary internal `MaterialShapeableImageView` shim.

- `ImageButtonHandler` now always creates `MauiShapeableImageView` and forwards the Material 3 feature state through a new public opt-in constructor.
- `MauiShapeableImageView(Context?, bool useMaterial3)` lets custom handlers and compatibility renderers request equivalent Material 3 theming without changing the behavior of the shipped constructors.
- The three shipped public constructors continue to pass their supplied context directly to `ShapeableImageView`, and their nullable annotations remain unchanged.
- Material 3 opt-in applies the requested MAUI theme deterministically while avoiding redundant wrapping of an existing `MauiMaterialContextThemeWrapper`.
- The existing measurement-time padding normalization remains on `MauiShapeableImageView`.
- Core Android device tests verify the concrete platform view type, both handler feature-switch paths, public-constructor compatibility, originating activity context, and padding normalization.

The handler's shipped `ShapeableImageView` base contract remains unchanged. This adds one non-breaking public constructor overload for the net11 Material 3 opt-in.

### Validation

- Built `src/Core/src/Core.csproj` for `net11.0-android37.0` with PublicAPI analysis (zero warnings and errors).
- Built the Core Android device-test APK for `net11.0-android`, including the updated tests.
- Device execution was not available locally because the Windows host had no emulator or connected Android device.

### Issues Fixed

Follow-up to #33649.