### PR TITLE
Update PatchVersion from 110 to 120

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
     <!-- The .NET product branding version -->
     <MajorVersion>10</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>110</PatchVersion>
+    <PatchVersion>120</PatchVersion>
     <SdkBandVersion>10.0.100</SdkBandVersion>
     <PreReleaseVersionLabel>ci.main</PreReleaseVersionLabel>
     <PreReleaseVersionLabel Condition="'$(BUILD_SOURCEBRANCH)' == 'refs/heads/inflight/current'">ci.inflight</PreReleaseVersionLabel>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

Advance `main` to the .NET 10 SR12 development cycle now that `release/10.0.1xx-sr11` has been cut from the merge of #37393 (`e047434fd22752a3e96187d55cd554a4a1c200b5`).

Change only `PatchVersion` in `eng/Versions.props` from `110` to `120`. Keep `SdkBandVersion=10.0.100`, `PreReleaseVersionLabel=ci.main` (including the inflight override), and `StabilizePackageVersion=false` unchanged.

This is separate from the SR11 servicing-flip PR and does not change the release branch.

Related: #38210.

## Validation

- Evaluated `eng/Versions.props` using `dotnet msbuild -getProperty`: version `10.0.120`, SDK band `10.0.100`, prerelease label `ci.main`, stable versions disabled.
- Ran the repository formatter scoped to `eng/Versions.props` and confirmed the final diff is exactly one changed line.