### PR TITLE
[WIP][iOS/Mac] Fix CollectionView2 height not updating when ItemsSource changes

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -207,6 +207,14 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 			base.ViewWillLayoutSubviews();
 			LayoutEmptyView();
+		}
+
+		public override void ViewDidLayoutSubviews()
+		{
+			base.ViewDidLayoutSubviews();
+
+			// Compositional layout can resolve estimated, self-sizing cells during layout.
+			// Check the updated content size after layout completes.
 			InvalidateMeasureIfContentSizeChanged();
 		}
 

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -16,3 +16,4 @@ override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
+override Microsoft.Maui.Controls.Handlers.Items2.ItemsViewController2<TItemsView>.ViewDidLayoutSubviews() -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -16,3 +16,4 @@ override Microsoft.Maui.Controls.TitleBar.OnBindingContextChanged() -> void
 Microsoft.Maui.Controls.Label.~Label() -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
+override Microsoft.Maui.Controls.Handlers.Items2.ItemsViewController2<TItemsView>.ViewDidLayoutSubviews() -> void

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue38276.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue38276.cs
@@ -1,0 +1,73 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 38276, "CollectionView does not update its rendered height after ItemsSource changes", PlatformAffected.iOS)]
+public class Issue38276 : ContentPage
+{
+	const double MaximumCollectionHeight = 180;
+
+	public Issue38276()
+	{
+		CollectionView collectionView = new CollectionView
+		{
+			AutomationId = "CollectionView",
+			Background = Colors.LightGrey,
+			MaximumHeightRequest = MaximumCollectionHeight,
+			VerticalOptions = LayoutOptions.Start,
+			ItemsSource = CreateItems(10),
+			ItemTemplate = new DataTemplate(() =>
+			{
+				Label label = new Label
+				{
+					FontFamily = "OpenSansRegular",
+					FontSize = 13,
+					FontAttributes = FontAttributes.Bold,
+					LineBreakMode = LineBreakMode.TailTruncation
+				};
+				label.SetBinding(Label.TextProperty, ".");
+
+				return new Border
+				{
+					StrokeThickness = 0,
+					Padding = new Thickness(8, 4),
+					Margin = new Thickness(0, 2),
+					Content = label
+				};
+			})
+		};
+
+		Button largeItemsButton = new Button
+		{
+			AutomationId = "LargeItemsButton",
+			Text = "Show 10 items"
+		};
+		largeItemsButton.Clicked += (sender, args) => collectionView.ItemsSource = CreateItems(10);
+
+		Button singleItemButton = new Button
+		{
+			AutomationId = "SingleItemButton",
+			Text = "Show 1 item"
+		};
+		singleItemButton.Clicked += (sender, args) => collectionView.ItemsSource = CreateItems(1);
+
+		var layout = new Grid
+		{
+			Padding = 20,
+			RowSpacing = 8,
+			RowDefinitions =
+			[
+				new RowDefinition(GridLength.Auto),
+				new RowDefinition(GridLength.Auto),
+				new RowDefinition(GridLength.Auto)
+			]
+		};
+
+		layout.Add(collectionView, row: 0);
+		layout.Add(singleItemButton, row: 1);
+		layout.Add(largeItemsButton, row: 2);
+
+		Content = layout;
+	}
+
+	static List<string> CreateItems(int count) =>
+		Enumerable.Range(1, count).Select(index => $"Item {index}").ToList();
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue38276.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue38276.cs
@@ -1,0 +1,58 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue38276 : _IssuesUITest
+{
+	public Issue38276(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue => "CollectionView does not update its rendered height after ItemsSource changes";
+
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void CollectionViewHeightUpdatesAfterItemsSourceChanges()
+	{
+		App.WaitForElement("LargeItemsButton");
+		App.WaitForElement("SingleItemButton");
+		var collectionView = App.WaitForElement("CollectionView");
+		var largeItemsInitialHeight = collectionView.GetRect().Height;
+
+		App.Tap("SingleItemButton");
+
+		App.RetryAssert(() =>
+		{
+			var height = App.FindElement("CollectionView").GetRect().Height;
+			Assert.That(
+				height,
+				Is.LessThan(largeItemsInitialHeight),
+				"CollectionView should shrink after the first ItemsSource update.");
+		});
+
+		var singleItemHeight = App.FindElement("CollectionView").GetRect().Height;
+		Assert.That(
+			singleItemHeight,
+			Is.LessThan(largeItemsInitialHeight),
+			"CollectionView height should decrease when ItemsSource changes from 10 items to 1 item.");
+
+		App.Tap("LargeItemsButton");
+
+		App.RetryAssert(() =>
+		{
+			var height = App.FindElement("CollectionView").GetRect().Height;
+			Assert.That(
+				height,
+				Is.GreaterThan(singleItemHeight),
+				"CollectionView should grow after the second ItemsSource update.");
+		});
+
+		var largeItemsFinalHeight = App.FindElement("CollectionView").GetRect().Height;
+		Assert.That(
+			largeItemsFinalHeight,
+			Is.GreaterThan(singleItemHeight),
+			"CollectionView height should increase when ItemsSource changes from 1 item to 10 items.");
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
- On Mac Catalyst and iOS, when a CollectionView is initially populated with a larger number of items, it expands and reports a larger rendered height through the SizeChanged event. If the ItemsSource is subsequently updated with fewer items, the CollectionView retains the previously measured height instead of recalculating and shrinking to match the new content size.

### Root Cause
- InvalidateMeasureIfContentSizeChanged() ran in ViewWillLayoutSubviews(), where CV2's compositional layout could still expose the previous content size because estimated, self-sizing cells had not completed layout. Once UIKit produced the updated size later in the layout pass, MAUI received no subsequent measure invalidation and retained the stale CollectionView height.


### Description of Change
- Moved the CV2 content-size check to ViewDidLayoutSubviews() so MAUI invalidates and remeasures the CollectionView after UIKit has updated the compositional layout's content size. Added the ViewDidLayoutSubviews override to ItemsViewController2 and updated the public API files for iOS and Mac Catalyst.


### Issues Fixed
Fixes #38276

### Validated the behaviour in the following platforms
- [ ] Windows
- [ ] Android
- [x] iOS
- [x] Mac

### Output
| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/bd45e97e-0915-4296-9fb0-cf5845cabfaf"> | <video src="https://github.com/user-attachments/assets/503bd075-9031-4029-b2aa-b84c39be8fb9"> |