### PR TITLE
Fix .NET 9 integration tests after the servicing SDK update

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -13,6 +13,10 @@
     <add key="darc-pub-dotnet-dotnet-e17b0d0" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-dotnet-e17b0d08/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-dotnet -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
+    <!-- .NET 9 integration tests need the 9.0.21 targeting/runtime packs requested by the .NET 10 servicing SDK. -->
+    <add key="darc-pub-dotnet-aspnetcore-58518050" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspnetcore-58518050/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-runtime-db534f81" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-db534f81/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-windowsdesktop-0bd7f472" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-windowsdesktop-0bd7f472/nuget/v3/index.json" />
     <add key="local" value="LOCAL_PLACEHOLDER" />
     <add key="nuget-only" value="NUGET_ONLY_PLACEHOLDER" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" protocolVersion="3" />

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/DotnetInternal.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/DotnetInternal.cs
@@ -58,6 +58,9 @@ namespace Microsoft.Maui.IntegrationTests
 				// affect only C# compiler warnings).
 				buildArgs += " -warnaserror";
 
+				// Previous-.NET compatibility tests intentionally exercise workloads after end of support.
+				buildArgs += " -warnnotaserror:NETSDK1202";
+
 				// However, we need to ignore specific MSBuild warnings that are acceptable in these tests:
 				var csWarningsToIgnore = new List<string>
 				{


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Address both .NET 9 integration-test failures exposed by the servicing SDK update in #38318, while preserving its SDK/dependency upgrades:

- Add the public ASP.NET Core, runtime, and Windows Desktop servicing feeds containing the **9.0.21** targeting/runtime packs. Keep these sources outside the Dependency Flow-managed block.
- In the integration-test build helper, retain the `NETSDK1202` workload end-of-support diagnostic as a **warning**, rather than promoting it to an error with `-warnaserror`. The compatibility matrix intentionally exercises previous .NET workloads. Other warnings remain errors; no test cases are skipped, and shipped templates/support policy are unchanged.

The installed SDK is now `10.0.113-servicing.26454.107`. When targeting `net9.0`, it requests 9.0.21 packs, but the new .NET 10 coherent feed supplies 10.0.13 packages and none of the previously configured sources supplies the required 9.0.21 packs. Adding the general `dotnet9` feed alone would not help: it does not contain these servicing versions.

The same 26 unique .NET 9 integration cases failed on [main build 1587498](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1587498) and [inflight/candidate build 1587610](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1587610). These builds also reported `NETSDK1202` for `net9.0-android`.

### Validation

**Final [maui-pr build 1589411](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1589411) succeeded on commit `d6ed823714`: all 26 jobs passed, with no failed, canceled, pending, or skipped jobs.** Build Analysis and Build Insights also passed.

The actual test logs confirm all four affected integration jobs passed, with no missing-package or fatal EOL errors:

| Integration job | Passed | Failed | Skipped |
| --- | ---: | ---: | ---: |
| [Build macOS](https://dev.azure.com/dnceng-public/public/_apis/build/builds/1589411/logs/965?api-version=7.1) | 67 | 0 | 0 |
| [Build windows](https://dev.azure.com/dnceng-public/public/_apis/build/builds/1589411/logs/956?api-version=7.1) | 67 | 0 | 0 |
| [WindowsTemplates](https://dev.azure.com/dnceng-public/public/_apis/build/builds/1589411/logs/909?api-version=7.1) | 29 | 0 | 0 |
| [RunOnAndroid](https://dev.azure.com/dnceng-public/public/_apis/build/builds/1589411/logs/900?api-version=7.1) | 11 | 0 | 0 |

An isolated restore using the repository's NuGet.config reproduced `NU1102` before the feed change for all six package IDs below at exactly `9.0.21`. The same restore succeeded afterward; package metadata confirms the intended public sources.

- `Microsoft.AspNetCore.App.Ref`
- `Microsoft.WindowsDesktop.App.Ref`
- `Microsoft.NETCore.App.Ref`
- `Microsoft.NETCore.App.Host.win-x64`
- `Microsoft.NETCore.App.Runtime.win-x64`
- `Microsoft.NETCore.App.Crossgen2.win-x64`

The first [PR CI build, 1589155](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1589155), confirmed the completed affected integration logs no longer contained missing-package errors. RunOnAndroid passed all 11 cases. Build macOS and WindowsTemplates still failed because they promoted `NETSDK1202` to an error, motivating the test-helper follow-up.

For that follow-up, the real .NET SDK `_CheckForEolWorkloads` target fails under `-warnaserror` and succeeds, with the warning still printed, when adding `-warnnotaserror:NETSDK1202`. An unrelated control warning still fails. Verified with installed .NET 10 and .NET 11 MSBuild; the integration harness compiles successfully with .NET 10.

### Issues Fixed

Fixes the main and inflight/candidate integration regression introduced by #38318. No separate issue was supplied. No other open PR referencing #38318, 9.0.21, or NETSDK1202 was found when preparing the fixes.