### PR TITLE
[iOS/MacCatalyst] Fix for TapGestureRecognizer.NumberOfTapsRequired is not reactive at runtime

### DIFF
--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
@@ -890,7 +890,21 @@ namespace Microsoft.Maui.Controls.Platform
 		void OnTapGestureRecognizerPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
 		{
 			if (e.Is(TapGestureRecognizer.ButtonsProperty))
+			{
 				LoadRecognizers();
+			}
+			else if (e.Is(TapGestureRecognizer.NumberOfTapsRequiredProperty) &&
+				sender is TapGestureRecognizer tapGesture &&
+				_gestureRecognizers.TryGetValue(tapGesture, out var uiRecognizers))
+			{
+				foreach (var uiRecognizer in uiRecognizers)
+				{
+					if (uiRecognizer is UITapGestureRecognizer uiTapGestureRecognizer)
+					{
+						uiTapGestureRecognizer.NumberOfTapsRequired = (uint)tapGesture.NumberOfTapsRequired;
+					}
+				}
+			}
 		}
 
 		void OnSwipeGestureRecognizerPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)

--- a/src/Controls/tests/DeviceTests/GestureTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/GestureTests.iOS.cs
@@ -9,6 +9,7 @@ using Microsoft.Maui.Dispatching;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.TestUtils.DeviceTests.Runners;
+using UIKit;
 using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
@@ -90,5 +91,31 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 #endif
+
+		[Theory]
+		[InlineData(1, 2)]
+		[InlineData(2, 3)]
+		[InlineData(3, 1)]
+		[InlineData(1, 3)]
+		public async Task ChangingNumberOfTapsRequiredUpdatesNativeGestureRecognizer(int initialTaps, int updatedTaps)
+		{
+			var label = new Label();
+			var tapGestureRecognizer = new TapGestureRecognizer { NumberOfTapsRequired = initialTaps };
+			label.GestureRecognizers.Add(tapGestureRecognizer);
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var handler = CreateHandler<LabelHandler>(label);
+
+				UITapGestureRecognizer GetNativeTapGestureRecognizer() =>
+					handler.PlatformView.GestureRecognizers?.OfType<UITapGestureRecognizer>().FirstOrDefault();
+
+				Assert.Equal((nuint)initialTaps, GetNativeTapGestureRecognizer().NumberOfTapsRequired);
+
+				tapGestureRecognizer.NumberOfTapsRequired = updatedTaps;
+
+				Assert.Equal((nuint)updatedTaps, GetNativeTapGestureRecognizer().NumberOfTapsRequired);
+			});
+		}
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### RootCause: 

In `GesturePlatformManager.iOS.cs`, the native `UITapGestureRecognizer` is created once in `CreateTapRecognizer` with the `NumberOfTapsRequired` value snapshotted at creation time. The PropertyChanged handler OnTapGestureRecognizerPropertyChanged only reacted to TapGestureRecognizer.ButtonsProperty changes (triggering LoadRecognizers()), so changing NumberOfTapsRequired at runtime never propagated to the native recognizer. (Android already reads NumberOfTapsRequired dynamically on each tap via a predicate filter, so it wasn't affected.)
 
### Fix Description:

Mirrored the existing `OnSwipeGestureRecognizerPropertyChanged` pattern — when NumberOfTapsRequiredProperty changes, look up the already-created native `UITapGestureRecognizer` instances in `_gestureRecognizers` and update NumberOfTapsRequired directly, since UIKit allows changing this property on a live recognizer.

### Issues Fixed
Fixes #38291 

### Tested the behaviour in the following platforms
- [ ] Android
- [ ] Windows
- [x] iOS
- [x] Mac

### Output Screenshot
Before Issue Fix | After Issue Fix |
|----------|----------|
|<video width="100" height="100" alt="Before Fix" src="https://github.com/user-attachments/assets/24f29bdd-e499-474a-9f38-adf317cb3add">|<video width="100" height="100" alt="After Fix" src="https://github.com/user-attachments/assets/c8d078fb-c5c4-4762-a559-5f8c885bfb52">|
