### PR TITLE
Use weak events for SwipeView and ShellContent child subscriptions

### DIFF
--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -25,3 +25,5 @@ override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.OnH
 override Microsoft.Maui.Controls.Handlers.Items.MauiRecyclerView<TItemsView, TAdapter, TItemsViewSource>.OnSizeChanged(int w, int h, int oldw, int oldh) -> void
 ~override Microsoft.Maui.Controls.SwipeItems.OnPropertyChanged(string propertyName = null) -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
+Microsoft.Maui.Controls.SwipeView.~SwipeView() -> void
+Microsoft.Maui.Controls.ShellContent.~ShellContent() -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -16,3 +16,5 @@ override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
+Microsoft.Maui.Controls.SwipeView.~SwipeView() -> void
+Microsoft.Maui.Controls.ShellContent.~ShellContent() -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -16,3 +16,5 @@ override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
+Microsoft.Maui.Controls.SwipeView.~SwipeView() -> void
+Microsoft.Maui.Controls.ShellContent.~ShellContent() -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -5,3 +5,5 @@ override Microsoft.Maui.Controls.GraphicsView.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
 ~override Microsoft.Maui.Controls.SwipeItems.OnPropertyChanged(string propertyName = null) -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
+Microsoft.Maui.Controls.SwipeView.~SwipeView() -> void
+Microsoft.Maui.Controls.ShellContent.~ShellContent() -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -7,3 +7,5 @@ override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.Handlers.Items.CarouselViewHandler.UpdateEmptyViewVisibility() -> void
 ~override Microsoft.Maui.Controls.SwipeItems.OnPropertyChanged(string propertyName = null) -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
+Microsoft.Maui.Controls.SwipeView.~SwipeView() -> void
+Microsoft.Maui.Controls.ShellContent.~ShellContent() -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -5,3 +5,5 @@ override Microsoft.Maui.Controls.GraphicsView.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
 ~override Microsoft.Maui.Controls.SwipeItems.OnPropertyChanged(string propertyName = null) -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
+Microsoft.Maui.Controls.SwipeView.~SwipeView() -> void
+Microsoft.Maui.Controls.ShellContent.~ShellContent() -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -5,3 +5,5 @@ override Microsoft.Maui.Controls.GraphicsView.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
 ~override Microsoft.Maui.Controls.SwipeItems.OnPropertyChanged(string propertyName = null) -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
+Microsoft.Maui.Controls.SwipeView.~SwipeView() -> void
+Microsoft.Maui.Controls.ShellContent.~ShellContent() -> void

--- a/src/Controls/src/Core/Shell/ShellContent.cs
+++ b/src/Controls/src/Core/Shell/ShellContent.cs
@@ -1,4 +1,4 @@
-#nullable disable
+﻿#nullable disable
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -16,6 +16,15 @@ namespace Microsoft.Maui.Controls
 	[TypeConverter(typeof(ShellContentConverter))]
 	public class ShellContent : BaseShellItem, IShellContentController, IVisualTreeElement
 	{
+		readonly Dictionary<Page, WeakNotifyPropertyChangedProxy> _pageProxies = new();
+		PropertyChangedEventHandler _pagePropertyChanged;
+
+		~ShellContent()
+		{
+			foreach (var proxy in _pageProxies.Values)
+				proxy.Unsubscribe();
+		}
+
 		static readonly BindablePropertyKey MenuItemsPropertyKey =
 			BindableProperty.CreateReadOnly(nameof(MenuItems), typeof(MenuItemCollection), typeof(ShellContent), null,
 				defaultValueCreator: bo => new MenuItemCollection());
@@ -187,7 +196,7 @@ namespace Microsoft.Maui.Controls
 			base.OnChildAdded(child);
 			if (child is Page page)
 			{
-				page.PropertyChanged += OnPagePropertyChanged;
+				AttachPage(page);
 				_isPageVisibleChanged?.Invoke(this, EventArgs.Empty);
 			}
 		}
@@ -197,8 +206,29 @@ namespace Microsoft.Maui.Controls
 			base.OnChildRemoved(child, oldLogicalIndex);
 			if (child is Page page)
 			{
-				page.PropertyChanged -= OnPagePropertyChanged;
+				DetachPage(page);
 			}
+		}
+
+		// A Page can outlive the ShellContent that hosted it -- it may be cached by the app, or
+		// re-parented onto another ShellContent -- so a plain PropertyChanged handler keeps every
+		// ShellContent the page was ever attached to alive, and with it that whole Shell subtree.
+		void AttachPage(Page page)
+		{
+			if (page is null || _pageProxies.ContainsKey(page))
+				return;
+
+			_pagePropertyChanged ??= OnPagePropertyChanged;
+
+			var proxy = new WeakNotifyPropertyChangedProxy();
+			proxy.Subscribe(page, _pagePropertyChanged);
+			_pageProxies[page] = proxy;
+		}
+
+		void DetachPage(Page page)
+		{
+			if (page is not null && _pageProxies.Remove(page, out var proxy))
+				proxy.Unsubscribe();
 		}
 
 

--- a/src/Controls/src/Core/SwipeView/SwipeView.cs
+++ b/src/Controls/src/Core/SwipeView/SwipeView.cs
@@ -1,4 +1,4 @@
-#nullable disable
+﻿#nullable disable
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -16,6 +16,15 @@ namespace Microsoft.Maui.Controls
 		readonly Lazy<PlatformConfigurationRegistry<SwipeView>> _platformConfigurationRegistry;
 
 		readonly List<ISwipeItem> _swipeItems = new List<ISwipeItem>();
+
+		readonly Dictionary<Element, WeakNotifyPropertyChangedProxy> _childProxies = new();
+		PropertyChangedEventHandler _childPropertyChanged;
+
+		~SwipeView()
+		{
+			foreach (var proxy in _childProxies.Values)
+				proxy.Unsubscribe();
+		}
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="SwipeView"/> class.
@@ -278,7 +287,7 @@ namespace Microsoft.Maui.Controls
 			// potentially cached/long-lived SwipeItems back to this SwipeView.
 			if (child is not SwipeItems)
 			{
-				child.PropertyChanged += OnPropertyChanged;
+				AttachChild(child);
 			}
 		}
 
@@ -288,8 +297,29 @@ namespace Microsoft.Maui.Controls
 
 			if (child is not SwipeItems)
 			{
-				child.PropertyChanged -= OnPropertyChanged;
+				DetachChild(child);
 			}
+		}
+
+		// A content view can be reused -- moved between SwipeViews, or held by the app and
+		// re-parented -- so a plain PropertyChanged handler keeps every SwipeView it ever sat in
+		// alive. Same reasoning as the SwipeItems exclusion above, applied to ordinary children.
+		void AttachChild(Element child)
+		{
+			if (child is null || _childProxies.ContainsKey(child))
+				return;
+
+			_childPropertyChanged ??= OnPropertyChanged;
+
+			var proxy = new WeakNotifyPropertyChangedProxy();
+			proxy.Subscribe(child, _childPropertyChanged);
+			_childProxies[child] = proxy;
+		}
+
+		void DetachChild(Element child)
+		{
+			if (child is not null && _childProxies.Remove(child, out var proxy))
+				proxy.Unsubscribe();
 		}
 
 		void OnPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)

--- a/src/Controls/tests/Core.UnitTests/ContentWeakEventTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ContentWeakEventTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	// A child can outlive the parent that hosted it -- cached by the app, or re-parented onto a
+	// different host. A plain PropertyChanged handler on the child therefore keeps every parent it
+	// was ever attached to alive, and with it that parent's whole subtree.
+	public class ContentWeakEventTests : BaseTestFixture
+	{
+		// https://github.com/dotnet/maui/issues/37218
+		[Fact]
+		public async Task ReusedContentDoesNotRootSwipeView()
+		{
+			var shared = new Label { Text = "shared" };
+
+			var reference = CreateSwipeView(shared);
+
+			Assert.False(await reference.WaitForCollect(), "SwipeView should not be alive!");
+			GC.KeepAlive(shared);
+		}
+
+		// https://github.com/dotnet/maui/issues/37217
+		[Fact]
+		public async Task ReusedPageDoesNotRootShellContent()
+		{
+			var shared = new ContentPage();
+
+			var reference = CreateShellContent(shared);
+
+			Assert.False(await reference.WaitForCollect(), "ShellContent should not be alive!");
+			GC.KeepAlive(shared);
+		}
+
+		[Fact]
+		public void SwipeViewStillTracksContentIsEnabled()
+		{
+			var content = new Label { Text = "a" };
+			var swipe = new SwipeView { Content = content };
+
+			// Attached content still notifies: flipping IsEnabled reaches the SwipeView's handler
+			// path without throwing, and the content stays parented.
+			content.IsEnabled = false;
+
+			Assert.Same(swipe, content.Parent);
+			GC.KeepAlive(swipe);
+		}
+
+		[Fact]
+		public void RemovingContentDetachesIt()
+		{
+			var content = new Label { Text = "a" };
+			var swipe = new SwipeView { Content = content };
+			Assert.Same(swipe, content.Parent);
+
+			swipe.Content = null;
+
+			Assert.Null(content.Parent);
+			GC.KeepAlive(swipe);
+		}
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		static WeakReference CreateSwipeView(View content) =>
+			new WeakReference(new SwipeView { Content = content });
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		static WeakReference CreateShellContent(Page page)
+		{
+			var sc = new ShellContent { Content = page };
+			return new WeakReference(sc);
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

`SwipeView` and `ShellContent` both subscribe to a child's `PropertyChanged` in `OnChildAdded` and unsubscribe in `OnChildRemoved`, using plain CLR handlers. A child can outlive the parent that hosted it — cached by the app, or re-parented onto a different host — and the handler then keeps every parent the child was ever attached to alive, along with that parent's whole subtree.

Both now route the subscription through the existing `WeakNotifyPropertyChangedProxy`, tracking one proxy per child so removal still detaches deterministically, plus the finalizer the proxy contract requires.

This is the pattern the surrounding code already reaches for. `SwipeView.OnChildAdded` carries a comment explaining that `SwipeItems` children are deliberately *not* subscribed for exactly this reason, and `OnSwipeItemsChanged` documents the earlier fix for #35481 where captured closures kept shared `SwipeItems` from being collected. This change extends the same reasoning to ordinary content children.

Same defect class as #38397, #38403, #38405, #38408, #38410 and #38412.

### Tests

`src/Controls/tests/Core.UnitTests/ContentWeakEventTests.cs` adds four tests: one leak test per control (a retained `Label` assigned as `SwipeView.Content`, a retained `ContentPage` assigned as `ShellContent.Content`), plus two guards pinning that attached content is still parented and that removing it still detaches.

Reverting the `src/Controls/src/Core` changes fails exactly the two leak tests and passes both guards. With the fix all four pass and the full `Controls.Core.UnitTests` suite is green (5651 passed, 0 failed).

### Issues Fixed

Fixes #37217
Fixes #37218
