### PR TITLE
[leak-scan] Routing.s_implicitPageRoutes — cancelled Shell push retains the page

### DIFF
--- a/src/Controls/src/Core/Routing.cs
+++ b/src/Controls/src/Core/Routing.cs
@@ -25,23 +25,36 @@ namespace Microsoft.Maui.Controls
 			s_routeKeys = null;
 		}
 
-		internal static void RegisterImplicitPageRoute(Page page)
+		internal static Page RegisterImplicitPageRoute(Page page)
 		{
 			var route = GetRoute(page);
 			if (!IsUserDefined(route))
 			{
+				s_implicitPageRoutes.TryGetValue(route, out var previousPage);
 				s_implicitPageRoutes[route] = page;
 				s_routeKeys = null;
+
+				return previousPage;
 			}
+
+			return null;
 		}
 
-		internal static void UnregisterImplicitPageRoute(Page page)
+		internal static void UnregisterImplicitPageRoute(Page page, Page previousPage = null)
 		{
 			var route = GetRoute(page);
 			if (s_implicitPageRoutes.TryGetValue(route, out var registeredPage) &&
 				ReferenceEquals(registeredPage, page))
 			{
-				s_implicitPageRoutes.Remove(route);
+				if (previousPage is not null)
+				{
+					s_implicitPageRoutes[route] = previousPage;
+				}
+				else
+				{
+					s_implicitPageRoutes.Remove(route);
+				}
+
 				s_routeKeys = null;
 			}
 		}

--- a/src/Controls/src/Core/Routing.cs
+++ b/src/Controls/src/Core/Routing.cs
@@ -40,9 +40,8 @@ namespace Microsoft.Maui.Controls
 			return null;
 		}
 
-		internal static void UnregisterImplicitPageRoute(Page page, Page previousPage = null)
+		internal static void UnregisterImplicitPageRoute(Page page, string route, Page previousPage = null)
 		{
-			var route = GetRoute(page);
 			if (s_implicitPageRoutes.TryGetValue(route, out var registeredPage) &&
 				ReferenceEquals(registeredPage, page))
 			{

--- a/src/Controls/src/Core/Routing.cs
+++ b/src/Controls/src/Core/Routing.cs
@@ -35,6 +35,17 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
+		internal static void UnregisterImplicitPageRoute(Page page)
+		{
+			var route = GetRoute(page);
+			if (s_implicitPageRoutes.TryGetValue(route, out var registeredPage) &&
+				ReferenceEquals(registeredPage, page))
+			{
+				s_implicitPageRoutes.Remove(route);
+				s_routeKeys = null;
+			}
+		}
+
 		// Shell works much better if the entire nav stack can be represented by a string
 		// If the users pushes pages without using routes we want these page keys tracked
 		internal static void RegisterImplicitPageRoutes(Shell shell)

--- a/src/Controls/src/Core/Shell/ShellNavigationManager.cs
+++ b/src/Controls/src/Core/Shell/ShellNavigationManager.cs
@@ -53,9 +53,11 @@ namespace Microsoft.Maui.Controls
 				await (_shell?.CurrentItem?.CurrentItem?.PendingNavigationTask ?? Task.CompletedTask);
 
 			bool registeredPagePushingRoute = shellNavigationParameters.PagePushing is not null && navigationRequest is null;
+			string pagePushingRoute = null;
 			Page previousPagePushingRoute = null;
 			if (registeredPagePushingRoute)
 			{
+				pagePushingRoute = Routing.GetRoute(shellNavigationParameters.PagePushing);
 				previousPagePushingRoute = Routing.RegisterImplicitPageRoute(shellNavigationParameters.PagePushing);
 			}
 
@@ -89,7 +91,7 @@ namespace Microsoft.Maui.Controls
 					{
 						if (registeredPagePushingRoute)
 						{
-							Routing.UnregisterImplicitPageRoute(shellNavigationParameters.PagePushing, previousPagePushingRoute);
+							Routing.UnregisterImplicitPageRoute(shellNavigationParameters.PagePushing, pagePushingRoute, previousPagePushingRoute);
 						}
 
 						return;

--- a/src/Controls/src/Core/Shell/ShellNavigationManager.cs
+++ b/src/Controls/src/Core/Shell/ShellNavigationManager.cs
@@ -53,9 +53,10 @@ namespace Microsoft.Maui.Controls
 				await (_shell?.CurrentItem?.CurrentItem?.PendingNavigationTask ?? Task.CompletedTask);
 
 			bool registeredPagePushingRoute = shellNavigationParameters.PagePushing is not null && navigationRequest is null;
+			Page previousPagePushingRoute = null;
 			if (registeredPagePushingRoute)
 			{
-				Routing.RegisterImplicitPageRoute(shellNavigationParameters.PagePushing);
+				previousPagePushingRoute = Routing.RegisterImplicitPageRoute(shellNavigationParameters.PagePushing);
 			}
 
 			var state = shellNavigationParameters.TargetState ?? new ShellNavigationState(Routing.GetRoute(shellNavigationParameters.PagePushing), false);
@@ -88,7 +89,7 @@ namespace Microsoft.Maui.Controls
 					{
 						if (registeredPagePushingRoute)
 						{
-							Routing.UnregisterImplicitPageRoute(shellNavigationParameters.PagePushing);
+							Routing.UnregisterImplicitPageRoute(shellNavigationParameters.PagePushing, previousPagePushingRoute);
 						}
 
 						return;

--- a/src/Controls/src/Core/Shell/ShellNavigationManager.cs
+++ b/src/Controls/src/Core/Shell/ShellNavigationManager.cs
@@ -52,8 +52,11 @@ namespace Microsoft.Maui.Controls
 			if (_shell?.CurrentItem?.CurrentItem?.PendingNavigationTask != null)
 				await (_shell?.CurrentItem?.CurrentItem?.PendingNavigationTask ?? Task.CompletedTask);
 
-			if (shellNavigationParameters.PagePushing != null && navigationRequest == null)
+			bool registeredPagePushingRoute = shellNavigationParameters.PagePushing is not null && navigationRequest is null;
+			if (registeredPagePushingRoute)
+			{
 				Routing.RegisterImplicitPageRoute(shellNavigationParameters.PagePushing);
+			}
 
 			var state = shellNavigationParameters.TargetState ?? new ShellNavigationState(Routing.GetRoute(shellNavigationParameters.PagePushing), false);
 			bool? animate = shellNavigationParameters.Animated;
@@ -82,7 +85,14 @@ namespace Microsoft.Maui.Controls
 						accept = await navigatingArgs.DeferredTask;
 
 					if (!accept)
+					{
+						if (registeredPagePushingRoute)
+						{
+							Routing.UnregisterImplicitPageRoute(shellNavigationParameters.PagePushing);
+						}
+
 						return;
+					}
 				}
 			}
 

--- a/src/Controls/tests/Core.UnitTests/ShellNavigatingTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellNavigatingTests.cs
@@ -82,6 +82,27 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public async Task CancelledPushRestoresDisplacedImplicitRoute()
+		{
+			const string route = "IMPL_cancelledPush";
+			var shell = new TestShell
+			{
+				Items = { CreateShellItem<FlyoutItem>() }
+			};
+			var existingPage = new ContentPage();
+			var cancelledPage = new ContentPage();
+			Routing.SetRoute(existingPage, route);
+			Routing.SetRoute(cancelledPage, route);
+
+			Routing.RegisterImplicitPageRoute(existingPage);
+			shell.Navigating += (_, args) => args.Cancel();
+
+			await shell.Navigation.PushAsync(cancelledPage);
+
+			Assert.Same(existingPage, Routing.GetOrCreateContent(route));
+		}
+
+		[Fact]
 		public void CancelNavigationOccurringOutsideGotoAsyncWithoutDelay()
 		{
 			var flyoutItem = CreateShellItem<FlyoutItem>();

--- a/src/Controls/tests/Core.UnitTests/ShellNavigatingTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellNavigatingTests.cs
@@ -103,6 +103,26 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public async Task CancelledPushRemovesImplicitRouteWhenPageRouteChangesDuringNavigation()
+		{
+			var shell = new TestShell
+			{
+				Items = { CreateShellItem<FlyoutItem>() }
+			};
+			var cancelledPage = new ContentPage();
+			var registeredRoute = Routing.GetRoute(cancelledPage);
+			shell.Navigating += (_, args) =>
+			{
+				Routing.SetRoute(cancelledPage, "ChangedDuringNavigating");
+				args.Cancel();
+			};
+
+			await shell.Navigation.PushAsync(cancelledPage);
+
+			Assert.Null(Routing.GetOrCreateContent(registeredRoute));
+		}
+
+		[Fact]
 		public void CancelNavigationOccurringOutsideGotoAsyncWithoutDelay()
 		{
 			var flyoutItem = CreateShellItem<FlyoutItem>();

--- a/src/Controls/tests/Core.UnitTests/ShellNavigatingTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellNavigatingTests.cs
@@ -61,6 +61,27 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public async Task CancelledPushRemovesOnlyPushedPageImplicitRoute()
+		{
+			var shell = new TestShell
+			{
+				Items = { CreateShellItem<FlyoutItem>() }
+			};
+			var existingPage = new ContentPage();
+			var cancelledPage = new ContentPage();
+			var existingRoute = Routing.GetRoute(existingPage);
+			var cancelledRoute = Routing.GetRoute(cancelledPage);
+
+			Routing.RegisterImplicitPageRoute(existingPage);
+			shell.Navigating += (_, args) => args.Cancel();
+
+			await shell.Navigation.PushAsync(cancelledPage);
+
+			Assert.Same(existingPage, Routing.GetOrCreateContent(existingRoute));
+			Assert.Null(Routing.GetOrCreateContent(cancelledRoute));
+		}
+
+		[Fact]
 		public void CancelNavigationOccurringOutsideGotoAsyncWithoutDelay()
 		{
 			var flyoutItem = CreateShellItem<FlyoutItem>();


### PR DESCRIPTION
<!-- Please keep the note below for people who find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment whether this change resolves your issue. Thank you!

This pull request improves the handling of implicit page routes during navigation, especially in scenarios where navigation is cancelled. The changes ensure that implicit routes are properly registered, unregistered, or restored, preventing route leaks or incorrect route assignments. Additionally, new unit tests are added to verify these behaviors.

**Improvements to implicit route management:**

* Modified `RegisterImplicitPageRoute` in `Routing` to return any previously registered page for a given route, and added `UnregisterImplicitPageRoute` to restore or remove routes as needed.
* Updated `ShellNavigationManager.GoToAsync` to track and restore displaced implicit routes if navigation is cancelled, ensuring that only the correct routes remain registered. [[1]](diffhunk://#diff-8258a0822ba244b2e93e257647c9edd28bb117d146acb53e1889a4556c7734edL55-R62) [[2]](diffhunk://#diff-8258a0822ba244b2e93e257647c9edd28bb117d146acb53e1889a4556c7734edR91-R100)

**Testing and validation:**

* Added three new unit tests in `ShellNavigatingTests` to verify that cancelled navigation properly removes or restores implicit routes, including scenarios where the route changes during navigation.


<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #38256 

### Tested the behavior in the following platforms

- [x] Windows
- [x] Android
- [x] iOS
- [x] Mac

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/648b3be0-93b7-4d4b-871f-0011776f4194"> | <video src="https://github.com/user-attachments/assets/10e45f87-f430-4427-bcac-ccfa58174843"> |
<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
