### PR TITLE
[.Net 11] Fix obsolete ExifInterface.TagIso usage

### DIFF
--- a/src/Essentials/src/MediaPicker/ImageProcessor.android.cs
+++ b/src/Essentials/src/MediaPicker/ImageProcessor.android.cs
@@ -255,7 +255,7 @@ internal static partial class ImageProcessor
 					ExifInterface.TagGpsAltitude,
 					ExifInterface.TagExposureTime,
 					ExifInterface.TagFNumber,
-					ExifInterface.TagIso,
+					ExifInterface.TagIsoSpeedRatings,
 					ExifInterface.TagWhiteBalance,
 					ExifInterface.TagFlash,
 					ExifInterface.TagFocalLength


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
- The .NET 11 UI-test sample builds fail because MAUI Essentials uses the obsolete Android.Media.ExifInterface.TagIso, which produces CS0618 when warnings are treated as errors for the net11.0-android37.0 target.

### Root cause 
- The Android reference pack update in PR #38355 exposed the existing obsolete ExifInterface.TagIso usage as compiler-visible [Obsolete] metadata, causing CS0618 and failing the UI-test build because warnings are treated as errors.

### Description of Change
- Replaced the obsolete ExifInterface.TagIso constant with ExifInterface.TagIsoSpeedRatings, which has the same underlying value and preserves the existing behavior while removing the obsolete API usage
- Docs : [TAG_ISO_SPEED_RATINGS](https://developer.android.com/reference/android/media/ExifInterface#TAG_ISO_SPEED_RATINGS)

### Issues Fixed
Fixes #38418

### Output
| Before Fix | After Fix |
|----------|----------|
| <img src="https://github.com/user-attachments/assets/34160f19-90b5-496a-bec2-27e94ff4957c"> | <img src="https://github.com/user-attachments/assets/8241930e-5670-41f5-952c-d445f39ee777"> |