### PR TITLE
[Android] Fix Material 3 Editor expanding to MaximumHeightRequest

### DIFF
--- a/src/Controls/src/Core/Editor/Editor.cs
+++ b/src/Controls/src/Core/Editor/Editor.cs
@@ -151,6 +151,18 @@ namespace Microsoft.Maui.Controls
 
 		protected override Size ArrangeOverride(Rect bounds)
 		{
+			// When AutoSize is TextChanges, the Editor's height must be driven by its content
+			// (bounded by Minimum/MaximumHeightRequest). Fill layout would otherwise stretch it
+			// to the parent's height (see LayoutExtensions.ComputeFrame), making an empty Editor
+			// snap to MaximumHeightRequest.
+			if (AutoSize == EditorAutoSizeOption.TextChanges
+				&& !IsExplicitSet(((IView)this).Height)
+				&& DesiredSize.Height > 0
+				&& DesiredSize.Height < bounds.Height)
+			{
+				bounds = new Rect(bounds.X, bounds.Y, bounds.Width, DesiredSize.Height);
+			}
+
 			_previousBounds = bounds;
 			return base.ArrangeOverride(bounds);
 		}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue37440.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue37440.cs
@@ -5,23 +5,37 @@ public class Issue37440 : ContentPage
 {
     public Issue37440()
     {
-        Content = new Border
+        Content = new VerticalStackLayout
         {
-            HeightRequest = 200,
-            Background = Colors.Green,
-            Content = new Border
+            Padding = new Thickness(16, 40, 16, 16),
+            Spacing = 12,
+            Children =
             {
-                HeightRequest = 150,
-                Background = Colors.Blue,
-                Content = new Editor
+                new Label
                 {
-                    Text = "Type here",
-                    AutomationId = "Issue37440Editor",
-                    MinimumHeightRequest = 50,
-                    MaximumHeightRequest = 150,
-                    AutoSize = EditorAutoSizeOption.TextChanges,
-                    Background = Colors.Yellow,
-                    TextColor = Colors.Black,
+                    AutomationId = "WaitForLabel",
+                    FontSize = 18,
+                    Text = "Blue border must be visible above/below the yellow editor.",
+                },
+                new Border
+                {
+                    HeightRequest = 200,
+                    Background = Colors.Green,
+                    Content = new Border
+                    {
+                        HeightRequest = 150,
+                        Background = Colors.Blue,
+                        Content = new Editor
+                        {
+                            Text = "Type here",
+                            AutomationId = "Issue37440Editor",
+                            MinimumHeightRequest = 50,
+                            MaximumHeightRequest = 150,
+                            AutoSize = EditorAutoSizeOption.TextChanges,
+                            Background = Colors.Yellow,
+                            TextColor = Colors.Black,
+                        },
+                    },
                 },
             },
         };

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue37440.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue37440.cs
@@ -1,0 +1,29 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 37440, "Editor auto expands wrongly to MaximumHeightRequest", PlatformAffected.All)]
+public class Issue37440 : ContentPage
+{
+    public Issue37440()
+    {
+        Content = new Border
+        {
+            HeightRequest = 200,
+            Background = Colors.Green,
+            Content = new Border
+            {
+                HeightRequest = 150,
+                Background = Colors.Blue,
+                Content = new Editor
+                {
+                    Text = "Type here",
+                    AutomationId = "Issue37440Editor",
+                    MinimumHeightRequest = 50,
+                    MaximumHeightRequest = 150,
+                    AutoSize = EditorAutoSizeOption.TextChanges,
+                    Background = Colors.Yellow,
+                    TextColor = Colors.Black,
+                },
+            },
+        };
+    }
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue37440.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue37440.cs
@@ -14,7 +14,7 @@ public class Issue37440 : _IssuesUITest
     [Category(UITestCategories.Editor)]
     public void Issue37440EmptyAutoSizeEditorDoesNotSnapToMaximumHeight()
     {
-        App.WaitForElement("Issue37440Editor");
+        App.WaitForElement("WaitForLabel");
         VerifyScreenshot();
     }
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue37440.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue37440.cs
@@ -1,0 +1,20 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue37440 : _IssuesUITest
+{
+    public Issue37440(TestDevice device) : base(device) { }
+
+    public override string Issue => "Editor auto expands wrongly to MaximumHeightRequest";
+
+    [Test]
+    [Category(UITestCategories.Editor)]
+    public void Issue37440EmptyAutoSizeEditorDoesNotSnapToMaximumHeight()
+    {
+        App.WaitForElement("Issue37440Editor");
+        VerifyScreenshot();
+    }
+}

--- a/src/Core/src/Platform/Android/Material3Controls/MauiMaterialEditText.cs
+++ b/src/Core/src/Platform/Android/Material3Controls/MauiMaterialEditText.cs
@@ -37,11 +37,10 @@ internal class MauiMaterialEditText : TextInputEditText
 
 	protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)
 	{
-		// Get the measure spec mode and size
 		var heightMode = MeasureSpec.GetMode(heightMeasureSpec);
 		var heightSize = MeasureSpec.GetSize(heightMeasureSpec);
 
-		if (heightMode == MeasureSpecMode.AtMost && heightSize > 0)
+		if (heightMode == MeasureSpecMode.AtMost && heightSize > 0 && MaxLines == 1)
 		{
 			heightMeasureSpec = MeasureSpec.MakeMeasureSpec(heightSize, MeasureSpecMode.Exactly);
 		}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->


### Issue Details
On Android with Material 3, an Editor starts at its maximum height instead of growing as text is entered.

### Root Cause
The Editor was forced to use all available height, changing MaximumHeightRequest from a limit into its starting height.

### Description of Change
Force the available height only for single-line controls such as Entry, allowing the multiline Editor to grow with its content.

Validated the behavior in the following platforms
 
- [x] Android
- [ ] Windows
- [ ] iOS
- [ ] Mac
 
### Issues Fixed
  
Fixes #37440 

### Output  ScreenShot

|Before|After|
|--|--|
| <img width="363" height="657" alt="image" src="https://github.com/user-attachments/assets/3dc925f8-5621-44d7-95ea-39b9e3bdd19b" /> | <img width="363" height="657" alt="image" src="https://github.com/user-attachments/assets/e085a680-f78c-4ce3-8f83-351569155f74" /> |