### PR TITLE
Target RC2 for automated net11.0 release merges

### DIFF
--- a/github-merge-flow-release-11.jsonc
+++ b/github-merge-flow-release-11.jsonc
@@ -2,7 +2,7 @@
 {
     "merge-flow-configurations": {
         "net11.0": {
-            "MergeToBranch": "release/11.0.1xx-rc1",
+            "MergeToBranch": "release/11.0.1xx-rc2",
             "ExtraSwitches": "-QuietComments",
             "ResetToTargetPaths": "global.json;NuGet.config;eng/Version.Details.xml;eng/Versions.props;eng/common/*"
         }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Change `MergeToBranch` in `github-merge-flow-release-11.jsonc` from `release/11.0.1xx-rc1` to `release/11.0.1xx-rc2`. Preserve all other merge-flow settings.

This PR intentionally targets **net11.0**: both the open-PR guard and the Arcade merge job load this configuration from that branch. A local change or a change on main alone does not update the active target.

### Issues Fixed

Stops the recurring automated net11.0-to-RC1 merge PRs seen in #38458 and #38461. Future automated release merges should target RC2.

Keep #38461 open until this fix lands so the existing open-PR guard prevents another RC1 PR from being created. Close the obsolete RC1 PR after merging this change.