### PR TITLE
Use the shared CommandElement plumbing in BackButtonBehavior

### DIFF
--- a/src/Controls/src/Core/Shell/BackButtonBehavior.cs
+++ b/src/Controls/src/Core/Shell/BackButtonBehavior.cs
@@ -8,17 +8,18 @@ namespace Microsoft.Maui.Controls
 	/// <summary>
 	/// Customizes the appearance and behavior of the back button in a <see cref="Shell"/> application.
 	/// </summary>
-	public class BackButtonBehavior : BindableObject
+	public class BackButtonBehavior : BindableObject, ICommandElement
 	{
 		/// <summary>Bindable property for <see cref="CommandParameter"/>.</summary>
 		public static readonly BindableProperty CommandParameterProperty =
 			BindableProperty.Create(nameof(CommandParameter), typeof(object), typeof(BackButtonBehavior), null, BindingMode.OneTime,
-				propertyChanged: OnCommandParameterChanged);
+				propertyChanged: CommandElement.OnCommandParameterChanged);
 
 		/// <summary>Bindable property for <see cref="Command"/>.</summary>
 		public static readonly BindableProperty CommandProperty =
 			BindableProperty.Create(nameof(Command), typeof(ICommand), typeof(BackButtonBehavior), null, BindingMode.OneTime,
-				propertyChanged: OnCommandChanged);
+				propertyChanging: CommandElement.OnCommandChanging,
+				propertyChanged: CommandElement.OnCommandChanged);
 
 		/// <summary>Bindable property for <see cref="IconOverride"/>.</summary>
 		public static readonly BindableProperty IconOverrideProperty =
@@ -108,46 +109,15 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		static void OnCommandChanged(BindableObject bindable, object oldValue, object newValue)
+		// Command subscription goes through CommandElement/WeakCommandSubscription rather than a
+		// direct CanExecuteChanged handler: a command is usually owned by a view model that outlives
+		// the Shell page, and a strong handler kept every BackButtonBehavior ever bound to it alive.
+		WeakCommandSubscription ICommandElement.CleanupTracker { get; set; }
+
+		void ICommandElement.CanExecuteChanged(object sender, EventArgs e)
 		{
-			var self = (BackButtonBehavior)bindable;
-			var oldCommand = (ICommand)oldValue;
-			var newCommand = (ICommand)newValue;
-			self.OnCommandChanged(oldCommand, newCommand);
+			IsEnabledCore = CommandElement.GetCanExecute(this);
 		}
 
-		static void OnCommandParameterChanged(BindableObject bindable, object oldValue, object newValue)
-		{
-			((BackButtonBehavior)bindable).OnCommandParameterChanged();
-		}
-
-		void CanExecuteChanged(object sender, EventArgs e)
-		{
-			IsEnabledCore = Command.CanExecute(CommandParameter);
-		}
-
-		void OnCommandChanged(ICommand oldCommand, ICommand newCommand)
-		{
-			if (oldCommand != null)
-			{
-				oldCommand.CanExecuteChanged -= CanExecuteChanged;
-			}
-
-			if (newCommand != null)
-			{
-				newCommand.CanExecuteChanged += CanExecuteChanged;
-				IsEnabledCore = Command.CanExecute(CommandParameter);
-			}
-			else
-			{
-				IsEnabledCore = true;
-			}
-		}
-
-		void OnCommandParameterChanged()
-		{
-			if (Command != null)
-				IsEnabledCore = Command.CanExecute(CommandParameter);
-		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/BackButtonBehaviorCommandTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BackButtonBehaviorCommandTests.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	// A command is normally owned by a view model that outlives the Shell page it is bound from, so a
+	// direct CanExecuteChanged handler roots every BackButtonBehavior ever bound to that command.
+	public class BackButtonBehaviorCommandTests : BaseTestFixture
+	{
+		// Note this uses a hand-rolled ICommand rather than Maui's own Command: Command backs
+		// CanExecuteChanged with a WeakEventManager, so it never retains its subscribers and cannot
+		// reproduce this. Most app-side RelayCommand implementations use a plain CLR event, which does.
+		// https://github.com/dotnet/maui/issues/37635
+		[Fact]
+		public async Task SharedCommandDoesNotRootBehavior()
+		{
+			var shared = new PlainCommand();
+
+			var reference = CreateBehavior(shared);
+
+			Assert.False(await reference.WaitForCollect(), "BackButtonBehavior should not be alive!");
+			GC.KeepAlive(shared);
+		}
+
+		// Guards that the weak subscription still delivers for a plain-event command.
+		[Fact]
+		public void IsEnabledTracksPlainCommandCanExecuteChanged()
+		{
+			var command = new PlainCommand { CanExecuteResult = false };
+			var behavior = new BackButtonBehavior { Command = command };
+
+			Assert.False(behavior.IsEnabled);
+
+			command.CanExecuteResult = true;
+			command.RaiseCanExecuteChanged();
+
+			Assert.True(behavior.IsEnabled);
+			GC.KeepAlive(behavior);
+		}
+
+		[Fact]
+		public void IsEnabledReflectsCanExecuteWhenCommandIsSet()
+		{
+			var behavior = new BackButtonBehavior { Command = new Command(() => { }, () => false) };
+
+			Assert.False(behavior.IsEnabled);
+			GC.KeepAlive(behavior);
+		}
+
+		[Fact]
+		public void IsEnabledTracksChangeCanExecute()
+		{
+			bool canExecute = false;
+			var command = new Command(() => { }, () => canExecute);
+			var behavior = new BackButtonBehavior { Command = command };
+
+			Assert.False(behavior.IsEnabled);
+
+			canExecute = true;
+			command.ChangeCanExecute();
+
+			Assert.True(behavior.IsEnabled);
+			GC.KeepAlive(behavior);
+		}
+
+		[Fact]
+		public void IsEnabledReevaluatesWhenCommandParameterChanges()
+		{
+			var command = new Command<string>(_ => { }, p => p == "yes");
+			var behavior = new BackButtonBehavior { Command = command, CommandParameter = "no" };
+
+			Assert.False(behavior.IsEnabled);
+
+			behavior.CommandParameter = "yes";
+
+			Assert.True(behavior.IsEnabled);
+			GC.KeepAlive(behavior);
+		}
+
+		[Fact]
+		public void ClearingCommandRestoresEnabled()
+		{
+			var behavior = new BackButtonBehavior { Command = new Command(() => { }, () => false) };
+			Assert.False(behavior.IsEnabled);
+
+			behavior.Command = null;
+
+			Assert.True(behavior.IsEnabled);
+			GC.KeepAlive(behavior);
+		}
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		static WeakReference CreateBehavior(ICommand command) =>
+			new WeakReference(new BackButtonBehavior { Command = command });
+
+		sealed class PlainCommand : ICommand
+		{
+			public bool CanExecuteResult { get; set; } = true;
+
+			public event EventHandler CanExecuteChanged;
+
+			public bool CanExecute(object parameter) => CanExecuteResult;
+
+			public void Execute(object parameter) { }
+
+			public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

`BackButtonBehavior` subscribed to `ICommand.CanExecuteChanged` with a direct instance handler and only unsubscribed when `Command` was reassigned. A command is normally owned by a view model that outlives the Shell page it is bound from, so the subscription rooted every `BackButtonBehavior` ever bound to it.

Rather than add another bespoke proxy, this adopts the pattern the repo already has for exactly this problem: `ICommandElement` + `CommandElement`, which routes the subscription through `WeakCommandSubscription`. `BackButtonBehavior` already exposes `Command` and `CommandParameter` publicly, so implementing the interface is mostly deleting code — the hand-rolled `OnCommandChanged`, `OnCommandParameterChanged` and `CanExecuteChanged` are replaced by `CommandElement.OnCommandChanging` / `OnCommandChanged` / `OnCommandParameterChanged` and a single explicit `ICommandElement.CanExecuteChanged`.

This matches the direction of #38316, which is migrating `SwipeItemView` to the same interface.

Behaviour is preserved: `IsEnabledCore` is still driven by `CanExecute`, still re-evaluates when `CommandParameter` changes, and still returns to enabled when `Command` is cleared (`CommandElement.GetCanExecute` returns `true` for a null command, and `OnCommandChanged` invokes the handler after every change).

**Worth knowing for review:** MAUI's own `Command` already backs `CanExecuteChanged` with a `WeakEventManager`, so it never retained subscribers and this leak was invisible with it. The leak only bites with a hand-rolled `ICommand` that uses a plain CLR event — which is what most app-side `RelayCommand` implementations are. The test below uses such a command deliberately; a first version written against `Command` passed even against the unfixed code and would have proved nothing.

### Tests

`src/Controls/tests/Core.UnitTests/BackButtonBehaviorCommandTests.cs` adds six tests. Reverting the source change fails exactly one — `SharedCommandDoesNotRootBehavior`, the leak, using the plain-event command. The other five pin behaviour the refactor must preserve: `IsEnabled` reflecting `CanExecute` on assignment, tracking `ChangeCanExecute`, tracking a plain-event command's `CanExecuteChanged` (which proves the weak subscription still delivers), re-evaluating on `CommandParameter` change, and returning to enabled when the command is cleared.

With the fix all six pass and the full `Controls.Core.UnitTests` suite is green (5653 passed, 0 failed).

### Issues Fixed

Fixes #37635
Fixes #38175
