### PR TITLE
Fix SR10 official pipeline YAML

### DIFF
--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -78,6 +78,4 @@ variables:
     - group: DotNet-HelixApi-Access
     - group: SDL_Settings
     - group: AzureDevOps-Artifact-Feeds-Pats
-    - ${{ if eq(variables['Build.DefinitionName'], 'dotnet-maui') }}:
-
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Removes the empty Azure Pipelines conditional left in `eng/pipelines/common/variables.yml` after #37594 removed the `Publish-Build-Assets` variable group.

The dangling mapping prevents the official `dotnet-maui` pipeline from compiling:

```text
/eng/pipelines/common/variables.yml (Line: 81, Col: 70): Expected a mapping
/eng/pipelines/common/variables.yml (Line: 81, Col: 7): Expected at least one key-value pair in the mapping
```

This blocked [official build 3063359](https://dev.azure.com/dnceng/internal/_build/results?buildId=3063359) before any jobs ran, preventing creation and default-channel promotion of the SR10.1 BAR build.

## Validation

- Parsed `eng/pipelines/common/variables.yml` successfully with Ruby Psych.
- `git diff --check` passes.

After merge, rerun the `dotnet-maui` official pipeline for `release/10.0.1xx-sr10`; its existing `.NET 10.0.1xx SDK` default-channel mapping should create the per-build validation feed.