### PR TITLE
[iOS] Read NavPage once in SetStatusBarStyle so the null guard is effective

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -1037,13 +1037,17 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void SetStatusBarStyle()
 		{
-			if (NavPage is null)
+			// NavPage resolves Element through a weak reference on every access, so it can
+			// become null between the guard and the uses below. Read it once.
+			var navPage = NavPage;
+
+			if (navPage is null)
 			{
 				return;
 			}
 
-			var barTextColor = NavPage.BarTextColor;
-			var statusBarColorMode = NavPage.OnThisPlatform().GetStatusBarTextColorMode();
+			var barTextColor = navPage.BarTextColor;
+			var statusBarColorMode = navPage.OnThisPlatform().GetStatusBarTextColorMode();
 
 #pragma warning disable CA1416, CA1422 // TODO:   'UIApplication.StatusBarStyle' is unsupported on: 'ios' 9.0 and later
 			if (statusBarColorMode == StatusBarTextColorMode.DoNotAdjust || barTextColor?.GetLuminosity() <= 0.5)

--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -1037,8 +1037,6 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void SetStatusBarStyle()
 		{
-			// NavPage resolves Element through a weak reference on every access, so it can
-			// become null between the guard and the uses below. Read it once.
 			var navPage = NavPage;
 
 			if (navPage is null)


### PR DESCRIPTION
### Description of Change

`SetStatusBarStyle()` guarded against a null `NavPage` and then dereferenced it twice more:

```csharp
if (NavPage is null)
{
    return;
}

var barTextColor = NavPage.BarTextColor;
var statusBarColorMode = NavPage.OnThisPlatform().GetStatusBarTextColorMode();
```

`NavPage` is a computed property (`Element as NavigationPage`) and `Element` resolves through a weak reference:

```csharp
NavigationPage NavPage => Element as NavigationPage;
public VisualElement Element { get => _viewHandlerWrapper.Element ?? _element?.GetTargetOrDefault(); }
```

Each access re-reads it, so the guard validated a value that was then discarded. If the element was released or the handler disconnected between the check and the uses, the method threw `NullReferenceException`.

Because `SetStatusBarStyle()` is called from `ViewWillAppear`, that exception escapes through the ObjC registrar to `UIApplicationMain` and terminates the process rather than surfacing as a catchable managed exception:

```
System.NullReferenceException: Arg_NullReferenceException
   at Microsoft.Maui.Controls.Handlers.Compatibility.NavigationRenderer.SetStatusBarStyle()
   at Microsoft.Maui.Controls.Handlers.Compatibility.NavigationRenderer.ViewWillAppear(Boolean animated)
   at ...callback_..._ViewWillAppear(IntPtr pobj, IntPtr sel, Byte p0, IntPtr* exception_gchandle)
   at ObjCRuntime.Runtime.ThrowException(IntPtr gchandle)
   at UIKit.UIApplication.UIApplicationMain(...)
```

This change reads `NavPage` into a local once so the guard protects the uses that follow. It is behaviour-preserving while the element is alive, and returns early instead of crashing when it is not.

This is the same crash signature as #29535 and #29564. The guard added when those were closed cannot prevent it, because it re-reads the property rather than capturing it — which is why the crash still occurs on builds that contain the guard. The method is byte-identical across 10.0.71, 10.0.90, 10.0.100 and current `main`.

No test is included: the failure is a race between handler teardown and `ViewWillAppear`, and I could not find a way to exercise it deterministically. Happy to add one if you can suggest a reliable way to force the element release at that point.

### Issues Fixed

Fixes #38153
