### PR TITLE
Update PatchVersion from 100 to 101

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
     <!-- The .NET product branding version -->
     <MajorVersion>10</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>100</PatchVersion>
+    <PatchVersion>101</PatchVersion>
     <SdkBandVersion>10.0.100</SdkBandVersion>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

Bumps the SR10 release branch package patch version from `10.0.100` to `10.0.101` after the SR10.1 payload merge.

## Changes

- Updates `eng/Versions.props` `PatchVersion` from `100` to `101`.
- Leaves `SdkBandVersion`, `PreReleaseVersionLabel=servicing`, and stable-package settings unchanged.

## Context

Follow-up to #37746 for the 10.0.101 release completion checklist.