### PR TITLE
[Android] Fix blurry Material 3 images when scaled

### DIFF
--- a/src/Core/src/Handlers/Image/ImageHandler2.Android.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler2.Android.cs
@@ -9,7 +9,7 @@ internal class ImageHandler2 : ImageHandler
     {
         var imageView = new ShapeableImageView(MauiMaterialContextThemeWrapper.Create(Context));
 
-        // Disable the hardware layer to prevent high-resolution images from becoming blurry when scaled.
+        // Clear any forced per-view layer type (e.g. a hardware layer) to avoid blurry scaling when the view is transformed.
         imageView.SetLayerType(global::Android.Views.LayerType.None, null);
         // Enable view bounds adjustment on measure.
         // This allows the ImageView's OnMeasure method to account for the image's intrinsic

--- a/src/Core/src/Handlers/Image/ImageHandler2.Android.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler2.Android.cs
@@ -9,6 +9,8 @@ internal class ImageHandler2 : ImageHandler
     {
         var imageView = new ShapeableImageView(MauiMaterialContextThemeWrapper.Create(Context));
 
+        // Disable the hardware layer to prevent high-resolution images from becoming blurry when scaled.
+        imageView.SetLayerType(global::Android.Views.LayerType.None, null);
         // Enable view bounds adjustment on measure.
         // This allows the ImageView's OnMeasure method to account for the image's intrinsic
         // aspect ratio during measurement, which gives us more useful values during constrained

--- a/src/Core/tests/DeviceTests/Handlers/Image/ImageHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Image/ImageHandlerTests.Android.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Android.Graphics.Drawables;
 using Android.Widget;
+using Google.Android.Material.ImageView;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Xunit;
 
@@ -9,6 +10,20 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class ImageHandlerTests<TImageHandler, TStub>
 	{
+		[Fact]
+		public async Task ImageHandler2PlatformViewDoesNotUseHardwareLayer()
+		{
+			var image = new TStub();
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var handler = CreateHandler<ImageHandler2>(image);
+				var platformView = Assert.IsType<ShapeableImageView>(handler.PlatformView);
+
+				Assert.Equal(global::Android.Views.LayerType.None, platformView.LayerType);
+			});
+		}
+
 		[Fact]
 		public async Task UpdatingSourceWorks()
 		{

--- a/src/Core/tests/DeviceTests/Handlers/Image/ImageHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Image/ImageHandlerTests.Android.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Android.Graphics.Drawables;
 using Android.Widget;
 using Microsoft.Maui.DeviceTests.Stubs;
+using Google.Android.Material.ImageView;
 using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
@@ -102,6 +103,21 @@ namespace Microsoft.Maui.DeviceTests
 				});
 			});
 		}
+
+		[Fact]
+		public async Task ImageHandler2PlatformViewDoesNotUseHardwareLayer()
+		{
+			var image = new TStub();
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var handler = CreateHandler<ImageHandler2>(image);
+				var platformView = Assert.IsType<ShapeableImageView>(handler.PlatformView);
+
+				Assert.Equal(global::Android.Views.LayerType.None, platformView.LayerType);
+			});
+		}
+
 
 		ImageView GetPlatformImageView(IImageHandler imageHandler) =>
 			imageHandler.PlatformView;

--- a/src/Core/tests/DeviceTests/Handlers/Image/ImageHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Image/ImageHandlerTests.Android.cs
@@ -2,7 +2,6 @@ using System;
 using System.Threading.Tasks;
 using Android.Graphics.Drawables;
 using Android.Widget;
-using Google.Android.Material.ImageView;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Xunit;
 
@@ -10,20 +9,6 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class ImageHandlerTests<TImageHandler, TStub>
 	{
-		[Fact]
-		public async Task ImageHandler2PlatformViewDoesNotUseHardwareLayer()
-		{
-			var image = new TStub();
-
-			await InvokeOnMainThreadAsync(() =>
-			{
-				var handler = CreateHandler<ImageHandler2>(image);
-				var platformView = Assert.IsType<ShapeableImageView>(handler.PlatformView);
-
-				Assert.Equal(global::Android.Views.LayerType.None, platformView.LayerType);
-			});
-		}
-
 		[Fact]
 		public async Task UpdatingSourceWorks()
 		{


### PR DESCRIPTION
<!-- Please keep the note below for people who find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment whether this change resolves your issue. Thank you!


### Rootcause: 
On Android with Material 3 enabled, high-resolution images displayed using the MAUI Image control appear blurry when zoomed. The issue does not occur with Material 3 disabled because the standard handler uses `AppCompatImageView`, which does not force a dedicated hardware layer.

### Description of Change
Updated `ImageHandler2` to set the `ShapeableImageView` layer type to `LAYER_TYPE_NONE`. This restores Android’s normal view rendering without disabling application-level hardware acceleration, while preserving `ShapeableImageView` and Material 3 functionality
<!-- Enter description of the fix in this section -->

### Why test not Added ?
A visual test using the .NET Bot image was evaluated on a Pixel 3 XL, but it passed with and without the fix because the screenshots did not show a measurable difference. Since it did not reliably detect the regression, it was not added. The fix was validated manually using a high-resolution document image with fine details.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #38298 

### Tested the behavior in the following platforms

- [ ] Windows
- [x] Android
- [ ] iOS
- [ ] Mac


| Before Issue Fix | After Issue Fix |
|----------|----------|
| <img width="1080" height="2400" alt="Beforefix38298" src="https://github.com/user-attachments/assets/7e813199-f910-4c6a-8226-0875ea89b434" /> | <img width="1080" height="2400" alt="AfterFixBlur" src="https://github.com/user-attachments/assets/2dc27067-087c-441a-bcf3-7528fec0f62c" />|
<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
