### PR TITLE
[iOS] Obsolete NavigationRenderer DidRotate override

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -103,7 +103,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			get { return this; }
 		}
 
-		//TODO: this was deprecated in iOS8.0 and is not called in 9.0+
+#pragma warning disable CS0809 // Obsolete override provides migration guidance beyond UIKit's platform obsoletion.
+		[Obsolete("NavigationRenderer.DidRotate is obsolete and will be removed in .NET 12. Use ViewWillTransitionToSize for size-transition work and ViewDidLayoutSubviews for final layout updates.")]
 		[System.Runtime.Versioning.UnsupportedOSPlatform("ios8.0")]
 		[System.Runtime.Versioning.UnsupportedOSPlatform("tvos")]
 		public override void DidRotate(UIInterfaceOrientation fromInterfaceOrientation)
@@ -115,6 +116,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			var parentingViewController = GetParentingViewController();
 			parentingViewController?.UpdateLeftBarButtonItem();
 		}
+#pragma warning restore CS0809
 
 		public Task<bool> PopToRootAsync(Page page, bool animated = true)
 		{


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Obsoletes the shipped iOS and Mac Catalyst `NavigationRenderer.DidRotate` override ahead of its planned removal in .NET 12.

UIKit deprecated `DidRotate` in iOS 8 and does not invoke it on MAUI's supported iOS versions. The warning directs third-party subclasses to:

- `ViewWillTransitionToSize` for size-transition work.
- `ViewDidLayoutSubviews` for final layout updates.

A narrowly scoped `CS0809` suppression is required because the .NET UIKit binding represents this as platform obsoletion rather than C# `[Obsolete]`. No PublicAPI or compatibility analyzer is suppressed, and the shipped method signature remains unchanged.

### Compatibility

Existing subclasses that override `DidRotate` or call `base.DidRotate` continue to compile and run, with the intended `CS0618` migration warning.

### Validation

- Built `Controls.Core` for `net11.0-ios26.5`.
- Built `Controls.Core` for `net11.0-maccatalyst26.5`.
- Compiled a temporary compatibility probe overriding `DidRotate` and calling `base.DidRotate` for both platforms.
- Verified `Issue32722.TitleViewExpandsOnRotation` on an iPadOS 26.5 simulator.
- Verified `Issue28986_NavigationPage.ToolbarExtendsAllTheWayLeftAndRight_NavigationPage` on an iPhone 11 Pro iOS 26.5 simulator.

### Issues Fixed

N/A
