### PR TITLE
[ci-scan] Fix for Issue24996 ChangingTranslationShouldNotCauseLayoutPassOnAncestors failure on Mac

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24996.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24996.cs
@@ -1,5 +1,4 @@
 ﻿using NUnit.Framework;
-using NUnit.Framework.Legacy;
 using UITest.Appium;
 using UITest.Core;
 
@@ -22,9 +21,11 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 			for (int i = 0; i < 4; i++)
 			{
 				App.Tap("Stats");
-				// Re-query element after tap to avoid stale reference and wait for UI to settle
-				var element = App.WaitForElement("Stats");
-				ClassicAssert.True(element.GetText()!.StartsWith("Lvl1[0/0]"));
+				// The app updates the "Stats" text asynchronously ~100ms after the tap.
+				// Waiting only for the element to exist (WaitForElement) races with that
+				// update and can read stale text, so wait for the expected text instead.
+				bool textUpdated = App.WaitForTextToBePresentInElement("Stats", "Lvl1[0/0]");
+				Assert.That(textUpdated, Is.True);
 			}
 		}
 	}


### PR DESCRIPTION

### Root cause
App.WaitForElement("Stats") only waited for the existing element, not for its asynchronously updated text. CI could therefore read stale initialization/layout-pass values such as Lvl1[1/1], causing a flaky failure.
 
### Description of change
Replaced the immediate text read with WaitForTextToBePresentInElement, which polls for Lvl1[0/0] for up to 15 seconds before asserting success. This allows the asynchronous counter reset and UI update to complete.



<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #36051