### PR TITLE
[Android] Route Issue36543 to SafeAreaEdges UI tests

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36543.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue36543.cs
@@ -12,8 +12,7 @@ public class Issue36543 : _IssuesUITest
 	public override string Issue => "[Android] RTL CollectionView content is truncated / shifted into the display cutout after landscape rotation";
 
 	[Test]
-	// TODO: Remove [Material3] once dotnet/maui#31631 merges. That PR adds a dedicated SafeAreaEdges stage on Pixel 3 XL API 36; until then, [Material3] is the only category that routes this test to a notched device (required to reproduce this bug).
-	[Category(UITestCategories.Material3)]
+	[Category(UITestCategories.SafeAreaEdges)]
 	public void RtlCollectionViewShouldNotBeTruncatedAfterLandscapeRotation()
 	{
 		try


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Routes the Android-only Issue36543 UI test to the dedicated `SafeAreaEdges` category now that #31631 has added the API 36 Pixel 3 XL CI stage. Removes the resolved temporary-category TODO.

## Testing

- Confirmed `SafeAreaEdges` is an existing UI-test category.
- Confirmed Android `SafeAreaEdges` tests are excluded from the common Android matrix and run in the dedicated API 36 Pixel 3 XL stage.
- The targeted Android UI-test runner could not start locally because the Android SDK/`adb` is unavailable on this machine.