### PR TITLE
[Android] Fix WebView SIGSEGV crash in GLFunctorDrawable on ScrollView overscroll (#38080)

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue38080.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue38080.cs
@@ -47,7 +47,9 @@ public class Issue38080 : NavigationPage
 				Text = "Page loaded — no crash"
 			});
 
-			AddFiller(stack, FillerRows);
+			// The first/last rows are sentinels the UITest asserts on to prove the scroll
+			// actually reached the top/bottom extreme.
+			AddFiller(stack, FillerRows, sentinelRow: 1, sentinelId: "Issue38080TopSentinel");
 
 			// Single fixed-size WebView mid-list, so it is off-screen at both extremes.
 			stack.Children.Add(new WebView
@@ -59,7 +61,7 @@ public class Issue38080 : NavigationPage
 				}
 			});
 
-			AddFiller(stack, FillerRows);
+			AddFiller(stack, FillerRows, sentinelRow: FillerRows, sentinelId: "Issue38080BottomSentinel");
 
 			Content = new ScrollView
 			{
@@ -68,11 +70,16 @@ public class Issue38080 : NavigationPage
 			};
 		}
 
-		static void AddFiller(VerticalStackLayout stack, int rows)
+		static void AddFiller(VerticalStackLayout stack, int rows, int sentinelRow, string sentinelId)
 		{
 			for (int i = 1; i <= rows; i++)
 			{
-				stack.Children.Add(new Label { Text = $"Filler row {i}", FontSize = 20 });
+				stack.Children.Add(new Label
+				{
+					AutomationId = i == sentinelRow ? sentinelId : null,
+					Text = $"Filler row {i}",
+					FontSize = 20
+				});
 			}
 		}
 	}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue38080.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue38080.cs
@@ -1,0 +1,79 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 38080, "Android SIGSEGV crash in GLFunctorDrawable when a ScrollView with an off-screen WebView is overscrolled", PlatformAffected.Android)]
+public class Issue38080 : NavigationPage
+{
+	public Issue38080() : base(new Issue38080HomePage()) { }
+
+	class Issue38080HomePage : ContentPage
+	{
+		public Issue38080HomePage()
+		{
+			Content = new VerticalStackLayout
+			{
+				VerticalOptions = LayoutOptions.Center,
+				Children =
+				{
+					new Button
+					{
+						AutomationId = "Issue38080NavigateButton",
+						Text = "Open repro page",
+						Command = new Command(async () => await Navigation.PushAsync(new Issue38080ReproPage()))
+					}
+				}
+			};
+		}
+	}
+
+	// Reproduces #38080: a single fixed-size WebView placed mid-list in a ScrollView is off-screen
+	// at both scroll extremes. Flinging to either extreme (or back-navigating) previously SIGSEGV'd
+	// the RenderThread in GLFunctorDrawable because the WebView carried a non-null ClipBounds that
+	// routed its off-screen compositing through the AOSP hwui GL-functor path.
+	class Issue38080ReproPage : ContentPage
+	{
+		const int FillerRows = 50;
+
+		public Issue38080ReproPage()
+		{
+			var stack = new VerticalStackLayout
+			{
+				Padding = new Thickness(12),
+				Spacing = 12
+			};
+
+			stack.Children.Add(new Label
+			{
+				AutomationId = "Issue38080Ready",
+				Text = "Page loaded — no crash"
+			});
+
+			AddFiller(stack, FillerRows);
+
+			// Single fixed-size WebView mid-list, so it is off-screen at both extremes.
+			stack.Children.Add(new WebView
+			{
+				HeightRequest = 220,
+				Source = new HtmlWebViewSource
+				{
+					Html = "<html><body style='background:#d6e4ff'><h3>WebView</h3></body></html>"
+				}
+			});
+
+			AddFiller(stack, FillerRows);
+
+			Content = new ScrollView
+			{
+				AutomationId = "Issue38080ScrollView",
+				Content = stack
+			};
+		}
+
+		static void AddFiller(VerticalStackLayout stack, int rows)
+		{
+			for (int i = 1; i <= rows; i++)
+			{
+				stack.Children.Add(new Label { Text = $"Filler row {i}", FontSize = 20 });
+			}
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue38080.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue38080.cs
@@ -32,6 +32,7 @@ public class Issue38080 : NavigationPage
 	class Issue38080ReproPage : ContentPage
 	{
 		const int FillerRows = 50;
+		const int MaxDiagnosticRefreshAttempts = 50;
 
 		public Issue38080ReproPage()
 		{
@@ -47,19 +48,42 @@ public class Issue38080 : NavigationPage
 				Text = "Page loaded — no crash"
 			});
 
+			var clipBoundsStatus = new Label
+			{
+				AutomationId = "Issue38080ClipBoundsStatus",
+				Text = "ClipBounds=pending"
+			};
+			stack.Children.Add(clipBoundsStatus);
+
+			var webViewLoadStatus = new Label
+			{
+				AutomationId = "Issue38080WebViewLoadStatus",
+				Text = "WebView load pending"
+			};
+
 			// The first/last rows are sentinels the UITest asserts on to prove the scroll
 			// actually reached the top/bottom extreme.
 			AddFiller(stack, FillerRows, sentinelRow: 1, sentinelId: "Issue38080TopSentinel");
 
-			// Single fixed-size WebView mid-list, so it is off-screen at both extremes.
-			stack.Children.Add(new WebView
+			stack.Children.Add(new Label
 			{
+				AutomationId = "Issue38080WebViewTopMarker",
+				Text = "Issue38080 WebView starts below"
+			});
+
+			// Single fixed-size WebView mid-list, so it is off-screen at both extremes.
+			var webView = new WebView
+			{
+				AutomationId = "Issue38080WebView",
 				HeightRequest = 220,
 				Source = new HtmlWebViewSource
 				{
-					Html = "<html><body style='background:#d6e4ff'><h3>WebView</h3></body></html>"
+					Html = "<html><body style='background:#d6e4ff; margin:0; padding:24px'><h3 id='Issue38080HtmlProbe'>Issue38080 WebView HTML loaded</h3></body></html>"
 				}
-			});
+			};
+			RegisterWebViewDiagnostics(webView, clipBoundsStatus, webViewLoadStatus);
+			stack.Children.Add(webView);
+			stack.Children.Add(webViewLoadStatus);
 
 			AddFiller(stack, FillerRows, sentinelRow: FillerRows, sentinelId: "Issue38080BottomSentinel");
 
@@ -82,5 +106,73 @@ public class Issue38080 : NavigationPage
 				});
 			}
 		}
+
+		static void RegisterWebViewDiagnostics(WebView webView, Label diagnosticsLabel, Label loadStatusLabel)
+		{
+			webView.Navigated += async (_, args) =>
+			{
+				if (args.Result != WebNavigationResult.Success)
+				{
+					loadStatusLabel.Text = $"WebView load result: {args.Result}";
+					return;
+				}
+
+				var htmlProbe = await webView.EvaluateJavaScriptAsync("document.getElementById('Issue38080HtmlProbe').textContent");
+				loadStatusLabel.Text = $"WebView load result: {args.Result}; HtmlProbe={htmlProbe}";
+			};
+
+#if ANDROID
+			webView.HandlerChanged += (_, _) => UpdateClipBoundsDiagnostics(webView, diagnosticsLabel, attempt: 0);
+			webView.Loaded += (_, _) => UpdateClipBoundsDiagnostics(webView, diagnosticsLabel, attempt: 0);
+			webView.SizeChanged += (_, _) => UpdateClipBoundsDiagnostics(webView, diagnosticsLabel, attempt: 0);
+#endif
+		}
+
+#if ANDROID
+		static void UpdateClipBoundsDiagnostics(WebView webView, Label diagnosticsLabel, int attempt)
+		{
+			var nativeWebView = webView.Handler?.PlatformView as Android.Webkit.WebView;
+			var diagnosticsReady = false;
+
+			if (nativeWebView is null)
+			{
+				diagnosticsLabel.Text = "ClipBounds=pending; NativeWebView=null";
+			}
+			else
+			{
+				using var clipBounds = nativeWebView.ClipBounds;
+				var clipBoundsText = clipBounds is null
+					? "null"
+					: $"{clipBounds.Left},{clipBounds.Top},{clipBounds.Right},{clipBounds.Bottom}";
+				var nativeParent = nativeWebView.Parent;
+				var parentViewGroup = nativeParent as Android.Views.ViewGroup;
+				var parentClipChildren = parentViewGroup is null
+					? "null"
+					: parentViewGroup.ClipChildren.ToString();
+				var parentType = nativeParent?.GetType().Name ?? "null";
+				var isAttachedToWindow = nativeWebView.IsAttachedToWindow;
+				var isHardwareAccelerated = nativeWebView.IsHardwareAccelerated;
+
+				diagnosticsReady =
+					nativeWebView.Width > 0 &&
+					nativeWebView.Height > 0 &&
+					isAttachedToWindow &&
+					isHardwareAccelerated;
+
+				diagnosticsLabel.Text =
+					$"ClipBounds={clipBoundsText}; " +
+					$"Size={nativeWebView.Width}x{nativeWebView.Height}; " +
+					$"IsAttachedToWindow={isAttachedToWindow}; " +
+					$"HardwareAccelerated={isHardwareAccelerated}; " +
+					$"Parent={parentType}; " +
+					$"ParentClipChildren={parentClipChildren}";
+			}
+
+			if (!diagnosticsReady && attempt < MaxDiagnosticRefreshAttempts)
+				webView.Dispatcher.DispatchDelayed(TimeSpan.FromMilliseconds(100), () => UpdateClipBoundsDiagnostics(webView, diagnosticsLabel, attempt + 1));
+			else if (!diagnosticsReady)
+				diagnosticsLabel.Text += "; DiagnosticsTimeout=True";
+		}
+#endif
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue38080.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue38080.cs
@@ -1,0 +1,40 @@
+// Crash is Android-specific: RenderThread GL functor SIGSEGVs when a non-null ClipBounds
+// routes an off-screen WebView's compositing through GLFunctorDrawable on overscroll.
+#if ANDROID
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue38080 : _IssuesUITest
+{
+	public Issue38080(TestDevice device) : base(device) { }
+
+	public override string Issue => "Android SIGSEGV crash in GLFunctorDrawable when a ScrollView with an off-screen WebView is overscrolled";
+
+	[Test]
+	[Category(UITestCategories.WebView)]
+	public void OffScreenWebViewInScrollViewShouldNotCrashOnOverscroll()
+	{
+		App.WaitForElement("Issue38080NavigateButton");
+		App.Tap("Issue38080NavigateButton");
+		App.WaitForElement("Issue38080Ready");
+
+		// Fling to the top extreme: the WebView is off-screen below the fold and the
+		// ScrollView overscrolls past its top edge.
+		for (int i = 0; i < 6; i++)
+			App.ScrollDown("Issue38080ScrollView", ScrollStrategy.Gesture, 0.9, 100);
+
+		// Fling to the bottom extreme: the WebView is off-screen above the fold and the
+		// ScrollView overscrolls past its bottom edge.
+		for (int i = 0; i < 15; i++)
+			App.ScrollUp("Issue38080ScrollView", ScrollStrategy.Gesture, 0.9, 100);
+
+		// The WebView is now off-screen at the bottom; back navigation also reproduced the
+		// RenderThread crash while compositing. Assert we returned to the home page alive.
+		App.Back();
+		App.WaitForElement("Issue38080NavigateButton");
+	}
+}
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue38080.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue38080.cs
@@ -21,16 +21,15 @@ public class Issue38080 : _IssuesUITest
 		App.Tap("Issue38080NavigateButton");
 		App.WaitForElement("Issue38080Ready");
 
-		// Fling to the top extreme: the WebView is off-screen below the fold and the
+		// Overscroll at the top extreme: the WebView is off-screen below the fold and the
 		// ScrollView overscrolls past its top edge.
 		for (int i = 0; i < 6; i++)
-			App.ScrollDown("Issue38080ScrollView", ScrollStrategy.Gesture, 0.9, 100);
-
-		// Fling to the bottom extreme: the WebView is off-screen above the fold and the
-		// ScrollView overscrolls past its bottom edge.
-		for (int i = 0; i < 15; i++)
 			App.ScrollUp("Issue38080ScrollView", ScrollStrategy.Gesture, 0.9, 100);
 
+		// Scroll/overscroll at the bottom extreme: the WebView is off-screen above the fold and the
+		// ScrollView overscrolls past its bottom edge.
+		for (int i = 0; i < 15; i++)
+			App.ScrollDown("Issue38080ScrollView", ScrollStrategy.Gesture, 0.9, 100);
 		// The WebView is now off-screen at the bottom; back navigation also reproduced the
 		// RenderThread crash while compositing. Assert we returned to the home page alive.
 		App.Back();

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue38080.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue38080.cs
@@ -30,14 +30,35 @@ public class Issue38080 : _IssuesUITest
 		for (int i = 0; i < 6; i++)
 			App.ScrollUp("Issue38080ScrollView", ScrollStrategy.Gesture, 0.9, 100);
 
+		// Prove the flings reached the top extreme.
+		AssertSentinelDisplayed("Issue38080TopSentinel", "top");
+
 		// Scroll/overscroll at the bottom extreme: the WebView is off-screen above the fold and the
 		// ScrollView overscrolls past its bottom edge.
 		for (int i = 0; i < 15; i++)
 			App.ScrollDown("Issue38080ScrollView", ScrollStrategy.Gesture, 0.9, 100);
+
+		// Prove the flings reached the bottom extreme: the bottom sentinel is ~100 rows below the
+		// initial viewport, so ignored/flaky gestures would never display it and the test fails.
+		AssertSentinelDisplayed("Issue38080BottomSentinel", "bottom");
+
 		// The WebView is now off-screen at the bottom; back navigation also reproduced the
 		// RenderThread crash while compositing. Assert we returned to the home page alive.
 		App.Back();
 		App.WaitForElement("Issue38080NavigateButton");
+	}
+
+	// Displayed is a viewport check, not a view-hierarchy presence check: it proves the sentinel
+	// row is actually on screen at the extreme, so ignored/flaky scroll gestures fail the test
+	// instead of letting it pass as a false positive.
+	void AssertSentinelDisplayed(string automationId, string extreme)
+	{
+		App.RetryAssert(() =>
+		{
+			var sentinel = App.WaitForElement(automationId, timeout: TimeSpan.FromSeconds(5));
+			Assert.That(sentinel.IsDisplayed(), Is.True,
+				$"The {extreme} extreme was not reached: {automationId} is not displayed after scrolling");
+		}, timeout: TimeSpan.FromSeconds(30));
 	}
 }
 #endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue38080.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue38080.cs
@@ -21,6 +21,10 @@ public class Issue38080 : _IssuesUITest
 		App.Tap("Issue38080NavigateButton");
 		App.WaitForElement("Issue38080Ready");
 
+		// ScrollUp/ScrollDown silently no-op when the element lookup returns null, which would
+		// turn this regression test into a false positive. Wait so a failed lookup fails the test.
+		App.WaitForElement("Issue38080ScrollView");
+
 		// Overscroll at the top extreme: the WebView is off-screen below the fold and the
 		// ScrollView overscrolls past its top edge.
 		for (int i = 0; i < 6; i++)

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue38080.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue38080.cs
@@ -119,7 +119,7 @@ public class Issue38080 : _IssuesUITest
 		var loadStatus = App.FindElements("Issue38080WebViewLoadStatus").FirstOrDefault();
 		return topMarker?.IsDisplayed() == true &&
 			loadStatus?.IsDisplayed() == true &&
-			loadStatus.GetText().Contains("HtmlProbe=Issue38080 WebView HTML loaded");
+			loadStatus.GetText()?.Contains("HtmlProbe=Issue38080 WebView HTML loaded", StringComparison.Ordinal) == true;
 	}
 
 	void AssertWebViewRenderedAndDisplayed()

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue38080.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue38080.cs
@@ -1,6 +1,8 @@
 // Crash is Android-specific: RenderThread GL functor SIGSEGVs when a non-null ClipBounds
 // routes an off-screen WebView's compositing through GLFunctorDrawable on overscroll.
 #if ANDROID
+using System;
+using System.Linq;
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue38080.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue38080.cs
@@ -24,29 +24,50 @@ public class Issue38080 : _IssuesUITest
 		// ScrollUp/ScrollDown silently no-op when the element lookup returns null, which would
 		// turn this regression test into a false positive. Wait so a failed lookup fails the test.
 		App.WaitForElement("Issue38080ScrollView");
+		AssertFixedSizeWebViewIsMeasuredAndHardwareAccelerated();
+		ScrollToAndAssertWebViewRendered();
 
 		// Overscroll at the top extreme: the WebView is off-screen below the fold and the
 		// ScrollView overscrolls past its top edge.
-		for (int i = 0; i < 6; i++)
-			App.ScrollUp("Issue38080ScrollView", ScrollStrategy.Gesture, 0.9, 100);
-
-		// Prove the flings reached the top extreme.
-		AssertSentinelDisplayed("Issue38080TopSentinel", "top");
+		ScrollToExtremeAndAssert("Issue38080TopSentinel", "top", scrollDown: false, swipePercentage: 0.9);
 
 		// Scroll/overscroll at the bottom extreme: the WebView is off-screen above the fold and the
 		// ScrollView overscrolls past its bottom edge.
-		for (int i = 0; i < 15; i++)
-			App.ScrollDown("Issue38080ScrollView", ScrollStrategy.Gesture, 0.9, 100);
-
-		// Prove the flings reached the bottom extreme: the bottom sentinel is ~100 rows below the
-		// initial viewport, so ignored/flaky gestures would never display it and the test fails.
-		AssertSentinelDisplayed("Issue38080BottomSentinel", "bottom");
+		// Use a mid-viewport gesture for the downward pass: once the WebView is visible near the
+		// bottom of the viewport, a bottom-origin fling can be consumed by the WebView itself instead
+		// of the parent ScrollView, leaving the test stuck at the midpoint.
+		ScrollToExtremeAndAssert("Issue38080BottomSentinel", "bottom", scrollDown: true, swipePercentage: 0.45);
 
 		// The WebView is now off-screen at the bottom; back navigation also reproduced the
 		// RenderThread crash while compositing. Assert we returned to the home page alive.
 		App.Back();
 		App.WaitForElement("Issue38080NavigateButton");
 	}
+
+	void ScrollToExtremeAndAssert(string automationId, string extreme, bool scrollDown, double swipePercentage)
+	{
+		for (int i = 0; i < 60 && !TrySentinelDisplayed(automationId); i++)
+			ScrollOnce(scrollDown, swipePercentage);
+
+		AssertSentinelDisplayed(automationId, extreme);
+
+		// Exercise actual overscroll at the edge after proving we reached it.
+		for (int overscroll = 0; overscroll < 5; overscroll++)
+			ScrollOnce(scrollDown, swipePercentage);
+
+		AssertSentinelDisplayed(automationId, extreme);
+	}
+
+	void ScrollOnce(bool scrollDown, double swipePercentage)
+	{
+		if (scrollDown)
+			App.ScrollDown("Issue38080ScrollView", ScrollStrategy.Gesture, swipePercentage, 100);
+		else
+			App.ScrollUp("Issue38080ScrollView", ScrollStrategy.Gesture, swipePercentage, 100);
+	}
+
+	bool TrySentinelDisplayed(string automationId) =>
+		App.FindElements(automationId).Any(element => element.IsDisplayed());
 
 	// Displayed is a viewport check, not a view-hierarchy presence check: it proves the sentinel
 	// row is actually on screen at the extreme, so ignored/flaky scroll gestures fail the test
@@ -59,6 +80,59 @@ public class Issue38080 : _IssuesUITest
 			Assert.That(sentinel.IsDisplayed(), Is.True,
 				$"The {extreme} extreme was not reached: {automationId} is not displayed after scrolling");
 		}, timeout: TimeSpan.FromSeconds(30));
+	}
+
+	void AssertFixedSizeWebViewIsMeasuredAndHardwareAccelerated()
+	{
+		App.RetryAssert(() =>
+		{
+			var statusText = App.WaitForElement("Issue38080ClipBoundsStatus", timeout: TimeSpan.FromSeconds(5)).GetText();
+			Assert.That(statusText, Does.Match(@"Size=[1-9]\d*x[1-9]\d*"),
+				$"The diagnostic assertion should only pass after the native WebView has non-zero dimensions. Actual diagnostics: {statusText}");
+			Assert.That(statusText, Does.Contain("IsAttachedToWindow=True"),
+				$"The diagnostic assertion should only pass after the native WebView is attached. Actual diagnostics: {statusText}");
+			Assert.That(statusText, Does.Contain("HardwareAccelerated=True"),
+				$"This regression must exercise Android hardware-accelerated WebView rendering. Actual diagnostics: {statusText}");
+			Assert.That(statusText, Does.Contain("ParentClipChildren=True"),
+				$"The native WebView should be clipped by its Android parent wrapper. Actual diagnostics: {statusText}");
+			Assert.That(statusText, Does.Not.Contain("DiagnosticsTimeout=True"),
+				$"The native WebView diagnostics timed out before reaching a ready attached/hardware-accelerated state. Actual diagnostics: {statusText}");
+		}, timeout: TimeSpan.FromSeconds(30));
+	}
+
+	void ScrollToAndAssertWebViewRendered()
+	{
+		for (int i = 0; i < 20; i++)
+		{
+			if (IsWebViewRenderedAndDisplayed())
+				return;
+
+			App.ScrollDown("Issue38080ScrollView", ScrollStrategy.Gesture, 0.25, 100);
+		}
+
+		AssertWebViewRenderedAndDisplayed();
+	}
+
+	bool IsWebViewRenderedAndDisplayed()
+	{
+		var topMarker = App.FindElements("Issue38080WebViewTopMarker").FirstOrDefault();
+		var loadStatus = App.FindElements("Issue38080WebViewLoadStatus").FirstOrDefault();
+		return topMarker?.IsDisplayed() == true &&
+			loadStatus?.IsDisplayed() == true &&
+			loadStatus.GetText().Contains("HtmlProbe=Issue38080 WebView HTML loaded");
+	}
+
+	void AssertWebViewRenderedAndDisplayed()
+	{
+		var topMarker = App.WaitForElement("Issue38080WebViewTopMarker", timeout: TimeSpan.FromSeconds(1));
+		Assert.That(topMarker.IsDisplayed(), Is.True,
+			"The marker immediately above the WebView must be visible before overscroll.");
+
+		var loadStatus = App.WaitForElement("Issue38080WebViewLoadStatus", timeout: TimeSpan.FromSeconds(1));
+		Assert.That(loadStatus.IsDisplayed(), Is.True,
+			"The WebView load status label immediately below the WebView should be visible with the midpoint check.");
+		Assert.That(loadStatus.GetText(), Does.Contain("HtmlProbe=Issue38080 WebView HTML loaded"),
+			"The WebView HTML must finish loading before the off-screen overscroll checks run.");
 	}
 }
 #endif

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Android.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Android.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Android.Views;
 using Android.Webkit;
 using static Android.Views.ViewGroup;
 using AWebView = Android.Webkit.WebView;
@@ -7,6 +8,20 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class HybridWebViewHandler : ViewHandler<IHybridWebView, AWebView>
 	{
+		/// <inheritdoc/>
+		public override bool NeedsContainer => true;
+
+		/// <inheritdoc/>
+		protected override void SetupContainer()
+		{
+			base.SetupContainer();
+
+			// Use native child clipping, including HWUI's off-screen rejection,
+			// rather than an explicit WebView ClipBounds rectangle (#38080).
+			if (ContainerView is ViewGroup container)
+				container.SetClipChildren(true);
+		}
+
 		protected override AWebView CreatePlatformView()
 		{
 			var platformView = new MauiHybridWebView(this, Context!)
@@ -68,7 +83,9 @@ namespace Microsoft.Maui.Handlers
 			//platformView.SetWebChromeClient(null);
 
 			platformView.StopLoading();
-
+			if (ContainerView?.Parent is ViewGroup containerParent)
+				containerParent.RemoveView(ContainerView);
+			HasContainer = false;
 
 			base.DisconnectHandler(platformView);
 		}

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.Android.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.Android.cs
@@ -21,6 +21,8 @@ namespace Microsoft.Maui.Handlers
 			WrapperView.SetupContainer(PlatformView, Context, ContainerView, (cv) => ContainerView = cv);
 
 		protected override void RemoveContainer() =>
-			WrapperView.RemoveContainer(PlatformView, Context, ContainerView, () => ContainerView = null);
+			// ElementHandler clears PlatformView before disconnecting; the wrapper
+			// cleanup also supports that null state.
+			WrapperView.RemoveContainer(base.PlatformView, Context, ContainerView, () => ContainerView = null);
 	}
 }

--- a/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
@@ -19,6 +19,20 @@ namespace Microsoft.Maui.Handlers
 
 		protected internal string? UrlCanceled { get; set; }
 
+		/// <inheritdoc/>
+		public override bool NeedsContainer => true;
+
+		/// <inheritdoc/>
+		protected override void SetupContainer()
+		{
+			base.SetupContainer();
+
+			// Native child clipping both bounds WebView drawing and lets HWUI reject
+			// off-screen nodes before invoking Chromium during overscroll (#38080).
+			if (ContainerView is ViewGroup container)
+				container.SetClipChildren(true);
+		}
+
 		protected override AWebView CreatePlatformView()
 		{
 			var platformView = new MauiWebView(this, Context!)
@@ -75,6 +89,10 @@ namespace Microsoft.Maui.Handlers
 			platformView.SetWebChromeClient(null);
 
 			platformView.StopLoading();
+			if (ContainerView?.Parent is ViewGroup containerParent)
+				containerParent.RemoveView(ContainerView);
+			HasContainer = false;
+
 			if (platformView.Parent is ViewGroup parent)
 				parent.RemoveView(platformView);
 			platformView.RemoveAllViews();

--- a/src/Core/src/Platform/Android/MauiHybridWebView.cs
+++ b/src/Core/src/Platform/Android/MauiHybridWebView.cs
@@ -117,23 +117,17 @@ namespace Microsoft.Maui.Platform
 				return;
 			}
 
-			// Normal (non-auto-sizing) WebView: apply flash prevention from issue #31475.
 			if (width > 0 && height > 0)
 			{
-				if (Parent is WrapperView)
-				{
-					// Parent is WrapperView (shadow/border/clip applied).
-					// Remove ClipBounds to allow visual effects like shadows
-					// to render outside the view area.
-					ClipBounds = null;
-				}
-				else
-				{
-					// No WrapperView — apply exact bounds to prevent the WebView
-					// from briefly rendering at full screen size before layout.
-					_clipRect.Set(0, 0, width, height);
-					ClipBounds = _clipRect;
-				}
+				// The view has a real size, so the pre-layout full-screen flash from
+				// issue #31475 is no longer possible — that window is already covered
+				// by the zero clip set in the constructor before the view is attached.
+				// A non-null ClipBounds on an attached WebView routes its drawing
+				// through the RenderThread GL-functor path (GLFunctorDrawable), which
+				// SIGSEGVs when the view is scrolled off-screen and its parent
+				// ScrollView is overscrolled. Null is the only safe value here.
+				// https://github.com/dotnet/maui/issues/38080
+				ClipBounds = null;
 			}
 			else
 			{

--- a/src/Core/src/Platform/Android/MauiHybridWebView.cs
+++ b/src/Core/src/Platform/Android/MauiHybridWebView.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using Android.Content;
-using Android.Graphics;
 using Android.OS;
 using Android.Webkit;
 using AUri = Android.Net.Uri;
@@ -17,25 +16,12 @@ namespace Microsoft.Maui.Platform
 	{
 		private readonly WeakReference<HybridWebViewHandler> _handler;
 		private static readonly AUri AndroidAppOriginUri = AUri.Parse(HybridWebViewHandler.AppOrigin)!;
-		readonly Rect _clipRect;
 		volatile bool _detachPending;
-
-		// True after the first layout pass where exactly one dimension is positive and the other is zero.
-		// Auto-sizing layouts produce this intermediate state; a zero-area ClipBounds here
-		// causes RenderThread to crash on an incomplete Skia canvas (SIGSEGV).
-		// https://github.com/dotnet/maui/issues/35771
-		bool _isAutoSizing;
 
 		public MauiHybridWebView(HybridWebViewHandler handler, Context context) : base(context)
 		{
 			ArgumentNullException.ThrowIfNull(handler, nameof(handler));
 			_handler = new WeakReference<HybridWebViewHandler>(handler);
-
-			// Initialize with empty clip bounds to prevent the WebView from briefly
-			// rendering at full screen size before layout is complete.
-			// https://github.com/dotnet/maui/issues/31475
-			_clipRect = new Rect(0, 0, 0, 0);
-			ClipBounds = _clipRect;
 
 			// Pre-register the JS bridge BEFORE any page loads.
 			// Android WebView only exposes addJavascriptInterface bindings for pages that
@@ -49,7 +35,6 @@ namespace Microsoft.Maui.Platform
 		protected override void OnSizeChanged(int width, int height, int oldWidth, int oldHeight)
 		{
 			base.OnSizeChanged(width, height, oldWidth, oldHeight);
-			UpdateClipBounds(width, height);
 		}
 
 		// OnAttachedToWindow — calls Attach(this) when inside a SwipeRefreshLayout.
@@ -58,9 +43,6 @@ namespace Microsoft.Maui.Platform
 			_detachPending = false;
 
 			base.OnAttachedToWindow();
-
-			// Re-evaluate ClipBounds when re-parented (e.g., wrapped in WrapperView for shadow)
-			UpdateClipBounds(Width, Height);
 
 			if (RefreshViewWebViewScrollCapture.IsInsideMauiSwipeRefreshLayout(this))
 			{
@@ -100,41 +82,6 @@ namespace Microsoft.Maui.Platform
 			}
 
 			base.OnDetachedFromWindow();
-		}
-
-		void UpdateClipBounds(int width, int height)
-		{
-			// Auto-sizing layouts produce an intermediate layout pass where exactly one dimension
-			// is positive and the other is zero: vertical layouts give (w>0, h=0) first; horizontal
-			// layouts give (w=0, h>0) first. A zero-area ClipBounds in either state causes
-			// RenderThread to crash (SIGSEGV). Null disables clipping; the latch prevents later
-			// layout passes from re-enabling it before both dimensions are stable.
-			// https://github.com/dotnet/maui/issues/35771
-			if (_isAutoSizing || (width > 0 && height == 0) || (width == 0 && height > 0))
-			{
-				_isAutoSizing = true;
-				ClipBounds = null;
-				return;
-			}
-
-			if (width > 0 && height > 0)
-			{
-				// The view has a real size, so the pre-layout full-screen flash from
-				// issue #31475 is no longer possible — that window is already covered
-				// by the zero clip set in the constructor before the view is attached.
-				// A non-null ClipBounds on an attached WebView routes its drawing
-				// through the RenderThread GL-functor path (GLFunctorDrawable), which
-				// SIGSEGVs when the view is scrolled off-screen and its parent
-				// ScrollView is overscrolled. Null is the only safe value here.
-				// https://github.com/dotnet/maui/issues/38080
-				ClipBounds = null;
-			}
-			else
-			{
-				// View has no area yet or is fully collapsed — keep a zero clip rect.
-				_clipRect.Set(0, 0, 0, 0);
-				ClipBounds = _clipRect;
-			}
 		}
 
 		public void SendRawMessage(string rawMessage)

--- a/src/Core/src/Platform/Android/MauiWebView.cs
+++ b/src/Core/src/Platform/Android/MauiWebView.cs
@@ -120,23 +120,17 @@ namespace Microsoft.Maui.Platform
 				return;
 			}
 
-			// Normal (non-auto-sizing) WebView: apply flash prevention from issue #31475.
 			if (width > 0 && height > 0)
 			{
-				if (Parent is WrapperView)
-				{
-					// Parent is WrapperView (shadow/border/clip applied).
-					// Remove ClipBounds to allow visual effects like shadows
-					// to render outside the view area.
-					ClipBounds = null;
-				}
-				else
-				{
-					// No WrapperView — apply exact bounds to prevent the WebView
-					// from briefly rendering at full screen size before layout.
-					_clipRect.Set(0, 0, width, height);
-					ClipBounds = _clipRect;
-				}
+				// The view has a real size, so the pre-layout full-screen flash from
+				// issue #31475 is no longer possible — that window is already covered
+				// by the zero clip set in the constructor before the view is attached.
+				// A non-null ClipBounds on an attached WebView routes its drawing
+				// through the RenderThread GL-functor path (GLFunctorDrawable), which
+				// SIGSEGVs when the view is scrolled off-screen and its parent
+				// ScrollView is overscrolled. Null is the only safe value here.
+				// https://github.com/dotnet/maui/issues/38080
+				ClipBounds = null;
 			}
 			else
 			{

--- a/src/Core/src/Platform/Android/MauiWebView.cs
+++ b/src/Core/src/Platform/Android/MauiWebView.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Android.Content;
-using Android.Graphics;
 using Android.OS;
 using Android.Views;
 using Android.Webkit;
@@ -12,15 +11,8 @@ namespace Microsoft.Maui.Platform
 		public const string AssetBaseUrl = "file:///android_asset/";
 
 		readonly WebViewHandler _handler;
-		readonly Rect _clipRect;
 		bool _hasSwipeViewParent;
 		volatile bool _detachPending;
-
-		// True after the first layout pass where exactly one dimension is positive and the other is zero.
-		// Auto-sizing layouts produce this intermediate state; a zero-area ClipBounds here
-		// causes RenderThread to crash on an incomplete Skia canvas (SIGSEGV).
-		// https://github.com/dotnet/maui/issues/35771
-		bool _isAutoSizing;
 
 		// Tracks whether about:blank was loaded synthetically for layout (null source).
 		// MauiWebViewClient clears this entry from the native back stack once the real URL loads,
@@ -30,12 +22,6 @@ namespace Microsoft.Maui.Platform
 		public MauiWebView(WebViewHandler handler, Context context) : base(context)
 		{
 			_handler = handler ?? throw new ArgumentNullException(nameof(handler));
-
-			// Initialize with empty clip bounds to prevent the WebView from briefly
-			// rendering at full screen size before layout is complete.
-			// https://github.com/dotnet/maui/issues/31475
-			_clipRect = new Rect(0, 0, 0, 0);
-			ClipBounds = _clipRect;
 
 			// Pre-register the JS bridge BEFORE any page loads.
 			// Android WebView only exposes addJavascriptInterface bindings for pages that
@@ -49,7 +35,6 @@ namespace Microsoft.Maui.Platform
 		protected override void OnSizeChanged(int width, int height, int oldWidth, int oldHeight)
 		{
 			base.OnSizeChanged(width, height, oldWidth, oldHeight);
-			UpdateClipBounds(width, height);
 		}
 
 		protected override void OnAttachedToWindow()
@@ -57,9 +42,6 @@ namespace Microsoft.Maui.Platform
 			_detachPending = false;
 
 			base.OnAttachedToWindow();
-
-			// Re-evaluate ClipBounds when re-parented (e.g., wrapped in WrapperView for shadow)
-			UpdateClipBounds(Width, Height);
 
 			_hasSwipeViewParent = ((View)this).GetParentOfType<MauiSwipeView>() is not null;
 
@@ -103,41 +85,6 @@ namespace Microsoft.Maui.Platform
 
 			base.OnDetachedFromWindow();
 			_hasSwipeViewParent = false;
-		}
-
-		void UpdateClipBounds(int width, int height)
-		{
-			// Auto-sizing layouts produce an intermediate layout pass where exactly one dimension
-			// is positive and the other is zero: vertical layouts give (w>0, h=0) first; horizontal
-			// layouts give (w=0, h>0) first. A zero-area ClipBounds in either state causes
-			// RenderThread to crash (SIGSEGV). Null disables clipping; the latch prevents later
-			// layout passes from re-enabling it before both dimensions are stable.
-			// https://github.com/dotnet/maui/issues/35771
-			if (_isAutoSizing || (width > 0 && height == 0) || (width == 0 && height > 0))
-			{
-				_isAutoSizing = true;
-				ClipBounds = null;
-				return;
-			}
-
-			if (width > 0 && height > 0)
-			{
-				// The view has a real size, so the pre-layout full-screen flash from
-				// issue #31475 is no longer possible — that window is already covered
-				// by the zero clip set in the constructor before the view is attached.
-				// A non-null ClipBounds on an attached WebView routes its drawing
-				// through the RenderThread GL-functor path (GLFunctorDrawable), which
-				// SIGSEGVs when the view is scrolled off-screen and its parent
-				// ScrollView is overscrolled. Null is the only safe value here.
-				// https://github.com/dotnet/maui/issues/38080
-				ClipBounds = null;
-			}
-			else
-			{
-				// View has no area yet or is fully collapsed — keep a zero clip rect.
-				_clipRect.Set(0, 0, 0, 0);
-				ClipBounds = _clipRect;
-			}
 		}
 
 		public override bool OnTouchEvent(MotionEvent? e)

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,4 +1,8 @@
 #nullable enable
+override Microsoft.Maui.Handlers.HybridWebViewHandler.NeedsContainer.get -> bool
+override Microsoft.Maui.Handlers.HybridWebViewHandler.SetupContainer() -> void
+override Microsoft.Maui.Handlers.WebViewHandler.NeedsContainer.get -> bool
+override Microsoft.Maui.Handlers.WebViewHandler.SetupContainer() -> void
 Microsoft.Maui.PlatformDrawable
 Microsoft.Maui.PlatformDrawable.PlatformDrawable(Android.Content.Context? context) -> void
 Microsoft.Maui.PlatformDrawable.PlatformDrawable(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBasementOfT.Android.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBasementOfT.Android.cs
@@ -52,54 +52,64 @@ namespace Microsoft.Maui.DeviceTests
 			return viewHandler.VirtualView.Semantics.HeadingLevel;
 		}
 
-		protected float GetOpacity(IViewHandler viewHandler) =>
-			((View)viewHandler.PlatformView).Alpha;
+		protected float GetOpacity(IViewHandler viewHandler)
+		{
+			var platformView = (View)viewHandler.PlatformView;
+			var alpha = platformView.Alpha;
+
+			// Android initializes opacity on the native view while later container-mapped
+			// updates can apply it to the wrapper. Assert the effective rendered alpha.
+			if (viewHandler.ContainerView is View containerView)
+				alpha *= containerView.Alpha;
+
+			return alpha;
+		}
 
 		protected double GetTranslationX(IViewHandler viewHandler)
 		{
-			var platformView = (View)viewHandler.PlatformView;
+			var platformView = viewHandler.VirtualView.ToPlatform();
 
 			return Math.Floor(platformView.Context.FromPixels(platformView.TranslationX));
 		}
 
 		protected double GetTranslationY(IViewHandler viewHandler)
 		{
-			var platformView = (View)viewHandler.PlatformView;
+			var platformView = viewHandler.VirtualView.ToPlatform();
 
 			return Math.Floor(platformView.Context.FromPixels(platformView.TranslationY));
 		}
 
 		protected double GetScaleX(IViewHandler viewHandler)
 		{
-			var platformView = (View)viewHandler.PlatformView;
+			var platformView = viewHandler.VirtualView.ToPlatform();
 
 			return Math.Floor(platformView.ScaleX);
 		}
 
 		protected double GetScaleY(IViewHandler viewHandler)
 		{
-			var platformView = (View)viewHandler.PlatformView;
+			var platformView = viewHandler.VirtualView.ToPlatform();
 
 			return Math.Floor(platformView.ScaleY);
 		}
 
 		protected double GetRotation(IViewHandler viewHandler)
 		{
-			var platformView = (View)viewHandler.PlatformView;
+			var platformView = viewHandler.VirtualView.ToPlatform();
 
 			return Math.Floor(platformView.Rotation);
 		}
 
 		protected double GetRotationX(IViewHandler viewHandler)
 		{
-			var platformView = (View)viewHandler.PlatformView;
+			var platformView = viewHandler.VirtualView.ToPlatform();
 
 			return Math.Floor(platformView.RotationX);
 		}
 
 		protected double GetRotationY(IViewHandler viewHandler)
 		{
-			var platformView = (View)viewHandler.PlatformView;
+			var platformView = viewHandler.VirtualView.ToPlatform();
 
 			return Math.Floor(platformView.RotationY);
 		}
@@ -145,6 +155,6 @@ namespace Microsoft.Maui.DeviceTests
 			viewHandler.VirtualView.ToPlatform().GetBoundingBox();
 
 		protected Matrix4x4 GetViewTransform(IViewHandler viewHandler) =>
-			((View)viewHandler.PlatformView).GetViewTransform();
+			viewHandler.VirtualView.ToPlatform().GetViewTransform();
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/WebView/WebViewHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/WebView/WebViewHandlerTests.Android.cs
@@ -53,16 +53,29 @@ namespace Microsoft.Maui.DeviceTests
 					var webView = new WebViewStub();
 					var handler = CreateHandler(webView);
 					var parent = new FrameLayout(handler.MauiContext!.Context!);
-					parent.AddView(handler.PlatformView);
+					var container = Assert.IsType<WrapperView>(handler.ContainerView);
+					parent.AddView(container);
 
-					Assert.Same(parent, handler.PlatformView.Parent);
+					Assert.Same(parent, container.Parent);
+					Assert.Same(container, handler.PlatformView.Parent);
+					Assert.True(container.ClipChildren);
+					Assert.Null(handler.PlatformView.ClipBounds);
 
 					((IElementHandler)handler).DisconnectHandler();
 
 					var destroyTrackingWebView = platformView ?? throw new InvalidOperationException("Expected the WebView factory to create a platform view.");
 					Assert.True(destroyTrackingWebView.DestroyCalled);
 					Assert.Null(destroyTrackingWebView.ParentWhenDestroyed);
+					Assert.Null(handler.ContainerView);
+					Assert.False(handler.HasContainer);
 					Assert.Equal(0, parent.ChildCount);
+
+					handler.SetVirtualView(webView);
+					var newContainer = Assert.IsType<WrapperView>(handler.ContainerView);
+					Assert.NotSame(container, newContainer);
+					Assert.Same(newContainer, handler.PlatformView.Parent);
+					Assert.True(newContainer.ClipChildren);
+					((IElementHandler)handler).DisconnectHandler();
 				});
 			}
 			finally


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description of Change

Use Android's native parent-owned child clipping for `WebView` and `HybridWebView`, instead of maintaining an explicit `ClipBounds` rectangle on each native WebView.

The reported scenario places a fixed-height WebView between two long groups of rows in a ScrollView. The WebView is off-screen at both scroll extremes; overscroll or back navigation can crash the Android RenderThread in `GLFunctorDrawable`. The reporter observed the regression between MAUI 10.0.60 and 10.0.100.

### Why simply clearing ClipBounds is insufficient

The original version of this PR cleared the clip after layout. Its new overscroll test passed in CI, but the existing `WebViewBackgroundColorShouldBeApplied` test failed on both Android Mono and CoreCLR: the WebView painted green outside its allocated bounds. The visual baseline must not be changed to accept that overflow.

MAUI layout parents allow children to draw outside their bounds. An explicit WebView `ClipBounds` rectangle constrains rendering, but it does not enable the same native off-screen rejection as Android's parent `clipChildren` policy.

### Fix

- Android `WebViewHandler` and `HybridWebViewHandler` always use the existing MAUI `WrapperView` and enable `SetClipChildren(true)` on that wrapper.
- This sets the child render node's `clipToBounds` flag. Android HWUI uses that flag to reject fully off-screen nodes before replaying their drawing commands.
- The native WebViews no longer maintain an explicit clip rectangle or a one-way auto-sizing latch. Their parent supplies layout-bound clipping, including zero-size layout states.
- Both handlers clear their containers safely on disconnect so reconnect creates the correct wrapper. WebView retains its native detach/destroy cleanup.
- No software layer or change to hardware acceleration is required.

The tradeoff is one native wrapper per Android WebView. Existing wrapper-based shadows and custom clips remain on the wrapper; the child WebView is bounded independently.

This does **not** disable Chromium's hardware-accelerated compositor. The distinction is native bounds clipping and off-screen rejection, not selecting or disabling the GL-functor renderer.

### Tests and empirical evidence

- `Issue38080` now loads the HTML and visits the WebView midpoint before reaching and overscrolling both extremes and navigating back. It also checks positive native size, attachment, hardware acceleration, and parent child-clipping.
- `WebViewBackgroundColorShouldBeApplied` guards against drawing beyond the allocated WebView bounds; its visual baseline is unchanged.
- `DisconnectHandlerDestroysNativeWebView` attaches the actual container and verifies cleanup and recreation on reconnect.
- Shared Android device-test probes now read transforms from the effective platform root and account for effective opacity when a wrapper is present.

[Before/after recordings, detailed results, and limitations](https://github.com/dotnet/maui/pull/38181#issuecomment-5623311734): the original native SIGSEGV and the original PR's green overflow were both reproduced. The correction passed all 5 targeted UI tests and 77 Core WebView tests (3 skipped). Two HybridWebView screenshot tests also fail unchanged on pre-PR production code in the tested environment; no baselines were updated. These local results do not replace fresh CI for the pushed commits.

### Native implementation references

- [Android ViewGroup child clipping](https://github.com/aosp-mirror/platform_frameworks_base/blob/android-15.0.0_r1/core/java/android/view/ViewGroup.java)
- [HWUI RenderNodeDrawable bounds rejection](https://github.com/aosp-mirror/platform_frameworks_base/blob/android-15.0.0_r1/libs/hwui/pipeline/skia/RenderNodeDrawable.cpp)

## Issues Fixed

Fixes #38080.

Preserves the bounds-rendering behavior covered by #34518 and addresses the explicit WebView clipping mechanism involved in #31475 and #35771.