### PR TITLE
Use SkiaSharp arc drawing API

### DIFF
--- a/.github/scripts/SetupVallyRuntime.sh
+++ b/.github/scripts/SetupVallyRuntime.sh
@@ -82,7 +82,7 @@ if grep -Fqx -- "--experimental" "$probe_output"; then
 	exit 1
 fi
 
-# Vally 0.12 normally creates an empty per-run Copilot home and passes it as the
+# Vally normally creates an empty per-run Copilot home and passes it as the
 # session configDirectory, which takes precedence over COPILOT_HOME. Confirm the
 # pinned executor honors the opt-out before any model credential enters the job.
 copilot_home_module="$install_root/node_modules/@microsoft/vally/dist/executor/copilot-home.js"

--- a/.github/skills/agentic-labeler/tests/eval.vally.yaml
+++ b/.github/skills/agentic-labeler/tests/eval.vally.yaml
@@ -37,7 +37,7 @@
 # Legacy scenarios AND-gated up to ~15 `output_not_contains` assertions
 # (every triage/partner/kind label spelled out) plus, for noop scenarios,
 # a fragile ~10-branch alternation regex matching phrasings of "no labels."
-# With scoring.weights omitted, Vally 0.12 computes the trial score as the
+# With scoring.weights omitted, Vally computes the trial score as the
 # UNWEIGHTED MEAN of
 # grader scores, so piling on 12 floors drowns the judge (1/13 weight) and
 # a single wrong label can't move the aggregate. This port keeps, per
@@ -998,7 +998,7 @@ stimuli:
     constraints: { max_duration: 5m, expect_skills: [agentic-labeler] }
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of grader [0,1] scores; stimulus
   # passes when the mean across runs >= threshold. Invocation is a separate
   # workflow hard veto, while 0.90 preserves the suite's prior semantic bar

--- a/.github/skills/analyze-sessions/SKILL.md
+++ b/.github/skills/analyze-sessions/SKILL.md
@@ -242,7 +242,7 @@ scoring:
 Then validate every emitted file:
 
 ```bash
-npx -y @microsoft/vally-cli@0.12.0 lint --eval-spec <path-to-eval> --strict
+npx -y @microsoft/vally-cli@0.14.0 lint --eval-spec <path-to-eval> --strict
 ```
 
 ## Privacy & safety

--- a/.github/skills/analyze-sessions/references/design-rationale.md
+++ b/.github/skills/analyze-sessions/references/design-rationale.md
@@ -162,7 +162,7 @@ generic `.github/evals/` paths are not valid targets. A different skill's
 Each eval pairs a refutation-proof **structural floor** (`output-matches` on a
 forced token line) with **one LLM judge** (`scale_1_5`, `threshold: 0.6`) so the
 judge carries ~half the weight. Each emitted file must pass
-`npx -y @microsoft/vally-cli@0.12.0 lint --eval-spec <f> --strict`. This is the
+`npx -y @microsoft/vally-cli@0.14.0 lint --eval-spec <f> --strict`. This is the
 mechanism that makes the analysis *iterative*: a failure found today becomes a
 regression test that fails if we regress tomorrow.
 

--- a/.github/skills/analyze-sessions/tests/eval.vally.yaml
+++ b/.github/skills/analyze-sessions/tests/eval.vally.yaml
@@ -19,7 +19,7 @@
 # line — immune to "mentions the word" false-fails) with ONE LLM JUDGE
 # (scale_1_5, threshold 0.6) so the judge carries ~50% of every score.
 #
-# Scoring: this suite deliberately omits scoring.weights, so Vally 0.12 uses the
+# Scoring: this suite deliberately omits scoring.weights, so Vally uses the
 # unweighted mean of grader [0,1] scores; a stimulus passes when the mean across
 # runs >= scoring.threshold (0.6). With a scale_1_5 judge (normalized =
 # (raw-1)/4):
@@ -295,7 +295,7 @@ stimuli:
       reject_skills: [analyze-sessions]
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of each stimulus's two graders
   # (one refutation-proof structural floor + one LLM judge), keeping the judge
   # at ~50% of every score per the house convention.

--- a/.github/skills/code-review/tests/eval.inline-findings.vally.yaml
+++ b/.github/skills/code-review/tests/eval.inline-findings.vally.yaml
@@ -159,7 +159,7 @@ stimuli:
         - code-review
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of the two graders' [0,1] scores;
   # the stimulus passes when the mean across runs >= threshold, and the CI
   # check keys off that mean-vs-threshold `passed` property. Two graders (one

--- a/.github/skills/code-review/tests/eval.vally.yaml
+++ b/.github/skills/code-review/tests/eval.vally.yaml
@@ -440,7 +440,7 @@ stimuli:
       max_duration: 10m
 
 scoring:
-  # Vally 0.12 supports scoring.weights, but this suite deliberately omits
+  # Vally supports scoring.weights, but this suite deliberately omits
   # them so a trial's score is the unweighted mean of its graders' [0,1]
   # scores; the stimulus score is the mean across runs. The deterministic
   # tool-calls grader is the manipulation check: a trial that never reads the

--- a/.github/skills/code-review/tests/hermeticity.vally.yaml
+++ b/.github/skills/code-review/tests/hermeticity.vally.yaml
@@ -101,7 +101,7 @@ stimuli:
       max_turns: 10
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean. Threshold 1.0 means the single stimulus must score a perfect 1.0
   # to "pass" — i.e. the agent's output matched the anonymous rate limit
   # (CORE_LIMIT:60). The hermeticity-gate job reads the verdict directly:

--- a/.github/skills/code-review/tests/soak.capability.vally.yaml
+++ b/.github/skills/code-review/tests/soak.capability.vally.yaml
@@ -474,7 +474,7 @@ stimuli:
         - code-review
 
 scoring:
-  # Vally 0.12 supports scoring.weights, but this suite deliberately omits
+  # Vally supports scoring.weights, but this suite deliberately omits
   # them so a trial's score is the unweighted mean of its graders' [0,1]
   # scores. The `prompt`
   # grader contributes ONE holistic score, so rubric criteria are not

--- a/.github/skills/evaluate-pr-tests/tests/eval.vally.yaml
+++ b/.github/skills/evaluate-pr-tests/tests/eval.vally.yaml
@@ -34,13 +34,13 @@
 # brittle (a correct finding phrased differently fails). Those move into
 # the LLM-judge rubric. Each scenario keeps at most 1–2 structural / crisp-
 # negative floors so the judge stays decisive (this suite omits
-# scoring.weights, so Vally 0.12 scores a trial as the unweighted mean of its
+# scoring.weights, so Vally scores a trial as the unweighted mean of its
 # graders). The two purely-semantic
 # detection scenarios (weak assertions, edge-case gaps) are judge-only — a
 # single prompt grader means the trial score IS the judge's normalized
 # rubric score.
 #
-# Scoring: scoring.weights is deliberately omitted, so Vally 0.12 uses the
+# Scoring: scoring.weights is deliberately omitted, so Vally uses the
 # equal-weight aggregate and the 0.6 threshold remains active.
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -405,7 +405,7 @@ stimuli:
     constraints: { max_duration: 5m, expect_skills: [evaluate-pr-tests] }
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of grader [0,1] scores; skill passes
   # when the mean across runs >= threshold. Structural section-heading floors
   # are kept only where producing the report format IS the capability; the

--- a/.github/skills/pr-review/tests/eval.gh-auth.vally.yaml
+++ b/.github/skills/pr-review/tests/eval.gh-auth.vally.yaml
@@ -160,7 +160,7 @@ stimuli:
       max_duration: 5m
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of the three graders' [0,1] scores. The structural floor
   # and guidance-read check are necessary but insufficient. Threshold 0.8
   # keeps the judge load-bearing: a partial regression (`no`, guidance read,

--- a/.github/skills/try-fix/tests/eval.vally.yaml
+++ b/.github/skills/try-fix/tests/eval.vally.yaml
@@ -28,7 +28,7 @@
 #   structural floors (e.g. "claims PASS when no device was available").
 #
 # Scoring (see scoring block): this suite deliberately omits scoring.weights,
-# so Vally 0.12 uses the unweighted mean of grader [0,1] scores; skill passes
+# so Vally uses the unweighted mean of grader [0,1] scores; skill passes
 # when the mean >= scoring.threshold (0.8), unless any trial has an execution
 # error (a separate hard failure regardless of the numeric aggregate). Every
 # scenario also has a deterministic skill-invocation grader. The workflow
@@ -463,7 +463,7 @@ stimuli:
         - try-fix
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of grader [0,1] scores; skill passes when the mean across runs >=
   # threshold. At 0.6, passing invocation/structural floors could dilute every
   # semantic judge failure to a suite score of 0.607. The 0.8 threshold keeps

--- a/.github/skills/verify-tests-fail-without-fix/tests/eval.vally.yaml
+++ b/.github/skills/verify-tests-fail-without-fix/tests/eval.vally.yaml
@@ -23,7 +23,7 @@
 # whose aggregate threshold is undefined so every grader must pass its own
 # threshold.
 #
-# Scoring: this suite deliberately omits scoring.weights, so Vally 0.12 uses
+# Scoring: this suite deliberately omits scoring.weights, so Vally uses
 # the unweighted mean of grader [0,1] scores. Every scenario also has a
 # deterministic invocation grader, and the workflow applies invocation failures
 # as a hard veto. The threshold preserves the prior semantic-judge floor after
@@ -266,7 +266,7 @@ stimuli:
         - verify-tests-fail-without-fix
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of grader [0,1] scores. At 0.87, a stimulus with invocation
   # plus one structural floor still requires judge >= 0.61, preserving the old
   # 0.60 semantic bar. Stimuli without the extra floor are intentionally

--- a/.github/workflows/skill-evaluation-soak.yml
+++ b/.github/workflows/skill-evaluation-soak.yml
@@ -22,7 +22,7 @@ permissions:
   contents: read
 
 env:
-  VALLY_VERSION: "0.12.0"
+  VALLY_VERSION: "0.14.0"
   NODE_VERSION: "22"
 
 jobs:

--- a/.github/workflows/skill-validation.yml
+++ b/.github/workflows/skill-validation.yml
@@ -94,8 +94,8 @@ permissions:
 
 env:
   # Vally CLI is run via npx from npm. Pinned for reproducibility.
-  # Vally 0.12 requires Node >=22, so we pin Node 22 on the runners.
-  VALLY_VERSION: "0.12.0"
+  # Vally requires Node >=22.12, so we pin Node 22 on the runners.
+  VALLY_VERSION: "0.14.0"
   NODE_VERSION: "22"
 
 jobs:

--- a/src/Graphics/src/Graphics.Skia/SkiaCanvas.cs
+++ b/src/Graphics/src/Graphics.Skia/SkiaCanvas.cs
@@ -466,6 +466,13 @@ namespace Microsoft.Maui.Graphics.Skia
 				_canvas.DrawPath(platformPath, CurrentState.StrokePaintWithAlpha);
 				platformPath.Dispose();
 			}
+			else if (Math.Abs(sweep) >= 360)
+			{
+				var platformPath = new SKPath();
+				platformPath.AddArc(rect, startAngle, sweep);
+				_canvas.DrawPath(platformPath, CurrentState.StrokePaintWithAlpha);
+				platformPath.Dispose();
+			}
 			else
 			{
 				_canvas.DrawArc(rect, startAngle, sweep, false, CurrentState.StrokePaintWithAlpha);

--- a/src/Graphics/src/Graphics.Skia/SkiaCanvas.cs
+++ b/src/Graphics/src/Graphics.Skia/SkiaCanvas.cs
@@ -468,7 +468,7 @@ namespace Microsoft.Maui.Graphics.Skia
 			}
 			else if (Math.Abs(sweep) >= 360)
 			{
-				// AddArc closes full sweeps; DrawArc leaves stroked sweeps open and can render caps at the seam.
+				// Preserve AddArc's full-sweep behavior: cardinal starts close the oval, while non-cardinal starts may produce an empty contour.
 				var platformPath = new SKPath();
 				platformPath.AddArc(rect, startAngle, sweep);
 				_canvas.DrawPath(platformPath, CurrentState.StrokePaintWithAlpha);

--- a/src/Graphics/src/Graphics.Skia/SkiaCanvas.cs
+++ b/src/Graphics/src/Graphics.Skia/SkiaCanvas.cs
@@ -468,14 +468,7 @@ namespace Microsoft.Maui.Graphics.Skia
 			}
 			else
 			{
-				// todo: delete this after the api is bound
-				var platformPath = new SKPath();
-				platformPath.AddArc(rect, startAngle, sweep);
-				_canvas.DrawPath(platformPath, CurrentState.StrokePaintWithAlpha);
-				platformPath.Dispose();
-
-				// todo: restore this when the api is bound.
-				//_canvas.DrawArc (rect, startAngle, sweep, false, CurrentState.StrokePaintWithAlpha);
+				_canvas.DrawArc(rect, startAngle, sweep, false, CurrentState.StrokePaintWithAlpha);
 			}
 		}
 
@@ -511,14 +504,7 @@ namespace Microsoft.Maui.Graphics.Skia
 			if (!clockwise)
 				sweep *= -1;
 
-			// todo: delete this after the api is bound
-			var platformPath = new SKPath();
-			platformPath.AddArc(rect, startAngle, sweep);
-			_canvas.DrawPath(platformPath, CurrentState.FillPaintWithAlpha);
-			platformPath.Dispose();
-
-			// todo: restore this when the api is bound.
-			//_canvas.DrawArc (rect, startAngle, sweep, false, CurrentState.FillPaintWithAlpha);
+			_canvas.DrawArc(rect, startAngle, sweep, false, CurrentState.FillPaintWithAlpha);
 		}
 
 		protected override void PlatformDrawRectangle(

--- a/src/Graphics/src/Graphics.Skia/SkiaCanvas.cs
+++ b/src/Graphics/src/Graphics.Skia/SkiaCanvas.cs
@@ -512,8 +512,18 @@ namespace Microsoft.Maui.Graphics.Skia
 			if (!clockwise)
 				sweep *= -1;
 
-			// Full sweeps use DrawArc's closed-oval fast path because fill paint never has a path effect.
-			_canvas.DrawArc(rect, startAngle, sweep, false, CurrentState.FillPaintWithAlpha);
+			if (Math.Abs(sweep) >= 360)
+			{
+				// Preserve AddArc's full-sweep behavior: cardinal starts close the oval, while non-cardinal starts may produce an empty contour.
+				var platformPath = new SKPath();
+				platformPath.AddArc(rect, startAngle, sweep);
+				_canvas.DrawPath(platformPath, CurrentState.FillPaintWithAlpha);
+				platformPath.Dispose();
+			}
+			else
+			{
+				_canvas.DrawArc(rect, startAngle, sweep, false, CurrentState.FillPaintWithAlpha);
+			}
 		}
 
 		protected override void PlatformDrawRectangle(

--- a/src/Graphics/src/Graphics.Skia/SkiaCanvas.cs
+++ b/src/Graphics/src/Graphics.Skia/SkiaCanvas.cs
@@ -468,7 +468,8 @@ namespace Microsoft.Maui.Graphics.Skia
 			}
 			else if (Math.Abs(sweep) >= 360)
 			{
-				// Preserve AddArc's full-sweep behavior: cardinal starts close the oval, while non-cardinal starts may produce an empty contour.
+				// Preserve legacy full-sweep strokes: AddArc closes cardinal starts as ovals, while DrawArc leaves an open contour with caps at the seam.
+				// The same fallback also retains AddArc's empty contours for some non-cardinal starts.
 				var platformPath = new SKPath();
 				platformPath.AddArc(rect, startAngle, sweep);
 				_canvas.DrawPath(platformPath, CurrentState.StrokePaintWithAlpha);
@@ -514,7 +515,8 @@ namespace Microsoft.Maui.Graphics.Skia
 
 			if (Math.Abs(sweep) >= 360)
 			{
-				// Preserve AddArc's full-sweep behavior: cardinal starts close the oval, while non-cardinal starts may produce an empty contour.
+				// Preserve legacy Skia full-sweep compatibility, including empty contours for some non-cardinal starts.
+				// Other ICanvas implementations fill those contours, but correcting that deviation is outside this binding cleanup.
 				var platformPath = new SKPath();
 				platformPath.AddArc(rect, startAngle, sweep);
 				_canvas.DrawPath(platformPath, CurrentState.FillPaintWithAlpha);

--- a/src/Graphics/src/Graphics.Skia/SkiaCanvas.cs
+++ b/src/Graphics/src/Graphics.Skia/SkiaCanvas.cs
@@ -468,6 +468,7 @@ namespace Microsoft.Maui.Graphics.Skia
 			}
 			else if (Math.Abs(sweep) >= 360)
 			{
+				// AddArc closes full sweeps; DrawArc leaves stroked sweeps open and can render caps at the seam.
 				var platformPath = new SKPath();
 				platformPath.AddArc(rect, startAngle, sweep);
 				_canvas.DrawPath(platformPath, CurrentState.StrokePaintWithAlpha);
@@ -511,6 +512,7 @@ namespace Microsoft.Maui.Graphics.Skia
 			if (!clockwise)
 				sweep *= -1;
 
+			// Full sweeps use DrawArc's closed-oval fast path because fill paint never has a path effect.
 			_canvas.DrawArc(rect, startAngle, sweep, false, CurrentState.FillPaintWithAlpha);
 		}
 

--- a/src/Graphics/tests/Graphics.Tests/SkiaCanvasTests.cs
+++ b/src/Graphics/tests/Graphics.Tests/SkiaCanvasTests.cs
@@ -1,0 +1,68 @@
+using Microsoft.Maui.Graphics.Skia;
+using SkiaSharp;
+using Xunit;
+
+namespace Microsoft.Maui.Graphics.Tests;
+
+public class SkiaCanvasTests
+{
+	[Theory]
+	[InlineData(false, -30, -210)]
+	[InlineData(true, -30, 150)]
+	public void DrawArcMatchesPathRendering(bool clockwise, float expectedStartAngle, float expectedSweep)
+	{
+		using var actual = CreateBitmap();
+		using var expected = CreateBitmap();
+		using var actualPlatformCanvas = new SKCanvas(actual);
+		using var expectedPlatformCanvas = new SKCanvas(expected);
+		using var canvas = new SkiaCanvas { Canvas = actualPlatformCanvas };
+		using var paint = new SKPaint
+		{
+			Color = SKColors.Red,
+			IsAntialias = true,
+			IsStroke = true,
+			StrokeMiter = CanvasDefaults.DefaultMiterLimit,
+			StrokeWidth = 3,
+		};
+		using var path = new SKPath();
+
+		canvas.StrokeColor = Colors.Red;
+		canvas.StrokeSize = 3;
+		canvas.DrawArc(5, 7, 25, 18, 30, 240, clockwise, false);
+
+		path.AddArc(new SKRect(5, 7, 30, 25), expectedStartAngle, expectedSweep);
+		expectedPlatformCanvas.DrawPath(path, paint);
+
+		Assert.Equal(expected.Bytes, actual.Bytes);
+	}
+
+	[Theory]
+	[InlineData(false, -30, -210)]
+	[InlineData(true, -30, 150)]
+	public void FillArcMatchesPathRendering(bool clockwise, float expectedStartAngle, float expectedSweep)
+	{
+		using var actual = CreateBitmap();
+		using var expected = CreateBitmap();
+		using var actualPlatformCanvas = new SKCanvas(actual);
+		using var expectedPlatformCanvas = new SKCanvas(expected);
+		using var canvas = new SkiaCanvas { Canvas = actualPlatformCanvas };
+		using var paint = new SKPaint
+		{
+			Color = SKColors.Red,
+			IsAntialias = true,
+			IsStroke = false,
+		};
+		using var path = new SKPath();
+
+		canvas.FillColor = Colors.Red;
+		canvas.FillArc(5, 7, 25, 18, 30, 240, clockwise);
+
+		path.AddArc(new SKRect(5, 7, 30, 25), expectedStartAngle, expectedSweep);
+		expectedPlatformCanvas.DrawPath(path, paint);
+
+		Assert.Equal(expected.Bytes, actual.Bytes);
+	}
+
+	private static SKBitmap CreateBitmap() =>
+		new(new SKImageInfo(40, 40, SKColorType.Rgba8888, SKAlphaType.Premul));
+}

--- a/src/Graphics/tests/Graphics.Tests/SkiaCanvasTests.cs
+++ b/src/Graphics/tests/Graphics.Tests/SkiaCanvasTests.cs
@@ -51,13 +51,29 @@ public class SkiaCanvasTests
 		path.AddArc(new SKRect(5, 7, 5 + width, 7 + height), expectedStartAngle, expectedSweep);
 		expectedPlatformCanvas.DrawPath(path, paint);
 
+		var shouldDrawPixels = width > 0 && height > 0 && expectedSweep != 0;
+		Assert.Equal(shouldDrawPixels, HasPixels(expected));
+		Assert.Equal(shouldDrawPixels, HasPixels(actual));
 		Assert.Equal(expected.Bytes, actual.Bytes);
 	}
 
 	[Theory]
-	[InlineData(false, -30, -210)]
-	[InlineData(true, -30, 150)]
-	public void FillArcMatchesPathRendering(bool clockwise, float expectedStartAngle, float expectedSweep)
+	[InlineData(25, 18, 30, 240, false, -30, -210)]
+	[InlineData(25, 18, 30, 240, true, -30, 150)]
+	[InlineData(25, 18, 0, 360, false, 0, -360)]
+	[InlineData(25, 18, 0, 360, true, 0, 0)]
+	[InlineData(25, 18, 360, 0, false, -360, 0)]
+	[InlineData(25, 18, 360, 0, true, -360, 360)]
+	[InlineData(0, 18, 30, 240, false, -30, -210)]
+	[InlineData(25, 0, 30, 240, false, -30, -210)]
+	public void FillArcMatchesPathRendering(
+		float width,
+		float height,
+		float startAngle,
+		float endAngle,
+		bool clockwise,
+		float expectedStartAngle,
+		float expectedSweep)
 	{
 		using var actual = CreateBitmap();
 		using var expected = CreateBitmap();
@@ -73,11 +89,14 @@ public class SkiaCanvasTests
 		using var path = new SKPath();
 
 		canvas.FillColor = Colors.Red;
-		canvas.FillArc(5, 7, 25, 18, 30, 240, clockwise);
+		canvas.FillArc(5, 7, width, height, startAngle, endAngle, clockwise);
 
-		path.AddArc(new SKRect(5, 7, 30, 25), expectedStartAngle, expectedSweep);
+		path.AddArc(new SKRect(5, 7, 5 + width, 7 + height), expectedStartAngle, expectedSweep);
 		expectedPlatformCanvas.DrawPath(path, paint);
 
+		var shouldDrawPixels = width > 0 && height > 0 && expectedSweep != 0;
+		Assert.Equal(shouldDrawPixels, HasPixels(expected));
+		Assert.Equal(shouldDrawPixels, HasPixels(actual));
 		Assert.Equal(expected.Bytes, actual.Bytes);
 	}
 
@@ -87,6 +106,17 @@ public class SkiaCanvasTests
 			new SKImageInfo(40, 40, SKColorType.Rgba8888, SKAlphaType.Premul));
 		bitmap.Erase(SKColors.Transparent);
 		return bitmap;
+	}
+
+	private static bool HasPixels(SKBitmap bitmap)
+	{
+		foreach (var value in bitmap.Bytes)
+		{
+			if (value != 0)
+				return true;
+		}
+
+		return false;
 	}
 
 	private static SKStrokeCap GetStrokeCap(LineCap lineCap) =>

--- a/src/Graphics/tests/Graphics.Tests/SkiaCanvasTests.cs
+++ b/src/Graphics/tests/Graphics.Tests/SkiaCanvasTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Microsoft.Maui.Graphics.Skia;
 using SkiaSharp;
 using Xunit;
@@ -53,7 +54,7 @@ public class SkiaCanvasTests
 		};
 		using var pathEffect = strokePattern is null
 			? null
-			: SKPathEffect.CreateDash([6, 3], 0);
+			: SKPathEffect.CreateDash(strokePattern.Select(interval => interval * paint.StrokeWidth).ToArray(), 0);
 		paint.PathEffect = pathEffect;
 		using var path = new SKPath();
 
@@ -72,14 +73,15 @@ public class SkiaCanvasTests
 	}
 
 	[Theory]
-	[InlineData(25, 18, 30, 240, false, -30, -210)]
-	[InlineData(25, 18, 30, 240, true, -30, 150)]
-	[InlineData(25, 18, 0, 360, false, 0, -360)]
-	[InlineData(25, 18, 0, 360, true, 0, 0)]
-	[InlineData(25, 18, 360, 0, false, -360, 0)]
-	[InlineData(25, 18, 360, 0, true, -360, 360)]
-	[InlineData(0, 18, 30, 240, false, -30, -210)]
-	[InlineData(25, 0, 30, 240, false, -30, -210)]
+	[InlineData(25, 18, 30, 240, false, -30, -210, true)]
+	[InlineData(25, 18, 30, 240, true, -30, 150, true)]
+	[InlineData(25, 18, 0, 360, false, 0, -360, true)]
+	[InlineData(25, 18, 0, 360, true, 0, 0, false)]
+	[InlineData(25, 18, 360, 0, false, -360, 0, false)]
+	[InlineData(25, 18, 360, 0, true, -360, 360, true)]
+	[InlineData(25, 18, 30, 390, false, -30, -360, false)]
+	[InlineData(0, 18, 30, 240, false, -30, -210, false)]
+	[InlineData(25, 0, 30, 240, false, -30, -210, false)]
 	public void FillArcMatchesPathRendering(
 		float width,
 		float height,
@@ -87,7 +89,8 @@ public class SkiaCanvasTests
 		float endAngle,
 		bool clockwise,
 		float expectedStartAngle,
-		float expectedSweep)
+		float expectedSweep,
+		bool shouldDrawPixels)
 	{
 		using var actual = CreateBitmap();
 		using var expected = CreateBitmap();
@@ -108,7 +111,6 @@ public class SkiaCanvasTests
 		path.AddArc(new SKRect(5, 7, 5 + width, 7 + height), expectedStartAngle, expectedSweep);
 		expectedPlatformCanvas.DrawPath(path, paint);
 
-		var shouldDrawPixels = width > 0 && height > 0 && expectedSweep != 0;
 		Assert.Equal(shouldDrawPixels, HasPixels(expected));
 		Assert.Equal(shouldDrawPixels, HasPixels(actual));
 		Assert.Equal(expected.Bytes, actual.Bytes);

--- a/src/Graphics/tests/Graphics.Tests/SkiaCanvasTests.cs
+++ b/src/Graphics/tests/Graphics.Tests/SkiaCanvasTests.cs
@@ -8,7 +8,11 @@ public class SkiaCanvasTests
 {
 	[Theory]
 	[InlineData(25, 18, 30, 240, false, LineCap.Butt, -30, -210)]
+	[InlineData(25, 18, 30, 240, false, LineCap.Round, -30, -210)]
+	[InlineData(25, 18, 30, 240, false, LineCap.Square, -30, -210)]
 	[InlineData(25, 18, 30, 240, true, LineCap.Butt, -30, 150)]
+	[InlineData(25, 18, 30, 240, true, LineCap.Round, -30, 150)]
+	[InlineData(25, 18, 30, 240, true, LineCap.Square, -30, 150)]
 	[InlineData(25, 18, 0, 360, false, LineCap.Butt, 0, -360)]
 	[InlineData(25, 18, 0, 360, false, LineCap.Round, 0, -360)]
 	[InlineData(25, 18, 0, 360, false, LineCap.Square, 0, -360)]

--- a/src/Graphics/tests/Graphics.Tests/SkiaCanvasTests.cs
+++ b/src/Graphics/tests/Graphics.Tests/SkiaCanvasTests.cs
@@ -63,6 +63,11 @@ public class SkiaCanvasTests
 		Assert.Equal(expected.Bytes, actual.Bytes);
 	}
 
-	private static SKBitmap CreateBitmap() =>
-		new(new SKImageInfo(40, 40, SKColorType.Rgba8888, SKAlphaType.Premul));
+	private static SKBitmap CreateBitmap()
+	{
+		var bitmap = new SKBitmap(
+			new SKImageInfo(40, 40, SKColorType.Rgba8888, SKAlphaType.Premul));
+		bitmap.Erase(SKColors.Transparent);
+		return bitmap;
+	}
 }

--- a/src/Graphics/tests/Graphics.Tests/SkiaCanvasTests.cs
+++ b/src/Graphics/tests/Graphics.Tests/SkiaCanvasTests.cs
@@ -7,9 +7,25 @@ namespace Microsoft.Maui.Graphics.Tests;
 public class SkiaCanvasTests
 {
 	[Theory]
-	[InlineData(false, -30, -210)]
-	[InlineData(true, -30, 150)]
-	public void DrawArcMatchesPathRendering(bool clockwise, float expectedStartAngle, float expectedSweep)
+	[InlineData(25, 18, 30, 240, false, LineCap.Butt, -30, -210)]
+	[InlineData(25, 18, 30, 240, true, LineCap.Butt, -30, 150)]
+	[InlineData(25, 18, 0, 360, false, LineCap.Butt, 0, -360)]
+	[InlineData(25, 18, 0, 360, false, LineCap.Round, 0, -360)]
+	[InlineData(25, 18, 0, 360, false, LineCap.Square, 0, -360)]
+	[InlineData(25, 18, 360, 0, true, LineCap.Butt, -360, 360)]
+	[InlineData(25, 18, 360, 0, true, LineCap.Round, -360, 360)]
+	[InlineData(25, 18, 360, 0, true, LineCap.Square, -360, 360)]
+	[InlineData(0, 18, 30, 240, false, LineCap.Butt, -30, -210)]
+	[InlineData(25, 0, 30, 240, false, LineCap.Butt, -30, -210)]
+	public void DrawArcMatchesPathRendering(
+		float width,
+		float height,
+		float startAngle,
+		float endAngle,
+		bool clockwise,
+		LineCap lineCap,
+		float expectedStartAngle,
+		float expectedSweep)
 	{
 		using var actual = CreateBitmap();
 		using var expected = CreateBitmap();
@@ -21,16 +37,18 @@ public class SkiaCanvasTests
 			Color = SKColors.Red,
 			IsAntialias = true,
 			IsStroke = true,
+			StrokeCap = GetStrokeCap(lineCap),
 			StrokeMiter = CanvasDefaults.DefaultMiterLimit,
 			StrokeWidth = 3,
 		};
 		using var path = new SKPath();
 
 		canvas.StrokeColor = Colors.Red;
+		canvas.StrokeLineCap = lineCap;
 		canvas.StrokeSize = 3;
-		canvas.DrawArc(5, 7, 25, 18, 30, 240, clockwise, false);
+		canvas.DrawArc(5, 7, width, height, startAngle, endAngle, clockwise, false);
 
-		path.AddArc(new SKRect(5, 7, 30, 25), expectedStartAngle, expectedSweep);
+		path.AddArc(new SKRect(5, 7, 5 + width, 7 + height), expectedStartAngle, expectedSweep);
 		expectedPlatformCanvas.DrawPath(path, paint);
 
 		Assert.Equal(expected.Bytes, actual.Bytes);
@@ -70,4 +88,12 @@ public class SkiaCanvasTests
 		bitmap.Erase(SKColors.Transparent);
 		return bitmap;
 	}
+
+	private static SKStrokeCap GetStrokeCap(LineCap lineCap) =>
+		lineCap switch
+		{
+			LineCap.Round => SKStrokeCap.Round,
+			LineCap.Square => SKStrokeCap.Square,
+			_ => SKStrokeCap.Butt,
+		};
 }

--- a/src/Graphics/tests/Graphics.Tests/SkiaCanvasTests.cs
+++ b/src/Graphics/tests/Graphics.Tests/SkiaCanvasTests.cs
@@ -7,20 +7,23 @@ namespace Microsoft.Maui.Graphics.Tests;
 public class SkiaCanvasTests
 {
 	[Theory]
-	[InlineData(25, 18, 30, 240, false, LineCap.Butt, -30, -210)]
-	[InlineData(25, 18, 30, 240, false, LineCap.Round, -30, -210)]
-	[InlineData(25, 18, 30, 240, false, LineCap.Square, -30, -210)]
-	[InlineData(25, 18, 30, 240, true, LineCap.Butt, -30, 150)]
-	[InlineData(25, 18, 30, 240, true, LineCap.Round, -30, 150)]
-	[InlineData(25, 18, 30, 240, true, LineCap.Square, -30, 150)]
-	[InlineData(25, 18, 0, 360, false, LineCap.Butt, 0, -360)]
-	[InlineData(25, 18, 0, 360, false, LineCap.Round, 0, -360)]
-	[InlineData(25, 18, 0, 360, false, LineCap.Square, 0, -360)]
-	[InlineData(25, 18, 360, 0, true, LineCap.Butt, -360, 360)]
-	[InlineData(25, 18, 360, 0, true, LineCap.Round, -360, 360)]
-	[InlineData(25, 18, 360, 0, true, LineCap.Square, -360, 360)]
-	[InlineData(0, 18, 30, 240, false, LineCap.Butt, -30, -210)]
-	[InlineData(25, 0, 30, 240, false, LineCap.Butt, -30, -210)]
+	[InlineData(25, 18, 30, 240, false, LineCap.Butt, -30, -210, true, false)]
+	[InlineData(25, 18, 30, 240, false, LineCap.Butt, -30, -210, true, true)]
+	[InlineData(25, 18, 30, 240, false, LineCap.Round, -30, -210, true, false)]
+	[InlineData(25, 18, 30, 240, false, LineCap.Square, -30, -210, true, false)]
+	[InlineData(25, 18, 30, 240, true, LineCap.Butt, -30, 150, true, false)]
+	[InlineData(25, 18, 30, 240, true, LineCap.Round, -30, 150, true, false)]
+	[InlineData(25, 18, 30, 240, true, LineCap.Square, -30, 150, true, false)]
+	[InlineData(25, 18, 0, 360, false, LineCap.Butt, 0, -360, true, false)]
+	[InlineData(25, 18, 0, 360, false, LineCap.Round, 0, -360, true, false)]
+	[InlineData(25, 18, 0, 360, false, LineCap.Square, 0, -360, true, false)]
+	[InlineData(25, 18, 360, 0, true, LineCap.Butt, -360, 360, true, false)]
+	[InlineData(25, 18, 360, 0, true, LineCap.Round, -360, 360, true, false)]
+	[InlineData(25, 18, 360, 0, true, LineCap.Square, -360, 360, true, false)]
+	[InlineData(25, 18, 30, 390, false, LineCap.Round, -30, -360, false, false)]
+	[InlineData(25, 18, 30, 390, false, LineCap.Square, -30, -360, false, false)]
+	[InlineData(0, 18, 30, 240, false, LineCap.Butt, -30, -210, false, false)]
+	[InlineData(25, 0, 30, 240, false, LineCap.Butt, -30, -210, false, false)]
 	public void DrawArcMatchesPathRendering(
 		float width,
 		float height,
@@ -29,8 +32,11 @@ public class SkiaCanvasTests
 		bool clockwise,
 		LineCap lineCap,
 		float expectedStartAngle,
-		float expectedSweep)
+		float expectedSweep,
+		bool shouldDrawPixels,
+		bool dashed)
 	{
+		float[] strokePattern = dashed ? [2, 1] : null;
 		using var actual = CreateBitmap();
 		using var expected = CreateBitmap();
 		using var actualPlatformCanvas = new SKCanvas(actual);
@@ -45,17 +51,21 @@ public class SkiaCanvasTests
 			StrokeMiter = CanvasDefaults.DefaultMiterLimit,
 			StrokeWidth = 3,
 		};
+		using var pathEffect = strokePattern is null
+			? null
+			: SKPathEffect.CreateDash([6, 3], 0);
+		paint.PathEffect = pathEffect;
 		using var path = new SKPath();
 
 		canvas.StrokeColor = Colors.Red;
 		canvas.StrokeLineCap = lineCap;
 		canvas.StrokeSize = 3;
+		canvas.StrokeDashPattern = strokePattern;
 		canvas.DrawArc(5, 7, width, height, startAngle, endAngle, clockwise, false);
 
 		path.AddArc(new SKRect(5, 7, 5 + width, 7 + height), expectedStartAngle, expectedSweep);
 		expectedPlatformCanvas.DrawPath(path, paint);
 
-		var shouldDrawPixels = width > 0 && height > 0 && expectedSweep != 0;
 		Assert.Equal(shouldDrawPixels, HasPixels(expected));
 		Assert.Equal(shouldDrawPixels, HasPixels(actual));
 		Assert.Equal(expected.Bytes, actual.Bytes);

--- a/src/Graphics/tests/Graphics.Tests/SkiaCanvasTests.cs
+++ b/src/Graphics/tests/Graphics.Tests/SkiaCanvasTests.cs
@@ -16,11 +16,14 @@ public class SkiaCanvasTests
 	[InlineData(25, 18, 30, 240, true, LineCap.Round, -30, 150, true, false)]
 	[InlineData(25, 18, 30, 240, true, LineCap.Square, -30, 150, true, false)]
 	[InlineData(25, 18, 0, 360, false, LineCap.Butt, 0, -360, true, false)]
+	[InlineData(25, 18, 0, 360, false, LineCap.Butt, 0, -360, true, true)]
 	[InlineData(25, 18, 0, 360, false, LineCap.Round, 0, -360, true, false)]
 	[InlineData(25, 18, 0, 360, false, LineCap.Square, 0, -360, true, false)]
 	[InlineData(25, 18, 360, 0, true, LineCap.Butt, -360, 360, true, false)]
 	[InlineData(25, 18, 360, 0, true, LineCap.Round, -360, 360, true, false)]
 	[InlineData(25, 18, 360, 0, true, LineCap.Square, -360, 360, true, false)]
+	// Empty non-cardinal full sweeps document a known deviation from other ICanvas implementations, not a desired contract.
+	[InlineData(25, 18, 30, 390, false, LineCap.Butt, -30, -360, false, true)]
 	[InlineData(25, 18, 30, 390, false, LineCap.Round, -30, -360, false, false)]
 	[InlineData(25, 18, 30, 390, false, LineCap.Square, -30, -360, false, false)]
 	[InlineData(0, 18, 30, 240, false, LineCap.Butt, -30, -210, false, false)]
@@ -79,6 +82,7 @@ public class SkiaCanvasTests
 	[InlineData(25, 18, 0, 360, true, 0, 0, false)]
 	[InlineData(25, 18, 360, 0, false, -360, 0, false)]
 	[InlineData(25, 18, 360, 0, true, -360, 360, true)]
+	// This empty result preserves a known Skia deviation from other ICanvas implementations, not a desired contract.
 	[InlineData(25, 18, 30, 390, false, -30, -360, false)]
 	[InlineData(0, 18, 30, 240, false, -30, -210, false)]
 	[InlineData(25, 0, 30, 240, false, -30, -210, false)]

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
@@ -120,7 +120,6 @@ namespace Microsoft.Maui.IntegrationTests
 				buildProps.Add("PublishAot=true");
 				buildProps.Add("PublishAotUsingRuntimePack=true"); // TODO: This parameter will become obsolete https://github.com/dotnet/runtime/issues/87060
 				buildProps.Add("_IsPublishing=true"); // using dotnet build with -p:_IsPublishing=true enables targeting simulators
-				buildProps.Add("IlcTreatWarningsAsErrors=false"); // TODO: Remove this once all warnings are fixed https://github.com/dotnet/maui/issues/19397
 				// Restrict to iOS-only to avoid restoring NativeAOT packages for other platforms (e.g., Android)
 				// which may not be available in the configured NuGet sources
 				buildProps.Add($"TargetFrameworks={framework}-ios");


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Replace the temporary `SKPath` workaround for partial Skia canvas arcs with the supported `SKCanvas.DrawArc` API.

Full sweeps retain `SKPath.AddArc` for behavioral compatibility. For strokes, cardinal full sweeps must remain closed ovals rather than open contours with caps at the seam. For fills and strokes, some non-cardinal full sweeps retain the existing empty-contour behavior; this is a known deviation from other `ICanvas` implementations, but correcting that observable behavior is outside this binding-cleanup scope.

Bitmap filtering and unrelated unimplemented Graphics.Skia TODOs remain unchanged because resolving them could alter rendering behavior or requires separate feature work.

## Testing

- Added pixel-equivalence tests for clockwise and counterclockwise partial arcs
- Added cardinal and non-cardinal full-sweep compatibility coverage, including stroke caps and dash patterns
- Added degenerate rectangle and non-empty/empty rendering assertions
- Existing Windows Skia golden rendering scenarios remain unchanged
- Built Graphics.Skia for `netstandard2.0`, `netstandard2.1`, and `net10.0-windows10.0.19041.0`