### PR TITLE
[Mac] Fix window freeze during repeated resizing

### DIFF
--- a/src/Core/src/Platform/iOS/WindowViewController.cs
+++ b/src/Core/src/Platform/iOS/WindowViewController.cs
@@ -94,6 +94,11 @@ internal class WindowViewController : UIViewController
 		base.ViewWillLayoutSubviews();
 	}
 
+	public override void ViewDidLayoutSubviews()
+	{
+		base.ViewDidLayoutSubviews();
+	}
+
 	/// <summary>
 	/// Sets up the TitleBar in the ViewController.
 	/// </summary>

--- a/src/Core/src/Platform/iOS/WindowViewController.cs
+++ b/src/Core/src/Platform/iOS/WindowViewController.cs
@@ -1,7 +1,6 @@
 #if MACCATALYST
 using System;
 using System.Diagnostics.CodeAnalysis;
-using CoreGraphics;
 using UIKit;
 using System.Threading.Tasks;
 
@@ -50,6 +49,8 @@ internal class WindowViewController : UIViewController
 			{
 				TranslatesAutoresizingMaskIntoConstraints = false
 			};
+
+			contentViewController.View.TranslatesAutoresizingMaskIntoConstraints = false;
 			View.AddSubview(_contentWrapperView);
 			_contentWrapperView.AddSubview(contentViewController.View);
 			_contentWrapperTopConstraint = _contentWrapperView.TopAnchor.ConstraintEqualTo(View.TopAnchor, 0);
@@ -59,7 +60,11 @@ internal class WindowViewController : UIViewController
 				_contentWrapperView.LeadingAnchor.ConstraintEqualTo(View.LeadingAnchor),
 				_contentWrapperView.TrailingAnchor.ConstraintEqualTo(View.TrailingAnchor),
 				_contentWrapperTopConstraint,
-				_contentWrapperView.BottomAnchor.ConstraintEqualTo(View.BottomAnchor)
+				_contentWrapperView.BottomAnchor.ConstraintEqualTo(View.BottomAnchor),
+				contentViewController.View.LeadingAnchor.ConstraintEqualTo(_contentWrapperView.LeadingAnchor),
+				contentViewController.View.TrailingAnchor.ConstraintEqualTo(_contentWrapperView.TrailingAnchor),
+				contentViewController.View.TopAnchor.ConstraintEqualTo(_contentWrapperView.TopAnchor),
+				contentViewController.View.BottomAnchor.ConstraintEqualTo(_contentWrapperView.BottomAnchor)
 			});
 
 		}
@@ -87,24 +92,6 @@ internal class WindowViewController : UIViewController
 	{
 		LayoutTitleBar();
 		base.ViewWillLayoutSubviews();
-	}
-
-	public override void ViewDidLayoutSubviews()
-	{
-		UpdateContentWrapperContentFrame();
-		base.ViewDidLayoutSubviews();
-	}
-
-	void UpdateContentWrapperContentFrame()
-	{
-		// At this point the _contentWrapperView bounds haven't been set
-		// so we just use the windows bounds to set this value
-		var frame = new CGRect(0, 0, View!.Bounds.Width, View!.Bounds.Height - (_contentWrapperTopConstraint?.Constant ?? 0));
-
-		if (_contentWrapperView is not null && _contentWrapperView.Subviews[0].Frame != frame)
-		{
-			_contentWrapperView.Subviews[0].Frame = frame;
-		}
 	}
 
 	/// <summary>
@@ -185,8 +172,6 @@ internal class WindowViewController : UIViewController
 		}
 
 		_contentWrapperTopConstraint.Constant = titleBarHeight;
-
-		UpdateContentWrapperContentFrame();
 	}
 
 	public void SetTitleBarVisibility(bool isVisible)


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
On Mac Catalyst, repeatedly resizing a .NET MAUI window vertically caused the window to become progressively slower and eventually freeze. The issue was initially reported with a CollectionView and navigation scenario, but further testing confirmed that it also reproduced with a simple Grid containing a Button and Label, a page containing only a Label, and an empty ContentPage. This confirmed that the issue was not specific to CollectionView, navigation, or individual controls.
 
### Root Cause
WindowViewController hosts the application's root view controller inside _contentWrapperView to position the content below an optional custom title bar. The wrapper was sized using Auto Layout, while the child view was also resized manually through UpdateContentWrapperContentFrame, which was called from both ViewDidLayoutSubviews and LayoutTitleBar. This caused repeated manual child-frame updates during window resizing. Removing only ViewDidLayoutSubviews did not resolve the issue because LayoutTitleBar continued to call UpdateContentWrapperContentFrame.

### Description of Change
The child view is now constrained to all four edges of _contentWrapperView, with TranslatesAutoresizingMaskIntoConstraints disabled. Auto Layout now handles resizing the child view when the wrapper changes size. The manual frame-sizing method UpdateContentWrapperContentFrame was removed. The existing title-bar behavior is preserved. LayoutTitleBar continues to measure the custom title bar and update _contentWrapperTopConstraint, while Auto Layout handles the wrapper and child view sizing.

### Why Tests Were Not Added
The issue occurs during repeated interactive resizing of a Mac Catalyst window and is related to performance and responsiveness. Existing automated tests cannot reliably reproduce this resize scenario or detect the progressive slowdown and freeze. Therefore, the fix was validated manually by comparing the behavior before and after the change.
 
### Issues Fixed
Fixes #37667

### Screenshots

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/a9445c2b-12cb-49c0-8970-2d4bbf047e25"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/b5b62c77-db67-4d03-affc-909db4c5cdd1"> |