### PR TITLE
[Net11][Android][ShellHandler]Fix Navigation stops working when changing Window[0].Page from Shell

### DIFF
--- a/src/Controls/src/Core/Handlers/Shell/ShellHandler.Android.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellHandler.Android.cs
@@ -56,6 +56,8 @@ namespace Microsoft.Maui.Controls.Handlers
         // Pending fragment transaction (from RunOrWaitForResume, same as FlyoutViewHandler)
         IDisposable? _pendingFragment;
 
+        bool _releasingDrawerCallback;
+
         protected override MauiDrawerLayout CreatePlatformView()
         {
             // Create MauiDrawerLayout (same as FlyoutViewHandler)
@@ -157,8 +159,32 @@ namespace Microsoft.Maui.Controls.Handlers
             base.DisconnectHandler(platformView);
         }
 
+        internal void ReleaseDrawerCallbackBeforePageChange()
+        {
+            if (!OperatingSystem.IsAndroidVersionAtLeast(36))
+            {
+                return;
+            }
+
+            _releasingDrawerCallback = true;
+            try
+            {
+                PlatformView.CloseFlyout(false);
+                PlatformView.SetDrawerLockMode(DrawerLayout.LockModeLockedClosed);
+            }
+            finally
+            {
+                _releasingDrawerCallback = false;
+            }
+        }
+
         void OnFlyoutPresentedChanged(bool isPresented)
         {
+            if (_releasingDrawerCallback)
+            {
+                return;
+            }
+
             // Sync the Shell's FlyoutIsPresented property with actual drawer state
             if (_currentBehavior == FlyoutBehavior.Flyout)
             {

--- a/src/Controls/src/Core/Window/Window.cs
+++ b/src/Controls/src/Core/Window/Window.cs
@@ -688,6 +688,12 @@ namespace Microsoft.Maui.Controls
 		// the FlyoutPage) and the nested case (e.g. NavigationPage wrapping a FlyoutPage).
 		static void ReleaseFlyoutDrawerCallbacks(Page page)
 		{
+			if (page.Handler is Handlers.ShellHandler shellHandler)
+			{
+				shellHandler.ReleaseDrawerCallbackBeforePageChange();
+				return;
+			}
+
 			if (page.Handler is FlyoutViewHandler flyoutHandler)
 			{
 				flyoutHandler.ReleaseDrawerCallbackBeforePageChange();

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue38026.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue38026.cs
@@ -1,0 +1,74 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(
+    IssueTracker.Github,
+    38026,
+    "Navigation stops working after changing Window.Page from Shell",
+    PlatformAffected.Android)]
+public class Issue38026 : ContentPage
+{
+    public Issue38026()
+    {
+        Content = new Button
+        {
+            AutomationId = "InstallNavigationPageButton",
+            Text = "Install NavigationPage",
+            Command = new Command(() =>
+                Application.Current!.Windows[0].Page = new NavigationPage(new NavigationRootPage())),
+        };
+    }
+
+    sealed class NavigationRootPage : ContentPage
+    {
+        public NavigationRootPage()
+        {
+            Content = new Button
+            {
+                AutomationId = "ShowShellButton",
+                Text = "Show Shell",
+                Command = new Command(() => Application.Current!.Windows[0].Page = new TestShell()),
+            };
+        }
+    }
+
+    sealed class TestShell : Shell
+    {
+        public TestShell()
+        {
+            FlyoutBehavior = FlyoutBehavior.Flyout;
+
+            var openFlyoutButton = new Button
+            {
+                AutomationId = "OpenShellFlyoutButton",
+                Text = "Open Shell flyout",
+            };
+            openFlyoutButton.Clicked += (_, _) => FlyoutIsPresented = true;
+
+            Items.Add(new ShellContent
+            {
+                Title = "Home",
+                Content = new ContentPage { Content = openFlyoutButton },
+            });
+
+            FlyoutFooter = new Button
+            {
+                AutomationId = "ReplaceShellButton",
+                Text = "Replace Shell",
+                Command = new Command(() =>
+                    Application.Current!.Windows[0].Page = new NavigationPage(new ReplacementPage())),
+            };
+        }
+    }
+
+    sealed class ReplacementPage : ContentPage
+    {
+        public ReplacementPage()
+        {
+            Content = new Label
+            {
+                Text = "Replacement NavigationPage",
+                AutomationId = "ReplacementPageLabel",
+            };
+        }
+    }
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue38026.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue38026.cs
@@ -1,0 +1,39 @@
+#if ANDROID     // This issue is reproduced only on Android API 36, so added an Android-specific test and restricted it from running on other platforms, also categorized the test under SafeAreaEdges.                                                                                                                                                                                                  
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue38026 : _IssuesUITest
+{
+	public Issue38026(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue => "Navigation stops working after changing Window.Page from Shell";
+
+	[Test]
+	[Category(UITestCategories.SafeAreaEdges)]
+	public void BackWorksAfterReplacingShellWithNavigationPage()
+	{
+		App.WaitForElement("InstallNavigationPageButton");
+		App.Tap("InstallNavigationPageButton");
+
+		App.WaitForElement("ShowShellButton");
+		App.Tap("ShowShellButton");
+
+		App.WaitForElement("OpenShellFlyoutButton");
+		App.Tap("OpenShellFlyoutButton");
+
+		App.WaitForElement("ReplaceShellButton");
+		App.Tap("ReplaceShellButton");
+
+		App.WaitForElement("ReplacementPageLabel");
+
+		App.Back();
+
+		App.WaitForNoElement("ReplacementPageLabel");
+	}
+}
+#endif


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details
On Android 16, replacing Window.Page from Shell to NavigationPage leaves Shell’s old DrawerLayout back callback registered. This stale callback intercepts Android back navigation even though Shell is no longer visible.

### Description of Change

<!-- Enter description of the fix in this section -->
Before replacing Window.Page, the fix: 
* Detects an outgoing Shell. Closes its flyout if open. 
* Locks the DrawerLayout closed to release its back callback. 
* Refreshes Android’s back-navigation state after installing the new page. 

This restores back navigation after switching from Shell to NavigationPage.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #38436 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

 **Tested the behavior in the following platforms.**
- [x] Android
- [ ] Windows
- [ ] iOS
- [ ] Mac

| Before  | After  |
|---------|--------|
| **Android**<br> <video src="https://github.com/user-attachments/assets/cc202510-daff-4788-80b0-fae2d8cec189" width="300" height="600"> | **Android**<br> <video src="https://github.com/user-attachments/assets/f2cb6881-e5be-4746-8680-15bc5ff68afc" width="300" height="600"> |