### PR TITLE
Repair Resizetizer integration tests

### DIFF
--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/ResizetizerTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/ResizetizerTests.cs
@@ -13,23 +13,26 @@ public class ResizetizerTests : BaseBuildTest
 		</svg>
 		""";
 
+	static string AppleArchitecture => TestEnvironment.IsArm64 ? "arm64" : "x64";
+
+	static string WindowsRuntimeIdentifier => TestEnvironment.IsArm64 ? "win-arm64" : "win-x64";
+
 	[Theory]
 	// windows unpackaged/exe
-	[InlineData("maui", "classlib", true)] // net9.0
-	[InlineData("maui", "mauilib", true)] // net9.0-xxx
-	[InlineData("maui-blazor", "classlib", true)] // net9.0
-	[InlineData("maui-blazor", "mauilib", true)] // net9.0-xxx
-											   // windows packaged/msix
-	[InlineData("maui", "classlib", false)] // net9.0
-	[InlineData("maui", "mauilib", false)] // net9.0-xxx
-	[InlineData("maui-blazor", "classlib", false)] // net9.0
-	[InlineData("maui-blazor", "mauilib", false)] // net9.0-xxx
+	[InlineData("maui", "classlib", true)]
+	[InlineData("maui", "mauilib", true)]
+	[InlineData("maui-blazor", "classlib", true)]
+	[InlineData("maui-blazor", "mauilib", true)]
+	// windows packaged/msix
+	[InlineData("maui", "classlib", false)]
+	[InlineData("maui", "mauilib", false)]
+	[InlineData("maui-blazor", "classlib", false)]
+	[InlineData("maui-blazor", "mauilib", false)]
 	public void CollectsAssets(string id, string libid, bool unpackaged)
 	{
 		SetTestIdentifier(id, libid, unpackaged);
-		// TODO: fix the tests as they have been disabled too long!
 		if (!TestEnvironment.IsWindows)
-			if (true) return; // Skip: "Running Windows templates is only supported on Windows."
+			throw SkipException.ForSkip("Running Windows templates is only supported on Windows.");
 
 		// new app
 		var appDir = Path.Combine(TestDirectory, "theapp");
@@ -54,17 +57,11 @@ public class ResizetizerTests : BaseBuildTest
 			""");
 
 		// toggle packaged / unpackaged
-		if (unpackaged)
+		if (!unpackaged)
 		{
 			FileUtilities.ReplaceInFile(appFile,
-				"</Project>",
-				"""
-				<PropertyGroup>
-					<WindowsPackageType>None</WindowsPackageType>
-				</PropertyGroup>
-				</Project>
-				""");
-
+				"<WindowsPackageType>None</WindowsPackageType>",
+				"");
 		}
 
 		// add the svg file
@@ -84,20 +81,17 @@ public class ResizetizerTests : BaseBuildTest
 			</Project>
 			""");
 
-		// build
-		Assert.True(DotnetInternal.Build(appFile, "Debug", properties: BuildProps, output: _output),
-			$"Project {Path.GetFileName(appFile)} failed to build. Check test output/attachments for errors.");
+		BuildResizetizerTargets(appFile);
 
 		// assert
 		Assert.True(File.Exists(Path.Combine(appDir, $"obj\\Debug\\{DotNetCurrent}-android\\resizetizer\\r\\drawable-mdpi\\the_image.png")),
 			"Android was missing the image file.");
-		Assert.True(File.Exists(Path.Combine(appDir, $"obj\\Debug\\{DotNetCurrent}-ios\\iossimulator-x64\\resizetizer\\r\\the_image.png")),
+		Assert.True(File.Exists(Path.Combine(appDir, $"obj\\Debug\\{DotNetCurrent}-ios\\iossimulator-{AppleArchitecture}\\resizetizer\\r\\the_image.png")),
 			"iOS was missing the image file.");
-		Assert.True(File.Exists(Path.Combine(appDir, $"obj\\Debug\\{DotNetCurrent}-maccatalyst\\maccatalyst-x64\\resizetizer\\r\\the_image.png")),
+		Assert.True(File.Exists(Path.Combine(appDir, $"obj\\Debug\\{DotNetCurrent}-maccatalyst\\maccatalyst-{AppleArchitecture}\\resizetizer\\r\\the_image.png")),
 			"Mac Catalyst was missing the image file.");
-		if (TestEnvironment.IsWindows)
-			Assert.True(File.Exists(Path.Combine(appDir, $"obj\\Debug\\{DotNetCurrent}-windows10.0.19041.0\\win-x64\\resizetizer\\r\\the_image.scale-100.png")),
-				"Windows was missing the image file.");
+		Assert.True(File.Exists(Path.Combine(appDir, $"obj\\Debug\\{DotNetCurrent}-windows10.0.19041.0\\{WindowsRuntimeIdentifier}\\resizetizer\\r\\the_image.scale-100.png")),
+			"Windows was missing the image file.");
 	}
 
 	[Theory]
@@ -106,9 +100,8 @@ public class ResizetizerTests : BaseBuildTest
 	public void AdditionalPropertiesExcludesImage(string id, string libid, bool unpackaged)
 	{
 		SetTestIdentifier(id, libid, unpackaged);
-		// TODO: fix the tests as they have been disabled too long!
 		if (!TestEnvironment.IsWindows)
-			if (true) return; // Skip: "Running Windows templates is only supported on Windows."
+			throw SkipException.ForSkip("Running Windows templates is only supported on Windows.");
 
 		// new app
 		var appDir = Path.Combine(TestDirectory, "theapp");
@@ -133,16 +126,11 @@ public class ResizetizerTests : BaseBuildTest
 			""");
 
 		// toggle packaged / unpackaged
-		if (unpackaged)
+		if (!unpackaged)
 		{
 			FileUtilities.ReplaceInFile(appFile,
-				"</Project>",
-				"""
-				<PropertyGroup>
-					<WindowsPackageType>None</WindowsPackageType>
-				</PropertyGroup>
-				</Project>
-				""");
+				"<WindowsPackageType>None</WindowsPackageType>",
+				"");
 		}
 
 		// add the svg file to the library
@@ -163,16 +151,13 @@ public class ResizetizerTests : BaseBuildTest
 			</Project>
 			""");
 
-		// build
-		Assert.True(DotnetInternal.Build(appFile, "Debug", properties: BuildProps, output: _output),
-			$"Project {Path.GetFileName(appFile)} failed to build. Check test output/attachments for errors.");
+		BuildResizetizerTargets(appFile);
 
 		// assert - the image should NOT be collected because AdditionalProperties excluded it
 		Assert.False(File.Exists(Path.Combine(appDir, $"obj\\Debug\\{DotNetCurrent}-android\\resizetizer\\r\\drawable-mdpi\\the_image.png")),
 			"Android should NOT have the image file (AdditionalProperties should have excluded it).");
-		if (TestEnvironment.IsWindows)
-			Assert.False(File.Exists(Path.Combine(appDir, $"obj\\Debug\\{DotNetCurrent}-windows10.0.19041.0\\win-x64\\resizetizer\\r\\the_image.scale-100.png")),
-				"Windows should NOT have the image file (AdditionalProperties should have excluded it).");
+		Assert.False(File.Exists(Path.Combine(appDir, $"obj\\Debug\\{DotNetCurrent}-windows10.0.19041.0\\{WindowsRuntimeIdentifier}\\resizetizer\\r\\the_image.scale-100.png")),
+			"Windows should NOT have the image file (AdditionalProperties should have excluded it).");
 	}
 
 	[Theory]
@@ -181,9 +166,8 @@ public class ResizetizerTests : BaseBuildTest
 	public void AdditionalPropertiesSelectsImageInLibrary(string id, string libid, bool unpackaged)
 	{
 		SetTestIdentifier(id, libid, unpackaged);
-		// TODO: fix the tests as they have been disabled too long!
 		if (!TestEnvironment.IsWindows)
-			if (true) return; // Skip: "Running Windows templates is only supported on Windows."
+			throw SkipException.ForSkip("Running Windows templates is only supported on Windows.");
 
 		// new app
 		var appDir = Path.Combine(TestDirectory, "theapp");
@@ -208,16 +192,11 @@ public class ResizetizerTests : BaseBuildTest
 			""");
 
 		// toggle packaged / unpackaged
-		if (unpackaged)
+		if (!unpackaged)
 		{
 			FileUtilities.ReplaceInFile(appFile,
-				"</Project>",
-				"""
-				<PropertyGroup>
-					<WindowsPackageType>None</WindowsPackageType>
-				</PropertyGroup>
-				</Project>
-				""");
+				"<WindowsPackageType>None</WindowsPackageType>",
+				"");
 		}
 
 		// add two svg files to the library — the property selects which one is included
@@ -239,9 +218,7 @@ public class ResizetizerTests : BaseBuildTest
 			</Project>
 			""");
 
-		// build
-		Assert.True(DotnetInternal.Build(appFile, "Debug", properties: BuildProps, output: _output),
-			$"Project {Path.GetFileName(appFile)} failed to build. Check test output/attachments for errors.");
+		BuildResizetizerTargets(appFile);
 
 		// assert - alternate_image should be collected (property was propagated)
 		Assert.True(File.Exists(Path.Combine(appDir, $"obj\\Debug\\{DotNetCurrent}-android\\resizetizer\\r\\drawable-mdpi\\alternate_image.png")),
@@ -249,12 +226,27 @@ public class ResizetizerTests : BaseBuildTest
 		// assert - default_image should NOT be collected (it was excluded by the property)
 		Assert.False(File.Exists(Path.Combine(appDir, $"obj\\Debug\\{DotNetCurrent}-android\\resizetizer\\r\\drawable-mdpi\\default_image.png")),
 			"Android should NOT have default_image — AdditionalProperties should have selected the alternate.");
-		if (TestEnvironment.IsWindows)
+		Assert.True(File.Exists(Path.Combine(appDir, $"obj\\Debug\\{DotNetCurrent}-windows10.0.19041.0\\{WindowsRuntimeIdentifier}\\resizetizer\\r\\alternate_image.scale-100.png")),
+			"Windows was missing alternate_image — AdditionalProperties was not propagated.");
+		Assert.False(File.Exists(Path.Combine(appDir, $"obj\\Debug\\{DotNetCurrent}-windows10.0.19041.0\\{WindowsRuntimeIdentifier}\\resizetizer\\r\\default_image.scale-100.png")),
+			"Windows should NOT have default_image — AdditionalProperties should have selected the alternate.");
+	}
+
+	void BuildResizetizerTargets(string projectFile)
+	{
+		var targetFrameworks = new[]
 		{
-			Assert.True(File.Exists(Path.Combine(appDir, $"obj\\Debug\\{DotNetCurrent}-windows10.0.19041.0\\win-x64\\resizetizer\\r\\alternate_image.scale-100.png")),
-				"Windows was missing alternate_image — AdditionalProperties was not propagated.");
-			Assert.False(File.Exists(Path.Combine(appDir, $"obj\\Debug\\{DotNetCurrent}-windows10.0.19041.0\\win-x64\\resizetizer\\r\\default_image.scale-100.png")),
-				"Windows should NOT have default_image — AdditionalProperties should have selected the alternate.");
+			$"{DotNetCurrent}-android",
+			$"{DotNetCurrent}-ios",
+			$"{DotNetCurrent}-maccatalyst",
+			$"{DotNetCurrent}-windows10.0.19041.0",
+		};
+
+		foreach (var targetFramework in targetFrameworks)
+		{
+			Assert.True(
+				DotnetInternal.Build(projectFile, "Debug", target: "ResizetizeImages", framework: targetFramework, properties: BuildProps, output: _output),
+				$"Project {Path.GetFileName(projectFile)} failed to run Resizetizer for {targetFramework}. Check test output/attachments for errors.");
 		}
 	}
 }

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/ResizetizerTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/ResizetizerTests.cs
@@ -1,5 +1,14 @@
 namespace Microsoft.Maui.IntegrationTests;
 
+sealed class WindowsOnlyTheoryAttribute : TheoryAttribute
+{
+	public WindowsOnlyTheoryAttribute()
+	{
+		if (!TestEnvironment.IsWindows)
+			Skip = "Running Windows templates is only supported on Windows.";
+	}
+}
+
 [Trait("Category", "Build")]
 public class ResizetizerTests : BaseBuildTest
 {
@@ -17,7 +26,7 @@ public class ResizetizerTests : BaseBuildTest
 
 	static string WindowsRuntimeIdentifier => TestEnvironment.IsArm64 ? "win-arm64" : "win-x64";
 
-	[Theory]
+	[WindowsOnlyTheory]
 	// windows unpackaged/exe
 	[InlineData("maui", "classlib", true)]
 	[InlineData("maui", "mauilib", true)]
@@ -31,8 +40,6 @@ public class ResizetizerTests : BaseBuildTest
 	public void CollectsAssets(string id, string libid, bool unpackaged)
 	{
 		SetTestIdentifier(id, libid, unpackaged);
-		if (!TestEnvironment.IsWindows)
-			throw SkipException.ForSkip("Running Windows templates is only supported on Windows.");
 
 		// new app
 		var appDir = Path.Combine(TestDirectory, "theapp");
@@ -94,14 +101,12 @@ public class ResizetizerTests : BaseBuildTest
 			"Windows was missing the image file.");
 	}
 
-	[Theory]
+	[WindowsOnlyTheory]
 	[InlineData("maui", "mauilib", true)]
 	[InlineData("maui", "mauilib", false)]
 	public void AdditionalPropertiesExcludesImage(string id, string libid, bool unpackaged)
 	{
 		SetTestIdentifier(id, libid, unpackaged);
-		if (!TestEnvironment.IsWindows)
-			throw SkipException.ForSkip("Running Windows templates is only supported on Windows.");
 
 		// new app
 		var appDir = Path.Combine(TestDirectory, "theapp");
@@ -160,14 +165,12 @@ public class ResizetizerTests : BaseBuildTest
 			"Windows should NOT have the image file (AdditionalProperties should have excluded it).");
 	}
 
-	[Theory]
+	[WindowsOnlyTheory]
 	[InlineData("maui", "mauilib", true)]
 	[InlineData("maui", "mauilib", false)]
 	public void AdditionalPropertiesSelectsImageInLibrary(string id, string libid, bool unpackaged)
 	{
 		SetTestIdentifier(id, libid, unpackaged);
-		if (!TestEnvironment.IsWindows)
-			throw SkipException.ForSkip("Running Windows templates is only supported on Windows.");
 
 		// new app
 		var appDir = Path.Combine(TestDirectory, "theapp");


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause

The tests were Windows-only NUnit tests that used `Assert.Ignore` on unsupported hosts. During the integration-test conversion to xUnit, those skips were mechanically replaced with `if (true) return`, which made unsupported runs report false passes and left the Windows execution path effectively unmaintained.

The template behavior had also changed since the tests were written: MAUI app templates are now unpackaged by default. The existing setup added another `WindowsPackageType=None` property for the unpackaged rows and did not remove the template property for packaged rows, so the two modes were no longer distinct.

### Description of Change

Repairs the Resizetizer integration tests so they genuinely execute on supported Windows environments:

- replaces silent early returns with real xUnit platform skips
- restores distinct packaged and unpackaged template setup
- invokes the focused `ResizetizeImages` target separately for Android, iOS, Mac Catalyst, and Windows, exercising image collection without coupling these tests to unrelated application compilation and packaging steps
- uses host-appropriate Apple and Windows runtime identifier output paths rather than assuming x64
- preserves the existing asset collection and `ProjectReference` `AdditionalProperties` assertions

The three repaired test methods execute 12 theory rows and run Resizetizer for all four target platforms in each row.

### Test Results

- Resizetizer tests: 12 passed, 0 failed, 0 skipped
- Related Build-category baseline: 4 passed, 0 failed, 0 skipped

### Issues Fixed

Repairs integration-test candidate #19; no GitHub issue is linked.