### PR TITLE
[XAML] Add ENC1002 regression coverage

### DIFF
--- a/src/Controls/tests/SourceGen.UnitTests/HotReload/Maui36824Tests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/HotReload/Maui36824Tests.cs
@@ -1,0 +1,168 @@
+#nullable enable
+
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Microsoft.CodeAnalysis;
+using Microsoft.Maui.Controls.SourceGen.UnitTests.HotReload;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.SourceGen.UnitTests;
+
+[Collection("XamlHotReloadTests")]
+public class Maui36824Tests
+{
+	const string PageClass = "Maui36824.MainPage";
+
+	static string PageSource(int codeVersion) => $$"""
+		namespace Maui36824;
+
+		public partial class MainPage : global::Microsoft.Maui.Controls.ContentPage
+		{
+			private partial void InitializeComponent();
+
+			public MainPage()
+			{
+				InitializeComponent();
+			}
+
+			public int GetCodeVersion() => {{codeVersion}};
+		}
+		""";
+
+	static string PageXaml(string text, string content = """<Label Text="{0}" />""") => $$"""
+		<?xml version="1.0" encoding="utf-8" ?>
+		<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+		             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+		             x:Class="Maui36824.MainPage">
+		    {{string.Format(content, text)}}
+		</ContentPage>
+		""";
+
+	static XamlHotReloadTestHarness CreateHarness(
+		string pageSource,
+		[CallerMemberName] string scenarioName = "") =>
+		new(scenarioName, PageClass, pageSource);
+
+	[MetadataUpdateFact]
+	public void XamlThenCSharpThenXaml_AppliesEveryDeltaWithoutENC1002()
+	{
+		var xamlV1 = PageXaml("First");
+		var xamlV2 = PageXaml("Second");
+		var xamlV3 = PageXaml("Third");
+		var pageSourceV1 = PageSource(1);
+		var pageSourceV2 = PageSource(2);
+
+		using var harness = CreateHarness(pageSourceV1);
+		var generation = harness.GenerateWithPageSources(
+			new(Xaml: xamlV1, PageSource: pageSourceV1),
+			new(Xaml: xamlV2, PageSource: pageSourceV1),
+			new(Xaml: xamlV2, PageSource: pageSourceV2),
+			new(Xaml: xamlV3, PageSource: pageSourceV2));
+
+		Assert.All(generation.Versions, version => Assert.NotNull(version.UpdateComponentSource));
+
+		harness.RunLive(generation, live =>
+		{
+			var page = live.GetInstance<ContentPage>();
+			Assert.Equal("First", Assert.IsType<Label>(page.Content).Text);
+			Assert.Equal(1, InvokeCodeVersion(page));
+
+			live.ApplyUpdate<ContentPage>(1);
+			Assert.Equal("Second", Assert.IsType<Label>(page.Content).Text);
+			Assert.Equal(1, InvokeCodeVersion(page));
+
+			live.ApplyUpdate<ContentPage>(2, "GetCodeVersion");
+			Assert.Equal("Second", Assert.IsType<Label>(page.Content).Text);
+			Assert.Equal(2, InvokeCodeVersion(page));
+
+			live.ApplyUpdate<ContentPage>(3);
+			Assert.Equal("Third", Assert.IsType<Label>(page.Content).Text);
+			Assert.Equal(2, InvokeCodeVersion(page));
+		});
+	}
+
+	[Fact]
+	public void UpdateComponent_IsPresentFromBaselineThroughNoOpAndStructuralGenerations()
+	{
+		const string stack = """
+			<VerticalStackLayout>
+			    <Label Text="{0}" />
+			    <Button Text="Added" />
+			</VerticalStackLayout>
+			""";
+		var pageSource = PageSource(1);
+
+		using var harness = CreateHarness(pageSource);
+		var generation = harness.Generate(
+			PageXaml("First"),
+			PageXaml("Second"),
+			PageXaml("Second"),
+			PageXaml("Third", stack));
+
+		Assert.All(generation.Versions, version =>
+		{
+			Assert.NotNull(version.UpdateComponentSource);
+			Assert.Contains(
+				"internal void UpdateComponent()",
+				version.UpdateComponentSource!,
+				StringComparison.Ordinal);
+		});
+	}
+
+	[Fact]
+	public void InvalidIntermediateXaml_RecoveryRestoresStableUpdateComponentIdentity()
+	{
+		const string invalidXaml = """
+			<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			             x:Class="Maui36824.MainPage">
+			    <Label Text="Broken">
+			</ContentPage>
+			""";
+		var pageSource = PageSource(1);
+
+		using var harness = CreateHarness(pageSource);
+		var generation = harness.GenerateAllowingDiagnostics(
+			PageXaml("Stable"),
+			invalidXaml,
+			PageXaml("Stable"));
+
+		Assert.NotNull(generation[0].UpdateComponentSource);
+		Assert.Contains(
+			generation[1].GeneratorResult.Diagnostics,
+			diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+		Assert.NotNull(generation[2].UpdateComponentSource);
+		Assert.Contains(
+			"internal void UpdateComponent()",
+			generation[2].UpdateComponentSource!,
+			StringComparison.Ordinal);
+		Assert.Equal(generation[0].UpdateComponentSource, generation[2].UpdateComponentSource);
+		Assert.True(harness.Compile(generation[2]).PeImage.Length > 0);
+	}
+
+	[Fact]
+	public void SeparateCompilations_ProduceIdenticalBaselineUpdateComponent()
+	{
+		var xaml = PageXaml("Stable");
+		var pageSource = PageSource(1);
+		string firstSource;
+
+		using (var firstHarness = CreateHarness(pageSource))
+			firstSource = firstHarness.Generate(xaml)[0].UpdateComponentSource!;
+
+		using var secondHarness = CreateHarness(pageSource);
+		var secondSource = secondHarness.Generate(xaml)[0].UpdateComponentSource;
+
+		Assert.Equal(firstSource, secondSource);
+	}
+
+	static int InvokeCodeVersion(ContentPage page)
+	{
+		var method = page.GetType().GetMethod(
+			"GetCodeVersion",
+			BindingFlags.Instance | BindingFlags.Public);
+		Assert.NotNull(method);
+		return Assert.IsType<int>(method!.Invoke(page, null));
+	}
+}

--- a/src/Controls/tests/SourceGen.UnitTests/HotReload/XamlHotReloadTestHarness.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/HotReload/XamlHotReloadTestHarness.cs
@@ -82,21 +82,32 @@ internal sealed class XamlHotReloadTestHarness : IDisposable
 	public string XamlPath { get; }
 
 	public XamlHotReloadGeneration Generate(params string[] xamlVersions)
-		=> Generate(CreateMainPageSnapshots(xamlVersions), allowDiagnostics: false);
+		=> Generate(CreateMainPageSnapshots(xamlVersions), pageSources: null, allowDiagnostics: false);
 
 	public XamlHotReloadGeneration GenerateAllowingDiagnostics(params string[] xamlVersions)
-		=> Generate(CreateMainPageSnapshots(xamlVersions), allowDiagnostics: true);
+		=> Generate(CreateMainPageSnapshots(xamlVersions), pageSources: null, allowDiagnostics: true);
+
+	public XamlHotReloadGeneration GenerateWithPageSources(params XamlHotReloadSourceVersion[] versions)
+	{
+		ArgumentNullException.ThrowIfNull(versions);
+
+		return Generate(
+			CreateMainPageSnapshots([.. versions.Select(static version => version.Xaml)]),
+			[.. versions.Select(static version => version.PageSource)],
+			allowDiagnostics: false);
+	}
 
 	public XamlHotReloadGeneration GenerateDocuments(
 		params IReadOnlyDictionary<string, XamlHotReloadDocument>[] documentVersions)
-		=> Generate(documentVersions, allowDiagnostics: false);
+		=> Generate(documentVersions, pageSources: null, allowDiagnostics: false);
 
 	public XamlHotReloadGeneration GenerateDocumentsAllowingDiagnostics(
 		params IReadOnlyDictionary<string, XamlHotReloadDocument>[] documentVersions)
-		=> Generate(documentVersions, allowDiagnostics: true);
+		=> Generate(documentVersions, pageSources: null, allowDiagnostics: true);
 
 	XamlHotReloadGeneration Generate(
 		IReadOnlyDictionary<string, XamlHotReloadDocument>[] documentVersions,
+		IReadOnlyList<string>? pageSources,
 		bool allowDiagnostics)
 	{
 		ObjectDisposedException.ThrowIf(_disposed, this);
@@ -106,10 +117,13 @@ internal sealed class XamlHotReloadTestHarness : IDisposable
 			throw new InvalidOperationException("A hot reload harness can generate only one scenario.");
 		if (documentVersions.Length == 0)
 			throw new ArgumentException("At least one document version is required.", nameof(documentVersions));
+		if (pageSources is not null && pageSources.Count != documentVersions.Length)
+			throw new ArgumentException("Each document version must have a corresponding page source.", nameof(pageSources));
 
 		_generated = true;
 
-		var compilation = CreateCompilation(includeGeneratedSources: false);
+		var currentPageSource = pageSources?[0] ?? _pageSource;
+		var compilation = CreateCompilation(includeGeneratedSources: false, pageSource: currentPageSource);
 		var driverOptions = new GeneratorDriverOptions(
 			disabledOutputs: IncrementalGeneratorOutputKind.None,
 			trackIncrementalGeneratorSteps: true);
@@ -122,7 +136,16 @@ internal sealed class XamlHotReloadTestHarness : IDisposable
 
 		for (var index = 0; index < documentVersions.Length; index++)
 		{
-			var files = CreateAdditionalFiles(documentVersions[index]);
+			var pageSource = pageSources?[index] ?? _pageSource;
+			if (!string.Equals(pageSource, currentPageSource, StringComparison.Ordinal))
+			{
+				var pageTree = compilation.SyntaxTrees.Single(static tree => tree.FilePath == "Page.cs");
+				compilation = compilation.ReplaceSyntaxTree(pageTree, ParseSource(pageSource, "Page.cs"));
+				currentPageSource = pageSource;
+			}
+			var files = RetainUnchangedAdditionalTexts(
+				previousFiles,
+				CreateAdditionalFiles(documentVersions[index]));
 			driver = UpdateAdditionalTexts(driver, previousFiles, files);
 			driver = driver
 				.WithUpdatedAnalyzerConfigOptions(SourceGeneratorDriver.CreateAnalyzerConfigOptionsProvider(
@@ -149,7 +172,8 @@ internal sealed class XamlHotReloadTestHarness : IDisposable
 				generatedRoots,
 				files.ToImmutableDictionary(
 					static pair => pair.Key,
-					static pair => pair.Value.Document)));
+					static pair => pair.Value.Document),
+				pageSource));
 			previousFiles = files;
 		}
 
@@ -219,11 +243,12 @@ internal sealed class XamlHotReloadTestHarness : IDisposable
 
 	CSharpCompilation CreateCompilation(
 		bool includeGeneratedSources,
-		XamlHotReloadGeneratedVersion? generatedVersion = null)
+		XamlHotReloadGeneratedVersion? generatedVersion = null,
+		string? pageSource = null)
 	{
 		var compilation = (CSharpCompilation)SourceGeneratorDriver.CreateMauiCompilation(AssemblyName);
 		var trees = ImmutableArray.CreateBuilder<SyntaxTree>();
-		trees.Add(ParseSource(_pageSource, "Page.cs"));
+		trees.Add(ParseSource(pageSource ?? generatedVersion?.PageSource ?? _pageSource, "Page.cs"));
 
 		for (var index = 0; index < _additionalSources.Length; index++)
 			trees.Add(ParseSource(_additionalSources[index], $"Additional{index}.cs"));
@@ -293,6 +318,22 @@ internal sealed class XamlHotReloadTestHarness : IDisposable
 		}
 
 		return files.ToImmutable();
+	}
+
+	static ImmutableDictionary<string, XamlHotReloadAdditionalFile> RetainUnchangedAdditionalTexts(
+		ImmutableDictionary<string, XamlHotReloadAdditionalFile> previousFiles,
+		ImmutableDictionary<string, XamlHotReloadAdditionalFile> currentFiles)
+	{
+		foreach (var currentFile in currentFiles)
+		{
+			if (previousFiles.TryGetValue(currentFile.Key, out var previousFile)
+				&& previousFile.Document == currentFile.Value.Document)
+			{
+				currentFiles = currentFiles.SetItem(currentFile.Key, previousFile);
+			}
+		}
+
+		return currentFiles;
 	}
 
 	static GeneratorDriver UpdateAdditionalTexts(
@@ -417,6 +458,10 @@ internal sealed record XamlHotReloadDocument(
 	string? TargetFramework = "net11.0",
 	string? NoWarn = null);
 
+internal sealed record XamlHotReloadSourceVersion(
+	string Xaml,
+	string PageSource);
+
 internal sealed record XamlHotReloadGeneratedVersion(
 	string ScenarioIdentity,
 	int Index,
@@ -425,7 +470,8 @@ internal sealed record XamlHotReloadGeneratedVersion(
 	string? UpdateComponentSource,
 	GeneratorDriverRunResult GeneratorResult,
 	ImmutableArray<XamlHotReloadGeneratedRoot> GeneratedRoots,
-	ImmutableDictionary<string, XamlHotReloadDocument> Documents);
+	ImmutableDictionary<string, XamlHotReloadDocument> Documents,
+	string PageSource);
 
 internal sealed record XamlHotReloadGeneratedRoot(
 	string TypeName,
@@ -500,11 +546,11 @@ internal sealed class XamlHotReloadLiveSession : IDisposable
 	public T CreateInstance<T>() where T : class =>
 		Assert.IsAssignableFrom<T>(CreateInstance());
 
-	public T ApplyUpdate<T>(int versionIndex) where T : class
+	public T ApplyUpdate<T>(int versionIndex, params string[] changedMethodNames) where T : class
 	{
 		ObjectDisposedException.ThrowIf(_disposed, this);
 
-		var (nextVersion, semanticEdits) = PrepareUpdate(versionIndex);
+		var (nextVersion, semanticEdits) = PrepareUpdate(versionIndex, changedMethodNames);
 
 		_harness.ApplicationHost?.Dispatch(() => ApplyUpdate(nextVersion, semanticEdits));
 		if (_harness.ApplicationHost is null)
@@ -517,7 +563,7 @@ internal sealed class XamlHotReloadLiveSession : IDisposable
 	{
 		ObjectDisposedException.ThrowIf(_disposed, this);
 
-		var (nextVersion, semanticEdits) = PrepareUpdate(versionIndex);
+		var (nextVersion, semanticEdits) = PrepareUpdate(versionIndex, []);
 		ApplyMetadataUpdate(nextVersion, semanticEdits);
 		global::Microsoft.Maui.Controls.Xaml.XamlIncrementalHotReloadHandler.UpdateApplication([_pageType!]);
 
@@ -580,7 +626,9 @@ internal sealed class XamlHotReloadLiveSession : IDisposable
 		}
 	}
 
-	(XamlHotReloadCompiledVersion NextVersion, XamlHotReloadSemanticEdits SemanticEdits) PrepareUpdate(int versionIndex)
+	(XamlHotReloadCompiledVersion NextVersion, XamlHotReloadSemanticEdits SemanticEdits) PrepareUpdate(
+		int versionIndex,
+		IReadOnlyList<string> changedMethodNames)
 	{
 		if (versionIndex != _versionIndex + 1)
 			throw new ArgumentOutOfRangeException(nameof(versionIndex), "Updates must be applied sequentially.");
@@ -590,7 +638,9 @@ internal sealed class XamlHotReloadLiveSession : IDisposable
 			_compiledVersion!.Compilation,
 			nextVersion.Compilation,
 			_compiledVersion.GeneratedVersion,
-			nextVersion.GeneratedVersion);
+			nextVersion.GeneratedVersion,
+			_harness.PageClass,
+			changedMethodNames);
 		return (nextVersion, semanticEdits);
 	}
 
@@ -630,7 +680,9 @@ internal sealed class XamlHotReloadLiveSession : IDisposable
 		CSharpCompilation previousCompilation,
 		CSharpCompilation nextCompilation,
 		XamlHotReloadGeneratedVersion previousVersion,
-		XamlHotReloadGeneratedVersion nextVersion)
+		XamlHotReloadGeneratedVersion nextVersion,
+		string pageClass,
+		IReadOnlyList<string> changedMethodNames)
 	{
 		var edits = ImmutableArray.CreateBuilder<SemanticEdit>();
 		var insertedSymbols = ImmutableArray.CreateBuilder<ISymbol>();
@@ -672,6 +724,27 @@ internal sealed class XamlHotReloadLiveSession : IDisposable
 			}
 
 			affectedTypes.Add(nextRoot.TypeName);
+		}
+
+		if (changedMethodNames.Count > 0)
+		{
+			var previousPageType = previousCompilation.GetTypeByMetadataName(pageClass);
+			var nextPageType = nextCompilation.GetTypeByMetadataName(pageClass);
+			Assert.NotNull(previousPageType);
+			Assert.NotNull(nextPageType);
+
+			foreach (var methodName in changedMethodNames)
+			{
+				var previousMethod = previousPageType!
+					.GetMembers(methodName)
+					.OfType<IMethodSymbol>()
+					.Single();
+				var nextMethod = nextPageType!
+					.GetMembers(methodName)
+					.OfType<IMethodSymbol>()
+					.Single();
+				edits.Add(new SemanticEdit(SemanticEditKind.Update, previousMethod, nextMethod));
+			}
 		}
 
 		return new XamlHotReloadSemanticEdits(


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Adds direct regression coverage for the repeated-edit `ENC1002` failure tracked by #36824.

The product fix already merged in #36833: `UpdateComponent()` is emitted from generation zero and retained across every subsequent generator run, preventing Roslyn from losing the identity of a method first introduced in an EnC delta. The tracking issue remained open because the exact reported sequence was not represented by one test.

This change extends the Hot Reload harness so a scenario can update `Page.cs` between XAML generations and include the changed user method in Roslyn's semantic edits. The issue-specific tests now exercise:

- a XAML edit, followed by a C#-only edit, followed by another XAML edit through real `EmitDifference` and `MetadataUpdater.ApplyUpdate` calls;
- `UpdateComponent()` presence across baseline, property, no-op, and structural generations;
- invalid intermediate XAML followed by deterministic recovery;
- deterministic baseline output across isolated compilations.

The harness also retains the registered `AdditionalText` instance for unchanged XAML documents. Without that, a no-op generation replaced the harness's bookkeeping object without replacing the driver's object, and the next real XAML edit failed before reaching Roslyn EnC.

### Issues Fixed

Fixes #36824

### Tests

- `Maui36824Tests`: 4 passed
- `SourceGen.UnitTests`: 545 passed
