### PR TITLE
[release/10.0.1xx-sr11] Restore SoftInput modal dismissal regression coverage

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue37691.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue37691.cs
@@ -1,0 +1,123 @@
+#nullable enable
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 37691, "Page scrolling behavior upon keyboard hide is broken", PlatformAffected.iOS)]
+public class Issue37691 : ContentPage
+{
+	readonly Label _layoutStatus;
+	readonly Label _bottomMarker;
+
+	public Issue37691()
+	{
+		Title = "Keyboard modal layout restoration";
+		BackgroundColor = Colors.DarkBlue;
+
+		_layoutStatus = new Label
+		{
+			AutomationId = "LayoutStatus",
+			TextColor = Colors.White,
+			HorizontalOptions = LayoutOptions.Center
+		};
+
+		_bottomMarker = new Label
+		{
+			AutomationId = "BottomMarker",
+			Text = "BOTTOM OF UNDERLYING PAGE",
+			BackgroundColor = Colors.Lime,
+			TextColor = Colors.Black,
+			HorizontalTextAlignment = TextAlignment.Center,
+			VerticalTextAlignment = TextAlignment.Center,
+			HeightRequest = 48
+		};
+
+		var showModalButton = new Button
+		{
+			AutomationId = "ShowModal",
+			Text = "Show modal",
+			HorizontalOptions = LayoutOptions.Center
+		};
+		showModalButton.Clicked += OnShowModal;
+
+		var grid = new Grid
+		{
+			SafeAreaEdges = new SafeAreaEdges(SafeAreaRegions.SoftInput),
+			RowDefinitions =
+			{
+				new RowDefinition(GridLength.Auto),
+				new RowDefinition(GridLength.Star),
+				new RowDefinition(GridLength.Auto)
+			}
+		};
+		grid.Add(_layoutStatus);
+		grid.Add(showModalButton, row: 1);
+		grid.Add(_bottomMarker, row: 2);
+
+		Content = grid;
+		SizeChanged += (_, _) => UpdateLayoutStatus();
+		_bottomMarker.SizeChanged += (_, _) => UpdateLayoutStatus();
+	}
+
+	protected override async void OnAppearing()
+	{
+		base.OnAppearing();
+		await Task.Delay(300);
+		UpdateLayoutStatus();
+	}
+
+	async void OnShowModal(object? sender, EventArgs e)
+	{
+		await Navigation.PushModalAsync(new KeyboardModalPage());
+	}
+
+	void UpdateLayoutStatus()
+	{
+		_layoutStatus.Text = $"Page height: {Height:F1}; bottom: {_bottomMarker.Y + _bottomMarker.Height:F1}";
+	}
+
+	sealed class KeyboardModalPage : ContentPage
+	{
+		readonly Entry _entry;
+
+		public KeyboardModalPage()
+		{
+			BackgroundColor = Colors.LightGray;
+
+			_entry = new Entry
+			{
+				AutomationId = "ModalEntry",
+				Placeholder = "Keyboard must remain visible"
+			};
+
+			var dismissButton = new Button
+			{
+				AutomationId = "DismissModal",
+				Text = "Dismiss modal"
+			};
+			dismissButton.Clicked += async (_, _) => await Navigation.PopModalAsync();
+
+			Content = new VerticalStackLayout
+			{
+				Padding = 30,
+				VerticalOptions = LayoutOptions.Center,
+				Children =
+				{
+					new Label
+					{
+						Text = "Dismiss this modal while the keyboard is visible.",
+						TextColor = Colors.Black
+					},
+					_entry,
+					dismissButton
+				}
+			};
+		}
+
+		protected override async void OnAppearing()
+		{
+			base.OnAppearing();
+			await Task.Delay(300);
+			_entry.Focus();
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue37691.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue37691.cs
@@ -1,0 +1,46 @@
+#if IOS
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue37691 : _IssuesUITest
+{
+	public Issue37691(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue => "Page scrolling behavior upon keyboard hide is broken";
+
+	[Test]
+	[Category(UITestCategories.SafeAreaEdges)]
+	public void UnderlyingPageRestoresAfterDismissingModalWithKeyboardVisible()
+	{
+		App.WaitForElement("ShowModal");
+		var initialBottom = App.WaitForElement("BottomMarker").GetRect().Bottom;
+		App.Screenshot("Underlying page before showing modal");
+
+		for (var cycle = 1; cycle <= 3; cycle++)
+		{
+			App.Tap("ShowModal");
+			App.WaitForElement("ModalEntry");
+			Assert.That(App.WaitForKeyboardToShow(), Is.True, "The keyboard must be visible before dismissing the modal.");
+
+			if (cycle == 1)
+				App.Screenshot("Modal with keyboard visible");
+
+			App.Tap("DismissModal");
+			App.WaitForElement("ShowModal");
+			Assert.That(App.WaitForKeyboardToHide(), Is.True, "The keyboard must hide after dismissing the modal.");
+
+			var restoredBottom = App.WaitForElement("BottomMarker").GetRect().Bottom;
+			TestContext.Progress.WriteLine($"Cycle {cycle}: initial bottom={initialBottom}; restored bottom={restoredBottom}");
+			Assert.That(restoredBottom, Is.EqualTo(initialBottom).Within(5),
+				$"The underlying page did not restore its original height after cycle {cycle}. Initial bottom: {initialBottom}; restored bottom: {restoredBottom}.");
+		}
+
+		App.Screenshot("Underlying page after dismissing modal");
+	}
+}
+#endif


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

Backport of #37708 to `release/10.0.1xx-sr11` using a focused manual fallback after the automated backport failed: https://github.com/dotnet/maui/actions/runs/34705427768

Source squash commit: `90c55197d1925f99480482d51be7f53aae0d194c` (issue #37691).

SR11 already inherits the runtime fix through `7c523245e64fca92f376a76298ed6cfd263cad3e`, including `ClearKeyboardState()` and the stronger `InvalidateSafeAreaWithDescendants()` behavior. This fallback intentionally preserves that runtime and adds only the two missing regression test files from the source squash commit.

## Validation

- Both added files are byte-identical to their blobs in source commit `90c55197d1925f99480482d51be7f53aae0d194c`.
- `src/Core/src/Platform/iOS/MauiView.cs` is unchanged.
- `eng/Versions.props` remains at `PatchVersion` 110.
- The equivalent targeted test previously passed on iPhone 17 / iOS 26.5 with all three cycles restoring the bottom marker to 874.
- A fresh SR11-targeted run was attempted on iPhone 17 / iOS 26.5, but executed 0 tests because this worktree lacked bootstrapped MAUI build tasks. The documented bootstrap was attempted and bounded; it did not complete in time, so no new SR11-local pass result is claimed.