### PR TITLE
Use a weak event for VisualElement.Resources ValuesChanged

### DIFF
--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -302,6 +302,12 @@ namespace Microsoft.Maui.Controls
 		WeakNotifyPropertyChangedProxy _shadowProxy = null;
 		PropertyChangedEventHandler _shadowChanged;
 
+		// A ResourceDictionary assigned to Resources is owned by the app and is routinely shared --
+		// merged into several elements, or held in App.Resources. A non-weak ValuesChanged handler
+		// therefore roots every element the dictionary is assigned to, and its whole visual tree.
+		WeakResourcesChangedProxy _resourcesProxy;
+		EventHandler<ResourcesChangedEventArgs> _resourcesChanged;
+
 		/// <summary>
 		/// Frees all resources associated with the handle.
 		/// </summary>
@@ -310,6 +316,7 @@ namespace Microsoft.Maui.Controls
 			_clipProxy?.Unsubscribe();
 			_backgroundProxy?.Unsubscribe();
 			_shadowProxy?.Unsubscribe();
+			_resourcesProxy?.Unsubscribe();
 		}
 
 		void NotifyBackgroundChanges()
@@ -342,6 +349,50 @@ namespace Microsoft.Maui.Controls
 
 				SetInheritedBindingContext(background, null);
 				_backgroundProxy?.Unsubscribe();
+			}
+		}
+
+		void SubscribeToResources(ResourceDictionary resources)
+		{
+			_resourcesProxy ??= new WeakResourcesChangedProxy();
+			_resourcesChanged ??= OnResourcesChanged;
+			_resourcesProxy.Subscribe((IResourceDictionary)resources, _resourcesChanged);
+		}
+
+		class WeakResourcesChangedProxy : WeakEventProxy<IResourceDictionary, EventHandler<ResourcesChangedEventArgs>>
+		{
+			void OnValuesChanged(object sender, ResourcesChangedEventArgs e)
+			{
+				if (TryGetHandler(out var handler))
+				{
+					handler(sender, e);
+				}
+				else
+				{
+					Unsubscribe();
+				}
+			}
+
+			public override void Subscribe(IResourceDictionary source, EventHandler<ResourcesChangedEventArgs> handler)
+			{
+				if (TryGetSource(out var s))
+				{
+					s.ValuesChanged -= OnValuesChanged;
+				}
+
+				source.ValuesChanged += OnValuesChanged;
+
+				base.Subscribe(source, handler);
+			}
+
+			public override void Unsubscribe()
+			{
+				if (TryGetSource(out var s))
+				{
+					s.ValuesChanged -= OnValuesChanged;
+				}
+
+				base.Unsubscribe();
 			}
 		}
 
@@ -1174,7 +1225,7 @@ namespace Microsoft.Maui.Controls
 				if (_resources != null)
 					return _resources;
 				_resources = new ResourceDictionary();
-				((IResourceDictionary)_resources).ValuesChanged += OnResourcesChanged;
+				SubscribeToResources(_resources);
 				return _resources;
 			}
 			set
@@ -1183,11 +1234,11 @@ namespace Microsoft.Maui.Controls
 					return;
 				OnPropertyChanging();
 				if (_resources != null)
-					((IResourceDictionary)_resources).ValuesChanged -= OnResourcesChanged;
+					_resourcesProxy?.Unsubscribe();
 				_resources = value;
 				OnResourcesChanged(value);
 				if (_resources != null)
-					((IResourceDictionary)_resources).ValuesChanged += OnResourcesChanged;
+					SubscribeToResources(_resources);
 				OnPropertyChanged();
 			}
 		}

--- a/src/Controls/tests/Core.UnitTests/ResourcesWeakEventTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ResourcesWeakEventTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Microsoft.Maui.Graphics;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	// A ResourceDictionary assigned to VisualElement.Resources is owned by the app and is routinely
+	// shared -- merged into several elements, or held in App.Resources for the lifetime of the app.
+	// A non-weak ValuesChanged subscription therefore roots every element it is assigned to.
+	public class ResourcesWeakEventTests : BaseTestFixture
+	{
+		// https://github.com/dotnet/maui/issues/36389
+		[Fact]
+		public async Task SharedResourceDictionaryDoesNotRootElement()
+		{
+			var shared = new ResourceDictionary { { "accent", Colors.Red } };
+
+			var reference = CreateElement(shared);
+
+			Assert.False(await reference.WaitForCollect(), "VisualElement should not be alive!");
+			GC.KeepAlive(shared);
+		}
+
+		// The same dictionary assigned to several elements must not root any of them.
+		[Fact]
+		public async Task ResourceDictionaryReusedAcrossElementsDoesNotRootThem()
+		{
+			var shared = new ResourceDictionary { { "accent", Colors.Red } };
+
+			var first = CreateElement(shared);
+			var second = CreateElement(shared);
+
+			Assert.False(await first.WaitForCollect(), "First VisualElement should not be alive!");
+			Assert.False(await second.WaitForCollect(), "Second VisualElement should not be alive!");
+			GC.KeepAlive(shared);
+		}
+
+		// Guards that the weak subscription still delivers: DynamicResource resolution runs through
+		// ValuesChanged, so this would break if the subscription were merely dropped.
+		[Fact]
+		public void DynamicResourceStillUpdatesWhenResourceChanges()
+		{
+			var resources = new ResourceDictionary();
+			var label = new Label { Resources = resources };
+			label.SetDynamicResource(Label.TextProperty, "greeting");
+
+			resources["greeting"] = "hello";
+
+			Assert.Equal("hello", label.Text);
+			GC.KeepAlive(label);
+		}
+
+		[Fact]
+		public void DynamicResourceStillUpdatesOnSubsequentChanges()
+		{
+			var resources = new ResourceDictionary { { "greeting", "hello" } };
+			var label = new Label { Resources = resources };
+			label.SetDynamicResource(Label.TextProperty, "greeting");
+
+			Assert.Equal("hello", label.Text);
+
+			resources["greeting"] = "goodbye";
+
+			Assert.Equal("goodbye", label.Text);
+			GC.KeepAlive(label);
+		}
+
+		// Replacing the dictionary must detach from the old one.
+		[Fact]
+		public void ReplacingResourcesDetachesFromOldDictionary()
+		{
+			var original = new ResourceDictionary { { "greeting", "hello" } };
+			var label = new Label { Resources = original };
+			label.SetDynamicResource(Label.TextProperty, "greeting");
+
+			label.Resources = new ResourceDictionary { { "greeting", "replaced" } };
+			Assert.Equal("replaced", label.Text);
+
+			original["greeting"] = "ignored";
+
+			Assert.Equal("replaced", label.Text);
+			GC.KeepAlive(label);
+		}
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		static WeakReference CreateElement(ResourceDictionary resources) =>
+			new WeakReference(new Label { Resources = resources });
+	}
+}


### PR DESCRIPTION
### Description of Change

`VisualElement.Resources` subscribes to the dictionary's `ValuesChanged` with a plain CLR handler and only unsubscribes when the property is reassigned. A `ResourceDictionary` is owned by the app and is routinely long-lived and shared — merged into several elements, or held in `App.Resources` for the lifetime of the process — so the subscription roots every element the dictionary is ever assigned to, and through each element its entire visual tree.

This is probably the widest-reaching instance of the defect class addressed in #38397, #38403, #38405 and #38408: any page that assigns a shared dictionary leaks the whole page.

`VisualElement` already defines local weak-event proxies for exactly this reason (`WeakClipChangedProxy`, `WeakBackgroundChangedProxy`) and already has a finalizer, so this change follows the pattern already established in the file rather than introducing a new one:

- adds a nested `WeakResourcesChangedProxy : WeakEventProxy<IResourceDictionary, EventHandler<ResourcesChangedEventArgs>>`, shaped exactly like the two proxies beside it;
- routes both subscription sites (the lazy getter and the setter) through a single `SubscribeToResources` helper;
- adds `_resourcesProxy?.Unsubscribe()` to the existing `~VisualElement()`.

Because the finalizer already existed, there is **no public API change** and no `PublicAPI.Unshipped.txt` churn.

Note the getter's dictionary is created by the element itself and could not leak; it goes through the same proxy purely so there is one code path rather than two.

**Not covered here:** `ResourceDictionary.MergedDictionaries` has the same non-weak `ValuesChanged` subscription between a parent dictionary and its merged children (#38173). That one needs the proxy lifted out of `VisualElement` and a finalizer on `ResourceDictionary` itself, so it is left for a follow-up rather than widening this change.

### Tests

`src/Controls/tests/Core.UnitTests/ResourcesWeakEventTests.cs` adds five tests: two leak tests (one element with a shared dictionary, and two elements sharing one dictionary), plus three behavioural guards covering `DynamicResource` resolution — which runs *through* `ValuesChanged` and so would break outright if the subscription were merely dropped instead of made weak — on first set, on a subsequent change, and after the dictionary is replaced.

Verified by reverting the `src/Controls/src/Core` changes and re-running: both leak tests fail, all three guards pass. With the fix all five pass and the full `Controls.Core.UnitTests` suite is green.

### Issues Fixed

Fixes #36251
Fixes #36389
Fixes #38178
Fixes #38288
