### PR TITLE
[WIP] [Android] Fix ObjectDisposedException when Glide restarts stream images

### DIFF
--- a/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformInterop.java
+++ b/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformInterop.java
@@ -363,6 +363,14 @@ public class PlatformInterop {
         loadInto(builder, imageView, false, callback, inputStream);
     }
 
+    public static void loadImageFromBytes(ImageView imageView, byte[] bytes, ImageLoaderCallback callback) {
+        RequestBuilder<Drawable> builder = Glide
+            .with(imageView)
+            .load(bytes)
+            .override(Target.SIZE_ORIGINAL, Target.SIZE_ORIGINAL);
+        loadInto(builder, imageView, false, callback, bytes);
+    }
+
     public static void loadImageFromFont(ImageView imageView, @ColorInt int color, String glyph, Typeface typeface, float textSize, ImageLoaderCallback callback) {
         FontModel fontModel = new FontModel(color, glyph, textSize, typeface);
         RequestBuilder<Drawable> builder = Glide
@@ -409,6 +417,18 @@ public class PlatformInterop {
             .load(inputStream)
             .override(Target.SIZE_ORIGINAL, Target.SIZE_ORIGINAL);
         load(builder, context, false, callback, inputStream);
+    }
+
+    public static void loadImageFromBytes(Context context, byte[] bytes, ImageLoaderCallback callback) {
+        if (isContextDestroyed(context)) {
+            callback.onComplete(false, null, null);
+            return;
+        }
+        RequestBuilder<Drawable> builder = Glide
+            .with(context)
+            .load(bytes)
+            .override(Target.SIZE_ORIGINAL, Target.SIZE_ORIGINAL);
+        load(builder, context, false, callback, bytes);
     }
 
     public static void loadImageFromFont(Context context, @ColorInt int color, String glyph, Typeface typeface, float textSize, ImageLoaderCallback callback) {

--- a/src/Core/src/ImageSources/StreamImageSourceService/StreamImageSourceService.Android.cs
+++ b/src/Core/src/ImageSources/StreamImageSourceService/StreamImageSourceService.Android.cs
@@ -23,10 +23,11 @@ namespace Microsoft.Maui
 				try
 				{
 					stream = await streamImageSource.GetStreamAsync(cancellationToken);
+					var bytes = await GetStreamBytesAsync(stream, cancellationToken);
 
 					var callback = new ImageLoaderCallback();
 
-					PlatformInterop.LoadImageFromStream(imageView, stream, callback);
+					PlatformInterop.LoadImageFromBytes(imageView, bytes, callback);
 
 					var result = await callback.Result;
 
@@ -60,10 +61,11 @@ namespace Microsoft.Maui
 				try
 				{
 					stream = await streamImageSource.GetStreamAsync(cancellationToken).ConfigureAwait(false);
+					var bytes = await GetStreamBytesAsync(stream, cancellationToken).ConfigureAwait(false);
 
 					var drawableCallback = new ImageLoaderResultCallback();
 
-					PlatformInterop.LoadImageFromStream(context, stream, drawableCallback);
+					PlatformInterop.LoadImageFromBytes(context, bytes, drawableCallback);
 
 					var result = await drawableCallback.Result.ConfigureAwait(false);
 
@@ -84,6 +86,13 @@ namespace Microsoft.Maui
 			}
 
 			return null;
+		}
+
+		static async Task<byte[]> GetStreamBytesAsync(Stream stream, CancellationToken cancellationToken)
+		{
+			using var memoryStream = new MemoryStream();
+			await stream.CopyToAsync(memoryStream, cancellationToken).ConfigureAwait(false);
+			return memoryStream.ToArray();
 		}
 	}
 }

--- a/src/Core/src/ImageSources/StreamImageSourceService/StreamImageSourceService.Android.cs
+++ b/src/Core/src/ImageSources/StreamImageSourceService/StreamImageSourceService.Android.cs
@@ -19,31 +19,22 @@ namespace Microsoft.Maui
 
 			if (!streamImageSource.IsEmpty)
 			{
-				Stream? stream = null;
 				try
 				{
-					stream = await streamImageSource.GetStreamAsync(cancellationToken);
-					var bytes = await GetStreamBytesAsync(stream, cancellationToken);
+					byte[] bytes;
+					using (var stream = await streamImageSource.GetStreamAsync(cancellationToken))
+						bytes = await GetStreamBytesAsync(stream, cancellationToken);
 
 					var callback = new ImageLoaderCallback();
 
 					PlatformInterop.LoadImageFromBytes(imageView, bytes, callback);
 
-					var result = await callback.Result;
-
-					stream?.Dispose();
-
-					return result;
+					return await callback.Result;
 				}
 				catch (Exception ex)
 				{
 					Logger?.LogWarning(ex, "Unable to load image stream.");
 					throw;
-				}
-				finally
-				{
-					if (stream != null)
-						GC.KeepAlive(stream);
 				}
 			}
 
@@ -56,32 +47,22 @@ namespace Microsoft.Maui
 
 			if (!streamImageSource.IsEmpty)
 			{
-				Stream? stream = null;
-
 				try
 				{
-					stream = await streamImageSource.GetStreamAsync(cancellationToken).ConfigureAwait(false);
-					var bytes = await GetStreamBytesAsync(stream, cancellationToken).ConfigureAwait(false);
+					byte[] bytes;
+					using (var stream = await streamImageSource.GetStreamAsync(cancellationToken).ConfigureAwait(false))
+						bytes = await GetStreamBytesAsync(stream, cancellationToken).ConfigureAwait(false);
 
 					var drawableCallback = new ImageLoaderResultCallback();
 
 					PlatformInterop.LoadImageFromBytes(context, bytes, drawableCallback);
 
-					var result = await drawableCallback.Result.ConfigureAwait(false);
-
-					stream?.Dispose();
-
-					return result;
+					return await drawableCallback.Result.ConfigureAwait(false);
 				}
 				catch (Exception ex)
 				{
 					Logger?.LogWarning(ex, "Unable to load image stream.");
 					throw;
-				}
-				finally
-				{
-					if (stream != null)
-						GC.KeepAlive(stream);
 				}
 			}
 

--- a/src/Core/tests/DeviceTests/Services/ImageSource/StreamImageSourceServiceTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Services/ImageSource/StreamImageSourceServiceTests.Android.cs
@@ -1,11 +1,10 @@
 using System;
 using System.IO;
-using System.Threading;
 using System.Threading.Tasks;
 using Android.Graphics.Drawables;
-using Android.Runtime;
 using Android.Widget;
 using Bumptech.Glide;
+using Bumptech.Glide.Request;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Xunit;
 using Color = Microsoft.Maui.Graphics.Color;
@@ -55,115 +54,82 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			var expectedColor = Colors.Red.ToPlatform();
 			using var bitmapStream = Assert.IsType<MemoryStream>(CreateBitmapStream(100, 100, expectedColor));
-			using var blockingStream = new BlockingReadStream(bitmapStream.ToArray());
-			var imageSource = new StreamImageSourceStub(blockingStream);
+			using var trackingStream = new TrackingStream(bitmapStream.ToArray());
+			var imageSource = new StreamImageSourceStub(trackingStream);
 			var service = new StreamImageSourceService();
-			using var imageView = new ImageView(MauiProgram.DefaultContext);
-			var unhandledException = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
+			using var imageView = new RequestTrackingImageView(MauiProgram.DefaultContext, trackingStream);
 
-			void OnUnhandledException(object sender, RaiseThrowableEventArgs args)
+			await InvokeOnMainThreadAsync(() => imageView.AttachAndRun(async () =>
 			{
-				if (args.Exception?.ToString().Contains(nameof(BlockingReadStream), StringComparison.Ordinal) == true)
+				var requestManager = Glide.With(imageView);
+				var loadTask = service.LoadDrawableAsync(imageSource, imageView);
+
+				var submission = await imageView.RequestSubmitted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+				var requestManagerStopped = false;
+
+				try
 				{
-					unhandledException.TrySetResult(args.Exception);
-					args.Handled = true;
-				}
-			}
+					Assert.True(submission.SourceDisposed);
+					Assert.True(submission.Request.IsRunning);
 
-			AndroidEnvironment.UnhandledExceptionRaiser += OnUnhandledException;
-
-			try
-			{
-				await InvokeOnMainThreadAsync(() => imageView.AttachAndRun(async () =>
-				{
-					var requestManager = Glide.With(imageView);
-					var loadTask = service.LoadDrawableAsync(imageSource, imageView);
-
-					await blockingStream.ReadStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
 					requestManager.OnStop();
-
-					blockingStream.ReleaseRead();
-					await blockingStream.ReadCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+					requestManagerStopped = true;
+					Assert.False(submission.Request.IsRunning);
 
 					requestManager.OnStart();
-					var completedTask = await Task.WhenAny(loadTask, unhandledException.Task).WaitAsync(TimeSpan.FromSeconds(5));
+					requestManagerStopped = false;
 
-					if (completedTask == unhandledException.Task)
-						Assert.Null(await unhandledException.Task);
-
-					using var result = await loadTask;
+					using var result = await loadTask.WaitAsync(TimeSpan.FromSeconds(5));
 					Assert.NotNull(result);
 
 					var bitmapDrawable = Assert.IsType<BitmapDrawable>(imageView.Drawable);
 					await bitmapDrawable.Bitmap.AssertContainsColor(expectedColor);
-				}));
-			}
-			finally
+				}
+				finally
+				{
+					if (requestManagerStopped)
+						requestManager.OnStart();
+
+					requestManager.Clear(imageView);
+				}
+			}));
+		}
+
+		sealed class RequestTrackingImageView : ImageView
+		{
+			readonly TrackingStream _sourceStream;
+
+			public RequestTrackingImageView(global::Android.Content.Context context, TrackingStream sourceStream)
+				: base(context)
 			{
-				blockingStream.ReleaseRead();
-				AndroidEnvironment.UnhandledExceptionRaiser -= OnUnhandledException;
+				_sourceStream = sourceStream;
+			}
+
+			public TaskCompletionSource<(IRequest Request, bool SourceDisposed)> RequestSubmitted { get; } =
+				new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+			public override void SetTag(int key, Java.Lang.Object tag)
+			{
+				base.SetTag(key, tag);
+
+				if (tag is IRequest request)
+					RequestSubmitted.TrySetResult((request, _sourceStream.IsDisposed));
 			}
 		}
 
-		sealed class BlockingReadStream : MemoryStream
+		sealed class TrackingStream : MemoryStream
 		{
-			readonly TaskCompletionSource _releaseRead = new(TaskCreationOptions.RunContinuationsAsynchronously);
-			int _blockNextRead = 1;
-
-			public BlockingReadStream(byte[] buffer)
+			public TrackingStream(byte[] buffer)
 				: base(buffer)
 			{
 			}
 
-			public TaskCompletionSource ReadStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
-			public TaskCompletionSource ReadCompleted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+			public bool IsDisposed { get; private set; }
 
-			public void ReleaseRead() => _releaseRead.TrySetResult();
-
-			public override int Read(byte[] buffer, int offset, int count)
+			protected override void Dispose(bool disposing)
 			{
-				BlockRead();
-
-				try
-				{
-					return base.Read(buffer, offset, count);
-				}
-				finally
-				{
-					ReadCompleted.TrySetResult();
-				}
-			}
-
-			public override async Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
-			{
-				await BlockReadAsync(cancellationToken);
-
-				try
-				{
-					await base.CopyToAsync(destination, bufferSize, cancellationToken);
-				}
-				finally
-				{
-					ReadCompleted.TrySetResult();
-				}
-			}
-
-			void BlockRead()
-			{
-				if (Interlocked.Exchange(ref _blockNextRead, 0) == 0)
-					return;
-
-				ReadStarted.TrySetResult();
-				_releaseRead.Task.GetAwaiter().GetResult();
-			}
-
-			async Task BlockReadAsync(CancellationToken cancellationToken)
-			{
-				if (Interlocked.Exchange(ref _blockNextRead, 0) == 0)
-					return;
-
-				ReadStarted.TrySetResult();
-				await _releaseRead.Task.WaitAsync(cancellationToken);
+				IsDisposed = true;
+				base.Dispose(disposing);
 			}
 		}
 	}

--- a/src/Core/tests/DeviceTests/Services/ImageSource/StreamImageSourceServiceTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Services/ImageSource/StreamImageSourceServiceTests.Android.cs
@@ -1,6 +1,11 @@
 using System;
+using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Android.Graphics.Drawables;
+using Android.Runtime;
+using Android.Widget;
+using Bumptech.Glide;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Xunit;
 using Color = Microsoft.Maui.Graphics.Color;
@@ -43,6 +48,123 @@ namespace Microsoft.Maui.DeviceTests
 			var bitmap = bitmapDrawable.Bitmap;
 
 			await bitmap.AssertContainsColor(expectedColor).ConfigureAwait(false);
+		}
+
+		[Fact]
+		public async Task LoadDrawableAsyncSurvivesGlideRestart()
+		{
+			var expectedColor = Colors.Red.ToPlatform();
+			using var bitmapStream = Assert.IsType<MemoryStream>(CreateBitmapStream(100, 100, expectedColor));
+			using var blockingStream = new BlockingReadStream(bitmapStream.ToArray());
+			var imageSource = new StreamImageSourceStub(blockingStream);
+			var service = new StreamImageSourceService();
+			using var imageView = new ImageView(MauiProgram.DefaultContext);
+			var unhandledException = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+			void OnUnhandledException(object sender, RaiseThrowableEventArgs args)
+			{
+				if (args.Exception?.ToString().Contains(nameof(BlockingReadStream), StringComparison.Ordinal) == true)
+				{
+					unhandledException.TrySetResult(args.Exception);
+					args.Handled = true;
+				}
+			}
+
+			AndroidEnvironment.UnhandledExceptionRaiser += OnUnhandledException;
+
+			try
+			{
+				await InvokeOnMainThreadAsync(() => imageView.AttachAndRun(async () =>
+				{
+					var requestManager = Glide.With(imageView);
+					var loadTask = service.LoadDrawableAsync(imageSource, imageView);
+
+					await blockingStream.ReadStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+					requestManager.OnStop();
+
+					blockingStream.ReleaseRead();
+					await blockingStream.ReadCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+					requestManager.OnStart();
+					var completedTask = await Task.WhenAny(loadTask, unhandledException.Task).WaitAsync(TimeSpan.FromSeconds(5));
+
+					if (completedTask == unhandledException.Task)
+						Assert.Null(await unhandledException.Task);
+
+					using var result = await loadTask;
+					Assert.NotNull(result);
+
+					var bitmapDrawable = Assert.IsType<BitmapDrawable>(imageView.Drawable);
+					await bitmapDrawable.Bitmap.AssertContainsColor(expectedColor);
+				}));
+			}
+			finally
+			{
+				blockingStream.ReleaseRead();
+				AndroidEnvironment.UnhandledExceptionRaiser -= OnUnhandledException;
+			}
+		}
+
+		sealed class BlockingReadStream : MemoryStream
+		{
+			readonly TaskCompletionSource _releaseRead = new(TaskCreationOptions.RunContinuationsAsynchronously);
+			int _blockNextRead = 1;
+
+			public BlockingReadStream(byte[] buffer)
+				: base(buffer)
+			{
+			}
+
+			public TaskCompletionSource ReadStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+			public TaskCompletionSource ReadCompleted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+			public void ReleaseRead() => _releaseRead.TrySetResult();
+
+			public override int Read(byte[] buffer, int offset, int count)
+			{
+				BlockRead();
+
+				try
+				{
+					return base.Read(buffer, offset, count);
+				}
+				finally
+				{
+					ReadCompleted.TrySetResult();
+				}
+			}
+
+			public override async Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+			{
+				await BlockReadAsync(cancellationToken);
+
+				try
+				{
+					await base.CopyToAsync(destination, bufferSize, cancellationToken);
+				}
+				finally
+				{
+					ReadCompleted.TrySetResult();
+				}
+			}
+
+			void BlockRead()
+			{
+				if (Interlocked.Exchange(ref _blockNextRead, 0) == 0)
+					return;
+
+				ReadStarted.TrySetResult();
+				_releaseRead.Task.GetAwaiter().GetResult();
+			}
+
+			async Task BlockReadAsync(CancellationToken cancellationToken)
+			{
+				if (Interlocked.Exchange(ref _blockNextRead, 0) == 0)
+					return;
+
+				ReadStarted.TrySetResult();
+				await _releaseRead.Task.WaitAsync(cancellationToken);
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details:

- On Android, stream-backed images can throw  ObjectDisposedException  and remain blank when the Activity stops and resumes while Glide is still loading the image.

### Root Cause of the issue:

- MAUI passed Glide a single managed stream instance. When an Activity stopped, the custom Glide loader's cleanup closed that stream. Glide then restarted the request after resume using the same closed stream, causing  ObjectDisposedException  and leaving the image blank.

### Description of Change

**Image loading API changes:**

* Added `PlatformInterop.loadImageFromBytes` methods for both `ImageView` and `Context` to allow loading images directly from byte arrays instead of streams, leveraging Glide for image rendering. 
* Updated `StreamImageSourceService` to read stream contents into a byte array before passing them to the new `PlatformInterop.loadImageFromBytes` methods, and removed manual stream disposal and related resource management code. 

**Testing improvements:**

* Added a new test (`LoadDrawableAsyncSurvivesGlideRestart`) to verify that image loading is robust even when Glide is stopped and restarted mid-operation, using a custom `BlockingReadStream` to simulate delayed reads.
* Introduced the `BlockingReadStream` helper class in the test suite to enable fine-grained control over stream read operations during testing.
* Included necessary test imports for stream and threading support.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #37834

### Tested the behavior in the following platforms
 
- [ ] Windows
- [x] Android
- [ ] iOS
- [ ] Mac

### Output
 
| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/4a6b07f9-762a-4343-b24f-58890d9a927a"> | <video src="https://github.com/user-attachments/assets/4e057627-16b0-4b91-9068-63654a4b43c0"> |







<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
