### PR TITLE
Clarify legacy Shell renderer arrange no-ops

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
@@ -315,7 +315,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void IViewHandler.PlatformArrange(Graphics.Rect rect)
 		{
-			//TODO I don't think we need this
+			// The flyout root is arranged from OnElementSizeChanged.
 		}
 
 		void IElementHandler.SetMauiContext(IMauiContext mauiContext)

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellRenderer.cs
@@ -418,7 +418,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void IViewHandler.PlatformArrange(Rect rect)
 		{
-			//TODO I don't think we need this
+			// The view controller hierarchy owns native layout.
 		}
 
 		void IElementHandler.SetMauiContext(IMauiContext mauiContext)


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Clarifies the intentionally empty `IViewHandler.PlatformArrange` implementations in the legacy Android and iOS `ShellRenderer` classes and removes their stale speculative TODOs.

`IPlatformViewHandler` inherits `IViewHandler`, so both compatibility renderers must implement `PlatformArrange`. They intentionally do no work because native layout is already owned elsewhere: Android arranges the flyout root from `OnElementSizeChanged`, while iOS uses the view controller hierarchy and `ViewDidLayoutSubviews`.

No layout behavior changes.

## Validation

- `Controls.Core.csproj` builds for `net11.0-android37.0`
- `Controls.Core.csproj` builds for `net11.0-ios26.5`