### PR TITLE
[net11.0] Polish Apple CollectionView test cleanup

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/CollectionViewHostBuilderExtentions.cs
+++ b/src/Controls/tests/TestCases.HostApp/CollectionViewHostBuilderExtentions.cs
@@ -7,7 +7,7 @@ namespace Maui.Controls.Sample
 	public static partial class CollectionViewHostBuilderExtensions
 	{
 		/// <summary>
-		/// Registers explicit Items2 handlers for the test-only CollectionView2 and CarouselView2 controls.
+		/// On iOS and Mac Catalyst, registers explicit Items2 handlers for the test-only CollectionView2 and CarouselView2 controls.
 		/// </summary>
 		public static MauiAppBuilder ConfigureCollectionViewHandlers(this MauiAppBuilder builder)
 		{

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28716.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28716.xaml
@@ -32,7 +32,7 @@
             </local:CollectionView2.ItemsLayout>
             <local:CollectionView2.ItemTemplate>
                 <DataTemplate>
-                    <Label Text="{Binding . ,StringFormat='{0}cv2'}"/>
+                    <Label Text="{Binding . ,StringFormat='{0}view2'}"/>
                 </DataTemplate>
             </local:CollectionView2.ItemTemplate>
         </local:CollectionView2>
@@ -46,7 +46,7 @@
             </local:CollectionView2.ItemsLayout>
             <local:CollectionView2.ItemTemplate>
                 <DataTemplate>
-                    <Label Text="{Binding . ,StringFormat='{0}cv3'}"/>
+                    <Label Text="{Binding . ,StringFormat='{0}view3'}"/>
                 </DataTemplate>
             </local:CollectionView2.ItemTemplate>
         </local:CollectionView2>

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/CarouselViewUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/CarouselViewUITests.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Maui.TestCases.Tests
 
 		protected override bool ResetAfterEachTest => true;
 
+		// Items2 still fails initial position and orientation preservation on Apple; Android Items coverage remains.
 #if !IOS && !MACCATALYST
 		[Test]
 		[Category(UITestCategories.CarouselView)]

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/CarouselViewUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/CarouselViewUITests.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Maui.TestCases.Tests
 
 		protected override bool ResetAfterEachTest => true;
 
-		// Items2 still fails initial position and orientation preservation on Apple; Android Items coverage remains.
-#if !IOS && !MACCATALYST
+		// Items2 still fails initial position on iOS; Android Items and Mac Catalyst Items2 coverage remain.
+#if !IOS
 		[Test]
 		[Category(UITestCategories.CarouselView)]
 		public void CarouselViewSetPosition()
@@ -68,6 +68,7 @@ namespace Microsoft.Maui.TestCases.Tests
 			CheckLabelValue("lblSelected", previousIndex);
 		}
 
+		// Items2 does not preserve position on iOS, and Mac Catalyst does not support orientation changes.
 #if !IOS && !MACCATALYST
 		[Test]
 		[Category(UITestCategories.CarouselView)]

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28716.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28716.cs
@@ -18,7 +18,7 @@ public class Issue28716 : _IssuesUITest
 		App.WaitForElement("AddItemButton");
 		App.Click("AddItemButton");
 		App.WaitForElement("Item20view1");
-		App.WaitForElement("Item20cv2");
-		App.WaitForElement("Item20cv3");
+		App.WaitForElement("Item20view2");
+		App.WaitForElement("Item20view3");
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Follows up on review feedback left after #38082 merged:

- clarifies that the test-only Items2 handler registrations apply only to iOS and Mac Catalyst;
- renames the remaining Issue28716 scenario suffixes from `cv2`/`cv3` to `view2`/`view3`, matching `view1` and avoiding obsolete-handler terminology; and
- documents the platform-specific CarouselView exclusions, restoring initial-position coverage on Mac Catalyst while retaining Android Items coverage.

### Validation

- Built the iOS and Mac Catalyst HostApp targets with `CS0618` treated as an error.
- Built the iOS, Mac Catalyst, and Android Appium test projects with `CS0618` treated as an error.
- Parsed the updated Issue28716 XAML.
- Reviewed the complete delta against current `net11.0`; no additional findings.

### Issues Fixed

Follow-up to #38082.