### PR TITLE
[release/11.0.1xx-rc2] Update MAUI prerelease version to RC2

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,9 +5,9 @@
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <SdkBandVersion>11.0.100</SdkBandVersion>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>rc</PreReleaseVersionLabel>
     <PreReleaseVersionLabel Condition="'$(BUILD_SOURCEBRANCH)' == 'refs/heads/inflight/current'">ci.inflight</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>7</PreReleaseVersionIteration>
+    <PreReleaseVersionIteration>2</PreReleaseVersionIteration>
     <!-- Essentials.AI preview versioning — bump this for new AI previews -->
     <EssentialsAIPreviewVersionIteration>1</EssentialsAIPreviewVersionIteration>
     <!-- Servicing builds have different characteristics for the way dependencies, baselines, and versions are handled. -->


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Update `eng/Versions.props` on `release/11.0.1xx-rc2` from Preview 7 to RC2:

- Set `PreReleaseVersionLabel` to `rc`.
- Set `PreReleaseVersionIteration` to `2`.

This produces the `-rc.2` workload version suffix. Preserve the existing inflight label override, Essentials.AI preview iteration, SDK/runtime pins, and package stabilization settings.

The release branch was cut before the version bump, so this PR targets `release/11.0.1xx-rc2` rather than `net11.0` or `main`.

### Issues Fixed

Addresses the RC2 version-metadata prerequisite tracked in #38215. The overall readiness tracker remains open.

### Validation

Evaluated `eng/Versions.props` with MSBuild: release metadata resolves to `rc` / `2`, workload suffix to `-rc.2`, and SDK workload band to `11.0.100-rc.2`. The inflight override still resolves to `ci.inflight`.