### PR TITLE
[net11.0] Bump Android/MacIOS manifest bands to rc.2 and dependency versions

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -8,7 +8,6 @@
     <!--  Begin: Package sources from dotnet-android -->
     <!--  End: Package sources from dotnet-android -->
     <!--  Begin: Package sources from dotnet-macios -->
-    <add key="darc-pub-dotnet-macios-af61ca0" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-af61ca08/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-macios -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <!--  Begin: Package sources from dotnet-dotnet -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,161 +1,161 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.Sdk" Version="11.0.100-rc.1.26379.102">
+    <Dependency Name="Microsoft.NET.Sdk" Version="11.0.100-rc.2.26431.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>147c024e64965dd98d68ed8419e4f5320852e8ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-rc.2.26431.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>147c024e64965dd98d68ed8419e4f5320852e8ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="37.0.0-ci.main.2160">
+    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="37.0.0-rc.2.2352">
       <Uri>https://github.com/dotnet/android</Uri>
-      <Sha>444db99f7b362334b2785498c57064a4c66a7165</Sha>
+      <Sha>a199d8f76be961b9c40b7d19e04b9fc8ab14a6ff</Sha>
     </Dependency>
     <!-- Previous .NET Android version(s) -->
     <Dependency Name="Microsoft.NET.Sdk.Android.Manifest-10.0.100" Version="36.1.69" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
       <Uri>https://github.com/dotnet/android</Uri>
       <Sha>d549e1dc4e2a083b08b4f24cb5495e81b99d79b5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net11.0_26.5" Version="26.5.11992-net11-rc.1">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net11.0_26.5" Version="26.5.12125-net11-rc.2">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>17d5ebd7632ca2960ab6e3d4bdb68697d24bc2ba</Sha>
+      <Sha>b0aa98a8c6a7287dad8d2cf4971e16c87114cfb7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net11.0_26.5" Version="26.5.11992-net11-rc.1">
+    <Dependency Name="Microsoft.macOS.Sdk.net11.0_26.5" Version="26.5.12125-net11-rc.2">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>17d5ebd7632ca2960ab6e3d4bdb68697d24bc2ba</Sha>
+      <Sha>b0aa98a8c6a7287dad8d2cf4971e16c87114cfb7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net11.0_26.5" Version="26.5.11992-net11-rc.1">
+    <Dependency Name="Microsoft.iOS.Sdk.net11.0_26.5" Version="26.5.12125-net11-rc.2">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>17d5ebd7632ca2960ab6e3d4bdb68697d24bc2ba</Sha>
+      <Sha>b0aa98a8c6a7287dad8d2cf4971e16c87114cfb7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net11.0_26.5" Version="26.5.11992-net11-rc.1">
+    <Dependency Name="Microsoft.tvOS.Sdk.net11.0_26.5" Version="26.5.12125-net11-rc.2">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>17d5ebd7632ca2960ab6e3d4bdb68697d24bc2ba</Sha>
+      <Sha>b0aa98a8c6a7287dad8d2cf4971e16c87114cfb7</Sha>
     </Dependency>
     <!-- Previous .NET iOS version(s) -->
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_26.5" Version="26.5.10311" CoherentParentDependency="Microsoft.MacCatalyst.Sdk.net11.0_26.5">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_26.5" Version="26.5.10315" CoherentParentDependency="Microsoft.MacCatalyst.Sdk.net11.0_26.5">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>af61ca08ed24c08c40949ba72ccd82479ec2c73d</Sha>
+      <Sha>ac895e19154cd3305df029b18849b2e5ed98e036</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net10.0_26.5" Version="26.5.10311" CoherentParentDependency="Microsoft.macOS.Sdk.net11.0_26.5">
+    <Dependency Name="Microsoft.macOS.Sdk.net10.0_26.5" Version="26.5.10315" CoherentParentDependency="Microsoft.macOS.Sdk.net11.0_26.5">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>af61ca08ed24c08c40949ba72ccd82479ec2c73d</Sha>
+      <Sha>ac895e19154cd3305df029b18849b2e5ed98e036</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net10.0_26.5" Version="26.5.10311" CoherentParentDependency="Microsoft.iOS.Sdk.net11.0_26.5">
+    <Dependency Name="Microsoft.iOS.Sdk.net10.0_26.5" Version="26.5.10315" CoherentParentDependency="Microsoft.iOS.Sdk.net11.0_26.5">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>af61ca08ed24c08c40949ba72ccd82479ec2c73d</Sha>
+      <Sha>ac895e19154cd3305df029b18849b2e5ed98e036</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_26.5" Version="26.5.10311" CoherentParentDependency="Microsoft.tvOS.Sdk.net11.0_26.5">
+    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_26.5" Version="26.5.10315" CoherentParentDependency="Microsoft.tvOS.Sdk.net11.0_26.5">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>af61ca08ed24c08c40949ba72ccd82479ec2c73d</Sha>
+      <Sha>ac895e19154cd3305df029b18849b2e5ed98e036</Sha>
     </Dependency>
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="11.0.0-rc.2.26431.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>147c024e64965dd98d68ed8419e4f5320852e8ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="11.0.0-rc.2.26431.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>147c024e64965dd98d68ed8419e4f5320852e8ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="11.0.0-rc.2.26431.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>147c024e64965dd98d68ed8419e4f5320852e8ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="11.0.0-rc.2.26431.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>147c024e64965dd98d68ed8419e4f5320852e8ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.AspNetCore.Components" Version="11.0.0-rc.2.26431.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>147c024e64965dd98d68ed8419e4f5320852e8ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="11.0.0-rc.2.26431.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>147c024e64965dd98d68ed8419e4f5320852e8ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="11.0.0-rc.2.26431.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>147c024e64965dd98d68ed8419e4f5320852e8ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="11.0.0-rc.2.26431.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>147c024e64965dd98d68ed8419e4f5320852e8ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="11.0.0-rc.2.26431.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>147c024e64965dd98d68ed8419e4f5320852e8ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="11.0.0-rc.2.26431.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>147c024e64965dd98d68ed8419e4f5320852e8ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="11.0.0-rc.2.26431.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>147c024e64965dd98d68ed8419e4f5320852e8ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="11.0.0-rc.2.26431.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>147c024e64965dd98d68ed8419e4f5320852e8ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.JSInterop" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.JSInterop" Version="11.0.0-rc.2.26431.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>147c024e64965dd98d68ed8419e4f5320852e8ca</Sha>
     </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-preview.2.22102.8">
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>3f4da9ced34942d83054e647f3b1d9d7dde281e8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.Extensions.Configuration" Version="11.0.0-rc.2.26431.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>147c024e64965dd98d68ed8419e4f5320852e8ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="11.0.0-rc.2.26431.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>147c024e64965dd98d68ed8419e4f5320852e8ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="11.0.0-rc.2.26431.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>147c024e64965dd98d68ed8419e4f5320852e8ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="11.0.0-rc.2.26431.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>147c024e64965dd98d68ed8419e4f5320852e8ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="11.0.0-rc.2.26431.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>147c024e64965dd98d68ed8419e4f5320852e8ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="11.0.0-rc.2.26431.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>147c024e64965dd98d68ed8419e4f5320852e8ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="11.0.0-rc.2.26431.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>147c024e64965dd98d68ed8419e4f5320852e8ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.Extensions.Logging" Version="11.0.0-rc.2.26431.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>147c024e64965dd98d68ed8419e4f5320852e8ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="11.0.0-rc.2.26431.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>147c024e64965dd98d68ed8419e4f5320852e8ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="11.0.0-rc.2.26431.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>147c024e64965dd98d68ed8419e4f5320852e8ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Primitives" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.Extensions.Primitives" Version="11.0.0-rc.2.26431.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>147c024e64965dd98d68ed8419e4f5320852e8ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="11.0.0-rc.2.26431.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>147c024e64965dd98d68ed8419e4f5320852e8ca</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="11.0.0-prerelease.26064.3">
       <Uri>https://github.com/dotnet/xharness</Uri>
@@ -175,41 +175,41 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="11.0.0-beta.26379.102">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="11.0.0-beta.26431.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>147c024e64965dd98d68ed8419e4f5320852e8ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26379.102">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26431.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>147c024e64965dd98d68ed8419e4f5320852e8ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="11.0.0-beta.26379.102">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="11.0.0-beta.26431.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>147c024e64965dd98d68ed8419e4f5320852e8ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="11.0.0-beta.26379.102">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="11.0.0-beta.26431.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>147c024e64965dd98d68ed8419e4f5320852e8ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26379.102">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26431.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>147c024e64965dd98d68ed8419e4f5320852e8ca</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Helix.JobMonitor" Version="11.0.0-beta.26427.10">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2cdfe99944d984749c8bdfc7d8d6a2589ed15d6d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="11.0.0-beta.26379.102">
+    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="11.0.0-beta.26431.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>147c024e64965dd98d68ed8419e4f5320852e8ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="11.0.0-beta.26379.102">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="11.0.0-beta.26431.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>147c024e64965dd98d68ed8419e4f5320852e8ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="11.0.0-beta.26379.102">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="11.0.0-beta.26431.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>147c024e64965dd98d68ed8419e4f5320852e8ca</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -31,10 +31,10 @@
     <!-- Current previous .NET SDK major version's stable release of MAUI packages -->
     <MicrosoftMauiPreviousDotNetReleasedVersion>10.0.20</MicrosoftMauiPreviousDotNetReleasedVersion>
     <!-- dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>11.0.100-rc.1.26379.102</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>11.0.100-rc.2.26431.104</MicrosoftNETSdkPackageVersion>
     <MicrosoftDotnetSdkInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-rc.1.26379.102</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-rc.2.26431.104</MicrosoftNETCoreAppRefPackageVersion>
     <SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextJsonPackageVersion>
     <SystemTextEncodingsWebPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextEncodingsWebPackageVersion>
     <MicrosoftBclAsyncInterfacesPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftBclAsyncInterfacesPackageVersion>
@@ -42,18 +42,18 @@
     <optimizationandroidx64MIBCRuntimePackageVersion>1.0.0-prerelease.26420.2</optimizationandroidx64MIBCRuntimePackageVersion>
     <!-- Microsoft/Extensions -->
     <SystemCodeDomPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemCodeDomPackageVersion>
-    <MicrosoftExtensionsConfigurationVersion>11.0.0-rc.1.26379.102</MicrosoftExtensionsConfigurationVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsVersion>11.0.0-rc.1.26379.102</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationJsonVersion>11.0.0-rc.1.26379.102</MicrosoftExtensionsConfigurationJsonVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>11.0.0-rc.1.26379.102</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>11.0.0-rc.1.26379.102</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
-    <MicrosoftExtensionsFileProvidersAbstractionsVersion>11.0.0-rc.1.26379.102</MicrosoftExtensionsFileProvidersAbstractionsVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>11.0.0-rc.1.26379.102</MicrosoftExtensionsLoggingAbstractionsVersion>
-    <MicrosoftExtensionsLoggingVersion>11.0.0-rc.1.26379.102</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>11.0.0-rc.1.26379.102</MicrosoftExtensionsLoggingConsoleVersion>
-    <MicrosoftExtensionsLoggingDebugVersion>11.0.0-rc.1.26379.102</MicrosoftExtensionsLoggingDebugVersion>
-    <MicrosoftExtensionsPrimitivesVersion>11.0.0-rc.1.26379.102</MicrosoftExtensionsPrimitivesVersion>
-    <MicrosoftExtensionsHostingAbstractionsVersion>11.0.0-rc.1.26379.102</MicrosoftExtensionsHostingAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>11.0.0-rc.2.26431.104</MicrosoftExtensionsConfigurationVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>11.0.0-rc.2.26431.104</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationJsonVersion>11.0.0-rc.2.26431.104</MicrosoftExtensionsConfigurationJsonVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>11.0.0-rc.2.26431.104</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>11.0.0-rc.2.26431.104</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
+    <MicrosoftExtensionsFileProvidersAbstractionsVersion>11.0.0-rc.2.26431.104</MicrosoftExtensionsFileProvidersAbstractionsVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>11.0.0-rc.2.26431.104</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingVersion>11.0.0-rc.2.26431.104</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>11.0.0-rc.2.26431.104</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingDebugVersion>11.0.0-rc.2.26431.104</MicrosoftExtensionsLoggingDebugVersion>
+    <MicrosoftExtensionsPrimitivesVersion>11.0.0-rc.2.26431.104</MicrosoftExtensionsPrimitivesVersion>
+    <MicrosoftExtensionsHostingAbstractionsVersion>11.0.0-rc.2.26431.104</MicrosoftExtensionsHostingAbstractionsVersion>
     <MicrosoftExtensionsAIVersion>10.3.0</MicrosoftExtensionsAIVersion>
     <MicrosoftExtensionsAIAbstractionsVersion>10.3.0</MicrosoftExtensionsAIAbstractionsVersion>
     <MicrosoftExtensionsHttpVersion>11.0.0-preview.2.26103.111</MicrosoftExtensionsHttpVersion>
@@ -63,19 +63,19 @@
     <MicrosoftAgentsAIWorkflowsGeneratorsVersion>1.0.0-rc2</MicrosoftAgentsAIWorkflowsGeneratorsVersion>
     <MicrosoftAgentsAIHostingVersion>1.0.0-preview.260225.1</MicrosoftAgentsAIHostingVersion>
     <!-- xamarin/xamarin-android -->
-    <MicrosoftAndroidSdkWindowsPackageVersion>37.0.0-ci.main.2160</MicrosoftAndroidSdkWindowsPackageVersion>
+    <MicrosoftAndroidSdkWindowsPackageVersion>37.0.0-rc.2.2352</MicrosoftAndroidSdkWindowsPackageVersion>
     <MicrosoftNETSdkAndroidManifest100100PackageVersion>36.1.69</MicrosoftNETSdkAndroidManifest100100PackageVersion>
     <AndroidNetPreviousVersion>$(MicrosoftNetSdkAndroidManifest100100PackageVersion)</AndroidNetPreviousVersion>
     <!-- dotnet/macios -->
-    <MicrosoftMacCatalystSdknet110_265PackageVersion>26.5.11992-net11-rc.1</MicrosoftMacCatalystSdknet110_265PackageVersion>
-    <MicrosoftmacOSSdknet110_265PackageVersion>26.5.11992-net11-rc.1</MicrosoftmacOSSdknet110_265PackageVersion>
-    <MicrosoftiOSSdknet110_265PackageVersion>26.5.11992-net11-rc.1</MicrosoftiOSSdknet110_265PackageVersion>
-    <MicrosofttvOSSdknet110_265PackageVersion>26.5.11992-net11-rc.1</MicrosofttvOSSdknet110_265PackageVersion>
+    <MicrosoftMacCatalystSdknet110_265PackageVersion>26.5.12125-net11-rc.2</MicrosoftMacCatalystSdknet110_265PackageVersion>
+    <MicrosoftmacOSSdknet110_265PackageVersion>26.5.12125-net11-rc.2</MicrosoftmacOSSdknet110_265PackageVersion>
+    <MicrosoftiOSSdknet110_265PackageVersion>26.5.12125-net11-rc.2</MicrosoftiOSSdknet110_265PackageVersion>
+    <MicrosofttvOSSdknet110_265PackageVersion>26.5.12125-net11-rc.2</MicrosofttvOSSdknet110_265PackageVersion>
     <!-- This is a subscription of the .NET 10 latest stable versions of our packages -->
-    <MicrosoftMacCatalystSdknet100_265PackageVersion>26.5.10311</MicrosoftMacCatalystSdknet100_265PackageVersion>
-    <MicrosoftmacOSSdknet100_265PackageVersion>26.5.10311</MicrosoftmacOSSdknet100_265PackageVersion>
-    <MicrosoftiOSSdknet100_265PackageVersion>26.5.10311</MicrosoftiOSSdknet100_265PackageVersion>
-    <MicrosofttvOSSdknet100_265PackageVersion>26.5.10311</MicrosofttvOSSdknet100_265PackageVersion>
+    <MicrosoftMacCatalystSdknet100_265PackageVersion>26.5.10315</MicrosoftMacCatalystSdknet100_265PackageVersion>
+    <MicrosoftmacOSSdknet100_265PackageVersion>26.5.10315</MicrosoftmacOSSdknet100_265PackageVersion>
+    <MicrosoftiOSSdknet100_265PackageVersion>26.5.10315</MicrosoftiOSSdknet100_265PackageVersion>
+    <MicrosofttvOSSdknet100_265PackageVersion>26.5.10315</MicrosofttvOSSdknet100_265PackageVersion>
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>8.0.148</SamsungTizenSdkPackageVersion>
     <!-- wasdk -->
@@ -86,19 +86,19 @@
     <MicrosoftGraphicsWin2DPackageVersion>1.4.0</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.4078.44</MicrosoftWindowsWebView2PackageVersion>
     <!-- Everything else -->
-    <MicrosoftAspNetCoreAuthorizationPackageVersion>11.0.0-rc.1.26379.102</MicrosoftAspNetCoreAuthorizationPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>11.0.0-rc.1.26379.102</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>11.0.0-rc.1.26379.102</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
-    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>11.0.0-rc.1.26379.102</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
-    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>11.0.0-rc.1.26379.102</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreComponentsFormsPackageVersion>11.0.0-rc.1.26379.102</MicrosoftAspNetCoreComponentsFormsPackageVersion>
-    <MicrosoftAspNetCoreComponentsPackageVersion>11.0.0-rc.1.26379.102</MicrosoftAspNetCoreComponentsPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebPackageVersion>11.0.0-rc.1.26379.102</MicrosoftAspNetCoreComponentsWebPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>11.0.0-rc.1.26379.102</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>11.0.0-rc.1.26379.102</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>11.0.0-rc.1.26379.102</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
-    <MicrosoftAspNetCoreMetadataPackageVersion>11.0.0-rc.1.26379.102</MicrosoftAspNetCoreMetadataPackageVersion>
-    <MicrosoftJSInteropPackageVersion>11.0.0-rc.1.26379.102</MicrosoftJSInteropPackageVersion>
+    <MicrosoftAspNetCoreAuthorizationPackageVersion>11.0.0-rc.2.26431.104</MicrosoftAspNetCoreAuthorizationPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>11.0.0-rc.2.26431.104</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>11.0.0-rc.2.26431.104</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
+    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>11.0.0-rc.2.26431.104</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
+    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>11.0.0-rc.2.26431.104</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreComponentsFormsPackageVersion>11.0.0-rc.2.26431.104</MicrosoftAspNetCoreComponentsFormsPackageVersion>
+    <MicrosoftAspNetCoreComponentsPackageVersion>11.0.0-rc.2.26431.104</MicrosoftAspNetCoreComponentsPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebPackageVersion>11.0.0-rc.2.26431.104</MicrosoftAspNetCoreComponentsWebPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>11.0.0-rc.2.26431.104</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>11.0.0-rc.2.26431.104</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>11.0.0-rc.2.26431.104</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
+    <MicrosoftAspNetCoreMetadataPackageVersion>11.0.0-rc.2.26431.104</MicrosoftAspNetCoreMetadataPackageVersion>
+    <MicrosoftJSInteropPackageVersion>11.0.0-rc.2.26431.104</MicrosoftJSInteropPackageVersion>
     <MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion>11.0.0-rc.1.26379.102</MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion>
     <MicrosoftEntityFrameworkCoreSqlitePackageVersion>11.0.0-rc.1.26379.102</MicrosoftEntityFrameworkCoreSqlitePackageVersion>
     <!-- Everything else (previous edition) -->
@@ -150,14 +150,14 @@
     <TizenUIExtensionsVersion>0.9.0</TizenUIExtensionsVersion>
     <ExCSSPackageVersion>4.2.3</ExCSSPackageVersion>
     <SystemDrawingCommonPackageVersion>9.0.0</SystemDrawingCommonPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>11.0.0-beta.26379.102</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetBuildTasksInstallersPackageVersion>11.0.0-beta.26379.102</MicrosoftDotNetBuildTasksInstallersPackageVersion>
-    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>11.0.0-beta.26379.102</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>11.0.0-beta.26431.104</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksInstallersPackageVersion>11.0.0-beta.26431.104</MicrosoftDotNetBuildTasksInstallersPackageVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>11.0.0-beta.26431.104</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
     <MicrosoftDotNetHelixJobMonitorPackageVersion>11.0.0-beta.26427.10</MicrosoftDotNetHelixJobMonitorPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26379.102</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26431.104</MicrosoftDotNetHelixSdkPackageVersion>
     <MicroBuildPluginsSwixBuildDotnetPackageVersion>1.1.87-gba258badda</MicroBuildPluginsSwixBuildDotnetPackageVersion>
-    <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.26379.102</MicrosoftDotNetRemoteExecutorPackageVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>11.0.0-beta.26379.102</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.26431.104</MicrosoftDotNetRemoteExecutorPackageVersion>
+    <MicrosoftDotNetXUnitExtensionsPackageVersion>11.0.0-beta.26431.104</MicrosoftDotNetXUnitExtensionsPackageVersion>
     <MicrosoftWixVersion>6.0.3-dotnet.4</MicrosoftWixVersion>
   </PropertyGroup>
   <PropertyGroup>
@@ -228,9 +228,9 @@
     <MonoVersionBand>$(DotNetVersionBand)</MonoVersionBand>
     <DotNetSdkManifestsFolder>$(DotNetVersionBand)</DotNetSdkManifestsFolder>
     <DotNetMauiManifestVersionBand>$(DotNetVersionBand)</DotNetMauiManifestVersionBand>
-    <!-- Android and macOS still publish Preview 7 manifest package IDs while the VMR has advanced to RC 1. -->
-    <DotNetAndroidManifestVersionBand>11.0.100-preview.7</DotNetAndroidManifestVersionBand>
-    <DotNetMaciOSManifestVersionBand>11.0.100-preview.7</DotNetMaciOSManifestVersionBand>
+    <!-- Android and macOS still publish Preview 7 manifest package IDs while the VMR has advanced to RC 2. -->
+    <DotNetAndroidManifestVersionBand>11.0.100-rc.2</DotNetAndroidManifestVersionBand>
+    <DotNetMaciOSManifestVersionBand>11.0.100-rc.2</DotNetMaciOSManifestVersionBand>
     <DotNetTizenManifestVersionBand>9.0.100</DotNetTizenManifestVersionBand>
     <MicrosoftMacCatalystSdkPackageVersion>$(MicrosoftMacCatalystSdknet110_265PackageVersion)</MicrosoftMacCatalystSdkPackageVersion>
     <MicrosoftmacOSSdkPackageVersion>$(MicrosoftmacOSSdknet110_265PackageVersion)</MicrosoftmacOSSdkPackageVersion>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "11.0.100-rc.1.26379.102"
+    "dotnet": "11.0.100-rc.2.26431.104"
   },
   "sdk": {
     "paths": [
@@ -11,7 +11,7 @@
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44",
     "Microsoft.Build.NoTargets": "3.7.0",
-    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26379.102",
-    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26379.102"
+    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26431.104",
+    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26431.104"
   }
 }

--- a/src/DotNet/DotNet.csproj
+++ b/src/DotNet/DotNet.csproj
@@ -13,6 +13,9 @@
     <PrivateSdk Condition=" '$(PrivateSdk)' == ''">false</PrivateSdk>
     <_SkipUpgradeNetAnalyzersNuGetWarning>true</_SkipUpgradeNetAnalyzersNuGetWarning>
     <_SkipUpdateBuildNumber>true</_SkipUpdateBuildNumber>
+    <_NormalizedMSBuildExtensionsPath>$([MSBuild]::EnsureTrailingSlash('$(MSBuildExtensionsPath)'))</_NormalizedMSBuildExtensionsPath>
+    <_WorkloadManifestInstallDirectory>$(_NormalizedMSBuildExtensionsPath)../../sdk-manifests/$(DotNetSdkManifestsFolder)</_WorkloadManifestInstallDirectory>
+    <_WorkloadInstallDotNetPath>$(_NormalizedMSBuildExtensionsPath)../../dotnet</_WorkloadInstallDotNetPath>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('windows'))">
     <DotNetInstallScriptUrl>https://builds.dotnet.microsoft.com/dotnet/scripts/v1/dotnet-install.ps1</DotNetInstallScriptUrl>
@@ -73,7 +76,7 @@
     <CopyWorkloadFiles
         Name="microsoft.net.sdk.maui"
         Files="@(_WorkloadFiles)"
-        WorkloadDirectory="$(MSBuildExtensionsPath)../../sdk-manifests/$(DotNetSdkManifestsFolder)"
+        WorkloadDirectory="$(_WorkloadManifestInstallDirectory)"
     />
     <RemoveDir Directories="$(_InstallTempDirectory)" />
 
@@ -88,7 +91,7 @@
     </ItemGroup>
     <Copy SourceFiles="$(MauiRootDirectory)NuGet.config" DestinationFolder="$(DotNetTempDirectory)" />
     <Exec Command="dotnet nuget add source &quot;$(NugetArtifactsPath)&quot; --name artifacts --configfile &quot;$(DotNetTempDirectory)NuGet.config&quot;" />
-    <Exec Command="&quot;$(MSBuildExtensionsPath)../../dotnet&quot; workload install %(_LocalWorkloadIds.Identity) --skip-sign-check --skip-manifest-update --verbosity diag --temp-dir &quot;$(DotNetTempDirectory)&quot; --configfile &quot;$(DotNetTempDirectory)NuGet.config&quot;" WorkingDirectory="$(MauiRootDirectory)" />
+    <Exec Command="&quot;$(_WorkloadInstallDotNetPath)&quot; workload install %(_LocalWorkloadIds.Identity) --skip-sign-check --skip-manifest-update --verbosity diag --temp-dir &quot;$(DotNetTempDirectory)&quot; --configfile &quot;$(DotNetTempDirectory)NuGet.config&quot;" WorkingDirectory="$(MauiRootDirectory)" />
 
   </Target>
 

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/DotNetProjectTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/DotNetProjectTests.cs
@@ -1,0 +1,88 @@
+namespace Microsoft.Maui.IntegrationTests;
+
+[Trait("Category", "Build")]
+public class DotNetProjectTests
+{
+	readonly ITestOutputHelper _output;
+
+	public DotNetProjectTests(ITestOutputHelper output)
+	{
+		_output = output;
+	}
+
+	[Fact]
+	public void WorkloadInstallPathsAreIndependentOfTrailingSeparator()
+	{
+		var projectFile = Path.Combine(
+			TestEnvironment.GetMauiDirectory(),
+			"src",
+			"DotNet",
+			"DotNet.csproj");
+		var defaultExtensionsPath = GetProjectProperty(projectFile, "MSBuildExtensionsPath");
+		var extensionsPathWithoutSeparator = defaultExtensionsPath.TrimEnd(
+			Path.DirectorySeparatorChar,
+			Path.AltDirectorySeparatorChar);
+		var extensionsPathWithSeparator = extensionsPathWithoutSeparator + Path.DirectorySeparatorChar;
+
+		var withoutSeparator = GetWorkloadPaths(projectFile, extensionsPathWithoutSeparator);
+		var withSeparator = GetWorkloadPaths(projectFile, extensionsPathWithSeparator);
+
+		Assert.Equal(withSeparator, withoutSeparator);
+		Assert.True(
+			withoutSeparator.ExtensionsPath.EndsWith(
+				Path.DirectorySeparatorChar.ToString(),
+				StringComparison.Ordinal) ||
+			withoutSeparator.ExtensionsPath.EndsWith(
+				Path.AltDirectorySeparatorChar.ToString(),
+				StringComparison.Ordinal));
+		Assert.Equal(
+			$"{withoutSeparator.ExtensionsPath}../../sdk-manifests/{withoutSeparator.ManifestBand}",
+			withoutSeparator.ManifestDirectory);
+		Assert.Equal(
+			$"{withoutSeparator.ExtensionsPath}../../dotnet",
+			withoutSeparator.DotNetPath);
+	}
+
+	(string ExtensionsPath, string ManifestDirectory, string DotNetPath, string ManifestBand) GetWorkloadPaths(
+		string projectFile,
+		string extensionsPath)
+	{
+		return (
+			GetProjectProperty(projectFile, "_NormalizedMSBuildExtensionsPath", extensionsPath),
+			GetProjectProperty(projectFile, "_WorkloadManifestInstallDirectory", extensionsPath),
+			GetProjectProperty(projectFile, "_WorkloadInstallDotNetPath", extensionsPath),
+			GetProjectProperty(projectFile, "DotNetSdkManifestsFolder", extensionsPath));
+	}
+
+	string GetProjectProperty(string projectFile, string propertyName, string? extensionsPath = null)
+	{
+		var arguments = new List<string>
+		{
+			"msbuild",
+			projectFile,
+			"-nologo",
+			"-verbosity:quiet",
+			$"-getProperty:{propertyName}",
+		};
+		if (extensionsPath is not null)
+			arguments.Add($"-p:MSBuildExtensionsPath={extensionsPath}");
+
+		var output = DotnetInternal.RunForOutput(
+			arguments,
+			out var exitCode,
+			timeoutInSeconds: 60,
+			output: _output);
+
+		Assert.True(exitCode == 0, $"MSBuild property evaluation failed:{Environment.NewLine}{output}");
+
+		var value = output
+			.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+			.LastOrDefault()?
+			.Trim();
+
+		if (string.IsNullOrEmpty(value))
+			throw new XunitException($"MSBuild property '{propertyName}' was empty.");
+
+		return value;
+	}
+}

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/DotnetInternal.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/DotnetInternal.cs
@@ -179,10 +179,28 @@ namespace Microsoft.Maui.IntegrationTests
 			output?.WriteLine($"Running: '{DotnetTool}' with '{command}'");
 			output?.WriteLine($"Args list: {args}");
 			var pinfo = new ProcessStartInfo(DotnetTool, $"{command} {args}");
-			pinfo.EnvironmentVariables["DOTNET_MULTILEVEL_LOOKUP"] = "0";
-			pinfo.EnvironmentVariables["DOTNET_ROOT"] = DotnetRoot;
+			ConfigureDotnetEnvironment(pinfo);
 
 			return ToolRunner.Run(pinfo, out exitCode, timeoutInSeconds: timeoutInSeconds, output: output);
+		}
+
+		public static string RunForOutput(IReadOnlyList<string> arguments, out int exitCode, int timeoutInSeconds = DEFAULT_TIMEOUT, ITestOutputHelper? output = null)
+		{
+			output?.WriteLine($"Running: '{DotnetTool}'");
+			output?.WriteLine($"Args list: {string.Join(" | ", arguments)}");
+			var pinfo = new ProcessStartInfo(DotnetTool);
+			foreach (var argument in arguments)
+				pinfo.ArgumentList.Add(argument);
+
+			ConfigureDotnetEnvironment(pinfo);
+
+			return ToolRunner.Run(pinfo, out exitCode, timeoutInSeconds: timeoutInSeconds, output: output);
+		}
+
+		static void ConfigureDotnetEnvironment(ProcessStartInfo pinfo)
+		{
+			pinfo.EnvironmentVariables["DOTNET_MULTILEVEL_LOOKUP"] = "0";
+			pinfo.EnvironmentVariables["DOTNET_ROOT"] = DotnetRoot;
 		}
 
 	}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

`net11.0`'s `DotNetAndroidManifestVersionBand` and `DotNetMaciOSManifestVersionBand` were still pinned to `11.0.100-preview.7` while the VMR's dependency versions had advanced to the `11.0.100-rc.2` band. This caused every Maestro dependency-flow PR that bumped Android/iOS/MacCatalyst/tvOS SDK packages past what the `preview.7` manifest band supports to fail CI with `NU1102 "Unable to find package Microsoft.NET.Sdk.*.Manifest-11.0.100-preview.7"` errors, since those manifest packages are now only published under the `rc.2` band.

This is the same class of bug fixed on `release/11.0.1xx-rc1` in #38041, just recurring on `net11.0` at the next version band. It has caused PRs #37792, #37866, and #36966 to fail CI and be closed/superseded.

### Changes
- Bump `DotNetAndroidManifestVersionBand` / `DotNetMaciOSManifestVersionBand` from `11.0.100-preview.7` to `11.0.100-rc.2`.
- Bump `Microsoft.NET.Sdk` / `Microsoft.NETCore.App.Ref` and the coherent `Microsoft.Extensions.*`/`Microsoft.AspNetCore.*`/`Microsoft.DotNet.*` package set from `11.0.100-rc.1.26379.102` to `11.0.100-rc.2.26431.104` (matching the target build from PR #37866).
- Bump `Microsoft.Android.Sdk.Windows` from `37.0.0-ci.main.2160` to `37.0.0-rc.2.2352`.
- Bump the MacIOS `net11.0_26.5` SDK packages from `26.5.11992-net11-rc.1` to `26.5.12125-net11-rc.2`, and their coherent `net10.0_26.5` parents from `26.5.10311` to `26.5.10315`.
- Remove the now-unneeded `darc-pub-dotnet-macios-af61ca08` NuGet source (the `net10.0_26.5` coherent parent packages resolve from `dotnet-public`).

### Second fix: workload install path separator (cherry-pick of #37711)

Bumping to SDK `11.0.100-rc.2.26431.104` surfaced a second, latent bug. .NET SDK commit `dotnet/sdk@bc6956b2` stopped leaving a trailing directory separator on `MSBuildExtensionsPath`, and `src/DotNet/DotNet.csproj` appended `../../` directly — producing a malformed path like `.../sdk/11.0.100-rc.2.26431.104../../dotnet`. Every integration-test job failed fast with exit code `9009` (Windows) / `127` (macOS) on the `Install dotnet preview workloads from PackageArtifacts` step.

This was already fixed by #37711, but that fix landed **only** on `release/11.0.1xx-rc1` and was never forward-merged to `net11.0`. It stayed latent there because `net11.0` was pinned to the older SDK that still emitted a trailing separator. This PR cherry-picks commit `1ae9af6f1a` to normalize the path via `$([MSBuild]::EnsureTrailingSlash(...))`, along with its accompanying regression tests.

### Local verification

- Restored the workload via `src/DotNet/DotNet.csproj` — all five manifest packages (Android, iOS, MacCatalyst, tvOS, macOS) resolve under the `rc.2` band with no NU1102 errors.
- Confirmed `bgen` runs without a runtime mismatch (`bgen` requires `Microsoft.NETCore.App 11.0.0-rc.2.26426.102`, the locally pinned `11.0.0-rc.2.26431.104` satisfies `rollForward=Major`) — this was the specific gotcha that bit the RC1 fix, so it was re-checked here.
- Built `Core.csproj` for both `net11.0-ios26.5` and `net11.0-maccatalyst26.5` successfully.

### Issues Fixed

Unblocks the recurring `net11.0` Maestro dependency-flow PR pattern (most recently #37866).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
Copilot-Session: fea89d86-97e8-41a3-ba90-c58392f1cfcb
