### PR TITLE
Fix SetDynamicResource does not update the Background property of the Label

### DIFF
--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -492,6 +492,18 @@ namespace Microsoft.Maui.Controls
 			if (string.IsNullOrEmpty(key))
 				throw new ArgumentNullException(nameof(key));
 
+			// An explicit dynamic-resource assignment (SetterSpecificity.DynamicResourceSetter) must still take
+			// effect even if the property already has a manually-set local value (e.g. set previously in XAML
+			// or code), the same way an explicit SetValue call already overrides a prior Binding/DynamicResource.
+			// We only clear the stale ManualValueSetter entry here -- we do NOT raise the new value's own
+			// specificity -- so the resource stays correctly tracked at DynamicResourceSetter specificity for
+			// any future ambient resource-dictionary updates (see https://github.com/dotnet/maui/issues/37540).
+			// This lives at the shared entry point so it applies uniformly whether SetDynamicResource is called
+			// explicitly in code, via Element's public wrapper, or via the IDynamicResourceHandler interface
+			// used by XAML-compiled {DynamicResource} markup.
+			if (specificity == SetterSpecificity.DynamicResourceSetter)
+				ClearValue(property, SetterSpecificity.ManualValueSetter);
+
 			OnSetDynamicResource(property, key, specificity);
 		}
 

--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -501,10 +501,10 @@ namespace Microsoft.Maui.Controls
 			// This lives at the shared entry point so it applies uniformly whether SetDynamicResource is called
 			// explicitly in code, via Element's public wrapper, or via the IDynamicResourceHandler interface
 			// used by XAML-compiled {DynamicResource} markup.
+			OnSetDynamicResource(property, key, specificity);
+
 			if (specificity == SetterSpecificity.DynamicResourceSetter)
 				ClearValue(property, SetterSpecificity.ManualValueSetter);
-
-			OnSetDynamicResource(property, key, specificity);
 		}
 
 		/// <summary>

--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -491,8 +491,11 @@ namespace Microsoft.Maui.Controls
 			if (string.IsNullOrEmpty(key))
 				throw new ArgumentNullException(nameof(key));
 
-			BindablePropertyContext context = GetOrCreateContext(property);
-			context.Attributes |= BindableContextAttributes.IsDynamicResource;
+			if (specificity == SetterSpecificity.DynamicResourceSetter)
+			{
+				BindablePropertyContext context = GetOrCreateContext(property);
+				context.Attributes |= BindableContextAttributes.IsDynamicResource;
+			}
 			OnSetDynamicResource(property, key, specificity);
 		}
 
@@ -679,7 +682,9 @@ namespace Microsoft.Maui.Controls
 
 			context.Attributes &= ~BindableContextAttributes.IsDefaultValueCreated;
 
-			if ((context.Attributes & BindableContextAttributes.IsDynamicResource) != 0 && clearDynamicResources && !currentlyApplying)
+			if ((context.Attributes & BindableContextAttributes.IsDynamicResource) != 0
+				&& clearDynamicResources
+				&& (specificity == SetterSpecificity.ManualValueSetter || (specificity.IsBinding && !currentlyApplying)))
 				RemoveDynamicResource(property);
 
 			BindingBase binding = context.Bindings.GetValue();

--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -492,6 +492,16 @@ namespace Microsoft.Maui.Controls
 			if (string.IsNullOrEmpty(key))
 				throw new ArgumentNullException(nameof(key));
 
+			var context = GetOrCreateContext(property);
+			var currentSpecificity = context.Values.GetSpecificity();
+			if (specificity == SetterSpecificity.DynamicResourceSetter && currentSpecificity == SetterSpecificity.ManualValueSetter)
+			{
+				var currentValue = context.Values.GetValue();
+
+				context.Values.Remove(currentSpecificity);
+				context.Values[SetterSpecificity.DynamicResourceSetter] = currentValue;
+			}
+
 			OnSetDynamicResource(property, key, specificity);
 		}
 
@@ -607,15 +617,13 @@ namespace Microsoft.Maui.Controls
 				if (delayQueue == null)
 					context.DelayedSetters = delayQueue = new Queue<SetValueArgs>();
 
-				delayQueue.Enqueue(new SetValueArgs(property, context, value, currentlyApplying, attributes, specificity,
-					(privateAttributes & SetValuePrivateFlags.ReplaceManualValue) != 0));
+				delayQueue.Enqueue(new SetValueArgs(property, context, value, currentlyApplying, attributes, specificity));
 			}
 			else
 			{
 				var silent = (privateAttributes & SetValuePrivateFlags.Silent) != 0;
 				context.Attributes |= BindableContextAttributes.IsBeingSet;
-				SetValueActual(property, context, value, currentlyApplying, attributes, specificity, silent,
-					(privateAttributes & SetValuePrivateFlags.ReplaceManualValue) != 0);
+				SetValueActual(property, context, value, currentlyApplying, attributes, specificity, silent);
 
 				Queue<SetValueArgs> delayQueue = context.DelayedSetters;
 				if (delayQueue != null)
@@ -624,7 +632,7 @@ namespace Microsoft.Maui.Controls
 					{
 						SetValueArgs s = delayQueue.Dequeue();
 						if (s != null)
-							SetValueActual(s.Property, s.Context, s.Value, s.CurrentlyApplying, s.Attributes, s.Specificity, silent, s.ReplaceManualValue);
+							SetValueActual(s.Property, s.Context, s.Value, s.CurrentlyApplying, s.Attributes, s.Specificity, silent);
 					}
 
 					context.DelayedSetters = null;
@@ -634,17 +642,11 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		void SetValueActual(BindableProperty property, BindablePropertyContext context, object value, bool currentlyApplying, SetValueFlags attributes, SetterSpecificity specificity, bool silent = false, bool replaceManualValue = false)
+		void SetValueActual(BindableProperty property, BindablePropertyContext context, object value, bool currentlyApplying, SetValueFlags attributes, SetterSpecificity specificity, bool silent = false)
 		{
 			var specificityAndValue = context.Values.GetSpecificityAndValue();
 			var original = specificityAndValue.Value;
 			var originalSpecificity = specificityAndValue.Key;
-
-			if (replaceManualValue)
-			{
-				context.Values.Remove(SetterSpecificity.ManualValueSetter);
-				originalSpecificity = context.Values.GetSpecificity();
-			}
 
 			//if the last value was set from handler, override it
 			if (specificity != SetterSpecificity.FromHandler
@@ -903,7 +905,6 @@ namespace Microsoft.Maui.Controls
 			Silent = 1 << 1,
 			FromStyle = 1 << 3,
 			Converted = 1 << 4,
-			ReplaceManualValue = 1 << 5,
 			Default = None
 		}
 
@@ -913,11 +914,10 @@ namespace Microsoft.Maui.Controls
 			public readonly BindablePropertyContext Context;
 			public readonly bool CurrentlyApplying;
 			public readonly BindableProperty Property;
-			public readonly bool ReplaceManualValue;
 			public readonly object Value;
 			public readonly SetterSpecificity Specificity;
 
-			public SetValueArgs(BindableProperty property, BindablePropertyContext context, object value, bool currentlyApplying, SetValueFlags attributes, SetterSpecificity specificity, bool replaceManualValue = false)
+			public SetValueArgs(BindableProperty property, BindablePropertyContext context, object value, bool currentlyApplying, SetValueFlags attributes, SetterSpecificity specificity)
 			{
 				Property = property;
 				Context = context;
@@ -925,7 +925,6 @@ namespace Microsoft.Maui.Controls
 				CurrentlyApplying = currentlyApplying;
 				Attributes = attributes;
 				Specificity = specificity;
-				ReplaceManualValue = replaceManualValue;
 			}
 		}
 	}

--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -484,7 +484,6 @@ namespace Microsoft.Maui.Controls
 		internal void SetDynamicResource(BindableProperty property, string key)
 			=> SetDynamicResource(property, key, SetterSpecificity.DynamicResourceSetter);
 
-		//FIXME, use specificity
 		internal void SetDynamicResource(BindableProperty property, string key, SetterSpecificity specificity)
 		{
 			if (property == null)
@@ -492,16 +491,8 @@ namespace Microsoft.Maui.Controls
 			if (string.IsNullOrEmpty(key))
 				throw new ArgumentNullException(nameof(key));
 
-			var context = GetOrCreateContext(property);
-			var currentSpecificity = context.Values.GetSpecificity();
-			if (specificity == SetterSpecificity.DynamicResourceSetter && currentSpecificity == SetterSpecificity.ManualValueSetter)
-			{
-				var currentValue = context.Values.GetValue();
-
-				context.Values.Remove(currentSpecificity);
-				context.Values[SetterSpecificity.DynamicResourceSetter] = currentValue;
-			}
-
+			BindablePropertyContext context = GetOrCreateContext(property);
+			context.Attributes |= BindableContextAttributes.IsDynamicResource;
 			OnSetDynamicResource(property, key, specificity);
 		}
 
@@ -656,6 +647,13 @@ namespace Microsoft.Maui.Controls
 				originalSpecificity = context.Values.GetSpecificity();
 			}
 
+			if (specificity == SetterSpecificity.DynamicResourceSetter
+				&& (context.Attributes & BindableContextAttributes.IsDynamicResource) != 0)
+			{
+				context.Values.Remove(SetterSpecificity.ManualValueSetter);
+				originalSpecificity = context.Values.GetSpecificity();
+			}
+
 			//We keep setter of lower specificity so we can unapply
 			if (specificity < originalSpecificity)
 			{
@@ -681,7 +679,7 @@ namespace Microsoft.Maui.Controls
 
 			context.Attributes &= ~BindableContextAttributes.IsDefaultValueCreated;
 
-			if ((context.Attributes & BindableContextAttributes.IsDynamicResource) != 0 && clearDynamicResources)
+			if ((context.Attributes & BindableContextAttributes.IsDynamicResource) != 0 && clearDynamicResources && !currentlyApplying)
 				RemoveDynamicResource(property);
 
 			BindingBase binding = context.Bindings.GetValue();

--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -492,19 +492,7 @@ namespace Microsoft.Maui.Controls
 			if (string.IsNullOrEmpty(key))
 				throw new ArgumentNullException(nameof(key));
 
-			// An explicit dynamic-resource assignment (SetterSpecificity.DynamicResourceSetter) must still take
-			// effect even if the property already has a manually-set local value (e.g. set previously in XAML
-			// or code), the same way an explicit SetValue call already overrides a prior Binding/DynamicResource.
-			// We only clear the stale ManualValueSetter entry here -- we do NOT raise the new value's own
-			// specificity -- so the resource stays correctly tracked at DynamicResourceSetter specificity for
-			// any future ambient resource-dictionary updates (see https://github.com/dotnet/maui/issues/37540).
-			// This lives at the shared entry point so it applies uniformly whether SetDynamicResource is called
-			// explicitly in code, via Element's public wrapper, or via the IDynamicResourceHandler interface
-			// used by XAML-compiled {DynamicResource} markup.
 			OnSetDynamicResource(property, key, specificity);
-
-			if (specificity == SetterSpecificity.DynamicResourceSetter)
-				ClearValue(property, SetterSpecificity.ManualValueSetter);
 		}
 
 		/// <summary>
@@ -619,13 +607,15 @@ namespace Microsoft.Maui.Controls
 				if (delayQueue == null)
 					context.DelayedSetters = delayQueue = new Queue<SetValueArgs>();
 
-				delayQueue.Enqueue(new SetValueArgs(property, context, value, currentlyApplying, attributes, specificity));
+				delayQueue.Enqueue(new SetValueArgs(property, context, value, currentlyApplying, attributes, specificity,
+					(privateAttributes & SetValuePrivateFlags.ReplaceManualValue) != 0));
 			}
 			else
 			{
 				var silent = (privateAttributes & SetValuePrivateFlags.Silent) != 0;
 				context.Attributes |= BindableContextAttributes.IsBeingSet;
-				SetValueActual(property, context, value, currentlyApplying, attributes, specificity, silent);
+				SetValueActual(property, context, value, currentlyApplying, attributes, specificity, silent,
+					(privateAttributes & SetValuePrivateFlags.ReplaceManualValue) != 0);
 
 				Queue<SetValueArgs> delayQueue = context.DelayedSetters;
 				if (delayQueue != null)
@@ -634,7 +624,7 @@ namespace Microsoft.Maui.Controls
 					{
 						SetValueArgs s = delayQueue.Dequeue();
 						if (s != null)
-							SetValueActual(s.Property, s.Context, s.Value, s.CurrentlyApplying, s.Attributes, s.Specificity, silent);
+							SetValueActual(s.Property, s.Context, s.Value, s.CurrentlyApplying, s.Attributes, s.Specificity, silent, s.ReplaceManualValue);
 					}
 
 					context.DelayedSetters = null;
@@ -644,11 +634,17 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		void SetValueActual(BindableProperty property, BindablePropertyContext context, object value, bool currentlyApplying, SetValueFlags attributes, SetterSpecificity specificity, bool silent = false)
+		void SetValueActual(BindableProperty property, BindablePropertyContext context, object value, bool currentlyApplying, SetValueFlags attributes, SetterSpecificity specificity, bool silent = false, bool replaceManualValue = false)
 		{
 			var specificityAndValue = context.Values.GetSpecificityAndValue();
 			var original = specificityAndValue.Value;
 			var originalSpecificity = specificityAndValue.Key;
+
+			if (replaceManualValue)
+			{
+				context.Values.Remove(SetterSpecificity.ManualValueSetter);
+				originalSpecificity = context.Values.GetSpecificity();
+			}
 
 			//if the last value was set from handler, override it
 			if (specificity != SetterSpecificity.FromHandler
@@ -907,6 +903,7 @@ namespace Microsoft.Maui.Controls
 			Silent = 1 << 1,
 			FromStyle = 1 << 3,
 			Converted = 1 << 4,
+			ReplaceManualValue = 1 << 5,
 			Default = None
 		}
 
@@ -916,10 +913,11 @@ namespace Microsoft.Maui.Controls
 			public readonly BindablePropertyContext Context;
 			public readonly bool CurrentlyApplying;
 			public readonly BindableProperty Property;
+			public readonly bool ReplaceManualValue;
 			public readonly object Value;
 			public readonly SetterSpecificity Specificity;
 
-			public SetValueArgs(BindableProperty property, BindablePropertyContext context, object value, bool currentlyApplying, SetValueFlags attributes, SetterSpecificity specificity)
+			public SetValueArgs(BindableProperty property, BindablePropertyContext context, object value, bool currentlyApplying, SetValueFlags attributes, SetterSpecificity specificity, bool replaceManualValue = false)
 			{
 				Property = property;
 				Context = context;
@@ -927,6 +925,7 @@ namespace Microsoft.Maui.Controls
 				CurrentlyApplying = currentlyApplying;
 				Attributes = attributes;
 				Specificity = specificity;
+				ReplaceManualValue = replaceManualValue;
 			}
 		}
 	}

--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -651,7 +651,8 @@ namespace Microsoft.Maui.Controls
 			}
 
 			if (specificity == SetterSpecificity.DynamicResourceSetter
-				&& (context.Attributes & BindableContextAttributes.IsDynamicResource) != 0)
+				&& (context.Attributes & BindableContextAttributes.IsDynamicResource) != 0
+				&& originalSpecificity == SetterSpecificity.ManualValueSetter)
 			{
 				context.Values.Remove(SetterSpecificity.ManualValueSetter);
 				originalSpecificity = context.Values.GetSpecificity();
@@ -684,7 +685,8 @@ namespace Microsoft.Maui.Controls
 
 			if ((context.Attributes & BindableContextAttributes.IsDynamicResource) != 0
 				&& clearDynamicResources
-				&& (specificity == SetterSpecificity.ManualValueSetter || (specificity.IsBinding && !currentlyApplying)))
+				&& (specificity == SetterSpecificity.ManualValueSetter
+					|| (!currentlyApplying && (specificity == SetterSpecificity.FromHandler || specificity.IsBinding))))
 				RemoveDynamicResource(property);
 
 			BindingBase binding = context.Bindings.GetValue();

--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -858,7 +858,10 @@ namespace Microsoft.Maui.Controls
 			if (!DynamicResources.TryGetValue(property, out var existing) || existing.Item2 <= specificity)
 				DynamicResources[property] = (key, specificity);
 			if (this.TryGetResource(key, out var value))
-				OnResourceChanged(property, value, specificity);
+				OnResourceChanged(property, value, specificity, specificity == SetterSpecificity.DynamicResourceSetter);
+			else if (specificity == SetterSpecificity.DynamicResourceSetter)
+				SetValueCore(property, GetValue(property), SetValueFlags.None,
+					SetValuePrivateFlags.Silent | SetValuePrivateFlags.ReplaceManualValue, specificity);
 		}
 
 		internal event EventHandler ParentSet;
@@ -987,8 +990,9 @@ namespace Microsoft.Maui.Controls
 			RealParent?.OnDescendantRemoved(child);
 		}
 
-		void OnResourceChanged(BindableProperty property, object value, SetterSpecificity specificity)
-			=> SetValueCore(property, value, SetValueFlags.ClearOneWayBindings | SetValueFlags.ClearTwoWayBindings, SetValuePrivateFlags.Default, specificity);
+		void OnResourceChanged(BindableProperty property, object value, SetterSpecificity specificity, bool replaceManualValue = false)
+			=> SetValueCore(property, value, SetValueFlags.ClearOneWayBindings | SetValueFlags.ClearTwoWayBindings,
+				replaceManualValue ? SetValuePrivateFlags.ReplaceManualValue : SetValuePrivateFlags.Default, specificity);
 
 		/// <summary>Raised whenever the element's starts to change.</summary>
 		public event EventHandler<ParentChangingEventArgs> ParentChanging;

--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -858,10 +858,7 @@ namespace Microsoft.Maui.Controls
 			if (!DynamicResources.TryGetValue(property, out var existing) || existing.Item2 <= specificity)
 				DynamicResources[property] = (key, specificity);
 			if (this.TryGetResource(key, out var value))
-				OnResourceChanged(property, value, specificity, specificity == SetterSpecificity.DynamicResourceSetter);
-			else if (specificity == SetterSpecificity.DynamicResourceSetter)
-				SetValueCore(property, GetValue(property), SetValueFlags.None,
-					SetValuePrivateFlags.Silent | SetValuePrivateFlags.ReplaceManualValue, specificity);
+				OnResourceChanged(property, value, specificity);
 		}
 
 		internal event EventHandler ParentSet;
@@ -990,9 +987,8 @@ namespace Microsoft.Maui.Controls
 			RealParent?.OnDescendantRemoved(child);
 		}
 
-		void OnResourceChanged(BindableProperty property, object value, SetterSpecificity specificity, bool replaceManualValue = false)
-			=> SetValueCore(property, value, SetValueFlags.ClearOneWayBindings | SetValueFlags.ClearTwoWayBindings,
-				replaceManualValue ? SetValuePrivateFlags.ReplaceManualValue : SetValuePrivateFlags.Default, specificity);
+		void OnResourceChanged(BindableProperty property, object value, SetterSpecificity specificity)
+			=> SetValueCore(property, value, SetValueFlags.ClearOneWayBindings | SetValueFlags.ClearTwoWayBindings, SetValuePrivateFlags.Default, specificity);
 
 		/// <summary>Raised whenever the element's starts to change.</summary>
 		public event EventHandler<ParentChangingEventArgs> ParentChanging;

--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -617,7 +617,9 @@ namespace Microsoft.Maui.Controls
 		/// <param name="key">The key for the requested resource.</param>
 		public new void SetDynamicResource(BindableProperty property, string key)
 		{
-			base.SetDynamicResource(property, key);
+			// An explicit call to SetDynamicResource should override a prior manual value,
+			// similar to how an explicit SetValue overrides a prior binding.
+			base.SetDynamicResource(property, key, SetterSpecificity.ManualValueSetter);
 		}
 
 		/// <inheritdoc/>

--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -617,9 +617,7 @@ namespace Microsoft.Maui.Controls
 		/// <param name="key">The key for the requested resource.</param>
 		public new void SetDynamicResource(BindableProperty property, string key)
 		{
-			// An explicit call to SetDynamicResource should override a prior manual value,
-			// similar to how an explicit SetValue overrides a prior binding.
-			base.SetDynamicResource(property, key, SetterSpecificity.ManualValueSetter);
+			base.SetDynamicResource(property, key);
 		}
 
 		/// <inheritdoc/>

--- a/src/Controls/tests/Core.UnitTests/DynamicResourceTests.cs
+++ b/src/Controls/tests/Core.UnitTests/DynamicResourceTests.cs
@@ -455,6 +455,23 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public void SetDynamicResourceDoesNotExposeIntermediateDefaultValue()
+		{
+			var label = new Label { Text = "Manual" };
+			var observedValues = new List<string>();
+			label.PropertyChanged += (_, args) =>
+			{
+				if (args.PropertyName == nameof(Label.Text))
+					observedValues.Add(label.Text);
+			};
+
+			Application.Current.Resources = new ResourceDictionary { { "textKey", "FromResource" } };
+			label.SetDynamicResource(Label.TextProperty, "textKey");
+
+			Assert.Equal(new[] { "FromResource" }, observedValues);
+		}
+
+		[Fact]
 		public void DynamicResourceReplacesLocalValue()
 		{
 			var label = new Label

--- a/src/Controls/tests/Core.UnitTests/DynamicResourceTests.cs
+++ b/src/Controls/tests/Core.UnitTests/DynamicResourceTests.cs
@@ -677,6 +677,61 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public void ManualValueSurvivesResourceUpdateUnderActiveVisualState()
+		{
+			var label = new Label
+			{
+				Resources = new ResourceDictionary { { "textKey", "FromResource" } }
+			};
+			label.SetDynamicResource(Label.TextProperty, "textKey");
+			VisualStateManager.SetVisualStateGroups(label, new VisualStateGroupList
+			{
+				new VisualStateGroup
+				{
+					States =
+					{
+						new VisualState { Name = "Normal" },
+						new VisualState
+						{
+							Name = "Active",
+							Setters = { new Setter { Property = Label.TextProperty, Value = "FromVisualState" } }
+						}
+					}
+				}
+			});
+
+			VisualStateManager.GoToState(label, "Active");
+			label.Text = "Manual";
+			label.Resources["textKey"] = "UpdatedResource";
+			VisualStateManager.GoToState(label, "Normal");
+
+			Assert.Equal("Manual", label.Text);
+		}
+
+		[Fact]
+		public void ManualValueSurvivesResourceUpdateUnderActiveTrigger()
+		{
+			var label = new Label
+			{
+				Resources = new ResourceDictionary { { "textKey", "FromResource" } }
+			};
+			label.SetDynamicResource(Label.TextProperty, "textKey");
+			label.Triggers.Add(new Trigger(typeof(Label))
+			{
+				Property = Label.IsEnabledProperty,
+				Value = false,
+				Setters = { new Setter { Property = Label.TextProperty, Value = "FromTrigger" } }
+			});
+
+			label.IsEnabled = false;
+			label.Text = "Manual";
+			label.Resources["textKey"] = "UpdatedResource";
+			label.IsEnabled = true;
+
+			Assert.Equal("Manual", label.Text);
+		}
+
+		[Fact]
 		public void ClearValueFallsBackToLastDynamicResourceValueAfterManualOverride()
 		{
 			var label = new Label

--- a/src/Controls/tests/Core.UnitTests/DynamicResourceTests.cs
+++ b/src/Controls/tests/Core.UnitTests/DynamicResourceTests.cs
@@ -368,6 +368,74 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal("FOO", label.Text);
 		}
 
+		[Fact]
+		public void SetDynamicResourceOverridesPriorManualValue()
+		{
+			// https://github.com/dotnet/maui/issues/37540
+			var page = new ContentPage
+			{
+				Resources = new ResourceDictionary { { "LabelTextColor", Colors.Red } }
+			};
+			var label = new Label { Background = Brush.Transparent };
+			page.Content = label;
+
+			label.SetDynamicResource(VisualElement.BackgroundProperty, "LabelTextColor");
+
+			Assert.Equal(Colors.Red, ((SolidColorBrush)label.Background).Color);
+		}
+
+		[Fact]
+		public void SetDynamicResourceOverridesPriorManualValueForAnyProperty()
+		{
+			// https://github.com/dotnet/maui/issues/37540
+			var page = new ContentPage
+			{
+				Resources = new ResourceDictionary { { "SomeText", "FOO" } }
+			};
+			var label = new Label { Text = "Manual" };
+			page.Content = label;
+
+			label.SetDynamicResource(Label.TextProperty, "SomeText");
+
+			Assert.Equal("FOO", label.Text);
+		}
+
+		[Fact]
+		public void SetDynamicResourceWithoutPriorManualValueStillApplies()
+		{
+			// https://github.com/dotnet/maui/issues/37540
+			var page = new ContentPage
+			{
+				Resources = new ResourceDictionary { { "LabelTextColor", Colors.Red } }
+			};
+			var label = new Label();
+			page.Content = label;
+
+			label.SetDynamicResource(VisualElement.BackgroundProperty, "LabelTextColor");
+
+			Assert.Equal(Colors.Red, ((SolidColorBrush)label.Background).Color);
+		}
+
+		[Fact]
+		public void ManualValueSetAfterSetDynamicResourceStillOverridesIt()
+		{
+			// https://github.com/dotnet/maui/issues/37540
+			// Ensures the fix implements "most recent explicit action wins" semantics,
+			// not "DynamicResource unconditionally wins".
+			var page = new ContentPage
+			{
+				Resources = new ResourceDictionary { { "LabelTextColor", Colors.Red } }
+			};
+			var label = new Label();
+			page.Content = label;
+
+			label.SetDynamicResource(VisualElement.BackgroundProperty, "LabelTextColor");
+			Assert.Equal(Colors.Red, ((SolidColorBrush)label.Background).Color);
+
+			label.Background = Brush.Transparent;
+			Assert.Equal(Brush.Transparent, label.Background);
+		}
+
 		class DynamicResourceOrderView : View
 		{
 			public static readonly BindableProperty FirstProperty = BindableProperty.Create(nameof(First), typeof(string), typeof(DynamicResourceOrderView), default(string),

--- a/src/Controls/tests/Core.UnitTests/DynamicResourceTests.cs
+++ b/src/Controls/tests/Core.UnitTests/DynamicResourceTests.cs
@@ -472,6 +472,55 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public void ManualValueSetDuringDynamicResourceChangeWins()
+		{
+			var label = new Label { Text = "Manual" };
+			var updateFromCallback = true;
+
+			label.PropertyChanging += (_, args) =>
+			{
+				if (args.PropertyName == nameof(Label.Text) && updateFromCallback)
+				{
+					updateFromCallback = false;
+					label.Text = "FromCallback";
+				}
+			};
+
+			Application.Current.Resources = new ResourceDictionary { { "textKey", "FromResource" } };
+
+			label.SetDynamicResource(Label.TextProperty, "textKey");
+
+			Assert.Equal("FromCallback", label.Text);
+		}
+
+		[Fact]
+		public void UnresolvedDynamicResourceRetainsLocalValueUntilResourceIsAvailable()
+		{
+			var label = new Label { Text = "Manual" };
+
+			label.SetDynamicResource(Label.TextProperty, "textKey");
+
+			Assert.Equal("Manual", label.Text);
+
+			label.Resources["textKey"] = "FromResource";
+
+			Assert.Equal("FromResource", label.Text);
+		}
+
+		[Fact]
+		public void UnresolvedDynamicResourceDoesNotOverrideNewerManualValue()
+		{
+			var label = new Label { Text = "Manual" };
+
+			label.SetDynamicResource(Label.TextProperty, "textKey");
+			label.Text = "ManualAgain";
+
+			label.Resources["textKey"] = "FromResource";
+
+			Assert.Equal("ManualAgain", label.Text);
+		}
+
+		[Fact]
 		public void DynamicResourceReplacesLocalValue()
 		{
 			var label = new Label

--- a/src/Controls/tests/Core.UnitTests/DynamicResourceTests.cs
+++ b/src/Controls/tests/Core.UnitTests/DynamicResourceTests.cs
@@ -368,74 +368,6 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal("FOO", label.Text);
 		}
 
-		[Fact]
-		public void SetDynamicResourceOverridesPriorManualValue()
-		{
-			// https://github.com/dotnet/maui/issues/37540
-			var page = new ContentPage
-			{
-				Resources = new ResourceDictionary { { "LabelTextColor", Colors.Red } }
-			};
-			var label = new Label { Background = Brush.Transparent };
-			page.Content = label;
-
-			label.SetDynamicResource(VisualElement.BackgroundProperty, "LabelTextColor");
-
-			Assert.Equal(Colors.Red, ((SolidColorBrush)label.Background).Color);
-		}
-
-		[Fact]
-		public void SetDynamicResourceOverridesPriorManualValueForAnyProperty()
-		{
-			// https://github.com/dotnet/maui/issues/37540
-			var page = new ContentPage
-			{
-				Resources = new ResourceDictionary { { "SomeText", "FOO" } }
-			};
-			var label = new Label { Text = "Manual" };
-			page.Content = label;
-
-			label.SetDynamicResource(Label.TextProperty, "SomeText");
-
-			Assert.Equal("FOO", label.Text);
-		}
-
-		[Fact]
-		public void SetDynamicResourceWithoutPriorManualValueStillApplies()
-		{
-			// https://github.com/dotnet/maui/issues/37540
-			var page = new ContentPage
-			{
-				Resources = new ResourceDictionary { { "LabelTextColor", Colors.Red } }
-			};
-			var label = new Label();
-			page.Content = label;
-
-			label.SetDynamicResource(VisualElement.BackgroundProperty, "LabelTextColor");
-
-			Assert.Equal(Colors.Red, ((SolidColorBrush)label.Background).Color);
-		}
-
-		[Fact]
-		public void ManualValueSetAfterSetDynamicResourceStillOverridesIt()
-		{
-			// https://github.com/dotnet/maui/issues/37540
-			// Ensures the fix implements "most recent explicit action wins" semantics,
-			// not "DynamicResource unconditionally wins".
-			var page = new ContentPage
-			{
-				Resources = new ResourceDictionary { { "LabelTextColor", Colors.Red } }
-			};
-			var label = new Label();
-			page.Content = label;
-
-			label.SetDynamicResource(VisualElement.BackgroundProperty, "LabelTextColor");
-			Assert.Equal(Colors.Red, ((SolidColorBrush)label.Background).Color);
-
-			label.Background = Brush.Transparent;
-			Assert.Equal(Brush.Transparent, label.Background);
-		}
-
 		class DynamicResourceOrderView : View
 		{
 			public static readonly BindableProperty FirstProperty = BindableProperty.Create(nameof(First), typeof(string), typeof(DynamicResourceOrderView), default(string),
@@ -456,6 +388,96 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			public static readonly BindableProperty ResourceProperty = BindableProperty.Create(nameof(Resource), typeof(object), typeof(BindableResourceView));
 
 			public object Resource => GetValue(ResourceProperty);
+		}
+
+		// Regression tests for https://github.com/dotnet/maui/issues/37540
+		// SetDynamicResource did not update a property that already had a manually-set local value.
+
+		[Fact]
+		public void SetDynamicResourceOverridesPriorManualValue()
+		{
+			var label = new Label();
+			label.Text = "Manual"; // manual value set first
+
+			Application.Current.Resources = new ResourceDictionary { { "textKey", "FromResource" } };
+			label.SetDynamicResource(Label.TextProperty, "textKey");
+
+			Assert.Equal("FromResource", label.Text);
+		}
+
+		[Fact]
+		public void SetDynamicResourceViaIDynamicResourceHandlerOverridesPriorManualValue()
+		{
+			// Exercises the same path used by XAML-compiled {DynamicResource} markup extensions.
+			var label = new Label();
+			label.Text = "Manual"; // manual value set first
+
+			Application.Current.Resources = new ResourceDictionary { { "textKey", "FromResource" } };
+			((IDynamicResourceHandler)label).SetDynamicResource(Label.TextProperty, "textKey");
+
+			Assert.Equal("FromResource", label.Text);
+		}
+
+		[Fact]
+		public void SetDynamicResourceKeepsDynamicResourceSpecificityAfterOverridingManualValue()
+		{
+			// After SetDynamicResource wins over a stale manual value, a later manual SetValue
+			// must still be able to override it (i.e. the resolved value must not be permanently
+			// re-tagged as a manual value with equal priority to future manual assignments).
+			var label = new Label();
+			label.Text = "Manual";
+
+			Application.Current.Resources = new ResourceDictionary { { "textKey", "FromResource" } };
+			label.SetDynamicResource(Label.TextProperty, "textKey");
+			Assert.Equal("FromResource", label.Text);
+
+			label.Text = "ManualAgain";
+			Assert.Equal("ManualAgain", label.Text);
+		}
+
+		[Fact]
+		public void AmbientResourceChangeDoesNotOverrideLaterManualValueAfterSetDynamicResource()
+		{
+			// A subsequent ambient ResourceDictionary change for the same key must not clobber a
+			// manual value that was set *after* SetDynamicResource ran.
+			var label = new Label();
+			label.Text = "Manual";
+
+			Application.Current.Resources = new ResourceDictionary { { "textKey", "FromResource" } };
+			label.SetDynamicResource(Label.TextProperty, "textKey");
+			Assert.Equal("FromResource", label.Text);
+
+			label.Text = "ManualAgain";
+			Assert.Equal("ManualAgain", label.Text);
+
+			Application.Current.Resources = new ResourceDictionary { { "textKey", "FromResourceUpdated" } };
+			Assert.Equal("ManualAgain", label.Text);
+		}
+
+		[Fact]
+		public void DynamicResourceReplacesLocalValue()
+		{
+			var label = new Label
+			{
+				Text = "LOCAL",
+				Resources = new ResourceDictionary
+				{
+					{ "foo", "RESOURCE" }
+				}
+			};
+
+			// The dynamic resource should replace the old local value.
+			label.SetDynamicResource(Label.TextProperty, "foo");
+
+			Assert.Equal("RESOURCE", label.Text);
+
+			// A newer local value should replace the dynamic resource.
+			label.Text = "NEW LOCAL";
+
+			// Updating the resource must not replace that newer local value.
+			label.Resources["foo"] = "UPDATED RESOURCE";
+
+			Assert.Equal("NEW LOCAL", label.Text);
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/DynamicResourceTests.cs
+++ b/src/Controls/tests/Core.UnitTests/DynamicResourceTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
@@ -544,6 +545,191 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			label.Resources["foo"] = "UPDATED RESOURCE";
 
 			Assert.Equal("NEW LOCAL", label.Text);
+		}
+
+		[Fact]
+		public void StyleDynamicResourceFallsBackToUpdatedValueAfterManualOverrideIsCleared()
+		{
+			var label = new Label
+			{
+				Resources = new ResourceDictionary { { "textKey", "FromResource" } },
+				Style = new Style(typeof(Label))
+				{
+					Setters =
+					{
+						new Setter { Property = Label.TextProperty, Value = new DynamicResource("textKey") }
+					}
+				}
+			};
+
+			label.Text = "Manual";
+			label.Resources["textKey"] = "UpdatedResource";
+			Assert.Equal("Manual", label.Text);
+
+			label.ClearValue(Label.TextProperty);
+
+			Assert.Equal("UpdatedResource", label.Text);
+		}
+
+		[Fact]
+		public void StyleDynamicResourceFallsBackToUpdatedValueAfterBindingIsRemoved()
+		{
+			var viewModel = new MockViewModel { Text = "FromBinding" };
+			var label = new Label
+			{
+				BindingContext = viewModel,
+				Resources = new ResourceDictionary { { "textKey", "FromResource" } },
+				Style = new Style(typeof(Label))
+				{
+					Setters =
+					{
+						new Setter { Property = Label.TextProperty, Value = new DynamicResource("textKey") }
+					}
+				}
+			};
+
+			label.SetBinding(Label.TextProperty, nameof(MockViewModel.Text));
+			label.Resources["textKey"] = "UpdatedResource";
+			Assert.Equal("FromBinding", label.Text);
+
+			label.RemoveBinding(Label.TextProperty);
+			label.ClearValue(Label.TextProperty, SetterSpecificity.FromBinding);
+
+			Assert.Equal("UpdatedResource", label.Text);
+		}
+
+		[Fact]
+		public void ManualValueSetDuringTwoWayBindingApplicationRemovesDynamicResource()
+		{
+			var viewModel = new MockViewModel { Text = "FromBinding" };
+			var label = new Label
+			{
+				BindingContext = viewModel,
+				Resources = new ResourceDictionary { { "textKey", "FromResource" } }
+			};
+			var converter = new ManualValueDuringBindingConverter(() => label.Text = "Manual");
+			label.SetBinding(Label.TextProperty, new Binding(nameof(MockViewModel.Text), BindingMode.TwoWay, converter: converter));
+			label.SetDynamicResource(Label.TextProperty, "textKey");
+
+			converter.SetManualValue = true;
+			label.Resources["textKey"] = "UpdatedResource";
+
+			Assert.Equal("Manual", label.Text);
+			label.Resources["textKey"] = "LaterResource";
+			Assert.Equal("Manual", label.Text);
+		}
+
+		[Fact]
+		public void VisualStateOverridePreservesDynamicResourceFallback()
+		{
+			var label = new Label
+			{
+				Resources = new ResourceDictionary { { "textKey", "FromResource" } }
+			};
+			label.SetDynamicResource(Label.TextProperty, "textKey");
+			VisualStateManager.SetVisualStateGroups(label, new VisualStateGroupList
+			{
+				new VisualStateGroup
+				{
+					States =
+					{
+						new VisualState { Name = "Normal" },
+						new VisualState
+						{
+							Name = "Active",
+							Setters = { new Setter { Property = Label.TextProperty, Value = "FromVisualState" } }
+						}
+					}
+				}
+			});
+
+			VisualStateManager.GoToState(label, "Active");
+			label.Resources["textKey"] = "UpdatedResource";
+			Assert.Equal("FromVisualState", label.Text);
+
+			VisualStateManager.GoToState(label, "Normal");
+
+			Assert.Equal("UpdatedResource", label.Text);
+		}
+
+		[Fact]
+		public void TriggerOverridePreservesDynamicResourceFallback()
+		{
+			var label = new Label
+			{
+				Resources = new ResourceDictionary { { "textKey", "FromResource" } }
+			};
+			label.SetDynamicResource(Label.TextProperty, "textKey");
+			label.Triggers.Add(new Trigger(typeof(Label))
+			{
+				Property = Label.IsEnabledProperty,
+				Value = false,
+				Setters = { new Setter { Property = Label.TextProperty, Value = "FromTrigger" } }
+			});
+
+			label.IsEnabled = false;
+			label.Resources["textKey"] = "UpdatedResource";
+			Assert.Equal("FromTrigger", label.Text);
+
+			label.IsEnabled = true;
+
+			Assert.Equal("UpdatedResource", label.Text);
+		}
+
+		[Fact]
+		public void ClearValueFallsBackToLastDynamicResourceValueAfterManualOverride()
+		{
+			var label = new Label
+			{
+				Resources = new ResourceDictionary { { "textKey", "FromResource" } }
+			};
+			label.SetDynamicResource(Label.TextProperty, "textKey");
+			label.Text = "Manual";
+			label.Resources["textKey"] = "UpdatedResource";
+
+			label.ClearValue(Label.TextProperty);
+
+			Assert.Equal("FromResource", label.Text);
+		}
+
+		[Fact]
+		public void RemoveDynamicResourceRetainsValueAndStopsUpdates()
+		{
+			var label = new Label
+			{
+				Resources = new ResourceDictionary { { "textKey", "FromResource" } }
+			};
+			label.SetDynamicResource(Label.TextProperty, "textKey");
+
+			label.RemoveDynamicResource(Label.TextProperty);
+			label.Resources["textKey"] = "UpdatedResource";
+
+			Assert.Equal("FromResource", label.Text);
+		}
+
+		sealed class ManualValueDuringBindingConverter : IValueConverter
+		{
+			readonly Action _setManualValue;
+
+			public ManualValueDuringBindingConverter(Action setManualValue)
+			{
+				_setManualValue = setManualValue;
+			}
+
+			public bool SetManualValue { get; set; }
+
+			public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+			{
+				if (!SetManualValue)
+					return value;
+
+				SetManualValue = false;
+				_setManualValue();
+				return "Manual";
+			}
+
+			public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+				=> value;
 		}
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
 
### Issue Details

Calling  label.SetDynamicResource(BackgroundProperty, key)  after the property already had a manually-assigned value (e.g.  Background="Transparent"  in XAML, or any manual assignment before the call — such as from a  Loaded  handler firing after the element already has a  Parent ) silently failed to update the property.

### Root Cause 

Calling  label.SetDynamicResource(BackgroundProperty, key)  after the property already had a manually-assigned value (e.g.  Background="Transparent"  in XAML, or any manual assignment before the call — such as from a  Loaded  handler firing after the element already has a  Parent ) silently failed to update the property.
 
Why:  SetterSpecificity  ( src/Controls/src/Core/SetterSpecificity.cs ) encodes a CSS-like priority order where  ManualValueSetter  always outranks  DynamicResourceSetter  — regardless of which was set later.
 
 Element.OnSetDynamicResource  ( Element.cs:855-862 ) always applied the resolved dynamic resource value at fixed  DynamicResourceSetter  specificity. In  BindableObject.SetValueActual  ( BindableObject.cs:632-638 ):
 
```
if (specificity < originalSpecificity)
{
    context.Values[specificity] = value;
    return;   // new value stored but never becomes effective
}
```
 
Since a prior manual value already occupied the higher-priority  ManualValueSetter  slot, the newly-resolved dynamic resource value was silently stashed and never surfaced — even though  TryGetResource  succeeded and resolved the key correctly. This reproduces for any  BindableProperty  (confirmed with  Label.Text  too), and is not a Color→Brush conversion bug (that path works fine via  TypeConversionHelper 's implicit-operator lookup).
 
This specificity rule is intentional for ambient propagation (a parent's  ResourceDictionary  changing shouldn't clobber a manually-set local value), but it incorrectly also blocked an explicit, imperative  SetDynamicResource  call, which a developer expects to take effect immediately — just like an explicit  SetValue  already overrides a prior Binding / DynamicResource .
 
### Description of Change
 
The existing manual value had higher specificity, preventing the resolved resource from becoming effective.

Direct Dynamic Resource Tracking
Only direct SetDynamicResource registrations are marked:
```
if (specificity == SetterSpecificity.DynamicResourceSetter)
{
    BindablePropertyContext context = GetOrCreateContext(property);
    context.Attributes |= BindableContextAttributes.IsDynamicResource;
}
```
A later explicit manual assignment or newly attached binding removes the direct dynamic-resource registration:

```
if ((context.Attributes & BindableContextAttributes.IsDynamicResource) != 0
    && clearDynamicResources
    && (specificity == SetterSpecificity.ManualValueSetter
        || (!currentlyApplying
            && (specificity == SetterSpecificity.FromHandler
                || specificity.IsBinding))))
{
    RemoveDynamicResource(property);
}
```
 
### Issues Fixed
 
Fixes #37540  
 
**Tested the behavior in the following platforms.**
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
| Before  | After  |
|---------|--------|
| <img src="https://github.com/user-attachments/assets/f65ea55a-dd2a-4c01-ac25-cf8f829deec5" Width="300" Height="600" /> | <img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/26e4528c-a50b-4887-aaf2-301b236f2812" /> |