### PR TITLE
[leak-scan] Fix VisualState trigger lifecycle when states are added or removed

### DIFF
--- a/src/Controls/src/Core/VisualStateManager.cs
+++ b/src/Controls/src/Core/VisualStateManager.cs
@@ -190,6 +190,19 @@ namespace Microsoft.Maui.Controls
 			stateName == CommonStates.PointerOver ||
 			stateName == ButtonElement.PressedVisualState;
 
+		internal static void UnapplyState(VisualElement visualElement, VisualState state, SetterSpecificity vsgSpecificity)
+		{
+			var baseSpecificity = vsgSpecificity.CopyStyle(1, 0, 0, 0);
+			var unapplySpecificity = IsSystemDrivenState(state.Name)
+				? baseSpecificity.WithFullVsmPriority()
+				: baseSpecificity;
+
+			foreach (var setter in state.Setters)
+			{
+				setter.UnApply(visualElement, unapplySpecificity);
+			}
+		}
+
 		/// <summary>
 		/// Determines whether the specified <paramref name="element"/> has any visual state groups defined.
 		/// </summary>
@@ -290,7 +303,7 @@ namespace Microsoft.Maui.Controls
 		public VisualStateGroupList(bool isDefault)
 		{
 			IsDefault = isDefault;
-			_internalList = new WatchAddList<VisualStateGroup>(ValidateAndNotify);
+			_internalList = new WatchList<VisualStateGroup>(ValidateAndNotify);
 		}
 
 		void ValidateAndNotify(object sender, EventArgs eventArgs)
@@ -481,7 +494,7 @@ namespace Microsoft.Maui.Controls
 		/// </summary>
 		public VisualStateGroup()
 		{
-			States = new WatchAddList<VisualState>(OnStatesChanged, OnStateRemoved);
+			States = new WatchList<VisualState>(OnStatesCollectionChanged, OnStateAdded, OnStateRemoving);
 		}
 
 		/// <summary>
@@ -656,7 +669,7 @@ namespace Microsoft.Maui.Controls
 
 		internal event EventHandler StatesChanged;
 
-		void OnStatesChanged(IList<VisualState> states)
+		void OnStatesCollectionChanged(IList<VisualState> states)
 		{
 			if (states.Any(state => string.IsNullOrEmpty(state.Name)))
 			{
@@ -671,8 +684,32 @@ namespace Microsoft.Maui.Controls
 			StatesChanged?.Invoke(this, EventArgs.Empty);
 		}
 
-		void OnStateRemoved(VisualState state)
+		void OnStateAdded(VisualState state)
 		{
+			if (VisualElement?.Window == null)
+			{
+				return;
+			}
+
+			foreach (var trigger in state.StateTriggers)
+			{
+				trigger.SendAttached();
+			}
+		}
+
+		void OnStateRemoving(VisualState state)
+		{
+			if (CurrentState == state)
+			{
+				if (VisualElement is { } visualElement &&
+					VisualStateManager.GetVisualStateGroups(visualElement) is VisualStateGroupList groups)
+				{
+					VisualStateManager.UnapplyState(visualElement, state, groups.Specificity);
+				}
+
+				CurrentState = null;
+			}
+
 			foreach (var trigger in state.StateTriggers)
 			{
 				trigger.SendDetached();
@@ -725,7 +762,7 @@ namespace Microsoft.Maui.Controls
 		public VisualState()
 		{
 			Setters = new ObservableCollection<Setter>();
-			StateTriggers = new WatchAddList<StateTriggerBase>(OnStateTriggersChanged);
+			StateTriggers = new WatchList<StateTriggerBase>(OnStateTriggersChanged);
 		}
 
 		/// <summary>
@@ -865,16 +902,18 @@ namespace Microsoft.Maui.Controls
 		}
 	}
 
-	internal class WatchAddList<T> : IList<T>
+	internal class WatchList<T> : IList<T>
 	{
-		readonly Action<List<T>> _onAdd;
-		readonly Action<T> _onRemove;
+		readonly Action<List<T>> _onCollectionChanged;
+		readonly Action<T> _onItemAdded;
+		readonly Action<T> _onItemRemoving;
 		readonly List<T> _internalList;
 
-		public WatchAddList(Action<List<T>> onAdd, Action<T> onRemove = null)
+		public WatchList(Action<List<T>> onCollectionChanged, Action<T> onItemAdded = null, Action<T> onItemRemoving = null)
 		{
-			_onAdd = onAdd;
-			_onRemove = onRemove;
+			_onCollectionChanged = onCollectionChanged;
+			_onItemAdded = onItemAdded;
+			_onItemRemoving = onItemRemoving;
 			_internalList = new List<T>();
 		}
 
@@ -891,20 +930,25 @@ namespace Microsoft.Maui.Controls
 		public void Add(T item)
 		{
 			_internalList.Add(item);
-			_onAdd(_internalList);
+			_onCollectionChanged(_internalList);
+			_onItemAdded?.Invoke(item);
 		}
 
 		public void Clear()
 		{
-			if (_onRemove != null)
+			if (_onItemRemoving != null)
 			{
 				foreach (var item in _internalList)
 				{
-					_onRemove(item);
+					_onItemRemoving(item);
 				}
 			}
 
 			_internalList.Clear();
+			if (_onItemRemoving != null)
+			{
+				_onCollectionChanged(_internalList);
+			}
 		}
 
 		public bool Contains(T item)
@@ -939,13 +983,18 @@ namespace Microsoft.Maui.Controls
 		public void Insert(int index, T item)
 		{
 			_internalList.Insert(index, item);
-			_onAdd(_internalList);
+			_onCollectionChanged(_internalList);
+			_onItemAdded?.Invoke(item);
 		}
 
 		public void RemoveAt(int index)
 		{
-			_onRemove?.Invoke(_internalList[index]);
+			_onItemRemoving?.Invoke(_internalList[index]);
 			_internalList.RemoveAt(index);
+			if (_onItemRemoving != null)
+			{
+				_onCollectionChanged(_internalList);
+			}
 		}
 
 		public T this[int index]
@@ -953,9 +1002,10 @@ namespace Microsoft.Maui.Controls
 			get => _internalList[index];
 			set
 			{
-				_onRemove?.Invoke(_internalList[index]);
+				_onItemRemoving?.Invoke(_internalList[index]);
 				_internalList[index] = value;
-				_onAdd(_internalList);
+				_onCollectionChanged(_internalList);
+				_onItemAdded?.Invoke(value);
 			}
 		}
 	}

--- a/src/Controls/src/Core/VisualStateManager.cs
+++ b/src/Controls/src/Core/VisualStateManager.cs
@@ -303,7 +303,51 @@ namespace Microsoft.Maui.Controls
 		public VisualStateGroupList(bool isDefault)
 		{
 			IsDefault = isDefault;
-			_internalList = new WatchList<VisualStateGroup>(ValidateAndNotify);
+			_internalList = new WatchList<VisualStateGroup>(ValidateAndNotify, OnGroupAdded, OnGroupRemoving);
+		}
+
+		void OnGroupAdded(VisualStateGroup group)
+		{
+			group.StatesChanged += ValidateAndNotify;
+			group.VisualElement = VisualElement;
+
+			if (VisualElement?.Window == null)
+			{
+				return;
+			}
+
+			foreach (var state in group.States)
+			{
+				foreach (var trigger in state.StateTriggers)
+				{
+					trigger.SendAttached();
+				}
+			}
+		}
+
+		void OnGroupRemoving(VisualStateGroup group)
+		{
+			group.StatesChanged -= ValidateAndNotify;
+
+			if (group.CurrentState is { } currentState)
+			{
+				if (group.VisualElement is { } visualElement)
+				{
+					VisualStateManager.UnapplyState(visualElement, currentState, Specificity);
+				}
+
+				group.CurrentState = null;
+			}
+
+			foreach (var state in group.States)
+			{
+				foreach (var trigger in state.StateTriggers)
+				{
+					trigger.SendDetached();
+				}
+			}
+
+			group.VisualElement = null;
 		}
 
 		void ValidateAndNotify(object sender, EventArgs eventArgs)
@@ -347,7 +391,6 @@ namespace Microsoft.Maui.Controls
 				{
 					if (string.Equals(_internalList[i].Name, item.Name, StringComparison.Ordinal))
 					{
-						_internalList[i].StatesChanged -= ValidateAndNotify;
 						_internalList.Remove(_internalList[i]);
 						break;
 					}
@@ -355,18 +398,11 @@ namespace Microsoft.Maui.Controls
 			}
 
 			_internalList.Add(item);
-
-			item.StatesChanged += ValidateAndNotify;
 		}
 
 		/// <inheritdoc />
 		public void Clear()
 		{
-			foreach (var group in _internalList)
-			{
-				group.StatesChanged -= ValidateAndNotify;
-			}
-
 			_internalList.Clear();
 		}
 
@@ -390,7 +426,6 @@ namespace Microsoft.Maui.Controls
 				throw new ArgumentNullException(nameof(item));
 			}
 
-			item.StatesChanged -= ValidateAndNotify;
 			return _internalList.Remove(item);
 		}
 
@@ -414,14 +449,12 @@ namespace Microsoft.Maui.Controls
 				throw new ArgumentNullException(nameof(item));
 			}
 
-			item.StatesChanged += ValidateAndNotify;
 			_internalList.Insert(index, item);
 		}
 
 		/// <inheritdoc />
 		public void RemoveAt(int index)
 		{
-			_internalList[index].StatesChanged -= ValidateAndNotify;
 			_internalList.RemoveAt(index);
 		}
 
@@ -686,7 +719,9 @@ namespace Microsoft.Maui.Controls
 
 		void OnStateAdded(VisualState state)
 		{
-			if (VisualElement?.Window == null)
+			if (VisualElement is not { Window: not null } visualElement ||
+				VisualStateManager.GetVisualStateGroups(visualElement) is not VisualStateGroupList groups ||
+				!groups.Any(group => ReferenceEquals(group, this)))
 			{
 				return;
 			}

--- a/src/Controls/src/Core/VisualStateManager.cs
+++ b/src/Controls/src/Core/VisualStateManager.cs
@@ -481,7 +481,7 @@ namespace Microsoft.Maui.Controls
 		/// </summary>
 		public VisualStateGroup()
 		{
-			States = new WatchAddList<VisualState>(OnStatesChanged);
+			States = new WatchAddList<VisualState>(OnStatesChanged, OnStateRemoved);
 		}
 
 		/// <summary>
@@ -671,6 +671,16 @@ namespace Microsoft.Maui.Controls
 			StatesChanged?.Invoke(this, EventArgs.Empty);
 		}
 
+		void OnStateRemoved(VisualState state)
+		{
+			foreach (var trigger in state.StateTriggers)
+			{
+				trigger.SendDetached();
+			}
+
+			state.VisualStateGroup = null;
+		}
+
 		public override bool Equals(object obj) => Equals(obj as VisualStateGroup);
 
 		bool Equals(VisualStateGroup other)
@@ -858,11 +868,13 @@ namespace Microsoft.Maui.Controls
 	internal class WatchAddList<T> : IList<T>
 	{
 		readonly Action<List<T>> _onAdd;
+		readonly Action<T> _onRemove;
 		readonly List<T> _internalList;
 
-		public WatchAddList(Action<List<T>> onAdd)
+		public WatchAddList(Action<List<T>> onAdd, Action<T> onRemove = null)
 		{
 			_onAdd = onAdd;
+			_onRemove = onRemove;
 			_internalList = new List<T>();
 		}
 
@@ -884,6 +896,14 @@ namespace Microsoft.Maui.Controls
 
 		public void Clear()
 		{
+			if (_onRemove != null)
+			{
+				foreach (var item in _internalList)
+				{
+					_onRemove(item);
+				}
+			}
+
 			_internalList.Clear();
 		}
 
@@ -899,7 +919,12 @@ namespace Microsoft.Maui.Controls
 
 		public bool Remove(T item)
 		{
-			return _internalList.Remove(item);
+			var index = _internalList.IndexOf(item);
+			if (index < 0)
+				return false;
+
+			RemoveAt(index);
+			return true;
 		}
 
 		public int Count => _internalList.Count;
@@ -919,13 +944,19 @@ namespace Microsoft.Maui.Controls
 
 		public void RemoveAt(int index)
 		{
+			_onRemove?.Invoke(_internalList[index]);
 			_internalList.RemoveAt(index);
 		}
 
 		public T this[int index]
 		{
 			get => _internalList[index];
-			set => _internalList[index] = value;
+			set
+			{
+				_onRemove?.Invoke(_internalList[index]);
+				_internalList[index] = value;
+				_onAdd(_internalList);
+			}
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/AdaptiveTriggerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/AdaptiveTriggerTests.cs
@@ -66,6 +66,32 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public void StateTriggerReattachesWhenStateIsReaddedAfterAttach()
+		{
+			var label = new Label();
+			var trigger = new AdaptiveTrigger { MinWindowWidth = 300 };
+			var state = new VisualState
+			{
+				Name = "Large",
+				StateTriggers = { trigger }
+			};
+			var group = new VisualStateGroup { States = { state } };
+
+			VisualStateManager.SetVisualStateGroups(label, new VisualStateGroupList { group });
+			_ = new Window { Page = new ContentPage { Content = label } };
+
+			Assert.True(trigger.IsAttached);
+
+			group.States.Remove(state);
+
+			Assert.False(trigger.IsAttached);
+
+			group.States.Add(state);
+
+			Assert.True(trigger.IsAttached);
+		}
+
+		[Fact]
 		public void ResizingWindowPageActivatesTrigger()
 		{
 			var redBrush = new SolidColorBrush(Colors.Red);

--- a/src/Controls/tests/Core.UnitTests/AdaptiveTriggerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/AdaptiveTriggerTests.cs
@@ -92,6 +92,61 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public void StateTriggerDoesNotAttachWhenStateIsAddedToRemovedGroup()
+		{
+			var label = new Label();
+			var groups = new VisualStateGroupList();
+			var group = new VisualStateGroup();
+			var originalTrigger = new AdaptiveTrigger { MinWindowWidth = 300 };
+			group.States.Add(new VisualState { Name = "Original", StateTriggers = { originalTrigger } });
+			groups.Add(group);
+			VisualStateManager.SetVisualStateGroups(label, groups);
+			_ = new Window { Page = new ContentPage { Content = label } };
+
+			Assert.True(originalTrigger.IsAttached);
+
+			groups.Remove(group);
+
+			Assert.False(originalTrigger.IsAttached);
+			Assert.Null(group.VisualElement);
+
+			var addedTrigger = new AdaptiveTrigger { MinWindowWidth = 500 };
+			group.States.Add(new VisualState { Name = "Added", StateTriggers = { addedTrigger } });
+
+			Assert.False(addedTrigger.IsAttached);
+		}
+
+		[Fact]
+		public void StateTriggersAttachWhenGroupIsAddedAfterElementIsAttached()
+		{
+			var label = new Label();
+			var groups = new VisualStateGroupList
+			{
+				new VisualStateGroup
+				{
+					Name = "Existing",
+					States = { new VisualState { Name = "Normal" } }
+				}
+			};
+			VisualStateManager.SetVisualStateGroups(label, groups);
+			_ = new Window { Page = new ContentPage { Content = label } };
+
+			var trigger = new AdaptiveTrigger { MinWindowWidth = 300 };
+			var group = new VisualStateGroup
+			{
+				States =
+				{
+					new VisualState { Name = "Added", StateTriggers = { trigger } }
+				}
+			};
+
+			groups.Add(group);
+
+			Assert.Same(label, group.VisualElement);
+			Assert.True(trigger.IsAttached);
+		}
+
+		[Fact]
 		public void ResizingWindowPageActivatesTrigger()
 		{
 			var redBrush = new SolidColorBrush(Colors.Red);

--- a/src/Controls/tests/Core.UnitTests/VisualStateManagerMemoryLeakTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualStateManagerMemoryLeakTests.cs
@@ -1,0 +1,82 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+    public class VisualStateManagerMemoryLeakTests : BaseTestFixture
+    {
+        const int N = 30;
+        enum Scenario { Control, Leaky, Mitigation }
+
+        [Fact, Category(TestCategory.Memory)]
+        public void VisualStateGroup_States_Clear_Leaks()
+        {
+            var control = Create(Scenario.Control);
+            var leaky = Create(Scenario.Leaky);
+            var mitigation = Create(Scenario.Mitigation);
+            for (var i = 0; i < 7; i++)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+            }
+            Assert.Equal(0, Alive(control));
+            Assert.Equal(0, Alive(leaky));
+            Assert.Equal(0, Alive(mitigation));
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static List<WeakReference<byte[]>> Create(Scenario scenario)
+        {
+            var result = new List<WeakReference<byte[]>>();
+            var attach = typeof(StateTriggerBase).GetMethod(
+                "SendAttached", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            var detach = typeof(StateTriggerBase).GetMethod(
+                "SendDetached", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+            for (var i = 0; i < N; i++)
+            {
+                var payload = new byte[1024 * 1024];
+                result.Add(new(payload));
+                if (scenario == Scenario.Control)
+                    continue;
+
+                var trigger = new ProbeTrigger(payload);
+                var state = new VisualState { Name = "Probe" };
+                state.StateTriggers.Add(trigger);
+                var group = new VisualStateGroup();
+                group.States.Add(state);
+                VisualStateManager.SetVisualStateGroups(
+                    new Label(), new VisualStateGroupList { group });
+                attach.Invoke(trigger, null);
+                if (scenario == Scenario.Mitigation)
+                    detach.Invoke(trigger, null);
+                group.States.Clear();
+            }
+            return result;
+        }
+
+        static int Alive(IEnumerable<WeakReference<byte[]>> items)
+            => items.Count(item => item.TryGetTarget(out _));
+
+        sealed class ProbeTrigger(byte[] payload) : StateTriggerBase
+        {
+            protected override void OnAttached() => Publisher.Changed += Changed;
+            protected override void OnDetached() => Publisher.Changed -= Changed;
+            void Changed(object? sender, EventArgs e) => GC.KeepAlive(payload);
+        }
+
+        static class Publisher
+        {
+#pragma warning disable CS0414
+            public static event EventHandler? Changed;
+#pragma warning restore CS0414
+        }
+    }
+}

--- a/src/Controls/tests/Core.UnitTests/VisualStateManagerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualStateManagerTests.cs
@@ -315,6 +315,31 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public void RemovingCurrentStateClearsStateAndUnappliesSetters()
+		{
+			var label = new Label();
+			var state = new VisualState
+			{
+				Name = NormalStateName,
+				Setters =
+				{
+					new Setter { Property = Label.TextProperty, Value = "Active" }
+				}
+			};
+			var group = new VisualStateGroup { States = { state } };
+
+			VisualStateManager.SetVisualStateGroups(label, new VisualStateGroupList { group });
+
+			Assert.Same(state, group.CurrentState);
+			Assert.Equal("Active", label.Text);
+
+			group.States.Remove(state);
+
+			Assert.Null(group.CurrentState);
+			Assert.Null(label.Text);
+		}
+
+		[Fact]
 		public void CanRemoveAGroupAndAddANewGroupWithTheSameName()
 		{
 			var stateGroups = new VisualStateGroupList();


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
Removing a VisualState from VisualStateGroup.States does not properly detach its triggers. If a trigger is subscribed to a long-lived event, it can remain subscribed even after the state is removed. This can keep the trigger and its referenced objects alive and cause objects to be retained. The issue can occur with operations such as Clear(), Remove(), RemoveAt(), and state replacement.

### Root Cause
VisualStateGroup.States previously used WatchAddList<VisualState>, which did not provide callbacks for individual state removal. As a result, removing a state did not detach its triggers or clear the state's VisualStateGroup reference. This could leave trigger event subscriptions active and prevent the trigger and its referenced objects from being garbage-collected.

### Description of Change
Updated the VisualState collection handling to support individual state addition and removal callbacks.

- Attach triggers when a VisualState is added to an existing VisualStateGroup.
- Detach triggers when a VisualState is removed.
- Unapply the active state before removing it and clear CurrentState.
- Clear the removed state's VisualStateGroup reference.
- Attach triggers for existing states when a VisualStateGroup is added to an attached element.
- Detach triggers and clear the group association when a VisualStateGroup is removed.

This ensures that VisualState triggers are correctly attached and detached throughout the state and group lifecycle and prevents trigger event subscriptions from keeping removed states and referenced objects alive.

### Issues Fixed
  
Fixes #38244

### Output

|Before|After|
|--|--|
| <img width="1200" height="400" alt="image" src="https://github.com/user-attachments/assets/42f48169-1fc7-41e5-9f1e-bbc65551843c" /> | <img width="700" height="210" alt="image" src="https://github.com/user-attachments/assets/417f0517-3235-4a47-960e-cea352efa278" /> |


