### PR TITLE
[Windows] TextBox: Cache template ScrollViewer

### DIFF
--- a/.github/scripts/SetupVallyRuntime.sh
+++ b/.github/scripts/SetupVallyRuntime.sh
@@ -82,7 +82,7 @@ if grep -Fqx -- "--experimental" "$probe_output"; then
 	exit 1
 fi
 
-# Vally 0.12 normally creates an empty per-run Copilot home and passes it as the
+# Vally normally creates an empty per-run Copilot home and passes it as the
 # session configDirectory, which takes precedence over COPILOT_HOME. Confirm the
 # pinned executor honors the opt-out before any model credential enters the job.
 copilot_home_module="$install_root/node_modules/@microsoft/vally/dist/executor/copilot-home.js"

--- a/.github/skills/agentic-labeler/tests/eval.vally.yaml
+++ b/.github/skills/agentic-labeler/tests/eval.vally.yaml
@@ -37,7 +37,7 @@
 # Legacy scenarios AND-gated up to ~15 `output_not_contains` assertions
 # (every triage/partner/kind label spelled out) plus, for noop scenarios,
 # a fragile ~10-branch alternation regex matching phrasings of "no labels."
-# With scoring.weights omitted, Vally 0.12 computes the trial score as the
+# With scoring.weights omitted, Vally computes the trial score as the
 # UNWEIGHTED MEAN of
 # grader scores, so piling on 12 floors drowns the judge (1/13 weight) and
 # a single wrong label can't move the aggregate. This port keeps, per
@@ -998,7 +998,7 @@ stimuli:
     constraints: { max_duration: 5m, expect_skills: [agentic-labeler] }
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of grader [0,1] scores; stimulus
   # passes when the mean across runs >= threshold. Invocation is a separate
   # workflow hard veto, while 0.90 preserves the suite's prior semantic bar

--- a/.github/skills/analyze-sessions/SKILL.md
+++ b/.github/skills/analyze-sessions/SKILL.md
@@ -242,7 +242,7 @@ scoring:
 Then validate every emitted file:
 
 ```bash
-npx -y @microsoft/vally-cli@0.12.0 lint --eval-spec <path-to-eval> --strict
+npx -y @microsoft/vally-cli@0.14.0 lint --eval-spec <path-to-eval> --strict
 ```
 
 ## Privacy & safety

--- a/.github/skills/analyze-sessions/references/design-rationale.md
+++ b/.github/skills/analyze-sessions/references/design-rationale.md
@@ -162,7 +162,7 @@ generic `.github/evals/` paths are not valid targets. A different skill's
 Each eval pairs a refutation-proof **structural floor** (`output-matches` on a
 forced token line) with **one LLM judge** (`scale_1_5`, `threshold: 0.6`) so the
 judge carries ~half the weight. Each emitted file must pass
-`npx -y @microsoft/vally-cli@0.12.0 lint --eval-spec <f> --strict`. This is the
+`npx -y @microsoft/vally-cli@0.14.0 lint --eval-spec <f> --strict`. This is the
 mechanism that makes the analysis *iterative*: a failure found today becomes a
 regression test that fails if we regress tomorrow.
 

--- a/.github/skills/analyze-sessions/tests/eval.vally.yaml
+++ b/.github/skills/analyze-sessions/tests/eval.vally.yaml
@@ -19,7 +19,7 @@
 # line — immune to "mentions the word" false-fails) with ONE LLM JUDGE
 # (scale_1_5, threshold 0.6) so the judge carries ~50% of every score.
 #
-# Scoring: this suite deliberately omits scoring.weights, so Vally 0.12 uses the
+# Scoring: this suite deliberately omits scoring.weights, so Vally uses the
 # unweighted mean of grader [0,1] scores; a stimulus passes when the mean across
 # runs >= scoring.threshold (0.6). With a scale_1_5 judge (normalized =
 # (raw-1)/4):
@@ -295,7 +295,7 @@ stimuli:
       reject_skills: [analyze-sessions]
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of each stimulus's two graders
   # (one refutation-proof structural floor + one LLM judge), keeping the judge
   # at ~50% of every score per the house convention.

--- a/.github/skills/code-review/tests/eval.inline-findings.vally.yaml
+++ b/.github/skills/code-review/tests/eval.inline-findings.vally.yaml
@@ -159,7 +159,7 @@ stimuli:
         - code-review
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of the two graders' [0,1] scores;
   # the stimulus passes when the mean across runs >= threshold, and the CI
   # check keys off that mean-vs-threshold `passed` property. Two graders (one

--- a/.github/skills/code-review/tests/eval.vally.yaml
+++ b/.github/skills/code-review/tests/eval.vally.yaml
@@ -440,7 +440,7 @@ stimuli:
       max_duration: 10m
 
 scoring:
-  # Vally 0.12 supports scoring.weights, but this suite deliberately omits
+  # Vally supports scoring.weights, but this suite deliberately omits
   # them so a trial's score is the unweighted mean of its graders' [0,1]
   # scores; the stimulus score is the mean across runs. The deterministic
   # tool-calls grader is the manipulation check: a trial that never reads the

--- a/.github/skills/code-review/tests/hermeticity.vally.yaml
+++ b/.github/skills/code-review/tests/hermeticity.vally.yaml
@@ -101,7 +101,7 @@ stimuli:
       max_turns: 10
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean. Threshold 1.0 means the single stimulus must score a perfect 1.0
   # to "pass" — i.e. the agent's output matched the anonymous rate limit
   # (CORE_LIMIT:60). The hermeticity-gate job reads the verdict directly:

--- a/.github/skills/code-review/tests/soak.capability.vally.yaml
+++ b/.github/skills/code-review/tests/soak.capability.vally.yaml
@@ -474,7 +474,7 @@ stimuli:
         - code-review
 
 scoring:
-  # Vally 0.12 supports scoring.weights, but this suite deliberately omits
+  # Vally supports scoring.weights, but this suite deliberately omits
   # them so a trial's score is the unweighted mean of its graders' [0,1]
   # scores. The `prompt`
   # grader contributes ONE holistic score, so rubric criteria are not

--- a/.github/skills/evaluate-pr-tests/tests/eval.vally.yaml
+++ b/.github/skills/evaluate-pr-tests/tests/eval.vally.yaml
@@ -34,13 +34,13 @@
 # brittle (a correct finding phrased differently fails). Those move into
 # the LLM-judge rubric. Each scenario keeps at most 1–2 structural / crisp-
 # negative floors so the judge stays decisive (this suite omits
-# scoring.weights, so Vally 0.12 scores a trial as the unweighted mean of its
+# scoring.weights, so Vally scores a trial as the unweighted mean of its
 # graders). The two purely-semantic
 # detection scenarios (weak assertions, edge-case gaps) are judge-only — a
 # single prompt grader means the trial score IS the judge's normalized
 # rubric score.
 #
-# Scoring: scoring.weights is deliberately omitted, so Vally 0.12 uses the
+# Scoring: scoring.weights is deliberately omitted, so Vally uses the
 # equal-weight aggregate and the 0.6 threshold remains active.
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -405,7 +405,7 @@ stimuli:
     constraints: { max_duration: 5m, expect_skills: [evaluate-pr-tests] }
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of grader [0,1] scores; skill passes
   # when the mean across runs >= threshold. Structural section-heading floors
   # are kept only where producing the report format IS the capability; the

--- a/.github/skills/pr-review/tests/eval.gh-auth.vally.yaml
+++ b/.github/skills/pr-review/tests/eval.gh-auth.vally.yaml
@@ -160,7 +160,7 @@ stimuli:
       max_duration: 5m
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of the three graders' [0,1] scores. The structural floor
   # and guidance-read check are necessary but insufficient. Threshold 0.8
   # keeps the judge load-bearing: a partial regression (`no`, guidance read,

--- a/.github/skills/try-fix/tests/eval.vally.yaml
+++ b/.github/skills/try-fix/tests/eval.vally.yaml
@@ -28,7 +28,7 @@
 #   structural floors (e.g. "claims PASS when no device was available").
 #
 # Scoring (see scoring block): this suite deliberately omits scoring.weights,
-# so Vally 0.12 uses the unweighted mean of grader [0,1] scores; skill passes
+# so Vally uses the unweighted mean of grader [0,1] scores; skill passes
 # when the mean >= scoring.threshold (0.8), unless any trial has an execution
 # error (a separate hard failure regardless of the numeric aggregate). Every
 # scenario also has a deterministic skill-invocation grader. The workflow
@@ -463,7 +463,7 @@ stimuli:
         - try-fix
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of grader [0,1] scores; skill passes when the mean across runs >=
   # threshold. At 0.6, passing invocation/structural floors could dilute every
   # semantic judge failure to a suite score of 0.607. The 0.8 threshold keeps

--- a/.github/skills/verify-tests-fail-without-fix/tests/eval.vally.yaml
+++ b/.github/skills/verify-tests-fail-without-fix/tests/eval.vally.yaml
@@ -23,7 +23,7 @@
 # whose aggregate threshold is undefined so every grader must pass its own
 # threshold.
 #
-# Scoring: this suite deliberately omits scoring.weights, so Vally 0.12 uses
+# Scoring: this suite deliberately omits scoring.weights, so Vally uses
 # the unweighted mean of grader [0,1] scores. Every scenario also has a
 # deterministic invocation grader, and the workflow applies invocation failures
 # as a hard veto. The threshold preserves the prior semantic-judge floor after
@@ -266,7 +266,7 @@ stimuli:
         - verify-tests-fail-without-fix
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of grader [0,1] scores. At 0.87, a stimulus with invocation
   # plus one structural floor still requires judge >= 0.61, preserving the old
   # 0.60 semantic bar. Stimuli without the extra floor are intentionally

--- a/.github/workflows/skill-evaluation-soak.yml
+++ b/.github/workflows/skill-evaluation-soak.yml
@@ -22,7 +22,7 @@ permissions:
   contents: read
 
 env:
-  VALLY_VERSION: "0.12.0"
+  VALLY_VERSION: "0.14.0"
   NODE_VERSION: "22"
 
 jobs:

--- a/.github/workflows/skill-validation.yml
+++ b/.github/workflows/skill-validation.yml
@@ -94,8 +94,8 @@ permissions:
 
 env:
   # Vally CLI is run via npx from npm. Pinned for reproducibility.
-  # Vally 0.12 requires Node >=22, so we pin Node 22 on the runners.
-  VALLY_VERSION: "0.12.0"
+  # Vally requires Node >=22.12, so we pin Node 22 on the runners.
+  VALLY_VERSION: "0.14.0"
   NODE_VERSION: "22"
 
 jobs:

--- a/src/BlazorWebView/src/Maui/Tizen/TizenMauiAssetFileProvider.cs
+++ b/src/BlazorWebView/src/Maui/Tizen/TizenMauiAssetFileProvider.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Primitives;
+using Microsoft.Maui.Storage;
 using Tizen.Applications;
 
 namespace Microsoft.AspNetCore.Components.WebView.Maui
@@ -21,10 +22,20 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		}
 
 		public IDirectoryContents GetDirectoryContents(string subpath)
-			=> new TizenMauiAssetDirectoryContents(Path.Combine(_resDir, subpath));
+		{
+			var resolvedPath = FileSystemUtils.Combine(_resDir, subpath);
+			if (resolvedPath is null)
+				return NotFoundDirectoryContents.Singleton;
+			return new TizenMauiAssetDirectoryContents(resolvedPath);
+		}
 
 		public IFileInfo GetFileInfo(string subpath)
-			=> new TizenMauiAssetFileInfo(Path.Combine(_resDir, subpath));
+		{
+			var resolvedPath = FileSystemUtils.Combine(_resDir, subpath);
+			if (resolvedPath is null)
+				return new NotFoundFileInfo(subpath);
+			return new TizenMauiAssetFileInfo(resolvedPath);
+		}
 
 		public IChangeToken Watch(string filter)
 			=> NullChangeToken.Singleton;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32941.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32941.cs
@@ -19,6 +19,7 @@ public class Issue32941 : _IssuesUITest
 	public void ShellContentShouldRespectSafeAreaEdges_After_Navigation()
 	{
 		App.WaitForElement("MainPageLabel");
+		App.WaitForElement("GoToSignOutButton");
 		App.Tap("GoToSignOutButton");
 		App.WaitForElement("SignOutLabel");
 

--- a/src/Core/src/Platform/Windows/MauiTextBox.cs
+++ b/src/Core/src/Platform/Windows/MauiTextBox.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Maui.Platform
 		sealed class TextBoxTemplateCache
 		{
 			public WeakReference<ScrollViewer>? ContentElement { get; set; }
+			public int ContentElementSearchCount { get; set; }
 		}
 
 		public static void InvalidateAttachedProperties(DependencyObject obj)
@@ -54,18 +55,28 @@ namespace Microsoft.Maui.Platform
 
 		static ScrollViewer? GetContentElement(FrameworkElement element)
 		{
-			var cache = s_templateCaches.GetOrCreateValue(element);
-
-			if (cache.ContentElement?.TryGetTarget(out var contentElement) == true &&
+			s_templateCaches.TryGetValue(element, out var cache);
+			if (cache?.ContentElement?.TryGetTarget(out var contentElement) == true &&
 				IsDescendantOf(contentElement, element))
 			{
 				return contentElement;
 			}
 
 			contentElement = element.GetDescendantByName<ScrollViewer>(ContentElementName);
-			cache.ContentElement = contentElement is null ? null : new(contentElement);
+			if (cache is null && contentElement is not null)
+				cache = s_templateCaches.GetOrCreateValue(element);
+
+			if (cache is not null)
+			{
+				cache.ContentElement = contentElement is null ? null : new(contentElement);
+				cache.ContentElementSearchCount++;
+			}
+
 			return contentElement;
 		}
+
+		internal static int GetContentElementSearchCount(FrameworkElement element) =>
+			s_templateCaches.TryGetValue(element, out var cache) ? cache.ContentElementSearchCount : 0;
 
 		static bool IsDescendantOf(DependencyObject element, DependencyObject ancestor)
 		{

--- a/src/Core/src/Platform/Windows/MauiTextBox.cs
+++ b/src/Core/src/Platform/Windows/MauiTextBox.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.UI.Xaml;
+﻿using System;
+using System.Runtime.CompilerServices;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 
@@ -9,6 +11,12 @@ namespace Microsoft.Maui.Platform
 		const string ContentElementName = "ContentElement";
 		const string PlaceholderTextContentPresenterName = "PlaceholderTextContentPresenter";
 		const string DeleteButtonElementName = "DeleteButton";
+		static readonly ConditionalWeakTable<FrameworkElement, TextBoxTemplateCache> s_templateCaches = new();
+
+		sealed class TextBoxTemplateCache
+		{
+			public WeakReference<ScrollViewer>? ContentElement { get; set; }
+		}
 
 		public static void InvalidateAttachedProperties(DependencyObject obj)
 		{
@@ -30,22 +38,47 @@ namespace Microsoft.Maui.Platform
 
 		static void OnVerticalTextAlignmentPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs? e = null)
 		{
-			// TODO: cache the scrollViewer value on the textBox
+			if (d is not FrameworkElement element)
+			{
+				return;
+			}
 
-			var element = d as FrameworkElement;
 			var verticalAlignment = GetVerticalTextAlignment(d);
 
-			var scrollViewer = element?.GetDescendantByName<ScrollViewer>(ContentElementName);
-			if (scrollViewer is not null)
+			var scrollViewer = GetContentElement(element);
+			scrollViewer?.VerticalAlignment = verticalAlignment;
+
+			var placeholder = element.GetDescendantByName<TextBlock>(PlaceholderTextContentPresenterName);
+			placeholder?.VerticalAlignment = verticalAlignment;
+		}
+
+		static ScrollViewer? GetContentElement(FrameworkElement element)
+		{
+			var cache = s_templateCaches.GetOrCreateValue(element);
+
+			if (cache.ContentElement?.TryGetTarget(out var contentElement) == true &&
+				IsDescendantOf(contentElement, element))
 			{
-				scrollViewer.VerticalAlignment = verticalAlignment;
+				return contentElement;
 			}
 
-			var placeholder = element?.GetDescendantByName<TextBlock>(PlaceholderTextContentPresenterName);
-			if (placeholder is not null)
+			contentElement = element.GetDescendantByName<ScrollViewer>(ContentElementName);
+			cache.ContentElement = contentElement is null ? null : new(contentElement);
+			return contentElement;
+		}
+
+		static bool IsDescendantOf(DependencyObject element, DependencyObject ancestor)
+		{
+			var current = VisualTreeHelper.GetParent(element);
+			while (current is not null)
 			{
-				placeholder.VerticalAlignment = verticalAlignment;
+				if (current == ancestor)
+					return true;
+
+				current = VisualTreeHelper.GetParent(current);
 			}
+
+			return false;
 		}
 
 		public static bool GetIsDeleteButtonEnabled(DependencyObject obj) =>

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Windows.cs
@@ -7,15 +7,57 @@ using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Markup;
 using Microsoft.UI.Xaml.Media;
 using Xunit;
-
 using NativeVerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment;
 
 namespace Microsoft.Maui.DeviceTests
 {
 	public partial class EditorHandlerTests
 	{
+		[Fact(DisplayName = "Vertical text alignment uses the current template content")]
+		public async Task VerticalTextAlignmentUsesCurrentTemplateContent()
+		{
+			var editor = new EditorStub();
+
+			await AttachAndRun(editor, handler =>
+			{
+				var textBox = GetNativeEditor(handler);
+				MauiTextBox.SetVerticalTextAlignment(textBox, NativeVerticalAlignment.Bottom);
+
+				var previousContentElement = textBox.GetDescendantByName<ScrollViewer>("ContentElement");
+				Assert.NotNull(previousContentElement);
+				Assert.Equal(NativeVerticalAlignment.Bottom, previousContentElement.VerticalAlignment);
+
+				textBox.Template = CreateTextBoxTemplate();
+				textBox.ApplyTemplate();
+
+				var currentContentElement = textBox.GetDescendantByName<ScrollViewer>("ContentElement");
+				Assert.NotNull(currentContentElement);
+				Assert.NotSame(previousContentElement, currentContentElement);
+
+				MauiTextBox.SetVerticalTextAlignment(textBox, NativeVerticalAlignment.Top);
+
+				Assert.Equal(NativeVerticalAlignment.Top, currentContentElement.VerticalAlignment);
+				Assert.Equal(NativeVerticalAlignment.Bottom, previousContentElement.VerticalAlignment);
+			});
+		}
+
+		static ControlTemplate CreateTextBoxTemplate() =>
+			(ControlTemplate)XamlReader.Load(
+				"""
+				<ControlTemplate
+					xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					TargetType="TextBox">
+					<Grid>
+						<ScrollViewer x:Name="ContentElement" />
+						<TextBlock x:Name="PlaceholderTextContentPresenter" />
+					</Grid>
+				</ControlTemplate>
+				""");
+
 		static TextBox GetNativeEditor(EditorHandler editorHandler) =>
 			editorHandler.PlatformView;
 

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Windows.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Maui.DeviceTests
 	{
 		const string ContentElementName = "ContentElement";
 
-		[Fact(DisplayName = "Vertical text alignment uses the current template content")]
-		public async Task VerticalTextAlignmentUsesCurrentTemplateContent()
+		[Fact(DisplayName = "Content element cache is reused and invalidated with template changes")]
+		public async Task ContentElementCacheIsReusedAndInvalidatedWithTemplateChanges()
 		{
 			var editor = new EditorStub();
 
@@ -32,6 +32,15 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.NotNull(previousContentElement);
 				Assert.Equal(NativeVerticalAlignment.Bottom, previousContentElement.VerticalAlignment);
 
+				var cachedSearchCount = MauiTextBox.GetContentElementSearchCount(textBox);
+				Assert.True(cachedSearchCount > 0);
+
+				MauiTextBox.SetVerticalTextAlignment(textBox, NativeVerticalAlignment.Top);
+				Assert.Equal(cachedSearchCount, MauiTextBox.GetContentElementSearchCount(textBox));
+
+				MauiTextBox.SetVerticalTextAlignment(textBox, NativeVerticalAlignment.Bottom);
+				Assert.Equal(cachedSearchCount, MauiTextBox.GetContentElementSearchCount(textBox));
+
 				textBox.Template = CreateTextBoxTemplate();
 				textBox.ApplyTemplate();
 
@@ -41,6 +50,7 @@ namespace Microsoft.Maui.DeviceTests
 
 				MauiTextBox.SetVerticalTextAlignment(textBox, NativeVerticalAlignment.Top);
 
+				Assert.True(MauiTextBox.GetContentElementSearchCount(textBox) > cachedSearchCount);
 				Assert.Equal(NativeVerticalAlignment.Top, currentContentElement.VerticalAlignment);
 				Assert.Equal(NativeVerticalAlignment.Bottom, previousContentElement.VerticalAlignment);
 			});
@@ -106,7 +116,7 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			var textBox = GetNativeEditor(editorHandler);
 
-			var sv = textBox.GetDescendantByName<ScrollViewer>("ContentElement");
+			var sv = textBox.GetDescendantByName<ScrollViewer>(ContentElementName);
 			var placeholder = textBox.GetDescendantByName<TextBlock>("PlaceholderTextContentPresenter");
 
 			Assert.Equal(sv.VerticalAlignment, placeholder.VerticalAlignment);

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Windows.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class EditorHandlerTests
 	{
+		const string ContentElementName = "ContentElement";
+
 		[Fact(DisplayName = "Vertical text alignment uses the current template content")]
 		public async Task VerticalTextAlignmentUsesCurrentTemplateContent()
 		{
@@ -26,14 +28,14 @@ namespace Microsoft.Maui.DeviceTests
 				var textBox = GetNativeEditor(handler);
 				MauiTextBox.SetVerticalTextAlignment(textBox, NativeVerticalAlignment.Bottom);
 
-				var previousContentElement = textBox.GetDescendantByName<ScrollViewer>("ContentElement");
+				var previousContentElement = textBox.GetDescendantByName<ScrollViewer>(ContentElementName);
 				Assert.NotNull(previousContentElement);
 				Assert.Equal(NativeVerticalAlignment.Bottom, previousContentElement.VerticalAlignment);
 
 				textBox.Template = CreateTextBoxTemplate();
 				textBox.ApplyTemplate();
 
-				var currentContentElement = textBox.GetDescendantByName<ScrollViewer>("ContentElement");
+				var currentContentElement = textBox.GetDescendantByName<ScrollViewer>(ContentElementName);
 				Assert.NotNull(currentContentElement);
 				Assert.NotSame(previousContentElement, currentContentElement);
 

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
@@ -120,7 +120,6 @@ namespace Microsoft.Maui.IntegrationTests
 				buildProps.Add("PublishAot=true");
 				buildProps.Add("PublishAotUsingRuntimePack=true"); // TODO: This parameter will become obsolete https://github.com/dotnet/runtime/issues/87060
 				buildProps.Add("_IsPublishing=true"); // using dotnet build with -p:_IsPublishing=true enables targeting simulators
-				buildProps.Add("IlcTreatWarningsAsErrors=false"); // TODO: Remove this once all warnings are fixed https://github.com/dotnet/maui/issues/19397
 				// Restrict to iOS-only to avoid restoring NativeAOT packages for other platforms (e.g., Android)
 				// which may not be available in the configured NuGet sources
 				buildProps.Add($"TargetFrameworks={framework}-ios");


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Caches the Windows `TextBox` template `ScrollViewer` used to apply vertical text alignment, avoiding repeated recursive visual-tree searches on property updates and `SizeChanged` callbacks.

#### Lifetime and invalidation

- Stores cache state per owning `FrameworkElement` in a `ConditionalWeakTable` only after `ContentElement` is found.
- Holds the template `ScrollViewer` through `WeakReference<ScrollViewer>`, so the cache does not retain a detached template child.
- Validates the cached child's current visual ancestry before every reuse. Template replacement or reapplication detaches the old child, fails validation, and performs one fresh lookup.
- Adds no `Loaded`, `Unloaded`, template, or handler-disconnect event subscriptions. A valid child can be reused across unload/reload, while disconnected controls and stale children remain collectable.

#### Performance

After the first lookup, the hot path uses a weak-table lookup and the short parent chain instead of recursively traversing the control's visual subtree to find `ContentElement`. A full subtree lookup occurs only on first use, after collection, or after template replacement.

#### Tests

Added `ContentElementCacheIsReusedAndInvalidatedWithTemplateChanges`, which uses the per-control full-search count to prove repeated alignment updates reuse the cached `ScrollViewer`, then replaces and reapplies the Windows `TextBox` template and proves exactly one new full search retargets the cache. It also verifies that the new `ScrollViewer` receives the updated alignment while the detached child remains unchanged.

Local Windows validation:

- `Microsoft.Maui.Core.DeviceTests`: 2,092 total, 1,981 passed, 0 failed, 111 skipped, 0 errors.
- `ContentElementCacheIsReusedAndInvalidatedWithTemplateChanges`: passed in 0.122253 seconds.
- Without-fix verification cannot execute because the focused test intentionally references the new internal search-count hook, which is absent at the base SHA; the gate fails compilation with CS0117. The passing current-head suite and direct count assertions provide the behavioral cache-hit/invalidation evidence.

#### Empirical before/after

https://github.com/user-attachments/assets/9c6195fc-7760-42e1-a3d3-913e25edc966

The recording compares base `abdfbef0` with the PR implementation on the same Windows ARM64 machine. A temporary diagnostic Sandbox template placed `ContentElement` after 600 inert children to amplify the visual-tree lookup cost, then Windows UI Automation invoked 5,000 vertical-alignment updates:

| Version | 5,000 updates | Mean |
| --- | ---: | ---: |
| Base (uncached) | 5,256.37 ms | 1,051.274 µs/update |
| PR (cached) | 355.92 ms | 71.185 µs/update |

That recorded sample is **14.77x faster** (**93.2% less elapsed time**). The PR run also confirmed the cached target remained current in 100/100 identity checks. After replacing and reapplying the native template, the old `ScrollViewer` was detached and remained `Bottom`, the new viewer received `Top`, and the cache retargeted to the new child.

These timings intentionally use a synthetic amplified template and one recorded sample per version; they demonstrate the eliminated repeated traversal but are not representative of absolute timing for a normal app. The diagnostic Sandbox changes were not committed.

### Issues Fixed

N/A - resolves an existing Windows performance TODO.