### PR TITLE
[iOS] Fix MediaPicker UIKit threading when picking multiple items

### DIFF
--- a/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
@@ -269,22 +269,44 @@ namespace Microsoft.Maui.Media
 			if (results == null || results.Length == 0)
 				return [];
 
-			var fileResults = new List<FileResult>(results.Length);
-			PHPickerFileResult fileResult = null;
+			// PHPickerResult.ItemProvider is a UIKit call and must be read on the main thread.
+			// This method is invoked from the picker delegate, so we are on the main thread here,
+			// but awaiting below resumes on the thread pool. Read every ItemProvider up front,
+			// before the first await, so no read is left straddling a continuation.
+			var pickerResults = new List<PHPickerFileResult>(results.Length);
 			try
 			{
 				foreach (var file in results)
 				{
-					fileResult = new PHPickerFileResult(file.ItemProvider);
-					await fileResult.LoadFileRepresentationAsync().ConfigureAwait(false);
-					fileResults.Add(fileResult);
-					fileResult = null;
+					pickerResults.Add(new PHPickerFileResult(file.ItemProvider));
 				}
 			}
 			catch
 			{
-				fileResult?.Dispose();
+				foreach (var pickerResult in pickerResults)
+				{
+					pickerResult.Dispose();
+				}
+				throw;
+			}
+
+			var fileResults = new List<FileResult>(pickerResults.Count);
+			try
+			{
+				foreach (var pickerResult in pickerResults)
+				{
+					await pickerResult.LoadFileRepresentationAsync().ConfigureAwait(false);
+					fileResults.Add(pickerResult);
+				}
+			}
+			catch
+			{
+				// Dispose the loaded results, then the ones left unloaded by the failure.
 				DisposeFileResults(fileResults);
+				for (var i = fileResults.Count; i < pickerResults.Count; i++)
+				{
+					pickerResults[i].Dispose();
+				}
 				throw;
 			}
 


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Forward-ports the merged fix from #37879 (`inflight/current`) to `main` for #37878.

`PickerResultsToMediaFiles` previously read each `PHPickerResult.ItemProvider` after an awaited operation resumed on a thread-pool thread. Picking two or more items could therefore throw `UIKitThreadAccessException`. The fix materializes all item providers on the UI thread before the first await, then loads their file representations separately. It also disposes providers that remain unloaded if loading fails.

### SR11 Backport Sequence

This `main` forward-port must merge before the SR11 backport is created. After this PR merges, its merge commit can be backported to `release/10.0.1xx-sr11`. No SR11 PR, release-ref push, or `/backport` request has been created yet.

### Provenance

Cherry-picked the single-parent squash merge commit `11ed1aeb65f7fd2fbfb0fed5de967380d7fa54a4` from #37879 with explicit provenance. The patch applied without conflicts and has the same stable patch ID as the source (`2097bc330feea531a113c4d3eb3a56cb0263f67a`). Patch version 120 remains unchanged.

### Validation

- `dotnet format src/Essentials/src/Essentials.csproj --no-restore --include src/Essentials/src/MediaPicker/MediaPicker.ios.cs --verify-no-changes`
- `dotnet build src/Essentials/src/Essentials.csproj -f net10.0-ios26.0 --no-restore /p:BuildIpa=false /p:EnableSourceLink=false /p:UseSharedCompilation=false`
- `dotnet build src/Essentials/src/Essentials.csproj -f net10.0-maccatalyst26.0 --no-restore /p:EnableSourceLink=false /p:UseSharedCompilation=false`

Both builds completed with 0 warnings and 0 errors. The original runtime verification remains documented in #37879.

### Issues Addressed

#37878