### PR TITLE
Fix Windows TabbedPage back-nav crash when tabs are shared (fixes #26214)

### DIFF
--- a/src/Controls/src/Core/TabbedPage/TabbedPage.Windows.cs
+++ b/src/Controls/src/Core/TabbedPage/TabbedPage.Windows.cs
@@ -167,11 +167,15 @@ namespace Microsoft.Maui.Controls
 			{
 				child.PropertyChanged -= OnPagePropertyChanged;
 			}
-			if (_navigationView != null)
-			{
+		if (_navigationView != null)
+		{
+			// Only clear the shared view's selection if it is still showing this
+			// page's tabs; another TabbedPage may already have taken over (pop).
+			// Always unsubscribe to avoid leaking the handler.
+			if (OwnsNavigationViewItems())
 				_navigationView.SelectedItem = null;
-				_navigationView.SelectionChanged -= OnSelectedMenuItemChanged;
-			}
+			_navigationView.SelectionChanged -= OnSelectedMenuItemChanged;
+		}
 
 			OnTabbedPageDisappearing(this, EventArgs.Empty);
 
@@ -186,6 +190,11 @@ namespace Microsoft.Maui.Controls
 			if (_navigationView != null)
 			{
 				_navigationView.PaneDisplayMode = NavigationViewPaneDisplayMode.Top;
+
+				// The shared root NavigationView still shows the previous TabbedPage's
+				// tabs after a pop, so re-sync to this page's children first. Without
+				// this the selection restore below would run against stale items.
+				Handler?.UpdateValue(nameof(TabbedPage.ItemsSource));
 
 				// Restore the correct selection when this TabbedPage re-appears (e.g. after
 				// navigating back from another TabbedPage pushed onto the NavigationPage stack).
@@ -203,9 +212,26 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
+		// The root NavigationView is shared by every TabbedPage in the NavigationPage,
+		// so only the TabbedPage whose tabs are currently displayed may reset it.
+		// Without this, a disconnecting (popped) page would clear the selection and
+		// collapse the pane after the revealed page has already taken over the view.
+		bool OwnsNavigationViewItems()
+		{
+			if (_navigationView?.MenuItemsSource is IList<NavigationViewItemViewModel> items)
+			{
+				foreach (var item in items)
+				{
+					if (item.Data is Page page && Children.Contains(page))
+						return true;
+				}
+			}
+			return false;
+		}
+
 		void OnTabbedPageDisappearing(object? sender, EventArgs e)
 		{
-			if (_navigationView != null)
+			if (_navigationView != null && OwnsNavigationViewItems())
 			{
 				// Clear stale selection so the NavigationView does not ghost-show this
 				// TabbedPage's selected tab when another TabbedPage takes over the view.
@@ -272,8 +298,14 @@ namespace Microsoft.Maui.Controls
 
 		void OnSelectedMenuItemChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)
 		{
+			// Multiple TabbedPages in a NavigationPage share the same root NavigationView,
+			// so every connected TabbedPage sees every selection change. Only react when
+			// the selected page is one of this TabbedPage's own children; otherwise a
+			// hidden TabbedPage would steal and reparent the visible page's content,
+			// crashing layout on Windows (https://github.com/dotnet/maui/issues/26214).
 			if (args.SelectedItem is NavigationViewItemViewModel itemViewModel &&
-				itemViewModel.Data is Page page)
+				itemViewModel.Data is Page page &&
+				Children.Contains(page))
 			{
 				NavigateToPage(page);
 			}

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Windows.cs
@@ -235,5 +235,177 @@ namespace Microsoft.Maui.DeviceTests
 				return Task.CompletedTask;
 			});
 		}
+
+		[Fact(DisplayName = "Issue 26214 - Nested TabbedPage Back Navigation Keeps Tabs Intact")]
+		public async Task NestedTabbedPageBackNavigationKeepsTabsIntact()
+		{
+			// https://github.com/dotnet/maui/issues/26214
+			// TabbedPages pushed onto a NavigationPage share the same root NavigationView.
+			// Popping back after switching tabs must not let the hidden TabbedPage steal
+			// the visible page's selection, and the tab bar must show the revealed page's tabs.
+			SetupBuilder();
+
+			var mainTabbedPage = CreateBasicTabbedPage(pages: new[]
+			{
+				new ContentPage() { Title = "Home Tab 1" },
+				new ContentPage() { Title = "Home Tab 2" }
+			});
+			var productTabbedPage = CreateBasicTabbedPage(pages: new[]
+			{
+				new ContentPage() { Title = "Product Tab 1" },
+				new ContentPage() { Title = "Product Tab 2" }
+			});
+			var navPage = new NavigationPage(mainTabbedPage);
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), async (handler) =>
+			{
+				var navView = GetMauiNavigationView(handler.MauiContext);
+
+				await navPage.PushAsync(productTabbedPage);
+				productTabbedPage.CurrentPage = productTabbedPage.Children[1];
+				await navPage.PopAsync();
+
+				// The popped page must not have adopted the revealed page's tab
+				Assert.Equal(productTabbedPage.Children[1], productTabbedPage.CurrentPage);
+				Assert.DoesNotContain(mainTabbedPage.Children[0], productTabbedPage.Children);
+
+				// The shared tab bar must be showing this page's tabs with its selection restored
+				var items = (navView.MenuItemsSource as IEnumerable<NavigationViewItemViewModel>).ToList();
+				Assert.Equal(mainTabbedPage.Children.Count, items.Count);
+				Assert.All(items, item => Assert.Contains(item.Data, mainTabbedPage.Children));
+				Assert.Equal(mainTabbedPage.CurrentPage, (navView.SelectedItem as NavigationViewItemViewModel)?.Data);
+			});
+		}
+
+		[Fact(DisplayName = "Issue 26214 - ContentPage Push Pop Keeps TabbedPage Intact")]
+		public async Task ContentPagePushPopKeepsTabbedPageIntact()
+		{
+			// A ContentPage pushed over a TabbedPage must not disturb the shared tab bar:
+			// popping back restores this page's tabs and selection.
+			SetupBuilder();
+
+			var mainTabbedPage = CreateBasicTabbedPage(pages: new[]
+			{
+				new ContentPage() { Title = "Home Tab 1" },
+				new ContentPage() { Title = "Home Tab 2" }
+			});
+			var navPage = new NavigationPage(mainTabbedPage);
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), async (handler) =>
+			{
+				var navView = GetMauiNavigationView(handler.MauiContext);
+
+				await navPage.PushAsync(new ContentPage() { Title = "Overlay" });
+				mainTabbedPage.CurrentPage = mainTabbedPage.Children[1];
+				await navPage.PopAsync();
+
+				var items = (navView.MenuItemsSource as IEnumerable<NavigationViewItemViewModel>).ToList();
+				Assert.Equal(mainTabbedPage.Children.Count, items.Count);
+				Assert.All(items, item => Assert.Contains(item.Data, mainTabbedPage.Children));
+				Assert.Equal(mainTabbedPage.CurrentPage, (navView.SelectedItem as NavigationViewItemViewModel)?.Data);
+			});
+		}
+
+		[Fact(DisplayName = "Issue 26214 - Revealed TabbedPage Switches Tabs After Pop")]
+		public async Task RevealedTabbedPageSwitchesTabsAfterPop()
+		{
+			// After popping back, the revealed TabbedPage must be fully interactive and
+			// the popped page must not observe its tab switches.
+			SetupBuilder();
+
+			var mainTabbedPage = CreateBasicTabbedPage(pages: new[]
+			{
+				new ContentPage() { Title = "Home Tab 1" },
+				new ContentPage() { Title = "Home Tab 2" }
+			});
+			var productTabbedPage = CreateBasicTabbedPage(pages: new[]
+			{
+				new ContentPage() { Title = "Product Tab 1" },
+				new ContentPage() { Title = "Product Tab 2" }
+			});
+			var navPage = new NavigationPage(mainTabbedPage);
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), async (handler) =>
+			{
+				var navView = GetMauiNavigationView(handler.MauiContext);
+
+				await navPage.PushAsync(productTabbedPage);
+				productTabbedPage.CurrentPage = productTabbedPage.Children[1];
+				await navPage.PopAsync();
+
+				mainTabbedPage.CurrentPage = mainTabbedPage.Children[1];
+
+				Assert.Equal(mainTabbedPage.Children[1], mainTabbedPage.CurrentPage);
+				Assert.Equal(mainTabbedPage.Children[1], (navView.SelectedItem as NavigationViewItemViewModel)?.Data);
+				Assert.Equal(productTabbedPage.Children[1], productTabbedPage.CurrentPage);
+			});
+		}
+
+		[Fact(DisplayName = "Issue 26214 - Empty TabbedPage Pops Cleanly")]
+		public async Task EmptyTabbedPagePopsCleanly()
+		{
+			// A TabbedPage with no children owns no tab items, so its teardown must
+			// neither throw nor leave another page's tabs behind.
+			SetupBuilder();
+
+			var mainTabbedPage = new TabbedPage();
+			var productTabbedPage = CreateBasicTabbedPage(pages: new[]
+			{
+				new ContentPage() { Title = "Product Tab 1" },
+				new ContentPage() { Title = "Product Tab 2" }
+			});
+			var navPage = new NavigationPage(mainTabbedPage);
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), async (handler) =>
+			{
+				var navView = GetMauiNavigationView(handler.MauiContext);
+
+				await navPage.PushAsync(productTabbedPage);
+				productTabbedPage.CurrentPage = productTabbedPage.Children[1];
+				await navPage.PopAsync();
+
+				var items = (navView.MenuItemsSource as IEnumerable<NavigationViewItemViewModel>).ToList();
+				Assert.Empty(items);
+				Assert.Null(navView.SelectedItem);
+			});
+		}
+
+		[Fact(DisplayName = "Issue 26214 - Disconnect Then Pop Restores Tabs")]
+		public async Task DisconnectThenPopRestoresTabs()
+		{
+			// If the pushed page's handler is torn down before the pop (order
+			// variation), the pop's Appearing pass must still restore this page's tabs.
+			SetupBuilder();
+
+			var mainTabbedPage = CreateBasicTabbedPage(pages: new[]
+			{
+				new ContentPage() { Title = "Home Tab 1" },
+				new ContentPage() { Title = "Home Tab 2" }
+			});
+			var productTabbedPage = CreateBasicTabbedPage(pages: new[]
+			{
+				new ContentPage() { Title = "Product Tab 1" },
+				new ContentPage() { Title = "Product Tab 2" }
+			});
+			var navPage = new NavigationPage(mainTabbedPage);
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), async (handler) =>
+			{
+				var navView = GetMauiNavigationView(handler.MauiContext);
+
+				await navPage.PushAsync(productTabbedPage);
+				productTabbedPage.CurrentPage = productTabbedPage.Children[1];
+
+				((IElementHandler)productTabbedPage.Handler).DisconnectHandler();
+				Assert.Null(navView.SelectedItem);
+
+				await navPage.PopAsync();
+
+				var items = (navView.MenuItemsSource as IEnumerable<NavigationViewItemViewModel>).ToList();
+				Assert.Equal(mainTabbedPage.Children.Count, items.Count);
+				Assert.All(items, item => Assert.Contains(item.Data, mainTabbedPage.Children));
+				Assert.Equal(mainTabbedPage.CurrentPage, (navView.SelectedItem as NavigationViewItemViewModel)?.Data);
+			});
+		}
 	}
 }


### PR DESCRIPTION
Fixes #26214.

## Problem
TabbedPages inside a NavigationPage share the single root WinUI NavigationView on Windows, so every connected TabbedPage observes every SelectionChanged. Repro (from the issue): push a TabbedPage, switch tabs, navigate back -> crash.

Captured live on 10.0.100 (full managed stack):
```
TabbedPage.OnSelectedMenuItemChanged -> NavigateToPage -> Frame.NavigateToType
  -> OnNavigated -> UpdateCurrentPageContent -> ContentPresenter.set_Content -> E_BOUNDS
```
The hidden (popping) page reacted to the revealed page restoring its selection, navigated its own Frame to the other page's content, and reparented it. On 9.0.x the same steal surfaces as E_INVALIDARG in MeasureOverride, or a native 0x80070490 with no managed frames.

## Fix (src/Controls/src/Core/TabbedPage/TabbedPage.Windows.cs)
- OnSelectedMenuItemChanged only reacts when the selected page is one of this TabbedPage's own Children.
- OnTabbedPageAppearing re-syncs MenuItemsSource to this page's children before restoring selection (pop left the pushed page's stale tabs behind).
- Disappear/disconnect only reset the shared view when it still shows this page's tabs (OwnsNavigationViewItems), since disconnect runs after the revealed page's Appearing. Unsubscribing still always happens.

## Verification
- Scripted UI replay (FlaUI clicks: push -> tab2 -> back): stock 9.0.120 and stock 10.0.100 crash 100%; patched assembly (DLL swap, same 10.0.0.0 AssemblyVersion) survives with correct tabs restored; stock restored -> crash returns.
- In-process self-test (5 scenarios / 14 assertions against the live shared NavigationView): patched 14/14 PASS; stock dies in case 1.
- New xunit device tests mirror those scenarios (could not compile/run locally - test project needs the VS/cake pipeline; relying on CI).

## Tests added
TabbedPageTests.Windows.cs: NestedTabbedPageBackNavigationKeepsTabsIntact, ContentPagePushPopKeepsTabbedPageIntact, RevealedTabbedPageSwitchesTabsAfterPop, EmptyTabbedPagePopsCleanly, DisconnectThenPopRestoresTabs.