### PR TITLE
Fix UI test compilation after CollectionView sharding

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34271.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34271.cs
@@ -11,7 +11,7 @@ public class Issue34271 : _IssuesUITest
 	public override string Issue => "CollectionView scroll position resets to top after ScrollTo last item when Picker is dismissed";
 
 	[Test]
-	[Category(UITestCategories.CollectionView)]
+	[ShardedTestCategory(UITestCategories.CollectionView, shard: 1)]
 	public void CollectionViewScrollPositionPreservedAfterPickerDismiss()
 	{
 		// Scroll CollectionView to the last item (Proboscis Monkey)

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35889.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35889.cs
@@ -13,7 +13,7 @@ public class Issue35889 : _IssuesUITest
 	public override string Issue => "Empty CollectionView (CV2) expands to fill available space on iOS instead of collapsing to zero height";
 
 	[Test]
-	[Category(UITestCategories.CollectionView)]
+	[ShardedTestCategory(UITestCategories.CollectionView, shard: 1)]
 	public void EmptyCollectionViewCollapsesAndExpandsWithItems()
 	{
 		App.WaitForElement("BeforeCVLabel");

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue38321.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue38321.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		public override string Issue => "Grouped CollectionView with GridItemsLayout throws ArgumentOutOfRangeException after an item is removed";
 
 		[Test]
-		[Category(UITestCategories.CollectionView)]
+		[ShardedTestCategory(UITestCategories.CollectionView, shard: 1)]
 		public void GroupedCollectionViewRemovalsUseCurrentAdapterPositions()
 		{
 			App.WaitForElement("RemoveItemButton");


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Replace the remaining `[Category(UITestCategories.CollectionView)]` annotations in `Issue34271`, `Issue35889`, and `Issue38321` with `[ShardedTestCategory(UITestCategories.CollectionView, shard: 1)]`.

Each test remains discoverable through the `CollectionView` umbrella and exactly one CI shard, `CollectionView1`. Test bodies, platform coverage, pipeline configuration, and analyzer enforcement are unchanged.

### Root Cause

#37732 introduced the `MAUI0003` error for direct use of sharded categories, but its migration missed `Issue34271` and `Issue35889` already present on the final main base. #38486 subsequently added `Issue38321` with the old annotation. Every UI-test job compiles the shared test suite before applying its category filter, so these errors also block unrelated categories.

The first build of the exact #37732 merge, [1594198](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1594198), failed all 189 UI jobs with the first two diagnostics. The subsequent main build, [1594249](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1594249), reports all three; one job separately stopped earlier on an emulator boot timeout.

Keep the additive attribute and the analyzer safeguard: suppressing `MAUI0003` would leave these tests outside the numbered CI filters, while reverting sharding is unnecessary.

### Validation

- Before the fix, compiling `Controls.TestCases.WinUI.Tests` reproduced exactly the three `MAUI0003` errors.
- After the fix, the same project compiled with zero warnings and errors, with analyzers enabled.
- NUnit discovery confirmed each repaired method has both `CollectionView` and exactly one numbered category, `CollectionView1`.
- Local validation covered compilation and discovery only, not UI execution. CI must confirm runtime results; unrelated pre-existing UI failures may remain.

### Issues Fixed

Fixes the UI-test compilation regression introduced by #37732, including the additional affected test from #38486. No separate issue was filed.