### PR TITLE
[release/11.0.1xx-rc1] Update MAUI branding to RC1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,9 +5,9 @@
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <SdkBandVersion>11.0.100</SdkBandVersion>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>rc</PreReleaseVersionLabel>
     <PreReleaseVersionLabel Condition="'$(BUILD_SOURCEBRANCH)' == 'refs/heads/inflight/current'">ci.inflight</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>7</PreReleaseVersionIteration>
+    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
     <!-- Essentials.AI preview versioning — bump this for new AI previews -->
     <EssentialsAIPreviewVersionIteration>1</EssentialsAIPreviewVersionIteration>
     <!-- Servicing builds have different characteristics for the way dependencies, baselines, and versions are handled. -->


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

- Change the .NET 11 MAUI product branding from `preview.7` to `rc.1` on `release/11.0.1xx-rc1`.
- Ensure the next official build produces `11.0.0-rc.1.*` MAUI packages while retaining the `11.0.100-rc.1` workload manifest band.

## Release context

The staged .NET 11 RC1 workload set currently references `Microsoft.NET.Sdk.Maui.Manifest-11.0.100-rc.1` version `11.0.0-preview.7.26425.9`. The manifest ID is correctly associated with the RC1 SDK band, but the MAUI package version inherited the stale preview 7 branding from `eng/Versions.props`.

The official release pipeline publishes the existing BAR artifacts without rebranding them, so a newly branded MAUI build is required before the RC1 workload set is restaged.

## Validation

Evaluated the manifest project through its `SetVersions` target with an official-build ID:

```text
PreReleaseVersionLabel: rc
PreReleaseVersionIteration: 1
PackageVersion: 11.0.0-rc.1.26431.1
PackageReferenceVersion: 11.0.0-rc.1.26431.1
DotNetMauiManifestVersionBand: 11.0.100-rc.1
```

### Issues Fixed

N/A
