### PR TITLE
[main] Backport #37708 regression coverage (conflict fallback)

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue37691.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue37691.cs
@@ -1,0 +1,123 @@
+#nullable enable
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 37691, "Page scrolling behavior upon keyboard hide is broken", PlatformAffected.iOS)]
+public class Issue37691 : ContentPage
+{
+	readonly Label _layoutStatus;
+	readonly Label _bottomMarker;
+
+	public Issue37691()
+	{
+		Title = "Keyboard modal layout restoration";
+		BackgroundColor = Colors.DarkBlue;
+
+		_layoutStatus = new Label
+		{
+			AutomationId = "LayoutStatus",
+			TextColor = Colors.White,
+			HorizontalOptions = LayoutOptions.Center
+		};
+
+		_bottomMarker = new Label
+		{
+			AutomationId = "BottomMarker",
+			Text = "BOTTOM OF UNDERLYING PAGE",
+			BackgroundColor = Colors.Lime,
+			TextColor = Colors.Black,
+			HorizontalTextAlignment = TextAlignment.Center,
+			VerticalTextAlignment = TextAlignment.Center,
+			HeightRequest = 48
+		};
+
+		var showModalButton = new Button
+		{
+			AutomationId = "ShowModal",
+			Text = "Show modal",
+			HorizontalOptions = LayoutOptions.Center
+		};
+		showModalButton.Clicked += OnShowModal;
+
+		var grid = new Grid
+		{
+			SafeAreaEdges = new SafeAreaEdges(SafeAreaRegions.SoftInput),
+			RowDefinitions =
+			{
+				new RowDefinition(GridLength.Auto),
+				new RowDefinition(GridLength.Star),
+				new RowDefinition(GridLength.Auto)
+			}
+		};
+		grid.Add(_layoutStatus);
+		grid.Add(showModalButton, row: 1);
+		grid.Add(_bottomMarker, row: 2);
+
+		Content = grid;
+		SizeChanged += (_, _) => UpdateLayoutStatus();
+		_bottomMarker.SizeChanged += (_, _) => UpdateLayoutStatus();
+	}
+
+	protected override async void OnAppearing()
+	{
+		base.OnAppearing();
+		await Task.Delay(300);
+		UpdateLayoutStatus();
+	}
+
+	async void OnShowModal(object? sender, EventArgs e)
+	{
+		await Navigation.PushModalAsync(new KeyboardModalPage());
+	}
+
+	void UpdateLayoutStatus()
+	{
+		_layoutStatus.Text = $"Page height: {Height:F1}; bottom: {_bottomMarker.Y + _bottomMarker.Height:F1}";
+	}
+
+	sealed class KeyboardModalPage : ContentPage
+	{
+		readonly Entry _entry;
+
+		public KeyboardModalPage()
+		{
+			BackgroundColor = Colors.LightGray;
+
+			_entry = new Entry
+			{
+				AutomationId = "ModalEntry",
+				Placeholder = "Keyboard must remain visible"
+			};
+
+			var dismissButton = new Button
+			{
+				AutomationId = "DismissModal",
+				Text = "Dismiss modal"
+			};
+			dismissButton.Clicked += async (_, _) => await Navigation.PopModalAsync();
+
+			Content = new VerticalStackLayout
+			{
+				Padding = 30,
+				VerticalOptions = LayoutOptions.Center,
+				Children =
+				{
+					new Label
+					{
+						Text = "Dismiss this modal while the keyboard is visible.",
+						TextColor = Colors.Black
+					},
+					_entry,
+					dismissButton
+				}
+			};
+		}
+
+		protected override async void OnAppearing()
+		{
+			base.OnAppearing();
+			await Task.Delay(300);
+			_entry.Focus();
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue37691.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue37691.cs
@@ -1,0 +1,46 @@
+#if IOS
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue37691 : _IssuesUITest
+{
+	public Issue37691(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue => "Page scrolling behavior upon keyboard hide is broken";
+
+	[Test]
+	[Category(UITestCategories.SafeAreaEdges)]
+	public void UnderlyingPageRestoresAfterDismissingModalWithKeyboardVisible()
+	{
+		App.WaitForElement("ShowModal");
+		var initialBottom = App.WaitForElement("BottomMarker").GetRect().Bottom;
+		App.Screenshot("Underlying page before showing modal");
+
+		for (var cycle = 1; cycle <= 3; cycle++)
+		{
+			App.Tap("ShowModal");
+			App.WaitForElement("ModalEntry");
+			Assert.That(App.WaitForKeyboardToShow(), Is.True, "The keyboard must be visible before dismissing the modal.");
+
+			if (cycle == 1)
+				App.Screenshot("Modal with keyboard visible");
+
+			App.Tap("DismissModal");
+			App.WaitForElement("ShowModal");
+			Assert.That(App.WaitForKeyboardToHide(), Is.True, "The keyboard must hide after dismissing the modal.");
+
+			var restoredBottom = App.WaitForElement("BottomMarker").GetRect().Bottom;
+			TestContext.Progress.WriteLine($"Cycle {cycle}: initial bottom={initialBottom}; restored bottom={restoredBottom}");
+			Assert.That(restoredBottom, Is.EqualTo(initialBottom).Within(5),
+				$"The underlying page did not restore its original height after cycle {cycle}. Initial bottom: {initialBottom}; restored bottom: {restoredBottom}.");
+		}
+
+		App.Screenshot("Underlying page after dismissing modal");
+	}
+}
+#endif


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Backport of #37708 to `main`: focused manual conflict fallback, adding only the missing iOS regression coverage.

The requested `/backport to main` automation [failed](https://github.com/dotnet/maui/actions/runs/34706173137) because the original PR patch includes unrelated historical commits that conflict in skill/workflow files. This existing focused PR is retained as the fallback rather than opening a duplicate or importing that unrelated history.

Both `main` and SR11 already contain the runtime fix behavior through the newer `InvalidateSafeAreaWithDescendants()` implementation. This PR preserves that stronger behavior and adds only the two missing `Issue37691` UI-test files. The test dismisses a keyboard-visible modal three times and verifies after each cycle that the underlying page returns to its original bottom edge.

This PR targets `main` only. SR11 coverage is being handled separately after its `/backport` run also failed. Merging into `main` first is not a requirement of the backport automation; the earlier description stating that prerequisite was incorrect.

## Source provenance

- Source PR: #37708
- Source squash merge commit: `90c55197d1925f99480482d51be7f53aae0d194c`
- Original target: `inflight/current`
- Runtime behavior already inherited via `7c523245e64fca92f376a76298ed6cfd263cad3e`.

## Validation

- `pwsh .github/scripts/BuildAndRunHostApp.ps1 -Platform ios -TestFilter "FullyQualifiedName~Issue37691" -DeviceUdid "5BA96735-B558-4355-B16A-B41143C6718A"`
- Result: 1 passed; all three cycles restored the bottom edge from `874` to `874`.

Related: #37691.