### PR TITLE
[WIP] Fix compiled binding generation for null-conditional SetBinding calls

### DIFF
--- a/src/Controls/src/BindingSourceGen/BindingSourceGenerator.cs
+++ b/src/Controls/src/BindingSourceGen/BindingSourceGenerator.cs
@@ -65,12 +65,19 @@ public class BindingSourceGenerator : IIncrementalGenerator
 	private static bool IsSetBindingMethod(SyntaxNode node)
 	{
 		return node is InvocationExpressionSyntax invocation
-			&& invocation.Expression is MemberAccessExpressionSyntax method
-			&& method.Name.Identifier.Text == "SetBinding"
+			&& GetInvokedMethodName(invocation.Expression)?.Identifier.Text == "SetBinding"
 			&& invocation.ArgumentList.Arguments.Count >= 2
 			&& invocation.ArgumentList.Arguments[1].Expression is not LiteralExpressionSyntax
 			&& invocation.ArgumentList.Arguments[1].Expression is not ObjectCreationExpressionSyntax;
 	}
+
+	internal static SimpleNameSyntax? GetInvokedMethodName(ExpressionSyntax expression)
+		=> expression switch
+		{
+			MemberAccessExpressionSyntax memberAccess => memberAccess.Name,
+			MemberBindingExpressionSyntax memberBinding => memberBinding.Name,
+			_ => null
+		};
 
 	private static bool IsCreateMethod(SyntaxNode node)
 	{
@@ -110,7 +117,7 @@ public class BindingSourceGenerator : IIncrementalGenerator
 		var enabledNullable = IsNullableContextEnabled(context);
 
 		var invocation = (InvocationExpressionSyntax)context.Node;
-		var method = (MemberAccessExpressionSyntax)invocation.Expression;
+		var methodName = GetInvokedMethodName(invocation.Expression) ?? throw new NotSupportedException();
 
 		var invocationParser = new InvocationParser(context);
 		var interceptedMethodTypeResult = invocationParser.ParseInvocation(invocation, t);
@@ -124,7 +131,7 @@ public class BindingSourceGenerator : IIncrementalGenerator
 		var interceptableLocation = context.SemanticModel.GetInterceptableLocation(invocation, t);
 #pragma warning restore RSEXPERIMENTAL002
 
-		var sourceCodeLocation = SourceCodeLocation.CreateFrom(method.Name.GetLocation());
+		var sourceCodeLocation = SourceCodeLocation.CreateFrom(methodName.GetLocation());
 
 
 		if (interceptableLocation == null || sourceCodeLocation == null)

--- a/src/Controls/src/BindingSourceGen/BindingSourceGenerator.cs
+++ b/src/Controls/src/BindingSourceGen/BindingSourceGenerator.cs
@@ -72,12 +72,14 @@ public class BindingSourceGenerator : IIncrementalGenerator
 	}
 
 	internal static SimpleNameSyntax? GetInvokedMethodName(ExpressionSyntax expression)
-		=> expression switch
+	{
+		return expression switch
 		{
 			MemberAccessExpressionSyntax memberAccess => memberAccess.Name,
 			MemberBindingExpressionSyntax memberBinding => memberBinding.Name,
 			_ => null
 		};
+	}
 
 	private static bool IsCreateMethod(SyntaxNode node)
 	{

--- a/src/Controls/src/BindingSourceGen/InvocationParser.cs
+++ b/src/Controls/src/BindingSourceGen/InvocationParser.cs
@@ -20,7 +20,10 @@ internal class InvocationParser
 
 	internal Result<InterceptedMethodType> ParseInvocation(InvocationExpressionSyntax invocationSyntax, CancellationToken t)
 	{
-		return ((MemberAccessExpressionSyntax)invocationSyntax.Expression).Name.Identifier.Text switch
+		var methodName = BindingSourceGenerator.GetInvokedMethodName(invocationSyntax.Expression)?.Identifier.Text
+			?? throw new NotSupportedException();
+
+		return methodName switch
 		{
 			InterceptedMethodsNames.SetBinding => VerifyCorrectOverloadSetBinding(invocationSyntax, t),
 			InterceptedMethodsNames.Create => VerifyCorrectOverloadBindingCreate(invocationSyntax, t),

--- a/src/Controls/tests/BindingSourceGen.UnitTests/IntegrationTests.cs
+++ b/src/Controls/tests/BindingSourceGen.UnitTests/IntegrationTests.cs
@@ -115,6 +115,22 @@ public class IntegrationTests
 	}
 
 	[Fact]
+	public void GenerateBindingForNullConditionalTarget()
+	{
+		var source = """
+        using Microsoft.Maui.Controls;
+        Label? label = new Label();
+        label?.SetBinding(Label.RotationProperty, static (string s) => s.Length);
+        """;
+
+		var result = SourceGenHelpers.Run(source);
+
+		AssertExtensions.AssertNoDiagnostics(result);
+		Assert.NotNull(result.Binding);
+		Assert.NotNull(result.Binding.InterceptableLocation);
+	}
+
+	[Fact]
 	public void GenerateSimpleBindingCreate()
 	{
 		var source = """


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->


### Issue Details
label?.SetBinding(...) should create a compiled binding when label is not null.
Instead, MAUI did not generate the required interceptor, so the app compiled but threw Call to SetBinding<...> was not intercepted at runtime.

### Root Cause
label.SetBinding(...) and label?.SetBinding(...) have different C# syntax-tree shapes.
The MAUI generator recognized only the ordinary call shape, so it skipped null-conditional calls and did not generate an interceptor.

### Description of Change
GetInvokedMethodName now recognizes both syntax types.
Therefore, ordinary and null-conditional SetBinding calls follow the same interceptor-generation process.

Validated the behavior in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
### Issues Fixed
  
Fixes #38365 

### Output  ScreenShot

|Before|After|
|--|--|
| <video src="https://github.com/user-attachments/assets/0c5a735d-4a06-4261-8488-f19f464a2be9" >| <video src="https://github.com/user-attachments/assets/b700be4b-776f-4def-bbd2-8325d1007bd1">|