### PR TITLE
[Android] MediaPicker: Stop overwriting picked source files

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -24,7 +24,7 @@
       "rollForward": false
     },
     "microsoft.dotnet.xharness.cli": {
-      "version": "11.0.0-prerelease.26419.1",
+      "version": "11.0.0-prerelease.26428.1",
       "commands": [
         "xharness"
       ],

--- a/.github/scripts/SetupVallyRuntime.sh
+++ b/.github/scripts/SetupVallyRuntime.sh
@@ -82,7 +82,7 @@ if grep -Fqx -- "--experimental" "$probe_output"; then
 	exit 1
 fi
 
-# Vally 0.12 normally creates an empty per-run Copilot home and passes it as the
+# Vally normally creates an empty per-run Copilot home and passes it as the
 # session configDirectory, which takes precedence over COPILOT_HOME. Confirm the
 # pinned executor honors the opt-out before any model credential enters the job.
 copilot_home_module="$install_root/node_modules/@microsoft/vally/dist/executor/copilot-home.js"

--- a/.github/skills/agentic-labeler/tests/eval.vally.yaml
+++ b/.github/skills/agentic-labeler/tests/eval.vally.yaml
@@ -37,7 +37,7 @@
 # Legacy scenarios AND-gated up to ~15 `output_not_contains` assertions
 # (every triage/partner/kind label spelled out) plus, for noop scenarios,
 # a fragile ~10-branch alternation regex matching phrasings of "no labels."
-# With scoring.weights omitted, Vally 0.12 computes the trial score as the
+# With scoring.weights omitted, Vally computes the trial score as the
 # UNWEIGHTED MEAN of
 # grader scores, so piling on 12 floors drowns the judge (1/13 weight) and
 # a single wrong label can't move the aggregate. This port keeps, per
@@ -998,7 +998,7 @@ stimuli:
     constraints: { max_duration: 5m, expect_skills: [agentic-labeler] }
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of grader [0,1] scores; stimulus
   # passes when the mean across runs >= threshold. Invocation is a separate
   # workflow hard veto, while 0.90 preserves the suite's prior semantic bar

--- a/.github/skills/analyze-sessions/SKILL.md
+++ b/.github/skills/analyze-sessions/SKILL.md
@@ -242,7 +242,7 @@ scoring:
 Then validate every emitted file:
 
 ```bash
-npx -y @microsoft/vally-cli@0.12.0 lint --eval-spec <path-to-eval> --strict
+npx -y @microsoft/vally-cli@0.14.0 lint --eval-spec <path-to-eval> --strict
 ```
 
 ## Privacy & safety

--- a/.github/skills/analyze-sessions/references/design-rationale.md
+++ b/.github/skills/analyze-sessions/references/design-rationale.md
@@ -162,7 +162,7 @@ generic `.github/evals/` paths are not valid targets. A different skill's
 Each eval pairs a refutation-proof **structural floor** (`output-matches` on a
 forced token line) with **one LLM judge** (`scale_1_5`, `threshold: 0.6`) so the
 judge carries ~half the weight. Each emitted file must pass
-`npx -y @microsoft/vally-cli@0.12.0 lint --eval-spec <f> --strict`. This is the
+`npx -y @microsoft/vally-cli@0.14.0 lint --eval-spec <f> --strict`. This is the
 mechanism that makes the analysis *iterative*: a failure found today becomes a
 regression test that fails if we regress tomorrow.
 

--- a/.github/skills/analyze-sessions/tests/eval.vally.yaml
+++ b/.github/skills/analyze-sessions/tests/eval.vally.yaml
@@ -19,7 +19,7 @@
 # line — immune to "mentions the word" false-fails) with ONE LLM JUDGE
 # (scale_1_5, threshold 0.6) so the judge carries ~50% of every score.
 #
-# Scoring: this suite deliberately omits scoring.weights, so Vally 0.12 uses the
+# Scoring: this suite deliberately omits scoring.weights, so Vally uses the
 # unweighted mean of grader [0,1] scores; a stimulus passes when the mean across
 # runs >= scoring.threshold (0.6). With a scale_1_5 judge (normalized =
 # (raw-1)/4):
@@ -295,7 +295,7 @@ stimuli:
       reject_skills: [analyze-sessions]
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of each stimulus's two graders
   # (one refutation-proof structural floor + one LLM judge), keeping the judge
   # at ~50% of every score per the house convention.

--- a/.github/skills/code-review/tests/eval.inline-findings.vally.yaml
+++ b/.github/skills/code-review/tests/eval.inline-findings.vally.yaml
@@ -159,7 +159,7 @@ stimuli:
         - code-review
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of the two graders' [0,1] scores;
   # the stimulus passes when the mean across runs >= threshold, and the CI
   # check keys off that mean-vs-threshold `passed` property. Two graders (one

--- a/.github/skills/code-review/tests/eval.vally.yaml
+++ b/.github/skills/code-review/tests/eval.vally.yaml
@@ -440,7 +440,7 @@ stimuli:
       max_duration: 10m
 
 scoring:
-  # Vally 0.12 supports scoring.weights, but this suite deliberately omits
+  # Vally supports scoring.weights, but this suite deliberately omits
   # them so a trial's score is the unweighted mean of its graders' [0,1]
   # scores; the stimulus score is the mean across runs. The deterministic
   # tool-calls grader is the manipulation check: a trial that never reads the

--- a/.github/skills/code-review/tests/hermeticity.vally.yaml
+++ b/.github/skills/code-review/tests/hermeticity.vally.yaml
@@ -101,7 +101,7 @@ stimuli:
       max_turns: 10
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean. Threshold 1.0 means the single stimulus must score a perfect 1.0
   # to "pass" — i.e. the agent's output matched the anonymous rate limit
   # (CORE_LIMIT:60). The hermeticity-gate job reads the verdict directly:

--- a/.github/skills/code-review/tests/soak.capability.vally.yaml
+++ b/.github/skills/code-review/tests/soak.capability.vally.yaml
@@ -474,7 +474,7 @@ stimuli:
         - code-review
 
 scoring:
-  # Vally 0.12 supports scoring.weights, but this suite deliberately omits
+  # Vally supports scoring.weights, but this suite deliberately omits
   # them so a trial's score is the unweighted mean of its graders' [0,1]
   # scores. The `prompt`
   # grader contributes ONE holistic score, so rubric criteria are not

--- a/.github/skills/evaluate-pr-tests/tests/eval.vally.yaml
+++ b/.github/skills/evaluate-pr-tests/tests/eval.vally.yaml
@@ -34,13 +34,13 @@
 # brittle (a correct finding phrased differently fails). Those move into
 # the LLM-judge rubric. Each scenario keeps at most 1–2 structural / crisp-
 # negative floors so the judge stays decisive (this suite omits
-# scoring.weights, so Vally 0.12 scores a trial as the unweighted mean of its
+# scoring.weights, so Vally scores a trial as the unweighted mean of its
 # graders). The two purely-semantic
 # detection scenarios (weak assertions, edge-case gaps) are judge-only — a
 # single prompt grader means the trial score IS the judge's normalized
 # rubric score.
 #
-# Scoring: scoring.weights is deliberately omitted, so Vally 0.12 uses the
+# Scoring: scoring.weights is deliberately omitted, so Vally uses the
 # equal-weight aggregate and the 0.6 threshold remains active.
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -405,7 +405,7 @@ stimuli:
     constraints: { max_duration: 5m, expect_skills: [evaluate-pr-tests] }
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of grader [0,1] scores; skill passes
   # when the mean across runs >= threshold. Structural section-heading floors
   # are kept only where producing the report format IS the capability; the

--- a/.github/skills/pr-review/tests/eval.gh-auth.vally.yaml
+++ b/.github/skills/pr-review/tests/eval.gh-auth.vally.yaml
@@ -160,7 +160,7 @@ stimuli:
       max_duration: 5m
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of the three graders' [0,1] scores. The structural floor
   # and guidance-read check are necessary but insufficient. Threshold 0.8
   # keeps the judge load-bearing: a partial regression (`no`, guidance read,

--- a/.github/skills/try-fix/tests/eval.vally.yaml
+++ b/.github/skills/try-fix/tests/eval.vally.yaml
@@ -28,7 +28,7 @@
 #   structural floors (e.g. "claims PASS when no device was available").
 #
 # Scoring (see scoring block): this suite deliberately omits scoring.weights,
-# so Vally 0.12 uses the unweighted mean of grader [0,1] scores; skill passes
+# so Vally uses the unweighted mean of grader [0,1] scores; skill passes
 # when the mean >= scoring.threshold (0.8), unless any trial has an execution
 # error (a separate hard failure regardless of the numeric aggregate). Every
 # scenario also has a deterministic skill-invocation grader. The workflow
@@ -463,7 +463,7 @@ stimuli:
         - try-fix
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of grader [0,1] scores; skill passes when the mean across runs >=
   # threshold. At 0.6, passing invocation/structural floors could dilute every
   # semantic judge failure to a suite score of 0.607. The 0.8 threshold keeps

--- a/.github/skills/verify-tests-fail-without-fix/tests/eval.vally.yaml
+++ b/.github/skills/verify-tests-fail-without-fix/tests/eval.vally.yaml
@@ -23,7 +23,7 @@
 # whose aggregate threshold is undefined so every grader must pass its own
 # threshold.
 #
-# Scoring: this suite deliberately omits scoring.weights, so Vally 0.12 uses
+# Scoring: this suite deliberately omits scoring.weights, so Vally uses
 # the unweighted mean of grader [0,1] scores. Every scenario also has a
 # deterministic invocation grader, and the workflow applies invocation failures
 # as a hard veto. The threshold preserves the prior semantic-judge floor after
@@ -266,7 +266,7 @@ stimuli:
         - verify-tests-fail-without-fix
 
 scoring:
-  # This suite deliberately omits scoring.weights, so Vally 0.12 uses the
+  # This suite deliberately omits scoring.weights, so Vally uses the
   # unweighted mean of grader [0,1] scores. At 0.87, a stimulus with invocation
   # plus one structural floor still requires judge >= 0.61, preserving the old
   # 0.60 semantic bar. Stimuli without the extra floor are intentionally

--- a/.github/workflows/skill-evaluation-soak.yml
+++ b/.github/workflows/skill-evaluation-soak.yml
@@ -22,7 +22,7 @@ permissions:
   contents: read
 
 env:
-  VALLY_VERSION: "0.12.0"
+  VALLY_VERSION: "0.14.0"
   NODE_VERSION: "22"
 
 jobs:

--- a/.github/workflows/skill-validation.yml
+++ b/.github/workflows/skill-validation.yml
@@ -94,8 +94,8 @@ permissions:
 
 env:
   # Vally CLI is run via npx from npm. Pinned for reproducibility.
-  # Vally 0.12 requires Node >=22, so we pin Node 22 on the runners.
-  VALLY_VERSION: "0.12.0"
+  # Vally requires Node >=22.12, so we pin Node 22 on the runners.
+  VALLY_VERSION: "0.14.0"
   NODE_VERSION: "22"
 
 jobs:

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -158,17 +158,17 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="11.0.0-prerelease.26419.1">
+    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="11.0.0-prerelease.26428.1">
       <Uri>https://github.com/dotnet/xharness</Uri>
-      <Sha>8dd9b8e6004e22c7b120af0631f0809865ff2088</Sha>
+      <Sha>b355c0507b19670c2d386677d7f99260f07cefa5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="11.0.0-prerelease.26419.1">
+    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="11.0.0-prerelease.26428.1">
       <Uri>https://github.com/dotnet/xharness</Uri>
-      <Sha>8dd9b8e6004e22c7b120af0631f0809865ff2088</Sha>
+      <Sha>b355c0507b19670c2d386677d7f99260f07cefa5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="11.0.0-prerelease.26419.1">
+    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="11.0.0-prerelease.26428.1">
       <Uri>https://github.com/dotnet/xharness</Uri>
-      <Sha>8dd9b8e6004e22c7b120af0631f0809865ff2088</Sha>
+      <Sha>b355c0507b19670c2d386677d7f99260f07cefa5</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -128,9 +128,9 @@
     <_HarfBuzzSharpVersion>8.3.0.1</_HarfBuzzSharpVersion>
     <_SkiaSharpNativeAssetsVersion>0.0.0-commit.e57e2a11dac4ccc72bea52939dede49816842005.1728</_SkiaSharpNativeAssetsVersion>
     <MicrosoftTemplateEngineTasksVersion>7.0.120</MicrosoftTemplateEngineTasksVersion>
-    <MicrosoftDotNetXHarnessTestRunnersCommonVersion>11.0.0-prerelease.26419.1</MicrosoftDotNetXHarnessTestRunnersCommonVersion>
-    <MicrosoftDotNetXHarnessTestRunnersXunitVersion>11.0.0-prerelease.26419.1</MicrosoftDotNetXHarnessTestRunnersXunitVersion>
-    <MicrosoftDotNetXHarnessCLIVersion>11.0.0-prerelease.26419.1</MicrosoftDotNetXHarnessCLIVersion>
+    <MicrosoftDotNetXHarnessTestRunnersCommonVersion>11.0.0-prerelease.26428.1</MicrosoftDotNetXHarnessTestRunnersCommonVersion>
+    <MicrosoftDotNetXHarnessTestRunnersXunitVersion>11.0.0-prerelease.26428.1</MicrosoftDotNetXHarnessTestRunnersXunitVersion>
+    <MicrosoftDotNetXHarnessCLIVersion>11.0.0-prerelease.26428.1</MicrosoftDotNetXHarnessCLIVersion>
     <TizenUIExtensionsVersion>0.9.2</TizenUIExtensionsVersion>
     <SvgSkiaPackageVersion>2.0.0.4</SvgSkiaPackageVersion>
     <FizzlerPackageVersion>1.3.0</FizzlerPackageVersion>

--- a/src/BlazorWebView/src/Maui/Tizen/TizenMauiAssetFileProvider.cs
+++ b/src/BlazorWebView/src/Maui/Tizen/TizenMauiAssetFileProvider.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Primitives;
+using Microsoft.Maui.Storage;
 using Tizen.Applications;
 
 namespace Microsoft.AspNetCore.Components.WebView.Maui
@@ -21,10 +22,20 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		}
 
 		public IDirectoryContents GetDirectoryContents(string subpath)
-			=> new TizenMauiAssetDirectoryContents(Path.Combine(_resDir, subpath));
+		{
+			var resolvedPath = FileSystemUtils.Combine(_resDir, subpath);
+			if (resolvedPath is null)
+				return NotFoundDirectoryContents.Singleton;
+			return new TizenMauiAssetDirectoryContents(resolvedPath);
+		}
 
 		public IFileInfo GetFileInfo(string subpath)
-			=> new TizenMauiAssetFileInfo(Path.Combine(_resDir, subpath));
+		{
+			var resolvedPath = FileSystemUtils.Combine(_resDir, subpath);
+			if (resolvedPath is null)
+				return new NotFoundFileInfo(subpath);
+			return new TizenMauiAssetFileInfo(resolvedPath);
+		}
 
 		public IChangeToken Watch(string filter)
 			=> NullChangeToken.Singleton;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32941.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32941.cs
@@ -19,6 +19,7 @@ public class Issue32941 : _IssuesUITest
 	public void ShellContentShouldRespectSafeAreaEdges_After_Navigation()
 	{
 		App.WaitForElement("MainPageLabel");
+		App.WaitForElement("GoToSignOutButton");
 		App.Tap("GoToSignOutButton");
 		App.WaitForElement("SignOutLabel");
 

--- a/src/Essentials/src/FileSystem/FileSystemUtils.android.cs
+++ b/src/Essentials/src/FileSystem/FileSystemUtils.android.cs
@@ -52,6 +52,33 @@ namespace Microsoft.Maui.Storage
 			return tmpFile;
 		}
 
+		internal static bool IsMauiOwnedTemporaryFile(string path)
+		{
+			if (string.IsNullOrEmpty(path))
+				return false;
+
+			try
+			{
+				var canonicalPath = new Java.IO.File(path).CanonicalPath;
+
+				foreach (var root in new[] { Application.Context.CacheDir, Application.Context.ExternalCacheDir })
+				{
+					if (root is null)
+						continue;
+
+					var ownedRoot = new Java.IO.File(root, EssentialsFolderHash).CanonicalPath + Java.IO.File.Separator;
+					if (canonicalPath.StartsWith(ownedRoot, StringComparison.Ordinal))
+						return true;
+				}
+			}
+			catch
+			{
+				// Paths that cannot be canonicalized must not be treated as MAUI-owned.
+			}
+
+			return false;
+		}
+
 		public static string EnsurePhysicalPath(AndroidUri uri, bool requireExtendedAccess = true)
 		{
 			// if this is a file, use that

--- a/src/Essentials/src/MediaPicker/MediaPicker.android.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.android.cs
@@ -23,18 +23,92 @@ namespace Microsoft.Maui.Media
 		public bool IsCaptureSupported
 			=> Application.Context?.PackageManager?.HasSystemFeature(PackageManager.FeatureCameraAny) ?? false;
 
-		static async Task RotateImageInPlace(string filePath, MediaPickerOptions options)
+		internal static async Task<string> ProcessImage(string imagePath, MediaPickerOptions options)
 		{
-			using var inputStream = File.OpenRead(filePath);
-			var fileName = System.IO.Path.GetFileName(filePath);
-			using var rotatedStream = await ImageProcessor.RotateImageAsync(inputStream, fileName);
-			rotatedStream.Position = 0;
-			inputStream.Dispose(); // explicit close before delete
+			if (string.IsNullOrEmpty(imagePath) || !File.Exists(imagePath))
+				return imagePath;
+
+			var needsRotation = ImageProcessor.IsRotationNeeded(options);
+			var needsProcessing = ImageProcessor.IsProcessingNeeded(
+				options?.MaximumWidth,
+				options?.MaximumHeight,
+				options?.CompressionQuality ?? 100);
+
+			if (!needsRotation && !needsProcessing)
+				return imagePath;
+
 			try
-			{ File.Delete(filePath); }
-			catch { }
-			using var outputStream = File.Create(filePath);
-			await rotatedStream.CopyToAsync(outputStream);
+			{
+				var inputFileName = System.IO.Path.GetFileName(imagePath);
+				Stream currentStream = File.OpenRead(imagePath);
+
+				try
+				{
+					if (needsRotation)
+					{
+						var rotatedStream = await ImageProcessor.RotateImageAsync(currentStream, inputFileName);
+						currentStream.Dispose();
+						currentStream = rotatedStream;
+						currentStream.Position = 0;
+					}
+
+					if (needsProcessing)
+					{
+						var processedStream = await ImageProcessor.ProcessImageAsync(
+							currentStream,
+							options?.MaximumWidth,
+							options?.MaximumHeight,
+							options?.CompressionQuality ?? 100,
+							inputFileName,
+							false,
+							options?.PreserveMetaData ?? true);
+
+						if (processedStream is not null)
+						{
+							currentStream.Dispose();
+							currentStream = processedStream;
+							currentStream.Position = 0;
+						}
+					}
+
+					var outputExtension = ImageProcessor.DetermineOutputExtension(
+						currentStream,
+						options?.CompressionQuality ?? 100,
+						inputFileName);
+					var originalExtension = System.IO.Path.GetExtension(inputFileName);
+					var outputFileName = inputFileName;
+
+					if (!string.Equals(outputExtension, originalExtension, StringComparison.OrdinalIgnoreCase))
+						outputFileName = System.IO.Path.ChangeExtension(inputFileName, outputExtension);
+
+					var outputFile = FileSystemUtils.GetTemporaryFile(Application.Context.CacheDir, outputFileName);
+					var outputPath = outputFile.AbsolutePath;
+
+					using (var outputStream = File.Create(outputPath))
+					{
+						currentStream.Position = 0;
+						await currentStream.CopyToAsync(outputStream);
+					}
+
+					if (FileSystemUtils.IsMauiOwnedTemporaryFile(imagePath) &&
+						!string.Equals(imagePath, outputPath, StringComparison.Ordinal))
+					{
+						try
+						{ File.Delete(imagePath); }
+						catch { }
+					}
+
+					return outputPath;
+				}
+				finally
+				{
+					currentStream.Dispose();
+				}
+			}
+			catch
+			{
+				return imagePath;
+			}
 		}
 
 		internal static bool IsPhotoPickerAvailable
@@ -99,15 +173,7 @@ namespace Microsoft.Maui.Media
 				if (photo)
 				{
 					captureResult = await CapturePhotoAsync(captureIntent);
-					// Apply rotation if needed for photos
-					if (captureResult is not null && ImageProcessor.IsRotationNeeded(options))
-						await RotateImageInPlace(captureResult, options);
-
-					// Apply compression/resizing if needed for photos
-					if (captureResult is not null && ImageProcessor.IsProcessingNeeded(options?.MaximumWidth, options?.MaximumHeight, options?.CompressionQuality ?? 100))
-					{
-						captureResult = await CompressImageIfNeeded(captureResult, options);
-					}
+					captureResult = await ProcessImage(captureResult, options);
 				}
 				else
 				{
@@ -153,15 +219,7 @@ namespace Microsoft.Maui.Media
 				{
 					if (photo)
 					{
-						// Apply rotation if needed
-						if (ImageProcessor.IsRotationNeeded(options))
-							await RotateImageInPlace(path, options);
-
-						// Apply compression/resizing if needed
-						if (ImageProcessor.IsProcessingNeeded(options?.MaximumWidth, options?.MaximumHeight, options?.CompressionQuality ?? 100))
-						{
-							path = await CompressImageIfNeeded(path, options);
-						}
+						path = await ProcessImage(path, options);
 					}
 
 					return new FileResult(path);
@@ -192,15 +250,7 @@ namespace Microsoft.Maui.Media
 
 			if (photo)
 			{
-				// Apply rotation if needed
-				if (ImageProcessor.IsRotationNeeded(options))
-					await RotateImageInPlace(path, options);
-
-				// Apply compression/resizing if needed
-				if (ImageProcessor.IsProcessingNeeded(options?.MaximumWidth, options?.MaximumHeight, options?.CompressionQuality ?? 100))
-				{
-					path = await CompressImageIfNeeded(path, options);
-				}
+				path = await ProcessImage(path, options);
 			}
 
 			return new FileResult(path);
@@ -248,15 +298,7 @@ namespace Microsoft.Maui.Media
 
 					if (photo)
 					{
-						// Apply rotation if needed
-						if (ImageProcessor.IsRotationNeeded(options))
-							await RotateImageInPlace(path, options);
-
-						// Apply compression/resizing if needed
-						if (ImageProcessor.IsProcessingNeeded(options?.MaximumWidth, options?.MaximumHeight, options?.CompressionQuality ?? 100))
-						{
-							path = await CompressImageIfNeeded(path, options);
-						}
+						path = await ProcessImage(path, options);
 					}
 
 					resultList.Add(new FileResult(path));
@@ -288,70 +330,6 @@ namespace Microsoft.Maui.Media
 			await IntermediateActivity.StartAsync(captureIntent, PlatformUtils.requestCodeMediaCapture, OnCreate);
 
 			return tmpFile.AbsolutePath;
-		}
-
-		static async Task<string> CompressImageIfNeeded(string imagePath, MediaPickerOptions options)
-		{
-			if (!ImageProcessor.IsProcessingNeeded(options?.MaximumWidth, options?.MaximumHeight, options?.CompressionQuality ?? 100) || string.IsNullOrEmpty(imagePath))
-				return imagePath;
-
-			try
-			{
-				var originalFile = new Java.IO.File(imagePath);
-				if (!originalFile.Exists())
-				{
-					return imagePath;
-				}
-
-				// Use ImageProcessor for unified image processing
-				using var inputStream = File.OpenRead(imagePath);
-				var inputFileName = System.IO.Path.GetFileName(imagePath);
-				using var processedStream = await ImageProcessor.ProcessImageAsync(
-					inputStream,
-					options?.MaximumWidth,
-					options?.MaximumHeight,
-					options?.CompressionQuality ?? 100,
-					inputFileName,
-					options?.RotateImage ?? false,
-					options?.PreserveMetaData ?? true);
-
-				if (processedStream != null)
-				{
-					// Determine the correct output extension based on the processed format
-					processedStream.Position = 0;
-					var outputExtension = ImageProcessor.DetermineOutputExtension(processedStream, options?.CompressionQuality ?? 100, inputFileName);
-					var originalExtension = System.IO.Path.GetExtension(imagePath);
-
-					// If format changed (e.g., PNG -> JPEG), use new extension
-					string outputPath = imagePath;
-					if (!string.Equals(outputExtension, originalExtension, StringComparison.OrdinalIgnoreCase))
-					{
-						outputPath = System.IO.Path.ChangeExtension(imagePath, outputExtension);
-					}
-
-					// Delete original file first
-					try
-					{ originalFile.Delete(); }
-					catch { }
-
-					// Write processed image to output path with correct extension
-					using var outputStream = File.Create(outputPath);
-					processedStream.Position = 0;
-					await processedStream.CopyToAsync(outputStream);
-
-					return outputPath;
-				}
-
-				// If ImageProcessor returns null (e.g., on .NET Standard), ImageProcessor.IsProcessingNeeded would have returned false,
-				// so we shouldn't reach this point. Return original path as fallback.
-				return imagePath;
-			}
-			catch
-			{
-				// If processing fails, return original path
-			}
-
-			return imagePath;
 		}
 
 		async Task<string> CaptureVideoAsync(Intent captureIntent)
@@ -459,17 +437,7 @@ namespace Microsoft.Maui.Media
 
 					foreach (var path in tempResultList)
 					{
-						string processedPath = path;
-
-						// Apply rotation if needed
-						if (ImageProcessor.IsRotationNeeded(options))
-							await RotateImageInPlace(processedPath, options);
-
-						// Apply compression/resizing if needed
-						if (ImageProcessor.IsProcessingNeeded(options?.MaximumWidth, options?.MaximumHeight, options?.CompressionQuality ?? 100))
-						{
-							processedPath = await CompressImageIfNeeded(processedPath, options);
-						}
+						var processedPath = await ProcessImage(path, options);
 
 						resultList.Add(new FileResult(processedPath));
 					}

--- a/src/Essentials/src/MediaPicker/MediaPicker.android.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.android.cs
@@ -84,10 +84,21 @@ namespace Microsoft.Maui.Media
 					var outputFile = FileSystemUtils.GetTemporaryFile(Application.Context.CacheDir, outputFileName);
 					var outputPath = outputFile.AbsolutePath;
 
-					using (var outputStream = File.Create(outputPath))
+					try
 					{
-						currentStream.Position = 0;
-						await currentStream.CopyToAsync(outputStream);
+						using (var outputStream = File.Create(outputPath))
+						{
+							currentStream.Position = 0;
+							await currentStream.CopyToAsync(outputStream);
+						}
+					}
+					catch
+					{
+						try
+						{ File.Delete(outputPath); }
+						catch { }
+
+						throw;
 					}
 
 					if (FileSystemUtils.IsMauiOwnedTemporaryFile(imagePath) &&

--- a/src/Essentials/test/DeviceTests/Tests/Android/MediaPicker_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Android/MediaPicker_Tests.cs
@@ -1,0 +1,183 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Android.App;
+using Android.Graphics;
+using Microsoft.Maui.Media;
+using Microsoft.Maui.Storage;
+using Xunit;
+using Path = System.IO.Path;
+
+namespace Microsoft.Maui.Essentials.DeviceTests.Shared
+{
+	[Category("MediaPicker")]
+	public class Android_MediaPicker_Tests
+	{
+		[Fact]
+		public Task ProcessImage_Rotation_DoesNotModifySource_And_WritesSingleCacheFile()
+			=> AssertProcessedToCacheWithoutTouchingSource(
+				new MediaPickerOptions { RotateImage = true });
+
+		[Fact]
+		public Task ProcessImage_Compression_DoesNotModifySource_And_WritesSingleCacheFile()
+			=> AssertProcessedToCacheWithoutTouchingSource(
+				new MediaPickerOptions { CompressionQuality = 50 });
+
+		[Fact]
+		public Task ProcessImage_RotationAndCompression_DoesNotModifySource_And_WritesSingleCacheFile()
+			=> AssertProcessedToCacheWithoutTouchingSource(
+				new MediaPickerOptions { RotateImage = true, CompressionQuality = 50 });
+
+		[Fact]
+		public async Task ProcessImage_NoProcessingNeeded_ReturnsOriginalPath_Unchanged()
+		{
+			var baseName = "mp_noop_" + Guid.NewGuid().ToString("N");
+			var sourcePath = CreateJpegOutsideCache(baseName + ".jpg");
+			var originalBytes = File.ReadAllBytes(sourcePath);
+
+			try
+			{
+				// No rotation, full quality, no resize -> there is nothing to process.
+				var options = new MediaPickerOptions { RotateImage = false, CompressionQuality = 100 };
+
+				var outputPath = await MediaPickerImplementation.ProcessImage(sourcePath, options);
+
+				// The original path is returned as-is and the file is untouched.
+				Assert.Equal(sourcePath, outputPath);
+				Assert.True(File.Exists(sourcePath));
+				Assert.Equal(originalBytes, File.ReadAllBytes(sourcePath));
+
+				// No cache copy is created when there is nothing to do.
+				Assert.Empty(FindCacheFiles(baseName));
+			}
+			finally
+			{
+				SafeDelete(sourcePath);
+				DeleteCacheFiles(baseName);
+			}
+		}
+
+		[Fact]
+		public async Task ProcessImage_MauiOwnedCacheInput_IsReplaced_NotOrphaned()
+		{
+			var baseName = "mp_owned_" + Guid.NewGuid().ToString("N");
+
+			// Create a MAUI-owned temporary cache file, exactly like a camera capture
+			// (CapturePhotoAsync) or a content:// URI that EnsurePhysicalPath copied into cache.
+			var ownedFile = FileSystemUtils.GetTemporaryFile(Application.Context.CacheDir, baseName + ".jpg");
+			var inputPath = ownedFile.AbsolutePath;
+			WriteJpeg(inputPath);
+
+			string outputPath = null;
+			try
+			{
+				var options = new MediaPickerOptions { CompressionQuality = 50 };
+
+				outputPath = await MediaPickerImplementation.ProcessImage(inputPath, options);
+
+				// A new terminal cache file is produced under the app cache dir.
+				Assert.NotEqual(inputPath, outputPath);
+				Assert.True(File.Exists(outputPath));
+				Assert.StartsWith(FileSystem.CacheDirectory, outputPath, StringComparison.Ordinal);
+
+				// The MAUI-owned input is deleted - not left orphaned alongside the output.
+				Assert.False(File.Exists(inputPath));
+
+				// Exactly one terminal cache file remains for this image (the output).
+				var cacheCopies = FindCacheFiles(baseName);
+				Assert.Single(cacheCopies);
+				Assert.Equal(Path.GetFullPath(outputPath), Path.GetFullPath(cacheCopies[0]));
+
+				// The original base filename is preserved (#33258).
+				Assert.Equal(baseName, Path.GetFileNameWithoutExtension(outputPath));
+			}
+			finally
+			{
+				SafeDelete(inputPath);
+				SafeDelete(outputPath);
+				DeleteCacheFiles(baseName);
+			}
+		}
+
+		static async Task AssertProcessedToCacheWithoutTouchingSource(MediaPickerOptions options)
+		{
+			var baseName = "mp_src_" + Guid.NewGuid().ToString("N");
+			var sourcePath = CreateJpegOutsideCache(baseName + ".jpg");
+			var originalBytes = File.ReadAllBytes(sourcePath);
+
+			try
+			{
+				var outputPath = await MediaPickerImplementation.ProcessImage(sourcePath, options);
+
+				// The picked source is left untouched - no in-place overwrite, no data loss.
+				Assert.True(File.Exists(sourcePath));
+				Assert.Equal(originalBytes, File.ReadAllBytes(sourcePath));
+
+				// The processed image is a brand new file under the app cache dir.
+				Assert.NotEqual(sourcePath, outputPath);
+				Assert.True(File.Exists(outputPath));
+				Assert.StartsWith(FileSystem.CacheDirectory, outputPath, StringComparison.Ordinal);
+
+				// The original base filename is preserved (#33258); only the extension may change.
+				Assert.Equal(baseName, Path.GetFileNameWithoutExtension(outputPath));
+
+				// Exactly one terminal cache file is written - no orphaned intermediate,
+				// even when both rotation and compression are applied.
+				var cacheCopies = FindCacheFiles(baseName);
+				Assert.Single(cacheCopies);
+				Assert.Equal(Path.GetFullPath(outputPath), Path.GetFullPath(cacheCopies[0]));
+			}
+			finally
+			{
+				SafeDelete(sourcePath);
+				DeleteCacheFiles(baseName);
+			}
+		}
+
+		static string CreateJpegOutsideCache(string fileName)
+		{
+			// AppDataDirectory (/data/user/0/<pkg>/files) is separate from the cache dir and
+			// stands in for a picked file that MAUI does not own.
+			var dir = Path.Combine(FileSystem.AppDataDirectory, "mediapicker-source-tests");
+			Directory.CreateDirectory(dir);
+
+			var filePath = Path.Combine(dir, fileName);
+			WriteJpeg(filePath);
+			return filePath;
+		}
+
+		static void WriteJpeg(string filePath)
+		{
+			using var bitmap = Bitmap.CreateBitmap(64, 64, Bitmap.Config.Argb8888);
+			using var stream = File.Create(filePath);
+			bitmap.Compress(Bitmap.CompressFormat.Jpeg, 100, stream);
+		}
+
+		static string[] FindCacheFiles(string baseName)
+		{
+			if (!Directory.Exists(FileSystem.CacheDirectory))
+				return Array.Empty<string>();
+
+			return Directory.GetFiles(FileSystem.CacheDirectory, baseName + ".*", SearchOption.AllDirectories);
+		}
+
+		static void DeleteCacheFiles(string baseName)
+		{
+			foreach (var file in FindCacheFiles(baseName))
+				SafeDelete(file);
+		}
+
+		static void SafeDelete(string path)
+		{
+			try
+			{
+				if (!string.IsNullOrEmpty(path) && File.Exists(path))
+					File.Delete(path);
+			}
+			catch
+			{
+				// best-effort cleanup
+			}
+		}
+	}
+}

--- a/src/Essentials/test/DeviceTests/Tests/Android/MediaPicker_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Android/MediaPicker_Tests.cs
@@ -155,10 +155,11 @@ namespace Microsoft.Maui.Essentials.DeviceTests.Shared
 
 		static string[] FindCacheFiles(string baseName)
 		{
-			if (!Directory.Exists(FileSystem.CacheDirectory))
+			var mauiCacheDirectory = Path.Combine(FileSystem.CacheDirectory, FileSystemUtils.EssentialsFolderHash);
+			if (!Directory.Exists(mauiCacheDirectory))
 				return Array.Empty<string>();
 
-			return Directory.GetFiles(FileSystem.CacheDirectory, baseName + ".*", SearchOption.AllDirectories);
+			return Directory.GetFiles(mauiCacheDirectory, baseName + ".*", SearchOption.AllDirectories);
 		}
 
 		static void DeleteCacheFiles(string baseName)

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
@@ -120,7 +120,6 @@ namespace Microsoft.Maui.IntegrationTests
 				buildProps.Add("PublishAot=true");
 				buildProps.Add("PublishAotUsingRuntimePack=true"); // TODO: This parameter will become obsolete https://github.com/dotnet/runtime/issues/87060
 				buildProps.Add("_IsPublishing=true"); // using dotnet build with -p:_IsPublishing=true enables targeting simulators
-				buildProps.Add("IlcTreatWarningsAsErrors=false"); // TODO: Remove this once all warnings are fixed https://github.com/dotnet/maui/issues/19397
 				// Restrict to iOS-only to avoid restoring NativeAOT packages for other platforms (e.g., Android)
 				// which may not be available in the configured NuGet sources
 				buildProps.Add($"TargetFrameworks={framework}-ios");


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

Adapts the Android MediaPicker source-file protection from #36572 to `main`.

Picked external source images are now treated as read-only. Rotation and compression are composed through streams, and the final result is written once to a MAUI-owned cache file. MAUI-owned temporary inputs are deleted only after the output is successfully written. Partial cache outputs are removed if writing fails. The existing main-branch result filename behavior is preserved.

## Provenance

- Original PR: #36572
- Original merge commit: https://github.com/dotnet/maui/commit/45024c679ec962ca1f346756bc4f7f97c207dc70
- Original commits:
  - https://github.com/dotnet/maui/commit/937544b4363a6faa20d9388a0eea851c710b6aed
  - https://github.com/dotnet/maui/commit/aed75449dbeec652c83988c65b619e252ffb7771
  - https://github.com/dotnet/maui/commit/9b0d5d4de71340db4341194b4c094c0855e432be
- Main-targeted adaptation: https://github.com/dotnet/maui/commit/a8ea9894ad7091d724002dc760129b7b44f16a4a
- Review follow-up: https://github.com/dotnet/maui/commit/f5fc79a8c7a30de31045a23a0edbf95ad8bdb852

## Tests

Added Android device regressions covering rotation-only, compression-only, combined processing, no-op behavior, external source byte preservation, a single terminal cache output, and MAUI-owned temporary-input cleanup.

Validated on an Android API 25 emulator: **282 passed, 0 failed** in the Essentials device-test suite; all five MediaPicker regressions passed.