### PR TITLE
Use weak events for shape and geometry child collections

### DIFF
--- a/src/Controls/src/Core/Internals/WeakEventProxy.cs
+++ b/src/Controls/src/Core/Internals/WeakEventProxy.cs
@@ -202,6 +202,50 @@ namespace Microsoft.Maui.Controls
 	}
 
 	/// <summary>
+	/// A "proxy" class for subscribing PathFigure.InvalidatePathSegmentRequested via WeakReference.
+	/// General usage is to store this in a member variable and call Subscribe()/Unsubscribe() appropriately.
+	/// Your class should have a finalizer that calls Unsubscribe() to prevent WeakPathFigureInvalidateProxy objects from leaking.
+	/// </summary>
+	class WeakPathFigureInvalidateProxy : WeakEventProxy<PathFigure, EventHandler>
+	{
+		public WeakPathFigureInvalidateProxy() { }
+
+		void OnInvalidateRequested(object? sender, EventArgs e)
+		{
+			if (TryGetHandler(out var handler))
+			{
+				handler(sender, e);
+			}
+			else
+			{
+				Unsubscribe();
+			}
+		}
+
+		public override void Subscribe(PathFigure source, EventHandler handler)
+		{
+			if (TryGetSource(out var s))
+			{
+				s.InvalidatePathSegmentRequested -= OnInvalidateRequested;
+			}
+
+			source.InvalidatePathSegmentRequested += OnInvalidateRequested;
+
+			base.Subscribe(source, handler);
+		}
+
+		public override void Unsubscribe()
+		{
+			if (TryGetSource(out var s))
+			{
+				s.InvalidatePathSegmentRequested -= OnInvalidateRequested;
+			}
+
+			base.Unsubscribe();
+		}
+	}
+
+	/// <summary>
 	/// A "proxy" class for subscribing Geometry and PathGeometry invalidation via WeakReference.
 	/// General usage is to store this in a member variable and call Subscribe()/Unsubscribe() appropriately.
 	/// Your class should have a finalizer that calls Unsubscribe() to prevent WeakGeometryChangedProxy objects from leaking.

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -25,3 +25,7 @@ override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.OnH
 override Microsoft.Maui.Controls.Handlers.Items.MauiRecyclerView<TItemsView, TAdapter, TItemsViewSource>.OnSizeChanged(int w, int h, int oldw, int oldh) -> void
 ~override Microsoft.Maui.Controls.SwipeItems.OnPropertyChanged(string propertyName = null) -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
+Microsoft.Maui.Controls.Shapes.TransformGroup.~TransformGroup() -> void
+Microsoft.Maui.Controls.Shapes.GeometryGroup.~GeometryGroup() -> void
+Microsoft.Maui.Controls.Shapes.PathFigure.~PathFigure() -> void
+Microsoft.Maui.Controls.Shapes.PathGeometry.~PathGeometry() -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -16,3 +16,7 @@ override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
+Microsoft.Maui.Controls.Shapes.TransformGroup.~TransformGroup() -> void
+Microsoft.Maui.Controls.Shapes.GeometryGroup.~GeometryGroup() -> void
+Microsoft.Maui.Controls.Shapes.PathFigure.~PathFigure() -> void
+Microsoft.Maui.Controls.Shapes.PathGeometry.~PathGeometry() -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -16,3 +16,7 @@ override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
+Microsoft.Maui.Controls.Shapes.TransformGroup.~TransformGroup() -> void
+Microsoft.Maui.Controls.Shapes.GeometryGroup.~GeometryGroup() -> void
+Microsoft.Maui.Controls.Shapes.PathFigure.~PathFigure() -> void
+Microsoft.Maui.Controls.Shapes.PathGeometry.~PathGeometry() -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -5,3 +5,7 @@ override Microsoft.Maui.Controls.GraphicsView.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
 ~override Microsoft.Maui.Controls.SwipeItems.OnPropertyChanged(string propertyName = null) -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
+Microsoft.Maui.Controls.Shapes.TransformGroup.~TransformGroup() -> void
+Microsoft.Maui.Controls.Shapes.GeometryGroup.~GeometryGroup() -> void
+Microsoft.Maui.Controls.Shapes.PathFigure.~PathFigure() -> void
+Microsoft.Maui.Controls.Shapes.PathGeometry.~PathGeometry() -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -7,3 +7,7 @@ override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.Handlers.Items.CarouselViewHandler.UpdateEmptyViewVisibility() -> void
 ~override Microsoft.Maui.Controls.SwipeItems.OnPropertyChanged(string propertyName = null) -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
+Microsoft.Maui.Controls.Shapes.TransformGroup.~TransformGroup() -> void
+Microsoft.Maui.Controls.Shapes.GeometryGroup.~GeometryGroup() -> void
+Microsoft.Maui.Controls.Shapes.PathFigure.~PathFigure() -> void
+Microsoft.Maui.Controls.Shapes.PathGeometry.~PathGeometry() -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -5,3 +5,7 @@ override Microsoft.Maui.Controls.GraphicsView.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
 ~override Microsoft.Maui.Controls.SwipeItems.OnPropertyChanged(string propertyName = null) -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
+Microsoft.Maui.Controls.Shapes.TransformGroup.~TransformGroup() -> void
+Microsoft.Maui.Controls.Shapes.GeometryGroup.~GeometryGroup() -> void
+Microsoft.Maui.Controls.Shapes.PathFigure.~PathFigure() -> void
+Microsoft.Maui.Controls.Shapes.PathGeometry.~PathGeometry() -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -5,3 +5,7 @@ override Microsoft.Maui.Controls.GraphicsView.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
 ~override Microsoft.Maui.Controls.SwipeItems.OnPropertyChanged(string propertyName = null) -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
+Microsoft.Maui.Controls.Shapes.TransformGroup.~TransformGroup() -> void
+Microsoft.Maui.Controls.Shapes.GeometryGroup.~GeometryGroup() -> void
+Microsoft.Maui.Controls.Shapes.PathFigure.~PathFigure() -> void
+Microsoft.Maui.Controls.Shapes.PathGeometry.~PathGeometry() -> void

--- a/src/Controls/src/Core/Shapes/GeometryGroup.cs
+++ b/src/Controls/src/Core/Shapes/GeometryGroup.cs
@@ -12,7 +12,22 @@ namespace Microsoft.Maui.Controls.Shapes
 	[ContentProperty("Children")]
 	public class GeometryGroup : Geometry
 	{
-		readonly Dictionary<Geometry, int> _subscriptionRefCounts = new();
+		// A GeometryCollection and the geometries inside it can outlive the group that consumes them --
+		// for example when they are declared in a ResourceDictionary and shared between groups. Both the
+		// collection subscription and the per-geometry subscriptions are therefore weak, so a long-lived
+		// collection or geometry never roots a discarded GeometryGroup.
+		WeakNotifyCollectionChangedProxy _childrenProxy;
+		NotifyCollectionChangedEventHandler _childrenChanged;
+		PropertyChangedEventHandler _childPropertyChanged;
+		readonly Dictionary<Geometry, (int Count, WeakNotifyPropertyChangedProxy Proxy)> _subscriptionRefCounts = new();
+
+		~GeometryGroup()
+		{
+			_childrenProxy?.Unsubscribe();
+
+			foreach (var entry in _subscriptionRefCounts.Values)
+				entry.Proxy.Unsubscribe();
+		}
 
 		/// <summary>Bindable property for <see cref="Children"/>.</summary>
 		public static readonly BindableProperty ChildrenProperty =
@@ -69,7 +84,9 @@ namespace Microsoft.Maui.Controls.Shapes
 			if (collection == null)
 				return;
 
-			collection.CollectionChanged += OnChildrenCollectionChanged;
+			_childrenProxy ??= new WeakNotifyCollectionChangedProxy();
+			_childrenChanged ??= OnChildrenCollectionChanged;
+			_childrenProxy.Subscribe(collection, _childrenChanged);
 
 			foreach (var geometry in collection)
 			{
@@ -82,7 +99,7 @@ namespace Microsoft.Maui.Controls.Shapes
 			if (collection == null)
 				return;
 
-			collection.CollectionChanged -= OnChildrenCollectionChanged;
+			_childrenProxy?.Unsubscribe();
 
 			foreach (var geometry in collection)
 			{
@@ -162,14 +179,17 @@ namespace Microsoft.Maui.Controls.Shapes
 			if (geometry == null)
 				return;
 
-			if (_subscriptionRefCounts.TryGetValue(geometry, out var count))
+			if (_subscriptionRefCounts.TryGetValue(geometry, out var entry))
 			{
-				_subscriptionRefCounts[geometry] = count + 1;
+				_subscriptionRefCounts[geometry] = (entry.Count + 1, entry.Proxy);
 				return;
 			}
 
-			_subscriptionRefCounts[geometry] = 1;
-			geometry.PropertyChanged += OnChildrenPropertyChanged;
+			_childPropertyChanged ??= OnChildrenPropertyChanged;
+
+			var proxy = new WeakNotifyPropertyChangedProxy();
+			proxy.Subscribe(geometry, _childPropertyChanged);
+			_subscriptionRefCounts[geometry] = (1, proxy);
 		}
 
 		void UnsubscribeFromGeometry(Geometry geometry)
@@ -177,24 +197,24 @@ namespace Microsoft.Maui.Controls.Shapes
 			if (geometry == null)
 				return;
 
-			if (!_subscriptionRefCounts.TryGetValue(geometry, out var count))
+			if (!_subscriptionRefCounts.TryGetValue(geometry, out var entry))
 				return;
 
-			if (count > 1)
+			if (entry.Count > 1)
 			{
-				_subscriptionRefCounts[geometry] = count - 1;
+				_subscriptionRefCounts[geometry] = (entry.Count - 1, entry.Proxy);
 				return;
 			}
 
 			_subscriptionRefCounts.Remove(geometry);
-			geometry.PropertyChanged -= OnChildrenPropertyChanged;
+			entry.Proxy.Unsubscribe();
 		}
 
 		void UnsubscribeFromAllChildren()
 		{
-			foreach (var geometry in _subscriptionRefCounts.Keys)
+			foreach (var entry in _subscriptionRefCounts.Values)
 			{
-				geometry.PropertyChanged -= OnChildrenPropertyChanged;
+				entry.Proxy.Unsubscribe();
 			}
 
 			_subscriptionRefCounts.Clear();

--- a/src/Controls/src/Core/Shapes/PathFigure.cs
+++ b/src/Controls/src/Core/Shapes/PathFigure.cs
@@ -14,7 +14,14 @@ namespace Microsoft.Maui.Controls.Shapes
 	[ContentProperty("Segments")]
 	public sealed class PathFigure : BindableObject, IAnimatable
 	{
-		readonly List<PathSegment> _subscribedSegments = new();
+		// A PathSegmentCollection and the segments inside it can outlive the figure that consumes them --
+		// for example when they are declared in a ResourceDictionary and shared between figures. Both the
+		// collection subscription and the per-segment subscriptions are therefore weak, so a long-lived
+		// collection or segment never roots a discarded PathFigure.
+		WeakNotifyCollectionChangedProxy _segmentsProxy;
+		NotifyCollectionChangedEventHandler _segmentsChanged;
+		PropertyChangedEventHandler _segmentPropertyChanged;
+		readonly Dictionary<PathSegment, WeakNotifyPropertyChangedProxy> _subscribedSegments = new();
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="PathFigure"/> class.
@@ -22,6 +29,14 @@ namespace Microsoft.Maui.Controls.Shapes
 		public PathFigure()
 		{
 			Segments = new PathSegmentCollection();
+		}
+
+		~PathFigure()
+		{
+			_segmentsProxy?.Unsubscribe();
+
+			foreach (var proxy in _subscribedSegments.Values)
+				proxy.Unsubscribe();
 		}
 
 		/// <summary>Bindable property for <see cref="Segments"/>.</summary>
@@ -98,14 +113,16 @@ namespace Microsoft.Maui.Controls.Shapes
 
 		void UpdatePathSegmentCollection(PathSegmentCollection oldCollection, PathSegmentCollection newCollection)
 		{
-			oldCollection?.CollectionChanged -= OnPathSegmentCollectionChanged;
+			_segmentsProxy?.Unsubscribe();
 
 			UnsubscribeFromAllPathSegmentPropertyChanged();
 
 			if (newCollection == null)
 				return;
 
-			newCollection.CollectionChanged += OnPathSegmentCollectionChanged;
+			_segmentsProxy ??= new WeakNotifyCollectionChangedProxy();
+			_segmentsChanged ??= OnPathSegmentCollectionChanged;
+			_segmentsProxy.Subscribe(newCollection, _segmentsChanged);
 
 			foreach (var newPathSegment in newCollection)
 			{
@@ -117,10 +134,7 @@ namespace Microsoft.Maui.Controls.Shapes
 		{
 			if (e.Action == NotifyCollectionChangedAction.Reset)
 			{
-				for (int i = _subscribedSegments.Count - 1; i >= 0; i--)
-				{
-					UnsubscribeFromPathSegmentPropertyChanged(_subscribedSegments[i]);
-				}
+				UnsubscribeFromAllPathSegmentPropertyChanged();
 
 				if (sender is PathSegmentCollection pathSegmentCollection)
 				{
@@ -161,32 +175,36 @@ namespace Microsoft.Maui.Controls.Shapes
 
 		void SubscribeToPathSegmentPropertyChanged(PathSegment pathSegment)
 		{
-			if (_subscribedSegments.Contains(pathSegment))
+			if (pathSegment is null || _subscribedSegments.ContainsKey(pathSegment))
 			{
 				return;
 			}
 
-			pathSegment.PropertyChanged += OnPathSegmentPropertyChanged;
-			_subscribedSegments.Add(pathSegment);
+			_segmentPropertyChanged ??= OnPathSegmentPropertyChanged;
+
+			var proxy = new WeakNotifyPropertyChangedProxy();
+			proxy.Subscribe(pathSegment, _segmentPropertyChanged);
+			_subscribedSegments[pathSegment] = proxy;
 		}
 
 		void UnsubscribeFromPathSegmentPropertyChanged(PathSegment pathSegment)
 		{
-			if (!_subscribedSegments.Contains(pathSegment))
+			if (pathSegment is null || !_subscribedSegments.Remove(pathSegment, out var proxy))
 			{
 				return;
 			}
 
-			pathSegment.PropertyChanged -= OnPathSegmentPropertyChanged;
-			_subscribedSegments.Remove(pathSegment);
+			proxy.Unsubscribe();
 		}
 
 		void UnsubscribeFromAllPathSegmentPropertyChanged()
 		{
-			for (int i = _subscribedSegments.Count - 1; i >= 0; i--)
+			foreach (var proxy in _subscribedSegments.Values)
 			{
-				UnsubscribeFromPathSegmentPropertyChanged(_subscribedSegments[i]);
+				proxy.Unsubscribe();
 			}
+
+			_subscribedSegments.Clear();
 		}
 
 		void OnPathSegmentPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/Controls/src/Core/Shapes/PathGeometry.cs
+++ b/src/Controls/src/Core/Shapes/PathGeometry.cs
@@ -17,7 +17,16 @@ namespace Microsoft.Maui.Controls.Shapes
 		// Tracks figures whose PropertyChanged and InvalidatePathSegmentRequested events are
 		// subscribed so we can unsubscribe them even when the collection is cleared (Reset
 		// action does not populate OldItems).
-		readonly List<PathFigure> _subscribedFigures = new List<PathFigure>();
+		//
+		// A PathFigureCollection and the figures inside it can outlive the geometry that consumes them
+		// -- for example when they are declared in a ResourceDictionary and shared between geometries --
+		// so every subscription here is weak, and a long-lived collection or figure never roots a
+		// discarded PathGeometry.
+		WeakNotifyCollectionChangedProxy _figuresProxy;
+		NotifyCollectionChangedEventHandler _figuresChanged;
+		PropertyChangedEventHandler _figurePropertyChanged;
+		EventHandler _figureInvalidateRequested;
+		readonly Dictionary<PathFigure, (WeakNotifyPropertyChangedProxy PropertyChanged, WeakPathFigureInvalidateProxy Invalidate)> _subscribedFigures = new();
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="PathGeometry"/> class.
@@ -45,6 +54,17 @@ namespace Microsoft.Maui.Controls.Shapes
 		{
 			Figures = figures;
 			FillRule = fillRule;
+		}
+
+		~PathGeometry()
+		{
+			_figuresProxy?.Unsubscribe();
+
+			foreach (var proxies in _subscribedFigures.Values)
+			{
+				proxies.PropertyChanged.Unsubscribe();
+				proxies.Invalidate.Unsubscribe();
+			}
 		}
 
 		/// <summary>Bindable property for <see cref="Figures"/>.</summary>
@@ -205,24 +225,36 @@ namespace Microsoft.Maui.Controls.Shapes
 
 		void SubscribeFigure(PathFigure figure)
 		{
-			figure.PropertyChanged += OnPathFigurePropertyChanged;
-			figure.InvalidatePathSegmentRequested += OnInvalidatePathSegmentRequested;
-			_subscribedFigures.Add(figure);
+			if (figure is null || _subscribedFigures.ContainsKey(figure))
+				return;
+
+			_figurePropertyChanged ??= OnPathFigurePropertyChanged;
+			_figureInvalidateRequested ??= OnInvalidatePathSegmentRequested;
+
+			var propertyChangedProxy = new WeakNotifyPropertyChangedProxy();
+			propertyChangedProxy.Subscribe(figure, _figurePropertyChanged);
+
+			var invalidateProxy = new WeakPathFigureInvalidateProxy();
+			invalidateProxy.Subscribe(figure, _figureInvalidateRequested);
+
+			_subscribedFigures[figure] = (propertyChangedProxy, invalidateProxy);
 		}
 
 		void UnsubscribeFigure(PathFigure figure)
 		{
-			figure.PropertyChanged -= OnPathFigurePropertyChanged;
-			figure.InvalidatePathSegmentRequested -= OnInvalidatePathSegmentRequested;
-			_subscribedFigures.Remove(figure);
+			if (figure is null || !_subscribedFigures.Remove(figure, out var proxies))
+				return;
+
+			proxies.PropertyChanged.Unsubscribe();
+			proxies.Invalidate.Unsubscribe();
 		}
 
 		void UnsubscribeAllFigures()
 		{
-			foreach (var figure in _subscribedFigures)
+			foreach (var proxies in _subscribedFigures.Values)
 			{
-				figure.PropertyChanged -= OnPathFigurePropertyChanged;
-				figure.InvalidatePathSegmentRequested -= OnInvalidatePathSegmentRequested;
+				proxies.PropertyChanged.Unsubscribe();
+				proxies.Invalidate.Unsubscribe();
 			}
 			_subscribedFigures.Clear();
 		}
@@ -231,14 +263,16 @@ namespace Microsoft.Maui.Controls.Shapes
 		{
 			if (oldCollection != null)
 			{
-				oldCollection.CollectionChanged -= OnPathFigureCollectionChanged;
+				_figuresProxy?.Unsubscribe();
 				UnsubscribeAllFigures();
 			}
 
 			if (newCollection == null)
 				return;
 
-			newCollection.CollectionChanged += OnPathFigureCollectionChanged;
+			_figuresProxy ??= new WeakNotifyCollectionChangedProxy();
+			_figuresChanged ??= OnPathFigureCollectionChanged;
+			_figuresProxy.Subscribe(newCollection, _figuresChanged);
 
 			foreach (var newPathFigure in newCollection)
 			{

--- a/src/Controls/src/Core/Shapes/TransformGroup.cs
+++ b/src/Controls/src/Core/Shapes/TransformGroup.cs
@@ -11,7 +11,14 @@ namespace Microsoft.Maui.Controls.Shapes
 	[ContentProperty("Children")]
 	public sealed class TransformGroup : Transform
 	{
-		readonly Dictionary<INotifyPropertyChanged, int> _subscribedTransforms = new();
+		// A TransformCollection and the transforms inside it can outlive the group that consumes them --
+		// for example when they are declared in a ResourceDictionary and shared between groups. Both the
+		// collection subscription and the per-transform subscriptions are therefore weak, so a long-lived
+		// collection or transform never roots a discarded TransformGroup.
+		WeakNotifyCollectionChangedProxy _childrenProxy;
+		NotifyCollectionChangedEventHandler _childrenChanged;
+		PropertyChangedEventHandler _transformPropertyChanged;
+		readonly Dictionary<INotifyPropertyChanged, (int Count, WeakNotifyPropertyChangedProxy Proxy)> _subscribedTransforms = new();
 
 		/// <summary>Bindable property for <see cref="Children"/>.</summary>
 		public static readonly BindableProperty ChildrenProperty =
@@ -23,6 +30,14 @@ namespace Microsoft.Maui.Controls.Shapes
 		public TransformGroup()
 		{
 			Children = new TransformCollection();
+		}
+
+		~TransformGroup()
+		{
+			_childrenProxy?.Unsubscribe();
+
+			foreach (var entry in _subscribedTransforms.Values)
+				entry.Proxy.Unsubscribe();
 		}
 
 		/// <summary>
@@ -57,7 +72,9 @@ namespace Microsoft.Maui.Controls.Shapes
 				return;
 			}
 
-			collection.CollectionChanged += OnChildrenCollectionChanged;
+			_childrenProxy ??= new WeakNotifyCollectionChangedProxy();
+			_childrenChanged ??= OnChildrenCollectionChanged;
+			_childrenProxy.Subscribe(collection, _childrenChanged);
 
 			foreach (var transform in collection)
 			{
@@ -72,7 +89,7 @@ namespace Microsoft.Maui.Controls.Shapes
 				return;
 			}
 
-			collection.CollectionChanged -= OnChildrenCollectionChanged;
+			_childrenProxy?.Unsubscribe();
 
 			ClearAllTransformSubscriptions();
 		}
@@ -115,39 +132,42 @@ namespace Microsoft.Maui.Controls.Shapes
 
 		void SubscribeToTransformPropertyChanged(INotifyPropertyChanged item)
 		{
-			if (_subscribedTransforms.TryGetValue(item, out int count))
+			if (_subscribedTransforms.TryGetValue(item, out var entry))
 			{
-				_subscribedTransforms[item] = count + 1;
+				_subscribedTransforms[item] = (entry.Count + 1, entry.Proxy);
 				return;
 			}
 
-			item.PropertyChanged += OnTransformPropertyChanged;
-			_subscribedTransforms[item] = 1;
+			_transformPropertyChanged ??= OnTransformPropertyChanged;
+
+			var proxy = new WeakNotifyPropertyChangedProxy();
+			proxy.Subscribe(item, _transformPropertyChanged);
+			_subscribedTransforms[item] = (1, proxy);
 		}
 
 		void UnsubscribeFromTransformPropertyChanged(INotifyPropertyChanged item)
 		{
-			if (!_subscribedTransforms.TryGetValue(item, out int count))
+			if (!_subscribedTransforms.TryGetValue(item, out var entry))
 			{
 				return;
 			}
 
-			if (count > 1)
+			if (entry.Count > 1)
 			{
-				_subscribedTransforms[item] = count - 1;
+				_subscribedTransforms[item] = (entry.Count - 1, entry.Proxy);
 				return;
 			}
 
-			item.PropertyChanged -= OnTransformPropertyChanged;
+			entry.Proxy.Unsubscribe();
 			_subscribedTransforms.Remove(item);
 		}
 
 		// Unsubscribes all tracked transforms from PropertyChanged and clears the dictionary.
 		void ClearAllTransformSubscriptions()
 		{
-			foreach (var item in _subscribedTransforms)
+			foreach (var entry in _subscribedTransforms.Values)
 			{
-				item.Key.PropertyChanged -= OnTransformPropertyChanged;
+				entry.Proxy.Unsubscribe();
 			}
 
 			_subscribedTransforms.Clear();

--- a/src/Controls/tests/Core.UnitTests/Shapes/ShapesWeakEventTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Shapes/ShapesWeakEventTests.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Graphics;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	// Each of these types subscribes to a child collection and to the children inside it. When that
+	// collection is long-lived -- shared between owners, or declared in a ResourceDictionary -- a
+	// non-weak subscription roots every owner ever assigned it. None of these types set Parent on
+	// their children, so the event subscriptions are the only retention path under test.
+	public class ShapesWeakEventTests : BaseTestFixture
+	{
+		// https://github.com/dotnet/maui/issues/37583
+		[Fact]
+		public async Task SharedCollectionDoesNotRootTransformGroup()
+		{
+			var shared = new TransformCollection { new RotateTransform { Angle = 45 } };
+
+			var reference = CreateTransformGroup(shared);
+
+			Assert.False(await reference.WaitForCollect(), "TransformGroup should not be alive!");
+			GC.KeepAlive(shared);
+		}
+
+		// https://github.com/dotnet/maui/issues/37582
+		[Fact]
+		public async Task SharedCollectionDoesNotRootGeometryGroup()
+		{
+			var shared = new GeometryCollection { new EllipseGeometry { RadiusX = 1, RadiusY = 2 } };
+
+			var reference = CreateGeometryGroup(shared);
+
+			Assert.False(await reference.WaitForCollect(), "GeometryGroup should not be alive!");
+			GC.KeepAlive(shared);
+		}
+
+		// https://github.com/dotnet/maui/issues/37584
+		[Fact]
+		public async Task SharedCollectionDoesNotRootPathFigure()
+		{
+			var shared = new PathSegmentCollection { new LineSegment { Point = new Point(1, 1) } };
+
+			var reference = CreatePathFigure(shared);
+
+			Assert.False(await reference.WaitForCollect(), "PathFigure should not be alive!");
+			GC.KeepAlive(shared);
+		}
+
+		// https://github.com/dotnet/maui/issues/37585
+		[Fact]
+		public async Task SharedCollectionDoesNotRootPathGeometry()
+		{
+			var shared = new PathFigureCollection { new PathFigure { StartPoint = new Point(1, 1) } };
+
+			var reference = CreatePathGeometry(shared);
+
+			Assert.False(await reference.WaitForCollect(), "PathGeometry should not be alive!");
+			GC.KeepAlive(shared);
+		}
+
+		// The guards below prove the weak subscriptions still deliver events; without them the leak
+		// tests above would also pass if the subscriptions had simply been dropped.
+		[Fact]
+		public void TransformGroupStillRecomputesWhenChildChanges()
+		{
+			var rotate = new RotateTransform { Angle = 0 };
+			var group = new TransformGroup { Children = new TransformCollection { rotate } };
+
+			var before = group.Value;
+			rotate.Angle = 90;
+
+			Assert.NotEqual(before, group.Value);
+			GC.KeepAlive(group);
+		}
+
+		[Fact]
+		public void GeometryGroupStillInvalidatesWhenChildChanges()
+		{
+			var ellipse = new EllipseGeometry { RadiusX = 1, RadiusY = 1 };
+			var group = new GeometryGroup { Children = new GeometryCollection { ellipse } };
+
+			bool invalidated = false;
+			group.InvalidateGeometryRequested += (s, e) => invalidated = true;
+
+			ellipse.RadiusX = 5;
+
+			Assert.True(invalidated);
+			GC.KeepAlive(group);
+		}
+
+		[Fact]
+		public void GeometryGroupStillInvalidatesWhenCollectionChanges()
+		{
+			var group = new GeometryGroup { Children = new GeometryCollection() };
+
+			bool invalidated = false;
+			group.InvalidateGeometryRequested += (s, e) => invalidated = true;
+
+			group.Children.Add(new EllipseGeometry { RadiusX = 1, RadiusY = 1 });
+
+			Assert.True(invalidated);
+			GC.KeepAlive(group);
+		}
+
+		[Fact]
+		public void PathFigureStillInvalidatesWhenSegmentChanges()
+		{
+			var segment = new LineSegment { Point = new Point(0, 0) };
+			var figure = new PathFigure { Segments = new PathSegmentCollection { segment } };
+
+			bool invalidated = false;
+			figure.InvalidatePathSegmentRequested += (s, e) => invalidated = true;
+
+			segment.Point = new Point(5, 5);
+
+			Assert.True(invalidated);
+			GC.KeepAlive(figure);
+		}
+
+		// PathGeometry subscribes to each figure twice: PropertyChanged and the internal
+		// InvalidatePathSegmentRequested. Both are now weak, so both are covered here.
+		[Fact]
+		public void PathGeometryStillInvalidatesWhenFigureChanges()
+		{
+			var figure = new PathFigure { StartPoint = new Point(0, 0) };
+			var geometry = new PathGeometry { Figures = new PathFigureCollection { figure } };
+
+			bool invalidated = false;
+			geometry.InvalidatePathGeometryRequested += (s, e) => invalidated = true;
+
+			figure.StartPoint = new Point(5, 5);
+
+			Assert.True(invalidated);
+			GC.KeepAlive(geometry);
+		}
+
+		[Fact]
+		public void PathGeometryStillInvalidatesWhenSegmentInsideFigureChanges()
+		{
+			var segment = new LineSegment { Point = new Point(0, 0) };
+			var figure = new PathFigure { Segments = new PathSegmentCollection { segment } };
+			var geometry = new PathGeometry { Figures = new PathFigureCollection { figure } };
+
+			bool invalidated = false;
+			geometry.InvalidatePathGeometryRequested += (s, e) => invalidated = true;
+
+			segment.Point = new Point(5, 5);
+
+			Assert.True(invalidated);
+			GC.KeepAlive(geometry);
+		}
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		static WeakReference CreateTransformGroup(TransformCollection children) =>
+			new WeakReference(new TransformGroup { Children = children });
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		static WeakReference CreateGeometryGroup(GeometryCollection children) =>
+			new WeakReference(new GeometryGroup { Children = children });
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		static WeakReference CreatePathFigure(PathSegmentCollection segments) =>
+			new WeakReference(new PathFigure { Segments = segments });
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		static WeakReference CreatePathGeometry(PathFigureCollection figures) =>
+			new WeakReference(new PathGeometry { Figures = figures });
+	}
+}


### PR DESCRIPTION
### Description of Change

`TransformGroup`, `GeometryGroup`, `PathFigure` and `PathGeometry` each subscribe to a child collection and to every child inside it using plain CLR event handlers, and only unsubscribe when the owning bindable property is replaced. A `TransformCollection` / `GeometryCollection` / `PathSegmentCollection` / `PathFigureCollection` that outlives its owner — shared between owners, or declared in a `ResourceDictionary` — therefore roots every owner it is ever assigned to, along with everything those owners reference.

This is the same defect and the same fix as #38397 (`GradientBrush`), applied to the four remaining shape/geometry types. Each subscription now goes through the existing weak-event primitives in `src/Controls/src/Core/Internals/WeakEventProxy.cs`, matching the pattern already used by `Border` and by `Shape` in this same folder, and each type gains the finalizer those proxies require.

Per type:

- **`TransformGroup.Children`** — collection subscription plus the refcounted per-transform `PropertyChanged`. The refcount dictionary now carries a `WeakNotifyPropertyChangedProxy` alongside the count.
- **`GeometryGroup.Children`** — same shape as `TransformGroup`.
- **`PathFigure.Segments`** — the `List<PathSegment>` of subscribed segments becomes a `Dictionary<PathSegment, WeakNotifyPropertyChangedProxy>`; `Reset` handling is unchanged in behaviour.
- **`PathGeometry.Figures`** — subscribes to each figure *twice*: `PropertyChanged` and the internal `PathFigure.InvalidatePathSegmentRequested`. Making only the first weak would leave the figure still rooting the geometry, so this adds a `WeakPathFigureInvalidateProxy` to `WeakEventProxy.cs`, mirroring the existing `WeakGeometryChangedProxy` exactly. Both subscriptions per figure are now weak.

None of these four types set `Parent` on their children, so the event subscriptions are the only retention path — unlike `GradientBrush`, where `GradientStop.Parent` is a strong reference by design.

Existing `Reset` / refcount semantics are preserved throughout; the only behavioural change is that a discarded owner no longer stays alive.

### Tests

`src/Controls/tests/Core.UnitTests/Shapes/ShapesWeakEventTests.cs` adds 10 tests: one shared-collection leak test per type, plus six guards asserting that child property changes and collection changes still raise invalidation (`TransformGroup` recomputing its matrix, `GeometryGroup.InvalidateGeometryRequested`, `PathFigure.InvalidatePathSegmentRequested`, and `PathGeometry.InvalidatePathGeometryRequested` for both a figure change and a segment change nested inside a figure).

The guards matter: without them the four leak tests would also pass if the subscriptions had simply been dropped rather than made weak. Verified by reverting the `src/Controls/src/Core` changes and re-running — the four leak tests fail and all six guards pass. With the fix all 10 pass and the full `Controls.Core.UnitTests` suite is green.

### Issues Fixed

The leak scanner filed each of these twice; both descriptions refer to the same collection subscription.

Fixes #37582
Fixes #37583
Fixes #37584
Fixes #37585
Fixes #38284
Fixes #38285
Fixes #38286
Fixes #38287
