### PR TITLE
[Android] Configure image drag support for BlazorWebView

### DIFF
--- a/eng/AndroidX.targets
+++ b/eng/AndroidX.targets
@@ -16,6 +16,7 @@
     <PackageReference Update="Xamarin.AndroidX.Security.SecurityCrypto" Version="1.1.0.4-alpha07" />
     <PackageReference Update="Xamarin.AndroidX.SwipeRefreshLayout" Version="1.2.0.3" />
     <PackageReference Update="Xamarin.AndroidX.Transition" Version="1.7.0.2" />
+    <PackageReference Update="Xamarin.AndroidX.WebKit" Version="1.17.0" />
     <PackageReference Update="Xamarin.AndroidX.Window.WindowJava" Version="1.5.1.3" />
     <PackageReference Update="Xamarin.Firebase.AppIndexing" Version="120.0.0.29" />
     <PackageReference Update="Xamarin.Google.Android.Material" Version="1.14.0.5" />

--- a/eng/AndroidX.targets
+++ b/eng/AndroidX.targets
@@ -16,7 +16,7 @@
     <PackageReference Update="Xamarin.AndroidX.Security.SecurityCrypto" Version="1.1.0.4-alpha07" />
     <PackageReference Update="Xamarin.AndroidX.SwipeRefreshLayout" Version="1.2.0.3" />
     <PackageReference Update="Xamarin.AndroidX.Transition" Version="1.7.0.2" />
-    <PackageReference Update="Xamarin.AndroidX.WebKit" Version="1.17.0" />
+    <PackageReference Update="Xamarin.AndroidX.WebKit" Version="1.16.0.1" />
     <PackageReference Update="Xamarin.AndroidX.Window.WindowJava" Version="1.5.1.3" />
     <PackageReference Update="Xamarin.Firebase.AppIndexing" Version="120.0.0.29" />
     <PackageReference Update="Xamarin.Google.Android.Material" Version="1.14.0.5" />

--- a/src/BlazorWebView/src/Maui/Microsoft.AspNetCore.Components.WebView.Maui.csproj
+++ b/src/BlazorWebView/src/Maui/Microsoft.AspNetCore.Components.WebView.Maui.csproj
@@ -44,6 +44,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authorization" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebView" />
     <PackageReference Include="Microsoft.JSInterop" />
+    <!-- The app-level MauiEnableAndroidWebViewDragDrop property controls provider registration, not this package dependency. -->
     <PackageReference Include="Xamarin.AndroidX.WebKit" Condition=" '$(TargetPlatformIdentifier)' == 'android' " />
   </ItemGroup>
 

--- a/src/BlazorWebView/src/Maui/Microsoft.AspNetCore.Components.WebView.Maui.csproj
+++ b/src/BlazorWebView/src/Maui/Microsoft.AspNetCore.Components.WebView.Maui.csproj
@@ -44,6 +44,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authorization" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebView" />
     <PackageReference Include="Microsoft.JSInterop" />
+    <PackageReference Include="Xamarin.AndroidX.WebKit" Condition=" '$(TargetPlatformIdentifier)' == 'android' " />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BlazorWebView/src/Maui/build/Android/DropDataContentProvider.xml
+++ b/src/BlazorWebView/src/Maui/build/Android/DropDataContentProvider.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <application>
+    <provider
+      android:name="androidx.webkit.DropDataContentProvider"
+      android:authorities="${applicationId}.DropDataProvider"
+      android:exported="false"
+      android:grantUriPermissions="true" />
+  </application>
+</manifest>

--- a/src/BlazorWebView/src/Maui/build/Android/DropDataContentProvider.xml
+++ b/src/BlazorWebView/src/Maui/build/Android/DropDataContentProvider.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <application>
+    <!-- Set MauiEnableAndroidWebViewDragDrop to false if the app declares this provider itself. -->
     <provider
       android:name="androidx.webkit.DropDataContentProvider"
       android:authorities="${applicationId}.DropDataProvider"

--- a/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
+++ b/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
@@ -20,12 +20,21 @@
   <PropertyGroup>
     <StaticWebAssetBasePath>/</StaticWebAssetBasePath>
     <StaticWebAssetProjectMode>Root</StaticWebAssetProjectMode>
+    <!-- Controls automatic provider registration only. The AndroidX WebKit dependency remains available to apps that register the provider themselves. -->
     <MauiEnableAndroidWebViewDragDrop Condition=" '$(MauiEnableAndroidWebViewDragDrop)' == '' ">true</MauiEnableAndroidWebViewDragDrop>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(MauiEnableAndroidWebViewDragDrop)' == 'true' and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'android' ">
     <AndroidManifestOverlay Include="$(MSBuildThisFileDirectory)Android\DropDataContentProvider.xml" />
   </ItemGroup>
+
+  <Target Name="_WarnAboutLegacyAndroidManifestMergerForWebViewDragDrop"
+      BeforeTargets="_GenerateJavaStubs"
+      Condition=" '$(MauiEnableAndroidWebViewDragDrop)' == 'true'
+        and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'android'
+        and '$(AndroidManifestMerger)' == 'legacy' ">
+    <Warning Text="MauiEnableAndroidWebViewDragDrop is enabled, but AndroidManifestMerger is set to 'legacy', which ignores AndroidManifestOverlay items. Use 'manifestmerger.jar', or set MauiEnableAndroidWebViewDragDrop to false and declare androidx.webkit.DropDataContentProvider in Platforms/Android/AndroidManifest.xml." />
+  </Target>
 
   <Target Name="ConvertStaticWebAssetsToMauiAssets"
       BeforeTargets="GetMauiItems;ResizetizeCollectItems;_CollectBundleResources;_CollectHotRestartBundleResources;_CheckForContent"

--- a/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
+++ b/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
@@ -33,7 +33,9 @@
       Condition=" '$(MauiEnableAndroidWebViewDragDrop)' == 'true'
         and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'android'
         and '$(AndroidManifestMerger)' == 'legacy' ">
-    <Warning Text="MauiEnableAndroidWebViewDragDrop is enabled, but AndroidManifestMerger is set to 'legacy', which ignores AndroidManifestOverlay items. Use 'manifestmerger.jar', or set MauiEnableAndroidWebViewDragDrop to false and declare androidx.webkit.DropDataContentProvider in Platforms/Android/AndroidManifest.xml." />
+    <Warning
+        Code="MAUI1002"
+        Text="MauiEnableAndroidWebViewDragDrop is enabled, but AndroidManifestMerger is set to 'legacy', which ignores AndroidManifestOverlay items. Use 'manifestmerger.jar', or set MauiEnableAndroidWebViewDragDrop to false and declare androidx.webkit.DropDataContentProvider in Platforms/Android/AndroidManifest.xml." />
   </Target>
 
   <Target Name="ConvertStaticWebAssetsToMauiAssets"

--- a/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
+++ b/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
@@ -20,7 +20,12 @@
   <PropertyGroup>
     <StaticWebAssetBasePath>/</StaticWebAssetBasePath>
     <StaticWebAssetProjectMode>Root</StaticWebAssetProjectMode>
+    <MauiEnableAndroidWebViewDragDrop Condition=" '$(MauiEnableAndroidWebViewDragDrop)' == '' ">true</MauiEnableAndroidWebViewDragDrop>
   </PropertyGroup>
+
+  <ItemGroup Condition=" '$(MauiEnableAndroidWebViewDragDrop)' == 'true' and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'android' ">
+    <AndroidManifestOverlay Include="$(MSBuildThisFileDirectory)Android\DropDataContentProvider.xml" />
+  </ItemGroup>
 
   <Target Name="ConvertStaticWebAssetsToMauiAssets"
       BeforeTargets="GetMauiItems;ResizetizeCollectItems;_CollectBundleResources;_CollectHotRestartBundleResources;_CheckForContent"

--- a/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.DragDrop.cs
+++ b/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.DragDrop.cs
@@ -6,17 +6,30 @@ public partial class BlazorWebViewTests
 {
 #if ANDROID
 	[Fact]
-	public void ImageDragDropContentProviderIsRegistered()
+	public void ImageDragDropContentProviderIsAvailable()
 	{
 		var context = global::Android.App.Application.Context;
+		var authority = $"{context.PackageName}.DropDataProvider";
 		var provider = context.PackageManager?.ResolveContentProvider(
-			$"{context.PackageName}.DropDataProvider",
+			authority,
 			global::Android.Content.PM.PackageInfoFlags.MetaData);
 
 		Assert.NotNull(provider);
 		Assert.Equal("androidx.webkit.DropDataContentProvider", provider.Name);
 		Assert.False(provider.Exported);
 		Assert.True(provider.GrantUriPermissions);
+
+		var contentResolver = context.ContentResolver;
+		Assert.NotNull(contentResolver);
+
+		using var providerClient = contentResolver.AcquireUnstableContentProviderClient(authority);
+		Assert.NotNull(providerClient);
+
+		using var probeUri = global::Android.Net.Uri.Parse($"content://{authority}/maui-probe");
+		Assert.NotNull(probeUri);
+
+		// Force the provider to initialize its bridge to the WebView implementation.
+		_ = contentResolver.GetType(probeUri);
 	}
 #endif
 }

--- a/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.DragDrop.cs
+++ b/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.DragDrop.cs
@@ -1,0 +1,22 @@
+using Xunit;
+
+namespace Microsoft.Maui.MauiBlazorWebView.DeviceTests.Elements;
+
+public partial class BlazorWebViewTests
+{
+#if ANDROID
+	[Fact]
+	public void ImageDragDropContentProviderIsRegistered()
+	{
+		var context = global::Android.App.Application.Context;
+		var provider = context.PackageManager?.ResolveContentProvider(
+			$"{context.PackageName}.DropDataProvider",
+			global::Android.Content.PM.PackageInfoFlags.MetaData);
+
+		Assert.NotNull(provider);
+		Assert.Equal("androidx.webkit.DropDataContentProvider", provider.Name);
+		Assert.False(provider.Exported);
+		Assert.True(provider.GrantUriPermissions);
+	}
+#endif
+}

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/BlazorTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/BlazorTemplateTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO.Compression;
+using System.Xml.Linq;
 
 namespace Microsoft.Maui.IntegrationTests;
 
@@ -18,6 +19,68 @@ public class BlazorTemplateTest : BaseTemplateTests
 			$"Unable to create template {templateShortName}. Check test output for errors.");
 
 		AssertIncludesRootGitIgnore(solutionProjectDir);
+	}
+
+	[Fact]
+	public void MauiBlazorAndroidManifest_ConfiguresImageDragDropProvider()
+	{
+		SetTestIdentifier();
+		const string templateShortName = "maui-blazor";
+		const string config = "Debug";
+		var framework = $"{DotNetCurrent}-android";
+		var projectDir = TestDirectory;
+		var projectFile = Path.Combine(projectDir, $"{Path.GetFileName(projectDir)}.csproj");
+
+		Assert.True(DotnetInternal.New(templateShortName, outputDirectory: projectDir, framework: DotNetCurrent, output: _output),
+			$"Unable to create template {templateShortName}. Check test output for errors.");
+
+		var directoryBuildPropsPath = Path.Combine(projectDir, "Directory.Build.props");
+		var directoryBuildProps = File.Exists(directoryBuildPropsPath)
+			? XDocument.Load(directoryBuildPropsPath)
+			: new XDocument(new XElement("Project"));
+		directoryBuildProps.Root!.Add(
+			new XElement("PropertyGroup",
+				new XAttribute("Condition", "'$(MauiEnableAndroidWebViewDragDrop)' == 'false'"),
+				new XElement("BaseIntermediateOutputPath", "obj-drag-drop-opt-out/"),
+				new XElement("BaseOutputPath", "bin-drag-drop-opt-out/")));
+		directoryBuildProps.Save(directoryBuildPropsPath);
+
+		Assert.True(DotnetInternal.Build(projectFile, config, framework: framework, properties: BuildProps, msbuildWarningsAsErrors: true, output: _output),
+			$"Project {Path.GetFileName(projectFile)} failed to build with the default image drag provider configuration.");
+
+		var defaultManifest = Path.Combine(projectDir, "obj", config, framework, "android", "AndroidManifest.xml");
+		AssertImageDragDropProvider(defaultManifest, expected: true);
+
+		var optOutBuildProps = BuildProps;
+		optOutBuildProps.Add("MauiEnableAndroidWebViewDragDrop=false");
+
+		Assert.True(DotnetInternal.Build(projectFile, config, framework: framework, properties: optOutBuildProps, msbuildWarningsAsErrors: true, output: _output),
+			$"Project {Path.GetFileName(projectFile)} failed to build with image drag provider registration disabled.");
+
+		var optOutManifest = Path.Combine(projectDir, "obj-drag-drop-opt-out", config, framework, "android", "AndroidManifest.xml");
+		AssertImageDragDropProvider(optOutManifest, expected: false);
+	}
+
+	static void AssertImageDragDropProvider(string manifestPath, bool expected)
+	{
+		Assert.True(File.Exists(manifestPath), $"Merged Android manifest not found at {manifestPath}.");
+
+		XNamespace android = "http://schemas.android.com/apk/res/android";
+		var manifest = XDocument.Load(manifestPath);
+		var provider = manifest
+			.Descendants("provider")
+			.SingleOrDefault(element => (string?)element.Attribute(android + "name") == "androidx.webkit.DropDataContentProvider");
+
+		if (!expected)
+		{
+			Assert.Null(provider);
+			return;
+		}
+
+		Assert.NotNull(provider);
+		Assert.Equal($"{manifest.Root?.Attribute("package")?.Value}.DropDataProvider", (string?)provider.Attribute(android + "authorities"));
+		Assert.Equal("false", (string?)provider.Attribute(android + "exported"));
+		Assert.Equal("true", (string?)provider.Attribute(android + "grantUriPermissions"));
 	}
 
 	[Theory]
@@ -235,11 +298,11 @@ public class BlazorTemplateTest : BaseTemplateTests
 
 		// Assert: No precompressed files should be in the MAUI APK
 		// These files bloat the app bundle since Blazor Hybrid serves assets locally
-		Assert.True(gzFiles.Length == 0, 
+		Assert.True(gzFiles.Length == 0,
 			$"APK should not contain .gz files but found {gzFiles.Length}. " +
 			$"See https://github.com/dotnet/maui/issues/33773. Files: {string.Join(", ", gzFiles.Select(f => Path.GetFileName(f)))}");
-		
-		Assert.True(brFiles.Length == 0, 
+
+		Assert.True(brFiles.Length == 0,
 			$"APK should not contain .br files but found {brFiles.Length}. " +
 			$"See https://github.com/dotnet/maui/issues/33773. Files: {string.Join(", ", brFiles.Select(f => Path.GetFileName(f)))}");
 
@@ -250,10 +313,10 @@ public class BlazorTemplateTest : BaseTemplateTests
 		// Check that our test file exists (uncompressed)
 		var sharedContentDir = Directory.GetDirectories(Path.Combine(wwwrootDir, "_content"), "*Shared*", SearchOption.TopDirectoryOnly);
 		Assert.True(sharedContentDir.Length > 0, "Shared RCL content directory should exist in APK");
-		
+
 		var testJsInApk = Path.Combine(sharedContentDir[0], "test-compression.js");
 		Assert.True(File.Exists(testJsInApk), $"Test JS file should exist uncompressed at {testJsInApk}");
-		
+
 		_output.WriteLine("✅ APK correctly contains no precompressed .gz/.br files from RCL");
 	}
 
@@ -315,11 +378,11 @@ public class BlazorTemplateTest : BaseTemplateTests
 		}
 
 		// Assert: Web app SHOULD have precompressed files for HTTP serving
-		Assert.True(gzFiles.Length > 0, 
+		Assert.True(gzFiles.Length > 0,
 			"Web app publish output should contain .gz files for HTTP compression. " +
 			"If this fails, the compression system may be broken.");
-		
-		Assert.True(brFiles.Length > 0, 
+
+		Assert.True(brFiles.Length > 0,
 			"Web app publish output should contain .br files for HTTP compression. " +
 			"If this fails, the compression system may be broken.");
 
@@ -328,9 +391,9 @@ public class BlazorTemplateTest : BaseTemplateTests
 		var testJsGz = Directory.GetFiles(sharedContentDir, "test-compression.js.gz", SearchOption.AllDirectories);
 		var testJsBr = Directory.GetFiles(sharedContentDir, "test-compression.js.br", SearchOption.AllDirectories);
 
-		Assert.True(testJsGz.Length > 0, 
+		Assert.True(testJsGz.Length > 0,
 			"Test JS file should have a .gz compressed version in web publish output");
-		Assert.True(testJsBr.Length > 0, 
+		Assert.True(testJsBr.Length > 0,
 			"Test JS file should have a .br compressed version in web publish output");
 
 		_output.WriteLine("✅ Web app correctly contains precompressed .gz/.br files from RCL");

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/BlazorTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/BlazorTemplateTest.cs
@@ -34,22 +34,14 @@ public class BlazorTemplateTest : BaseTemplateTests
 		Assert.True(DotnetInternal.New(templateShortName, outputDirectory: projectDir, framework: DotNetCurrent, output: _output),
 			$"Unable to create template {templateShortName}. Check test output for errors.");
 
-		var directoryBuildPropsPath = Path.Combine(projectDir, "Directory.Build.props");
-		var directoryBuildProps = File.Exists(directoryBuildPropsPath)
-			? XDocument.Load(directoryBuildPropsPath)
-			: new XDocument(new XElement("Project"));
-		directoryBuildProps.Root!.Add(
-			new XElement("PropertyGroup",
-				new XAttribute("Condition", "'$(MauiEnableAndroidWebViewDragDrop)' == 'false'"),
-				new XElement("BaseIntermediateOutputPath", "obj-drag-drop-opt-out/"),
-				new XElement("BaseOutputPath", "bin-drag-drop-opt-out/")));
-		directoryBuildProps.Save(directoryBuildPropsPath);
-
 		Assert.True(DotnetInternal.Build(projectFile, config, framework: framework, properties: BuildProps, msbuildWarningsAsErrors: true, output: _output),
 			$"Project {Path.GetFileName(projectFile)} failed to build with the default image drag provider configuration.");
 
-		var defaultManifest = Path.Combine(projectDir, "obj", config, framework, "android", "AndroidManifest.xml");
+		var intermediatePath = Path.Combine(projectDir, "obj");
+		var defaultManifest = Path.Combine(intermediatePath, config, framework, "android", "AndroidManifest.xml");
 		AssertImageDragDropProvider(defaultManifest, expected: true);
+
+		Directory.Delete(intermediatePath, recursive: true);
 
 		var optOutBuildProps = BuildProps;
 		optOutBuildProps.Add("MauiEnableAndroidWebViewDragDrop=false");
@@ -57,7 +49,7 @@ public class BlazorTemplateTest : BaseTemplateTests
 		Assert.True(DotnetInternal.Build(projectFile, config, framework: framework, properties: optOutBuildProps, msbuildWarningsAsErrors: true, output: _output),
 			$"Project {Path.GetFileName(projectFile)} failed to build with image drag provider registration disabled.");
 
-		var optOutManifest = Path.Combine(projectDir, "obj-drag-drop-opt-out", config, framework, "android", "AndroidManifest.xml");
+		var optOutManifest = Path.Combine(intermediatePath, config, framework, "android", "AndroidManifest.xml");
 		AssertImageDragDropProvider(optOutManifest, expected: false);
 	}
 

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/BlazorTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/BlazorTemplateTest.cs
@@ -298,11 +298,11 @@ public class BlazorTemplateTest : BaseTemplateTests
 
 		// Assert: No precompressed files should be in the MAUI APK
 		// These files bloat the app bundle since Blazor Hybrid serves assets locally
-		Assert.True(gzFiles.Length == 0,
+		Assert.True(gzFiles.Length == 0, 
 			$"APK should not contain .gz files but found {gzFiles.Length}. " +
 			$"See https://github.com/dotnet/maui/issues/33773. Files: {string.Join(", ", gzFiles.Select(f => Path.GetFileName(f)))}");
-
-		Assert.True(brFiles.Length == 0,
+		
+		Assert.True(brFiles.Length == 0, 
 			$"APK should not contain .br files but found {brFiles.Length}. " +
 			$"See https://github.com/dotnet/maui/issues/33773. Files: {string.Join(", ", brFiles.Select(f => Path.GetFileName(f)))}");
 
@@ -313,10 +313,10 @@ public class BlazorTemplateTest : BaseTemplateTests
 		// Check that our test file exists (uncompressed)
 		var sharedContentDir = Directory.GetDirectories(Path.Combine(wwwrootDir, "_content"), "*Shared*", SearchOption.TopDirectoryOnly);
 		Assert.True(sharedContentDir.Length > 0, "Shared RCL content directory should exist in APK");
-
+		
 		var testJsInApk = Path.Combine(sharedContentDir[0], "test-compression.js");
 		Assert.True(File.Exists(testJsInApk), $"Test JS file should exist uncompressed at {testJsInApk}");
-
+		
 		_output.WriteLine("✅ APK correctly contains no precompressed .gz/.br files from RCL");
 	}
 
@@ -378,11 +378,11 @@ public class BlazorTemplateTest : BaseTemplateTests
 		}
 
 		// Assert: Web app SHOULD have precompressed files for HTTP serving
-		Assert.True(gzFiles.Length > 0,
+		Assert.True(gzFiles.Length > 0, 
 			"Web app publish output should contain .gz files for HTTP compression. " +
 			"If this fails, the compression system may be broken.");
-
-		Assert.True(brFiles.Length > 0,
+		
+		Assert.True(brFiles.Length > 0, 
 			"Web app publish output should contain .br files for HTTP compression. " +
 			"If this fails, the compression system may be broken.");
 
@@ -391,9 +391,9 @@ public class BlazorTemplateTest : BaseTemplateTests
 		var testJsGz = Directory.GetFiles(sharedContentDir, "test-compression.js.gz", SearchOption.AllDirectories);
 		var testJsBr = Directory.GetFiles(sharedContentDir, "test-compression.js.br", SearchOption.AllDirectories);
 
-		Assert.True(testJsGz.Length > 0,
+		Assert.True(testJsGz.Length > 0, 
 			"Test JS file should have a .gz compressed version in web publish output");
-		Assert.True(testJsBr.Length > 0,
+		Assert.True(testJsBr.Length > 0, 
 			"Test JS file should have a .br compressed version in web publish output");
 
 		_output.WriteLine("✅ Web app correctly contains precompressed .gz/.br files from RCL");


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description of Change

Android WebView image dragging requires AndroidX WebKit's `DropDataContentProvider`. Without it, draggable images in a MAUI `BlazorWebView` produce DOM drag activity but no usable provider-backed image data.

This change:

- Adds the centrally versioned `Xamarin.AndroidX.WebKit` 1.16.0.1 dependency for Android MAUI BlazorWebView builds. This version matches main's AndroidX Core 1.19.0.1 dependency graph.
- Registers `androidx.webkit.DropDataContentProvider` with the required `${applicationId}.DropDataProvider` authority.
- Enables registration by default and lets apps that declare the provider themselves opt out with `<MauiEnableAndroidWebViewDragDrop>false</MauiEnableAndroidWebViewDragDrop>`.
- Clarifies that the property controls automatic manifest registration only; the AndroidX dependency remains available for app-owned declarations.
- Emits suppressible warning `MAUI1002` when `AndroidManifestMerger=legacy`, because that merger ignores `AndroidManifestOverlay` items.
- Adds an Android device test that verifies the provider metadata, instantiates it through `ContentResolver`, and initializes its WebView bridge.
- Adds a packaged-app integration test for both default registration and the opt-out merged manifest.

## Compatibility and Scope

Identical existing app declarations merge into one provider entry. Apps with a differing/custom declaration can disable MAUI's overlay with `MauiEnableAndroidWebViewDragDrop=false`.

The provider remains scoped to `Microsoft.AspNetCore.Components.WebView.Maui` rather than `Microsoft.Maui.Core` so this fix does not add a WebKit dependency and manifest entry to every Android MAUI app. Plain `WebView` and `HybridWebView` can be considered separately if broader automatic registration is desired.

Android Files may still reject dragging files out of the app with "You can't move files from another app"; that destination behavior is outside MAUI and is unchanged.

No Appium UI test was added. The existing MAUI UI-test host has no BlazorWebView DOM-context support, and JavaScript-synthesized drag events would not exercise the native Android provider. The device and integration tests instead cover the provider's runtime and build-time contracts deterministically.

## Validation

- Rebased onto current `main` and aligned WebKit with the updated AndroidX dependency graph.
- Confirmed `Xamarin.AndroidX.WebKit` 1.16.0.1 is available from `dotnet-public` and completed a fresh isolated restore.
- Verified the default MSBuild evaluation includes the provider overlay and `MauiEnableAndroidWebViewDragDrop=false` omits it.
- Verified an identical app-owned provider declaration merges to one provider entry.
- Verified `AndroidManifestMerger=legacy` emits suppressible warning `MAUI1002`.
- Ran the Android BlazorWebView device tests on a Pixel API 36 emulator before the rebase: 26 tests run, 22 passed, 4 ignored, 0 failed. `ImageDragDropContentProviderIsAvailable` passed.
- Built the rebased integration-test project successfully.
- Fixed the initial integration-test CI failure by rebuilding the opt-out case from a clean `obj` directory instead of changing `BaseIntermediateOutputPath`, which had caused both generated-source trees to be compiled.

## What Not to Do

- Do not replace the AndroidX provider with a trivial managed `ContentProvider`; it bridges into Chromium's internal classloader implementation.
- Do not vendor the WebKit AAR or add NuGet.org to MAUI's package sources.
- Do not describe `MauiEnableAndroidWebViewDragDrop` as a dependency opt-out; NuGet dependencies are fixed when the package is built.

Fixes #37971