### PR TITLE
Restore lazy trigger specificity allocation

### DIFF
--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Maui.Controls
 		}
 
 		internal ushort _triggerCount = 0;
-		internal Dictionary<TriggerBase, SetterSpecificity> _triggerSpecificity = new();
+		internal Dictionary<TriggerBase, SetterSpecificity> _triggerSpecificity;
 		readonly Dictionary<int, BindablePropertyContext> _properties = new(4);
 		bool _applying;
 		WeakReference _inheritedContext;

--- a/src/Controls/tests/Core.UnitTests/BindableObjectUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindableObjectUnitTests.cs
@@ -76,6 +76,23 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 	public class BindableObjectUnitTests : BaseTestFixture
 	{
 		[Fact]
+		public void TriggerSpecificityIsNotAllocatedWithoutTriggers()
+		{
+			var mock = new MockBindable();
+			Assert.Null(mock._triggerSpecificity);
+
+			mock.BindingContext = new object();
+			mock.Text = "updated";
+			Assert.Equal("updated", mock.Text);
+			Assert.Null(mock._triggerSpecificity);
+
+			mock.ClearValue(MockBindable.TextProperty);
+			Assert.Equal("default", mock.Text);
+			Assert.Empty(mock.Triggers);
+			Assert.Null(mock._triggerSpecificity);
+		}
+
+		[Fact]
 		public void BindingContext()
 		{
 			var mock = new MockBindable();

--- a/src/Controls/tests/Core.UnitTests/EventTriggerTest.cs
+++ b/src/Controls/tests/Core.UnitTests/EventTriggerTest.cs
@@ -77,11 +77,24 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var triggeraction = new MockTriggerAction();
 			var eventtrigger = new EventTrigger() { Event = "MockEvent", Actions = { triggeraction } };
 			var collection = bindable.Triggers;
+			Assert.Null(bindable._triggerSpecificity);
 			collection.Add(eventtrigger);
 
 			Assert.False(triggeraction.Invoked);
 			bindable.FireEvent();
 			Assert.True(triggeraction.Invoked);
+			Assert.Null(bindable._triggerSpecificity);
+
+			collection.Remove(eventtrigger);
+			triggeraction.Invoked = false;
+			bindable.FireEvent();
+			Assert.False(triggeraction.Invoked);
+			Assert.Null(bindable._triggerSpecificity);
+
+			collection.Add(eventtrigger);
+			bindable.FireEvent();
+			Assert.True(triggeraction.Invoked);
+			Assert.Null(bindable._triggerSpecificity);
 		}
 
 		[Fact]

--- a/src/Controls/tests/Core.UnitTests/StyleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/StyleTests.cs
@@ -408,6 +408,53 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public void SharedStyleTriggersHaveIndependentSpecificity()
+		{
+			var style = new Style(typeof(Label))
+			{
+				Triggers = {
+					new Trigger(typeof(Label)) {
+						Property = VisualElement.IsEnabledProperty,
+						Value = false,
+						Setters = { new Setter { Property = VisualElement.ScaleProperty, Value = 2d } },
+					},
+					new Trigger(typeof(Label)) {
+						Property = VisualElement.IsVisibleProperty,
+						Value = false,
+						Setters = { new Setter { Property = VisualElement.ScaleProperty, Value = 3d } },
+					},
+				}
+			};
+			var first = new Label { IsEnabled = false, IsVisible = false };
+			var second = new Label();
+			Assert.Null(first._triggerSpecificity);
+			Assert.Null(second._triggerSpecificity);
+
+			first.Style = second.Style = style;
+			Assert.Equal(2, first._triggerSpecificity.Count);
+			Assert.Equal(2, second._triggerSpecificity.Count);
+			Assert.NotSame(first._triggerSpecificity, second._triggerSpecificity);
+			Assert.Equal(3d, first.Scale);
+			Assert.Equal(1d, second.Scale);
+
+			second.IsEnabled = false;
+			Assert.Equal(2d, second.Scale);
+			Assert.Equal(3d, first.Scale);
+			first.IsVisible = true;
+			Assert.Equal(2d, first.Scale);
+
+			first.Style = null;
+			Assert.Empty(first._triggerSpecificity);
+			Assert.Equal(1d, first.Scale);
+			Assert.Equal(2, second._triggerSpecificity.Count);
+			Assert.Equal(2d, second.Scale);
+
+			first.Style = style;
+			Assert.Equal(2d, first.Scale);
+			Assert.Equal(2d, second.Scale);
+		}
+
+		[Fact]
 		//https://bugzilla.xamarin.com/show_bug.cgi?id=28556
 		public void TriggersAppliedAfterSetters()
 		{

--- a/src/Controls/tests/Core.UnitTests/TriggerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/TriggerTests.cs
@@ -9,6 +9,52 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		{
 		}
 
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public void TriggerSpecificityIsAllocatedOnAttachAndReused(bool initiallyActive)
+		{
+			var element = new MockElement { IsEnabled = !initiallyActive };
+			var trigger = new Trigger(typeof(VisualElement))
+			{
+				Property = VisualElement.IsEnabledProperty,
+				Value = false,
+				Setters = {
+					new Setter { Property = VisualElement.ScaleProperty, Value = 2d },
+				}
+			};
+
+			Assert.Null(element._triggerSpecificity);
+			element.Triggers.Add(trigger);
+			var specificities = element._triggerSpecificity;
+			Assert.NotNull(specificities);
+			Assert.Same(trigger, Assert.Single(specificities).Key);
+			Assert.Equal(initiallyActive ? 2d : 1d, element.Scale);
+
+			element.IsEnabled = true;
+			Assert.Equal(1d, element.Scale);
+			element.IsEnabled = false;
+			Assert.Equal(2d, element.Scale);
+			Assert.Same(specificities, element._triggerSpecificity);
+
+			element.Triggers.Remove(trigger);
+			Assert.Empty(specificities);
+			Assert.Equal(1d, element.Scale);
+			element.IsEnabled = true;
+			element.IsEnabled = false;
+			Assert.Equal(1d, element.Scale);
+
+			element.Triggers.Add(trigger);
+			Assert.Same(specificities, element._triggerSpecificity);
+			Assert.Same(trigger, Assert.Single(specificities).Key);
+			Assert.Equal(2d, element.Scale);
+
+			element.Triggers.Clear();
+			Assert.Same(specificities, element._triggerSpecificity);
+			Assert.Empty(specificities);
+			Assert.Equal(1d, element.Scale);
+		}
+
 		[Fact]
 		public void SettersAppliedOnConditionChanged()
 		{


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Targets **net11.0** intentionally: its trigger consumers already support lazy storage.

Remove the eager `_triggerSpecificity` initializer from `BindableObject`. The existing `TriggerBase` attachment path allocates storage before condition setup, even when the condition is initially false. Objects without condition-bearing triggers, including those using only `EventTrigger`, no longer allocate the unused dictionary. Detach/reattach continues to reuse allocated storage; no consumer or public API changes.

Add regression coverage for unused storage, initially true/false conditions, condition changes, detach/reattach/clear, shared-style isolation and trigger precedence, and `EventTrigger` behavior.

Direct source-built host tests: **214 passed / 5 expected null-storage failures before the fix; 219 passed / 0 failed afterward**, including trigger, data-trigger, multi-trigger, style and bindable-object coverage. The verification wrapper could not resolve the test project; these results come from explicit `dotnet test` runs.

The existing `CreateManyLabels_NoTriggers` benchmark measured approximately **80 B less managed allocation per label** on macOS Arm64 with .NET 11 preview 7 (Release, BenchmarkDotNet short in-process job). This is warmed host allocation evidence, not retained-memory or phone startup/GC savings.

### Issues Fixed

Restores the lazy-allocation behavior from #34133, whose initializer removal was lost in the net11 merge #35932.