### PR TITLE
Add .NET 11 RC1 to bug report versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -42,6 +42,7 @@ body:
       label: Version with bug
       description: In what version do you see this issue? Run `dotnet workload list` to find your version.
       options:
+        - 11.0.0-rc.1
         - 11.0.0-preview.7
         - 11.0.0-preview.6
         - 11.0.0-preview.5
@@ -191,6 +192,7 @@ body:
         - 11.0.0-preview.5
         - 11.0.0-preview.6
         - 11.0.0-preview.7
+        - 11.0.0-rc.1
     validations:
       required: true
   - type: dropdown


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Adds `11.0.0-rc.1` to both version dropdowns in the bug report issue template:

- Version with bug
- Last version that worked well

This keeps the dropdowns current for the .NET 11 RC1 release.