### PR TITLE
Fix HybridWebView message handling across platforms

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_MessageOrigins.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_MessageOrigins.Android.cs
@@ -42,9 +42,9 @@ public partial class HybridWebViewTests_MessageOrigins
 		try
 		{
 			handler.PlatformView.LoadUrl(OtherOrigin);
-			await responseProvided.Task.WaitAsync(TimeSpan.FromSeconds(5));
+			await responseProvided.Task.WaitAsync(OperationWaitTimeout);
 
-			for (var attempt = 0; attempt < 20; attempt++)
+			for (var attempt = 0; attempt < 100; attempt++)
 			{
 				var loaded = await hybridWebView.EvaluateJavaScriptAsync(
 					"document.getElementById('otherOriginDocument') !== null");
@@ -53,7 +53,7 @@ public partial class HybridWebViewTests_MessageOrigins
 					return;
 				}
 
-				await Task.Delay(100);
+				await Task.Delay(250);
 			}
 
 			throw new TimeoutException("The other-origin document did not finish loading.");
@@ -81,7 +81,7 @@ public partial class HybridWebViewTests_MessageOrigins
 
 		try
 		{
-			await bridgeAttempted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+			await bridgeAttempted.Task.WaitAsync(OperationWaitTimeout);
 		}
 		finally
 		{

--- a/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_MessageOrigins.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_MessageOrigins.Android.cs
@@ -1,0 +1,91 @@
+﻿#nullable enable
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+
+namespace Microsoft.Maui.DeviceTests;
+
+public partial class HybridWebViewTests_MessageOrigins
+{
+	private static partial async Task LoadOtherOriginDocumentAsync(
+		HybridWebViewHandler handler,
+		HybridWebView hybridWebView,
+		string html)
+	{
+		var responseProvided = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		void OnWebResourceRequested(object? sender, WebViewWebResourceRequestedEventArgs args)
+		{
+			if (!new Uri(OtherOrigin).IsBaseOf(args.Uri))
+			{
+				return;
+			}
+
+			if (args.Uri == new Uri(OtherOrigin))
+			{
+				args.SetResponse(200, "OK", "text/html", new MemoryStream(Encoding.UTF8.GetBytes(html)));
+				responseProvided.TrySetResult();
+			}
+			else
+			{
+				args.SetResponse(404, "Not Found");
+			}
+
+			args.Handled = true;
+		}
+
+		hybridWebView.WebResourceRequested += OnWebResourceRequested;
+
+		try
+		{
+			handler.PlatformView.LoadUrl(OtherOrigin);
+			await responseProvided.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+			for (var attempt = 0; attempt < 20; attempt++)
+			{
+				var loaded = await hybridWebView.EvaluateJavaScriptAsync(
+					"document.getElementById('otherOriginDocument') !== null");
+				if (loaded == "true")
+				{
+					return;
+				}
+
+				await Task.Delay(100);
+			}
+
+			throw new TimeoutException("The other-origin document did not finish loading.");
+		}
+		finally
+		{
+			hybridWebView.WebResourceRequested -= OnWebResourceRequested;
+		}
+	}
+
+	private static partial async Task WaitForBridgeAttemptAsync(HybridWebView hybridWebView)
+	{
+		var bridgeAttempted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		void OnWebResourceRequested(object? sender, WebViewWebResourceRequestedEventArgs args)
+		{
+			if (args.Uri.Host == HybridWebViewHandler.AppOriginUri.Host &&
+				args.Uri.AbsolutePath == $"/{HybridWebViewHandler.SendMessagePath}")
+			{
+				bridgeAttempted.TrySetResult();
+			}
+		}
+
+		hybridWebView.WebResourceRequested += OnWebResourceRequested;
+
+		try
+		{
+			await bridgeAttempted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+		}
+		finally
+		{
+			hybridWebView.WebResourceRequested -= OnWebResourceRequested;
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_MessageOrigins.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_MessageOrigins.Windows.cs
@@ -1,0 +1,65 @@
+﻿#nullable enable
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using Microsoft.Web.WebView2.Core;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests;
+
+public partial class HybridWebViewTests_MessageOrigins
+{
+	private static partial async Task LoadOtherOriginDocumentAsync(
+		HybridWebViewHandler handler,
+		HybridWebView hybridWebView,
+		string html)
+	{
+		var responseProvided = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		var navigationCompleted = new TaskCompletionSource<CoreWebView2NavigationCompletedEventArgs>(
+			TaskCreationOptions.RunContinuationsAsynchronously);
+
+		void OnWebResourceRequested(object? sender, WebViewWebResourceRequestedEventArgs args)
+		{
+			if (!new Uri(OtherOrigin).IsBaseOf(args.Uri))
+			{
+				return;
+			}
+
+			if (args.Uri == new Uri(OtherOrigin))
+			{
+				args.SetResponse(200, "OK", "text/html", new MemoryStream(Encoding.UTF8.GetBytes(html)));
+				responseProvided.TrySetResult();
+			}
+			else
+			{
+				args.SetResponse(404, "Not Found");
+			}
+
+			args.Handled = true;
+		}
+
+		void OnNavigationCompleted(CoreWebView2 sender, CoreWebView2NavigationCompletedEventArgs args) =>
+			navigationCompleted.TrySetResult(args);
+
+		hybridWebView.WebResourceRequested += OnWebResourceRequested;
+		handler.PlatformView.CoreWebView2.NavigationCompleted += OnNavigationCompleted;
+
+		try
+		{
+			handler.PlatformView.CoreWebView2.Navigate(OtherOrigin);
+
+			await responseProvided.Task.WaitAsync(TimeSpan.FromSeconds(5));
+			var navigation = await navigationCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+			Assert.True(navigation.IsSuccess, $"Navigation failed with {navigation.WebErrorStatus}.");
+		}
+		finally
+		{
+			hybridWebView.WebResourceRequested -= OnWebResourceRequested;
+			handler.PlatformView.CoreWebView2.NavigationCompleted -= OnNavigationCompleted;
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_MessageOrigins.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_MessageOrigins.Windows.cs
@@ -51,8 +51,8 @@ public partial class HybridWebViewTests_MessageOrigins
 		{
 			handler.PlatformView.CoreWebView2.Navigate(OtherOrigin);
 
-			await responseProvided.Task.WaitAsync(TimeSpan.FromSeconds(5));
-			var navigation = await navigationCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+			await responseProvided.Task.WaitAsync(OperationWaitTimeout);
+			var navigation = await navigationCompleted.Task.WaitAsync(OperationWaitTimeout);
 
 			Assert.True(navigation.IsSuccess, $"Navigation failed with {navigation.WebErrorStatus}.");
 		}

--- a/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_MessageOrigins.cs
+++ b/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_MessageOrigins.cs
@@ -51,7 +51,8 @@ public partial class HybridWebViewTests_MessageOrigins : HybridWebViewTestsBase
 		</html>
 		""";
 
-	static readonly TimeSpan MessageWaitTimeout = TimeSpan.FromSeconds(1);
+	static readonly TimeSpan OperationWaitTimeout = TimeSpan.FromSeconds(25);
+	static readonly TimeSpan MessageWaitTimeout = TimeSpan.FromSeconds(5);
 
 	[Fact]
 	public Task RawMessagesFromOtherOriginsAreIgnored() =>

--- a/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_MessageOrigins.cs
+++ b/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_MessageOrigins.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.DeviceTests;
 public partial class HybridWebViewTests_MessageOrigins : HybridWebViewTestsBase
 {
 	const string OtherOrigin = "https://example.invalid/";
-	const string OtherOriginDocument = """
+	static readonly string OtherOriginDocument = $$"""
 		<!DOCTYPE html>
 		<html>
 			<body id="otherOriginDocument">
@@ -27,7 +27,7 @@ public partial class HybridWebViewTests_MessageOrigins : HybridWebViewTestsBase
 						} else if (window.webkit && window.webkit.messageHandlers) {
 							window.webkit.messageHandlers.webwindowinterop.postMessage(message);
 						} else {
-							return fetch("https://0.0.0.1/__hwvSendMessage", {
+							return fetch("{{new Uri(HybridWebViewHandler.AppOriginUri, HybridWebViewHandler.SendMessagePath).AbsoluteUri}}", {
 								method: "POST",
 								headers: {
 									"Content-Type": "text/plain",

--- a/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_MessageOrigins.cs
+++ b/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_MessageOrigins.cs
@@ -1,0 +1,135 @@
+﻿#if WINDOWS || IOS || MACCATALYST || ANDROID
+#nullable enable
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests;
+
+[Category(TestCategory.HybridWebView)]
+#if WINDOWS
+[Collection(WebViewsCollection)]
+#endif
+public partial class HybridWebViewTests_MessageOrigins : HybridWebViewTestsBase
+{
+	const string OtherOrigin = "https://example.invalid/";
+	const string OtherOriginDocument = """
+		<!DOCTYPE html>
+		<html>
+			<body id="otherOriginDocument">
+				<script>
+					function sendBridgeMessage(message) {
+						if (window.chrome && window.chrome.webview) {
+							window.chrome.webview.postMessage(encodeURIComponent(message));
+						} else if (window.webkit && window.webkit.messageHandlers) {
+							window.webkit.messageHandlers.webwindowinterop.postMessage(message);
+						} else {
+							return fetch("https://0.0.0.1/__hwvSendMessage", {
+								method: "POST",
+								headers: {
+									"Content-Type": "text/plain",
+									"X-Maui-Invoke-Token": "HybridWebView",
+									"X-Maui-Request-Body": message
+								},
+								body: message
+							}).catch(() => {});
+						}
+					}
+
+					function sendRawMessage() {
+						sendBridgeMessage("__RawMessage|Message from another origin");
+					}
+
+					function completeInvoke(taskId) {
+						sendBridgeMessage(`__InvokeJavaScriptCompleted|${taskId}|"Result from another origin"`);
+					}
+				</script>
+			</body>
+		</html>
+		""";
+
+	static readonly TimeSpan MessageWaitTimeout = TimeSpan.FromSeconds(1);
+
+	[Fact]
+	public Task RawMessagesFromOtherOriginsAreIgnored() =>
+		RunOriginTest(async (handler, hybridWebView) =>
+		{
+			var messageReceived = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
+			hybridWebView.RawMessageReceived += (_, args) => messageReceived.TrySetResult(args.Message);
+
+			await LoadOtherOriginDocumentAsync(handler, hybridWebView, OtherOriginDocument);
+			await AssertOtherOriginDocumentLoaded(hybridWebView);
+
+#if ANDROID
+			var bridgeAttempted = WaitForBridgeAttemptAsync(hybridWebView);
+#endif
+			await hybridWebView.EvaluateJavaScriptAsync("sendRawMessage()");
+#if ANDROID
+			await bridgeAttempted;
+#endif
+
+			Assert.False(
+				await CompletesWithinAsync(messageReceived.Task, MessageWaitTimeout),
+				"A raw message from another origin was delivered to the app.");
+		});
+
+	[Fact]
+	public Task InvokeCompletionsFromOtherOriginsAreIgnored() =>
+		RunOriginTest(async (handler, hybridWebView) =>
+		{
+			var taskManager = handler.GetRequiredService<IHybridWebViewTaskManager>();
+			var invokeTask = taskManager.CreateTask();
+
+			await LoadOtherOriginDocumentAsync(handler, hybridWebView, OtherOriginDocument);
+			await AssertOtherOriginDocumentLoaded(hybridWebView);
+
+#if ANDROID
+			var bridgeAttempted = WaitForBridgeAttemptAsync(hybridWebView);
+#endif
+			await hybridWebView.EvaluateJavaScriptAsync($"completeInvoke('{invokeTask.TaskId}')");
+#if ANDROID
+			await bridgeAttempted;
+#endif
+
+			Assert.False(
+				await CompletesWithinAsync(invokeTask.TaskCompletionSource.Task, MessageWaitTimeout),
+				"An invoke task was completed by a message from another origin.");
+		});
+
+	Task RunOriginTest(Func<HybridWebViewHandler, HybridWebView, Task> test)
+	{
+		var hybridWebView = new HybridWebView
+		{
+			WidthRequest = 100,
+			HeightRequest = 100,
+			HybridRoot = "HybridTestRoot",
+			DefaultFile = "index.html",
+		};
+
+		return RunTest(hybridWebView, test);
+	}
+
+	static async Task AssertOtherOriginDocumentLoaded(HybridWebView hybridWebView)
+	{
+		var loaded = await hybridWebView.EvaluateJavaScriptAsync(
+			"document.getElementById('otherOriginDocument') !== null");
+
+		Assert.Equal("true", loaded);
+	}
+
+	static async Task<bool> CompletesWithinAsync(Task task, TimeSpan timeout) =>
+		await Task.WhenAny(task, Task.Delay(timeout)) == task;
+
+	private static partial Task LoadOtherOriginDocumentAsync(
+		HybridWebViewHandler handler,
+		HybridWebView hybridWebView,
+		string html);
+
+#if ANDROID
+	private static partial Task WaitForBridgeAttemptAsync(HybridWebView hybridWebView);
+#endif
+}
+#endif

--- a/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_MessageOrigins.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_MessageOrigins.iOS.cs
@@ -1,0 +1,39 @@
+﻿#nullable enable
+using System;
+using System.Threading.Tasks;
+using Foundation;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using WebKit;
+
+namespace Microsoft.Maui.DeviceTests;
+
+public partial class HybridWebViewTests_MessageOrigins
+{
+	private static partial async Task LoadOtherOriginDocumentAsync(
+		HybridWebViewHandler handler,
+		HybridWebView hybridWebView,
+		string html)
+	{
+		var navigationDelegate = new NavigationDelegate();
+		handler.PlatformView.NavigationDelegate = navigationDelegate;
+
+		handler.PlatformView.LoadHtmlString(html, new NSUrl(OtherOrigin));
+		await navigationDelegate.NavigationCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+	}
+
+	sealed class NavigationDelegate : WKNavigationDelegate
+	{
+		public TaskCompletionSource NavigationCompleted { get; } =
+			new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		public override void DidFinishNavigation(WKWebView webView, WKNavigation? navigation) =>
+			NavigationCompleted.TrySetResult();
+
+		public override void DidFailNavigation(WKWebView webView, WKNavigation? navigation, NSError error) =>
+			NavigationCompleted.TrySetException(new InvalidOperationException(error.LocalizedDescription));
+
+		public override void DidFailProvisionalNavigation(WKWebView webView, WKNavigation? navigation, NSError error) =>
+			NavigationCompleted.TrySetException(new InvalidOperationException(error.LocalizedDescription));
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_MessageOrigins.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_MessageOrigins.iOS.cs
@@ -22,7 +22,7 @@ public partial class HybridWebViewTests_MessageOrigins
 		try
 		{
 			handler.PlatformView.LoadHtmlString(html, new NSUrl(OtherOrigin));
-			await navigationDelegate.NavigationCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+			await navigationDelegate.NavigationCompleted.Task.WaitAsync(OperationWaitTimeout);
 		}
 		finally
 		{

--- a/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_MessageOrigins.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_MessageOrigins.iOS.cs
@@ -16,10 +16,18 @@ public partial class HybridWebViewTests_MessageOrigins
 		string html)
 	{
 		var navigationDelegate = new NavigationDelegate();
+		var previousNavigationDelegate = handler.PlatformView.NavigationDelegate;
 		handler.PlatformView.NavigationDelegate = navigationDelegate;
 
-		handler.PlatformView.LoadHtmlString(html, new NSUrl(OtherOrigin));
-		await navigationDelegate.NavigationCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+		try
+		{
+			handler.PlatformView.LoadHtmlString(html, new NSUrl(OtherOrigin));
+			await navigationDelegate.NavigationCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+		}
+		finally
+		{
+			handler.PlatformView.NavigationDelegate = previousNavigationDelegate;
+		}
 	}
 
 	sealed class NavigationDelegate : WKNavigationDelegate

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Windows.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Maui.Handlers
 			if (!Uri.TryCreate(args.Source, UriKind.Absolute, out var sourceUri) ||
 				!AppOriginUri.IsBaseOf(sourceUri))
 			{
-				MauiContext?.CreateLogger<HybridWebViewHandler>()?.LogDebug("Ignoring web message from another origin.");
+				MauiContext?.CreateLogger<HybridWebViewHandler>()?.LogDebug("Ignoring web message from an unrecognized source.");
 				return;
 			}
 

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Windows.cs
@@ -98,6 +98,13 @@ namespace Microsoft.Maui.Handlers
 
 		private void OnWebMessageReceived(WebView2 sender, CoreWebView2WebMessageReceivedEventArgs args)
 		{
+			if (!Uri.TryCreate(args.Source, UriKind.Absolute, out var sourceUri) ||
+				!AppOriginUri.IsBaseOf(sourceUri))
+			{
+				MauiContext?.CreateLogger<HybridWebViewHandler>()?.LogDebug("Ignoring web message from another origin.");
+				return;
+			}
+
 			// The JS transport URL-encodes messages so embedded NUL characters survive WebView2's
 			// null-terminated string marshalling (TryGetWebMessageAsString returns an LPWSTR). Decode
 			// the payload before dispatching it.

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Maui.Handlers
 			if (!Uri.TryCreate(source, UriKind.Absolute, out var sourceUri) ||
 				!AppOriginUri.IsBaseOf(sourceUri))
 			{
-				MauiContext?.CreateLogger<HybridWebViewHandler>()?.LogDebug("Ignoring web message from another origin.");
+				MauiContext?.CreateLogger<HybridWebViewHandler>()?.LogDebug("Ignoring web message from an unrecognized source.");
 				return;
 			}
 

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
@@ -100,8 +100,15 @@ namespace Microsoft.Maui.Handlers
 			hybridPlatformWebView.SendRawMessage(hybridWebViewRawMessage.Message ?? "");
 		}
 
-		private void MessageReceived(Uri uri, string message)
+		private void MessageReceived(string? source, string message)
 		{
+			if (!Uri.TryCreate(source, UriKind.Absolute, out var sourceUri) ||
+				!AppOriginUri.IsBaseOf(sourceUri))
+			{
+				MauiContext?.CreateLogger<HybridWebViewHandler>()?.LogDebug("Ignoring web message from another origin.");
+				return;
+			}
+
 			MessageReceived(message);
 		}
 
@@ -141,7 +148,7 @@ namespace Microsoft.Maui.Handlers
 			public void DidReceiveScriptMessage(WKUserContentController userContentController, WKScriptMessage message)
 			{
 				ArgumentNullException.ThrowIfNull(message);
-				Handler?.MessageReceived(AppOriginUri, ((NSString)message.Body).ToString());
+				Handler?.MessageReceived(message.FrameInfo.Request.Url?.AbsoluteString, ((NSString)message.Body).ToString());
 			}
 		}
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause

`HybridWebView` uses platform-specific mechanisms to receive messages from its hosted content. The Windows and Apple callbacks exposed the sender location, but that value was not used when forwarding messages to the shared handler:

- Windows forwarded `CoreWebView2WebMessageReceivedEventArgs` payloads without checking `Source`.
- iOS and Mac Catalyst substituted `AppOriginUri` instead of using the URL from `WKScriptMessage.FrameInfo`.

As a result, message processing remained active when the same control displayed content outside the app content URI.

### Description of Change

This change validates the sender before dispatching incoming messages:

- **Windows:** parses `CoreWebView2WebMessageReceivedEventArgs.Source` and continues only when it is within `AppOriginUri`.
- **iOS and Mac Catalyst:** passes `WKScriptMessage.FrameInfo.Request.Url` into the message path and applies the same `AppOriginUri.IsBaseOf(...)` check.
- **Android:** keeps the existing runtime implementation. Android already routes page-to-.NET messages through the app URI endpoint and validates the request location before dispatching.

Messages with a missing, malformed, or different source URI are ignored. The source URL is not included in diagnostic output.

The implementation intentionally uses the existing `Uri.TryCreate(...)` and `AppOriginUri.IsBaseOf(...)` pattern rather than adding another URI comparison helper. This matches the existing WebView message and resource-routing code.

### Compatibility

- No public API changes.
- No new dependencies.
- Messages from packaged app content continue through the existing shared parser.
- Android behavior is unchanged.
- Content outside the app URI can still be displayed; only its messages are excluded from the app message path.

### Regression Coverage

Added Controls device tests that replace the packaged page with deterministic HTML at a different origin in the same `HybridWebView`. The tests verify that:

- `RawMessageReceived` is not raised for a raw message from that document.
- A JavaScript completion message from that document does not complete a pending invocation task.
- The replacement document finished loading before either assertion, so a navigation failure cannot make the test pass.

The test content is provided locally:

- Windows and Android return the HTML through `WebResourceRequested`.
- iOS and Mac Catalyst load the HTML with a separate base URL.
- Android additionally verifies that the app URI endpoint was attempted before asserting that no message was dispatched.

No external network service is required by these tests.

### Validation

- **Fail-before check:** both new tests fail without the Windows/Apple handler changes and pass with them.
- **Mac Catalyst:** 97 tests run, 96 passed, 0 failed, 1 existing skip.
- **iOS:** 97 tests run, 96 passed, 0 failed, 1 existing skip.
- **Android:** 100 tests run, 95 passed, 0 failed, 5 existing skips.
- **Windows:** Windows-specific regression coverage is included; runtime execution was not available on the current macOS host.

### Issues Fixed

N/A