### PR TITLE
[inflight/candidate] Backport BlazorWebView and HybridWebView fixes

### DIFF
--- a/src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs
+++ b/src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs
@@ -81,6 +81,17 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			})();
 			""";
 
+		private const ActivityFlags AllowedIntentFlags =
+			ActivityFlags.ExcludeStoppedPackages |
+			ActivityFlags.ClearTop |
+			ActivityFlags.SingleTop |
+			ActivityFlags.MatchExternal |
+			ActivityFlags.NewTask |
+			ActivityFlags.MultipleTask |
+			ActivityFlags.NewDocument |
+			ActivityFlags.RetainInRecents |
+			ActivityFlags.LaunchAdjacent;
+
 		private readonly BlazorWebViewHandler? _webViewHandler;
 
 		public WebKitWebViewClient(BlazorWebViewHandler webViewHandler)
@@ -119,7 +130,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				_webViewHandler.Logger.LaunchExternalBrowser(uri);
 				try
 				{
-					var intent = Intent.ParseUri(uri.OriginalString, IntentUriType.Scheme);
+					var intent = CreateIntentForExternalUri(uri);
 					_webViewHandler.Context.StartActivity(intent);
 				}
 				catch (URISyntaxException)
@@ -136,6 +147,24 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			}
 
 			return callbackArgs.UrlLoadingStrategy != UrlLoadingStrategy.OpenInWebView;
+		}
+
+		internal static Intent CreateIntentForExternalUri(Uri uri)
+		{
+			var intent = Intent.ParseUri(uri.OriginalString, IntentUriType.Scheme) ??
+				throw new URISyntaxException(uri.OriginalString, "Unable to create an intent from the URI.");
+
+			if (uri.Scheme.Equals("intent", StringComparison.OrdinalIgnoreCase) ||
+				uri.Scheme.Equals("android-app", StringComparison.OrdinalIgnoreCase))
+			{
+				// Keep structured intent URIs implicit and limited to handlers that accept browser navigation.
+				intent.AddCategory(Intent.CategoryBrowsable);
+				intent.SetComponent(null);
+				intent.Selector = null;
+				intent.SetFlags(intent.Flags & AllowedIntentFlags);
+			}
+
+			return intent;
 		}
 
 		public override WebResourceResponse? ShouldInterceptRequest(AWebView? view, IWebResourceRequest? request)

--- a/src/BlazorWebView/src/Maui/Properties/AssemblyInfo.cs
+++ b/src/BlazorWebView/src/Maui/Properties/AssemblyInfo.cs
@@ -7,3 +7,4 @@ using System.Runtime.CompilerServices;
 
 [assembly: XmlnsDefinition("http://schemas.microsoft.com/dotnet/2021/maui", "Microsoft.AspNetCore.Components.WebView.Maui")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.MauiBlazorWebView.UnitTests")]
+[assembly: InternalsVisibleTo("Microsoft.Maui.MauiBlazorWebView.DeviceTests")]

--- a/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.ExternalNavigation.Android.cs
+++ b/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.ExternalNavigation.Android.cs
@@ -1,0 +1,201 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Android.Content;
+using Microsoft.AspNetCore.Components.WebView.Maui;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.MauiBlazorWebView.DeviceTests.Components;
+using Xunit;
+
+namespace Microsoft.Maui.MauiBlazorWebView.DeviceTests.Elements;
+
+public partial class BlazorWebViewTests
+{
+	static readonly TimeSpan ActivityLaunchTimeout = TimeSpan.FromSeconds(10);
+	static readonly TimeSpan ActivityNotLaunchedTimeout = TimeSpan.FromSeconds(2);
+
+	[Theory]
+	[InlineData("https://example.com/path")]
+	[InlineData("tel:+15551234")]
+	[InlineData("mailto:user@example.com")]
+	[InlineData("geo:29.7604,-95.3698")]
+	public void OrdinaryExternalUriCreatesViewIntent(string uri)
+	{
+		using var intent = WebKitWebViewClient.CreateIntentForExternalUri(new Uri(uri));
+
+		Assert.Equal(Intent.ActionView, intent.Action);
+		Assert.Equal(uri, intent.DataString);
+		Assert.Null(intent.Package);
+		Assert.Null(intent.Component);
+		Assert.Null(intent.Selector);
+		Assert.Null(intent.Categories);
+	}
+
+	[Fact]
+	public void AndroidAppUriPreservesImplicitRoutingData()
+	{
+		const string androidAppUri = "android-app://com.example.app/https/example.com/path";
+
+		using var intent = WebKitWebViewClient.CreateIntentForExternalUri(new Uri(androidAppUri));
+
+		Assert.Equal(Intent.ActionView, intent.Action);
+		Assert.Equal("https://example.com/path", intent.DataString);
+		Assert.Equal("com.example.app", intent.Package);
+		Assert.Contains(Intent.CategoryBrowsable, intent.Categories);
+		Assert.Null(intent.Component);
+		Assert.Null(intent.Selector);
+	}
+
+	[Fact]
+	public void IntentUriPreservesImplicitRoutingData()
+	{
+		var intentUri =
+			$"intent://open/item/42#Intent;scheme={ExternalNavigationTestData.BrowsableScheme};package={ExternalNavigationTestData.ApplicationId};action={ExternalNavigationTestData.BrowsableAction};S.source=blazor;i.highlight=7;B.preview=true;end";
+
+		using var intent = WebKitWebViewClient.CreateIntentForExternalUri(new Uri(intentUri));
+
+		Assert.Equal(ExternalNavigationTestData.BrowsableAction, intent.Action);
+		Assert.Equal($"{ExternalNavigationTestData.BrowsableScheme}://open/item/42", intent.DataString);
+		Assert.Equal(ExternalNavigationTestData.ApplicationId, intent.Package);
+		Assert.Contains(Intent.CategoryBrowsable, intent.Categories);
+		Assert.Null(intent.Component);
+		Assert.Null(intent.Selector);
+		Assert.Equal("blazor", intent.GetStringExtra("source"));
+		Assert.Equal(7, intent.GetIntExtra("highlight", -1));
+		Assert.True(intent.GetBooleanExtra("preview", false));
+	}
+
+	[Theory]
+	[InlineData(
+		"intent:#Intent;component=com.microsoft.maui.mauiblazorwebview.devicetests/com.microsoft.maui.mauiblazorwebview.devicetests.ExplicitIntentTestActivity;end")]
+	[InlineData(
+		"intent:#Intent;SEL;component=com.microsoft.maui.mauiblazorwebview.devicetests/com.microsoft.maui.mauiblazorwebview.devicetests.ExplicitIntentTestActivity;end")]
+	[InlineData(
+		"android-app://com.microsoft.maui.mauiblazorwebview.devicetests/#Intent;component=com.microsoft.maui.mauiblazorwebview.devicetests/com.microsoft.maui.mauiblazorwebview.devicetests.ExplicitIntentTestActivity;end")]
+	public void StructuredIntentUriRemovesExplicitTargets(string uri)
+	{
+		using var intent = WebKitWebViewClient.CreateIntentForExternalUri(new Uri(uri));
+
+		Assert.Contains(Intent.CategoryBrowsable, intent.Categories);
+		Assert.Null(intent.Component);
+		Assert.Null(intent.Selector);
+	}
+
+	[Fact]
+	public void StructuredIntentUriRemovesUnsupportedActivityFlags()
+	{
+		const string intentUri = "intent:#Intent;launchFlags=0x10008000;end";
+
+		using var intent = WebKitWebViewClient.CreateIntentForExternalUri(new Uri(intentUri));
+
+		Assert.True(intent.Flags.HasFlag(ActivityFlags.NewTask));
+		Assert.False(intent.Flags.HasFlag(ActivityFlags.ClearTask));
+	}
+
+	[Theory]
+	[InlineData("intent")]
+	[InlineData("android-app")]
+	public async Task StructuredIntentUriWithExplicitComponentDoesNotLaunchActivity(string uriScheme)
+	{
+		var activityLaunch = ActivityLaunchMonitor<ExplicitIntentTestActivity>.PrepareForLaunch();
+		var intentUri = uriScheme == "intent"
+			? $"intent:#Intent;component={ExternalNavigationTestData.ApplicationId}/{ExternalNavigationTestData.ExplicitActivityName};S.test=value;end"
+			: $"android-app://{ExternalNavigationTestData.ApplicationId}/#Intent;component={ExternalNavigationTestData.ApplicationId}/{ExternalNavigationTestData.ExplicitActivityName};S.test=value;end";
+
+		try
+		{
+			await NavigateToExternalUriAsync(intentUri, uriScheme);
+
+			var completedTask = await Task.WhenAny(activityLaunch, Task.Delay(ActivityNotLaunchedTimeout));
+			Assert.NotSame(activityLaunch, completedTask);
+		}
+		finally
+		{
+			ActivityLaunchMonitor<ExplicitIntentTestActivity>.Reset();
+		}
+	}
+
+	[Fact]
+	public async Task IntentUriWithoutBrowsableHandlerDoesNotLaunchActivity()
+	{
+		var activityLaunch = ActivityLaunchMonitor<NonBrowsableIntentTestActivity>.PrepareForLaunch();
+		var intentUri =
+			$"intent://open/item#Intent;scheme={ExternalNavigationTestData.NonBrowsableScheme};package={ExternalNavigationTestData.ApplicationId};action={ExternalNavigationTestData.NonBrowsableAction};end";
+
+		try
+		{
+			await NavigateToExternalUriAsync(intentUri);
+
+			var completedTask = await Task.WhenAny(activityLaunch, Task.Delay(ActivityNotLaunchedTimeout));
+			Assert.NotSame(activityLaunch, completedTask);
+		}
+		finally
+		{
+			ActivityLaunchMonitor<NonBrowsableIntentTestActivity>.Reset();
+		}
+	}
+
+	[Fact]
+	public async Task IntentUriWithBrowsableHandlerLaunchesActivity()
+	{
+		var activityLaunch = ActivityLaunchMonitor<BrowsableIntentTestActivity>.PrepareForLaunch();
+		var intentUri =
+			$"intent://open/item/42#Intent;scheme={ExternalNavigationTestData.BrowsableScheme};package={ExternalNavigationTestData.ApplicationId};action={ExternalNavigationTestData.BrowsableAction};S.source=blazor;i.highlight=7;B.preview=true;end";
+
+		try
+		{
+			await NavigateToExternalUriAsync(intentUri);
+
+			var activity = await activityLaunch.WaitAsync(ActivityLaunchTimeout);
+			Assert.Equal(ExternalNavigationTestData.BrowsableAction, activity.Intent?.Action);
+			Assert.Equal($"{ExternalNavigationTestData.BrowsableScheme}://open/item/42", activity.Intent?.DataString);
+			Assert.Equal(ExternalNavigationTestData.ApplicationId, activity.Intent?.Package);
+			Assert.Equal("blazor", activity.Intent?.GetStringExtra("source"));
+			Assert.Equal(7, activity.Intent?.GetIntExtra("highlight", -1));
+			Assert.True(activity.Intent?.GetBooleanExtra("preview", false));
+		}
+		finally
+		{
+			ActivityLaunchMonitor<BrowsableIntentTestActivity>.Reset();
+		}
+	}
+
+	async Task NavigateToExternalUriAsync(string uri, string uriScheme = "intent")
+	{
+		EnsureHandlerCreated(additionalCreationActions: appBuilder =>
+		{
+			appBuilder.Services.AddMauiBlazorWebView();
+		});
+
+		var navigationObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		var bwv = new BlazorWebViewWithCustomFiles
+		{
+			HostPage = "wwwroot/index.html",
+			CustomFiles = new Dictionary<string, string>
+			{
+				{ "index.html", TestStaticFilesContents.DefaultMauiIndexHtmlContent },
+			},
+		};
+		bwv.RootComponents.Add(new RootComponent { ComponentType = typeof(NoOpComponent), Selector = "#app", });
+		bwv.UrlLoading += (_, args) =>
+		{
+			if (args.Url.Scheme.Equals(uriScheme, StringComparison.OrdinalIgnoreCase))
+			{
+				navigationObserved.TrySetResult();
+			}
+		};
+
+		await InvokeOnMainThreadAsync(async () =>
+		{
+			var bwvHandler = CreateHandler<BlazorWebViewHandler>(bwv);
+			var platformWebView = bwvHandler.PlatformView;
+			await WebViewHelpers.WaitForDocumentReady(platformWebView);
+			await WebViewHelpers.ExecuteScriptAsync(
+				platformWebView,
+				$"window.location.href = {JsonSerializer.Serialize(uri)};");
+		});
+
+		await navigationObserved.Task.WaitAsync(ActivityLaunchTimeout);
+	}
+}

--- a/src/BlazorWebView/tests/DeviceTests/Platforms/Android/ExternalNavigationTestActivities.Android.cs
+++ b/src/BlazorWebView/tests/DeviceTests/Platforms/Android/ExternalNavigationTestActivities.Android.cs
@@ -1,0 +1,84 @@
+#nullable enable
+
+using System.Threading;
+using System.Threading.Tasks;
+using Android.App;
+using Android.Content;
+using Android.OS;
+
+namespace Microsoft.Maui.MauiBlazorWebView.DeviceTests;
+
+internal static class ExternalNavigationTestData
+{
+	public const string ApplicationId = "com.microsoft.maui.mauiblazorwebview.devicetests";
+
+	public const string ExplicitActivityName = ApplicationId + ".ExplicitIntentTestActivity";
+
+	public const string NonBrowsableActivityName = ApplicationId + ".NonBrowsableIntentTestActivity";
+	public const string NonBrowsableAction = ApplicationId + ".action.NON_BROWSABLE";
+	public const string NonBrowsableScheme = "maui-blazor-non-browsable";
+
+	public const string BrowsableActivityName = ApplicationId + ".BrowsableIntentTestActivity";
+	public const string BrowsableAction = ApplicationId + ".action.BROWSABLE";
+	public const string BrowsableScheme = "maui-blazor-browsable";
+}
+
+internal static class ActivityLaunchMonitor<TActivity>
+	where TActivity : Activity
+{
+	static TaskCompletionSource<TActivity>? pendingLaunch;
+
+	public static Task<TActivity> PrepareForLaunch()
+	{
+		var launch = new TaskCompletionSource<TActivity>(TaskCreationOptions.RunContinuationsAsynchronously);
+		Interlocked.Exchange(ref pendingLaunch, launch)?.TrySetCanceled();
+		return launch.Task;
+	}
+
+	public static void RecordLaunch(TActivity activity) =>
+		Interlocked.Exchange(ref pendingLaunch, null)?.TrySetResult(activity);
+
+	public static void Reset() =>
+		Interlocked.Exchange(ref pendingLaunch, null)?.TrySetCanceled();
+}
+
+[Activity(Name = ExternalNavigationTestData.ExplicitActivityName, Exported = false, NoHistory = true)]
+public sealed class ExplicitIntentTestActivity : Activity
+{
+	protected override void OnCreate(Bundle? savedInstanceState)
+	{
+		base.OnCreate(savedInstanceState);
+		ActivityLaunchMonitor<ExplicitIntentTestActivity>.RecordLaunch(this);
+		Finish();
+	}
+}
+
+[Activity(Name = ExternalNavigationTestData.NonBrowsableActivityName, Exported = true, NoHistory = true)]
+[IntentFilter(
+	new[] { ExternalNavigationTestData.NonBrowsableAction },
+	Categories = new[] { Intent.CategoryDefault },
+	DataScheme = ExternalNavigationTestData.NonBrowsableScheme)]
+public sealed class NonBrowsableIntentTestActivity : Activity
+{
+	protected override void OnCreate(Bundle? savedInstanceState)
+	{
+		base.OnCreate(savedInstanceState);
+		ActivityLaunchMonitor<NonBrowsableIntentTestActivity>.RecordLaunch(this);
+		Finish();
+	}
+}
+
+[Activity(Name = ExternalNavigationTestData.BrowsableActivityName, Exported = true, NoHistory = true)]
+[IntentFilter(
+	new[] { ExternalNavigationTestData.BrowsableAction },
+	Categories = new[] { Intent.CategoryDefault, Intent.CategoryBrowsable },
+	DataScheme = ExternalNavigationTestData.BrowsableScheme)]
+public sealed class BrowsableIntentTestActivity : Activity
+{
+	protected override void OnCreate(Bundle? savedInstanceState)
+	{
+		base.OnCreate(savedInstanceState);
+		ActivityLaunchMonitor<BrowsableIntentTestActivity>.RecordLaunch(this);
+		Finish();
+	}
+}

--- a/src/BlazorWebView/tests/DeviceTests/WebViewHelpers.Android.cs
+++ b/src/BlazorWebView/tests/DeviceTests/WebViewHelpers.Android.cs
@@ -21,6 +21,26 @@ namespace Microsoft.Maui.MauiBlazorWebView.DeviceTests
 				});
 		}
 
+		public static async Task WaitForDocumentReady(AWebView webview)
+		{
+			await Retry(
+				async () =>
+				{
+					var documentReady = await ExecuteScriptAsync(
+						webview,
+						"""
+						(document.readyState === 'interactive' || document.readyState === 'complete') &&
+						document.head !== null &&
+						document.head.getAttribute('testhtmlloaded') === 'true'
+						""");
+					return documentReady == "true";
+				},
+				timeoutInMS =>
+				{
+					return Task.FromResult(new Exception($"Waited {timeoutInMS}ms but the test document never became ready."));
+				});
+		}
+
 		public static Task<string> ExecuteScriptAsync(AWebView webview, string script)
 		{
 			var jsResult = new JavascriptResult();

--- a/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_MessageOrigins.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_MessageOrigins.Android.cs
@@ -1,0 +1,91 @@
+﻿#nullable enable
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+
+namespace Microsoft.Maui.DeviceTests;
+
+public partial class HybridWebViewTests_MessageOrigins
+{
+	private static partial async Task LoadOtherOriginDocumentAsync(
+		HybridWebViewHandler handler,
+		HybridWebView hybridWebView,
+		string html)
+	{
+		var responseProvided = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		void OnWebResourceRequested(object? sender, WebViewWebResourceRequestedEventArgs args)
+		{
+			if (!new Uri(OtherOrigin).IsBaseOf(args.Uri))
+			{
+				return;
+			}
+
+			if (args.Uri == new Uri(OtherOrigin))
+			{
+				args.SetResponse(200, "OK", "text/html", new MemoryStream(Encoding.UTF8.GetBytes(html)));
+				responseProvided.TrySetResult();
+			}
+			else
+			{
+				args.SetResponse(404, "Not Found");
+			}
+
+			args.Handled = true;
+		}
+
+		hybridWebView.WebResourceRequested += OnWebResourceRequested;
+
+		try
+		{
+			handler.PlatformView.LoadUrl(OtherOrigin);
+			await responseProvided.Task.WaitAsync(OperationWaitTimeout);
+
+			for (var attempt = 0; attempt < 100; attempt++)
+			{
+				var loaded = await hybridWebView.EvaluateJavaScriptAsync(
+					"document.getElementById('otherOriginDocument') !== null");
+				if (loaded == "true")
+				{
+					return;
+				}
+
+				await Task.Delay(250);
+			}
+
+			throw new TimeoutException("The other-origin document did not finish loading.");
+		}
+		finally
+		{
+			hybridWebView.WebResourceRequested -= OnWebResourceRequested;
+		}
+	}
+
+	private static partial async Task WaitForBridgeAttemptAsync(HybridWebView hybridWebView)
+	{
+		var bridgeAttempted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		void OnWebResourceRequested(object? sender, WebViewWebResourceRequestedEventArgs args)
+		{
+			if (args.Uri.Host == HybridWebViewHandler.AppOriginUri.Host &&
+				args.Uri.AbsolutePath == $"/{HybridWebViewHandler.SendMessagePath}")
+			{
+				bridgeAttempted.TrySetResult();
+			}
+		}
+
+		hybridWebView.WebResourceRequested += OnWebResourceRequested;
+
+		try
+		{
+			await bridgeAttempted.Task.WaitAsync(OperationWaitTimeout);
+		}
+		finally
+		{
+			hybridWebView.WebResourceRequested -= OnWebResourceRequested;
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_MessageOrigins.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_MessageOrigins.Windows.cs
@@ -1,0 +1,65 @@
+﻿#nullable enable
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using Microsoft.Web.WebView2.Core;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests;
+
+public partial class HybridWebViewTests_MessageOrigins
+{
+	private static partial async Task LoadOtherOriginDocumentAsync(
+		HybridWebViewHandler handler,
+		HybridWebView hybridWebView,
+		string html)
+	{
+		var responseProvided = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		var navigationCompleted = new TaskCompletionSource<CoreWebView2NavigationCompletedEventArgs>(
+			TaskCreationOptions.RunContinuationsAsynchronously);
+
+		void OnWebResourceRequested(object? sender, WebViewWebResourceRequestedEventArgs args)
+		{
+			if (!new Uri(OtherOrigin).IsBaseOf(args.Uri))
+			{
+				return;
+			}
+
+			if (args.Uri == new Uri(OtherOrigin))
+			{
+				args.SetResponse(200, "OK", "text/html", new MemoryStream(Encoding.UTF8.GetBytes(html)));
+				responseProvided.TrySetResult();
+			}
+			else
+			{
+				args.SetResponse(404, "Not Found");
+			}
+
+			args.Handled = true;
+		}
+
+		void OnNavigationCompleted(CoreWebView2 sender, CoreWebView2NavigationCompletedEventArgs args) =>
+			navigationCompleted.TrySetResult(args);
+
+		hybridWebView.WebResourceRequested += OnWebResourceRequested;
+		handler.PlatformView.CoreWebView2.NavigationCompleted += OnNavigationCompleted;
+
+		try
+		{
+			handler.PlatformView.CoreWebView2.Navigate(OtherOrigin);
+
+			await responseProvided.Task.WaitAsync(OperationWaitTimeout);
+			var navigation = await navigationCompleted.Task.WaitAsync(OperationWaitTimeout);
+
+			Assert.True(navigation.IsSuccess, $"Navigation failed with {navigation.WebErrorStatus}.");
+		}
+		finally
+		{
+			hybridWebView.WebResourceRequested -= OnWebResourceRequested;
+			handler.PlatformView.CoreWebView2.NavigationCompleted -= OnNavigationCompleted;
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_MessageOrigins.cs
+++ b/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_MessageOrigins.cs
@@ -1,0 +1,136 @@
+﻿#if WINDOWS || IOS || MACCATALYST || ANDROID
+#nullable enable
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests;
+
+[Category(TestCategory.HybridWebView)]
+#if WINDOWS
+[Collection(WebViewsCollection)]
+#endif
+public partial class HybridWebViewTests_MessageOrigins : HybridWebViewTestsBase
+{
+	const string OtherOrigin = "https://example.invalid/";
+	static readonly string OtherOriginDocument = $$"""
+		<!DOCTYPE html>
+		<html>
+			<body id="otherOriginDocument">
+				<script>
+					function sendBridgeMessage(message) {
+						if (window.chrome && window.chrome.webview) {
+							window.chrome.webview.postMessage(encodeURIComponent(message));
+						} else if (window.webkit && window.webkit.messageHandlers) {
+							window.webkit.messageHandlers.webwindowinterop.postMessage(message);
+						} else {
+							return fetch("{{new Uri(HybridWebViewHandler.AppOriginUri, HybridWebViewHandler.SendMessagePath).AbsoluteUri}}", {
+								method: "POST",
+								headers: {
+									"Content-Type": "text/plain",
+									"X-Maui-Invoke-Token": "HybridWebView",
+									"X-Maui-Request-Body": message
+								},
+								body: message
+							}).catch(() => {});
+						}
+					}
+
+					function sendRawMessage() {
+						sendBridgeMessage("__RawMessage|Message from another origin");
+					}
+
+					function completeInvoke(taskId) {
+						sendBridgeMessage(`__InvokeJavaScriptCompleted|${taskId}|"Result from another origin"`);
+					}
+				</script>
+			</body>
+		</html>
+		""";
+
+	static readonly TimeSpan OperationWaitTimeout = TimeSpan.FromSeconds(25);
+	static readonly TimeSpan MessageWaitTimeout = TimeSpan.FromSeconds(5);
+
+	[Fact]
+	public Task RawMessagesFromOtherOriginsAreIgnored() =>
+		RunOriginTest(async (handler, hybridWebView) =>
+		{
+			var messageReceived = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
+			hybridWebView.RawMessageReceived += (_, args) => messageReceived.TrySetResult(args.Message);
+
+			await LoadOtherOriginDocumentAsync(handler, hybridWebView, OtherOriginDocument);
+			await AssertOtherOriginDocumentLoaded(hybridWebView);
+
+#if ANDROID
+			var bridgeAttempted = WaitForBridgeAttemptAsync(hybridWebView);
+#endif
+			await hybridWebView.EvaluateJavaScriptAsync("sendRawMessage()");
+#if ANDROID
+			await bridgeAttempted;
+#endif
+
+			Assert.False(
+				await CompletesWithinAsync(messageReceived.Task, MessageWaitTimeout),
+				"A raw message from another origin was delivered to the app.");
+		});
+
+	[Fact]
+	public Task InvokeCompletionsFromOtherOriginsAreIgnored() =>
+		RunOriginTest(async (handler, hybridWebView) =>
+		{
+			var taskManager = handler.GetRequiredService<IHybridWebViewTaskManager>();
+			var invokeTask = taskManager.CreateTask();
+
+			await LoadOtherOriginDocumentAsync(handler, hybridWebView, OtherOriginDocument);
+			await AssertOtherOriginDocumentLoaded(hybridWebView);
+
+#if ANDROID
+			var bridgeAttempted = WaitForBridgeAttemptAsync(hybridWebView);
+#endif
+			await hybridWebView.EvaluateJavaScriptAsync($"completeInvoke('{invokeTask.TaskId}')");
+#if ANDROID
+			await bridgeAttempted;
+#endif
+
+			Assert.False(
+				await CompletesWithinAsync(invokeTask.TaskCompletionSource.Task, MessageWaitTimeout),
+				"An invoke task was completed by a message from another origin.");
+		});
+
+	Task RunOriginTest(Func<HybridWebViewHandler, HybridWebView, Task> test)
+	{
+		var hybridWebView = new HybridWebView
+		{
+			WidthRequest = 100,
+			HeightRequest = 100,
+			HybridRoot = "HybridTestRoot",
+			DefaultFile = "index.html",
+		};
+
+		return RunTest(hybridWebView, test);
+	}
+
+	static async Task AssertOtherOriginDocumentLoaded(HybridWebView hybridWebView)
+	{
+		var loaded = await hybridWebView.EvaluateJavaScriptAsync(
+			"document.getElementById('otherOriginDocument') !== null");
+
+		Assert.Equal("true", loaded);
+	}
+
+	static async Task<bool> CompletesWithinAsync(Task task, TimeSpan timeout) =>
+		await Task.WhenAny(task, Task.Delay(timeout)) == task;
+
+	private static partial Task LoadOtherOriginDocumentAsync(
+		HybridWebViewHandler handler,
+		HybridWebView hybridWebView,
+		string html);
+
+#if ANDROID
+	private static partial Task WaitForBridgeAttemptAsync(HybridWebView hybridWebView);
+#endif
+}
+#endif

--- a/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_MessageOrigins.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_MessageOrigins.iOS.cs
@@ -1,0 +1,47 @@
+﻿#nullable enable
+using System;
+using System.Threading.Tasks;
+using Foundation;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using WebKit;
+
+namespace Microsoft.Maui.DeviceTests;
+
+public partial class HybridWebViewTests_MessageOrigins
+{
+	private static partial async Task LoadOtherOriginDocumentAsync(
+		HybridWebViewHandler handler,
+		HybridWebView hybridWebView,
+		string html)
+	{
+		var navigationDelegate = new NavigationDelegate();
+		var previousNavigationDelegate = handler.PlatformView.NavigationDelegate;
+		handler.PlatformView.NavigationDelegate = navigationDelegate;
+
+		try
+		{
+			handler.PlatformView.LoadHtmlString(html, new NSUrl(OtherOrigin));
+			await navigationDelegate.NavigationCompleted.Task.WaitAsync(OperationWaitTimeout);
+		}
+		finally
+		{
+			handler.PlatformView.NavigationDelegate = previousNavigationDelegate;
+		}
+	}
+
+	sealed class NavigationDelegate : WKNavigationDelegate
+	{
+		public TaskCompletionSource NavigationCompleted { get; } =
+			new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		public override void DidFinishNavigation(WKWebView webView, WKNavigation? navigation) =>
+			NavigationCompleted.TrySetResult();
+
+		public override void DidFailNavigation(WKWebView webView, WKNavigation? navigation, NSError error) =>
+			NavigationCompleted.TrySetException(new InvalidOperationException(error.LocalizedDescription));
+
+		public override void DidFailProvisionalNavigation(WKWebView webView, WKNavigation? navigation, NSError error) =>
+			NavigationCompleted.TrySetException(new InvalidOperationException(error.LocalizedDescription));
+	}
+}

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Windows.cs
@@ -98,6 +98,13 @@ namespace Microsoft.Maui.Handlers
 
 		private void OnWebMessageReceived(WebView2 sender, CoreWebView2WebMessageReceivedEventArgs args)
 		{
+			if (!Uri.TryCreate(args.Source, UriKind.Absolute, out var sourceUri) ||
+				!AppOriginUri.IsBaseOf(sourceUri))
+			{
+				MauiContext?.CreateLogger<HybridWebViewHandler>()?.LogDebug("Ignoring web message from an unrecognized source.");
+				return;
+			}
+
 			// The JS transport URL-encodes messages so embedded NUL characters survive WebView2's
 			// null-terminated string marshalling (TryGetWebMessageAsString returns an LPWSTR). Decode
 			// the payload before dispatching it.

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
@@ -100,8 +100,15 @@ namespace Microsoft.Maui.Handlers
 			hybridPlatformWebView.SendRawMessage(hybridWebViewRawMessage.Message ?? "");
 		}
 
-		private void MessageReceived(Uri uri, string message)
+		private void MessageReceived(string? source, string message)
 		{
+			if (!Uri.TryCreate(source, UriKind.Absolute, out var sourceUri) ||
+				!AppOriginUri.IsBaseOf(sourceUri))
+			{
+				MauiContext?.CreateLogger<HybridWebViewHandler>()?.LogDebug("Ignoring web message from an unrecognized source.");
+				return;
+			}
+
 			MessageReceived(message);
 		}
 
@@ -141,7 +148,7 @@ namespace Microsoft.Maui.Handlers
 			public void DidReceiveScriptMessage(WKUserContentController userContentController, WKScriptMessage message)
 			{
 				ArgumentNullException.ThrowIfNull(message);
-				Handler?.MessageReceived(AppOriginUri, ((NSString)message.Body).ToString());
+				Handler?.MessageReceived(message.FrameInfo.Request.Url?.AbsoluteString, ((NSString)message.Body).ToString());
 			}
 		}
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

Backports #38079 and #38078 to `inflight/candidate`.

### Changes

- Backports the Android `BlazorWebView` intent-link resolution fix from #38079.
- Backports the cross-platform `HybridWebView` message-origin validation fix from #38078.
- Includes the device-test coverage from both source PRs.

The landed squash commits were cherry-picked in landing order without conflicts.

### Validation

- `dotnet build Microsoft.Maui.BuildTasks.slnf -c Debug`
- `dotnet build src/BlazorWebView/tests/DeviceTests/MauiBlazorWebView.DeviceTests.csproj -f net10.0-android -c Debug`
- `dotnet build src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj -f net10.0-android -c Debug`
- `dotnet build src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj -f net10.0-maccatalyst -c Debug`
- Windows cross-build reaches the Windows-only `MakePri.exe` step and cannot complete on macOS.
