### PR TITLE
[Android] Fix incorrect top padding for translated views

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue37418.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue37418.cs
@@ -1,0 +1,177 @@
+using Microsoft.Maui.Controls.Shapes;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 37418, "TranslationY outside the screen adds incorrect top padding", PlatformAffected.Android)]
+public class Issue37418 : Shell
+{
+	public Issue37418()
+	{
+		Routing.RegisterRoute(nameof(Issue37418ModalPage), typeof(Issue37418ModalPage));
+
+		Items.Add(new ShellContent
+		{
+			Title = "Home",
+			Route = nameof(Issue37418HomePage),
+			ContentTemplate = new DataTemplate(typeof(Issue37418HomePage))
+		});
+	}
+}
+
+public class Issue37418HomePage : ContentPage
+{
+	public Issue37418HomePage()
+	{
+		Content = new ScrollView
+		{
+			Content = new VerticalStackLayout
+			{
+				Padding = new Thickness(30, 0),
+				Spacing = 25,
+				Children =
+				{
+					new Button
+					{
+						AutomationId = "OpenBottomSheetButton",
+						Text = "Open Bottom Sheet",
+						Command = new Command(async () => await Shell.Current.GoToAsync(nameof(Issue37418ModalPage)))
+					}
+				}
+			}
+		};
+	}
+}
+
+public class Issue37418ModalPage : ContentPage
+{
+	public Issue37418ModalPage()
+	{
+		Shell.SetPresentationMode(this, PresentationMode.ModalNotAnimated);
+		SafeAreaEdges = SafeAreaEdges.None;
+		Background = Colors.Transparent;
+		Content = new Issue37418BottomSheet
+		{
+			Content = new VerticalStackLayout
+			{
+				Padding = 16,
+				Spacing = 12,
+				Children =
+				{
+					new Label
+					{
+						AutomationId = "BottomSheetTitle",
+						Text = "Bottom Sheet Content",
+						TextColor = Colors.White,
+						FontSize = 24,
+						HorizontalOptions = LayoutOptions.Center
+					},
+					new Button
+					{
+						AutomationId = "BottomSheetCustomButton",
+						Text = "Custom button"
+					}
+				}
+			}
+		};
+	}
+}
+
+class Issue37418BottomSheet : ContentView
+{
+	Border _border;
+
+	public Issue37418BottomSheet()
+	{
+		ControlTemplate = new ControlTemplate(CreateTemplate);
+	}
+
+	View CreateTemplate()
+	{
+		var dismissArea = new Grid
+		{
+			Background = Colors.Black,
+			Opacity = 0.5
+		};
+		dismissArea.GestureRecognizers.Add(new TapGestureRecognizer
+		{
+			Command = new Command(async () => await CloseAsync())
+		});
+
+		var bottomBackdrop = new Grid
+		{
+			Background = Colors.Black,
+			Opacity = 0.5
+		};
+
+		var closeButton = new Button
+		{
+			AutomationId = "CloseBottomSheetButton",
+			HeightRequest = 48,
+			Text = "Close"
+		};
+		closeButton.Clicked += async (_, _) => await CloseAsync();
+
+		var sheetContent = new Grid
+		{
+			RowDefinitions =
+			{
+				new RowDefinition(48),
+				new RowDefinition(GridLength.Auto)
+			}
+		};
+		sheetContent.Add(closeButton, 0, 0);
+		sheetContent.Add(new ContentPresenter(), 0, 1);
+
+		_border = new Border
+		{
+			AutomationId = "BottomSheetBorder",
+			SafeAreaEdges = SafeAreaEdges.None,
+			StrokeShape = new RoundRectangle
+			{
+				CornerRadius = new CornerRadius(24, 24, 0, 0)
+			},
+			Background = Colors.Black,
+			IsVisible = false,
+			Content = sheetContent
+		};
+
+		var root = new Grid
+		{
+			SafeAreaEdges = SafeAreaEdges.None,
+			RowDefinitions =
+			{
+				new RowDefinition(GridLength.Star),
+				new RowDefinition(GridLength.Auto)
+			}
+		};
+		root.Add(dismissArea, 0, 0);
+		root.Add(bottomBackdrop, 0, 1);
+		root.Add(_border, 0, 1);
+
+		return root;
+	}
+
+	async Task CloseAsync()
+	{
+		if (_border is not null)
+		{
+			await _border.TranslateToAsync(_border.X, _border.Height, 300, Easing.CubicIn);
+		}
+
+		await Shell.Current.GoToAsync("..");
+	}
+
+	protected override async void OnSizeAllocated(double width, double height)
+	{
+		base.OnSizeAllocated(width, height);
+
+		if (_border is null)
+		{
+			return;
+		}
+
+		_border.TranslationY = _border.Measure(double.PositiveInfinity, double.PositiveInfinity).Height;
+		_border.IsVisible = true;
+		await _border.TranslateToAsync(_border.X, 0, 300, Easing.CubicIn);
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue37418.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue37418.cs
@@ -1,0 +1,30 @@
+#if ANDROID || IOS          // Issue related to SafeAreaEdges, which is only applicable to mobile platforms
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue37418 : _IssuesUITest
+{
+	public override string Issue => "TranslationY outside the screen adds incorrect top padding";
+
+	public Issue37418(TestDevice device) : base(device)
+	{
+	}
+
+	[Test]
+	[Category(UITestCategories.SafeAreaEdges)]
+	public void TranslatedBottomSheetDoesNotAddTopPadding()
+	{
+		App.WaitForElement("OpenBottomSheetButton");
+		App.Tap("OpenBottomSheetButton");
+
+		var borderRect = App.WaitForElement("BottomSheetBorder").GetRect();
+		var closeButtonRect = App.WaitForElement("CloseBottomSheetButton").GetRect();
+
+		Assert.That(closeButtonRect.Y - borderRect.Y, Is.LessThanOrEqualTo(5),
+			"The translated bottom sheet should not receive top safe-area padding.");
+	}
+}
+#endif

--- a/src/Core/src/Platform/Android/SafeAreaExtensions.cs
+++ b/src/Core/src/Platform/Android/SafeAreaExtensions.cs
@@ -142,11 +142,13 @@ internal static class SafeAreaExtensions
 					// extend beyond the screen bottom. This happens because the fragment animation
 					// slides the view in from off-screen. We detect this animating state by checking:
 					// 1. viewTop > top (view is below the status bar area - normal case would be viewTop <= top)
-					// 2. viewBottom > screenHeight (view extends beyond screen - confirms it's not just a small view)
-					// 3. viewTop > 0 (view is not at origin)
+					// 2. viewBottom > screenHeight (view extends beyond screen)
+					// 3. viewHeight covers the usable screen (excludes translated child controls)
 					// This is DIFFERENT from ScrollView where viewTop = 0 (at origin, not animating).
 					// When we detect animation state, apply the full top inset since view will settle at Y=0.
-					var viewIsAnimatingVertically = viewTop > top && viewTop > 0 && viewBottom > screenHeight;
+					var viewIsAnimatingVertically = viewTop > top &&
+						viewBottom > screenHeight &&
+						viewHeight >= screenHeight - top - bottom;
 
 					// Adjust for view's position relative to parent (including margins) to calculate
 					// safe area insets relative to the parent's position, not the view's visual position.


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description

Forward-ports the focused Android fix from #37772 to the current `main` branch.

The vertical safe-area animation heuristic now treats a translated view as a full-screen Shell navigation transition only when the view covers the usable screen height. Smaller translated controls, such as bottom sheets, no longer retain an incorrect top safe-area inset.

Adds the Issue37418 HostApp scenario and UI regression test. This intentionally excludes the unrelated `.github/skills/release-readiness/SKILL.md` change present in source merge commit `9d587ce9a6ce0b776496e930b5948da629b62ef2`.

### Issues Fixed

Fixes #37418

### Validation

- `dotnet build Microsoft.Maui.BuildTasks.slnf`
- `pwsh .github/scripts/BuildAndRunHostApp.ps1 -Platform android -TestFilter "FullyQualifiedName~Issue37418"`
