### PR TITLE
[net 11] Fix x:Reference NameScope resolution in lazy DataTemplate resources

### DIFF
--- a/src/Controls/src/SourceGen/KnownMarkups.cs
+++ b/src/Controls/src/SourceGen/KnownMarkups.cs
@@ -59,7 +59,7 @@ internal class KnownMarkups
 			value = string.Empty;
 			return false;
 		}
-
+		
 		var field = typeSymbol!.GetAllFields(membername, context).FirstOrDefault(f => f.IsStatic);
 		var property = typeSymbol!.GetAllProperties(membername, context).FirstOrDefault(p => p.IsStatic);
 
@@ -155,7 +155,7 @@ internal class KnownMarkups
 		if (!markupNode.Properties.TryGetValue(new XmlName("", "AncestorType"), out ancestorTypeNode)
 			&& !markupNode.Properties.TryGetValue(new XmlName(null, "AncestorType"), out ancestorTypeNode))
 			markupNode.Properties.TryGetValue(new XmlName(XamlParser.MauiUri, "AncestorType"), out ancestorTypeNode);
-
+		
 		if (ancestorTypeNode is not null)
 		{
 			if (ancestorTypeNode is ElementNode typeExtNode)
@@ -267,7 +267,7 @@ internal class KnownMarkups
 		}
 	}
 
-	public static bool ProvideValueForDynamicResourceExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context, NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
+	public static bool ProvideValueForDynamicResourceExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context,  NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
 	{
 		returnType = context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.Internals.DynamicResource")!;
 		string? key = null;
@@ -333,7 +333,7 @@ internal class KnownMarkups
 		}
 	}
 
-	internal static bool ProvideValueForTemplateBindingExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context, NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
+	internal static bool ProvideValueForTemplateBindingExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context,  NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
 	{
 		return ProvideValueForBindingExtension(markupNode, writer, context, isTemplateBinding: true, getNodeValue, out returnType, out value);
 	}
@@ -343,13 +343,13 @@ internal class KnownMarkups
 		return ProvideValueForBindingExtension(markupNode, writer, context, isTemplateBinding: false, getNodeValue, out returnType, out value);
 	}
 
-	private static bool ProvideValueForBindingExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context, bool isTemplateBinding, NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
+	private static bool ProvideValueForBindingExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context, bool isTemplateBinding,  NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
 	{
 		returnType = context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.BindingBase")!;
 		ITypeSymbol? dataTypeSymbol = null;
-
+		
 		context.Variables.TryGetValue(markupNode, out ILocalValue? extVariable);
-
+		
 		if (extVariable is not null)
 		{
 			// Determine the source type for compiled binding based on the binding's Source configuration:
@@ -475,7 +475,7 @@ internal class KnownMarkups
 				expression += $", source:global::Microsoft.Maui.Controls.RelativeBindingSource.TemplatedParent";
 			}
 			else
-			{
+            {
 				if (markupNode.Properties.TryGetValue(new XmlName(null, "Source"), out var sourceNode))
 					expression += $", source: {getNodeValue(sourceNode, context.Compilation.GetTypeByMetadataName("System.String")!).ValueAccessor}";
 				expression += ") {";
@@ -496,7 +496,7 @@ internal class KnownMarkups
 					expression += $"FallbackValue = {getNodeValue(fallbackValueNode, context.Compilation.GetTypeByMetadataName("System.Object")!).ValueAccessor}, ";
 				if (markupNode.Properties.TryGetValue(new XmlName(null, "TargetNullValue"), out var targetNullValueNode))
 					expression += $"TargetNullValue = {getNodeValue(targetNullValueNode, context.Compilation.GetTypeByMetadataName("System.Object")!).ValueAccessor}, ";
-			}
+            }
 
 			expression += "}";
 			value = expression;
@@ -951,7 +951,7 @@ internal class KnownMarkups
 		{
 			if (targetNode is null)
 				return null;
-
+				
 			if (targetNode is ValueNode vn)
 			{
 				// For ValueNode, convert directly using the property type
@@ -968,7 +968,7 @@ internal class KnownMarkups
 				var local = getNodeValue(targetNode, propertyType);
 				return local.ValueAccessor;
 			}
-
+			
 			return null;
 		}
 
@@ -1002,8 +1002,8 @@ internal class KnownMarkups
 		// At least one value must be set
 		if (lightValue is null && darkValue is null && defaultValue is null)
 		{
-			context.ReportDiagnostic(Diagnostic.Create(Descriptors.XamlParserError,
-				LocationHelpers.LocationCreate(context.ProjectItem.RelativePath!, (IXmlLineInfo)node, ""),
+			context.ReportDiagnostic(Diagnostic.Create(Descriptors.XamlParserError, 
+				LocationHelpers.LocationCreate(context.ProjectItem.RelativePath!, (IXmlLineInfo)node, ""), 
 				"AppThemeBindingExtension requires a non-null value to be specified for at least one theme or Default"));
 			value = string.Empty;
 			return false;
@@ -1011,13 +1011,13 @@ internal class KnownMarkups
 
 		// Build the AppThemeBinding initialization expression
 		var parts = new List<string>();
-
+		
 		if (lightValue is not null)
 			parts.Add($"Light = {lightValue}");
-
+		
 		if (darkValue is not null)
 			parts.Add($"Dark = {darkValue}");
-
+		
 		if (defaultValue is not null)
 			parts.Add($"Default = {defaultValue}");
 
@@ -1046,7 +1046,7 @@ internal class KnownMarkups
 
 		var key = (string)keyValueNode.Value;
 		var resource = GetResourceNode(eNode, context, key);
-
+		
 		// Try to find the variable in current context or parent contexts (for lambda context)
 		ILocalValue? variable = null;
 		if (resource != null)
@@ -1059,13 +1059,13 @@ internal class KnownMarkups
 				ctx = ctx.ParentContext;
 			}
 		}
-
+		
 		if (resource is null || variable is null)
 		{
 			// Resource not in Variables - might be a lazy resource
 			var lazyResource = GetResourceNodeIncludingLazy(eNode, context, key);
-			if (lazyResource != null
-				&& lazyResource.XmlType.TryResolveTypeSymbol(null, context.Compilation, context.XmlnsCache, context.TypeCache, out var lazyType)
+			if (lazyResource != null 
+				&& lazyResource.XmlType.TryResolveTypeSymbol(null, context.Compilation, context.XmlnsCache, context.TypeCache, out var lazyType) 
 				&& lazyType != null)
 			{
 				// Find the Resources property accessor by walking up to find the element with Resources
@@ -1079,13 +1079,13 @@ internal class KnownMarkups
 					{
 						actualType = provideValueReturnType;
 					}
-
+					
 					returnType = actualType;
 					value = $"({actualType.ToFQDisplayString()}){resourcesAccessor}[\"{key}\"]";
 					return true;
 				}
 			}
-
+			
 			returnType = context.Compilation.ObjectType;
 			value = string.Empty;
 			return false;
@@ -1110,7 +1110,7 @@ internal class KnownMarkups
 
 				var propertyType = typeandconverter?.type ?? propertySymbol?.Type;
 				var converter = typeandconverter?.converter;
-
+				
 				// If no converter from BP, check the property's TypeConverter attribute
 				if (converter == null && propertySymbol != null)
 				{
@@ -1139,7 +1139,7 @@ internal class KnownMarkups
 				return true;
 			}
 		}
-
+		
 		// If we get here and getNodeValue is provided, use it as fallback
 		if (getNodeValue != null)
 		{

--- a/src/Controls/src/SourceGen/KnownMarkups.cs
+++ b/src/Controls/src/SourceGen/KnownMarkups.cs
@@ -59,7 +59,7 @@ internal class KnownMarkups
 			value = string.Empty;
 			return false;
 		}
-		
+
 		var field = typeSymbol!.GetAllFields(membername, context).FirstOrDefault(f => f.IsStatic);
 		var property = typeSymbol!.GetAllProperties(membername, context).FirstOrDefault(p => p.IsStatic);
 
@@ -155,7 +155,7 @@ internal class KnownMarkups
 		if (!markupNode.Properties.TryGetValue(new XmlName("", "AncestorType"), out ancestorTypeNode)
 			&& !markupNode.Properties.TryGetValue(new XmlName(null, "AncestorType"), out ancestorTypeNode))
 			markupNode.Properties.TryGetValue(new XmlName(XamlParser.MauiUri, "AncestorType"), out ancestorTypeNode);
-		
+
 		if (ancestorTypeNode is not null)
 		{
 			if (ancestorTypeNode is ElementNode typeExtNode)
@@ -267,7 +267,7 @@ internal class KnownMarkups
 		}
 	}
 
-	public static bool ProvideValueForDynamicResourceExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context,  NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
+	public static bool ProvideValueForDynamicResourceExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context, NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
 	{
 		returnType = context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.Internals.DynamicResource")!;
 		string? key = null;
@@ -333,7 +333,7 @@ internal class KnownMarkups
 		}
 	}
 
-	internal static bool ProvideValueForTemplateBindingExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context,  NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
+	internal static bool ProvideValueForTemplateBindingExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context, NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
 	{
 		return ProvideValueForBindingExtension(markupNode, writer, context, isTemplateBinding: true, getNodeValue, out returnType, out value);
 	}
@@ -343,13 +343,13 @@ internal class KnownMarkups
 		return ProvideValueForBindingExtension(markupNode, writer, context, isTemplateBinding: false, getNodeValue, out returnType, out value);
 	}
 
-	private static bool ProvideValueForBindingExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context, bool isTemplateBinding,  NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
+	private static bool ProvideValueForBindingExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context, bool isTemplateBinding, NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
 	{
 		returnType = context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.BindingBase")!;
 		ITypeSymbol? dataTypeSymbol = null;
-		
+
 		context.Variables.TryGetValue(markupNode, out ILocalValue? extVariable);
-		
+
 		if (extVariable is not null)
 		{
 			// Determine the source type for compiled binding based on the binding's Source configuration:
@@ -475,7 +475,7 @@ internal class KnownMarkups
 				expression += $", source:global::Microsoft.Maui.Controls.RelativeBindingSource.TemplatedParent";
 			}
 			else
-            {
+			{
 				if (markupNode.Properties.TryGetValue(new XmlName(null, "Source"), out var sourceNode))
 					expression += $", source: {getNodeValue(sourceNode, context.Compilation.GetTypeByMetadataName("System.String")!).ValueAccessor}";
 				expression += ") {";
@@ -496,7 +496,7 @@ internal class KnownMarkups
 					expression += $"FallbackValue = {getNodeValue(fallbackValueNode, context.Compilation.GetTypeByMetadataName("System.Object")!).ValueAccessor}, ";
 				if (markupNode.Properties.TryGetValue(new XmlName(null, "TargetNullValue"), out var targetNullValueNode))
 					expression += $"TargetNullValue = {getNodeValue(targetNullValueNode, context.Compilation.GetTypeByMetadataName("System.Object")!).ValueAccessor}, ";
-            }
+			}
 
 			expression += "}";
 			value = expression;
@@ -951,7 +951,7 @@ internal class KnownMarkups
 		{
 			if (targetNode is null)
 				return null;
-				
+
 			if (targetNode is ValueNode vn)
 			{
 				// For ValueNode, convert directly using the property type
@@ -968,7 +968,7 @@ internal class KnownMarkups
 				var local = getNodeValue(targetNode, propertyType);
 				return local.ValueAccessor;
 			}
-			
+
 			return null;
 		}
 
@@ -1002,8 +1002,8 @@ internal class KnownMarkups
 		// At least one value must be set
 		if (lightValue is null && darkValue is null && defaultValue is null)
 		{
-			context.ReportDiagnostic(Diagnostic.Create(Descriptors.XamlParserError, 
-				LocationHelpers.LocationCreate(context.ProjectItem.RelativePath!, (IXmlLineInfo)node, ""), 
+			context.ReportDiagnostic(Diagnostic.Create(Descriptors.XamlParserError,
+				LocationHelpers.LocationCreate(context.ProjectItem.RelativePath!, (IXmlLineInfo)node, ""),
 				"AppThemeBindingExtension requires a non-null value to be specified for at least one theme or Default"));
 			value = string.Empty;
 			return false;
@@ -1011,13 +1011,13 @@ internal class KnownMarkups
 
 		// Build the AppThemeBinding initialization expression
 		var parts = new List<string>();
-		
+
 		if (lightValue is not null)
 			parts.Add($"Light = {lightValue}");
-		
+
 		if (darkValue is not null)
 			parts.Add($"Dark = {darkValue}");
-		
+
 		if (defaultValue is not null)
 			parts.Add($"Default = {defaultValue}");
 
@@ -1046,7 +1046,7 @@ internal class KnownMarkups
 
 		var key = (string)keyValueNode.Value;
 		var resource = GetResourceNode(eNode, context, key);
-		
+
 		// Try to find the variable in current context or parent contexts (for lambda context)
 		ILocalValue? variable = null;
 		if (resource != null)
@@ -1059,13 +1059,13 @@ internal class KnownMarkups
 				ctx = ctx.ParentContext;
 			}
 		}
-		
+
 		if (resource is null || variable is null)
 		{
 			// Resource not in Variables - might be a lazy resource
 			var lazyResource = GetResourceNodeIncludingLazy(eNode, context, key);
-			if (lazyResource != null 
-				&& lazyResource.XmlType.TryResolveTypeSymbol(null, context.Compilation, context.XmlnsCache, context.TypeCache, out var lazyType) 
+			if (lazyResource != null
+				&& lazyResource.XmlType.TryResolveTypeSymbol(null, context.Compilation, context.XmlnsCache, context.TypeCache, out var lazyType)
 				&& lazyType != null)
 			{
 				// Find the Resources property accessor by walking up to find the element with Resources
@@ -1079,13 +1079,13 @@ internal class KnownMarkups
 					{
 						actualType = provideValueReturnType;
 					}
-					
+
 					returnType = actualType;
 					value = $"({actualType.ToFQDisplayString()}){resourcesAccessor}[\"{key}\"]";
 					return true;
 				}
 			}
-			
+
 			returnType = context.Compilation.ObjectType;
 			value = string.Empty;
 			return false;
@@ -1110,7 +1110,7 @@ internal class KnownMarkups
 
 				var propertyType = typeandconverter?.type ?? propertySymbol?.Type;
 				var converter = typeandconverter?.converter;
-				
+
 				// If no converter from BP, check the property's TypeConverter attribute
 				if (converter == null && propertySymbol != null)
 				{
@@ -1139,7 +1139,7 @@ internal class KnownMarkups
 				return true;
 			}
 		}
-		
+
 		// If we get here and getNodeValue is provided, use it as fallback
 		if (getNodeValue != null)
 		{

--- a/src/Controls/src/SourceGen/KnownMarkups.cs
+++ b/src/Controls/src/SourceGen/KnownMarkups.cs
@@ -59,7 +59,7 @@ internal class KnownMarkups
 			value = string.Empty;
 			return false;
 		}
-		
+
 		var field = typeSymbol!.GetAllFields(membername, context).FirstOrDefault(f => f.IsStatic);
 		var property = typeSymbol!.GetAllProperties(membername, context).FirstOrDefault(p => p.IsStatic);
 
@@ -155,7 +155,7 @@ internal class KnownMarkups
 		if (!markupNode.Properties.TryGetValue(new XmlName("", "AncestorType"), out ancestorTypeNode)
 			&& !markupNode.Properties.TryGetValue(new XmlName(null, "AncestorType"), out ancestorTypeNode))
 			markupNode.Properties.TryGetValue(new XmlName(XamlParser.MauiUri, "AncestorType"), out ancestorTypeNode);
-		
+
 		if (ancestorTypeNode is not null)
 		{
 			if (ancestorTypeNode is ElementNode typeExtNode)
@@ -267,7 +267,7 @@ internal class KnownMarkups
 		}
 	}
 
-	public static bool ProvideValueForDynamicResourceExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context,  NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
+	public static bool ProvideValueForDynamicResourceExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context, NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
 	{
 		returnType = context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.Internals.DynamicResource")!;
 		string? key = null;
@@ -333,7 +333,7 @@ internal class KnownMarkups
 		}
 	}
 
-	internal static bool ProvideValueForTemplateBindingExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context,  NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
+	internal static bool ProvideValueForTemplateBindingExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context, NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
 	{
 		return ProvideValueForBindingExtension(markupNode, writer, context, isTemplateBinding: true, getNodeValue, out returnType, out value);
 	}
@@ -343,13 +343,13 @@ internal class KnownMarkups
 		return ProvideValueForBindingExtension(markupNode, writer, context, isTemplateBinding: false, getNodeValue, out returnType, out value);
 	}
 
-	private static bool ProvideValueForBindingExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context, bool isTemplateBinding,  NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
+	private static bool ProvideValueForBindingExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context, bool isTemplateBinding, NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
 	{
 		returnType = context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.BindingBase")!;
 		ITypeSymbol? dataTypeSymbol = null;
-		
+
 		context.Variables.TryGetValue(markupNode, out ILocalValue? extVariable);
-		
+
 		if (extVariable is not null)
 		{
 			// Determine the source type for compiled binding based on the binding's Source configuration:
@@ -475,7 +475,7 @@ internal class KnownMarkups
 				expression += $", source:global::Microsoft.Maui.Controls.RelativeBindingSource.TemplatedParent";
 			}
 			else
-            {
+			{
 				if (markupNode.Properties.TryGetValue(new XmlName(null, "Source"), out var sourceNode))
 					expression += $", source: {getNodeValue(sourceNode, context.Compilation.GetTypeByMetadataName("System.String")!).ValueAccessor}";
 				expression += ") {";
@@ -496,7 +496,7 @@ internal class KnownMarkups
 					expression += $"FallbackValue = {getNodeValue(fallbackValueNode, context.Compilation.GetTypeByMetadataName("System.Object")!).ValueAccessor}, ";
 				if (markupNode.Properties.TryGetValue(new XmlName(null, "TargetNullValue"), out var targetNullValueNode))
 					expression += $"TargetNullValue = {getNodeValue(targetNullValueNode, context.Compilation.GetTypeByMetadataName("System.Object")!).ValueAccessor}, ";
-            }
+			}
 
 			expression += "}";
 			value = expression;
@@ -751,10 +751,7 @@ internal class KnownMarkups
 				var namescope = currentContext.Scopes[node];
 				if (namescope.namesInScope != null && namescope.namesInScope.ContainsKey(name))
 					return namescope.namesInScope[name].Type;
-				INode n = node;
-				while (n.Parent is ListNode ln)
-					n = ln.Parent;
-				node = n.Parent as ElementNode;
+				node = GetParentElement(node);
 			}
 
 			return null;
@@ -822,6 +819,14 @@ internal class KnownMarkups
 
 			return false;
 		}
+	}
+
+	static ElementNode? GetParentElement(INode node)
+	{
+		INode? parent = node.Parent;
+		while (parent is ListNode listNode)
+			parent = listNode.Parent;
+		return parent as ElementNode;
 	}
 
 	internal static bool ProvideValueForDataTemplateExtension(ElementNode markupNode, IndentedTextWriter writer, SourceGenContext context, NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
@@ -892,10 +897,7 @@ internal class KnownMarkups
 				value = $"{namescope.namesInScope[name!].ValueAccessor}";
 				return true;
 			}
-			INode n = node;
-			while (n.Parent is ListNode ln)
-				n = ln.Parent;
-			node = n.Parent as ElementNode;
+			node = GetParentElement(node);
 		}
 
 		//TODO report diagnostic
@@ -949,7 +951,7 @@ internal class KnownMarkups
 		{
 			if (targetNode is null)
 				return null;
-				
+
 			if (targetNode is ValueNode vn)
 			{
 				// For ValueNode, convert directly using the property type
@@ -966,7 +968,7 @@ internal class KnownMarkups
 				var local = getNodeValue(targetNode, propertyType);
 				return local.ValueAccessor;
 			}
-			
+
 			return null;
 		}
 
@@ -1000,8 +1002,8 @@ internal class KnownMarkups
 		// At least one value must be set
 		if (lightValue is null && darkValue is null && defaultValue is null)
 		{
-			context.ReportDiagnostic(Diagnostic.Create(Descriptors.XamlParserError, 
-				LocationHelpers.LocationCreate(context.ProjectItem.RelativePath!, (IXmlLineInfo)node, ""), 
+			context.ReportDiagnostic(Diagnostic.Create(Descriptors.XamlParserError,
+				LocationHelpers.LocationCreate(context.ProjectItem.RelativePath!, (IXmlLineInfo)node, ""),
 				"AppThemeBindingExtension requires a non-null value to be specified for at least one theme or Default"));
 			value = string.Empty;
 			return false;
@@ -1009,13 +1011,13 @@ internal class KnownMarkups
 
 		// Build the AppThemeBinding initialization expression
 		var parts = new List<string>();
-		
+
 		if (lightValue is not null)
 			parts.Add($"Light = {lightValue}");
-		
+
 		if (darkValue is not null)
 			parts.Add($"Dark = {darkValue}");
-		
+
 		if (defaultValue is not null)
 			parts.Add($"Default = {defaultValue}");
 
@@ -1044,7 +1046,7 @@ internal class KnownMarkups
 
 		var key = (string)keyValueNode.Value;
 		var resource = GetResourceNode(eNode, context, key);
-		
+
 		// Try to find the variable in current context or parent contexts (for lambda context)
 		ILocalValue? variable = null;
 		if (resource != null)
@@ -1057,13 +1059,13 @@ internal class KnownMarkups
 				ctx = ctx.ParentContext;
 			}
 		}
-		
+
 		if (resource is null || variable is null)
 		{
 			// Resource not in Variables - might be a lazy resource
 			var lazyResource = GetResourceNodeIncludingLazy(eNode, context, key);
-			if (lazyResource != null 
-				&& lazyResource.XmlType.TryResolveTypeSymbol(null, context.Compilation, context.XmlnsCache, context.TypeCache, out var lazyType) 
+			if (lazyResource != null
+				&& lazyResource.XmlType.TryResolveTypeSymbol(null, context.Compilation, context.XmlnsCache, context.TypeCache, out var lazyType)
 				&& lazyType != null)
 			{
 				// Find the Resources property accessor by walking up to find the element with Resources
@@ -1077,13 +1079,13 @@ internal class KnownMarkups
 					{
 						actualType = provideValueReturnType;
 					}
-					
+
 					returnType = actualType;
 					value = $"({actualType.ToFQDisplayString()}){resourcesAccessor}[\"{key}\"]";
 					return true;
 				}
 			}
-			
+
 			returnType = context.Compilation.ObjectType;
 			value = string.Empty;
 			return false;
@@ -1108,7 +1110,7 @@ internal class KnownMarkups
 
 				var propertyType = typeandconverter?.type ?? propertySymbol?.Type;
 				var converter = typeandconverter?.converter;
-				
+
 				// If no converter from BP, check the property's TypeConverter attribute
 				if (converter == null && propertySymbol != null)
 				{
@@ -1137,7 +1139,7 @@ internal class KnownMarkups
 				return true;
 			}
 		}
-		
+
 		// If we get here and getNodeValue is provided, use it as fallback
 		if (getNodeValue != null)
 		{

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui37551.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui37551.xaml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui37551"
+             x:Name="PageRoot">
+    <ContentPage.Resources>
+        <DataTemplate x:Key="FirstDataTemplate">
+            <Label BindingContext="{x:Reference PageRoot}"/>
+        </DataTemplate>
+        <DataTemplate x:Key="SecondDataTemplate">
+            <Label BindingContext="{Binding Source={x:Reference PageRoot}}"/>
+        </DataTemplate>
+    </ContentPage.Resources>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui37551.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui37551.xaml.cs
@@ -1,0 +1,32 @@
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui37551 : ContentPage
+{
+    public Maui37551() => InitializeComponent();
+
+    [Collection("Issue")]
+    public class Tests
+    {
+        [Theory]
+        [XamlInflatorData]
+        internal void XReferenceInMultipleDataTemplateResourcesResolvesOuterNamescope(XamlInflator inflator)
+        {
+            if (inflator == XamlInflator.SourceGen)
+            {
+                var result = MockSourceGenerator.RunMauiSourceGenerator(typeof(Maui37551));
+                Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Id == "MAUIG1001");
+            }
+
+            var page = new Maui37551(inflator);
+            var firstTemplate = Assert.IsType<Microsoft.Maui.Controls.DataTemplate>(page.Resources["FirstDataTemplate"]);
+            var secondTemplate = Assert.IsType<Microsoft.Maui.Controls.DataTemplate>(page.Resources["SecondDataTemplate"]);
+            var firstLabel = Assert.IsType<Label>(firstTemplate.CreateContent());
+            var secondLabel = Assert.IsType<Label>(secondTemplate.CreateContent());
+
+            Assert.Same(page, firstLabel.BindingContext);
+            Assert.Same(page, secondLabel.BindingContext);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details
Multiple DataTemplate resources can use x:Reference to access a named element outside the template.
When these templates are generated as lazy resources, SourceGen incorrectly reports that the name cannot be found.
This causes the build to fail with MAUIG1001.

### Root Cause
SourceGen walks upward through the XAML tree to find the requested name.
When an internal ListNode is encountered, the old code moves up once to skip the list and then moves up again.
That second movement skips the real parent element that must be searched.

### Description of Change
The new helper starts at the immediate parent and skips only internal ListNode wrappers.
It returns the first real parent element instead of moving past it.
Both direct x:Reference and binding-source resolution now use this corrected traversal.

Validated the behavior in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
### Issues Fixed
  
Fixes #37551 

### Output  ScreenShot

|Before|After|
|--|--|
| <video src="https://github.com/user-attachments/assets/60ba519f-65f6-4893-a7d1-8bba23dc3cf1" >| <video src="https://github.com/user-attachments/assets/0b9deb16-a494-4182-801c-7ac8472d31a3">|
