### PR TITLE
[Android] Fix ArgumentOutOfRangeException when removing items from grouped CollectionView

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/SpacingItemDecoration.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/SpacingItemDecoration.cs
@@ -67,13 +67,19 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			base.GetItemOffsets(outRect, view, parent, state);
 
-			int position = parent.GetChildAdapterPosition(view);
-			if (position == RecyclerView.NoPosition)
+			var adapter = parent.GetAdapter();
+			if (adapter is null)
+			{
 				return;
+			}
 
-			int itemCount = parent.GetAdapter()?.ItemCount ?? state.ItemCount;
-			if (itemCount <= 0)
+			int position = parent.GetChildAdapterPosition(view);
+			int itemCount = adapter.ItemCount;
+
+			if (position == RecyclerView.NoPosition || position < 0 || position >= itemCount)
+			{
 				return;
+			}
 
 			outRect.Left = HorizontalOffset;
 			outRect.Right = HorizontalOffset;

--- a/src/Controls/src/Core/Handlers/Items/Android/SpacingItemDecoration.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/SpacingItemDecoration.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			if (position == RecyclerView.NoPosition)
 				return;
 
-			int itemCount = state.ItemCount;
+			int itemCount = parent.GetAdapter()?.ItemCount ?? state.ItemCount;
 			if (itemCount <= 0)
 				return;
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue38321.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue38321.cs
@@ -6,6 +6,9 @@ namespace Maui.Controls.Sample.Issues;
 [Issue(IssueTracker.Github, 38321, "Grouped CollectionView with GridItemsLayout throws ArgumentOutOfRangeException after an item is removed", PlatformAffected.Android)]
 public class Issue38321 : ContentPage
 {
+	readonly Label _statusLabel;
+	int _removalStep;
+
 	public ObservableCollection<Issue38321ItemGroup> Groups { get; } = new ObservableCollection<Issue38321ItemGroup>();
 
 	public Issue38321()
@@ -54,6 +57,12 @@ public class Issue38321 : ContentPage
 			Text = "Remove item"
 		};
 
+		_statusLabel = new Label
+		{
+			AutomationId = "ItemsRemainingLabel",
+			Text = "Items remaining: 8"
+		};
+
 		removeButton.Clicked += OnRemoveItemClicked;
 
 		var headerGrid = new Grid
@@ -63,11 +72,17 @@ public class Issue38321 : ContentPage
 				new ColumnDefinition(GridLength.Star),
 				new ColumnDefinition(GridLength.Auto)
 			},
+			RowDefinitions =
+			{
+				new RowDefinition(GridLength.Auto),
+				new RowDefinition(GridLength.Auto)
+			},
 			ColumnSpacing = 12
 		};
 
 		headerGrid.Add(headerLayout);
 		headerGrid.Add(removeButton, 1, 0);
+		headerGrid.Add(_statusLabel, 0, 1);
 
 		var collectionView = new CollectionView
 		{
@@ -155,14 +170,24 @@ public class Issue38321 : ContentPage
 		Content = grid;
 	}
 
-	private async void OnRemoveItemClicked(object sender, EventArgs e)
+	async void OnRemoveItemClicked(object sender, EventArgs e)
 	{
 		await Task.Delay(250);
 
-		if (Groups.Count > 0 && Groups[0].Count > 0)
+		if (Groups.Count == 0 || Groups[0].Count == 0)
+			return;
+
+		var group = Groups[0];
+		var (positionName, index) = _removalStep switch
 		{
-			Groups[0].RemoveAt(0);
-		}
+			0 => ("first", 0),
+			1 => ("middle", group.Count / 2),
+			_ => ("last", group.Count - 1)
+		};
+
+		group.RemoveAt(index);
+		_removalStep++;
+		_statusLabel.Text = $"Removed {positionName}; items remaining: {group.Count}";
 	}
 }
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue38321.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue38321.cs
@@ -1,0 +1,177 @@
+﻿using System.Collections.ObjectModel;
+using Microsoft.Maui.Controls.Shapes;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 38321, "Grouped CollectionView with GridItemsLayout throws ArgumentOutOfRangeException after an item is removed", PlatformAffected.Android)]
+public class Issue38321 : ContentPage
+{
+	public ObservableCollection<Issue38321ItemGroup> Groups { get; } = new ObservableCollection<Issue38321ItemGroup>();
+
+	public Issue38321()
+	{
+		Title = "Issue 38321";
+
+		for (var groupIndex = 1; groupIndex <= 4; groupIndex++)
+		{
+			var items = new List<Issue38321SampleItem>();
+
+			for (var itemIndex = 1; itemIndex <= 8; itemIndex++)
+			{
+				items.Add(new Issue38321SampleItem($"Item {groupIndex}.{itemIndex}"));
+			}
+
+			Groups.Add(new Issue38321ItemGroup($"Group {groupIndex}", items));
+		}
+
+		var titleLabel = new Label
+		{
+			Text = "Grouped grid removal",
+			FontAttributes = FontAttributes.Bold,
+			FontSize = 20
+		};
+
+		var descriptionLabel = new Label
+		{
+			Text = "Remove the first visible item on Android",
+			FontSize = 13
+		};
+
+		var headerLayout = new VerticalStackLayout
+		{
+			Spacing = 2,
+			VerticalOptions = LayoutOptions.Center,
+			Children =
+			{
+				titleLabel,
+				descriptionLabel
+			}
+		};
+
+		var removeButton = new Button
+		{
+			AutomationId = "RemoveItemButton",
+			Text = "Remove item"
+		};
+
+		removeButton.Clicked += OnRemoveItemClicked;
+
+		var headerGrid = new Grid
+		{
+			ColumnDefinitions =
+			{
+				new ColumnDefinition(GridLength.Star),
+				new ColumnDefinition(GridLength.Auto)
+			},
+			ColumnSpacing = 12
+		};
+
+		headerGrid.Add(headerLayout);
+		headerGrid.Add(removeButton, 1, 0);
+
+		var collectionView = new CollectionView
+		{
+			AutomationId = "GroupedCollectionView",
+			IsGrouped = true,
+			ItemsSource = Groups,
+			ItemsLayout = new GridItemsLayout(2, ItemsLayoutOrientation.Vertical)
+			{
+				HorizontalItemSpacing = 4,
+				VerticalItemSpacing = 4
+			}
+		};
+
+		collectionView.GroupHeaderTemplate = new DataTemplate(() =>
+		{
+			var label = new Label
+			{
+				Padding = 8,
+				Background = Color.FromArgb("#E7EEF8"),
+				FontAttributes = FontAttributes.Bold,
+				HeightRequest = 40,
+				TextColor = Color.FromArgb("#172033")
+			};
+
+			label.SetBinding(Label.TextProperty, "Name");
+
+			return label;
+		});
+
+		collectionView.GroupFooterTemplate = new DataTemplate(() =>
+		{
+			var label = new Label
+			{
+				Padding = 8,
+				Background = Color.FromArgb("#F1F3F6"),
+				HeightRequest = 40,
+				TextColor = Color.FromArgb("#303846")
+			};
+
+			label.SetBinding(
+				Label.TextProperty,
+				"Count",
+				stringFormat: "Items remaining: {0}");
+
+			return label;
+		});
+
+		collectionView.ItemTemplate = new DataTemplate(() =>
+		{
+			var label = new Label
+			{
+				TextColor = Color.FromArgb("#172033")
+			};
+
+			label.SetBinding(Label.TextProperty, "Name");
+
+			return new Border
+			{
+				Margin = 4,
+				Padding = 12,
+				Background = Colors.White,
+				Stroke = Color.FromArgb("#8792A5"),
+				StrokeShape = new RoundRectangle
+				{
+					CornerRadius = 6
+				},
+				Content = label
+			};
+		});
+
+		var grid = new Grid
+		{
+			Padding = 16,
+			RowSpacing = 12,
+			RowDefinitions =
+			{
+				new RowDefinition(GridLength.Auto),
+				new RowDefinition(GridLength.Star)
+			}
+		};
+
+		grid.Add(headerGrid);
+		grid.Add(collectionView, 0, 1);
+
+		Content = grid;
+	}
+
+	private async void OnRemoveItemClicked(object sender, EventArgs e)
+	{
+		await Task.Delay(250);
+
+		if (Groups.Count > 0 && Groups[0].Count > 0)
+		{
+			Groups[0].RemoveAt(0);
+		}
+	}
+}
+
+public sealed record Issue38321SampleItem(string Name);
+
+public sealed class Issue38321ItemGroup(
+	string name,
+	IEnumerable<Issue38321SampleItem> items)
+	: ObservableCollection<Issue38321SampleItem>(items)
+{
+	public string Name { get; } = name;
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue38321.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue38321.cs
@@ -14,18 +14,28 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 		[Test]
 		[Category(UITestCategories.CollectionView)]
-		public void GroupedCollectionViewRemoveItem()
+		public void GroupedCollectionViewRemovalsUseCurrentAdapterPositions()
 		{
 			App.WaitForElement("RemoveItemButton");
 
-			App.Tap("RemoveItemButton");
-			App.WaitForElement("RemoveItemButton");
+			string[] expectedResults =
+			{
+				"Removed first; items remaining: 7",
+				"Removed middle; items remaining: 6",
+				"Removed last; items remaining: 5"
+			};
 
-			App.Tap("RemoveItemButton");
-			App.WaitForElement("RemoveItemButton");
-
-			App.Tap("RemoveItemButton");
-			App.WaitForElement("RemoveItemButton");
+			for (int i = 0; i < expectedResults.Length; i++)
+			{
+				string expectedResult = expectedResults[i];
+				App.Tap("RemoveItemButton");
+				Assert.That(
+					App.WaitForTextToBePresentInElement(
+						"ItemsRemainingLabel",
+						expectedResult),
+					Is.True,
+					$"The grouped CollectionView did not complete the removal: {expectedResult}.");
+			}
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue38321.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue38321.cs
@@ -1,0 +1,31 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue38321 : _IssuesUITest
+	{
+		public Issue38321(TestDevice testDevice) : base(testDevice)
+		{
+		}
+
+		public override string Issue => "Grouped CollectionView with GridItemsLayout throws ArgumentOutOfRangeException after an item is removed";
+
+		[Test]
+		[Category(UITestCategories.CollectionView)]
+		public void GroupedCollectionViewRemoveItem()
+		{
+			App.WaitForElement("RemoveItemButton");
+
+			App.Tap("RemoveItemButton");
+			App.WaitForElement("RemoveItemButton");
+
+			App.Tap("RemoveItemButton");
+			App.WaitForElement("RemoveItemButton");
+
+			App.Tap("RemoveItemButton");
+			App.WaitForElement("RemoveItemButton");
+		}
+	}
+}


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
On Android, removing an item from a visible group in a grouped CollectionView using GridItemsLayout can cause an ArgumentOutOfRangeException. The issue occurs during RecyclerView's predictive layout. The spacing calculation uses an outdated item count, which can result in an invalid adapter position.

**Regression PR:** https://github.com/dotnet/maui/pull/35782

### Root Cause
SpacingItemDecoration uses RecyclerView.State.ItemCount to determine the last item position. During item removal, state.ItemCount can still contain the previous item count while the adapter has already been updated. This causes the calculated position to be outside the current adapter range, which eventually results in an ArgumentOutOfRangeException.

### Description of Change
On Android, updated SpacingItemDecoration to use consistent adapter state when calculating item positions and counts for SpanSizeLookup. The change ensures that the position and item count passed to SpanSizeLookup are obtained from the current adapter state, avoiding inconsistencies during CollectionView item updates. Added additional tests to cover item removal scenarios in a grouped CollectionView using GridItemsLayout and to verify that the collection updates correctly without throwing exceptions.

### Issues Fixed
Fixes #38321

### Screenshots

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/7d5e369f-127a-4a1e-a612-a10175f11286"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/402a6790-45d3-40e3-9063-e3308eaca50b"> |