### PR TITLE
[Android] Preserve last window on relaunch to prevent app restart (#38020)

### DIFF
--- a/src/Controls/src/Core/Application/Application.cs
+++ b/src/Controls/src/Core/Application/Application.cs
@@ -480,10 +480,20 @@ namespace Microsoft.Maui.Controls
 			// create a new one if there is no pending windows
 			if (window == null)
 			{
-				window = CreateWindow(activationState);
+#if ANDROID
+				// Reuse the existing (destroyed) single window on relaunch (back-to-home
+				// then reopened) so the app's state is preserved instead of recreated.
+				if (_windows.Count == 1 && _windows[0].IsDestroyed)
+					window = _windows[0];
+#endif
 
-				if (_singleWindowMainPage != null && window.Page != null && window.Page != _singleWindowMainPage)
-					throw new InvalidOperationException($"Both {nameof(MainPage)} was set and {nameof(Application.CreateWindow)} was overridden to provide a page.");
+				if (window == null)
+				{
+					window = CreateWindow(activationState);
+
+					if (_singleWindowMainPage != null && window.Page != null && window.Page != _singleWindowMainPage)
+						throw new InvalidOperationException($"Both {nameof(MainPage)} was set and {nameof(Application.CreateWindow)} was overridden to provide a page.");
+				}
 			}
 
 			// make sure it is added to the windows list
@@ -523,6 +533,13 @@ namespace Microsoft.Maui.Controls
 			// Window was closed, stop tracking it
 			if (window is null)
 				return;
+
+#if ANDROID
+			// Keep the last window on relaunch (back-to-home then reopened) so it can be
+			// re-attached instead of recreated, preserving the app's state.
+			if (_windows.Count == 1)
+				return;
+#endif
 
 			if (window is NavigableElement ne)
 				ne.NavigationProxy.Inner = null;

--- a/src/Controls/src/Core/Application/Application.cs
+++ b/src/Controls/src/Core/Application/Application.cs
@@ -535,9 +535,9 @@ namespace Microsoft.Maui.Controls
 				return;
 
 #if ANDROID
-			// Keep the last window on relaunch (back-to-home then reopened) so it can be
+			// Keep the last tracked window on relaunch (back-to-home then reopened) so it can be
 			// re-attached instead of recreated, preserving the app's state.
-			if (_windows.Count == 1)
+			if (_windows.Count == 1 && ReferenceEquals(_windows[0], window))
 				return;
 #endif
 

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Android.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Xunit;
@@ -38,5 +39,32 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact]
+		public async Task WindowDestroyingKeepsLastWindowOnAndroid()
+		{
+			// https://github.com/dotnet/maui/issues/38020
+			// On Android, pressing back destroys the Activity (and thus the window) but the
+			// process stays alive. Reopening the app must re-attach the existing window
+			// instead of recreating it, otherwise all UI state is lost.
+			SetupBuilder();
+
+			var window = new Window(new ContentPage());
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(window, async handler =>
+			{
+				await OnLoadedAsync(window.Page);
+
+				var application = MauiContext.Services.GetService<IApplication>();
+				Assert.NotNull(application);
+				Assert.Contains(window, application.Windows);
+
+				// Simulate the user pressing back (back-to-home), which destroys the window.
+				((IWindow)window).Destroying();
+				Assert.True(window.IsDestroyed);
+
+				// The last window is kept around so it can be re-attached on relaunch.
+				Assert.Contains(window, application.Windows);
+			});
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Android.cs
@@ -64,6 +64,10 @@ namespace Microsoft.Maui.DeviceTests
 
 				// The last window is kept around so it can be re-attached on relaunch.
 				Assert.Contains(window, application.Windows);
+
+				// Relaunch should reuse the existing destroyed window instead of creating a new one.
+				var relaunchedWindow = application.CreateWindow(null);
+				Assert.Same(window, relaunchedWindow);
 			});
 		}
 	}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

This fixes Android apps appearing to restart after the user presses back and then relaunches the app from the launcher.

#### Problem

Issue #38020 reports that on Android, a default MAUI app using `MainLauncher = true` and `LaunchMode = SingleTop` can lose UI state after this flow:

1. Launch the app.
2. Interact with the UI.
3. Press the Android back button.
4. Reopen the app from the launcher.

After reopening, the app returns to its initial state and `Application.CreateWindow` is called again, making it look like the app restarted, even though the process was not actually recreated.

#### Root cause

On Android, pressing back can destroy the current Activity/window while the .NET process remains alive. When that happened, MAUI removed the destroyed window from `Application._windows`. The next launch therefore had no existing window to re-attach, so `IApplication.CreateWindow` created a brand-new `Window` and page tree, causing the visible restart and UI state loss.

#### Fix

This change makes Android keep the last destroyed window instead of dropping it from `Application._windows`. On the next launch, if there is exactly one tracked window and it is already destroyed, `IApplication.CreateWindow` reuses that existing `Window` instead of calling the user's `CreateWindow` factory again.

The behavior is intentionally scoped:

- Android-only.
- Applies only to the single-window case.
- Does not change normal multi-window close behavior.
- Does not change non-Android platforms.

#### Test coverage

Added `WindowDestroyingKeepsLastWindowOnAndroid` to `WindowTests.Android.cs`. It creates a window, marks the window as destroying, and asserts that the window remains in `Application.Windows` so it can be reused on relaunch.

#### Validation

- Built `Controls.DeviceTests` for Android API 35.
- Ran targeted device tests on an API 35 emulator.
- `WindowDestroyingKeepsLastWindowOnAndroid` passed.

I also searched for existing PRs referencing #38020 and did not find any.

### Issues Fixed

Fixes #38020