### PR TITLE
[CI] Add /fix issue replication trigger

### DIFF
--- a/.github/docs/trigger-azdo-pipeline-setup.md
+++ b/.github/docs/trigger-azdo-pipeline-setup.md
@@ -170,7 +170,26 @@ In **dotnet/maui** → **Settings** → **Secrets and variables** → **Actions*
 
 ## Step 5: Create the GitHub Actions Workflow
 
-See [`.github/workflows/review-trigger.yml`](../workflows/review-trigger.yml) for a ready-to-use workflow.
+See [`.github/workflows/review-trigger.yml`](../workflows/review-trigger.yml) for the
+pull request review trigger and [`.github/workflows/fix-trigger.yml`](../workflows/fix-trigger.yml)
+for the issue replication trigger.
+
+### Issue replication command
+
+Maintainers with write, maintain, or admin permission can queue issue replication by
+commenting on an open issue:
+
+```text
+/fix -b <pipeline-branch>
+```
+
+`--branch <pipeline-branch>` is also accepted. The branch is required and selects the
+`dotnet/maui` repository ref used by Azure Pipelines, not a git base for the trigger
+workflow. The selected ref must exist and must expose the replicate-mode parameter
+contract (`Mode`, `IssueNumber`, `PRNumber`, and `Platform`) used by pipeline 27723.
+Use the implementation branch while replicate mode is under development, then use
+`main` after that support merges. The trigger never silently defaults the ref to
+`main`.
 
 ## How It Works (Token Flow)
 

--- a/.github/scripts/FixTrigger.Tests.ps1
+++ b/.github/scripts/FixTrigger.Tests.ps1
@@ -1,0 +1,326 @@
+#!/usr/bin/env pwsh
+#Requires -Modules Pester
+
+BeforeAll {
+    $workflowPath = Join-Path $PSScriptRoot '..' 'workflows' 'fix-trigger.yml' |
+        Resolve-Path |
+        Select-Object -ExpandProperty Path
+    $workflow = Get-Content -Raw -LiteralPath $workflowPath
+
+    function Get-WorkflowJob {
+        param(
+            [Parameter(Mandatory)]
+            [string] $Name
+        )
+
+        $pattern = "(?ms)^  $([regex]::Escape($Name)):\s.*?(?=^  [A-Za-z0-9_-]+:[ \t]*\r?$|\z)"
+        $match = [regex]::Match($workflow, $pattern)
+        if (-not $match.Success) {
+            throw "Could not find the $Name job in fix-trigger.yml."
+        }
+
+        return $match.Value
+    }
+
+    function Get-StepScript {
+        param(
+            [Parameter(Mandatory)]
+            [string] $Job,
+
+            [Parameter(Mandatory)]
+            [string] $Name
+        )
+
+        $pattern = "(?ms)^      - name: $([regex]::Escape($Name))\r?\n.*?^        run: \|\r?\n(?<script>.*?)(?=^      - name:|\z)"
+        $match = [regex]::Match($Job, $pattern)
+        if (-not $match.Success) {
+            throw "Could not find the '$Name' run script."
+        }
+
+        return (($match.Groups['script'].Value -split "`n") |
+            ForEach-Object { $_ -replace '^          ', '' }) -join "`n"
+    }
+
+    function Invoke-BashStep {
+        param(
+            [Parameter(Mandatory)]
+            [string] $Script,
+
+            [hashtable] $Environment = @{},
+
+            [string] $MockGh
+        )
+
+        $tempDirectory = Join-Path ([System.IO.Path]::GetTempPath()) "fix-trigger-$([guid]::NewGuid().ToString('n'))"
+        $scriptPath = Join-Path $tempDirectory 'step.sh'
+        $outputPath = Join-Path $tempDirectory 'github-output'
+        $oldValues = @{}
+
+        New-Item -ItemType Directory -Path $tempDirectory | Out-Null
+        Set-Content -LiteralPath $scriptPath -Value $Script -NoNewline
+
+        if ($MockGh) {
+            $ghPath = Join-Path $tempDirectory 'gh'
+            Set-Content -LiteralPath $ghPath -Value $MockGh -NoNewline
+            & chmod +x $ghPath
+            $Environment['PATH'] = "$tempDirectory$([IO.Path]::PathSeparator)$env:PATH"
+        }
+
+        $Environment['GITHUB_OUTPUT'] = $outputPath
+        try {
+            foreach ($entry in $Environment.GetEnumerator()) {
+                $oldValues[$entry.Key] = [Environment]::GetEnvironmentVariable($entry.Key)
+                [Environment]::SetEnvironmentVariable($entry.Key, [string] $entry.Value)
+            }
+
+            $console = & bash $scriptPath 2>&1
+            $exitCode = $LASTEXITCODE
+            $outputs = @{}
+            if (Test-Path -LiteralPath $outputPath) {
+                foreach ($line in Get-Content -LiteralPath $outputPath) {
+                    if ($line -match '^([^=]+)=(.*)$') {
+                        $outputs[$Matches[1]] = $Matches[2]
+                    }
+                }
+            }
+
+            return [pscustomobject] @{
+                ExitCode = $exitCode
+                Outputs = $outputs
+                Console = ($console -join "`n")
+            }
+        } finally {
+            foreach ($entry in $oldValues.GetEnumerator()) {
+                [Environment]::SetEnvironmentVariable($entry.Key, $entry.Value)
+            }
+            Remove-Item -LiteralPath $tempDirectory -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    $script:Workflow = $workflow
+    $script:PreflightJob = Get-WorkflowJob -Name 'preflight'
+    $script:TriggerJob = Get-WorkflowJob -Name 'trigger-fix'
+    $script:MatchScript = Get-StepScript -Job $script:PreflightJob -Name 'Match /fix command'
+    $script:PermissionScript = Get-StepScript -Job $script:PreflightJob -Name 'Check actor permission'
+    $script:ValidateScript = Get-StepScript -Job $script:PreflightJob -Name 'Validate issue, branch, and platform'
+}
+
+Describe '/fix command parsing' {
+    It 'accepts exactly one branch option: <Body>' -TestCases @(
+        @{ Body = '/fix -b main'; Branch = 'main' }
+        @{ Body = '  /fix --branch feature/replicate  '; Branch = 'feature/replicate' }
+        @{ Body = '/fix -b=users/name/replicate'; Branch = 'users/name/replicate' }
+        @{ Body = "`n/fix --branch=main"; Branch = 'main' }
+    ) {
+        param($Body, $Branch)
+
+        $result = Invoke-BashStep -Script $script:MatchScript -Environment @{ COMMENT_BODY = $Body }
+
+        $result.ExitCode | Should -Be 0
+        $result.Outputs.matched | Should -Be 'true'
+        $result.Outputs.pipeline_ref | Should -Be $Branch
+    }
+
+    It 'rejects malformed or extended input: <Body>' -TestCases @(
+        @{ Body = '/fix' }
+        @{ Body = '/fix -b' }
+        @{ Body = '/fix main' }
+        @{ Body = '/fix --unknown main' }
+        @{ Body = '/fix -b main trailing' }
+        @{ Body = 'please /fix -b main' }
+        @{ Body = '/fix -b --branch' }
+        @{ Body = '/fix -b=' }
+        @{ Body = '/fixing -b main' }
+    ) {
+        param($Body)
+
+        $result = Invoke-BashStep -Script $script:MatchScript -Environment @{ COMMENT_BODY = $Body }
+
+        $result.ExitCode | Should -Be 0
+        $result.Outputs.matched | Should -Be 'false'
+        $result.Outputs.ContainsKey('pipeline_ref') | Should -BeFalse
+    }
+}
+
+Describe '/fix event and authorization gates' {
+    It 'runs only for newly created issue comments and rejects pull request comments' {
+        $script:Workflow | Should -Match '(?ms)^on:\s+issue_comment:\s+types: \[created\]'
+        $script:Workflow | Should -Not -Match '(?m)^  pull_request(_target)?:'
+        $script:PreflightJob | Should -Match "(?m)^    if: github\.event_name == 'issue_comment' && !github\.event\.issue\.pull_request$"
+    }
+
+    It 'allows only write, maintain, and admin permission' -TestCases @(
+        @{ Permission = 'write'; Expected = 'true' }
+        @{ Permission = 'maintain'; Expected = 'true' }
+        @{ Permission = 'admin'; Expected = 'true' }
+        @{ Permission = 'read'; Expected = 'false' }
+        @{ Permission = 'triage'; Expected = 'false' }
+    ) {
+        param($Permission, $Expected)
+
+        $mockGh = @"
+#!/usr/bin/env bash
+printf '%s\n' '$Permission'
+"@
+        $result = Invoke-BashStep -Script $script:PermissionScript -MockGh $mockGh -Environment @{
+            ACTOR = 'maintainer'
+            REPO = 'dotnet/maui'
+        }
+
+        $result.ExitCode | Should -Be 0
+        $result.Outputs.authorized | Should -Be $Expected
+    }
+
+    It 'fails closed when permission lookup fails' {
+        $mockGh = @'
+#!/usr/bin/env bash
+exit 1
+'@
+        $result = Invoke-BashStep -Script $script:PermissionScript -MockGh $mockGh -Environment @{
+            ACTOR = 'unknown'
+            REPO = 'dotnet/maui'
+        }
+
+        $result.ExitCode | Should -Be 0
+        $result.Outputs.authorized | Should -Be 'false'
+        $result.Console | Should -Match 'treating the caller as unauthorized'
+    }
+
+    It 'does not provision the write-capable job before preflight succeeds' {
+        $script:TriggerJob | Should -Match "(?m)^    if: needs\.preflight\.outputs\.proceed == 'true'$"
+        $script:PreflightJob | Should -Not -Match 'id-token: write|issues: write'
+        $script:TriggerJob | Should -Match '(?m)^      id-token: write$'
+        $script:TriggerJob | Should -Match '(?m)^      issues: write$'
+    }
+}
+
+Describe '/fix issue, branch, and platform validation' {
+    BeforeAll {
+        $script:ValidationMockGh = @'
+#!/usr/bin/env bash
+if [[ "$*" == *"/issues/"* ]]; then
+  printf '%s\n' "${MOCK_ISSUE_JSON}"
+  exit 0
+fi
+if [[ "$*" == *"/git/ref/heads/"* ]]; then
+  [ "${MOCK_BRANCH_EXISTS}" = "true" ]
+  exit
+fi
+exit 1
+'@
+    }
+
+    It 'requires the issue to be open and not a pull request' -TestCases @(
+        @{
+            Json = '{"state":"closed","labels":[]}'
+            Message = 'is not open'
+        }
+        @{
+            Json = '{"state":"open","pull_request":{},"labels":[]}'
+            Message = 'only supported on issues'
+        }
+    ) {
+        param($Json, $Message)
+
+        $result = Invoke-BashStep -Script $script:ValidateScript -MockGh $script:ValidationMockGh -Environment @{
+            ISSUE_NUMBER = '123'
+            PIPELINE_REF = 'main'
+            REPO = 'dotnet/maui'
+            MOCK_ISSUE_JSON = $Json
+            MOCK_BRANCH_EXISTS = 'true'
+        }
+
+        $result.ExitCode | Should -Not -Be 0
+        $result.Outputs.ContainsKey('proceed') | Should -BeFalse
+        $result.Console | Should -Match $Message
+    }
+
+    It 'rejects malformed or missing branches' -TestCases @(
+        @{ Branch = 'refs/heads/main'; Exists = 'true'; Message = 'Invalid pipeline branch' }
+        @{ Branch = 'bad..branch'; Exists = 'true'; Message = 'Invalid pipeline branch' }
+        @{ Branch = 'main;echo'; Exists = 'true'; Message = 'Invalid pipeline branch' }
+        @{ Branch = 'missing/replicate'; Exists = 'false'; Message = 'does not exist' }
+    ) {
+        param($Branch, $Exists, $Message)
+
+        $result = Invoke-BashStep -Script $script:ValidateScript -MockGh $script:ValidationMockGh -Environment @{
+            ISSUE_NUMBER = '123'
+            PIPELINE_REF = $Branch
+            REPO = 'dotnet/maui'
+            MOCK_ISSUE_JSON = '{"state":"open","labels":[]}'
+            MOCK_BRANCH_EXISTS = $Exists
+        }
+
+        $result.ExitCode | Should -Not -Be 0
+        $result.Outputs.ContainsKey('proceed') | Should -BeFalse
+        $result.Console | Should -Match $Message
+    }
+
+    It 'maps issue labels to <Expected>' -TestCases @(
+        @{ Labels = '[{"name":"platform/iOS"}]'; Expected = 'ios' }
+        @{ Labels = '[{"name":"platform/macOS"}]'; Expected = 'catalyst' }
+        @{ Labels = '[{"name":"platform/MacCatalyst"}]'; Expected = 'catalyst' }
+        @{ Labels = '[{"name":"platform/Android"}]'; Expected = 'android' }
+        @{ Labels = '[{"name":"platform/Windows"}]'; Expected = 'windows' }
+        @{ Labels = '[]'; Expected = 'android' }
+        @{ Labels = '[{"name":"platform/iOS"},{"name":"platform/Windows"}]'; Expected = 'android' }
+    ) {
+        param($Labels, $Expected)
+
+        $result = Invoke-BashStep -Script $script:ValidateScript -MockGh $script:ValidationMockGh -Environment @{
+            ISSUE_NUMBER = '123'
+            PIPELINE_REF = 'feature/replicate'
+            REPO = 'dotnet/maui'
+            MOCK_ISSUE_JSON = "{`"state`":`"open`",`"labels`":$Labels}"
+            MOCK_BRANCH_EXISTS = 'true'
+        }
+
+        $result.ExitCode | Should -Be 0
+        $result.Outputs.proceed | Should -Be 'true'
+        $result.Outputs.issue_number | Should -Be '123'
+        $result.Outputs.pipeline_ref | Should -Be 'feature/replicate'
+        $result.Outputs.platform | Should -Be $Expected
+        if ($Labels -eq '[]' -or $Labels -match 'iOS.*Windows') {
+            $result.Console | Should -Match 'defaulting to android'
+        }
+    }
+}
+
+Describe '/fix pipeline dispatch and acknowledgement' {
+    It 'uses per-issue non-cancelling concurrency' {
+        $script:TriggerJob | Should -Match 'group: fix-trigger-\$\{\{ needs\.preflight\.outputs\.issue_number \}\}'
+        $script:TriggerJob | Should -Match '(?m)^      cancel-in-progress: false$'
+    }
+
+    It 'queues the exact replicate-mode payload on the selected repository ref' {
+        $script:TriggerJob | Should -Match 'pipelines/27723/runs\?api-version=7\.1'
+        $script:TriggerJob | Should -Match 'Mode: "replicate"'
+        $script:TriggerJob | Should -Match 'IssueNumber: \$issue'
+        $script:TriggerJob | Should -Match 'PRNumber: "0"'
+        $script:TriggerJob | Should -Match 'Platform: \$platform'
+        $script:TriggerJob | Should -Match 'resources: \{ repositories: \{ self: \{ refName: \$ref \} \} \}'
+        $script:TriggerJob | Should -Match '--arg ref "refs/heads/\$\{PIPELINE_REF\}"'
+    }
+
+    It 'keeps OIDC and AzDO tokens shell-local and never supplies a GitHub PAT' {
+        $script:TriggerJob | Should -Match 'ACTIONS_ID_TOKEN_REQUEST_URL'
+        $script:TriggerJob | Should -Match 'scope=499b84ac-1321-427f-aa17-267ca6975798/\.default'
+        $script:TriggerJob | Should -Match 'Authorization: Bearer \$\{AZDO_TOKEN\}'
+        $script:TriggerJob | Should -Match 'trap ''unset OIDC_TOKEN AZDO_TOKEN AZURE_RESPONSE'' EXIT'
+        $script:TriggerJob | Should -Match 'unset OIDC_TOKEN'
+        $script:TriggerJob | Should -Match 'unset AZDO_TOKEN'
+        $script:TriggerJob | Should -Not -Match 'oidc_token=.*GITHUB_OUTPUT|azdo_token=.*GITHUB_OUTPUT'
+        $script:TriggerJob | Should -Not -Match 'GH_PAT|PERSONAL_ACCESS_TOKEN'
+    }
+
+    It 'acknowledges and minimizes only after successful queueing' {
+        $script:TriggerJob | Should -Match "if: \$\{\{ !cancelled\(\) && github\.event_name == 'issue_comment' && steps\.trigger_azdo\.outputs\.queued == 'true' \}\}"
+        $script:TriggerJob | Should -Match 'issues/comments/\$\{COMMENT_ID\}/reactions'
+        $script:TriggerJob | Should -Match 'minimizeComment'
+        $script:TriggerJob | Should -Not -Match 'DELETE|--method DELETE|-X DELETE'
+    }
+
+    It 'does not checkout or execute repository code in either job' {
+        $script:Workflow | Should -Not -Match 'actions/checkout|dotnet (build|test|run|pack)|COPILOT_GITHUB_TOKEN'
+    }
+}

--- a/.github/workflows/fix-trigger.yml
+++ b/.github/workflows/fix-trigger.yml
@@ -1,0 +1,232 @@
+# Trigger issue replication when a maintainer comments `/fix -b <pipeline-branch>`.
+# Uses OIDC (no PAT) -- see .github/docs/trigger-azdo-pipeline-setup.md.
+
+name: Fix Trigger
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  # Keep command parsing, authorization, and validation in a read-only job.
+  # The OIDC-capable job is not provisioned unless every check succeeds.
+  preflight:
+    if: github.event_name == 'issue_comment' && !github.event.issue.pull_request
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      matched: ${{ steps.command.outputs.matched }}
+      authorized: ${{ steps.permission.outputs.authorized }}
+      proceed: ${{ steps.validate.outputs.proceed }}
+      issue_number: ${{ steps.validate.outputs.issue_number }}
+      pipeline_ref: ${{ steps.validate.outputs.pipeline_ref }}
+      platform: ${{ steps.validate.outputs.platform }}
+    steps:
+      - name: Match /fix command
+        id: command
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          PIPELINE_REF=""
+          if [[ "${COMMENT_BODY}" =~ ^[[:space:]]*/fix[[:space:]]+(-b|--branch)[[:space:]]+([^[:space:]-][^[:space:]]*)[[:space:]]*$ ]]; then
+            PIPELINE_REF="${BASH_REMATCH[2]}"
+          elif [[ "${COMMENT_BODY}" =~ ^[[:space:]]*/fix[[:space:]]+(-b=|--branch=)([^[:space:]-][^[:space:]]*)[[:space:]]*$ ]]; then
+            PIPELINE_REF="${BASH_REMATCH[2]}"
+          else
+            echo "matched=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "matched=true" >> "$GITHUB_OUTPUT"
+          echo "pipeline_ref=${PIPELINE_REF}" >> "$GITHUB_OUTPUT"
+
+      - name: Check actor permission
+        id: permission
+        if: steps.command.outputs.matched == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ACTOR: ${{ github.actor }}
+          REPO: ${{ github.repository }}
+        run: |
+          if ! PERMISSION=$(gh api "repos/${REPO}/collaborators/${ACTOR}/permission" --jq '.permission' 2>/dev/null); then
+            echo "::warning::Permission lookup failed for ${ACTOR}; treating the caller as unauthorized."
+            echo "authorized=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "User ${ACTOR} has permission: ${PERMISSION}"
+          if [[ "${PERMISSION}" != "admin" && "${PERMISSION}" != "maintain" && "${PERMISSION}" != "write" ]]; then
+            echo "::notice::Only users with write, maintain, or admin permission can trigger /fix."
+            echo "authorized=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "authorized=true" >> "$GITHUB_OUTPUT"
+
+      - name: Validate issue, branch, and platform
+        id: validate
+        if: steps.permission.outputs.authorized == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          PIPELINE_REF: ${{ steps.command.outputs.pipeline_ref }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          if ! [[ "${ISSUE_NUMBER}" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::The event did not provide a valid issue number."
+            exit 1
+          fi
+
+          ISSUE_JSON=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}")
+          if jq -e 'has("pull_request")' <<< "${ISSUE_JSON}" >/dev/null; then
+            echo "::error::/fix is only supported on issues, not pull requests."
+            exit 1
+          fi
+          ISSUE_STATE=$(jq -r '.state' <<< "${ISSUE_JSON}")
+          if [ "${ISSUE_STATE}" != "open" ]; then
+            echo "::error::Issue #${ISSUE_NUMBER} is not open (state: ${ISSUE_STATE})."
+            exit 1
+          fi
+
+          if ! [[ "${PIPELINE_REF}" =~ ^[A-Za-z0-9._/-]+$ ]] ||
+             [[ "${PIPELINE_REF}" == refs/* ]] ||
+             ! git check-ref-format --branch "${PIPELINE_REF}" >/dev/null 2>&1; then
+            echo "::error::Invalid pipeline branch name: '${PIPELINE_REF}'."
+            exit 1
+          fi
+          if ! gh api "repos/${REPO}/git/ref/heads/${PIPELINE_REF}" --silent >/dev/null 2>&1; then
+            echo "::error::Pipeline branch '${PIPELINE_REF}' does not exist in ${REPO}."
+            exit 1
+          fi
+
+          PLATFORMS=$(jq -r '
+            .labels[].name
+            | ascii_downcase
+            | if . == "platform/ios" then "ios"
+              elif . == "platform/macos" or . == "platform/maccatalyst" then "catalyst"
+              elif . == "platform/android" then "android"
+              elif . == "platform/windows" then "windows"
+              else empty
+              end
+          ' <<< "${ISSUE_JSON}" | sort -u)
+          PLATFORM_COUNT=$(printf '%s\n' "${PLATFORMS}" | sed '/^$/d' | wc -l | tr -d ' ')
+          if [ "${PLATFORM_COUNT}" = "1" ]; then
+            PLATFORM="${PLATFORMS}"
+            echo "Resolved platform '${PLATFORM}' from issue labels."
+          else
+            PLATFORM="android"
+            echo "::notice::Issue platform labels are inconclusive; defaulting to android."
+          fi
+
+          {
+            echo "issue_number=${ISSUE_NUMBER}"
+            echo "pipeline_ref=${PIPELINE_REF}"
+            echo "platform=${PLATFORM}"
+            echo "proceed=true"
+          } >> "$GITHUB_OUTPUT"
+
+  trigger-fix:
+    needs: preflight
+    if: needs.preflight.outputs.proceed == 'true'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: fix-trigger-${{ needs.preflight.outputs.issue_number }}
+      cancel-in-progress: false
+    timeout-minutes: 10
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
+    steps:
+      # Keep both credentials shell-local in this step. Neither credential is
+      # persisted through job outputs or passed to the queued pipeline.
+      - name: Trigger issue replication pipeline
+        id: trigger_azdo
+        env:
+          ISSUE_NUMBER: ${{ needs.preflight.outputs.issue_number }}
+          PIPELINE_REF: ${{ needs.preflight.outputs.pipeline_ref }}
+          PLATFORM: ${{ needs.preflight.outputs.platform }}
+          AZDO_TENANT_ID: ${{ secrets.AZDO_TRIGGER_TENANT_ID }}
+          AZDO_CLIENT_ID: ${{ secrets.AZDO_TRIGGER_CLIENT_ID }}
+        run: |
+          set -euo pipefail
+          trap 'unset OIDC_TOKEN AZDO_TOKEN AZURE_RESPONSE' EXIT
+
+          # 1. Get a GitHub OIDC token.
+          OIDC_TOKEN=$(curl -sS --fail-with-body \
+            -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=api://AzureADTokenExchange" \
+            | jq -er '.value')
+          echo "::add-mask::${OIDC_TOKEN}"
+
+          # 2. Exchange the OIDC token for an Azure DevOps access token.
+          AZURE_RESPONSE=$(curl -sS --fail-with-body -X POST \
+            "https://login.microsoftonline.com/${AZDO_TENANT_ID}/oauth2/v2.0/token" \
+            -d "grant_type=client_credentials" \
+            -d "client_id=${AZDO_CLIENT_ID}" \
+            -d "client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer" \
+            -d "client_assertion=${OIDC_TOKEN}" \
+            -d "scope=499b84ac-1321-427f-aa17-267ca6975798/.default")
+          unset OIDC_TOKEN
+
+          AZDO_TOKEN=$(jq -er '.access_token' <<< "${AZURE_RESPONSE}")
+          echo "::add-mask::${AZDO_TOKEN}"
+          unset AZURE_RESPONSE
+
+          # 3. Queue replicate mode from the selected pipeline implementation ref.
+          PAYLOAD=$(jq -n \
+            --arg issue "${ISSUE_NUMBER}" \
+            --arg platform "${PLATFORM}" \
+            --arg ref "refs/heads/${PIPELINE_REF}" \
+            '{
+              templateParameters: {
+                Mode: "replicate",
+                IssueNumber: $issue,
+                PRNumber: "0",
+                Platform: $platform
+              },
+              resources: { repositories: { self: { refName: $ref } } }
+            }')
+
+          RESPONSE=$(curl -sS --fail-with-body -w "\n%{http_code}" \
+            -X POST "https://dev.azure.com/DevDiv/DevDiv/_apis/pipelines/27723/runs?api-version=7.1" \
+            -H "Authorization: Bearer ${AZDO_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "${PAYLOAD}")
+          unset AZDO_TOKEN
+
+          HTTP_CODE=$(tail -n 1 <<< "${RESPONSE}")
+          RESPONSE_BODY=$(sed '$d' <<< "${RESPONSE}")
+          if ! [[ "${HTTP_CODE}" =~ ^2[0-9][0-9]$ ]]; then
+            echo "::error::Failed to queue issue replication pipeline (HTTP ${HTTP_CODE})."
+            jq . <<< "${RESPONSE_BODY}" 2>/dev/null || printf '%s\n' "${RESPONSE_BODY}"
+            exit 1
+          fi
+
+          RUN_ID=$(jq -r '.id' <<< "${RESPONSE_BODY}")
+          echo "Queued issue replication for #${ISSUE_NUMBER} on ${PLATFORM} from refs/heads/${PIPELINE_REF}."
+          echo "Run: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=${RUN_ID}"
+          echo "queued=true" >> "$GITHUB_OUTPUT"
+
+      - name: Acknowledge queued command
+        if: ${{ !cancelled() && github.event_name == 'issue_comment' && steps.trigger_azdo.outputs.queued == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          COMMENT_NODE_ID: ${{ github.event.comment.node_id }}
+          REPO: ${{ github.repository }}
+        run: |
+          if ! gh api -X POST "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" \
+            -f content=rocket --silent; then
+            echo "::warning::Could not add a reaction to the queued /fix command."
+          fi
+          if ! gh api graphql \
+            -f query="mutation(\$id:ID!){minimizeComment(input:{subjectId:\$id,classifier:RESOLVED}){minimizedComment{isMinimized}}}" \
+            -f id="${COMMENT_NODE_ID}" --silent; then
+            echo "::warning::Could not minimize the queued /fix command."
+          fi


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

- add a standalone `/fix -b <pipeline-branch>` issue-comment workflow without changing `/review`
- authorize maintainers in a read-only preflight, validate the live issue and selected `dotnet/maui` branch, infer the platform from labels, and queue DevDiv pipeline 27723 through GitHub OIDC
- add focused behavioral/security Pester coverage and document the required replicate-mode branch contract

## Independence from #37445

This PR targets `main` and is independent of #37445: it does not use that PR's branch or commits as its git base. [#37445](https://github.com/dotnet/maui/pull/37445) is linked only as development context for the replicate-mode implementation. The branch selected with `-b` must itself expose the `Mode`, `IssueNumber`, `PRNumber`, and `Platform` template parameters; after replicate mode merges, callers can select `main`.

## Validation

- 48 focused Pester tests passed (`FixTrigger.Tests.ps1` and `ReviewTrigger.Tests.ps1`)
- `actionlint .github/workflows/fix-trigger.yml`
- Ruby YAML parse and `git diff --check`