### PR TITLE
Prepare SR11 for servicing packages

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,14 +5,13 @@
     <MinorVersion>0</MinorVersion>
     <PatchVersion>110</PatchVersion>
     <SdkBandVersion>10.0.100</SdkBandVersion>
-    <PreReleaseVersionLabel>ci.main</PreReleaseVersionLabel>
-    <PreReleaseVersionLabel Condition="'$(BUILD_SOURCEBRANCH)' == 'refs/heads/inflight/current'">ci.inflight</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>
     </PreReleaseVersionIteration>
     <!-- Servicing builds have different characteristics for the way dependencies, baselines, and versions are handled. -->
     <IsServicingBuild Condition=" '$(PreReleaseVersionLabel)' == 'servicing' ">true</IsServicingBuild>
     <!-- Enable to remove prerelease label and produce stable package versions. -->
-    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
     <WorkloadVersionSuffix Condition="'$(DotNetFinalVersionKind)' != 'release' and '$(PreReleaseVersionIteration)' == ''">-$(PreReleaseVersionLabel)</WorkloadVersionSuffix>
     <WorkloadVersionSuffix Condition="'$(WorkloadVersionSuffix)' == '' and '$(DotNetFinalVersionKind)' != 'release'">-$(PreReleaseVersionLabel).$(PreReleaseVersionIteration)</WorkloadVersionSuffix>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

- preserve `PatchVersion` at `110`
- change `PreReleaseVersionLabel` from `ci.main` to `servicing`
- remove the `inflight/current` `ci.inflight` label override
- enable `StabilizePackageVersion` by default while preserving explicit overrides

## Validation

Evaluated the properties with MSBuild for the default environment, `BUILD_SOURCEBRANCH=refs/heads/inflight/current`, and an explicit `StabilizePackageVersion=false` override. Both branch environments resolve to patch 110 and the `servicing` label; stabilization defaults to `true`, while the explicit `false` override remains honored.

## Scope

This PR only prepares stable SR11 package versioning on `release/10.0.1xx-sr11`. It does not change `main`, resolve outstanding regression or backport decisions, update BAR state, or trigger release pipelines. Final release-head validation is still required after any later backports.