### PR TITLE
Fix memory leak when removing VisualState state triggers

### DIFF
--- a/src/Controls/src/Core/VisualStateManager.cs
+++ b/src/Controls/src/Core/VisualStateManager.cs
@@ -715,7 +715,7 @@ namespace Microsoft.Maui.Controls
 		public VisualState()
 		{
 			Setters = new ObservableCollection<Setter>();
-			StateTriggers = new WatchAddList<StateTriggerBase>(OnStateTriggersChanged);
+			StateTriggers = new WatchAddList<StateTriggerBase>(OnStateTriggersChanged, OnStateTriggersRemoved);
 		}
 
 		/// <summary>
@@ -765,6 +765,17 @@ namespace Microsoft.Maui.Controls
 			foreach (var stateTrigger in stateTriggers)
 			{
 				stateTrigger.VisualState = this;
+			}
+
+			VisualStateGroup?.UpdateStateTriggers();
+		}
+
+		void OnStateTriggersRemoved(IList<StateTriggerBase> stateTriggers)
+		{
+			foreach (var stateTrigger in stateTriggers)
+			{
+				stateTrigger.SendDetached();
+				stateTrigger.VisualState = null;
 			}
 
 			VisualStateGroup?.UpdateStateTriggers();
@@ -858,11 +869,13 @@ namespace Microsoft.Maui.Controls
 	internal class WatchAddList<T> : IList<T>
 	{
 		readonly Action<List<T>> _onAdd;
+		readonly Action<List<T>> _onRemove;
 		readonly List<T> _internalList;
 
-		public WatchAddList(Action<List<T>> onAdd)
+		public WatchAddList(Action<List<T>> onAdd, Action<List<T>> onRemove = null)
 		{
 			_onAdd = onAdd;
+			_onRemove = onRemove;
 			_internalList = new List<T>();
 		}
 
@@ -884,7 +897,12 @@ namespace Microsoft.Maui.Controls
 
 		public void Clear()
 		{
+			if (_internalList.Count == 0)
+				return;
+
+			var removedItems = new List<T>(_internalList);
 			_internalList.Clear();
+			_onRemove?.Invoke(removedItems);
 		}
 
 		public bool Contains(T item)
@@ -899,7 +917,14 @@ namespace Microsoft.Maui.Controls
 
 		public bool Remove(T item)
 		{
-			return _internalList.Remove(item);
+			var index = _internalList.IndexOf(item);
+			if (index < 0)
+				return false;
+
+			var removedItem = _internalList[index];
+			_internalList.RemoveAt(index);
+			_onRemove?.Invoke(new List<T> { removedItem });
+			return true;
 		}
 
 		public int Count => _internalList.Count;
@@ -919,13 +944,24 @@ namespace Microsoft.Maui.Controls
 
 		public void RemoveAt(int index)
 		{
+			var removedItem = _internalList[index];
 			_internalList.RemoveAt(index);
+			_onRemove?.Invoke(new List<T> { removedItem });
 		}
 
 		public T this[int index]
 		{
 			get => _internalList[index];
-			set => _internalList[index] = value;
+			set
+			{
+				var removedItem = _internalList[index];
+				if (ReferenceEquals(removedItem, value))
+					return;
+
+				_internalList[index] = value;
+				_onRemove?.Invoke(new List<T> { removedItem });
+				_onAdd(_internalList);
+			}
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/VisualStateManagerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualStateManagerTests.cs
@@ -760,6 +760,47 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal(VisualStateManager.CommonStates.Normal, groups[0].CurrentState.Name);
 		}
 
+		[Theory]
+		[InlineData(StateTriggerRemovalOperation.Clear)]
+		[InlineData(StateTriggerRemovalOperation.Remove)]
+		[InlineData(StateTriggerRemovalOperation.RemoveAt)]
+		[InlineData(StateTriggerRemovalOperation.Replace)]
+		public void RemovingStateTriggerDetachesIt(StateTriggerRemovalOperation operation)
+		{
+			var trigger = new LifecycleStateTrigger();
+			var state = new VisualState { Name = "Active", StateTriggers = { trigger } };
+			var label = new Label();
+
+			VisualStateManager.SetVisualStateGroups(label, new VisualStateGroupList
+			{
+				new VisualStateGroup { States = { state } }
+			});
+
+			var page = new ContentPage { Content = label };
+			_ = new Window { Page = page };
+			Assert.True(trigger.IsAttached);
+
+			switch (operation)
+			{
+				case StateTriggerRemovalOperation.Clear:
+					state.StateTriggers.Clear();
+					break;
+				case StateTriggerRemovalOperation.Remove:
+					state.StateTriggers.Remove(trigger);
+					break;
+				case StateTriggerRemovalOperation.RemoveAt:
+					state.StateTriggers.RemoveAt(0);
+					break;
+				case StateTriggerRemovalOperation.Replace:
+					state.StateTriggers[0] = new LifecycleStateTrigger();
+					break;
+			}
+
+			Assert.False(trigger.IsAttached);
+			Assert.Equal(1, trigger.DetachCount);
+			Assert.Null(trigger.VisualState);
+		}
+
 		static VisualStateGroupList CreateStateGroupsWithSelectedAndPointerOver()
 		{
 			return new VisualStateGroupList
@@ -782,6 +823,24 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		{
 			var field = typeof(VisualElement).GetField("_isPointerOver", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
 			field!.SetValue(element, value);
+		}
+
+		public enum StateTriggerRemovalOperation
+		{
+			Clear,
+			Remove,
+			RemoveAt,
+			Replace,
+		}
+
+		sealed class LifecycleStateTrigger : StateTriggerBase
+		{
+			public int DetachCount { get; private set; }
+
+			protected override void OnDetached()
+			{
+				DetachCount++;
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->


### Issue Details
Removing a StateTriggerBase from VisualState.StateTriggers does not detach the trigger. If it subscribed to a long-lived event, the subscription can retain the trigger and its referenced objects.
For example, calling state.StateTriggers.Clear() removes the trigger from the collection without calling its detach lifecycle.

### Root Cause
VisualState.StateTriggers uses WatchAddList<StateTriggerBase>, which previously notified only when triggers were added. Operations such as Clear(), Remove(), RemoveAt(), and replacement therefore removed triggers without calling SendDetached().

### Description of Change
Updated WatchAddList<T> to support an optional removal callback and added removal handling to VisualState. Removed triggers are detached, their VisualState references are cleared, and active triggers are recalculated.
Added regression coverage for Clear(), Remove(), RemoveAt(), and index replacement to verify that each removed trigger is detached exactly once.

Validated the behavior in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
### Issues Fixed
  
Fixes #38243 

### Output  ScreenShot

|Before|After|
|--|--|
| <img width="364" height="733" alt="image" src="https://github.com/user-attachments/assets/e2287141-a2b5-4791-970c-a5301b266b6b" /> | <img width="364" height="733" alt="image" src="https://github.com/user-attachments/assets/44aa8172-94ae-4698-96bd-2959981ccb4a" /> |
