### PR TITLE
Remove stale input transparency test TODO

### DIFF
--- a/src/Controls/tests/Core.UnitTests/VisualElementInputTransparentTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualElementInputTransparentTests.cs
@@ -293,8 +293,6 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.False(element.InputTransparent);
 		}
 
-		// TODO: the tests below may be duplicates of the tests above
-
 		[Theory]
 		[InlineData(typeof(Button), true)]
 		[InlineData(typeof(VerticalStackLayout), true)]


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

- Remove the stale TODO suggesting the later input-transparency tests may be duplicates.
- Preserve all existing test behavior because the later cases add complementary coverage.

## Coverage comparison

The earlier tests exhaust the five Boolean cascade/input states for a two-level `Grid` hierarchy with a `Button`, including property-order permutations and one-property inversions. The later tests additionally cover `Button`, `VerticalStackLayout`, `Editor`, and `Entry` children; direct and three-level-deep nesting; repeated parent state transitions back to the initial value; and nested cascade boundaries where parent and nested layouts independently enable or disable cascading. Those dimensions are not mechanically identical to the earlier matrix, so no tests were consolidated or deleted.

## Validation

- `dotnet format Microsoft.Maui.sln --no-restore --exclude Templates\src --exclude-diagnostics CA1822 --include src\Controls\tests\Core.UnitTests\VisualElementInputTransparentTests.cs --verbosity quiet`
- `eng\common\dotnet.cmd test src\Controls\tests\Core.UnitTests\Controls.Core.UnitTests.csproj --filter "FullyQualifiedName~Microsoft.Maui.Controls.Core.UnitTests.VisualElementInputTransparentTests" -p:IncludeAndroidTargetFrameworks=false -p:IncludeIosTargetFrameworks=false -p:IncludeMacCatalystTargetFrameworks=false -p:IncludeWindowsTargetFrameworks=false -p:IncludeMacOSTargetFrameworks=false -p:IncludeTizenTargetFrameworks=false --verbosity minimal` (372 passed)