### PR TITLE
Fix grouped CollectionView EmptyView on iOS

### DIFF
--- a/.github/scripts/SetupVallyRuntime.sh
+++ b/.github/scripts/SetupVallyRuntime.sh
@@ -82,7 +82,7 @@ if grep -Fqx -- "--experimental" "$probe_output"; then
 	exit 1
 fi
 
-# Vally 0.12 normally creates an empty per-run Copilot home and passes it as the
+# Vally normally creates an empty per-run Copilot home and passes it as the
 # session configDirectory, which takes precedence over COPILOT_HOME. Confirm the
 # pinned executor honors the opt-out before any model credential enters the job.
 copilot_home_module="$install_root/node_modules/@microsoft/vally/dist/executor/copilot-home.js"

--- a/.github/skills/agentic-labeler/tests/eval.vally.yaml
+++ b/.github/skills/agentic-labeler/tests/eval.vally.yaml
@@ -37,7 +37,7 @@
 # Legacy scenarios AND-gated up to ~15 `output_not_contains` assertions
 # (every triage/partner/kind label spelled out) plus, for noop scenarios,
 # a fragile ~10-branch alternation regex matching phrasings of "no labels."
-# With scoring.weights omitted, Vally 0.12 computes the trial score as the
+# With scoring.weights omitted, Vally computes the trial score as the
 # UNWEIGHTED MEAN of
 # grader scores, so piling on 12 floors drowns the judge (1/13 weight) and
 # a single wrong label can't move the aggregate. This port keeps, per
@@ -998,7 +998,7 @@ stimuli:
     constraints: { max_duration: 5m, expect_skills: [agentic-labeler] }
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of grader [0,1] scores; stimulus
   # passes when the mean across runs >= threshold. Invocation is a separate
   # workflow hard veto, while 0.90 preserves the suite's prior semantic bar

--- a/.github/skills/analyze-sessions/SKILL.md
+++ b/.github/skills/analyze-sessions/SKILL.md
@@ -242,7 +242,7 @@ scoring:
 Then validate every emitted file:
 
 ```bash
-npx -y @microsoft/vally-cli@0.12.0 lint --eval-spec <path-to-eval> --strict
+npx -y @microsoft/vally-cli@0.14.0 lint --eval-spec <path-to-eval> --strict
 ```
 
 ## Privacy & safety

--- a/.github/skills/analyze-sessions/references/design-rationale.md
+++ b/.github/skills/analyze-sessions/references/design-rationale.md
@@ -162,7 +162,7 @@ generic `.github/evals/` paths are not valid targets. A different skill's
 Each eval pairs a refutation-proof **structural floor** (`output-matches` on a
 forced token line) with **one LLM judge** (`scale_1_5`, `threshold: 0.6`) so the
 judge carries ~half the weight. Each emitted file must pass
-`npx -y @microsoft/vally-cli@0.12.0 lint --eval-spec <f> --strict`. This is the
+`npx -y @microsoft/vally-cli@0.14.0 lint --eval-spec <f> --strict`. This is the
 mechanism that makes the analysis *iterative*: a failure found today becomes a
 regression test that fails if we regress tomorrow.
 

--- a/.github/skills/analyze-sessions/tests/eval.vally.yaml
+++ b/.github/skills/analyze-sessions/tests/eval.vally.yaml
@@ -19,7 +19,7 @@
 # line — immune to "mentions the word" false-fails) with ONE LLM JUDGE
 # (scale_1_5, threshold 0.6) so the judge carries ~50% of every score.
 #
-# Scoring: this suite deliberately omits scoring.weights, so Vally 0.12 uses the
+# Scoring: this suite deliberately omits scoring.weights, so Vally uses the
 # unweighted mean of grader [0,1] scores; a stimulus passes when the mean across
 # runs >= scoring.threshold (0.6). With a scale_1_5 judge (normalized =
 # (raw-1)/4):
@@ -295,7 +295,7 @@ stimuli:
       reject_skills: [analyze-sessions]
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of each stimulus's two graders
   # (one refutation-proof structural floor + one LLM judge), keeping the judge
   # at ~50% of every score per the house convention.

--- a/.github/skills/code-review/tests/eval.inline-findings.vally.yaml
+++ b/.github/skills/code-review/tests/eval.inline-findings.vally.yaml
@@ -159,7 +159,7 @@ stimuli:
         - code-review
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of the two graders' [0,1] scores;
   # the stimulus passes when the mean across runs >= threshold, and the CI
   # check keys off that mean-vs-threshold `passed` property. Two graders (one

--- a/.github/skills/code-review/tests/eval.vally.yaml
+++ b/.github/skills/code-review/tests/eval.vally.yaml
@@ -440,7 +440,7 @@ stimuli:
       max_duration: 10m
 
 scoring:
-  # Vally 0.12 supports scoring.weights, but this suite deliberately omits
+  # Vally supports scoring.weights, but this suite deliberately omits
   # them so a trial's score is the unweighted mean of its graders' [0,1]
   # scores; the stimulus score is the mean across runs. The deterministic
   # tool-calls grader is the manipulation check: a trial that never reads the

--- a/.github/skills/code-review/tests/hermeticity.vally.yaml
+++ b/.github/skills/code-review/tests/hermeticity.vally.yaml
@@ -101,7 +101,7 @@ stimuli:
       max_turns: 10
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean. Threshold 1.0 means the single stimulus must score a perfect 1.0
   # to "pass" — i.e. the agent's output matched the anonymous rate limit
   # (CORE_LIMIT:60). The hermeticity-gate job reads the verdict directly:

--- a/.github/skills/code-review/tests/soak.capability.vally.yaml
+++ b/.github/skills/code-review/tests/soak.capability.vally.yaml
@@ -474,7 +474,7 @@ stimuli:
         - code-review
 
 scoring:
-  # Vally 0.12 supports scoring.weights, but this suite deliberately omits
+  # Vally supports scoring.weights, but this suite deliberately omits
   # them so a trial's score is the unweighted mean of its graders' [0,1]
   # scores. The `prompt`
   # grader contributes ONE holistic score, so rubric criteria are not

--- a/.github/skills/evaluate-pr-tests/tests/eval.vally.yaml
+++ b/.github/skills/evaluate-pr-tests/tests/eval.vally.yaml
@@ -34,13 +34,13 @@
 # brittle (a correct finding phrased differently fails). Those move into
 # the LLM-judge rubric. Each scenario keeps at most 1–2 structural / crisp-
 # negative floors so the judge stays decisive (this suite omits
-# scoring.weights, so Vally 0.12 scores a trial as the unweighted mean of its
+# scoring.weights, so Vally scores a trial as the unweighted mean of its
 # graders). The two purely-semantic
 # detection scenarios (weak assertions, edge-case gaps) are judge-only — a
 # single prompt grader means the trial score IS the judge's normalized
 # rubric score.
 #
-# Scoring: scoring.weights is deliberately omitted, so Vally 0.12 uses the
+# Scoring: scoring.weights is deliberately omitted, so Vally uses the
 # equal-weight aggregate and the 0.6 threshold remains active.
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -405,7 +405,7 @@ stimuli:
     constraints: { max_duration: 5m, expect_skills: [evaluate-pr-tests] }
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of grader [0,1] scores; skill passes
   # when the mean across runs >= threshold. Structural section-heading floors
   # are kept only where producing the report format IS the capability; the

--- a/.github/skills/pr-review/tests/eval.gh-auth.vally.yaml
+++ b/.github/skills/pr-review/tests/eval.gh-auth.vally.yaml
@@ -160,7 +160,7 @@ stimuli:
       max_duration: 5m
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of the three graders' [0,1] scores. The structural floor
   # and guidance-read check are necessary but insufficient. Threshold 0.8
   # keeps the judge load-bearing: a partial regression (`no`, guidance read,

--- a/.github/skills/try-fix/tests/eval.vally.yaml
+++ b/.github/skills/try-fix/tests/eval.vally.yaml
@@ -28,7 +28,7 @@
 #   structural floors (e.g. "claims PASS when no device was available").
 #
 # Scoring (see scoring block): this suite deliberately omits scoring.weights,
-# so Vally 0.12 uses the unweighted mean of grader [0,1] scores; skill passes
+# so Vally uses the unweighted mean of grader [0,1] scores; skill passes
 # when the mean >= scoring.threshold (0.8), unless any trial has an execution
 # error (a separate hard failure regardless of the numeric aggregate). Every
 # scenario also has a deterministic skill-invocation grader. The workflow
@@ -463,7 +463,7 @@ stimuli:
         - try-fix
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of grader [0,1] scores; skill passes when the mean across runs >=
   # threshold. At 0.6, passing invocation/structural floors could dilute every
   # semantic judge failure to a suite score of 0.607. The 0.8 threshold keeps

--- a/.github/skills/verify-tests-fail-without-fix/tests/eval.vally.yaml
+++ b/.github/skills/verify-tests-fail-without-fix/tests/eval.vally.yaml
@@ -23,7 +23,7 @@
 # whose aggregate threshold is undefined so every grader must pass its own
 # threshold.
 #
-# Scoring: this suite deliberately omits scoring.weights, so Vally 0.12 uses
+# Scoring: this suite deliberately omits scoring.weights, so Vally uses
 # the unweighted mean of grader [0,1] scores. Every scenario also has a
 # deterministic invocation grader, and the workflow applies invocation failures
 # as a hard veto. The threshold preserves the prior semantic-judge floor after
@@ -266,7 +266,7 @@ stimuli:
         - verify-tests-fail-without-fix
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of grader [0,1] scores. At 0.87, a stimulus with invocation
   # plus one structural floor still requires judge >= 0.61, preserving the old
   # 0.60 semantic bar. Stimuli without the extra floor are intentionally

--- a/.github/workflows/skill-evaluation-soak.yml
+++ b/.github/workflows/skill-evaluation-soak.yml
@@ -22,7 +22,7 @@ permissions:
   contents: read
 
 env:
-  VALLY_VERSION: "0.12.0"
+  VALLY_VERSION: "0.14.0"
   NODE_VERSION: "22"
 
 jobs:

--- a/.github/workflows/skill-validation.yml
+++ b/.github/workflows/skill-validation.yml
@@ -94,8 +94,8 @@ permissions:
 
 env:
   # Vally CLI is run via npx from npm. Pinned for reproducibility.
-  # Vally 0.12 requires Node >=22, so we pin Node 22 on the runners.
-  VALLY_VERSION: "0.12.0"
+  # Vally requires Node >=22.12, so we pin Node 22 on the runners.
+  VALLY_VERSION: "0.14.0"
   NODE_VERSION: "22"
 
 jobs:

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		bool _initialized;
 		bool _laidOut;
 		bool _isEmpty = true;
+		bool _hasNoItems = true;
 		bool _emptyViewDisplayed;
 		bool _disposed;
 
@@ -134,10 +135,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		void CheckForEmptySource()
 		{
 			var wasEmpty = _isEmpty;
+			var hadNoItems = _hasNoItems;
 
-			_isEmpty = ItemsSource.ItemCount == 0;
+			_hasNoItems = ItemsSource.ItemCount == 0;
+			_isEmpty = IsEmptySource();
 
-			if (_isEmpty)
+			if (_hasNoItems)
 			{
 				ClearMeasurementCells();
 				ItemsViewLayout?.ClearCellSizeCache();
@@ -148,7 +151,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				UpdateEmptyViewVisibility(_isEmpty);
 			}
 
-			if (wasEmpty && !_isEmpty)
+			if (hadNoItems && !_hasNoItems)
 			{
 				// If we're going from empty to having stuff, it's possible that we've never actually measured
 				// a prototype cell and our itemSize or estimatedItemSize are wrong/unset
@@ -779,7 +782,19 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			UpdateView(ItemsView?.EmptyView, ItemsView?.EmptyViewTemplate, ref _emptyUIView, ref _emptyViewFormsElement);
 
 			// We may need to show the updated empty view
-			UpdateEmptyViewVisibility(ItemsSource?.ItemCount == 0);
+			UpdateEmptyViewVisibility(IsEmptySource());
+		}
+
+		bool IsEmptySource()
+		{
+			if (ItemsSource is null)
+			{
+				return true;
+			}
+
+			return ItemsView is GroupableItemsView { IsGrouped: true }
+				? ItemsSource.GroupCount == 0
+				: ItemsSource.ItemCount == 0;
 		}
 
 		void UpdateEmptyViewVisibility(bool isEmpty)

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 		bool _initialized;
 		bool _isEmpty = true;
+		bool _hasNoItems = true;
 		bool _emptyViewDisplayed;
 		bool _disposed;
 
@@ -142,15 +143,17 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		void CheckForEmptySource()
 		{
 			var wasEmpty = _isEmpty;
+			var hadNoItems = _hasNoItems;
 
-			_isEmpty = ItemsSource.ItemCount == 0;
+			_hasNoItems = ItemsSource.ItemCount == 0;
+			_isEmpty = IsEmptySource();
 
 			if (wasEmpty != _isEmpty)
 			{
 				UpdateEmptyViewVisibility(_isEmpty);
 			}
 
-			if (wasEmpty && !_isEmpty)
+			if (hadNoItems && !_hasNoItems)
 			{
 				// If we're going from empty to having stuff, it's possible that we've never actually measured
 				// a prototype cell and our itemSize or estimatedItemSize are wrong/unset
@@ -546,7 +549,19 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			UpdateView(ItemsView?.EmptyView, ItemsView?.EmptyViewTemplate, ref _emptyUIView, ref _emptyViewFormsElement);
 
 			// We may need to show the updated empty view
-			UpdateEmptyViewVisibility(ItemsSource?.ItemCount == 0);
+			UpdateEmptyViewVisibility(IsEmptySource());
+		}
+
+		bool IsEmptySource()
+		{
+			if (ItemsSource is null)
+			{
+				return true;
+			}
+
+			return ItemsView is GroupableItemsView { IsGrouped: true }
+				? ItemsSource.GroupCount == 0
+				: ItemsSource.ItemCount == 0;
 		}
 
 		void UpdateEmptyViewVisibility(bool isEmpty)

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
@@ -16,11 +16,74 @@ using Microsoft.Maui.Platform;
 using UIKit;
 using Xunit;
 using Xunit.Sdk;
+using static Microsoft.Maui.DeviceTests.AssertHelpers;
 
 namespace Microsoft.Maui.DeviceTests
 {
 	public partial class CollectionViewTests
 	{
+		[Fact(DisplayName = "Grouped CollectionView EmptyView Tracks Groups")]
+		public Task GroupedCollectionViewEmptyViewTracksGroups()
+		{
+			return VerifyGroupedCollectionViewEmptyViewTracksGroups<CollectionViewHandler>();
+		}
+
+		[Fact(DisplayName = "CollectionViewHandler2 Grouped EmptyView Tracks Groups")]
+		public Task GroupedCollectionViewEmptyViewTracksGroups2()
+		{
+			return VerifyGroupedCollectionViewEmptyViewTracksGroups<CollectionViewHandler2>();
+		}
+
+		async Task VerifyGroupedCollectionViewEmptyViewTracksGroups<THandler>()
+			where THandler : class, IElementHandler
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler<CollectionView, THandler>();
+					handlers.AddHandler<Label, LabelHandler>();
+				});
+			});
+
+			var group = new ObservableCollection<string> { "Item 1" };
+			var groups = new ObservableCollection<ObservableCollection<string>> { group };
+			var emptyView = new Label { Text = "Empty" };
+			var collectionView = new CollectionView
+			{
+				IsGrouped = true,
+				ItemsSource = groups,
+				EmptyView = emptyView
+			};
+			var frame = collectionView.Frame;
+
+			await CreateHandlerAndAddToWindow<THandler>(collectionView, async handler =>
+			{
+				await WaitForUIUpdate(frame, collectionView);
+
+				var platformView = Assert.IsAssignableFrom<UIView>(handler.PlatformView);
+				var nativeCollectionView = platformView as UICollectionView
+					?? platformView.Subviews.OfType<UICollectionView>().FirstOrDefault();
+				Assert.NotNull(nativeCollectionView);
+
+				var emptyPlatformView = Assert.IsAssignableFrom<UIView>(emptyView.Handler.PlatformView);
+				var emptyViewWrapper = Assert.IsAssignableFrom<UIView>(emptyPlatformView.Superview);
+
+				await AssertEventually(() => nativeCollectionView.NumberOfItemsInSection(0) == 1);
+				Assert.Null(emptyViewWrapper.Superview);
+
+				group.RemoveAt(0);
+				await AssertEventually(() => nativeCollectionView.NumberOfItemsInSection(0) == 0);
+				Assert.Null(emptyViewWrapper.Superview);
+
+				groups.RemoveAt(0);
+				await AssertEventually(() => emptyViewWrapper.Superview is not null);
+
+				groups.Add(new());
+				await AssertEventually(() => emptyViewWrapper.Superview is null);
+			});
+		}
+
 		[Fact]
 		public async Task ItemsSourceGroupedClearDoestCrash()
 		{

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
@@ -120,7 +120,6 @@ namespace Microsoft.Maui.IntegrationTests
 				buildProps.Add("PublishAot=true");
 				buildProps.Add("PublishAotUsingRuntimePack=true"); // TODO: This parameter will become obsolete https://github.com/dotnet/runtime/issues/87060
 				buildProps.Add("_IsPublishing=true"); // using dotnet build with -p:_IsPublishing=true enables targeting simulators
-				buildProps.Add("IlcTreatWarningsAsErrors=false"); // TODO: Remove this once all warnings are fixed https://github.com/dotnet/maui/issues/19397
 				// Restrict to iOS-only to avoid restoring NativeAOT packages for other platforms (e.g., Android)
 				// which may not be available in the configured NuGet sources
 				buildProps.Add($"TargetFrameworks={framework}-ios");


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Fixes #37429.

On iOS, grouped `CollectionView` used the flattened leaf-item count to control `EmptyView` visibility. Removing the final item from an existing group therefore displayed `EmptyView` over a group that still existed. Grouped sources now use the outer `GroupCount`, so `EmptyView` remains hidden while any group exists and appears only after the final group is removed.

The fix applies to both iOS handler generations: the legacy `CollectionViewHandler` and current `CollectionViewHandler2`. Each handler also retains a separate leaf-item emptiness signal so measurement and cache behavior is not coupled to group-level `EmptyView` state.

This is the iOS-specific split of closed #37439, which maintainers requested be separated by platform. It intentionally contains no Android changes.

## Tests

Added iOS device tests for both handlers using eventual assertions. They cover the reported populated-group-to-empty-group transition, verify that `EmptyView` does not overlay the remaining empty group after its final item is removed, verify that removing the final group shows `EmptyView`, and verify that adding an empty group hides it again.

The iOS Debug device-test bundle builds successfully on Xcode 26.4. Local simulator execution could not complete because the installed XHarness 9 CLI cannot enumerate Xcode 26.4 simulators (exit code 71).
