### PR TITLE
[Resizetizer] Reenable integration tests

### DIFF
--- a/.github/scripts/SetupVallyRuntime.sh
+++ b/.github/scripts/SetupVallyRuntime.sh
@@ -82,7 +82,7 @@ if grep -Fqx -- "--experimental" "$probe_output"; then
 	exit 1
 fi
 
-# Vally 0.12 normally creates an empty per-run Copilot home and passes it as the
+# Vally normally creates an empty per-run Copilot home and passes it as the
 # session configDirectory, which takes precedence over COPILOT_HOME. Confirm the
 # pinned executor honors the opt-out before any model credential enters the job.
 copilot_home_module="$install_root/node_modules/@microsoft/vally/dist/executor/copilot-home.js"

--- a/.github/skills/agentic-labeler/tests/eval.vally.yaml
+++ b/.github/skills/agentic-labeler/tests/eval.vally.yaml
@@ -37,7 +37,7 @@
 # Legacy scenarios AND-gated up to ~15 `output_not_contains` assertions
 # (every triage/partner/kind label spelled out) plus, for noop scenarios,
 # a fragile ~10-branch alternation regex matching phrasings of "no labels."
-# With scoring.weights omitted, Vally 0.12 computes the trial score as the
+# With scoring.weights omitted, Vally computes the trial score as the
 # UNWEIGHTED MEAN of
 # grader scores, so piling on 12 floors drowns the judge (1/13 weight) and
 # a single wrong label can't move the aggregate. This port keeps, per
@@ -998,7 +998,7 @@ stimuli:
     constraints: { max_duration: 5m, expect_skills: [agentic-labeler] }
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of grader [0,1] scores; stimulus
   # passes when the mean across runs >= threshold. Invocation is a separate
   # workflow hard veto, while 0.90 preserves the suite's prior semantic bar

--- a/.github/skills/analyze-sessions/SKILL.md
+++ b/.github/skills/analyze-sessions/SKILL.md
@@ -242,7 +242,7 @@ scoring:
 Then validate every emitted file:
 
 ```bash
-npx -y @microsoft/vally-cli@0.12.0 lint --eval-spec <path-to-eval> --strict
+npx -y @microsoft/vally-cli@0.14.0 lint --eval-spec <path-to-eval> --strict
 ```
 
 ## Privacy & safety

--- a/.github/skills/analyze-sessions/references/design-rationale.md
+++ b/.github/skills/analyze-sessions/references/design-rationale.md
@@ -162,7 +162,7 @@ generic `.github/evals/` paths are not valid targets. A different skill's
 Each eval pairs a refutation-proof **structural floor** (`output-matches` on a
 forced token line) with **one LLM judge** (`scale_1_5`, `threshold: 0.6`) so the
 judge carries ~half the weight. Each emitted file must pass
-`npx -y @microsoft/vally-cli@0.12.0 lint --eval-spec <f> --strict`. This is the
+`npx -y @microsoft/vally-cli@0.14.0 lint --eval-spec <f> --strict`. This is the
 mechanism that makes the analysis *iterative*: a failure found today becomes a
 regression test that fails if we regress tomorrow.
 

--- a/.github/skills/analyze-sessions/tests/eval.vally.yaml
+++ b/.github/skills/analyze-sessions/tests/eval.vally.yaml
@@ -19,7 +19,7 @@
 # line — immune to "mentions the word" false-fails) with ONE LLM JUDGE
 # (scale_1_5, threshold 0.6) so the judge carries ~50% of every score.
 #
-# Scoring: this suite deliberately omits scoring.weights, so Vally 0.12 uses the
+# Scoring: this suite deliberately omits scoring.weights, so Vally uses the
 # unweighted mean of grader [0,1] scores; a stimulus passes when the mean across
 # runs >= scoring.threshold (0.6). With a scale_1_5 judge (normalized =
 # (raw-1)/4):
@@ -295,7 +295,7 @@ stimuli:
       reject_skills: [analyze-sessions]
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of each stimulus's two graders
   # (one refutation-proof structural floor + one LLM judge), keeping the judge
   # at ~50% of every score per the house convention.

--- a/.github/skills/code-review/tests/eval.inline-findings.vally.yaml
+++ b/.github/skills/code-review/tests/eval.inline-findings.vally.yaml
@@ -159,7 +159,7 @@ stimuli:
         - code-review
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of the two graders' [0,1] scores;
   # the stimulus passes when the mean across runs >= threshold, and the CI
   # check keys off that mean-vs-threshold `passed` property. Two graders (one

--- a/.github/skills/code-review/tests/eval.vally.yaml
+++ b/.github/skills/code-review/tests/eval.vally.yaml
@@ -440,7 +440,7 @@ stimuli:
       max_duration: 10m
 
 scoring:
-  # Vally 0.12 supports scoring.weights, but this suite deliberately omits
+  # Vally supports scoring.weights, but this suite deliberately omits
   # them so a trial's score is the unweighted mean of its graders' [0,1]
   # scores; the stimulus score is the mean across runs. The deterministic
   # tool-calls grader is the manipulation check: a trial that never reads the

--- a/.github/skills/code-review/tests/hermeticity.vally.yaml
+++ b/.github/skills/code-review/tests/hermeticity.vally.yaml
@@ -101,7 +101,7 @@ stimuli:
       max_turns: 10
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean. Threshold 1.0 means the single stimulus must score a perfect 1.0
   # to "pass" — i.e. the agent's output matched the anonymous rate limit
   # (CORE_LIMIT:60). The hermeticity-gate job reads the verdict directly:

--- a/.github/skills/code-review/tests/soak.capability.vally.yaml
+++ b/.github/skills/code-review/tests/soak.capability.vally.yaml
@@ -474,7 +474,7 @@ stimuli:
         - code-review
 
 scoring:
-  # Vally 0.12 supports scoring.weights, but this suite deliberately omits
+  # Vally supports scoring.weights, but this suite deliberately omits
   # them so a trial's score is the unweighted mean of its graders' [0,1]
   # scores. The `prompt`
   # grader contributes ONE holistic score, so rubric criteria are not

--- a/.github/skills/evaluate-pr-tests/tests/eval.vally.yaml
+++ b/.github/skills/evaluate-pr-tests/tests/eval.vally.yaml
@@ -34,13 +34,13 @@
 # brittle (a correct finding phrased differently fails). Those move into
 # the LLM-judge rubric. Each scenario keeps at most 1–2 structural / crisp-
 # negative floors so the judge stays decisive (this suite omits
-# scoring.weights, so Vally 0.12 scores a trial as the unweighted mean of its
+# scoring.weights, so Vally scores a trial as the unweighted mean of its
 # graders). The two purely-semantic
 # detection scenarios (weak assertions, edge-case gaps) are judge-only — a
 # single prompt grader means the trial score IS the judge's normalized
 # rubric score.
 #
-# Scoring: scoring.weights is deliberately omitted, so Vally 0.12 uses the
+# Scoring: scoring.weights is deliberately omitted, so Vally uses the
 # equal-weight aggregate and the 0.6 threshold remains active.
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -405,7 +405,7 @@ stimuli:
     constraints: { max_duration: 5m, expect_skills: [evaluate-pr-tests] }
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of grader [0,1] scores; skill passes
   # when the mean across runs >= threshold. Structural section-heading floors
   # are kept only where producing the report format IS the capability; the

--- a/.github/skills/pr-review/tests/eval.gh-auth.vally.yaml
+++ b/.github/skills/pr-review/tests/eval.gh-auth.vally.yaml
@@ -160,7 +160,7 @@ stimuli:
       max_duration: 5m
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of the three graders' [0,1] scores. The structural floor
   # and guidance-read check are necessary but insufficient. Threshold 0.8
   # keeps the judge load-bearing: a partial regression (`no`, guidance read,

--- a/.github/skills/try-fix/tests/eval.vally.yaml
+++ b/.github/skills/try-fix/tests/eval.vally.yaml
@@ -28,7 +28,7 @@
 #   structural floors (e.g. "claims PASS when no device was available").
 #
 # Scoring (see scoring block): this suite deliberately omits scoring.weights,
-# so Vally 0.12 uses the unweighted mean of grader [0,1] scores; skill passes
+# so Vally uses the unweighted mean of grader [0,1] scores; skill passes
 # when the mean >= scoring.threshold (0.8), unless any trial has an execution
 # error (a separate hard failure regardless of the numeric aggregate). Every
 # scenario also has a deterministic skill-invocation grader. The workflow
@@ -463,7 +463,7 @@ stimuli:
         - try-fix
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of grader [0,1] scores; skill passes when the mean across runs >=
   # threshold. At 0.6, passing invocation/structural floors could dilute every
   # semantic judge failure to a suite score of 0.607. The 0.8 threshold keeps

--- a/.github/skills/verify-tests-fail-without-fix/tests/eval.vally.yaml
+++ b/.github/skills/verify-tests-fail-without-fix/tests/eval.vally.yaml
@@ -23,7 +23,7 @@
 # whose aggregate threshold is undefined so every grader must pass its own
 # threshold.
 #
-# Scoring: this suite deliberately omits scoring.weights, so Vally 0.12 uses
+# Scoring: this suite deliberately omits scoring.weights, so Vally uses
 # the unweighted mean of grader [0,1] scores. Every scenario also has a
 # deterministic invocation grader, and the workflow applies invocation failures
 # as a hard veto. The threshold preserves the prior semantic-judge floor after
@@ -266,7 +266,7 @@ stimuli:
         - verify-tests-fail-without-fix
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of grader [0,1] scores. At 0.87, a stimulus with invocation
   # plus one structural floor still requires judge >= 0.61, preserving the old
   # 0.60 semantic bar. Stimuli without the extra floor are intentionally

--- a/.github/workflows/skill-evaluation-soak.yml
+++ b/.github/workflows/skill-evaluation-soak.yml
@@ -22,7 +22,7 @@ permissions:
   contents: read
 
 env:
-  VALLY_VERSION: "0.12.0"
+  VALLY_VERSION: "0.14.0"
   NODE_VERSION: "22"
 
 jobs:

--- a/.github/workflows/skill-validation.yml
+++ b/.github/workflows/skill-validation.yml
@@ -94,8 +94,8 @@ permissions:
 
 env:
   # Vally CLI is run via npx from npm. Pinned for reproducibility.
-  # Vally 0.12 requires Node >=22, so we pin Node 22 on the runners.
-  VALLY_VERSION: "0.12.0"
+  # Vally requires Node >=22.12, so we pin Node 22 on the runners.
+  VALLY_VERSION: "0.14.0"
   NODE_VERSION: "22"
 
 jobs:

--- a/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
+++ b/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
@@ -274,6 +274,8 @@
             <!-- If any resolved paths were missing OriginalProjectReferenceItemSpec or NearestTargetFramework, fall back to the 
                  previous functionality with using the ProjectReference items and the CURRENT project's TargetFramework -->
             <_ResizetizeCollectItemsProject Include="@(ProjectReference)" Exclude="@(_ResizetizeCollectItemsProject)" NearestTargetFramework="$(TargetFramework)" />
+            <!-- Restore metadata that is not retained when converting the resolved reference back to its original item spec. -->
+            <_ResizetizeCollectItemsProject Update="@(ProjectReference)" AdditionalProperties="%(ProjectReference.AdditionalProperties)" />
         </ItemGroup>
         <MSBuild
             Targets="GetMauiItems"

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
@@ -120,7 +120,6 @@ namespace Microsoft.Maui.IntegrationTests
 				buildProps.Add("PublishAot=true");
 				buildProps.Add("PublishAotUsingRuntimePack=true"); // TODO: This parameter will become obsolete https://github.com/dotnet/runtime/issues/87060
 				buildProps.Add("_IsPublishing=true"); // using dotnet build with -p:_IsPublishing=true enables targeting simulators
-				buildProps.Add("IlcTreatWarningsAsErrors=false"); // TODO: Remove this once all warnings are fixed https://github.com/dotnet/maui/issues/19397
 				// Restrict to iOS-only to avoid restoring NativeAOT packages for other platforms (e.g., Android)
 				// which may not be available in the configured NuGet sources
 				buildProps.Add($"TargetFrameworks={framework}-ios");

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/ResizetizerTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/ResizetizerTests.cs
@@ -15,21 +15,18 @@ public class ResizetizerTests : BaseBuildTest
 
 	[Theory]
 	// windows unpackaged/exe
-	[InlineData("maui", "classlib", true)] // net9.0
-	[InlineData("maui", "mauilib", true)] // net9.0-xxx
-	[InlineData("maui-blazor", "classlib", true)] // net9.0
-	[InlineData("maui-blazor", "mauilib", true)] // net9.0-xxx
-											   // windows packaged/msix
-	[InlineData("maui", "classlib", false)] // net9.0
-	[InlineData("maui", "mauilib", false)] // net9.0-xxx
-	[InlineData("maui-blazor", "classlib", false)] // net9.0
-	[InlineData("maui-blazor", "mauilib", false)] // net9.0-xxx
+	[InlineData("maui", "classlib", true)] // base TFM
+	[InlineData("maui", "mauilib", true)] // platform TFMs
+	[InlineData("maui-blazor", "classlib", true)] // base TFM
+	[InlineData("maui-blazor", "mauilib", true)] // platform TFMs
+												 // windows packaged/msix
+	[InlineData("maui", "classlib", false)] // base TFM
+	[InlineData("maui", "mauilib", false)] // platform TFMs
+	[InlineData("maui-blazor", "classlib", false)] // base TFM
+	[InlineData("maui-blazor", "mauilib", false)] // platform TFMs
 	public void CollectsAssets(string id, string libid, bool unpackaged)
 	{
 		SetTestIdentifier(id, libid, unpackaged);
-		// TODO: fix the tests as they have been disabled too long!
-		if (!TestEnvironment.IsWindows)
-			if (true) return; // Skip: "Running Windows templates is only supported on Windows."
 
 		// new app
 		var appDir = Path.Combine(TestDirectory, "theapp");
@@ -84,20 +81,41 @@ public class ResizetizerTests : BaseBuildTest
 			</Project>
 			""");
 
-		// build
-		Assert.True(DotnetInternal.Build(appFile, "Debug", properties: BuildProps, output: _output),
-			$"Project {Path.GetFileName(appFile)} failed to build. Check test output/attachments for errors.");
-
-		// assert
-		Assert.True(File.Exists(Path.Combine(appDir, $"obj\\Debug\\{DotNetCurrent}-android\\resizetizer\\r\\drawable-mdpi\\the_image.png")),
+		// build and assert Android
+		var androidFramework = $"{DotNetCurrent}-android";
+		Assert.True(DotnetInternal.Build(appFile, "Debug", framework: androidFramework, properties: BuildProps, output: _output),
+			$"Project {Path.GetFileName(appFile)} failed to build for Android. Check test output/attachments for errors.");
+		Assert.True(File.Exists(Path.Combine(appDir, "obj", "Debug", androidFramework, "resizetizer", "r", "drawable-mdpi", "the_image.png")),
 			"Android was missing the image file.");
-		Assert.True(File.Exists(Path.Combine(appDir, $"obj\\Debug\\{DotNetCurrent}-ios\\iossimulator-x64\\resizetizer\\r\\the_image.png")),
+
+		// build and assert iOS
+		var iosFramework = $"{DotNetCurrent}-ios";
+		var iosRuntimeIdentifier = TestEnvironment.IOSSimulatorRuntimeIdentifier;
+		Assert.True(DotnetInternal.Build(appFile, "Debug", framework: iosFramework, properties: BuildProps, runtimeIdentifier: iosRuntimeIdentifier, output: _output),
+			$"Project {Path.GetFileName(appFile)} failed to build for iOS. Check test output/attachments for errors.");
+		Assert.True(File.Exists(Path.Combine(appDir, "obj", "Debug", iosFramework, iosRuntimeIdentifier, "resizetizer", "r", "the_image.png")),
 			"iOS was missing the image file.");
-		Assert.True(File.Exists(Path.Combine(appDir, $"obj\\Debug\\{DotNetCurrent}-maccatalyst\\maccatalyst-x64\\resizetizer\\r\\the_image.png")),
+
+		// build and assert Mac Catalyst
+		var macCatalystFramework = $"{DotNetCurrent}-maccatalyst";
+		var macCatalystRuntimeIdentifier = TestEnvironment.IsArm64 ? "maccatalyst-arm64" : "maccatalyst-x64";
+		Assert.True(DotnetInternal.Build(appFile, "Debug", framework: macCatalystFramework, properties: BuildProps, runtimeIdentifier: macCatalystRuntimeIdentifier, output: _output),
+			$"Project {Path.GetFileName(appFile)} failed to build for Mac Catalyst. Check test output/attachments for errors.");
+		Assert.True(File.Exists(Path.Combine(appDir, "obj", "Debug", macCatalystFramework, macCatalystRuntimeIdentifier, "resizetizer", "r", "the_image.png")),
 			"Mac Catalyst was missing the image file.");
+
 		if (TestEnvironment.IsWindows)
-			Assert.True(File.Exists(Path.Combine(appDir, $"obj\\Debug\\{DotNetCurrent}-windows10.0.19041.0\\win-x64\\resizetizer\\r\\the_image.scale-100.png")),
+		{
+			// Use a single RID so the test does not build every architecture in the template.
+			var windowsFramework = $"{DotNetCurrent}-windows10.0.19041.0";
+			const string windowsRuntimeIdentifier = "win-x64";
+			var windowsBuildProps = BuildProps;
+			windowsBuildProps.Add("UseMonoRuntime=false");
+			Assert.True(DotnetInternal.Build(appFile, "Debug", framework: windowsFramework, properties: windowsBuildProps, runtimeIdentifier: windowsRuntimeIdentifier, output: _output),
+				$"Project {Path.GetFileName(appFile)} failed to build for Windows. Check test output/attachments for errors.");
+			Assert.True(File.Exists(Path.Combine(appDir, "obj", "Debug", windowsFramework, windowsRuntimeIdentifier, "resizetizer", "r", "the_image.scale-100.png")),
 				"Windows was missing the image file.");
+		}
 	}
 
 	[Theory]
@@ -106,9 +124,6 @@ public class ResizetizerTests : BaseBuildTest
 	public void AdditionalPropertiesExcludesImage(string id, string libid, bool unpackaged)
 	{
 		SetTestIdentifier(id, libid, unpackaged);
-		// TODO: fix the tests as they have been disabled too long!
-		if (!TestEnvironment.IsWindows)
-			if (true) return; // Skip: "Running Windows templates is only supported on Windows."
 
 		// new app
 		var appDir = Path.Combine(TestDirectory, "theapp");
@@ -163,16 +178,24 @@ public class ResizetizerTests : BaseBuildTest
 			</Project>
 			""");
 
-		// build
-		Assert.True(DotnetInternal.Build(appFile, "Debug", properties: BuildProps, output: _output),
-			$"Project {Path.GetFileName(appFile)} failed to build. Check test output/attachments for errors.");
-
-		// assert - the image should NOT be collected because AdditionalProperties excluded it
-		Assert.False(File.Exists(Path.Combine(appDir, $"obj\\Debug\\{DotNetCurrent}-android\\resizetizer\\r\\drawable-mdpi\\the_image.png")),
+		// build and assert Android - the image should NOT be collected because AdditionalProperties excluded it
+		var androidFramework = $"{DotNetCurrent}-android";
+		Assert.True(DotnetInternal.Build(appFile, "Debug", framework: androidFramework, properties: BuildProps, output: _output),
+			$"Project {Path.GetFileName(appFile)} failed to build for Android. Check test output/attachments for errors.");
+		Assert.False(File.Exists(Path.Combine(appDir, "obj", "Debug", androidFramework, "resizetizer", "r", "drawable-mdpi", "the_image.png")),
 			"Android should NOT have the image file (AdditionalProperties should have excluded it).");
+
 		if (TestEnvironment.IsWindows)
-			Assert.False(File.Exists(Path.Combine(appDir, $"obj\\Debug\\{DotNetCurrent}-windows10.0.19041.0\\win-x64\\resizetizer\\r\\the_image.scale-100.png")),
+		{
+			var windowsFramework = $"{DotNetCurrent}-windows10.0.19041.0";
+			const string windowsRuntimeIdentifier = "win-x64";
+			var windowsBuildProps = BuildProps;
+			windowsBuildProps.Add("UseMonoRuntime=false");
+			Assert.True(DotnetInternal.Build(appFile, "Debug", framework: windowsFramework, properties: windowsBuildProps, runtimeIdentifier: windowsRuntimeIdentifier, output: _output),
+				$"Project {Path.GetFileName(appFile)} failed to build for Windows. Check test output/attachments for errors.");
+			Assert.False(File.Exists(Path.Combine(appDir, "obj", "Debug", windowsFramework, windowsRuntimeIdentifier, "resizetizer", "r", "the_image.scale-100.png")),
 				"Windows should NOT have the image file (AdditionalProperties should have excluded it).");
+		}
 	}
 
 	[Theory]
@@ -181,9 +204,6 @@ public class ResizetizerTests : BaseBuildTest
 	public void AdditionalPropertiesSelectsImageInLibrary(string id, string libid, bool unpackaged)
 	{
 		SetTestIdentifier(id, libid, unpackaged);
-		// TODO: fix the tests as they have been disabled too long!
-		if (!TestEnvironment.IsWindows)
-			if (true) return; // Skip: "Running Windows templates is only supported on Windows."
 
 		// new app
 		var appDir = Path.Combine(TestDirectory, "theapp");
@@ -239,21 +259,26 @@ public class ResizetizerTests : BaseBuildTest
 			</Project>
 			""");
 
-		// build
-		Assert.True(DotnetInternal.Build(appFile, "Debug", properties: BuildProps, output: _output),
-			$"Project {Path.GetFileName(appFile)} failed to build. Check test output/attachments for errors.");
-
-		// assert - alternate_image should be collected (property was propagated)
-		Assert.True(File.Exists(Path.Combine(appDir, $"obj\\Debug\\{DotNetCurrent}-android\\resizetizer\\r\\drawable-mdpi\\alternate_image.png")),
+		// build and assert Android
+		var androidFramework = $"{DotNetCurrent}-android";
+		Assert.True(DotnetInternal.Build(appFile, "Debug", framework: androidFramework, properties: BuildProps, output: _output),
+			$"Project {Path.GetFileName(appFile)} failed to build for Android. Check test output/attachments for errors.");
+		Assert.True(File.Exists(Path.Combine(appDir, "obj", "Debug", androidFramework, "resizetizer", "r", "drawable-mdpi", "alternate_image.png")),
 			"Android was missing alternate_image — AdditionalProperties was not propagated.");
-		// assert - default_image should NOT be collected (it was excluded by the property)
-		Assert.False(File.Exists(Path.Combine(appDir, $"obj\\Debug\\{DotNetCurrent}-android\\resizetizer\\r\\drawable-mdpi\\default_image.png")),
+		Assert.False(File.Exists(Path.Combine(appDir, "obj", "Debug", androidFramework, "resizetizer", "r", "drawable-mdpi", "default_image.png")),
 			"Android should NOT have default_image — AdditionalProperties should have selected the alternate.");
+
 		if (TestEnvironment.IsWindows)
 		{
-			Assert.True(File.Exists(Path.Combine(appDir, $"obj\\Debug\\{DotNetCurrent}-windows10.0.19041.0\\win-x64\\resizetizer\\r\\alternate_image.scale-100.png")),
+			var windowsFramework = $"{DotNetCurrent}-windows10.0.19041.0";
+			const string windowsRuntimeIdentifier = "win-x64";
+			var windowsBuildProps = BuildProps;
+			windowsBuildProps.Add("UseMonoRuntime=false");
+			Assert.True(DotnetInternal.Build(appFile, "Debug", framework: windowsFramework, properties: windowsBuildProps, runtimeIdentifier: windowsRuntimeIdentifier, output: _output),
+				$"Project {Path.GetFileName(appFile)} failed to build for Windows. Check test output/attachments for errors.");
+			Assert.True(File.Exists(Path.Combine(appDir, "obj", "Debug", windowsFramework, windowsRuntimeIdentifier, "resizetizer", "r", "alternate_image.scale-100.png")),
 				"Windows was missing alternate_image — AdditionalProperties was not propagated.");
-			Assert.False(File.Exists(Path.Combine(appDir, $"obj\\Debug\\{DotNetCurrent}-windows10.0.19041.0\\win-x64\\resizetizer\\r\\default_image.scale-100.png")),
+			Assert.False(File.Exists(Path.Combine(appDir, "obj", "Debug", windowsFramework, windowsRuntimeIdentifier, "resizetizer", "r", "default_image.scale-100.png")),
 				"Windows should NOT have default_image — AdditionalProperties should have selected the alternate.");
 		}
 	}

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/ResizetizerTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/ResizetizerTests.cs
@@ -50,19 +50,7 @@ public class ResizetizerTests : BaseBuildTest
 			</Project>
 			""");
 
-		// toggle packaged / unpackaged
-		if (unpackaged)
-		{
-			FileUtilities.ReplaceInFile(appFile,
-				"</Project>",
-				"""
-				<PropertyGroup>
-					<WindowsPackageType>None</WindowsPackageType>
-				</PropertyGroup>
-				</Project>
-				""");
-
-		}
+		SetWindowsPackageType(appFile, unpackaged);
 
 		// add the svg file
 		File.WriteAllText(Path.Combine(libDir, "the_image.svg"), BlankSvgContents);
@@ -106,14 +94,10 @@ public class ResizetizerTests : BaseBuildTest
 
 		if (TestEnvironment.IsWindows)
 		{
-			// Use a single RID so the test does not build every architecture in the template.
 			var windowsFramework = $"{DotNetCurrent}-windows10.0.19041.0";
-			const string windowsRuntimeIdentifier = "win-x64";
-			var windowsBuildProps = BuildProps;
-			windowsBuildProps.Add("UseMonoRuntime=false");
-			Assert.True(DotnetInternal.Build(appFile, "Debug", framework: windowsFramework, properties: windowsBuildProps, runtimeIdentifier: windowsRuntimeIdentifier, output: _output),
+			Assert.True(DotnetInternal.Build(appFile, "Debug", framework: windowsFramework, properties: GetWindowsBuildProps(), output: _output),
 				$"Project {Path.GetFileName(appFile)} failed to build for Windows. Check test output/attachments for errors.");
-			Assert.True(File.Exists(Path.Combine(appDir, "obj", "Debug", windowsFramework, windowsRuntimeIdentifier, "resizetizer", "r", "the_image.scale-100.png")),
+			Assert.True(File.Exists(Path.Combine(appDir, "obj", "x64", "Debug", windowsFramework, "resizetizer", "r", "the_image.scale-100.png")),
 				"Windows was missing the image file.");
 		}
 	}
@@ -147,18 +131,7 @@ public class ResizetizerTests : BaseBuildTest
 			</Project>
 			""");
 
-		// toggle packaged / unpackaged
-		if (unpackaged)
-		{
-			FileUtilities.ReplaceInFile(appFile,
-				"</Project>",
-				"""
-				<PropertyGroup>
-					<WindowsPackageType>None</WindowsPackageType>
-				</PropertyGroup>
-				</Project>
-				""");
-		}
+		SetWindowsPackageType(appFile, unpackaged);
 
 		// add the svg file to the library
 		File.WriteAllText(Path.Combine(libDir, "the_image.svg"), BlankSvgContents);
@@ -188,12 +161,9 @@ public class ResizetizerTests : BaseBuildTest
 		if (TestEnvironment.IsWindows)
 		{
 			var windowsFramework = $"{DotNetCurrent}-windows10.0.19041.0";
-			const string windowsRuntimeIdentifier = "win-x64";
-			var windowsBuildProps = BuildProps;
-			windowsBuildProps.Add("UseMonoRuntime=false");
-			Assert.True(DotnetInternal.Build(appFile, "Debug", framework: windowsFramework, properties: windowsBuildProps, runtimeIdentifier: windowsRuntimeIdentifier, output: _output),
+			Assert.True(DotnetInternal.Build(appFile, "Debug", framework: windowsFramework, properties: GetWindowsBuildProps(), output: _output),
 				$"Project {Path.GetFileName(appFile)} failed to build for Windows. Check test output/attachments for errors.");
-			Assert.False(File.Exists(Path.Combine(appDir, "obj", "Debug", windowsFramework, windowsRuntimeIdentifier, "resizetizer", "r", "the_image.scale-100.png")),
+			Assert.False(File.Exists(Path.Combine(appDir, "obj", "x64", "Debug", windowsFramework, "resizetizer", "r", "the_image.scale-100.png")),
 				"Windows should NOT have the image file (AdditionalProperties should have excluded it).");
 		}
 	}
@@ -227,18 +197,7 @@ public class ResizetizerTests : BaseBuildTest
 			</Project>
 			""");
 
-		// toggle packaged / unpackaged
-		if (unpackaged)
-		{
-			FileUtilities.ReplaceInFile(appFile,
-				"</Project>",
-				"""
-				<PropertyGroup>
-					<WindowsPackageType>None</WindowsPackageType>
-				</PropertyGroup>
-				</Project>
-				""");
-		}
+		SetWindowsPackageType(appFile, unpackaged);
 
 		// add two svg files to the library — the property selects which one is included
 		File.WriteAllText(Path.Combine(libDir, "default_image.svg"), BlankSvgContents);
@@ -271,15 +230,30 @@ public class ResizetizerTests : BaseBuildTest
 		if (TestEnvironment.IsWindows)
 		{
 			var windowsFramework = $"{DotNetCurrent}-windows10.0.19041.0";
-			const string windowsRuntimeIdentifier = "win-x64";
-			var windowsBuildProps = BuildProps;
-			windowsBuildProps.Add("UseMonoRuntime=false");
-			Assert.True(DotnetInternal.Build(appFile, "Debug", framework: windowsFramework, properties: windowsBuildProps, runtimeIdentifier: windowsRuntimeIdentifier, output: _output),
+			Assert.True(DotnetInternal.Build(appFile, "Debug", framework: windowsFramework, properties: GetWindowsBuildProps(), output: _output),
 				$"Project {Path.GetFileName(appFile)} failed to build for Windows. Check test output/attachments for errors.");
-			Assert.True(File.Exists(Path.Combine(appDir, "obj", "Debug", windowsFramework, windowsRuntimeIdentifier, "resizetizer", "r", "alternate_image.scale-100.png")),
+			Assert.True(File.Exists(Path.Combine(appDir, "obj", "x64", "Debug", windowsFramework, "resizetizer", "r", "alternate_image.scale-100.png")),
 				"Windows was missing alternate_image — AdditionalProperties was not propagated.");
-			Assert.False(File.Exists(Path.Combine(appDir, "obj", "Debug", windowsFramework, windowsRuntimeIdentifier, "resizetizer", "r", "default_image.scale-100.png")),
+			Assert.False(File.Exists(Path.Combine(appDir, "obj", "x64", "Debug", windowsFramework, "resizetizer", "r", "default_image.scale-100.png")),
 				"Windows should NOT have default_image — AdditionalProperties should have selected the alternate.");
 		}
+	}
+
+	static void SetWindowsPackageType(string projectFile, bool unpackaged)
+	{
+		FileUtilities.ReplaceInFile(
+			projectFile,
+			"<WindowsPackageType>None</WindowsPackageType>",
+			$"<WindowsPackageType>{(unpackaged ? "None" : "MSIX")}</WindowsPackageType>");
+	}
+
+	List<string> GetWindowsBuildProps()
+	{
+		var properties = BuildProps;
+		// Constrain restore without producing RID-specific app output that mismatches project-reference PRI output.
+		properties.Add("RuntimeIdentifiers=win-x64");
+		properties.Add("Platform=x64");
+		properties.Add("UseMonoRuntime=false");
+		return properties;
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Reenables the three Resizetizer integration tests that contained long-standing TODOs and silently returned outside Windows.

Running the tests exposed that `ResizetizeCollectItems` still did not propagate `ProjectReference` `AdditionalProperties`. The resolved project-reference item is converted back to its original item spec, but that conversion drops the metadata before the nested `GetMauiItems` build. This change restores `AdditionalProperties` from the matching original `ProjectReference`.

The tests now:

- execute Android assertions on all integration-test hosts instead of returning on non-Windows hosts;
- build explicit Android, iOS, Mac Catalyst, and Windows framework slices for asset collection;
- use host-appropriate Apple runtime identifiers and cross-platform paths;
- constrain Windows validation to `win-x64` with CoreCLR, avoiding unrelated all-RID packaging failures;
- verify both packaged and unpackaged `AdditionalProperties` behavior.

## Tests

- `ResizetizerTests.AdditionalPropertiesExcludesImage`: 2 passed
- `ResizetizerTests.AdditionalPropertiesSelectsImageInLibrary`: 2 passed
- `ResizetizerTests.CollectsAssets`: 8 passed

All focused tests were run on Windows through the `run-integration-tests` workflow.