### PR TITLE
[Android] Fix TalkBack forward-swipe navigation in Task and Project Details

### DIFF
--- a/src/Templates/src/templates/maui-mobile/Pages/ProjectDetailPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/ProjectDetailPage.xaml
@@ -36,13 +36,13 @@
                         Text="{Binding Description}" SemanticProperties.Description="Description" />
                 </sf:SfTextInputLayout>
 
-              <sf:SfTextInputLayout
-                    Hint="Category"
-                    SemanticProperties.Description="ComboBox to select a category. Activate to browse and select a category">
+                <sf:SfTextInputLayout
+                    Hint="Category">
                     <Picker ItemsSource="{Binding Categories}"
                             SelectedItem="{Binding Category}"
                             SelectedIndex="{Binding CategoryIndex}"
-                            IsOpen="{Binding IsCategoryPickerExpanded, Mode=TwoWay}"/>
+                            IsOpen="{Binding IsCategoryPickerExpanded, Mode=TwoWay}"
+                            SemanticProperties.Description="ComboBox to select a category. Activate to browse and select a category"/>
                 </sf:SfTextInputLayout>
 
                 <Label 

--- a/src/Templates/src/templates/maui-mobile/Pages/ProjectDetailPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/ProjectDetailPage.xaml
@@ -42,7 +42,7 @@
                             SelectedItem="{Binding Category}"
                             SelectedIndex="{Binding CategoryIndex}"
                             IsOpen="{Binding IsCategoryPickerExpanded, Mode=TwoWay}"
-                            SemanticProperties.Description="ComboBox to select a category. Activate to browse and select a category"/>
+                            SemanticProperties.Hint="ComboBox to select a category. Activate to browse and select a category"/>
                 </sf:SfTextInputLayout>
 
                 <Label 

--- a/src/Templates/src/templates/maui-mobile/Pages/TaskDetailPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/TaskDetailPage.xaml
@@ -44,7 +44,7 @@
                         SelectedItem="{Binding Project}"
                         SelectedIndex="{Binding SelectedProjectIndex}"
                         IsOpen="{Binding IsProjectPickerExpanded, Mode=TwoWay}"
-                        SemanticProperties.Description="ComboBox to select a project. Activate to browse and select a project"/>
+                        SemanticProperties.Hint="ComboBox to select a project. Activate to browse and select a project"/>
                 </sf:SfTextInputLayout>
 
                 <Button 

--- a/src/Templates/src/templates/maui-mobile/Pages/TaskDetailPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/TaskDetailPage.xaml
@@ -35,16 +35,16 @@
                         SemanticProperties.Hint="Indicates if this task is completed" />
                 </sf:SfTextInputLayout>
 
-              <sf:SfTextInputLayout
+                <sf:SfTextInputLayout
                     IsVisible="{Binding IsExistingProject}"
-                    SemanticProperties.Description="ComboBox to select a project. Activate to browse and select a project"
                     Hint="Project">
                     <Picker 
                         ItemsSource="{Binding Projects}"
                         ItemDisplayBinding="{Binding Name, x:DataType=models:Project}"
                         SelectedItem="{Binding Project}"
                         SelectedIndex="{Binding SelectedProjectIndex}"
-                        IsOpen="{Binding IsProjectPickerExpanded, Mode=TwoWay}"/>
+                        IsOpen="{Binding IsProjectPickerExpanded, Mode=TwoWay}"
+                        SemanticProperties.Description="ComboBox to select a project. Activate to browse and select a project"/>
                 </sf:SfTextInputLayout>
 
                 <Button 


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
TalkBack forward-swipe navigation could not reach all content on the Task Details and Project Details pages generated by the .NET MAUI mobile project template.

- On Task Details, navigation stopped after the Completed checkbox, making the Project picker and Save button unreachable.
- On Project Details, navigation stopped after the Description entry, making the Category picker and following content unreachable.

All interactive controls should be reachable in their logical visual order using TalkBack swipe navigation.

### Root Cause
The Project and Category pickers are native .NET MAUI Picker controls hosted inside Syncfusion SfTextInputLayout wrappers. Their SemanticProperties.Description values were assigned to the SfTextInputLayout wrappers rather than to the interactive pickers. On Android, this caused the non-interactive wrapper to be exposed as the accessibility node instead of associating the semantic information directly with the native picker, which interrupted TalkBack forward-swipe navigation.

### Description of Change

- Moved the Project semantic hint from SfTextInputLayout to the native Picker.
- Moved the Category semantic hint from SfTextInputLayout to the native Picker.
- Kept SfTextInputLayout responsible only for visual presentation.
- Preserved the existing picker bindings, selection behavior, commands, and accessibility descriptions.
- Updated the implementation to use SemanticProperties.Hint, since the provided semantic text is read correctly with the hint on the native Picker.

The semantic hints are now assigned directly to the interactive Picker controls, allowing TalkBack to focus and activate the pickers and continue navigating through the remaining page content.

### Why Tests Were Not Added

This issue requires manual accessibility validation using TalkBack to verify the forward-swipe navigation and ensure that the semantic hint is read correctly. Since this behavior cannot be reliably validated through automated tests, no additional tests were added.


### Issues Fixed
Fixes #38328

### Screenshots

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/a757aa87-5bd6-44b4-921e-a6371efc4e6d"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/e149e943-4ace-434c-9015-bc88b49b1eff"> |