### PR TITLE
[iOS] Fix modal presentation style availability check

### DIFF
--- a/src/Controls/src/Core/Platform/iOS/ControlsModalWrapper.cs
+++ b/src/Controls/src/Core/Platform/iOS/ControlsModalWrapper.cs
@@ -24,11 +24,6 @@ namespace Microsoft.Maui.Controls.Platform
 				{
 					var result = style.ToPlatformModalPresentationStyle();
 
-					if (!(OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13)) && result == UIKit.UIModalPresentationStyle.Automatic)
-					{
-						result = UIKit.UIModalPresentationStyle.FullScreen;
-					}
-
 					if (result == UIKit.UIModalPresentationStyle.FullScreen)
 					{
 						var modalPage = (Page)_modal.VirtualView;

--- a/src/Controls/src/Core/Platform/iOS/Extensions/Extensions.cs
+++ b/src/Controls/src/Core/Platform/iOS/Extensions/Extensions.cs
@@ -16,10 +16,12 @@ namespace Microsoft.Maui.Controls.Platform
 					return UIModalPresentationStyle.FormSheet;
 				case PlatformConfiguration.iOSSpecific.UIModalPresentationStyle.FullScreen:
 					return UIModalPresentationStyle.FullScreen;
-#pragma warning disable CA1416 // TODO:  'UIModalPresentationStyle.Automatic' is only supported on: 'ios' 13.0 and later
 				case PlatformConfiguration.iOSSpecific.UIModalPresentationStyle.Automatic:
-					return UIModalPresentationStyle.Automatic;
-#pragma warning restore CA1416
+					return OperatingSystem.IsIOSVersionAtLeast(13) ||
+						OperatingSystem.IsMacCatalystVersionAtLeast(13) ||
+						OperatingSystem.IsTvOSVersionAtLeast(13)
+							? UIModalPresentationStyle.Automatic
+							: UIModalPresentationStyle.FullScreen;
 				case PlatformConfiguration.iOSSpecific.UIModalPresentationStyle.OverFullScreen:
 					return UIModalPresentationStyle.OverFullScreen;
 				case PlatformConfiguration.iOSSpecific.UIModalPresentationStyle.PageSheet:


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause

`ControlsModalWrapper` checked whether `UIModalPresentationStyle.Automatic` was available only after `ToPlatformModalPresentationStyle` had already evaluated that iOS 13+ UIKit enum value.

### Description of Change

Moves the availability check into `ToPlatformModalPresentationStyle`, which is the boundary that accesses the platform enum. Older iOS/tvOS versions continue to use `FullScreen`; supported iOS, Mac Catalyst, and tvOS versions use `Automatic`. The now-redundant caller fallback and stale CA1416 suppression/TODO are removed.

### Testing

- `git diff --check`
- Confirmed the changed converter compiles with the installed .NET 10 iOS workload until unrelated net11-on-net10 API incompatibilities in `ShellPageRendererTracker.cs`
- Authoritative net11.0 iOS and Mac Catalyst compilation will be provided by PR CI because this Windows host does not have the repository's required .NET 11 RC SDK or a Mac runtime

No test was added: reliably exercising the pre-iOS-13 branch requires an old Apple runtime or an injected OS-version seam, which would broaden this focused platform fix.

### Issues Fixed

N/A - candidate TODO cleanup #9.