### PR TITLE
[Mac] Fix VoiceOver does not announce initial ComboBox state in Task and Project Details

### DIFF
--- a/src/Templates/src/templates/maui-mobile/Pages/ProjectDetailPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/ProjectDetailPage.xaml
@@ -38,7 +38,8 @@
 
               <sf:SfTextInputLayout
                     Hint="Category"
-                    SemanticProperties.Description="ComboBox to select a category. Activate to browse and select a category">
+                    SemanticProperties.Description="ComboBox to select a category. Activate to browse and select a category"
+                    SemanticProperties.Hint="Category ComboBox, State Collapsed">
                     <Picker ItemsSource="{Binding Categories}"
                             SelectedItem="{Binding Category}"
                             SelectedIndex="{Binding CategoryIndex}"

--- a/src/Templates/src/templates/maui-mobile/Pages/TaskDetailPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/TaskDetailPage.xaml
@@ -38,6 +38,7 @@
               <sf:SfTextInputLayout
                     IsVisible="{Binding IsExistingProject}"
                     SemanticProperties.Description="ComboBox to select a project. Activate to browse and select a project"
+                    SemanticProperties.Hint="Project ComboBox, State Collapsed"
                     Hint="Project">
                     <Picker 
                         ItemsSource="{Binding Projects}"


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
VoiceOver on macOS does not announce the ComboBox control type or its initial "Collapsed" state when initially navigating to the Project and Category pickers in the .NET MAUI mobile project template (DeveloperBalance).  
Unknown
On initial linear navigation (`Control + Option + Right Arrow`), VoiceOver reads only the control's descriptive label without indicating that it is an expandable ComboBox or that its current state is collapsed.  

### Root Cause
In earlier versions, static semantic properties (`SemanticProperties.Description` and `SemanticProperties.Hint="State Collapsed"`) were assigned to the parent `SfTextInputLayout` container. The regression was introduced in PR #32286 , which attempted to make state announcements dynamic by removing the static `"State Collapsed"` hint and relying exclusively on `SemanticScreenReader.Announce` triggered via `Picker.IsOpen` property changes.  
Because synthetic announcements only fire on value changes, no state announcement was produced when the control initially received focus.

### Description of Change

Appended State Collapsed directly to the `SemanticProperties.Hint` of each native Picker on both the Project Details and Task Details pages.
Kept `SfTextInputLayout` responsible solely for visual presentation and floating labels.
Preserved existing bindings, commands, and dynamic expansion announcements from PR #32286  while ensuring the initial resting state is exposed to platform accessibility APIs.

### Why Tests Were Not Added

This issue requires manual accessibility validation using platform screen readers (macOS VoiceOver and Android TalkBack) to verify focus traversal and spoken announcements. Because these accessibility announcements cannot be reliably validated via automated UI/unit tests, manual verification was performed across macOS, Android, and Windows.

### Issues Fixed
Fixes #36471 

### Screenshots

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/8ab47eea-6061-4fcb-9780-e8eea0c4e785"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/b5d23234-2423-43fc-b3cb-915b14e73cd7"> |