### PR TITLE
[release/11.0.1xx-rc1] Update Android MIBC profiles

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -169,9 +169,9 @@
       <Uri>https://github.com/dotnet/xharness</Uri>
       <Sha>31e0b8e08f57890f7b7004b93361d69cd4b21079</Sha>
     </Dependency>
-    <Dependency Name="optimization.android-x64.MIBC.Runtime" Version="1.0.0-prerelease.26407.1">
+    <Dependency Name="optimization.android-x64.MIBC.Runtime" Version="1.0.0-prerelease.26420.2">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-optimization</Uri>
-      <Sha>e960b77a63b94a4b7c1f077c2d325d003a461d2d</Sha>
+      <Sha>eb2e9a7ebf54cdb4bc0ade04a042a23ee1568a6f</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -39,7 +39,7 @@
     <SystemTextEncodingsWebPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextEncodingsWebPackageVersion>
     <MicrosoftBclAsyncInterfacesPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftBclAsyncInterfacesPackageVersion>
     <!-- dotnet-optimization -->
-    <optimizationandroidx64MIBCRuntimePackageVersion>1.0.0-prerelease.26407.1</optimizationandroidx64MIBCRuntimePackageVersion>
+    <optimizationandroidx64MIBCRuntimePackageVersion>1.0.0-prerelease.26420.2</optimizationandroidx64MIBCRuntimePackageVersion>
     <!-- Microsoft/Extensions -->
     <SystemCodeDomPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemCodeDomPackageVersion>
     <MicrosoftExtensionsConfigurationVersion>11.0.0-rc.1.26420.103</MicrosoftExtensionsConfigurationVersion>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Updates `optimization.android-x64.MIBC.Runtime` on the RC1 branch to `1.0.0-prerelease.26420.2` (`eb2e9a7ebf54cdb4bc0ade04a042a23ee1568a6f`), restoring the dependency version previously flowed to `net11.0` by #37720.

## Changes

- Updates the dependency version and SHA in `eng/Version.Details.xml`.
- Keeps `eng/Versions.props` synchronized with the same package version.