### PR TITLE
[ci] Gate Mac Catalyst tests to release branches only

### DIFF
--- a/eng/pipelines/arcade/stage-device-tests.yml
+++ b/eng/pipelines/arcade/stage-device-tests.yml
@@ -414,6 +414,8 @@ stages:
   displayName: ${{ parameters.TargetFrameworkVersion }} CoreCLR MacCatalyst Helix Tests
   dependsOn: 
     - devicetests_build_coreclr
+  # Mac Catalyst device tests only run for release branches (or PRs targeting one); see runMacCatalystTestsCondition.
+  condition: and(succeeded(), eq(variables.runMacCatalystTestsCondition, true))
   jobs:
   - template: ${{ iif(eq(parameters.runAsPublic, 'true'), '/eng/common/templates/jobs/jobs.yml', '/eng/common/templates-official/jobs/jobs.yml@self') }}
     parameters:

--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -39,6 +39,9 @@ stages:
     ${{ else }}:
       dependsOn:
       - ${{ platform }}_device_tests_${{ replace(parameters.targetFrameworkVersion.dependsOn, '.', '') }}
+    ${{ if eq(platform, 'catalyst') }}:
+      # Mac Catalyst device tests only run for release branches (or PRs targeting one); see runMacCatalystTestsCondition.
+      condition: and(succeeded(), eq(variables.runMacCatalystTestsCondition, true))
     jobs:
 
     - ${{ if eq(platform, 'android') }}:

--- a/eng/pipelines/common/ui-tests.yml
+++ b/eng/pipelines/common/ui-tests.yml
@@ -524,6 +524,8 @@ stages:
   - stage: maccatalyst_ui_tests_coreclr
     displayName: MacCatalyst UITests CoreCLR
     dependsOn: build_ui_tests_coreclr
+    # Mac Catalyst UI tests only run for release branches (or PRs targeting one); see runMacCatalystTestsCondition.
+    condition: and(succeeded(), eq(variables.runMacCatalystTestsCondition, true))
     jobs:
       - ${{ each project in parameters.projects }}:
         - ${{ if ne(project.mac, '') }}:

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -34,6 +34,11 @@ variables:
   value: $[in(variables['Build.SourceBranch'], 'refs/heads/net9.0', 'refs/heads/net10.0', 'refs/heads/main')]
 - name: signingCondition
   value: $[or( eq(variables['Sign'], 'true'), in(variables['Build.SourceBranch'], 'refs/heads/net9.0', 'refs/heads/net10.0', 'refs/heads/main', 'refs/heads/inflight/current' ), startsWith(variables['Build.SourceBranch'], 'refs/tags/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/') )]
+# True only for a release/* branch build, or a PR targeting a release/* branch.
+# Mac Catalyst tests are expensive and largely redundant with iOS coverage, so they are
+# gated to release branches only; iOS testing is unaffected and always runs.
+- name: runMacCatalystTestsCondition
+  value: $[or( startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['System.PullRequest.TargetBranch'], 'release/') )]
 # Common Agent Pools in use
 # hostedMacImage is the source of truth for Azure Pipelines hosted macOS image lanes.
 # Keep the AcesMacImageOverride mapping below aligned so AcesShared lanes target


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Mac Catalyst device/UI tests are expensive and largely redundant with iOS test coverage on every normal CI build. This PR gates Mac Catalyst **test execution** so it only runs for release branches, while leaving iOS testing completely unchanged.

### Behavior

Mac Catalyst tests now run only when:
- the build's source branch is `refs/heads/release/*` (non-PR builds), **or**
- for a PR build, the PR target branch is `release/*`

Normal `main`, `net*.0`, feature branches, and PRs targeting them no longer run Mac Catalyst tests.

This is implemented via a single shared pipeline variable, `runMacCatalystTestsCondition`, added to `eng/pipelines/common/variables.yml`:

```yaml
- name: runMacCatalystTestsCondition
  value: $[or( startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['System.PullRequest.TargetBranch'], 'release/') )]
```

This mirrors the repo's existing `signingCondition` pattern already used for release-branch detection in this file, so no new convention is introduced.

### Stages gated

| File | Stage | Purpose |
|---|---|---|
| `eng/pipelines/arcade/stage-device-tests.yml` | `devicetests_catalyst_coreclr` | Mac Catalyst Helix/device tests (used by `ci-device-tests.yml`) |
| `eng/pipelines/common/ui-tests.yml` | `maccatalyst_ui_tests_coreclr` | Mac Catalyst Appium UI tests (used by `ci-uitests.yml` / `ui-tests.yml`) |
| `eng/pipelines/common/device-tests.yml` | `catalyst_device_tests_*` (legacy internal path, used when `Build.DefinitionName != 'maui-pr-devicetests'`) | Legacy internal Mac Catalyst device tests |

Each gated stage keeps its existing `dependsOn`/success semantics by using:

```yaml
condition: and(succeeded(), eq(variables.runMacCatalystTestsCondition, true))
```

### What was intentionally left alone

- **iOS testing is completely unchanged** — no iOS stage or condition was touched.
- **Shared product/test builds are not disabled.** `devicetests_build_coreclr` (Helix) and `build_ui_tests_coreclr` (UI tests) also feed the iOS/Android test stages, so gating those builds would break non-Catalyst coverage. Only the Catalyst-specific downstream *test* stages are gated.
- `eng/pipelines/ci-copilot.yml` (the manually-triggered, `trigger: none` / `pr: none` PR-reviewer-agent pipeline) is **not** gated — it is an on-demand pipeline invoked explicitly per PR/platform, not part of normal CI branch/PR triggers, and disabling Catalyst there would remove the ability to explicitly request Catalyst validation for a specific PR.

### Validation

- `python3 -c "import yaml; yaml.safe_load(open(f))"` run against all four edited files — all parse as valid YAML.
- Manually traced every current CI surface that executes Mac Catalyst tests (`grep -rniE "catalyst" eng/pipelines`) to confirm coverage; no other stage/pipeline runs Mac Catalyst tests outside the ones listed above.
- No product/application code changed, so no build was required.

Independent of #37990 and of the separate ListView-test-removal work.