### PR TITLE
[Android] Geolocation: Select providers explicitly on API 34

### DIFF
--- a/.github/scripts/SetupVallyRuntime.sh
+++ b/.github/scripts/SetupVallyRuntime.sh
@@ -82,7 +82,7 @@ if grep -Fqx -- "--experimental" "$probe_output"; then
 	exit 1
 fi
 
-# Vally 0.12 normally creates an empty per-run Copilot home and passes it as the
+# Vally normally creates an empty per-run Copilot home and passes it as the
 # session configDirectory, which takes precedence over COPILOT_HOME. Confirm the
 # pinned executor honors the opt-out before any model credential enters the job.
 copilot_home_module="$install_root/node_modules/@microsoft/vally/dist/executor/copilot-home.js"

--- a/.github/skills/agentic-labeler/tests/eval.vally.yaml
+++ b/.github/skills/agentic-labeler/tests/eval.vally.yaml
@@ -37,7 +37,7 @@
 # Legacy scenarios AND-gated up to ~15 `output_not_contains` assertions
 # (every triage/partner/kind label spelled out) plus, for noop scenarios,
 # a fragile ~10-branch alternation regex matching phrasings of "no labels."
-# With scoring.weights omitted, Vally 0.12 computes the trial score as the
+# With scoring.weights omitted, Vally computes the trial score as the
 # UNWEIGHTED MEAN of
 # grader scores, so piling on 12 floors drowns the judge (1/13 weight) and
 # a single wrong label can't move the aggregate. This port keeps, per
@@ -998,7 +998,7 @@ stimuli:
     constraints: { max_duration: 5m, expect_skills: [agentic-labeler] }
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of grader [0,1] scores; stimulus
   # passes when the mean across runs >= threshold. Invocation is a separate
   # workflow hard veto, while 0.90 preserves the suite's prior semantic bar

--- a/.github/skills/analyze-sessions/SKILL.md
+++ b/.github/skills/analyze-sessions/SKILL.md
@@ -242,7 +242,7 @@ scoring:
 Then validate every emitted file:
 
 ```bash
-npx -y @microsoft/vally-cli@0.12.0 lint --eval-spec <path-to-eval> --strict
+npx -y @microsoft/vally-cli@0.14.0 lint --eval-spec <path-to-eval> --strict
 ```
 
 ## Privacy & safety

--- a/.github/skills/analyze-sessions/references/design-rationale.md
+++ b/.github/skills/analyze-sessions/references/design-rationale.md
@@ -162,7 +162,7 @@ generic `.github/evals/` paths are not valid targets. A different skill's
 Each eval pairs a refutation-proof **structural floor** (`output-matches` on a
 forced token line) with **one LLM judge** (`scale_1_5`, `threshold: 0.6`) so the
 judge carries ~half the weight. Each emitted file must pass
-`npx -y @microsoft/vally-cli@0.12.0 lint --eval-spec <f> --strict`. This is the
+`npx -y @microsoft/vally-cli@0.14.0 lint --eval-spec <f> --strict`. This is the
 mechanism that makes the analysis *iterative*: a failure found today becomes a
 regression test that fails if we regress tomorrow.
 

--- a/.github/skills/analyze-sessions/tests/eval.vally.yaml
+++ b/.github/skills/analyze-sessions/tests/eval.vally.yaml
@@ -19,7 +19,7 @@
 # line — immune to "mentions the word" false-fails) with ONE LLM JUDGE
 # (scale_1_5, threshold 0.6) so the judge carries ~50% of every score.
 #
-# Scoring: this suite deliberately omits scoring.weights, so Vally 0.12 uses the
+# Scoring: this suite deliberately omits scoring.weights, so Vally uses the
 # unweighted mean of grader [0,1] scores; a stimulus passes when the mean across
 # runs >= scoring.threshold (0.6). With a scale_1_5 judge (normalized =
 # (raw-1)/4):
@@ -295,7 +295,7 @@ stimuli:
       reject_skills: [analyze-sessions]
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of each stimulus's two graders
   # (one refutation-proof structural floor + one LLM judge), keeping the judge
   # at ~50% of every score per the house convention.

--- a/.github/skills/code-review/tests/eval.inline-findings.vally.yaml
+++ b/.github/skills/code-review/tests/eval.inline-findings.vally.yaml
@@ -159,7 +159,7 @@ stimuli:
         - code-review
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of the two graders' [0,1] scores;
   # the stimulus passes when the mean across runs >= threshold, and the CI
   # check keys off that mean-vs-threshold `passed` property. Two graders (one

--- a/.github/skills/code-review/tests/eval.vally.yaml
+++ b/.github/skills/code-review/tests/eval.vally.yaml
@@ -440,7 +440,7 @@ stimuli:
       max_duration: 10m
 
 scoring:
-  # Vally 0.12 supports scoring.weights, but this suite deliberately omits
+  # Vally supports scoring.weights, but this suite deliberately omits
   # them so a trial's score is the unweighted mean of its graders' [0,1]
   # scores; the stimulus score is the mean across runs. The deterministic
   # tool-calls grader is the manipulation check: a trial that never reads the

--- a/.github/skills/code-review/tests/hermeticity.vally.yaml
+++ b/.github/skills/code-review/tests/hermeticity.vally.yaml
@@ -101,7 +101,7 @@ stimuli:
       max_turns: 10
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean. Threshold 1.0 means the single stimulus must score a perfect 1.0
   # to "pass" — i.e. the agent's output matched the anonymous rate limit
   # (CORE_LIMIT:60). The hermeticity-gate job reads the verdict directly:

--- a/.github/skills/code-review/tests/soak.capability.vally.yaml
+++ b/.github/skills/code-review/tests/soak.capability.vally.yaml
@@ -474,7 +474,7 @@ stimuli:
         - code-review
 
 scoring:
-  # Vally 0.12 supports scoring.weights, but this suite deliberately omits
+  # Vally supports scoring.weights, but this suite deliberately omits
   # them so a trial's score is the unweighted mean of its graders' [0,1]
   # scores. The `prompt`
   # grader contributes ONE holistic score, so rubric criteria are not

--- a/.github/skills/evaluate-pr-tests/tests/eval.vally.yaml
+++ b/.github/skills/evaluate-pr-tests/tests/eval.vally.yaml
@@ -34,13 +34,13 @@
 # brittle (a correct finding phrased differently fails). Those move into
 # the LLM-judge rubric. Each scenario keeps at most 1–2 structural / crisp-
 # negative floors so the judge stays decisive (this suite omits
-# scoring.weights, so Vally 0.12 scores a trial as the unweighted mean of its
+# scoring.weights, so Vally scores a trial as the unweighted mean of its
 # graders). The two purely-semantic
 # detection scenarios (weak assertions, edge-case gaps) are judge-only — a
 # single prompt grader means the trial score IS the judge's normalized
 # rubric score.
 #
-# Scoring: scoring.weights is deliberately omitted, so Vally 0.12 uses the
+# Scoring: scoring.weights is deliberately omitted, so Vally uses the
 # equal-weight aggregate and the 0.6 threshold remains active.
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -405,7 +405,7 @@ stimuli:
     constraints: { max_duration: 5m, expect_skills: [evaluate-pr-tests] }
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of grader [0,1] scores; skill passes
   # when the mean across runs >= threshold. Structural section-heading floors
   # are kept only where producing the report format IS the capability; the

--- a/.github/skills/pr-review/tests/eval.gh-auth.vally.yaml
+++ b/.github/skills/pr-review/tests/eval.gh-auth.vally.yaml
@@ -160,7 +160,7 @@ stimuli:
       max_duration: 5m
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of the three graders' [0,1] scores. The structural floor
   # and guidance-read check are necessary but insufficient. Threshold 0.8
   # keeps the judge load-bearing: a partial regression (`no`, guidance read,

--- a/.github/skills/try-fix/tests/eval.vally.yaml
+++ b/.github/skills/try-fix/tests/eval.vally.yaml
@@ -28,7 +28,7 @@
 #   structural floors (e.g. "claims PASS when no device was available").
 #
 # Scoring (see scoring block): this suite deliberately omits scoring.weights,
-# so Vally 0.12 uses the unweighted mean of grader [0,1] scores; skill passes
+# so Vally uses the unweighted mean of grader [0,1] scores; skill passes
 # when the mean >= scoring.threshold (0.8), unless any trial has an execution
 # error (a separate hard failure regardless of the numeric aggregate). Every
 # scenario also has a deterministic skill-invocation grader. The workflow
@@ -463,7 +463,7 @@ stimuli:
         - try-fix
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of grader [0,1] scores; skill passes when the mean across runs >=
   # threshold. At 0.6, passing invocation/structural floors could dilute every
   # semantic judge failure to a suite score of 0.607. The 0.8 threshold keeps

--- a/.github/skills/verify-tests-fail-without-fix/tests/eval.vally.yaml
+++ b/.github/skills/verify-tests-fail-without-fix/tests/eval.vally.yaml
@@ -23,7 +23,7 @@
 # whose aggregate threshold is undefined so every grader must pass its own
 # threshold.
 #
-# Scoring: this suite deliberately omits scoring.weights, so Vally 0.12 uses
+# Scoring: this suite deliberately omits scoring.weights, so Vally uses
 # the unweighted mean of grader [0,1] scores. Every scenario also has a
 # deterministic invocation grader, and the workflow applies invocation failures
 # as a hard veto. The threshold preserves the prior semantic-judge floor after
@@ -266,7 +266,7 @@ stimuli:
         - verify-tests-fail-without-fix
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of grader [0,1] scores. At 0.87, a stimulus with invocation
   # plus one structural floor still requires judge >= 0.61, preserving the old
   # 0.60 semantic bar. Stimuli without the extra floor are intentionally

--- a/.github/workflows/skill-evaluation-soak.yml
+++ b/.github/workflows/skill-evaluation-soak.yml
@@ -22,7 +22,7 @@ permissions:
   contents: read
 
 env:
-  VALLY_VERSION: "0.12.0"
+  VALLY_VERSION: "0.14.0"
   NODE_VERSION: "22"
 
 jobs:

--- a/.github/workflows/skill-validation.yml
+++ b/.github/workflows/skill-validation.yml
@@ -94,8 +94,8 @@ permissions:
 
 env:
   # Vally CLI is run via npx from npm. Pinned for reproducibility.
-  # Vally 0.12 requires Node >=22, so we pin Node 22 on the runners.
-  VALLY_VERSION: "0.12.0"
+  # Vally requires Node >=22.12, so we pin Node 22 on the runners.
+  VALLY_VERSION: "0.14.0"
   NODE_VERSION: "22"
 
 jobs:

--- a/src/Essentials/src/Geolocation/Geolocation.android.cs
+++ b/src/Essentials/src/Geolocation/Geolocation.android.cs
@@ -73,13 +73,12 @@ namespace Microsoft.Maui.Devices.Sensors
 			await Permissions.EnsureGrantedOrRestrictedAsync<Permissions.LocationWhenInUse>();
 
 			var enabledProviders = LocationManager.GetProviders(true);
-			var hasProviders = enabledProviders.Any(p => !ignoredProviders.Contains(p));
-
-			if (!hasProviders)
+			if (enabledProviders is null ||
+				!enabledProviders.Any(p => !ignoredProviders.Contains(p)))
 				throw new FeatureNotEnabledException("Location services are not enabled on device.");
 
 			// get the best possible provider for the requested accuracy
-			var providerInfo = GetBestProvider(LocationManager, request.DesiredAccuracy);
+			var providerInfo = GetBestProvider(LocationManager, enabledProviders, request.DesiredAccuracy);
 
 			// if no providers exist, we can't get a location
 			// let's punt and try to get the last known location
@@ -88,8 +87,9 @@ namespace Microsoft.Maui.Devices.Sensors
 
 			var tcs = new TaskCompletionSource<AndroidLocation?>();
 
-			var allProviders = LocationManager.GetProviders(false);
-			var providers = GetProviders(allProviders, providerInfo.Provider);
+			var useExplicitProvider = OperatingSystem.IsAndroidVersionAtLeast(34);
+			var availableProviders = useExplicitProvider ? enabledProviders : LocationManager.GetProviders(false);
+			var providers = GetProviders(availableProviders, providerInfo.Provider, useExplicitProvider);
 
 			var listener = new SingleLocationListener(LocationManager, providerInfo.Accuracy, providers);
 			listener.LocationHandler = HandleLocation;
@@ -157,21 +157,20 @@ namespace Microsoft.Maui.Devices.Sensors
 			await Permissions.EnsureGrantedOrRestrictedAsync<Permissions.LocationWhenInUse>();
 
 			var enabledProviders = LocationManager.GetProviders(true);
-			var hasProviders = enabledProviders is not null &&
-				enabledProviders.Any(p => !ignoredProviders.Contains(p));
-
-			if (!hasProviders)
+			if (enabledProviders is null ||
+				!enabledProviders.Any(p => !ignoredProviders.Contains(p)))
 				throw new FeatureNotEnabledException("Location services are not enabled on device.");
 
 			// get the best possible provider for the requested accuracy
-			var providerInfo = GetBestProvider(LocationManager, request.DesiredAccuracy);
+			var providerInfo = GetBestProvider(LocationManager, enabledProviders, request.DesiredAccuracy);
 
 			// if no providers exist, we can't listen for locations
 			if (string.IsNullOrEmpty(providerInfo.Provider))
 				return false;
 
-			var allProviders = LocationManager.GetProviders(false);
-			listeningProviders = GetProviders(allProviders, providerInfo.Provider);
+			var useExplicitProvider = OperatingSystem.IsAndroidVersionAtLeast(34);
+			var availableProviders = useExplicitProvider ? enabledProviders : LocationManager.GetProviders(false);
+			listeningProviders = GetProviders(availableProviders, providerInfo.Provider, useExplicitProvider);
 
 			continuousListener = new ContinuousLocationListener(LocationManager, providerInfo.Accuracy, listeningProviders);
 			continuousListener.LocationHandler = HandleLocation;
@@ -225,12 +224,12 @@ namespace Microsoft.Maui.Devices.Sensors
 			continuousListener = null;
 		}
 
-		static (string? Provider, float Accuracy) GetBestProvider(LocationManager locationManager, GeolocationAccuracy accuracy)
+		static (string? Provider, float Accuracy) GetBestProvider(LocationManager locationManager, IList<string> enabledProviders, GeolocationAccuracy accuracy)
 		{
 			var accuracyDistance = GetAccuracyDistance(accuracy);
 
 			if (OperatingSystem.IsAndroidVersionAtLeast(34))
-				return (SelectProvider(locationManager.GetProviders(true), accuracy), accuracyDistance);
+				return (SelectProvider(enabledProviders, accuracy), accuracyDistance);
 
 			var criteria = new Criteria
 			{
@@ -269,15 +268,17 @@ namespace Microsoft.Maui.Devices.Sensors
 					break;
 			}
 
-			var provider = locationManager.GetBestProvider(criteria, true) ?? locationManager.GetProviders(true).FirstOrDefault();
+			var provider = locationManager.GetBestProvider(criteria, true) ?? enabledProviders.FirstOrDefault();
 
 			return (provider, accuracyDistance);
 		}
 
-		internal static string? SelectProvider(IList<string> enabledProviders, GeolocationAccuracy accuracy)
+		internal static string? SelectProvider(IList<string>? enabledProviders, GeolocationAccuracy accuracy)
 		{
-			if (OperatingSystem.IsAndroidVersionAtLeast(31) &&
-				enabledProviders.Contains(LocationManager.FusedProvider))
+			if (enabledProviders is null)
+				return null;
+
+			if (enabledProviders.Contains(LocationManager.FusedProvider))
 				return LocationManager.FusedProvider;
 
 			var preferredProvider = accuracy switch
@@ -297,16 +298,20 @@ namespace Microsoft.Maui.Devices.Sensors
 			return enabledProviders.FirstOrDefault(provider => !ignoredProviders.Contains(provider));
 		}
 
-		internal static List<string> GetProviders(IList<string> allProviders, string fallbackProvider)
+		internal static List<string> GetProviders(IList<string> availableProviders, string selectedProvider, bool includeSelectedProvider)
 		{
 			var providers = new List<string>();
 
-			if (allProviders.Contains(LocationManager.GpsProvider))
+			if (includeSelectedProvider)
+				providers.Add(selectedProvider);
+			if (availableProviders.Contains(LocationManager.GpsProvider) &&
+				!providers.Contains(LocationManager.GpsProvider))
 				providers.Add(LocationManager.GpsProvider);
-			if (allProviders.Contains(LocationManager.NetworkProvider))
+			if (availableProviders.Contains(LocationManager.NetworkProvider) &&
+				!providers.Contains(LocationManager.NetworkProvider))
 				providers.Add(LocationManager.NetworkProvider);
 			if (providers.Count == 0)
-				providers.Add(fallbackProvider);
+				providers.Add(selectedProvider);
 
 			return providers;
 		}

--- a/src/Essentials/src/Geolocation/Geolocation.android.cs
+++ b/src/Essentials/src/Geolocation/Geolocation.android.cs
@@ -73,8 +73,7 @@ namespace Microsoft.Maui.Devices.Sensors
 			await Permissions.EnsureGrantedOrRestrictedAsync<Permissions.LocationWhenInUse>();
 
 			var enabledProviders = LocationManager.GetProviders(true);
-			if (enabledProviders is null ||
-				!enabledProviders.Any(p => !ignoredProviders.Contains(p)))
+			if (!enabledProviders.Any(p => !ignoredProviders.Contains(p)))
 				throw new FeatureNotEnabledException("Location services are not enabled on device.");
 
 			// get the best possible provider for the requested accuracy
@@ -157,8 +156,7 @@ namespace Microsoft.Maui.Devices.Sensors
 			await Permissions.EnsureGrantedOrRestrictedAsync<Permissions.LocationWhenInUse>();
 
 			var enabledProviders = LocationManager.GetProviders(true);
-			if (enabledProviders is null ||
-				!enabledProviders.Any(p => !ignoredProviders.Contains(p)))
+			if (!enabledProviders.Any(p => !ignoredProviders.Contains(p)))
 				throw new FeatureNotEnabledException("Location services are not enabled on device.");
 
 			// get the best possible provider for the requested accuracy
@@ -301,17 +299,16 @@ namespace Microsoft.Maui.Devices.Sensors
 		internal static string? SelectFallbackProvider(IList<string>? enabledProviders) =>
 			enabledProviders?.FirstOrDefault(provider => !ignoredProviders.Contains(provider));
 
-		internal static List<string> GetProviders(IList<string> availableProviders, string selectedProvider, bool includeSelectedProvider)
+		internal static List<string> GetProviders(IList<string> availableProviders, string selectedProvider, bool useExplicitProvider)
 		{
+			if (useExplicitProvider)
+				return new List<string> { selectedProvider };
+
 			var providers = new List<string>();
 
-			if (includeSelectedProvider)
-				providers.Add(selectedProvider);
-			if (availableProviders.Contains(LocationManager.GpsProvider) &&
-				!providers.Contains(LocationManager.GpsProvider))
+			if (availableProviders.Contains(LocationManager.GpsProvider))
 				providers.Add(LocationManager.GpsProvider);
-			if (availableProviders.Contains(LocationManager.NetworkProvider) &&
-				!providers.Contains(LocationManager.NetworkProvider))
+			if (availableProviders.Contains(LocationManager.NetworkProvider))
 				providers.Add(LocationManager.NetworkProvider);
 			if (providers.Count == 0)
 				providers.Add(selectedProvider);

--- a/src/Essentials/src/Geolocation/Geolocation.android.cs
+++ b/src/Essentials/src/Geolocation/Geolocation.android.cs
@@ -89,15 +89,7 @@ namespace Microsoft.Maui.Devices.Sensors
 			var tcs = new TaskCompletionSource<AndroidLocation?>();
 
 			var allProviders = LocationManager.GetProviders(false);
-
-			var providers = new List<string>();
-			if (allProviders.Contains(LocationManager.GpsProvider))
-				providers.Add(LocationManager.GpsProvider);
-			if (allProviders.Contains(LocationManager.NetworkProvider))
-				providers.Add(LocationManager.NetworkProvider);
-
-			if (providers.Count == 0)
-				providers.Add(providerInfo.Provider);
+			var providers = GetProviders(allProviders, providerInfo.Provider);
 
 			var listener = new SingleLocationListener(LocationManager, providerInfo.Accuracy, providers);
 			listener.LocationHandler = HandleLocation;
@@ -179,15 +171,7 @@ namespace Microsoft.Maui.Devices.Sensors
 				return false;
 
 			var allProviders = LocationManager.GetProviders(false);
-
-			listeningProviders = new List<string>();
-			if (allProviders.Contains(LocationManager.GpsProvider))
-				listeningProviders.Add(LocationManager.GpsProvider);
-			if (allProviders.Contains(LocationManager.NetworkProvider))
-				listeningProviders.Add(LocationManager.NetworkProvider);
-
-			if (listeningProviders.Count == 0)
-				listeningProviders.Add(providerInfo.Provider);
+			listeningProviders = GetProviders(allProviders, providerInfo.Provider);
 
 			continuousListener = new ContinuousLocationListener(LocationManager, providerInfo.Accuracy, listeningProviders);
 			continuousListener.LocationHandler = HandleLocation;
@@ -241,12 +225,12 @@ namespace Microsoft.Maui.Devices.Sensors
 			continuousListener = null;
 		}
 
-		// TODO: android.location.Criteria deprecated in API 34
-		// https://developer.android.com/reference/android/location/Criteria
-#pragma warning disable CA1422
 		static (string? Provider, float Accuracy) GetBestProvider(LocationManager locationManager, GeolocationAccuracy accuracy)
 		{
-			// Criteria: https://developer.android.com/reference/android/location/Criteria
+			var accuracyDistance = GetAccuracyDistance(accuracy);
+
+			if (OperatingSystem.IsAndroidVersionAtLeast(34))
+				return (SelectProvider(locationManager.GetProviders(true), accuracy), accuracyDistance);
 
 			var criteria = new Criteria
 			{
@@ -255,40 +239,33 @@ namespace Microsoft.Maui.Devices.Sensors
 				SpeedRequired = false
 			};
 
-			var accuracyDistance = 100;
-
 			switch (accuracy)
 			{
 				case GeolocationAccuracy.Lowest:
 					criteria.Accuracy = Accuracy.NoRequirement;
 					criteria.HorizontalAccuracy = Accuracy.NoRequirement;
 					criteria.PowerRequirement = LocationPower.NoRequirement;
-					accuracyDistance = 500;
 					break;
 				case GeolocationAccuracy.Low:
 					criteria.Accuracy = Accuracy.Coarse;
 					criteria.HorizontalAccuracy = Accuracy.Low;
 					criteria.PowerRequirement = LocationPower.Low;
-					accuracyDistance = 500;
 					break;
 				case GeolocationAccuracy.Default:
 				case GeolocationAccuracy.Medium:
 					criteria.Accuracy = Accuracy.Coarse;
 					criteria.HorizontalAccuracy = Accuracy.Medium;
 					criteria.PowerRequirement = LocationPower.Medium;
-					accuracyDistance = 250;
 					break;
 				case GeolocationAccuracy.High:
 					criteria.Accuracy = Accuracy.Fine;
 					criteria.HorizontalAccuracy = Accuracy.High;
 					criteria.PowerRequirement = LocationPower.High;
-					accuracyDistance = 100;
 					break;
 				case GeolocationAccuracy.Best:
 					criteria.Accuracy = Accuracy.Fine;
 					criteria.HorizontalAccuracy = Accuracy.High;
 					criteria.PowerRequirement = LocationPower.High;
-					accuracyDistance = 50;
 					break;
 			}
 
@@ -296,7 +273,52 @@ namespace Microsoft.Maui.Devices.Sensors
 
 			return (provider, accuracyDistance);
 		}
-#pragma warning restore CA1422
+
+		internal static string? SelectProvider(IList<string> enabledProviders, GeolocationAccuracy accuracy)
+		{
+			if (OperatingSystem.IsAndroidVersionAtLeast(31) &&
+				enabledProviders.Contains(LocationManager.FusedProvider))
+				return LocationManager.FusedProvider;
+
+			var preferredProvider = accuracy switch
+			{
+				GeolocationAccuracy.High or GeolocationAccuracy.Best => LocationManager.GpsProvider,
+				_ => LocationManager.NetworkProvider,
+			};
+			var alternateProvider = preferredProvider == LocationManager.GpsProvider
+				? LocationManager.NetworkProvider
+				: LocationManager.GpsProvider;
+
+			if (enabledProviders.Contains(preferredProvider))
+				return preferredProvider;
+			if (enabledProviders.Contains(alternateProvider))
+				return alternateProvider;
+
+			return enabledProviders.FirstOrDefault(provider => !ignoredProviders.Contains(provider));
+		}
+
+		internal static List<string> GetProviders(IList<string> allProviders, string fallbackProvider)
+		{
+			var providers = new List<string>();
+
+			if (allProviders.Contains(LocationManager.GpsProvider))
+				providers.Add(LocationManager.GpsProvider);
+			if (allProviders.Contains(LocationManager.NetworkProvider))
+				providers.Add(LocationManager.NetworkProvider);
+			if (providers.Count == 0)
+				providers.Add(fallbackProvider);
+
+			return providers;
+		}
+
+		internal static float GetAccuracyDistance(GeolocationAccuracy accuracy) =>
+			accuracy switch
+			{
+				GeolocationAccuracy.Lowest or GeolocationAccuracy.Low => 500,
+				GeolocationAccuracy.Default or GeolocationAccuracy.Medium => 250,
+				GeolocationAccuracy.Best => 50,
+				_ => 100,
+			};
 
 		internal static bool IsBetterLocation(AndroidLocation location, AndroidLocation? bestLocation)
 		{

--- a/src/Essentials/src/Geolocation/Geolocation.android.cs
+++ b/src/Essentials/src/Geolocation/Geolocation.android.cs
@@ -268,7 +268,7 @@ namespace Microsoft.Maui.Devices.Sensors
 					break;
 			}
 
-			var provider = locationManager.GetBestProvider(criteria, true) ?? enabledProviders.FirstOrDefault();
+			var provider = locationManager.GetBestProvider(criteria, true) ?? SelectFallbackProvider(enabledProviders);
 
 			return (provider, accuracyDistance);
 		}
@@ -295,8 +295,11 @@ namespace Microsoft.Maui.Devices.Sensors
 			if (enabledProviders.Contains(alternateProvider))
 				return alternateProvider;
 
-			return enabledProviders.FirstOrDefault(provider => !ignoredProviders.Contains(provider));
+			return SelectFallbackProvider(enabledProviders);
 		}
+
+		internal static string? SelectFallbackProvider(IList<string>? enabledProviders) =>
+			enabledProviders?.FirstOrDefault(provider => !ignoredProviders.Contains(provider));
 
 		internal static List<string> GetProviders(IList<string> availableProviders, string selectedProvider, bool includeSelectedProvider)
 		{

--- a/src/Essentials/test/DeviceTests/Tests/Android/Geolocation_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Android/Geolocation_Tests.cs
@@ -70,6 +70,16 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 			Assert.Equal("custom", provider);
 		}
 
+		[Fact]
+		public void SelectFallbackProvider_IgnoresPassiveAndLocalDatabaseProviders()
+		{
+			var enabledProviders = new[] { AndroidLocationManager.PassiveProvider, "local_database", "custom" };
+
+			var provider = GeolocationImplementation.SelectFallbackProvider(enabledProviders);
+
+			Assert.Equal("custom", provider);
+		}
+
 		[Theory]
 		[InlineData(GeolocationAccuracy.Best, AndroidLocationManager.NetworkProvider)]
 		[InlineData(GeolocationAccuracy.Lowest, AndroidLocationManager.GpsProvider)]

--- a/src/Essentials/test/DeviceTests/Tests/Android/Geolocation_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Android/Geolocation_Tests.cs
@@ -1,13 +1,98 @@
 using System;
+using System.Collections.Generic;
 using Microsoft.Maui.Devices.Sensors;
 using Xunit;
 using AndroidLocation = Android.Locations.Location;
+using AndroidLocationManager = Android.Locations.LocationManager;
 
 namespace Microsoft.Maui.Essentials.DeviceTests
 {
 	[Category("Geolocation")]
 	public class Android_Geolocation_Tests
 	{
+		public static IEnumerable<object[]> AccuracyDistances =>
+			new[]
+			{
+				new object[] { GeolocationAccuracy.Lowest, 500f },
+				new object[] { GeolocationAccuracy.Low, 500f },
+				new object[] { GeolocationAccuracy.Default, 250f },
+				new object[] { GeolocationAccuracy.Medium, 250f },
+				new object[] { GeolocationAccuracy.High, 100f },
+				new object[] { GeolocationAccuracy.Best, 50f },
+			};
+
+		public static IEnumerable<object[]> StandardProviderPreferences =>
+			new[]
+			{
+				new object[] { GeolocationAccuracy.Lowest, AndroidLocationManager.NetworkProvider },
+				new object[] { GeolocationAccuracy.Low, AndroidLocationManager.NetworkProvider },
+				new object[] { GeolocationAccuracy.Default, AndroidLocationManager.NetworkProvider },
+				new object[] { GeolocationAccuracy.Medium, AndroidLocationManager.NetworkProvider },
+				new object[] { GeolocationAccuracy.High, AndroidLocationManager.GpsProvider },
+				new object[] { GeolocationAccuracy.Best, AndroidLocationManager.GpsProvider },
+			};
+
+		[Theory]
+		[MemberData(nameof(AccuracyDistances))]
+		public void GetAccuracyDistance_ReturnsExpectedDistance(GeolocationAccuracy accuracy, float expectedDistance)
+		{
+			Assert.Equal(expectedDistance, GeolocationImplementation.GetAccuracyDistance(accuracy));
+		}
+
+		[Theory]
+		[MemberData(nameof(StandardProviderPreferences))]
+		public void SelectProvider_UsesAccuracyPreferenceWhenFusedIsUnavailable(GeolocationAccuracy accuracy, string expectedProvider)
+		{
+			var enabledProviders = new[] { AndroidLocationManager.GpsProvider, AndroidLocationManager.NetworkProvider };
+
+			var provider = GeolocationImplementation.SelectProvider(enabledProviders, accuracy);
+
+			Assert.Equal(expectedProvider, provider);
+		}
+
+		[Fact]
+		public void SelectProvider_PrefersFusedProvider()
+		{
+			if (!OperatingSystem.IsAndroidVersionAtLeast(31))
+				return;
+
+			var enabledProviders = new[] { AndroidLocationManager.GpsProvider, AndroidLocationManager.NetworkProvider, AndroidLocationManager.FusedProvider };
+
+			var provider = GeolocationImplementation.SelectProvider(enabledProviders, GeolocationAccuracy.Best);
+
+			Assert.Equal(AndroidLocationManager.FusedProvider, provider);
+		}
+
+		[Fact]
+		public void SelectProvider_FallsBackToFirstNonPassiveProvider()
+		{
+			var enabledProviders = new[] { AndroidLocationManager.PassiveProvider, "local_database", "custom" };
+
+			var provider = GeolocationImplementation.SelectProvider(enabledProviders, GeolocationAccuracy.Default);
+
+			Assert.Equal("custom", provider);
+		}
+
+		[Fact]
+		public void GetProviders_UsesGpsAndNetworkWhenAvailable()
+		{
+			var allProviders = new[] { "custom", AndroidLocationManager.NetworkProvider, AndroidLocationManager.GpsProvider };
+
+			var providers = GeolocationImplementation.GetProviders(allProviders, "custom");
+
+			Assert.Equal(new[] { AndroidLocationManager.GpsProvider, AndroidLocationManager.NetworkProvider }, providers);
+		}
+
+		[Theory]
+		[InlineData(AndroidLocationManager.FusedProvider)]
+		[InlineData("custom")]
+		public void GetProviders_UsesFallbackWhenStandardProvidersAreUnavailable(string fallbackProvider)
+		{
+			var providers = GeolocationImplementation.GetProviders(new[] { fallbackProvider }, fallbackProvider);
+
+			Assert.Equal(new[] { fallbackProvider }, providers);
+		}
+
 		[Fact]
 		public void ToLocation_NoAltitude_UsesUnspecifiedReferenceSystem()
 		{

--- a/src/Essentials/test/DeviceTests/Tests/Android/Geolocation_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Android/Geolocation_Tests.cs
@@ -113,27 +113,28 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		{
 			var allProviders = new[] { "custom", AndroidLocationManager.NetworkProvider, AndroidLocationManager.GpsProvider };
 
-			var providers = GeolocationImplementation.GetProviders(allProviders, "custom", includeSelectedProvider: false);
+			var providers = GeolocationImplementation.GetProviders(allProviders, "custom", useExplicitProvider: false);
 
 			Assert.Equal(new[] { AndroidLocationManager.GpsProvider, AndroidLocationManager.NetworkProvider }, providers);
 		}
 
-		[Fact]
-		public void GetProviders_IncludesExplicitProviderAndEnabledFallbacks()
+		[Theory]
+		[InlineData(AndroidLocationManager.FusedProvider)]
+		[InlineData(AndroidLocationManager.GpsProvider)]
+		[InlineData(AndroidLocationManager.NetworkProvider)]
+		public void GetProviders_UsesOnlyExplicitProvider(string selectedProvider)
 		{
 			var enabledProviders = new[] { AndroidLocationManager.FusedProvider, AndroidLocationManager.NetworkProvider, AndroidLocationManager.GpsProvider };
 
-			var providers = GeolocationImplementation.GetProviders(enabledProviders, AndroidLocationManager.FusedProvider, includeSelectedProvider: true);
+			var providers = GeolocationImplementation.GetProviders(enabledProviders, selectedProvider, useExplicitProvider: true);
 
-			Assert.Equal(
-				new[] { AndroidLocationManager.FusedProvider, AndroidLocationManager.GpsProvider, AndroidLocationManager.NetworkProvider },
-				providers);
+			Assert.Equal(new[] { selectedProvider }, providers);
 		}
 
 		[Fact]
 		public void GetProviders_UsesLegacyFallbackWhenStandardProvidersAreUnavailable()
 		{
-			var providers = GeolocationImplementation.GetProviders(new[] { "custom" }, "custom", includeSelectedProvider: false);
+			var providers = GeolocationImplementation.GetProviders(new[] { "custom" }, "custom", useExplicitProvider: false);
 
 			Assert.Equal(new[] { "custom" }, providers);
 		}
@@ -143,7 +144,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		[InlineData("custom")]
 		public void GetProviders_UsesFallbackWhenStandardProvidersAreUnavailable(string fallbackProvider)
 		{
-			var providers = GeolocationImplementation.GetProviders(new[] { fallbackProvider }, fallbackProvider, includeSelectedProvider: true);
+			var providers = GeolocationImplementation.GetProviders(new[] { fallbackProvider }, fallbackProvider, useExplicitProvider: true);
 
 			Assert.Equal(new[] { fallbackProvider }, providers);
 		}

--- a/src/Essentials/test/DeviceTests/Tests/Android/Geolocation_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Android/Geolocation_Tests.cs
@@ -53,9 +53,6 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		[Fact]
 		public void SelectProvider_PrefersFusedProvider()
 		{
-			if (!OperatingSystem.IsAndroidVersionAtLeast(31))
-				return;
-
 			var enabledProviders = new[] { AndroidLocationManager.GpsProvider, AndroidLocationManager.NetworkProvider, AndroidLocationManager.FusedProvider };
 
 			var provider = GeolocationImplementation.SelectProvider(enabledProviders, GeolocationAccuracy.Best);
@@ -73,14 +70,62 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 			Assert.Equal("custom", provider);
 		}
 
+		[Theory]
+		[InlineData(GeolocationAccuracy.Best, AndroidLocationManager.NetworkProvider)]
+		[InlineData(GeolocationAccuracy.Lowest, AndroidLocationManager.GpsProvider)]
+		public void SelectProvider_UsesAlternateStandardProvider(GeolocationAccuracy accuracy, string enabledProvider)
+		{
+			var provider = GeolocationImplementation.SelectProvider(new[] { enabledProvider }, accuracy);
+
+			Assert.Equal(enabledProvider, provider);
+		}
+
 		[Fact]
-		public void GetProviders_UsesGpsAndNetworkWhenAvailable()
+		public void SelectProvider_ReturnsNullWhenOnlyIgnoredProvidersAreEnabled()
+		{
+			var enabledProviders = new[] { AndroidLocationManager.PassiveProvider, "local_database" };
+
+			var provider = GeolocationImplementation.SelectProvider(enabledProviders, GeolocationAccuracy.Default);
+
+			Assert.Null(provider);
+		}
+
+		[Fact]
+		public void SelectProvider_ReturnsNullWhenProvidersAreUnavailable()
+		{
+			var provider = GeolocationImplementation.SelectProvider(null, GeolocationAccuracy.Default);
+
+			Assert.Null(provider);
+		}
+
+		[Fact]
+		public void GetProviders_UsesGpsAndNetworkForLegacySelection()
 		{
 			var allProviders = new[] { "custom", AndroidLocationManager.NetworkProvider, AndroidLocationManager.GpsProvider };
 
-			var providers = GeolocationImplementation.GetProviders(allProviders, "custom");
+			var providers = GeolocationImplementation.GetProviders(allProviders, "custom", includeSelectedProvider: false);
 
 			Assert.Equal(new[] { AndroidLocationManager.GpsProvider, AndroidLocationManager.NetworkProvider }, providers);
+		}
+
+		[Fact]
+		public void GetProviders_IncludesExplicitProviderAndEnabledFallbacks()
+		{
+			var enabledProviders = new[] { AndroidLocationManager.FusedProvider, AndroidLocationManager.NetworkProvider, AndroidLocationManager.GpsProvider };
+
+			var providers = GeolocationImplementation.GetProviders(enabledProviders, AndroidLocationManager.FusedProvider, includeSelectedProvider: true);
+
+			Assert.Equal(
+				new[] { AndroidLocationManager.FusedProvider, AndroidLocationManager.GpsProvider, AndroidLocationManager.NetworkProvider },
+				providers);
+		}
+
+		[Fact]
+		public void GetProviders_UsesLegacyFallbackWhenStandardProvidersAreUnavailable()
+		{
+			var providers = GeolocationImplementation.GetProviders(new[] { "custom" }, "custom", includeSelectedProvider: false);
+
+			Assert.Equal(new[] { "custom" }, providers);
 		}
 
 		[Theory]
@@ -88,7 +133,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		[InlineData("custom")]
 		public void GetProviders_UsesFallbackWhenStandardProvidersAreUnavailable(string fallbackProvider)
 		{
-			var providers = GeolocationImplementation.GetProviders(new[] { fallbackProvider }, fallbackProvider);
+			var providers = GeolocationImplementation.GetProviders(new[] { fallbackProvider }, fallbackProvider, includeSelectedProvider: true);
 
 			Assert.Equal(new[] { fallbackProvider }, providers);
 		}

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
@@ -120,7 +120,6 @@ namespace Microsoft.Maui.IntegrationTests
 				buildProps.Add("PublishAot=true");
 				buildProps.Add("PublishAotUsingRuntimePack=true"); // TODO: This parameter will become obsolete https://github.com/dotnet/runtime/issues/87060
 				buildProps.Add("_IsPublishing=true"); // using dotnet build with -p:_IsPublishing=true enables targeting simulators
-				buildProps.Add("IlcTreatWarningsAsErrors=false"); // TODO: Remove this once all warnings are fixed https://github.com/dotnet/maui/issues/19397
 				// Restrict to iOS-only to avoid restoring NativeAOT packages for other platforms (e.g., Android)
 				// which may not be available in the configured NuGet sources
 				buildProps.Add($"TargetFrameworks={framework}-ios");


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Android deprecated `android.location.Criteria` and its provider-selection APIs in API 34 because criteria cannot fully represent provider capabilities. Geolocation still used `Criteria` to select the fallback provider, requiring a `CA1422` suppression and leaving an API 34 TODO.

On Android API 34 and later, this change selects an enabled provider explicitly:

- prefer the system fused provider when available;
- otherwise prefer network for lowest through medium accuracy, or GPS for high and best accuracy;
- fall back to the alternate standard provider and then the first enabled custom provider;
- exclude passive and `local_database` providers from active fallback selection.

API 21 through 33 retain the existing `Criteria` behavior. The existing GPS and network update subscriptions, last-known-location fallback, permission handling, accuracy thresholds, timeout behavior, and cancellation cleanup are unchanged. No public API is changed.

Focused Android device tests cover provider preference and fallback behavior, the final requested-provider list, and every accuracy threshold.

### Validation

- `dotnet build .\src\Essentials\src\Essentials.csproj -f net10.0-android36.0 -c Release --no-restore`
- `dotnet build .\src\Essentials\test\DeviceTests\Essentials.DeviceTests.csproj -f net10.0-android -c Release --no-restore`

Both builds complete with 0 warnings and 0 errors. Runtime device tests were not run because no Android device or emulator tooling was available locally.

### Issues Fixed

N/A - resolves the API 34 TODO in `Geolocation.android.cs`.