### PR TITLE
Add stack and absolute layouts to the HandlerDoesNotLeak theory

### DIFF
--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -200,6 +200,7 @@ public class MemoryTests : ControlsHandlerTestBase
 #endif
 
 	[Theory("Handler Does Not Leak")]
+	[InlineData(typeof(AbsoluteLayout))]
 	[InlineData(typeof(ActivityIndicator))]
 	[InlineData(typeof(Border))]
 	[InlineData(typeof(BoxView))]
@@ -216,6 +217,7 @@ public class MemoryTests : ControlsHandlerTestBase
 #pragma warning restore CS0618 // Type or member is obsolete
 	[InlineData(typeof(GraphicsView))]
 	[InlineData(typeof(Grid))]
+	[InlineData(typeof(HorizontalStackLayout))]
 #if TESTS_FAILS_ON_WINDOWS //For more information, see: https://github.com/dotnet/maui/issues/35985
 	[InlineData(typeof(HybridWebView))]
 #endif
@@ -239,6 +241,7 @@ public class MemoryTests : ControlsHandlerTestBase
 	[InlineData(typeof(ScrollView))]
 	[InlineData(typeof(SearchBar))]
 	[InlineData(typeof(Slider))]
+	[InlineData(typeof(StackLayout))]
 #if TESTS_FAILS_ON_IOS && TESTS_FAILS_ON_MACCATALYST //For more information, see: https://github.com/dotnet/maui/issues/35985
 	[InlineData(typeof(Stepper))]
 #endif
@@ -250,6 +253,7 @@ public class MemoryTests : ControlsHandlerTestBase
 #pragma warning disable CS0618 // Type or member is obsolete
 	[InlineData(typeof(TableView))]
 #pragma warning restore CS0618 // Type or member is obsolete
+	[InlineData(typeof(VerticalStackLayout))]
 	//[InlineData(typeof(WebView))] - This test was moved to MemoryTests.cs inside Appium
 	[InlineData(typeof(CollectionView))]
 #if IOS || MACCATALYST


### PR DESCRIPTION
### Description of Change

The `HandlerDoesNotLeak` theory in `src/Controls/tests/DeviceTests/Memory/MemoryTests.cs` covers around forty controls, including `Grid` and `ContentView`, but no member of the stack/absolute layout family. `VerticalStackLayout`, `HorizontalStackLayout`, `StackLayout` and `AbsoluteLayout` are among the most-used containers in the framework and none of them is currently asserted to release its handler, platform view and managed view after leaving the visual tree.

All four are `Layout` / `StackBase` subclasses with public parameterless constructors, so they satisfy the theory's `Activator.CreateInstance` + `(View)` cast without any change to the test body — this is four `[InlineData]` entries and nothing else.

### Verification — please read

**I could not run these locally.** `Controls.DeviceTests` targets platform TFMs and needs a device or emulator, so CI is the first real execution of these four cases. The diff is inspection-verified only: the types exist, derive from `View`, and construct with no arguments.

That means one of two useful outcomes:

- they pass, and four widely-used layouts gain leak coverage they did not have; or
- one fails, in which case the theory has found a real leak in a very common container — which is the point of filing the gap.

I would rather surface that than quietly leave the gap open, but a maintainer should be ready for the second case rather than assume the first.

`StackLayout` is not marked `[Obsolete]`, so unlike the `Frame` / `ListView` / `TableView` entries nearby it needs no `CS0618` pragma.

**Not covered here:** #36338, the `MenuBar` / `MenuBarItem` / `MenuFlyoutItem` gap. As that issue notes, the menu types cannot go through this theory structurally and need a bespoke test, so they are left for a separate PR.

### Issues Fixed

Fixes #36337
