### PR TITLE
[DO NOT MERGE] .NET 11 CI monitor

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,4 +1,5 @@
 <Project>
+  <!-- CI monitoring only: retain a comment-only diff for Azure Pipelines path filters. -->
   <PropertyGroup>
     <!-- The .NET product branding version -->
     <MajorVersion>11</MajorVersion>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

> [!WARNING]
> Monitoring only. Keep this PR in draft and **do not merge it**. There are no functional changes.

### Purpose

Provide a standing Azure Pipelines checks page and comment-command entry point for `dotnet/maui:net11.0`.

The only file change is an XML comment in `eng/Versions.props`. Azure Pipelines filtered out the original zero-file-change PR even when explicitly requested with `/azp run maui-pr`; this comment-only diff keeps a CI-included path changed without altering build properties or product code.

### Run CI

Comment the following to request the PR pipelines:

```text
/azp run
```

To select a single pipeline, post one of these commands:

```text
/azp run maui-pr
/azp run maui-pr-devicetests
/azp run maui-pr-uitests
```

### Keeping results current

Azure PR validation builds the synthetic `refs/pull/38424/merge` ref, not the fixed fork head. As `net11.0` advances normally, that merge incorporates the latest development-branch commits plus only this inert XML comment.

Rerun CI after `net11.0` advances. An old green check is not evidence for a newer branch commit: compare the build source version to the current PR merge SHA and confirm the merged contents differ from current `net11.0` only by the monitoring comment. Do not add functional changes to this branch. If branch history is rewritten or the merge becomes conflicted, repair the monitor before relying on its results.

This monitors public PR CI for `net11.0`. It does not replace signed official-build validation and is not an RC2 release-branch monitor.