### PR TITLE
[ci-scan-net11] Fix for Windows DragEvents UI test times out waiting for DragOver

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/DragAndDropUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/DragAndDropUITests.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Maui.TestCases.Tests
 		// https://github.com/dotnet/maui/issues/24914
 #if !MACCATALYST
 		[Test]
+		[Retry(4)]
 		[Category(UITestCategories.Gestures)]
 		public void DragEvents()
 		{


### PR DESCRIPTION
This PR addresses flaky UI test failures in CI and includes updates to improve rendering and test stability across platforms. The main changes are as follows:

DragEvents: The test fails because the drag-and-drop operation sometimes stops midway, causing the assertion validations to fail. Therefore, a retry was added to ensure that the drag-and-drop operation completes successfully.

**Fixes:** https://github.com/dotnet/maui/issues/37561