### PR TITLE
[net11.0] Sync external dependency pins with RC1

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,16 +1,16 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.Sdk" Version="11.0.100-rc.1.26379.102">
+    <Dependency Name="Microsoft.NET.Sdk" Version="11.0.100-rc.1.26420.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>1d599674e31ad86ca9e6e1dad7055b531e4d58e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-rc.1.26420.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>1d599674e31ad86ca9e6e1dad7055b531e4d58e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="37.0.0-ci.main.2160">
+    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="37.0.0-rc.1.2256">
       <Uri>https://github.com/dotnet/android</Uri>
-      <Sha>444db99f7b362334b2785498c57064a4c66a7165</Sha>
+      <Sha>28d217e782c11e5b3396baec43c1b5d30e248687</Sha>
     </Dependency>
     <!-- Previous .NET Android version(s) -->
     <Dependency Name="Microsoft.NET.Sdk.Android.Manifest-10.0.100" Version="36.1.69" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
@@ -53,109 +53,109 @@
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="11.0.0-rc.1.26420.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>1d599674e31ad86ca9e6e1dad7055b531e4d58e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="11.0.0-rc.1.26420.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>1d599674e31ad86ca9e6e1dad7055b531e4d58e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="11.0.0-rc.1.26420.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>1d599674e31ad86ca9e6e1dad7055b531e4d58e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="11.0.0-rc.1.26420.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>1d599674e31ad86ca9e6e1dad7055b531e4d58e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.AspNetCore.Components" Version="11.0.0-rc.1.26420.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>1d599674e31ad86ca9e6e1dad7055b531e4d58e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="11.0.0-rc.1.26420.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>1d599674e31ad86ca9e6e1dad7055b531e4d58e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="11.0.0-rc.1.26420.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>1d599674e31ad86ca9e6e1dad7055b531e4d58e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="11.0.0-rc.1.26420.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>1d599674e31ad86ca9e6e1dad7055b531e4d58e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="11.0.0-rc.1.26420.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>1d599674e31ad86ca9e6e1dad7055b531e4d58e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="11.0.0-rc.1.26420.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>1d599674e31ad86ca9e6e1dad7055b531e4d58e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="11.0.0-rc.1.26420.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>1d599674e31ad86ca9e6e1dad7055b531e4d58e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="11.0.0-rc.1.26420.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>1d599674e31ad86ca9e6e1dad7055b531e4d58e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.JSInterop" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.JSInterop" Version="11.0.0-rc.1.26420.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>1d599674e31ad86ca9e6e1dad7055b531e4d58e4</Sha>
     </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-preview.2.22102.8">
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>3f4da9ced34942d83054e647f3b1d9d7dde281e8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.Extensions.Configuration" Version="11.0.0-rc.1.26420.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>1d599674e31ad86ca9e6e1dad7055b531e4d58e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="11.0.0-rc.1.26420.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>1d599674e31ad86ca9e6e1dad7055b531e4d58e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="11.0.0-rc.1.26420.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>1d599674e31ad86ca9e6e1dad7055b531e4d58e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="11.0.0-rc.1.26420.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>1d599674e31ad86ca9e6e1dad7055b531e4d58e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="11.0.0-rc.1.26420.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>1d599674e31ad86ca9e6e1dad7055b531e4d58e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="11.0.0-rc.1.26420.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>1d599674e31ad86ca9e6e1dad7055b531e4d58e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="11.0.0-rc.1.26420.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>1d599674e31ad86ca9e6e1dad7055b531e4d58e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.Extensions.Logging" Version="11.0.0-rc.1.26420.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>1d599674e31ad86ca9e6e1dad7055b531e4d58e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="11.0.0-rc.1.26420.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>1d599674e31ad86ca9e6e1dad7055b531e4d58e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="11.0.0-rc.1.26420.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>1d599674e31ad86ca9e6e1dad7055b531e4d58e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Primitives" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.Extensions.Primitives" Version="11.0.0-rc.1.26420.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>1d599674e31ad86ca9e6e1dad7055b531e4d58e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="11.0.0-rc.1.26379.102">
+    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="11.0.0-rc.1.26420.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>1d599674e31ad86ca9e6e1dad7055b531e4d58e4</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="11.0.0-prerelease.26064.3">
       <Uri>https://github.com/dotnet/xharness</Uri>
@@ -175,41 +175,41 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="11.0.0-beta.26379.102">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="11.0.0-beta.26420.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>1d599674e31ad86ca9e6e1dad7055b531e4d58e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26379.102">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26420.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>1d599674e31ad86ca9e6e1dad7055b531e4d58e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="11.0.0-beta.26379.102">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="11.0.0-beta.26420.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>1d599674e31ad86ca9e6e1dad7055b531e4d58e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="11.0.0-beta.26379.102">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="11.0.0-beta.26420.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>1d599674e31ad86ca9e6e1dad7055b531e4d58e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26379.102">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26420.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>1d599674e31ad86ca9e6e1dad7055b531e4d58e4</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Helix.JobMonitor" Version="11.0.0-beta.26427.10">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2cdfe99944d984749c8bdfc7d8d6a2589ed15d6d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="11.0.0-beta.26379.102">
+    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="11.0.0-beta.26420.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>1d599674e31ad86ca9e6e1dad7055b531e4d58e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="11.0.0-beta.26379.102">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="11.0.0-beta.26420.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>1d599674e31ad86ca9e6e1dad7055b531e4d58e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="11.0.0-beta.26379.102">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="11.0.0-beta.26420.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>813f634ceb016018f5acc9bd3c2b16e17dff4686</Sha>
+      <Sha>1d599674e31ad86ca9e6e1dad7055b531e4d58e4</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -31,10 +31,10 @@
     <!-- Current previous .NET SDK major version's stable release of MAUI packages -->
     <MicrosoftMauiPreviousDotNetReleasedVersion>10.0.20</MicrosoftMauiPreviousDotNetReleasedVersion>
     <!-- dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>11.0.100-rc.1.26379.102</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>11.0.100-rc.1.26420.103</MicrosoftNETSdkPackageVersion>
     <MicrosoftDotnetSdkInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-rc.1.26379.102</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-rc.1.26420.103</MicrosoftNETCoreAppRefPackageVersion>
     <SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextJsonPackageVersion>
     <SystemTextEncodingsWebPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextEncodingsWebPackageVersion>
     <MicrosoftBclAsyncInterfacesPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftBclAsyncInterfacesPackageVersion>
@@ -42,18 +42,18 @@
     <optimizationandroidx64MIBCRuntimePackageVersion>1.0.0-prerelease.26420.2</optimizationandroidx64MIBCRuntimePackageVersion>
     <!-- Microsoft/Extensions -->
     <SystemCodeDomPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemCodeDomPackageVersion>
-    <MicrosoftExtensionsConfigurationVersion>11.0.0-rc.1.26379.102</MicrosoftExtensionsConfigurationVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsVersion>11.0.0-rc.1.26379.102</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationJsonVersion>11.0.0-rc.1.26379.102</MicrosoftExtensionsConfigurationJsonVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>11.0.0-rc.1.26379.102</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>11.0.0-rc.1.26379.102</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
-    <MicrosoftExtensionsFileProvidersAbstractionsVersion>11.0.0-rc.1.26379.102</MicrosoftExtensionsFileProvidersAbstractionsVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>11.0.0-rc.1.26379.102</MicrosoftExtensionsLoggingAbstractionsVersion>
-    <MicrosoftExtensionsLoggingVersion>11.0.0-rc.1.26379.102</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>11.0.0-rc.1.26379.102</MicrosoftExtensionsLoggingConsoleVersion>
-    <MicrosoftExtensionsLoggingDebugVersion>11.0.0-rc.1.26379.102</MicrosoftExtensionsLoggingDebugVersion>
-    <MicrosoftExtensionsPrimitivesVersion>11.0.0-rc.1.26379.102</MicrosoftExtensionsPrimitivesVersion>
-    <MicrosoftExtensionsHostingAbstractionsVersion>11.0.0-rc.1.26379.102</MicrosoftExtensionsHostingAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>11.0.0-rc.1.26420.103</MicrosoftExtensionsConfigurationVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>11.0.0-rc.1.26420.103</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationJsonVersion>11.0.0-rc.1.26420.103</MicrosoftExtensionsConfigurationJsonVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>11.0.0-rc.1.26420.103</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>11.0.0-rc.1.26420.103</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
+    <MicrosoftExtensionsFileProvidersAbstractionsVersion>11.0.0-rc.1.26420.103</MicrosoftExtensionsFileProvidersAbstractionsVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>11.0.0-rc.1.26420.103</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingVersion>11.0.0-rc.1.26420.103</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>11.0.0-rc.1.26420.103</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingDebugVersion>11.0.0-rc.1.26420.103</MicrosoftExtensionsLoggingDebugVersion>
+    <MicrosoftExtensionsPrimitivesVersion>11.0.0-rc.1.26420.103</MicrosoftExtensionsPrimitivesVersion>
+    <MicrosoftExtensionsHostingAbstractionsVersion>11.0.0-rc.1.26420.103</MicrosoftExtensionsHostingAbstractionsVersion>
     <MicrosoftExtensionsAIVersion>10.3.0</MicrosoftExtensionsAIVersion>
     <MicrosoftExtensionsAIAbstractionsVersion>10.3.0</MicrosoftExtensionsAIAbstractionsVersion>
     <MicrosoftExtensionsHttpVersion>11.0.0-preview.2.26103.111</MicrosoftExtensionsHttpVersion>
@@ -63,7 +63,7 @@
     <MicrosoftAgentsAIWorkflowsGeneratorsVersion>1.0.0-rc2</MicrosoftAgentsAIWorkflowsGeneratorsVersion>
     <MicrosoftAgentsAIHostingVersion>1.0.0-preview.260225.1</MicrosoftAgentsAIHostingVersion>
     <!-- xamarin/xamarin-android -->
-    <MicrosoftAndroidSdkWindowsPackageVersion>37.0.0-ci.main.2160</MicrosoftAndroidSdkWindowsPackageVersion>
+    <MicrosoftAndroidSdkWindowsPackageVersion>37.0.0-rc.1.2256</MicrosoftAndroidSdkWindowsPackageVersion>
     <MicrosoftNETSdkAndroidManifest100100PackageVersion>36.1.69</MicrosoftNETSdkAndroidManifest100100PackageVersion>
     <AndroidNetPreviousVersion>$(MicrosoftNetSdkAndroidManifest100100PackageVersion)</AndroidNetPreviousVersion>
     <!-- dotnet/macios -->
@@ -86,21 +86,21 @@
     <MicrosoftGraphicsWin2DPackageVersion>1.4.0</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.4078.44</MicrosoftWindowsWebView2PackageVersion>
     <!-- Everything else -->
-    <MicrosoftAspNetCoreAuthorizationPackageVersion>11.0.0-rc.1.26379.102</MicrosoftAspNetCoreAuthorizationPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>11.0.0-rc.1.26379.102</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>11.0.0-rc.1.26379.102</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
-    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>11.0.0-rc.1.26379.102</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
-    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>11.0.0-rc.1.26379.102</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreComponentsFormsPackageVersion>11.0.0-rc.1.26379.102</MicrosoftAspNetCoreComponentsFormsPackageVersion>
-    <MicrosoftAspNetCoreComponentsPackageVersion>11.0.0-rc.1.26379.102</MicrosoftAspNetCoreComponentsPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebPackageVersion>11.0.0-rc.1.26379.102</MicrosoftAspNetCoreComponentsWebPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>11.0.0-rc.1.26379.102</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>11.0.0-rc.1.26379.102</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>11.0.0-rc.1.26379.102</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
-    <MicrosoftAspNetCoreMetadataPackageVersion>11.0.0-rc.1.26379.102</MicrosoftAspNetCoreMetadataPackageVersion>
-    <MicrosoftJSInteropPackageVersion>11.0.0-rc.1.26379.102</MicrosoftJSInteropPackageVersion>
-    <MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion>11.0.0-rc.1.26379.102</MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion>
-    <MicrosoftEntityFrameworkCoreSqlitePackageVersion>11.0.0-rc.1.26379.102</MicrosoftEntityFrameworkCoreSqlitePackageVersion>
+    <MicrosoftAspNetCoreAuthorizationPackageVersion>11.0.0-rc.1.26420.103</MicrosoftAspNetCoreAuthorizationPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>11.0.0-rc.1.26420.103</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>11.0.0-rc.1.26420.103</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
+    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>11.0.0-rc.1.26420.103</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
+    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>11.0.0-rc.1.26420.103</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreComponentsFormsPackageVersion>11.0.0-rc.1.26420.103</MicrosoftAspNetCoreComponentsFormsPackageVersion>
+    <MicrosoftAspNetCoreComponentsPackageVersion>11.0.0-rc.1.26420.103</MicrosoftAspNetCoreComponentsPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebPackageVersion>11.0.0-rc.1.26420.103</MicrosoftAspNetCoreComponentsWebPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>11.0.0-rc.1.26420.103</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>11.0.0-rc.1.26420.103</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>11.0.0-rc.1.26420.103</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
+    <MicrosoftAspNetCoreMetadataPackageVersion>11.0.0-rc.1.26420.103</MicrosoftAspNetCoreMetadataPackageVersion>
+    <MicrosoftJSInteropPackageVersion>11.0.0-rc.1.26420.103</MicrosoftJSInteropPackageVersion>
+    <MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion>11.0.0-rc.1.26420.103</MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion>
+    <MicrosoftEntityFrameworkCoreSqlitePackageVersion>11.0.0-rc.1.26420.103</MicrosoftEntityFrameworkCoreSqlitePackageVersion>
     <!-- Everything else (previous edition) -->
     <MicrosoftAspNetCorePackageVersion>10.0.2</MicrosoftAspNetCorePackageVersion>
     <MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>$(MicrosoftAspNetCorePackageVersion)</MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>
@@ -150,14 +150,14 @@
     <TizenUIExtensionsVersion>0.9.0</TizenUIExtensionsVersion>
     <ExCSSPackageVersion>4.2.3</ExCSSPackageVersion>
     <SystemDrawingCommonPackageVersion>9.0.0</SystemDrawingCommonPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>11.0.0-beta.26379.102</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetBuildTasksInstallersPackageVersion>11.0.0-beta.26379.102</MicrosoftDotNetBuildTasksInstallersPackageVersion>
-    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>11.0.0-beta.26379.102</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>11.0.0-beta.26420.103</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksInstallersPackageVersion>11.0.0-beta.26420.103</MicrosoftDotNetBuildTasksInstallersPackageVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>11.0.0-beta.26420.103</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
     <MicrosoftDotNetHelixJobMonitorPackageVersion>11.0.0-beta.26427.10</MicrosoftDotNetHelixJobMonitorPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26379.102</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26420.103</MicrosoftDotNetHelixSdkPackageVersion>
     <MicroBuildPluginsSwixBuildDotnetPackageVersion>1.1.87-gba258badda</MicroBuildPluginsSwixBuildDotnetPackageVersion>
-    <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.26379.102</MicrosoftDotNetRemoteExecutorPackageVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>11.0.0-beta.26379.102</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.26420.103</MicrosoftDotNetRemoteExecutorPackageVersion>
+    <MicrosoftDotNetXUnitExtensionsPackageVersion>11.0.0-beta.26420.103</MicrosoftDotNetXUnitExtensionsPackageVersion>
     <MicrosoftWixVersion>6.0.3-dotnet.4</MicrosoftWixVersion>
   </PropertyGroup>
   <PropertyGroup>
@@ -228,8 +228,8 @@
     <MonoVersionBand>$(DotNetVersionBand)</MonoVersionBand>
     <DotNetSdkManifestsFolder>$(DotNetVersionBand)</DotNetSdkManifestsFolder>
     <DotNetMauiManifestVersionBand>$(DotNetVersionBand)</DotNetMauiManifestVersionBand>
-    <!-- Android and macOS still publish Preview 7 manifest package IDs while the VMR has advanced to RC 1. -->
-    <DotNetAndroidManifestVersionBand>11.0.100-preview.7</DotNetAndroidManifestVersionBand>
+    <!-- macOS still publishes Preview 7 manifest package IDs while the VMR and Android have advanced to RC 1. -->
+    <DotNetAndroidManifestVersionBand>11.0.100-rc.1</DotNetAndroidManifestVersionBand>
     <DotNetMaciOSManifestVersionBand>11.0.100-preview.7</DotNetMaciOSManifestVersionBand>
     <DotNetTizenManifestVersionBand>9.0.100</DotNetTizenManifestVersionBand>
     <MicrosoftMacCatalystSdkPackageVersion>$(MicrosoftMacCatalystSdknet110_265PackageVersion)</MicrosoftMacCatalystSdkPackageVersion>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "11.0.100-rc.1.26379.102"
+    "dotnet": "11.0.100-rc.1.26420.103"
   },
   "sdk": {
     "paths": [
@@ -11,7 +11,7 @@
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44",
     "Microsoft.Build.NoTargets": "3.7.0",
-    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26379.102",
-    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26379.102"
+    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26420.103",
+    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26420.103"
   }
 }

--- a/src/DotNet/DotNet.csproj
+++ b/src/DotNet/DotNet.csproj
@@ -13,6 +13,9 @@
     <PrivateSdk Condition=" '$(PrivateSdk)' == ''">false</PrivateSdk>
     <_SkipUpgradeNetAnalyzersNuGetWarning>true</_SkipUpgradeNetAnalyzersNuGetWarning>
     <_SkipUpdateBuildNumber>true</_SkipUpdateBuildNumber>
+    <_NormalizedMSBuildExtensionsPath>$([MSBuild]::EnsureTrailingSlash('$(MSBuildExtensionsPath)'))</_NormalizedMSBuildExtensionsPath>
+    <_WorkloadManifestInstallDirectory>$(_NormalizedMSBuildExtensionsPath)../../sdk-manifests/$(DotNetSdkManifestsFolder)</_WorkloadManifestInstallDirectory>
+    <_WorkloadInstallDotNetPath>$(_NormalizedMSBuildExtensionsPath)../../dotnet</_WorkloadInstallDotNetPath>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('windows'))">
     <DotNetInstallScriptUrl>https://builds.dotnet.microsoft.com/dotnet/scripts/v1/dotnet-install.ps1</DotNetInstallScriptUrl>
@@ -73,7 +76,7 @@
     <CopyWorkloadFiles
         Name="microsoft.net.sdk.maui"
         Files="@(_WorkloadFiles)"
-        WorkloadDirectory="$(MSBuildExtensionsPath)../../sdk-manifests/$(DotNetSdkManifestsFolder)"
+        WorkloadDirectory="$(_WorkloadManifestInstallDirectory)"
     />
     <RemoveDir Directories="$(_InstallTempDirectory)" />
 
@@ -88,7 +91,7 @@
     </ItemGroup>
     <Copy SourceFiles="$(MauiRootDirectory)NuGet.config" DestinationFolder="$(DotNetTempDirectory)" />
     <Exec Command="dotnet nuget add source &quot;$(NugetArtifactsPath)&quot; --name artifacts --configfile &quot;$(DotNetTempDirectory)NuGet.config&quot;" />
-    <Exec Command="&quot;$(MSBuildExtensionsPath)../../dotnet&quot; workload install %(_LocalWorkloadIds.Identity) --skip-sign-check --skip-manifest-update --verbosity diag --temp-dir &quot;$(DotNetTempDirectory)&quot; --configfile &quot;$(DotNetTempDirectory)NuGet.config&quot;" WorkingDirectory="$(MauiRootDirectory)" />
+    <Exec Command="&quot;$(_WorkloadInstallDotNetPath)&quot; workload install %(_LocalWorkloadIds.Identity) --skip-sign-check --skip-manifest-update --verbosity diag --temp-dir &quot;$(DotNetTempDirectory)&quot; --configfile &quot;$(DotNetTempDirectory)NuGet.config&quot;" WorkingDirectory="$(MauiRootDirectory)" />
 
   </Target>
 

--- a/src/SingleProject/Resizetizer/test/UnitTests/BaseTest.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/BaseTest.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 
 		void DeleteDirectoryWithRetries(string directory)
 		{
-			const int attempts = 3;
+			const int attempts = 10;
 
 			for (var attempt = 1; ; attempt++)
 			{
@@ -69,7 +69,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 				Output.WriteLine($"Retrying cleanup for {directory} after attempt {attempt}: {cleanupException.Message}");
 				GC.Collect();
 				GC.WaitForPendingFinalizers();
-				System.Threading.Thread.Sleep(100);
+				System.Threading.Thread.Sleep(100 * attempt);
 			}
 		}
 

--- a/src/SingleProject/Resizetizer/test/UnitTests/MSBuildTaskFixture.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/MSBuildTaskFixture.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 		where TTask : Microsoft.Build.Framework.ITask
 	{
 		protected readonly TestLogger? Logger;
+		readonly object logEventsLock = new object();
 
 		protected List<BuildErrorEventArgs> LogErrorEvents = new List<BuildErrorEventArgs>();
 		protected List<BuildMessageEventArgs> LogMessageEvents = new List<BuildMessageEventArgs>();
@@ -36,25 +37,29 @@ namespace Microsoft.Maui.Resizetizer.Tests
 
 		void IBuildEngine.LogCustomEvent(CustomBuildEventArgs e)
 		{
-			LogCustomEvents.Add(e);
+			lock (logEventsLock)
+				LogCustomEvents.Add(e);
 			Output?.WriteLine($"CUSTOM : {e.Message}");
 		}
 
 		void IBuildEngine.LogErrorEvent(BuildErrorEventArgs e)
 		{
-			LogErrorEvents.Add(e);
+			lock (logEventsLock)
+				LogErrorEvents.Add(e);
 			Output?.WriteLine($"ERROR  : {e.Message}");
 		}
 
 		void IBuildEngine.LogMessageEvent(BuildMessageEventArgs e)
 		{
-			LogMessageEvents.Add(e);
+			lock (logEventsLock)
+				LogMessageEvents.Add(e);
 			Output?.WriteLine($"MESSAGE: {e.Message}");
 		}
 
 		void IBuildEngine.LogWarningEvent(BuildWarningEventArgs e)
 		{
-			LogWarningEvents.Add(e);
+			lock (logEventsLock)
+				LogWarningEvents.Add(e);
 			Output?.WriteLine($"WARNING: {e.Message}");
 		}
 	}

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/DotNetProjectTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/DotNetProjectTests.cs
@@ -13,6 +13,20 @@ public class DotNetProjectTests
 	}
 
 	[Fact]
+	public void ToolRunnerCapturesFastProcessOutput()
+	{
+		var output = DotnetInternal.RunForOutput(
+			"--version",
+			string.Empty,
+			out var exitCode,
+			timeoutInSeconds: 60,
+			output: _output);
+
+		Assert.Equal(0, exitCode);
+		Assert.False(string.IsNullOrWhiteSpace(output));
+	}
+
+	[Fact]
 	public void WorkloadInstallPathsAreIndependentOfTrailingSeparator()
 	{
 		var projectFile = Path.Combine(

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/DotNetProjectTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/DotNetProjectTests.cs
@@ -1,0 +1,106 @@
+namespace Microsoft.Maui.IntegrationTests;
+
+[Trait("Category", "Build")]
+public class DotNetProjectTests
+{
+	readonly ITestOutputHelper _output;
+
+	public DotNetProjectTests(ITestOutputHelper output)
+	{
+		_output = output;
+	}
+
+	[Fact]
+	public void WorkloadInstallPathsAreIndependentOfTrailingSeparator()
+	{
+		var projectFile = Path.Combine(
+			TestEnvironment.GetMauiDirectory(),
+			"src",
+			"DotNet",
+			"DotNet.csproj");
+		var sdkVersion = DotnetInternal.RunForOutput(
+			new[] { "--version" },
+			out var exitCode,
+			timeoutInSeconds: 60,
+			output: _output).Trim();
+		Assert.True(exitCode == 0, "Unable to determine the .NET SDK version.");
+		Assert.False(string.IsNullOrEmpty(sdkVersion), "The .NET SDK version was empty.");
+
+		var extensionsPathWithoutSeparator = Path.Combine(
+			TestEnvironment.GetMauiDirectory(),
+			".dotnet",
+			"sdk",
+			sdkVersion);
+		var extensionsPathWithSeparator = extensionsPathWithoutSeparator + Path.DirectorySeparatorChar;
+
+		var withoutSeparator = GetWorkloadPaths(projectFile, extensionsPathWithoutSeparator);
+		var withSeparator = GetWorkloadPaths(projectFile, extensionsPathWithSeparator);
+
+		Assert.Equal(withSeparator, withoutSeparator);
+		Assert.True(
+			withoutSeparator.ExtensionsPath.EndsWith(
+				Path.DirectorySeparatorChar.ToString(),
+				StringComparison.Ordinal) ||
+			withoutSeparator.ExtensionsPath.EndsWith(
+				Path.AltDirectorySeparatorChar.ToString(),
+				StringComparison.Ordinal));
+		Assert.Equal(
+			Path.GetFullPath(Path.Combine(
+				withoutSeparator.ExtensionsPath,
+				"..",
+				"..",
+				"sdk-manifests",
+				withoutSeparator.ManifestBand)),
+			Path.GetFullPath(withoutSeparator.ManifestDirectory));
+		Assert.Equal(
+			Path.GetFullPath(Path.Combine(
+				withoutSeparator.ExtensionsPath,
+				"..",
+				"..",
+				"dotnet")),
+			Path.GetFullPath(withoutSeparator.DotNetPath));
+	}
+
+	(string ExtensionsPath, string ManifestDirectory, string DotNetPath, string ManifestBand) GetWorkloadPaths(
+		string projectFile,
+		string extensionsPath)
+	{
+		return (
+			GetProjectProperty(projectFile, "_NormalizedMSBuildExtensionsPath", extensionsPath),
+			GetProjectProperty(projectFile, "_WorkloadManifestInstallDirectory", extensionsPath),
+			GetProjectProperty(projectFile, "_WorkloadInstallDotNetPath", extensionsPath),
+			GetProjectProperty(projectFile, "DotNetSdkManifestsFolder", extensionsPath));
+	}
+
+	string GetProjectProperty(string projectFile, string propertyName, string? extensionsPath = null)
+	{
+		var arguments = new List<string>
+		{
+			"msbuild",
+			projectFile,
+			"-nologo",
+			"-verbosity:quiet",
+			$"-getProperty:{propertyName}",
+		};
+		if (extensionsPath is not null)
+			arguments.Add($"-p:MSBuildExtensionsPath={extensionsPath}");
+
+		var output = DotnetInternal.RunForOutput(
+			arguments,
+			out var exitCode,
+			timeoutInSeconds: 60,
+			output: _output);
+
+		Assert.True(exitCode == 0, $"MSBuild property evaluation failed:{Environment.NewLine}{output}");
+
+		var value = output
+			.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+			.LastOrDefault()?
+			.Trim();
+
+		if (string.IsNullOrEmpty(value))
+			throw new XunitException($"MSBuild property '{propertyName}' was empty.");
+
+		return value;
+	}
+}

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/DotNetProjectTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/DotNetProjectTests.cs
@@ -13,20 +13,6 @@ public class DotNetProjectTests
 	}
 
 	[Fact]
-	public void ToolRunnerCapturesFastProcessOutput()
-	{
-		var output = DotnetInternal.RunForOutput(
-			"--version",
-			string.Empty,
-			out var exitCode,
-			timeoutInSeconds: 60,
-			output: _output);
-
-		Assert.Equal(0, exitCode);
-		Assert.False(string.IsNullOrWhiteSpace(output));
-	}
-
-	[Fact]
 	public void WorkloadInstallPathsAreIndependentOfTrailingSeparator()
 	{
 		var projectFile = Path.Combine(
@@ -85,32 +71,49 @@ public class DotNetProjectTests
 		string projectFile,
 		string extensionsPath)
 	{
-		return (
-			GetProjectProperty(projectFile, "_NormalizedMSBuildExtensionsPath", extensionsPath),
-			GetProjectProperty(projectFile, "_WorkloadManifestInstallDirectory", extensionsPath),
-			GetProjectProperty(projectFile, "_WorkloadInstallDotNetPath", extensionsPath),
-			GetProjectProperty(projectFile, "DotNetSdkManifestsFolder", extensionsPath));
+		var resultFile = Path.Combine(
+			Path.GetTempPath(),
+			$"maui-msbuild-properties-{Guid.NewGuid():N}.json");
+
+		try
+		{
+			var arguments =
+				$"\"{projectFile}\" -nologo -verbosity:quiet " +
+				$"-getProperty:_NormalizedMSBuildExtensionsPath,_WorkloadManifestInstallDirectory,_WorkloadInstallDotNetPath,DotNetSdkManifestsFolder " +
+				$"-getResultOutputFile:\"{resultFile}\" " +
+				$"-p:MSBuildExtensionsPath=\"{extensionsPath}\"";
+			var output = DotnetInternal.RunForOutput(
+				"msbuild",
+				arguments,
+				out var exitCode,
+				timeoutInSeconds: 60,
+				output: _output);
+
+			Assert.True(exitCode == 0, $"MSBuild property evaluation failed:{Environment.NewLine}{output}");
+			Assert.True(File.Exists(resultFile), $"MSBuild result file does not exist: {resultFile}");
+
+			using var result = JsonDocument.Parse(File.ReadAllText(resultFile));
+			var properties = result.RootElement.GetProperty("Properties");
+
+			return (
+				GetProperty(properties, "_NormalizedMSBuildExtensionsPath"),
+				GetProperty(properties, "_WorkloadManifestInstallDirectory"),
+				GetProperty(properties, "_WorkloadInstallDotNetPath"),
+				GetProperty(properties, "DotNetSdkManifestsFolder"));
+		}
+		finally
+		{
+			if (File.Exists(resultFile))
+				File.Delete(resultFile);
+		}
 	}
 
-	string GetProjectProperty(string projectFile, string propertyName, string? extensionsPath = null)
+	static string GetProperty(JsonElement properties, string propertyName)
 	{
-		var arguments = $"\"{projectFile}\" -nologo -verbosity:quiet -getProperty:{propertyName}";
-		if (extensionsPath is not null)
-			arguments += $" -p:MSBuildExtensionsPath=\"{extensionsPath}\"";
-
-		var output = DotnetInternal.RunForOutput(
-			"msbuild",
-			arguments,
-			out var exitCode,
-			timeoutInSeconds: 60,
-			output: _output);
-
-		Assert.True(exitCode == 0, $"MSBuild property evaluation failed:{Environment.NewLine}{output}");
-
-		var value = output
-			.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
-			.LastOrDefault()?
-			.Trim();
+		var value = properties.TryGetProperty(propertyName, out var property) &&
+			property.ValueKind == JsonValueKind.String
+				? property.GetString()
+				: null;
 
 		if (string.IsNullOrEmpty(value))
 			throw new XunitException($"MSBuild property '{propertyName}' was empty.");

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/DotNetProjectTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/DotNetProjectTests.cs
@@ -19,7 +19,8 @@ public class DotNetProjectTests
 			"DotNet",
 			"DotNet.csproj");
 		var sdkVersion = DotnetInternal.RunForOutput(
-			new[] { "--version" },
+			"--version",
+			string.Empty,
 			out var exitCode,
 			timeoutInSeconds: 60,
 			output: _output).Trim();
@@ -74,18 +75,12 @@ public class DotNetProjectTests
 
 	string GetProjectProperty(string projectFile, string propertyName, string? extensionsPath = null)
 	{
-		var arguments = new List<string>
-		{
-			"msbuild",
-			projectFile,
-			"-nologo",
-			"-verbosity:quiet",
-			$"-getProperty:{propertyName}",
-		};
+		var arguments = $"\"{projectFile}\" -nologo -verbosity:quiet -getProperty:{propertyName}";
 		if (extensionsPath is not null)
-			arguments.Add($"-p:MSBuildExtensionsPath={extensionsPath}");
+			arguments += $" -p:MSBuildExtensionsPath=\"{extensionsPath}\"";
 
 		var output = DotnetInternal.RunForOutput(
+			"msbuild",
 			arguments,
 			out var exitCode,
 			timeoutInSeconds: 60,

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/DotNetProjectTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/DotNetProjectTests.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 namespace Microsoft.Maui.IntegrationTests;
 
 [Trait("Category", "Build")]
@@ -18,13 +20,13 @@ public class DotNetProjectTests
 			"src",
 			"DotNet",
 			"DotNet.csproj");
-		var sdkVersion = DotnetInternal.RunForOutput(
-			"--version",
-			string.Empty,
-			out var exitCode,
-			timeoutInSeconds: 60,
-			output: _output).Trim();
-		Assert.True(exitCode == 0, "Unable to determine the .NET SDK version.");
+		var globalJson = JsonDocument.Parse(File.ReadAllText(Path.Combine(
+			TestEnvironment.GetMauiDirectory(),
+			"global.json")));
+		var sdkVersion = globalJson.RootElement
+			.GetProperty("tools")
+			.GetProperty("dotnet")
+			.GetString();
 		Assert.False(string.IsNullOrEmpty(sdkVersion), "The .NET SDK version was empty.");
 
 		var extensionsPathWithoutSeparator = Path.Combine(
@@ -32,6 +34,9 @@ public class DotNetProjectTests
 			".dotnet",
 			"sdk",
 			sdkVersion);
+		Assert.True(
+			Directory.Exists(extensionsPathWithoutSeparator),
+			$"The repo-local .NET SDK directory does not exist: {extensionsPathWithoutSeparator}");
 		var extensionsPathWithSeparator = extensionsPathWithoutSeparator + Path.DirectorySeparatorChar;
 
 		var withoutSeparator = GetWorkloadPaths(projectFile, extensionsPathWithoutSeparator);

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/DotnetInternal.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/DotnetInternal.cs
@@ -179,10 +179,28 @@ namespace Microsoft.Maui.IntegrationTests
 			output?.WriteLine($"Running: '{DotnetTool}' with '{command}'");
 			output?.WriteLine($"Args list: {args}");
 			var pinfo = new ProcessStartInfo(DotnetTool, $"{command} {args}");
-			pinfo.EnvironmentVariables["DOTNET_MULTILEVEL_LOOKUP"] = "0";
-			pinfo.EnvironmentVariables["DOTNET_ROOT"] = DotnetRoot;
+			ConfigureDotnetEnvironment(pinfo);
 
 			return ToolRunner.Run(pinfo, out exitCode, timeoutInSeconds: timeoutInSeconds, output: output);
+		}
+
+		public static string RunForOutput(IReadOnlyList<string> arguments, out int exitCode, int timeoutInSeconds = DEFAULT_TIMEOUT, ITestOutputHelper? output = null)
+		{
+			output?.WriteLine($"Running: '{DotnetTool}'");
+			output?.WriteLine($"Args list: {string.Join(" | ", arguments)}");
+			var pinfo = new ProcessStartInfo(DotnetTool);
+			foreach (var argument in arguments)
+				pinfo.ArgumentList.Add(argument);
+
+			ConfigureDotnetEnvironment(pinfo);
+
+			return ToolRunner.Run(pinfo, out exitCode, timeoutInSeconds: timeoutInSeconds, output: output);
+		}
+
+		static void ConfigureDotnetEnvironment(ProcessStartInfo pinfo)
+		{
+			pinfo.EnvironmentVariables["DOTNET_MULTILEVEL_LOOKUP"] = "0";
+			pinfo.EnvironmentVariables["DOTNET_ROOT"] = DotnetRoot;
 		}
 
 	}

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/DotnetInternal.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/DotnetInternal.cs
@@ -179,29 +179,10 @@ namespace Microsoft.Maui.IntegrationTests
 			output?.WriteLine($"Running: '{DotnetTool}' with '{command}'");
 			output?.WriteLine($"Args list: {args}");
 			var pinfo = new ProcessStartInfo(DotnetTool, $"{command} {args}");
-			ConfigureDotnetEnvironment(pinfo);
-
-			return ToolRunner.Run(pinfo, out exitCode, timeoutInSeconds: timeoutInSeconds, output: output);
-		}
-
-		public static string RunForOutput(IReadOnlyList<string> arguments, out int exitCode, int timeoutInSeconds = DEFAULT_TIMEOUT, ITestOutputHelper? output = null)
-		{
-			output?.WriteLine($"Running: '{DotnetTool}'");
-			output?.WriteLine($"Args list: {string.Join(" | ", arguments)}");
-			var pinfo = new ProcessStartInfo(DotnetTool);
-			foreach (var argument in arguments)
-				pinfo.ArgumentList.Add(argument);
-
-			ConfigureDotnetEnvironment(pinfo);
-
-			return ToolRunner.Run(pinfo, out exitCode, timeoutInSeconds: timeoutInSeconds, output: output);
-		}
-
-		static void ConfigureDotnetEnvironment(ProcessStartInfo pinfo)
-		{
 			pinfo.EnvironmentVariables["DOTNET_MULTILEVEL_LOOKUP"] = "0";
 			pinfo.EnvironmentVariables["DOTNET_ROOT"] = DotnetRoot;
-		}
 
+			return ToolRunner.Run(pinfo, out exitCode, timeoutInSeconds: timeoutInSeconds, output: output);
+		}
 	}
 }

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/ToolRunner.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/ToolRunner.cs
@@ -63,8 +63,6 @@ namespace Microsoft.Maui.IntegrationTests
 
 				if (p.WaitForExit(timeoutInSeconds * 1000))
 				{
-					// Ensure redirected async output callbacks have finished before returning their data.
-					p.WaitForExit();
 					exitCode = p.ExitCode;
 					output?.WriteLine($"[ToolRunner] Process '{Path.GetFileName(p.StartInfo.FileName)}' exited with code: {exitCode}");
 				}

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/ToolRunner.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/ToolRunner.cs
@@ -63,6 +63,8 @@ namespace Microsoft.Maui.IntegrationTests
 
 				if (p.WaitForExit(timeoutInSeconds * 1000))
 				{
+					// Ensure redirected async output callbacks have finished before returning their data.
+					p.WaitForExit();
 					exitCode = p.ExitCode;
 					output?.WriteLine($"[ToolRunner] Process '{Path.GetFileName(p.StartInfo.FileName)}' exited with code: {exitCode}");
 				}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

Synchronizes the complete external dependency graph from `release/11.0.1xx-rc1` at `4524eb46412e8290017c21d2bf211eb10aaf13b1` into `net11.0`.

The RC1 SDK `11.0.100-rc.1.26420.103` no longer supplies a trailing directory separator in `MSBuildExtensionsPath`. This PR therefore also ports the workload-path compatibility fix already shipping on `release/11.0.1xx-rc1`: normalize the property with `EnsureTrailingSlash` before composing the workload manifest and `dotnet` host paths. The fix is inseparable from using RC1's SDK dependency graph on `net11.0`; without it, every integration leg fails while installing local workloads.

Repeated clean CI runs also exposed existing Resizetizer test-infrastructure races. The separate test commits extend the bounded Windows directory-deletion retry window with linear backoff (#37967) and serialize MSBuild event-list writes used by parallel async tasks. Product behavior is unchanged, cleanup exceptions still escape after retry exhaustion, and test failures remain visible.

Windows integration testing additionally exposed unreliable stdout capture for fast MSBuild property evaluation. The workload-path regression test now requests all four evaluated properties in one MSBuild invocation per path variant and reads them from unique JSON files produced by `-getResultOutputFile`, avoiding dependence on redirected stdout while preserving the shared runner's bounded process behavior.

## Changes

- Copies all dependency entries and metadata in `eng/Version.Details.xml` from RC1.
- Synchronizes the corresponding dependency properties in `eng/Versions.props`.
- Copies the RC1 dependency/tool/MSBuild SDK pins in `global.json`.
- Normalizes `MSBuildExtensionsPath` before resolving workload installation paths.
- Adds regression coverage for paths both with and without a trailing separator, using the repo-local installed SDK directory so the test is valid on Windows and macOS.
- Captures workload path properties through MSBuild JSON result files without extending shared `ToolRunner` process waits.
- Hardens Resizetizer test cleanup against transient Windows image-file locks with bounded retries and linear backoff (#37967).
- Serializes Resizetizer test-fixture event collection for parallel async task logging.
- Leaves `NuGet.config` unchanged because it is identical between the source and target refs.

The `net11.0` product-version settings remain branch-specific: `PreReleaseVersionLabel=preview` and `PreReleaseVersionIteration=7`. These are the only remaining `eng/Versions.props` differences from RC1 (`rc` / `1` respectively).

## Validation

- Parsed dependency comparison: 52 entries on each branch, no source-only or target-only entries, and zero metadata mismatches.
- `global.json` matches RC1 exactly.
- `eng/Versions.props` matches RC1 except for the two intentional product-version settings above.
- `dotnet restore Microsoft.Maui.BuildTasks.slnf --no-cache`
- `dotnet build Microsoft.Maui.BuildTasks.slnf --no-restore --configuration Release`
- `pwsh .github/skills/run-integration-tests/scripts/Run-IntegrationTests.ps1 -TestFilter 'FullyQualifiedName~DotNetProjectTests' -SkipXcodeVersionCheck`
  - `WorkloadInstallPathsAreIndependentOfTrailingSeparator` passed (1/1 total), including result-file existence and non-empty values for all four evaluated properties.
- `pwsh .github/skills/run-integration-tests/scripts/Run-IntegrationTests.ps1 -TestFilter 'FullyQualifiedName~MultiProjectTemplateTest.NewSolutionIncludesGitIgnore' -SkipBuild -SkipInstall -SkipXcodeVersionCheck`
  - Passed (1/1 total), confirming a representative template child-process invocation completes without hanging.
- Full integration workflow with build, pack, and RC1 local workload installation succeeded.
- Focused `ResizetizeImagesTests` and `SkiaSharpRasterToolsTests` passed three consecutive runs after each Resizetizer infrastructure fix (369/369 each run); the command suppressed only pre-existing unrelated `xUnit2031` analyzer diagnostics.
- `darc verify` was run; it reports existing repository metadata diagnostics also present in the RC1 source (duplicate Tizen/XUnit property aliases and the pre-existing XHarness CLI mismatch), none introduced by this synchronization.
