### PR TITLE
 Fix [leak-scan] VisualStateGroupList.Clear — removed groups keep triggers attached

### DIFF
--- a/src/Controls/src/Core/VisualStateManager.cs
+++ b/src/Controls/src/Core/VisualStateManager.cs
@@ -334,8 +334,7 @@ namespace Microsoft.Maui.Controls
 				{
 					if (string.Equals(_internalList[i].Name, item.Name, StringComparison.Ordinal))
 					{
-						_internalList[i].StatesChanged -= ValidateAndNotify;
-						_internalList.Remove(_internalList[i]);
+						RemoveAt(i);
 						break;
 					}
 				}
@@ -351,7 +350,7 @@ namespace Microsoft.Maui.Controls
 		{
 			foreach (var group in _internalList)
 			{
-				group.StatesChanged -= ValidateAndNotify;
+				DetachGroup(group);
 			}
 
 			_internalList.Clear();
@@ -377,8 +376,14 @@ namespace Microsoft.Maui.Controls
 				throw new ArgumentNullException(nameof(item));
 			}
 
-			item.StatesChanged -= ValidateAndNotify;
-			return _internalList.Remove(item);
+			var index = _internalList.IndexOf(item);
+			if (index < 0)
+				return false;
+
+			var removedItem = _internalList[index];
+			_internalList.RemoveAt(index);
+			DetachGroup(removedItem);
+			return true;
 		}
 
 		/// <inheritdoc />
@@ -408,14 +413,43 @@ namespace Microsoft.Maui.Controls
 		/// <inheritdoc />
 		public void RemoveAt(int index)
 		{
-			_internalList[index].StatesChanged -= ValidateAndNotify;
+			var item = _internalList[index];
 			_internalList.RemoveAt(index);
+			DetachGroup(item);
 		}
 
 		public VisualStateGroup this[int index]
 		{
 			get => _internalList[index];
-			set => _internalList[index] = value;
+			set
+			{
+				if (value == null)
+					throw new ArgumentNullException(nameof(value));
+
+				var oldItem = _internalList[index];
+				if (ReferenceEquals(oldItem, value))
+					return;
+
+				_internalList[index] = value;
+				DetachGroup(oldItem);
+				value.StatesChanged += ValidateAndNotify;
+				ValidateAndNotify(_internalList);
+			}
+		}
+
+		void DetachGroup(VisualStateGroup group)
+		{
+			group.StatesChanged -= ValidateAndNotify;
+
+			foreach (var state in group.States)
+			{
+				foreach (var trigger in state.StateTriggers)
+				{
+					trigger.SendDetached();
+				}
+			}
+
+			group.VisualElement = null;
 		}
 
 		WeakReference<VisualElement> _visualElement;

--- a/src/Controls/src/Core/VisualStateManager.cs
+++ b/src/Controls/src/Core/VisualStateManager.cs
@@ -377,12 +377,7 @@ namespace Microsoft.Maui.Controls
 			}
 
 			var index = _internalList.IndexOf(item);
-			if (index < 0)
-				return false;
-
-			var removedItem = _internalList[index];
-			_internalList.RemoveAt(index);
-			DetachGroup(removedItem);
+			RemoveAt(index);
 			return true;
 		}
 
@@ -413,9 +408,13 @@ namespace Microsoft.Maui.Controls
 		/// <inheritdoc />
 		public void RemoveAt(int index)
 		{
+			if (index < 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(index));
+			}
 			var item = _internalList[index];
-			_internalList.RemoveAt(index);
 			DetachGroup(item);
+			_internalList.RemoveAt(index);
 		}
 
 		public VisualStateGroup this[int index]
@@ -424,14 +423,18 @@ namespace Microsoft.Maui.Controls
 			set
 			{
 				if (value == null)
+				{
 					throw new ArgumentNullException(nameof(value));
+				}
 
 				var oldItem = _internalList[index];
 				if (ReferenceEquals(oldItem, value))
+				{
 					return;
+				}
 
-				_internalList[index] = value;
 				DetachGroup(oldItem);
+				_internalList[index] = value;
 				value.StatesChanged += ValidateAndNotify;
 				ValidateAndNotify(_internalList);
 			}
@@ -443,9 +446,14 @@ namespace Microsoft.Maui.Controls
 
 			foreach (var state in group.States)
 			{
+				if (state is null)
+				{
+					continue;
+				}
+
 				foreach (var trigger in state.StateTriggers)
 				{
-					trigger.SendDetached();
+					trigger?.SendDetached();
 				}
 			}
 

--- a/src/Controls/tests/Core.UnitTests/VisualStateManagerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualStateManagerTests.cs
@@ -336,6 +336,85 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			stateGroups.Add(new VisualStateGroup { Name = name });
 		}
 
+		[Fact]
+		public void ClearDetachesStateTriggers()
+		{
+			var (groups, trigger) = CreateAttachedStateTriggerGroup();
+
+			groups.Clear();
+
+			Assert.False(trigger.IsAttached);
+		}
+
+		[Fact]
+		public void RemoveDetachesStateTriggers()
+		{
+			var (groups, trigger) = CreateAttachedStateTriggerGroup();
+
+			groups.Remove(groups[0]);
+
+			Assert.False(trigger.IsAttached);
+		}
+
+		[Fact]
+		public void RemoveAtDetachesStateTriggers()
+		{
+			var (groups, trigger) = CreateAttachedStateTriggerGroup();
+
+			groups.RemoveAt(0);
+
+			Assert.False(trigger.IsAttached);
+		}
+
+		[Fact]
+		public void AddingDuplicateNamedGroupDetachesReplacedStateTriggers()
+		{
+			var (groups, trigger) = CreateAttachedStateTriggerGroup();
+
+			groups.Add(new VisualStateGroup { Name = groups[0].Name });
+
+			Assert.False(trigger.IsAttached);
+		}
+
+		[Fact]
+		public void ReplacingGroupByIndexDetachesStateTriggers()
+		{
+			var (groups, trigger) = CreateAttachedStateTriggerGroup();
+
+			groups[0] = new VisualStateGroup { Name = "Replacement" };
+
+			Assert.False(trigger.IsAttached);
+		}
+
+		static (VisualStateGroupList Groups, StateTriggerBase Trigger) CreateAttachedStateTriggerGroup()
+		{
+			var trigger = new TestStateTrigger();
+			var groups = new VisualStateGroupList
+			{
+				new VisualStateGroup
+				{
+					Name = CommonStatesGroupName,
+					States =
+					{
+						new VisualState
+						{
+							Name = NormalStateName,
+							StateTriggers = { trigger }
+						}
+					}
+				}
+			};
+
+			trigger.SendAttached();
+			Assert.True(trigger.IsAttached);
+
+			return (groups, trigger);
+		}
+
+		sealed class TestStateTrigger : StateTriggerBase
+		{
+		}
+
 
 		public VisualStateManagerTests()
 		{


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
 
### Issue Details

Clearing an attached VisualStateGroupList removes groups without detaching the state triggers nested inside them. A trigger subscribed to a shared managed publisher in OnAttached() therefore stays subscribed and retained after its group is removed.

### Root Cause 

An attached `StateTriggerBase` runs `OnAttached()`, where custom triggers may subscribe to long-lived publishers such as static events. They rely on `SendDetached()` invoking `OnDetached()` to unsubscribe.
 
Replacing the entire `VisualStateGroups` attached property already performed this teardown. However, mutating the existing `VisualStateGroupList` did not:
 
- `Clear`
- `Remove`
- `RemoveAt`
- Adding a group that replaces one with the same name
- Replacing a group through the indexer
 
These paths only removed `StatesChanged` handlers and collection entries. Nested triggers remained attached, leaving retention paths such as:
 
```text
static publisher → event delegate → state trigger → page-local data
```

### Description of Change

Added a shared `DetachGroup` teardown method that:
 
1. Unsubscribes the group's `StatesChanged` handler.
2. Calls `SendDetached()` on every nested state trigger.
3. Removes the group's reference to its associated visual element.
 
All removal and replacement paths in `VisualStateGroupList` now use this teardown.
 
The `Remove` implementation also identifies the actual stored group before removing it. This ensures the correct instance is detached even when another equality-equivalent object is supplied.
 
## Regression coverage
 
Added tests to `VisualStateManagerTests.cs` verifying trigger detachment for:
 
- `Clear`
- `Remove`
- `RemoveAt`
- Duplicate-name replacement through `Add`
- Index replacement 
 
### Issues Fixed
 
Fixes #38245  
 
**Tested the behavior in the following platforms.**
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
| Before  | After  |
|---------|--------|
| <img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/3f5ede16-f0ee-4aac-b728-07835001f851" /> | <img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/dafc0ce1-e9b4-439d-949e-cbe29a29af49" /> |