### PR TITLE
[iOS] Migrate deprecated Browser, FilePicker, and font APIs

### DIFF
--- a/.github/scripts/SetupVallyRuntime.sh
+++ b/.github/scripts/SetupVallyRuntime.sh
@@ -82,7 +82,7 @@ if grep -Fqx -- "--experimental" "$probe_output"; then
 	exit 1
 fi
 
-# Vally 0.12 normally creates an empty per-run Copilot home and passes it as the
+# Vally normally creates an empty per-run Copilot home and passes it as the
 # session configDirectory, which takes precedence over COPILOT_HOME. Confirm the
 # pinned executor honors the opt-out before any model credential enters the job.
 copilot_home_module="$install_root/node_modules/@microsoft/vally/dist/executor/copilot-home.js"

--- a/.github/skills/agentic-labeler/tests/eval.vally.yaml
+++ b/.github/skills/agentic-labeler/tests/eval.vally.yaml
@@ -37,7 +37,7 @@
 # Legacy scenarios AND-gated up to ~15 `output_not_contains` assertions
 # (every triage/partner/kind label spelled out) plus, for noop scenarios,
 # a fragile ~10-branch alternation regex matching phrasings of "no labels."
-# With scoring.weights omitted, Vally 0.12 computes the trial score as the
+# With scoring.weights omitted, Vally computes the trial score as the
 # UNWEIGHTED MEAN of
 # grader scores, so piling on 12 floors drowns the judge (1/13 weight) and
 # a single wrong label can't move the aggregate. This port keeps, per
@@ -998,7 +998,7 @@ stimuli:
     constraints: { max_duration: 5m, expect_skills: [agentic-labeler] }
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of grader [0,1] scores; stimulus
   # passes when the mean across runs >= threshold. Invocation is a separate
   # workflow hard veto, while 0.90 preserves the suite's prior semantic bar

--- a/.github/skills/analyze-sessions/SKILL.md
+++ b/.github/skills/analyze-sessions/SKILL.md
@@ -242,7 +242,7 @@ scoring:
 Then validate every emitted file:
 
 ```bash
-npx -y @microsoft/vally-cli@0.12.0 lint --eval-spec <path-to-eval> --strict
+npx -y @microsoft/vally-cli@0.14.0 lint --eval-spec <path-to-eval> --strict
 ```
 
 ## Privacy & safety

--- a/.github/skills/analyze-sessions/references/design-rationale.md
+++ b/.github/skills/analyze-sessions/references/design-rationale.md
@@ -162,7 +162,7 @@ generic `.github/evals/` paths are not valid targets. A different skill's
 Each eval pairs a refutation-proof **structural floor** (`output-matches` on a
 forced token line) with **one LLM judge** (`scale_1_5`, `threshold: 0.6`) so the
 judge carries ~half the weight. Each emitted file must pass
-`npx -y @microsoft/vally-cli@0.12.0 lint --eval-spec <f> --strict`. This is the
+`npx -y @microsoft/vally-cli@0.14.0 lint --eval-spec <f> --strict`. This is the
 mechanism that makes the analysis *iterative*: a failure found today becomes a
 regression test that fails if we regress tomorrow.
 

--- a/.github/skills/analyze-sessions/tests/eval.vally.yaml
+++ b/.github/skills/analyze-sessions/tests/eval.vally.yaml
@@ -19,7 +19,7 @@
 # line — immune to "mentions the word" false-fails) with ONE LLM JUDGE
 # (scale_1_5, threshold 0.6) so the judge carries ~50% of every score.
 #
-# Scoring: this suite deliberately omits scoring.weights, so Vally 0.12 uses the
+# Scoring: this suite deliberately omits scoring.weights, so Vally uses the
 # unweighted mean of grader [0,1] scores; a stimulus passes when the mean across
 # runs >= scoring.threshold (0.6). With a scale_1_5 judge (normalized =
 # (raw-1)/4):
@@ -295,7 +295,7 @@ stimuli:
       reject_skills: [analyze-sessions]
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of each stimulus's two graders
   # (one refutation-proof structural floor + one LLM judge), keeping the judge
   # at ~50% of every score per the house convention.

--- a/.github/skills/code-review/tests/eval.inline-findings.vally.yaml
+++ b/.github/skills/code-review/tests/eval.inline-findings.vally.yaml
@@ -159,7 +159,7 @@ stimuli:
         - code-review
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of the two graders' [0,1] scores;
   # the stimulus passes when the mean across runs >= threshold, and the CI
   # check keys off that mean-vs-threshold `passed` property. Two graders (one

--- a/.github/skills/code-review/tests/eval.vally.yaml
+++ b/.github/skills/code-review/tests/eval.vally.yaml
@@ -440,7 +440,7 @@ stimuli:
       max_duration: 10m
 
 scoring:
-  # Vally 0.12 supports scoring.weights, but this suite deliberately omits
+  # Vally supports scoring.weights, but this suite deliberately omits
   # them so a trial's score is the unweighted mean of its graders' [0,1]
   # scores; the stimulus score is the mean across runs. The deterministic
   # tool-calls grader is the manipulation check: a trial that never reads the

--- a/.github/skills/code-review/tests/hermeticity.vally.yaml
+++ b/.github/skills/code-review/tests/hermeticity.vally.yaml
@@ -101,7 +101,7 @@ stimuli:
       max_turns: 10
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean. Threshold 1.0 means the single stimulus must score a perfect 1.0
   # to "pass" — i.e. the agent's output matched the anonymous rate limit
   # (CORE_LIMIT:60). The hermeticity-gate job reads the verdict directly:

--- a/.github/skills/code-review/tests/soak.capability.vally.yaml
+++ b/.github/skills/code-review/tests/soak.capability.vally.yaml
@@ -474,7 +474,7 @@ stimuli:
         - code-review
 
 scoring:
-  # Vally 0.12 supports scoring.weights, but this suite deliberately omits
+  # Vally supports scoring.weights, but this suite deliberately omits
   # them so a trial's score is the unweighted mean of its graders' [0,1]
   # scores. The `prompt`
   # grader contributes ONE holistic score, so rubric criteria are not

--- a/.github/skills/evaluate-pr-tests/tests/eval.vally.yaml
+++ b/.github/skills/evaluate-pr-tests/tests/eval.vally.yaml
@@ -34,13 +34,13 @@
 # brittle (a correct finding phrased differently fails). Those move into
 # the LLM-judge rubric. Each scenario keeps at most 1–2 structural / crisp-
 # negative floors so the judge stays decisive (this suite omits
-# scoring.weights, so Vally 0.12 scores a trial as the unweighted mean of its
+# scoring.weights, so Vally scores a trial as the unweighted mean of its
 # graders). The two purely-semantic
 # detection scenarios (weak assertions, edge-case gaps) are judge-only — a
 # single prompt grader means the trial score IS the judge's normalized
 # rubric score.
 #
-# Scoring: scoring.weights is deliberately omitted, so Vally 0.12 uses the
+# Scoring: scoring.weights is deliberately omitted, so Vally uses the
 # equal-weight aggregate and the 0.6 threshold remains active.
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -405,7 +405,7 @@ stimuli:
     constraints: { max_duration: 5m, expect_skills: [evaluate-pr-tests] }
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of grader [0,1] scores; skill passes
   # when the mean across runs >= threshold. Structural section-heading floors
   # are kept only where producing the report format IS the capability; the

--- a/.github/skills/pr-review/tests/eval.gh-auth.vally.yaml
+++ b/.github/skills/pr-review/tests/eval.gh-auth.vally.yaml
@@ -160,7 +160,7 @@ stimuli:
       max_duration: 5m
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of the three graders' [0,1] scores. The structural floor
   # and guidance-read check are necessary but insufficient. Threshold 0.8
   # keeps the judge load-bearing: a partial regression (`no`, guidance read,

--- a/.github/skills/try-fix/tests/eval.vally.yaml
+++ b/.github/skills/try-fix/tests/eval.vally.yaml
@@ -28,7 +28,7 @@
 #   structural floors (e.g. "claims PASS when no device was available").
 #
 # Scoring (see scoring block): this suite deliberately omits scoring.weights,
-# so Vally 0.12 uses the unweighted mean of grader [0,1] scores; skill passes
+# so Vally uses the unweighted mean of grader [0,1] scores; skill passes
 # when the mean >= scoring.threshold (0.8), unless any trial has an execution
 # error (a separate hard failure regardless of the numeric aggregate). Every
 # scenario also has a deterministic skill-invocation grader. The workflow
@@ -463,7 +463,7 @@ stimuli:
         - try-fix
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of grader [0,1] scores; skill passes when the mean across runs >=
   # threshold. At 0.6, passing invocation/structural floors could dilute every
   # semantic judge failure to a suite score of 0.607. The 0.8 threshold keeps

--- a/.github/skills/verify-tests-fail-without-fix/tests/eval.vally.yaml
+++ b/.github/skills/verify-tests-fail-without-fix/tests/eval.vally.yaml
@@ -23,7 +23,7 @@
 # whose aggregate threshold is undefined so every grader must pass its own
 # threshold.
 #
-# Scoring: this suite deliberately omits scoring.weights, so Vally 0.12 uses
+# Scoring: this suite deliberately omits scoring.weights, so Vally uses
 # the unweighted mean of grader [0,1] scores. Every scenario also has a
 # deterministic invocation grader, and the workflow applies invocation failures
 # as a hard veto. The threshold preserves the prior semantic-judge floor after
@@ -266,7 +266,7 @@ stimuli:
         - verify-tests-fail-without-fix
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of grader [0,1] scores. At 0.87, a stimulus with invocation
   # plus one structural floor still requires judge >= 0.61, preserving the old
   # 0.60 semantic bar. Stimuli without the extra floor are intentionally

--- a/.github/workflows/skill-evaluation-soak.yml
+++ b/.github/workflows/skill-evaluation-soak.yml
@@ -22,7 +22,7 @@ permissions:
   contents: read
 
 env:
-  VALLY_VERSION: "0.12.0"
+  VALLY_VERSION: "0.14.0"
   NODE_VERSION: "22"
 
 jobs:

--- a/.github/workflows/skill-validation.yml
+++ b/.github/workflows/skill-validation.yml
@@ -94,8 +94,8 @@ permissions:
 
 env:
   # Vally CLI is run via npx from npm. Pinned for reproducibility.
-  # Vally 0.12 requires Node >=22, so we pin Node 22 on the runners.
-  VALLY_VERSION: "0.12.0"
+  # Vally requires Node >=22.12, so we pin Node 22 on the runners.
+  VALLY_VERSION: "0.14.0"
   NODE_VERSION: "22"
 
 jobs:

--- a/src/BlazorWebView/src/Maui/Tizen/TizenMauiAssetFileProvider.cs
+++ b/src/BlazorWebView/src/Maui/Tizen/TizenMauiAssetFileProvider.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Primitives;
+using Microsoft.Maui.Storage;
 using Tizen.Applications;
 
 namespace Microsoft.AspNetCore.Components.WebView.Maui
@@ -21,10 +22,20 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		}
 
 		public IDirectoryContents GetDirectoryContents(string subpath)
-			=> new TizenMauiAssetDirectoryContents(Path.Combine(_resDir, subpath));
+		{
+			var resolvedPath = FileSystemUtils.Combine(_resDir, subpath);
+			if (resolvedPath is null)
+				return NotFoundDirectoryContents.Singleton;
+			return new TizenMauiAssetDirectoryContents(resolvedPath);
+		}
 
 		public IFileInfo GetFileInfo(string subpath)
-			=> new TizenMauiAssetFileInfo(Path.Combine(_resDir, subpath));
+		{
+			var resolvedPath = FileSystemUtils.Combine(_resDir, subpath);
+			if (resolvedPath is null)
+				return new NotFoundFileInfo(subpath);
+			return new TizenMauiAssetFileInfo(resolvedPath);
+		}
 
 		public IChangeToken Watch(string filter)
 			=> NullChangeToken.Singleton;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32941.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32941.cs
@@ -19,6 +19,7 @@ public class Issue32941 : _IssuesUITest
 	public void ShellContentShouldRespectSafeAreaEdges_After_Navigation()
 	{
 		App.WaitForElement("MainPageLabel");
+		App.WaitForElement("GoToSignOutButton");
 		App.Tap("GoToSignOutButton");
 		App.WaitForElement("SignOutLabel");
 

--- a/src/Core/src/Fonts/EmbeddedFontLoader.iOS.cs
+++ b/src/Core/src/Fonts/EmbeddedFontLoader.iOS.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.IO;
+using System.Security.Cryptography;
 using CoreGraphics;
 using CoreText;
 using Foundation;
@@ -13,11 +14,14 @@ namespace Microsoft.Maui
 	/// <inheritdoc/>
 	public partial class EmbeddedFontLoader
 	{
+		const string FontCacheFolderName = "Microsoft.Maui.Fonts";
+		static readonly object FontCacheLock = new();
 
 		/// <inheritdoc/>
 		public string? LoadFont(EmbeddedFont font)
 		{
-			string? temporaryFontPath = null;
+			string? cachedFontPath = null;
+			var deleteCachedFontOnFailure = false;
 
 			try
 			{
@@ -30,14 +34,8 @@ namespace Microsoft.Maui
 				}
 				else
 				{
-					temporaryFontPath = Path.ChangeExtension(
-						Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()),
-						Path.GetExtension(font.FontName));
-
-					using (var temporaryFontStream = File.Create(temporaryFontPath))
-						font.ResourceStream.CopyTo(temporaryFontStream);
-
-					fontPath = temporaryFontPath;
+					(cachedFontPath, deleteCachedFontOnFailure) = CacheFont(font);
+					fontPath = cachedFontPath;
 				}
 
 				using var provider = new CGDataProvider(fontPath);
@@ -61,15 +59,63 @@ namespace Microsoft.Maui
 			}
 			catch (Exception ex)
 			{
+				if (deleteCachedFontOnFailure && cachedFontPath is not null)
+					DeleteTemporaryFont(cachedFontPath);
+
 				_serviceProvider?.CreateLogger<EmbeddedFontLoader>()?.LogWarning(ex, "Unable register font {Font} with the system.", font.FontName);
-			}
-			finally
-			{
-				if (temporaryFontPath is not null)
-					DeleteTemporaryFont(temporaryFontPath);
 			}
 
 			return null;
+		}
+
+		(string FontPath, bool Created) CacheFont(EmbeddedFont font)
+		{
+			var cacheDirectory = Path.Combine(Path.GetTempPath(), FontCacheFolderName);
+			Directory.CreateDirectory(cacheDirectory);
+
+			var temporaryFontPath = Path.Combine(cacheDirectory, Path.GetRandomFileName());
+
+			try
+			{
+				byte[] hash;
+
+				using (var hashAlgorithm = SHA256.Create())
+				{
+					using (var temporaryFontStream = File.Create(temporaryFontPath))
+					using (var hashingStream = new CryptoStream(temporaryFontStream, hashAlgorithm, CryptoStreamMode.Write))
+					{
+						font.ResourceStream!.CopyTo(hashingStream);
+						hashingStream.FlushFinalBlock();
+					}
+
+					hash = hashAlgorithm.Hash!;
+				}
+
+				var extension = Path.GetExtension(font.FontName);
+				var cachedFontName = Convert.ToHexString(hash);
+				if (!string.IsNullOrEmpty(extension))
+					cachedFontName += extension;
+
+				var cachedFontPath = Path.Combine(cacheDirectory, cachedFontName);
+
+				lock (FontCacheLock)
+				{
+					if (File.Exists(cachedFontPath))
+					{
+						DeleteTemporaryFont(temporaryFontPath);
+						return (cachedFontPath, false);
+					}
+
+					File.Move(temporaryFontPath, cachedFontPath);
+				}
+
+				return (cachedFontPath, true);
+			}
+			catch
+			{
+				DeleteTemporaryFont(temporaryFontPath);
+				throw;
+			}
 		}
 
 		void DeleteTemporaryFont(string fontPath)

--- a/src/Core/src/Fonts/EmbeddedFontLoader.iOS.cs
+++ b/src/Core/src/Fonts/EmbeddedFontLoader.iOS.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.IO;
 using CoreGraphics;
 using CoreText;
 using Foundation;
@@ -16,54 +17,75 @@ namespace Microsoft.Maui
 		/// <inheritdoc/>
 		public string? LoadFont(EmbeddedFont font)
 		{
+			string? temporaryFontPath = null;
+
 			try
 			{
-				CGFont? cgFont;
+				var fontPath = font.FontName;
 
-				if (font.ResourceStream == null)
+				if (font.ResourceStream is null)
 				{
-					if (!System.IO.File.Exists(font.FontName))
+					if (!File.Exists(fontPath))
 						throw new InvalidOperationException("ResourceStream was null.");
-
-					var provider = new CGDataProvider(font.FontName);
-					cgFont = CGFont.CreateFromProvider(provider);
 				}
 				else
 				{
-					var data = NSData.FromStream(font.ResourceStream);
-					if (data == null)
-						throw new InvalidOperationException("Unable to load font stream data.");
-					var provider = new CGDataProvider(data);
-					cgFont = CGFont.CreateFromProvider(provider);
+					temporaryFontPath = Path.ChangeExtension(
+						Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()),
+						Path.GetExtension(font.FontName));
+
+					using (var temporaryFontStream = File.Create(temporaryFontPath))
+						font.ResourceStream.CopyTo(temporaryFontStream);
+
+					fontPath = temporaryFontPath;
 				}
+
+				using var provider = new CGDataProvider(fontPath);
+				using var cgFont = CGFont.CreateFromProvider(provider);
 
 				if (cgFont == null)
 					throw new InvalidOperationException("Unable to load font from the stream.");
 
 				var name = cgFont.PostScriptName;
 
-#pragma warning disable CA1416  // TODO:  'RegisterGraphicsFont' is obsolete on: 'ios' 15.0 and later
-#pragma warning disable CA1422
-				if (CTFontManager.RegisterGraphicsFont(cgFont, out var error))
+				using var fontUrl = NSUrl.FromFilename(fontPath);
+				var error = CTFontManager.RegisterFontsForUrl(fontUrl, CTFontManagerScope.Process);
+				if (error is null)
 					return name;
-#pragma warning restore CA1422
-#pragma warning restore CA1416
 
 				var uiFont = UIFont.FromName(name, 10);
 				if (uiFont != null)
 					return name;
 
-				if (error != null)
-					throw new NSErrorException(error);
-				else
-					throw new InvalidOperationException("Unable to load font from the stream.");
+				throw new NSErrorException(error);
 			}
 			catch (Exception ex)
 			{
 				_serviceProvider?.CreateLogger<EmbeddedFontLoader>()?.LogWarning(ex, "Unable register font {Font} with the system.", font.FontName);
 			}
+			finally
+			{
+				if (temporaryFontPath is not null)
+					DeleteTemporaryFont(temporaryFontPath);
+			}
 
 			return null;
+		}
+
+		void DeleteTemporaryFont(string fontPath)
+		{
+			try
+			{
+				File.Delete(fontPath);
+			}
+			catch (IOException ex)
+			{
+				_serviceProvider?.CreateLogger<EmbeddedFontLoader>()?.LogWarning(ex, "Unable to delete temporary font file {FontPath}.", fontPath);
+			}
+			catch (UnauthorizedAccessException ex)
+			{
+				_serviceProvider?.CreateLogger<EmbeddedFontLoader>()?.LogWarning(ex, "Unable to delete temporary font file {FontPath}.", fontPath);
+			}
 		}
 	}
 }

--- a/src/Core/src/Fonts/EmbeddedFontLoader.iOS.cs
+++ b/src/Core/src/Fonts/EmbeddedFontLoader.iOS.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui
 				if (font.ResourceStream is null)
 				{
 					if (!File.Exists(fontPath))
-						throw new InvalidOperationException("ResourceStream was null.");
+						throw new FileNotFoundException($"Font file '{fontPath}' was not found.", fontPath);
 				}
 				else
 				{

--- a/src/Core/tests/DeviceTests/Services/FontManagerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Services/FontManagerTests.iOS.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Foundation;
 using UIKit;
 using Xunit;
 
@@ -35,6 +36,11 @@ public partial class FontManagerTests : TestBase
 			manager.GetFont(Font.OfSize("embedded-dokdo", manager.DefaultFontSize)));
 
 		Assert.Equal("Dokdo", font.FamilyName);
+
+		using var text = new NSString("Maui");
+		var measuredSize = text.GetSizeUsingAttributes(new UIStringAttributes { Font = font });
+		Assert.True(measuredSize.Width > 0);
+		Assert.True(measuredSize.Height > 0);
 	}
 
 }

--- a/src/Core/tests/DeviceTests/Services/FontManagerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Services/FontManagerTests.iOS.cs
@@ -24,4 +24,17 @@ public partial class FontManagerTests : TestBase
 		Assert.Equal(expectedFamilyName, font.FamilyName);
 	}
 
+	[Fact]
+	public async System.Threading.Tasks.Task CanLoadEmbeddedFont()
+	{
+		var registrar = new FontRegistrar(new EmbeddedFontLoader());
+		registrar.Register("dokdo_regular.ttf", "embedded-dokdo", GetType().Assembly);
+		var manager = new FontManager(registrar);
+
+		var font = await InvokeOnMainThreadAsync(() =>
+			manager.GetFont(Font.OfSize("embedded-dokdo", manager.DefaultFontSize)));
+
+		Assert.Equal("Dokdo", font.FamilyName);
+	}
+
 }

--- a/src/Essentials/src/Browser/Browser.ios.cs
+++ b/src/Essentials/src/Browser/Browser.ios.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Maui.ApplicationModel
 		private static async Task LaunchSafariViewController(Uri uri, BrowserLaunchOptions options)
 		{
 			var nativeUrl = new NSUrl(uri.AbsoluteUri);
-			var configuration = new SFSafariViewControllerConfiguration
+			using var configuration = new SFSafariViewControllerConfiguration
 			{
 				EntersReaderIfAvailable = false,
 			};

--- a/src/Essentials/src/Browser/Browser.ios.cs
+++ b/src/Essentials/src/Browser/Browser.ios.cs
@@ -28,11 +28,11 @@ namespace Microsoft.Maui.ApplicationModel
 		private static async Task LaunchSafariViewController(Uri uri, BrowserLaunchOptions options)
 		{
 			var nativeUrl = new NSUrl(uri.AbsoluteUri);
-#pragma warning disable CA1416 // TODO: 'SFSafariViewController(NSUrl, bool)' is unsupported on: 'ios' 11.0 and later, there is an overload SFSafariViewController(NSUrl, SFSafariViewControllerConfiguration) supported from ios 11.0+
-#pragma warning disable CA1422 // Validate platform compatibility
-			var sfViewController = new SFSafariViewController(nativeUrl, false);
-#pragma warning restore CA1422 // Validate platform compatibility
-#pragma warning restore CA1416 // probably need to call the overloads depending on OS version
+			var configuration = new SFSafariViewControllerConfiguration
+			{
+				EntersReaderIfAvailable = false,
+			};
+			var sfViewController = new SFSafariViewController(nativeUrl, configuration);
 			var vc = WindowStateManager.Default.GetCurrentUIViewController(true)!;
 
 			if (options.PreferredToolbarColor != null)

--- a/src/Essentials/src/FilePicker/FilePicker.ios.cs
+++ b/src/Essentials/src/FilePicker/FilePicker.ios.cs
@@ -96,8 +96,7 @@ namespace Microsoft.Maui.Storage
 			{
 				var contentType = UTType.CreateFromIdentifier(allowedUti);
 
-				if (contentType is null &&
-					(!allowedUti.Contains(".", StringComparison.Ordinal) || allowedUti.StartsWith(".", StringComparison.Ordinal)))
+				if (contentType is null)
 					contentType = UTType.GetType(allowedUti.TrimStart('.'), UTTagClass.FilenameExtension, null);
 
 				contentTypes.Add(contentType ?? UTType.CreateImportedType(allowedUti));

--- a/src/Essentials/src/FilePicker/FilePicker.ios.cs
+++ b/src/Essentials/src/FilePicker/FilePicker.ios.cs
@@ -1,11 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Versioning;
 using System.Threading.Tasks;
 using Foundation;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Devices;
-using MobileCoreServices;
+using UniformTypeIdentifiers;
 using UIKit;
 
 namespace Microsoft.Maui.Storage
@@ -14,13 +15,11 @@ namespace Microsoft.Maui.Storage
 	{
 		async Task<IEnumerable<FileResult>> PlatformPickAsync(PickOptions options, bool allowMultiple = false)
 		{
-#pragma warning disable CA1416 // TODO: UTType has [UnsupportedOSPlatform("ios14.0")]
-#pragma warning disable CA1422 // Validate platform compatibility
 			var allowedUtis = options?.FileTypes?.Value?.ToArray() ?? new string[]
 			{
-				UTType.Content,
-				UTType.Item,
-				"public.data"
+				FilePickerUTType.Content,
+				FilePickerUTType.Item,
+				FilePickerUTType.Data
 			};
 
 			var tcs = new TaskCompletionSource<IEnumerable<FileResult>>();
@@ -28,9 +27,7 @@ namespace Microsoft.Maui.Storage
 			// Use Open instead of Import so that we can attempt to use the original file.
 			// If the file is from an external provider, then it will be downloaded.
 
-			using var documentPicker = new UIDocumentPickerViewController(allowedUtis, UIDocumentPickerMode.Open);
-#pragma warning restore CA1422 // Validate platform compatibility
-#pragma warning restore CA1416 // Constructor UIDocumentPickerViewController  has [UnsupportedOSPlatform("ios14.0")]
+			using var documentPicker = CreateDocumentPicker(allowedUtis);
 			documentPicker.AllowsMultipleSelection = allowMultiple;
 
 			if (OperatingSystem.IsIOSVersionAtLeast(11) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 1))
@@ -79,6 +76,36 @@ namespace Microsoft.Maui.Storage
 			return await tcs.Task;
 		}
 
+		static UIDocumentPickerViewController CreateDocumentPicker(string[] allowedUtis)
+		{
+			if (OperatingSystem.IsIOSVersionAtLeast(14) || OperatingSystem.IsMacCatalystVersionAtLeast(14))
+				return CreateModernDocumentPicker(allowedUtis);
+
+#pragma warning disable CA1416, CA1422 // The string-based constructor is required for MAUI's iOS 13 support.
+			return new UIDocumentPickerViewController(allowedUtis, UIDocumentPickerMode.Open);
+#pragma warning restore CA1416, CA1422
+		}
+
+		[SupportedOSPlatform("ios14.0")]
+		[SupportedOSPlatform("maccatalyst14.0")]
+		static UIDocumentPickerViewController CreateModernDocumentPicker(string[] allowedUtis)
+		{
+			var contentTypes = new List<UTType>(allowedUtis.Length);
+
+			foreach (var allowedUti in allowedUtis)
+			{
+				var contentType = UTType.CreateFromIdentifier(allowedUti);
+
+				if (contentType is null &&
+					(!allowedUti.Contains(".", StringComparison.Ordinal) || allowedUti.StartsWith(".", StringComparison.Ordinal)))
+					contentType = UTType.GetType(allowedUti.TrimStart('.'), UTTagClass.FilenameExtension, null);
+
+				contentTypes.Add(contentType ?? UTType.CreateImportedType(allowedUti));
+			}
+
+			return new UIDocumentPickerViewController(contentTypes.ToArray(), asCopy: false);
+		}
+
 		static async void GetFileResults(NSUrl[] urls, TaskCompletionSource<IEnumerable<FileResult>> tcs)
 		{
 			try
@@ -110,43 +137,54 @@ namespace Microsoft.Maui.Storage
 
 	public partial class FilePickerFileType
 	{
-#pragma warning disable CA1416 // TODO: UTType has [UnsupportedOSPlatform("ios14.0")]
-#pragma warning disable CA1422 // Validate platform compatibility
 		static FilePickerFileType PlatformImageFileType() =>
 			new(new Dictionary<DevicePlatform, IEnumerable<string>>
 			{
-				{ DevicePlatform.iOS, new[] { (string)UTType.Image } },
-				{ DevicePlatform.MacCatalyst, new[] { (string)UTType.Image } }
+				{ DevicePlatform.iOS, new[] { FilePickerUTType.Image } },
+				{ DevicePlatform.MacCatalyst, new[] { FilePickerUTType.Image } }
 			});
 
 		static FilePickerFileType PlatformPngFileType() =>
 			new(new Dictionary<DevicePlatform, IEnumerable<string>>
 			{
-				{ DevicePlatform.iOS, new[] { (string)UTType.PNG } },
-				{ DevicePlatform.MacCatalyst, new[] { (string)UTType.PNG } }
+				{ DevicePlatform.iOS, new[] { FilePickerUTType.Png } },
+				{ DevicePlatform.MacCatalyst, new[] { FilePickerUTType.Png } }
 			});
 
 		static FilePickerFileType PlatformJpegFileType() =>
 			new(new Dictionary<DevicePlatform, IEnumerable<string>>
 			{
-				{ DevicePlatform.iOS, new[] { (string)UTType.JPEG } },
-				{ DevicePlatform.MacCatalyst, new[] { (string)UTType.JPEG } }
+				{ DevicePlatform.iOS, new[] { FilePickerUTType.Jpeg } },
+				{ DevicePlatform.MacCatalyst, new[] { FilePickerUTType.Jpeg } }
 			});
 
 		static FilePickerFileType PlatformVideoFileType() =>
 			new(new Dictionary<DevicePlatform, IEnumerable<string>>
 			{
-				{ DevicePlatform.iOS, new string[] { UTType.MPEG4, UTType.Video, UTType.AVIMovie, UTType.AppleProtectedMPEG4Video, "mp4", "m4v", "mpg", "mpeg", "mp2", "mov", "avi", "mkv", "flv", "gifv", "qt" } },
-				{ DevicePlatform.MacCatalyst, new string[] { UTType.MPEG4, UTType.Video, UTType.AVIMovie, UTType.AppleProtectedMPEG4Video, "mp4", "m4v", "mpg", "mpeg", "mp2", "mov", "avi", "mkv", "flv", "gifv", "qt" } }
+				{ DevicePlatform.iOS, new string[] { FilePickerUTType.Mpeg4, FilePickerUTType.Video, FilePickerUTType.AviMovie, FilePickerUTType.AppleProtectedMpeg4Video, "mp4", "m4v", "mpg", "mpeg", "mp2", "mov", "avi", "mkv", "flv", "gifv", "qt" } },
+				{ DevicePlatform.MacCatalyst, new string[] { FilePickerUTType.Mpeg4, FilePickerUTType.Video, FilePickerUTType.AviMovie, FilePickerUTType.AppleProtectedMpeg4Video, "mp4", "m4v", "mpg", "mpeg", "mp2", "mov", "avi", "mkv", "flv", "gifv", "qt" } }
 			});
 
 		static FilePickerFileType PlatformPdfFileType() =>
 			new(new Dictionary<DevicePlatform, IEnumerable<string>>
 			{
-				{ DevicePlatform.iOS, new[] { (string)UTType.PDF } },
-				{ DevicePlatform.MacCatalyst, new[] { (string)UTType.PDF } }
+				{ DevicePlatform.iOS, new[] { FilePickerUTType.Pdf } },
+				{ DevicePlatform.MacCatalyst, new[] { FilePickerUTType.Pdf } }
 			});
-#pragma warning restore CA1422 // Validate platform compatibility
-#pragma warning restore CA1416
+	}
+
+	static class FilePickerUTType
+	{
+		public const string Content = "public.content";
+		public const string Item = "public.item";
+		public const string Data = "public.data";
+		public const string Image = "public.image";
+		public const string Png = "public.png";
+		public const string Jpeg = "public.jpeg";
+		public const string Mpeg4 = "public.mpeg-4";
+		public const string Video = "public.video";
+		public const string AviMovie = "public.avi";
+		public const string AppleProtectedMpeg4Video = "com.apple.protected-mpeg-4-video";
+		public const string Pdf = "com.adobe.pdf";
 	}
 }

--- a/src/Essentials/src/FilePicker/FilePicker.ios.cs
+++ b/src/Essentials/src/FilePicker/FilePicker.ios.cs
@@ -79,9 +79,13 @@ namespace Microsoft.Maui.Storage
 		static UIDocumentPickerViewController CreateDocumentPicker(string[] allowedUtis)
 		{
 			if (OperatingSystem.IsIOSVersionAtLeast(14) || OperatingSystem.IsMacCatalystVersionAtLeast(14))
-				return CreateModernDocumentPicker(allowedUtis);
+			{
+				var modernDocumentPicker = CreateModernDocumentPicker(allowedUtis);
+				if (modernDocumentPicker is not null)
+					return modernDocumentPicker;
+			}
 
-#pragma warning disable CA1416, CA1422 // The string-based constructor is required for MAUI's iOS 13 support.
+#pragma warning disable CA1416, CA1422 // Required for iOS 13 and to preserve unsupported custom identifier behavior.
 			return new UIDocumentPickerViewController(allowedUtis, UIDocumentPickerMode.Open);
 #pragma warning restore CA1416, CA1422
 		}
@@ -94,15 +98,19 @@ namespace Microsoft.Maui.Storage
 
 			foreach (var allowedUti in allowedUtis)
 			{
-				var contentType = UTType.CreateFromIdentifier(allowedUti);
+				var contentType = UTType.CreateFromIdentifier(allowedUti)
+					?? UTType.GetType(allowedUti.TrimStart('.'), UTTagClass.FilenameExtension, null);
 
-				if (contentType is null)
-					contentType = UTType.GetType(allowedUti.TrimStart('.'), UTTagClass.FilenameExtension, null);
+				if (contentType is null && allowedUti.IndexOf('.', StringComparison.Ordinal) > 0)
+					contentType = UTType.CreateImportedType(allowedUti);
 
-				contentTypes.Add(contentType ?? UTType.CreateImportedType(allowedUti));
+				if (contentType is not null)
+					contentTypes.Add(contentType);
 			}
 
-			return new UIDocumentPickerViewController(contentTypes.ToArray(), asCopy: false);
+			return contentTypes.Count == 0
+				? null
+				: new UIDocumentPickerViewController(contentTypes.ToArray(), asCopy: false);
 		}
 
 		static async void GetFileResults(NSUrl[] urls, TaskCompletionSource<IEnumerable<FileResult>> tcs)

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
@@ -120,7 +120,6 @@ namespace Microsoft.Maui.IntegrationTests
 				buildProps.Add("PublishAot=true");
 				buildProps.Add("PublishAotUsingRuntimePack=true"); // TODO: This parameter will become obsolete https://github.com/dotnet/runtime/issues/87060
 				buildProps.Add("_IsPublishing=true"); // using dotnet build with -p:_IsPublishing=true enables targeting simulators
-				buildProps.Add("IlcTreatWarningsAsErrors=false"); // TODO: Remove this once all warnings are fixed https://github.com/dotnet/maui/issues/19397
 				// Restrict to iOS-only to avoid restoring NativeAOT packages for other platforms (e.g., Android)
 				// which may not be available in the configured NuGet sources
 				buildProps.Add($"TargetFrameworks={framework}-ios");


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Migrates three deprecated Apple platform API usages while preserving behavior across MAUI's supported iOS 13+ and Mac Catalyst 15+ versions:

- Creates `SFSafariViewController` with `SFSafariViewControllerConfiguration`, explicitly retaining `EntersReaderIfAvailable = false`.
- Uses the `UniformTypeIdentifiers.UTType` document-picker API on iOS and Mac Catalyst 14+, while retaining the legacy string-based constructor for iOS 13 and when no custom identifier resolves. `asCopy: false` preserves the existing open-in-place behavior.
- Registers embedded fonts from file URLs with process scope instead of the obsolete graphics-font registration API. Stream-backed resources are copied into a SHA-256 content-addressed cache under the temporary directory and retained for the process lifetime because Core Text uses the URL as the font's backing store; cache entries are reused and newly created entries are removed if registration fails.
- Adds an Apple device test covering registration, resolution, and glyph measurement of an embedded font resource.

There are no public API changes. The replacement APIs predate MAUI's current platform minimums except for the modern document picker, which is guarded by the compatibility path.

### Validation

- Essentials built for `net10.0-ios26.0` and `net10.0-maccatalyst26.0` with no warnings or errors.
- Core built for both Apple TFMs with no warnings or errors.
- Core device tests compiled for iOS simulator and Mac Catalyst with no warnings or errors.
- Apple runtime execution remains for CI/macOS validation, particularly custom file-type filtering and stream-backed font registration.

### Issues Fixed

N/A — resolves TODO-linked deprecated API usage.