### PR TITLE
[Flaky-fix] Fix for flaky test (PickerShouldDismissWhenClickOnOutside) UI test in Maccatalyst

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19168.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19168.cs
@@ -18,7 +18,8 @@ public class Issue19168 : _IssuesUITest
 		App.WaitForElement("Picker");
 		App.Tap("Picker");
 #if MACCATALYST
-		App.TapCoordinates(600, 200);
+		var pickerRect = App.WaitForElement("Picker").GetRect();
+		App.TapCoordinates(pickerRect.X + 1, pickerRect.Y + 1);
 		App.WaitForElement("Button");
 #elif ANDROID
 		App.WaitForElement("Baboon");

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19168.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19168.cs
@@ -16,9 +16,11 @@ public class Issue19168 : _IssuesUITest
 	public void PickerShouldDismissWhenClickOnOutside()
 	{
 		App.WaitForElement("Picker");
-		App.Tap("Picker");
 #if MACCATALYST
 		var pickerRect = App.WaitForElement("Picker").GetRect();
+#endif
+		App.Tap("Picker");
+#if MACCATALYST
 		App.TapCoordinates(pickerRect.X + 1, pickerRect.Y + 1);
 		App.WaitForElement("Button");
 #elif ANDROID

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19168.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19168.cs
@@ -16,11 +16,9 @@ public class Issue19168 : _IssuesUITest
 	public void PickerShouldDismissWhenClickOnOutside()
 	{
 		App.WaitForElement("Picker");
-#if MACCATALYST
-		var pickerRect = App.WaitForElement("Picker").GetRect();
-#endif
 		App.Tap("Picker");
 #if MACCATALYST
+		var pickerRect = App.WaitForElement("Picker").GetRect();
 		App.TapCoordinates(pickerRect.X + 1, pickerRect.Y + 1);
 		App.WaitForElement("Button");
 #elif ANDROID


### PR DESCRIPTION
This pull request makes a targeted adjustment to the picker dismissal test for Maccatalyst by improving how the test simulates a tap outside the picker. Instead of tapping at hardcoded coordinates, the test now taps just outside the picker's actual position, making the test more robust and less likely to break if UI layouts change.

Test improvement:

* On Mac Catalyst, Updated the `PickerShouldDismissWhenClickOnOutside` in `Issue19168.cs` to calculate the tap location dynamically based on the picker's position, instead of using hardcoded coordinates.