### PR TITLE
[net11.0] Obsolete unused iOS image source extensions

### DIFF
--- a/src/Core/src/Platform/iOS/ImageViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ImageViewExtensions.cs
@@ -38,14 +38,14 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		// TODO: This method does not appear to be used, should we obsolete in net9?
+		[Obsolete("Set UIImageView.Image directly and call UpdateIsAnimationPlaying(IImageSourcePart) instead.")]
 		public static void UpdateSource(this UIImageView imageView, UIImage? uIImage, IImageSourcePart image)
 		{
 			imageView.Image = uIImage;
 			imageView.UpdateIsAnimationPlaying(image);
 		}
 
-		// TODO: This method does not appear to be used, should we obsolete in net9?
+		[Obsolete("Use ImageSourcePartLoader.UpdateImageSourceAsync() with an IImageSourcePartSetter instead.")]
 		public static Task<IImageSourceServiceResult<UIImage>?> UpdateSourceAsync(
 			this UIImageView imageView,
 			IImageSourcePart image,


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Marks the shipped iOS and Mac Catalyst `ImageViewExtensions.UpdateSource` and `UpdateSourceAsync` methods obsolete without removing or changing their behavior.

The synchronous helper is only a two-step convenience API; callers can set `UIImageView.Image` directly and call `UpdateIsAnimationPlaying(IImageSourcePart)`. For asynchronous loading, the supported public extension point is `ImageSourcePartLoader.UpdateImageSourceAsync()` with an `IImageSourcePartSetter`, which is the same abstraction used by current MAUI image, image button, button, and swipe-item handlers.

Repository history shows these helpers have had no internal callers since the image-loading pipeline moved to `ImageSourcePartLoader`. Public GitHub code search found no third-party calls to the `UIImageView.UpdateSourceAsync` overload outside MAUI source forks. The stale TODOs are removed as resolved.

### API review

This is warning-only obsoletion of two shipped platform APIs in .NET 11. Their signatures remain in the iOS and Mac Catalyst shipped API baselines; `ObsoleteAttribute` metadata is not represented separately by the repository PublicAPI text format, so no baseline entries change. The replacement guidance names public, documented APIs and does not strand custom-handler consumers.

### Validation

- Targeted repository formatting completed.
- Local Apple compilation is unavailable because this Windows host has .NET 10 Apple workloads while `net11.0` targets .NET 11 Apple TFMs; iOS and Mac Catalyst CI are the platform validation gate.

### Issues Fixed

Candidate TODO cleanup 13; no GitHub issue.