### PR TITLE
[iOS] CollectionView: Fix pull-to-refresh when empty

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -370,6 +370,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 			if (_emptyViewDisplayed)
 			{
+				UpdateEmptyViewFlowDirection();
 				AlignEmptyView();
 			}
 
@@ -573,10 +574,22 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 				return;
 			}
 
+			// Keep the empty view inside the collection view so its pan gesture can drive pull-to-refresh.
+			// In RTL, cancel the collection layout's coordinate-system flip; content flow direction is applied below.
+			var transform = CollectionView.EffectiveUserInterfaceLayoutDirection == UIUserInterfaceLayoutDirection.RightToLeft
+				? CGAffineTransform.MakeScale(-1, 1)
+				: CGAffineTransform.MakeIdentity();
+
+			if (!_emptyUIView.Transform.Equals(transform))
+			{
+				_emptyUIView.Transform = transform;
+			}
+		}
+
+		void UpdateEmptyViewFlowDirection()
+		{
 			if (_emptyViewFormsElement is not null)
 			{
-				// The empty view's FlowDirection is handled here instead of in UpdateFlowDirection()
-				// to ensure proper alignment independent of the CollectionView's layout flip behavior.
 				if (_emptyViewFormsElement.Handler?.PlatformView is UIView emptyView)
 				{
 					emptyView.UpdateFlowDirection(_emptyViewFormsElement);
@@ -605,34 +618,16 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			}
 
 			_emptyUIView.Tag = EmptyTag;
-
-			// Add the empty view to the CollectionView's superview instead of the CollectionView itself.
-			// The compositional layout's flipsHorizontallyInOppositeLayoutDirection (default true) causes
-			// the CollectionView to flip its content coordinate system when SemanticContentAttribute is
-			// ForceRightToLeft. Layout-managed views (cells, supplementary views) are compensated by the
-			// layout, but direct subviews are NOT — resulting in mirror-flipped rendering.
-			// Adding to the superview avoids this flip zone entirely.
-			var targetView = CollectionView.Superview;
-			if (targetView is not null)
-			{
-				targetView.InsertSubviewAbove(_emptyUIView, CollectionView);
-			}
-			else
-			{
-				// TODO: DetermineEmptyViewFrame() returns superview-coordinate-space values (CollectionView.Frame.X/Y),
-				// which are incorrect when the empty view is a child of CollectionView. This fallback is unlikely
-				// to execute in practice since Superview is expected to be non-null by the time ShowEmptyView() is called.
-				CollectionView.AddSubview(_emptyUIView);
-			}
+			CollectionView.AddSubview(_emptyUIView);
 
 			if (((IElementController)ItemsView).LogicalChildren.IndexOf(_emptyViewFormsElement) == -1)
 			{
 				ItemsView.AddLogicalChild(_emptyViewFormsElement);
 			}
 
+			UpdateEmptyViewFlowDirection();
 			LayoutEmptyView();
 
-			AlignEmptyView();
 			_emptyViewDisplayed = true;
 		}
 
@@ -681,7 +676,14 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 				}
 			}
 
-			_emptyUIView.Frame = frame;
+			if (!_emptyUIView.Frame.Equals(frame))
+			{
+				// UIKit's Frame is undefined under a non-identity transform.
+				_emptyUIView.Transform = CGAffineTransform.MakeIdentity();
+				_emptyUIView.Frame = frame;
+			}
+
+			AlignEmptyView();
 
 			return frame;
 		}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue37361.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue37361.cs
@@ -1,0 +1,94 @@
+using System.Collections.ObjectModel;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 37361, "RefreshView pull-to-refresh does nothing when CollectionView is empty", PlatformAffected.iOS)]
+public class Issue37361 : ContentPage
+{
+	readonly ObservableCollection<string> _items = [];
+	readonly Label _statusLabel;
+	int _refreshCount;
+
+	public Issue37361()
+	{
+		_statusLabel = new Label
+		{
+			AutomationId = "StatusLabel",
+			Text = "Refreshes: 0"
+		};
+
+		var collectionView = new CollectionView
+		{
+			AutomationId = "CollectionView",
+			ItemsSource = _items,
+			EmptyView = new Label
+			{
+				AutomationId = "EmptyViewLabel",
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center,
+				Text = "No items"
+			},
+			ItemTemplate = new DataTemplate(() =>
+			{
+				var label = new Label();
+				label.SetBinding(Label.TextProperty, ".");
+				return label;
+			})
+		};
+
+		var refreshView = new RefreshView
+		{
+			AutomationId = "RefreshView",
+			Content = collectionView
+		};
+		refreshView.Command = new Command(() =>
+		{
+			_refreshCount++;
+			_statusLabel.Text = $"Refreshes: {_refreshCount}";
+			refreshView.IsRefreshing = false;
+		});
+
+		var addButton = new Button
+		{
+			AutomationId = "AddItemButton",
+			Text = "Add item",
+			Command = new Command(() => _items.Add("Item"))
+		};
+
+		var clearButton = new Button
+		{
+			AutomationId = "ClearItemsButton",
+			Text = "Clear items",
+			Command = new Command(_items.Clear)
+		};
+
+		var buttonLayout = new HorizontalStackLayout
+		{
+			Children = { addButton, clearButton }
+		};
+		Grid.SetRow(buttonLayout, 1);
+
+		var refreshBorder = new Border
+		{
+			Content = refreshView
+		};
+		Grid.SetRow(refreshBorder, 2);
+
+		Content = new Grid
+		{
+			Padding = 12,
+			RowDefinitions =
+			{
+				new RowDefinition(GridLength.Auto),
+				new RowDefinition(GridLength.Auto),
+				new RowDefinition(GridLength.Star)
+			},
+			Children =
+			{
+				_statusLabel,
+				buttonLayout,
+				refreshBorder
+			}
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue37361.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue37361.cs
@@ -1,0 +1,33 @@
+#if TEST_FAILS_ON_CATALYST && TEST_FAILS_ON_WINDOWS // Windows requires touch interaction; App.ScrollUp does not work on MacCatalyst.
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue37361 : _IssuesUITest
+{
+	public Issue37361(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue => "RefreshView pull-to-refresh does nothing when CollectionView is empty";
+
+	[Test]
+	[Category(UITestCategories.RefreshView)]
+	public void PullToRefreshWorksWhenCollectionViewIsEmpty()
+	{
+		App.WaitForElement("EmptyViewLabel");
+
+		App.ScrollUp("RefreshView");
+		Assert.That(App.WaitForElement("StatusLabel").GetText(), Is.EqualTo("Refreshes: 1"));
+
+		App.Tap("AddItemButton");
+		App.Tap("ClearItemsButton");
+		App.WaitForElement("EmptyViewLabel");
+
+		App.ScrollUp("RefreshView");
+		Assert.That(App.WaitForElement("StatusLabel").GetText(), Is.EqualTo("Refreshes: 2"));
+	}
+}
+#endif


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause

PR #32674 moved the Items2 empty view above the native `UICollectionView` to avoid mirrored RTL rendering. As a full-size sibling, the empty view intercepted pull gestures before the collection view and its `RefreshView` integration could receive them.

### Description of Change

- Keep the empty view inside the native `UICollectionView` so pull gestures reach the scroll view.
- Preserve LTR/RTL rendering by applying the content flow direction separately and counter-transforming the empty-view host when needed.
- Reset the transform before assigning a changed frame, then restore alignment after layout because UIKit frame values are undefined under a non-identity transform.
- Add the Issue37361 HostApp scenario and iOS UI regression test for both an initially empty collection and an add/clear transition.

This is a focused forward-port of #37404 from `inflight/current` to `main` (source merge commit `53ba0dbbb67f13e864fb2e03cbb2d32335f2b2fb`).

### Issues Fixed

Fixes #37361

### Validation

- `dotnet build Microsoft.Maui.BuildTasks.slnf`
- `pwsh .github/scripts/BuildAndRunHostApp.ps1 -Platform ios -TestFilter "FullyQualifiedName~Issue37361"`
