### PR TITLE
Fix problem with null VirtualView in BlazorWebViewHandler on iOS

### DIFF
--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -274,6 +274,11 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			[SupportedOSPlatform("ios11.0")]
 			public void StartUrlSchemeTask(WKWebView webView, IWKUrlSchemeTask urlSchemeTask)
 			{
+				if (_webViewHandler is null || _webViewHandler is IViewHandler ivh && ivh.VirtualView is null)
+				{
+					return;
+				}
+				
 				var url = urlSchemeTask.Request.Url.AbsoluteString;
 				if (string.IsNullOrEmpty(url))
 				{
@@ -418,6 +423,13 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 
 			private byte[] GetResponseBytes(string? url, out string contentType, out int statusCode)
 			{
+			    if (_webViewHandler.Handler is null || _webViewHandler.Handler.VirtualView is null || _webViewHandler._webviewManager is null)
+			    {
+			        statusCode = 404;
+			        contentType = string.Empty;
+			        return Array.Empty<byte>();
+			    }
+
 				var allowFallbackOnHostPage = AppOriginUri.IsBaseOfPage(url);
 				url = QueryStringHelper.RemovePossibleQueryString(url);
 


### PR DESCRIPTION
Add null checks for _webViewHandler and related properties in StartUrlSchemeTask and GetResponseBytes methods.

Description of Change
Checking if Handler has container before using VirtualView which can crash app if is null

Issues Fixed
Fixes https://github.com/dotnet/maui/issues/38131