### PR TITLE
Remove no-op null registration from Registrar

### DIFF
--- a/src/Controls/src/Core/Registrar.cs
+++ b/src/Controls/src/Core/Registrar.cs
@@ -242,12 +242,7 @@ namespace Microsoft.Maui.Controls.Internals
 				{
 					// get RenderWith attribute for just this type, do not inherit attributes from base types
 					var attribute = viewType.GetCustomAttributes<RenderWithAttribute>(false).FirstOrDefault();
-					if (attribute == null)
-					{
-						// TODO this doesn't appear to do anything. Register just returns as a NOOP if the renderer is null
-						Register(viewType, null, new[] { visualType }); // Cache this result so we don't have to do GetCustomAttributes again
-					}
-					else
+					if (attribute != null)
 					{
 						Type specificTypeRenderer = attribute.Type;
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

`RegisterRenderWithTypes` called `Register(viewType, null, ...)` when no `RenderWithAttribute` was found, but `Registrar.Register` returns before mutating `_handlers` whenever the renderer type is null. Remove that ineffective call and its stale TODO while preserving the existing attribute-present path.

No test changes are needed because `TestGetRendererNullViewRenderer` already verifies that a null renderer registration leaves the existing registration unchanged.

## Testing

- `dotnet test src\Controls\tests\Core.UnitTests\Controls.Core.UnitTests.csproj "-p:MauiPlatforms=" --filter "FullyQualifiedName~Registrar" --verbosity minimal` (17 passed)