### PR TITLE
Use weak events for IndicatorView and Picker ItemsSource

### DIFF
--- a/src/Controls/src/Core/IndicatorView/IndicatorView.cs
+++ b/src/Controls/src/Core/IndicatorView/IndicatorView.cs
@@ -24,6 +24,13 @@ namespace Microsoft.Maui.Controls
 	{
 		const int DefaultPadding = 4;
 
+		// ItemsSource is owned by the app and routinely outlives the view that displays it, so this
+		// subscription is weak; a non-weak one roots every IndicatorView ever bound to the collection.
+		WeakNotifyCollectionChangedProxy _itemsSourceProxy;
+		NotifyCollectionChangedEventHandler _itemsSourceChanged;
+
+		~IndicatorView() => _itemsSourceProxy?.Unsubscribe();
+
 		/// <summary>Bindable property for <see cref="IndicatorsShape"/>.</summary>
 		public static readonly BindableProperty IndicatorsShapeProperty = BindableProperty.Create(nameof(IndicatorsShape), typeof(IndicatorShape), typeof(IndicatorView), Controls.IndicatorShape.Circle);
 
@@ -237,11 +244,15 @@ namespace Microsoft.Maui.Controls
 
 		void ResetItemsSource(IEnumerable oldItemsSource)
 		{
-			if (oldItemsSource is INotifyCollectionChanged oldCollection)
-				oldCollection.CollectionChanged -= OnCollectionChanged;
+			if (oldItemsSource is INotifyCollectionChanged)
+				_itemsSourceProxy?.Unsubscribe();
 
 			if (ItemsSource is INotifyCollectionChanged collection)
-				collection.CollectionChanged += OnCollectionChanged;
+			{
+				_itemsSourceProxy ??= new WeakNotifyCollectionChangedProxy();
+				_itemsSourceChanged ??= OnCollectionChanged;
+				_itemsSourceProxy.Subscribe(collection, _itemsSourceChanged);
+			}
 
 			OnCollectionChanged(ItemsSource, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
 

--- a/src/Controls/src/Core/Picker/Picker.cs
+++ b/src/Controls/src/Core/Picker/Picker.cs
@@ -82,9 +82,12 @@ namespace Microsoft.Maui.Controls
 		/// <summary>Initializes a new instance of the Picker class.</summary>
 		public Picker()
 		{
+			// Items is owned by this Picker, so a plain subscription cannot outlive it.
 			((INotifyCollectionChanged)Items).CollectionChanged += OnItemsCollectionChanged;
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<Picker>>(() => new PlatformConfigurationRegistry<Picker>(this));
 		}
+
+		~Picker() => _itemsSourceProxy?.Unsubscribe();
 		/// <summary>Gets a value that indicates whether the font for the searchbar text is bold, italic, or neither. This is a bindable property.</summary>
 		public FontAttributes FontAttributes
 		{
@@ -355,7 +358,12 @@ namespace Microsoft.Maui.Controls
 		}
 
 		readonly Queue<Action> _pendingIsOpenActions = new Queue<Action>();
+		// ItemsSource is owned by the app and routinely outlives the picker bound to it, so this
+		// subscription is weak; a non-weak one roots every Picker ever bound to the collection.
+		// The field is still held for the ReferenceEquals identity checks below.
 		INotifyCollectionChanged _subscribedItemsSourceCollection;
+		WeakNotifyCollectionChangedProxy _itemsSourceProxy;
+		NotifyCollectionChangedEventHandler _itemsSourceChanged;
 
 		void OnIsOpenPropertyChanged(bool oldValue, bool newValue)
 		{
@@ -417,7 +425,10 @@ namespace Microsoft.Maui.Controls
 
 			UnsubscribeFromItemsSourceCollection();
 			_subscribedItemsSourceCollection = collection;
-			_subscribedItemsSourceCollection.CollectionChanged += CollectionChanged;
+
+			_itemsSourceProxy ??= new WeakNotifyCollectionChangedProxy();
+			_itemsSourceChanged ??= CollectionChanged;
+			_itemsSourceProxy.Subscribe(_subscribedItemsSourceCollection, _itemsSourceChanged);
 		}
 
 		void UnsubscribeFromItemsSourceCollection()
@@ -427,7 +438,7 @@ namespace Microsoft.Maui.Controls
 				return;
 			}
 
-			_subscribedItemsSourceCollection.CollectionChanged -= CollectionChanged;
+			_itemsSourceProxy?.Unsubscribe();
 			_subscribedItemsSourceCollection = null;
 		}
 

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -25,3 +25,5 @@ override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.OnH
 override Microsoft.Maui.Controls.Handlers.Items.MauiRecyclerView<TItemsView, TAdapter, TItemsViewSource>.OnSizeChanged(int w, int h, int oldw, int oldh) -> void
 ~override Microsoft.Maui.Controls.SwipeItems.OnPropertyChanged(string propertyName = null) -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
+Microsoft.Maui.Controls.IndicatorView.~IndicatorView() -> void
+Microsoft.Maui.Controls.Picker.~Picker() -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -16,3 +16,5 @@ override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
+Microsoft.Maui.Controls.IndicatorView.~IndicatorView() -> void
+Microsoft.Maui.Controls.Picker.~Picker() -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -16,3 +16,5 @@ override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
+Microsoft.Maui.Controls.IndicatorView.~IndicatorView() -> void
+Microsoft.Maui.Controls.Picker.~Picker() -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -5,3 +5,5 @@ override Microsoft.Maui.Controls.GraphicsView.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
 ~override Microsoft.Maui.Controls.SwipeItems.OnPropertyChanged(string propertyName = null) -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
+Microsoft.Maui.Controls.IndicatorView.~IndicatorView() -> void
+Microsoft.Maui.Controls.Picker.~Picker() -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -7,3 +7,5 @@ override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.Handlers.Items.CarouselViewHandler.UpdateEmptyViewVisibility() -> void
 ~override Microsoft.Maui.Controls.SwipeItems.OnPropertyChanged(string propertyName = null) -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
+Microsoft.Maui.Controls.IndicatorView.~IndicatorView() -> void
+Microsoft.Maui.Controls.Picker.~Picker() -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -5,3 +5,5 @@ override Microsoft.Maui.Controls.GraphicsView.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
 ~override Microsoft.Maui.Controls.SwipeItems.OnPropertyChanged(string propertyName = null) -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
+Microsoft.Maui.Controls.IndicatorView.~IndicatorView() -> void
+Microsoft.Maui.Controls.Picker.~Picker() -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -5,3 +5,5 @@ override Microsoft.Maui.Controls.GraphicsView.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
 ~override Microsoft.Maui.Controls.SwipeItems.OnPropertyChanged(string propertyName = null) -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
+Microsoft.Maui.Controls.IndicatorView.~IndicatorView() -> void
+Microsoft.Maui.Controls.Picker.~Picker() -> void

--- a/src/Controls/tests/Core.UnitTests/ItemsSourceWeakEventTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ItemsSourceWeakEventTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	// ItemsSource is owned by the app and routinely outlives the control bound to it -- a view model
+	// collection survives the page that displayed it. A non-weak CollectionChanged subscription
+	// therefore roots every control ever bound to that collection.
+	public class ItemsSourceWeakEventTests : BaseTestFixture
+	{
+		// https://github.com/dotnet/maui/issues/37662
+		[Fact]
+		public async Task SharedItemsSourceDoesNotRootIndicatorView()
+		{
+			var shared = new ObservableCollection<string> { "a", "b" };
+
+			var reference = CreateIndicatorView(shared);
+
+			Assert.False(await reference.WaitForCollect(), "IndicatorView should not be alive!");
+			GC.KeepAlive(shared);
+		}
+
+		// https://github.com/dotnet/maui/issues/37636
+		[Fact]
+		public async Task SharedItemsSourceDoesNotRootPicker()
+		{
+			var shared = new ObservableCollection<string> { "a", "b" };
+
+			var reference = CreatePicker(shared);
+
+			Assert.False(await reference.WaitForCollect(), "Picker should not be alive!");
+			GC.KeepAlive(shared);
+		}
+
+		[Fact]
+		public void IndicatorViewStillTracksItemsSourceChanges()
+		{
+			var items = new ObservableCollection<string> { "a", "b" };
+			var indicatorView = new IndicatorView { ItemsSource = items };
+
+			Assert.Equal(2, indicatorView.Count);
+
+			items.Add("c");
+
+			Assert.Equal(3, indicatorView.Count);
+			GC.KeepAlive(indicatorView);
+		}
+
+		[Fact]
+		public void PickerStillTracksItemsSourceChanges()
+		{
+			var items = new ObservableCollection<string> { "a", "b" };
+			var picker = new Picker { ItemsSource = items };
+
+			Assert.Equal(2, picker.Items.Count);
+
+			items.Add("c");
+
+			Assert.Equal(3, picker.Items.Count);
+			Assert.Equal("c", picker.Items[2]);
+			GC.KeepAlive(picker);
+		}
+
+		[Fact]
+		public void PickerStillTracksItemsSourceRemoval()
+		{
+			var items = new ObservableCollection<string> { "a", "b", "c" };
+			var picker = new Picker { ItemsSource = items };
+
+			items.Remove("b");
+
+			Assert.Equal(2, picker.Items.Count);
+			Assert.Equal("c", picker.Items[1]);
+			GC.KeepAlive(picker);
+		}
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		static WeakReference CreateIndicatorView(ObservableCollection<string> itemsSource) =>
+			new WeakReference(new IndicatorView { ItemsSource = itemsSource });
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		static WeakReference CreatePicker(ObservableCollection<string> itemsSource) =>
+			new WeakReference(new Picker { ItemsSource = itemsSource });
+	}
+}


### PR DESCRIPTION
### Description of Change

`IndicatorView` and `Picker` subscribe to their `ItemsSource` with a plain CLR `CollectionChanged` handler and only unsubscribe when `ItemsSource` is replaced. `ItemsSource` is owned by the app — typically a view-model collection that outlives the page displaying it — so the subscription roots every control ever bound to that collection, along with its whole visual tree.

Both subscriptions now go through the existing `WeakNotifyCollectionChangedProxy` in `src/Controls/src/Core/Internals/WeakEventProxy.cs`, matching the pattern already used by `Border`, `Shape` and `BindableLayout`, and each control gains the finalizer the proxy requires.

- **`IndicatorView.ResetItemsSource`** — the subscribe/unsubscribe pair is replaced by the proxy. Everything else about the method, including the synthetic `Reset` it raises to recompute `Count`, is unchanged.
- **`Picker.SubscribeToItemsSourceCollection` / `UnsubscribeFromItemsSourceCollection`** — the same swap. `_subscribedItemsSourceCollection` is still held, because the surrounding code uses it for `ReferenceEquals` identity checks when deciding whether a resubscribe is needed.

`Picker`'s other subscription — to its own `Items` collection in the constructor — is deliberately left alone and now carries a comment saying why: `Items` is owned by the `Picker`, so that handler cannot outlive it and a cycle between the two is collectable.

This is the same defect and fix as #38397 (`GradientBrush`) and #38403 (shapes and geometries).

### Tests

`src/Controls/tests/Core.UnitTests/ItemsSourceWeakEventTests.cs` adds five tests: one shared-`ItemsSource` leak test per control, plus three guards asserting the controls still react to collection changes (`IndicatorView.Count` tracking adds, `Picker.Items` tracking both adds and removals).

The guards matter: without them the two leak tests would also pass if the subscriptions had simply been dropped rather than made weak. Verified by reverting the `src/Controls/src/Core` changes and re-running — both leak tests fail and all three guards pass. With the fix all five pass and the full `Controls.Core.UnitTests` suite is green.

### Issues Fixed

The leak scanner filed each control more than once; the descriptions all refer to the same `ItemsSource` subscription.

Fixes #37633
Fixes #37636
Fixes #37662
Fixes #38174
Fixes #38176
