### PR TITLE
Use weak events for FormattedString span subscriptions

### DIFF
--- a/src/Controls/src/Core/FormattedString.cs
+++ b/src/Controls/src/Core/FormattedString.cs
@@ -17,6 +17,14 @@ namespace Microsoft.Maui.Controls
 		readonly SpanCollection _spans = new SpanCollection();
 		readonly WeakEventManager _weakEventManager = new WeakEventManager();
 
+		// _spans is owned by this FormattedString, so subscribing to it directly cannot outlive us.
+		// Individual spans are a different matter: a Span the app holds on to -- or shares between
+		// FormattedStrings -- would root this instance through its PropertyChanged/PropertyChanging
+		// handlers, so those subscriptions go through weak proxies instead.
+		readonly Dictionary<Span, (WeakNotifyPropertyChangedProxy Changed, WeakNotifyPropertyChangingProxy Changing)> _subscribedSpans = new();
+		PropertyChangedEventHandler _itemPropertyChanged;
+		PropertyChangingEventHandler _itemPropertyChanging;
+
 		internal event NotifyCollectionChangedEventHandler SpansCollectionChanged
 		{
 			add => _weakEventManager.AddEventHandler(value, nameof(SpansCollectionChanged));
@@ -25,6 +33,15 @@ namespace Microsoft.Maui.Controls
 
 		/// <summary>Initializes a new instance of the FormattedString class.</summary>
 		public FormattedString() => _spans.CollectionChanged += OnCollectionChanged;
+
+		~FormattedString()
+		{
+			foreach (var proxies in _subscribedSpans.Values)
+			{
+				proxies.Changed.Unsubscribe();
+				proxies.Changing.Unsubscribe();
+			}
+		}
 
 		protected override void OnBindingContextChanged()
 		{
@@ -53,8 +70,7 @@ namespace Microsoft.Maui.Controls
 					if (bo != null)
 					{
 						bo.Parent?.RemoveLogicalChild(bo);
-						bo.PropertyChanging -= OnItemPropertyChanging;
-						bo.PropertyChanged -= OnItemPropertyChanged;
+						DetachSpan(bo);
 					}
 
 				}
@@ -68,8 +84,7 @@ namespace Microsoft.Maui.Controls
 					if (bo != null)
 					{
 						this.AddLogicalChild(bo);
-						bo.PropertyChanging += OnItemPropertyChanging;
-						bo.PropertyChanged += OnItemPropertyChanged;
+						AttachSpan(bo);
 					}
 
 				}
@@ -77,6 +92,37 @@ namespace Microsoft.Maui.Controls
 
 			OnPropertyChanged(nameof(Spans));
 			_weakEventManager.HandleEvent(sender, e, nameof(SpansCollectionChanged));
+		}
+
+		void AttachSpan(Span span)
+		{
+			// The same Span instance can legally appear more than once in the collection; subscribe once.
+			if (_subscribedSpans.ContainsKey(span))
+				return;
+
+			_itemPropertyChanged ??= OnItemPropertyChanged;
+			_itemPropertyChanging ??= OnItemPropertyChanging;
+
+			var changed = new WeakNotifyPropertyChangedProxy();
+			changed.Subscribe(span, _itemPropertyChanged);
+
+			var changing = new WeakNotifyPropertyChangingProxy();
+			changing.Subscribe(span, _itemPropertyChanging);
+
+			_subscribedSpans[span] = (changed, changing);
+		}
+
+		void DetachSpan(Span span)
+		{
+			// Only tear the subscription down once the last occurrence has gone.
+			if (_spans.Contains(span))
+				return;
+
+			if (_subscribedSpans.Remove(span, out var proxies))
+			{
+				proxies.Changed.Unsubscribe();
+				proxies.Changing.Unsubscribe();
+			}
 		}
 
 		void OnItemPropertyChanged(object sender, PropertyChangedEventArgs e) => OnPropertyChanged(nameof(Spans));

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -25,3 +25,4 @@ override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.OnH
 override Microsoft.Maui.Controls.Handlers.Items.MauiRecyclerView<TItemsView, TAdapter, TItemsViewSource>.OnSizeChanged(int w, int h, int oldw, int oldh) -> void
 ~override Microsoft.Maui.Controls.SwipeItems.OnPropertyChanged(string propertyName = null) -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
+Microsoft.Maui.Controls.FormattedString.~FormattedString() -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -16,3 +16,4 @@ override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
+Microsoft.Maui.Controls.FormattedString.~FormattedString() -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -16,3 +16,4 @@ override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
+Microsoft.Maui.Controls.FormattedString.~FormattedString() -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -5,3 +5,4 @@ override Microsoft.Maui.Controls.GraphicsView.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
 ~override Microsoft.Maui.Controls.SwipeItems.OnPropertyChanged(string propertyName = null) -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
+Microsoft.Maui.Controls.FormattedString.~FormattedString() -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -7,3 +7,4 @@ override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.Handlers.Items.CarouselViewHandler.UpdateEmptyViewVisibility() -> void
 ~override Microsoft.Maui.Controls.SwipeItems.OnPropertyChanged(string propertyName = null) -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
+Microsoft.Maui.Controls.FormattedString.~FormattedString() -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -5,3 +5,4 @@ override Microsoft.Maui.Controls.GraphicsView.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
 ~override Microsoft.Maui.Controls.SwipeItems.OnPropertyChanged(string propertyName = null) -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
+Microsoft.Maui.Controls.FormattedString.~FormattedString() -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -5,3 +5,4 @@ override Microsoft.Maui.Controls.GraphicsView.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
 ~override Microsoft.Maui.Controls.SwipeItems.OnPropertyChanged(string propertyName = null) -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
+Microsoft.Maui.Controls.FormattedString.~FormattedString() -> void

--- a/src/Controls/tests/Core.UnitTests/FormattedStringWeakEventTests.cs
+++ b/src/Controls/tests/Core.UnitTests/FormattedStringWeakEventTests.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	// FormattedString owns its Spans collection, so subscribing to that collection cannot outlive it.
+	// A Span is different: the app can hold one, or share it between FormattedStrings, and a non-weak
+	// PropertyChanged/PropertyChanging subscription then roots the FormattedString.
+	public class FormattedStringWeakEventTests : BaseTestFixture
+	{
+		// https://github.com/dotnet/maui/issues/36289
+		[Fact]
+		public async Task RetainedSpanDoesNotRootFormattedString()
+		{
+			var shared = new Span { Text = "shared" };
+
+			var reference = CreateFormattedString(shared);
+
+			Assert.False(await reference.WaitForCollect(), "FormattedString should not be alive!");
+			GC.KeepAlive(shared);
+		}
+
+		// A span removed from the collection must stop notifying entirely.
+		[Fact]
+		public async Task RemovedSpanDoesNotRootFormattedString()
+		{
+			var shared = new Span { Text = "shared" };
+
+			var reference = CreateFormattedStringAndRemove(shared);
+
+			Assert.False(await reference.WaitForCollect(), "FormattedString should not be alive after removal!");
+			GC.KeepAlive(shared);
+		}
+
+		[Fact]
+		public void SpanChangesStillRaisePropertyChanged()
+		{
+			var span = new Span { Text = "a" };
+			var formatted = new FormattedString();
+			formatted.Spans.Add(span);
+
+			bool raised = false;
+			formatted.PropertyChanged += (s, e) =>
+			{
+				if (e.PropertyName == nameof(FormattedString.Spans))
+					raised = true;
+			};
+
+			span.Text = "b";
+
+			Assert.True(raised);
+			GC.KeepAlive(formatted);
+		}
+
+		[Fact]
+		public void RemovedSpanNoLongerRaisesPropertyChanged()
+		{
+			var span = new Span { Text = "a" };
+			var formatted = new FormattedString();
+			formatted.Spans.Add(span);
+			formatted.Spans.Remove(span);
+
+			bool raised = false;
+			formatted.PropertyChanged += (s, e) =>
+			{
+				if (e.PropertyName == nameof(FormattedString.Spans))
+					raised = true;
+			};
+
+			span.Text = "b";
+
+			Assert.False(raised);
+			GC.KeepAlive(formatted);
+		}
+
+		[Fact]
+		public void ClearDetachesSpans()
+		{
+			var span = new Span { Text = "a" };
+			var formatted = new FormattedString();
+			formatted.Spans.Add(span);
+			formatted.Spans.Clear();
+
+			bool raised = false;
+			formatted.PropertyChanged += (s, e) =>
+			{
+				if (e.PropertyName == nameof(FormattedString.Spans))
+					raised = true;
+			};
+
+			span.Text = "b";
+
+			Assert.False(raised);
+			GC.KeepAlive(formatted);
+		}
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		static WeakReference CreateFormattedString(Span span)
+		{
+			var formatted = new FormattedString();
+			formatted.Spans.Add(span);
+			return new WeakReference(formatted);
+		}
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		static WeakReference CreateFormattedStringAndRemove(Span span)
+		{
+			var formatted = new FormattedString();
+			formatted.Spans.Add(span);
+			formatted.Spans.Remove(span);
+			return new WeakReference(formatted);
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

`FormattedString` subscribes to `PropertyChanged` and `PropertyChanging` on every `Span` added to its collection, with plain CLR handlers. A `Span` that the app holds on to — or shares between two `FormattedString`s — therefore roots the `FormattedString`, and through it the label or view that owns it.

The per-span subscriptions now go through the existing `WeakNotifyPropertyChangedProxy` and `WeakNotifyPropertyChangingProxy` in `src/Controls/src/Core/Internals/WeakEventProxy.cs`, and the type gains the finalizer those proxies require.

Two things are deliberately left alone:

- **The `_spans` collection subscription in the constructor.** `SpanCollection` is private and owned by this `FormattedString`, so that handler cannot outlive it; a cycle between the two is collectable. It now carries a comment saying so, since the surrounding code is being changed for exactly the opposite reason.
- **`Reset` handling.** `SpanCollection.ClearItems` is already overridden to raise a `Remove` carrying the removed items rather than a bare `Reset`, so unlike `GradientBrush` (#38397) there is no gap on `Clear()`. A test pins that behaviour.

A span that appears more than once in the collection is subscribed once and detached only when its last occurrence is gone, matching the approach taken in the earlier PRs in this series.

This is the same defect class as #38397, #38403 and #38405.

### Tests

`src/Controls/tests/Core.UnitTests/FormattedStringWeakEventTests.cs` adds five tests: two leak tests (a retained span, and a span that was removed from the collection), plus three behavioural guards — a span still raising `PropertyChanged(nameof(Spans))`, a removed span no longer doing so, and `Clear()` detaching its spans.

Reverting the `src/Controls/src/Core` changes and re-running fails exactly one of them, `RetainedSpanDoesNotRootFormattedString`. The other four pass either way, and that is deliberate: the existing `Remove` path already unsubscribed correctly and `ClearItems` already raises `Remove` rather than `Reset`, so those four pin behaviour this change must not break rather than proving a fix. Only the retained-span-still-in-the-collection case was actually leaking.

With the fix all five pass and the full `Controls.Core.UnitTests` suite is green.

### Issues Fixed

Fixes #36289
Fixes #38180
