### PR TITLE
[inflight/candidate] [Windows] Fix Device test failing in the PR 37746

### DIFF
--- a/src/Core/src/Handlers/ContentView/ContentViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/ContentView/ContentViewHandler.Windows.cs
@@ -24,34 +24,42 @@ namespace Microsoft.Maui.Handlers
 
 			if (handler.VirtualView.PresentedContent is IView view)
 			{
-				var platformView = view.ToPlatform(handler.MauiContext);
-
+				if (!ReferenceEquals(handler.VirtualView.Content, view))
+				{
+					handler.PlatformView.Content = null;
+				}
+				
 				// Detach from existing parent — mirrors Android RemoveFromParent / iOS RemoveFromSuperview.
 				// Always remove via CachedChildren directly: Content = null is a no-op when _content
 				// is null (e.g. ScrollViewHandler adds via paddingShim.CachedChildren.Add, not the
 				// Content setter), leaving the element with a live parent and causing a COM exception
 				// when we try to reparent it. Only clear _content when it actually tracks fwElement.
-				if (platformView is FrameworkElement fwElement && fwElement.Parent is not null)
-				{
-					if (fwElement.Parent is ContentPanel existingContentPanel)
-					{
-						existingContentPanel.CachedChildren.Remove(fwElement);
-						if (existingContentPanel.Content == fwElement)
-						{
-							existingContentPanel.Content = null;
-						}
-					}
-					else if (fwElement.Parent is MauiPanel existingPanel)
-					{
-						existingPanel.CachedChildren.Remove(fwElement);
-					}
-				}
+				var platformView = view.ToPlatform(handler.MauiContext);
+				RemoveFromParent(platformView);
 
-				handler.PlatformView.Content = platformView;
+				handler.PlatformView.CachedChildren.Clear();
+				handler.PlatformView.Content = platformView;	
 			}
 			else
 			{
 				handler.PlatformView.Content = null;
+				handler.PlatformView.CachedChildren.Clear();
+			}
+		}
+
+		static void RemoveFromParent(FrameworkElement? platformView)
+		{
+			if (platformView?.Parent is ContentPanel existingContentPanel)
+			{
+				existingContentPanel.CachedChildren.Remove(platformView);
+				if (existingContentPanel.Content == platformView)
+				{
+					existingContentPanel.Content = null;
+				}
+			}
+			else if (platformView?.Parent is MauiPanel existingPanel)
+			{
+				existingPanel.CachedChildren.Remove(platformView);
 			}
 		}
 


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details
On Windows, dynamically updating the content of a ContentPresenter can throw a System.ArgumentException when the content contains controls such as RefreshView or ScrollView. 
 
This happens when a platform view is reused while it is still attached to its previous WinUI parent, causing a “PointerEventRouter object already has an owner” exception. 

The initial fix detached the platform view from its previous parent, but some scenarios still failed because: 
* The logical content was not detached before creating the control-template platform tree.
* ContentPanel.Content = null could leave stale children in CachedChildren. 

### Description of Change

<!-- Enter description of the fix in this section -->
### Description of Change

<!-- Enter description of the fix in this section -->
Updated the Windows ContentViewHandler content-update flow to properly handle direct, templated, and empty content. 
* Detach the existing content before creating the template platform tree. 
* Added a RemoveFromParent helper to safely detach the incoming platform view without disconnecting its handler. 
* Clear ContentPanel.CachedChildren before assigning new content or when the content becomes null.

Fixed below test cases:
Control.DeviceTests:
* ControlTemplateInitializesCorrectly 
* ControlTemplateCanBeReplacedCorrectly 
* ContentView updating it's ControlTemplate works 
* PropagateContextCorrectly

Core.DeviceTests:

* Content Initializes Correctly
* Content Updates Correctly
* ContentIsSetInitially
* WindowSupportsEmptyPage_Platform
