### PR TITLE
[iOS] Fix modal page content not shown on subsequent navigation for singleton lifetime pages

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/iOS/DisposeHelpers.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/iOS/DisposeHelpers.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		{
 			if (view is Element rootElement && HandlerProperties.GetDisconnectPolicy(rootElement) == HandlerDisconnectPolicy.Manual)
 			{
+				DisposeModalWrapper(rootElement.Handler as IPlatformViewHandler);
 				return;
 			}
 
@@ -29,16 +30,23 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				renderer = (visualElement.Handler as IPlatformViewHandler);
 				if (renderer != null)
 				{
-					if (renderer.ViewController != null)
-					{
-						if (renderer.ViewController.ParentViewController is Platform.ControlsModalWrapper modalWrapper)
-							modalWrapper.Dispose();
-					}
+					DisposeModalWrapper(renderer);
 
 					renderer.PlatformView?.RemoveFromSuperview();
 
 					if (view.Handler is IDisposable disposable)
 						disposable.Dispose();
+				}
+			}
+		}
+
+		static void DisposeModalWrapper(IPlatformViewHandler renderer)
+		{
+			if (renderer?.ViewController is not null)
+			{
+				if (renderer.ViewController.ParentViewController is Platform.ControlsModalWrapper modalWrapper)
+				{
+					modalWrapper.Dispose();
 				}
 			}
 		}

--- a/src/Controls/src/Core/Compatibility/Handlers/iOS/DisposeHelpers.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/iOS/DisposeHelpers.cs
@@ -7,6 +7,11 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 	{
 		internal static void DisposeModalAndChildHandlers(this Maui.IElement view)
 		{
+			if (view is Element rootElement && HandlerProperties.GetDisconnectPolicy(rootElement) == HandlerDisconnectPolicy.Manual)
+			{
+				return;
+			}
+
 			IPlatformViewHandler renderer;
 			foreach (Element child in ((Element)view).Descendants())
 			{

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue38361.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue38361.cs
@@ -1,0 +1,82 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 38361, "A singleton modal page with a manual disconnect policy renders blank when presented a second time on iOS", PlatformAffected.iOS)]
+public class Issue38361 : TestShell
+{
+    const string ModalRoute = "Issue38361Modal";
+
+    protected override void Init()
+    {
+        Routing.RegisterRoute(ModalRoute, typeof(Issue38361ModalPage));
+
+        var mainPage = new ContentPage
+        {
+            Title = "Main",
+            Content = new VerticalStackLayout
+            {
+                Padding = 20,
+                Children =
+                {
+                    new Button
+                    {
+                        Text = "Show modal",
+                        AutomationId = "Issue38361ShowModalButton",
+                        Command = new Command(async () =>
+                            await Shell.Current.GoToAsync(ModalRoute))
+                    }
+                }
+            }
+        };
+
+        AddContentPage(mainPage, "Issue38361Main");
+    }
+}
+
+internal class Issue38361ModalPage : ContentPage
+{
+    public Issue38361ModalPage()
+    {
+        Title = "Modal";
+
+        HandlerProperties.SetDisconnectPolicy(
+            this,
+            HandlerDisconnectPolicy.Manual);
+
+        Shell.SetPresentationMode(
+            this,
+            PresentationMode.Modal);
+
+        Content = new VerticalStackLayout
+        {
+            Padding = 20,
+            Children =
+            {
+                new Label
+                {
+                    Text = "Modal content",
+                    AutomationId = "Issue38361ModalContent",
+                    FontSize = 24
+                },
+
+                new Button
+                {
+                    Text = "Dismiss modal",
+                    AutomationId = "Issue38361DismissModalButton",
+                    Command = new Command(async () =>
+                        await Shell.Current.GoToAsync(".."))
+                }
+            }
+        };
+    }
+}
+
+internal static class Issue38361Extensions
+{
+    public static MauiAppBuilder Issue38361RegisterServices(
+        this MauiAppBuilder builder)
+    {
+        builder.Services.AddSingleton<Issue38361ModalPage>();
+
+        return builder;
+    }
+}

--- a/src/Controls/tests/TestCases.HostApp/MauiProgram.cs
+++ b/src/Controls/tests/TestCases.HostApp/MauiProgram.cs
@@ -42,7 +42,8 @@ namespace Maui.Controls.Sample
 				.Issue18720TimePickerAddMappers()
 				.Issue28945AddMappers()
 				.Issue25436RegisterNavigationService()
-				.Issue36853RegisterServices();
+				.Issue36853RegisterServices()
+				.Issue38361RegisterServices();
 
 #if IOS || MACCATALYST
 			appBuilder.ConfigureCollectionViewHandlers();

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue38361.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue38361.cs
@@ -1,0 +1,35 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue38361 : _IssuesUITest
+{
+    public Issue38361(TestDevice testDevice) : base(testDevice)
+    {
+    }
+
+    public override string Issue =>
+        "A singleton modal page with a manual disconnect policy renders blank when presented a second time on iOS";
+
+    [Test]
+    [Category(UITestCategories.Shell)]
+    public void SingletonModalPageContentRemainsVisibleAfterSecondPresentation()
+    {
+        AssertModalContentIsVisible();
+
+        App.Tap("Issue38361DismissModalButton");
+        App.WaitForElement("Issue38361ShowModalButton");
+
+        AssertModalContentIsVisible();
+    }
+
+    void AssertModalContentIsVisible()
+    {
+        App.WaitForElement("Issue38361ShowModalButton");
+        App.Tap("Issue38361ShowModalButton");
+
+        App.WaitForElement("Issue38361ModalContent");
+    }
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details:

- On iOS, a modal page registered as a singleton and marked with HandlerDisconnectPolicy.Manual displays correctly only the first time. After dismissal, reopening the same modal instance shows blank content.

### Root Cause of the issue:
- PR [#35009](https://github.com/dotnet/maui/pull/35009) fixed an iOS modal memory leak by calling DisposeModalAndChildHandlers after every modal dismissal.
- DisposeModalAndChildHandlers unconditionally disconnects and disposes the modal's handlers without honoring HandlerDisconnectPolicy.Manual.
- As a result, the DI container retains the singleton managed page, but its handler and native view hierarchy have already been disposed. When the same page instance is presented again, its content is blank.

### Description of Change

**Bug fix for modal page rendering with manual disconnect policy:**

* Updated DisposeHelpers.DisposeModalAndChildHandlers to skip disposal when the modal root has a manual disconnect policy, preventing premature disposal of modal pages that should persist across presentations.


**Test coverage for the issue:**

* Added a new test case in `TestCases.HostApp/Issues/Issue38361.cs` to reproduce the modal rendering issue and ensure correct behavior when the modal is presented multiple times. This includes a main page to launch the modal, the modal page itself, and an extension to register the modal as a singleton service.
* Registered the new modal page service in `MauiProgram.cs` via the `Issue38361RegisterServices` extension, ensuring the singleton modal is available for the test.
* Added a UI test in `TestCases.Shared.Tests/Tests/Issues/Issue38361.cs` to verify that the modal content remains visible after being dismissed and presented again.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #38361 

### Tested the behavior in the following platforms
 
- [ ] Windows
- [ ] Android
- [x] iOS
- [x] Mac

### Output
 
| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/4a40db92-515e-433a-868e-131bc8b246ee"> | <video src="https://github.com/user-attachments/assets/5f464aa6-97b4-4d69-8b99-44c2a682ed45"> |








<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
