### PR TITLE
Keep StatesChanged subscriptions in step in the VisualStateGroupList indexer

### DIFF
--- a/src/Controls/src/Core/VisualStateManager.cs
+++ b/src/Controls/src/Core/VisualStateManager.cs
@@ -415,7 +415,25 @@ namespace Microsoft.Maui.Controls
 		public VisualStateGroup this[int index]
 		{
 			get => _internalList[index];
-			set => _internalList[index] = value;
+			set
+			{
+				// Every other mutation path keeps the StatesChanged subscriptions in step; replacing by
+				// index did not. That left the displaced group subscribed -- so it kept this list (and
+				// the element that owns it) alive and kept raising notifications -- while the incoming
+				// group was never subscribed at all, so its state changes went unnoticed.
+				var existing = _internalList[index];
+
+				if (ReferenceEquals(existing, value))
+					return;
+
+				if (existing is not null)
+					existing.StatesChanged -= ValidateAndNotify;
+
+				_internalList[index] = value;
+
+				if (value is not null)
+					value.StatesChanged += ValidateAndNotify;
+			}
 		}
 
 		WeakReference<VisualElement> _visualElement;

--- a/src/Controls/tests/Core.UnitTests/VisualStateGroupListIndexerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualStateGroupListIndexerTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	// Every mutation path on VisualStateGroupList keeps its StatesChanged subscriptions in step
+	// except the indexer, which replaced the element without touching either subscription.
+	public class VisualStateGroupListIndexerTests : BaseTestFixture
+	{
+		// The subscription runs group -> list (VisualStateGroup.StatesChanged holds the list's
+		// ValidateAndNotify), so a displaced group the app still holds keeps the whole list -- and the
+		// element that owns it -- alive.
+		// https://github.com/dotnet/maui/issues/37171
+		[Fact]
+		public async Task DisplacedGroupDoesNotRootTheList()
+		{
+			var displaced = CreateGroup("First");
+
+			var reference = ReplaceAndTrackList(displaced);
+
+			Assert.False(await reference.WaitForCollect(), "VisualStateGroupList should not be alive!");
+			GC.KeepAlive(displaced);
+		}
+
+		[Fact]
+		public void ReplacingByIndexSubscribesTheIncomingGroup()
+		{
+			var list = new VisualStateGroupList { CreateGroup("First") };
+			var incoming = CreateGroup("Second");
+
+			list[0] = incoming;
+
+			// A subscribed group propagates its state changes; validation rejects a duplicate state
+			// name, which only happens if the list is actually listening to the incoming group.
+			incoming.States.Add(new VisualState { Name = "Normal" });
+
+			Assert.Throws<InvalidOperationException>(() => incoming.States.Add(new VisualState { Name = "Normal" }));
+			GC.KeepAlive(list);
+		}
+
+		[Fact]
+		public void ReplacingByIndexUnsubscribesTheDisplacedGroup()
+		{
+			var displaced = CreateGroup("First");
+			var list = new VisualStateGroupList { displaced };
+
+			list[0] = CreateGroup("Second");
+
+			// The displaced group is no longer validated by the list, so a duplicate name is allowed.
+			displaced.States.Add(new VisualState { Name = "Normal" });
+			displaced.States.Add(new VisualState { Name = "Normal" });
+
+			Assert.Equal(3, displaced.States.Count);
+			GC.KeepAlive(list);
+		}
+
+		[Fact]
+		public void ReplacingWithTheSameInstanceIsANoOp()
+		{
+			var group = CreateGroup("First");
+			var list = new VisualStateGroupList { group };
+
+			list[0] = group;
+
+			Assert.Same(group, list[0]);
+			Assert.Single(list);
+			GC.KeepAlive(list);
+		}
+
+		static VisualStateGroup CreateGroup(string name)
+		{
+			var group = new VisualStateGroup { Name = name };
+			group.States.Add(new VisualState { Name = name + "State" });
+			return group;
+		}
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		static WeakReference ReplaceAndTrackList(VisualStateGroup displaced)
+		{
+			var list = new VisualStateGroupList { displaced };
+			list[0] = CreateGroup("Second");
+			return new WeakReference(list);
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

`VisualStateGroupList` keeps its `VisualStateGroup.StatesChanged` subscriptions in step on every mutation path — `Add`, `Insert`, `Remove`, `RemoveAt` and `Clear` all subscribe or unsubscribe as appropriate. The indexer setter did not: it assigned straight through to the backing list.

That left two defects:

- **A leak.** The subscription runs *group → list* (`VisualStateGroup.StatesChanged` holds the list's `ValidateAndNotify`), so a displaced group the app still holds kept the whole `VisualStateGroupList` alive, and with it the `VisualElement` that owns it. The displaced group also went on raising validation notifications for a list it was no longer part of.
- **A functional bug.** The incoming group was never subscribed, so its subsequent state changes did not reach the list's validation at all.

The setter now unsubscribes the displaced group, assigns, and subscribes the incoming one, with a reference-equality short circuit so assigning the same instance stays a no-op. Null is handled without subscribing rather than by throwing, to avoid introducing a new exception on a path that previously accepted it.

Same defect class as #38397, #38403, #38405, #38408 and #38410, though the fix here is a missing unsubscribe rather than a weak-event conversion — the group and list are peers with a shared lifetime, so a plain subscription is correct as long as it is torn down.

**Not covered here:** the three related `[leak-scan]` reports about `StateTriggerBase` detachment (#38243, #38244, #38245) — triggers are only sent `SendDetached()` when the entire `VisualStateGroups` collection is replaced, not when an individual group or state is removed. Fixing that means changing when triggers detach and re-attach, which is a behavioural change worth its own PR rather than a rider on this one.

### Tests

`src/Controls/tests/Core.UnitTests/VisualStateGroupListIndexerTests.cs` adds four tests. Reverting the source change fails two of them — `DisplacedGroupDoesNotRootTheList` (the leak) and `ReplacingByIndexSubscribesTheIncomingGroup` (the missed subscription). The other two pin behaviour the change must preserve: the displaced group no longer being validated by the list, and same-instance assignment being a no-op.

With the fix all four pass and the full `Controls.Core.UnitTests` suite is green.

### Issues Fixed

Fixes #37171
