### PR TITLE
[net11.0] Expose safe area contract for custom views

### DIFF
--- a/src/Controls/src/Core/Border/Border.cs
+++ b/src/Controls/src/Core/Border/Border.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Controls
 	/// background, shape, padding, and more to create visually rich containers.
 	/// </remarks>
 	[ContentProperty(nameof(Content))]
-	public class Border : View, IContentView, IBorderView, IPaddingElement, ISafeAreaElement, ISafeAreaView2
+	public class Border : View, IContentView, IBorderView, IPaddingElement, ISafeAreaElementController, ISafeAreaView2
 	{
 		float[]? _strokeDashPattern;
 
@@ -492,7 +492,7 @@ namespace Microsoft.Maui.Controls
 		/// Provides the default value for the <see cref="SafeAreaEdges"/> property.
 		/// </summary>
 		/// <returns>The default safe area edges of <see cref="SafeAreaEdges.None"/>.</returns>
-		SafeAreaEdges ISafeAreaElement.SafeAreaEdgesDefaultValueCreator()
+		SafeAreaEdges ISafeAreaElementController.SafeAreaEdgesDefaultValueCreator()
 		{
 			return SafeAreaEdges.None;
 		}

--- a/src/Controls/src/Core/ContentPage/ContentPage.cs
+++ b/src/Controls/src/Core/ContentPage/ContentPage.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Controls
 	/// <summary>A <see cref="Page"/> that displays a single view as its content.</summary>
 	[ContentProperty("Content")]
 	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
-	public partial class ContentPage : TemplatedPage, IContentView, HotReload.IHotReloadableView, ISafeAreaElement, ISafeAreaView2
+	public partial class ContentPage : TemplatedPage, IContentView, HotReload.IHotReloadableView, ISafeAreaElementController, ISafeAreaView2
 	{
 		/// <summary>Bindable property for <see cref="Content"/>.</summary>
 		public static readonly BindableProperty ContentProperty = BindableProperty.Create(nameof(Content), typeof(View), typeof(ContentPage), null, propertyChanged: TemplateUtilities.OnContentChanged);
@@ -206,7 +206,7 @@ namespace Microsoft.Maui.Controls
 #endif
 		}
 
-		SafeAreaEdges ISafeAreaElement.SafeAreaEdgesDefaultValueCreator()
+		SafeAreaEdges ISafeAreaElementController.SafeAreaEdgesDefaultValueCreator()
 		{
 			return SafeAreaEdges.None;
 		}

--- a/src/Controls/src/Core/ContentView/ContentView.cs
+++ b/src/Controls/src/Core/ContentView/ContentView.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Controls
 	/// </remarks>
 	[ContentProperty("Content")]
 	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
-	public partial class ContentView : TemplatedView, IContentView, ISafeAreaView2, ISafeAreaElement
+	public partial class ContentView : TemplatedView, IContentView, ISafeAreaView2, ISafeAreaElementController
 	{
 		/// <summary>Bindable property for <see cref="Content"/>.</summary>
 		public static readonly BindableProperty ContentProperty = BindableProperty.Create(nameof(Content), typeof(View), typeof(ContentView), null, propertyChanged: TemplateUtilities.OnContentChanged);
@@ -77,7 +77,7 @@ namespace Microsoft.Maui.Controls
 
 		IView IContentView.PresentedContent => ((this as IControlTemplated).TemplateRoot as IView) ?? Content;
 
-		SafeAreaEdges ISafeAreaElement.SafeAreaEdgesDefaultValueCreator()
+		SafeAreaEdges ISafeAreaElementController.SafeAreaEdgesDefaultValueCreator()
 		{
 			return SafeAreaEdges.None;
 		}

--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Controls
 	/// </summary>
 	[ContentProperty(nameof(Children))]
 	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
-	public abstract partial class Layout : View, Maui.ILayout, IList<IView>, IBindableLayout, IPaddingElement, IVisualTreeElement, ISafeAreaView, IInputTransparentContainerElement, ISafeAreaView2, ISafeAreaElement
+	public abstract partial class Layout : View, Maui.ILayout, IList<IView>, IBindableLayout, IPaddingElement, IVisualTreeElement, ISafeAreaView, IInputTransparentContainerElement, ISafeAreaView2, ISafeAreaElementController
 	{
 		protected ILayoutManager _layoutManager;
 
@@ -370,7 +370,7 @@ namespace Microsoft.Maui.Controls
 			return new Thickness(0);
 		}
 
-		SafeAreaEdges ISafeAreaElement.SafeAreaEdgesDefaultValueCreator()
+		SafeAreaEdges ISafeAreaElementController.SafeAreaEdgesDefaultValueCreator()
 		{
 			return SafeAreaEdges.Container;
 		}

--- a/src/Controls/src/Core/SafeAreaElement.cs
+++ b/src/Controls/src/Core/SafeAreaElement.cs
@@ -17,7 +17,9 @@ namespace Microsoft.Maui.Controls
 									defaultValueCreator: SafeAreaEdgesDefaultValueCreator);
 
 		static object SafeAreaEdgesDefaultValueCreator(BindableObject bindable)
-			=> ((ISafeAreaElement)bindable).SafeAreaEdgesDefaultValueCreator();
+			=> bindable is ISafeAreaElementController controller
+				? controller.SafeAreaEdgesDefaultValueCreator()
+				: SafeAreaEdges.Default;
 
 		/// <summary>
 		/// Gets the effective safe area behavior for a specific edge.

--- a/src/Controls/src/Core/ScrollView/ScrollView.cs
+++ b/src/Controls/src/Core/ScrollView/ScrollView.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Controls
 	[ContentProperty(nameof(Content))]
 	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
 #pragma warning disable CS0618 // Type or member is obsolete
-	public partial class ScrollView : Compatibility.Layout, ILayout, ILayoutController, IPaddingElement, IView, IVisualTreeElement, IInputTransparentContainerElement, IScrollViewController, IElementConfiguration<ScrollView>, IFlowDirectionController, IScrollView, IContentView, ISafeAreaElement, ISafeAreaView2
+	public partial class ScrollView : Compatibility.Layout, ILayout, ILayoutController, IPaddingElement, IView, IVisualTreeElement, IInputTransparentContainerElement, IScrollViewController, IElementConfiguration<ScrollView>, IFlowDirectionController, IScrollView, IContentView, ISafeAreaElementController, ISafeAreaView2
 #pragma warning restore CS0618 // Type or member is obsolete
 	{
 		#region IScrollViewController
@@ -550,7 +550,7 @@ namespace Microsoft.Maui.Controls
 		Size IContentView.CrossPlatformArrange(Rect bounds) =>
 			((ICrossPlatformLayout)this).CrossPlatformArrange(bounds);
 
-		SafeAreaEdges ISafeAreaElement.SafeAreaEdgesDefaultValueCreator()
+		SafeAreaEdges ISafeAreaElementController.SafeAreaEdgesDefaultValueCreator()
 		{
 			return SafeAreaEdges.Default;
 		}

--- a/src/Controls/tests/Core.UnitTests/SafeAreaTests.cs
+++ b/src/Controls/tests/Core.UnitTests/SafeAreaTests.cs
@@ -250,6 +250,51 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.IsAssignableFrom<ISafeAreaView2>(contentView);
 		}
 
+		[Fact]
+		public void CustomView_ImplementsPublicSafeAreaContract()
+		{
+			var view = new CustomSafeAreaView
+			{
+				SafeAreaEdges = new SafeAreaEdges(
+					SafeAreaRegions.Container,
+					SafeAreaRegions.None,
+					SafeAreaRegions.All,
+					SafeAreaRegions.SoftInput)
+			};
+
+			Assert.IsAssignableFrom<ISafeAreaElement>(view);
+			Assert.Equal(SafeAreaRegions.Container, view.GetSafeAreaRegionForEdge(0));
+			Assert.Equal(SafeAreaRegions.None, view.GetSafeAreaRegionForEdge(1));
+			Assert.Equal(SafeAreaRegions.All, view.GetSafeAreaRegionForEdge(2));
+			Assert.Equal(SafeAreaRegions.SoftInput, view.GetSafeAreaRegionForEdge(3));
+			Assert.Equal(view.SafeAreaEdges, view.GetEffectiveSafeAreaEdges());
+		}
+
+		[Fact]
+		public void CustomView_SafeAreaEdgesCanChange()
+		{
+			var view = new CustomSafeAreaView();
+
+			Assert.Equal(SafeAreaEdges.None, view.SafeAreaEdges);
+
+			view.SafeAreaEdges = SafeAreaEdges.Container;
+
+			Assert.Equal(SafeAreaEdges.Container, view.SafeAreaEdges);
+			Assert.Equal(SafeAreaRegions.Container, view.GetSafeAreaRegionForEdge(0));
+		}
+
+		[Fact]
+		public void BuiltInView_EffectiveSafeAreaEdgesPreserveLegacyBehavior()
+		{
+#pragma warning disable CS0618 // Type or member is obsolete
+			var layout = new Grid { IgnoreSafeArea = true };
+#pragma warning restore CS0618 // Type or member is obsolete
+
+			var effectiveEdges = ((ISafeAreaElement)layout).GetEffectiveSafeAreaEdges();
+
+			Assert.Equal(SafeAreaEdges.None, effectiveEdges);
+		}
+
 		[Theory]
 		[MemberData(nameof(SafeAreaView2Types))]
 		public void HasExplicitSafeAreaEdges_DefaultValueCreationDoesNotCountAsExplicit(Type safeAreaViewType)
@@ -318,6 +363,22 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		class SafeAreaBindingContext
 		{
 			public SafeAreaEdges Edges { get; set; }
+		}
+
+		sealed class CustomSafeAreaView : View, ISafeAreaElement
+		{
+			public static readonly BindableProperty SafeAreaEdgesProperty =
+				BindableProperty.Create(
+					nameof(SafeAreaEdges),
+					typeof(SafeAreaEdges),
+					typeof(CustomSafeAreaView),
+					SafeAreaEdges.None);
+
+			public SafeAreaEdges SafeAreaEdges
+			{
+				get => (SafeAreaEdges)GetValue(SafeAreaEdgesProperty);
+				set => SetValue(SafeAreaEdgesProperty, value);
+			}
 		}
 
 		static BindableObject CreateSafeAreaBindable(Type safeAreaViewType)

--- a/src/Core/src/Core/ISafeAreaElement.cs
+++ b/src/Core/src/Core/ISafeAreaElement.cs
@@ -1,14 +1,81 @@
-using System.ComponentModel;
-using Microsoft.Maui;
-
 namespace Microsoft.Maui
 {
-	[EditorBrowsable(EditorBrowsableState.Never)]
-	internal interface ISafeAreaElement
+	/// <summary>
+	/// Defines how a view's content is positioned relative to safe area regions.
+	/// </summary>
+	/// <remarks>
+	/// Implement this interface on a custom <see cref="IView"/> to participate in
+	/// .NET MAUI safe area handling on supported platforms.
+	/// </remarks>
+	public interface ISafeAreaElement
 	{
-		//note to implementor: implement this property publicly
+		/// <summary>
+		/// Gets the safe area regions that the view should avoid for each edge.
+		/// </summary>
 		SafeAreaEdges SafeAreaEdges { get; }
+	}
 
+	internal interface ISafeAreaElementController : ISafeAreaElement
+	{
 		SafeAreaEdges SafeAreaEdgesDefaultValueCreator();
+	}
+
+	/// <summary>
+	/// Provides methods for reading safe area configuration.
+	/// </summary>
+	public static class SafeAreaElementExtensions
+	{
+		/// <summary>
+		/// Gets the effective safe area configuration used by .NET MAUI platform handlers.
+		/// </summary>
+		/// <param name="safeAreaElement">The safe area element whose configuration to read.</param>
+		/// <returns>
+		/// The resolved handler input. Platform handlers may further adjust the applied insets
+		/// for keyboard geometry, view position, and ancestor handling.
+		/// </returns>
+		/// <exception cref="System.ArgumentNullException">
+		/// Thrown when <paramref name="safeAreaElement"/> is <see langword="null"/>.
+		/// </exception>
+		public static SafeAreaEdges GetEffectiveSafeAreaEdges(this ISafeAreaElement safeAreaElement)
+		{
+			if (safeAreaElement is null)
+			{
+				throw new System.ArgumentNullException(nameof(safeAreaElement));
+			}
+
+			if (safeAreaElement is ISafeAreaView2 safeAreaView2)
+			{
+				return new SafeAreaEdges(
+					safeAreaView2.GetSafeAreaRegionsForEdge(0),
+					safeAreaView2.GetSafeAreaRegionsForEdge(1),
+					safeAreaView2.GetSafeAreaRegionsForEdge(2),
+					safeAreaView2.GetSafeAreaRegionsForEdge(3));
+			}
+
+			return safeAreaElement.SafeAreaEdges;
+		}
+
+		internal static SafeAreaRegions GetSafeAreaRegionForEdge(this IView? view, int edge)
+		{
+			if (view is ISafeAreaView2 safeAreaView2)
+			{
+				return safeAreaView2.GetSafeAreaRegionsForEdge(edge);
+			}
+
+			if (view is ISafeAreaElement safeAreaElement)
+			{
+				return safeAreaElement.GetEffectiveSafeAreaEdges().GetEdge(edge);
+			}
+
+			if (view is ISafeAreaView safeAreaView)
+			{
+				return safeAreaView.IgnoreSafeArea ? SafeAreaRegions.None : SafeAreaRegions.Container;
+			}
+
+			return SafeAreaRegions.None;
+		}
+
+		internal static bool UsesSafeAreaEdges(this IView? view) =>
+			view is ISafeAreaView2 or ISafeAreaElement;
 	}
 }

--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Maui.Handlers
 				[nameof(IContextFlyoutElement.ContextFlyout)] = MapContextFlyout,
 #endif
 
-#if ANDROID || IOS
+#if ANDROID || IOS || MACCATALYST
 				[nameof(ISafeAreaElement.SafeAreaEdges)] = MapSafeAreaEdges
 #endif
 			};

--- a/src/Core/src/Handlers/View/ViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.iOS.cs
@@ -159,6 +159,11 @@ namespace Microsoft.Maui.Handlers
 				return;
 			}
 
+			if (handler.PlatformView is PlatformView platformView)
+			{
+				MauiView.InvalidateSafeArea(platformView);
+			}
+
 			view.InvalidateMeasure();
 		}
 	}

--- a/src/Core/src/Platform/Android/MauiWindowInsetListener.cs
+++ b/src/Core/src/Platform/Android/MauiWindowInsetListener.cs
@@ -172,8 +172,17 @@ namespace Microsoft.Maui.Platform
 
 		static bool HasExplicitSafeAreaEdges(AView view)
 		{
-			return view is ICrossPlatformLayoutBacking { CrossPlatformLayout: ISafeAreaView2 safeAreaView } &&
-				safeAreaView.HasExplicitSafeAreaEdges;
+			if (view is not ICrossPlatformLayoutBacking { CrossPlatformLayout: { } crossPlatformLayout })
+			{
+				return false;
+			}
+
+			return crossPlatformLayout switch
+			{
+				ISafeAreaView2 safeAreaView2 => safeAreaView2.HasExplicitSafeAreaEdges,
+				ISafeAreaElement => true,
+				_ => false
+			};
 		}
 
 		/// <summary>
@@ -358,10 +367,10 @@ namespace Microsoft.Maui.Platform
 
 		public bool HasTrackedView => _trackedViews.Count > 0;
 
-        public bool IsViewTracked(AView view)
-        {
-            return _trackedViews.Contains(view);
-        }
+		public bool IsViewTracked(AView view)
+		{
+			return _trackedViews.Contains(view);
+		}
 		public void ResetView(AView view)
 		{
 			if (view is IHandleWindowInsets customHandler)

--- a/src/Core/src/Platform/Android/SafeAreaExtensions.cs
+++ b/src/Core/src/Platform/Android/SafeAreaExtensions.cs
@@ -16,6 +16,14 @@ internal static class SafeAreaExtensions
 			_ => null
 		};
 
+	internal static ISafeAreaElement? GetSafeAreaElement(object? layout) =>
+		layout switch
+		{
+			ISafeAreaElement safeAreaElement => safeAreaElement,
+			IElementHandler { VirtualView: ISafeAreaElement virtualSafeAreaElement } => virtualSafeAreaElement,
+			_ => null
+		};
+
 	internal static ISafeAreaView? GetSafeAreaView(object? layout) =>
 		layout switch
 		{
@@ -35,6 +43,12 @@ internal static class SafeAreaExtensions
 			return safeAreaView2.GetSafeAreaRegionsForEdge(edge);
 		}
 
+		var safeAreaElement = GetSafeAreaElement(layout);
+		if (safeAreaElement is not null)
+		{
+			return safeAreaElement.SafeAreaEdges.GetEdge(edge);
+		}
+
 		var safeAreaView = GetSafeAreaView(layout);
 		return safeAreaView?.IgnoreSafeArea == false ? SafeAreaRegions.Container : SafeAreaRegions.None;
 	}
@@ -52,9 +66,10 @@ internal static class SafeAreaExtensions
 
 		var layout = crossPlatformLayout;
 		var safeAreaView2 = GetSafeAreaView2(layout);
-		var margins = (safeAreaView2 as IView)?.Margin ?? Thickness.Zero;
+		var safeAreaElement = GetSafeAreaElement(layout);
+		var margins = (safeAreaView2 as IView)?.Margin ?? (safeAreaElement as IView)?.Margin ?? Thickness.Zero;
 
-		if (safeAreaView2 is not null)
+		if (safeAreaView2 is not null || safeAreaElement is not null)
 		{
 			// Apply safe area selectively per edge based on SafeAreaRegions
 			var left = GetSafeAreaForEdge(GetSafeAreaRegionForEdge(0, layout), baseSafeArea.Left, 0, isKeyboardShowing, keyboardInsets);

--- a/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
+++ b/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
@@ -306,7 +306,7 @@ public static class KeyboardAutoManagerScroll
 	// all the fields are updated before calling AdjustPostition()
 	internal static async Task AdjustPositionDebounce()
 	{
-		// If View is inside a MauiView that implements ISafeAreaView2
+		// If View is inside a MauiView that handles SafeAreaEdges
 		// and has SafeAreaEdges.SoftInput set, do not perform auto-scrolling
 		// since SafeAreaEdges.SoftInput will handle the adjustments
 		if (View is not null && MauiView.IsSoftInputHandledByParent(View))

--- a/src/Core/src/Platform/iOS/MauiScrollView.cs
+++ b/src/Core/src/Platform/iOS/MauiScrollView.cs
@@ -192,14 +192,7 @@ namespace Microsoft.Maui.Platform
 		}
 
 		SafeAreaRegions GetSafeAreaRegionForEdge(int edge)
-		{
-			if (View is ISafeAreaView2 safeAreaPage)
-			{
-				return safeAreaPage.GetSafeAreaRegionsForEdge(edge);
-			}
-
-			return SafeAreaRegions.None; // Default: edge-to-edge content
-		}
+			=> View.GetSafeAreaRegionForEdge(edge);
 
 		SafeAreaEdges? _previousEdges;
 
@@ -621,8 +614,8 @@ namespace Microsoft.Maui.Platform
 		}
 
 		/// <summary>
-	    /// Called when the scroll orientation has changed to trigger proper RTL layout recalculation.
-	    /// </summary>
+		    /// Called when the scroll orientation has changed to trigger proper RTL layout recalculation.
+		    /// </summary>
 
 		internal void OnOrientationChanged()
 		{

--- a/src/Core/src/Platform/iOS/MauiView.cs
+++ b/src/Core/src/Platform/iOS/MauiView.cs
@@ -76,16 +76,16 @@ namespace Microsoft.Maui.Platform
 		/// </summary>
 		internal static void ApplyCellSafeAreaOverride(UIView cell, IView virtualView, UIView platformView)
 		{
-			if (virtualView is ISafeAreaView2 safeView && platformView is MauiView mauiView)
+			if (virtualView.UsesSafeAreaEdges() && platformView is MauiView mauiView)
 			{
-				var insets = ComputeCellSafeAreaInsets(cell, safeView);
+				var insets = ComputeCellSafeAreaInsets(cell, virtualView);
 				mauiView.CellSafeAreaOverride = insets != UIEdgeInsets.Zero
 					? insets.ToSafeAreaInsets()
 					: SafeAreaPadding.Empty;
 			}
 			else if (platformView is MauiView mv && !mv.CellSafeAreaOverride.IsEmpty)
 			{
-				// Clear stale override from a previous template that implemented ISafeAreaView2.
+				// Clear stale override from a previous template that used safe area edges.
 				mv.CellSafeAreaOverride = SafeAreaPadding.Empty;
 			}
 		}
@@ -95,7 +95,7 @@ namespace Microsoft.Maui.Platform
 		/// Returns <see cref="UIEdgeInsets.Zero"/> when all edges share the same region (e.g., default
 		/// Container×4), as the parent layout chain handles uniform safe area (#33604, #34635).
 		/// </summary>
-		static UIEdgeInsets ComputeCellSafeAreaInsets(UIView cell, ISafeAreaView2 safeView)
+		static UIEdgeInsets ComputeCellSafeAreaInsets(UIView cell, IView safeView)
 		{
 			var window = cell.Window;
 			if (window is null)
@@ -105,10 +105,10 @@ namespace Microsoft.Maui.Platform
 			if (windowSA == UIEdgeInsets.Zero)
 				return UIEdgeInsets.Zero;
 
-			var leftRegion = safeView.GetSafeAreaRegionsForEdge(0);
-			var topRegion = safeView.GetSafeAreaRegionsForEdge(1);
-			var rightRegion = safeView.GetSafeAreaRegionsForEdge(2);
-			var bottomRegion = safeView.GetSafeAreaRegionsForEdge(3);
+			var leftRegion = safeView.GetSafeAreaRegionForEdge(0);
+			var topRegion = safeView.GetSafeAreaRegionForEdge(1);
+			var rightRegion = safeView.GetSafeAreaRegionForEdge(2);
+			var bottomRegion = safeView.GetSafeAreaRegionForEdge(3);
 
 			// Uniform edges (Container×4, None×4, All×4) are handled by the parent layout chain.
 			bool allSameRegion = leftRegion == topRegion
@@ -214,20 +214,7 @@ namespace Microsoft.Maui.Platform
 		}
 
 		SafeAreaRegions GetSafeAreaRegionForEdge(int edge)
-		{
-			if (View is ISafeAreaView2 safeAreaPage)
-			{
-				return safeAreaPage.GetSafeAreaRegionsForEdge(edge);
-			}
-
-			// Fallback to legacy ISafeAreaView behavior
-			if (View is ISafeAreaView sav)
-			{
-				return sav.IgnoreSafeArea ? SafeAreaRegions.None : SafeAreaRegions.Container;
-			}
-
-			return SafeAreaRegions.None;
-		}
+			=> View.GetSafeAreaRegionForEdge(edge);
 
 		// Note: This method was changed from static to instance to access _isKeyboardShowing field
 		// which is needed to determine if SoftInput padding should be applied
@@ -281,11 +268,11 @@ namespace Microsoft.Maui.Platform
 		bool ShouldSubscribeToKeyboardNotifications()
 		{
 			// Only subscribe if any edge has All or SoftInput regions
-			if (View is ISafeAreaView2 safeAreaPage)
+			if (View.UsesSafeAreaEdges())
 			{
 				for (int edge = 0; edge < 4; edge++)
 				{
-					var region = safeAreaPage.GetSafeAreaRegionsForEdge(edge);
+					var region = GetSafeAreaRegionForEdge(edge);
 					if (SafeAreaEdges.IsSoftInput(region))
 					{
 						return true;
@@ -402,14 +389,14 @@ namespace Microsoft.Maui.Platform
 			var baseSafeArea = SafeAreaInsets.ToSafeAreaInsets();
 
 			// Check if keyboard-aware safe area adjustments are needed
-			if (View is ISafeAreaView2 safeAreaPage && _isKeyboardShowing)
+			if (View.UsesSafeAreaEdges() && _isKeyboardShowing)
 			{
 				// Check if any edge has SafeAreaRegions.SoftInput set
 				var needsKeyboardAdjustment = false;
 				for (int edge = 0; edge < 4; edge++)
 				{
 
-					var safeAreaRegion = safeAreaPage.GetSafeAreaRegionsForEdge(edge);
+					var safeAreaRegion = GetSafeAreaRegionForEdge(edge);
 					if (SafeAreaEdges.IsSoftInput(safeAreaRegion))
 					{
 						needsKeyboardAdjustment = true;
@@ -430,7 +417,7 @@ namespace Microsoft.Maui.Platform
 						// If keyboard is visible and intersects with window
 						if (!keyboardIntersection.IsEmpty)
 						{
-							var bottomEdgeRegion = safeAreaPage.GetSafeAreaRegionsForEdge(3); // 3 = bottom edge
+							var bottomEdgeRegion = GetSafeAreaRegionForEdge(3); // 3 = bottom edge
 
 							// For SafeAreaRegions.SoftInput: Always pad so content doesn't go under the keyboard
 							// Bottom edge is most commonly affected by keyboard
@@ -455,7 +442,7 @@ namespace Microsoft.Maui.Platform
 				}
 			}
 
-			if (View is ISafeAreaView2)
+			if (View.UsesSafeAreaEdges())
 			{
 				// Apply safe area selectively per edge based on SafeAreaRegions
 				var left = GetSafeAreaForEdge(baseSafeArea.Left, 0);
@@ -477,7 +464,7 @@ namespace Microsoft.Maui.Platform
 		}
 
 		/// <summary>
-		/// Checks if any parent view in the hierarchy is a MauiView that implements ISafeAreaView2
+		/// Checks if any parent view in the hierarchy is a MauiView that uses safe area edges
 		/// and has SafeAreaEdges.SoftInput set for the bottom edge. This is used to determine if
 		/// keyboard overlap/padding is already being handled by an ancestor, so the current view
 		/// should not apply additional adjustments.
@@ -486,8 +473,8 @@ namespace Microsoft.Maui.Platform
 		internal static bool IsSoftInputHandledByParent(UIView view)
 		{
 			return view.FindParent(x => x is MauiView mv
-				&& mv.View is ISafeAreaView2 safeAreaView2
-				&& SafeAreaEdges.IsSoftInput(safeAreaView2.GetSafeAreaRegionsForEdge(3))) is not null;
+				&& mv.View.UsesSafeAreaEdges()
+				&& SafeAreaEdges.IsSoftInput(mv.GetSafeAreaRegionForEdge(3))) is not null;
 		}
 
 
@@ -882,6 +869,24 @@ namespace Microsoft.Maui.Platform
 			_safeAreaInvalidated = true;
 			_parentHandlesSafeArea = null;
 			SetNeedsLayout();
+		}
+
+		internal static void InvalidateSafeArea(UIView platformView)
+		{
+			if (platformView is MauiView mauiView)
+			{
+				mauiView.InvalidateSafeArea();
+			}
+			else if (platformView is MauiScrollView mauiScrollView)
+			{
+				mauiScrollView.InvalidateSafeArea();
+			}
+
+			var subviews = platformView.Subviews;
+			for (int i = 0; i < subviews.Length; i++)
+			{
+				InvalidateSafeArea(subviews[i]);
+			}
 		}
 
 		/// <summary>

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -52,6 +52,10 @@ Microsoft.Maui.HybridWebViewInvoker.HybridWebViewInvoker(object? invokeJavaScrip
 Microsoft.Maui.IHybridWebView.Invoker.get -> Microsoft.Maui.HybridWebViewInvoker!
 Microsoft.Maui.IHybridWebView.Invoker.set -> void
 Microsoft.Maui.IHybridWebView.SetInvokeJavaScriptTarget<T>(T! target, System.Text.Json.Serialization.JsonSerializerContext! jsonSerializerContext) -> void
+Microsoft.Maui.ISafeAreaElement
+Microsoft.Maui.ISafeAreaElement.SafeAreaEdges.get -> Microsoft.Maui.SafeAreaEdges
+Microsoft.Maui.SafeAreaElementExtensions
+static Microsoft.Maui.SafeAreaElementExtensions.GetEffectiveSafeAreaEdges(this Microsoft.Maui.ISafeAreaElement! safeAreaElement) -> Microsoft.Maui.SafeAreaEdges
 Microsoft.Maui.ITab
 Microsoft.Maui.ITab.Icon.get -> Microsoft.Maui.IImageSource?
 Microsoft.Maui.ITab.IsEnabled.get -> bool

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -6,6 +6,10 @@ Microsoft.Maui.HybridWebViewInvoker.HybridWebViewInvoker(object? invokeJavaScrip
 Microsoft.Maui.IHybridWebView.Invoker.get -> Microsoft.Maui.HybridWebViewInvoker!
 Microsoft.Maui.IHybridWebView.Invoker.set -> void
 Microsoft.Maui.IHybridWebView.SetInvokeJavaScriptTarget<T>(T! target, System.Text.Json.Serialization.JsonSerializerContext! jsonSerializerContext) -> void
+Microsoft.Maui.ISafeAreaElement
+Microsoft.Maui.ISafeAreaElement.SafeAreaEdges.get -> Microsoft.Maui.SafeAreaEdges
+Microsoft.Maui.SafeAreaElementExtensions
+static Microsoft.Maui.SafeAreaElementExtensions.GetEffectiveSafeAreaEdges(this Microsoft.Maui.ISafeAreaElement! safeAreaElement) -> Microsoft.Maui.SafeAreaEdges
 Microsoft.Maui.ITab
 Microsoft.Maui.ITab.Icon.get -> Microsoft.Maui.IImageSource?
 Microsoft.Maui.ITab.IsEnabled.get -> bool

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -6,6 +6,10 @@ Microsoft.Maui.HybridWebViewInvoker.HybridWebViewInvoker(object? invokeJavaScrip
 Microsoft.Maui.IHybridWebView.Invoker.get -> Microsoft.Maui.HybridWebViewInvoker!
 Microsoft.Maui.IHybridWebView.Invoker.set -> void
 Microsoft.Maui.IHybridWebView.SetInvokeJavaScriptTarget<T>(T! target, System.Text.Json.Serialization.JsonSerializerContext! jsonSerializerContext) -> void
+Microsoft.Maui.ISafeAreaElement
+Microsoft.Maui.ISafeAreaElement.SafeAreaEdges.get -> Microsoft.Maui.SafeAreaEdges
+Microsoft.Maui.SafeAreaElementExtensions
+static Microsoft.Maui.SafeAreaElementExtensions.GetEffectiveSafeAreaEdges(this Microsoft.Maui.ISafeAreaElement! safeAreaElement) -> Microsoft.Maui.SafeAreaEdges
 Microsoft.Maui.ITab
 Microsoft.Maui.ITab.Icon.get -> Microsoft.Maui.IImageSource?
 Microsoft.Maui.ITab.IsEnabled.get -> bool

--- a/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -9,6 +9,10 @@ Microsoft.Maui.HybridWebViewInvoker
 Microsoft.Maui.HybridWebViewInvoker.HybridWebViewInvoker(object? invokeJavaScriptTarget, System.Type? invokeJavaScriptType) -> void
 Microsoft.Maui.IHybridWebView.Invoker.get -> Microsoft.Maui.HybridWebViewInvoker!
 Microsoft.Maui.IHybridWebView.Invoker.set -> void
+Microsoft.Maui.ISafeAreaElement
+Microsoft.Maui.ISafeAreaElement.SafeAreaEdges.get -> Microsoft.Maui.SafeAreaEdges
+Microsoft.Maui.SafeAreaElementExtensions
+static Microsoft.Maui.SafeAreaElementExtensions.GetEffectiveSafeAreaEdges(this Microsoft.Maui.ISafeAreaElement! safeAreaElement) -> Microsoft.Maui.SafeAreaEdges
 abstract Microsoft.Maui.HybridWebViewInvoker.InvokeMethodAsync(string! methodName, string![]? paramJsonValues) -> System.Threading.Tasks.Task<string?>!
 Microsoft.Maui.ITab
 Microsoft.Maui.ITab.Icon.get -> Microsoft.Maui.IImageSource?

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -5,6 +5,10 @@ Microsoft.Maui.HybridWebViewInvoker.HybridWebViewInvoker(object? invokeJavaScrip
 Microsoft.Maui.IHybridWebView.Invoker.get -> Microsoft.Maui.HybridWebViewInvoker!
 Microsoft.Maui.IHybridWebView.Invoker.set -> void
 Microsoft.Maui.IHybridWebView.SetInvokeJavaScriptTarget<T>(T! target, System.Text.Json.Serialization.JsonSerializerContext! jsonSerializerContext) -> void
+Microsoft.Maui.ISafeAreaElement
+Microsoft.Maui.ISafeAreaElement.SafeAreaEdges.get -> Microsoft.Maui.SafeAreaEdges
+Microsoft.Maui.SafeAreaElementExtensions
+static Microsoft.Maui.SafeAreaElementExtensions.GetEffectiveSafeAreaEdges(this Microsoft.Maui.ISafeAreaElement! safeAreaElement) -> Microsoft.Maui.SafeAreaEdges
 Microsoft.Maui.ITab
 Microsoft.Maui.ITab.Icon.get -> Microsoft.Maui.IImageSource?
 Microsoft.Maui.ITab.IsEnabled.get -> bool

--- a/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -4,6 +4,10 @@ Microsoft.Maui.HybridWebViewInvoker.HybridWebViewInvoker(object? invokeJavaScrip
 Microsoft.Maui.IHybridWebView.Invoker.get -> Microsoft.Maui.HybridWebViewInvoker!
 Microsoft.Maui.IHybridWebView.Invoker.set -> void
 Microsoft.Maui.IHybridWebView.SetInvokeJavaScriptTarget<T>(T! target, System.Text.Json.Serialization.JsonSerializerContext! jsonSerializerContext) -> void
+Microsoft.Maui.ISafeAreaElement
+Microsoft.Maui.ISafeAreaElement.SafeAreaEdges.get -> Microsoft.Maui.SafeAreaEdges
+Microsoft.Maui.SafeAreaElementExtensions
+static Microsoft.Maui.SafeAreaElementExtensions.GetEffectiveSafeAreaEdges(this Microsoft.Maui.ISafeAreaElement! safeAreaElement) -> Microsoft.Maui.SafeAreaEdges
 Microsoft.Maui.ISwipeItemMenuItemIconColor
 Microsoft.Maui.ISwipeItemMenuItemIconColor.IconColor.get -> Microsoft.Maui.Graphics.Color?
 Microsoft.Maui.ITab

--- a/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -8,6 +8,10 @@ Microsoft.Maui.HybridWebViewInvoker.HybridWebViewInvoker(object? invokeJavaScrip
 Microsoft.Maui.IHybridWebView.Invoker.get -> Microsoft.Maui.HybridWebViewInvoker!
 Microsoft.Maui.IHybridWebView.Invoker.set -> void
 Microsoft.Maui.IHybridWebView.SetInvokeJavaScriptTarget<T>(T! target, System.Text.Json.Serialization.JsonSerializerContext! jsonSerializerContext) -> void
+Microsoft.Maui.ISafeAreaElement
+Microsoft.Maui.ISafeAreaElement.SafeAreaEdges.get -> Microsoft.Maui.SafeAreaEdges
+Microsoft.Maui.SafeAreaElementExtensions
+static Microsoft.Maui.SafeAreaElementExtensions.GetEffectiveSafeAreaEdges(this Microsoft.Maui.ISafeAreaElement! safeAreaElement) -> Microsoft.Maui.SafeAreaEdges
 Microsoft.Maui.ITab
 Microsoft.Maui.ITab.Icon.get -> Microsoft.Maui.IImageSource?
 Microsoft.Maui.ITab.IsEnabled.get -> bool

--- a/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -4,6 +4,10 @@ Microsoft.Maui.HybridWebViewInvoker.HybridWebViewInvoker(object? invokeJavaScrip
 Microsoft.Maui.IHybridWebView.Invoker.get -> Microsoft.Maui.HybridWebViewInvoker!
 Microsoft.Maui.IHybridWebView.Invoker.set -> void
 Microsoft.Maui.IHybridWebView.SetInvokeJavaScriptTarget<T>(T! target, System.Text.Json.Serialization.JsonSerializerContext! jsonSerializerContext) -> void
+Microsoft.Maui.ISafeAreaElement
+Microsoft.Maui.ISafeAreaElement.SafeAreaEdges.get -> Microsoft.Maui.SafeAreaEdges
+Microsoft.Maui.SafeAreaElementExtensions
+static Microsoft.Maui.SafeAreaElementExtensions.GetEffectiveSafeAreaEdges(this Microsoft.Maui.ISafeAreaElement! safeAreaElement) -> Microsoft.Maui.SafeAreaEdges
 Microsoft.Maui.ISwipeItemMenuItemIconColor
 Microsoft.Maui.ISwipeItemMenuItemIconColor.IconColor.get -> Microsoft.Maui.Graphics.Color?
 Microsoft.Maui.ITab


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description of Change

Expose a focused public safe-area contract for third-party and custom views:

- make `ISafeAreaElement` public with its per-edge `SafeAreaEdges` configuration
- add `GetEffectiveSafeAreaEdges()` so native hosts can read the same compatibility-resolved values used by MAUI handlers
- keep MAUI control-specific default-value creation internal
- route iOS, Mac Catalyst, and Android safe-area handling through the public contract while retaining the existing `ISafeAreaView2` path for built-in controls
- invalidate the iOS native subtree when `SafeAreaEdges` changes at runtime
- treat custom `ISafeAreaElement` layouts as explicitly opted in when Android evaluates nested recycler/scroll-view listeners

This lets a custom view define its own bindable `SafeAreaEdges` property and participate in `Container`, `None`, `All`, and `SoftInput` behavior without implementing MAUI-internal interfaces. Existing built-in defaults and legacy `IgnoreSafeArea` behavior remain unchanged.

This PR supersedes and replaces #37750. That PR grew to 58 files and its current CI fails during compilation because stale `StatusBarTheme` entries are duplicated in `PublicAPI.Unshipped.txt`, preventing its platform tests from running. This replacement was developed independently from the current `net11.0` source, then compared afterward; it retains the necessary native-host resolution and runtime invalidation while avoiding the unrelated API baseline churn and broad safe-area refactor.

### Public API

```csharp
public interface ISafeAreaElement
{
    SafeAreaEdges SafeAreaEdges { get; }
}

public static SafeAreaEdges GetEffectiveSafeAreaEdges(this ISafeAreaElement safeAreaElement);
```

## Validation

### Unit and API validation

- `dotnet build Microsoft.Maui.BuildTasks.slnf --no-restore -p:PublicApiType=Validate --nologo --verbosity:minimal`
  - succeeded, including Core and Controls for iOS, Mac Catalyst, Android, .NET, and .NET Standard
- `dotnet test src/Controls/tests/Core.UnitTests/Controls.Core.UnitTests.csproj --no-restore -p:PublicApiType=Validate --filter FullyQualifiedName~SafeAreaTests --logger "console;verbosity=minimal"`
  - **61 passed, 0 failed**

### iOS

- `dotnet build src/Core/src/Core.csproj -f net11.0-ios26.5 -p:IncludeIosTargetFrameworks=true -p:PublicApiType=Validate --no-restore --nologo --verbosity:minimal`
  - **Build succeeded, 0 errors**
- `pwsh .github/scripts/BuildAndRunSandbox.ps1 -Platform ios -Configuration Debug -DeviceUdid 20F5E8A1-901C-4C42-B8AA-E41A0641E2C5`
  - iPhone 17 Pro simulator, iOS 26.5
  - custom `TemplatedView : ISafeAreaElement` toggled `None -> Container -> None`
  - observed top/bottom inset changes of **62 / 34 points**, then exact restoration

https://github.com/user-attachments/assets/78425540-621c-474c-a7cc-a0ec592f13d8

### Android

- `dotnet build src/Core/src/Core.csproj -f net11.0-android37.0 -p:IncludeAndroidTargetFrameworks=true -p:PublicApiType=Validate --no-restore --nologo --verbosity:minimal`
  - **Build succeeded, 0 errors**
- `ANDROID_SERIAL=emulator-5554 pwsh .github/scripts/BuildAndRunSandbox.ps1 -Platform android -Configuration Release -DeviceUdid emulator-5554`
  - Copilot_API_35 emulator, Android API 35
  - custom `TemplatedView : ISafeAreaElement` toggled `None -> Container -> None`
  - observed top/bottom inset changes of **128 / 63 pixels**, then exact restoration

https://github.com/user-attachments/assets/5eeb68c8-ec26-4d06-8e2b-3e44773302c7

The proof-only Sandbox scenario was removed after recording; production tests remain in the change.

## Issues Fixed

Fixes #37384
