### PR TITLE
[Android] Fix CollectionView item selection not triggered when using PointerGestureRecognizer

### DIFF
--- a/src/Controls/src/Core/Platform/Android/PointerGestureHandler.cs
+++ b/src/Controls/src/Core/Platform/Android/PointerGestureHandler.cs
@@ -21,6 +21,22 @@ namespace Microsoft.Maui.Controls.Platform
 
 		Func<View> GetView { get; }
 		Func<AView> GetControl { get; }
+		internal bool HasClickablePlatformViewInHierarchy
+		{
+			get
+			{
+				var platformView = GetControl();
+				while (platformView is not null)
+				{
+					if (platformView.Clickable)
+						return true;
+
+					platformView = platformView.Parent as AView;
+				}
+
+				return false;
+			}
+		}
 
 		public bool OnHover(AView control, MotionEvent e)
 		{

--- a/src/Controls/src/Core/Platform/Android/TapAndPanGestureDetector.cs
+++ b/src/Controls/src/Core/Platform/Android/TapAndPanGestureDetector.cs
@@ -47,7 +47,8 @@ namespace Microsoft.Maui.Controls.Platform
 				MotionEventActions.Up or MotionEventActions.Down or MotionEventActions.Move or MotionEventActions.Cancel)
 			{
 				_pointerGestureHandler.OnTouch(ev);
-				pointerHandled = _pointerGestureHandler.HasAnyPointerGestures();
+				pointerHandled = _pointerGestureHandler.HasAnyPointerGestures() &&
+					!_pointerGestureHandler.HasClickablePlatformViewInHierarchy;
 			}
 
 			if (_listener != null && ev?.Action == MotionEventActions.Up)

--- a/src/Controls/src/Core/Platform/Android/TapAndPanGestureDetector.cs
+++ b/src/Controls/src/Core/Platform/Android/TapAndPanGestureDetector.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Maui.Controls.Platform
 	{
 		InnerGestureListener? _listener;
 		PointerGestureHandler? _pointerGestureHandler;
+		bool _hasClickablePlatformViewInHierarchy;
 
 		public TapAndPanGestureDetector(Context context, InnerGestureListener listener) : base(context, listener)
 		{
@@ -46,9 +47,15 @@ namespace Microsoft.Maui.Controls.Platform
 			if (_pointerGestureHandler != null && ev?.Action is
 				MotionEventActions.Up or MotionEventActions.Down or MotionEventActions.Move or MotionEventActions.Cancel)
 			{
+				if (ev.Action == MotionEventActions.Down)
+					_hasClickablePlatformViewInHierarchy = _pointerGestureHandler.HasClickablePlatformViewInHierarchy;
+
 				_pointerGestureHandler.OnTouch(ev);
 				pointerHandled = _pointerGestureHandler.HasAnyPointerGestures() &&
-					!_pointerGestureHandler.HasClickablePlatformViewInHierarchy;
+					!_hasClickablePlatformViewInHierarchy;
+
+				if (ev.Action is MotionEventActions.Up or MotionEventActions.Cancel)
+					_hasClickablePlatformViewInHierarchy = false;
 			}
 
 			if (_listener != null && ev?.Action == MotionEventActions.Up)

--- a/src/Controls/src/Core/Platform/Android/TapAndPanGestureDetector.cs
+++ b/src/Controls/src/Core/Platform/Android/TapAndPanGestureDetector.cs
@@ -11,7 +11,6 @@ namespace Microsoft.Maui.Controls.Platform
 	{
 		InnerGestureListener? _listener;
 		PointerGestureHandler? _pointerGestureHandler;
-		bool _hasClickablePlatformViewInHierarchy;
 
 		public TapAndPanGestureDetector(Context context, InnerGestureListener listener) : base(context, listener)
 		{
@@ -47,15 +46,10 @@ namespace Microsoft.Maui.Controls.Platform
 			if (_pointerGestureHandler != null && ev?.Action is
 				MotionEventActions.Up or MotionEventActions.Down or MotionEventActions.Move or MotionEventActions.Cancel)
 			{
-				if (ev.Action == MotionEventActions.Down)
-					_hasClickablePlatformViewInHierarchy = _pointerGestureHandler.HasClickablePlatformViewInHierarchy;
-
 				_pointerGestureHandler.OnTouch(ev);
 				pointerHandled = _pointerGestureHandler.HasAnyPointerGestures() &&
-					!_hasClickablePlatformViewInHierarchy;
-
-				if (ev.Action is MotionEventActions.Up or MotionEventActions.Cancel)
-					_hasClickablePlatformViewInHierarchy = false;
+						ev.Action == MotionEventActions.Down &&
+						!_pointerGestureHandler.HasClickablePlatformViewInHierarchy;
 			}
 
 			if (_listener != null && ev?.Action == MotionEventActions.Up)


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root cause
In PR #34209 , the pointer gesture handling returned true whenever a PointerGestureRecognizer was present (return baseHandled || pointerHandled). This was required to ensure Android continued delivering PointerMoved and PointerReleased events. However, when the gesture was used inside a CollectionView.ItemTemplate, the same handling consumed the touch event before it could reach the CollectionView item. As a result, the CollectionView did not receive its native click event, preventing item selection and SelectionChanged from being triggered.
### Issue Details
On Android, adding a PointerGestureRecognizer to a view inside a CollectionView ItemTemplate prevented item selection. Tapping the item raised pointer events, but SelectionChanged did not fire.

### Description of Change

<!-- Enter description of the fix in this section -->
Updated Android pointer gesture handling in:  
* PointerGestureHandler now examines the native Android view hierarchy to determine whether the pointer-enabled view is inside a clickable native view.
* TapAndPanGestureDetector retains the touch sequence only when no clickable native view owns it.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #34491 

### Regarding test case
The test case requires user interaction, so haven't added a test case.

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

**Tested the behavior in the following platforms.**
- [x] Android
- [ ] Windows
- [ ] iOS
- [ ] Mac


| Before  | After  |
|---------|--------|
| **Android**<br> <video src="https://github.com/user-attachments/assets/3b880f2b-f76a-4fe8-ac50-03c65e2a10e0" width="300" height="600"> | **Android**<br> <video src="https://github.com/user-attachments/assets/e21172b8-d0fa-48e0-93a9-5c732c7159a9" width="300" height="600"> |
