### PR TITLE
Document UIWindow GetWindow extensions

### DIFF
--- a/src/Core/src/Platform/iOS/UIWindowExtensions.cs
+++ b/src/Core/src/Platform/iOS/UIWindowExtensions.cs
@@ -6,7 +6,11 @@ namespace Microsoft.Maui.Platform
 {
 	public static class UIWindowExtensions
 	{
-		// TODO Add public docs
+		/// <summary>
+		/// Gets the .NET MAUI window associated with the specified iOS or Mac Catalyst platform window.
+		/// </summary>
+		/// <param name="platformWindow">The <see cref="UIWindow"/> to resolve.</param>
+		/// <returns>The associated <see cref="IWindow"/>, or <see langword="null"/> if <paramref name="platformWindow"/> is <see langword="null"/> or no matching window is found.</returns>
 		public static IWindow? GetWindow(this UIWindow? platformWindow)
 			=> platformWindow.GetWindow(IPlatformApplication.Current?.Application);
 
@@ -24,7 +28,11 @@ namespace Microsoft.Maui.Platform
 			return null;
 		}
 
-		// TODO Add public docs
+		/// <summary>
+		/// Gets the .NET MAUI window associated with the specified iOS or Mac Catalyst window scene.
+		/// </summary>
+		/// <param name="windowScene">The <see cref="UIWindowScene"/> to resolve.</param>
+		/// <returns>The associated <see cref="IWindow"/>, or <see langword="null"/> if <paramref name="windowScene"/> is <see langword="null"/> or no matching window is found.</returns>
 		public static IWindow? GetWindow(this UIWindowScene? windowScene)
 		{
 			if (windowScene is null)


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

- Documents both public iOS/Mac Catalyst `GetWindow` extension overloads.
- Describes their parameters, return values, and null behavior.

## Testing

- `dotnet build src\Core\src\Core.csproj -f net11.0-ios26.5 --no-restore`
- `dotnet build src\Core\src\Core.csproj -f net11.0-maccatalyst26.5 --no-restore`