### PR TITLE
Use weak events for GradientBrush gradient stop subscriptions

### DIFF
--- a/src/Controls/src/Core/GradientBrush.cs
+++ b/src/Controls/src/Core/GradientBrush.cs
@@ -1,5 +1,6 @@
 #nullable disable
 using System;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
 
@@ -9,10 +10,32 @@ namespace Microsoft.Maui.Controls
 	[ContentProperty(nameof(GradientStops))]
 	public abstract class GradientBrush : Brush
 	{
+		// A GradientStopCollection and the stops inside it can outlive the brush that consumes them --
+		// for example when they are declared in a ResourceDictionary and shared between brushes, or
+		// simply kept alive by the app while the page that owned the brush is discarded. Both the
+		// collection subscription and the per-stop subscriptions are therefore made weakly, so a
+		// long-lived collection or stop never roots a transient brush.
+		WeakNotifyCollectionChangedProxy _gradientStopsProxy;
+		NotifyCollectionChangedEventHandler _gradientStopsChanged;
+		PropertyChangedEventHandler _gradientStopPropertyChanged;
+
+		// Tracks the stops we are currently subscribed to. A Reset (raised by GradientStopCollection.Clear)
+		// supplies no OldItems and the collection has already been emptied by the time we are notified,
+		// so this is the only record of which stops still need to be detached.
+		readonly Dictionary<GradientStop, WeakNotifyPropertyChangedProxy> _subscribedStops = new();
+
 		/// <summary>Initializes a new instance of the <see cref="GradientBrush"/> class.</summary>
 		public GradientBrush()
 		{
 			GradientStops = new GradientStopCollection();
+		}
+
+		~GradientBrush()
+		{
+			_gradientStopsProxy?.Unsubscribe();
+
+			foreach (var proxy in _subscribedStops.Values)
+				proxy.Unsubscribe();
 		}
 
 		public event EventHandler InvalidateGradientBrushRequested;
@@ -49,57 +72,99 @@ namespace Microsoft.Maui.Controls
 		{
 			if (oldCollection != null)
 			{
-				oldCollection.CollectionChanged -= OnGradientStopCollectionChanged;
-
-				foreach (var oldStop in oldCollection)
-				{
-					oldStop.Parent = null;
-					oldStop.PropertyChanged -= OnGradientStopPropertyChanged;
-				}
+				_gradientStopsProxy?.Unsubscribe();
+				DetachAllStops();
 			}
 
 			if (newCollection == null)
 				return;
 
-			newCollection.CollectionChanged += OnGradientStopCollectionChanged;
+			_gradientStopsProxy ??= new WeakNotifyCollectionChangedProxy();
+			_gradientStopsChanged ??= OnGradientStopCollectionChanged;
+			_gradientStopsProxy.Subscribe(newCollection, _gradientStopsChanged);
 
 			foreach (var newStop in newCollection)
-			{
-				if (newStop is not null)
-				{
-					newStop.Parent = this;
-					newStop.PropertyChanged += OnGradientStopPropertyChanged;
-				}
-			}
+				AttachStop(newStop);
 		}
 
 		void OnGradientStopCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
-			if (e.OldItems != null)
+			if (e.Action == NotifyCollectionChangedAction.Reset)
 			{
-				foreach (var oldItem in e.OldItems)
-				{
-					if (!(oldItem is GradientStop oldStop))
-						continue;
+				// Clear() raises a Reset with no OldItems, so detach everything we know about and
+				// rebuild from whatever the collection holds now.
+				DetachAllStops();
 
-					oldStop.Parent = null;
-					oldStop.PropertyChanged -= OnGradientStopPropertyChanged;
+				if (sender is GradientStopCollection collection)
+				{
+					foreach (var stop in collection)
+						AttachStop(stop);
 				}
 			}
-
-			if (e.NewItems != null)
+			else
 			{
-				foreach (var newItem in e.NewItems)
+				if (e.OldItems != null)
 				{
-					if (!(newItem is GradientStop newStop))
-						continue;
+					foreach (var oldItem in e.OldItems)
+					{
+						if (oldItem is GradientStop oldStop)
+							DetachStop(oldStop, sender as GradientStopCollection);
+					}
+				}
 
-					newStop.Parent = this;
-					newStop.PropertyChanged += OnGradientStopPropertyChanged;
+				if (e.NewItems != null)
+				{
+					foreach (var newItem in e.NewItems)
+					{
+						if (newItem is GradientStop newStop)
+							AttachStop(newStop);
+					}
 				}
 			}
 
 			Invalidate();
+		}
+
+		void AttachStop(GradientStop stop)
+		{
+			if (stop is null || _subscribedStops.ContainsKey(stop))
+				return;
+
+			stop.Parent = this;
+
+			_gradientStopPropertyChanged ??= OnGradientStopPropertyChanged;
+
+			var proxy = new WeakNotifyPropertyChangedProxy();
+			proxy.Subscribe(stop, _gradientStopPropertyChanged);
+			_subscribedStops[stop] = proxy;
+		}
+
+		void DetachStop(GradientStop stop, GradientStopCollection collection)
+		{
+			if (stop is null)
+				return;
+
+			// The same stop instance may legally appear more than once in a collection; only tear the
+			// subscription down once the last occurrence has gone.
+			if (collection is not null && collection.Contains(stop))
+				return;
+
+			if (_subscribedStops.Remove(stop, out var proxy))
+			{
+				proxy.Unsubscribe();
+				stop.Parent = null;
+			}
+		}
+
+		void DetachAllStops()
+		{
+			foreach (var pair in _subscribedStops)
+			{
+				pair.Value.Unsubscribe();
+				pair.Key.Parent = null;
+			}
+
+			_subscribedStops.Clear();
 		}
 
 		void OnGradientStopPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -25,3 +25,4 @@ override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.OnH
 override Microsoft.Maui.Controls.Handlers.Items.MauiRecyclerView<TItemsView, TAdapter, TItemsViewSource>.OnSizeChanged(int w, int h, int oldw, int oldh) -> void
 ~override Microsoft.Maui.Controls.SwipeItems.OnPropertyChanged(string propertyName = null) -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
+Microsoft.Maui.Controls.GradientBrush.~GradientBrush() -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -16,3 +16,4 @@ override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
+Microsoft.Maui.Controls.GradientBrush.~GradientBrush() -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -16,3 +16,4 @@ override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
+Microsoft.Maui.Controls.GradientBrush.~GradientBrush() -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -5,3 +5,4 @@ override Microsoft.Maui.Controls.GraphicsView.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
 ~override Microsoft.Maui.Controls.SwipeItems.OnPropertyChanged(string propertyName = null) -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
+Microsoft.Maui.Controls.GradientBrush.~GradientBrush() -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -7,3 +7,4 @@ override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.Handlers.Items.CarouselViewHandler.UpdateEmptyViewVisibility() -> void
 ~override Microsoft.Maui.Controls.SwipeItems.OnPropertyChanged(string propertyName = null) -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
+Microsoft.Maui.Controls.GradientBrush.~GradientBrush() -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -5,3 +5,4 @@ override Microsoft.Maui.Controls.GraphicsView.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
 ~override Microsoft.Maui.Controls.SwipeItems.OnPropertyChanged(string propertyName = null) -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
+Microsoft.Maui.Controls.GradientBrush.~GradientBrush() -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -5,3 +5,4 @@ override Microsoft.Maui.Controls.GraphicsView.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
 ~override Microsoft.Maui.Controls.SwipeItems.OnPropertyChanged(string propertyName = null) -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
+Microsoft.Maui.Controls.GradientBrush.~GradientBrush() -> void

--- a/src/Controls/tests/Core.UnitTests/GradientBrushTests.cs
+++ b/src/Controls/tests/Core.UnitTests/GradientBrushTests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Microsoft.Maui.Graphics;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	public class GradientBrushTests : BaseTestFixture
+	{
+		// A GradientStopCollection that outlives the brush must not root it through CollectionChanged.
+		// The collection is left empty so that GradientStop.Parent (a strong reference by design) cannot
+		// mask the subscription being tested.
+		// https://github.com/dotnet/maui/issues/37581
+		[Fact]
+		public async Task SharedEmptyCollectionDoesNotRootBrush()
+		{
+			var shared = new GradientStopCollection();
+
+			var reference = CreateBrush(shared);
+
+			Assert.False(await reference.WaitForCollect(), "GradientBrush should not be alive!");
+			GC.KeepAlive(shared);
+		}
+
+		// When several brushes share one collection, every brush but the last hands GradientStop.Parent
+		// over to its successor, so nothing but the stop's PropertyChanged subscription can retain it.
+		// https://github.com/dotnet/maui/issues/37581
+		[Fact]
+		public async Task SharedPopulatedCollectionDoesNotRootDiscardedBrush()
+		{
+			var shared = new GradientStopCollection
+			{
+				new GradientStop { Color = Colors.Red, Offset = 0.0f },
+				new GradientStop { Color = Colors.Blue, Offset = 1.0f }
+			};
+
+			var reference = CreateBrush(shared);
+
+			// A second brush takes ownership of the stops (Parent), leaving the first retained only by
+			// the events it subscribed to.
+			var successor = new LinearGradientBrush { GradientStops = shared };
+
+			Assert.False(await reference.WaitForCollect(), "Discarded GradientBrush should not be alive!");
+			GC.KeepAlive(shared);
+			GC.KeepAlive(successor);
+		}
+
+		// Clear() raises a Reset with no OldItems; the stops it removed must still be detached.
+		// https://github.com/dotnet/maui/issues/38179
+		[Fact]
+		public async Task RetainedStopDoesNotRootBrushAfterClear()
+		{
+			var retainedStop = new GradientStop { Color = Colors.Red, Offset = 0.0f };
+
+			var reference = CreateBrushAndClear(retainedStop);
+
+			Assert.False(await reference.WaitForCollect(), "GradientBrush should not be alive after Clear!");
+			GC.KeepAlive(retainedStop);
+		}
+
+		[Fact]
+		public void ClearDetachesStopParent()
+		{
+			var stop = new GradientStop { Color = Colors.Red, Offset = 0.0f };
+			var brush = new LinearGradientBrush();
+			brush.GradientStops.Add(stop);
+
+			Assert.Same(brush, stop.Parent);
+
+			brush.GradientStops.Clear();
+
+			Assert.Null(stop.Parent);
+		}
+
+		[Fact]
+		public void ClearStopsInvalidationFromRemovedStop()
+		{
+			var stop = new GradientStop { Color = Colors.Red, Offset = 0.0f };
+			var brush = new LinearGradientBrush();
+			brush.GradientStops.Add(stop);
+			brush.GradientStops.Clear();
+
+			bool invalidated = false;
+			brush.InvalidateGradientBrushRequested += (s, e) => invalidated = true;
+
+			stop.Color = Colors.Blue;
+
+			Assert.False(invalidated);
+			GC.KeepAlive(brush);
+		}
+
+		// Guards the weak subscriptions actually still deliver events.
+		[Fact]
+		public void AttachedStopStillRaisesInvalidation()
+		{
+			var stop = new GradientStop { Color = Colors.Red, Offset = 0.0f };
+			var brush = new LinearGradientBrush();
+			brush.GradientStops.Add(stop);
+
+			bool invalidated = false;
+			brush.InvalidateGradientBrushRequested += (s, e) => invalidated = true;
+
+			stop.Color = Colors.Blue;
+
+			Assert.True(invalidated);
+			GC.KeepAlive(brush);
+		}
+
+		[Fact]
+		public void CollectionChangesStillRaiseInvalidation()
+		{
+			var brush = new LinearGradientBrush();
+
+			bool invalidated = false;
+			brush.InvalidateGradientBrushRequested += (s, e) => invalidated = true;
+
+			brush.GradientStops.Add(new GradientStop { Color = Colors.Red, Offset = 0.0f });
+
+			Assert.True(invalidated);
+			GC.KeepAlive(brush);
+		}
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		static WeakReference CreateBrush(GradientStopCollection stops) =>
+			new WeakReference(new LinearGradientBrush { GradientStops = stops });
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		static WeakReference CreateBrushAndClear(GradientStop stop)
+		{
+			var brush = new LinearGradientBrush();
+			brush.GradientStops.Add(stop);
+			brush.GradientStops.Clear();
+			return new WeakReference(brush);
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

`GradientBrush` subscribes to its `GradientStops` collection and to each `GradientStop` with plain CLR event handlers, and only unsubscribes when the `GradientStops` property is replaced. A `GradientStopCollection` (or an individual stop) that outlives the brush therefore keeps the brush — and everything it references — alive.

There are two distinct retention paths:

1. **The collection.** `UpdateGradientStops` did `newCollection.CollectionChanged += OnGradientStopCollectionChanged`. A long-lived collection, for example one declared in a `ResourceDictionary` and shared between brushes, roots every transient brush ever assigned it.

2. **The stops, after `Clear()`.** `OnGradientStopCollectionChanged` detached handlers only from `e.OldItems`. `ObservableCollection.Clear()` raises a `Reset`, which carries no `OldItems`, so the removed stops kept both their `PropertyChanged` subscription and their `Parent` back-reference to the brush.

This change routes both subscriptions through the existing weak-event primitives in `src/Controls/src/Core/Internals/WeakEventProxy.cs` (`WeakNotifyCollectionChangedProxy` / `WeakNotifyPropertyChangedProxy`), following the pattern already used by `Border` and `Shape`, and adds a finalizer that unsubscribes — as the proxy documentation requires.

Because a `Reset` reports no old items and arrives after the collection has already been emptied, the brush now tracks the stops it is subscribed to in a `Dictionary<GradientStop, WeakNotifyPropertyChangedProxy>`. That set is the only record of what still needs detaching on `Clear()`, and it also lets a stop that legitimately appears more than once in a collection be detached only when its last occurrence is gone.

Behaviour is otherwise unchanged: collection changes and stop property changes still raise `InvalidateGradientBrushRequested`, and stops attached to a brush still get their `Parent` set. Stops removed by `Clear()` now correctly have `Parent` reset to `null`, which previously leaked as a stale parent.

Note that `GradientStop.Parent` remains a strong reference by design, so the brush that currently owns a set of stops is still reachable from them; this change only stops *discarded* brushes from being retained.

### Tests

`src/Controls/tests/Core.UnitTests/GradientBrushTests.cs` adds:

- `SharedEmptyCollectionDoesNotRootBrush` — isolates the `CollectionChanged` path (empty collection, so `Parent` cannot mask it).
- `SharedPopulatedCollectionDoesNotRootDiscardedBrush` — a second brush takes over `Parent`, leaving the first retained only by its subscriptions.
- `RetainedStopDoesNotRootBrushAfterClear` — the `Reset`/`Clear()` path.
- `ClearDetachesStopParent` and `ClearStopsInvalidationFromRemovedStop` — behavioural cover for the `Reset` fix.
- `AttachedStopStillRaisesInvalidation` and `CollectionChangesStillRaiseInvalidation` — guard that the weak subscriptions still deliver events.

Verified by reverting `GradientBrush.cs` to its current state and re-running: the five leak/`Reset` tests fail, and the two invalidation guards pass. With the fix all 7 pass, and the full `Controls.Core.UnitTests` suite is green (5654 passed, 0 failed, 30 skipped).

### Issues Fixed

The leak scanner filed the shared-collection retention four separate times; all four describe the same two code paths fixed here.

Fixes #37581
Fixes #38164
Fixes #38179
Fixes #38283
